### PR TITLE
[FIX] Find&Replace: always search cell content if `searchFormula`

### DIFF
--- a/src/plugins/ui/find_and_replace.ts
+++ b/src/plugins/ui/find_and_replace.ts
@@ -151,11 +151,7 @@ export class FindAndReplacePlugin extends UIPlugin {
           cell &&
           this.currentSearchRegex &&
           this.currentSearchRegex.test(
-            this.searchOptions.searchFormulas
-              ? cell.isFormula()
-                ? cell.content
-                : String(cell.evaluated.value)
-              : String(cell.evaluated.value)
+            this.searchOptions.searchFormulas ? cell.content : String(cell.evaluated.value)
           )
         ) {
           const position = this.getters.getCellPosition(cell.id);


### PR DESCRIPTION
The current implementation of a search with the option `serachFormula` will only look into the cell content if the cell is a valid formula cell and not a cell which results in an error following its evaluation.

e.g.  A1: '=SUM("a")' is invalid thus the related cell is not a formula cell but an error cell and will never be matched when looking for the term "sum".

Task: 4175968

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [4175968](https://www.odoo.com/web#id=4175968&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo