### PR TITLE
[FIX] clipboard: paint format after cut

### DIFF
--- a/src/plugins/ui_stateful/clipboard.ts
+++ b/src/plugins/ui_stateful/clipboard.ts
@@ -155,6 +155,7 @@ export class ClipboardPlugin extends UIPlugin {
         this.status = "invisible";
         if (this._isCutOperation) {
           this.copiedData = undefined;
+          this._isCutOperation = false;
         }
         break;
       }
@@ -256,6 +257,7 @@ export class ClipboardPlugin extends UIPlugin {
       }
       case "ACTIVATE_PAINT_FORMAT": {
         const zones = this.getters.getSelectedZones();
+        this._isCutOperation = false;
         this.copiedData = this.copy(zones);
         this.status = "visible";
         if (cmd.persistent) {

--- a/tests/clipboard/clipboard_plugin.test.ts
+++ b/tests/clipboard/clipboard_plugin.test.ts
@@ -82,7 +82,9 @@ describe("clipboard", () => {
     expect(getCell(model, "B2")).toMatchObject({
       content: "b2",
     });
+    expect(model.getters.isCutOperation()).toBe(true);
     paste(model, "D2");
+    expect(model.getters.isCutOperation()).toBe(false);
 
     expect(getCell(model, "B2")).toBeUndefined();
     expect(getCell(model, "D2")).toMatchObject({

--- a/tests/grid/grid_component.test.ts
+++ b/tests/grid/grid_component.test.ts
@@ -911,6 +911,19 @@ describe("Grid component", () => {
       gridMouseEvent(model, "pointerup", "D8");
       expect(getCell(model, "D8")!.style).toEqual({ bold: true });
     });
+
+    test("can paint format after a cut", async () => {
+      setCellContent(model, "B2", "b2");
+      cut(model, "A1");
+      selectCell(model, "B2");
+      setStyle(model, "B2", { bold: true });
+      model.dispatch("ACTIVATE_PAINT_FORMAT");
+      expect(model.getters.isCutOperation());
+
+      gridMouseEvent(model, "pointerdown", "D8");
+      gridMouseEvent(model, "pointerup", "D8");
+      expect(getCell(model, "D8")?.style).toEqual({ bold: true });
+    });
   });
 
   test("closing contextmenu focuses the grid", async () => {


### PR DESCRIPTION
## Description:

Steps to reproduce:
- cut & paste a cell
- use the paint format tool => it doesn't work

Task: : [4077449](https://www.odoo.com/web#id=4077449&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo