### PR TITLE
[IMP] pivot: allow to partially reload pivot runtime

### DIFF
--- a/src/plugins/ui_core_views/pivot_ui.ts
+++ b/src/plugins/ui_core_views/pivot_ui.ts
@@ -258,9 +258,11 @@ export class PivotUIPlugin extends UIPlugin {
 
   setupPivot(pivotId: UID, { recreate } = { recreate: false }) {
     const definition = this.getters.getPivotCoreDefinition(pivotId);
-    if (recreate || !(pivotId in this.pivots)) {
+    if (!(pivotId in this.pivots)) {
       const Pivot = pivotRegistry.get(definition.type).ui;
       this.pivots[pivotId] = new Pivot(this.custom, { definition, getters: this.getters });
+    } else if (recreate) {
+      this.pivots[pivotId].onDefinitionChange(definition);
     }
   }
 

--- a/src/types/pivot_runtime.ts
+++ b/src/types/pivot_runtime.ts
@@ -17,6 +17,7 @@ export interface Pivot<T = PivotRuntimeDefinition> {
   definition: T;
   init(params?: InitPivotParams): void;
   isValid(): boolean;
+  onDefinitionChange(nextDefinition: PivotCoreDefinition): void;
 
   getTableStructure(): SpreadsheetPivotTable;
   getFields(): PivotFields;


### PR DESCRIPTION
Currently, when a pivot is updated via an UPDATE_PIVOT command, the
entire pivot object is recreated from scratch. As a result, all the
setup of the pivot is executed (e.g. RPCs in Odoo, fields extraction
from dataSet, etc.) with each update. This is necessary when the pivot
'structure' changes (columns, rows, measures, etc.), but it is
unnecessary when only the name is updated. This will become an issue
with renaming pivot measures, adding calculated fields, and measures
shown as 'x', as these three operations do not require the setup to be
re-executed.

It's already useful in this PR to avoid re-extracting the fields from
the dataSet if it hasn't changed.

Task: 4070141