### PR TITLE
[IMP] data_validation: prevent creation of dv rules with empty ranges

### DIFF
--- a/src/plugins/core/data_validation.ts
+++ b/src/plugins/core/data_validation.ts
@@ -79,6 +79,7 @@ export class DataValidationPlugin
         return this.checkValidations(
           cmd,
           this.chainValidations(
+            this.checkEmptyRange,
             this.checkCriterionTypeIsValid,
             this.checkCriterionHasValidNumberOfValues,
             this.checkCriterionValuesAreValid
@@ -226,6 +227,10 @@ export class DataValidationPlugin
       };
       this.dispatch("UPDATE_CELL", { ...position, style });
     }
+  }
+
+  private checkEmptyRange(cmd: AddDataValidationCommand) {
+    return cmd.ranges.length ? CommandResult.Success : CommandResult.EmptyRange;
   }
 
   import(data: WorkbookData) {

--- a/tests/data_validation/data_validation_core_plugin.test.ts
+++ b/tests/data_validation/data_validation_core_plugin.test.ts
@@ -70,6 +70,15 @@ describe("Data validation", () => {
       const result = removeDataValidation(model, "notAnExistingId");
       expect(result).toBeCancelledBecause(CommandResult.UnknownDataValidationRule);
     });
+
+    test("Cannot create a data validation rule with an empty range", () => {
+      const result = model.dispatch("ADD_DATA_VALIDATION_RULE", {
+        sheetId,
+        ranges: [],
+        rule: { id: "id", criterion: { type: "isBoolean", values: [] } },
+      });
+      expect(result).toBeCancelledBecause(CommandResult.EmptyRange);
+    });
   });
 
   test("Can add a data validation rule", () => {


### PR DESCRIPTION
### [IMP] data_validation: prevent creation of dv rules with empty ranges

Task: [4100509](https://www.odoo.com/odoo/project/2328/tasks/4100509)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo