### PR TITLE
[IMP] tests: drop ts-jest in favor of swc/jest

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -11,7 +11,7 @@
     <script src="../node_modules/chart.js/dist/chart.umd.js"></script>
     <script src="../node_modules/luxon/build/global/luxon.js"></script>
     <script src="../node_modules/chartjs-adapter-luxon/dist/chartjs-adapter-luxon.umd.js"></script>
-    <script src="../build/o_spreadsheet.js"></script>
+    <script src="../build/o_spreadsheet.dev.js"></script>
     <script src="main.js" type="module"></script>
     <link rel="stylesheet" href="main.css" />
     <link rel="stylesheet" href="../node_modules/bootstrap/dist/css/bootstrap.min.css" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@prettier/plugin-xml": "^2.2.0",
         "@rollup/plugin-node-resolve": "^15.2.0",
         "@rollup/plugin-terser": "^0.4.3",
+        "@swc/jest": "^0.2.36",
         "@types/jest": "^27.0.1",
         "@types/node": "^13.13.23",
         "@types/rbush": "^3.0.3",
@@ -47,10 +48,9 @@
         "rollup": "^3.28.0",
         "rollup-plugin-dts": "^5.3.1",
         "rollup-plugin-typescript2": "^0.35.0",
-        "ts-jest": "^29.1.0",
-        "typedoc": "0.24.8",
-        "typedoc-plugin-markdown": "3.11.1",
-        "typescript": "^5.1.6",
+        "typedoc": "0.25.12",
+        "typedoc-plugin-markdown": "3.17.1",
+        "typescript": "^5.4.3",
         "xml-formatter": "^2.4.0"
       }
     },
@@ -781,6 +781,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/@jest/create-cache-key-function": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/create-cache-key-function/-/create-cache-key-function-29.7.0.tgz",
+      "integrity": "sha512-4QqS3LY5PBmTRHj9sAg1HLoPzqAI0uOX6wI/TRqHIcOxlFidy6YEmCQJk6FSZjNLGCeubDMfmkWL+qaLKhSGQA==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^29.6.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
     "node_modules/@jest/environment": {
       "version": "29.6.1",
       "dev": true,
@@ -979,9 +991,10 @@
       }
     },
     "node_modules/@jest/schemas": {
-      "version": "29.6.0",
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@sinclair/typebox": "^0.27.8"
       },
@@ -1140,11 +1153,12 @@
       }
     },
     "node_modules/@jest/types": {
-      "version": "29.6.1",
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@jest/schemas": "^29.6.0",
+        "@jest/schemas": "^29.6.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/istanbul-reports": "^3.0.0",
         "@types/node": "*",
@@ -1395,6 +1409,248 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/@swc/core": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.7.1.tgz",
+      "integrity": "sha512-M4gxJcvzZCH+QQJGVJDF3kT46C05IUPTFcA1wA65WAdg87MDzpr1mwtB/FmPsdcRFRbJIxET6uCsWgubn+KnJQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "peer": true,
+      "dependencies": {
+        "@swc/counter": "^0.1.3",
+        "@swc/types": "^0.1.12"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/swc"
+      },
+      "optionalDependencies": {
+        "@swc/core-darwin-arm64": "1.7.1",
+        "@swc/core-darwin-x64": "1.7.1",
+        "@swc/core-linux-arm-gnueabihf": "1.7.1",
+        "@swc/core-linux-arm64-gnu": "1.7.1",
+        "@swc/core-linux-arm64-musl": "1.7.1",
+        "@swc/core-linux-x64-gnu": "1.7.1",
+        "@swc/core-linux-x64-musl": "1.7.1",
+        "@swc/core-win32-arm64-msvc": "1.7.1",
+        "@swc/core-win32-ia32-msvc": "1.7.1",
+        "@swc/core-win32-x64-msvc": "1.7.1"
+      },
+      "peerDependencies": {
+        "@swc/helpers": "*"
+      },
+      "peerDependenciesMeta": {
+        "@swc/helpers": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@swc/core-darwin-arm64": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.7.1.tgz",
+      "integrity": "sha512-CuifMhtBNdIq6sHElOcu8E8SOO0BUlLyRw52wC+aiHrb5gR+iGlbi4L9sUhbR5bWoxD0Bz9ZJcE5uUhcLP+lJQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-darwin-x64": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.7.1.tgz",
+      "integrity": "sha512-IKtddGei7qGISSggN9WGmzoyRcLS0enT905K9GPB+7W5k8SxtNP3Yt2TKcKvfF8hzICk986kKt8Fl/QOTXV9mA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm-gnueabihf": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.7.1.tgz",
+      "integrity": "sha512-GQJydSLM7OVsxcFPJKe22D/h4Vl7FhDsPCTlEaPo+dz7yc2AdoQFJRPSFIRlBz0qm5CxXycDxU9yfH4Omzfxmg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-gnu": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.7.1.tgz",
+      "integrity": "sha512-Tp94iklMBAgtvlMVWbp9O+qADhNebS90zG835IucKEQB5rd3fEfWtiLP/3vz4hixJT63+yyeXQYs/Hld3vm7HQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-musl": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.7.1.tgz",
+      "integrity": "sha512-rbauhgFzeXNmg1jPUeiVkEMcoSHP0HvTklUOn1sUc4U0tu73uvPZI2e3TU1fo6sxE6FJeDJHZORatf+pAEo0fQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-gnu": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.7.1.tgz",
+      "integrity": "sha512-941tua/RtD/5GxHZOdLiRp/RIloqIlkJKy9ogbdSEI9VJ3Z5x1LznvxHfOI1mTifJMBwNSJLxtL9snUwxwLgEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-musl": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.7.1.tgz",
+      "integrity": "sha512-Iuh0XnOQcoeDsJvh8eO73fVldMU/ucZs2qBxr/9TkgpiGBdaluKxymo2MBBopmxqfBwxEdHUa0TDLgEFyZK6bw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-arm64-msvc": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.7.1.tgz",
+      "integrity": "sha512-H7Q44RZvDCPrKit202+NK014eOjd2VcsVxUX7Dk5D55sqgWgWskzGo7PzrosjiFgw5iVmpm4gDeaXCIS0FCE5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-ia32-msvc": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.7.1.tgz",
+      "integrity": "sha512-zbvjPX2hBu+uCEAvqQBc86yBLtWhRSkh4uLGWUQylCHi1CccRfBww9S4RjXzXxK9bCgZSWbXUmfzJTiFuuhgHQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-x64-msvc": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.7.1.tgz",
+      "integrity": "sha512-pVh/IIdKujW8QxNIAI/van8nOB6sb1fi7QMSteSxjOkL0GGDWpx7t3qm1rDboCdS+9iUXEHv+8UJnpya1ko+Dw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/counter": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+      "dev": true
+    },
+    "node_modules/@swc/jest": {
+      "version": "0.2.36",
+      "resolved": "https://registry.npmjs.org/@swc/jest/-/jest-0.2.36.tgz",
+      "integrity": "sha512-8X80dp81ugxs4a11z1ka43FPhP+/e+mJNXJSxiNYk8gIX/jPBtY4gQTrKu/KIoco8bzKuPI5lUxjfLiGsfvnlw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/create-cache-key-function": "^29.7.0",
+        "@swc/counter": "^0.1.3",
+        "jsonc-parser": "^3.2.0"
+      },
+      "engines": {
+        "npm": ">= 7.0.0"
+      },
+      "peerDependencies": {
+        "@swc/core": "*"
+      }
+    },
+    "node_modules/@swc/types": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.12.tgz",
+      "integrity": "sha512-wBJA+SdtkbFhHjTMYH+dEH1y4VpfGdAc2Kw/LK09i9bXd/K6j6PkDcFCEzb6iVfZMkPRrl/q0e3toqTAJdkIVA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@swc/counter": "^0.1.3"
       }
     },
     "node_modules/@tootallnate/once": {
@@ -1674,9 +1930,10 @@
       }
     },
     "node_modules/ansi-sequence-parser": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT"
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.1.tgz",
+      "integrity": "sha512-vJXt3yiaUL4UU546s3rPXlsry/RnM730G1+HkpKE012AN0sx1eOrxSu95oKDIonskeLTijMgqWZ3uDEe3NFvyg==",
+      "dev": true
     },
     "node_modules/ansi-styles": {
       "version": "3.2.1",
@@ -2202,17 +2459,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/browserslist"
-      }
-    },
-    "node_modules/bs-logger": {
-      "version": "0.2.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-json-stable-stringify": "2.x"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/bser": {
@@ -7505,11 +7751,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/lodash.memoize": {
-      "version": "4.1.2",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/log-update": {
       "version": "4.0.0",
       "dev": true,
@@ -7661,11 +7902,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/make-error": {
-      "version": "1.3.6",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
@@ -9436,9 +9672,10 @@
       "license": "MIT"
     },
     "node_modules/shiki": {
-      "version": "0.14.2",
+      "version": "0.14.7",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.7.tgz",
+      "integrity": "sha512-dNPAPrxSc87ua2sKJ3H5dQ/6ZaY8RNnaAqK+t0eG7p0Soi2ydiqbGOTaZCqaYvA/uZYfS1LJnemt3Q+mSfcPCg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ansi-sequence-parser": "^1.1.0",
         "jsonc-parser": "^3.2.0",
@@ -10268,62 +10505,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/ts-jest": {
-      "version": "29.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bs-logger": "0.x",
-        "fast-json-stable-stringify": "2.x",
-        "jest-util": "^29.0.0",
-        "json5": "^2.2.3",
-        "lodash.memoize": "4.x",
-        "make-error": "1.x",
-        "semver": "^7.5.3",
-        "yargs-parser": "^21.0.1"
-      },
-      "bin": {
-        "ts-jest": "cli.js"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": ">=7.0.0-beta.0 <8",
-        "@jest/types": "^29.0.0",
-        "babel-jest": "^29.0.0",
-        "jest": "^29.0.0",
-        "typescript": ">=4.3 <6"
-      },
-      "peerDependenciesMeta": {
-        "@babel/core": {
-          "optional": true
-        },
-        "@jest/types": {
-          "optional": true
-        },
-        "babel-jest": {
-          "optional": true
-        },
-        "esbuild": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ts-jest/node_modules/semver": {
-      "version": "7.5.4",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/tslib": {
       "version": "1.14.1",
       "dev": true,
@@ -10372,48 +10553,52 @@
       }
     },
     "node_modules/typedoc": {
-      "version": "0.24.8",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.25.12.tgz",
+      "integrity": "sha512-F+qhkK2VoTweDXd1c42GS/By2DvI2uDF4/EpG424dTexSHdtCH52C6IcAvMA6jR3DzAWZjHpUOW+E02kyPNUNw==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "lunr": "^2.3.9",
         "marked": "^4.3.0",
-        "minimatch": "^9.0.0",
-        "shiki": "^0.14.1"
+        "minimatch": "^9.0.3",
+        "shiki": "^0.14.7"
       },
       "bin": {
         "typedoc": "bin/typedoc"
       },
       "engines": {
-        "node": ">= 14.14"
+        "node": ">= 16"
       },
       "peerDependencies": {
-        "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x"
+        "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x"
       }
     },
     "node_modules/typedoc-plugin-markdown": {
-      "version": "3.11.1",
+      "version": "3.17.1",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.17.1.tgz",
+      "integrity": "sha512-QzdU3fj0Kzw2XSdoL15ExLASt2WPqD7FbLeaqwT70+XjKyTshBnUlQA5nNREO1C2P8Uen0CDjsBLMsCQ+zd0lw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "handlebars": "^4.7.7"
       },
       "peerDependencies": {
-        "typedoc": ">=0.22.0"
+        "typedoc": ">=0.24.0"
       }
     },
     "node_modules/typedoc/node_modules/brace-expansion": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
     },
     "node_modules/typedoc/node_modules/minimatch": {
-      "version": "9.0.1",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -10425,9 +10610,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -10650,13 +10835,15 @@
     },
     "node_modules/vscode-oniguruma": {
       "version": "1.7.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
+      "dev": true
     },
     "node_modules/vscode-textmate": {
       "version": "8.0.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
+      "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
+      "dev": true
     },
     "node_modules/w3c-xmlserializer": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -13,22 +13,24 @@
     "dist/*.xml"
   ],
   "scripts": {
-    "serve-static": "live-server --open=demo --watch=build/o_spreadsheet.js,build/o_spreadsheet.xml,demo",
-    "dev": "npm-run-all --print-label build --parallel server serve-static watch:*",
+    "serve-static": "live-server --open=demo --watch=build/o_spreadsheet.dev.js,build/o_spreadsheet.xml,demo",
+    "dev": "npm-run-all --print-label buildDev --parallel server serve-static watch:*",
     "server": "node tools/server/main.cjs",
     "build:js": "tsc --module es6 --incremental",
-    "build:bundleJs": "rollup -c -m --configDev",
+    "build:bundleJsDev": "rollup -c -m --configDev",
+    "build:bundleJs": "rollup -c -m --configDist",
     "build:bundleXml": "node tools/bundle_xml/main.cjs",
+    "buildDev": "npm-run-all build:js build:bundleJsDev \"build:bundleXml -- --outDir build\"",
     "build": "npm-run-all build:js build:bundleJs \"build:bundleXml -- --outDir build\"",
     "doc": "typedoc",
     "precommit": "npm run prettier && npm run doc",
-    "test": "jest",
+    "test": "tsc --noEmit --project tsconfig.jest.json && jest",
     "test:watch": "jest --watch",
     "prettier": "prettier . --write",
     "check-formatting": "prettier . --check",
     "dist": "tsc --module es6 --declaration --declarationDir dist/types && rollup -c && npm run build:bundleXml -- --outDir dist",
     "prepare": "husky install",
-    "watch:bundle": "npm run build:bundleJs -- --watch",
+    "watch:bundle": "npm run build:bundleJsDev -- --watch",
     "watch:ts": "npm run build:js -- --watch",
     "watch:xml": "node tools/bundle_xml/watch_xml_templates.cjs",
     "unzipXlsx": "node tools/bundle_xlsx/unzip_xlsx_demo.cjs",
@@ -57,6 +59,7 @@
     "@prettier/plugin-xml": "^2.2.0",
     "@rollup/plugin-node-resolve": "^15.2.0",
     "@rollup/plugin-terser": "^0.4.3",
+    "@swc/jest": "^0.2.36",
     "@types/jest": "^27.0.1",
     "@types/node": "^13.13.23",
     "@types/rbush": "^3.0.3",
@@ -87,10 +90,9 @@
     "rollup": "^3.28.0",
     "rollup-plugin-dts": "^5.3.1",
     "rollup-plugin-typescript2": "^0.35.0",
-    "ts-jest": "^29.1.0",
-    "typedoc": "0.24.8",
-    "typedoc-plugin-markdown": "3.11.1",
-    "typescript": "^5.1.6",
+    "typedoc": "0.25.12",
+    "typedoc-plugin-markdown": "3.17.1",
+    "typescript": "^5.4.3",
     "xml-formatter": "^2.4.0"
   },
   "prettier": {
@@ -111,10 +113,7 @@
     ],
     "transform": {
       "^.+\\.ts?$": [
-        "ts-jest",
-        {
-          "tsconfig": "tsconfig.jest.json"
-        }
+        "@swc/jest"
       ]
     },
     "verbose": false,

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -31,13 +31,11 @@ export default (commandLineArgs) => {
   let plugins = [nodeResolve()];
   let config = {};
 
-  if (commandLineArgs.configDev) {
-    // Only build iife version to improve speed
+  if (commandLineArgs.configDev || commandLineArgs.configDist) {
+    // Only build one version to improve speed
     input = "build/js/index.js";
     output = [
       {
-        file: `build/o_spreadsheet.js`,
-        format: "iife",
         name: "o_spreadsheet",
         extend: true,
         outro,
@@ -45,6 +43,13 @@ export default (commandLineArgs) => {
         globals: { "@odoo/owl": "owl" },
       },
     ];
+    if (commandLineArgs.configDev) {
+      output[0].file = `build/o_spreadsheet.dev.js`;
+      output[0].format = `iife`;
+    } else {
+      output[0].file = `build/o_spreadsheet.js`;
+      output[0].format = `esm`;
+    }
     config = {
       input,
       external: ["@odoo/owl"],

--- a/src/clipboard_handlers/cell_clipboard.ts
+++ b/src/clipboard_handlers/cell_clipboard.ts
@@ -1,4 +1,3 @@
-import { CommandResult } from "..";
 import { canonicalizeNumberValue } from "../formulas/formula_locale";
 import { formatValue } from "../helpers";
 import { getPasteZones } from "../helpers/clipboard/clipboard_helpers";
@@ -8,6 +7,7 @@ import {
   ClipboardCellData,
   ClipboardOptions,
   ClipboardPasteTarget,
+  CommandResult,
   HeaderIndex,
   UID,
   Zone,

--- a/src/components/helpers/draw_grid_hook.ts
+++ b/src/components/helpers/draw_grid_hook.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from "@odoo/owl";
-import { Model } from "../..";
 import { CANVAS_SHIFT } from "../../constants";
+import { Model } from "../../model";
 import { useStore } from "../../store_engine";
 import { GridRenderer } from "../../stores/grid_renderer_store";
 import { RendererStore } from "../../stores/renderer_store";

--- a/src/components/side_panel/conditional_formatting/cf_editor/cf_editor.ts
+++ b/src/components/side_panel/conditional_formatting/cf_editor/cf_editor.ts
@@ -1,14 +1,15 @@
 import { Component, useExternalListener, useState } from "@odoo/owl";
-import { CancelledReason, CommandResult } from "../../../..";
 import { DEFAULT_COLOR_SCALE_MIDPOINT_COLOR } from "../../../../constants";
 import { colorNumberString, rangeReference } from "../../../../helpers";
 import { canonicalizeCFRule } from "../../../../helpers/locale";
 import { cycleFixedReference } from "../../../../helpers/reference_type";
 import {
+  CancelledReason,
   CellIsRule,
   Color,
   ColorScaleRule,
   ColorScaleThreshold,
+  CommandResult,
   ConditionalFormat,
   ConditionalFormatRule,
   IconSetRule,

--- a/src/helpers/misc.ts
+++ b/src/helpers/misc.ts
@@ -297,7 +297,7 @@ export function debounce<T extends (...args: any) => void>(
   let timeout: any | undefined = undefined;
   const debounced = function (this: any): void {
     const context = this;
-    const args = arguments;
+    const args = Array.from(arguments);
     function later() {
       timeout = undefined;
       if (!immediate) {

--- a/src/helpers/ui/cut_interactive.ts
+++ b/src/helpers/ui/cut_interactive.ts
@@ -1,6 +1,5 @@
-import { CommandResult } from "../..";
 import { _t } from "../../translation";
-import { SpreadsheetChildEnv } from "../../types";
+import { CommandResult, SpreadsheetChildEnv } from "../../types";
 
 export function interactiveCut(env: SpreadsheetChildEnv) {
   const result = env.model.dispatch("CUT");

--- a/src/helpers/ui/paste_interactive.ts
+++ b/src/helpers/ui/paste_interactive.ts
@@ -1,6 +1,11 @@
-import { CommandResult, DispatchResult } from "../..";
 import { _t } from "../../translation";
-import { ClipboardPasteOptions, SpreadsheetChildEnv, Zone } from "../../types";
+import {
+  ClipboardPasteOptions,
+  CommandResult,
+  DispatchResult,
+  SpreadsheetChildEnv,
+  Zone,
+} from "../../types";
 
 export const PasteInteractiveContent = {
   wrongPasteSelection: _t("This operation is not allowed with multiple selections."),

--- a/src/helpers/ui/split_to_columns_interactive.ts
+++ b/src/helpers/ui/split_to_columns_interactive.ts
@@ -1,6 +1,5 @@
-import { CommandResult } from "../..";
 import { _t } from "../../translation";
-import { SpreadsheetChildEnv } from "../../types";
+import { CommandResult, SpreadsheetChildEnv } from "../../types";
 import { DispatchResult } from "./../../types/commands";
 
 export const SplitToColumnsInteractiveContent = {

--- a/src/helpers/ui/toggle_group_interactive.ts
+++ b/src/helpers/ui/toggle_group_interactive.ts
@@ -1,6 +1,5 @@
-import { CommandResult } from "../..";
 import { _t } from "../../translation";
-import { Dimension, HeaderIndex, SpreadsheetChildEnv, UID } from "../../types";
+import { CommandResult, Dimension, HeaderIndex, SpreadsheetChildEnv, UID } from "../../types";
 
 export const ToggleGroupInteractiveContent = {
   CannotHideAllRows: _t("Cannot hide all the rows of a sheet."),

--- a/tests/__mocks__/mock_misc_helpers.ts
+++ b/tests/__mocks__/mock_misc_helpers.ts
@@ -3,7 +3,7 @@ import { DebouncedFunction } from "../../src/types";
 /** Mocked debounce that doesn't actually do any debouncing, but just calls the function directly */
 export function debounce<T extends (...args: any) => void>(func: T): DebouncedFunction<T> {
   const debounced = function (this: any): void {
-    func.apply(this, arguments);
+    func.apply(this, Array.from(arguments));
   };
   debounced.isDebouncePending = () => false;
   debounced.stopDebounce = () => {};


### PR DESCRIPTION
SWC (speedy web compiler) is an rust-based faster alternative to the traditional typescript transpiler `tsc`. SInce it does not support typechecking, we cannot only rely on it in order to generate our declaration files our build our library. We can however leverage the already existing integration with jest, expecially the package `@swc/jest` that works as an alternative to  `js-test`.

In order to preserve the typechecking of the test files, we alter the `test` command to first run a simple typecheck with `tsc` and then run the test suite with `@swc/jest` as a TS transpiler.

Some pros:
- Better execution time for the whole test suite
- running a standalone test way faster
- a pre-step of typecheck takes less time than currently beacause jest will keep running every test file and will not stop its execution because of a single file in error

Benchmark
---------

Running command `npm run test -- -w 50%` -  11178 tests:

Before:  131 secondes
After:   82 secondes (17 of typecheck + 68 of actual tests transpiled
and run

On Runbot

closes odoo/o-spreadsheet#4649

Before: 250 secondes
After:  122 secondes
Task: 4049142
