### PR TITLE
[FIX] pivot: mark pivot as invalid if column name is empty

### DIFF
--- a/src/helpers/pivot/spreadsheet_pivot/spreadsheet_pivot.ts
+++ b/src/helpers/pivot/spreadsheet_pivot/spreadsheet_pivot.ts
@@ -346,7 +346,7 @@ export class SpreadsheetPivot implements Pivot<SpreadsheetPivotRuntimeDefinition
         _t("The pivot cannot be created because cell %s contains an error", toXC(col, row))
       );
     }
-    if (cell.type === CellValueType.empty) {
+    if (cell.type === CellValueType.empty || cell.value === "") {
       throw new EvaluationError(
         _t("The pivot cannot be created because cell %s is empty", toXC(col, row))
       );

--- a/tests/pivots/spreadsheet_pivot/spreadsheet_pivot.test.ts
+++ b/tests/pivots/spreadsheet_pivot/spreadsheet_pivot.test.ts
@@ -367,6 +367,14 @@ describe("Spreadsheet Pivot", () => {
     expect(getCellError(model, "A26")).toBe("The pivot cannot be created because cell A1 is empty");
   });
 
+  test("Pivot is correctly marked as error when a field name is an empty formula result", () => {
+    const model = createModelWithPivot("A1:I5");
+    setCellContent(model, "A1", `=""`);
+    setCellContent(model, "A26", `=pivot(1)`);
+    expect(model.getters.getPivot("1").isValid()).toBeFalsy();
+    expect(getCellError(model, "A26")).toBe("The pivot cannot be created because cell A1 is empty");
+  });
+
   test("Order of pivot date dimensions is not overridden by the default one if specified", () => {
     const model = createModelWithPivot("A1:I5");
     updatePivot(model, "1", {


### PR DESCRIPTION
Steps to reproduce, given a range with some data:
* Replace the column title by a formula resulting in an empty string (="")
* select the entire range and insert a pivot table => unexpected error: An unexpected error occurred. Submit a support ticket at odoo.com/help. Field undefined does not exist

This was caused by the verification function of the column name, which only checked if the column name was empty, but a cell with a formula can return an empty string, which is not the same as an empty cell.

Task: 4116392

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo