### PR TITLE
[FIX] charts: remove "Show values" for trendlines

### DIFF
--- a/src/components/figures/chart/chartJs/chartjs_show_values_plugin.ts
+++ b/src/components/figures/chart/chartJs/chartjs_show_values_plugin.ts
@@ -1,5 +1,8 @@
 import { ChartType, Plugin } from "chart.js";
-import { chartFontColor } from "../../../../helpers/figures/charts/chart_common";
+import {
+  TREND_LINE_XAXIS_ID,
+  chartFontColor,
+} from "../../../../helpers/figures/charts/chart_common";
 import { Color } from "../../../../types";
 
 interface ChartShowValuesPluginOptions {
@@ -35,6 +38,9 @@ export const chartShowValuesPlugin: Plugin = {
     ctx.strokeStyle = chartFontColor(ctx.fillStyle);
 
     chart._metasets.forEach(function (dataset) {
+      if (dataset.xAxisID === TREND_LINE_XAXIS_ID) {
+        return; // ignore trend lines
+      }
       switch (dataset.type) {
         case "doughnut":
         case "pie": {


### PR DESCRIPTION
Showing the values of the trendlines is both useless, as they are not actual data, and bloating the chart with a huge amount text, making the chart very hard to read.

Task: 4104524

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo