### PR TITLE
[FIX] pivot: sorting of undefined headers

### DIFF
--- a/src/helpers/pivot/spreadsheet_pivot/data_entry_spreadsheet_pivot.ts
+++ b/src/helpers/pivot/spreadsheet_pivot/data_entry_spreadsheet_pivot.ts
@@ -247,6 +247,12 @@ function orderDataEntriesKeys(
  * Used to order two values
  */
 function compareDimensionValues(dimension: PivotDimension, a: string, b: string): number {
+  if (a === "null") {
+    return dimension.order === "asc" ? 1 : -1;
+  }
+  if (b === "null") {
+    return dimension.order === "asc" ? -1 : 1;
+  }
   if (dimension.type === "integer" || dimension.type === "date") {
     return dimension.order === "asc" ? Number(a) - Number(b) : Number(b) - Number(a);
   }

--- a/tests/pivots/spreadsheet_pivot/spreadsheet_pivot.test.ts
+++ b/tests/pivots/spreadsheet_pivot/spreadsheet_pivot.test.ts
@@ -387,6 +387,54 @@ describe("Spreadsheet Pivot", () => {
     expect(model.getters.getPivot("1").definition.rows[0].order).toBeUndefined();
   });
 
+  test("Order of undefined value is correct when ordered asc", () => {
+    // prettier-ignore
+    const grid = {
+      A1: "Customer",   B1: "Price", C1: "=PIVOT(1)",
+      A2: "Alice",      B2: "10",
+      A3: "",           B3: "20",
+      A4: "Olaf",       B4: "30",
+    };
+    const model = createModelFromGrid(grid);
+    addPivot(model, "A1:B4", {
+      rows: [{ name: "Customer", order: "asc" }],
+      columns: [],
+      measures: [{ name: "Price", aggregator: "sum" }],
+    });
+    // prettier-ignore
+    expect(getEvaluatedGrid(model, "C1:C5")).toEqual([
+      ["(#1) Pivot"],
+      [""],
+      ["Alice"],
+      ["Olaf"],
+      ["(Undefined)"],
+    ]);
+  });
+
+  test("Order of undefined value is correct when ordered desc", () => {
+    // prettier-ignore
+    const grid = {
+      A1: "Customer",   B1: "Price", C1: "=PIVOT(1)",
+      A2: "Alice",      B2: "10",
+      A3: "",           B3: "20",
+      A4: "Olaf",       B4: "30",
+    };
+    const model = createModelFromGrid(grid);
+    addPivot(model, "A1:B4", {
+      rows: [{ name: "Customer", order: "desc" }],
+      columns: [],
+      measures: [{ name: "Price", aggregator: "sum" }],
+    });
+    // prettier-ignore
+    expect(getEvaluatedGrid(model, "C1:C5")).toEqual([
+      ["(#1) Pivot"],
+      [""],
+      ["(Undefined)"],
+      ["Olaf"],
+      ["Alice"],
+    ]);
+  });
+
   test("Measure count as a correct label", () => {
     const model = createModelWithPivot("A1:I5");
     updatePivot(model, "1", {


### PR DESCRIPTION
Steps to reproduce:
* Create a pivot table with headers value "Alice", "Olaf", "".

=> The headers are sorted in the following order: "Alice", "(Undefined)", "Olaf".

The root cause was that the sorting function sorts the keys of the groupby, and the key of the undefined object is the string "null" and so it was sorted between the A of Alice and the O of Olaf.

Task: 4123261

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo