### PR TITLE
[PERF] model: export lazily when leaving

### DIFF
--- a/src/collaborative/session.ts
+++ b/src/collaborative/session.ts
@@ -3,7 +3,7 @@ import { UuidGenerator } from "../helpers";
 import { EventBus } from "../helpers/event_bus";
 import { debounce, isDefined } from "../helpers/misc";
 import { SelectiveHistory as RevisionLog } from "../history/selective_history";
-import { CoreCommand, HistoryChange, UID, WorkbookData } from "../types";
+import { CoreCommand, HistoryChange, Lazy, UID, WorkbookData } from "../types";
 import {
   Client,
   ClientId,
@@ -159,9 +159,9 @@ export class Session extends EventBus<CollaborativeEvent> {
   /**
    * Notify the server that the user client left the collaborative session
    */
-  leave(data: WorkbookData) {
+  leave(data: Lazy<WorkbookData>) {
     if (Object.keys(this.clients).length === 1 && this.processedRevisions.size) {
-      this.snapshot(data);
+      this.snapshot(data());
     }
     delete this.clients[this.clientId];
     this.transportService.leave(this.clientId);

--- a/src/model.ts
+++ b/src/model.ts
@@ -3,7 +3,7 @@ import { LocalTransportService } from "./collaborative/local_transport_service";
 import { Session } from "./collaborative/session";
 import { DEFAULT_REVISION_ID } from "./constants";
 import { EventBus } from "./helpers/event_bus";
-import { deepCopy, UuidGenerator } from "./helpers/index";
+import { deepCopy, lazy, UuidGenerator } from "./helpers/index";
 import { buildRevisionLog } from "./history/factory";
 import {
   createEmptyExcelWorkbookData,
@@ -289,7 +289,7 @@ export class Model extends EventBus<any> implements CommandDispatcher {
   }
 
   leaveSession() {
-    this.session.leave(this.exportData());
+    this.session.leave(lazy(() => this.exportData()));
   }
 
   private setupUiPlugin(Plugin: UIPluginConstructor) {

--- a/tests/collaborative/collaborative_session.test.ts
+++ b/tests/collaborative/collaborative_session.test.ts
@@ -1,6 +1,7 @@
 import { Model } from "../../src";
 import { Session } from "../../src/collaborative/session";
 import { DEBOUNCE_TIME, MESSAGE_VERSION } from "../../src/constants";
+import { lazy } from "../../src/helpers";
 import { buildRevisionLog } from "../../src/history/factory";
 import { Client, CommandResult, WorkbookData } from "../../src/types";
 import { MockTransportService } from "../__mocks__/transport_service";
@@ -50,7 +51,7 @@ describe("Collaborative session", () => {
 
   test("local client leaves", () => {
     const spy = jest.spyOn(transport, "sendMessage");
-    session.leave({} as WorkbookData);
+    session.leave(lazy({} as WorkbookData));
     expect(spy).toHaveBeenCalledTimes(1);
     expect(spy).toHaveBeenCalledWith({
       type: "CLIENT_LEFT",
@@ -71,7 +72,7 @@ describe("Collaborative session", () => {
     });
     const spy = jest.spyOn(transport, "sendMessage");
     const data = { sheets: [{}] } as WorkbookData;
-    session.leave(data);
+    session.leave(lazy(data));
     expect(spy).toHaveBeenCalledWith({
       type: "SNAPSHOT",
       version: MESSAGE_VERSION,
@@ -123,7 +124,7 @@ describe("Collaborative session", () => {
     });
     const spy = jest.spyOn(transport, "sendMessage");
     const data = { sheets: [{}] } as WorkbookData;
-    session.leave(data);
+    session.leave(lazy(data));
     expect(spy).toHaveBeenCalledTimes(1);
     expect(spy).toHaveBeenCalledWith({
       type: "CLIENT_LEFT",
@@ -220,7 +221,7 @@ describe("Collaborative session", () => {
 
   test("Leave the session do not crash", () => {
     session.move({ sheetId: "sheetId", col: 1, row: 2 });
-    session.leave({} as WorkbookData);
+    session.leave(lazy({} as WorkbookData));
     jest.advanceTimersByTime(DEBOUNCE_TIME + 100);
   });
 


### PR DESCRIPTION


## Description:

Since 7bcff343946da, the model data is exported every time the spreadsheet is left.
Exporting the data can be slow though and it's actually not needed every time.

With this commit, the data is exported lazily, only when needed.

Task: : [4119536](https://www.odoo.com/web#id=4119536&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo