### PR TITLE
[PERF] compiler: allocate less memory

### DIFF
--- a/src/formulas/compiler.ts
+++ b/src/formulas/compiler.ts
@@ -1,6 +1,6 @@
 import { Token } from ".";
 import { functionRegistry } from "../functions/index";
-import { concat, parseNumber, removeStringQuotes, unquote } from "../helpers";
+import { parseNumber, removeStringQuotes, unquote } from "../helpers";
 import { _t } from "../translation";
 import { CompiledFormula, DEFAULT_LOCALE, FormulaToExecute } from "../types";
 import { BadExpressionError, UnknownFunctionError } from "../types/errors";
@@ -236,27 +236,35 @@ function compilationCacheKey(
   constantValues: ConstantValues,
   symbols: string[]
 ): string {
-  return concat(
-    tokens.map((token) => {
-      switch (token.type) {
-        case "STRING":
-          const value = removeStringQuotes(token.value);
-          return `|S${constantValues.strings.indexOf(value)}|`;
-        case "NUMBER":
-          return `|N${constantValues.numbers.indexOf(parseNumber(token.value, DEFAULT_LOCALE))}|`;
-        case "REFERENCE":
-        case "INVALID_REFERENCE":
-          if (token.value.includes(":")) {
-            return `R|${dependencies.indexOf(token.value)}|`;
-          }
-          return `C|${dependencies.indexOf(token.value)}|`;
-        case "SPACE":
-          return "";
-        default:
-          return token.value;
-      }
-    })
-  );
+  let cacheKey = "";
+  for (const token of tokens) {
+    switch (token.type) {
+      case "STRING":
+        const value = removeStringQuotes(token.value);
+        cacheKey += `|S${constantValues.strings.indexOf(value)}|`;
+        break;
+      case "NUMBER":
+        cacheKey += `|N${constantValues.numbers.indexOf(
+          parseNumber(token.value, DEFAULT_LOCALE)
+        )}|`;
+        break;
+      case "REFERENCE":
+      case "INVALID_REFERENCE":
+        if (token.value.includes(":")) {
+          cacheKey += `R|${dependencies.indexOf(token.value)}|`;
+        } else {
+          cacheKey += `C|${dependencies.indexOf(token.value)}|`;
+        }
+        break;
+      case "SPACE":
+        cacheKey += "";
+        break;
+      default:
+        cacheKey += token.value;
+        break;
+    }
+  }
+  return cacheKey;
 }
 
 /**


### PR DESCRIPTION
With the large formula data set:

`compilationCacheKey` allocates (including discarded by GC)

before: 131MB
after:	114Mb
	-13%

Task: 4167673

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [4167673](https://www.odoo.com/web#id=4167673&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo