### PR TITLE
[FIX] pivot: convert pivot to individual formula args

### DIFF
--- a/src/helpers/pivot/pivot_menu_items.ts
+++ b/src/helpers/pivot/pivot_menu_items.ts
@@ -1,5 +1,6 @@
 import { ActionSpec } from "../../actions/action";
 import { _t } from "../../translation";
+import { CellValueType } from "../../types";
 
 export const pivotProperties: ActionSpec = {
   name: _t("Edit Pivot"),
@@ -45,7 +46,12 @@ export const FIX_FORMULAS: ActionSpec = {
       return false;
     }
     const pivot = env.model.getters.getPivot(pivotId);
-    return pivot.isValid() && env.model.getters.isSpillPivotFormula(position);
+    const cell = env.model.getters.getEvaluatedCell(position);
+    return (
+      pivot.isValid() &&
+      env.model.getters.isSpillPivotFormula(position) &&
+      cell.type !== CellValueType.error
+    );
   },
   icon: "o-spreadsheet-Icon.PIVOT",
 };

--- a/src/helpers/pivot/pivot_menu_items.ts
+++ b/src/helpers/pivot/pivot_menu_items.ts
@@ -36,7 +36,6 @@ export const FIX_FORMULAS: ActionSpec = {
       col,
       row,
       pivotId,
-      table: pivot.getTableStructure().export(),
     });
   },
   isVisible: (env) => {

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -969,7 +969,6 @@ export interface InsertPivotWithTableCommand extends PositionDependentCommand {
 export interface SplitPivotFormulaCommand extends PositionDependentCommand {
   type: "SPLIT_PIVOT_FORMULA";
   pivotId: UID;
-  table: PivotTableData;
 }
 
 export type CoreCommand =

--- a/tests/pivots/pivot_menu_items.test.ts
+++ b/tests/pivots/pivot_menu_items.test.ts
@@ -13,13 +13,14 @@ import {
 } from "../test_helpers/commands_helpers";
 import {
   getCell,
+  getCellContent,
   getCellText,
   getCoreTable,
   getEvaluatedGrid,
   getTable,
 } from "../test_helpers/getters_helpers";
 import { createModelFromGrid, doAction, getNode, makeTestEnv } from "../test_helpers/helpers";
-import { addPivot } from "../test_helpers/pivot_helpers";
+import { addPivot, createModelWithPivot } from "../test_helpers/pivot_helpers";
 
 const reinsertDynamicPivotPath = ["data", "reinsert_dynamic_pivot", "reinsert_dynamic_pivot_1"];
 const reinsertStaticPivotPath = ["data", "reinsert_static_pivot", "reinsert_static_pivot_1"];
@@ -306,8 +307,18 @@ describe("Pivot fix formula menu item", () => {
     const pivot = model.getters.getPivot("1")!;
     expect(pivot.isValid()).toBe(false);
     selectCell(model, "C1");
-    cellMenuRegistry.get("pivot_fix_formulas").execute!(env);
-    expect(getCellText(model, "C1")).toBe("=PIVOT(1)");
+    expect(cellMenuRegistry.get("pivot_fix_formulas").isVisible!(env)).toBe(false);
+  });
+
+  test("It should  be invisible when the pivot cannot spill", () => {
+    const model = createModelWithPivot("A1:I5");
+    setCellContent(model, "A24", "=pivot(1)");
+    setCellContent(model, "A25", "block the spill");
+    const env = makeTestEnv({ model });
+
+    expect(getCellContent(model, "A24")).toEqual("#SPILL!");
+    selectCell(model, "A24");
+    expect(cellMenuRegistry.get("pivot_fix_formulas").isVisible!(env)).toBe(false);
   });
 
   test("It should ignore hidden measures", () => {


### PR DESCRIPTION
## Description

The menu item to convert a pivot to individual formula args was not taking into account the arguments of the `PIVOT()` function.

Task: [4039646](https://www.odoo.com/web#id=4039646&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo