### PR TITLE
[FIX] composer: auto-complete pivot dimension after operator

### DIFF
--- a/src/components/composer/composer/abstract_composer_store.ts
+++ b/src/components/composer/composer/abstract_composer_store.ts
@@ -577,10 +577,17 @@ export abstract class AbstractComposerStore extends SpreadsheetStore {
     const tokenAtCursor = content.startsWith("=")
       ? this.tokenAtCursor
       : { type: "STRING", value: content };
-    if (this.editionMode === "inactive" || !tokenAtCursor) {
+    if (
+      this.editionMode === "inactive" ||
+      !tokenAtCursor ||
+      ["TRUE", "FALSE"].includes(tokenAtCursor.value.toUpperCase()) ||
+      !(
+        this.canStartComposerRangeSelection() ||
+        ["SYMBOL", "STRING", "UNKNOWN"].includes(tokenAtCursor.type)
+      )
+    ) {
       return;
     }
-
     const thisCtx = { composer: this, getters: this.getters };
     const providersDefinitions = this.getAutoCompleteProviders();
     const providers = providersDefinitions

--- a/src/components/composer/composer/abstract_composer_store.ts
+++ b/src/components/composer/composer/abstract_composer_store.ts
@@ -602,7 +602,7 @@ export abstract class AbstractComposerStore extends SpreadsheetStore {
       if (
         searchTerm &&
         proposals &&
-        !["ARG_SEPARATOR", "LEFT_PAREN"].includes(tokenAtCursor.type)
+        !["ARG_SEPARATOR", "LEFT_PAREN", "OPERATOR"].includes(tokenAtCursor.type)
       ) {
         const filteredProposals = fuzzyLookup(
           searchTerm,

--- a/src/components/composer/composer/composer.ts
+++ b/src/components/composer/composer/composer.ts
@@ -789,7 +789,7 @@ export class Composer extends Component<CellComposerProps, SpreadsheetChildEnv> 
   }
 
   private autoComplete(value: string) {
-    if (!value) {
+    if (!value || this.assistant.forcedClosed) {
       return;
     }
     this.autoCompleteState.provider?.selectProposal(value);

--- a/src/registries/auto_completes/function_auto_complete.ts
+++ b/src/registries/auto_completes/function_auto_complete.ts
@@ -12,12 +12,7 @@ autoCompleteProviders.add("functions", {
       return [];
     }
     const searchTerm = tokenAtCursor.value;
-    const searchTermUpperCase = searchTerm.toUpperCase();
-    if (
-      !this.composer.currentContent.startsWith("=") ||
-      searchTermUpperCase === "TRUE" ||
-      searchTermUpperCase === "FALSE"
-    ) {
+    if (!this.composer.currentContent.startsWith("=")) {
       return [];
     }
     const values = Object.entries(functionRegistry.content)

--- a/src/registries/auto_completes/pivot_dimension_auto_complete.ts
+++ b/src/registries/auto_completes/pivot_dimension_auto_complete.ts
@@ -36,7 +36,10 @@ export function createMeasureAutoComplete(
       return measureProposals.concat(dimensionsProposals);
     },
     selectProposal(tokenAtCursor, value) {
-      const start = tokenAtCursor.start;
+      let start = tokenAtCursor.end;
+      if (tokenAtCursor.type === "SYMBOL") {
+        start = tokenAtCursor.start;
+      }
       const end = tokenAtCursor.end;
       this.composer.changeComposerCursorSelection(start, end);
       this.composer.replaceComposerCursorSelection(value);

--- a/tests/composer/auto_complete/pivot_auto_complete_store.test.ts
+++ b/tests/composer/auto_complete/pivot_auto_complete_store.test.ts
@@ -769,4 +769,69 @@ describe("spreadsheet pivot auto complete", () => {
     expect(composer.currentContent).toBe("=1+Stage");
     expect(composer.autocompleteProvider).toBeUndefined();
   });
+
+  test("auto complete dimension starting with the cursor after an operator token", async () => {
+    const model = createModelWithPivot("A1:I5");
+    updatePivot(model, "1", {
+      columns: [],
+      rows: [{ fieldName: "Stage" }],
+      measures: [{ id: "Expected Revenue:sum", fieldName: "Expected Revenue", aggregator: "sum" }],
+    });
+    const pivot = model.getters.getPivot("1");
+    const { store: composer } = makeStoreWithModel(model, StandaloneComposerStore, () => ({
+      content: "=",
+      defaultRangeSheetId: model.getters.getActiveSheetId(),
+      onConfirm: () => {},
+      contextualAutocomplete: createMeasureAutoComplete(
+        pivot.definition,
+        pivot.getMeasure("Expected Revenue:sum")
+      ),
+    }));
+    composer.startEdition();
+    const autoComplete = composer.autocompleteProvider;
+    expect(autoComplete?.proposals).toEqual([
+      {
+        text: "Stage",
+        description: "Stage",
+        fuzzySearchKey: "StageStageStage",
+        htmlContent: [{ color: "#4a4e4d", value: "Stage" }],
+      },
+    ]);
+    autoComplete?.selectProposal(autoComplete?.proposals[0].text);
+    expect(composer.currentContent).toBe("=Stage");
+    expect(composer.autocompleteProvider).toBeUndefined();
+  });
+
+  test("auto complete dimension with cursor after an operator token", async () => {
+    const model = createModelWithPivot("A1:I5");
+    updatePivot(model, "1", {
+      columns: [],
+      rows: [{ fieldName: "Stage" }],
+      measures: [{ id: "Expected Revenue:sum", fieldName: "Expected Revenue", aggregator: "sum" }],
+    });
+    const pivot = model.getters.getPivot("1");
+    const { store: composer } = makeStoreWithModel(model, StandaloneComposerStore, () => ({
+      content: "=0",
+      defaultRangeSheetId: model.getters.getActiveSheetId(),
+      onConfirm: () => {},
+      contextualAutocomplete: createMeasureAutoComplete(
+        pivot.definition,
+        pivot.getMeasure("Expected Revenue:sum")
+      ),
+    }));
+    composer.startEdition();
+    composer.setCurrentContent("="); // simulate a backspace to delete the "0"
+    const autoComplete = composer.autocompleteProvider;
+    expect(autoComplete?.proposals).toEqual([
+      {
+        text: "Stage",
+        description: "Stage",
+        fuzzySearchKey: "StageStageStage",
+        htmlContent: [{ color: "#4a4e4d", value: "Stage" }],
+      },
+    ]);
+    autoComplete?.selectProposal(autoComplete?.proposals[0].text);
+    expect(composer.currentContent).toBe("=Stage");
+    expect(composer.autocompleteProvider).toBeUndefined();
+  });
 });

--- a/tests/composer/autocomplete_dropdown_component.test.ts
+++ b/tests/composer/autocomplete_dropdown_component.test.ts
@@ -336,6 +336,24 @@ describe("Functions autocomplete", () => {
       expect(fixture.querySelector(".o-formula-assistant-container")).toBeTruthy();
       expect(fixture.querySelector("#formula-assistant-details")?.className).not.toContain("show");
     });
+
+    test("cannot auto-complete when it is closed", async () => {
+      await typeInComposer("=SU");
+      expect(document.activeElement).toBe(composerEl);
+      expect(fixture.querySelectorAll(".o-autocomplete-value")).toHaveLength(1);
+
+      // hide the auto-complete
+      await click(fixture, ".fa-times-circle");
+      expect(fixture.querySelectorAll(".o-autocomplete-value")).toHaveLength(0);
+      await keyDown({ key: "Enter" });
+      expect(composerStore.currentContent).toBe("=SU");
+
+      // show it again
+      await click(fixture, ".fa-question-circle");
+      expect(fixture.querySelectorAll(".o-autocomplete-value")).toHaveLength(1);
+      await keyDown({ key: "Enter" });
+      expect(composerStore.currentContent).toBe("=SUM(");
+    });
   });
 
   describe("autocomplete functions SUM IF", () => {


### PR DESCRIPTION
## Description:

Steps to reproduce:
- insert a pivot
- add a calculated measure (the default formula is "=0")
- delete the "0"

=> the auto-complete isn't displayed

Task: [4176433](https://www.odoo.com/web#id=4176433&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo