### PR TITLE
[IMP] pivot: add table when inserting spreadsheet pivot

### DIFF
--- a/src/plugins/ui_feature/insert_pivot.ts
+++ b/src/plugins/ui_feature/insert_pivot.ts
@@ -64,12 +64,15 @@ export class InsertPivotPlugin extends UIPlugin {
       sheetIdFrom: currentSheetId,
       sheetIdTo: sheetId,
     });
-    this.dispatch("UPDATE_CELL", {
+    const pivot = this.getters.getPivot(pivotId);
+    this.insertPivotWithTable(
       sheetId,
-      col: 0,
-      row: 0,
-      content: `=PIVOT(${formulaId})`,
-    });
+      0,
+      0,
+      pivotId,
+      pivot.getTableStructure().export(),
+      "dynamic"
+    );
   }
 
   private duplicatePivotInNewSheet(pivotId: UID, newPivotId: UID, newSheetId: UID) {

--- a/tests/pivots/pivot_insert.test.ts
+++ b/tests/pivots/pivot_insert.test.ts
@@ -1,7 +1,8 @@
 import { Model } from "../../src";
+import { PIVOT_TABLE_CONFIG } from "../../src/constants";
 import { toZone } from "../../src/helpers";
 import { insertPivot } from "../test_helpers/commands_helpers";
-import { getCellText } from "../test_helpers/getters_helpers";
+import { getCellText, getCoreTable } from "../test_helpers/getters_helpers";
 
 describe("Insert pivot command", () => {
   test("Can insert a pivot in a cell", () => {
@@ -35,5 +36,16 @@ describe("Insert pivot command", () => {
     });
     insertPivot(model, "A1", "pivot1", "Sheet2");
     expect(model.getters.getPivotCoreDefinition("pivot1")["dataSet"].zone).toEqual(toZone("A1:B2"));
+  });
+
+  test("Inserting a pivot create a table", () => {
+    const model = new Model();
+    insertPivot(model, "A1", "pivot1", "Sheet2");
+    expect(getCellText(model, "A1")).toEqual("=PIVOT(1)");
+    expect(getCoreTable(model, "A1")).toMatchObject({
+      range: { zone: toZone("A1") },
+      config: PIVOT_TABLE_CONFIG,
+      type: "dynamic",
+    });
   });
 });

--- a/tests/test_helpers/getters_helpers.ts
+++ b/tests/test_helpers/getters_helpers.ts
@@ -222,6 +222,15 @@ export function getTable(
   return model.getters.getTable({ sheetId, col, row });
 }
 
+export function getCoreTable(
+  model: Model,
+  xc: string,
+  sheetId: UID = model.getters.getActiveSheetId()
+) {
+  const { col, row } = toCartesian(xc);
+  return model.getters.getCoreTable({ sheetId, col, row });
+}
+
 export function getFilter(
   model: Model,
   xc: string,


### PR DESCRIPTION
## Description

The same ways we have a table when re-inserting a pivot, we should have a table when inserting a pivot for the first time.

Task: : [4132016](https://www.odoo.com/web#id=4132016&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo