### PR TITLE
[FIX] pivot: support empty values

### DIFF
--- a/src/helpers/pivot/pivot_helpers.ts
+++ b/src/helpers/pivot/pivot_helpers.ts
@@ -209,6 +209,9 @@ export function toNormalizedPivotValue(
     typeof groupValue === "boolean"
       ? toString(groupValue).toLocaleLowerCase()
       : toString(groupValue);
+  if (groupValueString === "null") {
+    return null;
+  }
   if (!pivotNormalizationValueRegistry.contains(dimension.type)) {
     throw new EvaluationError(
       _t("Field %(field)s is not supported because of its type (%(type)s)", {
@@ -236,6 +239,9 @@ export function toFunctionPivotValue(
   value: CellValue,
   dimension: Pick<PivotDimension, "type" | "granularity">
 ) {
+  if (value === null) {
+    return `"null"`;
+  }
   if (!pivotToFunctionValueRegistry.contains(dimension.type)) {
     return `"${value}"`;
   }

--- a/tests/clipboard/clipboard_plugin.test.ts
+++ b/tests/clipboard/clipboard_plugin.test.ts
@@ -1993,6 +1993,34 @@ describe("clipboard", () => {
     ]);
   });
 
+  test("copying a spread pivot cell with (Undefined)", () => {
+    // prettier-ignore
+    const grid = {
+      A1: "Customer", B1: "Price", C1: "=PIVOT(1)",
+      A2: "Alice",    B2: "10",
+      A3: "",         B3: "20"
+    };
+    const model = createModelFromGrid(grid);
+    addPivot(model, "A1:B3", {
+      columns: [],
+      rows: [{ name: "Customer" }],
+      measures: [{ name: "Price", aggregator: "sum" }],
+    });
+
+    // copy entire pivot
+    copy(model, "C1:D5");
+    paste(model, "G4");
+    model.dispatch("SET_FORMULA_VISIBILITY", { show: true });
+    // prettier-ignore
+    expect(getEvaluatedGrid(model, "G4:H8")).toEqual([
+      ["",                                      "=PIVOT.HEADER(1)"],
+      ["",                                      '=PIVOT.HEADER(1,"measure","Price")'],
+      ['=PIVOT.HEADER(1,"Customer","Alice")',   '=PIVOT.VALUE(1,"Price","Customer","Alice")'],
+      ['=PIVOT.HEADER(1,"Customer","null")',    '=PIVOT.VALUE(1,"Price","Customer","null")'],
+      ["=PIVOT.HEADER(1)",                      '=PIVOT.VALUE(1,"Price")'],
+    ]);
+  });
+
   test("copying only the cell with a spread pivot formula doesn't fix the pivot", () => {
     // prettier-ignore
     const grid = {

--- a/tests/pivots/pivot_menu_items.test.ts
+++ b/tests/pivots/pivot_menu_items.test.ts
@@ -158,6 +158,47 @@ describe("Pivot menu items", () => {
     ]);
   });
 
+  test("It should correctly manage empty values while fixing formulas", () => {
+    // prettier-ignore
+    const grid = {
+      A1: "Customer", B1: "Amount", C1: "=PIVOT(1)",
+      A2: "Alice",    B2: "10",
+      A3: "",         B3: "20",
+    };
+    const model = createModelFromGrid(grid);
+    const env = makeTestEnv({ model });
+    addPivot(model, "A1:B3", {
+      columns: [],
+      rows: [{ name: "Customer", order: "asc" }],
+      measures: [{ name: "Amount", aggregator: "sum" }],
+    });
+
+    // prettier-ignore
+    expect(getEvaluatedGrid(model, "C1:D4")).toEqual([
+      ["(#1) Pivot", "Total"],
+      ["",              "Amount"],
+      ["Alice",         "10",],
+      ["(Undefined)",   "20"],
+    ]);
+
+    selectCell(model, "C2");
+    cellMenuRegistry.get("pivot_fix_formulas").execute!(env);
+
+    // prettier-ignore
+    expect(getEvaluatedGrid(model, "C1:D4")).toEqual([
+      ["",            "Total"],
+      ["",            "Amount"],
+      ["Alice",       "10",],
+      ["(Undefined)", "20"],
+    ]);
+
+    model.dispatch("SET_FORMULA_VISIBILITY", { show: true });
+    expect(getEvaluatedGrid(model, "C3:D4")).toEqual([
+      [`=PIVOT.HEADER(1,"Customer","Alice")`, `=PIVOT.VALUE(1,"Amount","Customer","Alice")`],
+      [`=PIVOT.HEADER(1,"Customer","null")`, `=PIVOT.VALUE(1,"Amount","Customer","null")`],
+    ]);
+  });
+
   test("It should not fix formula when the pivot is not valid", () => {
     // prettier-ignore
     const grid = {


### PR DESCRIPTION
Steps to reproduce:
- Create a spreadsheet pivot, with some empty values in the data so that we have an (Undefined) header cell
- Copy/paste a cell child of the (undefined) header
- Freeze the pivot

=> The cells corresponding to empty values are empty.

Implementation note:
The pivot helper `toNormalizedPivotValue` takes `groupValue` as argument, but the type of `groupValue` is variable. It's either a CellValue or a FunctionResultObject. This is not ideal and should be fixed in the future.

Task: 4053215

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo