### PR TITLE
[FIX] pivot: insert pivot with id not in quotes

### DIFF
--- a/src/plugins/ui_feature/insert_pivot.ts
+++ b/src/plugins/ui_feature/insert_pivot.ts
@@ -117,7 +117,7 @@ export class InsertPivotPlugin extends UIPlugin {
       sheetId,
       col,
       row,
-      content: `=PIVOT("${pivotFormulaId}")`,
+      content: `=PIVOT(${pivotFormulaId})`,
     });
     const zone = {
       left: col,

--- a/tests/pivots/pivot_menu_items.test.ts
+++ b/tests/pivots/pivot_menu_items.test.ts
@@ -235,7 +235,7 @@ describe("Pivot menu items", () => {
     const env = makeTestEnv({ model });
     selectCell(model, "B8");
     doAction(reinsertPivotPath, env, topbarMenuRegistry);
-    expect(getCellText(model, "B8")).toEqual(`=PIVOT("1")`);
+    expect(getCellText(model, "B8")).toEqual(`=PIVOT(1)`);
     expect(
       model.getters.getCoreTable({
         sheetId: model.getters.getActiveSheetId(),
@@ -263,7 +263,7 @@ describe("Pivot menu items", () => {
     createSheet(model, { sheetId: "smallSheet", rows: 1, cols: 1, activate: true });
     const env = makeTestEnv({ model });
     doAction(reinsertPivotPath, env, topbarMenuRegistry);
-    expect(getCellText(model, "A1")).toEqual(`=PIVOT("1")`);
+    expect(getCellText(model, "A1")).toEqual(`=PIVOT(1)`);
     expect(model.getters.getPivot(model.getters.getPivotId("1")!).isValid()).toBeTruthy();
     expect(model.getters.getNumberCols("smallSheet")).toEqual(2);
     expect(model.getters.getNumberRows("smallSheet")).toEqual(4); // title, col group, row header, total
@@ -284,13 +284,13 @@ describe("Pivot menu items", () => {
     const env = makeTestEnv({ model });
     selectCell(model, "B8");
     doAction(reinsertPivotPath, env, topbarMenuRegistry);
-    expect(getCellText(model, "B8")).toEqual(`=PIVOT("1")`);
+    expect(getCellText(model, "B8")).toEqual(`=PIVOT(1)`);
     expect(getTable(model, "B8")).toBeDefined();
     undo(model);
     expect(getCell(model, "B8")).toBeUndefined();
     expect(getTable(model, "B8")).toBeUndefined();
     redo(model);
-    expect(getCellText(model, "B8")).toEqual(`=PIVOT("1")`);
+    expect(getCellText(model, "B8")).toEqual(`=PIVOT(1)`);
     expect(getTable(model, "B8")).toBeDefined();
   });
 });


### PR DESCRIPTION
Now, the formula that is inserted in the pivot is without quotes for the id.
Before: `=PIVOT("1")`
After: `=PIVOT(1)`

Task: 4066384

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo