### PR TITLE
[IMP] clipboard: copy whole pivot as dynamic pivot

### DIFF
--- a/src/clipboard_handlers/cell_clipboard.ts
+++ b/src/clipboard_handlers/cell_clipboard.ts
@@ -1,5 +1,5 @@
 import { canonicalizeNumberValue } from "../formulas/formula_locale";
-import { deepEquals, formatValue } from "../helpers";
+import { deepEquals, formatValue, isZoneInside } from "../helpers";
 import { getPasteZones } from "../helpers/clipboard/clipboard_helpers";
 import { createPivotFormula } from "../helpers/pivot/pivot_helpers";
 import {
@@ -46,8 +46,13 @@ export class CellClipboardHandler extends AbstractCellClipboardHandler<
         const evaluatedCell = this.getters.getEvaluatedCell(position);
         const pivotId = this.getters.getPivotIdFromPosition(position);
         const spreader = this.getters.getArrayFormulaSpreadingOn(position);
-        if (pivotId) {
-          if (spreader && (!deepEquals(spreader, position) || !isCopyingOneCell)) {
+        if (pivotId && spreader) {
+          const pivotZone = this.getters.getSpreadZone(spreader);
+          if (
+            (!deepEquals(spreader, position) || !isCopyingOneCell) &&
+            pivotZone &&
+            !data.zones.some((z) => isZoneInside(pivotZone, z))
+          ) {
             const pivotCell = this.getters.getPivotCellFromPosition(position);
             const formulaPivotId = this.getters.getPivotFormulaId(pivotId);
             const pivotFormula = createPivotFormula(formulaPivotId, pivotCell);


### PR DESCRIPTION
## Description

When we copy part of a dynamic pivot, we don't copy the values but pivot formulas instead.

But when copying (or cutting) the whole pivot, we should copy the dynamic pivot and not the pivot formulas. The intent of the user in this case is most likely to copy the pivot as a whole and not to replace it with pivot formulas (particularly when cutting).

Task: : [4123272](https://www.odoo.com/web#id=4123272&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo