### PR TITLE
[FIX] charts: fix combo chart export

### DIFF
--- a/src/xlsx/functions/charts.ts
+++ b/src/xlsx/functions/charts.ts
@@ -34,7 +34,9 @@ interface LineAttributes {
  * The value does not matter, it can be hardcoded.
  */
 const catAxId = 17781237;
+const secondaryCatAxId = 17781238;
 const valAxId = 88853993;
+const secondaryValAxId = 88853994;
 
 export function createChart(
   chart: FigureData<ExcelChartDefinition>,
@@ -398,8 +400,8 @@ function addComboChart(chart: ExcelChartDefinition): XMLString {
       <!-- each data marker in the series does not have a different color -->
       <c:varyColors val="0"/>
       ${barDataSetNode}
-      <c:axId val="${catAxId + (useRightAxisForBarSerie ? 1 : 0)}" />
-      <c:axId val="${valAxId + (useRightAxisForBarSerie ? 1 : 0)}" />
+      <c:axId val="${useRightAxisForBarSerie ? secondaryCatAxId : catAxId}" />
+      <c:axId val="${useRightAxisForBarSerie ? secondaryValAxId : valAxId}" />
     </c:barChart>
     ${
       leftDataSetsNodes.length
@@ -423,8 +425,8 @@ function addComboChart(chart: ExcelChartDefinition): XMLString {
           <!-- each data marker in the series does not have a different color -->
           <c:varyColors val="0"/>
           ${joinXmlNodes(rightDataSetsNodes)}
-          <c:axId val="${catAxId + 1}" />
-          <c:axId val="${valAxId + 1}" />
+          <c:axId val="${secondaryCatAxId}" />
+          <c:axId val="${secondaryValAxId}" />
         </c:lineChart>
       `
         : ""
@@ -435,20 +437,13 @@ function addComboChart(chart: ExcelChartDefinition): XMLString {
         ${addAx(
           "b",
           "c:catAx",
-          catAxId + 1,
-          valAxId + 1,
+          catAxId,
+          valAxId,
           chart.axesDesign?.x?.title,
           chart.fontColor,
           leftDataSetsNodes.length ? 1 : 0
         )}
-        ${addAx(
-          "r",
-          "c:valAx",
-          valAxId + 1,
-          catAxId + 1,
-          chart.axesDesign?.y1?.title,
-          chart.fontColor
-        )}
+        ${addAx("l", "c:valAx", valAxId, catAxId, chart.axesDesign?.y?.title, chart.fontColor)}
       `
         : ""
     }
@@ -458,13 +453,20 @@ function addComboChart(chart: ExcelChartDefinition): XMLString {
         ${addAx(
           "b",
           "c:catAx",
-          catAxId,
-          valAxId,
+          secondaryCatAxId,
+          secondaryValAxId,
           chart.axesDesign?.x?.title,
           chart.fontColor,
           leftDataSetsNodes.length || !useRightAxisForBarSerie ? 1 : 0
         )}
-        ${addAx("l", "c:valAx", valAxId, catAxId, chart.axesDesign?.y?.title, chart.fontColor)}
+        ${addAx(
+          "r",
+          "c:valAx",
+          secondaryValAxId,
+          secondaryCatAxId,
+          chart.axesDesign?.y1?.title,
+          chart.fontColor
+        )}
       `
         : ""
     }

--- a/tests/xlsx/__snapshots__/xlsx_export.test.ts.snap
+++ b/tests/xlsx/__snapshots__/xlsx_export.test.ts.snap
@@ -8557,8 +8557,8 @@ exports[`Test XLSX export Charts simple combo chart with customized axis 1`] = `
                 <c:axId val="88853994"/>
             </c:barChart>
             <c:catAx>
-                <c:axId val="17781237"/>
-                <c:crossAx val="88853993"/>
+                <c:axId val="17781238"/>
+                <c:crossAx val="88853994"/>
                 <!-- reference to the other axe of the chart -->
                 <c:crosses val="min"/>
                 <c:delete val="0"/>
@@ -8621,16 +8621,16 @@ exports[`Test XLSX export Charts simple combo chart with customized axis 1`] = `
             </c:catAx>
             <!-- <tickLblPos/> omitted -->
             <c:valAx>
-                <c:axId val="88853993"/>
-                <c:crossAx val="17781237"/>
+                <c:axId val="88853994"/>
+                <c:crossAx val="17781238"/>
                 <!-- reference to the other axe of the chart -->
-                <c:crosses val="min"/>
+                <c:crosses val="max"/>
                 <c:delete val="0"/>
                 <!-- by default, axis are not displayed -->
                 <c:scaling>
                     <c:orientation val="minMax"/>
                 </c:scaling>
-                <c:axPos val="l"/>
+                <c:axPos val="r"/>
                 <c:majorGridlines>
                     <c:spPr>
                         <a:ln cmpd="sng">
@@ -8652,7 +8652,7 @@ exports[`Test XLSX export Charts simple combo chart with customized axis 1`] = `
                                 <a:pPr lvl="0">
                                     <a:defRPr b="1" i="1">
                                         <a:solidFill>
-                                            <a:srgbClr val="00FF00"/>
+                                            <a:srgbClr val="0000FF"/>
                                         </a:solidFill>
                                         <a:latin typeface="+mn-lt"/>
                                     </a:defRPr>
@@ -8661,7 +8661,7 @@ exports[`Test XLSX export Charts simple combo chart with customized axis 1`] = `
                                     <!-- Runs -->
                                     <a:rPr b="1" i="1" sz="1000"/>
                                     <a:t>
-                                        Coucou 2
+                                        Coucou 3
                                     </a:t>
                                 </a:r>
                             </a:p>
@@ -9124,8 +9124,8 @@ exports[`Test XLSX export Charts simple combo chart with customized dataset 1`] 
                 <c:axId val="88853993"/>
             </c:barChart>
             <c:catAx>
-                <c:axId val="17781238"/>
-                <c:crossAx val="88853994"/>
+                <c:axId val="17781237"/>
+                <c:crossAx val="88853993"/>
                 <!-- reference to the other axe of the chart -->
                 <c:crosses val="min"/>
                 <c:delete val="0"/>
@@ -9186,16 +9186,16 @@ exports[`Test XLSX export Charts simple combo chart with customized dataset 1`] 
             </c:catAx>
             <!-- <tickLblPos/> omitted -->
             <c:valAx>
-                <c:axId val="88853994"/>
-                <c:crossAx val="17781238"/>
+                <c:axId val="88853993"/>
+                <c:crossAx val="17781237"/>
                 <!-- reference to the other axe of the chart -->
-                <c:crosses val="max"/>
+                <c:crosses val="min"/>
                 <c:delete val="0"/>
                 <!-- by default, axis are not displayed -->
                 <c:scaling>
                     <c:orientation val="minMax"/>
                 </c:scaling>
-                <c:axPos val="r"/>
+                <c:axPos val="l"/>
                 <c:majorGridlines>
                     <c:spPr>
                         <a:ln cmpd="sng">
@@ -9689,8 +9689,8 @@ exports[`Test XLSX export Charts simple combo chart with customized title 1`] = 
                 <c:axId val="88853993"/>
             </c:barChart>
             <c:catAx>
-                <c:axId val="17781238"/>
-                <c:crossAx val="88853994"/>
+                <c:axId val="17781237"/>
+                <c:crossAx val="88853993"/>
                 <!-- reference to the other axe of the chart -->
                 <c:crosses val="min"/>
                 <c:delete val="0"/>
@@ -9751,16 +9751,16 @@ exports[`Test XLSX export Charts simple combo chart with customized title 1`] = 
             </c:catAx>
             <!-- <tickLblPos/> omitted -->
             <c:valAx>
-                <c:axId val="88853994"/>
-                <c:crossAx val="17781238"/>
+                <c:axId val="88853993"/>
+                <c:crossAx val="17781237"/>
                 <!-- reference to the other axe of the chart -->
-                <c:crosses val="max"/>
+                <c:crosses val="min"/>
                 <c:delete val="0"/>
                 <!-- by default, axis are not displayed -->
                 <c:scaling>
                     <c:orientation val="minMax"/>
                 </c:scaling>
-                <c:axPos val="r"/>
+                <c:axPos val="l"/>
                 <c:majorGridlines>
                     <c:spPr>
                         <a:ln cmpd="sng">
@@ -10254,8 +10254,8 @@ exports[`Test XLSX export Charts simple combo chart with dataset [ [Object] ] 1`
                 <c:axId val="88853993"/>
             </c:barChart>
             <c:catAx>
-                <c:axId val="17781238"/>
-                <c:crossAx val="88853994"/>
+                <c:axId val="17781237"/>
+                <c:crossAx val="88853993"/>
                 <!-- reference to the other axe of the chart -->
                 <c:crosses val="min"/>
                 <c:delete val="0"/>
@@ -10316,16 +10316,16 @@ exports[`Test XLSX export Charts simple combo chart with dataset [ [Object] ] 1`
             </c:catAx>
             <!-- <tickLblPos/> omitted -->
             <c:valAx>
-                <c:axId val="88853994"/>
-                <c:crossAx val="17781238"/>
+                <c:axId val="88853993"/>
+                <c:crossAx val="17781237"/>
                 <!-- reference to the other axe of the chart -->
-                <c:crosses val="max"/>
+                <c:crosses val="min"/>
                 <c:delete val="0"/>
                 <!-- by default, axis are not displayed -->
                 <c:scaling>
                     <c:orientation val="minMax"/>
                 </c:scaling>
-                <c:axPos val="r"/>
+                <c:axPos val="l"/>
                 <c:majorGridlines>
                     <c:spPr>
                         <a:ln cmpd="sng">
@@ -10878,8 +10878,8 @@ exports[`Test XLSX export Charts simple combo chart with dataset [ [Object], [Ob
                 <c:axId val="88853993"/>
             </c:lineChart>
             <c:catAx>
-                <c:axId val="17781238"/>
-                <c:crossAx val="88853994"/>
+                <c:axId val="17781237"/>
+                <c:crossAx val="88853993"/>
                 <!-- reference to the other axe of the chart -->
                 <c:crosses val="min"/>
                 <c:delete val="1"/>
@@ -10940,16 +10940,16 @@ exports[`Test XLSX export Charts simple combo chart with dataset [ [Object], [Ob
             </c:catAx>
             <!-- <tickLblPos/> omitted -->
             <c:valAx>
-                <c:axId val="88853994"/>
-                <c:crossAx val="17781238"/>
+                <c:axId val="88853993"/>
+                <c:crossAx val="17781237"/>
                 <!-- reference to the other axe of the chart -->
-                <c:crosses val="max"/>
+                <c:crosses val="min"/>
                 <c:delete val="0"/>
                 <!-- by default, axis are not displayed -->
                 <c:scaling>
                     <c:orientation val="minMax"/>
                 </c:scaling>
-                <c:axPos val="r"/>
+                <c:axPos val="l"/>
                 <c:majorGridlines>
                     <c:spPr>
                         <a:ln cmpd="sng">


### PR DESCRIPTION
## Task Description

Since the chart customization PR, there is an issue in the combo chart export where there is a mismatch between the vertical left and right axes, leading to an wrong axis definition when exporting a combo chart and a removed chart when loading it to excel.
This commits aims to fix this issue.

## Related Task

Task: 4092078

## Review Checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo