### PR TITLE
[FIX] find & replace: remove debounce from store

### DIFF
--- a/src/components/side_panel/find_and_replace/find_and_replace.xml
+++ b/src/components/side_panel/find_and_replace/find_and_replace.xml
@@ -17,7 +17,7 @@
             /
             <t t-esc="store.searchMatches.length"/>
           </div>
-          <div t-elif="!store.pendingSearch and store.toSearch !== ''" class="o-input-count">
+          <div t-elif="!this.pendingSearch and store.toSearch !== ''" class="o-input-count">
             0 / 0
           </div>
         </div>

--- a/src/components/side_panel/find_and_replace/find_and_replace_store.ts
+++ b/src/components/side_panel/find_and_replace/find_and_replace_store.ts
@@ -1,4 +1,4 @@
-import { debounce, getSearchRegex, isInside, positionToZone } from "../../../helpers";
+import { getSearchRegex, isInside, positionToZone } from "../../../helpers";
 import { HighlightProvider, HighlightStore } from "../../../stores/highlight_store";
 import { CellPosition, Color, Command, Highlight } from "../../../types";
 
@@ -45,7 +45,6 @@ export class FindAndReplaceStore extends SpreadsheetStore implements HighlightPr
     specificRange: undefined,
   };
 
-  updateSearchContent = debounce(this._updateSearchContent.bind(this), 200);
   constructor(get: Get) {
     super(get);
     this.initialShowFormulaState = this.model.getters.shouldShowFormulas();
@@ -55,7 +54,6 @@ export class FindAndReplaceStore extends SpreadsheetStore implements HighlightPr
     highlightStore.register(this);
     this.onDispose(() => {
       this.model.dispatch("SET_FORMULA_VISIBILITY", { show: this.initialShowFormulaState });
-      this.updateSearchContent.stopDebounce();
       highlightStore.unRegister(this);
     });
   }
@@ -71,7 +69,7 @@ export class FindAndReplaceStore extends SpreadsheetStore implements HighlightPr
     }
   }
 
-  private _updateSearchContent(toSearch: string) {
+  updateSearchContent(toSearch: string) {
     this._updateSearch(toSearch, this.searchOptions);
   }
 
@@ -90,10 +88,6 @@ export class FindAndReplaceStore extends SpreadsheetStore implements HighlightPr
 
   selectNextMatch() {
     this.selectNextCell(Direction.next);
-  }
-
-  get pendingSearch() {
-    return this.updateSearchContent.isDebouncePending();
   }
 
   handle(cmd: Command) {

--- a/tests/find_and_replace/find_and_replace_store.test.ts
+++ b/tests/find_and_replace/find_and_replace_store.test.ts
@@ -30,14 +30,6 @@ import {
 } from "../test_helpers/getters_helpers";
 import { makeStore } from "../test_helpers/stores";
 
-// Disable debounce for tests
-jest.mock("../../src/helpers/misc.ts", () => {
-  return {
-    ...jest.requireActual("../../src/helpers/misc.ts"),
-    ...jest.requireActual("../__mocks__/mock_misc_helpers.ts"),
-  };
-});
-
 let model: Model;
 let store: FindAndReplaceStore;
 
@@ -312,17 +304,6 @@ describe("basic search", () => {
     deleteTable(model, "A1:A6");
     expect(store.searchMatches).toHaveLength(2);
     expect(store.selectedMatchIndex).toStrictEqual(0);
-  });
-
-  test("Store update search content method is debounced and debounce timeout is cleared on dispose", () => {
-    const debouncedSearch = store.updateSearchContent;
-    expect(typeof debouncedSearch).toBe("function");
-    expect(debouncedSearch.isDebouncePending).toBeTruthy();
-    expect(debouncedSearch.stopDebounce).toBeTruthy();
-
-    const spyStopDebounce = jest.spyOn(debouncedSearch, "stopDebounce");
-    store.dispose();
-    expect(spyStopDebounce).toHaveBeenCalled();
   });
 
   test("Switching sheet properly recomputes search results and shows them in the viewport", () => {

--- a/tests/find_and_replace/find_replace_side_panel_component.test.ts
+++ b/tests/find_and_replace/find_replace_side_panel_component.test.ts
@@ -171,6 +171,17 @@ describe("find and replace sidePanel component", () => {
       expect(getMatchesCount()).toBeUndefined();
     });
 
+    test("Search is debounced", async () => {
+      setCellContent(model, "A1", "ok");
+      setInputValueAndTrigger(selectors.inputSearch, "o");
+      await nextTick();
+      expect(getMatchesCount()).toBeUndefined();
+
+      jest.runOnlyPendingTimers();
+      await nextTick();
+      expect(getMatchesCount()).toMatchObject({ allSheets: 1, currentSheet: 1 });
+    });
+
     test("clicking on specific range and hitting confirm will search in the range", async () => {
       setCellContent(model, "A1", "1");
       inputSearchValue("1");


### PR DESCRIPTION
## Description

The method `updateSearchContent` was debounced inside the f&r store. This does not work as expected, as the re-rendering of the panel was done when calling the `updateSearchContent` method, and not when the debounced function was called and the store state was updated.

I'm not sure why it still worked 50% of the time.

Task: : [4102172](https://www.odoo.com/web#id=4102172&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo