### PR TITLE
[FIX] export: Fix default style ignored at export

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -162,7 +162,7 @@ export const DEFAULT_STYLE = {
   underline: false,
   fontSize: 10,
   fillColor: "",
-  textColor: "#000000",
+  textColor: "",
 } satisfies Required<Style>;
 
 export const DEFAULT_VERTICAL_ALIGN = DEFAULT_STYLE.verticalAlign;

--- a/tests/cells/style_plugin.test.ts
+++ b/tests/cells/style_plugin.test.ts
@@ -74,6 +74,14 @@ describe("styles", () => {
     expect(data.styles).toEqual({});
   });
 
+  test("textColor black(#000000) is exported as non default style", () => {
+    const model = new Model();
+    setStyle(model, "A1", { textColor: "#000000" });
+    const data = model.exportData();
+    expect(data.sheets[0].cells.A1?.style).toBe(1);
+    expect(data.styles).toEqual({ 1: { textColor: "#000000" } });
+  });
+
   test("only non default style values are exported", () => {
     const model = new Model();
     setStyle(model, "A1", {


### PR DESCRIPTION
The default style values ignored at export were targetting the font color black (#000000) as the default value. However, the default value is the simple absence of value (or rather an empty string) as we should be able to differentiate it from a choice from the user to set the font color to black (e.g. when the cell is also receiving its style from a CF or a table).

Task: 4178743

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo