### PR TITLE
[FIX] pivot: preserve sorting on dimension reorder

### DIFF
--- a/src/components/side_panel/pivot/pivot_layout_configurator/pivot_layout_configurator.ts
+++ b/src/components/side_panel/pivot/pivot_layout_configurator/pivot_layout_configurator.ts
@@ -1,7 +1,7 @@
 import { Component, useRef } from "@odoo/owl";
 import { SpreadsheetChildEnv } from "../../../..";
 import { isDefined } from "../../../../helpers";
-import { AGGREGATORS, isDateField, parseDimension } from "../../../../helpers/pivot/pivot_helpers";
+import { AGGREGATORS, isDateField } from "../../../../helpers/pivot/pivot_helpers";
 import { PivotRuntimeDefinition } from "../../../../helpers/pivot/pivot_runtime_definition";
 import {
   Aggregator,
@@ -63,6 +63,7 @@ export class PivotLayoutConfigurator extends Component<Props, SpreadsheetChildEn
       "__rows_title__",
       ...rows.map((row) => row.nameWithGranularity),
     ];
+    const allDimensions = columns.concat(rows);
     const offset = 1; // column title
     const draggableItems = draggableIds.map((id, index) => ({
       id,
@@ -85,8 +86,20 @@ export class PivotLayoutConfigurator extends Component<Props, SpreadsheetChildEn
         const columns = draggedItems.slice(0, draggedItems.indexOf("__rows_title__"));
         const rows = draggedItems.slice(draggedItems.indexOf("__rows_title__") + 1);
         this.props.onDimensionsUpdated({
-          columns: columns.map(parseDimension),
-          rows: rows.map(parseDimension),
+          columns: columns
+            .map((nameWithGranularity) =>
+              allDimensions.find(
+                (dimension) => dimension.nameWithGranularity === nameWithGranularity
+              )
+            )
+            .filter(isDefined),
+          rows: rows
+            .map((nameWithGranularity) =>
+              allDimensions.find(
+                (dimension) => dimension.nameWithGranularity === nameWithGranularity
+              )
+            )
+            .filter(isDefined),
         });
       },
     });


### PR DESCRIPTION
Steps to reproduce:
- Create a spreadsheet pivot, add some fields
- Re-order the fields with drag & drop => Every field is now "Unsorted' (or "ascending" for date fields)

When reordering dimensions in the pivot side panel, the sorting order of the pivot was being reset. This commit fixes the issue by preserving the sorting order when reordering dimensions.

Task: 4050440

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo