### PR TITLE
[FIX] pivot: add suggestion message to broken pivot formulas

### DIFF
--- a/src/components/side_panel/pivot/pivot_side_panel/pivot_side_panel_store.ts
+++ b/src/components/side_panel/pivot/pivot_side_panel/pivot_side_panel_store.ts
@@ -2,6 +2,7 @@ import { deepCopy, deepEquals } from "../../../../helpers";
 import { isDateField } from "../../../../helpers/pivot/pivot_helpers";
 import { pivotRegistry } from "../../../../helpers/pivot/pivot_registry";
 import { Get } from "../../../../store_engine";
+import { NotificationStore } from "../../../../stores/notification_store";
 import { SpreadsheetStore } from "../../../../stores/spreadsheet_store";
 import { _t } from "../../../../translation";
 import { Command, UID } from "../../../../types";
@@ -18,6 +19,9 @@ export class PivotSidePanelStore extends SpreadsheetStore {
 
   private updatesAreDeferred: boolean = false;
   private draft: PivotCoreDefinition | null = null;
+  private notification = this.get(NotificationStore);
+  private alreadyNotified = false;
+
   constructor(get: Get, private pivotId: UID) {
     super(get);
   }
@@ -140,6 +144,19 @@ export class PivotSidePanelStore extends SpreadsheetStore {
         pivot: this.draft,
       });
       this.draft = null;
+      if (!this.alreadyNotified && !this.isDynamicPivotInViewport()) {
+        const formulaId = this.getters.getPivotFormulaId(this.pivotId);
+        const pivotExample = `=PIVOT(${formulaId})`;
+        this.alreadyNotified = true;
+        this.notification.notifyUser({
+          type: "info",
+          text: _t(
+            "Pivot updates only work with dynamic pivot tables. Use %s or re-insert the static pivot from the Data menu.",
+            pivotExample
+          ),
+          sticky: false,
+        });
+      }
     }
   }
 
@@ -175,14 +192,23 @@ export class PivotSidePanelStore extends SpreadsheetStore {
       this.fields,
       cleanedDefinition
     );
-    if (this.updatesAreDeferred) {
-      this.draft = cleanedWithGranularity;
-    } else {
-      this.model.dispatch("UPDATE_PIVOT", {
-        pivotId: this.pivotId,
-        pivot: cleanedWithGranularity,
-      });
+    this.draft = cleanedWithGranularity;
+    if (!this.updatesAreDeferred) {
+      this.applyUpdate();
     }
+  }
+
+  private isDynamicPivotInViewport() {
+    const sheetId = this.getters.getActiveSheetId();
+    for (const col of this.getters.getSheetViewVisibleCols()) {
+      for (const row of this.getters.getSheetViewVisibleRows()) {
+        const isDynamicPivot = this.getters.isSpillPivotFormula({ sheetId, col, row });
+        if (isDynamicPivot) {
+          return true;
+        }
+      }
+    }
+    return false;
   }
 
   private addDefaultDateTimeGranularity(fields: PivotFields, definition: PivotCoreDefinition) {

--- a/src/functions/module_lookup.ts
+++ b/src/functions/module_lookup.ts
@@ -728,9 +728,13 @@ export const PIVOT_VALUE = {
     }
 
     if (!pivot.areDomainArgsFieldsValid(domainArgs)) {
+      const suggestion = _t(
+        "Consider using a dynamic pivot formula: %s. Or re-insert the static pivot from the Data menu.",
+        `=PIVOT(${_pivotFormulaId})`
+      );
       return {
         value: CellErrorType.GenericError,
-        message: _t("Dimensions don't match the pivot definition"),
+        message: _t("Dimensions don't match the pivot definition") + ". " + suggestion,
       };
     }
     const domain = pivot.parseArgsToPivotDomain(domainArgs);
@@ -761,9 +765,13 @@ export const PIVOT_HEADER = {
       return error;
     }
     if (!pivot.areDomainArgsFieldsValid(domainArgs)) {
+      const suggestion = _t(
+        "Consider using a dynamic pivot formula: %s. Or re-insert the static pivot from the Data menu.",
+        `=PIVOT(${_pivotFormulaId})`
+      );
       return {
         value: CellErrorType.GenericError,
-        message: _t("Dimensions don't match the pivot definition"),
+        message: _t("Dimensions don't match the pivot definition") + ". " + suggestion,
       };
     }
     const domain = pivot.parseArgsToPivotDomain(domainArgs);

--- a/tests/pivots/spreadsheet_pivot/spreadsheet_pivot.test.ts
+++ b/tests/pivots/spreadsheet_pivot/spreadsheet_pivot.test.ts
@@ -932,7 +932,7 @@ describe("Spreadsheet Pivot", () => {
     });
     setCellContent(model, "A27", '=PIVOT.HEADER(1, "Date:not_a_granularity", 2024)');
     expect(getEvaluatedCell(model, "A27").message).toBe(
-      "Dimensions don't match the pivot definition"
+      "Dimensions don't match the pivot definition. Consider using a dynamic pivot formula: =PIVOT(1). Or re-insert the static pivot from the Data menu."
     );
   });
 
@@ -966,7 +966,7 @@ describe("Spreadsheet Pivot", () => {
     // without granularity
     setCellContent(model, "A31", '=PIVOT.HEADER(1, "Date", )');
     expect(getEvaluatedCell(model, "A31").message).toBe(
-      "Dimensions don't match the pivot definition"
+      "Dimensions don't match the pivot definition. Consider using a dynamic pivot formula: =PIVOT(1). Or re-insert the static pivot from the Data menu."
     );
 
     // no a number
@@ -1009,7 +1009,7 @@ describe("Spreadsheet Pivot", () => {
     // without granularity
     setCellContent(model, "A31", '=PIVOT.HEADER(1, "Date", )');
     expect(getEvaluatedCell(model, "A31").message).toBe(
-      "Dimensions don't match the pivot definition"
+      "Dimensions don't match the pivot definition. Consider using a dynamic pivot formula: =PIVOT(1). Or re-insert the static pivot from the Data menu."
     );
     setCellContent(model, "A32", '=PIVOT.HEADER(1, "Date:quarter_number", "not a number")');
     expect(getEvaluatedCell(model, "A32").message).toBe(
@@ -1060,7 +1060,7 @@ describe("Spreadsheet Pivot", () => {
     // without granularity
     setCellContent(model, "A32", '=PIVOT.HEADER(1, "Date", )');
     expect(getEvaluatedCell(model, "A32").message).toBe(
-      "Dimensions don't match the pivot definition"
+      "Dimensions don't match the pivot definition. Consider using a dynamic pivot formula: =PIVOT(1). Or re-insert the static pivot from the Data menu."
     );
 
     // not a number
@@ -1106,7 +1106,7 @@ describe("Spreadsheet Pivot", () => {
     // without granularity
     setCellContent(model, "A31", '=PIVOT.HEADER(1, "Date", )');
     expect(getEvaluatedCell(model, "A31").message).toBe(
-      "Dimensions don't match the pivot definition"
+      "Dimensions don't match the pivot definition. Consider using a dynamic pivot formula: =PIVOT(1). Or re-insert the static pivot from the Data menu."
     );
 
     // not a number
@@ -1159,7 +1159,7 @@ describe("Spreadsheet Pivot", () => {
     // without granularity
     setCellContent(model, "A31", '=PIVOT.HEADER(1, "Date", )');
     expect(getEvaluatedCell(model, "A31").message).toBe(
-      "Dimensions don't match the pivot definition"
+      "Dimensions don't match the pivot definition. Consider using a dynamic pivot formula: =PIVOT(1). Or re-insert the static pivot from the Data menu."
     );
 
     // not a number
@@ -1209,7 +1209,7 @@ describe("Spreadsheet Pivot", () => {
     // without granularity
     setCellContent(model, "A31", '=PIVOT.HEADER(1, "Date", )');
     expect(getEvaluatedCell(model, "A31").message).toBe(
-      "Dimensions don't match the pivot definition"
+      "Dimensions don't match the pivot definition. Consider using a dynamic pivot formula: =PIVOT(1). Or re-insert the static pivot from the Data menu."
     );
 
     // not a number

--- a/tests/pivots/spreadsheet_pivot/spreadsheet_pivot_side_panel.test.ts
+++ b/tests/pivots/spreadsheet_pivot/spreadsheet_pivot_side_panel.test.ts
@@ -1,7 +1,13 @@
 import { Model, SpreadsheetChildEnv } from "../../../src";
 import { toZone } from "../../../src/helpers";
 import { SpreadsheetPivot } from "../../../src/helpers/pivot/spreadsheet_pivot/spreadsheet_pivot";
-import { createSheet, setCellContent, undo } from "../../test_helpers/commands_helpers";
+import { NotificationStore } from "../../../src/stores/notification_store";
+import {
+  createSheet,
+  setCellContent,
+  setViewportOffset,
+  undo,
+} from "../../test_helpers/commands_helpers";
 import { click, dragElement, setInputValueAndTrigger } from "../../test_helpers/dom_helper";
 import { getCellText } from "../../test_helpers/getters_helpers";
 import { mountSpreadsheet, nextTick } from "../../test_helpers/helpers";
@@ -233,6 +239,35 @@ describe("Spreadsheet pivot side panel", () => {
     expect(model.getters.getPivotCoreDefinition("1").rows).toEqual([
       { name: "Amount", order: "desc" },
     ]);
+  });
+
+  test("notify when no dynamic pivot is visible", async () => {
+    setCellContent(model, "A4", "=PIVOT(1)");
+    const mockNotify = jest.fn();
+    const notificationStore = env.getStore(NotificationStore);
+    notificationStore.updateNotificationCallbacks({
+      notifyUser: mockNotify,
+    });
+
+    await click(fixture.querySelector(".o-pivot-measure .add-dimension")!);
+    await click(fixture.querySelectorAll(".o-autocomplete-value")[1]);
+    // don't notify when dynamic pivot is visible
+    expect(mockNotify).toHaveBeenCalledTimes(0);
+
+    // scroll beyond the =PIVOT formula
+    setViewportOffset(model, 0, 1000);
+    await click(fixture.querySelector(".o-pivot-measure .add-dimension")!);
+    await click(fixture.querySelectorAll(".o-autocomplete-value")[1]);
+    expect(mockNotify).toHaveBeenCalledWith({
+      text: "Pivot updates only work with dynamic pivot tables. Use =PIVOT(1) or re-insert the static pivot from the Data menu.",
+      sticky: false,
+      type: "info",
+    });
+
+    // don't notify a second time
+    await click(fixture.querySelector(".o-pivot-measure .add-dimension")!);
+    await click(fixture.querySelectorAll(".o-autocomplete-value")[1]);
+    expect(mockNotify).toHaveBeenCalledTimes(1);
   });
 
   test("Invalid pivot dimensions are displayed as such in the side panel", async () => {


### PR DESCRIPTION
## Description:

Since the pivot insertion is inserting static formulas, if the user changes the groups, the static formulas are no longer correct and are in error. The user might not understand what's happening and how to fix the issue.

This commit adds more info to the error message to help the user.

A similar issue happens with measures: when adding a new measure, nothing happens in the grid => no feedback.

Technical note: instead of changing the existing message, I added a second one, which I concatenate to the existing one. The reason is to avoid breaking existing translations in a stable version.

Task: [4169586](https://www.odoo.com/web#id=4169586&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo