### PR TITLE
[IMP] pivots: table type synced with pivot structure

### DIFF
--- a/src/helpers/pivot/pivot_menu_items.ts
+++ b/src/helpers/pivot/pivot_menu_items.ts
@@ -31,7 +31,7 @@ export const FIX_FORMULAS: ActionSpec = {
     if (!pivot.isValid()) {
       return;
     }
-    env.model.dispatch("INSERT_PIVOT", {
+    env.model.dispatch("SPLIT_PIVOT_FORMULA", {
       sheetId,
       col,
       row,

--- a/src/plugins/ui_feature/insert_pivot.ts
+++ b/src/plugins/ui_feature/insert_pivot.ts
@@ -1,6 +1,6 @@
 import { PIVOT_TABLE_CONFIG } from "../../constants";
 import { SpreadsheetPivotTable } from "../../helpers/pivot/table_spreadsheet_pivot";
-import { getZoneArea } from "../../helpers/zones";
+import { getZoneArea, positionToZone } from "../../helpers/zones";
 import { _t } from "../../translation";
 import { HeaderIndex, PivotTableData, UID } from "../../types";
 import { Command } from "../../types/commands";
@@ -20,6 +20,8 @@ export class InsertPivotPlugin extends UIPlugin {
       case "INSERT_PIVOT_WITH_TABLE":
         this.insertPivotWithTable(cmd.sheetId, cmd.col, cmd.row, cmd.pivotId, cmd.table);
         break;
+      case "SPLIT_PIVOT_FORMULA":
+        this.splitPivotFormula(cmd.sheetId, cmd.col, cmd.row, cmd.pivotId, cmd.table);
     }
   }
 
@@ -163,6 +165,43 @@ export class InsertPivotPlugin extends UIPlugin {
         sheetId: sheetId,
         quantity: rowLimit - deltaRow,
         position: "after",
+      });
+    }
+  }
+
+  splitPivotFormula(
+    sheetId: UID,
+    col: HeaderIndex,
+    row: HeaderIndex,
+    pivotId: UID,
+    pivotTableData: PivotTableData
+  ) {
+    this.dispatch("INSERT_PIVOT", {
+      sheetId,
+      col,
+      row,
+      pivotId,
+      table: pivotTableData,
+    });
+    const table = this.getters.getCoreTable({ sheetId, col, row });
+    if (table?.type === "dynamic") {
+      const zone = positionToZone({ col, row });
+      const { cols, rows, measures, fieldsType } = pivotTableData;
+      const pivotTable = new SpreadsheetPivotTable(cols, rows, measures, fieldsType || {});
+      const colNumber = pivotTable.getNumberOfDataColumns() + 1;
+      const rowNumber = pivotTable.columns.length + pivotTable.rows.length;
+      const tableZone = {
+        left: col,
+        top: row,
+        right: col + colNumber - 1,
+        bottom: row + rowNumber - 1,
+      };
+      const rangeData = this.getters.getRangeDataFromZone(sheetId, tableZone);
+      this.dispatch("UPDATE_TABLE", {
+        sheetId,
+        zone,
+        newTableRange: rangeData,
+        tableType: "static",
       });
     }
   }

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -952,11 +952,14 @@ export interface DuplicatePivotInNewSheetCommand {
   newSheetId: UID;
 }
 
-export interface InsertPivotWithTableCommand {
+export interface InsertPivotWithTableCommand extends PositionDependentCommand {
   type: "INSERT_PIVOT_WITH_TABLE";
-  sheetId: UID;
-  col: HeaderIndex;
-  row: HeaderIndex;
+  pivotId: UID;
+  table: PivotTableData;
+}
+
+export interface SplitPivotFormulaCommand extends PositionDependentCommand {
+  type: "SPLIT_PIVOT_FORMULA";
   pivotId: UID;
   table: PivotTableData;
 }
@@ -1106,7 +1109,8 @@ export type LocalCommand =
   | RefreshPivotCommand
   | InsertNewPivotCommand
   | DuplicatePivotInNewSheetCommand
-  | InsertPivotWithTableCommand;
+  | InsertPivotWithTableCommand
+  | SplitPivotFormulaCommand;
 
 export type Command = CoreCommand | LocalCommand;
 


### PR DESCRIPTION
If a user had linked a dynamic table to a pivot formula (`=PIVOT(1)`) the table would not be adapted accordingly when the user converted their pivot into "splitted" individual formulas. This revision detects if a dynamic table is attached the anchor of the dynamic pivot formula and converts it along the pivot such that it matches the the pivot range.

Task: 4039655

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo