### PR TITLE
[FIX] pivot: Prevent faulty pivot domain to crash

### DIFF
--- a/src/plugins/ui_core_views/pivot_ui.ts
+++ b/src/plugins/ui_core_views/pivot_ui.ts
@@ -207,33 +207,37 @@ export class PivotUIPlugin extends UIPlugin {
       const pivotRow = position.row - mainPosition.row;
       return pivotCells[pivotCol][pivotRow];
     }
-    if (functionName === "PIVOT.HEADER" && args.at(-2) === "measure") {
+    try {
+      if (functionName === "PIVOT.HEADER" && args.at(-2) === "measure") {
+        const domain = pivot.parseArgsToPivotDomain(
+          args.slice(1, -2).map((value) => ({ value } as FunctionResultObject))
+        );
+        return {
+          type: "MEASURE_HEADER",
+          domain,
+          measure: args.at(-1)?.toString() || "",
+        };
+      } else if (functionName === "PIVOT.HEADER") {
+        const domain = pivot.parseArgsToPivotDomain(
+          args.slice(1).map((value) => ({ value } as FunctionResultObject))
+        );
+        return {
+          type: "HEADER",
+          domain,
+        };
+      }
+      const [measure, ...domainArgs] = args.slice(1);
       const domain = pivot.parseArgsToPivotDomain(
-        args.slice(1, -2).map((value) => ({ value } as FunctionResultObject))
+        domainArgs.map((value) => ({ value } as FunctionResultObject))
       );
       return {
-        type: "MEASURE_HEADER",
+        type: "VALUE",
         domain,
-        measure: args.at(-1)?.toString() || "",
+        measure: measure?.toString() || "",
       };
-    } else if (functionName === "PIVOT.HEADER") {
-      const domain = pivot.parseArgsToPivotDomain(
-        args.slice(1).map((value) => ({ value } as FunctionResultObject))
-      );
-      return {
-        type: "HEADER",
-        domain,
-      };
+    } catch (_) {
+      return EMPTY_PIVOT_CELL;
     }
-    const [measure, ...domainArgs] = args.slice(1);
-    const domain = pivot.parseArgsToPivotDomain(
-      domainArgs.map((value) => ({ value } as FunctionResultObject))
-    );
-    return {
-      type: "VALUE",
-      domain,
-      measure: measure?.toString() || "",
-    };
   }
 
   getPivot(pivotId: UID) {

--- a/tests/pivots/pivot_plugin.test.ts
+++ b/tests/pivots/pivot_plugin.test.ts
@@ -1,4 +1,5 @@
-import { setCellContent } from "../test_helpers/commands_helpers";
+import { EMPTY_PIVOT_CELL } from "../../src/helpers/pivot/table_spreadsheet_pivot";
+import { selectCell, setCellContent } from "../test_helpers/commands_helpers";
 import { createModelFromGrid, toCellPosition } from "../test_helpers/helpers";
 import { addPivot } from "../test_helpers/pivot_helpers";
 
@@ -27,5 +28,24 @@ describe("Pivot plugin", () => {
     expect(isSpillPivotFormula("G1")).toBe(false);
     setCellContent(model, "G1", "=PIVOT.HEADER(1)");
     expect(isSpillPivotFormula("G1")).toBe(false);
+  });
+
+  test("getPivotCellFromPosition doesn't throw with invalid pivot domain", () => {
+    // prettier-ignore
+    const grid = {
+      A1: "Customer", B1: "Price", C1: '=PIVOT.VALUE(1,"Price","5","Bob")',
+      A2: "Alice",    B2: "10",
+      A3: "Bob",      B3: "30",
+    };
+    const model = createModelFromGrid(grid);
+    addPivot(model, "A1:B3", {
+      columns: [],
+      rows: [{ name: "Customer" }],
+      measures: [{ name: "Price", aggregator: "sum" }],
+    });
+    selectCell(model, "C1");
+    expect(model.getters.getPivotCellFromPosition(model.getters.getActivePosition())).toMatchObject(
+      EMPTY_PIVOT_CELL
+    );
   });
 });


### PR DESCRIPTION
The getter `getPivotCellFromPosition` parses pivot cells domain args but this step assumes that the domain is valid (e.g. refers to a valid groupby,measure combination). Unfortunately, if the domain is invalid, the parsing will crash.

Similarly to the decision made for the getter `evaluateFormula`[^1] we wrap the parsing in a try/catch statement and in case of faulty evaluation, return the same result as for invalid/non-existing pivots, that is an empty Pivotcell.

[^1]: See https://github.com/odoo/o-spreadsheet/pull/3371

Task: 4088765

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo