### PR TITLE
Recompute format on collaborative change

### DIFF
--- a/src/plugins/ui_feature/cell_computed_style.ts
+++ b/src/plugins/ui_feature/cell_computed_style.ts
@@ -20,6 +20,7 @@ export class CellComputedStylePlugin extends UIPlugin {
     if (
       invalidateEvaluationCommands.has(cmd.type) ||
       cmd.type === "UPDATE_CELL" ||
+      cmd.type === "SET_FORMATTING" ||
       cmd.type === "EVALUATE_CELLS"
     ) {
       this.styles = {};

--- a/tests/collaborative/collaborative.test.ts
+++ b/tests/collaborative/collaborative.test.ts
@@ -780,6 +780,19 @@ describe("Multi users synchronisation", () => {
     );
   });
 
+  test("background color is updated for each client", () => {
+    setCellContent(alice, "A1", "Hi");
+    expect([alice, bob, charlie]).toHaveSynchronizedValue(
+      (user) => getStyle(user, "A1").fillColor,
+      undefined
+    );
+    setStyle(bob, "A1", { fillColor: "#112233" });
+    expect([alice, bob, charlie]).toHaveSynchronizedValue(
+      (user) => getStyle(user, "A1").fillColor,
+      "#112233"
+    );
+  });
+
   test.each(["COL", "ROW"] as const)("Can group headers concurrently", (dimension) => {
     const sheetId = alice.getters.getActiveSheetId();
 


### PR DESCRIPTION
## Description:

Steps to reproduce:

- open the same spreadsheet in two different tabs
- in one of the tab, change the background color of some cells

=> the background is not updated in the other tab

The UPDATE_CELL command is not dispatched to `CellComputedStylePlugin` of other clients because it's categorized as a "feature" plugin which is not supposed to react to collaborative core (sub) commands. It currently reacts to the root command.

The plugin cannot be a "core view" plugin because it depends on the filter values, which is a UI state.

Task: [4141034](https://www.odoo.com/web#id=4141034&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo