### PR TITLE
[FIX] pivot: wrong headers with hidden measures

### DIFF
--- a/src/helpers/pivot/spreadsheet_pivot/data_entry_spreadsheet_pivot.ts
+++ b/src/helpers/pivot/spreadsheet_pivot/data_entry_spreadsheet_pivot.ts
@@ -21,8 +21,9 @@ export function dataEntriesToSpreadsheetPivotTable(
   dataEntries: DataEntries,
   definition: SpreadsheetPivotRuntimeDefinition
 ) {
+  const measureIds = definition.measures.filter((measure) => !measure.isHidden).map((m) => m.id);
   const columnsTree = dataEntriesToColumnsTree(dataEntries, definition.columns, 0);
-  computeWidthOfColumnsNodes(columnsTree, definition.measures.length);
+  computeWidthOfColumnsNodes(columnsTree, measureIds.length);
   const cols = columnsTreeToColumns(columnsTree, definition);
 
   const rows = dataEntriesToRows(dataEntries, 0, definition.rows, [], []);
@@ -33,7 +34,6 @@ export function dataEntriesToSpreadsheetPivotTable(
     indent: 0,
   });
 
-  const measureIds = definition.measures.filter((measure) => !measure.isHidden).map((m) => m.id);
   const fieldsType: Record<string, string> = {};
   for (const columns of definition.columns) {
     fieldsType[columns.fieldName] = columns.type;

--- a/tests/pivots/spreadsheet_pivot/spreadsheet_pivot.test.ts
+++ b/tests/pivots/spreadsheet_pivot/spreadsheet_pivot.test.ts
@@ -2081,4 +2081,29 @@ describe("Spreadsheet arguments parsing", () => {
       ["Total",      "", ""],
     ]);
   });
+
+  test("Column headers are correct when hiding a measure", () => {
+    // prettier-ignore
+    const grid = {
+      A1: "Price",      B1: "Tax",    C1: "Salesman",
+      A2: "10",         B2: "2",      C2: "Alice",
+      A3: "20",         B3: "4",      C3: "Bob",
+      A5: "=PIVOT(1)",
+    };
+    const model = createModelFromGrid(grid);
+    addPivot(model, "A1:C3", {
+      rows: [],
+      columns: [{ fieldName: "Salesman" }],
+      measures: [
+        { id: "Price:sum", fieldName: "Price", aggregator: "sum" },
+        { id: "Tax:sum", fieldName: "Tax", aggregator: "sum", isHidden: true },
+      ],
+    });
+    // prettier-ignore
+    expect(getEvaluatedGrid(model, "A5:D7")).toEqual([
+      ["(#1) Pivot",  "Alice",  "Bob",   "Total"],
+      ["",            "Price",  "Price", "Price"],
+      ["Total",       "10",     "20",    "30"],
+    ]);
+  });
 });


### PR DESCRIPTION
## Description

The headers of the columns of the pivot were wrong if the pivot had hidden measures. This was because we computed the column width for the `SpreadsheetPivotTable `based on all the measures, not only the non-hidden ones.

Task: [4190869](https://www.odoo.com/web#id=4190869&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo