### PR TITLE
[FIX] chart: remove empty datasets for chart

### DIFF
--- a/src/plugins/ui/evaluation_chart.ts
+++ b/src/plugins/ui/evaluation_chart.ts
@@ -9,7 +9,7 @@ import {
 import { chartTerms } from "../../components/side_panel/translations_terms";
 import { MAX_CHAR_LABEL } from "../../constants";
 import { ChartColors } from "../../helpers/chart";
-import { recomputeZones, zoneToXc } from "../../helpers/index";
+import { isNumber, recomputeZones, zoneToXc } from "../../helpers/index";
 import { range } from "../../helpers/misc";
 import { Mode } from "../../model";
 import { Cell } from "../../types";
@@ -231,6 +231,10 @@ export class EvaluationChartPlugin extends UIPlugin {
       }
     }
     for (const [dsIndex, ds] of Object.entries(definition.dataSets)) {
+      const data = ds.dataRange ? this.getData(ds, definition.sheetId) : [];
+      if (data.every((cell) => cell === undefined || cell === null || !isNumber(cell.toString()))) {
+        continue;
+      }
       let label: string;
       if (ds.labelCell) {
         const labelRange = ds.labelCell;
@@ -247,7 +251,7 @@ export class EvaluationChartPlugin extends UIPlugin {
       const color = definition.type !== "pie" ? colors.next() : "#FFFFFF"; // white border for pie chart
       const dataset: ChartDataSets = {
         label,
-        data: ds.dataRange ? this.getData(ds, definition.sheetId) : [],
+        data,
         lineTension: 0, // 0 -> render straight lines, which is much faster
         borderColor: color,
         backgroundColor: color,

--- a/tests/plugins/chart.test.ts
+++ b/tests/plugins/chart.test.ts
@@ -417,6 +417,47 @@ describe("datasource tests", function () {
     expect(title).toBeUndefined();
   });
 
+  test("empty datasets are filtered", () => {
+    model = new Model({
+      sheets: [
+        {
+          name: "Sheet1",
+          colNumber: 10,
+          rowNumber: 10,
+          rows: {},
+          cells: {
+            A2: { content: "P1" },
+            A3: { content: "P2" },
+            A4: { content: "P3" },
+            A5: { content: "P4" },
+            B1: { content: "first column dataset" },
+            B2: { content: "10" },
+            B3: { content: "11" },
+            B4: { content: "12" },
+            B5: { content: "13" },
+            C1: { content: "" },
+            C2: { content: "" },
+            C3: { content: "" },
+            C4: { content: "" },
+            C5: { content: "" },
+          },
+        },
+      ],
+    });
+    createChart(
+      model,
+      {
+        dataSets: ["Sheet1!B1:B5", "Sheet1!C1:C5"],
+        labelRange: "Sheet1!A2:A5",
+        dataSetsHaveTitle: true,
+        type: "line",
+      },
+      "1"
+    );
+    const chart = model.getters.getChartRuntime("1")!;
+    expect(chart.data!.datasets?.length).toEqual(1);
+  });
+
   test("can delete an imported chart", () => {
     const sheetId = model.getters.getActiveSheetId();
     createChart(
@@ -689,8 +730,7 @@ describe("datasource tests", function () {
     );
     deleteRows(model, [1, 2, 3, 4]);
     const chart = model.getters.getChartRuntime("1")!;
-    expect(chart.data!.datasets![0].data).toEqual([]);
-    expect(chart.data!.datasets![1].data).toEqual([]);
+    expect(chart.data!.datasets?.length).toEqual(0);
     expect(chart.data!.labels).toEqual([]);
   });
 
@@ -1485,6 +1525,8 @@ describe("Chart without labels", () => {
   test("Labels are empty if there is only one dataSet and no label", () => {
     setCellContent(model, "A1", "1");
     setCellContent(model, "A2", "2");
+    setCellContent(model, "A3", "3");
+    setCellContent(model, "A4", "4");
     createChart(model, defaultChart, "42");
     expect(model.getters.getChartRuntime("42")?.data?.labels).toEqual(["", ""]);
 
@@ -1588,10 +1630,10 @@ describe("Chart evaluation", () => {
       },
       "1"
     );
-    expect(model.getters.getChartRuntime("1")!.data!.datasets![0]!.data![0]).toBeNull();
+    expect(model.getters.getChartRuntime("1")!.data!.datasets?.length).toBe(0);
     setCellContent(model, "C3", "1");
     expect(model.getters.getChartRuntime("1")!.data!.datasets![0]!.data![0]).toBe(1);
     deleteColumns(model, ["C"]);
-    expect(model.getters.getChartRuntime("1")!.data!.datasets![0]!.data![0]).toBe("#ERROR");
+    expect(model.getters.getChartRuntime("1")!.data!.datasets?.length).toBe(0);
   });
 });


### PR DESCRIPTION
## Task Description

This task aims to undisplay empty datasets from a chart (when all the values are undefined, not when they are equals to 0). This has been done by ignoring the empty datasets during the runtime creation.

## Related Task
- Task: 4085864

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo