### PR TITLE
[FIX] CF: 'Equal' & 'NotEqual' rules with empty values

### DIFF
--- a/src/plugins/core/conditional_format.ts
+++ b/src/plugins/core/conditional_format.ts
@@ -341,6 +341,8 @@ export class ConditionalFormatPlugin
             "LessThan",
             "LessThanOrEqual",
             "NotContains",
+            "Equal",
+            "NotEqual",
           ]),
           this.checkOperatorArgsNumber(0, ["IsEmpty", "IsNotEmpty"]),
           this.checkCFValues

--- a/tests/conditional_formatting/conditional_formatting_plugin.test.ts
+++ b/tests/conditional_formatting/conditional_formatting_plugin.test.ts
@@ -532,18 +532,6 @@ describe("conditional format", () => {
     });
   });
 
-  test("Set conditionalFormat on empty cell", () => {
-    let result = model.dispatch("ADD_CONDITIONAL_FORMAT", {
-      cf: createEqualCF("", { fillColor: "#FF0000" }, "1"),
-      ranges: toRangesData(sheetId, "A1"),
-      sheetId,
-    });
-    expect(result).toBeSuccessfullyDispatched();
-    expect(getStyle(model, "A1")).toEqual({
-      fillColor: "#FF0000",
-    });
-  });
-
   describe("Grid Manipulation", () => {
     const rule = {
       values: ["42"],
@@ -1641,6 +1629,10 @@ describe("conditional formats types", () => {
     });
 
     test.each([
+      ["Equal", []],
+      ["Equal", [""]],
+      ["NotEqual", []],
+      ["NotEqual", [""]],
       ["GreaterThan", []],
       ["GreaterThan", [""]],
       ["GreaterThan", ["", "1"]],

--- a/tests/renderer_store.test.ts
+++ b/tests/renderer_store.test.ts
@@ -757,7 +757,15 @@ describe("renderer", () => {
     fillStyle = [];
     const sheetId = model.getters.getActiveSheetId();
     let result = model.dispatch("ADD_CONDITIONAL_FORMAT", {
-      cf: createEqualCF("", { fillColor: "#DC6CDF" }, "1"),
+      cf: {
+        id: "1",
+        rule: {
+          type: "CellIsRule",
+          operator: "IsEmpty",
+          values: [],
+          style: { fillColor: "#DC6CDF" },
+        },
+      },
       ranges: toRangesData(sheetId, "A1"),
       sheetId,
     });


### PR DESCRIPTION
## Description:

How to reproduce:

- Start with an empty spreadsheet.
- Create a new CF with the rule type cellIsRule set to "is Equal to".
- Leave the input field empty.
- Upon validation, all cells in the CF zone are colored.
- Export the spreadsheet as an .xlsx file and then re-import it.
- After re-importing, the cells are no longer colored because the CF rule was exported with a missing value, which was converted to "undefined".

This commit resolves the issue by disallowing the creation of CF rules with empty values for the 'Equal' and 'NotEqual' operators.

Task: : [4092056](https://www.odoo.com/odoo/project/2328/tasks/4092056)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo