### PR TITLE
[FIX] pivot: pivot UI not removed on pivot deletion

### DIFF
--- a/src/plugins/ui_core_views/pivot_ui.ts
+++ b/src/plugins/ui_core_views/pivot_ui.ts
@@ -78,6 +78,10 @@ export class PivotUIPlugin extends UIPlugin {
         this.setupPivot(cmd.pivotId, { recreate: true });
         break;
       }
+      case "REMOVE_PIVOT": {
+        delete this.pivots[cmd.pivotId];
+        break;
+      }
       case "DELETE_SHEET":
       case "UPDATE_CELL": {
         this.unusedPivots = undefined;

--- a/tests/pivots/spreadsheet_pivot/spreadsheet_pivot.test.ts
+++ b/tests/pivots/spreadsheet_pivot/spreadsheet_pivot.test.ts
@@ -14,7 +14,12 @@ import {
   getEvaluatedGrid,
 } from "../../test_helpers/getters_helpers";
 import { createModelFromGrid } from "../../test_helpers/helpers";
-import { addPivot, createModelWithPivot, updatePivot } from "../../test_helpers/pivot_helpers";
+import {
+  addPivot,
+  createModelWithPivot,
+  removePivot,
+  updatePivot,
+} from "../../test_helpers/pivot_helpers";
 import { CellValue, CellValueType } from "./../../../src/types/cells";
 
 describe("Spreadsheet Pivot", () => {
@@ -1271,6 +1276,18 @@ describe("Spreadsheet Pivot", () => {
       setCellContent(model, "A1", "Tabouret");
       expect(model.getters.getPivot("1").isValid()).toBeTruthy();
     });
+  });
+
+  test("Pivot is removed on command REMOVE_PIVOT", () => {
+    const model = createModelWithPivot("A1:I5");
+    expect(model.getters.getPivotIds()).toEqual(["1"]);
+    expect(model.getters.getPivotCoreDefinition("1")).toBeTruthy();
+    expect(model.getters.getPivot("1")).toBeTruthy();
+
+    removePivot(model, "1");
+    expect(model.getters.getPivotIds()).toEqual([]);
+    expect(() => model.getters.getPivotCoreDefinition("1")).toThrow();
+    expect(model.getters.getPivot("1")).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Description

The command `REMOVE_PIVOT` was not handled inside the `PivotUIPlugin`.

Task: : [4115738](https://www.odoo.com/web#id=4115738&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo