### PR TITLE
[FIX] clipboard: fix copy/paste single cell formulas on firefox

### DIFF
--- a/src/plugins/ui_stateful/clipboard.ts
+++ b/src/plugins/ui_stateful/clipboard.ts
@@ -553,7 +553,9 @@ export class ClipboardPlugin extends UIPlugin {
     }
     const cells = this.copiedData.cells;
     if (cells.length === 1 && cells[0].length === 1) {
-      return this.getters.getCellText(cells[0][0].position);
+      return `<div data-clipboard-id="${this.clipboardId}">${this.getters.getCellText(
+        cells[0][0].position
+      )}</div>`;
     }
     if (!cells[0][0]) {
       return "";

--- a/tests/clipboard/clipboard_plugin.test.ts
+++ b/tests/clipboard/clipboard_plugin.test.ts
@@ -622,7 +622,9 @@ describe("clipboard", () => {
       const model = new Model();
       setCellContent(model, "A1", "1");
       copy(model, "A1");
-      expect(model.getters.getClipboardContent()[ClipboardMIMEType.Html]).toEqual("1");
+      expect(model.getters.getClipboardContent()[ClipboardMIMEType.Html]).toBe(
+        `<div data-clipboard-id="${model.getters.getClipboardId()}">1</div>`
+      );
     });
   });
 

--- a/tests/grid/grid_component.test.ts
+++ b/tests/grid/grid_component.test.ts
@@ -1376,7 +1376,7 @@ describe("Copy paste keyboard shortcut", () => {
     const clipboardContent = "content" in clipboard ? clipboard.content : {};
     expect(clipboardContent).toMatchObject({
       "text/plain": "things",
-      "text/html": "things",
+      "text/html": `<div data-clipboard-id="${model.getters.getClipboardId()}">things</div>`,
     });
     selectCell(model, "A2");
     document.body.dispatchEvent(getClipboardEvent("paste", clipboardData));
@@ -1392,7 +1392,7 @@ describe("Copy paste keyboard shortcut", () => {
     const clipboardContent = "content" in clipboard ? clipboard.content : {};
     expect(clipboardContent).toMatchObject({
       "text/plain": "things",
-      "text/html": "things",
+      "text/html": `<div data-clipboard-id="${model.getters.getClipboardId()}">things</div>`,
     });
     selectCell(model, "A2");
     document.body.dispatchEvent(getClipboardEvent("paste", clipboardData));


### PR DESCRIPTION
### [FIX] clipboard: fix copy/paste single cell formulas on firefox

Before this commit, on firefox, copy/pasting a single cell that contains a formula only gets the evaluated text content of the cell. This due to the `clipboardId` key not being set corretly in the html content when the copied content contains only one single cell.

Task: [4115672](https://www.odoo.com/odoo/project/2328/tasks/4115672)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo