### PR TITLE
[FIX] ranges: replace `MOVE_RANGES` with `MOVE_REFERENCES`

### DIFF
--- a/src/clipboard_handlers/cell_clipboard.ts
+++ b/src/clipboard_handlers/cell_clipboard.ts
@@ -184,12 +184,12 @@ export class CellClipboardHandler extends AbstractCellClipboardHandler<
     this.clearClippedZones(content);
     const selection = target[0];
     this.pasteZone(sheetId, selection.left, selection.top, content.cells, options);
-    this.dispatch("MOVE_RANGES", {
-      target: content.zones,
+    this.dispatch("MOVE_REFERENCES", {
+      zone: content.zones[0], // cut has only one target zone
       sheetId: content.sheetId,
       targetSheetId: sheetId,
-      col: selection.left,
-      row: selection.top,
+      targetCol: selection.left,
+      targetRow: selection.top,
     });
   }
 

--- a/src/clipboard_handlers/merge_clipboard.ts
+++ b/src/clipboard_handlers/merge_clipboard.ts
@@ -1,3 +1,4 @@
+import { isDefined } from "../helpers";
 import {
   CellPosition,
   ClipboardCellData,
@@ -11,6 +12,7 @@ import {
 import { AbstractCellClipboardHandler } from "./abstract_cell_clipboard_handler";
 
 interface ClipboardContent {
+  sheetId: UID;
   merges: Maybe<Merge>[][];
 }
 
@@ -31,7 +33,7 @@ export class MergeClipboardHandler extends AbstractCellClipboardHandler<
       }
       merges.push(mergesInRow);
     }
-    return { merges };
+    return { merges, sheetId };
   }
 
   /**
@@ -39,7 +41,8 @@ export class MergeClipboardHandler extends AbstractCellClipboardHandler<
    */
   paste(target: ClipboardPasteTarget, content: ClipboardContent, options: ClipboardOptions) {
     if (options.isCutOperation) {
-      return;
+      const copiedMerges = content.merges.flat().filter(isDefined);
+      this.dispatch("REMOVE_MERGE", { sheetId: content.sheetId, target: copiedMerges });
     }
     this.pasteFromCopy(target.sheetId, target.zones, content.merges, options);
   }

--- a/src/collaborative/ot/ot_helpers.ts
+++ b/src/collaborative/ot/ot_helpers.ts
@@ -1,5 +1,13 @@
 import { expandZoneOnInsertion, reduceZoneOnDeletion } from "../../helpers";
-import { CoreCommand, RangeData, UnboundedZone, Zone } from "../../types";
+import {
+  AddColumnsRowsCommand,
+  CoreCommand,
+  Position,
+  RangeData,
+  RemoveColumnsRowsCommand,
+  UnboundedZone,
+  Zone,
+} from "../../types";
 
 export function transformZone<Z extends Zone | UnboundedZone>(
   zone: Z,
@@ -36,4 +44,33 @@ export function transformRangeData(range: RangeData, executed: CoreCommand): Ran
     }
   }
   return undefined;
+}
+
+/**
+ * Transform a PositionDependentCommand after a grid shape modification. This
+ * transformation consists of updating the position.
+ */
+export function transformPositionWithGrid(
+  position: Position,
+  executed: AddColumnsRowsCommand | RemoveColumnsRowsCommand
+): Position | undefined {
+  const field = executed.dimension === "COL" ? "col" : "row";
+  let base = position[field];
+  if (executed.type === "REMOVE_COLUMNS_ROWS") {
+    const elements = [...executed.elements].sort((a, b) => b - a);
+    if (elements.includes(base)) {
+      return undefined;
+    }
+    for (let removedElement of elements) {
+      if (base >= removedElement) {
+        base--;
+      }
+    }
+  }
+  if (executed.type === "ADD_COLUMNS_ROWS") {
+    if (base > executed.base || (base === executed.base && executed.position === "before")) {
+      base = base + executed.quantity;
+    }
+  }
+  return { ...position, [field]: base };
 }

--- a/src/collaborative/ot/ot_specific.ts
+++ b/src/collaborative/ot/ot_specific.ts
@@ -24,7 +24,7 @@ import {
   GroupHeadersCommand,
   HeaderIndex,
   InsertPivotCommand,
-  MoveRangeCommand,
+  MoveReferencesCommand,
   RemoveColumnsRowsCommand,
   RemoveMergeCommand,
   RemovePivotCommand,
@@ -38,7 +38,7 @@ import {
   UpdateTableCommand,
   Zone,
 } from "../../types";
-import { transformRangeData, transformZone } from "./ot_helpers";
+import { transformPositionWithGrid, transformRangeData, transformZone } from "./ot_helpers";
 
 /*
  * This file contains the specifics transformations
@@ -57,7 +57,13 @@ otRegistry.addTransformation(
   ["CREATE_CHART", "UPDATE_CHART"],
   updateChartRangesTransformation
 );
-otRegistry.addTransformation("DELETE_SHEET", ["MOVE_RANGES"], transformTargetSheetId);
+otRegistry.addTransformation("DELETE_SHEET", ["MOVE_REFERENCES"], transformTargetSheetId);
+otRegistry.addTransformation("ADD_COLUMNS_ROWS", ["MOVE_REFERENCES"], moveReferencesTransformation);
+otRegistry.addTransformation(
+  "REMOVE_COLUMNS_ROWS",
+  ["MOVE_REFERENCES"],
+  moveReferencesTransformation
+);
 otRegistry.addTransformation("DELETE_FIGURE", ["UPDATE_FIGURE", "UPDATE_CHART"], updateChartFigure);
 otRegistry.addTransformation("CREATE_SHEET", ["CREATE_SHEET"], createSheetTransformation);
 otRegistry.addTransformation("ADD_MERGE", ["ADD_MERGE", "REMOVE_MERGE"], mergeTransformation);
@@ -151,9 +157,9 @@ function pivotRemovedTransformation(
 }
 
 function transformTargetSheetId(
-  toTransform: MoveRangeCommand,
+  toTransform: MoveReferencesCommand,
   executed: DeleteSheetCommand
-): MoveRangeCommand | undefined {
+): MoveReferencesCommand | undefined {
   const deletedSheetId = executed.sheetId;
   if (toTransform.targetSheetId === deletedSheetId || toTransform.sheetId === deletedSheetId) {
     return undefined;
@@ -336,4 +342,32 @@ function groupHeadersTransformation(
   }
 
   return { ...toTransform, start: Math.min(...results), end: Math.max(...results) };
+}
+
+function moveReferencesTransformation(
+  toTransform: MoveReferencesCommand,
+  executed: AddColumnsRowsCommand | RemoveColumnsRowsCommand
+): MoveReferencesCommand | undefined {
+  if (toTransform.sheetId === executed.sheetId) {
+    const newZone = transformZone(toTransform.zone, executed);
+    if (!newZone) {
+      return undefined;
+    }
+    toTransform = { ...toTransform, zone: newZone };
+  }
+
+  if (toTransform.targetSheetId === executed.sheetId) {
+    const targetPosition = { col: toTransform.targetCol, row: toTransform.targetRow };
+    const newTargetPosition = transformPositionWithGrid(targetPosition, executed);
+    if (!newTargetPosition) {
+      return undefined;
+    }
+    toTransform = {
+      ...toTransform,
+      targetCol: newTargetPosition.col,
+      targetRow: newTargetPosition.row,
+    };
+  }
+
+  return toTransform;
 }

--- a/src/model.ts
+++ b/src/model.ts
@@ -225,6 +225,7 @@ export class Model extends EventBus<any> implements CommandDispatcher {
     this.coreGetters.extendRange = this.range.extendRange.bind(this.range);
     this.coreGetters.getRangesUnion = this.range.getRangesUnion.bind(this.range);
     this.coreGetters.removeRangesSheetPrefix = this.range.removeRangesSheetPrefix.bind(this.range);
+    this.coreGetters.moveRangeInsideZone = this.range.moveRangeInsideZone.bind(this.range);
 
     this.getters = {
       isReadonly: () => this.config.mode === "readonly" || this.config.mode === "dashboard",

--- a/src/model.ts
+++ b/src/model.ts
@@ -225,7 +225,6 @@ export class Model extends EventBus<any> implements CommandDispatcher {
     this.coreGetters.extendRange = this.range.extendRange.bind(this.range);
     this.coreGetters.getRangesUnion = this.range.getRangesUnion.bind(this.range);
     this.coreGetters.removeRangesSheetPrefix = this.range.removeRangesSheetPrefix.bind(this.range);
-    this.coreGetters.moveRangeInsideZone = this.range.moveRangeInsideZone.bind(this.range);
 
     this.getters = {
       isReadonly: () => this.config.mode === "readonly" || this.config.mode === "dashboard",

--- a/src/plugins/core/cell.ts
+++ b/src/plugins/core/cell.ts
@@ -72,6 +72,10 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
     this.updateCellDependencies(applyChange);
   }
 
+  adaptReferences(applyChange: ApplyRangeChange, sheetId?: UID) {
+    this.updateCellDependencies(applyChange);
+  }
+
   // ---------------------------------------------------------------------------
   // Command Handling
   // ---------------------------------------------------------------------------
@@ -137,13 +141,6 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
       case "DELETE_CONTENT":
         this.clearZones(cmd.sheetId, cmd.target);
         break;
-      case "MOVE_REFERENCES": {
-        const target = { sheetId: cmd.targetSheetId, col: cmd.targetCol, row: cmd.targetRow };
-        this.updateCellDependencies((range) =>
-          this.getters.moveRangeInsideZone(range, cmd.sheetId, cmd.zone, target)
-        );
-        break;
-      }
     }
   }
 

--- a/src/plugins/core/chart.ts
+++ b/src/plugins/core/chart.ts
@@ -12,7 +12,6 @@ import {
   DOMDimension,
   Figure,
   FigureData,
-  Range,
   UID,
   UpdateChartCommand,
   WorkbookData,
@@ -46,6 +45,12 @@ export class ChartPlugin extends CorePlugin<ChartState> implements ChartState {
     validateChartDefinition(this, cmd.definition);
 
   adaptRanges(applyChange: ApplyRangeChange) {
+    for (const [chartId, chart] of Object.entries(this.charts)) {
+      this.history.update("charts", chartId, chart?.updateRanges(applyChange));
+    }
+  }
+
+  adaptReferences(applyChange: ApplyRangeChange) {
     for (const [chartId, chart] of Object.entries(this.charts)) {
       this.history.update("charts", chartId, chart?.updateRanges(applyChange));
     }
@@ -110,15 +115,6 @@ export class ChartPlugin extends CorePlugin<ChartState> implements ChartState {
           this.history.update("charts", id, undefined);
         }
         break;
-      case "MOVE_REFERENCES": {
-        const target = { sheetId: cmd.targetSheetId, col: cmd.targetCol, row: cmd.targetRow };
-        const adaptRange = (range: Range) =>
-          this.getters.moveRangeInsideZone(range, cmd.sheetId, cmd.zone, target);
-        for (const [chartId, chart] of Object.entries(this.charts)) {
-          this.history.update("charts", chartId, chart?.updateRanges(adaptRange));
-        }
-        break;
-      }
     }
   }
 

--- a/src/plugins/core/chart.ts
+++ b/src/plugins/core/chart.ts
@@ -12,6 +12,7 @@ import {
   DOMDimension,
   Figure,
   FigureData,
+  Range,
   UID,
   UpdateChartCommand,
   WorkbookData,
@@ -109,6 +110,15 @@ export class ChartPlugin extends CorePlugin<ChartState> implements ChartState {
           this.history.update("charts", id, undefined);
         }
         break;
+      case "MOVE_REFERENCES": {
+        const target = { sheetId: cmd.targetSheetId, col: cmd.targetCol, row: cmd.targetRow };
+        const adaptRange = (range: Range) =>
+          this.getters.moveRangeInsideZone(range, cmd.sheetId, cmd.zone, target);
+        for (const [chartId, chart] of Object.entries(this.charts)) {
+          this.history.update("charts", chartId, chart?.updateRanges(adaptRange));
+        }
+        break;
+      }
     }
   }
 

--- a/src/plugins/core_plugin.ts
+++ b/src/plugins/core_plugin.ts
@@ -52,6 +52,7 @@ export class CorePlugin<State = any>
   }: CorePluginConfig) {
     super(stateObserver, dispatch, canDispatch);
     range.addRangeProvider(this.adaptRanges.bind(this));
+    range.addReferencesProvider(this.adaptReferences.bind(this));
     this.getters = getters;
     this.uuidGenerator = uuidGenerator;
   }
@@ -74,6 +75,7 @@ export class CorePlugin<State = any>
    * @param sheetId an optional sheetId to adapt either range of that sheet specifically, or ranges pointing to that sheet
    */
   adaptRanges(applyChange: ApplyRangeChange, sheetId?: UID): void {}
+  adaptReferences(applyChange: ApplyRangeChange, sheetId?: UID): void {}
 
   /**
    * Implement this method to clean unused external resources, such as images

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -129,7 +129,7 @@ export const invalidateEvaluationCommands = new Set<CommandTypes>([
   "DUPLICATE_PIVOT",
 ]);
 
-export const invalidateDependenciesCommands = new Set<CommandTypes>(["MOVE_RANGES"]);
+export const invalidateDependenciesCommands = new Set<CommandTypes>(["MOVE_REFERENCES"]);
 
 export const invalidateCFEvaluationCommands = new Set<CommandTypes>([
   "DUPLICATE_SHEET",
@@ -195,7 +195,7 @@ export const coreTypes = new Set<CoreCommandTypes>([
   "SHOW_SHEET",
 
   /** RANGES MANIPULATION */
-  "MOVE_RANGES",
+  "MOVE_REFERENCES",
 
   /** CONDITIONAL FORMAT */
   "ADD_CONDITIONAL_FORMAT",
@@ -414,14 +414,13 @@ export interface ShowSheetCommand extends SheetDependentCommand {
 // Ranges Manipulation
 //------------------------------------------------------------------------------
 
-/**
- * Command created in order to apply a translational movement for all references
- * to cells/ranges within a specific zone.
- * Command particularly useful during CUT / PATE.
- */
-export interface MoveRangeCommand extends PositionDependentCommand, TargetDependentCommand {
-  type: "MOVE_RANGES";
+export interface MoveReferencesCommand {
+  type: "MOVE_REFERENCES";
+  sheetId: UID;
+  zone: Zone;
   targetSheetId: string;
+  targetCol: HeaderIndex;
+  targetRow: HeaderIndex;
 }
 
 //------------------------------------------------------------------------------
@@ -1002,7 +1001,7 @@ export type CoreCommand =
   | ShowSheetCommand
 
   /** RANGES MANIPULATION */
-  | MoveRangeCommand
+  | MoveReferencesCommand
 
   /** CONDITIONAL FORMAT */
   | AddConditionalFormatCommand

--- a/src/types/misc.ts
+++ b/src/types/misc.ts
@@ -285,6 +285,7 @@ export type ConsecutiveIndexes = HeaderIndex[];
 
 export interface RangeProvider {
   adaptRanges: (applyChange: ApplyRangeChange, sheetId?: UID) => void;
+  adaptReferences: (applyChange: ApplyRangeChange, sheetId?: UID) => void;
 }
 
 export type Validation<T> = (toValidate: T) => CommandResult | CommandResult[];

--- a/tests/clipboard/clipboard_plugin.test.ts
+++ b/tests/clipboard/clipboard_plugin.test.ts
@@ -4,6 +4,7 @@ import { markdownLink, toCartesian, toZone, zoneToXc } from "../../src/helpers";
 import { getClipboardDataPositions } from "../../src/helpers/clipboard/clipboard_helpers";
 import { urlRepresentation } from "../../src/helpers/links";
 import { Model } from "../../src/model";
+import { LineChartDefinition } from "../../src/types/chart";
 import {
   ClipboardMIMEType,
   ClipboardPasteTarget,
@@ -22,6 +23,7 @@ import {
   copy,
   copyPasteAboveCells,
   copyPasteCellsOnLeft,
+  createChart,
   createSheet,
   createSheetWithName,
   createTable,
@@ -347,20 +349,36 @@ describe("clipboard", () => {
     expect(model.getters.isInMerge({ sheetId, ...toCartesian("B5") })).toBe(true);
   });
 
+  test("can copy and paste merge not at the origin of the copy", () => {
+    const model = new Model();
+    merge(model, "B2:C3");
+    copy(model, "A1:C3");
+    paste(model, "A4");
+    const sheetId = model.getters.getActiveSheetId();
+    expect(model.getters.getMerges(sheetId).map(zoneToXc)).toEqual(["B2:C3", "B5:C6"]);
+  });
+
   test("can cut and paste merged content", () => {
     const model = new Model({
       sheets: [{ id: "s2", colNumber: 5, rowNumber: 5, merges: ["B1:C2"] }],
     });
     cut(model, "B1:C2");
     paste(model, "B4");
-    expect(model.getters.isInMerge({ sheetId: "s2", ...toCartesian("B1") })).toBe(false);
-    expect(model.getters.isInMerge({ sheetId: "s2", ...toCartesian("B2") })).toBe(false);
-    expect(model.getters.isInMerge({ sheetId: "s2", ...toCartesian("C1") })).toBe(false);
-    expect(model.getters.isInMerge({ sheetId: "s2", ...toCartesian("C2") })).toBe(false);
-    expect(model.getters.isInMerge({ sheetId: "s2", ...toCartesian("B4") })).toBe(true);
-    expect(model.getters.isInMerge({ sheetId: "s2", ...toCartesian("B5") })).toBe(true);
-    expect(model.getters.isInMerge({ sheetId: "s2", ...toCartesian("C4") })).toBe(true);
-    expect(model.getters.isInMerge({ sheetId: "s2", ...toCartesian("C5") })).toBe(true);
+    expect(model.getters.getMerges("s2").map(zoneToXc)).toEqual(["B4:C5"]);
+  });
+
+  test("can cut and paste merge in another sheet", () => {
+    const model = new Model();
+    const sheet1Id = model.getters.getActiveSheetId();
+    setCellContent(model, "B2", "text");
+    merge(model, "B2:C3");
+    cut(model, "B2:C3");
+    createSheet(model, { sheetId: "s2", activate: true });
+
+    paste(model, "A1");
+    expect(getCellContent(model, "A1", "s2")).toBe("text");
+    expect(model.getters.getMerges("s2").map(zoneToXc)).toEqual(["A1:B2"]);
+    expect(model.getters.getMerges(sheet1Id)).toEqual([]);
   });
 
   test("Pasting merge on content will remove the content", () => {
@@ -1575,6 +1593,32 @@ describe("clipboard", () => {
       expect(getCellText(model, "B1")).toBe("");
       expect(getCellText(model, "A2")).toBe("=SUM(B1:C1)+B2");
       expect(getCellText(model, "B2")).toBe("b1");
+    });
+  });
+
+  test("cut/paste ranges present in charts", () => {
+    const model = new Model();
+    createChart(
+      model,
+      {
+        type: "bar",
+        dataSets: [{ dataRange: "A1:A4" }, { dataRange: "B1:B4" }],
+        labelRange: "C1:C4",
+      },
+      "chartId"
+    );
+
+    cut(model, "A1:A4");
+    paste(model, "A5");
+
+    cut(model, "C1:C4");
+    createSheet(model, { activate: true, sheetId: "sh2" });
+    paste(model, "C1");
+
+    const chartDefinition = model.getters.getChartDefinition("chartId") as LineChartDefinition;
+    expect(chartDefinition).toMatchObject({
+      dataSets: [{ dataRange: "A5:A8" }, { dataRange: "B1:B4" }],
+      labelRange: "Sheet2!C1:C4",
     });
   });
 

--- a/tests/collaborative/ot/ot_columns_added.test.ts
+++ b/tests/collaborative/ot/ot_columns_added.test.ts
@@ -4,6 +4,7 @@ import {
   AddColumnsRowsCommand,
   FreezeColumnsCommand,
   FreezeRowsCommand,
+  MoveReferencesCommand,
   RemoveColumnsRowsCommand,
   ResizeColumnsRowsCommand,
   UpdateTableCommand,
@@ -418,6 +419,47 @@ describe("OT with ADD_COLUMNS_ROWS with dimension COL", () => {
       const command = { ...toTransform, quantity: 2 };
       const result = transform(command, addColumnsBefore);
       expect(result).toEqual({ ...command });
+    });
+  });
+
+  describe("OT with MOVE_REFERENCES", () => {
+    const moveReferencesCmd: MoveReferencesCommand = {
+      type: "MOVE_REFERENCES",
+      sheetId,
+      zone: toZone("A1:B2"),
+      targetSheetId: "Sheet2",
+      targetCol: 0,
+      targetRow: 0,
+    };
+
+    test("Columns added before origin zone", () => {
+      const addColumnsCmd = { ...addColumnsBefore, quantity: 2, base: 0 };
+      const result = transform(moveReferencesCmd, addColumnsCmd);
+      expect(result).toEqual({ ...moveReferencesCmd, zone: toZone("C1:D2") });
+    });
+
+    test("Columns added inside origin zone", () => {
+      const addColumnsCmd = { ...addColumnsBefore, quantity: 2, base: 1 };
+      const result = transform(moveReferencesCmd, addColumnsCmd);
+      expect(result).toEqual({ ...moveReferencesCmd, zone: toZone("A1:D2") });
+    });
+
+    test("Columns added after origin zone", () => {
+      const addColumnsCmd = { ...addColumnsAfter, quantity: 2, base: 2 };
+      const result = transform(moveReferencesCmd, addColumnsCmd);
+      expect(result).toEqual(moveReferencesCmd);
+    });
+
+    test("Columns added before target position", () => {
+      const addColumnsCmd = { ...addColumnsBefore, quantity: 2, base: 0, sheetId: "Sheet2" };
+      const result = transform(moveReferencesCmd, addColumnsCmd);
+      expect(result).toEqual({ ...moveReferencesCmd, targetCol: 2 });
+    });
+
+    test("Columns added after target position", () => {
+      const addColumnsCmd = { ...addColumnsAfter, quantity: 2, base: 2, sheetId: "Sheet2" };
+      const result = transform(moveReferencesCmd, addColumnsCmd);
+      expect(result).toEqual(moveReferencesCmd);
     });
   });
 });

--- a/tests/collaborative/ot/ot_columns_removed.test.ts
+++ b/tests/collaborative/ot/ot_columns_removed.test.ts
@@ -4,6 +4,7 @@ import {
   AddColumnsRowsCommand,
   FreezeColumnsCommand,
   FreezeRowsCommand,
+  MoveReferencesCommand,
   RemoveColumnsRowsCommand,
   ResizeColumnsRowsCommand,
   UpdateTableCommand,
@@ -428,6 +429,59 @@ describe("OT with REMOVE_COLUMN", () => {
       const command = { ...toTransform, quantity: 3 };
       const result = transform(command, removeColumns);
       expect(result).toEqual({ ...command });
+    });
+  });
+
+  describe("OT with MOVE_REFERENCES", () => {
+    const moveReferencesCmd: MoveReferencesCommand = {
+      type: "MOVE_REFERENCES",
+      sheetId,
+      zone: toZone("B2:C3"),
+      targetSheetId: "Sheet2",
+      targetCol: 1,
+      targetRow: 1,
+    };
+
+    test("Columns removed before origin zone", () => {
+      const removeColsCmd = { ...removeColumns, elements: [0] };
+      const result = transform(moveReferencesCmd, removeColsCmd);
+      expect(result).toEqual({ ...moveReferencesCmd, zone: toZone("A2:B3") });
+    });
+
+    test("Columns removed inside origin zone", () => {
+      const removeColsCmd = { ...removeColumns, elements: [1] };
+      const result = transform(moveReferencesCmd, removeColsCmd);
+      expect(result).toEqual({ ...moveReferencesCmd, zone: toZone("B2:B3") });
+    });
+
+    test("Columns removed after origin zone", () => {
+      const removeColsCmd = { ...removeColumns, elements: [4] };
+      const result = transform(moveReferencesCmd, removeColsCmd);
+      expect(result).toEqual(moveReferencesCmd);
+    });
+
+    test("Remove all columns of origin zone", () => {
+      const removeColsCmd = { ...removeColumns, elements: [1, 2] };
+      const result = transform(moveReferencesCmd, removeColsCmd);
+      expect(result).toEqual(undefined);
+    });
+
+    test("Columns removed before target position", () => {
+      const removeColsCmd = { ...removeColumns, elements: [0], sheetId: "Sheet2" };
+      const result = transform(moveReferencesCmd, removeColsCmd);
+      expect(result).toEqual({ ...moveReferencesCmd, targetCol: 0 });
+    });
+
+    test("Columns removed after target position", () => {
+      const removeColsCmd = { ...removeColumns, elements: [5], sheetId: "Sheet2" };
+      const result = transform(moveReferencesCmd, removeColsCmd);
+      expect(result).toEqual(moveReferencesCmd);
+    });
+
+    test("Remove column of target position ", () => {
+      const removeColsCmd = { ...removeColumns, elements: [1], sheetId: "Sheet2" };
+      const result = transform(moveReferencesCmd, removeColsCmd);
+      expect(result).toEqual(undefined);
     });
   });
 });

--- a/tests/collaborative/ot/ot_rows_added.test.ts
+++ b/tests/collaborative/ot/ot_rows_added.test.ts
@@ -4,6 +4,7 @@ import {
   AddColumnsRowsCommand,
   FreezeColumnsCommand,
   FreezeRowsCommand,
+  MoveReferencesCommand,
   RemoveColumnsRowsCommand,
   ResizeColumnsRowsCommand,
   UpdateTableCommand,
@@ -413,6 +414,47 @@ describe("OT with ADD_COLUMNS_ROWS with dimension ROW", () => {
       const command = { ...toTransform, quantity: 2 };
       const result = transform(command, addRowsBefore);
       expect(result).toEqual({ ...command });
+    });
+  });
+
+  describe("OT with MOVE_REFERENCES", () => {
+    const moveReferencesCmd: MoveReferencesCommand = {
+      type: "MOVE_REFERENCES",
+      sheetId,
+      zone: toZone("A1:B2"),
+      targetSheetId: "Sheet2",
+      targetCol: 0,
+      targetRow: 0,
+    };
+
+    test("Rows added before origin zone", () => {
+      const addRowsCmd = { ...addRowsBefore, quantity: 2, base: 0 };
+      const result = transform(moveReferencesCmd, addRowsCmd);
+      expect(result).toEqual({ ...moveReferencesCmd, zone: toZone("A3:B4") });
+    });
+
+    test("Rows added inside origin zone", () => {
+      const addRowsCmd = { ...addRowsBefore, quantity: 2, base: 1 };
+      const result = transform(moveReferencesCmd, addRowsCmd);
+      expect(result).toEqual({ ...moveReferencesCmd, zone: toZone("A1:B4") });
+    });
+
+    test("Rows added after origin zone", () => {
+      const addRowsCmd = { ...addRowsAfter, quantity: 2, base: 2 };
+      const result = transform(moveReferencesCmd, addRowsCmd);
+      expect(result).toEqual(moveReferencesCmd);
+    });
+
+    test("Rows added before target position", () => {
+      const addRowsCmd = { ...addRowsBefore, quantity: 2, base: 0, sheetId: "Sheet2" };
+      const result = transform(moveReferencesCmd, addRowsCmd);
+      expect(result).toEqual({ ...moveReferencesCmd, targetRow: 2 });
+    });
+
+    test("Rows added after target position", () => {
+      const addRowsCmd = { ...addRowsAfter, quantity: 2, base: 2, sheetId: "Sheet2" };
+      const result = transform(moveReferencesCmd, addRowsCmd);
+      expect(result).toEqual(moveReferencesCmd);
     });
   });
 });

--- a/tests/collaborative/ot/ot_rows_removed.test.ts
+++ b/tests/collaborative/ot/ot_rows_removed.test.ts
@@ -4,6 +4,7 @@ import {
   AddColumnsRowsCommand,
   FreezeColumnsCommand,
   FreezeRowsCommand,
+  MoveReferencesCommand,
   RemoveColumnsRowsCommand,
   ResizeColumnsRowsCommand,
   UpdateTableCommand,
@@ -429,6 +430,59 @@ describe("OT with REMOVE_COLUMNS_ROWS with dimension ROW", () => {
       const command = { ...toTransform, quantity: 3 };
       const result = transform(command, removeRows);
       expect(result).toEqual({ ...command });
+    });
+  });
+
+  describe("OT with MOVE_REFERENCES", () => {
+    const moveReferencesCmd: MoveReferencesCommand = {
+      type: "MOVE_REFERENCES",
+      sheetId,
+      zone: toZone("B2:C3"),
+      targetSheetId: "Sheet2",
+      targetCol: 1,
+      targetRow: 1,
+    };
+
+    test("Rows removed before origin zone", () => {
+      const removeRowsCmd = { ...removeRows, elements: [0] };
+      const result = transform(moveReferencesCmd, removeRowsCmd);
+      expect(result).toEqual({ ...moveReferencesCmd, zone: toZone("B1:C2") });
+    });
+
+    test("Rows removed inside origin zone", () => {
+      const removeRowsCmd = { ...removeRows, elements: [1] };
+      const result = transform(moveReferencesCmd, removeRowsCmd);
+      expect(result).toEqual({ ...moveReferencesCmd, zone: toZone("B2:C2") });
+    });
+
+    test("Rows removed after origin zone", () => {
+      const removeRowsCmd = { ...removeRows, elements: [4] };
+      const result = transform(moveReferencesCmd, removeRowsCmd);
+      expect(result).toEqual(moveReferencesCmd);
+    });
+
+    test("Remove all columns of origin zone", () => {
+      const removeRowsCmd = { ...removeRows, elements: [1, 2] };
+      const result = transform(moveReferencesCmd, removeRowsCmd);
+      expect(result).toEqual(undefined);
+    });
+
+    test("Rows removed before target position", () => {
+      const removeRowsCmd = { ...removeRows, elements: [0], sheetId: "Sheet2" };
+      const result = transform(moveReferencesCmd, removeRowsCmd);
+      expect(result).toEqual({ ...moveReferencesCmd, targetRow: 0 });
+    });
+
+    test("Rows removed after target position", () => {
+      const removeRowsCmd = { ...removeRows, elements: [5], sheetId: "Sheet2" };
+      const result = transform(moveReferencesCmd, removeRowsCmd);
+      expect(result).toEqual(moveReferencesCmd);
+    });
+
+    test("Remove column of target position ", () => {
+      const removeRowsCmd = { ...removeRows, elements: [1], sheetId: "Sheet2" };
+      const result = transform(moveReferencesCmd, removeRowsCmd);
+      expect(result).toEqual(undefined);
     });
   });
 });

--- a/tests/collaborative/ot/ot_sheet_deleted.test.ts
+++ b/tests/collaborative/ot/ot_sheet_deleted.test.ts
@@ -5,7 +5,7 @@ import {
   AddConditionalFormatCommand,
   DeleteSheetCommand,
   DuplicateSheetCommand,
-  MoveRangeCommand,
+  MoveReferencesCommand,
   RemoveColumnsRowsCommand,
   ResizeColumnsRowsCommand,
 } from "../../../src/types";
@@ -70,7 +70,6 @@ describe("OT with DELETE_SHEET", () => {
     resizeRows,
     TEST_COMMANDS.REMOVE_CONDITIONAL_FORMAT,
     TEST_COMMANDS.DELETE_SHEET,
-    TEST_COMMANDS.MOVE_RANGES,
     TEST_COMMANDS.GROUP_HEADERS,
     TEST_COMMANDS.UNGROUP_HEADERS,
     TEST_COMMANDS.FOLD_HEADER_GROUP,
@@ -107,16 +106,22 @@ describe("OT with DELETE_SHEET", () => {
     });
   });
 
-  describe("Delete sheet with move ranges", () => {
-    const cmd: Omit<MoveRangeCommand, "targetSheetId"> = {
-      type: "MOVE_RANGES",
+  describe("Delete sheet with move references", () => {
+    const cmd: MoveReferencesCommand = {
+      type: "MOVE_REFERENCES",
       sheetId,
-      col: 0,
-      row: 0,
-      target: [toZone("A1")],
+      targetSheetId: "sheet2",
+      targetCol: 0,
+      targetRow: 0,
+      zone: toZone("A1"),
     };
 
-    test("Delete the sheet on which the command is triggered", () => {
+    test("Delete the source sheet", () => {
+      const result = transform({ ...cmd, sheetId: deletedSheetId }, deleteSheet);
+      expect(result).toBeUndefined();
+    });
+
+    test("Delete the target sheet", () => {
       const result = transform({ ...cmd, targetSheetId: deletedSheetId }, deleteSheet);
       expect(result).toBeUndefined();
     });

--- a/tests/table/tables_plugin.test.ts
+++ b/tests/table/tables_plugin.test.ts
@@ -712,13 +712,6 @@ describe("Table plugin", () => {
       expect(getTable(model, "A1")).toBeFalsy();
       const copiedTable = getTable(model, "A5");
       expect(copiedTable).toBeTruthy();
-      expect(
-        model.getters.getFilterHiddenValues({
-          sheetId,
-          col: copiedTable!.range.zone.left,
-          row: copiedTable!.range.zone.top,
-        })
-      ).toEqual(["thisIsAValue"]);
     });
 
     test("Can cut and paste multiple tables", () => {
@@ -733,13 +726,6 @@ describe("Table plugin", () => {
 
       const copiedTable = getTable(model, "A5");
       expect(copiedTable).toBeTruthy();
-      expect(
-        model.getters.getFilterHiddenValues({
-          sheetId,
-          col: copiedTable!.range.zone.left,
-          row: copiedTable!.range.zone.top,
-        })
-      ).toEqual(["thisIsAValue"]);
       expect(getTable(model, "D9")).toBeTruthy();
     });
 

--- a/tests/test_helpers/constants.ts
+++ b/tests/test_helpers/constants.ts
@@ -325,13 +325,13 @@ export const TEST_COMMANDS: CommandMapping = {
     sheetId: "sheetId",
     areGridLinesVisible: true,
   },
-  MOVE_RANGES: {
-    type: "MOVE_RANGES",
-    target: target("A1"),
+  MOVE_REFERENCES: {
+    type: "MOVE_REFERENCES",
+    zone: toZone("A1"),
     sheetId: "sheetId",
     targetSheetId: "sheetId",
-    col: 0,
-    row: 0,
+    targetCol: 0,
+    targetRow: 0,
   },
   SET_ZONE_BORDERS: {
     type: "SET_ZONE_BORDERS",


### PR DESCRIPTION
## Description:

This commit changes the clipboard to display a new command
`MOVE_REFERENCE` instead of `MOVE_RANGES`. The new command only moves
the ranges that are references to cells (in formulas and in chart)
instead of modifying all the existing ranges.

There is two main reasons:

- the handling of `MOVE_RANGE` is bugged in most plugins when it moves
a range from a sheet to another. Fixing the command could lead to
broken spreadsheets, so for now we prefer to remove it.

- cut/paste was in a strange state where some operations were done
twice. For example a filter table was moved once when handling
`MOVE_RANGES` and then moved again when the cut/paste of the table
was actually done. It's better to handle everything inside the clipboard.


Task: [3899595](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo