### PR TITLE
[FIX] types: export types needed for .d.ts file

### DIFF
--- a/src/helpers/pivot/pivot_presentation.ts
+++ b/src/helpers/pivot/pivot_presentation.ts
@@ -48,7 +48,7 @@ type DomainGroups<T> = { [colDomain: string]: { [rowDomain: string]: T } };
  * to all pivots, regardless of the specific pivot implementation.
  * Examples of such features include calculated measures or "Show value as" options.
  */
-export function withPivotPresentationLayer(PivotClass: PivotUIConstructor) {
+export default function (PivotClass: PivotUIConstructor) {
   class PivotPresentationLayer extends PivotClass {
     private getters: Getters;
     private cache: Record<string, FunctionResultObject> = {};

--- a/src/plugins/ui_core_views/pivot_ui.ts
+++ b/src/plugins/ui_core_views/pivot_ui.ts
@@ -4,7 +4,7 @@ import {
   getFirstPivotFunction,
   getNumberOfPivotFunctions,
 } from "../../helpers/pivot/pivot_composer_helpers";
-import { withPivotPresentationLayer } from "../../helpers/pivot/pivot_presentation";
+import withPivotPresentationLayer from "../../helpers/pivot/pivot_presentation";
 import { pivotRegistry } from "../../helpers/pivot/pivot_registry";
 import { resetMapValueDimensionDate } from "../../helpers/pivot/spreadsheet_pivot/date_spreadsheet_pivot";
 import { EMPTY_PIVOT_CELL } from "../../helpers/pivot/table_spreadsheet_pivot";

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -588,7 +588,7 @@ export interface SetDecimalCommand extends TargetDependentCommand {
   step: SetDecimalStep;
 }
 
-interface SetContextualFormatCommand extends TargetDependentCommand {
+export interface SetContextualFormatCommand extends TargetDependentCommand {
   type: "SET_FORMATTING_WITH_PIVOT";
   format: Format;
 }


### PR DESCRIPTION
The process of creating a .d.ts file for o-spreadsheet was not working because the types needed for the file were not being exported.

Task: 0

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo