### PR TITLE
[FIX] table: fix bug when edit table with invalid range

### DIFF
--- a/src/components/side_panel/table_panel/table_panel.ts
+++ b/src/components/side_panel/table_panel/table_panel.ts
@@ -1,5 +1,5 @@
 import { Component, useState } from "@odoo/owl";
-import { positionToZone, rangeReference } from "../../../helpers";
+import { positionToZone } from "../../../helpers";
 import {
   CommandResult,
   DispatchResult,
@@ -106,10 +106,6 @@ export class TablePanel extends Component<Props, SpreadsheetChildEnv> {
   }
 
   onRangeChanged(ranges: string[]) {
-    if (!ranges[0] || !ranges[0].match(rangeReference)) {
-      this.state.tableZoneErrors = [CommandResult.InvalidRange];
-      return;
-    }
     const sheetId = this.env.model.getters.getActiveSheetId();
 
     this.state.tableXc = ranges[0];
@@ -136,10 +132,6 @@ export class TablePanel extends Component<Props, SpreadsheetChildEnv> {
         cell: position,
       });
     }
-    this.state.tableZoneErrors = [];
-    this.state.tableXc = result.isSuccessful
-      ? this.state.tableXc
-      : this.env.model.getters.getRangeString(this.props.table.range, sheetId);
   }
 
   deleteTable() {

--- a/src/components/side_panel/table_panel/table_panel.xml
+++ b/src/components/side_panel/table_panel/table_panel.xml
@@ -72,6 +72,7 @@
           t-key="props.table.id"
           ranges="[this.state.tableXc]"
           hasSingleRange="true"
+          isInvalid="this.state.tableZoneErrors.length !== 0"
           onSelectionChanged="(ranges) => this.onRangeChanged(ranges)"
           onSelectionConfirmed.bind="this.onRangeConfirmed"
         />

--- a/tests/table/table_panel_component.test.ts
+++ b/tests/table/table_panel_component.test.ts
@@ -117,15 +117,27 @@ describe("Table side panel", () => {
     expect(model.getters.getSelectedZone()).toEqual(toZone("D2"));
   });
 
-  test("Errors messages are displayed when wrong zone is entered and input is reset on confirm", async () => {
+  test("Errors messages are displayed when wrong zone is entered", async () => {
     createTable(model, "D1:D2");
     await simulateClick(".o-selection input");
     await setInputValueAndTrigger(".o-selection input", "D1:D5");
     expect(fixture.querySelector(".o-side-panel-error")).not.toBeNull();
 
     await click(fixture, ".o-selection .o-selection-ok");
+    expect(fixture.querySelector(".o-side-panel-error")).not.toBeNull();
+  });
+
+  test("Can update a table after entering an invalid range", async () => {
+    createTable(model, "D1:D2");
+    await simulateClick(".o-selection input");
+    await setInputValueAndTrigger(".o-selection input", "OK");
+    await simulateClick(".o-checkbox");
+    expect(fixture.querySelector(".o-side-panel-error")).not.toBeNull();
+    await simulateClick(".o-selection input");
+    await setInputValueAndTrigger(".o-selection input", "A1");
+    await click(fixture, ".o-selection .o-selection-ok");
     expect(fixture.querySelector(".o-side-panel-error")).toBeNull();
-    expect(fixture.querySelector<HTMLInputElement>(".o-selection input")!.value).toBe("A1:C4");
+    expect(getTable(model, sheetId).range.zone).toEqual(toZone("A1"));
   });
 
   test("Changing the selection changes the edited table", async () => {


### PR DESCRIPTION
### [FIX] table: fix bug when edit table with invalid range

Before this commit, when editing a table and entering an invalid range, the entire spreadsheet stops working and causes the browser to crash. This is due to an infinite call to `onWillUpdateProps` of the `SelectionInput` component.

This commit fixes the problem by removing a useless range validity check when the input changes.

Task: [4102425](https://www.odoo.com/web#id=4102425&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo