### PR TITLE
[FIX] composer: Pivot cell selection non adapted to locale

### DIFF
--- a/src/components/composer/composer/composer_store.ts
+++ b/src/components/composer/composer/composer_store.ts
@@ -1,4 +1,4 @@
-import { EnrichedToken, composerTokenize } from "../../../formulas/composer_tokenizer";
+import { composerTokenize, EnrichedToken } from "../../../formulas/composer_tokenizer";
 import { POSTFIX_UNARY_OPERATORS } from "../../../formulas/tokenizer";
 import { parseLiteral } from "../../../helpers/cells";
 import {
@@ -44,6 +44,7 @@ import {
   Format,
   HeaderIndex,
   Highlight,
+  isMatrix,
   Locale,
   Range,
   RangePart,
@@ -51,7 +52,6 @@ import {
   UID,
   UnboundedZone,
   Zone,
-  isMatrix,
 } from "../../../types";
 import { SelectionEvent } from "../../../types/event_stream";
 
@@ -647,7 +647,7 @@ export class ComposerStore extends SpreadsheetStore {
       if (pivotId && pivotCell.type !== "EMPTY" && !cell?.isFormula) {
         const formulaPivotId = this.getters.getPivotFormulaId(pivotId);
         const formula = createPivotFormula(formulaPivotId, pivotCell);
-        return formula.slice(1); // strip leading =
+        return localizeFormula(formula, this.getters.getLocale()).slice(1); // strip leading =
       }
     }
     const range = this.getters.getRangeFromZone(sheetId, zone);

--- a/tests/composer/composer_store.test.ts
+++ b/tests/composer/composer_store.test.ts
@@ -11,7 +11,7 @@ import { Model } from "../../src/model";
 import { DependencyContainer, Store } from "../../src/store_engine";
 import { HighlightStore } from "../../src/stores/highlight_store";
 import { NotificationStore } from "../../src/stores/notification_store";
-import { CellValueType, DEFAULT_LOCALE } from "../../src/types";
+import { CellValueType, DEFAULT_LOCALE, DEFAULT_LOCALES } from "../../src/types";
 import {
   activateSheet,
   addCellToSelection,
@@ -1171,6 +1171,27 @@ describe("edition", () => {
     // click on total value
     selectCell(model, "B5");
     expect(store.currentContent).toBe('=PIVOT.VALUE(1,"__count")');
+  });
+
+  test("click on a pivot value inserts the formula in the right locale", () => {
+    const grid = {
+      D1: "Name",
+      D2: "Alice",
+      D3: "Bob",
+      D4: "Bob",
+    };
+    const model = createModelFromGrid(grid);
+    updateLocale(model, DEFAULT_LOCALES[1]);
+    addPivot(model, "D1:D4", {
+      columns: [],
+      rows: [{ name: "Name" }],
+      measures: [{ name: "__count", aggregator: "sum" }],
+    });
+    setCellContent(model, "A1", "=PIVOT(1)");
+    const { store } = makeStoreWithModel(model, ComposerStore);
+    store.startEdition("=");
+    selectCell(model, "B3");
+    expect(store.currentContent).toBe('=PIVOT.VALUE(1;"__count";"Name";"Alice")');
   });
 
   test("click on a pivot measure header cell insert the formula", () => {


### PR DESCRIPTION
How to reproduce:

- Open a sheet with a =pivot() formula
- Change the locale to french
- Start editing a cell with "="
- Select a cell from the pivot formula

-> The formulat argument separator is set to comma and not a semicolon

Task: 4104502

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo