### PR TITLE
[IMP] pivot: improve day granularity format

### DIFF
--- a/src/helpers/pivot/pivot_time_adapter.ts
+++ b/src/helpers/pivot/pivot_time_adapter.ts
@@ -44,7 +44,7 @@ const dayAdapter: PivotTimeAdapterNotNull<number> = {
   toValueAndFormat(normalizedValue, locale) {
     return {
       value: toNumber(normalizedValue, DEFAULT_LOCALE),
-      format: (locale ?? DEFAULT_LOCALE).dateFormat,
+      format: "dd mmm yyyy",
     };
   },
   toFunctionValue(normalizedValue) {

--- a/tests/pivots/pivot_measure/pivot_measure_display_panel.test.ts
+++ b/tests/pivots/pivot_measure/pivot_measure_display_panel.test.ts
@@ -188,7 +188,7 @@ describe("Standalone side panel tests", () => {
 
     await click(fixture, '.o-pivot-measure-display-field input[value="FieldB:day"]');
     expect(fixture.querySelectorAll(".o-pivot-measure-display-value label")[2]).toHaveText(
-      "1/1/2021"
+      "01 Jan 2021"
     );
   });
 

--- a/tests/pivots/spreadsheet_pivot/spreadsheet_pivot.test.ts
+++ b/tests/pivots/spreadsheet_pivot/spreadsheet_pivot.test.ts
@@ -677,8 +677,8 @@ describe("Spreadsheet Pivot", () => {
 
     // prettier-ignore
     expect(getEvaluatedGrid(model, "C1:H2")).toEqual([
-      ["(#1) Pivot", "4/14/1995", "11/28/2024", "12/28/2024", "Total", ""],
-      ["",           "Price",     "Price",      "Price",      "Price", ""],
+      ["(#1) Pivot", "14 Apr 1995", "28 Nov 2024", "28 Dec 2024", "Total", ""],
+      ["",           "Price",       "Price",       "Price",      "Price", ""],
     ]);
 
     setCellContent(model, "C1", "=PIVOT(1,,,,0)");
@@ -691,8 +691,8 @@ describe("Spreadsheet Pivot", () => {
     setCellContent(model, "C1", "=PIVOT(1,,,,1)");
     // prettier-ignore
     expect(getEvaluatedGrid(model, "C1:E2")).toEqual([
-      ["(#1) Pivot", "4/14/1995", ""],
-      ["",           "Price",      ""],
+      ["(#1) Pivot", "14 Apr 1995", ""],
+      ["",           "Price",       ""],
     ]);
   });
 
@@ -720,11 +720,11 @@ describe("Spreadsheet Pivot", () => {
       { value: "", format: undefined },
       { value: 1995, format: "0* " },
       { value: "Q2", format: "    @* " },
-      { value: 34803, format: "        m/d/yyyy* " },
+      { value: 34803, format: "        dd mmm yyyy* " },
       { value: 2024, format: "0* " },
       { value: "Q4", format: "    @* " },
-      { value: 45624, format: "        m/d/yyyy* " },
-      { value: 45654, format: "        m/d/yyyy* " },
+      { value: 45624, format: "        dd mmm yyyy* " },
+      { value: 45654, format: "        dd mmm yyyy* " },
       { value: "Total", format: undefined },
     ]);
   });
@@ -1570,7 +1570,7 @@ describe("Spreadsheet Pivot", () => {
     });
     setCellContent(model, "A27", '=PIVOT.HEADER(1, "Date:day", DATE(2024, 12, 31))');
     expect(getEvaluatedCell(model, "A27").value).toBe(45657);
-    expect(getEvaluatedCell(model, "A27").format).toBe("m/d/yyyy");
+    expect(getEvaluatedCell(model, "A27").format).toBe("dd mmm yyyy");
 
     setCellContent(model, "A28", '=PIVOT.HEADER(1, "Date:day", "2024-12-31")');
     expect(getEvaluatedCell(model, "A28").value).toBe(45657);
@@ -1727,8 +1727,8 @@ describe("Spreadsheet Pivot", () => {
 
     // prettier-ignore
     expect(getEvaluatedGrid(model, "C1:I2")).toEqual([
-      ["(#1) Pivot", "11/28/2024", "",      "12/28/2024", "",      "Total", ""],
-      ["",           "Price",      "Price", "Price",      "Price", "Price", "Price"],
+      ["(#1) Pivot", "28 Nov 2024", "",      "28 Dec 2024", "",      "Total", ""],
+      ["",           "Price",       "Price", "Price",       "Price", "Price", "Price"],
     ]);
   });
 
@@ -1751,8 +1751,8 @@ describe("Spreadsheet Pivot", () => {
 
     // prettier-ignore
     expect(getEvaluatedGrid(model, "C1:I2")).toEqual([
-      ["(#1) Pivot", "11/28/2024", "",         "12/28/2024", "",         "Total", ""],
-      ["",           "Price",      "My price", "Price",      "My price", "Price", "My price"],
+      ["(#1) Pivot", "28 Nov 2024", "",         "28 Dec 2024", "",         "Total", ""],
+      ["",           "Price",       "My price", "Price",       "My price", "Price", "My price"],
     ]);
   });
 


### PR DESCRIPTION
## Description

Improve the format of headers with the day granularity in the pivot, from the locale's date format (e.g. `1/1/2021`) to `dd mmm yyyy` (e.g. `01 Jan 2021`).

Task: [3613511](https://www.odoo.com/web#id=3613511&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo