### PR TITLE
[IMP] migration: allow to add external migration steps

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -133,6 +133,7 @@ import {
   createEmptySheet,
   createEmptyWorkbookData,
 } from "./migrations/data";
+import { migrationStepRegistry } from "./migrations/migration_steps";
 import {
   corePluginRegistry,
   coreViewsPluginRegistry,
@@ -278,6 +279,7 @@ export const registries = {
   pivotNormalizationValueRegistry,
   supportedPivotPositionalFormulaRegistry,
   pivotToFunctionValueRegistry,
+  migrationStepRegistry,
 };
 export const helpers = {
   arg,

--- a/src/migrations/migration_steps.ts
+++ b/src/migrations/migration_steps.ts
@@ -1,0 +1,358 @@
+import {
+  BACKGROUND_CHART_COLOR,
+  FORBIDDEN_IN_EXCEL_REGEX,
+  FORMULA_REF_IDENTIFIER,
+} from "../constants";
+import { getItemId } from "../helpers";
+import { toXC } from "../helpers/coordinates";
+import { getMaxObjectId } from "../helpers/pivot/pivot_helpers";
+import { overlap, toZone, zoneToXc } from "../helpers/zones";
+import { Registry } from "../registries/registry";
+import { CustomizedDataSet, DEFAULT_LOCALE, Format, Zone } from "../types";
+import { normalizeV9 } from "./legacy_tools";
+
+interface MigrationStep {
+  version: string;
+  migrate: (data: any) => any;
+}
+
+export const migrationStepRegistry = new Registry<MigrationStep>();
+
+migrationStepRegistry
+  .add("migration_1", {
+    // add the `activeSheet` field on data
+    version: "1",
+    migrate(data: any): any {
+      if (data.sheets && data.sheets[0]) {
+        data.activeSheet = data.sheets[0].name;
+      }
+      return data;
+    },
+  })
+  .add("migration_2", {
+    // add an id field in each sheet
+    version: "2",
+    migrate(data: any): any {
+      if (data.sheets && data.sheets.length) {
+        for (let sheet of data.sheets) {
+          sheet.id = sheet.id || sheet.name;
+        }
+      }
+      return data;
+    },
+  })
+  .add("migration_3", {
+    // activeSheet is now an id, not the name of a sheet
+    version: "3",
+    migrate(data: any): any {
+      if (data.sheets && data.activeSheet) {
+        const activeSheet = data.sheets.find((s) => s.name === data.activeSheet);
+        data.activeSheet = activeSheet.id;
+      }
+      return data;
+    },
+  })
+  .add("migration_4", {
+    // add figures object in each sheets
+    version: "4",
+    migrate(data: any): any {
+      for (let sheet of data.sheets || []) {
+        sheet.figures = sheet.figures || [];
+      }
+      return data;
+    },
+  })
+  .add("migration_5", {
+    // normalize the content of the cell if it is a formula to avoid parsing all the formula that vary only by the cells they use
+    version: "5",
+    migrate(data: any): any {
+      for (let sheet of data.sheets || []) {
+        for (let xc in sheet.cells || []) {
+          const cell = sheet.cells[xc];
+          if (cell.content && cell.content.startsWith("=")) {
+            cell.formula = normalizeV9(cell.content);
+          }
+        }
+      }
+      return data;
+    },
+  })
+  .add("migration_6", {
+    // transform chart data structure
+    version: "6",
+    migrate(data: any): any {
+      for (let sheet of data.sheets || []) {
+        for (let f in sheet.figures || []) {
+          const { dataSets, ...newData } = sheet.figures[f].data;
+          const newDataSets: string[] = [];
+          for (let ds of dataSets) {
+            if (ds.labelCell) {
+              const dataRange = toZone(ds.dataRange);
+              const newRange = ds.labelCell + ":" + toXC(dataRange.right, dataRange.bottom);
+              newDataSets.push(newRange);
+            } else {
+              newDataSets.push(ds.dataRange);
+            }
+          }
+          newData.dataSetsHaveTitle = Boolean(dataSets[0].labelCell);
+          newData.dataSets = newDataSets;
+          sheet.figures[f].data = newData;
+        }
+      }
+      return data;
+    },
+  })
+  .add("migration_7", {
+    // remove single quotes in sheet names
+    version: "7",
+    migrate(data: any): any {
+      const namesTaken: string[] = [];
+      const globalForbiddenInExcel = new RegExp(FORBIDDEN_IN_EXCEL_REGEX, "g");
+      for (let sheet of data.sheets || []) {
+        if (!sheet.name) {
+          continue;
+        }
+        const oldName = sheet.name;
+        const escapedName: string = oldName.replace(globalForbiddenInExcel, "_");
+        let i = 1;
+        let newName = escapedName;
+        while (namesTaken.includes(newName)) {
+          newName = `${escapedName}${i}`;
+          i++;
+        }
+        sheet.name = newName;
+        namesTaken.push(newName);
+
+        const replaceName = (str: string | undefined) => {
+          if (str === undefined) {
+            return str;
+          }
+          // replaceAll is only available in next Typescript version
+          let newString: string = str.replace(oldName, newName);
+          let currentString: string = str;
+          while (currentString !== newString) {
+            currentString = newString;
+            newString = currentString.replace(oldName, newName);
+          }
+          return currentString;
+        };
+        //cells
+        for (let xc in sheet.cells) {
+          const cell = sheet.cells[xc];
+          if (cell.formula) {
+            cell.formula.dependencies = cell.formula.dependencies.map(replaceName);
+          }
+        }
+        //charts
+        for (let figure of sheet.figures || []) {
+          if (figure.type === "chart") {
+            const dataSets = figure.data.dataSets.map(replaceName);
+            const labelRange = replaceName(figure.data.labelRange);
+            figure.data = { ...figure.data, dataSets, labelRange };
+          }
+        }
+        //ConditionalFormats
+        for (let cf of sheet.conditionalFormats || []) {
+          cf.ranges = cf.ranges.map(replaceName);
+          for (const thresholdName of [
+            "minimum",
+            "maximum",
+            "midpoint",
+            "upperInflectionPoint",
+            "lowerInflectionPoint",
+          ] as const) {
+            if (cf.rule[thresholdName]?.type === "formula") {
+              cf.rule[thresholdName].value = replaceName(cf.rule[thresholdName].value);
+            }
+          }
+        }
+      }
+      return data;
+    },
+  })
+  .add("migration_8", {
+    // transform chart data structure with design attributes
+    version: "8",
+    migrate(data: any): any {
+      for (const sheet of data.sheets || []) {
+        for (const chart of sheet.figures || []) {
+          chart.data.background = BACKGROUND_CHART_COLOR;
+          chart.data.verticalAxisPosition = "left";
+          chart.data.legendPosition = "top";
+          chart.data.stacked = false;
+        }
+      }
+      return data;
+    },
+  })
+  .add("migration_9", {
+    // de-normalize formula to reduce exported json size (~30%)
+    version: "9",
+    migrate(data: any): any {
+      for (let sheet of data.sheets || []) {
+        for (let xc in sheet.cells || []) {
+          const cell = sheet.cells[xc];
+          if (cell.formula) {
+            let { text, dependencies } = cell.formula;
+            for (let [index, d] of Object.entries(dependencies)) {
+              const stringPosition = `\\${FORMULA_REF_IDENTIFIER}${index}\\${FORMULA_REF_IDENTIFIER}`;
+              text = text.replace(new RegExp(stringPosition, "g"), d);
+            }
+            cell.content = text;
+            delete cell.formula;
+          }
+        }
+      }
+      return data;
+    },
+  })
+  .add("migration_10", {
+    // normalize the formats of the cells
+    version: "10",
+    migrate(data: any): any {
+      const formats: { [formatId: number]: Format } = {};
+      for (let sheet of data.sheets || []) {
+        for (let xc in sheet.cells || []) {
+          const cell = sheet.cells[xc];
+          if (cell.format) {
+            cell.format = getItemId(cell.format, formats);
+          }
+        }
+      }
+      data.formats = formats;
+      return data;
+    },
+  })
+  .add("migration_11", {
+    // Add isVisible to sheets
+    version: "11",
+    migrate(data: any): any {
+      for (let sheet of data.sheets || []) {
+        sheet.isVisible = true;
+      }
+      return data;
+    },
+  })
+  .add("migration_12", {
+    // Fix data filter duplication
+    version: "12",
+    migrate(data: any): any {
+      return fixOverlappingFilters(data);
+    },
+  })
+  .add("migration_12_5", {
+    // Change Border description structure
+    version: "12.5",
+    migrate(data: any): any {
+      for (const borderId in data.borders) {
+        const border = data.borders[borderId];
+        for (const position in border) {
+          if (Array.isArray(border[position])) {
+            border[position] = {
+              style: border[position][0],
+              color: border[position][1],
+            };
+          }
+        }
+      }
+      return data;
+    },
+  })
+  .add("migration_13", {
+    // Add locale to spreadsheet settings
+    version: "13",
+    migrate(data: any): any {
+      if (!data.settings) {
+        data.settings = {};
+      }
+      if (!data.settings.locale) {
+        data.settings.locale = DEFAULT_LOCALE;
+      }
+      return data;
+    },
+  })
+  .add("migration_14", {
+    // Fix datafilter duplication (post saas-17.1)
+    version: "14",
+    migrate(data: any): any {
+      return fixOverlappingFilters(data);
+    },
+  })
+  .add("migration_14_5", {
+    // Rename filterTable to tables
+    version: "14.5",
+    migrate(data: any): any {
+      for (const sheetData of data.sheets || []) {
+        sheetData.tables = sheetData.tables || sheetData.filterTables || [];
+        delete sheetData.filterTables;
+      }
+      return data;
+    },
+  })
+  .add("migration_15", {
+    // Add pivots
+    version: "15",
+    migrate(data: any): any {
+      if (!data.pivots) {
+        data.pivots = {};
+      }
+      if (!data.pivotNextId) {
+        data.pivotNextId = getMaxObjectId(data.pivots) + 1;
+      }
+      return data;
+    },
+  })
+  .add("migration_16", {
+    // transform chart data structure (2)
+    version: "16",
+    migrate(data: any): any {
+      for (const sheet of data.sheets || []) {
+        for (const f in sheet.figures || []) {
+          const figure = sheet.figures[f];
+          if ("title" in figure.data && typeof figure.data.title === "string") {
+            figure.data.title = { text: figure.data.title };
+          }
+          const figureType = figure.data.type;
+          if (!["line", "bar", "pie", "scatter", "waterfall", "combo"].includes(figureType)) {
+            continue;
+          }
+          const { dataSets, ...newData } = sheet.figures[f].data;
+          const newDataSets: CustomizedDataSet = dataSets.map((dataRange) => ({ dataRange }));
+          newData.dataSets = newDataSets;
+          sheet.figures[f].data = newData;
+        }
+      }
+      return data;
+    },
+  })
+  .add("migration_17", {
+    // Empty migration to allow external modules to add their own migration steps
+    // before this version
+    version: "17",
+    migrate(data: any): any {
+      return data;
+    },
+  });
+
+function fixOverlappingFilters(data: any): any {
+  for (let sheet of data.sheets || []) {
+    let knownDataFilterZones: Zone[] = [];
+    for (let filterTable of sheet.filterTables || []) {
+      const zone = toZone(filterTable.range);
+      // See commit message of https://github.com/odoo/o-spreadsheet/pull/3632 of more details
+      const intersectZoneIndex = knownDataFilterZones.findIndex((knownZone) =>
+        overlap(knownZone, zone)
+      );
+      if (intersectZoneIndex !== -1) {
+        knownDataFilterZones[intersectZoneIndex] = zone;
+      } else {
+        knownDataFilterZones.push(zone);
+      }
+    }
+
+    sheet.filterTables = knownDataFilterZones.map((zone) => ({
+      range: zoneToXc(zone),
+    }));
+  }
+  return data;
+}


### PR DESCRIPTION
With this commit, it's now possible for an external integration to add custom migration steps. Before this commit, one could only add migration by creating its own migration system.

It will be useful for pivot migration, as some migrations are defined in odoo and some migrations will have to be defined in spreadsheet. But as spreadsheet migrations are run before odoo migrations, it could generate some conflicts.

Task: 4052912

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo