### PR TITLE
[FIX] table: update table style on header group removal

### DIFF
--- a/src/plugins/ui_feature/table_style.ts
+++ b/src/plugins/ui_feature/table_style.ts
@@ -46,6 +46,9 @@ export class TableStylePlugin extends UIPlugin {
       case "FOLD_HEADER_GROUP":
       case "FOLD_ALL_HEADER_GROUPS":
       case "UNFOLD_ALL_HEADER_GROUPS":
+      case "FOLD_HEADER_GROUPS_IN_ZONE":
+      case "UNFOLD_HEADER_GROUPS_IN_ZONE":
+      case "UNGROUP_HEADERS":
       case "UPDATE_TABLE":
       case "UPDATE_FILTER":
         delete this.tableStyles[cmd.sheetId];

--- a/src/plugins/ui_stateful/filter_evaluation.ts
+++ b/src/plugins/ui_stateful/filter_evaluation.ts
@@ -68,6 +68,8 @@ export class FilterEvaluationPlugin extends UIPlugin {
       case "UNFOLD_HEADER_GROUP":
       case "FOLD_ALL_HEADER_GROUPS":
       case "UNFOLD_ALL_HEADER_GROUPS":
+      case "FOLD_HEADER_GROUPS_IN_ZONE":
+      case "UNFOLD_HEADER_GROUPS_IN_ZONE":
         this.updateHiddenRows(cmd.sheetId);
         break;
       case "UPDATE_FILTER":

--- a/tests/table/table_style_plugin.test.ts
+++ b/tests/table/table_style_plugin.test.ts
@@ -4,7 +4,9 @@ import { TABLE_PRESETS } from "../../src/helpers/table_presets";
 import { Style, UID } from "../../src/types";
 import {
   createTable,
+  foldAllHeaderGroups,
   foldHeaderGroup,
+  foldHeaderGroupsInZone,
   groupRows,
   hideColumns,
   hideRows,
@@ -13,7 +15,10 @@ import {
   setStyle,
   setZoneBorders,
   undo,
+  unfoldAllHeaderGroups,
   unfoldHeaderGroup,
+  unfoldHeaderGroupsInZone,
+  ungroupHeaders,
   unhideColumns,
   unhideRows,
   updateFilter,
@@ -202,6 +207,25 @@ describe("Table style", () => {
       foldHeaderGroup(model, "ROW", 0, 2);
       expect(getFullTableStyle("A1:B4")).not.toEqual(tableStyle);
       unfoldHeaderGroup(model, "ROW", 0, 2);
+      expect(getFullTableStyle("A1:B4")).toEqual(tableStyle);
+
+      foldHeaderGroupsInZone(model, "ROW", "B1:B2");
+      expect(getFullTableStyle("A1:B4")).not.toEqual(tableStyle);
+      unfoldHeaderGroupsInZone(model, "ROW", "B1:B2");
+      expect(getFullTableStyle("A1:B4")).toEqual(tableStyle);
+
+      foldAllHeaderGroups(model, "ROW");
+      expect(getFullTableStyle("A1:B4")).not.toEqual(tableStyle);
+      unfoldAllHeaderGroups(model, "ROW");
+      expect(getFullTableStyle("A1:B4")).toEqual(tableStyle);
+    });
+
+    test("Table style is updated when removing a header group", () => {
+      const tableStyle = getFullTableStyle("A1:B4");
+      groupRows(model, 0, 2);
+      foldHeaderGroup(model, "ROW", 0, 2);
+      expect(getFullTableStyle("A1:B4")).not.toEqual(tableStyle);
+      ungroupHeaders(model, "ROW", 0, 2);
       expect(getFullTableStyle("A1:B4")).toEqual(tableStyle);
     });
 


### PR DESCRIPTION
## Description

The table styles were not updated when a header group was removed, because UNGROUP_HEADERS wasn't handled.

Task: [4081345](https://www.odoo.com/web#id=4081345&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo