### PR TITLE
[REM] translations: remove some charts translations terms

### DIFF
--- a/src/components/side_panel/chart/chart_with_axis/design_panel.ts
+++ b/src/components/side_panel/chart/chart_with_axis/design_panel.ts
@@ -146,10 +146,6 @@ export class ChartWithAxisDesignPanel extends Component<Props, SpreadsheetChildE
     return dataSets[this.state.index]?.label || this.getDataSeries()[this.state.index];
   }
 
-  get showValuesLabel(): string {
-    return ChartTerms.ShowValues;
-  }
-
   updateShowValues(showValues: boolean) {
     this.props.updateChart(this.props.figureId, { showValues });
   }

--- a/src/components/side_panel/chart/chart_with_axis/design_panel.xml
+++ b/src/components/side_panel/chart/chart_with_axis/design_panel.xml
@@ -22,7 +22,7 @@
           <t t-set-slot="title">Values</t>
           <Checkbox
             name="'showValues'"
-            label="showValuesLabel"
+            label.translate="Show values"
             value="props.definition.showValues"
             onChange="showValues => props.updateChart(this.props.figureId, {showValues})"
           />

--- a/src/components/side_panel/chart/pie_chart/pie_chart_design_panel.ts
+++ b/src/components/side_panel/chart/pie_chart/pie_chart_design_panel.ts
@@ -1,7 +1,6 @@
 import { Component } from "@odoo/owl";
 import { DispatchResult, SpreadsheetChildEnv, UID } from "../../../../types";
 import { PieChartDefinition } from "../../../../types/chart";
-import { ChartTerms } from "../../../translations_terms";
 import { Checkbox } from "../../components/checkbox/checkbox";
 import { Section } from "../../components/section/section";
 import { GeneralDesignEditor } from "../building_blocks/general_design/general_design_editor";
@@ -31,9 +30,5 @@ export class PieChartDesignPanel extends Component<Props, SpreadsheetChildEnv> {
     this.props.updateChart(this.props.figureId, {
       legendPosition: ev.target.value,
     });
-  }
-
-  get showValuesLabel(): string {
-    return ChartTerms.ShowValues;
   }
 }

--- a/src/components/side_panel/chart/pie_chart/pie_chart_design_panel.xml
+++ b/src/components/side_panel/chart/pie_chart/pie_chart_design_panel.xml
@@ -22,7 +22,7 @@
           <t t-set-slot="title">Values</t>
           <Checkbox
             name="'showValues'"
-            label="showValuesLabel"
+            label.translate="Show values"
             value="props.definition.showValues"
             onChange="showValues => props.updateChart(this.props.figureId, {showValues})"
           />

--- a/src/components/side_panel/chart/waterfall_chart/waterfall_chart_design_panel.ts
+++ b/src/components/side_panel/chart/waterfall_chart/waterfall_chart_design_panel.ts
@@ -8,7 +8,6 @@ import { CHART_AXIS_CHOICES } from "../../../../helpers/figures/charts";
 import { _t } from "../../../../translation";
 import { Color, DispatchResult, SpreadsheetChildEnv, UID } from "../../../../types";
 import { WaterfallChartDefinition } from "../../../../types/chart/waterfall_chart";
-import { ChartTerms } from "../../../translations_terms";
 import { SidePanelCollapsible } from "../../components/collapsible/side_panel_collapsible";
 import { RadioSelection } from "../../components/radio_selection/radio_selection";
 import { RoundColorPicker } from "../../components/round_color_picker/round_color_picker";
@@ -101,10 +100,6 @@ export class WaterfallChartDesignPanel extends Component<Props, SpreadsheetChild
     this.props.updateChart(this.props.figureId, {
       verticalAxisPosition: value,
     });
-  }
-
-  get showValuesLabel(): string {
-    return ChartTerms.ShowValues;
   }
 
   updateShowValues(showValues: boolean) {

--- a/src/components/side_panel/chart/waterfall_chart/waterfall_chart_design_panel.xml
+++ b/src/components/side_panel/chart/waterfall_chart/waterfall_chart_design_panel.xml
@@ -31,7 +31,7 @@
           <t t-set-slot="title">Values</t>
           <Checkbox
             name="'showValues'"
-            label="showValuesLabel"
+            label.translate="Show values"
             value="props.definition.showValues"
             onChange="showValues => props.updateChart(this.props.figureId, {showValues})"
           />

--- a/src/components/translations_terms.ts
+++ b/src/components/translations_terms.ts
@@ -59,7 +59,6 @@ export const ChartTerms = {
   CumulativeData: _t("Cumulative data"),
   TreatLabelsAsText: _t("Treat labels as text"),
   AggregatedChart: _t("Aggregate"),
-  ShowValues: _t("Show values"),
   Errors: {
     Unexpected: _t("The chart definition is invalid for an unknown reason"),
     // BASIC CHART ERRORS (LINE | BAR | PIE)

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,7 +49,6 @@ import { PivotLayoutConfigurator } from "./components/side_panel/pivot/pivot_lay
 import { PivotSidePanelStore } from "./components/side_panel/pivot/pivot_side_panel/pivot_side_panel_store";
 import { PivotTitleSection } from "./components/side_panel/pivot/pivot_title_section/pivot_title_section";
 import { SidePanelStore } from "./components/side_panel/side_panel/side_panel_store";
-import { ChartTerms } from "./components/translations_terms";
 import { ValidationMessages } from "./components/validation_messages/validation_messages";
 import {
   BOTTOMBAR_HEIGHT,
@@ -446,7 +445,6 @@ export const constants = {
   DEFAULT_LOCALE,
   HIGHLIGHT_COLOR,
   PIVOT_TABLE_CONFIG,
-  ChartTerms,
   TREND_LINE_XAXIS_ID,
   CHART_AXIS_CHOICES,
 };


### PR DESCRIPTION
## Task Description

TODO

## Related Task

Task: 0

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo