### PR TITLE
[FIX] evaluation: handle throwing error on each vectorized position

### DIFF
--- a/tests/functions/vectorization.test.ts
+++ b/tests/functions/vectorization.test.ts
@@ -153,6 +153,25 @@ describe("vectorization", () => {
     expect(checkFunctionDoesntSpreadBeyondRange(model, "D1:E2")).toBeTruthy();
   });
 
+  test("function which throws an error during the evaluation of the position of one of its vectors, will apply the error to this position and continue the evaluation for each vector position", () => {
+    // prettier-ignore
+    const grid = {
+      A1: "A1", B1: "B1",
+      A2: "A2", B2: "#ERROR",
+      A3: "A3", B3: "B3",
+    };
+    const model = createModelFromGrid(grid);
+    setCellContent(model, "D1", '=FUNCTION.WITHOUT.RANGE.ARGS("this is ", B1:B3)');
+    expect(getRangeValuesAsMatrix(model, "D1:D3")).toEqual([
+      ["this is B1"],
+      ["#ERROR"],
+      ["this is B3"],
+    ]);
+
+    setCellContent(model, "D1", '=FUNCTION.WITHOUT.RANGE.ARGS("#ERROR", A1:A3)');
+    expect(getRangeValuesAsMatrix(model, "D1:D3")).toEqual([["#ERROR"], ["#ERROR"], ["#ERROR"]]);
+  });
+
   test("binary operators should always accept vectors", () => {
     // mean binary operators args should always be simple args
     for (let op in OPERATOR_MAP) {


### PR DESCRIPTION
Before this commit, if an error was throw when evaluating a vectorized formula, then the evaluation stopped and only the cell with the formula was marked as an error.
No other values ​​were spread.

This behavior is functionally false, because depending on the arguments passed, it is possible that on this vector position, the evaluation does not return an error.

This commit changes that by making sure to try for each vector position if the evaluation works. Even though it only spreads errors in certain cases.

Task: : [4091276](https://www.odoo.com/web#id=4091276&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo