### PR TITLE
[FIX] pivot: aggregate sub-groups with date granularity

### DIFF
--- a/src/helpers/pivot/pivot_presentation.ts
+++ b/src/helpers/pivot/pivot_presentation.ts
@@ -149,7 +149,7 @@ export function withPivotPresentationLayer(PivotClass: PivotUIConstructor) {
       if (domainLevel > domain.length) {
         return [];
       }
-      if (!domain.length) {
+      if (domain.length === domainLevel) {
         return tree;
       }
       for (const node of tree) {

--- a/tests/pivots/pivot_calculated_measure.test.ts
+++ b/tests/pivots/pivot_calculated_measure.test.ts
@@ -618,16 +618,20 @@ describe("Pivot calculated measure", () => {
   });
 
   test("aggregate grouped by date field aggregated by month number", () => {
+    // prettier-ignore
     const grid = {
-      A1: "Date",
-      A2: "2024/01/01",
+      A1: "Date",       B1: "Name",
+      A2: "2024/01/01", B2: "Bob",
+      A3: "2024/01/01", B3: "Alice",
       A6: '=PIVOT.VALUE(1,"calc")',
+      A7: '=PIVOT.VALUE(1,"calc","Name","Bob")',
+      A8: '=PIVOT.VALUE(1,"calc","Name","Bob","Date:month_number",1)',
     };
     const model = createModelFromGrid(grid);
     const sheetId = model.getters.getActiveSheetId();
-    addPivot(model, "A1:A2", {
+    addPivot(model, "A1:B3", {
       columns: [],
-      rows: [{ fieldName: "Date", granularity: "month_number" }],
+      rows: [{ fieldName: "Name" }, { fieldName: "Date", granularity: "month_number" }],
       measures: [
         {
           id: "calc",
@@ -637,7 +641,9 @@ describe("Pivot calculated measure", () => {
         },
       ],
     });
-    expect(getEvaluatedCell(model, "A6").value).toEqual(10);
+    expect(getEvaluatedCell(model, "A6").value).toEqual(20);
+    expect(getEvaluatedCell(model, "A7").value).toEqual(10);
+    expect(getEvaluatedCell(model, "A8").value).toEqual(10);
   });
 
   test("aggregator preserves the format", () => {


### PR DESCRIPTION
## Description:

Steps to reproduce:
- Create a dataset Salesperson/Created on/Expected Revenue (demo dataset)
- In the pivot rows, group by Salesperson => Created On:Quarter (also crashes with month and day of month)
- In the measure, add any calculated measure

=> The pivot is in error " 0 is not a valid quarter (it should be a number
   between 1 and 4)"

Aggregating sub-groups doesn't work. Only the grand total was working or leaf values.

Task: [4176174](https://www.odoo.com/web#id=4176174&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo