### PR TITLE
[FIX] pivot: preserve pivot UI after undo

### DIFF
--- a/src/plugins/ui_core_views/pivot_ui.ts
+++ b/src/plugins/ui_core_views/pivot_ui.ts
@@ -78,10 +78,6 @@ export class PivotUIPlugin extends UIPlugin {
         this.setupPivot(cmd.pivotId, { recreate: true });
         break;
       }
-      case "REMOVE_PIVOT": {
-        delete this.pivots[cmd.pivotId];
-        break;
-      }
       case "DELETE_SHEET":
       case "UPDATE_CELL": {
         this.unusedPivots = undefined;
@@ -245,6 +241,9 @@ export class PivotUIPlugin extends UIPlugin {
   }
 
   getPivot(pivotId: UID) {
+    if (!this.getters.isExistingPivot(pivotId)) {
+      throw new Error(`pivot ${pivotId} not found`);
+    }
     return this.pivots[pivotId];
   }
 

--- a/tests/pivots/spreadsheet_pivot/spreadsheet_pivot.test.ts
+++ b/tests/pivots/spreadsheet_pivot/spreadsheet_pivot.test.ts
@@ -1287,7 +1287,11 @@ describe("Spreadsheet Pivot", () => {
     removePivot(model, "1");
     expect(model.getters.getPivotIds()).toEqual([]);
     expect(() => model.getters.getPivotCoreDefinition("1")).toThrow();
-    expect(model.getters.getPivot("1")).toBeUndefined();
+    expect(() => model.getters.getPivot("1")).toThrow();
+    undo(model);
+    expect(model.getters.getPivotIds()).toEqual(["1"]);
+    expect(model.getters.getPivotCoreDefinition("1")).toBeTruthy();
+    expect(model.getters.getPivot("1")).toBeTruthy();
   });
 });
 


### PR DESCRIPTION
Steps to reproduce (in odoo):
- insert a pivot in a spreadsheet
- snapshot the spreadsheet by leaving it and opening it again
- remove the pivot definition
- undo => crash boom

This is a partial revert of 22625e8730ccc

It was actually intended to keep the pivot runtime definition when deleting the pivot core definition. The goal was to avoid redoing RPC to reload the pivot after an UNDO.

2 alternatives considered:
- add `"REMOVE_PIVOT"` to `UNDO_REDO_PIVOT_COMMANDS` to properly recreate the pivot. But spreadsheet pivot would be recreated twice :/ (and it'd be more RPCs
- remove the cleaning and check if the pivot core definition exists.

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo