### PR TITLE
[FIX] clipboard: paste without asking permission

### DIFF
--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -609,7 +609,10 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
       this.env.model.dispatch("COPY");
     }
     const content = this.env.model.getters.getClipboardContent();
-    await this.env.clipboard.write(content);
+    // await this.env.clipboard.write(content);
+    for (const type in content) {
+      ev.clipboardData?.setData(type, content[type]);
+    }
     ev.preventDefault();
   }
 
@@ -652,6 +655,7 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
         "text/xml"
       );
       const clipboardId = htmlDocument.querySelector("div")?.getAttribute("data-clipboard-id");
+      debugger;
       return clipboardId;
     }
     const clipboard = await this.env.clipboard.read();

--- a/tests/grid/grid_component.test.ts
+++ b/tests/grid/grid_component.test.ts
@@ -1430,6 +1430,7 @@ describe("Copy paste keyboard shortcut", () => {
     setCellContent(model, "A1", "things");
     selectCell(model, "A1");
     document.body.dispatchEvent(getClipboardEvent("cut", clipboardData));
+    clipboardData.content = model.getters.getClipboardContent();
     const clipboard = await parent.env.clipboard.read!();
     const clipboardContent = "content" in clipboard ? clipboard.content : {};
     expect(clipboardContent).toMatchObject({
@@ -1448,6 +1449,7 @@ describe("Copy paste keyboard shortcut", () => {
     setStyle(model, "A1", { bold: true });
     selectCell(model, "A1");
     document.body.dispatchEvent(getClipboardEvent("cut", clipboardData));
+    clipboardData.content = model.getters.getClipboardContent();
     setCellContent(model, "A1", "new content");
     setStyle(model, "A1", { bold: false });
     selectCell(model, "A2");
@@ -1607,6 +1609,7 @@ describe("Copy paste keyboard shortcut", () => {
     createChart(model, { type: "bar" }, "chartId");
     model.dispatch("SELECT_FIGURE", { id: "chartId" });
     document.body.dispatchEvent(getClipboardEvent("copy", clipboardData));
+    clipboardData.content = model.getters.getClipboardContent();
     const clipboard = await parent.env.clipboard.read!();
     const clipboardContent = "content" in clipboard ? clipboard.content : {};
     expect(clipboardContent).toMatchObject({
@@ -1621,6 +1624,7 @@ describe("Copy paste keyboard shortcut", () => {
     createChart(model, { type: "bar" }, "chartId");
     model.dispatch("SELECT_FIGURE", { id: "chartId" });
     document.body.dispatchEvent(getClipboardEvent("cut", clipboardData));
+    clipboardData.content = model.getters.getClipboardContent();
     const clipboard = await parent.env.clipboard.read!();
     const clipboardContent = "content" in clipboard ? clipboard.content : {};
     expect(clipboardContent).toMatchObject({


### PR DESCRIPTION
## Description:

Since 825f0176d4e083f246f1775, copy and paste some cells in the spreadsheet requires the user to allow reading the OS clipboard.

It's annoying, and if the user dismisses (or blocks) the popup, copy-pasting doesn't work anymore (the permissions need to be reset).
Task: [4138195](https://www.odoo.com/web#id=4138195&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo