### PR TITLE
[IMP] pivot panel: make cog wheel menu use `Menu`

### DIFF
--- a/src/components/icons/icons.xml
+++ b/src/components/icons/icons.xml
@@ -583,7 +583,11 @@
       <i class="fa fa-refresh"/>
     </div>
   </t>
-
+  <t t-name="o-spreadsheet-Icon.EXCHANGE">
+    <div class="o-icon">
+      <i class="fa fa-exchange"/>
+    </div>
+  </t>
   <t t-name="o-spreadsheet-Icon.ARROW_DOWN">
     <svg
       class="o-cf-icon arrow-down"

--- a/src/components/menu/menu.ts
+++ b/src/components/menu/menu.ts
@@ -18,7 +18,7 @@ import {
   MENU_WIDTH,
 } from "../../constants";
 import { DOMCoordinates, MenuMouseEvent, Pixel, SpreadsheetChildEnv, UID } from "../../types";
-import { css } from "../helpers/css";
+import { css, cssPropertiesToCss } from "../helpers/css";
 import { getOpenedMenus, isChildEvent } from "../helpers/dom_helpers";
 import { useAbsoluteBoundingRect } from "../helpers/position_hook";
 import { useTimeOut } from "../helpers/time_hooks";
@@ -89,6 +89,7 @@ interface Props {
   onMenuClicked?: (ev: CustomEvent) => void;
   menuId?: UID;
   onMouseOver?: () => void;
+  width?: number;
 }
 
 export interface MenuState {
@@ -111,6 +112,7 @@ export class Menu extends Component<Props, SpreadsheetChildEnv> {
     onMenuClicked: { type: Function, optional: true },
     menuId: { type: String, optional: true },
     onMouseOver: { type: Function, optional: true },
+    width: { type: Number, optional: true },
   };
 
   static components = { Menu, Popover };
@@ -178,9 +180,9 @@ export class Menu extends Component<Props, SpreadsheetChildEnv> {
     const isRoot = this.props.depth === 1;
     return {
       anchorRect: {
-        x: this.props.position.x - MENU_WIDTH * (this.props.depth - 1),
+        x: this.props.position.x,
         y: this.props.position.y,
-        width: isRoot ? 0 : MENU_WIDTH,
+        width: isRoot ? 0 : this.props.width || MENU_WIDTH,
         height: isRoot ? 0 : MENU_ITEM_HEIGHT,
       },
       positioning: "TopRight",
@@ -264,7 +266,7 @@ export class Menu extends Component<Props, SpreadsheetChildEnv> {
     const y = parentMenuEl.getBoundingClientRect().top;
 
     this.subMenu.position = {
-      x: this.position.x + this.props.depth * MENU_WIDTH,
+      x: this.position.x,
       y: y - (this.subMenu.scrollOffset || 0),
     };
     this.subMenu.menuItems = menu.children(this.env);
@@ -328,5 +330,9 @@ export class Menu extends Component<Props, SpreadsheetChildEnv> {
     this.openingTimeOut.schedule(this.closeSubMenu.bind(this), TIMEOUT_DELAY);
     this.hoveredMenu = undefined;
     menu.onStopHover?.(this.env);
+  }
+
+  get menuStyle() {
+    return this.props.width ? cssPropertiesToCss({ width: this.props.width + "px" }) : "";
   }
 }

--- a/src/components/menu/menu.xml
+++ b/src/components/menu/menu.xml
@@ -4,6 +4,7 @@
       <div
         t-ref="menu"
         class="o-menu"
+        t-att-style="menuStyle"
         t-on-scroll="onScroll"
         t-on-wheel.stop=""
         t-on-click.stop=""
@@ -63,6 +64,7 @@
         onClose.bind="close"
         menuId="props.menuId"
         onMouseOver.bind="onMouseOverChildMenu"
+        width="props.width"
       />
     </Popover>
   </t>

--- a/src/components/side_panel/components/cog_wheel_menu/cog_wheel_menu.ts
+++ b/src/components/side_panel/components/cog_wheel_menu/cog_wheel_menu.ts
@@ -1,68 +1,40 @@
-import { Component, useExternalListener, useRef, useState } from "@odoo/owl";
+import { Component, useRef, useState } from "@odoo/owl";
+import { ActionSpec, createActions } from "../../../../actions/action";
+import { MenuMouseEvent } from "../../../../types";
 import { SpreadsheetChildEnv } from "../../../../types/env";
 import { css } from "../../../helpers";
-import { Popover } from "../../../popover";
-
-interface CogWheelMenuItem {
-  name: string;
-  icon?: string;
-  onClick: () => void;
-}
+import { Menu, MenuState } from "../../../menu/menu";
 
 interface Props {
-  items: CogWheelMenuItem[];
+  items: ActionSpec[];
 }
 
 css/* scss */ `
   .os-cog-wheel-menu-icon {
     cursor: pointer;
   }
-
-  .os-cog-wheel-menu {
-    background: white;
-    .btn-link {
-      text-decoration: none;
-      color: #017e84;
-      font-weight: 500;
-      &:hover {
-        color: #01585c;
-      }
-    }
-  }
 `;
 
 export class CogWheelMenu extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-CogWheelMenu";
-  static components = { Popover };
+  static components = { Menu };
   static props = {
     items: Array,
   };
 
   private buttonRef = useRef("button");
-  private popover = useState({ isOpen: false });
+  private menuState: MenuState = useState({ isOpen: false, position: null, menuItems: [] });
 
-  setup() {
-    useExternalListener(window, "click", (ev) => {
-      if (ev.target !== this.buttonRef.el) {
-        this.popover.isOpen = false;
-      }
-    });
-  }
+  private menuId = this.env.model.uuidGenerator.uuidv4();
 
-  onClick(item: CogWheelMenuItem) {
-    item.onClick();
-    this.popover.isOpen = false;
-  }
+  toggleMenu(ev: MenuMouseEvent) {
+    if (ev.closedMenuId === this.menuId) {
+      return;
+    }
 
-  get popoverProps() {
-    const { x, y, width, height } = this.buttonRef.el!.getBoundingClientRect();
-    return {
-      anchorRect: { x, y, width, height },
-      positioning: "BottomLeft",
-    };
-  }
-
-  togglePopover() {
-    this.popover.isOpen = !this.popover.isOpen;
+    const { x, y } = this.buttonRef.el!.getBoundingClientRect();
+    this.menuState.isOpen = !this.menuState.isOpen;
+    this.menuState.position = { x, y };
+    this.menuState.menuItems = createActions(this.props.items);
   }
 }

--- a/src/components/side_panel/components/cog_wheel_menu/cog_wheel_menu.xml
+++ b/src/components/side_panel/components/cog_wheel_menu/cog_wheel_menu.xml
@@ -1,18 +1,13 @@
 <templates>
   <t t-name="o-spreadsheet-CogWheelMenu">
-    <span class="fa fa-cog os-cog-wheel-menu-icon" t-on-click="togglePopover" t-ref="button"/>
-    <Popover t-if="popover.isOpen" t-props="popoverProps">
-      <div class="d-flex flex-column align-items-start os-cog-wheel-menu my-2">
-        <div
-          t-foreach="props.items"
-          t-as="item"
-          t-key="item.name"
-          t-on-click="() => this.onClick(item)"
-          class="btn btn-link me-3">
-          <i t-if="item.icon" t-att-class="'me-2 fa ' + item.icon"/>
-          <t t-esc="item.name"/>
-        </div>
-      </div>
-    </Popover>
+    <span class="fa fa-cog os-cog-wheel-menu-icon" t-on-click="toggleMenu" t-ref="button"/>
+    <Menu
+      t-if="menuState.isOpen"
+      menuId="menuId"
+      position="menuState.position"
+      menuItems="menuState.menuItems"
+      onClose="() => this.menuState.isOpen=false"
+      width="160"
+    />
   </t>
 </templates>

--- a/src/components/side_panel/pivot/pivot_title_section/pivot_title_section.ts
+++ b/src/components/side_panel/pivot/pivot_title_section/pivot_title_section.ts
@@ -1,4 +1,5 @@
 import { Component } from "@odoo/owl";
+import { ActionSpec } from "../../../../actions/action";
 import { _t } from "../../../../translation";
 import { SpreadsheetChildEnv, UID } from "../../../../types";
 import { CogWheelMenu } from "../../components/cog_wheel_menu/cog_wheel_menu";
@@ -18,22 +19,22 @@ export class PivotTitleSection extends Component<Props, SpreadsheetChildEnv> {
     flipAxis: Function,
   };
 
-  get cogWheelMenuItems() {
+  get cogWheelMenuItems(): ActionSpec[] {
     return [
       {
         name: _t("Flip axes"),
-        icon: "fa-exchange",
-        onClick: this.props.flipAxis,
+        icon: "o-spreadsheet-Icon.EXCHANGE",
+        execute: this.props.flipAxis,
       },
       {
         name: _t("Duplicate"),
-        icon: "fa-copy",
-        onClick: () => this.duplicatePivot(),
+        icon: "o-spreadsheet-Icon.COPY",
+        execute: () => this.duplicatePivot(),
       },
       {
         name: _t("Delete"),
-        icon: "fa-trash",
-        onClick: () => this.delete(),
+        icon: "o-spreadsheet-Icon.TRASH",
+        execute: () => this.delete(),
       },
     ];
   }

--- a/tests/__snapshots__/top_bar_component.test.ts.snap
+++ b/tests/__snapshots__/top_bar_component.test.ts.snap
@@ -615,6 +615,7 @@ exports[`TopBar component can set cell format 1`] = `
     >
       <div
         class="o-menu"
+        style=""
       >
         
         <div

--- a/tests/bottom_bar/__snapshots__/bottom_bar_component.test.ts.snap
+++ b/tests/bottom_bar/__snapshots__/bottom_bar_component.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`BottomBar component Can open the list of statistics 1`] = `
 <div
   class="o-menu"
+  style=""
 >
   
   <div

--- a/tests/cog_wheel_menu.test.ts
+++ b/tests/cog_wheel_menu.test.ts
@@ -18,8 +18,9 @@ async function mountCogWheelMenu(
 }
 
 const SELECTORS = {
-  COG: ".os-cog-wheel-menu-icon",
-  MENU: ".os-cog-wheel-menu",
+  COG: ".fa-cog",
+  MENU: ".o-menu",
+  MENU_ITEM: ".o-menu-item",
 };
 
 describe("CogWheelMenu", () => {
@@ -28,48 +29,36 @@ describe("CogWheelMenu", () => {
     expect(fixture).toMatchSnapshot();
   });
 
-  test("Clicking on the cog wheel menu opens the menu", async () => {
+  test("Clicking on the cog wheel menu toggles the menu", async () => {
     const { fixture } = await mountCogWheelMenu({
-      items: [
-        {
-          name: "test",
-          onClick: () => {},
-        },
-      ],
+      items: [{ name: "test", execute: () => {} }],
     });
-    expect(fixture.querySelector(".os-cog-wheel-menu")).toBeNull();
+    expect(fixture.querySelector(SELECTORS.MENU)).toBeNull();
     await click(fixture, SELECTORS.COG);
-    expect(fixture.querySelector(".os-cog-wheel-menu")).toBeTruthy();
-    expect(fixture.querySelectorAll(SELECTORS.MENU)).toHaveLength(1);
+    expect(fixture.querySelector(SELECTORS.MENU)).toBeTruthy();
+    expect(fixture.querySelectorAll(SELECTORS.MENU_ITEM)).toHaveLength(1);
+
+    await click(fixture, SELECTORS.COG);
+    expect(fixture.querySelector(SELECTORS.MENU)).toBeNull();
   });
 
   test("Clicking on an item execute the action", async () => {
-    const onClick = jest.fn();
+    const execute = jest.fn();
     const { fixture } = await mountCogWheelMenu({
-      items: [
-        {
-          name: "test",
-          onClick,
-        },
-      ],
+      items: [{ name: "test", execute }],
     });
     await click(fixture, SELECTORS.COG);
-    await click(fixture, `${SELECTORS.MENU} div`);
+    await click(fixture, SELECTORS.MENU_ITEM);
+    expect(execute).toHaveBeenCalled();
   });
 
   test("Clicking outside closes the menu", async () => {
-    const onClick = jest.fn();
     const { fixture } = await mountCogWheelMenu({
-      items: [
-        {
-          name: "test",
-          onClick,
-        },
-      ],
+      items: [{ name: "test", execute: () => {} }],
     });
     await click(fixture, SELECTORS.COG);
-    expect(fixture.querySelector(".os-cog-wheel-menu")).toBeTruthy();
+    expect(fixture.querySelector(SELECTORS.MENU)).toBeTruthy();
     await click(document.body);
-    expect(fixture.querySelector(".os-cog-wheel-menu")).toBeNull();
+    expect(fixture.querySelector(SELECTORS.MENU)).toBeNull();
   });
 });

--- a/tests/menus/__snapshots__/context_menu_component.test.ts.snap
+++ b/tests/menus/__snapshots__/context_menu_component.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`Context Menu integration tests context menu simple rendering 1`] = `
 <div
   class="o-menu"
+  style=""
 >
   
   <div

--- a/tests/menus/context_menu_component.test.ts
+++ b/tests/menus/context_menu_component.test.ts
@@ -152,6 +152,7 @@ function getSubMenuSize(depth = 1) {
 interface ContextMenuTestConfig {
   onClose?: () => void;
   menuItems?: Action[];
+  menuWidth?: number;
 }
 
 async function renderContextMenu(
@@ -196,6 +197,7 @@ class ContextMenuParent extends Component {
         onClose="() => this.onClose()"
         position="position"
         menuItems="menus"
+        width="props.config.menuWidth"
       />
     </div>
   `;
@@ -692,6 +694,15 @@ describe("Context Menu internal tests", () => {
     triggerMouseEvent("div[data-name='menuItem']", "mouseenter");
     parent.__owl__.destroy();
     expect(onStopHover).toHaveBeenCalled();
+  });
+
+  test("Can set the menu size with the props", async () => {
+    await renderContextMenu(300, 300, { menuItems: subMenu, menuWidth: 100 });
+    const rootMenuEl = fixture.querySelector<HTMLElement>(".o-menu")!;
+    expect(getStylePropertyInPx(rootMenuEl, "width")).toBe(100);
+    await mouseOverMenuElement(".o-menu div[data-name='root']");
+    const childMenu = fixture.querySelectorAll<HTMLElement>(".o-menu")[1]!;
+    expect(getStylePropertyInPx(childMenu, "width")).toBe(100);
   });
 });
 

--- a/tests/test_helpers/pivot_helpers.ts
+++ b/tests/test_helpers/pivot_helpers.ts
@@ -58,8 +58,8 @@ export function removePivot(model: Model, pivotId: UID) {
 }
 
 export const SELECTORS = {
-  COG_WHEEL: ".os-cog-wheel-menu-icon",
-  DUPLICATE_PIVOT: ".os-cog-wheel-menu .fa-copy",
-  DELETE_PIVOT: ".os-cog-wheel-menu .fa-trash",
-  FLIP_AXIS_PIVOT: ".os-cog-wheel-menu .fa-exchange",
+  COG_WHEEL: ".fa-cog",
+  DUPLICATE_PIVOT: ".o-menu .fa-clone",
+  DELETE_PIVOT: ".o-menu .fa-trash-o",
+  FLIP_AXIS_PIVOT: ".o-menu .fa-exchange",
 };


### PR DESCRIPTION
## Description

The cog wheel menu in the pivot panel was using a custom implementation of a menu, because we didn't want it to be as large as a regular menu.

This commit changes the cog wheel menu to use the `Menu` component, and add a new props to `Menu` to set its width.

Task: : [4008880](https://www.odoo.com/web#id=4008880&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo