### PR TITLE
Master format repeat char adrm

### DIFF
--- a/doc/extending/xlsx/xlsx_import.md
+++ b/doc/extending/xlsx/xlsx_import.md
@@ -106,21 +106,12 @@ Excel don't really use the theme.xml file for theme colors, but define its own s
 
 ### Number Formats
 
-We do not currently support many features in number formats. We try to convert the number formats of Excel into something we can use, dropping what we do not support.
+We try to convert the number formats of Excel into something we can use, dropping what we do not support.
 If we cannot convert the number format into something we can use, we drop it completely.
 
-- Multi-parts format :
-  - They are parts separated by ; in format
-  - We don't support those, we only take the first part
 - Locale/Date System info :
   - They are HexCodes in brackets in the format (eg . [\$-40C], [\$string-52B])
   - We drop them completely
-- Escaped sequences of character :
-  - They are blocks in the format that are pasted as-is in the parsed format. They can either be blocks with quotes "..." or brackets [\$...]
-  - We only support one of these escaped sequence by format. Drop the format if there are multiple of these.
-  - We only support brackets, convert "..." into [\$...]
-- Spaces :
-  - We only support spaces inside escaped sequence. Drop the spaces that are not in the escaped sequence.
 - Underscore character (\_) :
   - It marks the next character as a character to ignore when computing the alignment of the word.
   - We don't support this, drop \_ and the character that follows it in the format.

--- a/src/actions/format_actions.ts
+++ b/src/actions/format_actions.ts
@@ -13,7 +13,6 @@ import {
   CellValue,
   DEFAULT_LOCALE,
   Format,
-  PLAIN_TEXT_FORMAT,
   SpreadsheetChildEnv,
   VerticalAlign,
   Wrapping,
@@ -61,8 +60,8 @@ export const formatNumberAutomatic: NumberFormatActionSpec = {
 
 export const formatNumberPlainText: NumberFormatActionSpec = {
   name: _t("Plain text"),
-  execute: (env) => setFormatter(env, PLAIN_TEXT_FORMAT),
-  isActive: (env) => isFormatSelected(env, PLAIN_TEXT_FORMAT),
+  execute: (env) => setFormatter(env, "@"),
+  isActive: (env) => isFormatSelected(env, "@"),
 };
 
 export const formatNumberNumber = createFormatActionSpec({

--- a/src/actions/format_actions.ts
+++ b/src/actions/format_actions.ts
@@ -1,10 +1,11 @@
 import {
+  DEFAULT_CURRENCY,
   DEFAULT_FONT_SIZE,
   DEFAULT_VERTICAL_ALIGN,
   DEFAULT_WRAPPING_MODE,
   FONT_SIZES,
 } from "../constants";
-import { formatValue, roundFormat } from "../helpers";
+import { createAccountingFormat, createCurrencyFormat, formatValue, roundFormat } from "../helpers";
 import { parseLiteral } from "../helpers/cells";
 import { getDateTimeFormat } from "../helpers/locale";
 import { _t } from "../translation";
@@ -85,22 +86,30 @@ export const formatNumberPercent = createFormatActionSpec({
 export const formatNumberCurrency = createFormatActionSpec({
   name: _t("Currency"),
   descriptionValue: 1000.12,
-  format: (env) => env.model.config.defaultCurrencyFormat ?? DEFAULT_CURRENCY_FORMAT,
+  format: (env) => createCurrencyFormat(env.model.config.defaultCurrency || DEFAULT_CURRENCY),
 });
 
 export const formatNumberCurrencyRounded: NumberFormatActionSpec = {
   ...createFormatActionSpec({
     name: _t("Currency rounded"),
     descriptionValue: 1000,
-    format: (env) => roundFormat(env.model.config.defaultCurrencyFormat ?? DEFAULT_CURRENCY_FORMAT),
+    format: (env) =>
+      roundFormat(createCurrencyFormat(env.model.config.defaultCurrency || DEFAULT_CURRENCY)),
   }),
   isVisible: (env) => {
-    const currencyFormat = env.model.config.defaultCurrencyFormat;
-    return currencyFormat !== roundFormat(currencyFormat ?? DEFAULT_CURRENCY_FORMAT);
+    const currencyFormat = createCurrencyFormat(
+      env.model.config.defaultCurrency || DEFAULT_CURRENCY
+    );
+    const roundedFormat = roundFormat(currencyFormat);
+    return currencyFormat !== roundedFormat;
   },
 };
 
-const DEFAULT_CURRENCY_FORMAT = "[$$]#,##0.00";
+export const formatNumberAccounting = createFormatActionSpec({
+  name: _t("Accounting"),
+  descriptionValue: -1000.12,
+  format: (env) => createAccountingFormat(env.model.config.defaultCurrency || DEFAULT_CURRENCY),
+});
 
 export const EXAMPLE_DATE = parseLiteral("2023/09/26 10:43:00 PM", DEFAULT_LOCALE);
 

--- a/src/components/bottom_bar/bottom_bar_statistic/bottom_bar_statistic.ts
+++ b/src/components/bottom_bar/bottom_bar_statistic/bottom_bar_statistic.ts
@@ -1,5 +1,5 @@
 import { Component, onWillUpdateProps } from "@odoo/owl";
-import { formatValue } from "../../../helpers/format";
+import { formatValue } from "../../../helpers/format/format";
 import { MenuItemRegistry } from "../../../registries/menu_items_registry";
 import { Store, useStore } from "../../../store_engine";
 import { SpreadsheetChildEnv } from "../../../types";

--- a/src/components/side_panel/custom_currency/custom_currency.ts
+++ b/src/components/side_panel/custom_currency/custom_currency.ts
@@ -1,10 +1,16 @@
 import { Component, onWillStart, useState } from "@odoo/owl";
-import { createCurrencyFormat, formatValue, roundFormat } from "../../../helpers";
+import {
+  createAccountingFormat,
+  createCurrencyFormat,
+  formatValue,
+  isDefined,
+} from "../../../helpers";
 import { currenciesRegistry } from "../../../registries/currencies_registry";
 import { _t } from "../../../translation";
 import { Currency, Format, SpreadsheetChildEnv } from "../../../types";
 import { css } from "../../helpers/css";
 import { CustomCurrencyTerms } from "../../translations_terms";
+import { Checkbox } from "../components/checkbox/checkbox";
 import { Section } from "../components/section/section";
 
 css/* scss */ `
@@ -12,11 +18,20 @@ css/* scss */ `
     .o-format-proposals {
       color: black;
     }
+
+    .o-format-examples {
+      background: #f9fafb;
+      padding: 8px;
+      border-radius: 4px;
+      border: 1px solid #d8dadd;
+      color: #374151;
+    }
   }
 `;
 
 interface CurrencyProposal {
-  format: string;
+  format: Format;
+  accountingFormat: Format;
   example: string;
 }
 
@@ -29,11 +44,12 @@ interface State {
   currencyCode: string;
   currencySymbol: string;
   selectedFormatIndex: number;
+  isAccountingFormat: boolean;
 }
 
 export class CustomCurrencyPanel extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-CustomCurrencyPanel";
-  static components = { Section };
+  static components = { Section, Checkbox };
   static props = { onCloseSidePanel: Function };
 
   private availableCurrencies!: Currency[];
@@ -46,36 +62,32 @@ export class CustomCurrencyPanel extends Component<Props, SpreadsheetChildEnv> {
       currencyCode: "",
       currencySymbol: "",
       selectedFormatIndex: 0,
+      isAccountingFormat: false,
     });
     onWillStart(() => this.updateAvailableCurrencies());
   }
 
   get formatProposals(): CurrencyProposal[] {
-    const currency = this.availableCurrencies[this.state.selectedCurrencyIndex];
-    const position = currency.position;
-    const opposite = currency.position === "before" ? "after" : "before";
+    const baseCurrency = this.availableCurrencies[this.state.selectedCurrencyIndex];
+    const position = baseCurrency.position;
+    const opposite = baseCurrency.position === "before" ? "after" : "before";
     const symbol = this.state.currencySymbol.trim() ? this.state.currencySymbol : "";
     const code = this.state.currencyCode.trim() ? this.state.currencyCode : "";
-    const decimalPlaces = currency.decimalPlaces;
+    const decimalPlaces = baseCurrency.decimalPlaces;
     if (!symbol && !code) {
       return [];
     }
-    const simple = symbol ? createCurrencyFormat({ symbol, position, decimalPlaces }) : "";
-    const rounded = simple ? roundFormat(simple) : "";
-    const simpleWithCode = createCurrencyFormat({ symbol, position, decimalPlaces, code });
-    const roundedWithCode = roundFormat(simpleWithCode);
-    const simpleOpposite = symbol
-      ? createCurrencyFormat({ symbol, position: opposite, decimalPlaces })
-      : "";
-    const roundedOpposite = simpleOpposite ? roundFormat(simpleOpposite) : "";
-    const simpleOppositeWithCode = createCurrencyFormat({
-      symbol,
-      position: opposite,
-      decimalPlaces,
-      code,
-    });
-    const roundedOppositeWithCode = roundFormat(simpleOppositeWithCode);
-    const formats = new Set([
+
+    const simple = { symbol, position, decimalPlaces };
+    const rounded = { symbol, position, decimalPlaces: 0 };
+    const simpleWithCode = { symbol, position, decimalPlaces, code };
+    const roundedWithCode = { symbol, position, decimalPlaces: 0, code };
+    const simpleOpposite = { symbol, position: opposite, decimalPlaces };
+    const roundedOpposite = { symbol, position: opposite, decimalPlaces: 0 };
+    const simpleOppositeWithCode = { symbol, position: opposite, decimalPlaces, code };
+    const roundedOppositeWithCode = { symbol, position: opposite, decimalPlaces: 0, code };
+
+    const currencies = [
       rounded,
       simple,
       roundedWithCode,
@@ -84,13 +96,24 @@ export class CustomCurrencyPanel extends Component<Props, SpreadsheetChildEnv> {
       simpleOpposite,
       roundedOppositeWithCode,
       simpleOppositeWithCode,
-    ]);
-    return [...formats]
-      .filter((format) => format !== "")
-      .map((format) => ({
-        format,
-        example: formatValue(1000.0, { format, locale: this.env.model.getters.getLocale() }),
-      }));
+    ] as Partial<Currency>[];
+
+    const usedFormats = new Set<string>();
+    const locale = this.env.model.getters.getLocale();
+    return currencies
+      .map((currency) => {
+        const format = createCurrencyFormat(currency);
+        if ((!currency.symbol && !currency.code) || usedFormats.has(format)) {
+          return undefined;
+        }
+        usedFormats.add(format);
+        return {
+          format,
+          accountingFormat: createAccountingFormat(currency),
+          example: formatValue(1000.0, { format, locale }),
+        };
+      })
+      .filter(isDefined);
   }
 
   get isSameFormat(): boolean {
@@ -143,11 +166,10 @@ export class CustomCurrencyPanel extends Component<Props, SpreadsheetChildEnv> {
   }
 
   apply() {
-    const selectedFormat = this.formatProposals[this.state.selectedFormatIndex];
     this.env.model.dispatch("SET_FORMATTING", {
       sheetId: this.env.model.getters.getActiveSheetId(),
       target: this.env.model.getters.getSelectedZones(),
-      format: selectedFormat.format,
+      format: this.selectedFormat,
     });
   }
 
@@ -173,5 +195,24 @@ export class CustomCurrencyPanel extends Component<Props, SpreadsheetChildEnv> {
 
   currencyDisplayName(currency: Currency): string {
     return currency.name + (currency.code ? ` (${currency.code})` : "");
+  }
+
+  toggleAccountingFormat() {
+    this.state.isAccountingFormat = !this.state.isAccountingFormat;
+  }
+
+  getFormatExamples() {
+    const format = this.selectedFormat;
+    const locale = this.env.model.getters.getLocale();
+    return [
+      { label: _t("positive") + ":", value: formatValue(1234.56, { format, locale }) },
+      { label: _t("negative") + ":", value: formatValue(-1234.56, { format, locale }) },
+      { label: _t("zero") + ":", value: formatValue(0, { format, locale }) },
+    ];
+  }
+
+  get selectedFormat() {
+    const proposal = this.formatProposals[this.state.selectedFormatIndex];
+    return this.state.isAccountingFormat ? proposal?.accountingFormat : proposal?.format;
   }
 }

--- a/src/components/side_panel/custom_currency/custom_currency.xml
+++ b/src/components/side_panel/custom_currency/custom_currency.xml
@@ -38,7 +38,7 @@
       <Section>
         <t t-set-slot="title">Format</t>
         <select
-          class="o-input o-format-proposals"
+          class="o-input o-format-proposals mb-1"
           t-on-change="(ev) => this.updateSelectFormat(ev)"
           t-att-disabled="!formatProposals.length">
           <t t-foreach="formatProposals" t-as="proposal" t-key="proposal_index">
@@ -49,6 +49,23 @@
             />
           </t>
         </select>
+        <t t-set="accounting_format_label">Accounting format</t>
+        <Checkbox
+          name="'accountingFormat'"
+          label="accounting_format_label"
+          value="state.isAccountingFormat"
+          onChange="() => this.toggleAccountingFormat()"
+        />
+        <div class="o-format-examples mt-4" t-if="selectedFormat">
+          <table>
+            <t t-foreach="getFormatExamples()" t-as="example" t-key="example_index">
+              <tr>
+                <td class="pe-3 fw-bolder" t-esc="example.label"/>
+                <td t-esc="example.value"/>
+              </tr>
+            </t>
+          </table>
+        </div>
       </Section>
       <div class="o-sidePanelButtons">
         <button

--- a/src/components/side_panel/find_and_replace/find_and_replace_store.ts
+++ b/src/components/side_panel/find_and_replace/find_and_replace_store.ts
@@ -378,17 +378,16 @@ export class FindAndReplaceStore extends SpreadsheetStore implements HighlightPr
 
     const searchRegex = getSearchRegex(searchString, searchOptions);
     const replaceRegex = new RegExp(searchRegex.source, searchRegex.flags + "g");
-    const toReplace: string | null = this.getters.getCellText(
-      selectedMatch,
-      searchOptions.searchFormulas
-    );
+    const toReplace: string | null = this.getters.getCellText(selectedMatch, {
+      showFormula: searchOptions.searchFormulas,
+    });
     const content = toReplace.replace(replaceRegex, replaceWith);
     const canonicalContent = canonicalizeNumberContent(content, this.getters.getLocale());
     this.model.dispatch("UPDATE_CELL", { ...selectedMatch, content: canonicalContent });
   }
 
   private getSearchableString(position: CellPosition): string {
-    return this.getters.getCellText(position, this.searchOptions.searchFormulas);
+    return this.getters.getCellText(position, { showFormula: this.searchOptions.searchFormulas });
   }
 
   // ---------------------------------------------------------------------------

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,4 @@
-import { BorderDescr, Color, Style } from "./types";
+import { BorderDescr, Color, Currency, Style } from "./types";
 
 export const CANVAS_SHIFT = 0.5;
 
@@ -263,4 +263,12 @@ export const PIVOT_TABLE_CONFIG = {
   bandedRows: true,
   bandedColumns: false,
   styleId: "TableStyleMedium5",
+};
+
+export const DEFAULT_CURRENCY: Currency = {
+  symbol: "$",
+  position: "before",
+  decimalPlaces: 2,
+  code: "",
+  name: "Dollar",
 };

--- a/src/formulas/tokenizer.ts
+++ b/src/formulas/tokenizer.ts
@@ -1,5 +1,10 @@
 import { NEWLINE } from "../constants";
-import { getFormulaNumberRegex, rangeReference, replaceSpecialSpaces } from "../helpers/index";
+import {
+  TokenizingChars,
+  getFormulaNumberRegex,
+  rangeReference,
+  replaceSpecialSpaces,
+} from "../helpers/index";
 import { DEFAULT_LOCALE, Locale } from "../types";
 import { CellErrorType } from "../types/errors";
 
@@ -226,47 +231,4 @@ function tokenizeInvalidRange(chars: TokenizingChars): Token | null {
     return { type: "INVALID_REFERENCE", value: CellErrorType.InvalidReference };
   }
   return null;
-}
-
-class TokenizingChars {
-  private text: string;
-  private currentIndex: number = 0;
-  current: string;
-
-  constructor(text: string) {
-    this.text = text;
-    this.current = text[0];
-  }
-
-  shift() {
-    const current = this.current;
-    const next = this.text[++this.currentIndex];
-    this.current = next;
-    return current;
-  }
-
-  advanceBy(length: number) {
-    this.currentIndex += length;
-    this.current = this.text[this.currentIndex];
-  }
-
-  isOver() {
-    return this.currentIndex >= this.text.length;
-  }
-
-  remaining() {
-    return this.text.substring(this.currentIndex);
-  }
-
-  currentStartsWith(str: string) {
-    if (this.current !== str[0]) {
-      return false;
-    }
-    for (let j = 1; j < str.length; j++) {
-      if (this.text[this.currentIndex + j] !== str[j]) {
-        return false;
-      }
-    }
-    return true;
-  }
 }

--- a/src/functions/module_lookup.ts
+++ b/src/functions/module_lookup.ts
@@ -1,4 +1,5 @@
 import { getFullReference, range, splitReference, toXC, toZone } from "../helpers/index";
+import { addRowIndentToPivotHeader } from "../helpers/pivot/pivot_helpers";
 import { _t } from "../translation";
 import { AddFunctionDescription, FunctionResultObject, Matrix, Maybe, Zone } from "../types";
 import { CellErrorType, EvaluationError, InvalidReferenceError } from "../types/errors";
@@ -829,7 +830,8 @@ export const PIVOT = {
             result[col].push({ value: "" });
             break;
           case "HEADER":
-            result[col].push(pivot.getPivotHeaderValueAndFormat(pivotCell.domain));
+            const value = pivot.getPivotHeaderValueAndFormat(pivotCell.domain);
+            result[col].push(addRowIndentToPivotHeader(pivot, pivotCell.domain, value));
             break;
           case "MEASURE_HEADER":
             result[col].push(pivot.getPivotMeasureValue(pivotCell.measure, pivotCell.domain));

--- a/src/helpers/cells/cell_evaluation.ts
+++ b/src/helpers/cells/cell_evaluation.ts
@@ -16,7 +16,12 @@ import {
   PLAIN_TEXT_FORMAT,
 } from "../../types";
 import { parseDateTime } from "../dates";
-import { detectDateFormat, detectNumberFormat, formatValue, isDateTimeFormat } from "../format";
+import {
+  detectDateFormat,
+  detectNumberFormat,
+  formatValue,
+  isDateTimeFormat,
+} from "../format/format";
 import { detectLink } from "../links";
 import { isBoolean, memoize } from "../misc";
 import { isNumber, parseNumber } from "../numbers";

--- a/src/helpers/cells/cell_evaluation.ts
+++ b/src/helpers/cells/cell_evaluation.ts
@@ -13,7 +13,6 @@ import {
   Locale,
   LocaleFormat,
   NumberCell,
-  PLAIN_TEXT_FORMAT,
 } from "../../types";
 import { parseDateTime } from "../dates";
 import {
@@ -21,6 +20,7 @@ import {
   detectNumberFormat,
   formatValue,
   isDateTimeFormat,
+  isTextFormat,
 } from "../format/format";
 import { detectLink } from "../links";
 import { isBoolean, memoize } from "../misc";
@@ -30,8 +30,7 @@ export function evaluateLiteral(
   literalCell: LiteralCell,
   localeFormat: LocaleFormat
 ): EvaluatedCell {
-  const value =
-    localeFormat.format === PLAIN_TEXT_FORMAT ? literalCell.content : literalCell.parsedValue;
+  const value = isTextFormat(localeFormat.format) ? literalCell.content : literalCell.parsedValue;
   const functionResult = { value, format: localeFormat.format };
   return createEvaluatedCell(functionResult, localeFormat.locale);
 }
@@ -93,7 +92,7 @@ function _createEvaluatedCell(
   if (isEvaluationError(value)) {
     return errorCell(value, message);
   }
-  if (format === PLAIN_TEXT_FORMAT) {
+  if (isTextFormat(format)) {
     // TO DO:
     // with the next line, the value of the cell is transformed depending on the format.
     // This shouldn't happen, by doing this, the formulas handling numbers are not able

--- a/src/helpers/figures/charts/bar_chart.ts
+++ b/src/helpers/figures/charts/bar_chart.ts
@@ -27,7 +27,7 @@ import { CellErrorType } from "../../../types/errors";
 import { Validator } from "../../../types/validator";
 import { toXlsxHexColor } from "../../../xlsx/helpers/colors";
 import { ColorGenerator } from "../../color";
-import { formatValue } from "../../format";
+import { formatValue } from "../../format/format";
 import { createValidRange } from "../../range";
 import { AbstractChart } from "./abstract_chart";
 import {

--- a/src/helpers/figures/charts/chart_common_line_scatter.ts
+++ b/src/helpers/figures/charts/chart_common_line_scatter.ts
@@ -11,7 +11,7 @@ import {
 } from "../../../types/chart/chart";
 import { getChartTimeOptions, timeFormatLuxonCompatible } from "../../chart_date";
 import { ColorGenerator, colorToRGBA, rgbaToHex } from "../../color";
-import { formatValue } from "../../format";
+import { formatValue } from "../../format/format";
 import { deepCopy, findNextDefinedValue, range } from "../../misc";
 import { isNumber } from "../../numbers";
 import {

--- a/src/helpers/figures/charts/chart_ui_common.ts
+++ b/src/helpers/figures/charts/chart_ui_common.ts
@@ -6,7 +6,7 @@ import { _t } from "../../../translation";
 import { Color, Figure, Format, Getters, LocaleFormat, Range } from "../../../types";
 import { GaugeChartRuntime, ScorecardChartRuntime } from "../../../types/chart";
 import { ChartRuntime, DataSet, DatasetValues, LabelValues } from "../../../types/chart/chart";
-import { formatValue, isDateTimeFormat } from "../../format";
+import { formatValue, isDateTimeFormat } from "../../format/format";
 import { deepCopy, range } from "../../misc";
 import { recomputeZones } from "../../recompute_zones";
 import { AbstractChart } from "./abstract_chart";

--- a/src/helpers/figures/charts/combo_chart.ts
+++ b/src/helpers/figures/charts/combo_chart.ts
@@ -28,7 +28,7 @@ import { CellErrorType } from "../../../types/errors";
 import { Validator } from "../../../types/validator";
 import { toXlsxHexColor } from "../../../xlsx/helpers/colors";
 import { ColorGenerator } from "../../color";
-import { formatValue } from "../../format";
+import { formatValue } from "../../format/format";
 import { createValidRange } from "../../range";
 import { AbstractChart } from "./abstract_chart";
 import {

--- a/src/helpers/figures/charts/pie_chart.ts
+++ b/src/helpers/figures/charts/pie_chart.ts
@@ -32,7 +32,7 @@ import { CellErrorType } from "../../../types/errors";
 import { Validator } from "../../../types/validator";
 import { toXlsxHexColor } from "../../../xlsx/helpers/colors";
 import { ColorGenerator } from "../../color";
-import { formatValue } from "../../format";
+import { formatValue } from "../../format/format";
 import { largeMax } from "../../misc";
 import { createValidRange } from "../../range";
 import { AbstractChart } from "./abstract_chart";

--- a/src/helpers/figures/charts/scorecard_chart.ts
+++ b/src/helpers/figures/charts/scorecard_chart.ts
@@ -30,7 +30,7 @@ import {
   ScorecardChartRuntime,
 } from "../../../types/chart/scorecard_chart";
 import { Validator } from "../../../types/validator";
-import { formatValue, humanizeNumber } from "../../format";
+import { formatValue, humanizeNumber } from "../../format/format";
 import { isNumber } from "../../numbers";
 import { createValidRange } from "../../range";
 import { rangeReference } from "../../references";

--- a/src/helpers/figures/charts/waterfall_chart.ts
+++ b/src/helpers/figures/charts/waterfall_chart.ts
@@ -32,7 +32,7 @@ import {
   WaterfallChartRuntime,
 } from "../../../types/chart/waterfall_chart";
 import { Validator } from "../../../types/validator";
-import { formatValue } from "../../format";
+import { formatValue } from "../../format/format";
 import { createValidRange } from "../../range";
 import { AbstractChart } from "./abstract_chart";
 import {

--- a/src/helpers/format/format.ts
+++ b/src/helpers/format/format.ts
@@ -1,5 +1,5 @@
-import { toNumber, toString } from "../functions/helpers";
-import { _t } from "../translation";
+import { toNumber, toString } from "../../functions/helpers";
+import { _t } from "../../translation";
 import {
   CellValue,
   Currency,
@@ -10,10 +10,10 @@ import {
   LocaleFormat,
   Maybe,
   PLAIN_TEXT_FORMAT,
-} from "../types";
-import { EvaluationError } from "../types/errors";
-import { DateTime, INITIAL_1900_DAY, isDateTime, numberToJsDate, parseDateTime } from "./dates";
-import { escapeRegExp, memoize } from "./misc";
+} from "../../types";
+import { EvaluationError } from "../../types/errors";
+import { DateTime, INITIAL_1900_DAY, isDateTime, numberToJsDate, parseDateTime } from "../dates";
+import { escapeRegExp, memoize } from "../misc";
 
 /**
  *  Constant used to indicate the maximum of digits that is possible to display

--- a/src/helpers/format/format.ts
+++ b/src/helpers/format/format.ts
@@ -769,3 +769,13 @@ export function isExcelCompatible(format: Format): boolean {
   }
   return true;
 }
+
+export function isTextFormat(format: Format | undefined): boolean {
+  if (!format) return false;
+  try {
+    const internalFormat = parseFormat(format);
+    return internalFormat.positive.type === "text";
+  } catch {
+    return false;
+  }
+}

--- a/src/helpers/format/format.ts
+++ b/src/helpers/format/format.ts
@@ -558,6 +558,24 @@ export function createCurrencyFormat(currency: Partial<Currency>): Format {
   return insertTextInFormat(textExpression, position, numberFormat);
 }
 
+export function createAccountingFormat(currency: Partial<Currency>): Format {
+  const decimalPlaces = currency.decimalPlaces ?? 2;
+  const position = currency.position ?? "before";
+  const code = currency.code ?? "";
+  const symbol = currency.symbol ?? "";
+  const decimalRepresentation = decimalPlaces ? "." + "0".repeat(decimalPlaces) : "";
+  const numberFormat = "#,##0" + decimalRepresentation;
+
+  let textExpression = `${code} ${symbol}`.trim();
+  if (position === "after" && code) {
+    textExpression = " " + textExpression;
+  }
+  const positivePart = insertTextInFormat(textExpression, position, numberFormat);
+  const negativePart = insertTextInFormat(textExpression, position, `(${numberFormat})`);
+  const zeroPart = insertTextInFormat(textExpression, position, "-");
+  return [positivePart, negativePart, zeroPart].join(";");
+}
+
 function insertTextInFormat(text: string, position: "before" | "after", format: Format): Format {
   const textExpression = `[$${text}]`;
   return position === "before" ? textExpression + format : format + textExpression;
@@ -763,7 +781,11 @@ function addDecimalPlaces(format: NumberInternalFormat, step: number): NumberInt
 export function isExcelCompatible(format: Format): boolean {
   const internalFormat = parseFormat(format);
   for (const part of [internalFormat.positive, internalFormat.negative, internalFormat.zero]) {
-    if (part && part.type === "date" && part.tokens.some((token) => token.value.includes("q"))) {
+    if (
+      part &&
+      part.type === "date" &&
+      part.tokens.some((token) => token.type === "DATE_PART" && token.value.includes("q"))
+    ) {
       return false;
     }
   }

--- a/src/helpers/format/format.ts
+++ b/src/helpers/format/format.ts
@@ -1,4 +1,4 @@
-import { toNumber, toString } from "../../functions/helpers";
+import { toNumber } from "../../functions/helpers";
 import { _t } from "../../translation";
 import {
   CellValue,
@@ -9,55 +9,33 @@ import {
   Locale,
   LocaleFormat,
   Maybe,
-  PLAIN_TEXT_FORMAT,
 } from "../../types";
 import { EvaluationError } from "../../types/errors";
 import { DateTime, INITIAL_1900_DAY, isDateTime, numberToJsDate, parseDateTime } from "../dates";
-import { escapeRegExp, memoize } from "../misc";
-
-/**
- *  Constant used to indicate the maximum of digits that is possible to display
- *  in a cell with standard size.
- */
-const MAX_DECIMAL_PLACES = 20;
+import {
+  escapeRegExp,
+  insertItemsAtIndex,
+  memoize,
+  range,
+  removeIndexesFromArray,
+  replaceItemAtIndex,
+} from "../misc";
+import {
+  DateInternalFormat,
+  InternalFormat,
+  MAX_DECIMAL_PLACES,
+  NumberInternalFormat,
+  TextInternalFormat,
+  convertInternalFormatToFormat,
+  parseFormat,
+} from "./format_parsing";
+import { FormatToken } from "./format_tokenize";
 
 /**
  * Number of digits for the default number format. This number of digit make a number fit well in a cell
  * with default size and default font size.
  */
 const DEFAULT_FORMAT_NUMBER_OF_DIGITS = 11;
-
-//from https://stackoverflow.com/questions/721304/insert-commas-into-number-string @Thomas/Alan Moore
-const thousandsGroupsRegexp = /(\d+?)(?=(\d{3})+(?!\d)|$)/g;
-
-const zeroRegexp = /0/g;
-
-/**
- * This internal format allows to represent a string format into subparts.
- * This division simplifies:
- * - the interpretation of the format when apply it to a value
- * - its modification (ex: easier to change the number of decimals)
- *
- * The internal format was introduced with the custom currency. The challenge was
- * to separate the custom currency from the rest of the format to not interfere
- * during analysis.
- *
- * This internal format and functions related to its application or modification
- * are not perfect ! Unlike implementation of custom currencies, implementation
- * of custom formats will ask to completely revisit internal format. The custom
- * formats request a customization character by character.
- *
- * For mor information, see:
- * - ECMA 376 standard:
- *  - Part 1 “Fundamentals And Markup Language Reference”, 5th edition, December 2016:
- *   - 18.8.30 numFmt (Number Format)
- *   - 18.8.31 numFmts (Number Formats)
- */
-type InternalFormat = (
-  | { type: "NUMBER"; format: InternalNumberFormat }
-  | { type: "STRING"; format: string }
-  | { type: "DATE"; format: string }
-)[];
 
 // TODO in the future : remove these constants MONTHS/DAYS, and use a library such as luxon to handle it
 // + possibly handle automatic translation of day/month
@@ -86,153 +64,193 @@ const DAYS: Readonly<Record<number, string>> = {
   6: _t("Saturday"),
 };
 
-interface InternalNumberFormat {
-  readonly integerPart: string;
-  readonly isPercent: boolean;
-  readonly thousandsSeparator: boolean;
-  readonly magnitude: number;
-  /**
-   * optional because we need to differentiate a number
-   * with a dot but no decimals with a number without any decimals.
-   * i.e. '5.'  !=== '5' !=== '5.0'
-   */
-  readonly decimalPart?: string;
-}
-
-// -----------------------------------------------------------------------------
-// FORMAT REPRESENTATION CACHE
-// -----------------------------------------------------------------------------
-
-const internalFormatByFormatString: { [format: string]: InternalFormat } = {};
-
-function parseFormat(formatString: Format): InternalFormat {
-  let internalFormat = internalFormatByFormatString[formatString];
-  if (internalFormat === undefined) {
-    internalFormat = convertFormatToInternalFormat(formatString);
-    internalFormatByFormatString[formatString] = internalFormat;
-  }
-  return internalFormat;
-}
-
-// -----------------------------------------------------------------------------
-// APPLY FORMAT
-// -----------------------------------------------------------------------------
-
 /**
  * Formats a cell value with its format.
  */
 export function formatValue(value: CellValue, { format, locale }: LocaleFormat): FormattedValue {
-  if (format === PLAIN_TEXT_FORMAT) {
-    return toString(value) || "";
+  if (typeof value === "boolean") {
+    value = value ? "TRUE" : "FALSE";
+  } else if (typeof value === "string") {
+    if (value.includes('\\"')) {
+      value = value.replaceAll(/\\"/g, '"');
+    }
   }
   switch (typeof value) {
-    case "string":
-      if (value.includes('\\"')) {
-        return value.replace(/\\"/g, '"');
+    case "string": {
+      if (!format) {
+        return value;
       }
-      return value;
-    case "boolean":
-      return value ? "TRUE" : "FALSE";
+      const internalFormat = parseFormat(format);
+      let formatToApply = internalFormat.text || internalFormat.positive;
+      if (!formatToApply || formatToApply.type !== "text") {
+        return value;
+      }
+      return applyTextInternalFormat(value, formatToApply);
+    }
     case "number":
-      // transform to internalNumberFormat
       if (!format) {
         format = createDefaultFormat(value);
       }
+
       const internalFormat = parseFormat(format);
-      return applyInternalFormat(value, internalFormat, locale);
+      if (internalFormat.positive.type === "text") {
+        return applyTextInternalFormat(value.toString(), internalFormat.positive);
+      }
+
+      let formatToApply: InternalFormat = internalFormat.positive;
+      if (value < 0 && internalFormat.negative) {
+        formatToApply = internalFormat.negative;
+        value = -value;
+      } else if (value === 0 && internalFormat.zero) {
+        formatToApply = internalFormat.zero;
+      }
+      return applyNumberInternalFormat(value, formatToApply, locale);
     case "object": // case value === null
       return "";
   }
 }
 
-function applyInternalFormat(
+function applyNumberInternalFormat(
   value: number,
-  internalFormat: InternalFormat,
+  internalFormat: NumberInternalFormat | DateInternalFormat,
   locale: Locale
 ): FormattedValue {
-  if (internalFormat[0].type === "DATE") {
-    return applyDateTimeFormat(value, internalFormat[0].format);
+  if (internalFormat.type === "date") {
+    return applyDateTimeFormat(value, internalFormat);
   }
 
-  let formattedValue: FormattedValue = value < 0 ? "-" : "";
-  for (let part of internalFormat) {
-    switch (part.type) {
-      case "NUMBER":
-        formattedValue += applyInternalNumberFormat(Math.abs(value), part.format, locale);
+  const isNegative = value < 0;
+  const formatted = applyInternalNumberFormat(Math.abs(value), internalFormat, locale);
+  return isNegative ? "-" + formatted : formatted;
+}
+
+function applyTextInternalFormat(
+  value: string,
+  internalFormat: TextInternalFormat
+): FormattedValue {
+  let formattedValue = "";
+  for (let token of internalFormat.tokens) {
+    switch (token.type) {
+      case "TEXT_PLACEHOLDER":
+        formattedValue += value;
         break;
-      case "STRING":
-        formattedValue += part.format;
+      case "CHAR":
+      case "ESCAPED_STRING":
+        formattedValue += token.value;
         break;
     }
   }
   return formattedValue;
 }
 
-function applyInternalNumberFormat(value: number, format: InternalNumberFormat, locale: Locale) {
+function applyInternalNumberFormat(value: number, format: NumberInternalFormat, locale: Locale) {
   if (value === Infinity) {
-    return "∞" + (format.isPercent ? "%" : "");
+    return "∞" + (format.percentSymbols ? "%" : "");
   }
-  if (format.isPercent) {
-    value = value * 100;
-  }
-  value = value / format.magnitude;
+
+  const multiplier = format.percentSymbols * 2 - format.magnitude * 3;
+  value = value * 10 ** multiplier;
+
   let maxDecimals = 0;
   if (format.decimalPart !== undefined) {
-    maxDecimals = format.decimalPart.length;
+    maxDecimals = format.decimalPart.filter((token) => token.type === "DIGIT").length;
   }
-  const { integerDigits, decimalDigits } = splitNumber(value, maxDecimals);
+  const { integerDigits, decimalDigits } = splitNumber(Math.abs(value), maxDecimals);
 
   let formattedValue = applyIntegerFormat(
     integerDigits,
-    format.integerPart,
+    format,
     format.thousandsSeparator ? locale.thousandsSeparator : undefined
   );
 
   if (format.decimalPart !== undefined) {
-    formattedValue +=
-      locale.decimalSeparator + applyDecimalFormat(decimalDigits || "", format.decimalPart);
+    formattedValue += locale.decimalSeparator + applyDecimalFormat(decimalDigits || "", format);
   }
 
-  if (format.isPercent) {
-    formattedValue += "%";
-  }
   return formattedValue;
 }
 
 function applyIntegerFormat(
   integerDigits: string,
-  integerFormat: string,
+  internalFormat: NumberInternalFormat,
   thousandsSeparator: string | undefined
 ): string {
-  const _integerDigits = integerDigits === "0" ? "" : integerDigits;
+  let tokens = internalFormat.integerPart;
+  if (tokens.filter((token) => token.type === "DIGIT").length === 0) {
+    tokens = [...tokens, { type: "DIGIT", value: "#" }];
+  }
+  if (integerDigits === "0") {
+    integerDigits = "";
+  }
+  let formattedInteger = "";
 
-  let formattedInteger = _integerDigits;
-  const delta = integerFormat.length - _integerDigits.length;
-  if (delta > 0) {
-    // ex: format = "0#000000" and integerDigit: "123"
-    const restIntegerFormat = integerFormat.substring(0, delta); // restIntegerFormat = "0#00"
-    const countZero = (restIntegerFormat.match(zeroRegexp) || []).length; // countZero = 3
-    formattedInteger = "0".repeat(countZero) + formattedInteger; // return "000123"
+  const firstDigitIndex = tokens.findIndex((token) => token.type === "DIGIT");
+  let indexInIntegerString = integerDigits.length - 1;
+
+  function appendDigitToFormattedValue(digit: string | undefined, digitType: "0" | "#") {
+    if (digitType === "0") {
+      digit = digit || "0";
+    }
+    if (!digit) return;
+
+    const digitIndex = integerDigits.length - 1 - indexInIntegerString;
+    if (thousandsSeparator && digitIndex > 0 && digitIndex % 3 === 0) {
+      formattedInteger = digit + thousandsSeparator + formattedInteger;
+    } else {
+      formattedInteger = digit + formattedInteger;
+    }
   }
 
-  if (thousandsSeparator) {
-    formattedInteger =
-      formattedInteger.match(thousandsGroupsRegexp)?.join(thousandsSeparator) || formattedInteger;
+  // Loop in reverse so we can easily add the rest of the integer digits at the beginning
+  for (let i = tokens.length - 1; i >= 0; i--) {
+    const token = tokens[i];
+    switch (token.type) {
+      case "DIGIT":
+        let digit = integerDigits[indexInIntegerString];
+        appendDigitToFormattedValue(digit, token.value);
+
+        indexInIntegerString--;
+
+        // Apply the rest of the integer digits at the beginning
+        if (firstDigitIndex === i) {
+          while (indexInIntegerString >= 0) {
+            appendDigitToFormattedValue(integerDigits[indexInIntegerString], "0");
+            indexInIntegerString--;
+          }
+        }
+        break;
+      default:
+        formattedInteger = token.value + formattedInteger;
+        break;
+    }
   }
 
   return formattedInteger;
 }
 
-function applyDecimalFormat(decimalDigits: string, decimalFormat: string): string {
-  // assume the format is valid (no commas)
-  let formattedDecimals = decimalDigits;
-  if (decimalFormat.length - decimalDigits.length > 0) {
-    const restDecimalFormat = decimalFormat.substring(
-      decimalDigits.length,
-      decimalFormat.length + 1
-    );
-    const countZero = (restDecimalFormat.match(zeroRegexp) || []).length;
-    formattedDecimals = formattedDecimals + "0".repeat(countZero);
+function applyDecimalFormat(decimalDigits: string, internalFormat: NumberInternalFormat): string {
+  if (!internalFormat.decimalPart) {
+    return "";
+  }
+
+  let formattedDecimals = "";
+
+  let indexInDecimalString = 0;
+
+  for (const token of internalFormat.decimalPart) {
+    switch (token.type) {
+      case "DIGIT":
+        const digit =
+          token.value === "#"
+            ? decimalDigits[indexInDecimalString] || ""
+            : decimalDigits[indexInDecimalString] || "0";
+        formattedDecimals += digit;
+        indexInDecimalString++;
+        break;
+      default:
+        formattedDecimals += token.value;
+        break;
+    }
   }
 
   return formattedDecimals;
@@ -372,117 +390,95 @@ export function numberToString(number: number, decimalSeparator: string): string
 }
 
 /**
- * Check if the given format is a time, date or date time format.
+ * Check if the given format is a time, date or date time format. Only check the first part of a multi-part format.
  */
 export function isDateTimeFormat(format: Format) {
-  if (!allowedDateTimeFormatFirstChar.has(format[0])) {
-    // first check for performance reason
+  if (!format) {
     return false;
   }
   try {
-    applyDateTimeFormat(1, format);
-    return true;
+    const internalFormat = parseFormat(format);
+    return internalFormat.positive.type === "date";
   } catch (error) {
     return false;
   }
 }
-const allowedDateTimeFormatFirstChar = new Set(["h", "m", "y", "d", "q"]);
 
-export function applyDateTimeFormat(value: number, format: Format): FormattedValue {
-  // TODO: unify the format functions for date and datetime
-  // This requires some code to 'parse' or 'tokenize' the format, keep it in a
-  // cache, and use it in a single mapping, that recognizes the special list
-  // of tokens dd,d,m,y,h, ... and preserves the rest
-
+export function applyDateTimeFormat(
+  value: number,
+  internalFormat: DateInternalFormat
+): FormattedValue {
   const jsDate = numberToJsDate(value);
-  const indexH = format.indexOf("h");
-  let strDate: FormattedValue = "";
-  let strTime: FormattedValue = "";
-  if (indexH > 0) {
-    strDate = formatJSDate(jsDate, format.substring(0, indexH - 1));
-    strTime = formatJSTime(jsDate, format.substring(indexH));
-  } else if (indexH === 0) {
-    strTime = formatJSTime(jsDate, format);
-  } else if (indexH < 0) {
-    strDate = formatJSDate(jsDate, format);
-  }
-  return strDate + (strDate && strTime ? " " : "") + strTime;
-}
 
-function formatJSDate(jsDate: DateTime, format: Format): FormattedValue {
-  const sep = format.match(/\/|-|\s/)?.[0];
-  const parts = sep ? format.split(sep) : [format];
-  return parts
-    .map((p) => {
-      switch (p) {
-        case "d":
-          return jsDate.getDate();
-        case "dd":
-          return jsDate.getDate().toString().padStart(2, "0");
-        case "ddd":
-          return DAYS[jsDate.getDay()].slice(0, 3);
-        case "dddd":
-          return DAYS[jsDate.getDay()];
-        case "m":
-          return jsDate.getMonth() + 1;
-        case "mm":
-          return String(jsDate.getMonth() + 1).padStart(2, "0");
-        case "mmm":
-          return MONTHS[jsDate.getMonth()].slice(0, 3);
-        case "mmmm":
-          return MONTHS[jsDate.getMonth()];
-        case "mmmmm":
-          return MONTHS[jsDate.getMonth()].slice(0, 1);
-        case "qq":
-          return _t("Q%(quarter)s", { quarter: jsDate.getQuarter() });
-        case "qqqq":
-          return _t("Quarter %(quarter)s", { quarter: jsDate.getQuarter() });
-        case "yy":
-          const fullYear = String(jsDate.getFullYear()).replace("-", "").padStart(2, "0");
-          return fullYear.slice(fullYear.length - 2);
-        case "yyyy":
-          return jsDate.getFullYear();
-        default:
-          throw new Error(`invalid format: ${format}`);
-      }
-    })
-    .join(sep);
-}
-
-function formatJSTime(jsDate: DateTime, format: Format): FormattedValue {
-  let parts = format.split(/:|\s/);
-
-  const dateHours = jsDate.getHours();
-  const isMeridian = parts[parts.length - 1] === "a";
-  let hours = dateHours;
-  let meridian = "";
-  if (isMeridian) {
-    hours = hours === 0 ? 12 : hours > 12 ? hours - 12 : hours;
-    meridian = dateHours >= 12 ? " PM" : " AM";
-    parts.pop();
-  }
-
-  return (
-    parts
-      .map((p) => {
-        switch (p) {
-          case "hhhh":
-            const helapsedHours = Math.floor(
-              (jsDate.getTime() - INITIAL_1900_DAY.getTime()) / (60 * 60 * 1000)
-            );
-            return helapsedHours.toString();
-          case "hh":
-            return hours.toString().padStart(2, "0");
-          case "mm":
-            return jsDate.getMinutes().toString().padStart(2, "0");
-          case "ss":
-            return jsDate.getSeconds().toString().padStart(2, "0");
-          default:
-            throw new Error(`invalid format: ${format}`);
-        }
-      })
-      .join(":") + meridian
+  const isMeridian = internalFormat.tokens.some(
+    (token) => token.type === "DATE_PART" && token.value === "a"
   );
+
+  let currentValue = "";
+  for (const token of internalFormat.tokens) {
+    switch (token.type) {
+      case "DATE_PART":
+        currentValue += formatJSDatePart(jsDate, token.value, isMeridian);
+        break;
+      default:
+        currentValue += token.value;
+        break;
+    }
+  }
+
+  return currentValue;
+}
+
+function formatJSDatePart(jsDate: DateTime, tokenValue: string, isMeridian: boolean) {
+  switch (tokenValue) {
+    case "d":
+      return jsDate.getDate();
+    case "dd":
+      return jsDate.getDate().toString().padStart(2, "0");
+    case "ddd":
+      return DAYS[jsDate.getDay()].slice(0, 3);
+    case "dddd":
+      return DAYS[jsDate.getDay()];
+    case "m":
+      return jsDate.getMonth() + 1;
+    case "mm":
+      return String(jsDate.getMonth() + 1).padStart(2, "0");
+    case "mmm":
+      return MONTHS[jsDate.getMonth()].slice(0, 3);
+    case "mmmm":
+      return MONTHS[jsDate.getMonth()];
+    case "mmmmm":
+      return MONTHS[jsDate.getMonth()].slice(0, 1);
+    case "qq":
+      return _t("Q%(quarter)s", { quarter: jsDate.getQuarter() });
+    case "qqqq":
+      return _t("Quarter %(quarter)s", { quarter: jsDate.getQuarter() });
+    case "yy":
+      const fullYear = String(jsDate.getFullYear()).replace("-", "").padStart(2, "0");
+      return fullYear.slice(fullYear.length - 2);
+    case "yyyy":
+      return jsDate.getFullYear();
+    case "hhhh":
+      const elapsedHours = Math.floor(
+        (jsDate.getTime() - INITIAL_1900_DAY.getTime()) / (60 * 60 * 1000)
+      );
+      return elapsedHours.toString();
+    case "hh":
+      const dateHours = jsDate.getHours();
+      let hours = dateHours;
+      if (isMeridian) {
+        hours = hours === 0 ? 12 : hours > 12 ? hours - 12 : hours;
+      }
+      return hours.toString().padStart(2, "0");
+    case "MM": // "MM" replaces "mm" for minutes during format parsing
+      return jsDate.getMinutes().toString().padStart(2, "0");
+    case "ss":
+      return jsDate.getSeconds().toString().padStart(2, "0");
+    case "a":
+      return jsDate.getHours() >= 12 ? "PM" : "AM";
+    default:
+      throw new Error(`invalid date format token: ${tokenValue}`);
+  }
 }
 
 /**
@@ -568,20 +564,26 @@ function insertTextInFormat(text: string, position: "before" | "after", format: 
 }
 
 export function roundFormat(format: Format): Format {
-  const internalFormat = parseFormat(format);
-  const roundedFormat = internalFormat.map((formatPart) => {
-    if (formatPart.type === "NUMBER") {
-      return {
-        type: formatPart.type,
-        format: {
-          ...formatPart.format,
-          decimalPart: undefined,
-        },
-      };
-    }
-    return formatPart;
-  });
-  return convertInternalFormatToFormat(roundedFormat);
+  const multiPartFormat = parseFormat(format);
+  const roundedInternalFormat = {
+    positive: _roundFormat(multiPartFormat.positive),
+    negative: multiPartFormat.negative ? _roundFormat(multiPartFormat.negative) : undefined,
+    zero: multiPartFormat.zero ? _roundFormat(multiPartFormat.zero) : undefined,
+    text: multiPartFormat.text,
+  };
+  return convertInternalFormatToFormat(roundedInternalFormat);
+}
+
+function _roundFormat<T extends InternalFormat>(internalFormat: T): T {
+  if (internalFormat.type !== "number" || !internalFormat.decimalPart) {
+    return internalFormat;
+  }
+  const nonDigitDecimalPart = internalFormat.decimalPart.filter((token) => token.type !== "DIGIT");
+  return {
+    ...internalFormat,
+    decimalPart: undefined,
+    integerPart: [...internalFormat.integerPart, ...nonDigitDecimalPart],
+  };
 }
 
 export function humanizeNumber({ value, format }: FunctionResultObject, locale: Locale): string {
@@ -612,11 +614,11 @@ export function formatLargeNumber(
     const postFix = unit?.value;
     switch (postFix) {
       case "k":
-        return createLargeNumberFormat(format, 1e3, "k", locale);
+        return createLargeNumberFormat(format, 1, "k", locale);
       case "m":
-        return createLargeNumberFormat(format, 1e6, "m", locale);
+        return createLargeNumberFormat(format, 2, "m", locale);
       case "b":
-        return createLargeNumberFormat(format, 1e9, "b", locale);
+        return createLargeNumberFormat(format, 3, "b", locale);
       default:
         throw new EvaluationError(_t("The formatting unit should be 'k', 'm' or 'b'."));
     }
@@ -624,11 +626,11 @@ export function formatLargeNumber(
   if (value < 1e5) {
     return createLargeNumberFormat(format, 0, "", locale);
   } else if (value < 1e8) {
-    return createLargeNumberFormat(format, 1e3, "k", locale);
+    return createLargeNumberFormat(format, 1, "k", locale);
   } else if (value < 1e11) {
-    return createLargeNumberFormat(format, 1e6, "m", locale);
+    return createLargeNumberFormat(format, 2, "m", locale);
   }
-  return createLargeNumberFormat(format, 1e9, "b", locale);
+  return createLargeNumberFormat(format, 3, "b", locale);
 }
 
 export function createLargeNumberFormat(
@@ -637,208 +639,133 @@ export function createLargeNumberFormat(
   postFix: string,
   locale: Locale
 ): Format {
-  const internalFormat = parseFormat(format || "#,##0");
-  const largeNumberFormat: InternalFormat = [];
-  for (let i = 0; i < internalFormat.length; i++) {
-    const formatPart = internalFormat[i];
-    if (formatPart.type !== "NUMBER") {
-      largeNumberFormat.push(formatPart);
-      continue;
-    }
-
-    largeNumberFormat.push({
-      ...formatPart,
-      format: {
-        ...formatPart.format,
-        magnitude,
-        decimalPart: undefined,
-      },
-    });
-    largeNumberFormat.push({
-      type: "STRING" as const,
-      format: postFix,
-    });
-
-    const nextFormatPart = internalFormat[i + 1];
-    if (nextFormatPart?.type === "STRING" && ["k", "m", "b"].includes(nextFormatPart.format)) {
-      i++;
-    }
-  }
-  return convertInternalFormatToFormat(largeNumberFormat);
+  const multiPartFormat = parseFormat(format || "#,##0");
+  const roundedInternalFormat = {
+    positive: _createLargeNumberFormat(multiPartFormat.positive, magnitude, postFix),
+    negative: multiPartFormat.negative
+      ? _createLargeNumberFormat(multiPartFormat.negative, magnitude, postFix)
+      : undefined,
+    zero: multiPartFormat.zero
+      ? _createLargeNumberFormat(multiPartFormat.zero, magnitude, postFix)
+      : undefined,
+    text: multiPartFormat.text,
+  };
+  return convertInternalFormatToFormat(roundedInternalFormat);
 }
 
-export function changeDecimalPlaces(format: Format, step: number, locale: Locale) {
-  const internalFormat = parseFormat(format);
-  const newInternalFormat = internalFormat.map((intFmt) => {
-    if (intFmt.type === "NUMBER") {
-      return { ...intFmt, format: changeInternalNumberFormatDecimalPlaces(intFmt.format, step) };
-    } else {
-      return intFmt;
+export function _createLargeNumberFormat<T extends InternalFormat>(
+  format: T,
+  magnitude: number,
+  postFix: string
+): T {
+  if (format.type !== "number") {
+    return format;
+  }
+
+  const postFixToken: FormatToken = { type: "ESCAPED_STRING", value: postFix };
+  let newIntegerPart = [...format.integerPart];
+
+  const lastDigitIndex = newIntegerPart.findLastIndex((token) => token.type === "DIGIT");
+  if (lastDigitIndex === -1) {
+    throw new Error("Cannot create a large number format from a format with no digit.");
+  }
+
+  const tokenAfterDigits = newIntegerPart[lastDigitIndex + 1];
+  if (
+    tokenAfterDigits?.type === "ESCAPED_STRING" &&
+    ["m", "k", "b"].includes(tokenAfterDigits.value)
+  ) {
+    newIntegerPart = replaceItemAtIndex(newIntegerPart, postFixToken, lastDigitIndex + 1);
+  } else {
+    newIntegerPart = insertItemsAtIndex(newIntegerPart, [postFixToken], lastDigitIndex + 1);
+  }
+
+  return { ...format, integerPart: newIntegerPart, decimalPart: undefined, magnitude };
+}
+
+export function changeDecimalPlaces(format: Format, step: number) {
+  const multiPartFormat = parseFormat(format);
+  const newInternalFormat = {
+    positive: _changeDecimalPlace(multiPartFormat.positive, step),
+    negative: multiPartFormat.negative
+      ? _changeDecimalPlace(multiPartFormat.negative, step)
+      : undefined,
+    zero: multiPartFormat.zero ? _changeDecimalPlace(multiPartFormat.zero, step) : undefined,
+    text: multiPartFormat.text,
+  };
+  // Re-parse the format to make sure we don't break the number of digit limit
+  return convertInternalFormatToFormat(
+    parseFormat(convertInternalFormatToFormat(newInternalFormat))
+  );
+}
+
+function _changeDecimalPlace<T extends InternalFormat>(format: T, step: number): T {
+  if (format.type !== "number") {
+    return format;
+  }
+  return (
+    step > 0 ? addDecimalPlaces(format, step) : removeDecimalPlaces(format, Math.abs(step))
+  ) as T;
+}
+
+function removeDecimalPlaces(format: NumberInternalFormat, step: number): NumberInternalFormat {
+  let decimalPart = format.decimalPart;
+  if (!decimalPart) {
+    return format;
+  }
+
+  const indexesToRemove: number[] = [];
+  let digitCount = 0;
+  for (let i = decimalPart.length - 1; i >= 0; i--) {
+    if (digitCount >= Math.abs(step)) {
+      break;
     }
-  });
-  const newFormat = convertInternalFormatToFormat(newInternalFormat);
-  internalFormatByFormatString[newFormat] = newInternalFormat;
-  return newFormat;
+    if (decimalPart[i].type === "DIGIT") {
+      digitCount++;
+      indexesToRemove.push(i);
+    }
+  }
+  decimalPart = removeIndexesFromArray(decimalPart, indexesToRemove);
+
+  if (decimalPart.some((token) => token.type === "DIGIT")) {
+    return { ...format, decimalPart };
+  }
+
+  return {
+    ...format,
+    decimalPart: undefined,
+    integerPart: [...format.integerPart, ...decimalPart],
+  };
+}
+
+function addDecimalPlaces(format: NumberInternalFormat, step: number): NumberInternalFormat {
+  let integerPart = format.integerPart;
+  let decimalPart = format.decimalPart;
+
+  if (!decimalPart) {
+    const lastDigitIndex = integerPart.findLastIndex((token) => token.type === "DIGIT");
+    decimalPart = integerPart.slice(lastDigitIndex + 1);
+    integerPart = integerPart.slice(0, lastDigitIndex + 1);
+  }
+
+  const digitsToAdd = range(0, step).map(() => ({ type: "DIGIT", value: "0" } as const));
+  const lastDigitIndex = decimalPart.findLastIndex((token) => token.type === "DIGIT");
+
+  if (lastDigitIndex === -1) {
+    decimalPart = [...digitsToAdd, ...decimalPart];
+  } else {
+    decimalPart = insertItemsAtIndex(decimalPart, digitsToAdd, lastDigitIndex + 1);
+  }
+
+  return { ...format, decimalPart, integerPart };
 }
 
 export function isExcelCompatible(format: Format): boolean {
   const internalFormat = parseFormat(format);
-  for (let part of internalFormat) {
-    if (part.type === "DATE" && part.format.includes("q")) {
+  for (const part of [internalFormat.positive, internalFormat.negative, internalFormat.zero]) {
+    if (part && part.type === "date" && part.tokens.some((token) => token.value.includes("q"))) {
       return false;
     }
   }
   return true;
-}
-
-function changeInternalNumberFormatDecimalPlaces(
-  format: Readonly<InternalNumberFormat>,
-  step: number
-): InternalNumberFormat {
-  const _format = { ...format };
-  const sign = Math.sign(step);
-  const decimalLength = _format.decimalPart?.length || 0;
-  const countZero = Math.min(Math.max(0, decimalLength + sign), MAX_DECIMAL_PLACES);
-  _format.decimalPart = "0".repeat(countZero);
-  if (_format.decimalPart === "") {
-    delete _format.decimalPart;
-  }
-  return _format;
-}
-
-// -----------------------------------------------------------------------------
-// MANAGING FORMAT
-// -----------------------------------------------------------------------------
-
-/**
- * Validates the provided format string and returns an InternalFormat Object.
- */
-function convertFormatToInternalFormat(format: Format): InternalFormat {
-  if (format === "") {
-    throw new Error("A format cannot be empty");
-  }
-  let currentIndex = 0;
-  let result: InternalFormat = [];
-  while (currentIndex < format.length) {
-    let closingIndex: number;
-    if (format.charAt(currentIndex) === "[") {
-      if (format.charAt(currentIndex + 1) !== "$") {
-        throw new Error(`Currency formats have to be prefixed by a $: ${format}`);
-      }
-      // manage brackets/customStrings
-      closingIndex = format.substring(currentIndex + 1).indexOf("]") + currentIndex + 2;
-      if (closingIndex === 0) {
-        throw new Error(`Invalid currency brackets format: ${format}`);
-      }
-      // remove leading "[$"" and ending "]".
-      const str = format.substring(currentIndex + 2, closingIndex - 1);
-      if (str.includes("[")) {
-        throw new Error(`Invalid currency format: ${format}`);
-      }
-      result.push({
-        type: "STRING",
-        format: str,
-      });
-    } else {
-      // rest of the time
-      const nextPartIndex = format.substring(currentIndex).indexOf("[");
-      closingIndex = nextPartIndex > -1 ? nextPartIndex + currentIndex : format.length;
-      const subFormat = format.substring(currentIndex, closingIndex);
-      if (isDateTimeFormat(subFormat)) {
-        result.push({ type: "DATE", format: subFormat });
-      } else {
-        result.push({
-          type: "NUMBER",
-          format: convertToInternalNumberFormat(subFormat),
-        });
-      }
-    }
-    currentIndex = closingIndex;
-  }
-  return result;
-}
-
-const magnitudeRegex = /,*?$/;
-
-/**
- * @param format a formatString that is only applicable to numbers. I.e. composed of characters 0 # , . %
- */
-function convertToInternalNumberFormat(format: Format): InternalNumberFormat {
-  format = format.trim();
-  if (containsInvalidNumberChars(format)) {
-    throw new Error(`Invalid number format: ${format}`);
-  }
-  const isPercent = format.includes("%");
-  const magnitudeCommas = format.match(magnitudeRegex)?.[0] || "";
-  const magnitude = !magnitudeCommas ? 1 : 1000 ** magnitudeCommas.length;
-  let _format = format.slice(0, format.length - (magnitudeCommas.length || 0));
-  const thousandsSeparator = _format.includes(",");
-  if (/\..*,/.test(_format)) {
-    throw new Error("A format can't contain ',' symbol in the decimal part");
-  }
-  _format = _format.replace("%", "").replace(",", "");
-
-  const extraSigns = _format.match(/[\%|,]/);
-  if (extraSigns) {
-    throw new Error(`A format can only contain a single '${extraSigns[0]}' symbol`);
-  }
-  const [integerPart, decimalPart] = _format.split(".");
-  if (decimalPart && decimalPart.length > 20) {
-    throw new Error("A format can't contain more than 20 decimal places");
-  }
-  if (decimalPart !== undefined) {
-    return {
-      integerPart,
-      isPercent,
-      thousandsSeparator,
-      decimalPart,
-      magnitude,
-    };
-  } else {
-    return {
-      integerPart,
-      isPercent,
-      thousandsSeparator,
-      magnitude,
-    };
-  }
-}
-
-const validNumberChars = /[,#0.%@]/g;
-
-function containsInvalidNumberChars(format: Format): boolean {
-  return Boolean(format.replace(validNumberChars, ""));
-}
-
-function convertInternalFormatToFormat(internalFormat: InternalFormat): Format {
-  let format: Format = "";
-  for (let part of internalFormat) {
-    let currentFormat: string;
-    switch (part.type) {
-      case "NUMBER":
-        const fmt = part.format;
-        currentFormat = fmt.integerPart;
-        if (fmt.thousandsSeparator) {
-          currentFormat = currentFormat.slice(0, -3) + "," + currentFormat.slice(-3);
-        }
-        if (fmt.decimalPart !== undefined) {
-          currentFormat += "." + fmt.decimalPart;
-        }
-        if (fmt.isPercent) {
-          currentFormat += "%";
-        }
-        if (fmt.magnitude) {
-          currentFormat += ",".repeat(Math.log10(fmt.magnitude) / 3);
-        }
-        break;
-      case "STRING":
-        currentFormat = `[$${part.format}]`;
-        break;
-      case "DATE":
-        currentFormat = part.format;
-        break;
-    }
-    format += currentFormat;
-  }
-  return format;
 }

--- a/src/helpers/format/format_parsing.ts
+++ b/src/helpers/format/format_parsing.ts
@@ -1,0 +1,315 @@
+import { Format } from "../../types";
+import { insertItemsAtIndex, isDefined } from "../misc";
+import {
+  CharToken,
+  DatePartToken,
+  DecimalPointToken,
+  DigitToken,
+  EscapedStringToken,
+  FormatToken,
+  PercentToken,
+  TextPlaceholderToken,
+  ThousandsSeparatorToken,
+  shouldEscapeFormatChar,
+  tokenizeFormat,
+} from "./format_tokenize";
+
+/**
+ *  Constant used to indicate the maximum of digits that is possible to display
+ *  in a cell with standard size.
+ */
+export const MAX_DECIMAL_PLACES = 20;
+
+export interface MultiPartInternalFormat {
+  positive: NumberInternalFormat | DateInternalFormat | TextInternalFormat;
+  negative?: NumberInternalFormat | DateInternalFormat;
+  zero?: NumberInternalFormat | DateInternalFormat;
+  text?: TextInternalFormat;
+}
+
+export interface DateInternalFormat {
+  type: "date";
+  tokens: (DatePartToken | DecimalPointToken | EscapedStringToken | CharToken)[];
+}
+
+export interface NumberInternalFormat {
+  type: "number";
+  readonly integerPart: (DigitToken | EscapedStringToken | CharToken | PercentToken)[];
+  readonly percentSymbols: number;
+  readonly thousandsSeparator: boolean;
+  /** A thousand separator after the last digit in the format means that we divide the number by a thousand */
+  readonly magnitude: number;
+  /**
+   * optional because we need to differentiate a number
+   * with a dot but no decimals with a number without any decimals.
+   * i.e. '5.'  !=== '5' !=== '5.0'
+   */
+  readonly decimalPart?: (DigitToken | EscapedStringToken | CharToken | PercentToken)[];
+}
+
+export interface TextInternalFormat {
+  type: "text";
+  tokens: (EscapedStringToken | CharToken | TextPlaceholderToken)[];
+}
+
+export type InternalFormat = NumberInternalFormat | DateInternalFormat | TextInternalFormat;
+
+const internalFormatCache: { [format: string]: MultiPartInternalFormat } = {};
+
+export function parseFormat(formatString: Format): MultiPartInternalFormat {
+  let internalFormat = internalFormatCache[formatString];
+  if (internalFormat === undefined) {
+    internalFormat = convertFormatToInternalFormat(formatString);
+    internalFormatCache[formatString] = internalFormat;
+  }
+  return internalFormat;
+}
+
+export function convertFormatToInternalFormat(format: Format): MultiPartInternalFormat {
+  const formatParts = tokenizeFormat(format);
+
+  const positiveFormat =
+    parseDateFormatTokens(formatParts[0]) ||
+    parseNumberFormatTokens(formatParts[0]) ||
+    tokensToTextInternalFormat(formatParts[0]);
+  if (!positiveFormat) {
+    throw new Error("Invalid first format part of: " + format);
+  }
+  if (formatParts.length > 1 && positiveFormat.type === "text") {
+    throw new Error("The first format in a multi part format must be a number format: " + format);
+  }
+
+  const negativeFormat =
+    parseDateFormatTokens(formatParts[1]) || parseNumberFormatTokens(formatParts[1]);
+  if (formatParts[1]?.length && !negativeFormat) {
+    throw new Error("Invalid second format part of: " + format);
+  }
+
+  const zeroFormat =
+    parseDateFormatTokens(formatParts[2]) || parseNumberFormatTokens(formatParts[2]);
+  if (formatParts[2]?.length && !zeroFormat) {
+    throw new Error("Invalid third format part of: " + format);
+  }
+
+  const textFormat = tokensToTextInternalFormat(formatParts[3]);
+  if (formatParts[3]?.length && !textFormat) {
+    throw new Error("Invalid fourth format part of: " + format);
+  }
+
+  return { positive: positiveFormat, negative: negativeFormat, zero: zeroFormat, text: textFormat };
+}
+
+function areValidDateFormatTokens(tokens: FormatToken[]): tokens is DateInternalFormat["tokens"] {
+  return tokens.every(
+    (token) =>
+      token.type === "DATE_PART" ||
+      token.type === "DECIMAL_POINT" ||
+      token.type === "ESCAPED_STRING" ||
+      token.type === "CHAR"
+  );
+}
+
+function areValidNumberFormatTokens(
+  tokens: FormatToken[]
+): tokens is (
+  | DigitToken
+  | DecimalPointToken
+  | ThousandsSeparatorToken
+  | PercentToken
+  | EscapedStringToken
+  | CharToken
+)[] {
+  return tokens.every(
+    (token) =>
+      token.type === "DIGIT" ||
+      token.type === "DECIMAL_POINT" ||
+      token.type === "THOUSANDS_SEPARATOR" ||
+      token.type === "PERCENT" ||
+      token.type === "ESCAPED_STRING" ||
+      token.type === "CHAR"
+  );
+}
+
+function areValidTextFormatTokens(tokens: FormatToken[]): tokens is TextInternalFormat["tokens"] {
+  return tokens.every(
+    (token) =>
+      token.type === "ESCAPED_STRING" || token.type === "TEXT_PLACEHOLDER" || token.type === "CHAR"
+  );
+}
+
+function parseNumberFormatTokens(
+  tokens: FormatToken[] | undefined
+): NumberInternalFormat | undefined {
+  if (!tokens || !areValidNumberFormatTokens(tokens)) {
+    return undefined;
+  }
+  const integerPart: NumberInternalFormat["integerPart"] = [];
+  let decimalPart: NumberInternalFormat["decimalPart"] = undefined;
+
+  let parsedPart = integerPart;
+  let percentSymbols = 0;
+  let magnitude = 0;
+  let lastIndexOfDigit = tokens.findLastIndex((token) => token.type === "DIGIT");
+  let hasThousandSeparator = false;
+  let numberOfDecimalsDigits = 0;
+
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i];
+    switch (token.type) {
+      case "DIGIT":
+        if (parsedPart === integerPart) {
+          parsedPart.push(token);
+        } else if (numberOfDecimalsDigits < MAX_DECIMAL_PLACES) {
+          parsedPart.push(token);
+          numberOfDecimalsDigits++;
+        }
+        break;
+      case "DECIMAL_POINT":
+        if (parsedPart === integerPart) {
+          decimalPart = [];
+          parsedPart = decimalPart;
+        } else {
+          throw new Error("Multiple decimal points in a number format");
+        }
+        break;
+      case "CHAR":
+      case "ESCAPED_STRING":
+        parsedPart.push(token);
+        break;
+      case "PERCENT":
+        percentSymbols++;
+        parsedPart.push(token);
+        break;
+      // Per OpenXML Spec:
+      // - If a comma is between two DIGIT tokens, and in the integer part, a thousand separator is applied in the formatted value.
+      // - If a comma is at the end of the number placeholder, the number is divided by a thousand.
+      // - Otherwise, it's a string.
+      case "THOUSANDS_SEPARATOR":
+        if (i - 1 === lastIndexOfDigit) {
+          magnitude += 1;
+          lastIndexOfDigit++; // Can have multiple commas in a row
+        } else if (tokens[i + 1]?.type === "DIGIT" && tokens[i - 1]?.type === "DIGIT") {
+          if (parsedPart === integerPart) {
+            hasThousandSeparator = true;
+          }
+        } else {
+          parsedPart.push({ type: "CHAR", value: "," });
+        }
+        break;
+    }
+  }
+
+  return {
+    type: "number",
+    integerPart,
+    decimalPart,
+    percentSymbols,
+    thousandsSeparator: hasThousandSeparator,
+    magnitude,
+  };
+}
+
+function parseDateFormatTokens(tokens: FormatToken[] | undefined): DateInternalFormat | undefined {
+  const internalFormat =
+    tokens && areValidDateFormatTokens(tokens) ? { type: "date", tokens } : undefined;
+  if (!internalFormat) {
+    return undefined;
+  }
+  if (
+    internalFormat.tokens.length &&
+    internalFormat.tokens.every((token) => token.type === "DATE_PART" && token.value === "a")
+  ) {
+    throw new Error("Invalid date format");
+  }
+  const convertedTokens = convertTokensToMinutesInDateFormat(internalFormat.tokens);
+  return { type: "date", tokens: convertedTokens };
+}
+
+function tokensToTextInternalFormat(
+  tokens: FormatToken[] | undefined
+): TextInternalFormat | undefined {
+  return tokens && areValidTextFormatTokens(tokens) ? { type: "text", tokens } : undefined;
+}
+
+/**
+ * Replace in place tokens "mm" and "m" that denote minutes in date format with "MM" to avoid confusion with months.
+ *
+ * As per OpenXML specification, in date formats if a data token "m" or "mm" is followed by a date token "s" or
+ * preceded by a data token "h", then it's not a month but an minute.
+ */
+function convertTokensToMinutesInDateFormat(tokens: DateInternalFormat["tokens"]) {
+  const dateParts = tokens.filter((token) => token.type === "DATE_PART") as DatePartToken[];
+  for (let i = 0; i < dateParts.length; i++) {
+    if (!dateParts[i].value.startsWith("m") || dateParts[i].value.length > 2) {
+      continue;
+    }
+    if (dateParts[i - 1]?.value.startsWith("h") || dateParts[i + 1]?.value.startsWith("s")) {
+      dateParts[i].value = dateParts[i].value.replaceAll("m", "M");
+    }
+  }
+  return tokens;
+}
+
+export function convertInternalFormatToFormat(internalFormat: MultiPartInternalFormat): Format {
+  return [
+    internalFormatPartToFormat(internalFormat.positive),
+    internalFormatPartToFormat(internalFormat.negative),
+    internalFormatPartToFormat(internalFormat.zero),
+    internalFormatPartToFormat(internalFormat.text),
+  ]
+    .filter(isDefined)
+    .join(";");
+}
+
+function internalFormatPartToFormat(
+  internalFormat: InternalFormat | undefined
+): Format | undefined {
+  if (!internalFormat) {
+    return undefined;
+  }
+  let format = "";
+  const tokens =
+    internalFormat.type !== "number"
+      ? internalFormat.tokens
+      : numberInternalFormatToTokenList(internalFormat);
+  for (let token of tokens) {
+    switch (token.type) {
+      case "ESCAPED_STRING":
+        format += `[$${token.value}]`;
+        break;
+      case "CHAR":
+        format += shouldEscapeFormatChar(token.value) ? `\\${token.value}` : token.value;
+        break;
+      default:
+        format += token.value;
+    }
+  }
+  return format;
+}
+
+function numberInternalFormatToTokenList(internalFormat: NumberInternalFormat): FormatToken[] {
+  let tokens: FormatToken[] = [...internalFormat.integerPart];
+
+  if (internalFormat.thousandsSeparator) {
+    const index = tokens.findIndex(
+      (token, i) => token.type === "DIGIT" && tokens[i + 1]?.type === "DIGIT"
+    );
+    tokens = insertItemsAtIndex(tokens, [{ type: "THOUSANDS_SEPARATOR", value: "," }], index + 1);
+  }
+
+  if (internalFormat.decimalPart) {
+    tokens.push({ type: "DECIMAL_POINT", value: "." });
+    tokens.push(...internalFormat.decimalPart);
+  }
+
+  if (internalFormat.magnitude) {
+    const lastDigitIndex = tokens.findLastIndex((token) => token.type === "DIGIT");
+    const tokensToAdd = new Array(internalFormat.magnitude).fill({
+      type: "THOUSANDS_SEPARATOR",
+      value: ",",
+    });
+    tokens = insertItemsAtIndex(tokens, tokensToAdd, lastDigitIndex + 1);
+  }
+
+  return tokens;
+}

--- a/src/helpers/format/format_tokenize.ts
+++ b/src/helpers/format/format_tokenize.ts
@@ -1,0 +1,178 @@
+import { TokenizingChars } from "../misc";
+
+export interface DigitToken {
+  type: "DIGIT";
+  value: "0" | "#";
+}
+
+export interface DecimalPointToken {
+  type: "DECIMAL_POINT";
+  value: string;
+}
+
+export interface EscapedStringToken {
+  type: "ESCAPED_STRING";
+  value: string;
+}
+
+export interface CharToken {
+  type: "CHAR";
+  value: string;
+}
+
+export interface PercentToken {
+  type: "PERCENT";
+  value: string;
+}
+
+export interface ThousandsSeparatorToken {
+  type: "THOUSANDS_SEPARATOR";
+  value: string;
+}
+
+export interface TextPlaceholderToken {
+  type: "TEXT_PLACEHOLDER";
+  value: string;
+}
+
+export interface DatePartToken {
+  type: "DATE_PART";
+  value: string;
+}
+
+export type FormatToken =
+  | DigitToken
+  | DecimalPointToken
+  | EscapedStringToken
+  | CharToken
+  | PercentToken
+  | ThousandsSeparatorToken
+  | TextPlaceholderToken
+  | DatePartToken;
+
+export function tokenizeFormat(str: string): FormatToken[][] {
+  const chars = new TokenizingChars(str);
+  const result: FormatToken[][] = [];
+
+  let currentFormatPart: FormatToken[] = [];
+  result.push(currentFormatPart);
+
+  while (!chars.isOver()) {
+    if (chars.current === ";") {
+      currentFormatPart = [];
+      result.push(currentFormatPart);
+      chars.shift();
+      continue;
+    }
+    let token =
+      tokenizeDigit(chars) ||
+      tokenizeString(chars) ||
+      tokenizeEscapedChars(chars) ||
+      tokenizeThousandsSeparator(chars) ||
+      tokenizeDecimalPoint(chars) ||
+      tokenizePercent(chars) ||
+      tokenizeDatePart(chars) ||
+      tokenizeTextPlaceholder(chars);
+
+    if (!token) {
+      throw new Error("Unknown token at " + chars.remaining());
+    }
+
+    currentFormatPart.push(token);
+  }
+  return result;
+}
+
+function tokenizeString(chars: TokenizingChars): FormatToken | null {
+  let enfOfStringChar: string | undefined;
+  if (chars.current === '"') {
+    chars.shift();
+    enfOfStringChar = '"';
+  } else if (chars.currentStartsWith("[$")) {
+    chars.advanceBy(2);
+    enfOfStringChar = "]";
+  }
+
+  if (!enfOfStringChar) {
+    return null;
+  }
+  let letters: string = "";
+  while (chars.current && chars.current !== enfOfStringChar) {
+    letters += chars.shift();
+  }
+  if (chars.current === enfOfStringChar) {
+    chars.shift();
+  } else {
+    throw new Error("Unterminated string in format");
+  }
+  return {
+    type: "ESCAPED_STRING",
+    value: letters,
+  };
+}
+
+const alwaysEscapedChars = new Set("$+-/():!^&~{}<>= ");
+
+export function shouldEscapeFormatChar(char: string): boolean {
+  return !alwaysEscapedChars.has(char);
+}
+
+function tokenizeEscapedChars(chars: TokenizingChars): FormatToken | null {
+  if (chars.current === "\\") {
+    chars.shift();
+    const escapedChar = chars.shift();
+    if (!escapedChar) {
+      throw new Error("Unexpected end of format string");
+    }
+    return {
+      type: "CHAR",
+      value: escapedChar,
+    };
+  }
+  if (alwaysEscapedChars.has(chars.current)) {
+    return {
+      type: "CHAR",
+      value: chars.shift(),
+    };
+  }
+  return null;
+}
+
+function tokenizeThousandsSeparator(chars: TokenizingChars): FormatToken | null {
+  return chars.current === "," ? { type: "THOUSANDS_SEPARATOR", value: chars.shift() } : null;
+}
+
+function tokenizeTextPlaceholder(chars: TokenizingChars): FormatToken | null {
+  return chars.current === "@" ? { type: "TEXT_PLACEHOLDER", value: chars.shift() } : null;
+}
+
+function tokenizeDecimalPoint(chars: TokenizingChars): FormatToken | null {
+  return chars.current === "." ? { type: "DECIMAL_POINT", value: chars.shift() } : null;
+}
+
+function tokenizePercent(chars: TokenizingChars): FormatToken | null {
+  return chars.current === "%" ? { type: "PERCENT", value: chars.shift() } : null;
+}
+
+function tokenizeDigit(chars: TokenizingChars): FormatToken | null {
+  if (chars.current === "0" || chars.current === "#") {
+    const value = chars.current;
+    chars.shift();
+    return { type: "DIGIT", value };
+  }
+  return null;
+}
+
+const dateSymbols = new Set("dmqyhsa");
+
+function tokenizeDatePart(chars: TokenizingChars): FormatToken | null {
+  if (!dateSymbols.has(chars.current)) {
+    return null;
+  }
+  const char = chars.current;
+  let value = "";
+  while (chars.current === char) {
+    value += chars.shift();
+  }
+  return { type: "DATE_PART", value };
+}

--- a/src/helpers/format/format_tokenize.ts
+++ b/src/helpers/format/format_tokenize.ts
@@ -40,6 +40,11 @@ export interface DatePartToken {
   value: string;
 }
 
+export interface RepeatCharToken {
+  type: "REPEATED_CHAR";
+  value: string;
+}
+
 export type FormatToken =
   | DigitToken
   | DecimalPointToken
@@ -48,7 +53,8 @@ export type FormatToken =
   | PercentToken
   | ThousandsSeparatorToken
   | TextPlaceholderToken
-  | DatePartToken;
+  | DatePartToken
+  | RepeatCharToken;
 
 export function tokenizeFormat(str: string): FormatToken[][] {
   const chars = new TokenizingChars(str);
@@ -72,7 +78,8 @@ export function tokenizeFormat(str: string): FormatToken[][] {
       tokenizeDecimalPoint(chars) ||
       tokenizePercent(chars) ||
       tokenizeDatePart(chars) ||
-      tokenizeTextPlaceholder(chars);
+      tokenizeTextPlaceholder(chars) ||
+      tokenizeRepeatedChar(chars);
 
     if (!token) {
       throw new Error("Unknown token at " + chars.remaining());
@@ -175,4 +182,20 @@ function tokenizeDatePart(chars: TokenizingChars): FormatToken | null {
     value += chars.shift();
   }
   return { type: "DATE_PART", value };
+}
+
+function tokenizeRepeatedChar(chars: TokenizingChars): FormatToken | null {
+  if (chars.current !== "*") {
+    return null;
+  }
+
+  chars.shift();
+  const repeatedChar = chars.shift();
+  if (!repeatedChar) {
+    throw new Error("Unexpected end of format string");
+  }
+  return {
+    type: "REPEATED_CHAR",
+    value: repeatedChar,
+  };
 }

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -3,7 +3,7 @@ export * from "./coordinates";
 export * from "./data_validation_helpers";
 export * from "./dates";
 export * from "./edge_scrolling";
-export * from "./format";
+export * from "./format/format";
 export * from "./misc";
 export * from "./numbers";
 export * from "./range";

--- a/src/helpers/locale.ts
+++ b/src/helpers/locale.ts
@@ -9,7 +9,7 @@ import {
   Locale,
 } from "../types";
 import { isDateTime } from "./dates";
-import { formatValue, getDecimalNumberRegex } from "./format";
+import { formatValue, getDecimalNumberRegex } from "./format/format";
 import { deepCopy } from "./misc";
 import { isNumber } from "./numbers";
 

--- a/src/helpers/misc.ts
+++ b/src/helpers/misc.ts
@@ -522,6 +522,12 @@ export function insertItemsAtIndex<T>(array: readonly T[], items: T[], index: nu
   return newArray;
 }
 
+export function replaceItemAtIndex<T>(array: readonly T[], newItem: T, index: number): T[] {
+  const newArray = [...array];
+  newArray.splice(index, 1, newItem);
+  return newArray;
+}
+
 export function trimContent(content: string): string {
   const contentLines = content.split("\n");
   return contentLines.map((line) => line.replace(/\s+/g, " ").trim()).join("\n");
@@ -576,4 +582,47 @@ export function largeMin(array: number[]) {
     min = array[len] < min ? array[len] : min;
   }
   return min;
+}
+
+export class TokenizingChars {
+  private text: string;
+  private currentIndex: number = 0;
+  current: string;
+
+  constructor(text: string) {
+    this.text = text;
+    this.current = text[0];
+  }
+
+  shift() {
+    const current = this.current;
+    const next = this.text[++this.currentIndex];
+    this.current = next;
+    return current;
+  }
+
+  advanceBy(length: number) {
+    this.currentIndex += length;
+    this.current = this.text[this.currentIndex];
+  }
+
+  isOver() {
+    return this.currentIndex >= this.text.length;
+  }
+
+  remaining() {
+    return this.text.substring(this.currentIndex);
+  }
+
+  currentStartsWith(str: string) {
+    if (this.current !== str[0]) {
+      return false;
+    }
+    for (let j = 1; j < str.length; j++) {
+      if (this.text[this.currentIndex + j] !== str[j]) {
+        return false;
+      }
+    }
+    return true;
+  }
 }

--- a/src/helpers/pivot/pivot_domain_helpers.ts
+++ b/src/helpers/pivot/pivot_domain_helpers.ts
@@ -1,0 +1,12 @@
+import { Pivot, PivotColRowDomain, PivotDomain } from "../../types";
+
+/**
+ * Split a pivot domain into the part related to the rows of the pivot, and the part related to the columns.
+ */
+export function domainToColRowDomain(pivot: Pivot, domain: PivotDomain): PivotColRowDomain {
+  const rowFields = pivot.definition.rows.map((c) => c.nameWithGranularity);
+  const rowDomain = domain.filter((node) => rowFields.includes(node.field));
+  const columnFields = pivot.definition.columns.map((c) => c.nameWithGranularity);
+  const colDomain = domain.filter((node) => columnFields.includes(node.field));
+  return { colDomain, rowDomain };
+}

--- a/src/helpers/pivot/pivot_helpers.ts
+++ b/src/helpers/pivot/pivot_helpers.ts
@@ -12,6 +12,7 @@ import {
   FunctionResultObject,
   Locale,
   Matrix,
+  Pivot,
 } from "../../types";
 import { EvaluationError } from "../../types/errors";
 import {
@@ -22,6 +23,7 @@ import {
   PivotField,
   PivotTableCell,
 } from "../../types/pivot";
+import { domainToColRowDomain } from "./pivot_domain_helpers";
 import { PivotRuntimeDefinition } from "./pivot_runtime_definition";
 import { pivotTimeAdapter } from "./pivot_time_adapter";
 
@@ -276,3 +278,22 @@ pivotToFunctionValueRegistry
   .add("integer", (value: CellValue) => `${toNumber(value, DEFAULT_LOCALE)}`)
   .add("boolean", (value: CellValue) => (toBoolean(value) ? "TRUE" : "FALSE"))
   .add("char", (value: CellValue) => `"${toString(value).replace(/"/g, '\\"')}"`);
+
+export function addRowIndentToPivotHeader(
+  pivot: Pivot,
+  domain: PivotDomain,
+  functionResult: FunctionResultObject
+): FunctionResultObject {
+  const { rowDomain } = domainToColRowDomain(pivot, domain);
+  if (rowDomain.length === 0) {
+    return functionResult;
+  }
+  const indent = rowDomain.length - 1;
+
+  const format = functionResult.format || "@";
+
+  return {
+    ...functionResult,
+    format: `${"    ".repeat(indent)}${format}* `,
+  };
+}

--- a/src/helpers/pivot/pivot_time_adapter.ts
+++ b/src/helpers/pivot/pivot_time_adapter.ts
@@ -4,7 +4,7 @@ import { _t } from "../../translation";
 import { CellValue, DEFAULT_LOCALE } from "../../types";
 import { EvaluationError } from "../../types/errors";
 import { Granularity, PivotTimeAdapter, PivotTimeAdapterNotNull } from "../../types/pivot";
-import { MONTHS, formatValue } from "../format";
+import { MONTHS, formatValue } from "../format/format";
 
 export const pivotTimeAdapterRegistry = new Registry<PivotTimeAdapter<CellValue>>();
 

--- a/src/helpers/pivot/pivot_time_adapter.ts
+++ b/src/helpers/pivot/pivot_time_adapter.ts
@@ -117,7 +117,7 @@ const monthNumberAdapter: PivotTimeAdapterNotNull<number> = {
   toValueAndFormat(normalizedValue) {
     return {
       value: MONTHS[toNumber(normalizedValue, DEFAULT_LOCALE) - 1].toString(),
-      format: "0",
+      format: "@",
     };
   },
   toFunctionValue(normalizedValue) {
@@ -141,7 +141,7 @@ const quarterNumberAdapter: PivotTimeAdapterNotNull<number> = {
   toValueAndFormat(normalizedValue) {
     return {
       value: _t("Q%(quarter_number)s", { quarter_number: normalizedValue }),
-      format: "0",
+      format: "@",
     };
   },
   toFunctionValue(normalizedValue) {

--- a/src/helpers/pivot/spreadsheet_pivot/spreadsheet_pivot.ts
+++ b/src/helpers/pivot/spreadsheet_pivot/spreadsheet_pivot.ts
@@ -25,7 +25,7 @@ import {
 } from "../../../types/pivot";
 import { InitPivotParams, Pivot } from "../../../types/pivot_runtime";
 import { toXC } from "../../coordinates";
-import { isDateTimeFormat } from "../../format";
+import { isDateTimeFormat } from "../../format/format";
 import { isDefined } from "../../misc";
 import {
   AGGREGATORS_FN,

--- a/src/model.ts
+++ b/src/model.ts
@@ -3,7 +3,7 @@ import { LocalTransportService } from "./collaborative/local_transport_service";
 import { Session } from "./collaborative/session";
 import { DEFAULT_REVISION_ID } from "./constants";
 import { EventBus } from "./helpers/event_bus";
-import { deepCopy, UuidGenerator } from "./helpers/index";
+import { UuidGenerator, deepCopy } from "./helpers/index";
 import { buildRevisionLog } from "./history/factory";
 import {
   createEmptyExcelWorkbookData,
@@ -30,7 +30,6 @@ import { _t, setDefaultTranslationMethod } from "./translation";
 import { StateUpdateMessage, TransportService } from "./types/collaborative/transport_service";
 import { FileStore } from "./types/files";
 import {
-  canExecuteInReadonly,
   Client,
   ClientPosition,
   Color,
@@ -44,15 +43,15 @@ import {
   Currency,
   DEFAULT_LOCALES,
   DispatchResult,
-  Format,
   Getters,
   GridRenderingContext,
   InformationNotification,
-  isCoreCommand,
   LayerName,
   LocalCommand,
   Locale,
   UID,
+  canExecuteInReadonly,
+  isCoreCommand,
 } from "./types/index";
 import { WorkbookData } from "./types/workbook_data";
 import { XLSXExport } from "./types/xlsx";
@@ -95,7 +94,7 @@ export interface ModelConfig {
   readonly custom: Readonly<{
     [key: string]: any;
   }>;
-  readonly defaultCurrencyFormat?: Format;
+  readonly defaultCurrency?: Partial<Currency>;
   /**
    * External dependencies required to enable some features
    * such as uploading images.
@@ -451,7 +450,7 @@ export class Model extends EventBus<any> implements CommandDispatcher {
       custom: this.config.custom,
       uiActions: this.config,
       session: this.session,
-      defaultCurrencyFormat: this.config.defaultCurrencyFormat,
+      defaultCurrency: this.config.defaultCurrency,
       customColors: this.config.customColors || [],
     };
   }

--- a/src/plugins/core/cell.ts
+++ b/src/plugins/core/cell.ts
@@ -2,7 +2,7 @@ import { DEFAULT_STYLE } from "../../constants";
 import { Token, compile } from "../../formulas";
 import { compileTokens } from "../../formulas/compiler";
 import { isEvaluationError, toString } from "../../functions/helpers";
-import { deepEquals, isExcelCompatible, recomputeZones } from "../../helpers";
+import { deepEquals, isExcelCompatible, isTextFormat, recomputeZones } from "../../helpers";
 import { parseLiteral } from "../../helpers/cells";
 import {
   concat,
@@ -30,7 +30,6 @@ import {
   FormulaCell,
   HeaderIndex,
   LiteralCell,
-  PLAIN_TEXT_FORMAT,
   PositionDependentCommand,
   Range,
   RangeCompiledFormula,
@@ -575,7 +574,7 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
       (typeof parsedValue === "number"
         ? detectDateFormat(content, locale) || detectNumberFormat(content)
         : undefined);
-    if (format !== PLAIN_TEXT_FORMAT && !isEvaluationError(content)) {
+    if (!isTextFormat(format) && !isEvaluationError(content)) {
       content = toString(parsedValue);
     }
     return {

--- a/src/plugins/ui_feature/format.ts
+++ b/src/plugins/ui_feature/format.ts
@@ -49,8 +49,7 @@ export class FormatPlugin extends UIPlugin {
         if (numberFormat !== undefined) {
           // Depending on the step sign, increase or decrease the decimal representation
           // of the format
-          const locale = this.getters.getLocale();
-          const newFormat = changeDecimalPlaces(numberFormat, step, locale);
+          const newFormat = changeDecimalPlaces(numberFormat, step);
           // Apply the new format on the whole zone
           this.dispatch("SET_FORMATTING", {
             sheetId,

--- a/src/plugins/ui_feature/ui_sheet.ts
+++ b/src/plugins/ui_feature/ui_sheet.ts
@@ -2,6 +2,7 @@ import { GRID_ICON_MARGIN, ICON_EDGE_LENGTH, PADDING_AUTORESIZE_HORIZONTAL } fro
 import {
   computeIconWidth,
   computeTextWidth,
+  formatValue,
   isEqual,
   largeMax,
   positions,
@@ -118,12 +119,24 @@ export class SheetUIPlugin extends UIPlugin {
     return computeTextWidth(this.ctx, text, style);
   }
 
-  getCellText(position: CellPosition, showFormula: boolean = false): string {
+  getCellText(position: CellPosition, args?: { showFormula?: boolean; maxWidth?: number }): string {
     const cell = this.getters.getCell(position);
-    if (showFormula && cell?.isFormula) {
-      return localizeFormula(cell.content, this.getters.getLocale());
+    const locale = this.getters.getLocale();
+    if (args?.showFormula && cell?.isFormula) {
+      return localizeFormula(cell.content, locale);
     } else {
-      return this.getters.getEvaluatedCell(position).formattedValue;
+      const evaluatedCell = this.getters.getEvaluatedCell(position);
+      const formatWidth = args?.maxWidth
+        ? {
+            maxWidth: args.maxWidth,
+            measureText: (text: string) => computeTextWidth(this.ctx, text, cell?.style || {}),
+          }
+        : undefined;
+      return formatValue(evaluatedCell.value, {
+        format: evaluatedCell.format,
+        locale,
+        formatWidth,
+      });
     }
   }
 
@@ -131,10 +144,16 @@ export class SheetUIPlugin extends UIPlugin {
    * Return the text of a cell, split in multiple lines if needed. The text will be split in multiple
    * line if it contains NEWLINE characters, or if it's longer than the given width.
    */
-  getCellMultiLineText(position: CellPosition, width: number | undefined): string[] {
+  getCellMultiLineText(
+    position: CellPosition,
+    args: { wrapText: boolean; maxWidth: number }
+  ): string[] {
     const style = this.getters.getCellStyle(position);
-    const text = this.getters.getCellText(position, this.getters.shouldShowFormulas());
-    return splitTextToWidth(this.ctx, text, style, width);
+    const text = this.getters.getCellText(position, {
+      showFormula: this.getters.shouldShowFormulas(),
+      maxWidth: args.maxWidth,
+    });
+    return splitTextToWidth(this.ctx, text, style, args.wrapText ? args.maxWidth : undefined);
   }
 
   doesCellHaveGridIcon(position: CellPosition): boolean {

--- a/src/plugins/ui_plugin.ts
+++ b/src/plugins/ui_plugin.ts
@@ -7,7 +7,7 @@ import {
   Color,
   Command,
   CommandDispatcher,
-  Format,
+  Currency,
   Getters,
   GridRenderingContext,
   LayerName,
@@ -26,7 +26,7 @@ export interface UIPluginConfig {
   readonly uiActions: UIActions;
   readonly custom: ModelConfig["custom"];
   readonly session: Session;
-  readonly defaultCurrencyFormat?: Format;
+  readonly defaultCurrency?: Partial<Currency>;
   readonly customColors: Color[];
 }
 

--- a/src/registries/autofill_modifiers.ts
+++ b/src/registries/autofill_modifiers.ts
@@ -1,5 +1,5 @@
 import { evaluateLiteral } from "../helpers/cells";
-import { formatValue } from "../helpers/format";
+import { formatValue } from "../helpers/format/format";
 import {
   AutofillData,
   AutofillModifierImplementation,

--- a/src/registries/menus/number_format_menu_registry.ts
+++ b/src/registries/menus/number_format_menu_registry.ts
@@ -35,6 +35,11 @@ numberFormatMenuRegistry
     id: "format_number_currency",
     sequence: 40,
   })
+  .add("format_number_accounting", {
+    ...ACTION_FORMAT.formatNumberAccounting,
+    id: "format_number_accounting",
+    sequence: 45,
+  })
   .add("format_number_currency_rounded", {
     ...ACTION_FORMAT.formatNumberCurrencyRounded,
     id: "format_number_currency_rounded",

--- a/src/stores/grid_renderer_store.ts
+++ b/src/stores/grid_renderer_store.ts
@@ -623,9 +623,9 @@ export class GridRenderer {
     /** Content */
     const style = this.getters.getCellComputedStyle(position);
     const wrapping = style.wrapping || "overflow";
-    const maxWidth =
-      wrapping === "wrap" && !showFormula ? width - 2 * MIN_CELL_TEXT_MARGIN : undefined;
-    const multiLineText = this.getters.getCellMultiLineText(position, maxWidth);
+    const wrapText = wrapping === "wrap" && !showFormula;
+    const maxWidth = width - 2 * MIN_CELL_TEXT_MARGIN;
+    const multiLineText = this.getters.getCellMultiLineText(position, { maxWidth, wrapText });
     const textWidth = Math.max(
       ...multiLineText.map((line) => this.getters.getTextWidth(line, style) + MIN_CELL_TEXT_MARGIN)
     );

--- a/src/types/format.ts
+++ b/src/types/format.ts
@@ -9,5 +9,3 @@ export interface LocaleFormat {
   locale: Locale;
   format?: Format;
 }
-
-export const PLAIN_TEXT_FORMAT: Format = "@"; // see OpenXML spec §18.8.31

--- a/src/types/pivot.ts
+++ b/src/types/pivot.ts
@@ -153,3 +153,9 @@ export interface PivotNode {
 }
 
 export type PivotDomain = PivotNode[];
+
+/** Pivot domain splitted for the domain related to the pivot's rows and columns  */
+export interface PivotColRowDomain {
+  colDomain: PivotDomain;
+  rowDomain: PivotDomain;
+}

--- a/src/xlsx/conversion/conversion_maps.ts
+++ b/src/xlsx/conversion/conversion_maps.ts
@@ -4,7 +4,6 @@ import {
   BorderStyle,
   ConditionalFormattingOperatorValues,
   ExcelChartType,
-  PLAIN_TEXT_FORMAT,
   ThresholdType,
   VerticalAlign,
 } from "../../types";
@@ -262,7 +261,7 @@ export const XLSX_FORMATS_CONVERSION_MAP: Record<number, string | undefined> = {
   46: "hhhh:mm:ss",
   47: "hhhh:mm:ss",
   48: undefined,
-  49: PLAIN_TEXT_FORMAT,
+  49: "@",
 };
 
 /**

--- a/src/xlsx/conversion/format_conversion.ts
+++ b/src/xlsx/conversion/format_conversion.ts
@@ -25,24 +25,11 @@ export function convertXlsxFormat(
 
   if (format) {
     try {
-      let convertedFormat = format.replace(/(.*?);.*/, "$1"); // only take first part of multi-part format
-      convertedFormat = convertedFormat.replace(/\[(.*)-[A-Z0-9]{3}\]/g, "[$1]"); // remove currency and locale/date system/number system info (ECMA §18.8.31)
+      let convertedFormat = format.replace(/\[(.*)-[A-Z0-9]{3}\]/g, "[$1]"); // remove currency and locale/date system/number system info (ECMA §18.8.31)
       convertedFormat = convertedFormat.replace(/\[\$\]/g, ""); // remove empty bocks
-
-      // Quotes in format escape sequences of characters. ATM we only support [$...] blocks to escape characters, and only one of them per format
-      const numberOfQuotes = convertedFormat.match(/"/g)?.length || 0;
-      const numberOfOpenBrackets = convertedFormat.match(/\[/g)?.length || 0;
-      if (numberOfQuotes / 2 + numberOfOpenBrackets > 1) {
-        throw new Error("Multiple escaped blocks in format");
-      }
-      convertedFormat = convertedFormat.replace(/"(.*)"/g, "[$$$1]"); // replace '"..."' by '[$...]'
 
       convertedFormat = convertedFormat.replace(/_.{1}/g, ""); // _ === ignore width of next char for align purposes. Not supported ATM
       convertedFormat = convertedFormat.replace(/\*.{1}/g, ""); // * === repeat next character enough to fill the line. Not supported ATM
-
-      convertedFormat = convertedFormat.replace(/\\ /g, " "); // unescape spaces
-
-      convertedFormat = convertedFormat.replace(/\\./g, (match) => match[1]); // unescape other characters
 
       if (isXlsxDateFormat(convertedFormat)) {
         convertedFormat = convertDateFormat(convertedFormat);

--- a/src/xlsx/functions/worksheet.ts
+++ b/src/xlsx/functions/worksheet.ts
@@ -3,13 +3,14 @@ import {
   isInside,
   isMarkdownLink,
   isSheetUrl,
+  isTextFormat,
   parseMarkdownLink,
   parseSheetUrl,
   toXC,
   toZone,
 } from "../../helpers";
 import { withHttps } from "../../helpers/links";
-import { ExcelHeaderData, ExcelSheetData, ExcelWorkbookData, PLAIN_TEXT_FORMAT } from "../../types";
+import { ExcelHeaderData, ExcelSheetData, ExcelWorkbookData } from "../../types";
 import { CellErrorType } from "../../types/errors";
 import { XLSXStructure, XMLAttributes, XMLString } from "../../types/xlsx";
 import { XLSX_RELATION_TYPE } from "../constants";
@@ -105,7 +106,7 @@ export function addRows(
           ({ attrs: additionalAttrs, node: cellNode } = addContent(label, construct.sharedStrings));
         } else if (cell.content && cell.content !== "") {
           const isTableHeader = isCellTableHeader(c, r, sheet);
-          const isPlainText = !!(cell.format && data.formats[cell.format] === PLAIN_TEXT_FORMAT);
+          const isPlainText = !!(cell.format && isTextFormat(data.formats[cell.format]));
           ({ attrs: additionalAttrs, node: cellNode } = addContent(
             cell.content,
             construct.sharedStrings,

--- a/tests/__snapshots__/top_bar_component.test.ts.snap
+++ b/tests/__snapshots__/top_bar_component.test.ts.snap
@@ -768,6 +768,34 @@ exports[`TopBar component can set cell format 1`] = `
         
         <div
           class="o-menu-item d-flex justify-content-between align-items-center"
+          data-name="format_number_accounting"
+          title="Accounting"
+        >
+          <div
+            class="d-flex w-100"
+          >
+            <div
+              class="o-menu-item-icon d-flex align-items-center flex-shrink-0"
+            />
+            
+            <div
+              class="o-menu-item-name align-middle text-truncate"
+            >
+              Accounting
+            </div>
+            <div
+              class="o-menu-item-description ms-auto text-truncate"
+            >
+              $(1,000.12)
+            </div>
+            
+            
+            
+          </div>
+        </div>
+        
+        <div
+          class="o-menu-item d-flex justify-content-between align-items-center"
           data-name="format_number_currency_rounded"
           title="Currency rounded"
         >

--- a/tests/evaluation/compiler.test.ts
+++ b/tests/evaluation/compiler.test.ts
@@ -189,7 +189,7 @@ describe("compile functions", () => {
         compute: (arg1, arg2) => {
           return {
             value: arg2 === undefined,
-            format: arg2 === undefined ? "TRUE" : "FALSE",
+            format: arg2 === undefined ? '"TRUE"' : '"FALSE"',
           };
         },
       });
@@ -202,8 +202,8 @@ describe("compile functions", () => {
         ],
         compute: (arg1, arg2 = { value: 42, format: "42" }) => {
           return !Array.isArray(arg2) && arg2.value === 42 && arg2.format === "42"
-            ? { value: true, format: "TRUE" }
-            : { value: false, format: "FALSE" };
+            ? { value: true, format: '"TRUE"' }
+            : { value: false, format: '"FALSE"' };
         },
       });
     });
@@ -212,17 +212,17 @@ describe("compile functions", () => {
     });
     test("empty value interpreted as undefined", () => {
       expect(evaluateCell("A1", { A1: "=ISSECONDARGUNDEFINED(1,)" })).toBe(true);
-      expect(evaluateCellFormat("A1", { A1: "=ISSECONDARGUNDEFINED(1,)" })).toBe("TRUE");
+      expect(evaluateCellFormat("A1", { A1: "=ISSECONDARGUNDEFINED(1,)" })).toBe('"TRUE"');
     });
 
     test("if default value --> empty value interpreted as default value", () => {
       expect(evaluateCell("A1", { A1: "=SECONDARGDEFAULTVALUEEQUAL42(1,)" })).toBe(true);
-      expect(evaluateCellFormat("A1", { A1: "=SECONDARGDEFAULTVALUEEQUAL42(1,)" })).toBe("TRUE");
+      expect(evaluateCellFormat("A1", { A1: "=SECONDARGDEFAULTVALUEEQUAL42(1,)" })).toBe('"TRUE"');
     });
 
     test("if default value --> non-value interpreted as default value", () => {
       expect(evaluateCell("A1", { A1: "=SECONDARGDEFAULTVALUEEQUAL42(1)" })).toBe(true);
-      expect(evaluateCellFormat("A1", { A1: "=SECONDARGDEFAULTVALUEEQUAL42(1)" })).toBe("TRUE");
+      expect(evaluateCellFormat("A1", { A1: "=SECONDARGDEFAULTVALUEEQUAL42(1)" })).toBe('"TRUE"');
     });
   });
 

--- a/tests/figures/chart/chart_plugin.test.ts
+++ b/tests/figures/chart/chart_plugin.test.ts
@@ -1862,10 +1862,14 @@ describe("Chart design configuration", () => {
       (chartType) => {
         setCellFormat(model, "A2", "[$$]#,##0.00");
         createChart(model, { ...defaultChart, type: chartType as "bar" | "line" }, "42");
-        //@ts-ignore
         expect(
           getChartConfiguration(model, "42").options.scales.y?.ticks.callback!(60000000)
         ).toEqual("$60,000,000.00");
+
+        setCellFormat(model, "A2", "[$$]*A#,##"); // We should ignore repeated characters in format
+        expect(
+          getChartConfiguration(model, "42").options.scales.y?.ticks.callback!(60000000)
+        ).toEqual("$60,000,000");
       }
     );
 

--- a/tests/figures/chart/charts_component.test.ts
+++ b/tests/figures/chart/charts_component.test.ts
@@ -1797,7 +1797,7 @@ describe("charts", () => {
     const updateChart = jest.spyOn((window as any).Chart.prototype, "update");
     createTestChart("basicChart");
     await nextTick();
-    setCellFormat(model, "B2", "#.##0.00");
+    setCellFormat(model, "B2", "#,##0.00");
     await nextTick();
     expect(updateChart).toHaveBeenCalled();
   });

--- a/tests/formats/__snapshots__/custom_currency_side_panel_component.test.ts.snap
+++ b/tests/formats/__snapshots__/custom_currency_side_panel_component.test.ts.snap
@@ -25,7 +25,7 @@ exports[`Provided Currencies if currencies are provided in spreadsheet --> displ
 
 exports[`custom currency sidePanel component Sidepanel change code input or symbol input --> change currency proposals 1`] = `
 <select
-  class="o-input o-format-proposals"
+  class="o-input o-format-proposals mb-1"
 >
   <option
     value="0"
@@ -73,7 +73,7 @@ exports[`custom currency sidePanel component Sidepanel change code input or symb
 
 exports[`custom currency sidePanel component Sidepanel change code input or symbol input --> change currency proposals 2`] = `
 <select
-  class="o-input o-format-proposals"
+  class="o-input o-format-proposals mb-1"
 >
   <option
     value="0"
@@ -121,7 +121,7 @@ exports[`custom currency sidePanel component Sidepanel change code input or symb
 
 exports[`custom currency sidePanel component Sidepanel change code input or symbol input --> change currency proposals 3`] = `
 <select
-  class="o-input o-format-proposals"
+  class="o-input o-format-proposals mb-1"
 >
   <option
     value="0"
@@ -169,7 +169,7 @@ exports[`custom currency sidePanel component Sidepanel change code input or symb
 
 exports[`custom currency sidePanel component Sidepanel change code input or symbol input --> change currency proposals 4`] = `
 <select
-  class="o-input o-format-proposals"
+  class="o-input o-format-proposals mb-1"
 >
   <option
     value="0"
@@ -217,7 +217,7 @@ exports[`custom currency sidePanel component Sidepanel change code input or symb
 
 exports[`custom currency sidePanel component Sidepanel select currency in available currencies selector --> changes currency proposals 1`] = `
 <select
-  class="o-input o-format-proposals"
+  class="o-input o-format-proposals mb-1"
 >
   <option
     value="0"
@@ -265,7 +265,7 @@ exports[`custom currency sidePanel component Sidepanel select currency in availa
 
 exports[`custom currency sidePanel component Sidepanel select currency in available currencies selector --> changes currency proposals 2`] = `
 <select
-  class="o-input o-format-proposals"
+  class="o-input o-format-proposals mb-1"
 >
   <option
     value="0"

--- a/tests/formats/custom_currency_side_panel_component.test.ts
+++ b/tests/formats/custom_currency_side_panel_component.test.ts
@@ -442,9 +442,9 @@ describe("custom currency sidePanel component", () => {
 
     expect(getExampleValues()).toEqual(["1,235€", "-1,235€", "0€"]);
     await click(fixture, selectors.accountingFormatCheckbox);
-    expect(getExampleValues()).toEqual(["1,235€", "(1,235)€", "-€"]);
+    expect(getExampleValues()).toEqual([" 1,235 €", "(1,235)€", "  -  €"]);
     await click(fixture, selectors.applyFormat);
-    expect(getCell(model, "A1")?.format).toBe("#,##0[$€];(#,##0)[$€];-[$€]");
+    expect(getCell(model, "A1")?.format).toBe("*  #,##0 [$€];* (#,##0)[$€];*   -  [$€]");
   });
 });
 

--- a/tests/formats/custom_currency_side_panel_component.test.ts
+++ b/tests/formats/custom_currency_side_panel_component.test.ts
@@ -5,6 +5,7 @@ import { Currency } from "../../src/types/currency";
 import { setSelection, updateLocale } from "../test_helpers/commands_helpers";
 import { FR_LOCALE } from "../test_helpers/constants";
 import { click, setInputValueAndTrigger } from "../test_helpers/dom_helper";
+import { getCell } from "../test_helpers/getters_helpers";
 import { mountComponent, nextTick, spyModelDispatch } from "../test_helpers/helpers";
 jest.mock("../../src/helpers/uuid", () => require("../__mocks__/uuid"));
 jest.useFakeTimers();
@@ -15,6 +16,7 @@ const selectors = {
   inputSymbol: ".o-custom-currency .o-subsection-right input",
   formatProposals: ".o-custom-currency .o-format-proposals",
   formatProposalOptions: ".o-custom-currency .o-format-proposals option",
+  accountingFormatCheckbox: ".o-custom-currency input[name='accountingFormat']",
   applyFormat: ".o-custom-currency .o-sidePanelButtons button",
 };
 
@@ -48,6 +50,11 @@ let dispatch: jest.SpyInstance;
 let currenciesContent: { [key: string]: Currency };
 let model: Model;
 let fixture: HTMLElement;
+
+function getExampleValues() {
+  const tableRows = fixture.querySelectorAll(".o-custom-currency table tr");
+  return Array.from(tableRows).map((row) => row.children[1].textContent);
+}
 
 describe("custom currency sidePanel component", () => {
   beforeEach(async () => {
@@ -429,6 +436,16 @@ describe("custom currency sidePanel component", () => {
       );
     }
   );
+
+  test("Can apply accounting format in the panel", async () => {
+    await setInputValueAndTrigger(selectors.inputSymbol, "€");
+
+    expect(getExampleValues()).toEqual(["1,235€", "-1,235€", "0€"]);
+    await click(fixture, selectors.accountingFormatCheckbox);
+    expect(getExampleValues()).toEqual(["1,235€", "(1,235)€", "-€"]);
+    await click(fixture, selectors.applyFormat);
+    expect(getCell(model, "A1")?.format).toBe("#,##0[$€];(#,##0)[$€];-[$€]");
+  });
 });
 
 describe("Provided Currencies", () => {

--- a/tests/formats/format_helpers.test.ts
+++ b/tests/formats/format_helpers.test.ts
@@ -11,14 +11,25 @@ import { FR_LOCALE } from "../test_helpers/constants";
 const locale = DEFAULT_LOCALE;
 
 describe("formatValue on string", () => {
-  test("apply on regular strings", () => {
+  test("Number format have no impact on string", () => {
     expect(formatValue("", { locale })).toBe("");
     expect(formatValue("test", { locale })).toBe("test");
     expect(formatValue("test", { locale, format: "#,###.0" })).toBe("test");
   });
 
-  test("apply on strings with escape characters", () => {
+  test("Number format have no impact on strings with escape characters", () => {
     expect(formatValue('Hello \\"world\\"', { locale })).toBe('Hello "world"');
+  });
+
+  test("Text format on string", () => {
+    expect(formatValue("test", { locale, format: "[$Hey] @" })).toBe("Hey test");
+    expect(formatValue("test", { locale, format: '"€"@$\\C' })).toBe("€test$C");
+    expect(formatValue("test", { locale, format: "@ $$ @" })).toBe("test $$ test");
+  });
+
+  test("Booleans are formatted as string", () => {
+    expect(formatValue(true, { locale, format: "[$Hey] @" })).toBe("Hey TRUE");
+    expect(formatValue(false, { locale, format: '"€" @ $\\C' })).toBe("€ FALSE $C");
   });
 });
 
@@ -251,11 +262,11 @@ describe("formatValue on number", () => {
 
   test("apply format with thousand separator", () => {
     expect(formatValue(100, { format: "000", locale })).toBe("100");
-    expect(formatValue(100, { format: ",000", locale })).toBe("100");
+    expect(formatValue(100, { format: ",000", locale })).toBe(",100"); // Thousand separator not between digits is a simple string
     expect(formatValue(100, { format: "0,00", locale })).toBe("100");
 
     expect(formatValue(1000, { format: "000", locale })).toBe("1000");
-    expect(formatValue(1000, { format: ",000", locale })).toBe("1,000");
+    expect(formatValue(1000, { format: ",000", locale })).toBe(",1000");
     expect(formatValue(1000, { format: "0,00", locale })).toBe("1,000");
 
     expect(formatValue(1000, { format: "#,##0", locale })).toBe("1,000");
@@ -263,12 +274,21 @@ describe("formatValue on number", () => {
     expect(formatValue(100000, { format: "#,##0", locale })).toBe("100,000");
     expect(formatValue(1000000, { format: "#,##0", locale })).toBe("1,000,000");
 
-    expect(() => formatValue(1000, { format: "###0.0,0", locale })).toThrow(
-      "A format can't contain ',' symbol in the decimal part"
-    );
-    expect(() => formatValue(1000, { format: "#,##,0.0", locale })).toThrow(
-      "A format can only contain a single ',' symbol"
-    );
+    expect(formatValue(1000, { format: "###0.0,0", locale })).toBe("1000.00"); // Thousand separator is ignored in decimal part
+    expect(formatValue(1000, { format: "#,##,0.0", locale })).toBe("1,000.0"); // Multiple thousand separator are ignored
+  });
+
+  test("apply format with thousand separator as a magnitude marker", () => {
+    // Thousand separator at the end of the number placeholder divide the number by 1000
+    expect(formatValue(100, { format: "00,", locale })).toBe("00");
+    expect(formatValue(100, { format: "##.0,", locale })).toBe(".1");
+    expect(formatValue(1000, { format: "00,", locale })).toBe("01");
+    expect(formatValue(123456789, { format: "0,0.000,", locale })).toBe("123,456.789");
+    expect(formatValue(1.234, { format: "0.0000,", locale })).toBe("0.0012");
+
+    expect(formatValue(5000000, { format: "0,,", locale })).toBe("5");
+    expect(formatValue(5000000, { format: "0,,%", locale })).toBe("500%");
+    expect(formatValue(5, { format: "0%,,", locale })).toBe("500%,,"); // Thousand separator not at the end of number placeholder
   });
 
   test.each([
@@ -279,14 +299,13 @@ describe("formatValue on number", () => {
   ])("apply normal percent format: 0.00%", (value, result) => {
     expect(formatValue(value, { format: "0.00%", locale })).toBe(result);
   });
+
   test("apply various percent format", () => {
     expect(formatValue(0.1234, { format: "0%", locale })).toBe("12%");
     expect(formatValue(0.1234, { format: "0.0%", locale })).toBe("12.3%");
     expect(formatValue(0.1234, { format: "0.00%", locale })).toBe("12.34%");
     expect(formatValue(0.1234, { format: "0.000%", locale })).toBe("12.340%");
-    expect(() => formatValue(0.1234, { format: "0.%0%", locale })).toThrow(
-      "A format can only contain a single '%' symbol"
-    );
+    expect(formatValue(0.1234, { format: "0.%0%", locale })).toBe("1234.%0%"); // Each % symbol in the format multiply by 100 the value
   });
 
   test("various percent format give the same result for infinity", () => {
@@ -298,9 +317,10 @@ describe("formatValue on number", () => {
 
   test("can apply format with custom currencies", () => {
     expect(formatValue(1234, { format: "#,##0[$TEST]", locale })).toBe("1,234TEST");
-    expect(formatValue(1234, { format: "#,##0 [$TEST]", locale })).toBe("1,234TEST");
+    expect(formatValue(1234, { format: '#,##0 "TEST"', locale })).toBe("1,234 TEST");
+    expect(formatValue(1234, { format: "#,##0 \\€", locale })).toBe("1,234 €");
     expect(formatValue(1234, { format: "#,##0[$ TEST]", locale })).toBe("1,234 TEST");
-    expect(formatValue(1234, { format: "#,##0[$  TEST ]", locale })).toBe("1,234  TEST ");
+    expect(formatValue(1234, { format: '#,##0"  TEST "', locale })).toBe("1,234  TEST ");
     expect(formatValue(1234, { format: "#,##0[$ kikou lol ]", locale })).toBe("1,234 kikou lol ");
     expect(formatValue(1234, { format: "[$ tune ]#,##0.0", locale })).toBe(" tune 1,234.0");
     expect(
@@ -317,18 +337,45 @@ describe("formatValue on number", () => {
     );
   });
 
-  test("with brackets inside the string", () => {
-    expect(() => formatValue(1234, { format: "[$[]#,##0.0", locale })).toThrow();
-    expect(() => formatValue(1234, { format: "[$]]#,##0.0", locale })).toThrow();
-    expect(() => formatValue(1234, { format: "[$[]]#,##0.0", locale })).toThrow();
-    expect(() => formatValue(1234, { format: "[$][]#,##0.0", locale })).toThrow();
+  test("Can escape strings or characters in format", () => {
+    expect(formatValue(5, { format: "0\\%", locale })).toBe("5%");
+    expect(formatValue(5, { format: "0\\€", locale })).toBe("5€");
+    expect(() => formatValue(5, { format: "0€", locale })).toThrow();
+    expect(formatValue(5, { format: "0[$€]", locale })).toBe("5€");
+    expect(formatValue(5, { format: '0"€"', locale })).toBe("5€");
+    expect(formatValue(5, { format: '0"+"', locale })).toBe("5+");
+    expect(formatValue(123, { format: '"000"#', locale })).toBe("000123");
+
+    expect(() => formatValue(5, { format: '0"€', locale })).toThrow();
+    expect(() => formatValue(5, { format: "0[$", locale })).toThrow();
+    expect(() => formatValue(5, { format: "0\\", locale })).toThrow();
+  });
+
+  test("Some characters are always escaped in format string", () => {
+    for (const char of "$+-/():!^&~{}<>= ") {
+      expect(formatValue(5, { format: `0${char}`, locale })).toBe(`5${char}`);
+    }
+  });
+
+  test("Escaped string in the middle of a number format", () => {
+    expect(formatValue(1234, { format: '0"Str"000', locale })).toBe("1Str234");
+    expect(formatValue(1234, { format: '#,##0"Str"0', locale })).toBe("1,23Str4");
+    expect(formatValue(1234, { format: '#,##0"Str"0.00', locale })).toBe("1,23Str4.00");
+    expect(formatValue(1.234, { format: '0.0"Str"0', locale })).toBe("1.2Str3");
+    expect(formatValue(1234, { format: '0.0"Str"0,', locale })).toBe("1.2Str3");
+  });
+
+  test("Multiple escaped strings in a number format", () => {
+    expect(formatValue(1234, { format: '[$$]0"€"', locale })).toBe("$1234€");
+    expect(formatValue(1234, { format: "[$$]0.00[$€]0", locale })).toBe("$1234.00€0");
+    expect(formatValue(1234, { format: '0"$"0"€"', locale })).toBe("123$4€");
   });
 
   test.each(["#,##0 dd", "dd #,##0", "#,##0 dd/mm/yyyy", "dd/mm/yyyy #,##0"])(
     "mixing date and numbers",
     (format) => {
       expect(() => formatValue(1234, { format, locale })).toThrow(
-        `Invalid number format: ${format}`
+        `Invalid first format part of: ${format}`
       );
     }
   );
@@ -337,6 +384,15 @@ describe("formatValue on number", () => {
     expect(formatValue(1234, { format: "[$TEST]#,##0[$TEST]", locale })).toBe("TEST1,234TEST");
     expect(formatValue(1234, { format: "#,##0[$TEST][$TEST]", locale })).toBe("1,234TESTTEST");
     expect(formatValue(1234, { format: "[$TEST][$TEST]#,##0", locale })).toBe("TESTTEST1,234");
+  });
+
+  test("Cannot mix text, date and number formats", () => {
+    expect(() => formatValue(1234, { format: "#,##0 dd", locale })).toThrow();
+    expect(() => formatValue(1234, { format: "0 mm", locale })).toThrow();
+    expect(() => formatValue(1234, { format: "# yyyy", locale })).toThrow();
+    expect(() => formatValue(1234, { format: "@ dd", locale })).toThrow();
+    expect(() => formatValue(1234, { format: "# @", locale })).toThrow();
+    expect(() => formatValue(1234, { format: "@0", locale })).toThrow();
   });
 });
 
@@ -632,7 +688,7 @@ describe("formatValue on date and time", () => {
         ["12 5 2020 23:69", "12 6 2020 00:09:00"],
         ["12 5 2020 25 AM", "12 5 2020 01:00 PM"],
         ["12 5 2020 25:70 PM", "12 6 2020 02:10:00"],
-      ])("increment time test with 'm d yyyy'", (value, result) => {
+      ])("increment time test with m d yyyy", (value, result) => {
         const parsedDateTime = parseDateTime(value, locale)!;
         expect(
           formatValue(parsedDateTime.value, {
@@ -726,6 +782,7 @@ describe("formatValue on date and time", () => {
     test.each([
       [internalDate.format, "01/02/1954"],
       ["m/d/yyyy", "1/2/1954"],
+      ["m.d.yyyy", "1.2.1954"],
       ["mm/dd/yyyy", "01/02/1954"],
       ["mm/dd", "01/02"],
       ["m/d", "1/2"],
@@ -968,6 +1025,18 @@ describe("formatValue on date and time", () => {
       expect(formatValue(value, { format: "hhhh:mm:ss", locale })).toBe(result);
     });
   });
+
+  test("Date formats with escaped strings", () => {
+    const date = parseDateTime("01/01/2023 12:08:06", locale)!.value;
+    expect(formatValue(date, { format: "[$$]mm/dd/yyyy", locale })).toBe("$01/01/2023");
+    expect(formatValue(date, { format: "mm/dd/yyyy[$$]", locale })).toBe("01/01/2023$");
+    expect(formatValue(date, { format: "[$$]mm/dd/yyyy[$$]", locale })).toBe("$01/01/2023$");
+
+    expect(formatValue(date, { format: "[$$]mm+ddyyyy", locale })).toBe("$01+012023");
+    expect(formatValue(date, { format: 'mm.dd" Hey! "yyyy', locale })).toBe("01.01 Hey! 2023");
+
+    expect(formatValue(date, { format: 'hh.dd" !! "yyyymmss', locale })).toBe("12.01 !! 20230806");
+  });
 });
 
 describe("rounding format", () => {
@@ -978,6 +1047,13 @@ describe("rounding format", () => {
     expect(roundFormat("0.00%")).toBe("0%");
     expect(roundFormat("[$$]#,##0.00")).toBe("[$$]#,##0");
     expect(roundFormat("ddd-mm-yyyy")).toBe("ddd-mm-yyyy");
+    expect(roundFormat("#,##0,,")).toBe("#,##0,,");
+    expect(roundFormat("#,##0.00,")).toBe("#,##0,");
+  });
+
+  test("Round multi part format", () => {
+    expect(roundFormat("0.00\\€;$0.#; 0.00 ;@")).toBe("0\\€;$0; 0 ;@");
+    expect(roundFormat("dd/mm/yyyy;0.#")).toBe("dd/mm/yyyy;0");
   });
 });
 
@@ -1020,5 +1096,96 @@ describe("create currency format", () => {
     const format = createCurrencyFormat({ symbol, code, position: "after" });
     expect(format).toBe("#,##0.00[$ O$OO θ]");
     expect(formatValue(1234.56, { format, locale: DEFAULT_LOCALE })).toBe("1,234.56 O$OO θ");
+  });
+});
+
+describe("Multi-part format", () => {
+  test("Simple multi-part format", () => {
+    const format = "0;0;0;@";
+
+    expect(formatValue(1, { locale, format })).toBe("1");
+    expect(formatValue(0, { locale, format })).toBe("0");
+    expect(formatValue(-1, { locale, format })).toBe("1");
+    expect(formatValue("text", { locale, format })).toBe("text");
+  });
+
+  test("Multi-part format with negative values format", () => {
+    const format = "0[$$];0[$€]";
+
+    expect(formatValue(1, { locale, format })).toBe("1$");
+    expect(formatValue(0, { locale, format })).toBe("0$");
+    expect(formatValue(-1, { locale, format })).toBe("1€");
+    expect(formatValue("text", { locale, format })).toBe("text");
+  });
+
+  test("Multi-part format with zero values format", () => {
+    const format = "0[$$];0[$€];0[$£]";
+
+    expect(formatValue(1, { locale, format })).toBe("1$");
+    expect(formatValue(0, { locale, format })).toBe("0£");
+    expect(formatValue(-1, { locale, format })).toBe("1€");
+    expect(formatValue("text", { locale, format })).toBe("text");
+  });
+
+  test("Multi-part format with text values format", () => {
+    const format = "0[$$];0[$€];0[$£];@[$¥]";
+
+    expect(formatValue(1, { locale, format })).toBe("1$");
+    expect(formatValue(0, { locale, format })).toBe("0£");
+    expect(formatValue(-1, { locale, format })).toBe("1€");
+    expect(formatValue("text", { locale, format })).toBe("text¥");
+  });
+
+  test("Multi part format with two parts", () => {
+    const format = "0[$$];0[$€]";
+
+    expect(formatValue(1, { locale, format })).toBe("1$");
+    expect(formatValue(0, { locale, format })).toBe("0$");
+    expect(formatValue(-1, { locale, format })).toBe("1€");
+    expect(formatValue("text", { locale, format })).toBe("text");
+  });
+
+  test("Multi part format with three parts", () => {
+    const format = "0[$$];0[$€];0[$£]";
+
+    expect(formatValue(1, { locale, format })).toBe("1$");
+    expect(formatValue(0, { locale, format })).toBe("0£");
+    expect(formatValue(-1, { locale, format })).toBe("1€");
+    expect(formatValue("text", { locale, format })).toBe("text");
+  });
+
+  test("Text-part of format cannot be a number or date format", () => {
+    expect(() => formatValue(1, { locale, format: ";;;0" })).toThrow();
+    expect(() => formatValue(1, { locale, format: ";;;dd" })).toThrow();
+  });
+
+  test("negative and null format cannot be text format", () => {
+    expect(() => formatValue(1, { locale, format: "@;;;" })).toThrow();
+    expect(() => formatValue(1, { locale, format: ";@;;" })).toThrow();
+    expect(() => formatValue(1, { locale, format: ";;@;" })).toThrow();
+    expect(() => formatValue(1, { locale, format: ";;;@" })).not.toThrow();
+
+    expect(() => formatValue(1, { locale, format: "@;;" })).toThrow();
+    expect(() => formatValue(1, { locale, format: ";@;" })).toThrow();
+    expect(() => formatValue(1, { locale, format: ";;@" })).toThrow();
+
+    expect(() => formatValue(1, { locale, format: "@;" })).toThrow();
+    expect(() => formatValue(1, { locale, format: ";@" })).toThrow();
+
+    expect(() => formatValue(1, { locale, format: "@" })).not.toThrow();
+  });
+
+  test("Test some particular multi parts format", () => {
+    let format = ";;;"; // Empty format
+    expect(formatValue(1, { locale, format })).toBe("");
+    expect(formatValue(0, { locale, format })).toBe("");
+    expect(formatValue(-1, { locale, format })).toBe("");
+    expect(formatValue("text", { locale, format })).toBe("");
+
+    format = "0.0;dd/mm/yyyy"; // Mix of number and date format
+    expect(formatValue(1, { locale, format })).toBe("1.0");
+    expect(formatValue(0, { locale, format })).toBe("0.0");
+    expect(formatValue(-1, { locale, format })).toBe("31/12/1899");
+    expect(formatValue("text", { locale, format })).toBe("text");
   });
 });

--- a/tests/formats/format_helpers.test.ts
+++ b/tests/formats/format_helpers.test.ts
@@ -1,4 +1,5 @@
 import {
+  createAccountingFormat,
   createCurrencyFormat,
   formatValue,
   isDateTimeFormat,
@@ -1096,6 +1097,50 @@ describe("create currency format", () => {
     const format = createCurrencyFormat({ symbol, code, position: "after" });
     expect(format).toBe("#,##0.00[$ O$OO θ]");
     expect(formatValue(1234.56, { format, locale: DEFAULT_LOCALE })).toBe("1,234.56 O$OO θ");
+  });
+});
+
+describe("create accounting format", () => {
+  const symbol = "θ";
+  const code = "O$OO";
+
+  test("full accounting format", () => {
+    const currency: Currency = {
+      code,
+      symbol,
+      decimalPlaces: 2,
+      name: "Odoo Dollar",
+      position: "before",
+    };
+    const format = createAccountingFormat(currency);
+    expect(format).toBe("[$O$OO θ]#,##0.00;[$O$OO θ](#,##0.00);[$O$OO θ]-");
+    expect(formatValue(1234.56, { format, locale: DEFAULT_LOCALE })).toBe("O$OO θ1,234.56");
+    expect(formatValue(-1234.56, { format, locale: DEFAULT_LOCALE })).toBe("O$OO θ(1,234.56)");
+    expect(formatValue(0, { format, locale: DEFAULT_LOCALE })).toBe("O$OO θ-");
+  });
+
+  test("custom decimal places currency", () => {
+    const format = createAccountingFormat({ symbol, decimalPlaces: 4 });
+    expect(format).toBe("[$θ]#,##0.0000;[$θ](#,##0.0000);[$θ]-");
+    expect(formatValue(1234.56, { format, locale: DEFAULT_LOCALE })).toBe("θ1,234.5600");
+    expect(formatValue(-1234.56, { format, locale: DEFAULT_LOCALE })).toBe("θ(1,234.5600)");
+    expect(formatValue(0, { format, locale: DEFAULT_LOCALE })).toBe("θ-");
+  });
+
+  test("without decimal places currency", () => {
+    const format = createAccountingFormat({ symbol, decimalPlaces: 0 });
+    expect(format).toBe("[$θ]#,##0;[$θ](#,##0);[$θ]-");
+    expect(formatValue(1234.56, { format, locale: DEFAULT_LOCALE })).toBe("θ1,235");
+    expect(formatValue(-1234.56, { format, locale: DEFAULT_LOCALE })).toBe("θ(1,235)");
+    expect(formatValue(0, { format, locale: DEFAULT_LOCALE })).toBe("θ-");
+  });
+
+  test("currency with symbol placed after", () => {
+    const format = createAccountingFormat({ symbol, position: "after", decimalPlaces: 0 });
+    expect(format).toBe("#,##0[$θ];(#,##0)[$θ];-[$θ]");
+    expect(formatValue(1234.56, { format, locale: DEFAULT_LOCALE })).toBe("1,235θ");
+    expect(formatValue(-1234.56, { format, locale: DEFAULT_LOCALE })).toBe("(1,235)θ");
+    expect(formatValue(0, { format, locale: DEFAULT_LOCALE })).toBe("-θ");
   });
 });
 

--- a/tests/formats/format_helpers.test.ts
+++ b/tests/formats/format_helpers.test.ts
@@ -1113,34 +1113,34 @@ describe("create accounting format", () => {
       position: "before",
     };
     const format = createAccountingFormat(currency);
-    expect(format).toBe("[$O$OO θ]#,##0.00;[$O$OO θ](#,##0.00);[$O$OO θ]-");
-    expect(formatValue(1234.56, { format, locale: DEFAULT_LOCALE })).toBe("O$OO θ1,234.56");
+    expect(format).toBe("[$O$OO θ]*  #,##0.00 ;[$O$OO θ]* (#,##0.00);[$O$OO θ]*   -  ");
+    expect(formatValue(1234.56, { format, locale: DEFAULT_LOCALE })).toBe("O$OO θ 1,234.56 ");
     expect(formatValue(-1234.56, { format, locale: DEFAULT_LOCALE })).toBe("O$OO θ(1,234.56)");
-    expect(formatValue(0, { format, locale: DEFAULT_LOCALE })).toBe("O$OO θ-");
+    expect(formatValue(0, { format, locale: DEFAULT_LOCALE })).toBe("O$OO θ  -  ");
   });
 
   test("custom decimal places currency", () => {
     const format = createAccountingFormat({ symbol, decimalPlaces: 4 });
-    expect(format).toBe("[$θ]#,##0.0000;[$θ](#,##0.0000);[$θ]-");
-    expect(formatValue(1234.56, { format, locale: DEFAULT_LOCALE })).toBe("θ1,234.5600");
+    expect(format).toBe("[$θ]*  #,##0.0000 ;[$θ]* (#,##0.0000);[$θ]*   -  ");
+    expect(formatValue(1234.56, { format, locale: DEFAULT_LOCALE })).toBe("θ 1,234.5600 ");
     expect(formatValue(-1234.56, { format, locale: DEFAULT_LOCALE })).toBe("θ(1,234.5600)");
-    expect(formatValue(0, { format, locale: DEFAULT_LOCALE })).toBe("θ-");
+    expect(formatValue(0, { format, locale: DEFAULT_LOCALE })).toBe("θ  -  ");
   });
 
   test("without decimal places currency", () => {
     const format = createAccountingFormat({ symbol, decimalPlaces: 0 });
-    expect(format).toBe("[$θ]#,##0;[$θ](#,##0);[$θ]-");
-    expect(formatValue(1234.56, { format, locale: DEFAULT_LOCALE })).toBe("θ1,235");
+    expect(format).toBe("[$θ]*  #,##0 ;[$θ]* (#,##0);[$θ]*   -  ");
+    expect(formatValue(1234.56, { format, locale: DEFAULT_LOCALE })).toBe("θ 1,235 ");
     expect(formatValue(-1234.56, { format, locale: DEFAULT_LOCALE })).toBe("θ(1,235)");
-    expect(formatValue(0, { format, locale: DEFAULT_LOCALE })).toBe("θ-");
+    expect(formatValue(0, { format, locale: DEFAULT_LOCALE })).toBe("θ  -  ");
   });
 
   test("currency with symbol placed after", () => {
     const format = createAccountingFormat({ symbol, position: "after", decimalPlaces: 0 });
-    expect(format).toBe("#,##0[$θ];(#,##0)[$θ];-[$θ]");
-    expect(formatValue(1234.56, { format, locale: DEFAULT_LOCALE })).toBe("1,235θ");
+    expect(format).toBe(" #,##0 * [$θ];(#,##0)* [$θ];  -  * [$θ]");
+    expect(formatValue(1234.56, { format, locale: DEFAULT_LOCALE })).toBe(" 1,235 θ");
     expect(formatValue(-1234.56, { format, locale: DEFAULT_LOCALE })).toBe("(1,235)θ");
-    expect(formatValue(0, { format, locale: DEFAULT_LOCALE })).toBe("-θ");
+    expect(formatValue(0, { format, locale: DEFAULT_LOCALE })).toBe("  -  θ");
   });
 });
 
@@ -1232,5 +1232,38 @@ describe("Multi-part format", () => {
     expect(formatValue(0, { locale, format })).toBe("0.0");
     expect(formatValue(-1, { locale, format })).toBe("31/12/1899");
     expect(formatValue("text", { locale, format })).toBe("text");
+  });
+});
+
+describe("Format with repeated character", () => {
+  function measureText(str: string) {
+    return str.length;
+  }
+
+  test("Repeat a character to fit the width", () => {
+    const formatWidth = { measureText, maxWidth: 5 };
+    expect(formatValue(1, { locale, format: "0*c", formatWidth })).toBe("1cccc");
+    expect(formatValue(10, { locale, format: "0*c", formatWidth })).toBe("10ccc");
+    expect(formatValue(1000000, { locale, format: "0*c", formatWidth })).toBe("1000000");
+  });
+
+  test("Only first asterisk is repeated", () => {
+    expect(
+      formatValue(1, { locale, format: "*c0*c", formatWidth: { measureText, maxWidth: 5 } })
+    ).toBe("ccc1c");
+  });
+
+  test("Character is not repeated if no with is given to formatValue", () => {
+    expect(formatValue(1, { locale, format: "0* " })).toBe("1");
+    expect(formatValue(1, { locale, format: "* 0" })).toBe("1");
+  });
+
+  test("Can repeat a character in a multi part format", () => {
+    const formatWidth = { measureText, maxWidth: 5 };
+    const format = '0* "€";$* -0;"£"* 0;* @';
+    expect(formatValue(1, { locale, format, formatWidth })).toBe("1   €");
+    expect(formatValue(-1, { locale, format, formatWidth })).toBe("$  -1");
+    expect(formatValue(0, { locale, format, formatWidth })).toBe("£   0");
+    expect(formatValue("hey", { locale, format, formatWidth })).toBe("  hey");
   });
 });

--- a/tests/formats/formatting_plugin.test.ts
+++ b/tests/formats/formatting_plugin.test.ts
@@ -187,6 +187,42 @@ describe("formatting values (with formatters)", () => {
     expect(getEvaluatedCell(model, "A1")?.formattedValue).toEqual("10.12345679");
   });
 
+  test("SET_DECIMAL on format with escaped string", () => {
+    const model = new Model();
+    setCellContent(model, "A1", "10");
+
+    setFormat(model, "A1", "0.0\\€");
+    setDecimal(model, "A1", 1);
+    expect(getCell(model, "A1")?.format).toBe("0.00\\€");
+
+    setFormat(model, "A1", "0.0\\€");
+    setDecimal(model, "A1", -1);
+    expect(getCell(model, "A1")?.format).toBe("0\\€");
+
+    setFormat(model, "A1", "0.0$0");
+    setDecimal(model, "A1", -1);
+    expect(getCell(model, "A1")?.format).toBe("0.0$");
+    setDecimal(model, "A1", -1);
+    expect(getCell(model, "A1")?.format).toBe("0$");
+  });
+
+  test("SET_DECIMAL on multi-part format", () => {
+    const model = new Model();
+    setCellContent(model, "A1", "10");
+
+    setFormat(model, "A1", "0.0\\€;$0.#; 0 ;@");
+    setDecimal(model, "A1", 1);
+    expect(getCell(model, "A1")?.format).toBe("0.00\\€;$0.#0; 0.0 ;@");
+
+    setFormat(model, "A1", "0.0\\€;$0.#; 0 ;@");
+    setDecimal(model, "A1", -1);
+    expect(getCell(model, "A1")?.format).toBe("0\\€;$0; 0 ;@");
+
+    setFormat(model, "A1", ";;;@");
+    setDecimal(model, "A1", -1);
+    expect(getCell(model, "A1")?.format).toBe(";;;@");
+  });
+
   test("UPDATE_CELL on long number that are truncated due to default format don't loose truncated digits", () => {
     const model = new Model();
     setCellContent(model, "A1", "10.123456789123");

--- a/tests/formats/plain_text_format.test.ts
+++ b/tests/formats/plain_text_format.test.ts
@@ -1,5 +1,5 @@
 import { Model } from "../../src";
-import { DEFAULT_LOCALE, PLAIN_TEXT_FORMAT } from "../../src/types";
+import { CellValueType, DEFAULT_LOCALE } from "../../src/types";
 import { setCellContent, setFormat, updateLocale } from "../test_helpers/commands_helpers";
 import { getCell, getCellContent, getEvaluatedCell } from "../test_helpers/getters_helpers";
 import { FR_LOCALE } from "./../test_helpers/constants";
@@ -27,10 +27,20 @@ describe("Plain text format", () => {
       setCellContent(model, "A1", cellContent);
       expect(getEvaluatedCell(model, "A1").value).toBe(beforePlainText);
 
-      setFormat(model, "A1", PLAIN_TEXT_FORMAT);
+      setFormat(model, "A1", "@");
       expect(getEvaluatedCell(model, "A1").value).toBe(plainTextValue);
     }
   );
+
+  test("Set more complex text format to a cell", () => {
+    setCellContent(model, "A1", "89");
+    setFormat(model, "A1", "@ $");
+    expect(getEvaluatedCell(model, "A1")).toMatchObject({
+      value: "89",
+      type: CellValueType.text,
+      formattedValue: "89 $",
+    });
+  });
 
   test.each([
     ["hello", "hello"],
@@ -46,7 +56,7 @@ describe("Plain text format", () => {
   ])(
     "Set content to a cell formatted with plain text %s %s: text should be kept as is, not parsed",
     (inputValue: string, expectedCellValue: string) => {
-      setFormat(model, "A1", PLAIN_TEXT_FORMAT);
+      setFormat(model, "A1", "@");
       setCellContent(model, "A1", inputValue);
       expect(getEvaluatedCell(model, "A1").value).toBe(expectedCellValue);
     }
@@ -54,7 +64,7 @@ describe("Plain text format", () => {
 
   test("Input localized date on a plain text cell", () => {
     updateLocale(model, FR_LOCALE);
-    setFormat(model, "A1", PLAIN_TEXT_FORMAT);
+    setFormat(model, "A1", "@");
     setCellContent(model, "A1", "30/05/2015");
 
     expect(getCell(model, "A1")?.content).toBe("30/05/2015");
@@ -72,14 +82,14 @@ describe("Plain text format", () => {
   });
 
   test("can export/import plain text format", () => {
-    setFormat(model, "A1", PLAIN_TEXT_FORMAT);
+    setFormat(model, "A1", "@");
     setCellContent(model, "A1", "00009");
 
     expect(getCellContent(model, "A1")).toBe("00009");
     const exported = model.exportData();
 
     const importedModel = new Model(exported);
-    expect(getCell(importedModel, "A1")?.format).toBe(PLAIN_TEXT_FORMAT);
+    expect(getCell(importedModel, "A1")?.format).toBe("@");
     expect(getCellContent(importedModel, "A1")).toBe("00009");
   });
 });

--- a/tests/menus/menu_items_registry.test.ts
+++ b/tests/menus/menu_items_registry.test.ts
@@ -1137,7 +1137,7 @@ describe("Menu Item actions", () => {
       const action = getNode(["format", "format_number", "format_number_accounting"], env);
       expect(action.isVisible(env)).toBe(true);
       action.execute?.(env);
-      expect(getCell(model, "A1")?.format).toBe("[$€]#,##0;[$€](#,##0);[$€]-");
+      expect(getCell(model, "A1")?.format).toBe("[$€]*  #,##0 ;[$€]* (#,##0);[$€]*   -  ");
     });
 
     test.each(DEFAULT_LOCALES)("Date", (locale) => {

--- a/tests/menus/menu_items_registry.test.ts
+++ b/tests/menus/menu_items_registry.test.ts
@@ -49,7 +49,7 @@ import {
   target,
 } from "../test_helpers/helpers";
 
-import { Model } from "../../src";
+import { Currency, Model } from "../../src";
 import { ClipboardMIMEType } from "../../src/types";
 
 import { CellComposerStore } from "../../src/components/composer/composer/cell_composer_store";
@@ -61,6 +61,12 @@ import { DEFAULT_LOCALES } from "../../src/types/locale";
 import { FR_LOCALE } from "../test_helpers/constants";
 
 jest.mock("../../src/helpers/uuid", () => require("../__mocks__/uuid"));
+
+const TEST_CURRENCY: Partial<Currency> = {
+  symbol: "€",
+  decimalPlaces: 3,
+  position: "before",
+};
 
 describe("Top Bar Menu Item Registry", () => {
   let registry: MenuItemRegistry;
@@ -1093,7 +1099,7 @@ describe("Menu Item actions", () => {
     });
 
     test("currency format with custom default currency", () => {
-      const model = new Model({}, { defaultCurrencyFormat: "[$€]#,##0.000" });
+      const model = new Model({}, { defaultCurrency: TEST_CURRENCY });
       env = makeTestEnv({ model });
       const action = getNode(["format", "format_number", "format_number_currency"], env);
       expect(action.description(env)).toBe("€1,000.120");
@@ -1102,7 +1108,7 @@ describe("Menu Item actions", () => {
     });
 
     test("rounded currency format with custom default currency", () => {
-      const model = new Model({}, { defaultCurrencyFormat: "[$€]#,##0.000" });
+      const model = new Model({}, { defaultCurrency: TEST_CURRENCY });
       env = makeTestEnv({ model });
       const action = getNode(["format", "format_number", "format_number_currency_rounded"], env);
       expect(action.description(env)).toBe("€1,000");
@@ -1111,18 +1117,27 @@ describe("Menu Item actions", () => {
     });
 
     test("rounded currency format is invisible if the custom default format is already rounded", () => {
-      const model = new Model({}, { defaultCurrencyFormat: "[$€]#,##0" });
+      const model = new Model({}, { defaultCurrency: { decimalPlaces: 0 } });
       env = makeTestEnv({ model });
       const action = getNode(["format", "format_number", "format_number_currency_rounded"], env);
       expect(action.isVisible(env)).toBe(false);
     });
 
     test("currency format description with locale and custom default currency", () => {
-      const model = new Model({}, { defaultCurrencyFormat: "[$€]#,##0.000" });
+      const model = new Model({}, { defaultCurrency: TEST_CURRENCY });
       env = makeTestEnv({ model });
       updateLocale(model, FR_LOCALE);
       const action = getNode(["format", "format_number", "format_number_currency"], env);
       expect(action.description(env)).toBe("€1 000,120");
+    });
+
+    test("accounting format menu item", () => {
+      const model = new Model({}, { defaultCurrency: { ...TEST_CURRENCY, decimalPlaces: 0 } });
+      env = makeTestEnv({ model });
+      const action = getNode(["format", "format_number", "format_number_accounting"], env);
+      expect(action.isVisible(env)).toBe(true);
+      action.execute?.(env);
+      expect(getCell(model, "A1")?.format).toBe("[$€]#,##0;[$€](#,##0);[$€]-");
     });
 
     test.each(DEFAULT_LOCALES)("Date", (locale) => {

--- a/tests/renderer_store.test.ts
+++ b/tests/renderer_store.test.ts
@@ -36,6 +36,7 @@ import {
   resizeColumns,
   resizeRows,
   setCellContent,
+  setFormat,
   setSelection,
   setStyle,
   setZoneBorders,
@@ -698,7 +699,7 @@ describe("renderer", () => {
     expect(textAligns).toEqual(["left", "center"]);
     expect(getCellTextMock).toHaveBeenLastCalledWith(
       { sheetId: expect.any(String), col: 0, row: 0 },
-      true
+      { showFormula: true, maxWidth: DEFAULT_CELL_WIDTH - 2 * MIN_CELL_TEXT_MARGIN }
     );
   });
 
@@ -727,7 +728,7 @@ describe("renderer", () => {
     expect(textAligns).toEqual(["left", "center"]);
     expect(getCellTextMock).toHaveBeenLastCalledWith(
       { sheetId: expect.any(String), col: 0, row: 0 },
-      true
+      { showFormula: true, maxWidth: DEFAULT_CELL_WIDTH - 2 * MIN_CELL_TEXT_MARGIN }
     );
   });
 
@@ -2160,5 +2161,24 @@ describe("renderer", () => {
       drawGridRenderer(ctx);
       expect(renderedTexts).toContain("hello");
     });
+  });
+
+  test("Repeated character in format is repeated to fill the column", () => {
+    const { drawGridRenderer, model, gridRendererStore } = setRenderer();
+    setCellContent(model, "A1", "1");
+    setFormat(model, "A1", "* 0");
+    resizeColumns(model, ["A"], 20);
+
+    let ctx = new MockGridRenderingContext(model, 1000, 1000, {});
+    drawGridRenderer(ctx);
+
+    let box = gridRendererStore["getGridBoxes"]().filter((box) => box.content)[0];
+    const expectedSpaces = 20 - 2 * MIN_CELL_TEXT_MARGIN;
+    expect(box.content?.textLines).toEqual(["1".padStart(expectedSpaces)]);
+
+    setFormat(model, "A1", "0*c");
+    drawGridRenderer(ctx);
+    box = gridRendererStore["getGridBoxes"]().filter((box) => box.content)[0];
+    expect(box.content?.textLines).toEqual(["1".padEnd(expectedSpaces, "c")]);
   });
 });

--- a/tests/table/filter_menu_component.test.ts
+++ b/tests/table/filter_menu_component.test.ts
@@ -109,6 +109,13 @@ describe("Filter menu component", () => {
       expect(values.map((val) => val.value)).toEqual(["(Blanks)", "1", "1/1/1900"]);
     });
 
+    test("Repeated character in format is not shown", async () => {
+      setFormat(model, "A4", "$* 0");
+      await openFilterMenu();
+      const values = getFilterMenuValues();
+      expect(values.map((val) => val.value)).toEqual(["(Blanks)", "$2", "1"]);
+    });
+
     test("Values are checked depending on the filter state", async () => {
       updateFilter(model, "A1", ["1"]);
       await openFilterMenu();

--- a/tests/test_helpers/getters_helpers.ts
+++ b/tests/test_helpers/getters_helpers.ts
@@ -69,7 +69,10 @@ export function getCellContent(
   sheetId: UID = model.getters.getActiveSheetId()
 ): string {
   const { col, row } = toCartesian(xc);
-  return model.getters.getCellText({ sheetId, col, row }, model.getters.shouldShowFormulas());
+  return model.getters.getCellText(
+    { sheetId, col, row },
+    { showFormula: model.getters.shouldShowFormulas() }
+  );
 }
 
 /**
@@ -102,7 +105,7 @@ export function getCellText(
   sheetId: UID = model.getters.getActiveSheetId()
 ) {
   const { col, row } = toCartesian(xc);
-  return model.getters.getCellText({ sheetId, col, row }, true);
+  return model.getters.getCellText({ sheetId, col, row }, { showFormula: true });
 }
 
 export function getStyle(

--- a/tests/test_helpers/getters_helpers.ts
+++ b/tests/test_helpers/getters_helpers.ts
@@ -95,6 +95,23 @@ export function getEvaluatedGrid(
   return content;
 }
 
+export function getEvaluatedCells(
+  model: Model,
+  range: string,
+  sheetId: UID = model.getters.getActiveSheetId()
+): EvaluatedCell[][] {
+  const zone = toZone(range);
+  const content: EvaluatedCell[][] = [];
+  for (let row = zone.top; row <= zone.bottom; row++) {
+    const rowContent: EvaluatedCell[] = [];
+    for (let col = zone.left; col <= zone.right; col++) {
+      rowContent.push(model.getters.getEvaluatedCell({ sheetId, col, row }));
+    }
+    content.push(rowContent);
+  }
+  return content;
+}
+
 /**
  * Get the string representation of the content of a cell, and always formula
  * for formula cells

--- a/tests/xlsx/xlsx_export.test.ts
+++ b/tests/xlsx/xlsx_export.test.ts
@@ -2,7 +2,7 @@ import { arg, functionRegistry } from "../../src/functions";
 import { buildSheetLink, toXC } from "../../src/helpers";
 import { DEFAULT_TABLE_CONFIG } from "../../src/helpers/table_presets";
 import { Model } from "../../src/model";
-import { CustomizedDataSet, Dimension, ExcelChartType, PLAIN_TEXT_FORMAT } from "../../src/types";
+import { CustomizedDataSet, Dimension, ExcelChartType } from "../../src/types";
 import { XLSXExportXMLFile, XMLString } from "../../src/types/xlsx";
 import { adaptFormulaToExcel } from "../../src/xlsx/functions/cells";
 import { escapeXml, parseXML } from "../../src/xlsx/helpers/xml_helpers";
@@ -1582,7 +1582,7 @@ describe("Test XLSX export", () => {
 
   test("Cells with plain text format are exported in the shared strings", async () => {
     const model = new Model();
-    setFormat(model, "A1", PLAIN_TEXT_FORMAT);
+    setFormat(model, "A1", "@");
     setCellContent(model, "A1", "0006");
 
     expect(getCellContent(model, "A1")).toEqual("0006");

--- a/tests/xlsx/xlsx_import.test.ts
+++ b/tests/xlsx/xlsx_import.test.ts
@@ -7,7 +7,7 @@ import {
   toZone,
 } from "../../src/helpers";
 import { DEFAULT_TABLE_CONFIG } from "../../src/helpers/table_presets";
-import { CellIsRule, DEFAULT_LOCALE, IconSetRule, PLAIN_TEXT_FORMAT } from "../../src/types";
+import { CellIsRule, DEFAULT_LOCALE, IconSetRule } from "../../src/types";
 import { BarChartDefinition } from "../../src/types/chart/bar_chart";
 import { ComboChartDefinition } from "../../src/types/chart/combo_chart";
 import { LineChartDefinition } from "../../src/types/chart/line_chart";
@@ -820,7 +820,7 @@ test.each([
   ["#,##0.00[$MM/DD/YYYY]", "#,##0.00[$MM/DD/YYYY]", "0.00MM/DD/YYYY"],
   ["[$₪-40D] #,##0.00", "[$₪] #,##0.00", "₪ 0.00"],
   ['"€"#,##0.00 "€"', '"€"#,##0.00 "€"', "€0.00 €"],
-  ["@", PLAIN_TEXT_FORMAT, "0"],
+  ["@", "@", "0"],
 ])("convert format %s", async (excelFormat, convertedFormat, expectedValue) => {
   expect(
     convertXlsxFormat(80, [{ id: 80, format: excelFormat }], new XLSXImportWarningManager())

--- a/tests/xlsx/xlsx_import.test.ts
+++ b/tests/xlsx/xlsx_import.test.ts
@@ -207,19 +207,16 @@ describe("Import xlsx data", () => {
     ["0.00", "M2"],
     ["0.00%", "M3"],
     ["m/d/yyyy", "M4"],
-    ["#,##0.00 [$€]", "M5"],
+    ['#,##0.00\\ "€"', "M5"],
     ["[$$]#,##0.000", "M6"],
-    ["[$₪] #,##0", "M7"],
-    ["#,##0[$ EUR €]", "M8"],
-    ["not supported: multiple escaped sequences", "M9"],
+    ["[$₪]\\ #,##0", "M7"],
+    ['#,##0" EUR €"', "M8"],
+    ['"€"#,##0.00\\ "€"', "M9"],
   ])("Can import format %s", (format, cellXc) => {
     const testSheet = getWorkbookSheet("jestStyles", convertedData)!;
     const formattedCell = testSheet.cells[cellXc]!;
     const cellFormat = getWorkbookCellFormat(formattedCell, convertedData);
     let expectedFormat: string | undefined = format;
-    if (format.startsWith("not supported")) {
-      expectedFormat = undefined;
-    }
     expect(cellFormat).toEqual(expectedFormat);
   });
 
@@ -804,7 +801,7 @@ test.each([
 
 test.each([
   ["0.00", "0.00", "0.00"],
-  ["0.00;0.00%", "0.00", "0.00"],
+  ["0.00;0.00%", "0.00;0.00%", "0.00"],
   ["0.000%", "0.000%", "0.000%"],
   ["#,##0.00", "#,##0.00", "0.00"],
   ["m/d/yyyy", "m/d/yyyy", "12/30/1899"],
@@ -814,15 +811,15 @@ test.each([
   ["mmm dd yy", "mmm dd yy", "Dec 30 99"],
   ["h AM/PM", "hh a", "12 AM"],
   ["HHHH:MM a/m", "hh:mm a", "12:00 AM"],
-  ["m/d/yyyy\\ hh:mm:ss", "m/d/yyyy hh:mm:ss", "12/30/1899 00:00:00"],
+  ["m/d/yyyy\\ hh:mm:ss", "m/d/yyyy\\ hh:mm:ss", "12/30/1899 00:00:00"],
   ["hh:mm:ss a", "hh:mm:ss a", "12:00:00 AM"],
-  ['#,##0.00 "€"', "#,##0.00 [$€]", "0.00€"],
+  ['#,##0.00 "€"', '#,##0.00 "€"', "0.00 €"],
   ["[$$-409]#,##0.000", "[$$]#,##0.000", "$0.000"],
   ["[$-409]0.00", "0.00", "0.00"],
   ["[$MM/DD/YYYY]0", "[$MM/DD/YYYY]0", "MM/DD/YYYY0"],
   ["#,##0.00[$MM/DD/YYYY]", "#,##0.00[$MM/DD/YYYY]", "0.00MM/DD/YYYY"],
-  ["[$₪-40D] #,##0.00", "[$₪] #,##0.00", "₪0.00"],
-  ['"€"#,##0.00 "€"', undefined, "0"],
+  ["[$₪-40D] #,##0.00", "[$₪] #,##0.00", "₪ 0.00"],
+  ['"€"#,##0.00 "€"', '"€"#,##0.00 "€"', "€0.00 €"],
   ["@", PLAIN_TEXT_FORMAT, "0"],
 ])("convert format %s", async (excelFormat, convertedFormat, expectedValue) => {
   expect(


### PR DESCRIPTION
## Description:

### [IMP] format: add the handling of repeated character

This commit adds the handling of the `*` asterisk character in the format,
which repeats the character that comes after it enough times to fill
the column.

The asterisk is ignored in `cell.formattedValue`, and the character is
only repeated if the `formatValue` helper is given a `width` parameter,
which we now do only in the grid renderer.

The commit also adds this new format feature to the accounting format,
to match the behaviour of the other spreadsheet applications.

### [IMP] pivot: add indentation to row headers

This commit adds indentation to row headers in the pivot table, based
on the depth of the groupBy.

Task: : [3965246](https://www.odoo.com/web#id=3965246&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo