### PR TITLE
[FIX] clipboard: Fix paste as value for in localized sheet

### DIFF
--- a/src/helpers/clipboard/clipboard_cells_state.ts
+++ b/src/helpers/clipboard/clipboard_cells_state.ts
@@ -382,9 +382,7 @@ export class ClipboardCellsState extends ClipboardCellsAbstractState {
     const targetCell = this.getters.getEvaluatedCell(target);
 
     if (clipboardOption?.pasteOption === "onlyValue") {
-      const locale = this.getters.getLocale();
-      const content = formatValue(origin.evaluatedCell.value, { locale });
-      this.dispatch("UPDATE_CELL", { ...target, content });
+      this.dispatch("UPDATE_CELL", { ...target, content: origin.evaluatedCell.value.toString() });
       return;
     }
 

--- a/tests/clipboard/clipboard_plugin.test.ts
+++ b/tests/clipboard/clipboard_plugin.test.ts
@@ -2,7 +2,12 @@ import { DEFAULT_BORDER_DESC } from "../../src/constants";
 import { toCartesian, toZone, zoneToXc } from "../../src/helpers";
 import { ClipboardCellsState } from "../../src/helpers/clipboard/clipboard_cells_state";
 import { Model } from "../../src/model";
-import { ClipboardMIMEType, CommandResult, DEFAULT_LOCALE } from "../../src/types/index";
+import {
+  ClipboardMIMEType,
+  CommandResult,
+  DEFAULT_LOCALE,
+  DEFAULT_LOCALES,
+} from "../../src/types/index";
 import { XMLString } from "../../src/types/xlsx";
 import { parseXML, xmlEscape } from "../../src/xlsx/helpers/xml_helpers";
 import { MockClipboardData } from "../test_helpers/clipboard";
@@ -1250,6 +1255,17 @@ describe("clipboard", () => {
     expect(getCellContent(model, "B1")).toBe("3");
     expect(getCellContent(model, "B2")).toBe("TRUE");
     expect(getCellContent(model, "B3")).toBe("Kikou");
+  });
+
+  test("Can paste localized content as value", () => {
+    const model = new Model();
+    updateLocale(model, DEFAULT_LOCALES[1]);
+    setCellContent(model, "A1", "5.4");
+    setCellContent(model, "A2", "=SUM(4.5)");
+    copy(model, "A1:A2");
+    paste(model, "B1", "onlyValue");
+    expect(getCell(model, "B1")?.content).toBe("5.4");
+    expect(getCell(model, "B2")?.content).toBe("4.5");
   });
 
   test("can copy a formula and paste -> apply the format defined by user, if not apply the automatic evaluated format ", () => {


### PR DESCRIPTION
When pasting as value, we would re-localize the payload before writing it on the cell. However, The content of a cell is supposed to be "canonical" so the conversion to the localized value was probably a mistake.

Task: 4104432

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo