### PR TITLE
[REF] plugin cell: use a new command "CLEAR_CELLS"

### DIFF
--- a/src/helpers/clipboard/clipboard_cells_state.ts
+++ b/src/helpers/clipboard/clipboard_cells_state.ts
@@ -316,13 +316,10 @@ export class ClipboardCellsState extends ClipboardCellsAbstractState {
    * Clear the clipped zones: remove the cells and clear the formatting
    */
   private clearClippedZones() {
-    for (const row of this.cells) {
-      for (const cell of row) {
-        if (cell?.cell) {
-          this.dispatch("CLEAR_CELL", cell.position);
-        }
-      }
-    }
+    this.dispatch("CLEAR_CELLS", {
+      sheetId: this.sheetId,
+      target: this.zones,
+    });
     this.dispatch("CLEAR_FORMATTING", {
       sheetId: this.sheetId,
       target: this.zones,

--- a/src/plugins/core/cell.ts
+++ b/src/plugins/core/cell.ts
@@ -139,6 +139,9 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
           format: "",
         });
         break;
+      case "CLEAR_CELLS":
+        this.clearCells(cmd.sheetId, cmd.target);
+        break;
     }
   }
 
@@ -172,6 +175,26 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
             sheetId,
             col,
             row,
+            style: null,
+            format: "",
+          });
+        }
+      }
+    }
+  }
+
+  /**
+   * Clear the styles, the format and the content of zones
+   */
+  private clearCells(sheetId: UID, zones: Zone[]) {
+    for (const zone of zones) {
+      for (let col = zone.left; col <= zone.right; col++) {
+        for (let row = zone.top; row <= zone.bottom; row++) {
+          this.dispatch("UPDATE_CELL", {
+            sheetId: sheetId,
+            col,
+            row,
+            content: "",
             style: null,
             format: "",
           });

--- a/src/plugins/core/merge.ts
+++ b/src/plugins/core/merge.ts
@@ -1,4 +1,5 @@
 import {
+  RangeImpl,
   clip,
   deepEquals,
   getCanonicalSheetName,
@@ -6,7 +7,6 @@ import {
   isEqual,
   overlap,
   positions,
-  RangeImpl,
   splitReference,
   toXC,
   toZone,

--- a/src/plugins/core/sheet.ts
+++ b/src/plugins/core/sheet.ts
@@ -891,19 +891,24 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
   }
 
   private moveCellOnColumnsDeletion(sheet: Sheet, deletedColumn: number) {
+    this.dispatch("CLEAR_CELLS", {
+      sheetId: sheet.id,
+      target: [
+        {
+          left: deletedColumn,
+          top: 0,
+          right: deletedColumn,
+          bottom: sheet.rows.length - 1,
+        },
+      ],
+    });
+
     for (let rowIndex = 0; rowIndex < sheet.rows.length; rowIndex++) {
       const row = sheet.rows[rowIndex];
       for (let i in row.cells) {
         const colIndex = Number(i);
         const cellId = row.cells[i];
         if (cellId) {
-          if (colIndex === deletedColumn) {
-            this.dispatch("CLEAR_CELL", {
-              sheetId: sheet.id,
-              col: colIndex,
-              row: rowIndex,
-            });
-          }
           if (colIndex > deletedColumn) {
             this.setNewPosition(cellId, sheet.id, colIndex - 1, rowIndex);
           }
@@ -960,22 +965,21 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
     deleteFromRow: HeaderIndex,
     deleteToRow: HeaderIndex
   ) {
+    this.dispatch("CLEAR_CELLS", {
+      sheetId: sheet.id,
+      target: [
+        {
+          left: 0,
+          top: deleteFromRow,
+          right: this.getters.getNumberCols(sheet.id),
+          bottom: deleteToRow,
+        },
+      ],
+    });
+
     const numberRows = deleteToRow - deleteFromRow + 1;
     for (let rowIndex = 0; rowIndex < sheet.rows.length; rowIndex++) {
       const row = sheet.rows[rowIndex];
-      if (rowIndex >= deleteFromRow && rowIndex <= deleteToRow) {
-        for (let i in row.cells) {
-          const colIndex = Number(i);
-          const cellId = row.cells[i];
-          if (cellId) {
-            this.dispatch("CLEAR_CELL", {
-              sheetId: sheet.id,
-              col: colIndex,
-              row: rowIndex,
-            });
-          }
-        }
-      }
       if (rowIndex > deleteToRow) {
         for (let i in row.cells) {
           const colIndex = Number(i);

--- a/src/plugins/ui_feature/data_cleanup.ts
+++ b/src/plugins/ui_feature/data_cleanup.ts
@@ -83,9 +83,7 @@ export class DataCleanupPlugin extends UIPlugin {
       this.selection
     );
 
-    for (const { col, row } of positions(zone)) {
-      this.dispatch("CLEAR_CELL", { col, row, sheetId });
-    }
+    this.dispatch("CLEAR_CELLS", { target: [zone], sheetId });
 
     const zonePasted: Zone = {
       left: zone.left,

--- a/src/plugins/ui_stateful/clipboard.ts
+++ b/src/plugins/ui_stateful/clipboard.ts
@@ -1,7 +1,7 @@
 import { ClipboardCellsState } from "../../helpers/clipboard/clipboard_cells_state";
 import { ClipboardFigureState } from "../../helpers/clipboard/clipboard_figure_state";
 import { ClipboardOsState } from "../../helpers/clipboard/clipboard_os_state";
-import { isZoneValid, positions } from "../../helpers/index";
+import { isZoneValid } from "../../helpers/index";
 import {
   ClipboardContent,
   ClipboardMIMEType,
@@ -166,9 +166,10 @@ export class ClipboardPlugin extends UIPlugin {
       case "DELETE_CELL": {
         const { cut, paste } = this.getDeleteCellsTargets(cmd.zone, cmd.shiftDimension);
         if (!isZoneValid(cut[0])) {
-          for (const { col, row } of positions(cmd.zone)) {
-            this.dispatch("CLEAR_CELL", { col, row, sheetId: this.getters.getActiveSheetId() });
-          }
+          this.dispatch("CLEAR_CELLS", {
+            target: [cmd.zone],
+            sheetId: this.getters.getActiveSheetId(),
+          });
           break;
         }
         const state = this.getClipboardStateForCopyCells(cut, "CUT");

--- a/src/registries/repeat_commands_registry.ts
+++ b/src/registries/repeat_commands_registry.ts
@@ -40,6 +40,7 @@ export const repeatCommandTransformRegistry = new Registry<RepeatTransform>();
 
 repeatCommandTransformRegistry.add("UPDATE_CELL", genericRepeat);
 repeatCommandTransformRegistry.add("CLEAR_CELL", genericRepeat);
+repeatCommandTransformRegistry.add("CLEAR_CELLS", genericRepeat);
 repeatCommandTransformRegistry.add("DELETE_CONTENT", genericRepeat);
 
 repeatCommandTransformRegistry.add("ADD_MERGE", genericRepeat);

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -163,6 +163,7 @@ export const coreTypes = new Set<CoreCommandTypes>([
   "UPDATE_CELL",
   "UPDATE_CELL_POSITION",
   "CLEAR_CELL",
+  "CLEAR_CELLS",
   "DELETE_CONTENT",
 
   /** GRID SHAPE */
@@ -756,6 +757,10 @@ export interface ClearCellCommand extends PositionDependentCommand {
   type: "CLEAR_CELL";
 }
 
+export interface ClearCellsCommand extends TargetDependentCommand {
+  type: "CLEAR_CELLS";
+}
+
 export interface UndoCommand {
   type: "UNDO";
   commands: readonly CoreCommand[];
@@ -1016,6 +1021,7 @@ export type CoreCommand =
   | UpdateCellCommand
   | UpdateCellPositionCommand
   | ClearCellCommand
+  | ClearCellsCommand
   | DeleteContentCommand
 
   /** GRID SHAPE */

--- a/tests/cells/cell_plugin.test.ts
+++ b/tests/cells/cell_plugin.test.ts
@@ -7,6 +7,7 @@ import {
   addColumns,
   addRows,
   clearCell,
+  clearCells,
   copy,
   createSheet,
   deleteColumns,
@@ -160,17 +161,43 @@ describe("getCellText", () => {
     expect(getCell(model, "A1")).toBeUndefined();
   });
 
-  test("clear style", () => {
+  test("clear some content", () => {
+    const model = new Model();
+    setCellContent(model, "A1", "hello");
+    setCellContent(model, "A2", "there");
+    clearCells(model, ["A1:A2"]);
+    expect(getCell(model, "A1")).toBeUndefined();
+    expect(getCell(model, "A2")).toBeUndefined();
+  });
+
+  test("clear some style", () => {
     const model = new Model();
     setStyle(model, "A1", { bold: true });
     clearCell(model, "A1");
     expect(getCell(model, "A1")).toBeUndefined();
   });
 
+  test("clear some style", () => {
+    const model = new Model();
+    setStyle(model, "A1", { bold: true });
+    setStyle(model, "A2", { italic: true });
+    clearCells(model, ["A1:A2"]);
+    expect(getCell(model, "A1")).toBeUndefined();
+    expect(getCell(model, "A2")).toBeUndefined();
+  });
+
   test("clear format", () => {
     const model = new Model();
     setCellFormat(model, "A1", "#,##0.0");
     clearCell(model, "A1");
+    expect(getCell(model, "A1")).toBeUndefined();
+  });
+
+  test("clear some format", () => {
+    const model = new Model();
+    setCellFormat(model, "A1", "#,##0.0");
+    setCellFormat(model, "A2", "0%");
+    clearCells(model, ["A1:A2"]);
     expect(getCell(model, "A1")).toBeUndefined();
   });
 
@@ -181,6 +208,19 @@ describe("getCellText", () => {
     setCellFormat(model, "A1", "#,##0.0");
     clearCell(model, "A1");
     expect(getCell(model, "A1")).toBeUndefined();
+  });
+
+  test("clear some content, style and format", () => {
+    const model = new Model();
+    setCellContent(model, "A1", "hello");
+    setCellContent(model, "A2", "there");
+    setStyle(model, "A1", { bold: true });
+    setStyle(model, "A2", { italic: true });
+    setCellFormat(model, "A1", "#,##0.0");
+    setCellFormat(model, "A2", "0%");
+    clearCells(model, ["A1", "A2"]);
+    expect(getCell(model, "A1")).toBeUndefined();
+    expect(getCell(model, "A2")).toBeUndefined();
   });
 
   test("clear cell outside of sheet", () => {

--- a/tests/collaborative/inverses.test.ts
+++ b/tests/collaborative/inverses.test.ts
@@ -4,6 +4,7 @@ import {
   AddColumnsRowsCommand,
   AddMergeCommand,
   ClearCellCommand,
+  ClearCellsCommand,
   ClearFormattingCommand,
   CoreCommand,
   CreateSheetCommand,
@@ -249,6 +250,11 @@ describe("Inverses commands", () => {
       col: 1,
       row: 1,
     };
+    const clearCells: ClearCellsCommand = {
+      type: "CLEAR_CELLS",
+      sheetId: "1",
+      target: [toZone("A1")],
+    };
     const deleteContent: DeleteContentCommand = {
       type: "DELETE_CONTENT",
       sheetId: "1",
@@ -301,6 +307,7 @@ describe("Inverses commands", () => {
       updateCell,
       updateCellPosition,
       clearCell,
+      clearCells,
       deleteContent,
       resizeColumns,
       resizeRows,

--- a/tests/repeat_commands_plugin.test.ts
+++ b/tests/repeat_commands_plugin.test.ts
@@ -59,6 +59,7 @@ describe("Repeat commands basics", () => {
     const repeatableCommands = [
       "UPDATE_CELL",
       "CLEAR_CELL",
+      "CLEAR_CELLS",
       "DELETE_CONTENT",
       "ADD_MERGE",
       "REMOVE_MERGE",
@@ -136,6 +137,7 @@ describe("Repeat command transform generics", () => {
   test.each([
     TEST_COMMANDS.UPDATE_CELL,
     TEST_COMMANDS.CLEAR_CELL,
+    TEST_COMMANDS.CLEAR_CELLS,
     TEST_COMMANDS.DELETE_CONTENT,
     TEST_COMMANDS.ADD_MERGE,
     TEST_COMMANDS.REMOVE_MERGE,
@@ -168,6 +170,7 @@ describe("Repeat command transform generics", () => {
     TEST_COMMANDS.REMOVE_FILTER_TABLE,
     TEST_COMMANDS.SET_FORMATTING,
     TEST_COMMANDS.CLEAR_FORMATTING,
+    TEST_COMMANDS.CLEAR_CELLS,
   ])(
     "Target dependant commands have target equal to current current selection",
     (command: CoreCommand) => {

--- a/tests/test_helpers/commands_helpers.ts
+++ b/tests/test_helpers/commands_helpers.ts
@@ -557,6 +557,17 @@ export function clearCell(
 }
 
 /**
+ * Clear cells in zones
+ */
+export function clearCells(
+  model: Model,
+  xcs: string[],
+  sheetId: UID = model.getters.getActiveSheetId()
+) {
+  return model.dispatch("CLEAR_CELLS", { target: xcs.map(toZone), sheetId });
+}
+
+/**
  * Set the content of a cell
  */
 export function setCellContent(

--- a/tests/test_helpers/constants.ts
+++ b/tests/test_helpers/constants.ts
@@ -71,6 +71,11 @@ export const TEST_COMMANDS: CommandMapping = {
     row: 0,
     sheetId: "sheetId",
   },
+  CLEAR_CELLS: {
+    type: "CLEAR_CELLS",
+    target: target("A1"),
+    sheetId: "sheetId",
+  },
   DELETE_CONTENT: {
     type: "DELETE_CONTENT",
     target: target("A1"),
@@ -376,6 +381,7 @@ export const OT_TESTS_TARGET_DEPENDANT_COMMANDS = [
   TEST_COMMANDS.CLEAR_FORMATTING,
   TEST_COMMANDS.CREATE_FILTER_TABLE,
   TEST_COMMANDS.REMOVE_FILTER_TABLE,
+  TEST_COMMANDS.CLEAR_CELLS,
 ];
 
 export const OT_TESTS_ZONE_DEPENDANT_COMMANDS = [


### PR DESCRIPTION
for performance and clarification reasons, groups
the dispatch commands "CLEAR_CELL" with a single
command "CLEAR_CELLS" where possible.


Task : [4095732](https://www.odoo.com/web#id=4095732&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo