### PR TITLE
[IMP] pivot: persist defer update

### DIFF
--- a/src/components/side_panel/pivot/pivot_side_panel/pivot_side_panel_store.ts
+++ b/src/components/side_panel/pivot/pivot_side_panel/pivot_side_panel_store.ts
@@ -18,13 +18,15 @@ import {
 export class PivotSidePanelStore extends SpreadsheetStore {
   mutators = ["reset", "deferUpdates", "applyUpdate", "discardPendingUpdate", "update"] as const;
 
-  private updatesAreDeferred: boolean = false;
+  private updatesAreDeferred: boolean;
   private draft: PivotCoreDefinition | null = null;
   private notification = this.get(NotificationStore);
   private alreadyNotified = false;
 
   constructor(get: Get, private pivotId: UID) {
     super(get);
+    this.updatesAreDeferred =
+      this.getters.getPivotCoreDefinition(this.pivotId).deferUpdates ?? false;
   }
 
   handle(cmd: Command) {
@@ -127,10 +129,13 @@ export class PivotSidePanelStore extends SpreadsheetStore {
   }
 
   deferUpdates(shouldDefer: boolean) {
-    this.updatesAreDeferred = shouldDefer;
     if (shouldDefer === false && this.draft) {
+      this.draft.deferUpdates = false;
       this.applyUpdate();
+    } else {
+      this.update({ deferUpdates: shouldDefer });
     }
+    this.updatesAreDeferred = shouldDefer;
   }
 
   applyUpdate() {

--- a/src/types/pivot.ts
+++ b/src/types/pivot.ts
@@ -56,6 +56,7 @@ export interface CommonPivotCoreDefinition {
   rows: PivotCoreDimension[];
   measures: PivotCoreMeasure[];
   name: string;
+  deferUpdates?: boolean;
 }
 
 export interface SpreadsheetPivotCoreDefinition extends CommonPivotCoreDefinition {

--- a/tests/pivots/spreadsheet_pivot/spreadsheet_pivot_side_panel.test.ts
+++ b/tests/pivots/spreadsheet_pivot/spreadsheet_pivot_side_panel.test.ts
@@ -337,6 +337,21 @@ describe("Spreadsheet pivot side panel", () => {
     expect(measures).toEqual(["Count", "float", "integer", "text"]);
   });
 
+  test("defer update option is persistent", async () => {
+    const pivotId = model.getters.getPivotIds()[0];
+    expect(".pivot-defer-update input").toHaveValue(false);
+    expect(model.getters.getPivotCoreDefinition(pivotId).deferUpdates).toBeFalsy();
+
+    await click(fixture, ".pivot-defer-update input");
+    expect(".pivot-defer-update input").toHaveValue(true);
+    expect(model.getters.getPivotCoreDefinition(pivotId).deferUpdates).toBeTruthy();
+
+    await click(fixture, ".o-sidePanelClose");
+    env.openSidePanel("PivotSidePanel", { pivotId });
+    await nextTick();
+    expect(".pivot-defer-update input").toHaveValue(true);
+  });
+
   test("Measures have the correct default aggregator", async () => {
     setCellContent(model, "A1", "amount");
     setCellContent(model, "A2", "10");


### PR DESCRIPTION
### [IMP] pivot: persist defer update

Add the defer update option to the pivot core definition so it
is persisted when re-opening the side panel.

### [IMP] grid: add F9 shortcut

This commit adds the F9 shortcut to the grid component to refresh the 
evaluation.

Task: [4080797](https://www.odoo.com/web#id=4080797&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo