### PR TITLE
[FIX] chart: remove empty datasets for chart

### DIFF
--- a/src/helpers/figures/charts/chart_ui_common.ts
+++ b/src/helpers/figures/charts/chart_ui_common.ts
@@ -8,6 +8,7 @@ import { GaugeChartRuntime, ScorecardChartRuntime } from "../../../types/chart";
 import { ChartRuntime, DataSet, DatasetValues, LabelValues } from "../../../types/chart/chart";
 import { formatValue, isDateTimeFormat } from "../../format/format";
 import { deepCopy, range } from "../../misc";
+import { isNumber } from "../../numbers";
 import { recomputeZones } from "../../recompute_zones";
 import { AbstractChart } from "./abstract_chart";
 import { drawGaugeChart } from "./gauge_chart_rendering";
@@ -255,11 +256,21 @@ export function getChartDatasetValues(getters: Getters, dataSets: DataSet[]): Da
       label = `${ChartTerms.Series} ${parseInt(dsIndex) + 1}`;
     }
     let data = ds.dataRange ? getData(getters, ds) : [];
-    if (data.every((e) => typeof e === "string" && !isEvaluationError(e))) {
+    if (
+      data.every((e) => typeof e === "string" && !isEvaluationError(e)) &&
+      data.some((e) => e !== "")
+    ) {
       // In this case, we want a chart based on the string occurrences count
       // This will be done by associating each string with a value of 1 and
-      // the using the classical aggregation method to sum the values.
+      // then using the classical aggregation method to sum the values.
       data.fill(1);
+    } else if (
+      data.every(
+        (cell) =>
+          cell === undefined || cell === null || !isNumber(cell.toString(), getters.getLocale())
+      )
+    ) {
+      continue;
     }
     datasetValues.push({ data, label });
   }

--- a/tests/figures/chart/__snapshots__/chart_plugin.test.ts.snap
+++ b/tests/figures/chart/__snapshots__/chart_plugin.test.ts.snap
@@ -1107,21 +1107,9 @@ exports[`datasource tests create chart with only the dataset title (no data) 1`]
   "background": "#FFFFFF",
   "chartJsConfig": {
     "data": {
-      "datasets": [
-        {
-          "backgroundColor": "#4EA7F2",
-          "borderColor": "#4EA7F2",
-          "data": [
-            undefined,
-            undefined,
-          ],
-          "fill": false,
-          "label": "30",
-          "pointBackgroundColor": "#4EA7F2",
-          "tension": 0,
-        },
-      ],
+      "datasets": [],
       "labels": [
+        "P4",
         "P5",
         "P6",
       ],
@@ -1201,18 +1189,11 @@ exports[`datasource tests create chart with only the dataset title (no data) 1`]
     "type": "line",
   },
   "dataSetFormat": undefined,
-  "dataSetsValues": [
-    {
-      "data": [
-        undefined,
-        undefined,
-      ],
-      "label": "30",
-    },
-  ],
+  "dataSetsValues": [],
   "labelFormat": undefined,
   "labelValues": {
     "formattedValues": [
+      "P4",
       "P5",
       "P6",
     ],

--- a/tests/figures/chart/bar_chart_plugin.test.ts
+++ b/tests/figures/chart/bar_chart_plugin.test.ts
@@ -95,6 +95,22 @@ describe("bar chart", () => {
     });
 
     test("Horizontal bar chart cannot have datasets on the right", () => {
+      const model = new Model({
+        sheets: [
+          {
+            name: "Sheet1",
+            colNumber: 10,
+            rowNumber: 10,
+            rows: {},
+            cells: {
+              B1: { content: "first column dataset" },
+              B2: { content: "10" },
+              B3: { content: "11" },
+              B4: { content: "12" },
+            },
+          },
+        ],
+      });
       // Note: this is a chartJS limitation, it bugs when trying to display an horizontal bar chart with datasets with
       // axis on both right and left sides
       createChart(
@@ -102,7 +118,7 @@ describe("bar chart", () => {
         {
           horizontal: true,
           type: "bar",
-          dataSets: [{ dataRange: "A1", yAxisId: "y1" }],
+          dataSets: [{ dataRange: "B1:B4", yAxisId: "y1" }],
           axesDesign: { x: { title: { text: "xAxis" } }, y1: { title: { text: "yAxis" } } },
         },
         "id"

--- a/tests/figures/chart/line_chart_plugin.test.ts
+++ b/tests/figures/chart/line_chart_plugin.test.ts
@@ -43,23 +43,57 @@ describe("line chart", () => {
   });
 
   test("Stacked line chart", () => {
-    const model = new Model();
-    createChart(model, { type: "line", dataSets: [{ dataRange: "A1" }] }, "chartId");
+    const model = new Model({
+      sheets: [
+        {
+          name: "Sheet1",
+          colNumber: 10,
+          rowNumber: 10,
+          rows: {},
+          cells: {
+            B1: { content: "first column dataset" },
+            B2: { content: "10" },
+            B3: { content: "11" },
+            B4: { content: "12" },
+          },
+        },
+      ],
+    });
+    createChart(model, { type: "line", dataSets: [{ dataRange: "Sheet1!B1:B4" }] }, "chartId");
     expect(isChartAxisStacked(model, "chartId", "x")).toBeUndefined();
     expect(isChartAxisStacked(model, "chartId", "y")).toBeUndefined();
 
     updateChart(model, "chartId", { stacked: true });
-    let runtime = model.getters.getChartRuntime("chartId") as any;
+    const runtime = model.getters.getChartRuntime("chartId") as any;
     expect(isChartAxisStacked(model, "chartId", "x")).toBeUndefined();
     expect(isChartAxisStacked(model, "chartId", "y")).toBe(true);
     expect(runtime.chartJsConfig.data.datasets[0].fill).toBeFalsy();
   });
 
   test("Area chart", () => {
-    const model = new Model();
+    const model = new Model({
+      sheets: [
+        {
+          name: "Sheet1",
+          colNumber: 10,
+          rowNumber: 10,
+          rows: {},
+          cells: {
+            B1: { content: "first column dataset" },
+            B2: { content: "10" },
+            B3: { content: "11" },
+            B4: { content: "12" },
+            C1: { content: "second column dataset" },
+            C2: { content: "13" },
+            C3: { content: "14" },
+            C4: { content: "15" },
+          },
+        },
+      ],
+    });
     createChart(
       model,
-      { type: "line", dataSets: [{ dataRange: "A1" }, { dataRange: "A2" }] },
+      { type: "line", dataSets: [{ dataRange: "B1:B4" }, { dataRange: "C1:C4" }] },
       "chartId"
     );
     let runtime = model.getters.getChartRuntime("chartId") as any;
@@ -76,10 +110,29 @@ describe("line chart", () => {
   });
 
   test("Stacked area chart", () => {
-    const model = new Model();
+    const model = new Model({
+      sheets: [
+        {
+          name: "Sheet1",
+          colNumber: 10,
+          rowNumber: 10,
+          rows: {},
+          cells: {
+            B1: { content: "first column dataset" },
+            B2: { content: "10" },
+            B3: { content: "11" },
+            B4: { content: "12" },
+            C1: { content: "second column dataset" },
+            C2: { content: "13" },
+            C3: { content: "14" },
+            C4: { content: "15" },
+          },
+        },
+      ],
+    });
     createChart(
       model,
-      { type: "line", dataSets: [{ dataRange: "A1" }, { dataRange: "A2" }] },
+      { type: "line", dataSets: [{ dataRange: "B1:B4" }, { dataRange: "C1:C4" }] },
       "chartId"
     );
     let runtime = model.getters.getChartRuntime("chartId") as any;


### PR DESCRIPTION
## Task Description

This task aims to undisplay empty datasets from a chart (when all the values are undefined, not when they are equals to 0). This has been done by ignoring the empty datasets during the runtime creation.

## Related Task

- Task: 4085864

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo