### PR TITLE
[FIX] side panel: fix some css issues after revamp

### DIFF
--- a/src/components/color_picker/color_picker_widget.ts
+++ b/src/components/color_picker/color_picker_widget.ts
@@ -20,6 +20,7 @@ css/* scss */ `
     display: flex;
     position: relative;
     align-items: center;
+    height: 30px;
 
     .o-color-picker-button-style {
       display: flex;
@@ -35,11 +36,11 @@ css/* scss */ `
     }
 
     .o-color-picker-button {
-      height: 30px;
       > span {
         border-bottom: 4px solid;
         height: 16px;
         margin-top: 2px;
+        display: block;
       }
 
       &[disabled] {

--- a/src/components/data_validation_overlay/dv_list_icon/dv_list_icon.ts
+++ b/src/components/data_validation_overlay/dv_list_icon/dv_list_icon.ts
@@ -1,5 +1,5 @@
 import { Component } from "@odoo/owl";
-import { GRID_ICON_EDGE_LENGTH } from "../../../constants";
+import { GRID_ICON_EDGE_LENGTH, TEXT_BODY_MUTED } from "../../../constants";
 import { CellPosition, SpreadsheetChildEnv } from "../../../types";
 import { css } from "../../helpers";
 
@@ -7,14 +7,14 @@ const ICON_WIDTH = 13;
 
 css/* scss */ `
   .o-dv-list-icon {
-    color: #808080;
+    color: ${TEXT_BODY_MUTED};
     border-radius: 1px;
     height: ${GRID_ICON_EDGE_LENGTH}px;
     width: ${GRID_ICON_EDGE_LENGTH}px;
 
     &:hover {
       color: #ffffff;
-      background-color: #808080;
+      background-color: ${TEXT_BODY_MUTED};
     }
 
     svg {

--- a/src/components/link/link_editor/link_editor.xml
+++ b/src/components/link/link_editor/link_editor.xml
@@ -38,8 +38,10 @@
               disabled="1"
             />
           </t>
-          <button t-if="link.url" t-on-click="removeLink" class="o-remove-url">✖</button>
-          <button t-if="!link.url" t-on-click.stop="openMenu" class="o-special-link">
+          <button t-if="link.url" t-on-click="removeLink" class="o-remove-url o-button-icon">
+            ✖
+          </button>
+          <button t-if="!link.url" t-on-click.stop="openMenu" class="o-special-link o-button-icon">
             <t t-call="o-spreadsheet-Icon.LIST"/>
           </button>
         </div>

--- a/src/components/selection_input/selection_input.xml
+++ b/src/components/selection_input/selection_input.xml
@@ -21,7 +21,7 @@
             t-att-class="{
               'o-focused' : range.isFocused,
               'o-invalid border-danger position-relative': isInvalid || !range.isValidRange,
-              'text-decoration-underline': range.isFocused and state.mode === 'select-range'
+              'text-decoration-underline': range.xc and range.isFocused and state.mode === 'select-range'
             }"
             t-ref="{{range.isFocused ? 'focusedInput' : 'unfocusedInput' + range_index}}"
           />
@@ -33,7 +33,7 @@
           </span>
         </div>
         <button
-          class="o-btn border-0 bg-transparent fw-bold o-remove-selection o-text-muted pe-0"
+          class="border-0 bg-transparent fw-bold o-remove-selection o-button-icon pe-0"
           t-if="ranges.length > 1"
           t-on-click="() => this.removeInput(range.id)">
           <t t-call="o-spreadsheet-Icon.TRASH_FILLED"/>

--- a/src/components/side_panel/components/cog_wheel_menu/cog_wheel_menu.ts
+++ b/src/components/side_panel/components/cog_wheel_menu/cog_wheel_menu.ts
@@ -2,18 +2,11 @@ import { Component, useRef, useState } from "@odoo/owl";
 import { ActionSpec, createActions } from "../../../../actions/action";
 import { MenuMouseEvent } from "../../../../types";
 import { SpreadsheetChildEnv } from "../../../../types/env";
-import { css } from "../../../helpers";
 import { Menu, MenuState } from "../../../menu/menu";
 
 interface Props {
   items: ActionSpec[];
 }
-
-css/* scss */ `
-  .os-cog-wheel-menu-icon {
-    cursor: pointer;
-  }
-`;
 
 export class CogWheelMenu extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-CogWheelMenu";

--- a/src/components/side_panel/components/cog_wheel_menu/cog_wheel_menu.xml
+++ b/src/components/side_panel/components/cog_wheel_menu/cog_wheel_menu.xml
@@ -1,7 +1,7 @@
 <templates>
   <t t-name="o-spreadsheet-CogWheelMenu">
     <span
-      class="fa fa-cog o-text-muted os-cog-wheel-menu-icon"
+      class="fa fa-cog os-cog-wheel-menu-icon o-button-icon"
       t-on-click="toggleMenu"
       t-ref="button"
     />

--- a/src/components/side_panel/conditional_formatting/cf_editor/cf_editor.ts
+++ b/src/components/side_panel/conditional_formatting/cf_editor/cf_editor.ts
@@ -115,13 +115,6 @@ css/* scss */ `
           }
         }
       }
-
-      .o-cf-iconset-reverse {
-        font-size: 14px;
-        .o-icon {
-          font-size: 17px;
-        }
-      }
     }
 
     .o-icon.arrow-down {

--- a/src/components/side_panel/conditional_formatting/cf_editor/icon_set_rule_editor.xml
+++ b/src/components/side_panel/conditional_formatting/cf_editor/icon_set_rule_editor.xml
@@ -117,7 +117,7 @@
       <t t-call="o-spreadsheet-IconSets"/>
       <t t-call="o-spreadsheet-IconSetInflexionPoints"/>
       <div
-        class="btn btn-link ps-0 o-cf-iconset-reverse d-flex flex-row align-items-center"
+        class="o-button-link py-1 ps-0 d-flex flex-row align-items-center"
         t-on-click="reverseIcons">
         <t t-call="o-spreadsheet-Icon.REFRESH"/>
         <div class="ms-1">Reverse icons</div>

--- a/src/components/side_panel/conditional_formatting/cf_preview/cf_preview.xml
+++ b/src/components/side_panel/conditional_formatting/cf_preview/cf_preview.xml
@@ -9,7 +9,8 @@
       t-on-click="props.onPreviewClick"
       t-on-pointerdown="(ev) => this.onMouseDown(ev)">
       <div class="position-relative h-100 w-100 d-flex align-items-center">
-        <div class="o-cf-drag-handle h-100 position-absolute d-flex align-items-center text-muted">
+        <div
+          class="o-cf-drag-handle h-100 position-absolute d-flex align-items-center o-button-icon">
           <t t-call="o-spreadsheet-Icon.THIN_DRAG_HANDLE"/>
         </div>
         <t t-if="cf.rule.type==='IconSetRule'">
@@ -36,10 +37,10 @@
         </div>
         <div class="o-cf-delete">
           <div
-            class="o-cf-delete-button text-muted"
+            class="o-cf-delete-button o-button-icon"
             t-on-click.stop="(ev) => this.deleteConditionalFormat(cf, ev)"
             title="Remove rule">
-            <t t-call="o-spreadsheet-Icon.TRASH"/>
+            <t t-call="o-spreadsheet-Icon.TRASH_FILLED"/>
           </div>
         </div>
       </div>

--- a/src/components/side_panel/conditional_formatting/cf_preview_list/cf_preview_list.xml
+++ b/src/components/side_panel/conditional_formatting/cf_preview_list/cf_preview_list.xml
@@ -14,7 +14,7 @@
         </div>
       </t>
       <div
-        class="btn btn-link o-sidePanel-btn-link o-cf-add float-end"
+        class="o-button-link p-4 o-cf-add float-end"
         t-on-click.prevent.stop="props.onAddConditionalFormat">
         + Add another rule
       </div>

--- a/src/components/side_panel/data_validation/data_validation_panel.xml
+++ b/src/components/side_panel/data_validation/data_validation_panel.xml
@@ -10,9 +10,7 @@
             />
           </t>
         </div>
-        <div
-          class="o-dv-add btn btn-link o-sidePanel-btn-link float-end"
-          t-on-click="addDataValidationRule">
+        <div class="o-dv-add o-button-link p-4 float-end" t-on-click="addDataValidationRule">
           + Add another rule
         </div>
       </t>

--- a/src/components/side_panel/data_validation/dv_criterion_form/dv_value_in_list_criterion/dv_value_in_list_criterion.xml
+++ b/src/components/side_panel/data_validation/dv_criterion_form/dv_value_in_list_criterion/dv_value_in_list_criterion.xml
@@ -11,9 +11,9 @@
           onBlur.bind="onBlurInput"
         />
         <div
-          class="o-dv-list-item-delete ms-2 me-1"
+          class="o-dv-list-item-delete ms-2 o-button-icon"
           t-on-click="() => this.removeItem(value_index)">
-          <t t-call="o-spreadsheet-Icon.TRASH"/>
+          <t t-call="o-spreadsheet-Icon.TRASH_FILLED"/>
         </div>
       </div>
       <div class="mb-2"/>

--- a/src/components/side_panel/data_validation/dv_preview/dv_preview.xml
+++ b/src/components/side_panel/data_validation/dv_preview/dv_preview.xml
@@ -7,9 +7,9 @@
           <div class="o-dv-preview-ranges text-truncate" t-esc="rangesString"/>
         </div>
         <div
-          class="o-dv-preview-delete d-flex align-items-center text-muted px-3"
+          class="o-dv-preview-delete d-flex align-items-center o-button-icon px-3"
           t-on-click.stop="deleteDataValidation">
-          <t t-call="o-spreadsheet-Icon.TRASH"/>
+          <t t-call="o-spreadsheet-Icon.TRASH_FILLED"/>
         </div>
       </div>
     </div>

--- a/src/components/side_panel/pivot/editable_name/editable_name.xml
+++ b/src/components/side_panel/pivot/editable_name/editable_name.xml
@@ -4,16 +4,14 @@
       <div>
         <input type="text" class="o-input o_sp_en_name" t-model="state.name"/>
       </div>
-      <div class="btn btn-link o_sp_en_save" t-on-click="save">Save</div>
-      <br/>
+      <div class="o-button-link o_sp_en_save" t-on-click="save">Save</div>
     </t>
     <t t-else="">
       <div class="o_sp_en_display_name" t-esc="props.displayName"/>
-      <div class="btn btn-link o_sp_en_rename" t-on-click="rename">
+      <div class="o-button-link o_sp_en_rename" t-on-click="rename">
         <i class="fa fa-pencil me-1"/>
         Rename
       </div>
-      <br/>
     </t>
   </t>
 </templates>

--- a/src/components/side_panel/pivot/pivot_defer_update/pivot_defer_update.xml
+++ b/src/components/side_panel/pivot/pivot_defer_update/pivot_defer_update.xml
@@ -8,14 +8,14 @@
         value="props.deferUpdate"
         onChange="(value) => props.toggleDeferUpdate(value)"
       />
-      <div t-if="props.isDirty">
+      <div t-if="props.isDirty" class="d-flex align-items-center">
         <i
-          class="btn btn-sm pe-0 fa fa-undo"
+          class="o-button-icon pe-0 fa fa-undo"
           title="Discard all changes"
           t-on-click="() => props.discard()"
         />
         <span
-          class="btn btm-sm btn-link sp_apply_update"
+          class="o-button-link sp_apply_update small ps-2"
           title="Apply all changes"
           t-on-click="() => props.apply()">
           Update

--- a/src/components/side_panel/pivot/pivot_layout_configurator/add_dimension_button/add_dimension_button.xml
+++ b/src/components/side_panel/pivot/pivot_layout_configurator/add_dimension_button/add_dimension_button.xml
@@ -4,7 +4,7 @@
     <Popover t-if="popover.isOpen" t-props="popoverProps">
       <div
         class="p-2 bg-white border-bottom d-flex sticky-top align-items-baseline pivot-dimension-search">
-        <i class="pe-1 pivot-dimension-search-field-icon">
+        <i class="pe-1 pivot-dimension-search-field-icon text-muted">
           <t t-call="o-spreadsheet-Icon.SEARCH"/>
         </i>
         <input

--- a/src/components/side_panel/pivot/pivot_layout_configurator/pivot_dimension/pivot_dimension.xml
+++ b/src/components/side_panel/pivot/pivot_layout_configurator/pivot_dimension/pivot_dimension.xml
@@ -19,7 +19,7 @@
         <div class="d-flex flex-rows">
           <t t-slot="upper-right-icons"/>
           <i
-            class="btn fa fa-trash o-text-muted pe-0 ms-auto"
+            class="o-button-icon fa fa-trash pe-1 ps-2"
             t-if="props.onRemoved"
             t-on-click="() => props.onRemoved(props.dimension)"
           />

--- a/src/components/side_panel/pivot/pivot_layout_configurator/pivot_measure/pivot_measure.xml
+++ b/src/components/side_panel/pivot/pivot_layout_configurator/pivot_measure/pivot_measure.xml
@@ -8,7 +8,7 @@
         <i
           t-att-class="measure.isHidden ? 'fa fa-eye-slash': 'fa fa-eye'"
           t-att-title="hideTitle"
-          class="btn o-text-muted"
+          class="o-button-icon pe-1 ps-2"
           t-on-click="toggleMeasureVisibility"
         />
       </t>
@@ -22,11 +22,11 @@
           />
         </div>
       </div>
-      <div class="d-flex flex-column small">
-        <div class="d-flex py-1 px-2 w-100">
+      <div class="d-flex flex-row">
+        <div class="d-flex py-1 px-2 w-100 small">
           <div class="pivot-dim-operator-label">Aggregated by</div>
           <select
-            class="o-input flex-grow-1 me-3"
+            class="o-input flex-grow-1"
             t-on-change="(ev) => this.updateAggregator(ev.target.value)">
             <option
               t-foreach="Object.keys(props.aggregators[measure.type])"

--- a/src/components/side_panel/side_panel/side_panel.ts
+++ b/src/components/side_panel/side_panel/side_panel.ts
@@ -1,5 +1,5 @@
 import { Component, useEffect } from "@odoo/owl";
-import { GRAY_300, TEXT_BODY, TEXT_BODY_MUTED } from "../../../constants";
+import { GRAY_300, TEXT_BODY } from "../../../constants";
 import { sidePanelRegistry } from "../../../registries/side_panel_registry";
 import { Store, useStore } from "../../../store_engine";
 import { SpreadsheetChildEnv } from "../../../types";
@@ -19,23 +19,10 @@ css/* scss */ `
     user-select: none;
     color: ${TEXT_BODY};
 
-    .o-text-muted {
-      color: ${TEXT_BODY_MUTED};
-    }
-
     .o-heading-3 {
       line-height: 20px;
       font-size: 16px;
       font-weight: 600;
-    }
-
-    .btn-link {
-      text-decoration: none;
-      color: #017e84;
-      font-weight: 500;
-      &:hover {
-        color: #01585c;
-      }
     }
 
     .o-sidePanelHeader {
@@ -98,18 +85,6 @@ css/* scss */ `
     .o-sidePanelButtons {
       display: flex;
       gap: 8px;
-    }
-
-    .o-sidePanel-btn-link {
-      font-size: 14px;
-      padding: 20px 24px 11px 24px;
-      height: 44px;
-      cursor: pointer;
-      text-decoration: none;
-      &:hover {
-        color: #003a39;
-        text-decoration: none;
-      }
     }
 
     .o-invalid {

--- a/src/components/spreadsheet/spreadsheet.ts
+++ b/src/components/spreadsheet/spreadsheet.ts
@@ -11,6 +11,7 @@ import {
 } from "@odoo/owl";
 import {
   ACTION_COLOR,
+  ACTION_COLOR_HOVER,
   ALERT_DANGER_BORDER,
   BACKGROUND_GRAY_COLOR,
   BOTTOMBAR_HEIGHT,
@@ -300,6 +301,27 @@ css/* scss */ `
     &.o-button-danger:hover {
       color: #ffffff;
       background: ${ALERT_DANGER_BORDER};
+    }
+  }
+
+  .o-button-link {
+    cursor: pointer;
+    text-decoration: none;
+    color: ${ACTION_COLOR};
+    font-weight: 500;
+    &:hover,
+    &:active {
+      color: ${ACTION_COLOR_HOVER};
+    }
+  }
+
+  .o-button-icon {
+    cursor: pointer;
+    color: ${TEXT_BODY_MUTED};
+    font-weight: 500;
+    &:hover,
+    &:active {
+      color: ${TEXT_BODY};
     }
   }
 `;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -49,6 +49,7 @@ export const BUTTON_HOVER_TEXT_COLOR = "#111827";
 export const BUTTON_ACTIVE_BG = "#e6f2f3";
 export const BUTTON_ACTIVE_TEXT_COLOR = "#111827";
 export const ACTION_COLOR = "#017E84";
+export const ACTION_COLOR_HOVER = "#01585c";
 export const ALERT_WARNING_BG = "#FBEBCC";
 export const ALERT_WARNING_BORDER = "#F8E2B3";
 export const ALERT_WARNING_TEXT_COLOR = "#946D23";

--- a/tests/__snapshots__/cog_wheel_menu.test.ts.snap
+++ b/tests/__snapshots__/cog_wheel_menu.test.ts.snap
@@ -6,7 +6,7 @@ exports[`CogWheelMenu Can render a cog wheel menu 1`] = `
     class="o-spreadsheet"
   >
     <span
-      class="fa fa-cog o-text-muted os-cog-wheel-menu-icon"
+      class="fa fa-cog os-cog-wheel-menu-icon o-button-icon"
     />
     
   </div>

--- a/tests/conditional_formatting/__snapshots__/conditional_formatting_panel_component.test.ts.snap
+++ b/tests/conditional_formatting/__snapshots__/conditional_formatting_panel_component.test.ts.snap
@@ -22,7 +22,7 @@ exports[`UI of conditional formats Conditional format list simple snapshot 1`] =
             class="position-relative h-100 w-100 d-flex align-items-center"
           >
             <div
-              class="o-cf-drag-handle h-100 position-absolute d-flex align-items-center text-muted"
+              class="o-cf-drag-handle h-100 position-absolute d-flex align-items-center o-button-icon"
             >
               <svg
                 class="o-icon"
@@ -82,14 +82,14 @@ exports[`UI of conditional formats Conditional format list simple snapshot 1`] =
               class="o-cf-delete"
             >
               <div
-                class="o-cf-delete-button text-muted"
+                class="o-cf-delete-button o-button-icon"
                 title="Remove rule"
               >
                 <div
                   class="o-icon"
                 >
                   <i
-                    class="fa fa-trash-o"
+                    class="fa fa-trash"
                   />
                 </div>
               </div>
@@ -109,7 +109,7 @@ exports[`UI of conditional formats Conditional format list simple snapshot 1`] =
             class="position-relative h-100 w-100 d-flex align-items-center"
           >
             <div
-              class="o-cf-drag-handle h-100 position-absolute d-flex align-items-center text-muted"
+              class="o-cf-drag-handle h-100 position-absolute d-flex align-items-center o-button-icon"
             >
               <svg
                 class="o-icon"
@@ -169,14 +169,14 @@ exports[`UI of conditional formats Conditional format list simple snapshot 1`] =
               class="o-cf-delete"
             >
               <div
-                class="o-cf-delete-button text-muted"
+                class="o-cf-delete-button o-button-icon"
                 title="Remove rule"
               >
                 <div
                   class="o-icon"
                 >
                   <i
-                    class="fa fa-trash-o"
+                    class="fa fa-trash"
                   />
                 </div>
               </div>
@@ -187,7 +187,7 @@ exports[`UI of conditional formats Conditional format list simple snapshot 1`] =
       
       
       <div
-        class="btn btn-link o-sidePanel-btn-link o-cf-add float-end"
+        class="o-button-link p-4 o-cf-add float-end"
       >
          + Add another rule 
       </div>

--- a/tests/conditional_formatting/conditional_formatting_panel_component.test.ts
+++ b/tests/conditional_formatting/conditional_formatting_panel_component.test.ts
@@ -69,7 +69,7 @@ const selectors = {
         iconsets: ".o-cf .o-cf-iconset-rule .o-cf-iconsets .o-cf-iconset",
         inflextion: ".o-cf .o-cf-iconset-rule .o-inflection",
         icons: ".o-cf .o-cf-iconset-rule .o-inflection .o-icon",
-        reverse: ".o-cf .o-cf-iconset-rule .o-cf-iconset-reverse",
+        reverse: ".o-cf .o-cf-iconset-rule .o-button-link",
         rows: ".o-cf .o-cf-iconset-rule .o-inflection tr",
       },
     },

--- a/tests/pivots/spreadsheet_pivot/__snapshots__/spreadsheet_pivot_side_panel.test.ts.snap
+++ b/tests/pivots/spreadsheet_pivot/__snapshots__/spreadsheet_pivot_side_panel.test.ts.snap
@@ -76,7 +76,7 @@ exports[`Spreadsheet pivot side panel It should correctly be displayed 1`] = `
               >
                  Name 
                 <span
-                  class="fa fa-cog o-text-muted os-cog-wheel-menu-icon"
+                  class="fa fa-cog os-cog-wheel-menu-icon o-button-icon"
                 />
                 
                 
@@ -286,7 +286,7 @@ exports[`Spreadsheet pivot side panel It should display only the selection input
               >
                  Name 
                 <span
-                  class="fa fa-cog o-text-muted os-cog-wheel-menu-icon"
+                  class="fa fa-cog os-cog-wheel-menu-icon o-button-icon"
                 />
                 
                 
@@ -323,7 +323,7 @@ exports[`Spreadsheet pivot side panel It should display only the selection input
                   class="position-relative w-100"
                 >
                   <input
-                    class="o-input mb-2 o-focused o-invalid border-danger position-relative text-decoration-underline"
+                    class="o-input mb-2 o-focused o-invalid border-danger position-relative"
                     placeholder="e.g. A1:A2"
                     spellcheck="false"
                     style=""


### PR DESCRIPTION
## Description

Some small issues that were mostly caused by the revamp of the side panel are fixed here:

- selection input placeholder was underlined when focused
- border color in border dropdown was not centered
- pivot "Aggregated by" select does not have the same size as "Sort by"
- icons in the side panel didn't all have the same color/hover color

I also got rid of the `.btn`/`.btn-link` classes. Those are bootstrap classed, and we needed to overwrite some of the behaviour to have the desired look. It's simpler to just use custom classes.

Task: : [4125868](https://www.odoo.com/web#id=4125868&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo