### PR TITLE
[FIX] session: avoid concurrent updates

### DIFF
--- a/src/collaborative/local_transport_service.ts
+++ b/src/collaborative/local_transport_service.ts
@@ -8,7 +8,7 @@ import {
 export class LocalTransportService implements TransportService<CollaborationMessage> {
   private listeners: { id: UID; callback: NewMessageCallback }[] = [];
 
-  sendMessage(message: CollaborationMessage) {
+  async sendMessage(message: CollaborationMessage) {
     for (const { callback } of this.listeners) {
       callback(message);
     }

--- a/src/collaborative/session.ts
+++ b/src/collaborative/session.ts
@@ -159,9 +159,9 @@ export class Session extends EventBus<CollaborativeEvent> {
   /**
    * Notify the server that the user client left the collaborative session
    */
-  leave(data: Lazy<WorkbookData>) {
+  async leave(data: Lazy<WorkbookData>) {
     if (Object.keys(this.clients).length === 1 && this.processedRevisions.size) {
-      this.snapshot(data());
+      await this.snapshot(data());
     }
     delete this.clients[this.clientId];
     this.transportService.leave(this.clientId);
@@ -175,12 +175,12 @@ export class Session extends EventBus<CollaborativeEvent> {
   /**
    * Send a snapshot of the spreadsheet to the collaboration server
    */
-  snapshot(data: WorkbookData) {
+  async snapshot(data: WorkbookData) {
     if (this.pendingMessages.length !== 0) {
       return;
     }
     const snapshotId = this.uuidGenerator.uuidv4();
-    this.transportService.sendMessage({
+    await this.transportService.sendMessage({
       type: "SNAPSHOT",
       nextRevisionId: snapshotId,
       serverRevisionId: this.serverRevisionId,

--- a/src/model.ts
+++ b/src/model.ts
@@ -288,8 +288,8 @@ export class Model extends EventBus<any> implements CommandDispatcher {
     this.session.join(this.config.client);
   }
 
-  leaveSession() {
-    this.session.leave(lazy(() => this.exportData()));
+  async leaveSession() {
+    await this.session.leave(lazy(() => this.exportData()));
   }
 
   private setupUiPlugin(Plugin: UIPluginConstructor) {

--- a/src/types/collaborative/transport_service.ts
+++ b/src/types/collaborative/transport_service.ts
@@ -88,7 +88,7 @@ export interface TransportService<T = any> {
   /**
    * Send a message to all clients
    */
-  sendMessage: (message: T) => void;
+  sendMessage: (message: T) => Promise<void>;
   /**
    * Register a callback function which will be called each time
    * a new message is received.

--- a/tests/__mocks__/transport_service.ts
+++ b/tests/__mocks__/transport_service.ts
@@ -18,7 +18,7 @@ export class MockTransportService implements TransportService<CollaborationMessa
     this.listeners.push({ id, callback });
   }
 
-  sendMessage(message: CollaborationMessage) {
+  async sendMessage(message: CollaborationMessage) {
     const msg: CollaborationMessage = deepCopy(message);
     switch (msg.type) {
       case "REMOTE_REVISION":

--- a/tests/collaborative/collaborative_session.test.ts
+++ b/tests/collaborative/collaborative_session.test.ts
@@ -6,6 +6,7 @@ import { buildRevisionLog } from "../../src/history/factory";
 import { Client, CommandResult, WorkbookData } from "../../src/types";
 import { MockTransportService } from "../__mocks__/transport_service";
 import { selectCell, setCellContent } from "../test_helpers/commands_helpers";
+import { nextTick } from "../test_helpers/helpers";
 
 describe("Collaborative session", () => {
   let transport: MockTransportService;
@@ -82,7 +83,7 @@ describe("Collaborative session", () => {
     });
   });
 
-  test("do not snapshot when leaving if there are pending change", () => {
+  test("do not snapshot when leaving if there are pending change", async () => {
     const model = new Model(
       {},
       {
@@ -98,6 +99,7 @@ describe("Collaborative session", () => {
       // and leave before receiving the acknowledgement
       model.leaveSession();
     });
+    await nextTick();
     expect(spy).toHaveBeenCalledTimes(2);
     expect(spy).toHaveBeenCalledWith(expect.objectContaining({ type: "REMOTE_REVISION" }));
     expect(spy).toHaveBeenCalledWith(expect.objectContaining({ type: "CLIENT_LEFT" }));


### PR DESCRIPTION
Steps to reproduce (in odoo)
- Open a spreadsheet
- do something such that there's a least one revisions
- leave the spreadsheet

=> non-deterministic concurrent update because we save the thumbnail and we snapshot at the same time.

I'm able to reproduce more when my laptop power setting is on "performance" compared to "balanced"

With this commit `leaveSession` is now asynchronous and returns a promise which resolves after the snapshot was done.
It allows to await this promise to trigger other RPC updating the same record.

Task: 4080148

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo