### PR TITLE
[FIX] IconCF: Fix 'reverse icon' button style

### DIFF
--- a/src/components/side_panel/conditional_formatting/cf_editor/icon_set_rule_editor.xml
+++ b/src/components/side_panel/conditional_formatting/cf_editor/icon_set_rule_editor.xml
@@ -116,11 +116,13 @@
     <div class="o-cf-iconset-rule">
       <t t-call="o-spreadsheet-IconSets"/>
       <t t-call="o-spreadsheet-IconSetInflexionPoints"/>
-      <div
-        class="o-button-link py-1 ps-0 d-flex flex-row align-items-center"
-        t-on-click="reverseIcons">
-        <t t-call="o-spreadsheet-Icon.REFRESH"/>
-        <div class="ms-1">Reverse icons</div>
+      <div class="d-flex flex-row">
+        <div
+          class="o-button-link py-1 ps-0 o-cf-iconset-reverse d-flex align-items-center"
+          t-on-click="reverseIcons">
+          <t t-call="o-spreadsheet-Icon.REFRESH"/>
+          <div class="ms-1">Reverse icons</div>
+        </div>
       </div>
     </div>
   </t>


### PR DESCRIPTION
Following the css revamp of the sidepanels, the 'reverse icon' button action would span over the whole width of the sidepanel (you could click anywhere at the height of the button) instead of its text content.

Task: 4159765

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo