### PR TITLE
[FIX] functions: COUNTIF count string dates

### DIFF
--- a/src/functions/helpers.ts
+++ b/src/functions/helpers.ts
@@ -385,9 +385,11 @@ function evaluatePredicate(value: CellValue | undefined = "", criterion: Predica
   if (operand === undefined) {
     return false;
   }
-
   if (typeof operand === "number" && operator === "=") {
-    return toString(value) === toString(operand);
+    if (typeof value === "string" && (isNumber(value) || isDateTime(value))) {
+      return toNumber(value) === operand;
+    }
+    return value === operand;
   }
 
   if (operator === "<>" || operator === "=") {

--- a/tests/functions/module_math.test.ts
+++ b/tests/functions/module_math.test.ts
@@ -820,14 +820,43 @@ describe("COUNTIF formula", () => {
     const grid = {
       A1: "01/01/2024",
       A2: "01/02/2024",
+      A3: '="01/01/2024"',
       B1: '=COUNTIF(A1, "<01/02/2024")',
       B2: '=COUNTIF(A2, "<01/02/2024")',
       B3: '=COUNTIF(A2, "<=01/02/2024")',
+      B4: '=COUNTIF(A3, "01/01/2024")',
+      B5: '=COUNTIF(A3, "<=01/01/2024")',
+      B6: '=COUNTIF(A3, "01/2024")',
     };
     expect(evaluateGrid(grid)).toMatchObject({
       B1: 1,
       B2: 0,
       B3: 1,
+      B4: 1,
+      B5: 0,
+      B6: 0, // @compatibility: on google sheets, return 1
+    });
+  });
+
+  test("COUNTIF with string against a date predicate", () => {
+    const grid = {
+      A1: "hello",
+      B1: '=COUNTIF(A1, "01/02/2024")',
+    };
+    expect(evaluateGrid(grid)).toMatchObject({
+      B1: 0,
+    });
+  });
+
+  test("COUNTIF with number against a date predicate", () => {
+    const grid = {
+      A1: "0",
+      B1: '=COUNTIF(A1, "12/30/1899")',
+      B2: '=COUNTIF(A1, "<=12/30/1899")',
+    };
+    expect(evaluateGrid(grid)).toMatchObject({
+      B1: 1,
+      B2: 1,
     });
   });
 });


### PR DESCRIPTION
## Description:


Steps to reproduce:
in A1: ="01/01/2024"
in B1: =COUNTIF(A1, "01/01/2024")

The result of B1 is 0, but it should be 1

Bug introduced with bde73c8f277a96c420fbdf33d8b119d6f2742da0


Task: : [4077445](https://www.odoo.com/web#id=4077445&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo