### PR TITLE
[FIX] parser: parsing empty string throws meaningful error

### DIFF
--- a/src/formulas/parser.ts
+++ b/src/formulas/parser.ts
@@ -239,7 +239,7 @@ function parseExpression(tokens: Token[], bp: number): AST {
  */
 export function parse(str: NormalizedFormulaString): AST {
   const tokens = tokenize(str).filter((x) => x.type !== "SPACE");
-  if (tokens[0].type === "OPERATOR" && tokens[0].value === "=") {
+  if (tokens[0] && tokens[0].type === "OPERATOR" && tokens[0].value === "=") {
     tokens.splice(0, 1);
   }
   const result = parseExpression(tokens, 0);

--- a/tests/formulas/parser.test.ts
+++ b/tests/formulas/parser.test.ts
@@ -143,6 +143,10 @@ describe("parser", () => {
     expect(() => parse("#REF")).toThrowError("Invalid reference");
   });
 
+  test("Cannot parse empty string", () => {
+    expect(() => parse("")).toThrowError("Invalid expression");
+  });
+
   test("AND", () => {
     expect(parse("=AND(true, false)")).toEqual({
       type: "FUNCALL",


### PR DESCRIPTION
## Description:

`parse("")` throws an error like `cannot ready property of undefined`.

Note that it doesn't cause any (known) real bug, but let's make it more robust nonetheless.

With this commit, it throws a user friendly message.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo