### PR TITLE
[FIX] charts: export formatTickValue helper

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -70,6 +70,7 @@ import { isEvaluationError, toBoolean, toJsDate, toNumber, toString } from "./fu
 import { FunctionRegistry, arg, functionRegistry } from "./functions/index";
 import {
   chartFontColor,
+  formatTickValue,
   getChartAxisTitleRuntime,
   getDefaultChartJsRuntime,
   getFillingMode,
@@ -338,6 +339,7 @@ export const helpers = {
   UNDO_REDO_PIVOT_COMMANDS,
   createPivotFormula,
   areDomainArgsFieldsValid,
+  formatTickValue,
 };
 
 export const links = {


### PR DESCRIPTION
## Task Description

This commit exports the formatTickValue helper to be used for the show value options in the Odoo Chart

## Related Task/PR

- Task: 3953835
- OC PR: ﻿﻿https://github.com/odoo/odoo/pull/171553
- OE PR: ﻿﻿https://github.com/odoo/enterprise/pull/65890

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo