### PR TITLE
[FIX] PivotSidePanel: Allow unbounded range in the side panel

### DIFF
--- a/src/components/side_panel/pivot/pivot_side_panel/pivot_spreadsheet_side_panel/pivot_spreadsheet_side_panel.ts
+++ b/src/components/side_panel/pivot/pivot_side_panel/pivot_spreadsheet_side_panel/pivot_spreadsheet_side_panel.ts
@@ -1,5 +1,4 @@
 import { Component, useState } from "@odoo/owl";
-import { splitReference, toZone } from "../../../../../helpers";
 import { SpreadsheetPivotRuntimeDefinition } from "../../../../../helpers/pivot/spreadsheet_pivot/runtime_definition_spreadsheet_pivot";
 import { SpreadsheetPivot } from "../../../../../helpers/pivot/spreadsheet_pivot/spreadsheet_pivot";
 import { Store, useLocalStore } from "../../../../../store_engine";
@@ -76,15 +75,15 @@ export class PivotSpreadsheetSidePanel extends Component<Props, SpreadsheetChild
 
   onSelectionConfirmed() {
     if (this.state.range) {
-      const { sheetName, xc } = splitReference(this.state.range);
-      const sheetId = sheetName
-        ? this.env.model.getters.getSheetIdByName(sheetName)
-        : this.env.model.getters.getActiveSheetId();
-      if (!sheetId) {
+      const range = this.env.model.getters.getRangeFromSheetXC(
+        this.env.model.getters.getActiveSheetId(),
+        this.state.range
+      );
+      if (range.invalidSheetName || range.invalidXc) {
         return;
       }
-      const zone = toZone(xc);
-      const dataSet = { sheetId, zone };
+
+      const dataSet = { sheetId: range.sheetId, zone: range.zone };
       this.store.update({ dataSet });
       // Immediately apply the update to recompute the pivot fields
       this.store.applyUpdate();

--- a/tests/pivots/pivot_side_panel.test.ts
+++ b/tests/pivots/pivot_side_panel.test.ts
@@ -1,6 +1,7 @@
-import { Model, SpreadsheetChildEnv } from "../../src";
+import { Model, SpreadsheetChildEnv, SpreadsheetPivotCoreDefinition } from "../../src";
+import { toZone } from "../../src/helpers";
 import { createSheet, deleteSheet } from "../test_helpers/commands_helpers";
-import { click } from "../test_helpers/dom_helper";
+import { click, setInputValueAndTrigger, simulateClick } from "../test_helpers/dom_helper";
 import { mountSpreadsheet, nextTick } from "../test_helpers/helpers";
 import { SELECTORS, addPivot, removePivot } from "../test_helpers/pivot_helpers";
 
@@ -44,5 +45,19 @@ describe("Pivot side panel", () => {
     deleteSheet(model, "toDelete");
     await nextTick();
     expect(fixture.querySelector(".o-sidePanel")).not.toBeNull();
+  });
+
+  test("Side panel supports unbounded zone in definition", async () => {
+    env.openSidePanel("PivotSidePanel", { pivotId: "1" });
+    await nextTick();
+    setInputValueAndTrigger(SELECTORS.ZONE_INPUT, "A:A");
+    await nextTick();
+    await simulateClick(SELECTORS.ZONE_CONFIRM);
+    expect(
+      (model.getters.getPivotCoreDefinition("1") as SpreadsheetPivotCoreDefinition).dataSet
+    ).toMatchObject({
+      sheetId: model.getters.getActiveSheetId(),
+      zone: toZone("A1:A100"),
+    });
   });
 });

--- a/tests/test_helpers/pivot_helpers.ts
+++ b/tests/test_helpers/pivot_helpers.ts
@@ -62,4 +62,6 @@ export const SELECTORS = {
   DUPLICATE_PIVOT: ".os-cog-wheel-menu .fa-copy",
   DELETE_PIVOT: ".os-cog-wheel-menu .fa-trash",
   FLIP_AXIS_PIVOT: ".os-cog-wheel-menu .fa-exchange",
+  ZONE_INPUT: ".o-selection-input input",
+  ZONE_CONFIRM: ".o-selection-input .o-selection-ok",
 };


### PR DESCRIPTION
The code converting the selectionInput value into a valid dataset for the pivot definition did not account for unbounded zones.

Task: 4126669

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [4126669](https://www.odoo.com/web#id=4126669&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo