### PR TITLE
[FIX] auto-complete: hide auto-complete when selecting a cell

### DIFF
--- a/src/components/composer/composer/composer.ts
+++ b/src/components/composer/composer/composer.ts
@@ -1,4 +1,4 @@
-import { Component, onMounted, useEffect, useRef, useState } from "@odoo/owl";
+import { Component, onMounted, onWillUnmount, useEffect, useRef, useState } from "@odoo/owl";
 import { DEFAULT_FONT, NEWLINE } from "../../../constants";
 import { functionRegistry } from "../../../functions/index";
 import { clip, getZoneArea, isEqual, splitReference } from "../../../helpers/index";
@@ -233,7 +233,12 @@ export class Composer extends Component<ComposerProps, SpreadsheetChildEnv> {
       }
       this.contentHelper.updateEl(el);
     });
-
+    this.env.model.selection.observe(this, {
+      handleEvent: () => this.autoCompleteState.hide(),
+    });
+    onWillUnmount(() => {
+      this.env.model.selection.detachObserver(this);
+    });
     useEffect(() => {
       this.processContent();
     });

--- a/src/selection_stream/event_stream.ts
+++ b/src/selection_stream/event_stream.ts
@@ -65,6 +65,10 @@ export class EventStream<Event> {
     this.observers.set(owner, { owner, callbacks });
   }
 
+  detachObserver(owner: Owner) {
+    this.observers.delete(owner);
+  }
+
   /**
    * Capture the stream for yourself
    */

--- a/src/selection_stream/selection_stream_processor.ts
+++ b/src/selection_stream/selection_stream_processor.ts
@@ -31,6 +31,7 @@ type StatefulStream<Event, State> = {
   resetDefaultAnchor: (owner: unknown, state: State) => void;
   resetAnchor: (owner: unknown, state: State) => void;
   observe: (owner: unknown, callbacks: StreamCallbacks<Event>) => void;
+  detachObserver: (owner: unknown) => void;
   release: (owner: unknown) => void;
   getBackToDefault(): void;
 };
@@ -112,6 +113,10 @@ export class SelectionStreamProcessorImpl implements SelectionStreamProcessor {
 
   observe(owner: unknown, callbacks: StreamCallbacks<SelectionEvent>) {
     this.stream.observe(owner, callbacks);
+  }
+
+  detachObserver(owner: unknown) {
+    this.stream.detachObserver(owner);
   }
 
   release(owner: unknown) {

--- a/tests/composer/composer_integration_component.test.ts
+++ b/tests/composer/composer_integration_component.test.ts
@@ -38,6 +38,7 @@ import {
 import {
   getActivePosition,
   getActiveSheetFullScrollInfo,
+  getCell,
   getCellContent,
   getCellText,
   getSelectionAnchorCellXc,
@@ -51,6 +52,7 @@ import {
   typeInComposerGrid as typeInComposerGridHelper,
   typeInComposerTopBar as typeInComposerTopBarHelper,
 } from "../test_helpers/helpers";
+import { addPivot } from "../test_helpers/pivot_helpers";
 
 jest.mock("../../src/components/composer/content_editable_helper.ts", () =>
   require("../__mocks__/content_editable_helper")
@@ -153,6 +155,24 @@ describe("Composer interactions", () => {
     expect(fixture.querySelector(".o-grid .o-autocomplete-dropdown")).not.toBeNull();
     await click(topBarComposer);
     expect(fixture.querySelector(".o-grid .o-autocomplete-dropdown")).toBeNull();
+  });
+
+  test("autocomplete disappear when selecting a cell in the grid", async () => {
+    setCellContent(model, "B1", "Customer");
+    setCellContent(model, "B2", "Alice");
+
+    addPivot(model, "B1:B2", {
+      columns: [],
+      rows: [],
+      measures: [{ name: "Customer", aggregator: "count" }],
+    });
+    await keyDown({ key: "Enter" });
+    await typeInComposerGrid("=PIVOT(");
+    expect(fixture.querySelector(".o-grid .o-autocomplete-dropdown")).not.toBeNull();
+    await clickCell(model, "B3");
+    expect(fixture.querySelector(".o-grid .o-autocomplete-dropdown")).toBeNull();
+    await keyDown({ key: "Enter" });
+    expect(getCell(model, "A1")?.content).toBe("=PIVOT(B3)");
   });
 
   test("focus top bar composer does not resize grid composer when autocomplete is displayed", async () => {


### PR DESCRIPTION
Task: 4022927

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo