### PR TITLE
[FIX] autocomplete: Stop the range selection after selecting a pivot …

### DIFF
--- a/src/helpers/pivot/pivot_composer_helpers.ts
+++ b/src/helpers/pivot/pivot_composer_helpers.ts
@@ -1,6 +1,6 @@
 import { tokenColors } from "../../components/composer/composer/composer";
 import { ComposerStore } from "../../components/composer/composer/composer_store";
-import { Token, getFunctionsFromTokens } from "../../formulas";
+import { getFunctionsFromTokens, Token } from "../../formulas";
 import { EnrichedToken } from "../../formulas/composer_tokenizer";
 import { Granularity, PivotField } from "../../types";
 
@@ -41,6 +41,7 @@ export function insertTokenAfterArgSeparator(
     // replace the whole token
     start = tokenAtCursor.start;
   }
+  this.composer.stopComposerRangeSelection();
   this.composer.changeComposerCursorSelection(start, end);
   this.composer.replaceComposerCursorSelection(value);
 }
@@ -63,6 +64,7 @@ export function insertTokenAfterLeftParenthesis(
     // replace the whole token
     start = tokenAtCursor.start;
   }
+  this.composer.stopComposerRangeSelection();
   this.composer.changeComposerCursorSelection(start, end);
   this.composer.replaceComposerCursorSelection(value);
 }

--- a/tests/composer/auto_complete/pivot_auto_complete_store.test.ts
+++ b/tests/composer/auto_complete/pivot_auto_complete_store.test.ts
@@ -19,6 +19,8 @@ describe("spreadsheet pivot auto complete", () => {
     );
     for (const func of ["PIVOT", "PIVOT.HEADER", "PIVOT.VALUE"]) {
       composer.startEdition(`=${func}(`);
+      expect(composer.isSelectingRange).toBeTruthy();
+
       const autoComplete = composer.autocompleteProvider;
       expect(autoComplete?.proposals).toEqual([
         {
@@ -36,6 +38,8 @@ describe("spreadsheet pivot auto complete", () => {
       ]);
       autoComplete?.selectProposal(autoComplete?.proposals[0].text);
       expect(composer.currentContent).toBe(`=${func}(1`);
+      // range selection stops
+      expect(composer.isSelectingRange).toBeFalsy();
       expect(composer.autocompleteProvider).toBeUndefined();
       composer.cancelEdition();
     }
@@ -62,7 +66,7 @@ describe("spreadsheet pivot auto complete", () => {
     }
   });
 
-  test("PIVOT.VALUE measuresgd", async () => {
+  test("PIVOT.VALUE measures", async () => {
     const model = createModelWithPivot("A1:I5");
     updatePivot(model, "1", {
       columns: [],


### PR DESCRIPTION
…proposal

The proposal selection of pivot autocomplete would put the composer in an invalid state where we inserted some text while in range selection mode without modifying the said state.

How to reproduce:
- Go to a runbot and insert a pivot in a spreadsheet
- type =pivot(
- Your have the dropddown taht suggests the id 1
- type enter to select it --> your composer has =pivot(1 as content
- use the arrowkeys to the up/down --> It pipes a cell reference next to the pivotID

Task: 4176481

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo