### PR TITLE
[FIX] side_panel: resize handle on top

### DIFF
--- a/src/components/side_panel/side_panel/side_panel.ts
+++ b/src/components/side_panel/side_panel/side_panel.ts
@@ -152,6 +152,8 @@ css/* scss */ `
 
     .o-sidePanel-handle-container {
       width: 8px;
+      position: fixed;
+      top: 50%;
     }
     .o-sidePanel-handle {
       cursor: col-resize;

--- a/src/components/side_panel/side_panel/side_panel.xml
+++ b/src/components/side_panel/side_panel/side_panel.xml
@@ -6,7 +6,7 @@
         <div class="o-sidePanelClose" t-on-click="close">✕</div>
       </div>
       <div class="o-sidePanelBody-container d-flex flex-grow-1 ">
-        <div class="o-sidePanel-handle-container d-flex align-items-center">
+        <div class="o-sidePanel-handle-container">
           <div
             class="o-sidePanel-handle"
             t-on-pointerdown="startHandleDrag"

--- a/tests/pivots/spreadsheet_pivot/__snapshots__/spreadsheet_pivot_side_panel.test.ts.snap
+++ b/tests/pivots/spreadsheet_pivot/__snapshots__/spreadsheet_pivot_side_panel.test.ts.snap
@@ -22,7 +22,7 @@ exports[`Spreadsheet pivot side panel It should correctly be displayed 1`] = `
     class="o-sidePanelBody-container d-flex flex-grow-1 "
   >
     <div
-      class="o-sidePanel-handle-container d-flex align-items-center"
+      class="o-sidePanel-handle-container"
     >
       <div
         class="o-sidePanel-handle"
@@ -239,7 +239,7 @@ exports[`Spreadsheet pivot side panel It should display only the selection input
     class="o-sidePanelBody-container d-flex flex-grow-1 "
   >
     <div
-      class="o-sidePanel-handle-container d-flex align-items-center"
+      class="o-sidePanel-handle-container"
     >
       <div
         class="o-sidePanel-handle"


### PR DESCRIPTION

## Description:

Steps to reproduce:
- create a pivot
- open the pivot properties panel

=> the resize handle bar goes on top of the "Defer udpates" banner.

See screenshot in the task description.


Task: : [4070898](https://www.odoo.com/web#id=4070898&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo