### PR TITLE
[PERF] evaluation: don't create closure for each cell

### DIFF
--- a/src/functions/helper_lookup.ts
+++ b/src/functions/helper_lookup.ts
@@ -1,6 +1,6 @@
-import { toZone, zoneToXc } from "../helpers";
+import { zoneToXc } from "../helpers";
 import { _t } from "../translation";
-import { CellPosition, EvalContext, FunctionResultObject, Getters, Maybe, UID } from "../types";
+import { EvalContext, FunctionResultObject, Getters, Maybe, UID } from "../types";
 import { EvaluationError, InvalidReferenceError } from "../types/errors";
 import { PivotCoreDefinition } from "../types/pivot";
 
@@ -44,16 +44,8 @@ export function addPivotDependencies(
     return;
   }
   const { sheetId, zone } = coreDefinition.dataSet;
-  let originPosition: CellPosition | undefined;
-  const originSheetId = evalContext.__originSheetId;
-  const originCellXC = evalContext.__originCellXC?.();
-  if (originCellXC) {
-    const cellZone = toZone(originCellXC);
-    originPosition = {
-      sheetId: originSheetId,
-      col: cellZone.left,
-      row: cellZone.top,
-    };
+  const originPosition = evalContext.__originCellPosition;
+  if (originPosition) {
     // The following line is used to reset the dependencies of the cell, to avoid
     // keeping dependencies from previous evaluation of the PIVOT formula (i.e.
     // in case the reference has been changed).

--- a/src/functions/module_lookup.ts
+++ b/src/functions/module_lookup.ts
@@ -1,13 +1,6 @@
 import { getFullReference, range, splitReference, toXC, toZone } from "../helpers/index";
 import { _t } from "../translation";
-import {
-  AddFunctionDescription,
-  CellPosition,
-  FunctionResultObject,
-  Matrix,
-  Maybe,
-  Zone,
-} from "../types";
+import { AddFunctionDescription, FunctionResultObject, Matrix, Maybe, Zone } from "../types";
 import { CellErrorType, EvaluationError, InvalidReferenceError } from "../types/errors";
 import { arg } from "./arguments";
 import { assertPositive } from "./helper_assert";
@@ -129,14 +122,15 @@ export const COLUMN = {
     if (isEvaluationError(cellReference?.value)) {
       throw cellReference;
     }
-    const _cellReference =
-      cellReference === undefined ? this.__originCellXC?.() : cellReference.value;
+    const column =
+      cellReference === undefined
+        ? this.__originCellPosition?.col
+        : toZone(cellReference.value).left;
     assert(
-      () => !!_cellReference,
+      () => column !== undefined,
       "In this context, the function [[FUNCTION_NAME]] needs to have a cell or range in parameter."
     );
-    const zone = toZone(_cellReference!);
-    return zone.left + 1;
+    return column! + 1;
   },
   isExported: true,
 } satisfies AddFunctionDescription;
@@ -288,15 +282,8 @@ export const INDIRECT: AddFunctionDescription = {
       throw new EvaluationError(_t("R1C1 notation is not supported."));
     }
     const sheetId = this.__originSheetId;
-    let originPosition: CellPosition | undefined;
-    const __originCellXC = this.__originCellXC?.();
-    if (__originCellXC) {
-      const cellZone = toZone(__originCellXC);
-      originPosition = {
-        sheetId,
-        col: cellZone.left,
-        row: cellZone.top,
-      };
+    const originPosition = this.__originCellPosition;
+    if (originPosition) {
       // The following line is used to reset the dependencies of the cell, to avoid
       // keeping dependencies from previous evaluation of the INDIRECT formula (i.e.
       // in case the reference has been changed).
@@ -484,14 +471,15 @@ export const ROW = {
     if (isEvaluationError(cellReference?.value)) {
       throw cellReference;
     }
-    const _cellReference =
-      cellReference === undefined ? this.__originCellXC?.() : cellReference.value;
+    const row =
+      cellReference === undefined
+        ? this.__originCellPosition?.row
+        : toZone(cellReference.value).top;
     assert(
-      () => !!_cellReference,
+      () => row !== undefined,
       "In this context, the function [[FUNCTION_NAME]] needs to have a cell or range in parameter."
     );
-    const zone = toZone(_cellReference!);
-    return zone.top + 1;
+    return row! + 1;
   },
   isExported: true,
 } satisfies AddFunctionDescription;
@@ -929,15 +917,8 @@ export const OFFSET = {
     const _offsetRows = toNumber(offsetRows, this.locale);
     const _offsetColumns = toNumber(offsetColumns, this.locale);
 
-    let originPosition: CellPosition | undefined;
-    const __originCellXC = this.__originCellXC?.();
-    if (__originCellXC) {
-      const cellZone = toZone(__originCellXC);
-      originPosition = {
-        sheetId: this.__originSheetId,
-        col: cellZone.left,
-        row: cellZone.top,
-      };
+    const originPosition = this.__originCellPosition;
+    if (originPosition) {
       this.updateDependencies?.(originPosition);
     }
 

--- a/src/types/functions.ts
+++ b/src/types/functions.ts
@@ -52,7 +52,7 @@ export type FunctionDescription = AddFunctionDescription & {
 
 export type EvalContext = {
   __originSheetId: UID;
-  __originCellXC: () => string | undefined;
+  __originCellPosition?: CellPosition;
   locale: Locale;
   getters: Getters;
   [key: string]: any;


### PR DESCRIPTION



## Description:

Currently, `__originCellXc` is a closure created for each evaluated cell.
It needs:
1) to be instanciated
2) to be garbage collected later.

It takes CPU time.

It's currently a closure to lazily build the XC (which is even costy performance-wise)

This commit changes `__originCellXc` to be the cell position object. The object is already created. So it doesn't require ab extra allocation (and GC)

`evaluateAllCells` on the large formula data set allocated 132MB before, and only 88MB with this commit.

The timing performance improvement is difficult to measure because there's a lot of variation, and GC is not deterministic.

It also improves the performance of all formulas using `__originCellXc` because, they no longer needs to parse the XC string.

Task: : [4057810](https://www.odoo.com/web#id=4057810&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo