### PR TITLE
[IMP] pivot: correctly align column header

### DIFF
--- a/src/functions/module_lookup.ts
+++ b/src/functions/module_lookup.ts
@@ -1,5 +1,5 @@
 import { getFullReference, range, splitReference, toXC, toZone } from "../helpers/index";
-import { addRowIndentToPivotHeader } from "../helpers/pivot/pivot_helpers";
+import { addIndentAndAlignToPivotHeader } from "../helpers/pivot/pivot_helpers";
 import { _t } from "../translation";
 import { AddFunctionDescription, FunctionResultObject, Matrix, Maybe, Zone } from "../types";
 import { CellErrorType, EvaluationError, InvalidReferenceError } from "../types/errors";
@@ -831,7 +831,9 @@ export const PIVOT = {
             break;
           case "HEADER":
             const valueAndFormat = pivot.getPivotHeaderValueAndFormat(pivotCell.domain);
-            result[col].push(addRowIndentToPivotHeader(pivot, pivotCell.domain, valueAndFormat));
+            result[col].push(
+              addIndentAndAlignToPivotHeader(pivot, pivotCell.domain, valueAndFormat)
+            );
             break;
           case "MEASURE_HEADER":
             result[col].push(pivot.getPivotMeasureValue(pivotCell.measure, pivotCell.domain));

--- a/src/helpers/pivot/pivot_helpers.ts
+++ b/src/helpers/pivot/pivot_helpers.ts
@@ -274,15 +274,23 @@ export function getFieldDisplayName(field: PivotDimension) {
   return field.displayName + (field.granularity ? ` (${ALL_PERIODS[field.granularity]})` : "");
 }
 
-export function addRowIndentToPivotHeader(
+export function addIndentAndAlignToPivotHeader(
   pivot: Pivot,
   domain: PivotDomain,
   functionResult: FunctionResultObject
 ): FunctionResultObject {
-  const { rowDomain } = domainToColRowDomain(pivot, domain);
-  if (rowDomain.length === 0) {
+  const { rowDomain, colDomain } = domainToColRowDomain(pivot, domain);
+  if (rowDomain.length === 0 && colDomain.length === 0) {
     return functionResult;
   }
+
+  if (rowDomain.length === 0 && colDomain.length > 0) {
+    return {
+      ...functionResult,
+      format: (functionResult.format || "@") + "* ",
+    };
+  }
+
   const indent = rowDomain.length - 1;
 
   const format = functionResult.format || "@";

--- a/tests/pivots/spreadsheet_pivot/spreadsheet_pivot.test.ts
+++ b/tests/pivots/spreadsheet_pivot/spreadsheet_pivot.test.ts
@@ -729,6 +729,25 @@ describe("Spreadsheet Pivot", () => {
     ]);
   });
 
+  test("Pivot column headers are aligned left with their format", () => {
+    // prettier-ignore
+    const grid = {
+          A1: "Date",       B1: "Price", C1: "Active", D1: "=PIVOT(1)",
+          A2: "2024-12-28", B2: "10",    C2: "TRUE",
+          A3: "2024-12-29", B3: "20",    C3: "FALSE",
+    };
+    const model = createModelFromGrid(grid);
+    addPivot(model, "A1:C3", {
+      rows: [],
+      columns: [{ fieldName: "Date", granularity: "year" }, { fieldName: "Active" }],
+      measures: [{ id: "Price:sum", fieldName: "Price", aggregator: "sum" }],
+    });
+
+    expect(getEvaluatedCell(model, "E1")).toMatchObject({ value: 2024, format: "0* " });
+    expect(getEvaluatedCell(model, "E2")).toMatchObject({ value: "TRUE", format: "@* " });
+    expect(getEvaluatedCell(model, "F2")).toMatchObject({ value: "FALSE", format: "@* " });
+  });
+
   test("PIVOT.HEADER grand total", () => {
     const model = createModelWithPivot("A1:I5");
     updatePivot(model, "1", {


### PR DESCRIPTION
## Description

The pivot column headers were aligned all over the place if the header was a boolean or a number. This commit forces the alignment to be to the left with the "* " format.

Task: [4193485](https://www.odoo.com/web#id=4193485&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo