### PR TITLE
[IMP] composer: add placeholder for spreaded results

### DIFF
--- a/src/components/composer/composer/cell_composer_store.ts
+++ b/src/components/composer/composer/cell_composer_store.ts
@@ -115,6 +115,16 @@ export class CellComposerStore extends AbstractComposerStore {
   // Getters
   // ---------------------------------------------------------------------------
 
+  get placeholder(): string | undefined {
+    const position = this.getters.getActivePosition();
+    const spreader = this.model.getters.getArrayFormulaSpreadingOn(position);
+    if (!spreader) {
+      return undefined;
+    }
+    const cell = this.getters.getCell(spreader);
+    return cell?.content;
+  }
+
   get currentEditedCell(): CellPosition {
     return {
       sheetId: this.sheetId,
@@ -192,6 +202,10 @@ export class CellComposerStore extends AbstractComposerStore {
     const cell = this.getters.getCell(position);
     if (cell?.isFormula) {
       return localizeFormula(cell.content, locale);
+    }
+    const spreader = this.model.getters.getArrayFormulaSpreadingOn(position);
+    if (spreader) {
+      return "";
     }
     const { format, value, type, formattedValue } = this.getters.getEvaluatedCell(position);
     switch (type) {

--- a/src/components/composer/composer/cell_composer_store.ts
+++ b/src/components/composer/composer/cell_composer_store.ts
@@ -24,7 +24,7 @@ import {
   RemoveColumnsRowsCommand,
   isMatrix,
 } from "../../../types";
-import { AbstractComposerStore, ComposerSelection } from "./abstract_composer_store";
+import { AbstractComposerStore } from "./abstract_composer_store";
 
 const CELL_DELETED_MESSAGE = _t("The cell you are trying to edit has been deleted.");
 
@@ -115,20 +115,6 @@ export class CellComposerStore extends AbstractComposerStore {
   // Getters
   // ---------------------------------------------------------------------------
 
-  get currentContent(): string {
-    if (this.editionMode === "inactive") {
-      return this.getComposerContent(this.getters.getActivePosition());
-    }
-    return this._currentContent;
-  }
-
-  get composerSelection(): ComposerSelection {
-    return {
-      start: this.selectionStart,
-      end: this.selectionEnd,
-    };
-  }
-
   get currentEditedCell(): CellPosition {
     return {
       sheetId: this.sheetId,
@@ -136,6 +122,7 @@ export class CellComposerStore extends AbstractComposerStore {
       row: this.row,
     };
   }
+
   private onColumnsRemoved(cmd: RemoveColumnsRowsCommand) {
     if (cmd.elements.includes(this.col) && this.editionMode !== "inactive") {
       this.cancelEdition();

--- a/src/components/composer/composer/composer.ts
+++ b/src/components/composer/composer/composer.ts
@@ -131,7 +131,7 @@ interface FunctionDescriptionState {
   argToFocus: number;
 }
 
-export class CellComposer extends Component<CellComposerProps, SpreadsheetChildEnv> {
+export class Composer extends Component<CellComposerProps, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-Composer";
   static props = {
     focus: {

--- a/src/components/composer/composer/composer.ts
+++ b/src/components/composer/composer/composer.ts
@@ -84,9 +84,9 @@ css/* scss */ `
     }
     .o-composer[placeholder]:empty:not(:focus):not(.active)::before {
       content: attr(placeholder);
-      color: #ccc;
+      color: #bdbdbd;
       position: relative;
-      top: 20%;
+      top: 0%;
       pointer-events: none;
     }
 

--- a/src/components/composer/grid_composer/grid_composer.ts
+++ b/src/components/composer/grid_composer/grid_composer.ts
@@ -12,7 +12,7 @@ import { ComposerFocusType, DOMDimension, Rect, SpreadsheetChildEnv } from "../.
 import { getTextDecoration } from "../../helpers";
 import { css, cssPropertiesToCss } from "../../helpers/css";
 import { CellComposerStore } from "../composer/cell_composer_store";
-import { CellComposer, CellComposerProps } from "../composer/composer";
+import { CellComposerProps, Composer } from "../composer/composer";
 import { ComposerFocusStore, ComposerInterface } from "../composer_focus_store";
 
 const COMPOSER_BORDER_WIDTH = 3 * 0.4 * window.devicePixelRatio || 1;
@@ -57,7 +57,7 @@ export class GridComposer extends Component<Props, SpreadsheetChildEnv> {
     gridDims: Object,
     onInputContextMenu: Function,
   };
-  static components = { CellComposer };
+  static components = { Composer };
 
   private rect: Rect = this.defaultRect;
   private isEditing: boolean = false;

--- a/src/components/composer/grid_composer/grid_composer.xml
+++ b/src/components/composer/grid_composer/grid_composer.xml
@@ -7,7 +7,7 @@
       t-esc="cellReference"
     />
     <div class="o-grid-composer" t-att-style="containerStyle" t-ref="gridComposer">
-      <CellComposer t-props="composerProps"/>
+      <Composer t-props="composerProps"/>
     </div>
   </t>
 </templates>

--- a/src/components/composer/standalone_composer/standalone_composer.ts
+++ b/src/components/composer/standalone_composer/standalone_composer.ts
@@ -5,7 +5,7 @@ import { ComposerFocusType, SpreadsheetChildEnv } from "../../../types/index";
 import { css, cssPropertiesToCss } from "../../helpers/css";
 import { useSpreadsheetRect } from "../../helpers/position_hook";
 import { ComposerSelection } from "../composer/abstract_composer_store";
-import { CellComposer } from "../composer/composer";
+import { Composer } from "../composer/composer";
 import { ComposerFocusStore, ComposerInterface } from "../composer_focus_store";
 import { StandaloneComposerStore } from "./standalone_composer_store";
 
@@ -54,7 +54,7 @@ export class StandaloneComposer extends Component<Props, SpreadsheetChildEnv> {
     class: { type: String, optional: true },
     invalid: { type: Boolean, optional: true },
   };
-  static components = { CellComposer };
+  static components = { Composer };
   static defaultProps = {
     composerContent: "",
   };

--- a/src/components/composer/standalone_composer/standalone_composer.xml
+++ b/src/components/composer/standalone_composer/standalone_composer.xml
@@ -1,7 +1,7 @@
 <templates>
   <t t-name="o-spreadsheet-StandaloneComposer">
     <div class="o-standalone-composer" t-on-click.stop="" t-att-class="containerClass">
-      <CellComposer
+      <Composer
         focus="focus"
         inputStyle="composerStyle"
         onComposerContentFocused.bind="onFocus"

--- a/src/components/composer/top_bar_composer/top_bar_composer.ts
+++ b/src/components/composer/top_bar_composer/top_bar_composer.ts
@@ -11,7 +11,7 @@ import { CSSProperties, ComposerFocusType, SpreadsheetChildEnv } from "../../../
 import { css, cssPropertiesToCss } from "../../helpers/css";
 import { ComposerSelection } from "../composer/abstract_composer_store";
 import { CellComposerStore } from "../composer/cell_composer_store";
-import { CellComposer } from "../composer/composer";
+import { Composer } from "../composer/composer";
 import { ComposerFocusStore, ComposerInterface } from "../composer_focus_store";
 
 const COMPOSER_MAX_HEIGHT = 100;
@@ -46,7 +46,7 @@ css/* scss */ `
 export class TopBarComposer extends Component<any, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-TopBarComposer";
   static props = {};
-  static components = { CellComposer };
+  static components = { Composer };
 
   private composerFocusStore!: Store<ComposerFocusStore>;
   private composerStore!: Store<CellComposerStore>;

--- a/src/components/composer/top_bar_composer/top_bar_composer.xml
+++ b/src/components/composer/top_bar_composer/top_bar_composer.xml
@@ -9,6 +9,7 @@
         inputStyle="composerStyle"
         onComposerContentFocused.bind="onFocus"
         composerStore="composerStore"
+        placeholder="composerStore.placeholder"
       />
     </div>
   </t>

--- a/src/components/composer/top_bar_composer/top_bar_composer.xml
+++ b/src/components/composer/top_bar_composer/top_bar_composer.xml
@@ -4,7 +4,7 @@
       class="o-topbar-composer bg-white user-select-text"
       t-on-click.stop=""
       t-att-style="containerStyle">
-      <CellComposer
+      <Composer
         focus="focus"
         inputStyle="composerStyle"
         onComposerContentFocused.bind="onFocus"

--- a/tests/composer/composer_integration_component.test.ts
+++ b/tests/composer/composer_integration_component.test.ts
@@ -728,4 +728,22 @@ describe("TopBar composer", () => {
     expect(document.activeElement).toBe(composerEl);
     expect(fixture.querySelectorAll(".o-autocomplete-value")).toHaveLength(0);
   });
+
+  test("Spreaded cell has no value in the composer but has a placeholder", async () => {
+    ({ model, fixture } = await mountSpreadsheet());
+    setCellContent(model, "A1", "=MUNIT(3)");
+    selectCell(model, "A2");
+    await nextTick();
+
+    const topBarComposer = document.querySelector(".o-spreadsheet-topbar .o-composer")!;
+    expect(topBarComposer.textContent).toBe("");
+    expect(topBarComposer.attributes.getNamedItem("placeholder")?.value).toEqual("=MUNIT(3)");
+
+    await simulateClick(topBarComposer);
+    expect(topBarComposer!.textContent).toBe("");
+
+    await keyDown({ key: "Enter" });
+    expect(topBarComposer!.textContent).toBe("");
+    expect(topBarComposer.attributes.getNamedItem("placeholder")?.value).toEqual("=MUNIT(3)");
+  });
 });

--- a/tests/test_helpers/helpers.ts
+++ b/tests/test_helpers/helpers.ts
@@ -5,7 +5,7 @@ import { functionCache } from "../../src";
 import { Action } from "../../src/actions/action";
 import { ComposerSelection } from "../../src/components/composer/composer/abstract_composer_store";
 import { CellComposerStore } from "../../src/components/composer/composer/cell_composer_store";
-import { CellComposer, CellComposerProps } from "../../src/components/composer/composer/composer";
+import { CellComposerProps, Composer } from "../../src/components/composer/composer/composer";
 import { ComposerFocusStore } from "../../src/components/composer/composer_focus_store";
 import { SidePanelStore } from "../../src/components/side_panel/side_panel/side_panel_store";
 import { Spreadsheet, SpreadsheetProps } from "../../src/components/spreadsheet/spreadsheet";
@@ -889,9 +889,9 @@ type ComposerWrapperProps = {
   composerProps: Partial<CellComposerProps>;
 };
 export class ComposerWrapper extends Component<ComposerWrapperProps, SpreadsheetChildEnv> {
-  static components = { CellComposer };
+  static components = { Composer };
   static template = xml/*xml*/ `
-    <CellComposer t-props="composerProps"/>
+    <Composer t-props="composerProps"/>
   `;
   static props = { composerProps: Object, focusComposer: String };
   state = useState({ focusComposer: <ComposerFocusType>"inactive" });


### PR DESCRIPTION
## Description:
### [IMP] composer: add placeholder for spreaded results

This commit remove the composer value for the cells that are a result
of an array formula, and replace it by a placeholder.

### [REF] composer: rename `Composer` component

The `Composer` component was wrongly renamed to `CellComposer`.

Also the `CellComposerStore` implemented some methods that were
already in its parent class.

Task: : [3790235](https://www.odoo.com/web#id=3790235&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo