### PR TITLE
[PERF] evaluation: spreading relations with zones

### DIFF
--- a/src/plugins/ui_core_views/cell_evaluation/evaluation_plugin.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluation_plugin.ts
@@ -186,10 +186,11 @@ export class EvaluationPlugin extends UIPlugin {
         if (!("content" in cmd || "format" in cmd) || this.shouldRebuildDependenciesGraph) {
           return;
         }
-        this.positionsToUpdate.push(cmd);
+        const position = { sheetId: cmd.sheetId, row: cmd.row, col: cmd.col };
+        this.positionsToUpdate.push(position);
 
         if ("content" in cmd) {
-          this.evaluator.updateDependencies(cmd);
+          this.evaluator.updateDependencies(position);
         }
         break;
       case "EVALUATE_CELLS":

--- a/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
@@ -92,7 +92,7 @@ export class Evaluator {
     if (!hasArrayFormulaResult) {
       return this.spreadingRelations.isArrayFormula(position) ? position : undefined;
     }
-    const arrayFormulas = this.spreadingRelations.getFormulaPositionsSpreadingOn(
+    const arrayFormulas = this.spreadingRelations.searchFormulaPositionsSpreadingOn(
       position.sheetId,
       positionToZone(position)
     );
@@ -248,7 +248,7 @@ export class Evaluator {
    */
   private getArrayFormulasBlockedBy(sheetId: UID, zone: Zone): Iterable<CellPosition> {
     const arrayFormulaPositions = this.createEmptyPositionSet();
-    const arrayFormulas = this.spreadingRelations.getFormulaPositionsSpreadingOn(sheetId, zone);
+    const arrayFormulas = this.spreadingRelations.searchFormulaPositionsSpreadingOn(sheetId, zone);
     arrayFormulaPositions.addMany(arrayFormulas);
     const spilledPositions = [...arrayFormulas].filter(
       (position) => !this.blockedArrayFormulas.has(position)

--- a/src/plugins/ui_core_views/cell_evaluation/spreading_relation.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/spreading_relation.ts
@@ -50,7 +50,7 @@ export class SpreadingRelation {
   private readonly resultsToArrayFormulas = new SpreadsheetRTree<CellPosition>();
   private readonly arrayFormulasToResults: PositionMap<Zone> = new PositionMap();
 
-  getFormulaPositionsSpreadingOn(sheetId: UID, zone: Zone): Iterable<CellPosition> {
+  searchFormulaPositionsSpreadingOn(sheetId: UID, zone: Zone): Iterable<CellPosition> {
     return (
       this.resultsToArrayFormulas.search({ sheetId, zone }).map((node) => node.data) || EMPTY_ARRAY
     );

--- a/tests/helpers/zones_helpers.test.ts
+++ b/tests/helpers/zones_helpers.test.ts
@@ -1,5 +1,6 @@
 import {
   createAdaptedZone,
+  excludeTopLeft,
   isZoneValid,
   mergeContiguousZones,
   overlap,
@@ -193,5 +194,23 @@ describe("mergeContiguousZones", () => {
   test("Zones diagonally next to each other are not contiguous", () => {
     const zones = mergeContiguousZones(target("A1, B2, C3, A3"));
     expect(zones.map(zoneToXc)).toEqual(["A1", "B2", "C3", "A3"]);
+  });
+});
+
+describe("excludeTopLeft", () => {
+  test("single cell zone", () => {
+    expect(excludeTopLeft(toZone("A1"))).toEqual([]);
+  });
+
+  test("single column zone", () => {
+    expect(excludeTopLeft(toZone("A1:A4"))).toEqual([toZone("A2:A4")]);
+  });
+
+  test("single row zone", () => {
+    expect(excludeTopLeft(toZone("A1:D1"))).toEqual([toZone("B1:D1")]);
+  });
+
+  test("2d zone", () => {
+    expect(excludeTopLeft(toZone("A1:D4"))).toEqual([toZone("A2:A4"), toZone("B1:D4")]);
   });
 });


### PR DESCRIPTION
## Description:

Evaluating the large vectorized dataset is now as fast as evaluating the
large formula dataset.
Which means loading the entire vectorized model is ~4x faster since it
doesn't need to import 260k cells

This commit changes the implementation of the spreading relations
data structures.

The main objective is to work with spilled zones instead
of each individual positions in spilled zones.

Before, if a formula spilled on a zone of 10k cells, we added each of these
10k positions in the spreading relations data structure. Now we only add a
single zone (spanning those 10k cells).

For an extreme example: on the vectorized large dataset,
there a 26 spilled zones (26 array formulas) but there are
260k cell positions.

Insertions are faster:
- before: O(Z*C)
- after: O(Z*log Z)

where Z is the number of array formulas and C is the number
of cells in spilled zones. Note that C can be very large !

This comes with a trade-off though: looking up the array formula
spilling on a given position is slower:
- before: O(1)
- after: O(log Z)

It's still faster overall in most situations, because we can now lookup for
an entire zone at the same cost rather than position by position.
It's only slower when we actually need to lookup for many individual
positions.

Some measures:

*Evaluate large formula dataset:
no impact

*Evaluate RNG's "BE Timesheet" dashboard:
no impact

*Evaluate large vectorized dataset:
- before: 550ms
- after:  210ms (-61%)

*Copy all cells in the large vectorized dataset:
- before: 470ms
- after:  631ms (+34%)

* Copy all cells in the large formula dataste:
no impact

Detailed benchmarks: https://www.odoo.com/document/share/14324/e4d7b061-a69a-490b-abd4-6dabdd985ae9

Task: : [4116073](https://www.odoo.com/web#id=4116073&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo