### PR TITLE
[IMP] currency format: add accounting format

### DIFF
--- a/doc/extending/xlsx/xlsx_import.md
+++ b/doc/extending/xlsx/xlsx_import.md
@@ -106,21 +106,12 @@ Excel don't really use the theme.xml file for theme colors, but define its own s
 
 ### Number Formats
 
-We do not currently support many features in number formats. We try to convert the number formats of Excel into something we can use, dropping what we do not support.
+We try to convert the number formats of Excel into something we can use, dropping what we do not support.
 If we cannot convert the number format into something we can use, we drop it completely.
 
-- Multi-parts format :
-  - They are parts separated by ; in format
-  - We don't support those, we only take the first part
 - Locale/Date System info :
   - They are HexCodes in brackets in the format (eg . [\$-40C], [\$string-52B])
   - We drop them completely
-- Escaped sequences of character :
-  - They are blocks in the format that are pasted as-is in the parsed format. They can either be blocks with quotes "..." or brackets [\$...]
-  - We only support one of these escaped sequence by format. Drop the format if there are multiple of these.
-  - We only support brackets, convert "..." into [\$...]
-- Spaces :
-  - We only support spaces inside escaped sequence. Drop the spaces that are not in the escaped sequence.
 - Underscore character (\_) :
   - It marks the next character as a character to ignore when computing the alignment of the word.
   - We don't support this, drop \_ and the character that follows it in the format.

--- a/src/actions/format_actions.ts
+++ b/src/actions/format_actions.ts
@@ -13,7 +13,6 @@ import {
   CellValue,
   DEFAULT_LOCALE,
   Format,
-  PLAIN_TEXT_FORMAT,
   SpreadsheetChildEnv,
   VerticalAlign,
   Wrapping,
@@ -61,8 +60,8 @@ export const formatNumberAutomatic: NumberFormatActionSpec = {
 
 export const formatNumberPlainText: NumberFormatActionSpec = {
   name: _t("Plain text"),
-  execute: (env) => setFormatter(env, PLAIN_TEXT_FORMAT),
-  isActive: (env) => isFormatSelected(env, PLAIN_TEXT_FORMAT),
+  execute: (env) => setFormatter(env, "@"),
+  isActive: (env) => isFormatSelected(env, "@"),
 };
 
 export const formatNumberNumber = createFormatActionSpec({

--- a/src/actions/format_actions.ts
+++ b/src/actions/format_actions.ts
@@ -1,10 +1,11 @@
 import {
+  DEFAULT_CURRENCY,
   DEFAULT_FONT_SIZE,
   DEFAULT_VERTICAL_ALIGN,
   DEFAULT_WRAPPING_MODE,
   FONT_SIZES,
 } from "../constants";
-import { formatValue, roundFormat } from "../helpers";
+import { createAccountingFormat, createCurrencyFormat, formatValue, roundFormat } from "../helpers";
 import { parseLiteral } from "../helpers/cells";
 import { getDateTimeFormat } from "../helpers/locale";
 import { _t } from "../translation";
@@ -85,22 +86,30 @@ export const formatNumberPercent = createFormatActionSpec({
 export const formatNumberCurrency = createFormatActionSpec({
   name: _t("Currency"),
   descriptionValue: 1000.12,
-  format: (env) => env.model.config.defaultCurrencyFormat ?? DEFAULT_CURRENCY_FORMAT,
+  format: (env) => createCurrencyFormat(env.model.config.defaultCurrency || DEFAULT_CURRENCY),
 });
 
 export const formatNumberCurrencyRounded: NumberFormatActionSpec = {
   ...createFormatActionSpec({
     name: _t("Currency rounded"),
     descriptionValue: 1000,
-    format: (env) => roundFormat(env.model.config.defaultCurrencyFormat ?? DEFAULT_CURRENCY_FORMAT),
+    format: (env) =>
+      roundFormat(createCurrencyFormat(env.model.config.defaultCurrency || DEFAULT_CURRENCY)),
   }),
   isVisible: (env) => {
-    const currencyFormat = env.model.config.defaultCurrencyFormat;
-    return currencyFormat !== roundFormat(currencyFormat ?? DEFAULT_CURRENCY_FORMAT);
+    const currencyFormat = createCurrencyFormat(
+      env.model.config.defaultCurrency || DEFAULT_CURRENCY
+    );
+    const roundedFormat = roundFormat(currencyFormat);
+    return currencyFormat !== roundedFormat;
   },
 };
 
-const DEFAULT_CURRENCY_FORMAT = "[$$]#,##0.00";
+export const formatNumberAccounting = createFormatActionSpec({
+  name: _t("Accounting"),
+  descriptionValue: -1000.12,
+  format: (env) => createAccountingFormat(env.model.config.defaultCurrency || DEFAULT_CURRENCY),
+});
 
 export const EXAMPLE_DATE = parseLiteral("2023/09/26 10:43:00 PM", DEFAULT_LOCALE);
 

--- a/src/components/bottom_bar/bottom_bar_statistic/bottom_bar_statistic.ts
+++ b/src/components/bottom_bar/bottom_bar_statistic/bottom_bar_statistic.ts
@@ -1,5 +1,5 @@
 import { Component, onWillUpdateProps } from "@odoo/owl";
-import { formatValue } from "../../../helpers/format";
+import { formatValue } from "../../../helpers/format/format";
 import { MenuItemRegistry } from "../../../registries/menu_items_registry";
 import { Store, useStore } from "../../../store_engine";
 import { SpreadsheetChildEnv } from "../../../types";

--- a/src/components/side_panel/custom_currency/custom_currency.ts
+++ b/src/components/side_panel/custom_currency/custom_currency.ts
@@ -1,10 +1,16 @@
 import { Component, onWillStart, useState } from "@odoo/owl";
-import { createCurrencyFormat, formatValue, roundFormat } from "../../../helpers";
+import {
+  createAccountingFormat,
+  createCurrencyFormat,
+  formatValue,
+  isDefined,
+} from "../../../helpers";
 import { currenciesRegistry } from "../../../registries/currencies_registry";
 import { _t } from "../../../translation";
 import { Currency, Format, SpreadsheetChildEnv } from "../../../types";
 import { css } from "../../helpers/css";
 import { CustomCurrencyTerms } from "../../translations_terms";
+import { Checkbox } from "../components/checkbox/checkbox";
 import { Section } from "../components/section/section";
 
 css/* scss */ `
@@ -12,11 +18,20 @@ css/* scss */ `
     .o-format-proposals {
       color: black;
     }
+
+    .o-format-examples {
+      background: #f9fafb;
+      padding: 8px;
+      border-radius: 4px;
+      border: 1px solid #d8dadd;
+      color: #374151;
+    }
   }
 `;
 
 interface CurrencyProposal {
-  format: string;
+  format: Format;
+  accountingFormat: Format;
   example: string;
 }
 
@@ -29,11 +44,12 @@ interface State {
   currencyCode: string;
   currencySymbol: string;
   selectedFormatIndex: number;
+  isAccountingFormat: boolean;
 }
 
 export class CustomCurrencyPanel extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-CustomCurrencyPanel";
-  static components = { Section };
+  static components = { Section, Checkbox };
   static props = { onCloseSidePanel: Function };
 
   private availableCurrencies!: Currency[];
@@ -46,36 +62,32 @@ export class CustomCurrencyPanel extends Component<Props, SpreadsheetChildEnv> {
       currencyCode: "",
       currencySymbol: "",
       selectedFormatIndex: 0,
+      isAccountingFormat: false,
     });
     onWillStart(() => this.updateAvailableCurrencies());
   }
 
   get formatProposals(): CurrencyProposal[] {
-    const currency = this.availableCurrencies[this.state.selectedCurrencyIndex];
-    const position = currency.position;
-    const opposite = currency.position === "before" ? "after" : "before";
+    const baseCurrency = this.availableCurrencies[this.state.selectedCurrencyIndex];
+    const position = baseCurrency.position;
+    const opposite = baseCurrency.position === "before" ? "after" : "before";
     const symbol = this.state.currencySymbol.trim() ? this.state.currencySymbol : "";
     const code = this.state.currencyCode.trim() ? this.state.currencyCode : "";
-    const decimalPlaces = currency.decimalPlaces;
+    const decimalPlaces = baseCurrency.decimalPlaces;
     if (!symbol && !code) {
       return [];
     }
-    const simple = symbol ? createCurrencyFormat({ symbol, position, decimalPlaces }) : "";
-    const rounded = simple ? roundFormat(simple) : "";
-    const simpleWithCode = createCurrencyFormat({ symbol, position, decimalPlaces, code });
-    const roundedWithCode = roundFormat(simpleWithCode);
-    const simpleOpposite = symbol
-      ? createCurrencyFormat({ symbol, position: opposite, decimalPlaces })
-      : "";
-    const roundedOpposite = simpleOpposite ? roundFormat(simpleOpposite) : "";
-    const simpleOppositeWithCode = createCurrencyFormat({
-      symbol,
-      position: opposite,
-      decimalPlaces,
-      code,
-    });
-    const roundedOppositeWithCode = roundFormat(simpleOppositeWithCode);
-    const formats = new Set([
+
+    const simple = { symbol, position, decimalPlaces };
+    const rounded = { symbol, position, decimalPlaces: 0 };
+    const simpleWithCode = { symbol, position, decimalPlaces, code };
+    const roundedWithCode = { symbol, position, decimalPlaces: 0, code };
+    const simpleOpposite = { symbol, position: opposite, decimalPlaces };
+    const roundedOpposite = { symbol, position: opposite, decimalPlaces: 0 };
+    const simpleOppositeWithCode = { symbol, position: opposite, decimalPlaces, code };
+    const roundedOppositeWithCode = { symbol, position: opposite, decimalPlaces: 0, code };
+
+    const currencies = [
       rounded,
       simple,
       roundedWithCode,
@@ -84,18 +96,28 @@ export class CustomCurrencyPanel extends Component<Props, SpreadsheetChildEnv> {
       simpleOpposite,
       roundedOppositeWithCode,
       simpleOppositeWithCode,
-    ]);
-    return [...formats]
-      .filter((format) => format !== "")
-      .map((format) => ({
-        format,
-        example: formatValue(1000.0, { format, locale: this.env.model.getters.getLocale() }),
-      }));
+    ] as Partial<Currency>[];
+
+    const usedFormats = new Set<string>();
+    const locale = this.env.model.getters.getLocale();
+    return currencies
+      .map((currency) => {
+        const format = createCurrencyFormat(currency);
+        if ((!currency.symbol && !currency.code) || usedFormats.has(format)) {
+          return undefined;
+        }
+        usedFormats.add(format);
+        return {
+          format,
+          accountingFormat: createAccountingFormat(currency),
+          example: formatValue(1000.0, { format, locale }),
+        };
+      })
+      .filter(isDefined);
   }
 
   get isSameFormat(): boolean {
-    const selectedFormat = this.formatProposals[this.state.selectedFormatIndex];
-    return selectedFormat ? selectedFormat.format === this.getCommonFormat() : false;
+    return this.selectedFormat ? this.selectedFormat === this.getCommonFormat() : false;
   }
 
   async updateAvailableCurrencies() {
@@ -143,11 +165,10 @@ export class CustomCurrencyPanel extends Component<Props, SpreadsheetChildEnv> {
   }
 
   apply() {
-    const selectedFormat = this.formatProposals[this.state.selectedFormatIndex];
     this.env.model.dispatch("SET_FORMATTING", {
       sheetId: this.env.model.getters.getActiveSheetId(),
       target: this.env.model.getters.getSelectedZones(),
-      format: selectedFormat.format,
+      format: this.selectedFormat,
     });
   }
 
@@ -173,5 +194,24 @@ export class CustomCurrencyPanel extends Component<Props, SpreadsheetChildEnv> {
 
   currencyDisplayName(currency: Currency): string {
     return currency.name + (currency.code ? ` (${currency.code})` : "");
+  }
+
+  toggleAccountingFormat() {
+    this.state.isAccountingFormat = !this.state.isAccountingFormat;
+  }
+
+  getFormatExamples() {
+    const format = this.selectedFormat;
+    const locale = this.env.model.getters.getLocale();
+    return [
+      { label: _t("positive") + ":", value: formatValue(1234.56, { format, locale }) },
+      { label: _t("negative") + ":", value: formatValue(-1234.56, { format, locale }) },
+      { label: _t("zero") + ":", value: formatValue(0, { format, locale }) },
+    ];
+  }
+
+  get selectedFormat() {
+    const proposal = this.formatProposals[this.state.selectedFormatIndex];
+    return this.state.isAccountingFormat ? proposal?.accountingFormat : proposal?.format;
   }
 }

--- a/src/components/side_panel/custom_currency/custom_currency.xml
+++ b/src/components/side_panel/custom_currency/custom_currency.xml
@@ -40,7 +40,7 @@
       <Section>
         <t t-set-slot="title">Format</t>
         <select
-          class="o-input o-format-proposals"
+          class="o-input o-format-proposals mb-1"
           t-on-change="(ev) => this.updateSelectFormat(ev)"
           t-att-disabled="!formatProposals.length">
           <t t-foreach="formatProposals" t-as="proposal" t-key="proposal_index">
@@ -51,6 +51,23 @@
             />
           </t>
         </select>
+        <t t-set="accounting_format_label">Accounting format</t>
+        <Checkbox
+          name="'accountingFormat'"
+          label="accounting_format_label"
+          value="state.isAccountingFormat"
+          onChange.bind="toggleAccountingFormat"
+        />
+        <div class="o-format-examples mt-4" t-if="selectedFormat">
+          <table>
+            <t t-foreach="getFormatExamples()" t-as="example" t-key="example_index">
+              <tr>
+                <td class="pe-3 fw-bolder" t-esc="example.label"/>
+                <td t-esc="example.value"/>
+              </tr>
+            </t>
+          </table>
+        </div>
       </Section>
       <Section>
         <div class="o-sidePanelButtons">

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,4 @@
-import { BorderDescr, Color, Style } from "./types";
+import { BorderDescr, Color, Currency, Style } from "./types";
 
 export const CANVAS_SHIFT = 0.5;
 
@@ -290,4 +290,12 @@ export const PIVOT_TABLE_CONFIG = {
   bandedRows: true,
   bandedColumns: false,
   styleId: "TableStyleMedium5",
+};
+
+export const DEFAULT_CURRENCY: Currency = {
+  symbol: "$",
+  position: "before",
+  decimalPlaces: 2,
+  code: "",
+  name: "Dollar",
 };

--- a/src/formulas/tokenizer.ts
+++ b/src/formulas/tokenizer.ts
@@ -1,5 +1,10 @@
 import { NEWLINE } from "../constants";
-import { getFormulaNumberRegex, rangeReference, replaceSpecialSpaces } from "../helpers/index";
+import {
+  TokenizingChars,
+  getFormulaNumberRegex,
+  rangeReference,
+  replaceSpecialSpaces,
+} from "../helpers/index";
 import { DEFAULT_LOCALE, Locale } from "../types";
 import { CellErrorType } from "../types/errors";
 
@@ -226,47 +231,4 @@ function tokenizeInvalidRange(chars: TokenizingChars): Token | null {
     return { type: "INVALID_REFERENCE", value: CellErrorType.InvalidReference };
   }
   return null;
-}
-
-class TokenizingChars {
-  private text: string;
-  private currentIndex: number = 0;
-  current: string;
-
-  constructor(text: string) {
-    this.text = text;
-    this.current = text[0];
-  }
-
-  shift() {
-    const current = this.current;
-    const next = this.text[++this.currentIndex];
-    this.current = next;
-    return current;
-  }
-
-  advanceBy(length: number) {
-    this.currentIndex += length;
-    this.current = this.text[this.currentIndex];
-  }
-
-  isOver() {
-    return this.currentIndex >= this.text.length;
-  }
-
-  remaining() {
-    return this.text.substring(this.currentIndex);
-  }
-
-  currentStartsWith(str: string) {
-    if (this.current !== str[0]) {
-      return false;
-    }
-    for (let j = 1; j < str.length; j++) {
-      if (this.text[this.currentIndex + j] !== str[j]) {
-        return false;
-      }
-    }
-    return true;
-  }
 }

--- a/src/helpers/cells/cell_evaluation.ts
+++ b/src/helpers/cells/cell_evaluation.ts
@@ -16,7 +16,12 @@ import {
   PLAIN_TEXT_FORMAT,
 } from "../../types";
 import { parseDateTime } from "../dates";
-import { detectDateFormat, detectNumberFormat, formatValue, isDateTimeFormat } from "../format";
+import {
+  detectDateFormat,
+  detectNumberFormat,
+  formatValue,
+  isDateTimeFormat,
+} from "../format/format";
 import { detectLink } from "../links";
 import { isBoolean, memoize } from "../misc";
 import { isNumber, parseNumber } from "../numbers";

--- a/src/helpers/cells/cell_evaluation.ts
+++ b/src/helpers/cells/cell_evaluation.ts
@@ -13,7 +13,6 @@ import {
   Locale,
   LocaleFormat,
   NumberCell,
-  PLAIN_TEXT_FORMAT,
 } from "../../types";
 import { parseDateTime } from "../dates";
 import {
@@ -21,6 +20,7 @@ import {
   detectNumberFormat,
   formatValue,
   isDateTimeFormat,
+  isTextFormat,
 } from "../format/format";
 import { detectLink } from "../links";
 import { isBoolean, memoize } from "../misc";
@@ -30,8 +30,7 @@ export function evaluateLiteral(
   literalCell: LiteralCell,
   localeFormat: LocaleFormat
 ): EvaluatedCell {
-  const value =
-    localeFormat.format === PLAIN_TEXT_FORMAT ? literalCell.content : literalCell.parsedValue;
+  const value = isTextFormat(localeFormat.format) ? literalCell.content : literalCell.parsedValue;
   const functionResult = { value, format: localeFormat.format };
   return createEvaluatedCell(functionResult, localeFormat.locale);
 }
@@ -93,7 +92,7 @@ function _createEvaluatedCell(
   if (isEvaluationError(value)) {
     return errorCell(value, message);
   }
-  if (format === PLAIN_TEXT_FORMAT) {
+  if (isTextFormat(format)) {
     // TO DO:
     // with the next line, the value of the cell is transformed depending on the format.
     // This shouldn't happen, by doing this, the formulas handling numbers are not able

--- a/src/helpers/figures/charts/chart_common.ts
+++ b/src/helpers/figures/charts/chart_common.ts
@@ -34,7 +34,7 @@ import {
 } from "../../../types/chart/chart";
 import { CellErrorType } from "../../../types/errors";
 import { ColorGenerator, lightenColor, relativeLuminance } from "../../color";
-import { formatValue } from "../../format";
+import { formatValue } from "../../format/format";
 import { isDefined, range } from "../../misc";
 import { copyRangeWithNewSheetId } from "../../range";
 import { rangeReference } from "../../references";

--- a/src/helpers/figures/charts/chart_common_line_scatter.ts
+++ b/src/helpers/figures/charts/chart_common_line_scatter.ts
@@ -11,7 +11,7 @@ import {
 } from "../../../types/chart/chart";
 import { getChartTimeOptions, timeFormatLuxonCompatible } from "../../chart_date";
 import { colorToRGBA, rgbaToHex } from "../../color";
-import { formatValue } from "../../format";
+import { formatValue } from "../../format/format";
 import { deepCopy, findNextDefinedValue, range } from "../../misc";
 import { isNumber } from "../../numbers";
 import {

--- a/src/helpers/figures/charts/chart_ui_common.ts
+++ b/src/helpers/figures/charts/chart_ui_common.ts
@@ -6,7 +6,7 @@ import { _t } from "../../../translation";
 import { Color, Figure, Format, Getters, LocaleFormat, Range } from "../../../types";
 import { GaugeChartRuntime, ScorecardChartRuntime } from "../../../types/chart";
 import { ChartRuntime, DataSet, DatasetValues, LabelValues } from "../../../types/chart/chart";
-import { formatValue, isDateTimeFormat } from "../../format";
+import { formatValue, isDateTimeFormat } from "../../format/format";
 import { deepCopy, range } from "../../misc";
 import { recomputeZones } from "../../recompute_zones";
 import { AbstractChart } from "./abstract_chart";

--- a/src/helpers/figures/charts/pie_chart.ts
+++ b/src/helpers/figures/charts/pie_chart.ts
@@ -32,7 +32,7 @@ import { CellErrorType } from "../../../types/errors";
 import { Validator } from "../../../types/validator";
 import { toXlsxHexColor } from "../../../xlsx/helpers/colors";
 import { ColorGenerator } from "../../color";
-import { formatValue } from "../../format";
+import { formatValue } from "../../format/format";
 import { largeMax } from "../../misc";
 import { createValidRange } from "../../range";
 import { AbstractChart } from "./abstract_chart";

--- a/src/helpers/figures/charts/scorecard_chart.ts
+++ b/src/helpers/figures/charts/scorecard_chart.ts
@@ -30,7 +30,7 @@ import {
   ScorecardChartRuntime,
 } from "../../../types/chart/scorecard_chart";
 import { Validator } from "../../../types/validator";
-import { formatValue, humanizeNumber } from "../../format";
+import { formatValue, humanizeNumber } from "../../format/format";
 import { isNumber } from "../../numbers";
 import { createValidRange } from "../../range";
 import { rangeReference } from "../../references";

--- a/src/helpers/figures/charts/waterfall_chart.ts
+++ b/src/helpers/figures/charts/waterfall_chart.ts
@@ -32,7 +32,7 @@ import {
   WaterfallChartRuntime,
 } from "../../../types/chart/waterfall_chart";
 import { Validator } from "../../../types/validator";
-import { formatValue } from "../../format";
+import { formatValue } from "../../format/format";
 import { createValidRange } from "../../range";
 import { AbstractChart } from "./abstract_chart";
 import {

--- a/src/helpers/format/format.ts
+++ b/src/helpers/format/format.ts
@@ -1,5 +1,5 @@
-import { toNumber, toString } from "../functions/helpers";
-import { _t } from "../translation";
+import { toNumber, toString } from "../../functions/helpers";
+import { _t } from "../../translation";
 import {
   CellValue,
   Currency,
@@ -10,10 +10,10 @@ import {
   LocaleFormat,
   Maybe,
   PLAIN_TEXT_FORMAT,
-} from "../types";
-import { EvaluationError } from "../types/errors";
-import { DateTime, INITIAL_1900_DAY, isDateTime, numberToJsDate, parseDateTime } from "./dates";
-import { escapeRegExp, memoize } from "./misc";
+} from "../../types";
+import { EvaluationError } from "../../types/errors";
+import { DateTime, INITIAL_1900_DAY, isDateTime, numberToJsDate, parseDateTime } from "../dates";
+import { escapeRegExp, memoize } from "../misc";
 
 /**
  *  Constant used to indicate the maximum of digits that is possible to display

--- a/src/helpers/format/format.ts
+++ b/src/helpers/format/format.ts
@@ -769,3 +769,13 @@ export function isExcelCompatible(format: Format): boolean {
   }
   return true;
 }
+
+export function isTextFormat(format: Format | undefined): boolean {
+  if (!format) return false;
+  try {
+    const internalFormat = parseFormat(format);
+    return internalFormat.positive.type === "text";
+  } catch {
+    return false;
+  }
+}

--- a/src/helpers/format/format_parser.ts
+++ b/src/helpers/format/format_parser.ts
@@ -1,0 +1,331 @@
+import { Format } from "../../types";
+import { isDefined } from "../misc";
+import {
+  CharToken,
+  DatePartToken,
+  DecimalPointToken,
+  DigitToken,
+  FormatToken,
+  PercentToken,
+  StringToken,
+  TextPlaceholderToken,
+  ThousandsSeparatorToken,
+  alwaysEscapedCharsInFormat,
+  tokenizeFormat,
+} from "./format_tokenizer";
+
+/**
+ *  Constant used to indicate the maximum of digits that is possible to display
+ *  in a cell with standard size.
+ */
+export const MAX_DECIMAL_PLACES = 20;
+
+export interface MultiPartInternalFormat {
+  positive: NumberInternalFormat | DateInternalFormat | TextInternalFormat;
+  negative?: NumberInternalFormat | DateInternalFormat;
+  zero?: NumberInternalFormat | DateInternalFormat;
+  text?: TextInternalFormat;
+}
+
+export interface DateInternalFormat {
+  type: "date";
+  tokens: (DatePartToken | StringToken | CharToken)[];
+}
+
+export interface NumberInternalFormat {
+  type: "number";
+  readonly integerPart: (
+    | DigitToken
+    | StringToken
+    | CharToken
+    | PercentToken
+    | ThousandsSeparatorToken
+  )[];
+  readonly percentSymbols: number;
+  readonly thousandsSeparator: boolean;
+  /** A thousand separator after the last digit in the format means that we divide the number by a thousand */
+  readonly magnitude: number;
+  /**
+   * optional because we need to differentiate a number
+   * with a dot but no decimals with a number without any decimals.
+   * i.e. '5.'  !=== '5' !=== '5.0'
+   */
+  readonly decimalPart?: (
+    | DigitToken
+    | StringToken
+    | CharToken
+    | PercentToken
+    | ThousandsSeparatorToken
+  )[];
+}
+
+export interface TextInternalFormat {
+  type: "text";
+  tokens: (StringToken | CharToken | TextPlaceholderToken)[];
+}
+
+export type InternalFormat = NumberInternalFormat | DateInternalFormat | TextInternalFormat;
+
+const internalFormatCache: { [format: string]: MultiPartInternalFormat } = {};
+
+export function parseFormat(formatString: Format): MultiPartInternalFormat {
+  let internalFormat = internalFormatCache[formatString];
+  if (internalFormat === undefined) {
+    internalFormat = convertFormatToInternalFormat(formatString);
+    internalFormatCache[formatString] = internalFormat;
+  }
+  return internalFormat;
+}
+
+function convertFormatToInternalFormat(format: Format): MultiPartInternalFormat {
+  const formatParts = tokenizeFormat(format);
+
+  const positiveFormat =
+    parseDateFormatTokens(formatParts[0]) ||
+    parseNumberFormatTokens(formatParts[0]) ||
+    tokensToTextInternalFormat(formatParts[0]);
+  if (!positiveFormat) {
+    throw new Error("Invalid first format part of: " + format);
+  }
+  if (formatParts.length > 1 && positiveFormat.type === "text") {
+    throw new Error("The first format in a multi-part format must be a number format: " + format);
+  }
+
+  const negativeFormat =
+    parseDateFormatTokens(formatParts[1]) || parseNumberFormatTokens(formatParts[1]);
+  if (formatParts[1]?.length && !negativeFormat) {
+    throw new Error("Invalid second format part of: " + format);
+  }
+
+  const zeroFormat =
+    parseDateFormatTokens(formatParts[2]) || parseNumberFormatTokens(formatParts[2]);
+  if (formatParts[2]?.length && !zeroFormat) {
+    throw new Error("Invalid third format part of: " + format);
+  }
+
+  const textFormat = tokensToTextInternalFormat(formatParts[3]);
+  if (formatParts[3]?.length && !textFormat) {
+    throw new Error("Invalid fourth format part of: " + format);
+  }
+
+  return { positive: positiveFormat, negative: negativeFormat, zero: zeroFormat, text: textFormat };
+}
+
+function areValidDateFormatTokens(
+  tokens: FormatToken[]
+): tokens is (
+  | DatePartToken
+  | CharToken
+  | StringToken
+  | ThousandsSeparatorToken
+  | DecimalPointToken
+)[] {
+  return tokens.every(
+    (token) =>
+      token.type === "DATE_PART" ||
+      token.type === "DECIMAL_POINT" ||
+      token.type === "THOUSANDS_SEPARATOR" ||
+      token.type === "STRING" ||
+      token.type === "CHAR"
+  );
+}
+
+function areValidNumberFormatTokens(
+  tokens: FormatToken[]
+): tokens is (
+  | DigitToken
+  | DecimalPointToken
+  | ThousandsSeparatorToken
+  | PercentToken
+  | StringToken
+  | CharToken
+)[] {
+  return tokens.every(
+    (token) =>
+      token.type === "DIGIT" ||
+      token.type === "DECIMAL_POINT" ||
+      token.type === "THOUSANDS_SEPARATOR" ||
+      token.type === "PERCENT" ||
+      token.type === "STRING" ||
+      token.type === "CHAR"
+  );
+}
+
+function areValidTextFormatTokens(tokens: FormatToken[]): tokens is TextInternalFormat["tokens"] {
+  return tokens.every(
+    (token) => token.type === "STRING" || token.type === "TEXT_PLACEHOLDER" || token.type === "CHAR"
+  );
+}
+
+function parseNumberFormatTokens(
+  tokens: FormatToken[] | undefined
+): NumberInternalFormat | undefined {
+  if (!tokens || !areValidNumberFormatTokens(tokens)) {
+    return undefined;
+  }
+  const integerPart: NumberInternalFormat["integerPart"] = [];
+  let decimalPart: NumberInternalFormat["decimalPart"] = undefined;
+
+  let parsedPart = integerPart;
+  let percentSymbols = 0;
+  let magnitude = 0;
+  let lastIndexOfDigit = tokens.findLastIndex((token) => token.type === "DIGIT");
+  let hasThousandSeparator = false;
+  let numberOfDecimalsDigits = 0;
+
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i];
+    switch (token.type) {
+      case "DIGIT":
+        if (parsedPart === integerPart) {
+          parsedPart.push(token);
+        } else if (numberOfDecimalsDigits < MAX_DECIMAL_PLACES) {
+          parsedPart.push(token);
+          numberOfDecimalsDigits++;
+        }
+        break;
+      case "DECIMAL_POINT":
+        if (parsedPart === integerPart) {
+          decimalPart = [];
+          parsedPart = decimalPart;
+        } else {
+          throw new Error("Multiple decimal points in a number format");
+        }
+        break;
+      case "CHAR":
+      case "STRING":
+        parsedPart.push(token);
+        break;
+      case "PERCENT":
+        percentSymbols++;
+        parsedPart.push(token);
+        break;
+      // Per OpenXML Spec:
+      // - If a comma is between two DIGIT tokens, and in the integer part, a thousand separator is applied in the formatted value.
+      // - If a comma is at the end of the number placeholder, the number is divided by a thousand.
+      // - Otherwise, it's a string.
+      case "THOUSANDS_SEPARATOR":
+        if (i - 1 === lastIndexOfDigit) {
+          magnitude += 1;
+          lastIndexOfDigit++; // Can have multiple commas in a row
+          parsedPart.push(token);
+        } else if (tokens[i + 1]?.type === "DIGIT" && tokens[i - 1]?.type === "DIGIT") {
+          if (parsedPart === integerPart) {
+            hasThousandSeparator = true;
+          }
+          parsedPart.push(token);
+        } else {
+          parsedPart.push({ type: "CHAR", value: "," });
+        }
+        break;
+    }
+  }
+
+  return {
+    type: "number",
+    integerPart,
+    decimalPart,
+    percentSymbols,
+    thousandsSeparator: hasThousandSeparator,
+    magnitude,
+  };
+}
+
+function parseDateFormatTokens(tokens: FormatToken[] | undefined): DateInternalFormat | undefined {
+  const internalFormat =
+    tokens && areValidDateFormatTokens(tokens) ? { type: "date", tokens } : undefined;
+  if (!internalFormat) {
+    return undefined;
+  }
+  if (
+    internalFormat.tokens.length &&
+    internalFormat.tokens.every((token) => token.type === "DATE_PART" && token.value === "a")
+  ) {
+    throw new Error("Invalid date format");
+  }
+  const dateTokens: DateInternalFormat["tokens"] = internalFormat.tokens.map((token) => {
+    if (token.type === "THOUSANDS_SEPARATOR" || token.type === "DECIMAL_POINT") {
+      return { type: "CHAR", value: token.value };
+    }
+    return token;
+  });
+  const convertedTokens = convertTokensToMinutesInDateFormat(dateTokens);
+  return { type: "date", tokens: convertedTokens };
+}
+
+function tokensToTextInternalFormat(
+  tokens: FormatToken[] | undefined
+): TextInternalFormat | undefined {
+  return tokens && areValidTextFormatTokens(tokens) ? { type: "text", tokens } : undefined;
+}
+
+/**
+ * Replace in place tokens "mm" and "m" that denote minutes in date format with "MM" to avoid confusion with months.
+ *
+ * As per OpenXML specification, in date formats if a date token "m" or "mm" is followed by a date token "s" or
+ * preceded by a data token "h", then it's not a month but an minute.
+ */
+function convertTokensToMinutesInDateFormat(tokens: DateInternalFormat["tokens"]) {
+  const dateParts = tokens.filter((token) => token.type === "DATE_PART") as DatePartToken[];
+  for (let i = 0; i < dateParts.length; i++) {
+    if (!dateParts[i].value.startsWith("m") || dateParts[i].value.length > 2) {
+      continue;
+    }
+    if (dateParts[i - 1]?.value.startsWith("h") || dateParts[i + 1]?.value.startsWith("s")) {
+      dateParts[i].value = dateParts[i].value.replaceAll("m", "M");
+    }
+  }
+  return tokens;
+}
+
+export function convertInternalFormatToFormat(internalFormat: MultiPartInternalFormat): Format {
+  return [
+    internalFormatPartToFormat(internalFormat.positive),
+    internalFormatPartToFormat(internalFormat.negative),
+    internalFormatPartToFormat(internalFormat.zero),
+    internalFormatPartToFormat(internalFormat.text),
+  ]
+    .filter(isDefined)
+    .join(";");
+}
+
+function internalFormatPartToFormat(
+  internalFormat: InternalFormat | undefined
+): Format | undefined {
+  if (!internalFormat) {
+    return undefined;
+  }
+  let format = "";
+  const tokens =
+    internalFormat.type !== "number"
+      ? internalFormat.tokens
+      : numberInternalFormatToTokenList(internalFormat);
+  for (let token of tokens) {
+    switch (token.type) {
+      case "STRING":
+        format += `[$${token.value}]`;
+        break;
+      case "CHAR":
+        format += shouldEscapeFormatChar(token.value) ? `\\${token.value}` : token.value;
+        break;
+      default:
+        format += token.value;
+    }
+  }
+  return format;
+}
+
+function numberInternalFormatToTokenList(internalFormat: NumberInternalFormat): FormatToken[] {
+  let tokens: FormatToken[] = [...internalFormat.integerPart];
+
+  if (internalFormat.decimalPart) {
+    tokens.push({ type: "DECIMAL_POINT", value: "." });
+    tokens.push(...internalFormat.decimalPart);
+  }
+
+  return tokens;
+}
+
+function shouldEscapeFormatChar(char: string): boolean {
+  return !alwaysEscapedCharsInFormat.has(char);
+}

--- a/src/helpers/format/format_tokenizer.ts
+++ b/src/helpers/format/format_tokenizer.ts
@@ -1,0 +1,190 @@
+import { TokenizingChars } from "../misc";
+
+export interface DigitToken {
+  type: "DIGIT";
+  value: "0" | "#";
+}
+
+export interface DecimalPointToken {
+  type: "DECIMAL_POINT";
+  value: ".";
+}
+
+export interface StringToken {
+  type: "STRING";
+  value: string;
+}
+
+export interface CharToken {
+  type: "CHAR";
+  value: string;
+}
+
+export interface PercentToken {
+  type: "PERCENT";
+  value: "%";
+}
+
+export interface ThousandsSeparatorToken {
+  type: "THOUSANDS_SEPARATOR";
+  value: ",";
+}
+
+export interface TextPlaceholderToken {
+  type: "TEXT_PLACEHOLDER";
+  value: "@";
+}
+
+export interface DatePartToken {
+  type: "DATE_PART";
+  value: string;
+}
+
+export type FormatToken =
+  | DigitToken
+  | DecimalPointToken
+  | StringToken
+  | CharToken
+  | PercentToken
+  | ThousandsSeparatorToken
+  | TextPlaceholderToken
+  | DatePartToken;
+
+export function tokenizeFormat(str: string): FormatToken[][] {
+  const chars = new TokenizingChars(str);
+  const result: FormatToken[][] = [];
+
+  let currentFormatPart: FormatToken[] = [];
+  result.push(currentFormatPart);
+
+  while (!chars.isOver()) {
+    if (chars.current === ";") {
+      currentFormatPart = [];
+      result.push(currentFormatPart);
+      chars.shift();
+      continue;
+    }
+    let token =
+      tokenizeDigit(chars) ||
+      tokenizeString(chars) ||
+      tokenizeEscapedChars(chars) ||
+      tokenizeThousandsSeparator(chars) ||
+      tokenizeDecimalPoint(chars) ||
+      tokenizePercent(chars) ||
+      tokenizeDatePart(chars) ||
+      tokenizeTextPlaceholder(chars);
+
+    if (!token) {
+      throw new Error("Unknown token at " + chars.remaining());
+    }
+
+    currentFormatPart.push(token);
+  }
+  return result;
+}
+
+function tokenizeString(chars: TokenizingChars): FormatToken | null {
+  let enfOfStringChar: string | undefined;
+  if (chars.current === '"') {
+    chars.shift();
+    enfOfStringChar = '"';
+  } else if (chars.currentStartsWith("[$")) {
+    chars.advanceBy(2);
+    enfOfStringChar = "]";
+  }
+
+  if (!enfOfStringChar) {
+    return null;
+  }
+  let letters: string = "";
+  while (chars.current && chars.current !== enfOfStringChar) {
+    letters += chars.shift();
+  }
+  if (chars.current === enfOfStringChar) {
+    chars.shift();
+  } else {
+    throw new Error("Unterminated string in format");
+  }
+  return {
+    type: "STRING",
+    value: letters,
+  };
+}
+
+export const alwaysEscapedCharsInFormat = new Set("$+-/():!^&~{}<>= ");
+
+function tokenizeEscapedChars(chars: TokenizingChars): FormatToken | null {
+  if (chars.current === "\\") {
+    chars.shift();
+    const escapedChar = chars.shift();
+    if (!escapedChar) {
+      throw new Error("Unexpected end of format string");
+    }
+    return {
+      type: "CHAR",
+      value: escapedChar,
+    };
+  }
+  if (alwaysEscapedCharsInFormat.has(chars.current)) {
+    return {
+      type: "CHAR",
+      value: chars.shift(),
+    };
+  }
+  return null;
+}
+
+function tokenizeThousandsSeparator(chars: TokenizingChars): FormatToken | null {
+  if (chars.current === ",") {
+    chars.shift();
+    return { type: "THOUSANDS_SEPARATOR", value: "," };
+  }
+  return null;
+}
+
+function tokenizeTextPlaceholder(chars: TokenizingChars): FormatToken | null {
+  if (chars.current === "@") {
+    chars.shift();
+    return { type: "TEXT_PLACEHOLDER", value: "@" };
+  }
+  return null;
+}
+
+function tokenizeDecimalPoint(chars: TokenizingChars): FormatToken | null {
+  if (chars.current === ".") {
+    chars.shift();
+    return { type: "DECIMAL_POINT", value: "." };
+  }
+  return null;
+}
+
+function tokenizePercent(chars: TokenizingChars): FormatToken | null {
+  if (chars.current === "%") {
+    chars.shift();
+    return { type: "PERCENT", value: "%" };
+  }
+  return null;
+}
+
+function tokenizeDigit(chars: TokenizingChars): FormatToken | null {
+  if (chars.current === "0" || chars.current === "#") {
+    const value = chars.current;
+    chars.shift();
+    return { type: "DIGIT", value };
+  }
+  return null;
+}
+
+const dateSymbols = new Set("dmqyhsa");
+
+function tokenizeDatePart(chars: TokenizingChars): FormatToken | null {
+  if (!dateSymbols.has(chars.current)) {
+    return null;
+  }
+  const char = chars.current;
+  let value = "";
+  while (chars.current === char) {
+    value += chars.shift();
+  }
+  return { type: "DATE_PART", value };
+}

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -3,7 +3,7 @@ export * from "./coordinates";
 export * from "./data_validation_helpers";
 export * from "./dates";
 export * from "./edge_scrolling";
-export * from "./format";
+export * from "./format/format";
 export * from "./misc";
 export * from "./numbers";
 export * from "./range";

--- a/src/helpers/locale.ts
+++ b/src/helpers/locale.ts
@@ -9,7 +9,7 @@ import {
   Locale,
 } from "../types";
 import { isDateTime } from "./dates";
-import { formatValue, getDecimalNumberRegex } from "./format";
+import { formatValue, getDecimalNumberRegex } from "./format/format";
 import { deepCopy } from "./misc";
 import { isNumber } from "./numbers";
 

--- a/src/helpers/misc.ts
+++ b/src/helpers/misc.ts
@@ -522,6 +522,12 @@ export function insertItemsAtIndex<T>(array: readonly T[], items: T[], index: nu
   return newArray;
 }
 
+export function replaceItemAtIndex<T>(array: readonly T[], newItem: T, index: number): T[] {
+  const newArray = [...array];
+  newArray.splice(index, 1, newItem);
+  return newArray;
+}
+
 export function trimContent(content: string): string {
   const contentLines = content.split("\n");
   return contentLines.map((line) => line.replace(/\s+/g, " ").trim()).join("\n");
@@ -576,4 +582,47 @@ export function largeMin(array: number[]) {
     min = array[len] < min ? array[len] : min;
   }
   return min;
+}
+
+export class TokenizingChars {
+  private text: string;
+  private currentIndex: number = 0;
+  current: string;
+
+  constructor(text: string) {
+    this.text = text;
+    this.current = text[0];
+  }
+
+  shift() {
+    const current = this.current;
+    const next = this.text[++this.currentIndex];
+    this.current = next;
+    return current;
+  }
+
+  advanceBy(length: number) {
+    this.currentIndex += length;
+    this.current = this.text[this.currentIndex];
+  }
+
+  isOver() {
+    return this.currentIndex >= this.text.length;
+  }
+
+  remaining() {
+    return this.text.substring(this.currentIndex);
+  }
+
+  currentStartsWith(str: string) {
+    if (this.current !== str[0]) {
+      return false;
+    }
+    for (let j = 1; j < str.length; j++) {
+      if (this.text[this.currentIndex + j] !== str[j]) {
+        return false;
+      }
+    }
+    return true;
+  }
 }

--- a/src/helpers/pivot/pivot_time_adapter.ts
+++ b/src/helpers/pivot/pivot_time_adapter.ts
@@ -4,7 +4,7 @@ import { _t } from "../../translation";
 import { CellValue, DEFAULT_LOCALE } from "../../types";
 import { EvaluationError } from "../../types/errors";
 import { Granularity, PivotTimeAdapter, PivotTimeAdapterNotNull } from "../../types/pivot";
-import { MONTHS, formatValue } from "../format";
+import { MONTHS, formatValue } from "../format/format";
 
 export const pivotTimeAdapterRegistry = new Registry<PivotTimeAdapter<CellValue>>();
 

--- a/src/helpers/pivot/spreadsheet_pivot/spreadsheet_pivot.ts
+++ b/src/helpers/pivot/spreadsheet_pivot/spreadsheet_pivot.ts
@@ -25,7 +25,7 @@ import {
 } from "../../../types/pivot";
 import { InitPivotParams, Pivot } from "../../../types/pivot_runtime";
 import { toXC } from "../../coordinates";
-import { isDateTimeFormat } from "../../format";
+import { isDateTimeFormat } from "../../format/format";
 import { isDefined } from "../../misc";
 import {
   AGGREGATORS_FN,

--- a/src/model.ts
+++ b/src/model.ts
@@ -3,7 +3,7 @@ import { LocalTransportService } from "./collaborative/local_transport_service";
 import { Session } from "./collaborative/session";
 import { DEFAULT_REVISION_ID } from "./constants";
 import { EventBus } from "./helpers/event_bus";
-import { deepCopy, lazy, UuidGenerator } from "./helpers/index";
+import { UuidGenerator, deepCopy, lazy } from "./helpers/index";
 import { buildRevisionLog } from "./history/factory";
 import {
   createEmptyExcelWorkbookData,
@@ -30,7 +30,6 @@ import { _t, setDefaultTranslationMethod } from "./translation";
 import { StateUpdateMessage, TransportService } from "./types/collaborative/transport_service";
 import { FileStore } from "./types/files";
 import {
-  canExecuteInReadonly,
   Client,
   ClientPosition,
   Color,
@@ -44,15 +43,15 @@ import {
   Currency,
   DEFAULT_LOCALES,
   DispatchResult,
-  Format,
   Getters,
   GridRenderingContext,
   InformationNotification,
-  isCoreCommand,
   LayerName,
   LocalCommand,
   Locale,
   UID,
+  canExecuteInReadonly,
+  isCoreCommand,
 } from "./types/index";
 import { WorkbookData } from "./types/workbook_data";
 import { XLSXExport } from "./types/xlsx";
@@ -95,7 +94,7 @@ export interface ModelConfig {
   readonly custom: Readonly<{
     [key: string]: any;
   }>;
-  readonly defaultCurrencyFormat?: Format;
+  readonly defaultCurrency?: Partial<Currency>;
   /**
    * External dependencies required to enable some features
    * such as uploading images.
@@ -451,7 +450,7 @@ export class Model extends EventBus<any> implements CommandDispatcher {
       custom: this.config.custom,
       uiActions: this.config,
       session: this.session,
-      defaultCurrencyFormat: this.config.defaultCurrencyFormat,
+      defaultCurrency: this.config.defaultCurrency,
       customColors: this.config.customColors || [],
     };
   }

--- a/src/plugins/core/cell.ts
+++ b/src/plugins/core/cell.ts
@@ -2,7 +2,7 @@ import { DEFAULT_STYLE } from "../../constants";
 import { Token, compile } from "../../formulas";
 import { compileTokens } from "../../formulas/compiler";
 import { isEvaluationError, toString } from "../../functions/helpers";
-import { deepEquals, isExcelCompatible, recomputeZones } from "../../helpers";
+import { deepEquals, isExcelCompatible, isTextFormat, recomputeZones } from "../../helpers";
 import { parseLiteral } from "../../helpers/cells";
 import {
   concat,
@@ -30,7 +30,6 @@ import {
   FormulaCell,
   HeaderIndex,
   LiteralCell,
-  PLAIN_TEXT_FORMAT,
   PositionDependentCommand,
   Range,
   RangeCompiledFormula,
@@ -599,7 +598,7 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
       (typeof parsedValue === "number"
         ? detectDateFormat(content, locale) || detectNumberFormat(content)
         : undefined);
-    if (format !== PLAIN_TEXT_FORMAT && !isEvaluationError(content)) {
+    if (!isTextFormat(format) && !isEvaluationError(content)) {
       content = toString(parsedValue);
     }
     return {

--- a/src/plugins/ui_feature/format.ts
+++ b/src/plugins/ui_feature/format.ts
@@ -51,8 +51,7 @@ export class FormatPlugin extends UIPlugin {
         if (numberFormat !== undefined) {
           // Depending on the step sign, increase or decrease the decimal representation
           // of the format
-          const locale = this.getters.getLocale();
-          const newFormat = changeDecimalPlaces(numberFormat, step, locale);
+          const newFormat = changeDecimalPlaces(numberFormat, step);
           positionsByFormat[newFormat] = positionsByFormat[newFormat] || [];
           positionsByFormat[newFormat].push(position);
         }

--- a/src/plugins/ui_plugin.ts
+++ b/src/plugins/ui_plugin.ts
@@ -7,7 +7,7 @@ import {
   Color,
   Command,
   CommandDispatcher,
-  Format,
+  Currency,
   Getters,
   GridRenderingContext,
   LayerName,
@@ -26,7 +26,7 @@ export interface UIPluginConfig {
   readonly uiActions: UIActions;
   readonly custom: ModelConfig["custom"];
   readonly session: Session;
-  readonly defaultCurrencyFormat?: Format;
+  readonly defaultCurrency?: Partial<Currency>;
   readonly customColors: Color[];
 }
 

--- a/src/registries/autofill_modifiers.ts
+++ b/src/registries/autofill_modifiers.ts
@@ -1,5 +1,5 @@
 import { evaluateLiteral } from "../helpers/cells";
-import { formatValue } from "../helpers/format";
+import { formatValue } from "../helpers/format/format";
 import {
   AutofillData,
   AutofillModifierImplementation,

--- a/src/registries/menus/number_format_menu_registry.ts
+++ b/src/registries/menus/number_format_menu_registry.ts
@@ -35,6 +35,11 @@ numberFormatMenuRegistry
     id: "format_number_currency",
     sequence: 40,
   })
+  .add("format_number_accounting", {
+    ...ACTION_FORMAT.formatNumberAccounting,
+    id: "format_number_accounting",
+    sequence: 45,
+  })
   .add("format_number_currency_rounded", {
     ...ACTION_FORMAT.formatNumberCurrencyRounded,
     id: "format_number_currency_rounded",

--- a/src/types/format.ts
+++ b/src/types/format.ts
@@ -9,5 +9,3 @@ export interface LocaleFormat {
   locale: Locale;
   format?: Format;
 }
-
-export const PLAIN_TEXT_FORMAT: Format = "@"; // see OpenXML spec §18.8.31

--- a/src/xlsx/conversion/conversion_maps.ts
+++ b/src/xlsx/conversion/conversion_maps.ts
@@ -4,7 +4,6 @@ import {
   BorderStyle,
   ConditionalFormattingOperatorValues,
   ExcelChartType,
-  PLAIN_TEXT_FORMAT,
   ThresholdType,
   VerticalAlign,
 } from "../../types";
@@ -262,7 +261,7 @@ export const XLSX_FORMATS_CONVERSION_MAP: Record<number, string | undefined> = {
   46: "hhhh:mm:ss",
   47: "hhhh:mm:ss",
   48: undefined,
-  49: PLAIN_TEXT_FORMAT,
+  49: "@",
 };
 
 /**

--- a/src/xlsx/conversion/format_conversion.ts
+++ b/src/xlsx/conversion/format_conversion.ts
@@ -25,24 +25,11 @@ export function convertXlsxFormat(
 
   if (format) {
     try {
-      let convertedFormat = format.replace(/(.*?);.*/, "$1"); // only take first part of multi-part format
-      convertedFormat = convertedFormat.replace(/\[(.*)-[A-Z0-9]{3}\]/g, "[$1]"); // remove currency and locale/date system/number system info (ECMA §18.8.31)
+      let convertedFormat = format.replace(/\[(.*)-[A-Z0-9]{3}\]/g, "[$1]"); // remove currency and locale/date system/number system info (ECMA §18.8.31)
       convertedFormat = convertedFormat.replace(/\[\$\]/g, ""); // remove empty bocks
-
-      // Quotes in format escape sequences of characters. ATM we only support [$...] blocks to escape characters, and only one of them per format
-      const numberOfQuotes = convertedFormat.match(/"/g)?.length || 0;
-      const numberOfOpenBrackets = convertedFormat.match(/\[/g)?.length || 0;
-      if (numberOfQuotes / 2 + numberOfOpenBrackets > 1) {
-        throw new Error("Multiple escaped blocks in format");
-      }
-      convertedFormat = convertedFormat.replace(/"(.*)"/g, "[$$$1]"); // replace '"..."' by '[$...]'
 
       convertedFormat = convertedFormat.replace(/_.{1}/g, ""); // _ === ignore width of next char for align purposes. Not supported ATM
       convertedFormat = convertedFormat.replace(/\*.{1}/g, ""); // * === repeat next character enough to fill the line. Not supported ATM
-
-      convertedFormat = convertedFormat.replace(/\\ /g, " "); // unescape spaces
-
-      convertedFormat = convertedFormat.replace(/\\./g, (match) => match[1]); // unescape other characters
 
       if (isXlsxDateFormat(convertedFormat)) {
         convertedFormat = convertDateFormat(convertedFormat);

--- a/src/xlsx/functions/worksheet.ts
+++ b/src/xlsx/functions/worksheet.ts
@@ -3,13 +3,14 @@ import {
   isInside,
   isMarkdownLink,
   isSheetUrl,
+  isTextFormat,
   parseMarkdownLink,
   parseSheetUrl,
   toXC,
   toZone,
 } from "../../helpers";
 import { withHttps } from "../../helpers/links";
-import { ExcelHeaderData, ExcelSheetData, ExcelWorkbookData, PLAIN_TEXT_FORMAT } from "../../types";
+import { ExcelHeaderData, ExcelSheetData, ExcelWorkbookData } from "../../types";
 import { CellErrorType } from "../../types/errors";
 import { XLSXStructure, XMLAttributes, XMLString } from "../../types/xlsx";
 import { XLSX_RELATION_TYPE } from "../constants";
@@ -105,7 +106,7 @@ export function addRows(
           ({ attrs: additionalAttrs, node: cellNode } = addContent(label, construct.sharedStrings));
         } else if (cell.content && cell.content !== "") {
           const isTableHeader = isCellTableHeader(c, r, sheet);
-          const isPlainText = !!(cell.format && data.formats[cell.format] === PLAIN_TEXT_FORMAT);
+          const isPlainText = !!(cell.format && isTextFormat(data.formats[cell.format]));
           ({ attrs: additionalAttrs, node: cellNode } = addContent(
             cell.content,
             construct.sharedStrings,

--- a/tests/__snapshots__/top_bar_component.test.ts.snap
+++ b/tests/__snapshots__/top_bar_component.test.ts.snap
@@ -769,6 +769,34 @@ exports[`TopBar component can set cell format 1`] = `
         
         <div
           class="o-menu-item d-flex justify-content-between align-items-center"
+          data-name="format_number_accounting"
+          title="Accounting"
+        >
+          <div
+            class="d-flex w-100"
+          >
+            <div
+              class="o-menu-item-icon d-flex align-items-center flex-shrink-0"
+            />
+            
+            <div
+              class="o-menu-item-name align-middle text-truncate"
+            >
+              Accounting
+            </div>
+            <div
+              class="o-menu-item-description ms-auto text-truncate"
+            >
+              $(1,000.12)
+            </div>
+            
+            
+            
+          </div>
+        </div>
+        
+        <div
+          class="o-menu-item d-flex justify-content-between align-items-center"
           data-name="format_number_currency_rounded"
           title="Currency rounded"
         >

--- a/tests/evaluation/compiler.test.ts
+++ b/tests/evaluation/compiler.test.ts
@@ -189,7 +189,7 @@ describe("compile functions", () => {
         compute: (arg1, arg2) => {
           return {
             value: arg2 === undefined,
-            format: arg2 === undefined ? "TRUE" : "FALSE",
+            format: arg2 === undefined ? '"TRUE"' : '"FALSE"',
           };
         },
       });
@@ -202,8 +202,8 @@ describe("compile functions", () => {
         ],
         compute: (arg1, arg2 = { value: 42, format: "42" }) => {
           return !Array.isArray(arg2) && arg2.value === 42 && arg2.format === "42"
-            ? { value: true, format: "TRUE" }
-            : { value: false, format: "FALSE" };
+            ? { value: true, format: '"TRUE"' }
+            : { value: false, format: '"FALSE"' };
         },
       });
     });
@@ -212,17 +212,17 @@ describe("compile functions", () => {
     });
     test("empty value interpreted as undefined", () => {
       expect(evaluateCell("A1", { A1: "=ISSECONDARGUNDEFINED(1,)" })).toBe(true);
-      expect(evaluateCellFormat("A1", { A1: "=ISSECONDARGUNDEFINED(1,)" })).toBe("TRUE");
+      expect(evaluateCellFormat("A1", { A1: "=ISSECONDARGUNDEFINED(1,)" })).toBe('"TRUE"');
     });
 
     test("if default value --> empty value interpreted as default value", () => {
       expect(evaluateCell("A1", { A1: "=SECONDARGDEFAULTVALUEEQUAL42(1,)" })).toBe(true);
-      expect(evaluateCellFormat("A1", { A1: "=SECONDARGDEFAULTVALUEEQUAL42(1,)" })).toBe("TRUE");
+      expect(evaluateCellFormat("A1", { A1: "=SECONDARGDEFAULTVALUEEQUAL42(1,)" })).toBe('"TRUE"');
     });
 
     test("if default value --> non-value interpreted as default value", () => {
       expect(evaluateCell("A1", { A1: "=SECONDARGDEFAULTVALUEEQUAL42(1)" })).toBe(true);
-      expect(evaluateCellFormat("A1", { A1: "=SECONDARGDEFAULTVALUEEQUAL42(1)" })).toBe("TRUE");
+      expect(evaluateCellFormat("A1", { A1: "=SECONDARGDEFAULTVALUEEQUAL42(1)" })).toBe('"TRUE"');
     });
   });
 

--- a/tests/figures/chart/charts_component.test.ts
+++ b/tests/figures/chart/charts_component.test.ts
@@ -1792,7 +1792,7 @@ describe("charts", () => {
     const updateChart = jest.spyOn((window as any).Chart.prototype, "update");
     createTestChart("basicChart");
     await nextTick();
-    setCellFormat(model, "B2", "#.##0.00");
+    setCellFormat(model, "B2", "#,##0.00");
     await nextTick();
     expect(updateChart).toHaveBeenCalled();
   });

--- a/tests/formats/__snapshots__/custom_currency_side_panel_component.test.ts.snap
+++ b/tests/formats/__snapshots__/custom_currency_side_panel_component.test.ts.snap
@@ -25,7 +25,7 @@ exports[`Provided Currencies if currencies are provided in spreadsheet --> displ
 
 exports[`custom currency sidePanel component Sidepanel change code input or symbol input --> change currency proposals 1`] = `
 <select
-  class="o-input o-format-proposals"
+  class="o-input o-format-proposals mb-1"
 >
   <option
     value="0"
@@ -73,7 +73,7 @@ exports[`custom currency sidePanel component Sidepanel change code input or symb
 
 exports[`custom currency sidePanel component Sidepanel change code input or symbol input --> change currency proposals 2`] = `
 <select
-  class="o-input o-format-proposals"
+  class="o-input o-format-proposals mb-1"
 >
   <option
     value="0"
@@ -121,7 +121,7 @@ exports[`custom currency sidePanel component Sidepanel change code input or symb
 
 exports[`custom currency sidePanel component Sidepanel change code input or symbol input --> change currency proposals 3`] = `
 <select
-  class="o-input o-format-proposals"
+  class="o-input o-format-proposals mb-1"
 >
   <option
     value="0"
@@ -169,7 +169,7 @@ exports[`custom currency sidePanel component Sidepanel change code input or symb
 
 exports[`custom currency sidePanel component Sidepanel change code input or symbol input --> change currency proposals 4`] = `
 <select
-  class="o-input o-format-proposals"
+  class="o-input o-format-proposals mb-1"
 >
   <option
     value="0"
@@ -217,7 +217,7 @@ exports[`custom currency sidePanel component Sidepanel change code input or symb
 
 exports[`custom currency sidePanel component Sidepanel select currency in available currencies selector --> changes currency proposals 1`] = `
 <select
-  class="o-input o-format-proposals"
+  class="o-input o-format-proposals mb-1"
 >
   <option
     value="0"
@@ -265,7 +265,7 @@ exports[`custom currency sidePanel component Sidepanel select currency in availa
 
 exports[`custom currency sidePanel component Sidepanel select currency in available currencies selector --> changes currency proposals 2`] = `
 <select
-  class="o-input o-format-proposals"
+  class="o-input o-format-proposals mb-1"
 >
   <option
     value="0"

--- a/tests/formats/format_helpers.test.ts
+++ b/tests/formats/format_helpers.test.ts
@@ -1,4 +1,5 @@
 import {
+  createAccountingFormat,
   createCurrencyFormat,
   formatValue,
   isDateTimeFormat,
@@ -1099,6 +1100,50 @@ describe("create currency format", () => {
     const format = createCurrencyFormat({ symbol, code, position: "after" });
     expect(format).toBe("#,##0.00[$ O$OO θ]");
     expect(formatValue(1234.56, { format, locale: DEFAULT_LOCALE })).toBe("1,234.56 O$OO θ");
+  });
+});
+
+describe("create accounting format", () => {
+  const symbol = "θ";
+  const code = "O$OO";
+
+  test("full accounting format", () => {
+    const currency: Currency = {
+      code,
+      symbol,
+      decimalPlaces: 2,
+      name: "Odoo Dollar",
+      position: "before",
+    };
+    const format = createAccountingFormat(currency);
+    expect(format).toBe("[$O$OO θ]#,##0.00;[$O$OO θ](#,##0.00);[$O$OO θ]- ");
+    expect(formatValue(1234.56, { format, locale: DEFAULT_LOCALE })).toBe("O$OO θ1,234.56");
+    expect(formatValue(-1234.56, { format, locale: DEFAULT_LOCALE })).toBe("O$OO θ(1,234.56)");
+    expect(formatValue(0, { format, locale: DEFAULT_LOCALE })).toBe("O$OO θ- ");
+  });
+
+  test("custom decimal places on accounting format", () => {
+    const format = createAccountingFormat({ symbol, decimalPlaces: 4 });
+    expect(format).toBe("[$θ]#,##0.0000;[$θ](#,##0.0000);[$θ]- ");
+    expect(formatValue(1234.56, { format, locale: DEFAULT_LOCALE })).toBe("θ1,234.5600");
+    expect(formatValue(-1234.56, { format, locale: DEFAULT_LOCALE })).toBe("θ(1,234.5600)");
+    expect(formatValue(0, { format, locale: DEFAULT_LOCALE })).toBe("θ- ");
+  });
+
+  test("without decimal places currency", () => {
+    const format = createAccountingFormat({ symbol, decimalPlaces: 0 });
+    expect(format).toBe("[$θ]#,##0;[$θ](#,##0);[$θ]- ");
+    expect(formatValue(1234.56, { format, locale: DEFAULT_LOCALE })).toBe("θ1,235");
+    expect(formatValue(-1234.56, { format, locale: DEFAULT_LOCALE })).toBe("θ(1,235)");
+    expect(formatValue(0, { format, locale: DEFAULT_LOCALE })).toBe("θ- ");
+  });
+
+  test("currency with symbol placed after", () => {
+    const format = createAccountingFormat({ symbol, position: "after", decimalPlaces: 0 });
+    expect(format).toBe("#,##0[$θ];(#,##0)[$θ];- [$θ]");
+    expect(formatValue(1234.56, { format, locale: DEFAULT_LOCALE })).toBe("1,235θ");
+    expect(formatValue(-1234.56, { format, locale: DEFAULT_LOCALE })).toBe("(1,235)θ");
+    expect(formatValue(0, { format, locale: DEFAULT_LOCALE })).toBe("- θ");
   });
 });
 

--- a/tests/formats/formatting_plugin.test.ts
+++ b/tests/formats/formatting_plugin.test.ts
@@ -187,6 +187,42 @@ describe("formatting values (with formatters)", () => {
     expect(getEvaluatedCell(model, "A1")?.formattedValue).toEqual("10.12345679");
   });
 
+  test("SET_DECIMAL on format with escaped string", () => {
+    const model = new Model();
+    setCellContent(model, "A1", "10");
+
+    setFormat(model, "A1", "0.0\\€");
+    setDecimal(model, "A1", 1);
+    expect(getCell(model, "A1")?.format).toBe("0.00\\€");
+
+    setFormat(model, "A1", "0.0\\€");
+    setDecimal(model, "A1", -1);
+    expect(getCell(model, "A1")?.format).toBe("0\\€");
+
+    setFormat(model, "A1", "0.0$0");
+    setDecimal(model, "A1", -1);
+    expect(getCell(model, "A1")?.format).toBe("0.0$");
+    setDecimal(model, "A1", -1);
+    expect(getCell(model, "A1")?.format).toBe("0$");
+  });
+
+  test("SET_DECIMAL on multi-part format", () => {
+    const model = new Model();
+    setCellContent(model, "A1", "10");
+
+    setFormat(model, "A1", "0.0\\€;$0.#; 0 ;@");
+    setDecimal(model, "A1", 1);
+    expect(getCell(model, "A1")?.format).toBe("0.00\\€;$0.#0; 0.0 ;@");
+
+    setFormat(model, "A1", "0.0\\€;$0.#; 0 ;@");
+    setDecimal(model, "A1", -1);
+    expect(getCell(model, "A1")?.format).toBe("0\\€;$0; 0 ;@");
+
+    setFormat(model, "A1", ";;;@");
+    setDecimal(model, "A1", -1);
+    expect(getCell(model, "A1")?.format).toBe(";;;@");
+  });
+
   test("UPDATE_CELL on long number that are truncated due to default format don't loose truncated digits", () => {
     const model = new Model();
     setCellContent(model, "A1", "10.123456789123");

--- a/tests/formats/plain_text_format.test.ts
+++ b/tests/formats/plain_text_format.test.ts
@@ -1,5 +1,5 @@
 import { Model } from "../../src";
-import { DEFAULT_LOCALE, PLAIN_TEXT_FORMAT } from "../../src/types";
+import { CellValueType, DEFAULT_LOCALE } from "../../src/types";
 import { setCellContent, setFormat, updateLocale } from "../test_helpers/commands_helpers";
 import { getCell, getCellContent, getEvaluatedCell } from "../test_helpers/getters_helpers";
 import { FR_LOCALE } from "./../test_helpers/constants";
@@ -27,10 +27,20 @@ describe("Plain text format", () => {
       setCellContent(model, "A1", cellContent);
       expect(getEvaluatedCell(model, "A1").value).toBe(beforePlainText);
 
-      setFormat(model, "A1", PLAIN_TEXT_FORMAT);
+      setFormat(model, "A1", "@");
       expect(getEvaluatedCell(model, "A1").value).toBe(plainTextValue);
     }
   );
+
+  test("Set more complex text format to a cell", () => {
+    setCellContent(model, "A1", "89");
+    setFormat(model, "A1", "@ $");
+    expect(getEvaluatedCell(model, "A1")).toMatchObject({
+      value: "89",
+      type: CellValueType.text,
+      formattedValue: "89 $",
+    });
+  });
 
   test.each([
     ["hello", "hello"],
@@ -46,7 +56,7 @@ describe("Plain text format", () => {
   ])(
     "Set content to a cell formatted with plain text %s %s: text should be kept as is, not parsed",
     (inputValue: string, expectedCellValue: string) => {
-      setFormat(model, "A1", PLAIN_TEXT_FORMAT);
+      setFormat(model, "A1", "@");
       setCellContent(model, "A1", inputValue);
       expect(getEvaluatedCell(model, "A1").value).toBe(expectedCellValue);
     }
@@ -54,7 +64,7 @@ describe("Plain text format", () => {
 
   test("Input localized date on a plain text cell", () => {
     updateLocale(model, FR_LOCALE);
-    setFormat(model, "A1", PLAIN_TEXT_FORMAT);
+    setFormat(model, "A1", "@");
     setCellContent(model, "A1", "30/05/2015");
 
     expect(getCell(model, "A1")?.content).toBe("30/05/2015");
@@ -72,14 +82,14 @@ describe("Plain text format", () => {
   });
 
   test("can export/import plain text format", () => {
-    setFormat(model, "A1", PLAIN_TEXT_FORMAT);
+    setFormat(model, "A1", "@");
     setCellContent(model, "A1", "00009");
 
     expect(getCellContent(model, "A1")).toBe("00009");
     const exported = model.exportData();
 
     const importedModel = new Model(exported);
-    expect(getCell(importedModel, "A1")?.format).toBe(PLAIN_TEXT_FORMAT);
+    expect(getCell(importedModel, "A1")?.format).toBe("@");
     expect(getCellContent(importedModel, "A1")).toBe("00009");
   });
 });

--- a/tests/xlsx/xlsx_export.test.ts
+++ b/tests/xlsx/xlsx_export.test.ts
@@ -2,7 +2,7 @@ import { arg, functionRegistry } from "../../src/functions";
 import { buildSheetLink, toXC } from "../../src/helpers";
 import { DEFAULT_TABLE_CONFIG } from "../../src/helpers/table_presets";
 import { Model } from "../../src/model";
-import { CustomizedDataSet, Dimension, ExcelChartType, PLAIN_TEXT_FORMAT } from "../../src/types";
+import { CustomizedDataSet, Dimension, ExcelChartType } from "../../src/types";
 import { XLSXExportXMLFile, XMLString } from "../../src/types/xlsx";
 import { adaptFormulaToExcel } from "../../src/xlsx/functions/cells";
 import { escapeXml, parseXML } from "../../src/xlsx/helpers/xml_helpers";
@@ -1582,7 +1582,7 @@ describe("Test XLSX export", () => {
 
   test("Cells with plain text format are exported in the shared strings", async () => {
     const model = new Model();
-    setFormat(model, "A1", PLAIN_TEXT_FORMAT);
+    setFormat(model, "A1", "@");
     setCellContent(model, "A1", "0006");
 
     expect(getCellContent(model, "A1")).toEqual("0006");

--- a/tests/xlsx/xlsx_import.test.ts
+++ b/tests/xlsx/xlsx_import.test.ts
@@ -207,19 +207,16 @@ describe("Import xlsx data", () => {
     ["0.00", "M2"],
     ["0.00%", "M3"],
     ["m/d/yyyy", "M4"],
-    ["#,##0.00 [$€]", "M5"],
+    ['#,##0.00\\ "€"', "M5"],
     ["[$$]#,##0.000", "M6"],
-    ["[$₪] #,##0", "M7"],
-    ["#,##0[$ EUR €]", "M8"],
-    ["not supported: multiple escaped sequences", "M9"],
+    ["[$₪]\\ #,##0", "M7"],
+    ['#,##0" EUR €"', "M8"],
+    ['"€"#,##0.00\\ "€"', "M9"],
   ])("Can import format %s", (format, cellXc) => {
     const testSheet = getWorkbookSheet("jestStyles", convertedData)!;
     const formattedCell = testSheet.cells[cellXc]!;
     const cellFormat = getWorkbookCellFormat(formattedCell, convertedData);
     let expectedFormat: string | undefined = format;
-    if (format.startsWith("not supported")) {
-      expectedFormat = undefined;
-    }
     expect(cellFormat).toEqual(expectedFormat);
   });
 
@@ -838,7 +835,7 @@ test.each([
 
 test.each([
   ["0.00", "0.00", "0.00"],
-  ["0.00;0.00%", "0.00", "0.00"],
+  ["0.00;0.00%", "0.00;0.00%", "0.00"],
   ["0.000%", "0.000%", "0.000%"],
   ["#,##0.00", "#,##0.00", "0.00"],
   ["m/d/yyyy", "m/d/yyyy", "12/30/1899"],
@@ -848,15 +845,15 @@ test.each([
   ["mmm dd yy", "mmm dd yy", "Dec 30 99"],
   ["h AM/PM", "hh a", "12 AM"],
   ["HHHH:MM a/m", "hh:mm a", "12:00 AM"],
-  ["m/d/yyyy\\ hh:mm:ss", "m/d/yyyy hh:mm:ss", "12/30/1899 00:00:00"],
+  ["m/d/yyyy\\ hh:mm:ss", "m/d/yyyy\\ hh:mm:ss", "12/30/1899 00:00:00"],
   ["hh:mm:ss a", "hh:mm:ss a", "12:00:00 AM"],
-  ['#,##0.00 "€"', "#,##0.00 [$€]", "0.00€"],
+  ['#,##0.00 "€"', '#,##0.00 "€"', "0.00 €"],
   ["[$$-409]#,##0.000", "[$$]#,##0.000", "$0.000"],
   ["[$-409]0.00", "0.00", "0.00"],
   ["[$MM/DD/YYYY]0", "[$MM/DD/YYYY]0", "MM/DD/YYYY0"],
   ["#,##0.00[$MM/DD/YYYY]", "#,##0.00[$MM/DD/YYYY]", "0.00MM/DD/YYYY"],
-  ["[$₪-40D] #,##0.00", "[$₪] #,##0.00", "₪0.00"],
-  ['"€"#,##0.00 "€"', undefined, "0"],
+  ["[$₪-40D] #,##0.00", "[$₪] #,##0.00", "₪ 0.00"],
+  ['"€"#,##0.00 "€"', '"€"#,##0.00 "€"', "€0.00 €"],
   ["@", PLAIN_TEXT_FORMAT, "0"],
 ])("convert format %s", async (excelFormat, convertedFormat, expectedValue) => {
   expect(

--- a/tests/xlsx/xlsx_import.test.ts
+++ b/tests/xlsx/xlsx_import.test.ts
@@ -7,7 +7,7 @@ import {
   toZone,
 } from "../../src/helpers";
 import { DEFAULT_TABLE_CONFIG } from "../../src/helpers/table_presets";
-import { CellIsRule, DEFAULT_LOCALE, IconSetRule, PLAIN_TEXT_FORMAT } from "../../src/types";
+import { CellIsRule, DEFAULT_LOCALE, IconSetRule } from "../../src/types";
 import { BarChartDefinition } from "../../src/types/chart/bar_chart";
 import { ComboChartDefinition } from "../../src/types/chart/combo_chart";
 import { LineChartDefinition } from "../../src/types/chart/line_chart";
@@ -854,7 +854,7 @@ test.each([
   ["#,##0.00[$MM/DD/YYYY]", "#,##0.00[$MM/DD/YYYY]", "0.00MM/DD/YYYY"],
   ["[$₪-40D] #,##0.00", "[$₪] #,##0.00", "₪ 0.00"],
   ['"€"#,##0.00 "€"', '"€"#,##0.00 "€"', "€0.00 €"],
-  ["@", PLAIN_TEXT_FORMAT, "0"],
+  ["@", "@", "0"],
 ])("convert format %s", async (excelFormat, convertedFormat, expectedValue) => {
   expect(
     convertXlsxFormat(80, [{ id: 80, format: excelFormat }], new XLSXImportWarningManager())


### PR DESCRIPTION
### [IMP] format: implement multi-part format

This commits adds the possibility to have a format with multiple parts,
as well as improving/fixing the behaviour of currently implemented formats.

The formats are now tokenized and parsed in a more structured way, which
allows for more complex formats to be implemented. Some example of things
that are now supported are:

- multi parts format, separated by a semicolon
- multiple escaped strings in a number format
- strings can now be escaped with quotes, and chars with backslash
- escaped string now support `[` characters inside of them
- can now have any separator/escaped string inside a date format
- number formats with escaped strings in the middle are now correctly
handled (before formatting 123 with format `0[$$]0` would return
`123$123` instead of `12$3`)
- we support format on strings


### [IMP] format: handled more complex text format

Also removed the `PLAIN_TEXT_FORMAT` variable. The variable made it
looks like the `@` was an immutable special case, whereas `@` is just
a text placeholder that can be used in more complex text formats.

### [IMP] currency format: add accounting format:

This commits adds the accounting format. This is similar to a currency
format, except that negative values are displayed in parentheses
and zero is displayed as a dash.

Also changed the model config `defaultCurrencyFormat` to `defaultCurrency`,
so it can be used for both currency and accounting formats.

Task: : [4083126](https://www.odoo.com/web#id=4083126&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo