### PR TITLE
[IMP] TextInput: Auto-select all text on focus

### DIFF
--- a/src/components/text_input/text_input.ts
+++ b/src/components/text_input/text_input.ts
@@ -58,17 +58,45 @@ export class TextInput extends Component<Props, SpreadsheetChildEnv> {
           this.save();
         }
       },
-      {
-        capture: true,
-      }
+      { capture: true }
     );
   }
 
-  onChange() {
-    this.save();
+  onKeyDown(ev: KeyboardEvent) {
+    switch (ev.key) {
+      case "Enter":
+        this.save();
+        ev.preventDefault();
+        ev.stopPropagation();
+        break;
+      case "Escape":
+        if (this.inputRef.el) {
+          this.inputRef.el.value = this.props.value;
+          this.inputRef.el.blur();
+        }
+        ev.preventDefault();
+        ev.stopPropagation();
+        break;
+    }
   }
 
   save() {
-    this.props.onChange((this.inputRef.el?.value || "").trim());
+    const currentValue = (this.inputRef.el?.value || "").trim();
+    if (currentValue !== this.props.value) {
+      this.props.onChange(currentValue);
+    }
+    this.inputRef.el?.blur();
+  }
+
+  focusInputAndSelectContent() {
+    const inputEl = this.inputRef.el;
+    if (!inputEl) return;
+
+    // The onFocus event selects all text in the input.
+    // The subsequent mouseup event can deselect this text,
+    // so t-on-mouseup.prevent.stop is used to prevent this
+    // default behavior and preserve the selection.
+    inputEl.focus();
+    inputEl.select();
   }
 }

--- a/src/components/text_input/text_input.xml
+++ b/src/components/text_input/text_input.xml
@@ -8,7 +8,11 @@
       t-att-id="props.id"
       t-att-placeholder="props.placeholder"
       t-att-value="props.value"
-      t-on-change="onChange"
+      t-on-change="save"
+      t-on-focus="focusInputAndSelectContent"
+      t-on-blur="save"
+      t-on-mouseup.prevent.stop=""
+      t-on-keydown="onKeyDown"
     />
   </div>
 </templates>

--- a/tests/components/text_input.test.ts
+++ b/tests/components/text_input.test.ts
@@ -63,4 +63,30 @@ describe("TextInput", () => {
     await keyDown({ key: "Enter" });
     expect(onChange).toHaveBeenCalledWith("world");
   });
+
+  test("selects input content upon focus", async () => {
+    await mountTextInput({ value: "hello", onChange: () => {} });
+    fixture.querySelector("input")!.focus();
+    expect(fixture.querySelector("input")!.selectionStart).toEqual(0);
+    expect(fixture.querySelector("input")!.selectionEnd).toEqual(5);
+  });
+
+  test("saves the value on input blur", async () => {
+    const onChange = jest.fn();
+    await mountTextInput({ value: "hello", onChange });
+    setInputValueAndTrigger(fixture.querySelector("input")!, "world");
+    fixture.querySelector("input")!.blur();
+    expect(onChange).toHaveBeenCalledWith("world");
+  });
+
+  test("can reset the value with escape key", async () => {
+    const onChange = jest.fn();
+    await mountTextInput({ value: "hello", onChange });
+    const input = fixture.querySelector("input")! as HTMLInputElement;
+    input.value = "world";
+    input.dispatchEvent(new Event("input"));
+    input.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    expect(onChange).not.toHaveBeenCalled();
+    expect(input.value).toEqual("hello");
+  });
 });


### PR DESCRIPTION
## Description:

Automatically selects all text in the TextInput component when focused, allowing users to quickly replace it.

Added support for saving with Enter and canceling with Escape.

Task: [4080323](https://www.odoo.com/odoo/project/2328/tasks/4080323)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo