### PR TITLE
[IMP] pivot: single format for measure

### DIFF
--- a/src/helpers/pivot/pivot_helpers.ts
+++ b/src/helpers/pivot/pivot_helpers.ts
@@ -1,11 +1,10 @@
 import { boolAnd, boolOr } from "../../functions/helper_logical";
 import { countUnique, sum } from "../../functions/helper_math";
 import { average, countAny, max, min } from "../../functions/helper_statistical";
-import { inferFormat, toBoolean, toNumber, toString } from "../../functions/helpers";
+import { toBoolean, toNumber, toString } from "../../functions/helpers";
 import { Registry } from "../../registries/registry";
 import { _t } from "../../translation";
 import {
-  Arg,
   CellValue,
   DEFAULT_LOCALE,
   Format,
@@ -55,7 +54,7 @@ for (const type in AGGREGATORS_BY_FIELD_TYPE) {
 
 type AggregatorFN = {
   fn: (args: Matrix<FunctionResultObject>, locale?: Locale) => CellValue;
-  format: (data: Arg | undefined) => Format | undefined;
+  format: (fieldFormat: Format | undefined) => Format | undefined;
 };
 
 export const AGGREGATORS_FN: Record<string, AggregatorFN | undefined> = {
@@ -77,19 +76,19 @@ export const AGGREGATORS_FN: Record<string, AggregatorFN | undefined> = {
   },
   max: {
     fn: (args: Matrix<FunctionResultObject>, locale: Locale) => max([args], locale),
-    format: inferFormat,
+    format: (fieldFormat) => fieldFormat,
   },
   min: {
     fn: (args: Matrix<FunctionResultObject>, locale: Locale) => min([args], locale),
-    format: inferFormat,
+    format: (fieldFormat) => fieldFormat,
   },
   avg: {
     fn: (args: Matrix<FunctionResultObject>, locale: Locale) => average([args], locale),
-    format: inferFormat,
+    format: (fieldFormat) => fieldFormat,
   },
   sum: {
     fn: (args: Matrix<FunctionResultObject>, locale: Locale) => sum([args], locale),
-    format: inferFormat,
+    format: (fieldFormat) => fieldFormat,
   },
 };
 

--- a/src/types/pivot.ts
+++ b/src/types/pivot.ts
@@ -1,4 +1,5 @@
 import { CellValue } from "./cells";
+import { Format } from "./format";
 import { Locale } from "./locale";
 import { FunctionResultObject, UID, Zone } from "./misc";
 
@@ -70,6 +71,7 @@ export interface PivotField {
   string: string;
   aggregator?: string;
   help?: string;
+  format?: Format;
 }
 
 export type PivotFields = Record<TechnicalName, PivotField | undefined>;
@@ -78,6 +80,7 @@ export interface PivotMeasure extends PivotCoreMeasure {
   displayName: string;
   type: string;
   isValid: boolean;
+  format?: Format;
 }
 
 export interface PivotDimension extends PivotCoreDimension {

--- a/src/types/pivot_runtime.ts
+++ b/src/types/pivot_runtime.ts
@@ -1,5 +1,6 @@
 import { PivotRuntimeDefinition } from "../helpers/pivot/pivot_runtime_definition";
 import { SpreadsheetPivotTable } from "../helpers/pivot/table_spreadsheet_pivot";
+import { Format } from "./format";
 import { FunctionResultObject, Maybe } from "./misc";
 import {
   PivotCoreDefinition,
@@ -26,6 +27,7 @@ export interface Pivot<T = PivotRuntimeDefinition> {
   getPivotMeasureValue(measure: string, domain: PivotDomain): FunctionResultObject;
 
   getMeasure: (id: string) => PivotMeasure;
+  getMeasureFormat: (id: string) => Format | undefined;
 
   parseArgsToPivotDomain(args: Maybe<FunctionResultObject>[]): PivotDomain;
   areDomainArgsFieldsValid(args: Maybe<FunctionResultObject>[]): boolean;


### PR DESCRIPTION
Currently, in spreadhseet pivot the format is the format of the first cell matching the domain of the pivot cell. That means that different pivot cells on the same measure can have different formats.

Now the format is determined by the measure itself, so all cells with the same measure will have the same format. The commit also adds `getMeasureFormat` to the pivot's interface to get this format.

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo