### PR TITLE
[FIX] auto_complete: keep dropdown open on exact match for functions

### DIFF
--- a/src/components/composer/composer/composer_store.ts
+++ b/src/components/composer/composer/composer_store.ts
@@ -789,8 +789,11 @@ export class ComposerStore extends SpreadsheetStore {
       const exactMatch = proposals?.find((p) => p.text === tokenAtCursor.value);
       // remove tokens that are likely to be other parts of the formula that slipped in the token if it's a string
       const searchTerm = tokenAtCursor.value.replace(/[ ,\(\)]/g, "");
-      if (exactMatch && this._currentContent !== this.initialContent) {
-        // this means the user has chosen a proposal
+      if (
+        !provider.keepOpenOnExactMatch &&
+        exactMatch &&
+        this._currentContent !== this.initialContent
+      ) {
         return;
       }
       if (

--- a/src/registries/auto_completes/auto_complete_registry.ts
+++ b/src/registries/auto_completes/auto_complete_registry.ts
@@ -36,6 +36,7 @@ export interface AutoCompleteProviderDefinition {
   sequence?: number;
   autoSelectFirstProposal?: boolean;
   maxDisplayedProposals?: number;
+  keepOpenOnExactMatch?: boolean; // By default, the auto complete closes when the exact match is found.
   getProposals(
     this: { composer: ComposerStore; getters: Getters },
     tokenAtCursor: EnrichedToken,

--- a/src/registries/auto_completes/function_auto_complete.ts
+++ b/src/registries/auto_completes/function_auto_complete.ts
@@ -7,6 +7,7 @@ autoCompleteProviders.add("functions", {
   sequence: 100,
   autoSelectFirstProposal: true,
   maxDisplayedProposals: 10,
+  keepOpenOnExactMatch: true,
   getProposals(tokenAtCursor) {
     if (tokenAtCursor.type !== "SYMBOL") {
       return [];

--- a/tests/composer/autocomplete_dropdown_component.test.ts
+++ b/tests/composer/autocomplete_dropdown_component.test.ts
@@ -227,15 +227,17 @@ describe("Functions autocomplete", () => {
       );
     });
 
-    test("autocomplete not displayed for exact match", async () => {
-      functionRegistry.add("FUZZY", {
+    test("autocomplete dropdown remains open for exact function matches", async () => {
+      functionRegistry.add("SUMIF", {
         description: "",
         args: [],
         compute: () => 1,
         returns: ["ANY"],
       });
-      await typeInComposer("=FUZZY");
-      expect(fixture.querySelectorAll(".o-autocomplete-value")).toHaveLength(0);
+
+      await typeInComposer("=SUM");
+      expect(fixture.querySelectorAll(".o-autocomplete-value")).toHaveLength(2);
+      expect(fixture.querySelectorAll(".o-autocomplete-value")[0].textContent).toBe("SUM");
     });
 
     test("Mouse events on the autocomplete dropdown don't make the composer loose focus", async () => {


### PR DESCRIPTION
## Description:

Steps to reproduce:
 - Open a composer and type =SU, SUMIF appears in the autocomplete list.
 - Now type =SUM, the autocomplete closes itself, and you can't see the SUMIF function anymore.

Since PR#3401, the auto-complete dropdown closes when the user inputs an exact match of what is in the auto-complete proposals.

This behavior is not expected for functions, so a new property `keepOpenOnExactMatch` has been added to the auto-complete registry to control this.

By default, `keepOpenOnExactMatch` is set to `false` for all auto-completes. For functions, it is set to `true`, ensuring the dropdown doesn't close when the user inputs an exact match.

Task: 4061068

Task: : [4061068](https://www.odoo.com/odoo/project/2328/tasks/4061068?cids=2)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo