### PR TITLE
[IMP] Charts: ignore hidden row/cols in datasets and labels

### DIFF
--- a/src/helpers/figures/charts/chart_ui_common.ts
+++ b/src/helpers/figures/charts/chart_ui_common.ts
@@ -199,10 +199,21 @@ export function getChartLabelValues(
 ): LabelValues {
   let labels: LabelValues = { values: [], formattedValues: [] };
   if (labelRange) {
-    if (!labelRange.invalidXc && !labelRange.invalidSheetName) {
+    const { left } = labelRange.zone;
+    if (
+      !labelRange.invalidXc &&
+      !labelRange.invalidSheetName &&
+      !getters.isColHidden(labelRange.sheetId, left)
+    ) {
       labels = {
         formattedValues: getters.getRangeFormattedValues(labelRange),
         values: getters.getRangeValues(labelRange).map((val) => String(val ?? "")),
+      };
+    } else if (dataSets[0]) {
+      const ranges = getData(getters, dataSets[0]);
+      labels = {
+        formattedValues: range(0, ranges.length).map((r) => r.toString()),
+        values: labels.formattedValues,
       };
     }
   } else if (dataSets.length === 1) {
@@ -238,6 +249,9 @@ export function getChartDatasetFormat(getters: Getters, dataSets: DataSet[]): Fo
 export function getChartDatasetValues(getters: Getters, dataSets: DataSet[]): DatasetValues[] {
   const datasetValues: DatasetValues[] = [];
   for (const [dsIndex, ds] of Object.entries(dataSets)) {
+    if (getters.isColHidden(ds.dataRange.sheetId, ds.dataRange.zone.left)) {
+      continue;
+    }
     let label: string;
     if (ds.labelCell) {
       const labelRange = ds.labelCell;

--- a/src/plugins/ui_core_views/evaluation_chart.ts
+++ b/src/plugins/ui_core_views/evaluation_chart.ts
@@ -5,6 +5,7 @@ import { ChartRuntime, ExcelChartDefinition } from "../../types/chart/chart";
 import {
   CoreViewCommand,
   invalidateCFEvaluationCommands,
+  invalidateChartEvaluationCommands,
   invalidateEvaluationCommands,
 } from "../../types/commands";
 import { UIPlugin } from "../ui_plugin";
@@ -29,8 +30,7 @@ export class EvaluationChartPlugin extends UIPlugin<EvaluationChartState> {
     if (
       invalidateEvaluationCommands.has(cmd.type) ||
       invalidateCFEvaluationCommands.has(cmd.type) ||
-      cmd.type === "EVALUATE_CELLS" ||
-      cmd.type === "UPDATE_CELL"
+      invalidateChartEvaluationCommands.has(cmd.type)
     ) {
       for (const chartId in this.charts) {
         this.charts[chartId] = undefined;

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -129,6 +129,25 @@ export const invalidateEvaluationCommands = new Set<CommandTypes>([
   "DUPLICATE_PIVOT",
 ]);
 
+export const invalidateChartEvaluationCommands = new Set<CommandTypes>([
+  "EVALUATE_CELLS",
+  "UPDATE_CELL",
+  "UNHIDE_COLUMNS_ROWS",
+  "HIDE_COLUMNS_ROWS",
+  "GROUP_HEADERS",
+  "UNGROUP_HEADERS",
+  "FOLD_ALL_HEADER_GROUPS",
+  "FOLD_HEADER_GROUP",
+  "FOLD_HEADER_GROUPS_IN_ZONE",
+  "UNFOLD_ALL_HEADER_GROUPS",
+  "UNFOLD_HEADER_GROUP",
+  "UNFOLD_HEADER_GROUPS_IN_ZONE",
+  "UPDATE_TABLE",
+  "UPDATE_FILTER",
+  "UNDO",
+  "REDO",
+]);
+
 export const invalidateDependenciesCommands = new Set<CommandTypes>(["MOVE_RANGES"]);
 
 export const invalidateCFEvaluationCommands = new Set<CommandTypes>([


### PR DESCRIPTION
## Task Description

This Task aims to ignore the hidden columns/rows when computing the data values and labels in the charts runtime.

## Related Task
- Task: 3976159

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo