### PR TITLE
[FIX] composer: layout break when composer assistant is opened

### DIFF
--- a/src/components/composer/composer/composer.ts
+++ b/src/components/composer/composer/composer.ts
@@ -202,8 +202,8 @@ export class CellComposer extends Component<CellComposerProps, SpreadsheetChildE
         // render left
         assistantStyle.right = `0px`;
       }
-    } else if (this.props.delimitation) {
-      assistantStyle["max-height"] = `${this.props.delimitation.height}px`;
+    } else {
+      assistantStyle["max-height"] = `${this.spreadsheetRect.height - composerRect.bottom}px`;
       if (composerRect.left + ASSISTANT_WIDTH > this.spreadsheetRect.width) {
         assistantStyle.right = `0px`;
       }

--- a/src/components/composer/top_bar_composer/top_bar_composer.ts
+++ b/src/components/composer/top_bar_composer/top_bar_composer.ts
@@ -7,12 +7,7 @@ import {
   TOPBAR_TOOLBAR_HEIGHT,
 } from "../../../constants";
 import { Store, useStore } from "../../../store_engine";
-import {
-  CSSProperties,
-  ComposerFocusType,
-  DOMDimension,
-  SpreadsheetChildEnv,
-} from "../../../types/index";
+import { CSSProperties, ComposerFocusType, SpreadsheetChildEnv } from "../../../types/index";
 import { css, cssPropertiesToCss } from "../../helpers/css";
 import { ComposerSelection } from "../composer/abstract_composer_store";
 import { CellComposerStore } from "../composer/cell_composer_store";
@@ -98,14 +93,6 @@ export class TopBarComposer extends Component<any, SpreadsheetChildEnv> {
     return cssPropertiesToCss({
       "border-color": SELECTION_BORDER_COLOR,
     });
-  }
-
-  get delimitation(): DOMDimension {
-    const { width, height } = this.env.model.getters.getSheetViewDimensionWithHeaders();
-    return {
-      width,
-      height,
-    };
   }
 
   onFocus(selection: ComposerSelection) {

--- a/src/components/composer/top_bar_composer/top_bar_composer.xml
+++ b/src/components/composer/top_bar_composer/top_bar_composer.xml
@@ -8,7 +8,6 @@
         focus="focus"
         inputStyle="composerStyle"
         onComposerContentFocused.bind="onFocus"
-        delimitation="delimitation"
         composerStore="composerStore"
       />
     </div>

--- a/tests/composer/__snapshots__/autocomplete_dropdown_component.test.ts.snap
+++ b/tests/composer/__snapshots__/autocomplete_dropdown_component.test.ts.snap
@@ -120,7 +120,7 @@ exports[`composer Assistant render above the cell when not enough place below 1`
 exports[`composer Assistant render below the cell by default 1`] = `
 <div
   class="o-composer-assistant shadow"
-  style="min-width:300px; width:300px; "
+  style="min-width:96px; width:300px; max-height:327px; "
 >
   <div
     class="o-autocomplete-dropdown"

--- a/tests/composer/autocomplete_dropdown_component.test.ts
+++ b/tests/composer/autocomplete_dropdown_component.test.ts
@@ -440,7 +440,10 @@ describe("Autocomplete parenthesis", () => {
 
 describe("composer Assistant", () => {
   test("render below the cell by default", async () => {
-    ({ model, fixture, parent } = await mountComposerWrapper());
+    ({ model, fixture, parent } = await mountComposerWrapper(new Model(), {
+      delimitation: { width: 500, height: 500 },
+      rect: { width: DEFAULT_CELL_WIDTH, height: DEFAULT_CELL_HEIGHT, x: 150, y: 150 },
+    }));
     await typeInComposer("=s");
     expect(fixture.querySelectorAll(".o-composer-assistant").length).toBe(1);
     const assistantEl = fixture.querySelector(".o-composer-assistant")! as HTMLElement;


### PR DESCRIPTION
In FW, a PR#[4721](https://github.com/odoo/o-spreadsheet/pull/4721) was mistakenly approved (r+) because it had no conflicts, but it did not resolve the intended issue in the master branch. This new PR addresses that issue.

Description:

When typing =S in the composer, the composer assistant opens. If there isn't enough space on the right (default 300px width), it breaks the layout.

This PR fixes the issue by adding a width check for the composer assistant. If the width condition is met, the style right: 0px is applied to prevent the layout from breaking.

Task: [4037213](https://www.odoo.com/odoo/project/2328/tasks/4037213?cids=2)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo