### PR TITLE
[FIX] pivot: change `measureName` to `measureId`

### DIFF
--- a/src/helpers/pivot/spreadsheet_pivot/spreadsheet_pivot.ts
+++ b/src/helpers/pivot/spreadsheet_pivot/spreadsheet_pivot.ts
@@ -210,13 +210,13 @@ export class SpreadsheetPivot implements Pivot<SpreadsheetPivotRuntimeDefinition
     this.needsReevaluation = true;
   }
 
-  getMeasure(name: string): PivotMeasure {
-    return this.definition.getMeasure(name);
+  getMeasure(id: string): PivotMeasure {
+    return this.definition.getMeasure(id);
   }
 
-  getPivotMeasureValue(name: string): FunctionResultObject {
+  getPivotMeasureValue(id: string): FunctionResultObject {
     return {
-      value: this.getMeasure(name).displayName,
+      value: this.getMeasure(id).displayName,
     };
   }
 

--- a/src/types/pivot_runtime.ts
+++ b/src/types/pivot_runtime.ts
@@ -25,7 +25,7 @@ export interface Pivot<T = PivotRuntimeDefinition> {
   getPivotCellValueAndFormat(measure: string, domain: PivotDomain): FunctionResultObject;
   getPivotMeasureValue(measure: string, domain: PivotDomain): FunctionResultObject;
 
-  getMeasure: (name: string) => PivotMeasure;
+  getMeasure: (id: string) => PivotMeasure;
 
   parseArgsToPivotDomain(args: Maybe<FunctionResultObject>[]): PivotDomain;
   areDomainArgsFieldsValid(args: Maybe<FunctionResultObject>[]): boolean;


### PR DESCRIPTION
93ffeeefe changed the way we identified measures from `measure.name` to `measure.id`. The arguments of some methods were forgotten when changing the name of the variables.

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo