### PR TITLE
[FIX] scorecard: do not translate empty string

### DIFF
--- a/src/helpers/figures/charts/scorecard_chart.ts
+++ b/src/helpers/figures/charts/scorecard_chart.ts
@@ -455,7 +455,7 @@ export function createScorecardChartRuntime(
     title: {
       ...chart.title,
       // chart titles are extracted from .json files and they are translated at runtime here
-      text: _t(chart.title.text ?? ""),
+      text: chart.title.text ? _t(chart.title.text) : "",
     },
     keyValue: formattedKeyValue,
     baselineDisplay,


### PR DESCRIPTION
Trying to extract the translation of an empty string will throw a warning (https://github.com/python-babel/babel/blob/master/babel/messages/extract.py#L356)

This commit removes the translation of the empty string.

Task: 0

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo