### PR TITLE
[IMP] xlsx: add support for data bars in CF

### DIFF
--- a/src/components/side_panel/conditional_formatting/cf_editor/cf_editor.ts
+++ b/src/components/side_panel/conditional_formatting/cf_editor/cf_editor.ts
@@ -24,6 +24,7 @@ import {
   IconSetRule,
   SpreadsheetChildEnv,
 } from "../../../../types";
+import { hexaToInt } from "../../../../xlsx/conversion";
 import { ColorPickerWidget } from "../../../color_picker/color_picker_widget";
 import { StandaloneComposer } from "../../../composer/standalone_composer/standalone_composer";
 import { css, getTextDecoration } from "../../../helpers";
@@ -290,7 +291,7 @@ export class ConditionalFormattingEditor extends Component<Props, SpreadsheetChi
       },
       colorScale: {
         type: "ColorScaleRule",
-        minimum: { type: "value", color: 0xffffff },
+        minimum: { type: "value", color: hexaToInt("EFF7FF") },
         midpoint: undefined,
         maximum: { type: "value", color: 0x6aa84f },
       },

--- a/src/types/xlsx.ts
+++ b/src/types/xlsx.ts
@@ -466,6 +466,11 @@ export interface XLSXColorScale {
   cfvos: XLSXCfValueObject[];
 }
 
+export interface XLSXDataBar {
+  color: XLSXColor;
+  cfvos: XLSXCfValueObject[];
+}
+
 export interface XLSXIconSet {
   iconSet: ExcelIconSet;
   cfvos: XLSXCfValueObject[];
@@ -491,7 +496,7 @@ export interface XLSXCfRule {
   priority: number;
   formula?: string[];
   colorScale?: XLSXColorScale;
-  dataBar?: any;
+  dataBar?: XLSXDataBar;
   iconSet?: XLSXIconSet;
   dxfId?: number;
   stopIfTrue?: boolean;

--- a/src/xlsx/functions/conditional_formatting.ts
+++ b/src/xlsx/functions/conditional_formatting.ts
@@ -5,6 +5,7 @@ import {
   ColorScaleRule,
   ColorScaleThreshold,
   ConditionalFormat,
+  DataBarRule,
   IconSet,
   IconSetRule,
   IconThreshold,
@@ -36,6 +37,9 @@ export function addConditionalFormatting(
         break;
       case "IconSetRule":
         cfNodes.push(addIconSetRule(cf, cf.rule));
+        break;
+      case "DataBarRule":
+        cfNodes.push(addDataBarRule(cf, cf.rule));
         break;
       default:
         // @ts-ignore Typescript knows it will never happen at compile time
@@ -133,6 +137,25 @@ function cellRuleTypeAttributes(rule: CellIsRule): XMLAttributes {
     case "NotBetween":
       return [["type", "cellIs"]];
   }
+}
+
+function addDataBarRule(cf: ConditionalFormat, rule: DataBarRule): XMLString {
+  const ruleAttributes = commonCfAttributes(cf);
+  ruleAttributes.push(["type", "dataBar"]);
+
+  // TODO ATM we do not support min and max values, so to have the same result
+  // in Excel, we export with min=0 and max=100
+  return escapeXml/*xml*/ `
+    <conditionalFormatting sqref="${cf.ranges.join(" ")}">
+      <cfRule ${formatAttributes(ruleAttributes)}>
+        <dataBar>
+          <cfvo type="min" val="0"/>
+          <cfvo type="max" val="100"/>
+          <color rgb="${toXlsxHexColor(colorNumberString(rule.color))}"/>
+        </dataBar>
+      </cfRule>
+    </conditionalFormatting>
+  `;
 }
 
 function addColorScaleRule(cf: ConditionalFormat, rule: ColorScaleRule): XMLString {

--- a/tests/xlsx/__snapshots__/xlsx_export.test.ts.snap
+++ b/tests/xlsx/__snapshots__/xlsx_export.test.ts.snap
@@ -19471,6 +19471,133 @@ exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Conditional f
 }
 `;
 
+exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Conditional formatting with DataBar Rule is correctly exported 1`] = `
+{
+  "files": [
+    {
+      "content": "<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+    <sheets>
+        <sheet state="visible" name="Sheet1" sheetId="1" r:id="rId1"/>
+    </sheets>
+</workbook>",
+      "contentType": "workbook",
+      "path": "xl/workbook.xml",
+    },
+    {
+      "content": "<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+    <sheetViews>
+        <sheetView showGridLines="1" workbookViewId="0">
+        </sheetView>
+    </sheetViews>
+    <sheetFormatPr defaultRowHeight="17.25" defaultColWidth="13.73"/>
+    <cols>
+        <col min="1" max="1" width="13.73" customWidth="1" hidden="0"/>
+        <col min="2" max="2" width="13.73" customWidth="1" hidden="0"/>
+    </cols>
+    <sheetData>
+    </sheetData>
+    <conditionalFormatting sqref="B1:B5">
+        <cfRule priority="1" stopIfTrue="0" type="dataBar">
+            <dataBar>
+                <cfvo type="min" val="0"/>
+                <cfvo type="max" val="100"/>
+                <color rgb="EFF7FF"/>
+            </dataBar>
+        </cfRule>
+    </conditionalFormatting>
+</worksheet>",
+      "contentType": "sheet",
+      "path": "xl/worksheets/sheet0.xml",
+    },
+    {
+      "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+    <numFmts count="0">
+    </numFmts>
+    <fonts count="1">
+        <font>
+            <sz val="10"/>
+            <color rgb="000000"/>
+            <name val="Arial"/>
+        </font>
+    </fonts>
+    <fills count="2">
+        <fill>
+            <patternFill patternType="none"/>
+        </fill>
+        <fill>
+            <patternFill patternType="gray125"/>
+        </fill>
+    </fills>
+    <borders count="1">
+        <border>
+            <left>
+            </left>
+            <right>
+            </right>
+            <top>
+            </top>
+            <bottom>
+            </bottom>
+            <diagonal>
+            </diagonal>
+        </border>
+    </borders>
+    <cellXfs count="1">
+        <xf numFmtId="0" fillId="0" fontId="0" borderId="0"/>
+    </cellXfs>
+    <dxfs count="0">
+    </dxfs>
+</styleSheet>",
+      "contentType": "styles",
+      "path": "xl/styles.xml",
+    },
+    {
+      "content": "<sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" count="0" uniqueCount="0">
+</sst>",
+      "contentType": "sharedStrings",
+      "path": "xl/sharedStrings.xml",
+    },
+    {
+      "content": "<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+    <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
+    <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
+    <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+</Relationships>",
+      "contentType": undefined,
+      "path": "xl/_rels/workbook.xml.rels",
+    },
+    {
+      "content": "<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+    <Default Extension="avif" ContentType="image/avif"/>
+    <Default Extension="bmp" ContentType="image/bmp"/>
+    <Default Extension="gif" ContentType="image/gif"/>
+    <Default Extension="ico" ContentType="image/vnd.microsoft.icon"/>
+    <Default Extension="jpeg" ContentType="image/jpeg"/>
+    <Default Extension="png" ContentType="image/png"/>
+    <Default Extension="tiff" ContentType="image/tiff"/>
+    <Default Extension="webp" ContentType="image/webp"/>
+    <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+    <Default Extension="xml" ContentType="application/xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml" PartName="/xl/workbook.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
+</Types>",
+      "contentType": undefined,
+      "path": "[Content_Types].xml",
+    },
+    {
+      "content": "<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+    <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>",
+      "contentType": undefined,
+      "path": "_rels/.rels",
+    },
+  ],
+  "name": "my_spreadsheet.xlsx",
+}
+`;
+
 exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Conditional formatting with formula cannot be exported (for now) 1`] = `
 {
   "files": [

--- a/tests/xlsx/xlsx_export.test.ts
+++ b/tests/xlsx/xlsx_export.test.ts
@@ -6,6 +6,7 @@ import { DEFAULT_TABLE_CONFIG } from "../../src/helpers/table_presets";
 import { Model } from "../../src/model";
 import { CustomizedDataSet, Dimension, ExcelChartType } from "../../src/types";
 import { XLSXExportXMLFile, XMLString } from "../../src/types/xlsx";
+import { hexaToInt } from "../../src/xlsx/conversion";
 import { adaptFormulaToExcel } from "../../src/xlsx/functions/cells";
 import { escapeXml, parseXML } from "../../src/xlsx/helpers/xml_helpers";
 
@@ -678,6 +679,29 @@ describe("Test XLSX export", () => {
       expect(console.warn).toHaveBeenCalledWith(
         "Conditional formats with formula rules are not supported at the moment. The rule is therefore skipped."
       );
+    });
+
+    test("Conditional formatting with DataBar Rule is correctly exported", async () => {
+      const model = new Model({
+        sheets: [
+          {
+            colNumber: 2,
+            rowNumber: 5,
+            cells: {},
+            conditionalFormats: [
+              {
+                id: "1",
+                ranges: ["B1:B5"],
+                rule: {
+                  type: "DataBarRule",
+                  color: hexaToInt("EFF7FF"),
+                },
+              },
+            ],
+          },
+        ],
+      });
+      expect(await exportPrettifiedXlsx(model)).toMatchSnapshot();
     });
   });
 

--- a/tests/xlsx/xlsx_import.test.ts
+++ b/tests/xlsx/xlsx_import.test.ts
@@ -375,6 +375,15 @@ describe("Import xlsx data", () => {
     });
   });
 
+  test("Can import Data Bars", () => {
+    const testSheet = getWorkbookSheet("jestCfs", convertedData)!;
+    const cf = getCFBeginningAt("B25", testSheet)!;
+    expect(cf.rule).toMatchObject({
+      type: "DataBarRule",
+      color: hexaToInt("#63C384"),
+    });
+  });
+
   test.each([
     ["3Arrows percent", "H11"],
     ["3ArrowsGray num", "H12"],


### PR DESCRIPTION
This commit adds the support for import/export of data bars rules.

Task: 4179806

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo