### PR TITLE
[IMP] charts: open gauge design section by default

### DIFF
--- a/src/components/side_panel/chart/gauge_chart_panel/gauge_chart_design_panel.xml
+++ b/src/components/side_panel/chart/gauge_chart_panel/gauge_chart_design_panel.xml
@@ -5,7 +5,7 @@
       definition="props.definition"
       updateChart="props.updateChart"
     />
-    <SidePanelCollapsible collapsedAtInit="true">
+    <SidePanelCollapsible collapsedAtInit="false">
       <t t-set-slot="title">Gauge Design</t>
       <t t-set-slot="content">
         <Section class="'pt-0'">

--- a/src/components/side_panel/chart/scorecard_chart_panel/scorecard_chart_design_panel.xml
+++ b/src/components/side_panel/chart/scorecard_chart_panel/scorecard_chart_design_panel.xml
@@ -18,7 +18,7 @@
         </Section>
       </t>
     </GeneralDesignEditor>
-    <SidePanelCollapsible collapsedAtInit="true">
+    <SidePanelCollapsible collapsedAtInit="false">
       <t t-set-slot="title">Baseline</t>
       <t t-set-slot="content">
         <Section class="'pt-0'">


### PR DESCRIPTION
## Description:

The "Gauge Design" section is currently folded by default. But there's nothing else to show and there's room to show it. Let's show it by default instead of requiring one more click to see all options.

Task: [4170168](https://www.odoo.com/web#id=4170168&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo