### PR TITLE
[FIX] clipboard: paste without asking permission

### DIFF
--- a/src/actions/menu_items_actions.ts
+++ b/src/actions/menu_items_actions.ts
@@ -56,7 +56,7 @@ async function paste(env: SpreadsheetChildEnv, pasteOption?: ClipboardPasteOptio
     case "ok":
       const htmlDocument = new DOMParser().parseFromString(
         osClipboard.content[ClipboardMIMEType.Html] ?? "<div></div>",
-        "text/xml"
+        "text/html"
       );
       const osClipboardSpreadsheetContent =
         osClipboard.content[ClipboardMIMEType.OSpreadsheet] || "{}";

--- a/src/plugins/ui_stateful/clipboard.ts
+++ b/src/plugins/ui_stateful/clipboard.ts
@@ -517,7 +517,7 @@ export class ClipboardPlugin extends UIPlugin {
     );
   }
 
-  private getHTMLContent(): string | undefined {
+  private getHTMLContent(): string {
     if (!this.copiedData?.cells) {
       return `<div data-clipboard-id="${this.clipboardId}">\t</div>`;
     }

--- a/tests/grid/grid_component.test.ts
+++ b/tests/grid/grid_component.test.ts
@@ -1403,7 +1403,7 @@ describe("Copy paste keyboard shortcut", () => {
   });
 
   test("Can paste from OS", async () => {
-    await parent.env.clipboard.writeText("Excalibur");
+    clipboardData.setData(ClipboardMIMEType.PlainText, "Excalibur");
     selectCell(model, "A1");
     document.body.dispatchEvent(getClipboardEvent("paste", clipboardData));
     await nextTick();
@@ -1414,8 +1414,7 @@ describe("Copy paste keyboard shortcut", () => {
     setCellContent(model, "A1", "things");
     selectCell(model, "A1");
     document.body.dispatchEvent(getClipboardEvent("copy", clipboardData));
-    const clipboard = await parent.env.clipboard.read!();
-    const clipboardContent = "content" in clipboard ? clipboard.content : {};
+    const clipboardContent = clipboardData.content;
     expect(clipboardContent).toMatchObject({
       "text/plain": "things",
       "text/html": `<div data-clipboard-id="${model.getters.getClipboardId()}">things</div>`,
@@ -1430,8 +1429,7 @@ describe("Copy paste keyboard shortcut", () => {
     setCellContent(model, "A1", "things");
     selectCell(model, "A1");
     document.body.dispatchEvent(getClipboardEvent("cut", clipboardData));
-    const clipboard = await parent.env.clipboard.read!();
-    const clipboardContent = "content" in clipboard ? clipboard.content : {};
+    const clipboardContent = clipboardData.content;
     expect(clipboardContent).toMatchObject({
       "text/plain": "things",
       "text/html": `<div data-clipboard-id="${model.getters.getClipboardId()}">things</div>`,
@@ -1463,8 +1461,7 @@ describe("Copy paste keyboard shortcut", () => {
     setCellContent(model, "A1", "1");
     setCellFormat(model, "A1", "m/d/yyyy");
     document.body.dispatchEvent(getClipboardEvent("cut", clipboardData));
-    const clipboard = await parent.env.clipboard.read!();
-    const clipboardContent = "content" in clipboard ? clipboard.content : {};
+    const clipboardContent = clipboardData.content;
     expect(clipboardContent[ClipboardMIMEType.PlainText]).toEqual(getCellContent(model, "A1"));
     model.dispatch("SET_FORMULA_VISIBILITY", { show: false });
     selectCell(model, "A2");
@@ -1477,8 +1474,7 @@ describe("Copy paste keyboard shortcut", () => {
     setCellContent(model, "A1", "1");
     setCellFormat(model, "A1", "m/d/yyyy");
     document.body.dispatchEvent(getClipboardEvent("cut", clipboardData));
-    let clipboard = await parent.env.clipboard.read!();
-    let clipboardContent = "content" in clipboard ? clipboard.content : {};
+    let clipboardContent = clipboardData.content;
     expect(clipboardContent[ClipboardMIMEType.PlainText]).toEqual(
       getEvaluatedCell(model, "A1").formattedValue
     );
@@ -1491,8 +1487,7 @@ describe("Copy paste keyboard shortcut", () => {
     setCellContent(model, "B1", "1");
     selectCell(model, "B1");
     document.body.dispatchEvent(getClipboardEvent("cut", clipboardData));
-    clipboard = await parent.env.clipboard.read!();
-    clipboardContent = "content" in clipboard ? clipboard.content : {};
+    clipboardContent = clipboardData.content;
     expect(clipboardContent[ClipboardMIMEType.PlainText]).toEqual(
       getEvaluatedCell(model, "B1").formattedValue
     );
@@ -1512,6 +1507,7 @@ describe("Copy paste keyboard shortcut", () => {
     // Fake OS clipboard should have the same content
     // to make paste come from spreadsheet clipboard
     // which support paste as values
+    parent.env.clipboard.write(clipboardData.content);
     selectCell(model, "A2");
     document.activeElement!.dispatchEvent(
       new KeyboardEvent("keydown", { key: "V", ctrlKey: true, bubbles: true, shiftKey: true })
@@ -1607,8 +1603,7 @@ describe("Copy paste keyboard shortcut", () => {
     createChart(model, { type: "bar" }, "chartId");
     model.dispatch("SELECT_FIGURE", { id: "chartId" });
     document.body.dispatchEvent(getClipboardEvent("copy", clipboardData));
-    const clipboard = await parent.env.clipboard.read!();
-    const clipboardContent = "content" in clipboard ? clipboard.content : {};
+    const clipboardContent = clipboardData.content;
     expect(clipboardContent).toMatchObject({
       "text/plain": "\t",
     });
@@ -1621,8 +1616,7 @@ describe("Copy paste keyboard shortcut", () => {
     createChart(model, { type: "bar" }, "chartId");
     model.dispatch("SELECT_FIGURE", { id: "chartId" });
     document.body.dispatchEvent(getClipboardEvent("cut", clipboardData));
-    const clipboard = await parent.env.clipboard.read!();
-    const clipboardContent = "content" in clipboard ? clipboard.content : {};
+    const clipboardContent = clipboardData.content;
     expect(clipboardContent).toMatchObject({
       "text/plain": "\t",
     });


### PR DESCRIPTION
### [FIX] clipboard: paste without asking permission

Since 825f017, copy and paste some cells in the spreadsheet requires the user to allow reading the OS clipboard. It's annoying, and if the user dismisses (or blocks) the popup, copy-pasting doesn't work anymore (the permissions need to be reset).

Task: [4138195](https://www.odoo.com/web#id=4138195&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo