### PR TITLE
[PERF] compiler: build literal value objects once

### DIFF
--- a/demo/main.js
+++ b/demo/main.js
@@ -237,10 +237,10 @@ class Demo extends Component {
       this.transportService = undefined;
       this.stateUpdateMessages = [];
     }
-    this.createModel(data || demoData);
+    // this.createModel(data || demoData);
     // this.createModel(makePivotDataset(10_000));
     // this.createModel(makeLargeDataset(26, 10_000, ["numbers"]));
-    // this.createModel(makeLargeDataset(26, 10_000, ["formulas"]));
+    this.createModel(makeLargeDataset(26, 10_000, ["formulas"]));
     // this.createModel(makeLargeDataset(26, 10_000, ["arrayFormulas"]));
     // this.createModel(makeLargeDataset(26, 10_000, ["vectorizedFormulas"]));
     // this.createModel({});

--- a/src/formulas/compiler.ts
+++ b/src/formulas/compiler.ts
@@ -38,8 +38,13 @@ interface ConstantValues {
   strings: string[];
 }
 
+interface ConstantValueObjects {
+  numbers: { value: number }[];
+  strings: { value: string }[];
+}
+
 type InternalCompiledFormula = CompiledFormula & {
-  constantValues: ConstantValues;
+  constantValues: ConstantValueObjects;
 };
 
 // this cache contains all compiled function code, grouped by "structure". For
@@ -165,11 +170,11 @@ function compileTokensOrThrow(tokens: Token[]): CompiledFormula {
           return code.return(`{ value: ${ast.value} }`);
         case "NUMBER":
           return code.return(
-            `{ value: this.constantValues.numbers[${constantValues.numbers.indexOf(ast.value)}] }`
+            `this.constantValues.numbers[${constantValues.numbers.indexOf(ast.value)}]`
           );
         case "STRING":
           return code.return(
-            `{ value: this.constantValues.strings[${constantValues.strings.indexOf(ast.value)}] }`
+            `this.constantValues.strings[${constantValues.strings.indexOf(ast.value)}]`
           );
         case "REFERENCE":
           const referenceIndex = dependencies.indexOf(ast.value);
@@ -207,7 +212,10 @@ function compileTokensOrThrow(tokens: Token[]): CompiledFormula {
   const compiledFormula: InternalCompiledFormula = {
     execute: functionCache[cacheKey],
     dependencies,
-    constantValues,
+    constantValues: {
+      numbers: constantValues.numbers.map((value) => ({ value })),
+      strings: constantValues.strings.map((value) => ({ value })),
+    },
     tokens,
     isBadExpression: false,
   };

--- a/tests/evaluation/__snapshots__/compiler.test.ts.snap
+++ b/tests/evaluation/__snapshots__/compiler.test.ts.snap
@@ -53,7 +53,7 @@ exports[`expression compiler expressions with a debugger 1`] = `
 // =?C|0|/|N0|
 debugger;
 const _1 = ref(deps[0], false);
-const _2 = { value: this.constantValues.numbers[0] };
+const _2 = this.constantValues.numbers[0];
 return ctx['DIVIDE'](_1, _2);
 }"
 `;
@@ -73,7 +73,7 @@ exports[`expression compiler some arithmetic expressions 1`] = `
 "function anonymous(deps,ref,range,ctx
 ) {
 // =|N0|
-return { value: this.constantValues.numbers[0] };
+return this.constantValues.numbers[0];
 }"
 `;
 
@@ -89,7 +89,7 @@ exports[`expression compiler some arithmetic expressions 3`] = `
 "function anonymous(deps,ref,range,ctx
 ) {
 // =|S0|
-return { value: this.constantValues.strings[0] };
+return this.constantValues.strings[0];
 }"
 `;
 
@@ -97,8 +97,8 @@ exports[`expression compiler some arithmetic expressions 4`] = `
 "function anonymous(deps,ref,range,ctx
 ) {
 // =|N0|+|N1|
-const _1 = { value: this.constantValues.numbers[0] };
-const _2 = { value: this.constantValues.numbers[1] };
+const _1 = this.constantValues.numbers[0];
+const _2 = this.constantValues.numbers[1];
 return ctx['ADD'](_1, _2);
 }"
 `;
@@ -107,8 +107,8 @@ exports[`expression compiler some arithmetic expressions 5`] = `
 "function anonymous(deps,ref,range,ctx
 ) {
 // =|N0|*|N1|
-const _1 = { value: this.constantValues.numbers[0] };
-const _2 = { value: this.constantValues.numbers[1] };
+const _1 = this.constantValues.numbers[0];
+const _2 = this.constantValues.numbers[1];
 return ctx['MULTIPLY'](_1, _2);
 }"
 `;
@@ -117,8 +117,8 @@ exports[`expression compiler some arithmetic expressions 6`] = `
 "function anonymous(deps,ref,range,ctx
 ) {
 // =|N0|-|N1|
-const _1 = { value: this.constantValues.numbers[0] };
-const _2 = { value: this.constantValues.numbers[1] };
+const _1 = this.constantValues.numbers[0];
+const _2 = this.constantValues.numbers[1];
 return ctx['MINUS'](_1, _2);
 }"
 `;
@@ -127,8 +127,8 @@ exports[`expression compiler some arithmetic expressions 7`] = `
 "function anonymous(deps,ref,range,ctx
 ) {
 // =|N0|/|N1|
-const _1 = { value: this.constantValues.numbers[0] };
-const _2 = { value: this.constantValues.numbers[1] };
+const _1 = this.constantValues.numbers[0];
+const _2 = this.constantValues.numbers[1];
 return ctx['DIVIDE'](_1, _2);
 }"
 `;
@@ -137,7 +137,7 @@ exports[`expression compiler some arithmetic expressions 8`] = `
 "function anonymous(deps,ref,range,ctx
 ) {
 // =-|N0|
-const _1 = { value: this.constantValues.numbers[0] };
+const _1 = this.constantValues.numbers[0];
 return ctx['UMINUS'](_1);
 }"
 `;
@@ -146,12 +146,12 @@ exports[`expression compiler some arithmetic expressions 9`] = `
 "function anonymous(deps,ref,range,ctx
 ) {
 // =(|N0|+|N1|)*(-|N1|+|N2|)
-const _1 = { value: this.constantValues.numbers[0] };
-const _2 = { value: this.constantValues.numbers[1] };
+const _1 = this.constantValues.numbers[0];
+const _2 = this.constantValues.numbers[1];
 const _3 = ctx['ADD'](_1, _2);
-const _4 = { value: this.constantValues.numbers[1] };
+const _4 = this.constantValues.numbers[1];
 const _5 = ctx['UMINUS'](_4);
-const _6 = { value: this.constantValues.numbers[2] };
+const _6 = this.constantValues.numbers[2];
 const _7 = ctx['ADD'](_5, _6);
 return ctx['MULTIPLY'](_3, _7);
 }"
@@ -161,8 +161,8 @@ exports[`expression compiler some arithmetic expressions 10`] = `
 "function anonymous(deps,ref,range,ctx
 ) {
 // =sum(|N0|,|N1|)
-const _1 = { value: this.constantValues.numbers[0] };
-const _2 = { value: this.constantValues.numbers[1] };
+const _1 = this.constantValues.numbers[0];
+const _2 = this.constantValues.numbers[1];
 return ctx['SUM'](_1,_2);
 }"
 `;
@@ -172,7 +172,7 @@ exports[`expression compiler some arithmetic expressions 11`] = `
 ) {
 // =sum(true,|S0|)
 const _1 = { value: true };
-const _2 = { value: this.constantValues.strings[0] };
+const _2 = this.constantValues.strings[0];
 return ctx['SUM'](_1,_2);
 }"
 `;
@@ -181,9 +181,9 @@ exports[`expression compiler some arithmetic expressions 12`] = `
 "function anonymous(deps,ref,range,ctx
 ) {
 // =sum(|N0|,,|N1|)
-const _1 = { value: this.constantValues.numbers[0] };
+const _1 = this.constantValues.numbers[0];
 const _2 = undefined;
-const _3 = { value: this.constantValues.numbers[1] };
+const _3 = this.constantValues.numbers[1];
 return ctx['SUM'](_1,_2,_3);
 }"
 `;
@@ -192,7 +192,7 @@ exports[`expression compiler some arithmetic expressions 13`] = `
 "function anonymous(deps,ref,range,ctx
 ) {
 // =|N0|%
-const _1 = { value: this.constantValues.numbers[0] };
+const _1 = this.constantValues.numbers[0];
 return ctx['UNARY.PERCENT'](_1);
 }"
 `;
@@ -201,8 +201,8 @@ exports[`expression compiler some arithmetic expressions 14`] = `
 "function anonymous(deps,ref,range,ctx
 ) {
 // =(|N0|+|N1|)%
-const _1 = { value: this.constantValues.numbers[0] };
-const _2 = { value: this.constantValues.numbers[1] };
+const _1 = this.constantValues.numbers[0];
+const _2 = this.constantValues.numbers[1];
 const _3 = ctx['ADD'](_1, _2);
 return ctx['UNARY.PERCENT'](_3);
 }"

--- a/tests/evaluation/__snapshots__/compiler.test.ts.snap
+++ b/tests/evaluation/__snapshots__/compiler.test.ts.snap
@@ -53,7 +53,7 @@ exports[`expression compiler expressions with a debugger 1`] = `
 // =?C|0|/|N0|
 debugger;
 const _1 = ref(deps[0], false);
-const _2 = this.constantValues.numbers[0];
+const _2 = this.literalValues.numbers[0];
 return ctx['DIVIDE'](_1, _2);
 }"
 `;
@@ -73,7 +73,7 @@ exports[`expression compiler some arithmetic expressions 1`] = `
 "function anonymous(deps,ref,range,ctx
 ) {
 // =|N0|
-return this.constantValues.numbers[0];
+return this.literalValues.numbers[0];
 }"
 `;
 
@@ -89,7 +89,7 @@ exports[`expression compiler some arithmetic expressions 3`] = `
 "function anonymous(deps,ref,range,ctx
 ) {
 // =|S0|
-return this.constantValues.strings[0];
+return this.literalValues.strings[0];
 }"
 `;
 
@@ -97,8 +97,8 @@ exports[`expression compiler some arithmetic expressions 4`] = `
 "function anonymous(deps,ref,range,ctx
 ) {
 // =|N0|+|N1|
-const _1 = this.constantValues.numbers[0];
-const _2 = this.constantValues.numbers[1];
+const _1 = this.literalValues.numbers[0];
+const _2 = this.literalValues.numbers[1];
 return ctx['ADD'](_1, _2);
 }"
 `;
@@ -107,8 +107,8 @@ exports[`expression compiler some arithmetic expressions 5`] = `
 "function anonymous(deps,ref,range,ctx
 ) {
 // =|N0|*|N1|
-const _1 = this.constantValues.numbers[0];
-const _2 = this.constantValues.numbers[1];
+const _1 = this.literalValues.numbers[0];
+const _2 = this.literalValues.numbers[1];
 return ctx['MULTIPLY'](_1, _2);
 }"
 `;
@@ -117,8 +117,8 @@ exports[`expression compiler some arithmetic expressions 6`] = `
 "function anonymous(deps,ref,range,ctx
 ) {
 // =|N0|-|N1|
-const _1 = this.constantValues.numbers[0];
-const _2 = this.constantValues.numbers[1];
+const _1 = this.literalValues.numbers[0];
+const _2 = this.literalValues.numbers[1];
 return ctx['MINUS'](_1, _2);
 }"
 `;
@@ -127,8 +127,8 @@ exports[`expression compiler some arithmetic expressions 7`] = `
 "function anonymous(deps,ref,range,ctx
 ) {
 // =|N0|/|N1|
-const _1 = this.constantValues.numbers[0];
-const _2 = this.constantValues.numbers[1];
+const _1 = this.literalValues.numbers[0];
+const _2 = this.literalValues.numbers[1];
 return ctx['DIVIDE'](_1, _2);
 }"
 `;
@@ -137,7 +137,7 @@ exports[`expression compiler some arithmetic expressions 8`] = `
 "function anonymous(deps,ref,range,ctx
 ) {
 // =-|N0|
-const _1 = this.constantValues.numbers[0];
+const _1 = this.literalValues.numbers[0];
 return ctx['UMINUS'](_1);
 }"
 `;
@@ -146,12 +146,12 @@ exports[`expression compiler some arithmetic expressions 9`] = `
 "function anonymous(deps,ref,range,ctx
 ) {
 // =(|N0|+|N1|)*(-|N1|+|N2|)
-const _1 = this.constantValues.numbers[0];
-const _2 = this.constantValues.numbers[1];
+const _1 = this.literalValues.numbers[0];
+const _2 = this.literalValues.numbers[1];
 const _3 = ctx['ADD'](_1, _2);
-const _4 = this.constantValues.numbers[1];
+const _4 = this.literalValues.numbers[1];
 const _5 = ctx['UMINUS'](_4);
-const _6 = this.constantValues.numbers[2];
+const _6 = this.literalValues.numbers[2];
 const _7 = ctx['ADD'](_5, _6);
 return ctx['MULTIPLY'](_3, _7);
 }"
@@ -161,8 +161,8 @@ exports[`expression compiler some arithmetic expressions 10`] = `
 "function anonymous(deps,ref,range,ctx
 ) {
 // =sum(|N0|,|N1|)
-const _1 = this.constantValues.numbers[0];
-const _2 = this.constantValues.numbers[1];
+const _1 = this.literalValues.numbers[0];
+const _2 = this.literalValues.numbers[1];
 return ctx['SUM'](_1,_2);
 }"
 `;
@@ -172,7 +172,7 @@ exports[`expression compiler some arithmetic expressions 11`] = `
 ) {
 // =sum(true,|S0|)
 const _1 = { value: true };
-const _2 = this.constantValues.strings[0];
+const _2 = this.literalValues.strings[0];
 return ctx['SUM'](_1,_2);
 }"
 `;
@@ -181,9 +181,9 @@ exports[`expression compiler some arithmetic expressions 12`] = `
 "function anonymous(deps,ref,range,ctx
 ) {
 // =sum(|N0|,,|N1|)
-const _1 = this.constantValues.numbers[0];
+const _1 = this.literalValues.numbers[0];
 const _2 = undefined;
-const _3 = this.constantValues.numbers[1];
+const _3 = this.literalValues.numbers[1];
 return ctx['SUM'](_1,_2,_3);
 }"
 `;
@@ -192,7 +192,7 @@ exports[`expression compiler some arithmetic expressions 13`] = `
 "function anonymous(deps,ref,range,ctx
 ) {
 // =|N0|%
-const _1 = this.constantValues.numbers[0];
+const _1 = this.literalValues.numbers[0];
 return ctx['UNARY.PERCENT'](_1);
 }"
 `;
@@ -201,8 +201,8 @@ exports[`expression compiler some arithmetic expressions 14`] = `
 "function anonymous(deps,ref,range,ctx
 ) {
 // =(|N0|+|N1|)%
-const _1 = this.constantValues.numbers[0];
-const _2 = this.constantValues.numbers[1];
+const _1 = this.literalValues.numbers[0];
+const _2 = this.literalValues.numbers[1];
 const _3 = ctx['ADD'](_1, _2);
 return ctx['UNARY.PERCENT'](_3);
 }"


### PR DESCRIPTION
With this commit, literal value objects like
`{ value: this.constantValues.numbers[0] }` are built only once, at compile time, instead of being created (and garbage collected) at every evaluation

before: coming soon
after: coming soon

Task: 4134564

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo