### PR TITLE
[FIX] sheetUi: a spilled cell has no core content

### DIFF
--- a/src/plugins/ui_feature/ui_sheet.ts
+++ b/src/plugins/ui_feature/ui_sheet.ts
@@ -105,6 +105,8 @@ export class SheetUIPlugin extends UIPlugin {
     const cell = this.getters.getCell(position);
     if (showFormula && cell?.isFormula) {
       return localizeFormula(cell.content, this.getters.getLocale());
+    } else if (showFormula && !cell?.content) {
+      return "";
     } else {
       return this.getters.getEvaluatedCell(position).formattedValue;
     }

--- a/tests/renderer_plugin.test.ts
+++ b/tests/renderer_plugin.test.ts
@@ -2062,4 +2062,15 @@ describe("renderer", () => {
     model.drawGrid(ctx);
     expect(borderRenderingContext).toEqual([[1, [[1, 1]]]]);
   });
+
+  test("Cells of splilled formula are empty is we display the formulas", () => {
+    const model = new Model({ sheets: [{ colNumber: 2, rowNumber: 2 }] });
+    model.dispatch("SET_FORMULA_VISIBILITY", { show: true });
+    setCellContent(model, "A1", "=MUNIT(2)");
+    let ctx = new MockGridRenderingContext(model, 1000, 1000, {});
+    model.drawGrid(ctx);
+    const boxes = getPlugin(model, RendererPlugin)["boxes"];
+    const boxesText = boxes.map((box) => box.content?.textLines.join(""));
+    expect(boxesText).toEqual(["=MUNIT(2)", "", "", ""]);
+  });
 });


### PR DESCRIPTION
The spilled cell of a formula don't have any content. As such, when choosing to display the formula, those cells should be empty and not display their evaluated value.

Task: 4105162

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo