### PR TITLE
[IMP] pivots: add "Show value as" to measures

### DIFF
--- a/src/components/side_panel/components/radio_selection/radio_selection.ts
+++ b/src/components/side_panel/components/radio_selection/radio_selection.ts
@@ -4,15 +4,16 @@ import { SpreadsheetChildEnv } from "../../../../types";
 import { css } from "../../../helpers/css";
 
 interface Choice {
-  value: string;
+  value: unknown;
   label: string;
 }
 
 interface Props {
   choices: Choice[];
-  onChange: (value: string) => void;
+  onChange: (value: unknown) => void;
   selectedValue: string;
   name: string;
+  direction: "horizontal" | "vertical";
 }
 
 const CIRCLE_SVG = /*xml*/ `
@@ -48,12 +49,11 @@ export class RadioSelection extends Component<Props, SpreadsheetChildEnv> {
   static props = {
     choices: Array,
     onChange: Function,
-    selectedValue: String,
+    selectedValue: { optional: false },
     name: String,
+    direction: { type: String, optional: true },
   };
-
-  onChange(ev: InputEvent) {
-    const value = (ev.target as HTMLInputElement).value;
-    this.props.onChange(value);
-  }
+  static defaultProps = {
+    direction: "horizontal",
+  };
 }

--- a/src/components/side_panel/components/radio_selection/radio_selection.xml
+++ b/src/components/side_panel/components/radio_selection/radio_selection.xml
@@ -1,15 +1,21 @@
 <templates>
   <t t-name="o-spreadsheet.RadioSelection">
-    <div class="d-flex flex-row">
+    <div
+      class="d-flex"
+      t-att-class="{
+            'flex-row': props.direction === 'horizontal',
+            'flex-column': props.direction === 'vertical'}">
       <t t-foreach="props.choices" t-as="choice" t-key="choice.value">
         <label class="o-radio d-flex align-items-center me-4">
           <input
-            class="me-1"
+            t-att-class="{
+              'me-1': props.direction === 'horizontal',
+              'me-2': props.direction === 'vertical'}"
             type="radio"
             t-att-name="props.name"
             t-att-value="choice.value"
             t-att-checked="choice.value === props.selectedValue"
-            t-on-change="onChange"
+            t-on-change="() => props.onChange(choice.value)"
           />
           <t t-esc="choice.label"/>
         </label>

--- a/src/components/side_panel/pivot/pivot_layout_configurator/pivot_dimension/pivot_dimension.ts
+++ b/src/components/side_panel/pivot/pivot_layout_configurator/pivot_dimension/pivot_dimension.ts
@@ -1,13 +1,16 @@
 import { Component } from "@odoo/owl";
+import { PivotCoreDimension, PivotCoreMeasure } from "../../../../..";
 import { GRAY_300 } from "../../../../../constants";
 import { SpreadsheetChildEnv } from "../../../../../types";
 import { css } from "../../../../helpers";
 import { TextInput } from "../../../../text_input/text_input";
+import { CogWheelMenu } from "../../../components/cog_wheel_menu/cog_wheel_menu";
 
 interface Props {
-  dimension: PivotDimension;
-  onRemoved: (dimension: PivotDimension) => void;
-  onNameUpdated?: (dimension: PivotDimension, name?: string) => void;
+  dimension: PivotCoreDimension | PivotCoreMeasure;
+  onRemoved: (dimension: PivotCoreDimension | PivotCoreMeasure) => void;
+  onNameUpdated?: (dimension: PivotCoreDimension | PivotCoreMeasure, name?: string) => void;
+  type: "row" | "col" | "measure";
 }
 
 // don't use bg-white since it's flipped to dark in dark mode and we don't support dark mode
@@ -47,7 +50,7 @@ export class PivotDimension extends Component<Props, SpreadsheetChildEnv> {
     onNameUpdated: { type: Function, optional: true },
     slots: { type: Object, optional: true },
   };
-  static components = { TextInput };
+  static components = { CogWheelMenu, TextInput };
 
   updateName(name: string) {
     this.props.onNameUpdated?.(

--- a/src/components/side_panel/pivot/pivot_layout_configurator/pivot_layout_configurator.xml
+++ b/src/components/side_panel/pivot/pivot_layout_configurator/pivot_layout_configurator.xml
@@ -73,6 +73,7 @@
           t-att-class="measure.isHidden ? 'opacity-50' : ''"
           class="pt-1 pivot-measure">
           <PivotMeasureEditor
+            pivotId="props.pivotId"
             definition="props.definition"
             measure="measure"
             aggregators="AGGREGATORS"

--- a/src/components/side_panel/pivot/pivot_layout_configurator/pivot_measure/pivot_measure.ts
+++ b/src/components/side_panel/pivot/pivot_layout_configurator/pivot_measure/pivot_measure.ts
@@ -6,6 +6,7 @@ import { StandaloneComposer } from "../../../../composer/standalone_composer/sta
 import { PivotDimension } from "../pivot_dimension/pivot_dimension";
 
 interface Props {
+  pivotId: string;
   definition: PivotRuntimeDefinition;
   measure: PivotMeasure;
   onMeasureUpdated: (measure: PivotMeasure) => void;
@@ -26,6 +27,7 @@ export class PivotMeasureEditor extends Component<Props> {
     onRemoved: Function,
     generateMeasureId: Function,
     aggregators: Object,
+    pivotId: String,
   };
 
   getMeasureAutocomplete() {
@@ -70,6 +72,13 @@ export class PivotMeasureEditor extends Component<Props> {
     this.props.onMeasureUpdated({
       ...this.props.measure,
       isHidden: !this.props.measure.isHidden,
+    });
+  }
+
+  openShowValuesAs() {
+    this.env.openSidePanel("PivotMeasureDisplayPanel", {
+      pivotId: this.props.pivotId,
+      measure: this.props.measure,
     });
   }
 }

--- a/src/components/side_panel/pivot/pivot_layout_configurator/pivot_measure/pivot_measure.xml
+++ b/src/components/side_panel/pivot/pivot_layout_configurator/pivot_measure/pivot_measure.xml
@@ -11,6 +11,11 @@
           class="o-button-icon pe-1 ps-2"
           t-on-click="toggleMeasureVisibility"
         />
+        <i
+          class="o-button-icon pe-1 ps-2 fa fa-cog"
+          title="Show values as"
+          t-on-click="openShowValuesAs"
+        />
       </t>
       <div t-if="measure.computedBy" class="d-flex flex-row small">
         <div class="d-flex flex-column py-2 px-2 w-100">

--- a/src/components/side_panel/pivot/pivot_measure_display_panel/pivot_measure_display_panel.ts
+++ b/src/components/side_panel/pivot/pivot_measure_display_panel/pivot_measure_display_panel.ts
@@ -1,0 +1,72 @@
+import { Component } from "@odoo/owl";
+import { PivotCoreMeasure, SpreadsheetChildEnv, UID } from "../../../..";
+import { GRAY_300 } from "../../../../constants";
+import { Store, useLocalStore } from "../../../../store_engine";
+import { css } from "../../../helpers";
+import { measureDisplayTerms } from "../../../translations_terms";
+import { Checkbox } from "../../components/checkbox/checkbox";
+import { RadioSelection } from "../../components/radio_selection/radio_selection";
+import { Section } from "../../components/section/section";
+import { PivotMeasureDisplayPanelStore } from "./pivot_measure_display_panel_store";
+
+interface Props {
+  onCloseSidePanel: () => void;
+  pivotId: UID;
+  measure: PivotCoreMeasure;
+}
+
+css/* scss */ `
+  .o-sidePanel {
+    .o-pivot-measure-display-field,
+    .o-pivot-measure-display-value {
+      box-sizing: border-box;
+      border: solid 1px ${GRAY_300};
+      border-radius: 3px;
+    }
+
+    .o-pivot-measure-display-description {
+      white-space: pre-wrap;
+      color: dimgray;
+      border-left: 2px solid ${GRAY_300};
+    }
+  }
+`;
+
+export class PivotMeasureDisplayPanel extends Component<Props, SpreadsheetChildEnv> {
+  static template = "o-spreadsheet-PivotMeasureDisplayPanel";
+  static props = {
+    onCloseSidePanel: Function,
+    pivotId: String,
+    measure: Object,
+  };
+  static components = { Section, Checkbox, RadioSelection };
+
+  measureDisplayTypeLabels = measureDisplayTerms.labels;
+  measureDisplayDescription = measureDisplayTerms.documentation;
+
+  store!: Store<PivotMeasureDisplayPanelStore>;
+
+  setup() {
+    this.store = useLocalStore(
+      PivotMeasureDisplayPanelStore,
+      this.props.pivotId,
+      this.props.measure
+    );
+  }
+
+  onSave() {
+    this.env.openSidePanel("PivotSidePanel", { pivotId: this.props.pivotId });
+  }
+
+  onCancel() {
+    this.store.cancelMeasureDisplayEdition();
+    this.env.openSidePanel("PivotSidePanel", { pivotId: this.props.pivotId });
+  }
+
+  get fieldChoices() {
+    return this.store.fields.map((field) => ({
+      value: field.nameWithGranularity,
+      label: field.displayName,
+    }));
+  }
+}

--- a/src/components/side_panel/pivot/pivot_measure_display_panel/pivot_measure_display_panel.xml
+++ b/src/components/side_panel/pivot/pivot_measure_display_panel/pivot_measure_display_panel.xml
@@ -1,0 +1,61 @@
+<templates>
+  <t t-name="o-spreadsheet-PivotMeasureDisplayPanel">
+    <Section>
+      <t t-set-slot="title">Show measure as:</t>
+      <select
+        class="o-pivot-measure-display-type o-input"
+        t-on-change="(ev) => this.store.updateMeasureDisplayType(ev.target.value)">
+        <t t-foreach="measureDisplayTypeLabels" t-as="measureType" t-key="measureType">
+          <option
+            t-att-value="measureType"
+            t-att-selected="measureType === store.measureDisplay.type"
+            t-esc="measureType_value"
+          />
+        </t>
+      </select>
+      <div
+        class="o-pivot-measure-display-description mt-3 ps-3"
+        t-esc="measureDisplayDescription[store.measureDisplay.type]"
+      />
+    </Section>
+
+    <Section t-if="store.doesDisplayNeedsField">
+      <t t-set-slot="title">Base field:</t>
+      <div class="o-pivot-measure-display-field w-100 py-1 px-3">
+        <t t-if="store.fields.length">
+          <RadioSelection
+            choices="fieldChoices"
+            selectedValue="store.measureDisplay.fieldNameWithGranularity"
+            name="'baseField'"
+            onChange.bind="(val) => store.updateMeasureDisplayField(val)"
+            direction="'vertical'"
+          />
+        </t>
+        <t t-else="">
+          <div class="text-muted text-center my-3">No active dimension in the pivot</div>
+        </t>
+      </div>
+    </Section>
+
+    <t t-set="values" t-value="store.values"/>
+    <Section t-if="store.doesDisplayNeedsValue and values.length">
+      <t t-set-slot="title">Base item:</t>
+      <div class="o-pivot-measure-display-value w-100 py-1 px-3">
+        <RadioSelection
+          choices="values"
+          selectedValue="store.measureDisplay.value"
+          name="'baseValue'"
+          onChange.bind="(val) => store.updateMeasureDisplayValue(val)"
+          direction="'vertical'"
+        />
+      </div>
+    </Section>
+
+    <Section>
+      <div class="o-sidePanelButtons">
+        <button t-on-click="onCancel" class="o-pivot-measure-cancel o-button">Cancel</button>
+        <button t-on-click="onSave" class="o-pivot-measure-save o-button primary">Save</button>
+      </div>
+    </Section>
+  </t>
+</templates>

--- a/src/components/side_panel/pivot/pivot_measure_display_panel/pivot_measure_display_panel_store.ts
+++ b/src/components/side_panel/pivot/pivot_measure_display_panel/pivot_measure_display_panel_store.ts
@@ -1,0 +1,183 @@
+import { deepCopy } from "../../../../helpers";
+import {
+  NEXT_VALUE,
+  PREVIOUS_VALUE,
+  getFieldDisplayName,
+} from "../../../../helpers/pivot/pivot_helpers";
+import { Get } from "../../../../store_engine";
+import { SpreadsheetStore } from "../../../../stores";
+import { _t } from "../../../../translation";
+import {
+  PivotCoreDefinition,
+  PivotCoreMeasure,
+  PivotMeasureDisplay,
+  PivotMeasureDisplayType,
+  UID,
+} from "../../../../types";
+
+export class PivotMeasureDisplayPanelStore extends SpreadsheetStore {
+  mutators = [
+    "cancelMeasureDisplayEdition",
+    "updateMeasureDisplayType",
+    "updateMeasureDisplayField",
+    "updateMeasureDisplayValue",
+  ] as const;
+
+  measureDisplay: PivotMeasureDisplay;
+
+  constructor(get: Get, private pivotId: UID, private initialMeasure: PivotCoreMeasure) {
+    super(get);
+    this.measureDisplay = initialMeasure.display || { type: "no_calculations" };
+  }
+
+  updateMeasureDisplayType(measureDisplayType: PivotMeasureDisplayType) {
+    this.updatePivotMeasureDisplay(
+      this.getMeasureDisplay(
+        measureDisplayType,
+        this.measureDisplay.fieldNameWithGranularity,
+        this.measureDisplay.value
+      )
+    );
+  }
+
+  updateMeasureDisplayField(fieldNameWithGranularity: string) {
+    this.updatePivotMeasureDisplay(
+      this.getMeasureDisplay(
+        this.measureDisplay.type,
+        fieldNameWithGranularity,
+        this.measureDisplay.value
+      )
+    );
+  }
+
+  updateMeasureDisplayValue(value: string) {
+    this.updatePivotMeasureDisplay(
+      this.getMeasureDisplay(
+        this.measureDisplay.type,
+        this.measureDisplay.fieldNameWithGranularity,
+        value
+      )
+    );
+  }
+
+  private updatePivotMeasureDisplay(newDisplay: PivotMeasureDisplay) {
+    const pivotDefinition = deepCopy(this.model.getters.getPivotCoreDefinition(this.pivotId));
+    const measureIndex = this.getMeasureIndex(this.initialMeasure.id, pivotDefinition);
+    const newMeasure = { ...pivotDefinition.measures[measureIndex], display: newDisplay };
+    pivotDefinition.measures[measureIndex] = newMeasure;
+    const result = this.model.dispatch("UPDATE_PIVOT", {
+      pivot: pivotDefinition,
+      pivotId: this.pivotId,
+    });
+    if (result.isSuccessful) {
+      this.measureDisplay = newDisplay;
+    }
+  }
+
+  private getMeasureDisplay(
+    measureDisplayType: PivotMeasureDisplayType,
+    fieldNameWithGranularity: string | undefined,
+    value: string | boolean | number | undefined
+  ): PivotMeasureDisplay {
+    switch (measureDisplayType) {
+      case "no_calculations":
+      case "%_of_grand_total":
+      case "%_of_col_total":
+      case "%_of_row_total":
+      case "%_of_parent_row_total":
+      case "%_of_parent_col_total":
+      case "index":
+        return { type: measureDisplayType };
+      case "%_of_parent_total":
+      case "running_total":
+      case "%_running_total":
+      case "rank_asc":
+      case "rank_desc":
+        if (!fieldNameWithGranularity) {
+          fieldNameWithGranularity = this.fields[0]?.nameWithGranularity;
+        }
+        return { type: measureDisplayType, fieldNameWithGranularity };
+      case "%_of":
+      case "difference_from":
+      case "%_difference_from":
+        if (!fieldNameWithGranularity) {
+          fieldNameWithGranularity = this.fields[0]?.nameWithGranularity;
+        }
+        const possibleValues = this.getPossibleValues(fieldNameWithGranularity);
+        if (value === undefined || !possibleValues.find((v) => v.value === value)) {
+          value = PREVIOUS_VALUE;
+        }
+        return {
+          type: measureDisplayType,
+          fieldNameWithGranularity,
+          value: value ?? PREVIOUS_VALUE,
+        };
+    }
+  }
+
+  private getMeasureIndex(measureId: string, pivotDefinition: PivotCoreDefinition): number {
+    const measureIndex = pivotDefinition.measures.findIndex((m) => m.id === measureId);
+    if (measureIndex === -1) {
+      throw new Error(`Measure with id ${measureId} not found in pivot.`);
+    }
+    return measureIndex;
+  }
+
+  get doesDisplayNeedsField(): boolean {
+    return (
+      ["%_of_parent_total", "running_total", "%_running_total", "rank_asc", "rank_desc"].includes(
+        this.measureDisplay.type
+      ) || this.doesDisplayNeedsValue
+    );
+  }
+
+  get fields() {
+    const definition = this.getters.getPivot(this.pivotId).definition;
+    return [...definition.columns, ...definition.rows].map((f) => ({
+      ...f,
+      displayName: getFieldDisplayName(f),
+    }));
+  }
+
+  get doesDisplayNeedsValue(): boolean {
+    return this.isDisplayValueDependant(this.measureDisplay);
+  }
+
+  private isDisplayValueDependant(display: PivotMeasureDisplay): boolean {
+    return ["%_of", "difference_from", "%_difference_from"].includes(display.type);
+  }
+
+  get values() {
+    const display = this.measureDisplay;
+    if (!this.isDisplayValueDependant(display)) {
+      return [];
+    }
+    return this.getPossibleValues(display.fieldNameWithGranularity);
+  }
+
+  private getPossibleValues(fieldNameWithGranularity: string | undefined) {
+    const baseValues = [
+      { value: PREVIOUS_VALUE, label: _t("(previous)") },
+      { value: NEXT_VALUE, label: _t("(next)") },
+    ];
+    const field = this.fields.find((f) => f.nameWithGranularity === fieldNameWithGranularity);
+    if (!field) {
+      return [];
+    }
+    const values = this.getters.getPivot(this.pivotId).getPossibleFieldValues(field);
+    return [...baseValues, ...values];
+  }
+
+  cancelMeasureDisplayEdition() {
+    const pivotDefinition = deepCopy(this.model.getters.getPivotCoreDefinition(this.pivotId));
+    const measureIndex = this.getMeasureIndex(this.initialMeasure.id, pivotDefinition);
+    pivotDefinition.measures[measureIndex] = {
+      ...pivotDefinition.measures[measureIndex],
+      display: this.initialMeasure.display,
+    };
+    this.model.dispatch("UPDATE_PIVOT", {
+      pivot: pivotDefinition,
+      pivotId: this.pivotId,
+    });
+  }
+}

--- a/src/components/side_panel/pivot/pivot_side_panel/pivot_side_panel_store.ts
+++ b/src/components/side_panel/pivot/pivot_side_panel/pivot_side_panel_store.ts
@@ -149,7 +149,7 @@ export class PivotSidePanelStore extends SpreadsheetStore {
       ...definitionUpdate,
     };
     // clean to make sure we only keep the core properties
-    const cleanedDefinition = {
+    const cleanedDefinition: PivotCoreDefinition = {
       ...definition,
       columns: definition.columns.map((col) => ({
         fieldName: col.fieldName,
@@ -169,6 +169,7 @@ export class PivotSidePanelStore extends SpreadsheetStore {
         computedBy: measure.computedBy,
         isHidden: measure.isHidden,
         format: measure.format,
+        display: measure.display,
       })),
     };
     if (!this.draft && deepEquals(coreDefinition, cleanedDefinition)) {

--- a/src/components/side_panel/pivot/pivot_side_panel/pivot_spreadsheet_side_panel/pivot_spreadsheet_side_panel.xml
+++ b/src/components/side_panel/pivot/pivot_side_panel/pivot_spreadsheet_side_panel/pivot_spreadsheet_side_panel.xml
@@ -28,6 +28,7 @@
           allGranularities="store.allGranularities"
           definition="definition"
           onDimensionsUpdated.bind="onDimensionsUpdated"
+          pivotId="props.pivotId"
         />
       </div>
       <PivotDeferUpdate

--- a/src/components/side_panel/side_panel/side_panel_store.ts
+++ b/src/components/side_panel/side_panel/side_panel_store.ts
@@ -3,7 +3,7 @@ import { SpreadsheetStore } from "../../../stores";
 
 interface SidePanelProps {
   onCloseSidePanel?: () => void;
-  [key: string]: unknown;
+  [key: string]: any;
 }
 
 interface OpenSidePanel {

--- a/src/components/translations_terms.ts
+++ b/src/components/translations_terms.ts
@@ -173,3 +173,84 @@ export const TableTerms = {
     isDynamic: _t("For tables based on array formulas only"),
   },
 };
+
+export const measureDisplayTerms = {
+  labels: {
+    no_calculations: _t("No calculations"),
+    "%_of_grand_total": _t("% of grand total"),
+    "%_of_col_total": _t("% of column total"),
+    "%_of_row_total": _t("% of row total"),
+    "%_of": _t("% of"),
+    "%_of_parent_row_total": _t("% of parent row total"),
+    "%_of_parent_col_total": _t("% of parent column total"),
+    "%_of_parent_total": _t("% of parent total"),
+    difference_from: _t("Difference from"),
+    "%_difference_from": _t("% difference from"),
+    running_total: _t("Running total"),
+    "%_running_total": _t("% Running total"),
+    rank_asc: _t("Rank smallest to largest"),
+    rank_desc: _t("Rank largest to smallest"),
+    index: _t("Index"),
+  },
+  descriptions: {
+    "%_of_grand_total": () => _t("Displayed as % of grand total"),
+    "%_of_col_total": () => _t("Displayed as % of column total"),
+    "%_of_row_total": () => _t("Displayed as % of row total"),
+    "%_of": (field: string) => _t('Displayed as % of "%s"', field),
+    "%_of_parent_row_total": (field: string) =>
+      _t('Displayed as % of parent row total of "%s"', field),
+    "%_of_parent_col_total": () => _t("Displayed as % of parent column total"),
+    "%_of_parent_total": (field: string) => _t('Displayed as % of parent "%s" total', field),
+    difference_from: (field: string) => _t('Displayed as difference from "%s"', field),
+    "%_difference_from": (field: string) => _t('Displayed as % difference from "%s"', field),
+    running_total: (field: string) => _t('Displayed as running total based on "%s"', field),
+    "%_running_total": (field: string) => _t('Displayed as % running total based on "%s"', field),
+    rank_asc: (field: string) =>
+      _t('Displayed as rank from smallest to largest based on "%s"', field),
+    rank_desc: (field: string) => _t('Displayed as rank largest to smallest based on "%s"', field),
+    index: () => _t("Displayed as index"),
+  },
+  documentation: {
+    no_calculations: _t("Displays the value that is entered in the field."),
+    "%_of_grand_total": _t(
+      "Displays values as a percentage of the grand total of all the values or data points in the report."
+    ),
+    "%_of_col_total": _t(
+      "Displays all the values in each column or series as a percentage of the total for the column or series."
+    ),
+    "%_of_row_total": _t(
+      "Displays the value in each row or category as a percentage of the total for the row or category."
+    ),
+    "%_of": _t("Displays values as a percentage of the value of the Base item in the Base field."),
+    "%_of_parent_row_total": _t(
+      "Calculates values as follows:\n(value for the item) / (value for the parent item on rows)"
+    ),
+    "%_of_parent_col_total": _t(
+      "Calculates values as follows:\n(value for the item) / (value for the parent item on columns)"
+    ),
+    "%_of_parent_total": _t(
+      "Calculates values as follows:\n(value for the item) / (value for the parent item of the selected Base field)"
+    ),
+    difference_from: _t(
+      "Displays values as the difference from the value of the Base item in the Base field."
+    ),
+    "%_difference_from": _t(
+      "Displays values as the percentage difference from the value of the Base item in the Base field."
+    ),
+    running_total: _t(
+      "Displays the value for successive items in the Base field as a running total."
+    ),
+    "%_running_total": _t(
+      "Calculates the value as a percentage for successive items in the Base field that are displayed as a running total."
+    ),
+    rank_asc: _t(
+      "Displays the rank of selected values in a specific field, listing the smallest item in the field as 1, and each larger value with a higher rank value."
+    ),
+    rank_desc: _t(
+      "Displays the rank of selected values in a specific field, listing the largest item in the field as 1, and each smaller value with a higher rank value."
+    ),
+    index: _t(
+      "Calculates values as follows:\n((value in cell) x (Grand Total of Grand Totals)) / ((Grand Row Total) x (Grand Column Total))"
+    ),
+  },
+};

--- a/src/helpers/misc.ts
+++ b/src/helpers/misc.ts
@@ -626,3 +626,42 @@ export class TokenizingChars {
     return true;
   }
 }
+
+/**
+ * Remove duplicates from an array.
+ *
+ * @param array The array to remove duplicates from.
+ * @param cb A callback to get an element value.
+ */
+export function removeDuplicates<T>(array: T[], cb: (a: T) => any = (a) => a): T[] {
+  const set = new Set();
+  return array.filter((item) => {
+    const key = cb(item);
+    if (set.has(key)) {
+      return false;
+    }
+    set.add(key);
+    return true;
+  });
+}
+
+/**
+ * Similar to transposing and array, but with POJOs instead of arrays. Useful, for example, when manipulating
+ * a POJO grid[col][row] and you want to transpose it to grid[row][col].
+ *
+ * The resulting object is created such as result[key1][key2] = pojo[key2][key1]
+ */
+export function transpose2dPOJO<T>(
+  pojo: Record<string, Record<string, T>>
+): Record<string, Record<string, T>> {
+  const result: Record<string, Record<string, T>> = {};
+  for (const key in pojo) {
+    for (const subKey in pojo[key]) {
+      if (!result[subKey]) {
+        result[subKey] = {};
+      }
+      result[subKey][key] = pojo[key][subKey];
+    }
+  }
+  return result;
+}

--- a/src/helpers/pivot/pivot_domain_helpers.ts
+++ b/src/helpers/pivot/pivot_domain_helpers.ts
@@ -1,12 +1,253 @@
-import { Pivot, PivotDomain } from "../../types";
+import {
+  CellValue,
+  DimensionTree,
+  Pivot,
+  PivotColRowDomain,
+  PivotDomain,
+  PivotNode,
+} from "../../types";
+import { clip, deepCopy } from "../misc";
+import { NEXT_VALUE, PREVIOUS_VALUE } from "./pivot_helpers";
+
+export function getDomainOfParentRow(pivot: Pivot, domain: PivotDomain): PivotDomain {
+  const { colDomain, rowDomain } = domainToColRowDomain(pivot, domain);
+  return [...colDomain, ...rowDomain.slice(0, rowDomain.length - 1)];
+}
+
+export function getDomainOfParentCol(pivot: Pivot, domain: PivotDomain): PivotDomain {
+  const { colDomain, rowDomain } = domainToColRowDomain(pivot, domain);
+  return [...colDomain.slice(0, colDomain.length - 1), ...rowDomain];
+}
 
 /**
  * Split a pivot domain into the part related to the rows of the pivot, and the part related to the columns.
  */
-export function domainToColRowDomain(pivot: Pivot, domain: PivotDomain) {
+export function domainToColRowDomain(pivot: Pivot, domain: PivotDomain): PivotColRowDomain {
   const rowFields = pivot.definition.rows.map((c) => c.nameWithGranularity);
   const rowDomain = domain.filter((node) => rowFields.includes(node.field));
   const columnFields = pivot.definition.columns.map((c) => c.nameWithGranularity);
   const colDomain = domain.filter((node) => columnFields.includes(node.field));
   return { colDomain, rowDomain };
+}
+
+export function getDimensionDomain(
+  pivot: Pivot,
+  dimension: "column" | "row",
+  domain: PivotDomain
+): PivotDomain {
+  return dimension === "column"
+    ? domainToColRowDomain(pivot, domain).colDomain
+    : domainToColRowDomain(pivot, domain).rowDomain;
+}
+
+function getFieldValueInDomain(
+  fieldNameWithGranularity: string,
+  domain: PivotDomain
+): CellValue | undefined {
+  const node = domain.find((n) => n.field === fieldNameWithGranularity);
+  return node?.value;
+}
+
+export function isDomainIsInPivot(pivot: Pivot, domain: PivotDomain) {
+  const { rowDomain, colDomain } = domainToColRowDomain(pivot, domain);
+  return (
+    checkIfDomainInInTree(rowDomain, pivot.getTableStructure().getRowTree()) &&
+    checkIfDomainInInTree(colDomain, pivot.getTableStructure().getColTree())
+  );
+}
+
+function checkIfDomainInInTree(domain: PivotDomain, tree: DimensionTree) {
+  return walkDomainTree(domain, tree) !== undefined;
+}
+
+/**
+ * Given a tree of the col/rows of a pivot, and a domain related to those col/rows, return the node of the tree
+ * corresponding to the domain.
+ *
+ * @param domain The domain to find in the tree
+ * @param tree The tree to search in7
+ * @param stopAtField If provided, the search will stop at the field with this name
+ */
+function walkDomainTree(
+  domain: PivotDomain,
+  tree: DimensionTree,
+  stopAtField?: string
+): DimensionTree | undefined {
+  let currentTreeNode = tree;
+  for (const node of domain) {
+    const child = currentTreeNode.find((n) => n.value === node.value);
+    if (!child) {
+      return undefined;
+    }
+    if (child.field === stopAtField) {
+      return currentTreeNode;
+    }
+    currentTreeNode = child.children;
+  }
+  return currentTreeNode;
+}
+
+/**
+ * Get the domain parent of the given domain with the field `parentFieldName` as leaf of the domain.
+ *
+ * In practice, if the `parentFieldName` is a row in the pivot, the helper will return a domain with the same column
+ * domain, and with a row domain all groupBys children to `parentFieldName` removed.
+ */
+export function getFieldParentDomain(
+  pivot: Pivot,
+  parentFieldName: string,
+  domain: PivotDomain
+): PivotDomain {
+  let { rowDomain, colDomain } = domainToColRowDomain(pivot, domain);
+  const dimension = getFieldDimensionType(pivot, parentFieldName);
+
+  if (dimension === "row") {
+    const index = rowDomain.findIndex((node) => node.field === parentFieldName);
+    if (index === -1) {
+      return domain;
+    }
+    rowDomain = rowDomain.slice(0, index + 1);
+  } else {
+    const index = colDomain.findIndex((node) => node.field === parentFieldName);
+    if (index === -1) {
+      return domain;
+    }
+    colDomain = colDomain.slice(0, index + 1);
+  }
+
+  return [...rowDomain, ...colDomain];
+}
+
+/**
+ * Replace in the domain the value of the field `fieldNameWithGranularity` with the given `value`
+ */
+export function replaceFieldValueInDomain(
+  domain: PivotDomain,
+  fieldNameWithGranularity: string,
+  value: CellValue
+): PivotDomain {
+  domain = deepCopy(domain);
+  const node = domain.find((n) => n.field === fieldNameWithGranularity);
+  if (!node) {
+    return domain;
+  }
+  node.value = value;
+  return domain;
+}
+
+export function isFieldInDomain(nameWithGranularity: string, domain: PivotDomain): boolean {
+  return domain.some((node) => node.field === nameWithGranularity);
+}
+
+/**
+ * Check if the field is in the rows or columns of the pivot
+ */
+export function getFieldDimensionType(pivot: Pivot, nameWithGranularity: string): "row" | "column" {
+  const rowFields = pivot.definition.rows.map((c) => c.nameWithGranularity);
+  if (rowFields.includes(nameWithGranularity)) {
+    return "row";
+  }
+  const columnFields = pivot.definition.columns.map((c) => c.nameWithGranularity);
+  if (columnFields.includes(nameWithGranularity)) {
+    return "column";
+  }
+  throw new Error(`Field ${nameWithGranularity} not found in pivot`);
+}
+
+/**
+ * Replace in the given domain the value of the field `fieldNameWithGranularity` with the previous or next value.
+ */
+export function getPreviousOrNextValueDomain(
+  pivot: Pivot,
+  domain: PivotDomain,
+  fieldNameWithGranularity: string,
+  direction: typeof PREVIOUS_VALUE | typeof NEXT_VALUE
+): PivotDomain | undefined {
+  const dimension = getFieldDimensionType(pivot, fieldNameWithGranularity);
+  const tree =
+    dimension === "row"
+      ? pivot.getTableStructure().getRowTree()
+      : pivot.getTableStructure().getColTree();
+  const dimDomain = getDimensionDomain(pivot, dimension, domain);
+
+  const currentTreeNode = walkDomainTree(dimDomain, tree, fieldNameWithGranularity);
+  const values = currentTreeNode?.map((n) => n.value) ?? [];
+  const value = getFieldValueInDomain(fieldNameWithGranularity, domain);
+  if (value === undefined) {
+    return undefined;
+  }
+
+  const valueIndex = values.indexOf(value);
+  if (value === undefined || valueIndex === -1) {
+    return undefined;
+  }
+
+  const offset = direction === PREVIOUS_VALUE ? -1 : 1;
+  const newIndex = clip(valueIndex + offset, 0, values.length - 1);
+  return replaceFieldValueInDomain(domain, fieldNameWithGranularity, values[newIndex]);
+}
+
+export function domainToString(domain: PivotDomain | undefined): string {
+  return domain ? domain.map(domainNodeToString).join(", ") : "";
+}
+
+export function domainNodeToString(domainNode: PivotNode | undefined): string {
+  return domainNode ? `${domainNode.field}=${domainNode.value}` : "";
+}
+
+/**
+ *
+ * For the ranking, the pivot cell values of a column (or row) at the same depth are grouped together before being sorted
+ * and ranked.
+ *
+ * The grouping of a pivot cell is done with both the value of the domain nodes that are parent of the field
+ * `fieldNameWithGranularity` and the value of the last node of the domain of the pivot cell, if it's not the field
+ * `fieldNameWithGranularity`.
+ *
+ * For example, let's take a pivot grouped by (Date:year, Stage, User, Product), where we want to rank by "Stage" field.
+ * The domain nodes parents of the "Stage" are [Date:year]. The pivot cell with domain:
+ * - [Date:year=2021] is not ranked because it does not contain the "Stage" field
+ * - [Date:year=2021, Stage=Lead] is grouped with the cells [Date:year=2021, Stage=*, User=None, Product=None],
+ *      and then ranked within the group
+ * - [Date:year=2021, Stage=Lead, User=Bob] is grouped with the cells [Date:year=2021, Stage=*, User=Bob, Product=None],
+ *      and then ranked within the group
+ * - [Date:year=2021, Stage=Lead, User=Bob, Product=Table] is grouped with the cells [Date:year=2021, Stage=*, User=*, Product=Table],
+ *      and then ranked within the group
+ *
+ * If we rank the pivot on "User" instead, the parent domain becomes [Date:year, Sage] .The cell with domain:
+ * - [Date:year=2021] is not ranked because it does not contain the "Stage" field
+ * - [Date:year=2021, Stage=Lead] is not ranked because it does not contain the "User" field
+ * - [Date:year=2021, Stage=Lead, User=Bob] is grouped with the cells [Date:year=2021, Stage=Lead, User=Bob, Product=None],
+ *      and then ranked within the group
+ * - [Date:year=2021, Stage=Lead, User=Bob, Product=Table] is grouped with the cells with [Date:year=2021, Stage=Lead, User=*, Product=Table],
+ *     and then ranked within the group
+ *
+ */
+export function getRankingDomainKey(domain: PivotDomain, fieldNameWithGranularity: string): string {
+  const index = domain.findIndex((node) => node.field === fieldNameWithGranularity);
+  if (index === -1) {
+    return "";
+  }
+
+  const parent = domain.slice(0, index);
+  const lastNode = domain.at(-1)!;
+  return domainToString(
+    lastNode.field === fieldNameWithGranularity ? parent : [...parent, lastNode]
+  );
+}
+
+/**
+ * The running total domain is the domain without the field `fieldNameWithGranularity`, ie. we do the running total of
+ * all the pivot cells of the column that have any value for the field `fieldNameWithGranularity` and the same value for
+ * the other fields.
+ */
+export function getRunningTotalDomainKey(
+  domain: PivotDomain,
+  fieldNameWithGranularity: string
+): string {
+  const index = domain.findIndex((node) => node.field === fieldNameWithGranularity);
+  if (index === -1) {
+    return "";
+  }
+  return domainToString([...domain.slice(0, index), ...domain.slice(index + 1)]);
 }

--- a/src/helpers/pivot/pivot_helpers.ts
+++ b/src/helpers/pivot/pivot_helpers.ts
@@ -257,3 +257,10 @@ pivotToFunctionValueRegistry
   .add("integer", (value: CellValue) => `${toNumber(value, DEFAULT_LOCALE)}`)
   .add("boolean", (value: CellValue) => (toBoolean(value) ? "TRUE" : "FALSE"))
   .add("char", (value: CellValue) => `"${toString(value).replace(/"/g, '\\"')}"`);
+
+export const PREVIOUS_VALUE = "(previous)";
+export const NEXT_VALUE = "(next)";
+
+export function getFieldDisplayName(field: PivotDimension) {
+  return field.displayName + (field.granularity ? ` (${ALL_PERIODS[field.granularity]})` : "");
+}

--- a/src/helpers/pivot/pivot_presentation.ts
+++ b/src/helpers/pivot/pivot_presentation.ts
@@ -1,17 +1,48 @@
 import { handleError } from "../../functions";
+import { transposeMatrix } from "../../functions/helpers";
 import { ModelConfig } from "../../model";
+import { _t } from "../../translation";
 import {
+  CellValue,
   DimensionTree,
   FunctionResultObject,
   Getters,
   InitPivotParams,
   PivotDomain,
   PivotMeasure,
+  PivotMeasureDisplay,
+  PivotValueCell,
   isMatrix,
 } from "../../types";
-import { domainToColRowDomain } from "./pivot_domain_helpers";
-import { AGGREGATORS_FN, toNormalizedPivotValue } from "./pivot_helpers";
+import { CellErrorType, NotAvailableError } from "../../types/errors";
+import { deepEquals, removeDuplicates, transpose2dPOJO } from "../misc";
+import {
+  domainToColRowDomain,
+  domainToString,
+  getDimensionDomain,
+  getDomainOfParentCol,
+  getDomainOfParentRow,
+  getFieldDimensionType,
+  getFieldParentDomain,
+  getPreviousOrNextValueDomain,
+  getRankingDomainKey,
+  getRunningTotalDomainKey,
+  isDomainIsInPivot,
+  isFieldInDomain,
+  replaceFieldValueInDomain,
+} from "./pivot_domain_helpers";
+import {
+  AGGREGATORS_FN,
+  NEXT_VALUE,
+  PREVIOUS_VALUE,
+  toNormalizedPivotValue,
+} from "./pivot_helpers";
 import { PivotParams, PivotUIConstructor } from "./pivot_registry";
+
+const PERCENT_FORMAT = "0.00%";
+
+type CacheForMeasureAndField<T> = { [measureId: string]: { [field: string]: T } };
+type DomainGroups<T> = { [colDomain: string]: { [rowDomain: string]: T } };
 
 /**
  * Dynamically creates a presentation layer wrapper around a given pivot class.
@@ -24,6 +55,14 @@ export function withPivotPresentationLayer(PivotClass: PivotUIConstructor) {
   class PivotPresentationLayer extends PivotClass {
     private getters: Getters;
     private cache: Record<string, FunctionResultObject> = {};
+    private rankAsc: CacheForMeasureAndField<DomainGroups<number> | undefined> = {};
+    private rankDesc: CacheForMeasureAndField<DomainGroups<number> | undefined> = {};
+    private runningTotal: CacheForMeasureAndField<DomainGroups<number | undefined> | undefined> =
+      {};
+
+    private runningTotalInPercent: CacheForMeasureAndField<
+      DomainGroups<number | undefined> | undefined
+    > = {};
 
     constructor(custom: ModelConfig["custom"], params: PivotParams) {
       super(custom, params);
@@ -32,10 +71,21 @@ export function withPivotPresentationLayer(PivotClass: PivotUIConstructor) {
 
     init(params?: InitPivotParams | undefined): void {
       this.cache = {};
+      this.rankAsc = {};
+      this.rankDesc = {};
+      this.runningTotal = {};
+      this.runningTotalInPercent = {};
       super.init(params);
     }
 
     getPivotCellValueAndFormat(measureName: string, domain: PivotDomain): FunctionResultObject {
+      return this.getMeasureDisplayValue(measureName, domain);
+    }
+
+    private _getPivotCellValueAndFormat(
+      measureName: string,
+      domain: PivotDomain
+    ): FunctionResultObject {
       const cacheKey = `${measureName}-${domain
         .map((node) => node.field + "=" + node.value)
         .join(",")}`;
@@ -84,7 +134,7 @@ export function withPivotPresentationLayer(PivotClass: PivotUIConstructor) {
           const symbolIndex = rowDomain.findIndex((row) => row.field === symbolName);
           return this.getPivotHeaderValueAndFormat(rowDomain.slice(0, symbolIndex + 1));
         }
-        return this.getPivotCellValueAndFormat(symbolName, domain);
+        return this._getPivotCellValueAndFormat(symbolName, domain);
       };
       const result = this.getters.evaluateCompiledFormula(
         measure.computedBy.sheetId,
@@ -113,7 +163,7 @@ export function withPivotPresentationLayer(PivotClass: PivotUIConstructor) {
         for (const colDomain of colDomains) {
           for (const subRowDomain of rowDomains) {
             values.push(
-              this.getPivotCellValueAndFormat(
+              this._getPivotCellValueAndFormat(
                 measure.id,
                 rowDomain.concat(subRowDomain).concat(colDomain)
               )
@@ -127,7 +177,7 @@ export function withPivotPresentationLayer(PivotClass: PivotUIConstructor) {
         const subTree = this.getSubTreeMatchingDomain(tree, colDomain);
         const domains = this.treeToLeafDomains(subTree, colDomain);
         for (const domain of domains) {
-          values.push(this.getPivotCellValueAndFormat(measure.id, rowDomain.concat(domain)));
+          values.push(this._getPivotCellValueAndFormat(measure.id, rowDomain.concat(domain)));
         }
         return values;
       } else {
@@ -135,7 +185,7 @@ export function withPivotPresentationLayer(PivotClass: PivotUIConstructor) {
         const subTree = this.getSubTreeMatchingDomain(tree, rowDomain);
         const domains = this.treeToLeafDomains(subTree, rowDomain);
         for (const domain of domains) {
-          values.push(this.getPivotCellValueAndFormat(measure.id, domain.concat(colDomain)));
+          values.push(this._getPivotCellValueAndFormat(measure.id, domain.concat(colDomain)));
         }
         return values;
       }
@@ -177,6 +227,511 @@ export function withPivotPresentationLayer(PivotClass: PivotUIConstructor) {
         }
       }
       return domains;
+    }
+
+    private getMeasureDisplayValue(measureId: string, domain: PivotDomain): FunctionResultObject {
+      const measure = this.getMeasure(measureId);
+      const rawValue = this._getPivotCellValueAndFormat(measureId, domain);
+      if (!measure.display || measure.display.type === "no_calculations" || rawValue.message) {
+        return rawValue;
+      }
+      const fieldName = measure.display.fieldNameWithGranularity;
+      if (fieldName && !this.isFieldInPivot(fieldName)) {
+        return {
+          value: CellErrorType.NotAvailable,
+          message: _t('Field "%s" not found in pivot for measure display calculation', fieldName),
+        };
+      }
+
+      try {
+        const display = measure.display;
+        switch (display.type) {
+          case "%_of_grand_total":
+            return this.asPercentOfGrandTotal(rawValue, measure);
+          case "%_of_col_total":
+            return this.asPercentOfColumnTotal(rawValue, measure, domain);
+          case "%_of_row_total":
+            return this.asPercentOfRowTotal(rawValue, measure, domain);
+          case "%_of_parent_row_total":
+            return this.asPercentOfParentRowTotal(rawValue, measure, domain);
+          case "%_of_parent_col_total":
+            return this.asPercentOfParentColumnTotal(rawValue, measure, domain);
+          case "index":
+            return this.asIndex(rawValue, measure, domain);
+          case "%_of_parent_total":
+            return this.asPercentOfParentTotal(rawValue, measure, domain, display);
+          case "running_total":
+            return this.asRunningTotal(rawValue, measure, domain, display, "running_total");
+          case "%_running_total":
+            return this.asRunningTotal(rawValue, measure, domain, display, "%_running_total");
+          case "rank_asc":
+            return this.asRank(rawValue, measure, domain, display, "asc");
+          case "rank_desc":
+            return this.asRank(rawValue, measure, domain, display, "desc");
+          case "%_of":
+            return this.asPercentOf(rawValue, measure, domain, display);
+          case "difference_from":
+            return this.asDifferenceFrom(rawValue, measure, domain, display);
+          case "%_difference_from":
+            return this.asDifferenceFromInPercent(rawValue, measure, domain, display);
+        }
+        return rawValue;
+      } catch (e) {
+        return handleError(e, "COMPUTE_MEASURE_DISPLAY_VALUE");
+      }
+    }
+
+    private asPercentOfGrandTotal(
+      rawValue: FunctionResultObject,
+      measure: PivotMeasure
+    ): FunctionResultObject {
+      const grandTotal = this.getGrandTotal(measure.id);
+      return grandTotal === 0
+        ? { value: CellErrorType.DivisionByZero }
+        : { value: this.measureValueToNumber(rawValue) / grandTotal, format: PERCENT_FORMAT };
+    }
+
+    private asPercentOfRowTotal(
+      rawValue: FunctionResultObject,
+      measure: PivotMeasure,
+      domain: PivotDomain
+    ): FunctionResultObject {
+      const rowTotal = this.getRowTotal(measure.id, domain);
+      return rowTotal === 0
+        ? { value: CellErrorType.DivisionByZero }
+        : { value: this.measureValueToNumber(rawValue) / rowTotal, format: PERCENT_FORMAT };
+    }
+
+    private asPercentOfColumnTotal(
+      rawValue: FunctionResultObject,
+      measure: PivotMeasure,
+      domain: PivotDomain
+    ): FunctionResultObject {
+      const columnTotal = this.getColumnTotal(measure.id, domain);
+      return columnTotal === 0
+        ? { value: CellErrorType.DivisionByZero }
+        : { value: this.measureValueToNumber(rawValue) / columnTotal, format: PERCENT_FORMAT };
+    }
+
+    private asPercentOfParentRowTotal(
+      rawValue: FunctionResultObject,
+      measure: PivotMeasure,
+      domain: PivotDomain
+    ): FunctionResultObject {
+      const parentRowDomain = getDomainOfParentRow(this, domain);
+      const parentRowValue = this.measureValueToNumber(
+        this._getPivotCellValueAndFormat(measure.id, parentRowDomain)
+      );
+      return parentRowValue === 0
+        ? { value: "" }
+        : { value: this.measureValueToNumber(rawValue) / parentRowValue, format: PERCENT_FORMAT };
+    }
+
+    private asPercentOfParentColumnTotal(
+      rawValue: FunctionResultObject,
+      measure: PivotMeasure,
+      domain: PivotDomain
+    ): FunctionResultObject {
+      const parentColumnDomain = getDomainOfParentCol(this, domain);
+      const parentColValue = this.measureValueToNumber(
+        this._getPivotCellValueAndFormat(measure.id, parentColumnDomain)
+      );
+      return parentColValue === 0
+        ? { value: "" }
+        : { value: this.measureValueToNumber(rawValue) / parentColValue, format: PERCENT_FORMAT };
+    }
+
+    private asPercentOfParentTotal(
+      rawValue: FunctionResultObject,
+      measure: PivotMeasure,
+      domain: PivotDomain,
+      display: PivotMeasureDisplay
+    ): FunctionResultObject {
+      const { fieldNameWithGranularity } = display;
+      if (!fieldNameWithGranularity) {
+        return rawValue;
+      }
+      if (!isFieldInDomain(fieldNameWithGranularity, domain)) {
+        return { value: "" };
+      }
+      const parentDomain = getFieldParentDomain(this, fieldNameWithGranularity, domain);
+      const parentTotal = this._getPivotCellValueAndFormat(measure.id, parentDomain);
+      const parentTotalValue = this.measureValueToNumber(parentTotal);
+
+      return parentTotalValue === 0
+        ? { value: "" }
+        : { value: this.measureValueToNumber(rawValue) / parentTotalValue, format: PERCENT_FORMAT };
+    }
+
+    private asIndex(
+      rawValue: FunctionResultObject,
+      measure: PivotMeasure,
+      domain: PivotDomain
+    ): FunctionResultObject {
+      const value = this.measureValueToNumber(rawValue);
+      const parentRowTotal = this.getRowTotal(measure.id, domain);
+      const parentColTotal = this.getColumnTotal(measure.id, domain);
+      const grandTotal = this.getGrandTotal(measure.id);
+
+      return parentRowTotal === 0 || parentColTotal === 0
+        ? { value: CellErrorType.DivisionByZero }
+        : { value: (value * grandTotal) / (parentColTotal * parentRowTotal), format: undefined };
+    }
+
+    private asRunningTotal(
+      rawValue: FunctionResultObject,
+      measure: PivotMeasure,
+      domain: PivotDomain,
+      display: PivotMeasureDisplay,
+      mode: "running_total" | "%_running_total"
+    ): FunctionResultObject {
+      const { fieldNameWithGranularity } = display;
+      if (!fieldNameWithGranularity) {
+        return rawValue;
+      }
+
+      const totalCache = mode === "running_total" ? this.runningTotal : this.runningTotalInPercent;
+
+      let runningTotals = totalCache[measure.id]?.[fieldNameWithGranularity];
+      if (!runningTotals) {
+        runningTotals = this.computeRunningTotal(measure, fieldNameWithGranularity, mode);
+        if (!totalCache[measure.id]) {
+          totalCache[measure.id] = {};
+        }
+        totalCache[measure.id][fieldNameWithGranularity] = runningTotals;
+      }
+
+      const { rowDomain, colDomain } = domainToColRowDomain(this, domain);
+      const colDomainKey = domainToString(colDomain);
+      const rowDomainKey = domainToString(rowDomain);
+      const runningTotal = runningTotals[colDomainKey]?.[rowDomainKey];
+
+      return {
+        value: runningTotal ?? "",
+        format: mode === "running_total" ? rawValue.format : PERCENT_FORMAT,
+      };
+    }
+
+    private asPercentOf(
+      rawValue: FunctionResultObject,
+      measure: PivotMeasure,
+      domain: PivotDomain,
+      display: PivotMeasureDisplay
+    ): FunctionResultObject {
+      const { fieldNameWithGranularity, value } = display;
+      if (value === undefined || !fieldNameWithGranularity) {
+        return rawValue;
+      }
+      if (!isFieldInDomain(fieldNameWithGranularity, domain)) {
+        return { value: "" };
+      }
+
+      let comparedValue = this.getComparisonValue(measure, domain, fieldNameWithGranularity, value);
+      let numberValue = this.strictMeasureValueToNumber(rawValue);
+
+      if (comparedValue === 0 || (comparedValue === "sameValue" && numberValue === 0)) {
+        return { value: CellErrorType.DivisionByZero };
+      } else if (!comparedValue || (comparedValue === "sameValue" && !numberValue)) {
+        return { value: "" };
+      } else if (comparedValue === "sameValue") {
+        return { value: 1, format: PERCENT_FORMAT };
+      } else if (numberValue === undefined) {
+        return { value: CellErrorType.NullError };
+      }
+      return { value: numberValue / comparedValue, format: PERCENT_FORMAT };
+    }
+
+    private asDifferenceFrom(
+      rawValue: FunctionResultObject,
+      measure: PivotMeasure,
+      domain: PivotDomain,
+      display: PivotMeasureDisplay
+    ): FunctionResultObject {
+      const { fieldNameWithGranularity, value } = display;
+      if (value === undefined || !fieldNameWithGranularity) {
+        return rawValue;
+      }
+      if (!isFieldInDomain(fieldNameWithGranularity, domain)) {
+        return { value: "" };
+      }
+
+      const comparedValue =
+        this.getComparisonValue(measure, domain, fieldNameWithGranularity, value) || 0;
+      return comparedValue === "sameValue"
+        ? { value: "" }
+        : {
+            value: this.measureValueToNumber(rawValue) - comparedValue,
+            format: rawValue.format,
+          };
+    }
+
+    private asDifferenceFromInPercent(
+      rawValue: FunctionResultObject,
+      measure: PivotMeasure,
+      domain: PivotDomain,
+      display: PivotMeasureDisplay
+    ): FunctionResultObject {
+      const { fieldNameWithGranularity, value } = display;
+      if (value === undefined || !fieldNameWithGranularity) {
+        return rawValue;
+      }
+      if (!isFieldInDomain(fieldNameWithGranularity, domain)) {
+        return { value: "" };
+      }
+
+      let comparedValue = this.getComparisonValue(measure, domain, fieldNameWithGranularity, value);
+      const numberValue = this.strictMeasureValueToNumber(rawValue);
+
+      if (comparedValue === 0) {
+        return { value: CellErrorType.DivisionByZero };
+      } else if (!comparedValue || comparedValue === "sameValue") {
+        return { value: "" };
+      } else if (numberValue === undefined) {
+        return { value: CellErrorType.NullError };
+      }
+
+      return { value: (numberValue - comparedValue) / comparedValue, format: PERCENT_FORMAT };
+    }
+
+    private asRank(
+      rawValue: FunctionResultObject,
+      measure: PivotMeasure,
+      domain: PivotDomain,
+      display: PivotMeasureDisplay,
+      order: "asc" | "desc"
+    ): FunctionResultObject {
+      const { fieldNameWithGranularity } = display;
+      if (!fieldNameWithGranularity) {
+        return rawValue;
+      }
+      if (!isFieldInDomain(fieldNameWithGranularity, domain)) {
+        return { value: "" };
+      }
+
+      const rankingCache = order === "asc" ? this.rankAsc : this.rankDesc;
+
+      let ranking = rankingCache[measure.id]?.[fieldNameWithGranularity];
+      if (!ranking) {
+        ranking = this.computeRank(measure, fieldNameWithGranularity, order);
+        if (!rankingCache[measure.id]) {
+          rankingCache[measure.id] = {};
+        }
+        rankingCache[measure.id][fieldNameWithGranularity] = ranking;
+      }
+
+      const { rowDomain, colDomain } = domainToColRowDomain(this, domain);
+      const colDomainKey = domainToString(colDomain);
+      const rowDomainKey = domainToString(rowDomain);
+      const rank = ranking[colDomainKey]?.[rowDomainKey];
+
+      return { value: rank ?? "" };
+    }
+
+    private computeRank(
+      measure: PivotMeasure,
+      fieldNameWithGranularity: string,
+      order: "asc" | "desc"
+    ): DomainGroups<number> {
+      const ranking: DomainGroups<number> = {};
+      const mainDimension = getFieldDimensionType(this, fieldNameWithGranularity);
+      const secondaryDimension = mainDimension === "row" ? "column" : "row";
+
+      let pivotCells = this.getPivotValueCells();
+
+      if (mainDimension === "column") {
+        // Transpose the pivot cells so we can do the same operations on the columns as on the rows
+        // This means that we need to transpose back the ranking at the end
+        pivotCells = transposeMatrix(pivotCells);
+      }
+
+      for (const col of pivotCells) {
+        const colDomain = getDimensionDomain(this, secondaryDimension, col[0].domain);
+        const colDomainKey = domainToString(colDomain);
+
+        const cells = col
+          .map((cell) => ({
+            ...cell,
+            value: this.strictMeasureValueToNumber(
+              this._getPivotCellValueAndFormat(measure.id, cell.domain)
+            ),
+            rowDomain: getDimensionDomain(this, mainDimension, cell.domain),
+          }))
+          .filter((cell) => isFieldInDomain(fieldNameWithGranularity, cell.rowDomain));
+
+        // Group the cells by ranking domain, and sort them to get the ranking
+        const groupedCell = Object.groupBy(cells, (cell) =>
+          getRankingDomainKey(cell.rowDomain, fieldNameWithGranularity)
+        );
+        for (const rankingDomainKey in groupedCell) {
+          groupedCell[rankingDomainKey] = removeDuplicates(
+            groupedCell[rankingDomainKey] || [],
+            (cell) => cell.value
+          )
+            .filter((cell) => cell.value !== undefined)
+            .sort((a, b) => (order === "asc" ? a.value! - b.value! : b.value! - a.value!));
+        }
+
+        ranking[colDomainKey] = {};
+        for (const cell of cells) {
+          const rowDomain = getDimensionDomain(this, mainDimension, cell.domain);
+          const rowDomainKey = domainToString(rowDomain);
+          const rankingDomainKey = getRankingDomainKey(cell.rowDomain, fieldNameWithGranularity);
+          const group = groupedCell[rankingDomainKey];
+          if (!group) {
+            continue;
+          }
+
+          const rank = group.findIndex((c) => c.value === cell.value);
+          if (rank !== -1) {
+            ranking[colDomainKey][rowDomainKey] = rank + 1; // Ranks start at 1
+          }
+        }
+      }
+
+      return mainDimension === "row" ? ranking : transpose2dPOJO(ranking);
+    }
+
+    private computeRunningTotal(
+      measure: PivotMeasure,
+      fieldNameWithGranularity: string,
+      mode: "running_total" | "%_running_total"
+    ): DomainGroups<number | undefined> {
+      const cellsRunningTotals: DomainGroups<number | undefined> = {};
+      const mainDimension = getFieldDimensionType(this, fieldNameWithGranularity);
+      const secondaryDimension = mainDimension === "row" ? "column" : "row";
+
+      let pivotCells = this.getPivotValueCells();
+
+      if (mainDimension === "column") {
+        // Transpose the pivot cells so we can do the same operations on the columns as on the rows
+        // This means that we need to transpose back the totals at the end
+        pivotCells = transposeMatrix(pivotCells);
+      }
+
+      for (const col of pivotCells) {
+        const colDomain = getDimensionDomain(this, secondaryDimension, col[0].domain);
+        const colDomainKey = domainToString(colDomain);
+        cellsRunningTotals[colDomainKey] = {};
+        const runningTotals: { [runningTotalKey: string]: number } = {};
+
+        const cellsWithValue = col
+          .map((cell) => ({
+            ...cell,
+            rowDomain: getDimensionDomain(this, mainDimension, cell.domain),
+            value: this.measureValueToNumber(
+              this._getPivotCellValueAndFormat(measure.id, cell.domain)
+            ),
+          }))
+          .filter((cell) => isFieldInDomain(fieldNameWithGranularity, cell.rowDomain));
+
+        for (const cell of cellsWithValue) {
+          const rowDomainKey = domainToString(cell.rowDomain);
+          const runningTotalKey = getRunningTotalDomainKey(
+            cell.rowDomain,
+            fieldNameWithGranularity
+          );
+
+          const runningTotal = (runningTotals[runningTotalKey] || 0) + cell.value;
+          runningTotals[runningTotalKey] = runningTotal;
+          cellsRunningTotals[colDomainKey][rowDomainKey] = runningTotal;
+        }
+
+        if (mode === "%_running_total") {
+          for (const cell of cellsWithValue) {
+            const rowDomain = cell.rowDomain;
+            const rowDomainKey = domainToString(rowDomain);
+            const runningTotalKey = getRunningTotalDomainKey(rowDomain, fieldNameWithGranularity);
+
+            const cellRunningTotal = cellsRunningTotals[colDomainKey][rowDomainKey] || 0;
+            const finalRunningTotal = runningTotals[runningTotalKey];
+            cellsRunningTotals[colDomainKey][rowDomainKey] = !finalRunningTotal
+              ? undefined
+              : cellRunningTotal / finalRunningTotal;
+          }
+        }
+      }
+      return mainDimension === "row" ? cellsRunningTotals : transpose2dPOJO(cellsRunningTotals);
+    }
+
+    private getGrandTotal(measureId: string): number {
+      const grandTotal = this._getPivotCellValueAndFormat(measureId, []);
+      return this.measureValueToNumber(grandTotal);
+    }
+
+    private getRowTotal(measureId: string, domain: PivotDomain) {
+      const totalDomain = domainToColRowDomain(this, domain).rowDomain;
+      const rowTotal = this._getPivotCellValueAndFormat(measureId, totalDomain);
+      return this.measureValueToNumber(rowTotal);
+    }
+
+    private getColumnTotal(measureId: string, domain: PivotDomain) {
+      const totalDomain = domainToColRowDomain(this, domain).colDomain;
+      const columnTotal = this._getPivotCellValueAndFormat(measureId, totalDomain);
+      return this.measureValueToNumber(columnTotal);
+    }
+
+    private isFieldInPivot(nameWithGranularity: string): boolean {
+      return (
+        this.definition.columns.some((c) => c.nameWithGranularity === nameWithGranularity) ||
+        this.definition.rows.some((r) => r.nameWithGranularity === nameWithGranularity)
+      );
+    }
+
+    /**
+     * With the given measure, fetch the value of the cell in the pivot that has the given domain with
+     * the value of the field `fieldNameWithGranularity` replaced by `valueToCompare`.
+     *
+     * @param valueToCompare either a value to replace the field value with, or "(previous)" or "(next)"
+     * @returns the value of the cell in the pivot with the new domain, or "sameValue" if the domain is the same
+     */
+    private getComparisonValue(
+      measure: PivotMeasure,
+      domain: PivotDomain,
+      fieldNameWithGranularity: string,
+      valueToCompare: CellValue | typeof PREVIOUS_VALUE | typeof NEXT_VALUE
+    ): number | "sameValue" | undefined {
+      const comparedDomain =
+        valueToCompare === PREVIOUS_VALUE || valueToCompare === NEXT_VALUE
+          ? getPreviousOrNextValueDomain(this, domain, fieldNameWithGranularity, valueToCompare)
+          : replaceFieldValueInDomain(domain, fieldNameWithGranularity, valueToCompare);
+      if (deepEquals(comparedDomain, domain)) {
+        return "sameValue";
+      }
+      if (!comparedDomain || !isDomainIsInPivot(this, comparedDomain)) {
+        throw new NotAvailableError();
+      }
+
+      const comparedValue = this._getPivotCellValueAndFormat(measure.id, comparedDomain);
+      const comparedValueNumber = this.strictMeasureValueToNumber(comparedValue);
+      return comparedValueNumber;
+    }
+
+    private getPivotValueCells(): PivotValueCell[][] {
+      return this.getTableStructure()
+        .getPivotCells()
+        .map((col) => col.filter((cell) => cell.type === "VALUE"))
+        .filter((col) => col.length > 0) as PivotValueCell[][];
+    }
+
+    private measureValueToNumber(result: FunctionResultObject): number {
+      if (typeof result.value === "number") {
+        return result.value;
+      }
+      if (!result.value) {
+        return 0;
+      }
+      // Should not happen, measures aggregates are always numbers or undefined
+      throw new Error(`Value ${result.value} is not a number`);
+    }
+
+    private strictMeasureValueToNumber(result: FunctionResultObject): number | undefined {
+      if (typeof result.value === "number") {
+        return result.value;
+      }
+      if (!result.value) {
+        return undefined;
+      }
+      throw new Error(`Value ${result.value} is not a number`);
     }
   }
   return PivotPresentationLayer;

--- a/src/helpers/pivot/pivot_runtime_definition.ts
+++ b/src/helpers/pivot/pivot_runtime_definition.ts
@@ -82,6 +82,7 @@ function createMeasure(fields: PivotFields, measure: PivotCoreMeasure): PivotMea
     isHidden: measure.isHidden,
     format: measure.format,
     computedBy: measure.computedBy,
+    display: measure.display,
   };
 }
 

--- a/src/helpers/pivot/spreadsheet_pivot/data_entry_spreadsheet_pivot.ts
+++ b/src/helpers/pivot/spreadsheet_pivot/data_entry_spreadsheet_pivot.ts
@@ -9,7 +9,7 @@ import { SpreadsheetPivotTable } from "../table_spreadsheet_pivot";
 import { SpreadsheetPivotRuntimeDefinition } from "./runtime_definition_spreadsheet_pivot";
 
 export type FieldName = string;
-export type FieldValue = Pick<EvaluatedCell, "type" | "format" | "value">;
+export type FieldValue = Pick<EvaluatedCell, "type" | "format" | "value" | "formattedValue">;
 
 export type DataEntry = Record<FieldName, FieldValue | undefined>;
 export type DataEntries = DataEntry[];
@@ -102,11 +102,11 @@ function dataEntriesToColumnsTree(
   const colName = columns[index].nameWithGranularity;
   const groups = groupPivotDataEntriesBy(dataEntries, column);
   const orderedKeys = orderDataEntriesKeys(groups, columns[index]);
-  return orderedKeys.map((value) => {
+  return orderedKeys.map((key) => {
     return {
-      value,
+      value: groups[key]?.[0]?.[column.nameWithGranularity]?.value ?? null,
       field: colName,
-      children: dataEntriesToColumnsTree(groups[value] || [], columns, index + 1),
+      children: dataEntriesToColumnsTree(groups[key] || [], columns, index + 1),
       width: 0,
     };
   });
@@ -226,7 +226,7 @@ function keySelector(dimension: PivotDimension): (item: DataEntry, index: number
 /**
  * Order the keys of the given data entries, based on the given dimension
  */
-function orderDataEntriesKeys(
+export function orderDataEntriesKeys(
   groups: Partial<Record<string, DataEntries>>,
   dimension: PivotDimension
 ): string[] {

--- a/src/helpers/pivot/spreadsheet_pivot/spreadsheet_pivot.ts
+++ b/src/helpers/pivot/spreadsheet_pivot/spreadsheet_pivot.ts
@@ -26,7 +26,7 @@ import {
 import { InitPivotParams, Pivot } from "../../../types/pivot_runtime";
 import { toXC } from "../../coordinates";
 import { formatValue, isDateTimeFormat } from "../../format/format";
-import { isDefined } from "../../misc";
+import { deepEquals, isDefined } from "../../misc";
 import {
   AGGREGATORS_FN,
   areDomainArgsFieldsValid,
@@ -50,6 +50,23 @@ interface SpreadsheetPivotParams extends PivotParams {
   definition: SpreadsheetPivotCoreDefinition;
 }
 
+interface MetaData {
+  fields: PivotFields;
+  /**
+   * This array contains the keys of the fields. It is used to keep the order
+   * of the fields as they are in the range.
+   */
+  fieldKeys: TechnicalName[];
+}
+
+enum ReloadType {
+  NONE = 0,
+  TABLE = 1,
+  DATA = 2,
+  DEFINITION = 3,
+  ALL = 4,
+}
+
 /**
  * This class represents a pivot table that is created from a range of cells.
  * It will extract the fields from the first row of the range and the data from
@@ -60,18 +77,12 @@ export class SpreadsheetPivot implements Pivot<SpreadsheetPivotRuntimeDefinition
   private getters: Getters;
   private _definition: SpreadsheetPivotRuntimeDefinition | undefined;
   private coreDefinition: SpreadsheetPivotCoreDefinition;
-
+  private metaData: MetaData = { fields: {}, fieldKeys: [] };
   /**
    * This array contains the data entries of the pivot. Each entry is an object
    * that contains the values of the fields for a row.
    */
   private dataEntries: DataEntries = [];
-  private fields: PivotFields = {};
-  /**
-   * This array contains the keys of the fields. It is used to keep the order
-   * of the fields as they are in the range.
-   */
-  private fieldKeys: TechnicalName[] = [];
   /**
    * This object contains the pivot table structure. It is created from the
    * data entries and the pivot definition.
@@ -96,35 +107,46 @@ export class SpreadsheetPivot implements Pivot<SpreadsheetPivotRuntimeDefinition
 
   init(params: InitPivotParams = {}) {
     if (!this._definition || params.reload) {
-      this.invalidRangeError = undefined;
-      if (this.coreDefinition.dataSet) {
-        const { zone, sheetId } = this.coreDefinition.dataSet;
-        const range = this.getters.getRangeFromZone(sheetId, zone);
-        try {
-          ({ fields: this.fields, fieldKeys: this.fieldKeys } = this.extractFieldsFromRange(range));
-        } catch (e) {
-          this.fields = {};
-          this.fieldKeys = [];
-          this.invalidRangeError = e;
-        }
-      } else {
-        this.invalidRangeError = new EvaluationError(
-          _t("The pivot cannot be created because the dataset is missing.")
-        );
-      }
-      this._definition = new SpreadsheetPivotRuntimeDefinition(
-        this.coreDefinition,
-        this.fields,
-        this.getters
-      );
-      this.table = undefined;
-      this.dataEntries = [];
-      const range = this._definition.range;
-      if (this.isValid() && range) {
-        this.dataEntries = this.extractDataEntriesFromRange(range);
-      }
+      this.reload(ReloadType.ALL);
       this.needsReevaluation = false;
     }
+  }
+
+  reload(type: ReloadType) {
+    if (type === ReloadType.ALL) {
+      this.metaData = this.loadMetaData();
+    }
+    if (type >= ReloadType.DEFINITION) {
+      this._definition = this.loadRuntimeDefinition();
+    }
+    if (type >= ReloadType.DATA) {
+      this.dataEntries = this.loadData();
+    }
+    if (type >= ReloadType.TABLE) {
+      this.table = undefined;
+    }
+  }
+
+  onDefinitionChange(nextDefinition: SpreadsheetPivotCoreDefinition) {
+    const actualDefinition = this.coreDefinition;
+    this.coreDefinition = nextDefinition;
+    if (this._definition) {
+      const reloadType = Math.max(
+        this.computeShouldReload(actualDefinition, nextDefinition),
+        ReloadType.NONE
+      );
+      this.reload(reloadType);
+    }
+  }
+
+  private computeShouldReload(
+    actualDefinition: SpreadsheetPivotCoreDefinition,
+    nextDefinition: SpreadsheetPivotCoreDefinition
+  ): ReloadType {
+    if (deepEquals(actualDefinition.dataSet, nextDefinition.dataSet)) {
+      return ReloadType.DEFINITION;
+    }
+    return ReloadType.ALL;
   }
 
   get isInvalidRange() {
@@ -297,7 +319,39 @@ export class SpreadsheetPivot implements Pivot<SpreadsheetPivotRuntimeDefinition
   }
 
   getFields(): PivotFields {
-    return this.fields;
+    return this.metaData.fields;
+  }
+
+  get fields(): PivotFields {
+    return this.getFields();
+  }
+
+  private loadMetaData(): MetaData {
+    this.invalidRangeError = undefined;
+    if (this.coreDefinition.dataSet) {
+      const { zone, sheetId } = this.coreDefinition.dataSet;
+      const range = this.getters.getRangeFromZone(sheetId, zone);
+      try {
+        return this.extractFieldsFromRange(range);
+      } catch (e) {
+        this.invalidRangeError = e;
+        return { fields: {}, fieldKeys: [] };
+      }
+    } else {
+      this.invalidRangeError = new EvaluationError(
+        _t("The pivot cannot be created because the dataset is missing.")
+      );
+      return { fields: {}, fieldKeys: [] };
+    }
+  }
+
+  private loadRuntimeDefinition() {
+    return new SpreadsheetPivotRuntimeDefinition(this.coreDefinition, this.fields, this.getters);
+  }
+
+  private loadData() {
+    const range = this._definition?.range;
+    return this.isValid() && range ? this.extractDataEntriesFromRange(range) : [];
   }
 
   private getTypeOfDimension(fieldWithGranularity: string): string {
@@ -370,7 +424,7 @@ export class SpreadsheetPivot implements Pivot<SpreadsheetPivotRuntimeDefinition
    * Create the fields from the given range. It will extract all the fields from
    * the first row of the range.
    */
-  private extractFieldsFromRange(range: Range) {
+  private extractFieldsFromRange(range: Range): MetaData {
     const fields: PivotFields = {};
     const fieldKeys: TechnicalName[] = [];
     const sheetId = range.sheetId;
@@ -420,9 +474,9 @@ export class SpreadsheetPivot implements Pivot<SpreadsheetPivotRuntimeDefinition
       const entry: DataEntry = {};
       for (const index in cells) {
         const cell = cells[index];
-        const field = this.fields[this.fieldKeys[index]];
+        const field = this.fields[this.metaData.fieldKeys[index]];
         if (!field) {
-          throw new Error(`Field ${this.fieldKeys[index]} does not exist`);
+          throw new Error(`Field ${this.metaData.fieldKeys[index]} does not exist`);
         }
         if (cell.value === "") {
           entry[field.name] = { value: null, type: CellValueType.empty, formattedValue: "" };

--- a/src/index.ts
+++ b/src/index.ts
@@ -119,6 +119,7 @@ import { supportedPivotPositionalFormulaRegistry } from "./helpers/pivot/pivot_p
 
 import { CellComposerStore } from "./components/composer/composer/cell_composer_store";
 import { SidePanelCollapsible } from "./components/side_panel/components/collapsible/side_panel_collapsible";
+import { PivotMeasureDisplayPanelStore } from "./components/side_panel/pivot/pivot_measure_display_panel/pivot_measure_display_panel_store";
 import { TextInput } from "./components/text_input/text_input";
 import {
   getChartAxisType,
@@ -430,6 +431,7 @@ export const stores = {
   useLocalStore,
   SidePanelStore,
   PivotSidePanelStore,
+  PivotMeasureDisplayPanelStore,
 };
 
 export type { StoreConstructor, StoreParams } from "./store_engine";

--- a/src/plugins/ui_core_views/pivot_ui.ts
+++ b/src/plugins/ui_core_views/pivot_ui.ts
@@ -280,9 +280,11 @@ export class PivotUIPlugin extends UIPlugin {
 
   setupPivot(pivotId: UID, { recreate } = { recreate: false }) {
     const definition = this.getters.getPivotCoreDefinition(pivotId);
-    if (recreate || !(pivotId in this.pivots)) {
+    if (!(pivotId in this.pivots)) {
       const Pivot = withPivotPresentationLayer(pivotRegistry.get(definition.type).ui);
       this.pivots[pivotId] = new Pivot(this.custom, { definition, getters: this.getters });
+    } else if (recreate) {
+      this.pivots[pivotId].onDefinitionChange(definition);
     }
   }
 

--- a/src/registries/auto_completes/pivot_auto_complete.ts
+++ b/src/registries/auto_completes/pivot_auto_complete.ts
@@ -254,11 +254,12 @@ autoCompleteProviders.add("pivot_group_values", {
       const isString = typeof value === "string";
       const text = isString ? `"${value}"` : value.toString();
       const color = isString ? tokenColors.STRING : tokenColors.NUMBER;
+      const usedLabel = label === value ? "" : label;
       return {
         text,
-        description: label,
+        description: usedLabel,
         htmlContent: [{ value: text, color }],
-        fuzzySearchKey: value + label,
+        fuzzySearchKey: value + usedLabel,
       };
     });
   },

--- a/src/registries/side_panel_registry_entries.ts
+++ b/src/registries/side_panel_registry_entries.ts
@@ -5,6 +5,7 @@ import { DataValidationPanel } from "../components/side_panel/data_validation/da
 import { DataValidationEditor } from "../components/side_panel/data_validation/dv_editor/dv_editor";
 import { FindAndReplacePanel } from "../components/side_panel/find_and_replace/find_and_replace";
 import { MoreFormatsPanel } from "../components/side_panel/more_formats/more_formats";
+import { PivotMeasureDisplayPanel } from "../components/side_panel/pivot/pivot_measure_display_panel/pivot_measure_display_panel";
 import { PivotSidePanel } from "../components/side_panel/pivot/pivot_side_panel/pivot_side_panel";
 import { RemoveDuplicatesPanel } from "../components/side_panel/remove_duplicates/remove_duplicates";
 import { SettingsPanel } from "../components/side_panel/settings/settings_panel";
@@ -117,5 +118,22 @@ sidePanelRegistry.add("PivotSidePanel", {
       props,
       key: `pivot_key_${props.pivotId}`,
     };
+  },
+});
+
+sidePanelRegistry.add("PivotMeasureDisplayPanel", {
+  title: (env: SpreadsheetChildEnv, props: PivotMeasureDisplayPanel["props"]) => {
+    const measure = env.model.getters.getPivot(props.pivotId).getMeasure(props.measure.id);
+    return _t('Measure "%s" options', measure.displayName);
+  },
+  Body: PivotMeasureDisplayPanel,
+  computeState: (getters: Getters, props: PivotMeasureDisplayPanel["props"]) => {
+    try {
+      // This will throw if the pivot or measure does not exist
+      getters.getPivot(props.pivotId).getMeasure(props.measure.id);
+      return { isOpen: true, props, key: "pivot_measure_display" };
+    } catch (e) {
+      return { isOpen: false };
+    }
   },
 });

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -9,6 +9,7 @@ export const CellErrorType = {
   DivisionByZero: "#DIV/0!",
   SpilledBlocked: "#SPILL!",
   GenericError: "#ERROR",
+  NullError: "#NULL!",
 } as const;
 
 export const errorTypes: Set<string> = new Set(Object.values(CellErrorType));

--- a/src/types/pivot.ts
+++ b/src/types/pivot.ts
@@ -1,3 +1,4 @@
+import { NEXT_VALUE, PREVIOUS_VALUE } from "../helpers/pivot/pivot_helpers";
 import { CellValue } from "./cells";
 import { Format } from "./format";
 import { Locale } from "./locale";
@@ -43,6 +44,7 @@ export interface PivotCoreMeasure {
   isHidden?: boolean;
   format?: Format;
   computedBy?: { sheetId: UID; formula: string };
+  display?: PivotMeasureDisplay;
 }
 
 export interface CommonPivotCoreDefinition {
@@ -157,6 +159,35 @@ export interface PivotNode {
 }
 
 export type PivotDomain = PivotNode[];
+
+/** Pivot domain splitted for the domain related to the pivot's rows and columns  */
+export interface PivotColRowDomain {
+  colDomain: PivotDomain;
+  rowDomain: PivotDomain;
+}
+
+export interface PivotMeasureDisplay {
+  type: PivotMeasureDisplayType;
+  fieldNameWithGranularity?: string;
+  value?: string | boolean | number | typeof PREVIOUS_VALUE | typeof NEXT_VALUE;
+}
+
+export type PivotMeasureDisplayType =
+  | "no_calculations"
+  | "%_of_grand_total"
+  | "%_of_col_total"
+  | "%_of_row_total"
+  | "%_of_parent_row_total"
+  | "%_of_parent_col_total"
+  | "index"
+  | "%_of_parent_total"
+  | "running_total"
+  | "%_running_total"
+  | "rank_asc"
+  | "rank_desc"
+  | "%_of"
+  | "difference_from"
+  | "%_difference_from";
 
 export interface DimensionTreeNode {
   value: CellValue;

--- a/src/types/pivot_runtime.ts
+++ b/src/types/pivot_runtime.ts
@@ -17,6 +17,7 @@ export interface Pivot<T = PivotRuntimeDefinition> {
   definition: T;
   init(params?: InitPivotParams): void;
   isValid(): boolean;
+  onDefinitionChange(nextDefinition: PivotCoreDefinition): void;
 
   getTableStructure(): SpreadsheetPivotTable;
   getFields(): PivotFields;

--- a/tests/pivots/pivot_measure/pivot_measure_display_model.test.ts
+++ b/tests/pivots/pivot_measure/pivot_measure_display_model.test.ts
@@ -1,0 +1,1596 @@
+import { CellErrorType, PivotMeasureDisplay, SpreadsheetPivotCoreDefinition } from "../../../src";
+import { NEXT_VALUE, PREVIOUS_VALUE } from "../../../src/helpers/pivot/pivot_helpers";
+import { setCellContent } from "../../test_helpers/commands_helpers";
+import { getCell, getEvaluatedCell } from "../../test_helpers/getters_helpers";
+import { createModelFromGrid, getFormattedGrid, getGrid } from "../../test_helpers/helpers";
+import { addPivot, updatePivot, updatePivotMeasureDisplay } from "../../test_helpers/pivot_helpers";
+
+const pivotId = "pivotId";
+const measureId = "m1";
+
+function createModelWithTestPivot(pivotDefinition?: Partial<SpreadsheetPivotCoreDefinition>) {
+  // prettier-ignore
+  const grid = {
+    A1:"Created on",    B1: "Salesperson",  C1: "Expected Revenue",  D1: "Stage",  E1: "Active",
+    A2: "04/02/2024",   B2: "Bob",          C2: "2000",              D2: "Won",    E2: "TRUE",
+    A3: "03/28/2024",   B3: "Bob",          C3: "11000",             D3: "New",    E3: "TRUE",
+    A4: "04/02/2024",   B4: "Alice",        C4: "4500",              D4: "Won",    E4: "TRUE",
+    A5: "04/02/2024",   B5: "Alice",        C5: "9000",              D5: "New",    E5: "TRUE",
+    A6: "03/27/2024",   B6: "Alice",        C6: "19800",             D6: "Won",    E6: "TRUE",
+    A7: "04/01/2024",   B7: "Alice",        C7: "3800",              D7: "Won",    E7: "TRUE",
+    A8: "04/02/2024",   B8: "Bob",          C8: "24000",             D8: "New",    E8: "TRUE",
+    A9: "02/03/2024",   B9: "Alice",        C9: "22500",             D9: "Won",    E9: "FALSE",
+    A10: "03/03/2024",  B10: "Alice",       C10: "40000",            D10: "New",   E10: "FALSE",
+    A11: "03/26/2024",  B11: "Alice",       C11: "5600",             D11: "New",   E11: "FALSE",
+    A12: "03/27/2024",  B12: "Bob",         C12: "15000",            D12: "New",   E12: "FALSE",
+    A13: "03/27/2024",  B13: "Bob",         C13: "35000",            D13: "Won",   E13: "FALSE",
+    A14: "03/31/2024",  B14: "Bob",         C14: "1000",             D14: "Won",   E14: "FALSE",
+    A15: "04/02/2024",  B15: "Alice",       C15: "25000",            D15: "Won",   E15: "FALSE",
+    A16: "04/02/2024",  B16: "Alice",       C16: "40000",            D16: "New",   E16: "FALSE",
+    A17: "03/27/2024",  B17: "Alice",       C17: "60000",            D17: "New",   E17: "FALSE",
+    A18: "03/27/2024",  B18: "Bob",         C18: "2000",             D18: "Won",   E18: "FALSE",
+  };
+  const model = createModelFromGrid(grid);
+
+  pivotDefinition = {
+    columns: [{ fieldName: "Salesperson", order: "asc" }],
+    rows: [{ fieldName: "Created on", granularity: "month_number", order: "asc" }],
+    measures: [{ fieldName: "Expected Revenue", aggregator: "sum", id: measureId }],
+    ...pivotDefinition,
+  };
+  addPivot(model, "A1:E18", pivotDefinition, pivotId);
+  setCellContent(model, "A20", "=PIVOT(1)");
+  return model;
+}
+
+describe("Measure display", () => {
+  test("Can display measures with no calculations", () => {
+    const model = createModelWithTestPivot();
+    updatePivotMeasureDisplay(model, pivotId, measureId, { type: "no_calculations" });
+
+    expect(model.getters.getPivotCoreDefinition(pivotId).measures[0].display).toEqual({
+      type: "no_calculations",
+    });
+
+    // prettier-ignore
+    expect(getGrid(model)).toMatchObject({
+        A20: "(#1) Pivot",  B20: "Alice",  C20: "Bob",  D20: "Total",
+        A22: "February",    B22: 22500,    C22: "",     D22: 22500,
+        A23: "March",       B23: 125400,   C23: 64000,  D23: 189400,
+        A24: "April",       B24: 82300,    C24: 26000,  D24: 108300,
+        A25: "Total",       B25: 230200,   C25: 90000,  D25: 320200,
+    });
+  });
+
+  test("%_of_grand_total display type", () => {
+    const model = createModelWithTestPivot();
+    updatePivotMeasureDisplay(model, pivotId, measureId, { type: "%_of_grand_total" });
+
+    // prettier-ignore
+    expect(getFormattedGrid(model)).toMatchObject({
+        A20: "(#1) Pivot",  B20: "Alice",   C20: "Bob",     D20: "Total",
+        A22: "February",    B22: "7.03%",   C22: "0.00%",   D22: "7.03%",
+        A23: "March",       B23: "39.16%",  C23: "19.99%",  D23: "59.15%",
+        A24: "April",       B24: "25.70%",  C24: "8.12%",   D24: "33.82%",
+        A25: "Total",       B25: "71.89%",  C25: "28.11%",  D25: "100.00%",
+    });
+  });
+
+  test("Displayed measure are updated when changing the aggregator", () => {
+    const model = createModelWithTestPivot();
+    updatePivot(model, pivotId, {
+      measures: [
+        {
+          fieldName: "Expected Revenue",
+          aggregator: "max",
+          id: measureId,
+          display: { type: "%_of_grand_total" },
+        },
+      ],
+    });
+
+    // prettier-ignore
+    expect(getFormattedGrid(model)).toMatchObject({
+        A20: "(#1) Pivot",  B20: "Alice",    C20: "Bob",     D20: "Total",
+        A22: "February",    B22: "37.50%",   C22: "0.00%",   D22: "37.50%",
+        A23: "March",       B23: "100.00%",  C23: "58.33%",  D23: "100.00%",
+        A24: "April",       B24: "66.67%",   C24: "40.00%",  D24: "66.67%",
+        A25: "Total",       B25: "100.00%",  C25: "58.33%",  D25: "100.00%",
+    });
+  });
+
+  test("%_of_col_total display type", () => {
+    const model = createModelWithTestPivot();
+    updatePivotMeasureDisplay(model, pivotId, measureId, { type: "%_of_col_total" });
+
+    // prettier-ignore
+    expect(getFormattedGrid(model)).toMatchObject({
+      A20: "(#1) Pivot",  B20: "Alice",    C20: "Bob",      D20: "Total",
+      A22: "February",    B22: "9.77%",    C22: "0.00%",    D22: "7.03%",
+      A23: "March",       B23: "54.47%",   C23: "71.11%",   D23: "59.15%",
+      A24: "April",       B24: "35.75%",   C24: "28.89%",   D24: "33.82%",
+      A25: "Total",       B25: "100.00%",  C25: "100.00%",  D25: "100.00%",
+    });
+  });
+
+  test("%_of_row_total display type", () => {
+    const model = createModelWithTestPivot();
+    updatePivotMeasureDisplay(model, pivotId, measureId, { type: "%_of_row_total" });
+
+    // prettier-ignore
+    expect(getFormattedGrid(model)).toMatchObject({
+      A20: "(#1) Pivot",  B20: "Alice",    C20: "Bob",     D20: "Total",
+      A22: "February",    B22: "100.00%",  C22: "0.00%",   D22: "100.00%",
+      A23: "March",       B23: "66.21%",   C23: "33.79%",  D23: "100.00%",
+      A24: "April",       B24: "75.99%",   C24: "24.01%",  D24: "100.00%",
+      A25: "Total",       B25: "71.89%",   C25: "28.11%",  D25: "100.00%",
+    });
+  });
+
+  test("%_of_parent_row_total display type", () => {
+    const model = createModelWithTestPivot({
+      rows: [
+        { fieldName: "Created on", granularity: "month_number", order: "asc" },
+        { fieldName: "Active", order: "asc" },
+      ],
+      measures: [
+        {
+          fieldName: "Expected Revenue",
+          aggregator: "sum",
+          id: measureId,
+          display: { type: "%_of_parent_row_total" },
+        },
+      ],
+    });
+
+    // prettier-ignore
+    expect(getFormattedGrid(model)).toMatchObject({
+      A20: "(#1) Pivot",  B20: "Alice",    C20: "Bob",      D20: "Total",
+      A22: "February",    B22: "9.77%",    C22: "0.00%",    D22: "7.03%",
+      A23: "FALSE",       B23: "100.00%",  C23: "",         D23: "100.00%",
+      A24: "March",       B24: "54.47%",   C24: "71.11%",   D24: "59.15%",
+      A25: "FALSE",       B25: "84.21%",   C25: "82.81%",   D25: "83.74%",
+      A26: "TRUE",        B26: "15.79%",   C26: "17.19%",   D26: "16.26%",
+      A27: "April",       B27: "35.75%",   C27: "28.89%",   D27: "33.82%",
+      A28: "FALSE",       B28: "78.98%",   C28: "0.00%",    D28: "60.02%",
+      A29: "TRUE",        B29: "21.02%",   C29: "100.00%",  D29: "39.98%",
+      A30: "Total",       B30: "100.00%",  C30: "100.00%",  D30: "100.00%",
+    });
+  });
+
+  test("%_of_parent_col_total display type", () => {
+    const model = createModelWithTestPivot();
+    updatePivot(model, pivotId, {
+      columns: [
+        { fieldName: "Salesperson", order: "asc" },
+        { fieldName: "Active", order: "asc" },
+      ],
+      measures: [
+        {
+          fieldName: "Expected Revenue",
+          aggregator: "sum",
+          id: measureId,
+          display: { type: "%_of_parent_col_total" },
+        },
+      ],
+    });
+
+    // prettier-ignore
+    expect(getFormattedGrid(model)).toMatchObject({
+      A20:"(#1) Pivot",  B20: "Alice",    C20: "",        D20: "Bob",     E20: "",         F20: "",
+      A21: "",           B21: "FALSE",    C21: "TRUE",    D21: "FALSE",   E21: "TRUE",     F21: "Total",
+      A23: "February",   B23: "100.00%",  C23: "0.00%",   D23: "",        E23: "",         F23: "100.00%",
+      A24: "March",      B24: "84.21%",   C24: "15.79%",  D24: "82.81%",  E24: "17.19%",   F24: "100.00%",
+      A25: "April",      B25: "78.98%",   C25: "21.02%",  D25: "0.00%",   E25: "100.00%",  F25: "100.00%",
+      A26: "Total",      B26: "83.88%",   C26: "16.12%",  D26: "58.89%",  E26: "41.11%",   F26: "100.00%",
+    });
+  });
+
+  describe("%_of_parent_total", () => {
+    test("%_of_parent_total on row", () => {
+      const measureDisplay: PivotMeasureDisplay = {
+        type: "%_of_parent_total",
+        fieldNameWithGranularity: "Created on:month_number",
+      };
+      const model = createModelWithTestPivot({
+        rows: [
+          { fieldName: "Created on", granularity: "month_number", order: "asc" },
+          { fieldName: "Active", order: "asc" },
+          { fieldName: "Stage", order: "asc" },
+        ],
+        measures: [
+          {
+            fieldName: "Expected Revenue",
+            aggregator: "sum",
+            id: measureId,
+            display: measureDisplay,
+          },
+        ],
+      });
+
+      // prettier-ignore
+      expect(getFormattedGrid(model)).toMatchObject({
+        A20:"(#1) Pivot",  B20: "Alice",    C20: "Bob",      D20: "Total",
+        A22: "February",   B22: "100.00%",  C22: "",         D22: "100.00%",
+        A23: "FALSE",      B23: "100.00%",  C23: "",         D23: "100.00%",
+        A24: "Won",        B24: "100.00%",  C24: "",         D24: "100.00%",
+        A25: "March",      B25: "100.00%",  C25: "100.00%",  D25: "100.00%",
+        A26: "FALSE",      B26: "84.21%",   C26: "82.81%",   D26: "83.74%",
+        A27: "New",        B27: "84.21%",   C27: "23.44%",   D27: "63.67%",
+        A28: "Won",        B28: "0.00%",    C28: "59.38%",   D28: "20.06%",
+        A29: "TRUE",       B29: "15.79%",   C29: "17.19%",   D29: "16.26%",
+        A30: "New",        B30: "0.00%",    C30: "17.19%",   D30: "5.81%",
+        A31: "Won",        B31: "15.79%",   C31: "0.00%",    D31: "10.45%",
+        A32: "April",      B32: "100.00%",  C32: "100.00%",  D32: "100.00%",
+        A33: "FALSE",      B33: "78.98%",   C33: "0.00%",    D33: "60.02%",
+        A34: "New",        B34: "48.60%",   C34: "0.00%",    D34: "36.93%",
+        A35: "Won",        B35: "30.38%",   C35: "0.00%",    D35: "23.08%",
+        A36: "TRUE",       B36: "21.02%",   C36: "100.00%",  D36: "39.98%",
+        A37: "New",        B37: "10.94%",   C37: "92.31%",   D37: "30.47%",
+        A38: "Won",        B38: "10.09%",   C38: "7.69%",    D38: "9.51%",
+        A39: "Total",      B39: "",         C39: "",         D39: "",
+      });
+    });
+
+    test("Can display measure as percentage of given parent field on non-root parent row", () => {
+      const measureDisplay: PivotMeasureDisplay = {
+        type: "%_of_parent_total",
+        fieldNameWithGranularity: "Active",
+      };
+      const model = createModelWithTestPivot({
+        rows: [
+          { fieldName: "Created on", granularity: "month_number", order: "asc" },
+          { fieldName: "Active", order: "asc" },
+          { fieldName: "Stage", order: "asc" },
+        ],
+        measures: [
+          {
+            fieldName: "Expected Revenue",
+            aggregator: "sum",
+            id: measureId,
+            display: measureDisplay,
+          },
+        ],
+      });
+
+      // prettier-ignore
+      expect(getFormattedGrid(model)).toMatchObject({
+        A20:"(#1) Pivot",  B20: "Alice",    C20: "Bob",      D20: "Total",
+        A22: "February",   B22: "",         C22: "",         D22: "",
+        A23: "FALSE",      B23: "100.00%",  C23: "",         D23: "100.00%",
+        A24: "Won",        B24: "100.00%",  C24: "",         D24: "100.00%",
+        A25: "March",      B25: "",         C25: "",         D25: "",
+        A26: "FALSE",      B26: "100.00%",  C26: "100.00%",  D26: "100.00%",
+        A27: "New",        B27: "100.00%",  C27: "28.30%",   D27: "76.04%",
+        A28: "Won",        B28: "0.00%",    C28: "71.70%",   D28: "23.96%",
+        A29: "TRUE",       B29: "100.00%",  C29: "100.00%",  D29: "100.00%",
+        A30: "New",        B30: "0.00%",    C30: "100.00%",  D30: "35.71%",
+        A31: "Won",        B31: "100.00%",  C31: "0.00%",    D31: "64.29%",
+        A32: "April",      B32: "",         C32: "",         D32: "",
+        A33: "FALSE",      B33: "100.00%",  C33: "",         D33: "100.00%",
+        A34: "New",        B34: "61.54%",   C34: "",         D34: "61.54%",
+        A35: "Won",        B35: "38.46%",   C35: "",         D35: "38.46%",
+        A36: "TRUE",       B36: "100.00%",  C36: "100.00%",  D36: "100.00%",
+        A37: "New",        B37: "52.02%",   C37: "92.31%",   D37: "76.21%",
+        A38: "Won",        B38: "47.98%",   C38: "7.69%",    D38: "23.79%",
+        A39: "Total",      B39: "",         C39: "",         D39: "",
+      });
+    });
+
+    test("Can display measure as percentage of given parent field on a parent column", () => {
+      const measureDisplay: PivotMeasureDisplay = {
+        type: "%_of_parent_total",
+        fieldNameWithGranularity: "Salesperson",
+      };
+      const model = createModelWithTestPivot({
+        columns: [
+          { fieldName: "Salesperson", order: "asc" },
+          { fieldName: "Stage", order: "asc" },
+        ],
+        measures: [
+          {
+            fieldName: "Expected Revenue",
+            aggregator: "sum",
+            id: measureId,
+            display: measureDisplay,
+          },
+        ],
+      });
+
+      // prettier-ignore
+      expect(getFormattedGrid(model)).toMatchObject({
+        A20:"(#1) Pivot",  B20: "Alice",   C20: "",         D20: "Bob",     E20: "",        F20: "",
+        A21: "",           B21: "New",     C21: "Won",      D21: "New",     E21: "Won",     F21: "Total",
+        A23: "February",   B23: "0.00%",   C23: "100.00%",  D23: "",        E23: "",        F23: "",
+        A24: "March",      B24: "84.21%",  C24: "15.79%",   D24: "40.63%",  E24: "59.38%",  F24: "",
+        A25: "April",      B25: "59.54%",  C25: "40.46%",   D25: "92.31%",  E25: "7.69%",   F25: "",
+        A26: "Total",      B26: "67.16%",  C26: "32.84%",   D26: "55.56%",  E26: "44.44%",  F26: "",
+      });
+    });
+
+    test("%_of_parent_total with field not in the pivot", () => {
+      const measureDisplay: PivotMeasureDisplay = {
+        type: "%_of_parent_total",
+        fieldNameWithGranularity: "Active",
+      };
+      const model = createModelWithTestPivot({
+        measures: [
+          {
+            fieldName: "Expected Revenue",
+            aggregator: "sum",
+            id: measureId,
+            display: measureDisplay,
+          },
+        ],
+      });
+
+      // prettier-ignore
+      expect(getFormattedGrid(model)).toMatchObject({
+        A20:"(#1) Pivot",  B20: "Alice",  C20: "Bob",   D20: "Total",
+        A22: "February",   B22: "#N/A",   C22: "#N/A",  D22: "#N/A",
+        A23: "March",      B23: "#N/A",   C23: "#N/A",  D23: "#N/A",
+        A24: "April",      B24: "#N/A",   C24: "#N/A",  D24: "#N/A",
+        A25: "Total",      B25: "#N/A",   C25: "#N/A",  D25: "#N/A",
+      });
+      expect(getEvaluatedCell(model, "B22").message).toEqual(
+        'Field "Active" not found in pivot for measure display calculation'
+      );
+    });
+  });
+
+  describe("%_of", () => {
+    test("Can display measure as %_of given row field value", () => {
+      const measureDisplay: PivotMeasureDisplay = {
+        type: "%_of",
+        fieldNameWithGranularity: "Created on:month_number",
+        value: 2,
+      };
+      const model = createModelWithTestPivot({
+        measures: [
+          {
+            fieldName: "Expected Revenue",
+            aggregator: "sum",
+            id: measureId,
+            display: measureDisplay,
+          },
+        ],
+      });
+
+      // prettier-ignore
+      expect(getFormattedGrid(model)).toMatchObject({
+        A20:"(#1) Pivot",  B20: "Alice",    C20: "Bob",  D20: "Total",
+        A22: "February",   B22: "100.00%",  C22: "",     D22: "100.00%", // No value for Bob in February, so the whole col is empty
+        A23: "March",      B23: "557.33%",  C23: "",     D23: "841.78%",
+        A24: "April",      B24: "365.78%",  C24: "",     D24: "481.33%",
+        A25: "Total",      B25: "",         C25: "",     D25: "",
+      });
+    });
+
+    test("Can display measure as %_of given col field value", () => {
+      const measureDisplay: PivotMeasureDisplay = {
+        type: "%_of",
+        fieldNameWithGranularity: "Salesperson",
+        value: "Alice",
+      };
+      const model = createModelWithTestPivot({
+        measures: [
+          {
+            fieldName: "Expected Revenue",
+            aggregator: "sum",
+            id: measureId,
+            display: measureDisplay,
+          },
+        ],
+      });
+
+      // prettier-ignore
+      expect(getFormattedGrid(model)).toMatchObject({
+        A20:"(#1) Pivot",  B20: "Alice",    C20: "Bob",     D20: "Total",
+        A22: "February",   B22: "100.00%",  C22: "#NULL!",  D22: "",
+        A23: "March",      B23: "100.00%",  C23: "51.04%",  D23: "",
+        A24: "April",      B24: "100.00%",  C24: "31.59%",  D24: "",
+        A25: "Total",      B25: "100.00%",  C25: "39.10%",  D25: "",
+      });
+    });
+
+    test("%_of with multi level grouping", () => {
+      const measureDisplay: PivotMeasureDisplay = {
+        type: "%_of",
+        fieldNameWithGranularity: "Active",
+        value: false,
+      };
+      const model = createModelWithTestPivot({
+        rows: [
+          { fieldName: "Created on", granularity: "month_number", order: "asc" },
+          { fieldName: "Active", order: "asc" },
+          { fieldName: "Stage", order: "asc" },
+        ],
+        measures: [
+          {
+            fieldName: "Expected Revenue",
+            aggregator: "sum",
+            id: measureId,
+            display: measureDisplay,
+          },
+        ],
+      });
+
+      // prettier-ignore
+      expect(getFormattedGrid(model)).toMatchObject({
+        A20:"(#1) Pivot",  B20: "Alice",    C20: "Bob",      D20: "Total",
+        A22: "February",   B22: "",         C22: "",         D22: "",
+        A23: "FALSE",      B23: "100.00%",  C23: "",         D23: "100.00%",
+        A24: "Won",        B24: "100.00%",  C24: "",         D24: "100.00%",
+        A25: "March",      B25: "",         C25: "",         D25: "",
+        A26: "FALSE",      B26: "100.00%",  C26: "100.00%",  D26: "100.00%",
+        A27: "New",        B27: "100.00%",  C27: "100.00%",  D27: "100.00%",
+        A28: "Won",        B28: "",         C28: "100.00%",  D28: "100.00%",
+        A29: "TRUE",       B29: "18.75%",   C29: "20.75%",   D29: "19.42%",
+        A30: "New",        B30: "#NULL!",   C30: "73.33%",   D30: "9.12%",
+        A31: "Won",        B31: "",         C31: "#NULL!",   D31: "52.11%",
+        A32: "April",      B32: "",         C32: "",         D32: "",
+        A33: "FALSE",      B33: "100.00%",  C33: "",         D33: "100.00%",
+        A34: "New",        B34: "100.00%",  C34: "",         D34: "100.00%",
+        A35: "Won",        B35: "100.00%",  C35: "",         D35: "100.00%",
+        A36: "TRUE",       B36: "26.62%",   C36: "",         D36: "66.62%",
+        A37: "New",        B37: "22.50%",   C37: "",         D37: "82.50%",
+        A38: "Won",        B38: "33.20%",   C38: "",         D38: "41.20%",
+        A39: "Total",      B39: "",         C39: "",         D39: "",
+      });
+    });
+
+    test("%_of (previous)", () => {
+      const measureDisplay: PivotMeasureDisplay = {
+        type: "%_of",
+        fieldNameWithGranularity: "Created on:month_number",
+        value: PREVIOUS_VALUE,
+      };
+      const model = createModelWithTestPivot({
+        measures: [
+          {
+            fieldName: "Expected Revenue",
+            aggregator: "sum",
+            id: measureId,
+            display: measureDisplay,
+          },
+        ],
+      });
+
+      // prettier-ignore
+      expect(getFormattedGrid(model)).toMatchObject({
+        A20:"(#1) Pivot",  B20: "Alice",    C20: "Bob",     D20: "Total",
+        A22: "February",   B22: "100.00%",  C22: "",        D22: "100.00%",
+        A23: "March",      B23: "557.33%",  C23: "",        D23: "841.78%",
+        A24: "April",      B24: "65.63%",   C24: "40.63%",  D24: "57.18%",
+        A25: "Total",      B25: "",         C25: "",        D25: "",
+      });
+    });
+
+    test("%_of (next)", () => {
+      const measureDisplay: PivotMeasureDisplay = {
+        type: "%_of",
+        fieldNameWithGranularity: "Salesperson",
+        value: NEXT_VALUE,
+      };
+      const model = createModelWithTestPivot({
+        measures: [
+          {
+            fieldName: "Expected Revenue",
+            aggregator: "sum",
+            id: measureId,
+            display: measureDisplay,
+          },
+        ],
+      });
+
+      // prettier-ignore
+      expect(getFormattedGrid(model)).toMatchObject({
+        A20:"(#1) Pivot",  B20: "Alice",    C20: "Bob",      D20: "Total",
+        A22: "February",   B22: "",         C22: "",         D22: "",
+        A23: "March",      B23: "195.94%",  C23: "100.00%",  D23: "",
+        A24: "April",      B24: "316.54%",  C24: "100.00%",  D24: "",
+        A25: "Total",      B25: "255.78%",  C25: "100.00%",  D25: "",
+      });
+    });
+
+    test("%_of (previous) with multi level grouping", () => {
+      const measureDisplay: PivotMeasureDisplay = {
+        type: "%_of",
+        fieldNameWithGranularity: "Active",
+        value: PREVIOUS_VALUE,
+      };
+      const model = createModelWithTestPivot({
+        rows: [
+          { fieldName: "Created on", granularity: "month_number", order: "asc" },
+          { fieldName: "Active", order: "asc" },
+          { fieldName: "Stage", order: "asc" },
+        ],
+        measures: [
+          {
+            fieldName: "Expected Revenue",
+            aggregator: "sum",
+            id: measureId,
+            display: measureDisplay,
+          },
+        ],
+      });
+
+      // prettier-ignore
+      expect(getFormattedGrid(model)).toMatchObject({
+        A20:"(#1) Pivot",  B20: "Alice",    C20: "Bob",      D20: "Total",
+        A22: "February",   B22: "",         C22: "",         D22: "",
+        A23: "FALSE",      B23: "100.00%",  C23: "",         D23: "100.00%",
+        A24: "Won",        B24: "100.00%",  C24: "",         D24: "100.00%",
+        A25: "March",      B25: "",         C25: "",         D25: "",
+        A26: "FALSE",      B26: "100.00%",  C26: "100.00%",  D26: "100.00%",
+        A27: "New",        B27: "100.00%",  C27: "100.00%",  D27: "100.00%",
+        A28: "Won",        B28: "",         C28: "100.00%",  D28: "100.00%",
+        A29: "TRUE",       B29: "18.75%",   C29: "20.75%",   D29: "19.42%",
+        A30: "New",        B30: "#NULL!",   C30: "73.33%",   D30: "9.12%",
+        A31: "Won",        B31: "",         C31: "#NULL!",   D31: "52.11%",
+        A32: "April",      B32: "",         C32: "",         D32: "",
+        A33: "FALSE",      B33: "100.00%",  C33: "",         D33: "100.00%",
+        A34: "New",        B34: "100.00%",  C34: "",         D34: "100.00%",
+        A35: "Won",        B35: "100.00%",  C35: "",         D35: "100.00%",
+        A36: "TRUE",       B36: "26.62%",   C36: "",         D36: "66.62%",
+        A37: "New",        B37: "22.50%",   C37: "",         D37: "82.50%",
+        A38: "Won",        B38: "33.20%",   C38: "",         D38: "41.20%",
+        A39: "Total",      B39: "",         C39: "",         D39: "",
+      });
+    });
+
+    test("%_of (previous) with field sorted in descending order", () => {
+      const measureDisplay: PivotMeasureDisplay = {
+        type: "%_of",
+        fieldNameWithGranularity: "Created on:month_number",
+        value: PREVIOUS_VALUE,
+      };
+      const model = createModelWithTestPivot({
+        rows: [{ fieldName: "Created on", granularity: "month_number", order: "desc" }],
+        measures: [
+          {
+            fieldName: "Expected Revenue",
+            aggregator: "sum",
+            id: measureId,
+            display: measureDisplay,
+          },
+        ],
+      });
+
+      // prettier-ignore
+      expect(getFormattedGrid(model)).toMatchObject({
+        A20:"(#1) Pivot",  B20: "Alice",    C20: "Bob",      D20: "Total",
+        A22: "April",      B22: "100.00%",  C22: "100.00%",  D22: "100.00%",
+        A23: "March",      B23: "152.37%",  C23: "246.15%",  D23: "174.88%",
+        A24: "February",   B24: "17.94%",   C24: "#NULL!",   D24: "11.88%",
+        A25: "Total",      B25: "",         C25: "",         D25: "",
+      });
+    });
+
+    test("%_of with field not in pivot", () => {
+      const measureDisplay: PivotMeasureDisplay = {
+        type: "%_of",
+        fieldNameWithGranularity: "Stages",
+        value: "Won",
+      };
+      const model = createModelWithTestPivot({
+        measures: [
+          {
+            fieldName: "Expected Revenue",
+            aggregator: "sum",
+            id: measureId,
+            display: measureDisplay,
+          },
+        ],
+      });
+
+      // prettier-ignore
+      expect(getFormattedGrid(model)).toMatchObject({
+        A20:"(#1) Pivot",  B20: "Alice",  C20: "Bob",   D20: "Total",
+        A22: "February",   B22: "#N/A",   C22: "#N/A",  D22: "#N/A",
+        A23: "March",      B23: "#N/A",   C23: "#N/A",  D23: "#N/A",
+        A24: "April",      B24: "#N/A",   C24: "#N/A",  D24: "#N/A",
+        A25: "Total",      B25: "#N/A",   C25: "#N/A",  D25: "#N/A",
+      });
+    });
+
+    test("%_of with field value not in pivot", () => {
+      const measureDisplay: PivotMeasureDisplay = {
+        type: "%_of",
+        fieldNameWithGranularity: "Salesperson",
+        value: "Annette",
+      };
+      const model = createModelWithTestPivot({
+        measures: [
+          {
+            fieldName: "Expected Revenue",
+            aggregator: "sum",
+            id: measureId,
+            display: measureDisplay,
+          },
+        ],
+      });
+
+      // prettier-ignore
+      expect(getFormattedGrid(model)).toMatchObject({
+        A20:"(#1) Pivot",  B20: "Alice",  C20: "Bob",   D20: "Total",
+        A22: "February",   B22: "#N/A",   C22: "#N/A",  D22: "",
+        A23: "March",      B23: "#N/A",   C23: "#N/A",  D23: "",
+        A24: "April",      B24: "#N/A",   C24: "#N/A",  D24: "",
+        A25: "Total",      B25: "#N/A",   C25: "#N/A",  D25: "",
+      });
+    });
+
+    test("%_of make the difference between value 0 and empty value", () => {
+      const measureDisplay: PivotMeasureDisplay = {
+        type: "%_of",
+        fieldNameWithGranularity: "Salesperson",
+        value: "Bob",
+      };
+      const model = createModelWithTestPivot({
+        measures: [
+          {
+            fieldName: "Expected Revenue",
+            aggregator: "sum",
+            id: measureId,
+            display: measureDisplay,
+          },
+        ],
+      });
+
+      // No value for Bob in February, so the percentage from Bob for Alice is empty
+      expect(getEvaluatedCell(model, "B22").value).toEqual("");
+      expect(getEvaluatedCell(model, "C22").value).toEqual("");
+
+      setCellContent(model, "A2", "02/02/2024");
+      setCellContent(model, "C2", ""); // Empty Expected Revenue for Bob in February
+      expect(getEvaluatedCell(model, "B22").value).toEqual("");
+      expect(getEvaluatedCell(model, "C22").value).toEqual("");
+
+      setCellContent(model, "C2", "0"); // 0 Expected Revenue for Bob in February
+      expect(getEvaluatedCell(model, "B22").value).toEqual(CellErrorType.DivisionByZero);
+      expect(getEvaluatedCell(model, "C22").value).toEqual(CellErrorType.DivisionByZero);
+    });
+  });
+
+  describe("difference_from", () => {
+    test("Can display measure as difference_from given row field value", () => {
+      const measureDisplay: PivotMeasureDisplay = {
+        type: "difference_from",
+        fieldNameWithGranularity: "Created on:month_number",
+        value: 2,
+      };
+      const model = createModelWithTestPivot({
+        measures: [
+          {
+            fieldName: "Expected Revenue",
+            aggregator: "sum",
+            id: measureId,
+            display: measureDisplay,
+          },
+        ],
+      });
+
+      // prettier-ignore
+      expect(getFormattedGrid(model)).toMatchObject({
+        A20:"(#1) Pivot",  B20: "Alice",   C20: "Bob",    D20: "Total",
+        A22: "February",   B22: "",        C22: "",       D22: "",
+        A23: "March",      B23: "102900",  C23: "64000",  D23: "166900",
+        A24: "April",      B24: "59800",   C24: "26000",  D24: "85800",
+        A25: "Total",      B25: "",        C25: "",       D25: "",
+      });
+    });
+
+    test("Can display measure as difference_from given col field value", () => {
+      const measureDisplay: PivotMeasureDisplay = {
+        type: "difference_from",
+        fieldNameWithGranularity: "Salesperson",
+        value: "Alice",
+      };
+      const model = createModelWithTestPivot({
+        measures: [
+          {
+            fieldName: "Expected Revenue",
+            aggregator: "sum",
+            id: measureId,
+            display: measureDisplay,
+          },
+        ],
+      });
+
+      // prettier-ignore
+      expect(getFormattedGrid(model)).toMatchObject({
+        A20:"(#1) Pivot",  B20: "Alice",  C20: "Bob",      D20: "Total",
+        A22: "February",   B22: "",       C22: "-22500",   D22: "",
+        A23: "March",      B23: "",       C23: "-61400",   D23: "",
+        A24: "April",      B24: "",       C24: "-56300",   D24: "",
+        A25: "Total",      B25: "",       C25: "-140200",  D25: "",
+      });
+    });
+
+    test("difference_from with multi level grouping", () => {
+      const measureDisplay: PivotMeasureDisplay = {
+        type: "difference_from",
+        fieldNameWithGranularity: "Active",
+        value: true,
+      };
+      const model = createModelWithTestPivot({
+        rows: [
+          { fieldName: "Created on", granularity: "month_number", order: "asc" },
+          { fieldName: "Active", order: "asc" },
+          { fieldName: "Stage", order: "asc" },
+        ],
+        measures: [
+          {
+            fieldName: "Expected Revenue",
+            aggregator: "sum",
+            id: measureId,
+            display: measureDisplay,
+          },
+        ],
+      });
+
+      // prettier-ignore
+      expect(getFormattedGrid(model)).toMatchObject({
+        A20:"(#1) Pivot",  B20: "Alice",   C20: "Bob",     D20: "Total",
+        A22: "February",   B22: "",        C22: "",        D22: "",
+        A23: "FALSE",      B23: "#N/A",    C23: "#N/A",    D23: "#N/A",
+        A24: "Won",        B24: "#N/A",    C24: "#N/A",    D24: "#N/A",
+        A25: "March",      B25: "",        C25: "",        D25: "",
+        A26: "FALSE",      B26: "85800",   C26: "42000",   D26: "127800",
+        A27: "New",        B27: "105600",  C27: "4000",    D27: "109600",
+        A28: "Won",        B28: "-19800",  C28: "38000",   D28: "18200",
+        A29: "TRUE",       B29: "",        C29: "",        D29: "",
+        A30: "New",        B30: "",        C30: "",        D30: "",
+        A31: "Won",        B31: "",        C31: "",        D31: "",
+        A32: "April",      B32: "",        C32: "",        D32: "",
+        A33: "FALSE",      B33: "47700",   C33: "-26000",  D33: "21700",
+        A34: "New",        B34: "31000",   C34: "-24000",  D34: "7000",
+        A35: "Won",        B35: "16700",   C35: "-2000",   D35: "14700",
+        A36: "TRUE",       B36: "",        C36: "",        D36: "",
+        A37: "New",        B37: "",        C37: "",        D37: "",
+        A38: "Won",        B38: "",        C38: "",        D38: "",
+        A39: "Total",      B39: "",        C39: "",        D39: "",
+      });
+    });
+
+    test("difference_from (previous) with multi level grouping", () => {
+      const measureDisplay: PivotMeasureDisplay = {
+        type: "difference_from",
+        fieldNameWithGranularity: "Active",
+        value: PREVIOUS_VALUE,
+      };
+      const model = createModelWithTestPivot({
+        rows: [
+          { fieldName: "Created on", granularity: "month_number", order: "asc" },
+          { fieldName: "Active", order: "asc" },
+          { fieldName: "Stage", order: "asc" },
+        ],
+        measures: [
+          {
+            fieldName: "Expected Revenue",
+            aggregator: "sum",
+            id: measureId,
+            display: measureDisplay,
+          },
+        ],
+      });
+
+      // prettier-ignore
+      expect(getFormattedGrid(model)).toMatchObject({
+        A20:"(#1) Pivot",  B20: "Alice",    C20: "Bob",     D20: "Total",
+        A22: "February",   B22: "",         C22: "",        D22: "",
+        A23: "FALSE",      B23: "",         C23: "",        D23: "",
+        A24: "Won",        B24: "",         C24: "",        D24: "",
+        A25: "March",      B25: "",         C25: "",        D25: "",
+        A26: "FALSE",      B26: "",         C26: "",        D26: "",
+        A27: "New",        B27: "",         C27: "",        D27: "",
+        A28: "Won",        B28: "",         C28: "",        D28: "",
+        A29: "TRUE",       B29: "-85800",   C29: "-42000",  D29: "-127800",
+        A30: "New",        B30: "-105600",  C30: "-4000",   D30: "-109600",
+        A31: "Won",        B31: "19800",    C31: "-38000",  D31: "-18200",
+        A32: "April",      B32: "",         C32: "",        D32: "",
+        A33: "FALSE",      B33: "",         C33: "",        D33: "",
+        A34: "New",        B34: "",         C34: "",        D34: "",
+        A35: "Won",        B35: "",         C35: "",        D35: "",
+        A36: "TRUE",       B36: "-47700",   C36: "26000",   D36: "-21700",
+        A37: "New",        B37: "-31000",   C37: "24000",   D37: "-7000",
+        A38: "Won",        B38: "-16700",   C38: "2000",    D38: "-14700",
+        A39: "Total",      B39: "",         C39: "",        D39: "",
+      });
+    });
+  });
+
+  describe("%_difference_from", () => {
+    test("Can display measure as %_difference_from given row field value", () => {
+      const measureDisplay: PivotMeasureDisplay = {
+        type: "%_difference_from",
+        fieldNameWithGranularity: "Created on:month_number",
+        value: 2,
+      };
+      const model = createModelWithTestPivot({
+        measures: [
+          {
+            fieldName: "Expected Revenue",
+            aggregator: "sum",
+            id: measureId,
+            display: measureDisplay,
+          },
+        ],
+      });
+
+      // prettier-ignore
+      expect(getFormattedGrid(model)).toMatchObject({
+        A20:"(#1) Pivot",  B20: "Alice",    C20: "Bob",  D20: "Total",
+        A22: "February",   B22: "",         C22: "",     D22: "",
+        A23: "March",      B23: "457.33%",  C23: "",     D23: "741.78%",
+        A24: "April",      B24: "265.78%",  C24: "",     D24: "381.33%",
+        A25: "Total",      B25: "",         C25: "",     D25: "",
+      });
+    });
+
+    test("Can display measure as %_difference_from given col field value", () => {
+      const measureDisplay: PivotMeasureDisplay = {
+        type: "%_difference_from",
+        fieldNameWithGranularity: "Salesperson",
+        value: "Alice",
+      };
+      const model = createModelWithTestPivot({
+        measures: [
+          {
+            fieldName: "Expected Revenue",
+            aggregator: "sum",
+            id: measureId,
+            display: measureDisplay,
+          },
+        ],
+      });
+
+      // prettier-ignore
+      expect(getFormattedGrid(model)).toMatchObject({
+        A20:"(#1) Pivot",  B20: "Alice",  C20: "Bob",      D20: "Total",
+        A22: "February",   B22: "",       C22: "#NULL!",   D22: "",
+        A23: "March",      B23: "",       C23: "-48.96%",  D23: "",
+        A24: "April",      B24: "",       C24: "-68.41%",  D24: "",
+        A25: "Total",      B25: "",       C25: "-60.90%",  D25: "",
+      });
+    });
+
+    test("%_difference_from with multi level grouping", () => {
+      const measureDisplay: PivotMeasureDisplay = {
+        type: "%_difference_from",
+        fieldNameWithGranularity: "Active",
+        value: true,
+      };
+      const model = createModelWithTestPivot({
+        rows: [
+          { fieldName: "Created on", granularity: "month_number", order: "asc" },
+          { fieldName: "Active", order: "asc" },
+          { fieldName: "Stage", order: "asc" },
+        ],
+        measures: [
+          {
+            fieldName: "Expected Revenue",
+            aggregator: "sum",
+            id: measureId,
+            display: measureDisplay,
+          },
+        ],
+      });
+
+      // prettier-ignore
+      expect(getFormattedGrid(model)).toMatchObject({
+        A20:"(#1) Pivot",  B20: "Alice",    C20: "Bob",      D20: "Total",
+        A22: "February",   B22: "",         C22: "",         D22: "",
+        A23: "FALSE",      B23: "#N/A",     C23: "#N/A",     D23: "#N/A",
+        A24: "Won",        B24: "#N/A",     C24: "#N/A",     D24: "#N/A",
+        A25: "March",      B25: "",         C25: "",         D25: "",
+        A26: "FALSE",      B26: "433.33%",  C26: "381.82%",  D26: "414.94%",
+        A27: "New",        B27: "",         C27: "36.36%",   D27: "996.36%",
+        A28: "Won",        B28: "#NULL!",    C28: "",        D28: "91.92%",
+        A29: "TRUE",       B29: "",         C29: "",         D29: "",
+        A30: "New",        B30: "",         C30: "",         D30: "",
+        A31: "Won",        B31: "",         C31: "",         D31: "",
+        A32: "April",      B32: "",         C32: "",         D32: "",
+        A33: "FALSE",      B33: "275.72%",  C33: "#NULL!",   D33: "50.12%",
+        A34: "New",        B34: "344.44%",  C34: "#NULL!",   D34: "21.21%",
+        A35: "Won",        B35: "201.20%",  C35: "#NULL!",   D35: "142.72%",
+        A36: "TRUE",       B36: "",         C36: "",         D36: "",
+        A37: "New",        B37: "",         C37: "",         D37: "",
+        A38: "Won",        B38: "",         C38: "",         D38: "",
+        A39: "Total",      B39: "",         C39: "",         D39: "",
+      });
+    });
+
+    test("%_difference_from (previous) with multi level grouping", () => {
+      const measureDisplay: PivotMeasureDisplay = {
+        type: "%_difference_from",
+        fieldNameWithGranularity: "Active",
+        value: PREVIOUS_VALUE,
+      };
+      const model = createModelWithTestPivot({
+        rows: [
+          { fieldName: "Created on", granularity: "month_number", order: "asc" },
+          { fieldName: "Active", order: "asc" },
+          { fieldName: "Stage", order: "asc" },
+        ],
+        measures: [
+          {
+            fieldName: "Expected Revenue",
+            aggregator: "sum",
+            id: measureId,
+            display: measureDisplay,
+          },
+        ],
+      });
+
+      // prettier-ignore
+      expect(getFormattedGrid(model)).toMatchObject({
+        A20:"(#1) Pivot",  B20: "Alice",    C20: "Bob",      D20: "Total",
+        A22: "February",   B22: "",         C22: "",         D22: "",
+        A23: "FALSE",      B23: "",         C23: "",         D23: "",
+        A24: "Won",        B24: "",         C24: "",         D24: "",
+        A25: "March",      B25: "",         C25: "",         D25: "",
+        A26: "FALSE",      B26: "",         C26: "",         D26: "",
+        A27: "New",        B27: "",         C27: "",         D27: "",
+        A28: "Won",        B28: "",         C28: "",         D28: "",
+        A29: "TRUE",       B29: "-81.25%",  C29: "-79.25%",  D29: "-80.58%",
+        A30: "New",        B30: "#NULL!",   C30: "-26.67%",  D30: "-90.88%",
+        A31: "Won",        B31: "",         C31: "#NULL!",   D31: "-47.89%",
+        A32: "April",      B32: "",         C32: "",         D32: "",
+        A33: "FALSE",      B33: "",         C33: "",         D33: "",
+        A34: "New",        B34: "",         C34: "",         D34: "",
+        A35: "Won",        B35: "",         C35: "",         D35: "",
+        A36: "TRUE",       B36: "-73.38%",  C36: "",         D36: "-33.38%",
+        A37: "New",        B37: "-77.50%",  C37: "",         D37: "-17.50%",
+        A38: "Won",        B38: "-66.80%",  C38: "",         D38: "-58.80%",
+        A39: "Total",      B39: "",         C39: "",         D39: "",
+      });
+    });
+
+    test("%_difference_from make the difference between value 0 and empty value", () => {
+      const measureDisplay: PivotMeasureDisplay = {
+        type: "%_difference_from",
+        fieldNameWithGranularity: "Salesperson",
+        value: "Bob",
+      };
+      const model = createModelWithTestPivot({
+        measures: [
+          {
+            fieldName: "Expected Revenue",
+            aggregator: "sum",
+            id: measureId,
+            display: measureDisplay,
+          },
+        ],
+      });
+
+      // No value for Bob in February, so the percentage from Bob for Alice is empty
+      expect(getEvaluatedCell(model, "B22").value).toEqual("");
+      expect(getEvaluatedCell(model, "C22").value).toEqual("");
+
+      setCellContent(model, "A2", "02/02/2024");
+      setCellContent(model, "C2", ""); // Empty Expected Revenue for Bob in February
+      expect(getEvaluatedCell(model, "B22").value).toEqual("");
+      expect(getEvaluatedCell(model, "C22").value).toEqual("");
+
+      setCellContent(model, "C2", "0"); // 0 Expected Revenue for Bob in February
+      expect(getEvaluatedCell(model, "B22").value).toEqual(CellErrorType.DivisionByZero);
+      expect(getEvaluatedCell(model, "C22").value).toEqual("");
+    });
+  });
+
+  describe("index", () => {
+    test("Can display measure as index with simple grouping", () => {
+      const model = createModelWithTestPivot();
+      updatePivotMeasureDisplay(model, pivotId, measureId, { type: "index" });
+
+      // prettier-ignore
+      expect(getFormattedGrid(model)).toMatchObject({
+        A20:"(#1) Pivot",  B20: "Alice",        C20: "Bob",          D20: "Total",
+        A22: "February",   B22: "1.390964379",  C22: "0",            D22: "1",
+        A23: "March",      B23: "0.920944737",  C23: "1.202205796",  D23: "1",
+        A24: "April",      B24: "1.057030179",  C24: "0.854129476",  D24: "1",
+        A25: "Total",      B25: "1",            C25: "1",            D25: "1",
+      });
+    });
+
+    test("Can display measure as index with multi-level grouping", () => {
+      const model = createModelWithTestPivot({
+        rows: [
+          { fieldName: "Created on", granularity: "month_number", order: "asc" },
+          { fieldName: "Active", order: "asc" },
+          { fieldName: "Stage", order: "asc" },
+        ],
+        measures: [
+          {
+            fieldName: "Expected Revenue",
+            aggregator: "sum",
+            id: measureId,
+            display: { type: "index" },
+          },
+        ],
+      });
+
+      // prettier-ignore
+      expect(getFormattedGrid(model)).toMatchObject({
+        A20:"(#1) Pivot",  B20: "Alice",        C20: "Bob",          D20: "Total",
+        A22: "February",   B22: "1.390964379",  C22: "0",            D22: "1",
+        A23: "FALSE",      B23: "1.390964379",  C23: "0",            D23: "1",
+        A24: "Won",        B24: "1.390964379",  C24: "0",            D24: "1",
+        A25: "March",      B25: "0.920944737",  C25: "1.202205796",  D25: "1",
+        A26: "FALSE",      B26: "0.926140217",  C26: "1.188916912",  D26: "1",
+        A27: "New",        B27: "1.217958859",  C27: "0.442509674",  D27: "1",
+        A28: "Won",        B28: "0",            C28: "3.557777778",  D28: "1",
+        A29: "TRUE",       B29: "0.894191386",  C29: "1.270634921",  D29: "1",
+        A30: "New",        B30: "0",            C30: "3.557777778",  D30: "1",
+        A31: "Won",        B31: "1.390964379",  C31: "0",            D31: "1",
+        A32: "April",      B32: "1.057030179",  C32: "0.854129476",  D32: "1",
+        A33: "FALSE",      B33: "1.390964379",  C33: "0",            D33: "1",
+        A34: "New",        B34: "1.390964379",  C34: "0",            D34: "1",
+        A35: "Won",        B35: "1.390964379",  C35: "0",            D35: "1",
+        A36: "TRUE",       B36: "0.555743274",  C36: "2.136309982",  D36: "1",
+        A37: "New",        B37: "0.379353921",  C37: "2.587474747",  D37: "1",
+        A38: "Won",        B38: "1.120874208",  C38: "0.690830636",  D38: "1",
+        A39: "Total",      B39: "1",            C39: "1",            D39: "1",
+      });
+    });
+  });
+
+  describe("rank_asc", () => {
+    test("Can display measure as ascending ranking on a row field", () => {
+      const model = createModelWithTestPivot();
+      updatePivotMeasureDisplay(model, pivotId, measureId, {
+        type: "rank_asc",
+        fieldNameWithGranularity: "Created on:month_number",
+      });
+
+      // prettier-ignore
+      expect(getFormattedGrid(model)).toMatchObject({
+        A20:"(#1) Pivot",  B20: "Alice",  C20: "Bob",  D20: "Total",
+        A22: "February",   B22: "1",      C22: "",     D22: "1",
+        A23: "March",      B23: "3",      C23: "2",    D23: "3",
+        A24: "April",      B24: "2",      C24: "1",    D24: "2",
+        A25: "Total",      B25: "",       C25: "",     D25: "",
+      });
+    });
+
+    test("Can display measure as ascending ranking on multi-level row fields", () => {
+      let display: PivotMeasureDisplay = {
+        type: "rank_asc",
+        fieldNameWithGranularity: "Created on:month_number",
+      };
+      const model = createModelWithTestPivot({
+        rows: [
+          { fieldName: "Created on", granularity: "month_number", order: "asc" },
+          { fieldName: "Active", order: "asc" },
+          { fieldName: "Stage", order: "asc" },
+        ],
+        measures: [{ fieldName: "Expected Revenue", aggregator: "sum", id: measureId, display }],
+      });
+
+      // prettier-ignore
+      expect(getFormattedGrid(model)).toMatchObject({
+        A20:"(#1) Pivot",  B20: "Alice",  C20: "Bob",  D20: "Total",
+        A22: "February",   B22: "1",      C22: "",     D22: "1",
+        A23: "FALSE",      B23: "1",      C23: "",     D23: "1",
+        A24: "Won",        B24: "3",      C24: "",     D24: "3",
+        A25: "March",      B25: "3",      C25: "2",    D25: "3",
+        A26: "FALSE",      B26: "3",      C26: "1",    D26: "3",
+        A27: "New",        B27: "3",      C27: "2",    D27: "4",
+        A28: "Won",        B28: "",       C28: "2",    D28: "5",
+        A29: "TRUE",       B29: "2",      C29: "1",    D29: "1",
+        A30: "New",        B30: "",       C30: "1",    D30: "1",
+        A31: "Won",        B31: "2",      C31: "",     D31: "2",
+        A32: "April",      B32: "2",      C32: "1",    D32: "2",
+        A33: "FALSE",      B33: "2",      C33: "",     D33: "2",
+        A34: "New",        B34: "2",      C34: "",     D34: "3",
+        A35: "Won",        B35: "4",      C35: "",     D35: "4",
+        A36: "TRUE",       B36: "1",      C36: "2",    D36: "2",
+        A37: "New",        B37: "1",      C37: "3",    D37: "2",
+        A38: "Won",        B38: "1",      C38: "1",    D38: "1",
+        A39: "Total",      B39: "",       C39: "",     D39: "",
+      });
+
+      updatePivotMeasureDisplay(model, pivotId, measureId, {
+        type: "rank_asc",
+        fieldNameWithGranularity: "Active",
+      });
+      // prettier-ignore
+      expect(getFormattedGrid(model)).toMatchObject({
+        A20:"(#1) Pivot",  B20: "Alice",  C20: "Bob",  D20: "Total",
+        A22: "February",   B22: "",       C22: "",     D22: "",
+        A23: "FALSE",      B23: "1",      C23: "",     D23: "1",
+        A24: "Won",        B24: "1",      C24: "",     D24: "1",
+        A25: "March",      B25: "",       C25: "",     D25: "",
+        A26: "FALSE",      B26: "2",      C26: "2",    D26: "2",
+        A27: "New",        B27: "1",      C27: "2",    D27: "2",
+        A28: "Won",        B28: "",       C28: "1",    D28: "2",
+        A29: "TRUE",       B29: "1",      C29: "1",    D29: "1",
+        A30: "New",        B30: "",       C30: "1",    D30: "1",
+        A31: "Won",        B31: "1",      C31: "",     D31: "1",
+        A32: "April",      B32: "",       C32: "",     D32: "",
+        A33: "FALSE",      B33: "2",      C33: "",     D33: "2",
+        A34: "New",        B34: "2",      C34: "",     D34: "2",
+        A35: "Won",        B35: "2",      C35: "",     D35: "2",
+        A36: "TRUE",       B36: "1",      C36: "1",    D36: "1",
+        A37: "New",        B37: "1",      C37: "1",    D37: "1",
+        A38: "Won",        B38: "1",      C38: "1",    D38: "1",
+        A39: "Total",      B39: "",       C39: "",     D39: "",
+      });
+
+      updatePivotMeasureDisplay(model, pivotId, measureId, {
+        type: "rank_asc",
+        fieldNameWithGranularity: "Stage",
+      });
+      // prettier-ignore
+      expect(getFormattedGrid(model)).toMatchObject({
+        A20:"(#1) Pivot",  B20: "Alice",  C20: "Bob",  D20: "Total",
+        A22: "February",   B22: "",       C22: "",     D22: "",
+        A23: "FALSE",      B23: "",       C23: "",     D23: "",
+        A24: "Won",        B24: "1",      C24: "",     D24: "1",
+        A25: "March",      B25: "",       C25: "",     D25: "",
+        A26: "FALSE",      B26: "",       C26: "",     D26: "",
+        A27: "New",        B27: "1",      C27: "1",    D27: "2",
+        A28: "Won",        B28: "",       C28: "2",    D28: "1",
+        A29: "TRUE",       B29: "",       C29: "",     D29: "",
+        A30: "New",        B30: "",       C30: "1",    D30: "1",
+        A31: "Won",        B31: "1",      C31: "",     D31: "2",
+        A32: "April",      B32: "",       C32: "",     D32: "",
+        A33: "FALSE",      B33: "",       C33: "",     D33: "",
+        A34: "New",        B34: "2",      C34: "",     D34: "2",
+        A35: "Won",        B35: "1",      C35: "",     D35: "1",
+        A36: "TRUE",       B36: "",       C36: "",     D36: "",
+        A37: "New",        B37: "2",      C37: "2",    D37: "2",
+        A38: "Won",        B38: "1",      C38: "1",    D38: "1",
+        A39: "Total",      B39: "",       C39: "",     D39: "",
+      });
+    });
+
+    test("Can display measure as ascending ranking on a column field", () => {
+      const model = createModelWithTestPivot();
+      updatePivotMeasureDisplay(model, pivotId, measureId, {
+        type: "rank_asc",
+        fieldNameWithGranularity: "Salesperson",
+      });
+
+      // prettier-ignore
+      expect(getFormattedGrid(model)).toMatchObject({
+        A20:"(#1) Pivot",  B20: "Alice",  C20: "Bob",  D20: "Total",
+        A22: "February",   B22: "1",      C22: "",     D22: "",
+        A23: "March",      B23: "2",      C23: "1",    D23: "",
+        A24: "April",      B24: "2",      C24: "1",    D24: "",
+        A25: "Total",      B25: "2",      C25: "1",    D25: "",
+      });
+    });
+  });
+
+  describe("rank_desc", () => {
+    test("Can display measure as descending ranking on a row field", () => {
+      const model = createModelWithTestPivot();
+      updatePivotMeasureDisplay(model, pivotId, measureId, {
+        type: "rank_desc",
+        fieldNameWithGranularity: "Created on:month_number",
+      });
+
+      // prettier-ignore
+      expect(getFormattedGrid(model)).toMatchObject({
+        A20:"(#1) Pivot",  B20: "Alice",  C20: "Bob",  D20: "Total",
+        A22: "February",   B22: "3",      C22: "",     D22: "3",
+        A23: "March",      B23: "1",      C23: "1",    D23: "1",
+        A24: "April",      B24: "2",      C24: "2",    D24: "2",
+        A25: "Total",      B25: "",       C25: "",     D25: "",
+      });
+    });
+
+    test("Can display measure as descending ranking on multi-level row fields", () => {
+      let display: PivotMeasureDisplay = {
+        type: "rank_desc",
+        fieldNameWithGranularity: "Active",
+      };
+      const model = createModelWithTestPivot({
+        rows: [
+          { fieldName: "Created on", granularity: "month_number", order: "asc" },
+          { fieldName: "Active", order: "asc" },
+          { fieldName: "Stage", order: "asc" },
+        ],
+        measures: [{ fieldName: "Expected Revenue", aggregator: "sum", id: measureId, display }],
+      });
+
+      // prettier-ignore
+      expect(getFormattedGrid(model)).toMatchObject({
+        A20:"(#1) Pivot",  B20: "Alice",  C20: "Bob",  D20: "Total",
+        A22: "February",   B22: "",       C22: "",     D22: "",
+        A23: "FALSE",      B23: "1",      C23: "",     D23: "1",
+        A24: "Won",        B24: "1",      C24: "",     D24: "1",
+        A25: "March",      B25: "",       C25: "",     D25: "",
+        A26: "FALSE",      B26: "1",      C26: "1",    D26: "1",
+        A27: "New",        B27: "1",      C27: "1",    D27: "1",
+        A28: "Won",        B28: "",       C28: "1",    D28: "1",
+        A29: "TRUE",       B29: "2",      C29: "2",    D29: "2",
+        A30: "New",        B30: "",       C30: "2",    D30: "2",
+        A31: "Won",        B31: "1",      C31: "",     D31: "2",
+        A32: "April",      B32: "",       C32: "",     D32: "",
+        A33: "FALSE",      B33: "1",      C33: "",     D33: "1",
+        A34: "New",        B34: "1",      C34: "",     D34: "1",
+        A35: "Won",        B35: "1",      C35: "",     D35: "1",
+        A36: "TRUE",       B36: "2",      C36: "1",    D36: "2",
+        A37: "New",        B37: "2",      C37: "1",    D37: "2",
+        A38: "Won",        B38: "2",      C38: "1",    D38: "2",
+        A39: "Total",      B39: "",       C39: "",     D39: "",
+      });
+    });
+
+    test("Can display measure as descending ranking on a column field", () => {
+      const model = createModelWithTestPivot();
+      updatePivotMeasureDisplay(model, pivotId, measureId, {
+        type: "rank_desc",
+        fieldNameWithGranularity: "Salesperson",
+      });
+
+      // prettier-ignore
+      expect(getFormattedGrid(model)).toMatchObject({
+        A20:"(#1) Pivot",  B20: "Alice",  C20: "Bob",  D20: "Total",
+        A22: "February",   B22: "1",      C22: "",     D22: "",
+        A23: "March",      B23: "1",      C23: "2",    D23: "",
+        A24: "April",      B24: "1",      C24: "2",    D24: "",
+        A25: "Total",      B25: "1",      C25: "2",    D25: "",
+      });
+    });
+  });
+
+  describe("running_total", () => {
+    test("Can display measure as running total of a row field", () => {
+      const model = createModelWithTestPivot();
+      updatePivotMeasureDisplay(model, pivotId, measureId, {
+        type: "running_total",
+        fieldNameWithGranularity: "Created on:month_number",
+      });
+
+      // prettier-ignore
+      expect(getFormattedGrid(model)).toMatchObject({
+        A20:"(#1) Pivot",  B20: "Alice",   C20: "Bob",    D20: "Total",
+        A22: "February",   B22: "22500",   C22: "0",      D22: "22500",
+        A23: "March",      B23: "147900",  C23: "64000",  D23: "211900",
+        A24: "April",      B24: "230200",  C24: "90000",  D24: "320200",
+        A25: "Total",      B25: "",        C25: "",       D25: "",
+      });
+    });
+
+    test("Can display measure as running total of multi-level row fields", () => {
+      let display: PivotMeasureDisplay = {
+        type: "running_total",
+        fieldNameWithGranularity: "Created on:month_number",
+      };
+      const model = createModelWithTestPivot({
+        rows: [
+          { fieldName: "Created on", granularity: "month_number", order: "asc" },
+          { fieldName: "Active", order: "asc" },
+          { fieldName: "Stage", order: "asc" },
+        ],
+        measures: [{ fieldName: "Expected Revenue", aggregator: "sum", id: measureId, display }],
+      });
+
+      // prettier-ignore
+      expect(getFormattedGrid(model)).toMatchObject({
+        A20:"(#1) Pivot",  B20: "Alice",   C20: "Bob",    D20: "Total",
+        A22: "February",   B22: "22500",   C22: "0",      D22: "22500",
+        A23: "FALSE",      B23: "22500",   C23: "0",      D23: "22500",
+        A24: "Won",        B24: "22500",   C24: "0",      D24: "22500",
+        A25: "March",      B25: "147900",  C25: "64000",  D25: "211900",
+        A26: "FALSE",      B26: "128100",  C26: "53000",  D26: "181100",
+        A27: "New",        B27: "105600",  C27: "15000",  D27: "120600",
+        A28: "Won",        B28: "22500",   C28: "38000",  D28: "60500",
+        A29: "TRUE",       B29: "19800",   C29: "11000",  D29: "30800",
+        A30: "New",        B30: "0",       C30: "11000",  D30: "11000",
+        A31: "Won",        B31: "19800",   C31: "0",      D31: "19800",
+        A32: "April",      B32: "230200",  C32: "90000",  D32: "320200",
+        A33: "FALSE",      B33: "193100",  C33: "53000",  D33: "246100",
+        A34: "New",        B34: "145600",  C34: "15000",  D34: "160600",
+        A35: "Won",        B35: "47500",   C35: "38000",  D35: "85500",
+        A36: "TRUE",       B36: "37100",   C36: "37000",  D36: "74100",
+        A37: "New",        B37: "9000",    C37: "35000",  D37: "44000",
+        A38: "Won",        B38: "28100",   C38: "2000",   D38: "30100",
+        A39: "Total",      B39: "",        C39: "",       D39: "",
+      });
+
+      updatePivotMeasureDisplay(model, pivotId, measureId, {
+        type: "running_total",
+        fieldNameWithGranularity: "Active",
+      });
+
+      // prettier-ignore
+      expect(getFormattedGrid(model)).toMatchObject({
+        A20:"(#1) Pivot",  B20: "Alice",   C20: "Bob",    D20: "Total",
+        A22: "February",   B22: "",        C22: "",       D22: "",
+        A23: "FALSE",      B23: "22500",   C23: "0",      D23: "22500",
+        A24: "Won",        B24: "22500",   C24: "0",      D24: "22500",
+        A25: "March",      B25: "",        C25: "",       D25: "",
+        A26: "FALSE",      B26: "105600",  C26: "53000",  D26: "158600",
+        A27: "New",        B27: "105600",  C27: "15000",  D27: "120600",
+        A28: "Won",        B28: "0",       C28: "38000",  D28: "38000",
+        A29: "TRUE",       B29: "125400",  C29: "64000",  D29: "189400",
+        A30: "New",        B30: "105600",  C30: "26000",  D30: "131600",
+        A31: "Won",        B31: "19800",   C31: "38000",  D31: "57800",
+        A32: "April",      B32: "",        C32: "",       D32: "",
+        A33: "FALSE",      B33: "65000",   C33: "0",      D33: "65000",
+        A34: "New",        B34: "40000",   C34: "0",      D34: "40000",
+        A35: "Won",        B35: "25000",   C35: "0",      D35: "25000",
+        A36: "TRUE",       B36: "82300",   C36: "26000",  D36: "108300",
+        A37: "New",        B37: "49000",   C37: "24000",  D37: "73000",
+        A38: "Won",        B38: "33300",   C38: "2000",   D38: "35300",
+        A39: "Total",      B39: "",        C39: "",       D39: "",
+      });
+
+      updatePivotMeasureDisplay(model, pivotId, measureId, {
+        type: "running_total",
+        fieldNameWithGranularity: "Stage",
+      });
+
+      // prettier-ignore
+      expect(getFormattedGrid(model)).toMatchObject({
+        A20:"(#1) Pivot",  B20: "Alice",   C20: "Bob",    D20: "Total",
+        A22: "February",   B22: "",        C22: "",       D22: "",
+        A23: "FALSE",      B23: "",        C23: "",       D23: "",
+        A24: "Won",        B24: "22500",   C24: "0",      D24: "22500",
+        A25: "March",      B25: "",        C25: "",       D25: "",
+        A26: "FALSE",      B26: "",        C26: "",       D26: "",
+        A27: "New",        B27: "105600",  C27: "15000",  D27: "120600",
+        A28: "Won",        B28: "105600",  C28: "53000",  D28: "158600",
+        A29: "TRUE",       B29: "",        C29: "",       D29: "",
+        A30: "New",        B30: "0",       C30: "11000",  D30: "11000",
+        A31: "Won",        B31: "19800",   C31: "11000",  D31: "30800",
+        A32: "April",      B32: "",        C32: "",       D32: "",
+        A33: "FALSE",      B33: "",        C33: "",       D33: "",
+        A34: "New",        B34: "40000",   C34: "0",      D34: "40000",
+        A35: "Won",        B35: "65000",   C35: "0",      D35: "65000",
+        A36: "TRUE",       B36: "",        C36: "",       D36: "",
+        A37: "New",        B37: "9000",    C37: "24000",  D37: "33000",
+        A38: "Won",        B38: "17300",   C38: "26000",  D38: "43300",
+        A39: "Total",      B39: "",        C39: "",       D39: "",
+      });
+    });
+
+    test("Can display measure as running_total of a column field", () => {
+      const model = createModelWithTestPivot();
+      updatePivotMeasureDisplay(model, pivotId, measureId, {
+        type: "running_total",
+        fieldNameWithGranularity: "Salesperson",
+      });
+
+      // prettier-ignore
+      expect(getFormattedGrid(model)).toMatchObject({
+        A20:"(#1) Pivot",  B20: "Alice",   C20: "Bob",     D20: "Total",
+        A22: "February",   B22: "22500",   C22: "22500",   D22: "",
+        A23: "March",      B23: "125400",  C23: "189400",  D23: "",
+        A24: "April",      B24: "82300",   C24: "108300",  D24: "",
+        A25: "Total",      B25: "230200",  C25: "320200",  D25: "",
+      });
+    });
+
+    test("Running total with row sorted in descending order", () => {
+      let display: PivotMeasureDisplay = {
+        type: "running_total",
+        fieldNameWithGranularity: "Created on:month_number",
+      };
+      const model = createModelWithTestPivot({
+        rows: [{ fieldName: "Created on", granularity: "month_number", order: "desc" }],
+        measures: [{ fieldName: "Expected Revenue", aggregator: "sum", id: measureId, display }],
+      });
+
+      // prettier-ignore
+      expect(getFormattedGrid(model)).toMatchObject({
+        A20:"(#1) Pivot",  B20: "Alice",   C20: "Bob",    D20: "Total",
+        A22: "April",      B22: "82300",   C22: "26000",  D22: "108300",
+        A23: "March",      B23: "207700",  C23: "90000",  D23: "297700",
+        A24: "February",   B24: "230200",  C24: "90000",  D24: "320200",
+        A25: "Total",      B25: "",        C25: "",       D25: "",
+      });
+    });
+  });
+
+  describe("%_running_total", () => {
+    test("Can display measure as percentage of running total of a row field", () => {
+      const model = createModelWithTestPivot();
+      updatePivotMeasureDisplay(model, pivotId, measureId, {
+        type: "%_running_total",
+        fieldNameWithGranularity: "Created on:month_number",
+      });
+
+      // prettier-ignore
+      expect(getFormattedGrid(model)).toMatchObject({
+        A20:"(#1) Pivot",  B20: "Alice",    C20: "Bob",      D20: "Total",
+        A22: "February",   B22: "9.77%",    C22: "0.00%",    D22: "7.03%",
+        A23: "March",      B23: "64.25%",   C23: "71.11%",   D23: "66.18%",
+        A24: "April",      B24: "100.00%",  C24: "100.00%",  D24: "100.00%",
+        A25: "Total",      B25: "",         C25: "",         D25: "",
+      });
+    });
+
+    test("Can display measure as percentage of running total of multi-level row fields", () => {
+      let display: PivotMeasureDisplay = {
+        type: "%_running_total",
+        fieldNameWithGranularity: "Created on:month_number",
+      };
+      const model = createModelWithTestPivot({
+        rows: [
+          { fieldName: "Created on", granularity: "month_number", order: "asc" },
+          { fieldName: "Active", order: "asc" },
+          { fieldName: "Stage", order: "asc" },
+        ],
+        measures: [{ fieldName: "Expected Revenue", aggregator: "sum", id: measureId, display }],
+      });
+
+      // prettier-ignore
+      expect(getFormattedGrid(model)).toMatchObject({
+        A20:"(#1) Pivot",  B20: "Alice",    C20: "Bob",      D20: "Total",
+        A22: "February",   B22: "9.77%",    C22: "0.00%",    D22: "7.03%",
+        A23: "FALSE",      B23: "11.65%",   C23: "0.00%",    D23: "9.14%",
+        A24: "Won",        B24: "47.37%",   C24: "0.00%",    D24: "26.32%",
+        A25: "March",      B25: "64.25%",   C25: "71.11%",   D25: "66.18%",
+        A26: "FALSE",      B26: "66.34%",   C26: "100.00%",  D26: "73.59%",
+        A27: "New",        B27: "72.53%",   C27: "100.00%",  D27: "75.09%",
+        A28: "Won",        B28: "47.37%",   C28: "100.00%",  D28: "70.76%",
+        A29: "TRUE",       B29: "53.37%",   C29: "29.73%",   D29: "41.57%",
+        A30: "New",        B30: "0.00%",    C30: "31.43%",   D30: "25.00%",
+        A31: "Won",        B31: "70.46%",   C31: "0.00%",    D31: "65.78%",
+        A32: "April",      B32: "100.00%",  C32: "100.00%",  D32: "100.00%",
+        A33: "FALSE",      B33: "100.00%",  C33: "100.00%",  D33: "100.00%",
+        A34: "New",        B34: "100.00%",  C34: "100.00%",  D34: "100.00%",
+        A35: "Won",        B35: "100.00%",  C35: "100.00%",  D35: "100.00%",
+        A36: "TRUE",       B36: "100.00%",  C36: "100.00%",  D36: "100.00%",
+        A37: "New",        B37: "100.00%",  C37: "100.00%",  D37: "100.00%",
+        A38: "Won",        B38: "100.00%",  C38: "100.00%",  D38: "100.00%",
+        A39: "Total",      B39: "",         C39: "",         D39: "",
+      });
+
+      updatePivotMeasureDisplay(model, pivotId, measureId, {
+        type: "%_running_total",
+        fieldNameWithGranularity: "Active",
+      });
+
+      // prettier-ignore
+      expect(getFormattedGrid(model)).toMatchObject({
+        A20:"(#1) Pivot",  B20: "Alice",    C20: "Bob",      D20: "Total",
+        A22: "February",   B22: "",         C22: "",         D22: "",
+        A23: "FALSE",      B23: "100.00%",  C23: "",         D23: "100.00%",
+        A24: "Won",        B24: "100.00%",  C24: "",         D24: "100.00%",
+        A25: "March",      B25: "",         C25: "",         D25: "",
+        A26: "FALSE",      B26: "84.21%",   C26: "82.81%",   D26: "83.74%",
+        A27: "New",        B27: "100.00%",  C27: "57.69%",   D27: "91.64%",
+        A28: "Won",        B28: "0.00%",    C28: "100.00%",  D28: "65.74%",
+        A29: "TRUE",       B29: "100.00%",  C29: "100.00%",  D29: "100.00%",
+        A30: "New",        B30: "100.00%",  C30: "100.00%",  D30: "100.00%",
+        A31: "Won",        B31: "100.00%",  C31: "100.00%",  D31: "100.00%",
+        A32: "April",      B32: "",         C32: "",         D32: "",
+        A33: "FALSE",      B33: "78.98%",   C33: "0.00%",    D33: "60.02%",
+        A34: "New",        B34: "81.63%",   C34: "0.00%",    D34: "54.79%",
+        A35: "Won",        B35: "75.08%",   C35: "0.00%",    D35: "70.82%",
+        A36: "TRUE",       B36: "100.00%",  C36: "100.00%",  D36: "100.00%",
+        A37: "New",        B37: "100.00%",  C37: "100.00%",  D37: "100.00%",
+        A38: "Won",        B38: "100.00%",  C38: "100.00%",  D38: "100.00%",
+        A39: "Total",      B39: "",         C39: "",         D39: "",
+      });
+
+      updatePivotMeasureDisplay(model, pivotId, measureId, {
+        type: "%_running_total",
+        fieldNameWithGranularity: "Stage",
+      });
+
+      // prettier-ignore
+      expect(getFormattedGrid(model)).toMatchObject({
+        A20:"(#1) Pivot",  B20: "Alice",    C20: "Bob",      D20: "Total",
+        A22: "February",   B22: "",         C22: "",         D22: "",
+        A23: "FALSE",      B23: "",         C23: "",         D23: "",
+        A24: "Won",        B24: "100.00%",  C24: "",         D24: "100.00%",
+        A25: "March",      B25: "",         C25: "",         D25: "",
+        A26: "FALSE",      B26: "",         C26: "",         D26: "",
+        A27: "New",        B27: "100.00%",  C27: "28.30%",   D27: "76.04%",
+        A28: "Won",        B28: "100.00%",  C28: "100.00%",  D28: "100.00%",
+        A29: "TRUE",       B29: "",         C29: "",         D29: "",
+        A30: "New",        B30: "0.00%",    C30: "100.00%",  D30: "35.71%",
+        A31: "Won",        B31: "100.00%",  C31: "100.00%",  D31: "100.00%",
+        A32: "April",      B32: "",         C32: "",         D32: "",
+        A33: "FALSE",      B33: "",         C33: "",         D33: "",
+        A34: "New",        B34: "61.54%",   C34: "",         D34: "61.54%",
+        A35: "Won",        B35: "100.00%",  C35: "",         D35: "100.00%",
+        A36: "TRUE",       B36: "",         C36: "",         D36: "",
+        A37: "New",        B37: "52.02%",   C37: "92.31%",   D37: "76.21%",
+        A38: "Won",        B38: "100.00%",  C38: "100.00%",  D38: "100.00%",
+        A39: "Total",      B39: "",         C39: "",         D39: "",
+      });
+    });
+
+    test("Can display measure as percentage of running total of a column field", () => {
+      const model = createModelWithTestPivot();
+      updatePivotMeasureDisplay(model, pivotId, measureId, {
+        type: "%_running_total",
+        fieldNameWithGranularity: "Salesperson",
+      });
+
+      // prettier-ignore
+      expect(getFormattedGrid(model)).toMatchObject({
+        A20:"(#1) Pivot",  B20: "Alice",    C20: "Bob",      D20: "Total",
+        A22: "February",   B22: "100.00%",  C22: "100.00%",  D22: "",
+        A23: "March",      B23: "66.21%",   C23: "100.00%",  D23: "",
+        A24: "April",      B24: "75.99%",   C24: "100.00%",  D24: "",
+        A25: "Total",      B25: "71.89%",   C25: "100.00%",  D25: "",
+      });
+    });
+  });
+
+  test("Display measure as works with PIVOT.VALUE formulas", () => {
+    const measureDisplay: PivotMeasureDisplay = {
+      type: "%_of",
+      fieldNameWithGranularity: "Created on:month_number",
+      value: 2,
+    };
+    const model = createModelWithTestPivot({
+      measures: [
+        {
+          fieldName: "Expected Revenue",
+          aggregator: "sum",
+          id: measureId,
+          display: measureDisplay,
+        },
+      ],
+    });
+    const pivot = model.getters.getPivot(pivotId);
+    model.dispatch("INSERT_PIVOT", {
+      sheetId: model.getters.getActiveSheetId(),
+      col: 0,
+      row: 19,
+      pivotId,
+      table: pivot.getTableStructure().export(),
+    });
+
+    expect(getCell(model, "B22")?.content).toContain("PIVOT.VALUE");
+
+    // prettier-ignore
+    expect(getFormattedGrid(model)).toMatchObject({
+                         B20: "Alice",    C20: "Bob",  D20: "Total",
+      A22: "February",   B22: "100.00%",  C22: "",     D22: "100.00%",
+      A23: "March",      B23: "557.33%",  C23: "",     D23: "841.78%",
+      A24: "April",      B24: "365.78%",  C24: "",     D24: "481.33%",
+      A25: "Total",      B25: "",         C25: "",     D25: "",
+    });
+  });
+
+  test("Can change measure display with calculated measure", () => {
+    const measureDisplay: PivotMeasureDisplay = {
+      type: "%_of_grand_total",
+      fieldNameWithGranularity: "Created on:month_number",
+      value: 2,
+    };
+    const model = createModelWithTestPivot();
+    const sheetId = model.getters.getActiveSheetId();
+    updatePivot(model, pivotId, {
+      measures: [
+        {
+          fieldName: "Expected Revenue",
+          userDefinedName: "m1",
+          aggregator: "sum",
+          id: measureId,
+          display: measureDisplay,
+        },
+        {
+          fieldName: "Expected Revenue + 1000",
+          userDefinedName: "m2",
+          aggregator: "sum",
+          id: "calculated",
+          computedBy: { formula: "='m1' + 1000", sheetId },
+          display: measureDisplay,
+        },
+      ],
+    });
+    // prettier-ignore
+    expect(getFormattedGrid(model)).toMatchObject({
+      A20:"(#1) Pivot",  B20: "Alice",   C20: "",        D20: "Bob",     E20: "",        F20: "Total",    G20: "",
+      A21: "",           B21: "m1",      C21: "m2",      D21: "m1",      E21: "m2",      F21: "m1",       G21: "m2",
+      A22: "February",   B22: "7.03%",   C22: "7.20%",   D22: "0.00%",   E22: "0.31%",   F22: "7.03%",    G22: "7.51%",
+      A23: "March",      B23: "39.16%",  C23: "38.75%",  D23: "19.99%",  E23: "19.93%",  F23: "59.15%",   G23: "58.68%",
+      A24: "April",      B24: "25.70%",  C24: "25.54%",  D24: "8.12%",   E24: "8.28%",   F24: "33.82%",   G24: "33.81%",
+      A25: "Total",      B25: "71.89%",  C25: "71.49%",  D25: "28.11%",  E25: "28.51%",  F25: "100.00%",  G25: "100.00%",
+    });
+  });
+});

--- a/tests/pivots/pivot_measure/pivot_measure_display_panel.test.ts
+++ b/tests/pivots/pivot_measure/pivot_measure_display_panel.test.ts
@@ -1,0 +1,269 @@
+import { Model, PivotCoreMeasure, SpreadsheetChildEnv, UID } from "../../../src";
+import { PivotMeasureDisplayPanel } from "../../../src/components/side_panel/pivot/pivot_measure_display_panel/pivot_measure_display_panel";
+import { toZone } from "../../../src/helpers";
+import { PREVIOUS_VALUE } from "../../../src/helpers/pivot/pivot_helpers";
+import { setCellContent, setFormat } from "../../test_helpers/commands_helpers";
+import { click, setInputValueAndTrigger } from "../../test_helpers/dom_helper";
+import { mountComponent, mountSpreadsheet, nextTick } from "../../test_helpers/helpers";
+import { addPivot, removePivot, updatePivot } from "../../test_helpers/pivot_helpers";
+
+let model: Model;
+let pivotId: UID = "pivotId";
+let sheetId: UID;
+let fixture: HTMLElement;
+let openSidePanelSpy: jest.Mock;
+let env: SpreadsheetChildEnv;
+
+function getPivotMeasures() {
+  return model.getters.getPivotCoreDefinition(pivotId).measures;
+}
+
+describe("Standalone side panel tests", () => {
+  openSidePanelSpy = jest.fn();
+  async function mountPanel(measure?: PivotCoreMeasure) {
+    ({ fixture } = await mountComponent(PivotMeasureDisplayPanel, {
+      model,
+      env: { openSidePanel: openSidePanelSpy },
+      props: {
+        onCloseSidePanel: () => {},
+        pivotId: pivotId,
+        measure: measure || { fieldName: "TestMeasure", aggregator: "count", id: "m1" },
+      },
+    }));
+  }
+
+  beforeEach(() => {
+    model = new Model();
+    sheetId = model.getters.getActiveSheetId();
+    setCellContent(model, "A1", "TestMeasure");
+    addPivot(
+      model,
+      "A1:A2",
+      { measures: [{ fieldName: "TestMeasure", aggregator: "count", id: "m1" }] },
+      pivotId
+    );
+  });
+
+  test("Initial panel state is correct", async () => {
+    setCellContent(model, "B1", "FieldA");
+    setCellContent(model, "B2", "Alice");
+    setCellContent(model, "B3", "Bob");
+    setCellContent(model, "C1", "FieldB");
+    updatePivot(model, pivotId, {
+      columns: [{ fieldName: "FieldA" }, { fieldName: "FieldB" }],
+      dataSet: { sheetId, zone: toZone("A1:C3") },
+    });
+
+    await mountPanel({
+      fieldName: "MyTestMeasure",
+      aggregator: "count",
+      id: "m1",
+      display: { type: "%_of", fieldNameWithGranularity: "FieldA", value: "Alice" },
+    });
+    expect(".o-pivot-measure-display-type").toHaveValue("%_of");
+    expect(".o-pivot-measure-display-field input[value=FieldA]").toHaveValue(true);
+    expect(".o-pivot-measure-display-value input[value=Alice]").toHaveValue(true);
+  });
+
+  test("Can change measure display type", async () => {
+    await mountPanel();
+    await setInputValueAndTrigger(".o-pivot-measure-display-type", "index");
+    expect(".o-pivot-measure-display-type").toHaveValue("index");
+    expect(getPivotMeasures()[0].display).toEqual({ type: "index" });
+  });
+
+  test("Can change base field of measure display type that requires it", async () => {
+    setCellContent(model, "B1", "FieldA");
+    setCellContent(model, "C1", "FieldB");
+    updatePivot(model, pivotId, {
+      columns: [{ fieldName: "FieldA" }, { fieldName: "FieldB" }],
+      dataSet: { sheetId, zone: toZone("A1:C2") },
+    });
+    await mountPanel();
+    expect(".o-pivot-measure-display-field").toHaveCount(0);
+
+    await setInputValueAndTrigger(".o-pivot-measure-display-type", "%_of_parent_total");
+    expect(".o-pivot-measure-display-field").toHaveCount(1);
+    expect(".o-pivot-measure-display-field input").toHaveCount(2);
+    expect(".o-pivot-measure-display-field input[value=FieldA]").toHaveValue(true);
+    expect(".o-pivot-measure-display-field input[value=FieldB]").toHaveValue(false);
+    expect(model.getters.getPivotCoreDefinition(pivotId).measures[0].display).toEqual({
+      type: "%_of_parent_total",
+      fieldNameWithGranularity: "FieldA",
+    });
+
+    await click(fixture, ".o-pivot-measure-display-field input[value=FieldB]");
+    expect(".o-pivot-measure-display-field input[value=FieldA]").toHaveValue(false);
+    expect(".o-pivot-measure-display-field input[value=FieldB]").toHaveValue(true);
+    expect(model.getters.getPivotCoreDefinition(pivotId).measures[0].display).toEqual({
+      type: "%_of_parent_total",
+      fieldNameWithGranularity: "FieldB",
+    });
+  });
+
+  test("Base field have a placeholder when the pivot has no active fields", async () => {
+    await mountPanel();
+    await setInputValueAndTrigger(".o-pivot-measure-display-type", "%_of_parent_total");
+    expect(".o-pivot-measure-display-field").toHaveText("No active dimension in the pivot");
+  });
+
+  test("Can change base value of measure display type that requires it", async () => {
+    setCellContent(model, "B1", "FieldA");
+    setCellContent(model, "B2", "Alice");
+    setCellContent(model, "B3", "Bob");
+    updatePivot(model, pivotId, {
+      columns: [{ fieldName: "FieldA" }],
+      dataSet: { sheetId, zone: toZone("A1:B3") },
+    });
+    await mountPanel();
+    expect(".o-pivot-measure-display-value").toHaveCount(0);
+
+    await setInputValueAndTrigger(".o-pivot-measure-display-type", "%_of");
+    expect(".o-pivot-measure-display-value").toHaveCount(1);
+    expect(".o-pivot-measure-display-value input").toHaveCount(4);
+    expect('.o-pivot-measure-display-value input[value="(previous)"]').toHaveValue(true);
+    expect('.o-pivot-measure-display-value input[value="Alice"]').toHaveValue(false);
+
+    await click(fixture, '.o-pivot-measure-display-value input[value="Alice"]');
+    expect('.o-pivot-measure-display-value input[value="(previous)"]').toHaveValue(false);
+    expect('.o-pivot-measure-display-value input[value="Alice"]').toHaveValue(true);
+    expect(model.getters.getPivotCoreDefinition(pivotId).measures[0].display).toEqual({
+      type: "%_of",
+      fieldNameWithGranularity: "FieldA",
+      value: "Alice",
+    });
+  });
+
+  test("Changing the base field change the selected value to a valid one", async () => {
+    setCellContent(model, "B1", "FieldA");
+    setCellContent(model, "B2", "Alice");
+    setCellContent(model, "C1", "FieldB");
+    updatePivot(model, pivotId, {
+      columns: [{ fieldName: "FieldA" }, { fieldName: "FieldB" }],
+      dataSet: { sheetId, zone: toZone("A1:C3") },
+    });
+    await mountPanel();
+    await setInputValueAndTrigger(".o-pivot-measure-display-type", "%_of");
+
+    await click(fixture, '.o-pivot-measure-display-value input[value="Alice"]');
+    expect(model.getters.getPivotCoreDefinition(pivotId).measures[0].display).toEqual({
+      type: "%_of",
+      fieldNameWithGranularity: "FieldA",
+      value: "Alice",
+    });
+
+    await click(fixture, '.o-pivot-measure-display-field input[value="FieldB"]');
+    expect(model.getters.getPivotCoreDefinition(pivotId).measures[0].display).toEqual({
+      type: "%_of",
+      fieldNameWithGranularity: "FieldB",
+      value: PREVIOUS_VALUE,
+    });
+  });
+
+  test("Values are formatted in the side panel", async () => {
+    setCellContent(model, "B1", "FieldA");
+    setCellContent(model, "B2", "5");
+    setFormat(model, "B2", "#,##0[$ Tabourets]");
+    setCellContent(model, "C1", "FieldB");
+    setCellContent(model, "C2", "01/01/2021");
+    updatePivot(model, pivotId, {
+      columns: [
+        { fieldName: "FieldA" },
+        { fieldName: "FieldB", granularity: "month_number" },
+        { fieldName: "FieldB", granularity: "day" },
+      ],
+      dataSet: { sheetId, zone: toZone("A1:C2") },
+    });
+    await mountPanel();
+    await setInputValueAndTrigger(".o-pivot-measure-display-type", "%_of");
+
+    expect(fixture.querySelectorAll(".o-pivot-measure-display-value label")[2]).toHaveText(
+      "5 Tabourets"
+    );
+
+    await click(fixture, '.o-pivot-measure-display-field input[value="FieldB:month_number"]');
+    expect(fixture.querySelectorAll(".o-pivot-measure-display-value label")[2]).toHaveText(
+      "January"
+    );
+
+    await click(fixture, '.o-pivot-measure-display-field input[value="FieldB:day"]');
+    expect(fixture.querySelectorAll(".o-pivot-measure-display-value label")[2]).toHaveText(
+      "1/1/2021"
+    );
+  });
+
+  test("Can change base value of measure display type that requires it", async () => {
+    setCellContent(model, "B1", "FieldA");
+    setCellContent(model, "B2", "Alice");
+    setCellContent(model, "B3", "Bob");
+    updatePivot(model, pivotId, {
+      columns: [{ fieldName: "FieldA" }],
+      dataSet: { sheetId, zone: toZone("A1:B3") },
+    });
+    await mountPanel();
+    expect(".o-pivot-measure-display-value").toHaveCount(0);
+
+    await setInputValueAndTrigger(".o-pivot-measure-display-type", "%_of");
+    expect(".o-pivot-measure-display-value").toHaveCount(1);
+    expect(".o-pivot-measure-display-value input").toHaveCount(4);
+    expect('.o-pivot-measure-display-value input[value="(previous)"]').toHaveValue(true);
+    expect('.o-pivot-measure-display-value input[value="Alice"]').toHaveValue(false);
+
+    await click(fixture, '.o-pivot-measure-display-value input[value="Alice"]');
+    expect('.o-pivot-measure-display-value input[value="(previous)"]').toHaveValue(false);
+    expect('.o-pivot-measure-display-value input[value="Alice"]').toHaveValue(true);
+    expect(model.getters.getPivotCoreDefinition(pivotId).measures[0].display).toEqual({
+      type: "%_of",
+      fieldNameWithGranularity: "FieldA",
+      value: "Alice",
+    });
+  });
+
+  test("Saving the display opens back the pivot side panel", async () => {
+    await mountPanel();
+    await click(fixture, ".o-pivot-measure-save");
+
+    expect(openSidePanelSpy).toHaveBeenCalledWith("PivotSidePanel", { pivotId });
+  });
+
+  test("Can cancel the edition of the measure display", async () => {
+    await mountPanel();
+    expect(getPivotMeasures()[0].display).toEqual(undefined);
+
+    await setInputValueAndTrigger(".o-pivot-measure-display-type", "%_of_grand_total");
+    expect(getPivotMeasures()[0].display).toEqual({ type: "%_of_grand_total" });
+
+    await click(fixture, ".o-pivot-measure-cancel");
+    expect(openSidePanelSpy).toHaveBeenCalledWith("PivotSidePanel", { pivotId });
+    expect(getPivotMeasures()[0].display).toEqual(undefined);
+  });
+});
+
+describe("Integration test", () => {
+  beforeEach(async () => {
+    ({ model, fixture, env } = await mountSpreadsheet());
+    addPivot(
+      model,
+      "A1:A2",
+      { measures: [{ fieldName: "TestMeasure", aggregator: "count", id: "m1" }] },
+      pivotId
+    );
+    const pivot = model.getters.getPivot(pivotId);
+    env.openSidePanel("PivotMeasureDisplayPanel", { pivotId, measure: pivot.getMeasure("m1") });
+    await nextTick();
+  });
+
+  test("Deleting the pivot closes the side panel", async () => {
+    expect(".o-sidePanel").toHaveCount(1);
+    removePivot(model, pivotId);
+    await nextTick();
+    expect(".o-sidePanel").toHaveCount(0);
+  });
+
+  test("Deleting the measure closes the side panel", async () => {
+    expect(".o-sidePanel").toHaveCount(1);
+    updatePivot(model, pivotId, { measures: [] });
+    await nextTick();
+    expect(".o-sidePanel").toHaveCount(0);
+  });
+});

--- a/tests/setup/jest_extend.ts
+++ b/tests/setup/jest_extend.ts
@@ -157,7 +157,8 @@ CancelledReasons: ${this.utils.printReceived(dispatchResult.reasons)}
       return { pass: false, message: () => message };
     }
     const value =
-      element instanceof HTMLInputElement && element.type === "checkbox"
+      element instanceof HTMLInputElement &&
+      (element.type === "checkbox" || element.type === "radio")
         ? element.checked
         : element.value;
     if (value !== expectedValue) {

--- a/tests/side_panels/components/checkbox.test.ts
+++ b/tests/side_panels/components/checkbox.test.ts
@@ -24,8 +24,6 @@ describe("Checkbox", () => {
     await mountCheckbox({ value: true, onChange });
     await click(fixture, "input[type=checkbox]");
     expect(onChange).toHaveBeenCalledWith(false);
-    await click(fixture, "input[type=checkbox]");
-    expect(onChange).toHaveBeenCalledWith(true);
   });
 
   test("Can render a checkbox with a name", async () => {

--- a/tests/test_helpers/helpers.ts
+++ b/tests/test_helpers/helpers.ts
@@ -362,6 +362,14 @@ export function getGrid(model: Model): GridResult {
   return result;
 }
 
+export function getFormattedGrid(model: Model): GridResult {
+  const result: GridResult = {};
+  for (const [xc, cell] of Object.entries(getCellGrid(model))) {
+    result[xc] = cell.formattedValue ?? "";
+  }
+  return result;
+}
+
 export function getGridFormat(model: Model): GridFormatDescr {
   const result: GridFormatDescr = {};
   for (const [xc, cell] of Object.entries(getCellGrid(model))) {

--- a/tests/test_helpers/pivot_helpers.ts
+++ b/tests/test_helpers/pivot_helpers.ts
@@ -1,6 +1,6 @@
 import { DispatchResult, Model, UID } from "../../src";
-import { toZone } from "../../src/helpers";
-import { SpreadsheetPivotCoreDefinition } from "../../src/types/pivot";
+import { deepCopy, toZone } from "../../src/helpers";
+import { PivotMeasureDisplay, SpreadsheetPivotCoreDefinition } from "../../src/types/pivot";
 import { pivotModelData } from "../pivots/pivot_data";
 
 export function createModelWithPivot(range: string): Model {
@@ -68,3 +68,15 @@ export const SELECTORS = {
   ZONE_INPUT: ".o-selection-input input",
   ZONE_CONFIRM: ".o-selection-input .o-selection-ok",
 };
+
+export function updatePivotMeasureDisplay(
+  model: Model,
+  pivotId: string,
+  measureId: string,
+  display: PivotMeasureDisplay
+) {
+  const measures = deepCopy(model.getters.getPivotCoreDefinition(pivotId)).measures;
+  const measure = measures.find((m) => m.id === measureId)!;
+  measure.display = display;
+  updatePivot(model, pivotId, { measures });
+}


### PR DESCRIPTION
## Description:

### [IMP] tests: add additional jest matchers

This commit adds the `expect().toHaveValue()` and `expect().toHaveText()`
custom jest matchers, inspired from Hoot.

### [IMP] pivots: add "Show value as" to measures

This commits adds the "Show value as" feature to measures. This allow
users to display the value of a measure in a different way, like
percentage of column total, percentage of row total, etc.

Task: [4045799](https://www.odoo.com/web#id=4045799&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo