### PR TITLE
[FIX] Formats: largeFormatNumber should account for percentage

### DIFF
--- a/src/helpers/format/format.ts
+++ b/src/helpers/format/format.ts
@@ -698,6 +698,12 @@ function _createLargeNumberFormat<T extends InternalFormat>(
       lastDigitIndex + 1
     );
   }
+
+  const missingPercents =
+    format.percentSymbols - newIntegerPart.filter((tk) => tk.type === "PERCENT").length;
+
+  newIntegerPart.push(...new Array(missingPercents).fill({ type: "PERCENT", value: "%" }));
+
   return { ...format, integerPart: newIntegerPart, decimalPart: undefined, magnitude };
 }
 

--- a/tests/functions/module_custom.test.ts
+++ b/tests/functions/module_custom.test.ts
@@ -170,4 +170,12 @@ describe("FORMAT.LARGE.NUMBER formula", () => {
     // should be "5,000mk" in a perfect world. But we cannot tell the difference between a custom currency and a unit in a format.
     expect(getCellContent(model, "A2")).toBe("5,000m");
   });
+
+  test("Percentage in decimal part is preserved by FORMAT.LARGE.NUMBER", () => {
+    const model = new Model();
+    setCellContent(model, "A1", "100000");
+    setFormat(model, "A1", "#,##0.0%");
+    setCellContent(model, "A2", "=FORMAT.LARGE.NUMBER(A1)");
+    expect(getCellContent(model, "A2")).toBe("10,000k%");
+  });
 });


### PR DESCRIPTION
The function that creates large format numbers did account for the thousand separator but not the percentages when those were in the decimal part of the format because we simply ignore the content of the latter.

How to reproduce:
- A1: '=LARGE.FORMAT.NUMBER(100,000, "#,##0,0%")' The percentage did not appear in the result.

It also affects the scorecard charts where we use the same process to humanize the values of the chart.

Task: 4163487

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo