### PR TITLE
[FIX] pivot: update pivot formulas when data set changes

### DIFF
--- a/src/functions/module_lookup.ts
+++ b/src/functions/module_lookup.ts
@@ -721,6 +721,7 @@ export const PIVOT_VALUE = {
     const coreDefinition = this.getters.getPivotCoreDefinition(pivotId);
 
     addPivotDependencies(this, coreDefinition);
+    pivot.init({ reload: pivot.needsReevaluation });
     const error = pivot.assertIsValid({ throwOnError: false });
     if (error) {
       return error;
@@ -754,6 +755,7 @@ export const PIVOT_HEADER = {
     const pivot = this.getters.getPivot(_pivotId);
     const coreDefinition = this.getters.getPivotCoreDefinition(_pivotId);
     addPivotDependencies(this, coreDefinition);
+    pivot.init({ reload: pivot.needsReevaluation });
     const error = pivot.assertIsValid({ throwOnError: false });
     if (error) {
       return error;

--- a/tests/pivots/spreadsheet_pivot/spreadsheet_pivot.test.ts
+++ b/tests/pivots/spreadsheet_pivot/spreadsheet_pivot.test.ts
@@ -1422,4 +1422,42 @@ describe("Spreadsheet arguments parsing", () => {
       },
     ]);
   });
+
+  test("update PIVOT.VALUE when data set changes", () => {
+    const grid = {
+      A1: "Price",
+      B1: "Customer",
+      A2: "2",
+      B2: "Alice",
+      A3: '=PIVOT.VALUE(1, "Price")',
+    };
+    const model = createModelFromGrid(grid);
+    addPivot(model, "A1:B2", {
+      columns: [],
+      rows: [{ name: "Customer" }],
+      measures: [{ name: "Price", aggregator: "sum" }],
+    });
+    expect(getEvaluatedCell(model, "A3").value).toBe(2);
+    setCellContent(model, "A2", "3");
+    expect(getEvaluatedCell(model, "A3").value).toBe(3);
+  });
+
+  test("update PIVOT.HEADER when data set changes", () => {
+    const grid = {
+      A1: "Price",
+      B1: "Customer",
+      A2: "2",
+      B2: "Alice",
+      A3: '=PIVOT.HEADER(1, "Customer", "Alice")',
+    };
+    const model = createModelFromGrid(grid);
+    addPivot(model, "A1:B2", {
+      columns: [],
+      rows: [{ name: "Customer" }],
+      measures: [{ name: "Price", aggregator: "sum" }],
+    });
+    expect(getEvaluatedCell(model, "A3").value).toBe("Alice");
+    setCellContent(model, "B2", "Bob");
+    expect(getEvaluatedCell(model, "A3").value).toBe("");
+  });
 });


### PR DESCRIPTION
## Description:

Steps to reproduce:
- create a pivot based on a range
- remove the `=PIVOT(1)` formula
- add a few individual `PIVOT.VALUE` or `PIVOT.HEADER` formula
- change values in the range data set => the formulas are not updated

Task: : [4082765](https://www.odoo.com/web#id=4082765&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo