### PR TITLE
[IMP] charts: export TrendDatasetGenerators

### DIFF
--- a/src/helpers/figures/charts/chart_common_line_scatter.ts
+++ b/src/helpers/figures/charts/chart_common_line_scatter.ts
@@ -124,7 +124,7 @@ function isLuxonTimeAdapterInstalled() {
   return isInstalled;
 }
 
-function getTrendDatasetForLineChart(
+export function getTrendDatasetForLineChart(
   config: TrendConfiguration,
   dataset: any,
   axisType: AxisType,

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,10 +68,12 @@ import { getFunctionsFromTokens } from "./formulas";
 import { isEvaluationError, toBoolean, toJsDate, toNumber, toString } from "./functions/helpers";
 import { FunctionRegistry, arg, functionRegistry } from "./functions/index";
 import {
+  TREND_LINE_XAXIS_ID,
   chartFontColor,
   getChartAxisTitleRuntime,
   getDefaultChartJsRuntime,
   getFillingMode,
+  getTrendDatasetForBarChart,
 } from "./helpers/figures/charts";
 import {
   ColorGenerator,
@@ -114,6 +116,10 @@ import {
 import { supportedPivotPositionalFormulaRegistry } from "./helpers/pivot/pivot_positional_formula_registry";
 
 import { CellComposerStore } from "./components/composer/composer/cell_composer_store";
+import {
+  getChartAxisType,
+  getTrendDatasetForLineChart,
+} from "./helpers/figures/charts/chart_common_line_scatter";
 import {
   areDomainArgsFieldsValid,
   createPivotFormula,
@@ -306,6 +312,9 @@ export const helpers = {
   getDefaultChartJsRuntime,
   chartFontColor,
   getChartAxisTitleRuntime,
+  getChartAxisType,
+  getTrendDatasetForBarChart,
+  getTrendDatasetForLineChart,
   getFillingMode,
   rgbaToHex,
   colorToRGBA,
@@ -431,6 +440,7 @@ export const constants = {
   HIGHLIGHT_COLOR,
   PIVOT_TABLE_CONFIG,
   ChartTerms,
+  TREND_LINE_XAXIS_ID,
 };
 
 export { PivotRuntimeDefinition } from "./helpers/pivot/pivot_runtime_definition";


### PR DESCRIPTION
## Description

To add the trending line in for the Odoo charts, we need to be able to create trending line dataset in these charts. In order to do that, we need getTrendDatasetFor{Bar|Line}Chart helpers, which are now exported by o-spreadsheet.

## Related Task

- Task: 3997500

## Review Checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo