### PR TITLE
[IMP] function: better inferred format for MIN,MAX,MEDIAN

### DIFF
--- a/src/components/bottom_bar/bottom_bar_statistic/aggregate_statistics_store.ts
+++ b/src/components/bottom_bar/bottom_bar_statistic/aggregate_statistics_store.ts
@@ -37,12 +37,12 @@ const selectionStatisticFunctions: SelectionStatisticFunction[] = [
   {
     name: _t("Min"),
     types: [CellValueType.number],
-    compute: (values, locale) => min([[values]], locale),
+    compute: (values, locale) => min([[values]], locale).value,
   },
   {
     name: _t("Max"),
     types: [CellValueType.number],
-    compute: (values, locale) => max([[values]], locale),
+    compute: (values, locale) => max([[values]], locale).value,
   },
   {
     name: _t("Count"),

--- a/src/functions/helper_statistical.ts
+++ b/src/functions/helper_statistical.ts
@@ -10,6 +10,7 @@ import {
   reduceAny,
   reduceNumbers,
   transposeMatrix,
+  visitNumbers,
 } from "./helpers";
 
 export function assertSameNumberOfElements(...args: any[][]) {
@@ -71,13 +72,31 @@ export function countAny(values: Arg[]): number {
 }
 
 export function max(values: Arg[], locale: Locale) {
-  const result = reduceNumbers(values, (acc, a) => (acc < a ? a : acc), -Infinity, locale);
-  return result === -Infinity ? 0 : result;
+  let max = { value: -Infinity };
+  visitNumbers(
+    values,
+    (a) => {
+      if (a.value >= max.value) {
+        max = a;
+      }
+    },
+    locale
+  );
+  return max.value === -Infinity ? { value: 0 } : max;
 }
 
-export function min(values: Arg[], locale: Locale): number {
-  const result = reduceNumbers(values, (acc, a) => (a < acc ? a : acc), Infinity, locale);
-  return result === Infinity ? 0 : result;
+export function min(values: Arg[], locale: Locale) {
+  let min = { value: Infinity };
+  visitNumbers(
+    values,
+    (a) => {
+      if (a.value <= min.value) {
+        min = a;
+      }
+    },
+    locale
+  );
+  return min.value === Infinity ? { value: 0 } : min;
 }
 
 function prepareDataForRegression(X: Matrix<number>, Y: Matrix<number>, newX: Matrix<number>) {

--- a/src/functions/helpers.ts
+++ b/src/functions/helpers.ts
@@ -3,7 +3,16 @@ import { DateTime, isDateTime, numberToJsDate, parseDateTime } from "../helpers/
 import { memoize } from "../helpers/misc";
 import { isNumber, parseNumber } from "../helpers/numbers";
 import { _t } from "../translation";
-import { Arg, CellValue, FunctionResultObject, Locale, Matrix, Maybe, isMatrix } from "../types";
+import {
+  Arg,
+  CellValue,
+  FunctionResultNumber,
+  FunctionResultObject,
+  Locale,
+  Matrix,
+  Maybe,
+  isMatrix,
+} from "../types";
 import { CellErrorType, EvaluationError, errorTypes } from "../types/errors";
 
 const SORT_TYPES_ORDER = ["number", "string", "boolean", "undefined"];
@@ -280,20 +289,23 @@ export function visitAny(args: Arg[], cb: (a: Maybe<FunctionResultObject>) => vo
   );
 }
 
-export function visitNumbers(args: Arg[], cb: (arg: number) => void, locale: Locale): void {
+export function visitNumbers(
+  args: Arg[],
+  cb: (arg: FunctionResultNumber) => void,
+  locale: Locale
+): void {
   visitArgs(
     args,
     (cell) => {
-      const cellValue = cell?.value;
-      if (typeof cellValue === "number") {
-        cb(cellValue);
+      if (typeof cell?.value === "number") {
+        cb(cell as FunctionResultNumber);
       }
-      if (isEvaluationError(cellValue)) {
+      if (isEvaluationError(cell?.value)) {
         throw cell;
       }
     },
     (arg) => {
-      cb(strictToNumber(arg, locale));
+      cb({ value: strictToNumber(arg, locale), format: arg?.format });
     }
   );
 }

--- a/src/functions/module_financial.ts
+++ b/src/functions/module_financial.ts
@@ -1209,7 +1209,7 @@ export const IRR = {
 
     visitNumbers(
       [cashFlowAmounts],
-      (amount) => {
+      ({ value: amount }) => {
         if (amount > 0) positive = true;
         if (amount < 0) negative = true;
         amounts.push(amount);

--- a/src/functions/module_statistical.ts
+++ b/src/functions/module_statistical.ts
@@ -805,10 +805,7 @@ export const MAX = {
     ),
   ],
   compute: function (...values: Arg[]): FunctionResultNumber {
-    return {
-      value: max(values, this.locale),
-      format: inferFormat(values[0]),
-    };
+    return max(values, this.locale);
   },
   isExported: true,
 } satisfies AddFunctionDescription;
@@ -901,13 +898,13 @@ export const MEDIAN = {
     visitNumbers(
       values,
       (value) => {
-        data.push({ value });
+        data.push(value);
       },
       this.locale
     );
     return {
       value: centile(data, { value: 0.5 }, true, this.locale),
-      format: inferFormat(values[0]),
+      format: inferFormat(data[0]),
     };
   },
   isExported: true,
@@ -929,10 +926,7 @@ export const MIN = {
     ),
   ],
   compute: function (...values: Arg[]): FunctionResultNumber {
-    return {
-      value: min(values, this.locale),
-      format: inferFormat(values[0]),
-    };
+    return min(values, this.locale);
   },
   isExported: true,
 } satisfies AddFunctionDescription;

--- a/src/helpers/pivot/pivot_helpers.ts
+++ b/src/helpers/pivot/pivot_helpers.ts
@@ -76,11 +76,11 @@ export const AGGREGATORS_FN: Record<string, AggregatorFN | undefined> = {
     format: () => undefined,
   },
   max: {
-    fn: (args: Matrix<FunctionResultObject>, locale: Locale) => max([args], locale),
+    fn: (args: Matrix<FunctionResultObject>, locale: Locale) => max([args], locale).value,
     format: inferFormat,
   },
   min: {
-    fn: (args: Matrix<FunctionResultObject>, locale: Locale) => min([args], locale),
+    fn: (args: Matrix<FunctionResultObject>, locale: Locale) => min([args], locale).value,
     format: inferFormat,
   },
   avg: {

--- a/src/helpers/pivot/pivot_helpers.ts
+++ b/src/helpers/pivot/pivot_helpers.ts
@@ -4,15 +4,7 @@ import { average, countAny, max, min } from "../../functions/helper_statistical"
 import { inferFormat, toBoolean, toNumber, toString } from "../../functions/helpers";
 import { Registry } from "../../registries/registry";
 import { _t } from "../../translation";
-import {
-  Arg,
-  CellValue,
-  DEFAULT_LOCALE,
-  Format,
-  FunctionResultObject,
-  Locale,
-  Matrix,
-} from "../../types";
+import { CellValue, DEFAULT_LOCALE, FunctionResultObject, Locale, Matrix } from "../../types";
 import { EvaluationError } from "../../types/errors";
 import {
   Granularity,
@@ -53,44 +45,33 @@ for (const type in AGGREGATORS_BY_FIELD_TYPE) {
   }
 }
 
-type AggregatorFN = {
-  fn: (args: Matrix<FunctionResultObject>, locale?: Locale) => CellValue;
-  format: (data: Arg | undefined) => Format | undefined;
-};
+type AggregatorFN = (args: Matrix<FunctionResultObject>, locale?: Locale) => FunctionResultObject;
 
 export const AGGREGATORS_FN: Record<string, AggregatorFN | undefined> = {
-  count: {
-    fn: (args: Matrix<FunctionResultObject>) => countAny([args]),
-    format: () => "0",
-  },
-  count_distinct: {
-    fn: (args: Matrix<FunctionResultObject>) => countUnique([args]),
-    format: () => "0",
-  },
-  bool_and: {
-    fn: (args: Matrix<FunctionResultObject>) => boolAnd([args]).result,
-    format: () => undefined,
-  },
-  bool_or: {
-    fn: (args: Matrix<FunctionResultObject>) => boolOr([args]).result,
-    format: () => undefined,
-  },
-  max: {
-    fn: (args: Matrix<FunctionResultObject>, locale: Locale) => max([args], locale).value,
-    format: inferFormat,
-  },
-  min: {
-    fn: (args: Matrix<FunctionResultObject>, locale: Locale) => min([args], locale).value,
-    format: inferFormat,
-  },
-  avg: {
-    fn: (args: Matrix<FunctionResultObject>, locale: Locale) => average([args], locale),
-    format: inferFormat,
-  },
-  sum: {
-    fn: (args: Matrix<FunctionResultObject>, locale: Locale) => sum([args], locale),
-    format: inferFormat,
-  },
+  count: (args: Matrix<FunctionResultObject>) => ({
+    value: countAny([args]),
+    format: "0",
+  }),
+  count_distinct: (args: Matrix<FunctionResultObject>) => ({
+    value: countUnique([args]),
+    format: "0",
+  }),
+  bool_and: (args: Matrix<FunctionResultObject>) => ({
+    value: boolAnd([args]).result,
+  }),
+  bool_or: (args: Matrix<FunctionResultObject>) => ({
+    value: boolOr([args]).result,
+  }),
+  max: (args: Matrix<FunctionResultObject>, locale: Locale) => max([args], locale),
+  min: (args: Matrix<FunctionResultObject>, locale: Locale) => min([args], locale),
+  avg: (args: Matrix<FunctionResultObject>, locale: Locale) => ({
+    value: average([args], locale),
+    format: inferFormat(args),
+  }),
+  sum: (args: Matrix<FunctionResultObject>, locale: Locale) => ({
+    value: sum([args], locale),
+    format: inferFormat(args),
+  }),
 };
 
 /**

--- a/src/helpers/pivot/pivot_presentation.ts
+++ b/src/helpers/pivot/pivot_presentation.ts
@@ -62,11 +62,11 @@ export function withPivotPresentationLayer(PivotClass: PivotUIConstructor) {
       if (columns.length + rows.length !== domain.length) {
         const values = this.getValuesToAggregate(measure, domain);
         const aggregator = AGGREGATORS_FN[measure.aggregator];
+        if (!aggregator) {
+          return { value: 0 };
+        }
         try {
-          return {
-            value: aggregator?.fn([values], this.getters.getLocale()) || 0,
-            format: aggregator?.format([values]),
-          };
+          return aggregator([values], this.getters.getLocale());
         } catch (error) {
           return handleError(error, measure.aggregator.toUpperCase());
         }

--- a/src/helpers/pivot/spreadsheet_pivot/spreadsheet_pivot.ts
+++ b/src/helpers/pivot/spreadsheet_pivot/spreadsheet_pivot.ts
@@ -250,10 +250,8 @@ export class SpreadsheetPivot implements Pivot<SpreadsheetPivotRuntimeDefinition
       return { value: "" };
     }
     const measure = this.getMeasure(measureId);
-    const allValues = dataEntries.map((value) => value[measure.fieldName]);
-    const values = allValues
-      .filter((cell) => cell && cell.type !== CellValueType.empty)
-      .filter(isDefined);
+    const allValues = dataEntries.map((value) => value[measure.fieldName]).filter(isDefined);
+    const values = allValues.filter((cell) => cell.type !== CellValueType.empty);
     const aggregator = measure.aggregator;
     const operator = AGGREGATORS_FN[aggregator];
     if (!operator) {
@@ -261,10 +259,11 @@ export class SpreadsheetPivot implements Pivot<SpreadsheetPivotRuntimeDefinition
     }
 
     try {
-      return {
-        value: values.length ? operator.fn([values], this.getters.getLocale()) : "",
-        format: operator.format(allValues.find((cell) => cell?.format)),
-      };
+      const result = operator([allValues], this.getters.getLocale());
+      if (values.length === 0) {
+        return { ...result, value: "" };
+      }
+      return result;
     } catch (e) {
       return handleError(e, aggregator.toUpperCase());
     }

--- a/tests/functions/module_statistical.test.ts
+++ b/tests/functions/module_statistical.test.ts
@@ -1037,10 +1037,12 @@ describe("MAX formula", () => {
     expect(gridResult.E1).toEqual(0);
   });
 
-  test("result format depends on 1st argument", () => {
+  test("result format depends on the maximum value", () => {
     expect(evaluateCellFormat("A1", { A1: "=MAX(A2, 2)", A2: "42" })).toBe("");
-    expect(evaluateCellFormat("A1", { A1: "=MAX(A2:A3)", A2: "42%", A3: "1" })).toBe("0%");
-    expect(evaluateCellFormat("A1", { A1: "=MAX(A2:A3)", A2: "1", A3: "42%" })).toBe("");
+    expect(evaluateCellFormat("A1", { A1: "=MAX(A2:A3)", A2: "42%", A3: "0.1" })).toBe("0%");
+    expect(evaluateCellFormat("A1", { A1: "=MAX(A2:A3)", A2: "0.1", A3: "42%" })).toBe("0%");
+    expect(evaluateCellFormat("A1", { A1: "=MAX(A2, A3)", A2: "42%", A3: "0.1" })).toBe("0%");
+    expect(evaluateCellFormat("A1", { A1: "=MAX(A2, A3)", A2: "0.1", A3: "42%" })).toBe("0%");
   });
 });
 
@@ -1304,10 +1306,12 @@ describe("MEDIAN formula", () => {
     });
   });
 
-  test("result format depends on 1st argument", () => {
+  test("result format depends on 1st numeric cell", () => {
     expect(evaluateCellFormat("A1", { A1: "=MEDIAN(A2, 2)", A2: "42" })).toBe("");
     expect(evaluateCellFormat("A1", { A1: "=MEDIAN(A2:A3)", A2: "42%", A3: "1" })).toBe("0%");
     expect(evaluateCellFormat("A1", { A1: "=MEDIAN(A2:A3)", A2: "1", A3: "42%" })).toBe("");
+    expect(evaluateCellFormat("A1", { A1: "=MEDIAN(A2:A3)", A2: "hi", A3: "42%" })).toBe("0%");
+    expect(evaluateCellFormat("A1", { A1: "=MEDIAN(A2:A3)", A3: "42%" })).toBe("0%");
   });
 
   test("MEDIAN doesn't accept errors", () => {
@@ -1434,10 +1438,12 @@ describe("MIN formula", () => {
     expect(gridResult.E1).toEqual(0);
   });
 
-  test("result format depends on 1st argument", () => {
+  test("result format depends on the minimum value", () => {
     expect(evaluateCellFormat("A1", { A1: "=MIN(A2, 2)", A2: "42" })).toBe("");
     expect(evaluateCellFormat("A1", { A1: "=MIN(A2:A3)", A2: "42%", A3: "1" })).toBe("0%");
-    expect(evaluateCellFormat("A1", { A1: "=MIN(A2:A3)", A2: "1", A3: "42%" })).toBe("");
+    expect(evaluateCellFormat("A1", { A1: "=MIN(A2:A3)", A2: "1", A3: "42%" })).toBe("0%");
+    expect(evaluateCellFormat("A1", { A1: "=MIN(A2, A3)", A2: "42%", A3: "1" })).toBe("0%");
+    expect(evaluateCellFormat("A1", { A1: "=MIN(A2, A3)", A2: "1", A3: "42%" })).toBe("0%");
   });
 });
 

--- a/tests/pivots/spreadsheet_pivot/spreadsheet_pivot.test.ts
+++ b/tests/pivots/spreadsheet_pivot/spreadsheet_pivot.test.ts
@@ -5,6 +5,7 @@ import {
   deleteSheet,
   redo,
   setCellContent,
+  setFormat,
   undo,
 } from "../../test_helpers/commands_helpers";
 import {
@@ -660,6 +661,29 @@ describe("Spreadsheet Pivot", () => {
     });
     setCellContent(model, "A27", `=PIVOT.VALUE(1, "Name:${aggregator}")`);
     expect(getEvaluatedCell(model, "A27").value).toBe(aggregatedValue);
+  });
+
+  test("min and max aggregate format is inferred", () => {
+    // prettier-ignore
+    const grid = {
+      A1: "Name",   B1: "Revenue",
+      A2: "Alice",  B2: "Hi",
+      A3: "Bob",    B3: "5",
+    };
+    const model = createModelFromGrid(grid);
+    setFormat(model, "B3", "[$$]#,##0");
+    addPivot(model, "A1:B3", {
+      columns: [],
+      rows: [{ fieldName: "Name" }],
+      measures: [
+        { id: "Revenue:max", fieldName: "Revenue", aggregator: "max" },
+        { id: "Revenue:min", fieldName: "Revenue", aggregator: "min" },
+      ],
+    });
+    setCellContent(model, "A27", '=PIVOT.VALUE(1, "Revenue:max")');
+    setCellContent(model, "A28", '=PIVOT.VALUE(1, "Revenue:min")');
+    expect(getEvaluatedCell(model, "A27").format).toBe("[$$]#,##0");
+    expect(getEvaluatedCell(model, "A28").format).toBe("[$$]#,##0");
   });
 
   test.each([


### PR DESCRIPTION


## Description:

Currently the result format of MIN,MAX and MEDIAN function is inferred from the very first cell of the given dataset.

If that cell has no format (because it's empty or any other reason), then the result has no format.

Specifically for MAX and MIN, the format should be the format of the max/min value.

For MEDIAN, the format is now inferred from the first numeric cell.

Task: [4137785](https://www.odoo.com/web#id=4137785&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo