### PR TITLE
[FIX] composer: auto grow standalone composer

### DIFF
--- a/src/components/composer/standalone_composer/standalone_composer.ts
+++ b/src/components/composer/standalone_composer/standalone_composer.ts
@@ -3,6 +3,7 @@ import { SELECTION_BORDER_COLOR } from "../../../constants";
 import { Store, useLocalStore, useStore } from "../../../store_engine";
 import { ComposerFocusType, SpreadsheetChildEnv } from "../../../types/index";
 import { css, cssPropertiesToCss } from "../../helpers/css";
+import { useSpreadsheetRect } from "../../helpers/position_hook";
 import { ComposerSelection } from "../composer/abstract_composer_store";
 import { CellComposer } from "../composer/composer";
 import { ComposerFocusStore, ComposerInterface } from "../composer_focus_store";
@@ -11,7 +12,7 @@ import { StandaloneComposerStore } from "./standalone_composer_store";
 css/* scss */ `
   .o-spreadsheet {
     .o-standalone-composer {
-      height: 28px;
+      min-height: 28px;
       overflow: auto;
       box-sizing: border-box;
 
@@ -61,6 +62,7 @@ export class StandaloneComposer extends Component<Props, SpreadsheetChildEnv> {
   private composerFocusStore!: Store<ComposerFocusStore>;
   private standaloneComposerStore!: Store<StandaloneComposerStore>;
   private composerInterface!: ComposerInterface;
+  readonly spreadsheetRect = useSpreadsheetRect();
 
   setup() {
     this.composerFocusStore = useStore(ComposerFocusStore);

--- a/src/components/composer/standalone_composer/standalone_composer.xml
+++ b/src/components/composer/standalone_composer/standalone_composer.xml
@@ -7,6 +7,7 @@
         onComposerContentFocused.bind="onFocus"
         composerStore="standaloneComposerStore"
         placeholder="props.placeholder"
+        delimitation="spreadsheetRect"
       />
     </div>
   </t>


### PR DESCRIPTION


## Description:

Open a Color scale conditional formatting side panel, choose "Formula" and type a long formula such that it's mutliple lines.

=> the autocomplete dropdown is badly positioned

Task: : [4075551](https://www.odoo.com/web#id=4075551&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo