### PR TITLE
[IMP] pivot: duplicate pivot with table

### DIFF
--- a/src/plugins/ui_feature/insert_pivot.ts
+++ b/src/plugins/ui_feature/insert_pivot.ts
@@ -97,12 +97,15 @@ export class InsertPivotPlugin extends UIPlugin {
     });
     if (result.isSuccessful) {
       this.dispatch("ACTIVATE_SHEET", { sheetIdFrom: activeSheetId, sheetIdTo: newSheetId });
-      this.dispatch("UPDATE_CELL", {
-        sheetId: newSheetId,
-        col: 0,
-        row: 0,
-        content: `=PIVOT(${formulaId})`,
-      });
+      const pivot = this.getters.getPivot(pivotId);
+      this.insertPivotWithTable(
+        newSheetId,
+        0,
+        0,
+        newPivotId,
+        pivot.getTableStructure().export(),
+        "dynamic"
+      );
     }
   }
 

--- a/tests/pivots/spreadsheet_pivot/spreadsheet_pivot_side_panel.test.ts
+++ b/tests/pivots/spreadsheet_pivot/spreadsheet_pivot_side_panel.test.ts
@@ -1,4 +1,5 @@
 import { Model, SpreadsheetChildEnv } from "../../../src";
+import { PIVOT_TABLE_CONFIG } from "../../../src/constants";
 import { toZone } from "../../../src/helpers";
 import { SpreadsheetPivot } from "../../../src/helpers/pivot/spreadsheet_pivot/spreadsheet_pivot";
 import { NotificationStore } from "../../../src/stores/notification_store";
@@ -16,7 +17,7 @@ import {
   keyDown,
   setInputValueAndTrigger,
 } from "../../test_helpers/dom_helper";
-import { getCellText } from "../../test_helpers/getters_helpers";
+import { getCellText, getCoreTable } from "../../test_helpers/getters_helpers";
 import { editStandaloneComposer, mountSpreadsheet, nextTick } from "../../test_helpers/helpers";
 import { mockGetBoundingClientRect } from "../../test_helpers/mock_helpers";
 import { SELECTORS, addPivot, updatePivot } from "../../test_helpers/pivot_helpers";
@@ -242,12 +243,18 @@ describe("Spreadsheet pivot side panel", () => {
       "Pivot (copy) (Pivot #2)"
     );
     expect(getCellText(model, "A1")).toBe("=PIVOT(2)");
+    expect(getCoreTable(model, "A1")).toMatchObject({
+      range: { zone: toZone("A1") },
+      config: PIVOT_TABLE_CONFIG,
+      type: "dynamic",
+    });
 
     undo(model);
 
     expect(model.getters.getPivotId("2")).toBeUndefined();
     expect(model.getters.getSheetIds()).toHaveLength(1);
     expect(model.getters.getSheetName(model.getters.getActiveSheetId())).toBe("Sheet1");
+    expect(getCoreTable(model, "A1")).toBe(undefined);
   });
 
   test("Can duplicate a pivot when a duplicate sheet name already exists", async () => {


### PR DESCRIPTION
## Description:

Duplicate pivots with the table style

Task: [4048028](https://www.odoo.com/web#id=4048028&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo