### PR TITLE
[FIX] Pivot: `automaticAutofill` is active when inserting a pivot wit…

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -263,4 +263,5 @@ export const PIVOT_TABLE_CONFIG = {
   bandedRows: true,
   bandedColumns: false,
   styleId: "TableStyleMedium5",
+  automaticAutofill: true,
 };

--- a/tests/pivots/pivot_menu_items.test.ts
+++ b/tests/pivots/pivot_menu_items.test.ts
@@ -243,7 +243,7 @@ describe("Pivot menu items", () => {
       })
     ).toMatchObject({
       range: { zone: toZone("B8") },
-      config: { numberOfHeaders: 1 },
+      config: { numberOfHeaders: 1, automaticAutofill: true },
       type: "dynamic",
     });
   });


### PR DESCRIPTION
…h a table

The  pivot reinsertion addedin #4501 did not activate `automaticAutofill` of the related table by default whereas it is activated when we insert a table manually.

Task: 4081309

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo