### PR TITLE
[FIX] bottom bar: handle horizontal scroll

### DIFF
--- a/src/components/bottom_bar/bottom_bar.ts
+++ b/src/components/bottom_bar/bottom_bar.ts
@@ -41,6 +41,17 @@ css/* scss */ `
       .o-bottom-bar-fade-in {
         background-image: linear-gradient(90deg, #cfcfcf, transparent 1%);
       }
+
+      .o-sheet-list {
+        overflow-y: hidden;
+        overflow-x: auto;
+
+        &::-webkit-scrollbar {
+          display: none; /* Chrome */
+        }
+        -ms-overflow-style: none; /* IE and Edge */
+        scrollbar-width: none; /* Firefox */
+      }
     }
 
     .o-bottom-bar-arrows {

--- a/src/components/bottom_bar/bottom_bar.xml
+++ b/src/components/bottom_bar/bottom_bar.xml
@@ -24,7 +24,7 @@
           t-if="state.isSheetListScrollableLeft"
         />
         <div
-          class="o-sheet-list d-flex w-100 overflow-hidden px-1"
+          class="o-sheet-list d-flex w-100 px-1"
           t-ref="sheetList"
           t-on-wheel="onWheel"
           t-on-scroll="onScroll">

--- a/tests/bottom_bar/__snapshots__/bottom_bar_component.test.ts.snap
+++ b/tests/bottom_bar/__snapshots__/bottom_bar_component.test.ts.snap
@@ -204,7 +204,7 @@ exports[`BottomBar component simple rendering 1`] = `
   >
     
     <div
-      class="o-sheet-list d-flex w-100 overflow-hidden px-1"
+      class="o-sheet-list d-flex w-100 px-1"
     >
       <div
         class="o-ripple-container position-relative"

--- a/tests/spreadsheet/__snapshots__/spreadsheet_component.test.ts.snap
+++ b/tests/spreadsheet/__snapshots__/spreadsheet_component.test.ts.snap
@@ -835,7 +835,7 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
     >
       
       <div
-        class="o-sheet-list d-flex w-100 overflow-hidden px-1"
+        class="o-sheet-list d-flex w-100 px-1"
       >
         <div
           class="o-ripple-container position-relative"


### PR DESCRIPTION
## Description

We can handle the horizontal scroll in the bottom bar with simple CSS enabling the overflow, but hiding the scrollbar.

Task: : [4129625](https://www.odoo.com/web#id=4129625&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo