### PR TITLE
[FIX] pivot: divergent collaborative duplicated pivot name

### DIFF
--- a/src/plugins/core/pivot.ts
+++ b/src/plugins/core/pivot.ts
@@ -95,7 +95,7 @@ export class PivotCorePlugin extends CorePlugin<CoreState> implements CoreState 
       case "DUPLICATE_PIVOT": {
         const { pivotId, newPivotId } = cmd;
         const pivot = deepCopy(this.getPivotCore(pivotId).definition);
-        pivot.name = _t("%s (copy)", pivot.name);
+        pivot.name = cmd.duplicatedPivotName ?? pivot.name + " (copy)";
         this.addPivot(newPivotId, pivot);
         break;
       }

--- a/src/plugins/ui_feature/insert_pivot.ts
+++ b/src/plugins/ui_feature/insert_pivot.ts
@@ -67,6 +67,7 @@ export class InsertPivotPlugin extends UIPlugin {
     this.dispatch("DUPLICATE_PIVOT", {
       pivotId,
       newPivotId,
+      duplicatedPivotName: _t("%s (copy)", this.getters.getPivotCoreDefinition(pivotId).name),
     });
     const activeSheetId = this.getters.getActiveSheetId();
     const position = this.getters.getSheetIds().indexOf(activeSheetId) + 1;

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -623,6 +623,8 @@ export interface DuplicatePivotCommand {
   type: "DUPLICATE_PIVOT";
   pivotId: UID;
   newPivotId: string;
+  // an early version of the command did not include the duplicatedPivotName
+  duplicatedPivotName?: string;
 }
 
 // ------------------------------------------------

--- a/tests/test_helpers/constants.ts
+++ b/tests/test_helpers/constants.ts
@@ -441,6 +441,7 @@ export const TEST_COMMANDS: CommandMapping = {
     type: "DUPLICATE_PIVOT",
     pivotId: "1",
     newPivotId: "2",
+    duplicatedPivotName: "newName",
   },
   RENAME_PIVOT: {
     type: "RENAME_PIVOT",


### PR DESCRIPTION
## Description:

Currently, if two users are connected to the same spreadsheet, both have
different languages and one of them duplicates a pivot: the spreadsheet
states have diverged because `_t(...)` gives two different results on both
sides.

Note that the command should ideally be upgraded with a script, but it's
not possible to get the original pivot name on the upgrade platform.
Task: [4199949](https://www.odoo.com/web#id=4199949&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo