### PR TITLE
[IMP] charts: better handling of charts with two Y axis

### DIFF
--- a/src/components/figures/chart/chartJs/chartjs_show_values_plugin.ts
+++ b/src/components/figures/chart/chartJs/chartjs_show_values_plugin.ts
@@ -9,7 +9,7 @@ interface ChartShowValuesPluginOptions {
   showValues: boolean;
   background?: Color;
   horizontal?: boolean;
-  callback: (value: number | string) => string;
+  callback: (value: number | string, axisId?: string) => string;
 }
 
 declare module "chart.js" {
@@ -64,10 +64,14 @@ export const chartShowValuesPlugin: Plugin = {
         case "bar":
         case "line": {
           const yOffset = dataset.type === "bar" && !options.horizontal ? 0 : 3;
+
+          const horizontalChart = dataset.type === "bar" && options.horizontal;
+          const axisId = horizontalChart ? dataset.xAxisID : dataset.yAxisID;
+
           for (let i = 0; i < dataset._parsed.length; i++) {
             const point = dataset.data[i];
             const value = options.horizontal ? dataset._parsed[i].x : dataset._parsed[i].y;
-            const displayedValue = options.callback(value - 0);
+            const displayedValue = options.callback(value - 0, axisId);
             let xPosition = 0,
               yPosition = 0;
             if (options.horizontal) {

--- a/src/helpers/figures/charts/chart_common.ts
+++ b/src/helpers/figures/charts/chart_common.ts
@@ -19,6 +19,7 @@ import {
   DOMCoordinates,
   DOMDimension,
   Getters,
+  Locale,
   LocaleFormat,
   Range,
   RemoveColumnsRowsCommand,
@@ -28,6 +29,7 @@ import {
 } from "../../../types";
 import {
   AxisDesign,
+  ChartAxisFormats,
   ChartWithAxisDefinition,
   CustomizedDataSet,
   DataSet,
@@ -612,6 +614,13 @@ export function interpolateData(
     default:
       return [];
   }
+}
+
+export function formatChartDatasetValue(axisFormats: ChartAxisFormats, locale: Locale) {
+  return (value: any, axisId: string | undefined) => {
+    const format = axisId ? axisFormats?.[axisId] : undefined;
+    return formatTickValue({ format, locale })(value);
+  };
 }
 
 export function formatTickValue(localeFormat: LocaleFormat) {

--- a/src/helpers/figures/charts/chart_common.ts
+++ b/src/helpers/figures/charts/chart_common.ts
@@ -1,4 +1,5 @@
-import { ChartDataset } from "chart.js";
+import { ChartDataset, LinearScaleOptions } from "chart.js";
+import { DeepPartial } from "chart.js/dist/types/utils";
 import { transformZone } from "../../../collaborative/ot/ot_helpers";
 import { LINE_FILL_TRANSPARENCY } from "../../../constants";
 import {
@@ -448,6 +449,54 @@ export function getDefinedAxis(definition: ChartWithAxisDefinition): {
   }
   useLeftAxis ||= !useRightAxis;
   return { useLeftAxis, useRightAxis };
+}
+
+export function getChartAxis(
+  definition: ChartWithAxisDefinition,
+  position: "left" | "right" | "bottom",
+  type: "values" | "labels",
+  options: LocaleFormat & { stacked?: boolean }
+): DeepPartial<LinearScaleOptions> | undefined {
+  const { useLeftAxis, useRightAxis } = getDefinedAxis(definition);
+  if ((position === "left" && !useLeftAxis) || (position === "right" && !useRightAxis)) {
+    return undefined;
+  }
+
+  const fontColor = chartFontColor(definition.background);
+  let design: AxisDesign | undefined;
+  if (position === "bottom") {
+    design = definition.axesDesign?.x;
+  } else if (position === "left") {
+    design = definition.axesDesign?.y;
+  } else {
+    design = definition.axesDesign?.y1;
+  }
+
+  if (type === "values") {
+    const displayGridLines = position === "left" || (position === "right" && !useLeftAxis);
+    return {
+      position: position,
+      title: getChartAxisTitleRuntime(design),
+      grid: {
+        display: displayGridLines,
+      },
+      beginAtZero: true,
+      stacked: options?.stacked,
+      ticks: {
+        color: fontColor,
+        callback: formatTickValue(options),
+      },
+    };
+  } else {
+    return {
+      ticks: {
+        padding: 5,
+        color: fontColor,
+      },
+      stacked: options?.stacked,
+      title: getChartAxisTitleRuntime(design),
+    };
+  }
 }
 
 export function computeChartPadding({

--- a/src/helpers/figures/charts/chart_common_line_scatter.ts
+++ b/src/helpers/figures/charts/chart_common_line_scatter.ts
@@ -1,12 +1,12 @@
-import { ChartConfiguration, ChartDataset, LegendOptions } from "chart.js";
+import { ChartDataset, LegendOptions } from "chart.js";
 import { DeepPartial } from "chart.js/dist/types/utils";
 import { BACKGROUND_CHART_COLOR, LINE_FILL_TRANSPARENCY } from "../../../constants";
 import { toJsDate, toNumber } from "../../../functions/helpers";
-import { Color, Format, Getters, Locale, Range } from "../../../types";
+import { Getters, Locale, Range } from "../../../types";
 import {
   AxisType,
+  ChartJSRuntime,
   DatasetValues,
-  LabelValues,
   TrendConfiguration,
 } from "../../../types/chart/chart";
 import { getChartTimeOptions, timeFormatLuxonCompatible } from "../../chart_date";
@@ -193,14 +193,7 @@ export function getTrendDatasetForLineChart(
 export function createLineOrScatterChartRuntime(
   chart: LineChart | ScatterChart,
   getters: Getters
-): {
-  chartJsConfig: ChartConfiguration;
-  background: Color;
-  dataSetsValues: DatasetValues[];
-  labelValues: LabelValues;
-  dataSetFormat: Format | undefined;
-  labelFormat: Format | undefined;
-} {
+): ChartJSRuntime {
   const axisType = getChartAxisType(chart, getters);
   const labelValues = getChartLabelValues(getters, chart.dataSets, chart.labelRange);
   let labels = axisType === "linear" ? labelValues.values : labelValues.formattedValues;
@@ -399,9 +392,5 @@ export function createLineOrScatterChartRuntime(
   return {
     chartJsConfig: config,
     background: chart.background || BACKGROUND_CHART_COLOR,
-    dataSetsValues,
-    labelValues,
-    dataSetFormat: leftAxisFormat,
-    labelFormat,
   };
 }

--- a/src/helpers/figures/charts/combo_chart.ts
+++ b/src/helpers/figures/charts/combo_chart.ts
@@ -29,6 +29,7 @@ import {
 import { CellErrorType } from "../../../types/errors";
 import { Validator } from "../../../types/validator";
 import { toXlsxHexColor } from "../../../xlsx/helpers/colors";
+import { removeFalsyAttributes } from "../../misc";
 import { createValidRange } from "../../range";
 import { AbstractChart } from "./abstract_chart";
 import {
@@ -41,7 +42,7 @@ import {
   copyLabelRangeWithNewSheetId,
   createDataSets,
   formatTickValue,
-  getChartAxisTitleRuntime,
+  getChartAxis,
   getChartColorsGenerator,
   getDefinedAxis,
   getTrendDatasetForBarChart,
@@ -271,49 +272,14 @@ export function createComboChartRuntime(chart: ComboChart, getters: Getters): Co
     }),
   };
 
-  config.options.scales = {
-    x: {
-      ticks: {
-        padding: 5,
-        color: fontColor,
-      },
-      title: getChartAxisTitleRuntime(chart.axesDesign?.x),
-    },
-  };
-
-  const leftVerticalAxis = {
-    beginAtZero: true, // the origin of the y axis is always zero
-    ticks: {
-      color: fontColor,
-      callback: formatTickValue({ format: mainDataSetFormat, locale }),
-    },
-  };
-  const rightVerticalAxis = {
-    beginAtZero: true, // the origin of the y axis is always zero
-    ticks: {
-      color: fontColor,
-      callback: formatTickValue({ format: lineDataSetsFormat, locale }),
-    },
-  };
   const definition = chart.getDefinition();
-  const { useLeftAxis, useRightAxis } = getDefinedAxis(definition);
-  if (useLeftAxis) {
-    config.options.scales.y = {
-      ...leftVerticalAxis,
-      position: "left",
-      title: getChartAxisTitleRuntime(chart.axesDesign?.y),
-    };
-  }
-  if (useRightAxis) {
-    config.options.scales.y1 = {
-      ...rightVerticalAxis,
-      position: "right",
-      grid: {
-        display: false,
-      },
-      title: getChartAxisTitleRuntime(chart.axesDesign?.y1),
-    };
-  }
+  config.options.scales = {
+    x: getChartAxis(definition, "bottom", "labels", { locale }),
+    y: getChartAxis(definition, "left", "values", { locale, format: mainDataSetFormat }),
+    y1: getChartAxis(definition, "right", "values", { locale, format: lineDataSetsFormat }),
+  };
+  config.options.scales = removeFalsyAttributes(config.options.scales);
+
   config.options.plugins!.chartShowValuesPlugin = {
     showValues: chart.showValues,
     background: chart.background,

--- a/src/helpers/figures/charts/combo_chart.ts
+++ b/src/helpers/figures/charts/combo_chart.ts
@@ -41,7 +41,7 @@ import {
   copyDataSetsWithNewSheetId,
   copyLabelRangeWithNewSheetId,
   createDataSets,
-  formatTickValue,
+  formatChartDatasetValue,
   getChartAxis,
   getChartColorsGenerator,
   getDefinedAxis,
@@ -230,10 +230,8 @@ export class ComboChart extends AbstractChart {
 }
 
 export function createComboChartRuntime(chart: ComboChart, getters: Getters): ComboChartRuntime {
-  const mainDataSetFormat = chart.dataSets.length
-    ? getChartDatasetFormat(getters, [chart.dataSets[0]])
-    : undefined;
-  const lineDataSetsFormat = getChartDatasetFormat(getters, chart.dataSets.slice(1));
+  const mainDataSetFormat = getChartDatasetFormat(getters, chart.dataSets, "left");
+  const lineDataSetsFormat = getChartDatasetFormat(getters, chart.dataSets, "right");
   const locale = getters.getLocale();
 
   const labelValues = getChartLabelValues(getters, chart.dataSets, chart.labelRange);
@@ -252,10 +250,9 @@ export function createComboChartRuntime(chart: ComboChart, getters: Getters): Co
     ({ labels, dataSetsValues } = aggregateDataForLabels(labels, dataSetsValues));
   }
 
-  const localeFormat = { format: mainDataSetFormat, locale };
-
   const fontColor = chartFontColor(chart.background);
-  const config = getDefaultChartJsRuntime(chart, labels, fontColor, localeFormat);
+  const axisFormats = { y: mainDataSetFormat, y1: lineDataSetsFormat };
+  const config = getDefaultChartJsRuntime(chart, labels, fontColor, { locale, axisFormats });
   const legend: DeepPartial<LegendOptions<"bar">> = {
     labels: { color: fontColor },
   };
@@ -283,7 +280,7 @@ export function createComboChartRuntime(chart: ComboChart, getters: Getters): Co
   config.options.plugins!.chartShowValuesPlugin = {
     showValues: chart.showValues,
     background: chart.background,
-    callback: formatTickValue({ format: mainDataSetFormat, locale }),
+    callback: formatChartDatasetValue(axisFormats, locale),
   };
 
   const colors = getChartColorsGenerator(definition, dataSetsValues.length);

--- a/src/helpers/figures/charts/pie_chart.ts
+++ b/src/helpers/figures/charts/pie_chart.ts
@@ -323,7 +323,7 @@ export function createPieChartRuntime(chart: PieChart, getters: Getters): PieCha
 
   ({ dataSetsValues, labels } = filterNegativeValues(labels, dataSetsValues));
 
-  const dataSetFormat = getChartDatasetFormat(getters, chart.dataSets);
+  const dataSetFormat = getChartDatasetFormat(getters, chart.dataSets, "left");
   const locale = getters.getLocale();
   const config = getPieConfiguration(chart, labels, { format: dataSetFormat, locale });
   const dataSetsLength = Math.max(0, ...dataSetsValues.map((ds) => ds?.data?.length ?? 0));

--- a/src/helpers/figures/charts/pyramid_chart.ts
+++ b/src/helpers/figures/charts/pyramid_chart.ts
@@ -210,8 +210,8 @@ export function createPyramidChartRuntime(
     return tooltipLabelCallback(tooltipItem);
   };
   const callback = config.options!.plugins!.chartShowValuesPlugin!.callback;
-  config.options!.plugins!.chartShowValuesPlugin!.callback = (x) =>
-    callback!(Math.abs(x as number));
+  config.options!.plugins!.chartShowValuesPlugin!.callback = (x, axisId) =>
+    callback!(Math.abs(x as number), axisId);
 
   return { chartJsConfig: config, background: chart.background || BACKGROUND_CHART_COLOR };
 }

--- a/src/helpers/figures/charts/waterfall_chart.ts
+++ b/src/helpers/figures/charts/waterfall_chart.ts
@@ -358,7 +358,9 @@ export function createWaterfallChartRuntime(
     labels.push(_t("Subtotal"));
   }
 
-  const dataSetFormat = getChartDatasetFormat(getters, chart.dataSets);
+  const dataSetFormat =
+    getChartDatasetFormat(getters, chart.dataSets, "left") ||
+    getChartDatasetFormat(getters, chart.dataSets, "right");
   const locale = getters.getLocale();
   const dataSeriesLabels = dataSetsValues.map((dataSet) => dataSet.label);
   const config = getWaterfallConfiguration(chart, labels, dataSeriesLabels, {

--- a/src/types/chart/chart.ts
+++ b/src/types/chart/chart.ts
@@ -1,4 +1,4 @@
-import { Align, Color, Range } from "../../types";
+import { Align, Color, Format, Range } from "../../types";
 import { XlsxHexColor } from "../xlsx";
 import { BarChartDefinition, BarChartRuntime } from "./bar_chart";
 import { ComboChartDefinition, ComboChartRuntime } from "./combo_chart";
@@ -151,3 +151,5 @@ export interface ChartCreationContext {
   readonly fillArea?: boolean;
   readonly showValues?: boolean;
 }
+
+export type ChartAxisFormats = { [axisId: string]: Format | undefined } | undefined;

--- a/tests/figures/chart/__snapshots__/chart_plugin.test.ts.snap
+++ b/tests/figures/chart/__snapshots__/chart_plugin.test.ts.snap
@@ -27,6 +27,7 @@ exports[`Linear/Time charts font color is white with a dark background color 1`]
           "label": "10",
           "pointBackgroundColor": "#4EA7F2",
           "tension": 0,
+          "yAxisID": "y",
         },
       ],
       "labels": [
@@ -176,6 +177,7 @@ exports[`Linear/Time charts snapshot test of chartJS configuration for date char
           "label": "Series 1",
           "pointBackgroundColor": "#4EA7F2",
           "tension": 0,
+          "yAxisID": "y",
         },
       ],
       "labels": [
@@ -334,6 +336,7 @@ exports[`Linear/Time charts snapshot test of chartJS configuration for linear ch
           "label": "Series 1",
           "pointBackgroundColor": "#4EA7F2",
           "tension": 0,
+          "yAxisID": "y",
         },
       ],
       "labels": [
@@ -469,6 +472,8 @@ exports[`datasource tests create a chart with stacked bar 1`] = `
             30,
           ],
           "label": "P4",
+          "xAxisID": "x",
+          "yAxisID": "y",
         },
       ],
       "labels": [
@@ -574,6 +579,7 @@ exports[`datasource tests create chart with a dataset of one cell (no title) 1`]
           "label": "Series 1",
           "pointBackgroundColor": "#4EA7F2",
           "tension": 0,
+          "yAxisID": "y",
         },
       ],
       "labels": [
@@ -698,6 +704,7 @@ exports[`datasource tests create chart with column datasets 1`] = `
           "label": "first column dataset",
           "pointBackgroundColor": "#4EA7F2",
           "tension": 0,
+          "yAxisID": "y",
         },
         {
           "backgroundColor": "#EA6175",
@@ -711,6 +718,7 @@ exports[`datasource tests create chart with column datasets 1`] = `
           "label": "second column datase…",
           "pointBackgroundColor": "#EA6175",
           "tension": 0,
+          "yAxisID": "y",
         },
       ],
       "labels": [
@@ -851,6 +859,7 @@ exports[`datasource tests create chart with column datasets with category title 
           "label": "first column dataset",
           "pointBackgroundColor": "#4EA7F2",
           "tension": 0,
+          "yAxisID": "y",
         },
         {
           "backgroundColor": "#EA6175",
@@ -864,6 +873,7 @@ exports[`datasource tests create chart with column datasets with category title 
           "label": "second column datase…",
           "pointBackgroundColor": "#EA6175",
           "tension": 0,
+          "yAxisID": "y",
         },
       ],
       "labels": [
@@ -1005,6 +1015,7 @@ exports[`datasource tests create chart with column datasets without series title
           "label": "Series 1",
           "pointBackgroundColor": "#4EA7F2",
           "tension": 0,
+          "yAxisID": "y",
         },
         {
           "backgroundColor": "#EA6175",
@@ -1018,6 +1029,7 @@ exports[`datasource tests create chart with column datasets without series title
           "label": "Series 2",
           "pointBackgroundColor": "#EA6175",
           "tension": 0,
+          "yAxisID": "y",
         },
       ],
       "labels": [
@@ -1267,6 +1279,7 @@ exports[`datasource tests create chart with rectangle dataset 1`] = `
           "label": "first column dataset",
           "pointBackgroundColor": "#4EA7F2",
           "tension": 0,
+          "yAxisID": "y",
         },
         {
           "backgroundColor": "#EA6175",
@@ -1280,6 +1293,7 @@ exports[`datasource tests create chart with rectangle dataset 1`] = `
           "label": "second column datase…",
           "pointBackgroundColor": "#EA6175",
           "tension": 0,
+          "yAxisID": "y",
         },
       ],
       "labels": [
@@ -1420,6 +1434,7 @@ exports[`datasource tests create chart with row datasets 1`] = `
           "label": "first row dataset",
           "pointBackgroundColor": "#4EA7F2",
           "tension": 0,
+          "yAxisID": "y",
         },
         {
           "backgroundColor": "#EA6175",
@@ -1433,6 +1448,7 @@ exports[`datasource tests create chart with row datasets 1`] = `
           "label": "second row dataset",
           "pointBackgroundColor": "#EA6175",
           "tension": 0,
+          "yAxisID": "y",
         },
       ],
       "labels": [
@@ -1573,6 +1589,7 @@ exports[`datasource tests create chart with row datasets with category title 1`]
           "label": "first row dataset",
           "pointBackgroundColor": "#4EA7F2",
           "tension": 0,
+          "yAxisID": "y",
         },
         {
           "backgroundColor": "#EA6175",
@@ -1586,6 +1603,7 @@ exports[`datasource tests create chart with row datasets with category title 1`]
           "label": "second row dataset",
           "pointBackgroundColor": "#EA6175",
           "tension": 0,
+          "yAxisID": "y",
         },
       ],
       "labels": [
@@ -1727,6 +1745,7 @@ exports[`datasource tests create chart with row datasets without series title 1`
           "label": "Series 1",
           "pointBackgroundColor": "#4EA7F2",
           "tension": 0,
+          "yAxisID": "y",
         },
         {
           "backgroundColor": "#EA6175",
@@ -1740,6 +1759,7 @@ exports[`datasource tests create chart with row datasets without series title 1`
           "label": "Series 2",
           "pointBackgroundColor": "#EA6175",
           "tension": 0,
+          "yAxisID": "y",
         },
       ],
       "labels": [

--- a/tests/figures/chart/__snapshots__/chart_plugin.test.ts.snap
+++ b/tests/figures/chart/__snapshots__/chart_plugin.test.ts.snap
@@ -118,31 +118,6 @@ exports[`Linear/Time charts font color is white with a dark background color 1`]
     "plugins": [],
     "type": "line",
   },
-  "dataSetFormat": undefined,
-  "dataSetsValues": [
-    {
-      "data": [
-        11,
-        12,
-        13,
-      ],
-      "label": "10",
-    },
-  ],
-  "labelFormat": undefined,
-  "labelValues": {
-    "formattedValues": [
-      "20",
-      "19",
-      "18",
-      "17",
-    ],
-    "values": [
-      "19",
-      "18",
-      "17",
-    ],
-  },
 }
 `;
 
@@ -275,33 +250,6 @@ exports[`Linear/Time charts snapshot test of chartJS configuration for date char
     "plugins": [],
     "type": "line",
   },
-  "dataSetFormat": undefined,
-  "dataSetsValues": [
-    {
-      "data": [
-        10,
-        11,
-        12,
-        13,
-      ],
-      "label": "Series 1",
-    },
-  ],
-  "labelFormat": "m/d/yyyy",
-  "labelValues": {
-    "formattedValues": [
-      "1/19/1900",
-      "1/18/1900",
-      "1/17/1900",
-      "1/16/1900",
-    ],
-    "values": [
-      "20",
-      "19",
-      "18",
-      "17",
-    ],
-  },
 }
 `;
 
@@ -427,33 +375,6 @@ exports[`Linear/Time charts snapshot test of chartJS configuration for linear ch
     "platform": undefined,
     "plugins": [],
     "type": "line",
-  },
-  "dataSetFormat": undefined,
-  "dataSetsValues": [
-    {
-      "data": [
-        10,
-        11,
-        12,
-        13,
-      ],
-      "label": "Series 1",
-    },
-  ],
-  "labelFormat": undefined,
-  "labelValues": {
-    "formattedValues": [
-      "20",
-      "19",
-      "18",
-      "17",
-    ],
-    "values": [
-      "20",
-      "19",
-      "18",
-      "17",
-    ],
   },
 }
 `;
@@ -665,24 +586,6 @@ exports[`datasource tests create chart with a dataset of one cell (no title) 1`]
     "plugins": [],
     "type": "line",
   },
-  "dataSetFormat": undefined,
-  "dataSetsValues": [
-    {
-      "data": [
-        30,
-      ],
-      "label": "Series 1",
-    },
-  ],
-  "labelFormat": undefined,
-  "labelValues": {
-    "formattedValues": [
-      "P4",
-    ],
-    "values": [
-      "P4",
-    ],
-  },
 }
 `;
 
@@ -805,38 +708,6 @@ exports[`datasource tests create chart with column datasets 1`] = `
     "platform": undefined,
     "plugins": [],
     "type": "line",
-  },
-  "dataSetFormat": undefined,
-  "dataSetsValues": [
-    {
-      "data": [
-        10,
-        11,
-        12,
-      ],
-      "label": "first column dataset",
-    },
-    {
-      "data": [
-        20,
-        19,
-        18,
-      ],
-      "label": "second column datase…",
-    },
-  ],
-  "labelFormat": undefined,
-  "labelValues": {
-    "formattedValues": [
-      "P1",
-      "P2",
-      "P3",
-    ],
-    "values": [
-      "P1",
-      "P2",
-      "P3",
-    ],
   },
 }
 `;
@@ -961,39 +832,6 @@ exports[`datasource tests create chart with column datasets with category title 
     "plugins": [],
     "type": "line",
   },
-  "dataSetFormat": undefined,
-  "dataSetsValues": [
-    {
-      "data": [
-        10,
-        11,
-        12,
-      ],
-      "label": "first column dataset",
-    },
-    {
-      "data": [
-        20,
-        19,
-        18,
-      ],
-      "label": "second column datase…",
-    },
-  ],
-  "labelFormat": undefined,
-  "labelValues": {
-    "formattedValues": [
-      "P1",
-      "P2",
-      "P3",
-    ],
-    "values": [
-      "",
-      "P1",
-      "P2",
-      "P3",
-    ],
-  },
 }
 `;
 
@@ -1117,38 +955,6 @@ exports[`datasource tests create chart with column datasets without series title
     "plugins": [],
     "type": "line",
   },
-  "dataSetFormat": undefined,
-  "dataSetsValues": [
-    {
-      "data": [
-        10,
-        11,
-        12,
-      ],
-      "label": "Series 1",
-    },
-    {
-      "data": [
-        20,
-        19,
-        18,
-      ],
-      "label": "Series 2",
-    },
-  ],
-  "labelFormat": undefined,
-  "labelValues": {
-    "formattedValues": [
-      "P1",
-      "P2",
-      "P3",
-    ],
-    "values": [
-      "P1",
-      "P2",
-      "P3",
-    ],
-  },
 }
 `;
 
@@ -1242,21 +1048,6 @@ exports[`datasource tests create chart with only the dataset title (no data) 1`]
     "platform": undefined,
     "plugins": [],
     "type": "line",
-  },
-  "dataSetFormat": undefined,
-  "dataSetsValues": [],
-  "labelFormat": undefined,
-  "labelValues": {
-    "formattedValues": [
-      "P4",
-      "P5",
-      "P6",
-    ],
-    "values": [
-      "P4",
-      "P5",
-      "P6",
-    ],
   },
 }
 `;
@@ -1381,38 +1172,6 @@ exports[`datasource tests create chart with rectangle dataset 1`] = `
     "plugins": [],
     "type": "line",
   },
-  "dataSetFormat": undefined,
-  "dataSetsValues": [
-    {
-      "data": [
-        10,
-        11,
-        12,
-      ],
-      "label": "first column dataset",
-    },
-    {
-      "data": [
-        20,
-        19,
-        18,
-      ],
-      "label": "second column datase…",
-    },
-  ],
-  "labelFormat": undefined,
-  "labelValues": {
-    "formattedValues": [
-      "P1",
-      "P2",
-      "P3",
-    ],
-    "values": [
-      "P1",
-      "P2",
-      "P3",
-    ],
-  },
 }
 `;
 
@@ -1535,38 +1294,6 @@ exports[`datasource tests create chart with row datasets 1`] = `
     "platform": undefined,
     "plugins": [],
     "type": "line",
-  },
-  "dataSetFormat": undefined,
-  "dataSetsValues": [
-    {
-      "data": [
-        30,
-        31,
-        32,
-      ],
-      "label": "first row dataset",
-    },
-    {
-      "data": [
-        40,
-        41,
-        42,
-      ],
-      "label": "second row dataset",
-    },
-  ],
-  "labelFormat": undefined,
-  "labelValues": {
-    "formattedValues": [
-      "P4",
-      "P5",
-      "P6",
-    ],
-    "values": [
-      "P4",
-      "P5",
-      "P6",
-    ],
   },
 }
 `;
@@ -1691,39 +1418,6 @@ exports[`datasource tests create chart with row datasets with category title 1`]
     "plugins": [],
     "type": "line",
   },
-  "dataSetFormat": undefined,
-  "dataSetsValues": [
-    {
-      "data": [
-        30,
-        31,
-        32,
-      ],
-      "label": "first row dataset",
-    },
-    {
-      "data": [
-        40,
-        41,
-        42,
-      ],
-      "label": "second row dataset",
-    },
-  ],
-  "labelFormat": undefined,
-  "labelValues": {
-    "formattedValues": [
-      "P4",
-      "P5",
-      "P6",
-    ],
-    "values": [
-      "",
-      "P4",
-      "P5",
-      "P6",
-    ],
-  },
 }
 `;
 
@@ -1846,38 +1540,6 @@ exports[`datasource tests create chart with row datasets without series title 1`
     "platform": undefined,
     "plugins": [],
     "type": "line",
-  },
-  "dataSetFormat": undefined,
-  "dataSetsValues": [
-    {
-      "data": [
-        30,
-        31,
-        32,
-      ],
-      "label": "Series 1",
-    },
-    {
-      "data": [
-        40,
-        41,
-        42,
-      ],
-      "label": "Series 2",
-    },
-  ],
-  "labelFormat": undefined,
-  "labelValues": {
-    "formattedValues": [
-      "P4",
-      "P5",
-      "P6",
-    ],
-    "values": [
-      "P4",
-      "P5",
-      "P6",
-    ],
   },
 }
 `;

--- a/tests/figures/chart/__snapshots__/chart_plugin.test.ts.snap
+++ b/tests/figures/chart/__snapshots__/chart_plugin.test.ts.snap
@@ -89,6 +89,7 @@ exports[`Linear/Time charts font color is white with a dark background color 1`]
       "responsive": true,
       "scales": {
         "x": {
+          "stacked": undefined,
           "ticks": {
             "callback": [Function],
             "color": "#FFFFFF",
@@ -99,7 +100,11 @@ exports[`Linear/Time charts font color is white with a dark background color 1`]
         },
         "y": {
           "beginAtZero": true,
+          "grid": {
+            "display": true,
+          },
           "position": "left",
+          "stacked": false,
           "ticks": {
             "callback": [Function],
             "color": "#FFFFFF",
@@ -233,6 +238,7 @@ exports[`Linear/Time charts snapshot test of chartJS configuration for date char
       "responsive": true,
       "scales": {
         "x": {
+          "stacked": undefined,
           "ticks": {
             "color": "#000000",
             "maxTicksLimit": 15,
@@ -250,7 +256,11 @@ exports[`Linear/Time charts snapshot test of chartJS configuration for date char
         },
         "y": {
           "beginAtZero": true,
+          "grid": {
+            "display": true,
+          },
           "position": "left",
+          "stacked": false,
           "ticks": {
             "callback": [Function],
             "color": "#000000",
@@ -387,6 +397,7 @@ exports[`Linear/Time charts snapshot test of chartJS configuration for linear ch
       "responsive": true,
       "scales": {
         "x": {
+          "stacked": undefined,
           "ticks": {
             "callback": [Function],
             "color": "#000000",
@@ -397,7 +408,11 @@ exports[`Linear/Time charts snapshot test of chartJS configuration for linear ch
         },
         "y": {
           "beginAtZero": true,
+          "grid": {
+            "display": true,
+          },
           "position": "left",
+          "stacked": false,
           "ticks": {
             "callback": [Function],
             "color": "#000000",
@@ -523,6 +538,9 @@ exports[`datasource tests create a chart with stacked bar 1`] = `
         },
         "y": {
           "beginAtZero": true,
+          "grid": {
+            "display": true,
+          },
           "position": "left",
           "stacked": true,
           "ticks": {
@@ -615,6 +633,7 @@ exports[`datasource tests create chart with a dataset of one cell (no title) 1`]
       "responsive": true,
       "scales": {
         "x": {
+          "stacked": undefined,
           "ticks": {
             "color": "#000000",
             "padding": 5,
@@ -623,7 +642,11 @@ exports[`datasource tests create chart with a dataset of one cell (no title) 1`]
         },
         "y": {
           "beginAtZero": true,
+          "grid": {
+            "display": true,
+          },
           "position": "left",
+          "stacked": false,
           "ticks": {
             "callback": [Function],
             "color": "#000000",
@@ -749,6 +772,7 @@ exports[`datasource tests create chart with column datasets 1`] = `
       "responsive": true,
       "scales": {
         "x": {
+          "stacked": undefined,
           "ticks": {
             "color": "#000000",
             "padding": 5,
@@ -757,7 +781,11 @@ exports[`datasource tests create chart with column datasets 1`] = `
         },
         "y": {
           "beginAtZero": true,
+          "grid": {
+            "display": true,
+          },
           "position": "left",
+          "stacked": false,
           "ticks": {
             "callback": [Function],
             "color": "#000000",
@@ -897,6 +925,7 @@ exports[`datasource tests create chart with column datasets with category title 
       "responsive": true,
       "scales": {
         "x": {
+          "stacked": undefined,
           "ticks": {
             "color": "#000000",
             "padding": 5,
@@ -905,7 +934,11 @@ exports[`datasource tests create chart with column datasets with category title 
         },
         "y": {
           "beginAtZero": true,
+          "grid": {
+            "display": true,
+          },
           "position": "left",
+          "stacked": false,
           "ticks": {
             "callback": [Function],
             "color": "#000000",
@@ -1046,6 +1079,7 @@ exports[`datasource tests create chart with column datasets without series title
       "responsive": true,
       "scales": {
         "x": {
+          "stacked": undefined,
           "ticks": {
             "color": "#000000",
             "padding": 5,
@@ -1054,7 +1088,11 @@ exports[`datasource tests create chart with column datasets without series title
         },
         "y": {
           "beginAtZero": true,
+          "grid": {
+            "display": true,
+          },
           "position": "left",
+          "stacked": false,
           "ticks": {
             "callback": [Function],
             "color": "#000000",
@@ -1167,6 +1205,7 @@ exports[`datasource tests create chart with only the dataset title (no data) 1`]
       "responsive": true,
       "scales": {
         "x": {
+          "stacked": undefined,
           "ticks": {
             "color": "#000000",
             "padding": 5,
@@ -1175,7 +1214,11 @@ exports[`datasource tests create chart with only the dataset title (no data) 1`]
         },
         "y": {
           "beginAtZero": true,
+          "grid": {
+            "display": true,
+          },
           "position": "left",
+          "stacked": false,
           "ticks": {
             "callback": [Function],
             "color": "#000000",
@@ -1298,6 +1341,7 @@ exports[`datasource tests create chart with rectangle dataset 1`] = `
       "responsive": true,
       "scales": {
         "x": {
+          "stacked": undefined,
           "ticks": {
             "color": "#000000",
             "padding": 5,
@@ -1306,7 +1350,11 @@ exports[`datasource tests create chart with rectangle dataset 1`] = `
         },
         "y": {
           "beginAtZero": true,
+          "grid": {
+            "display": true,
+          },
           "position": "left",
+          "stacked": false,
           "ticks": {
             "callback": [Function],
             "color": "#000000",
@@ -1446,6 +1494,7 @@ exports[`datasource tests create chart with row datasets 1`] = `
       "responsive": true,
       "scales": {
         "x": {
+          "stacked": undefined,
           "ticks": {
             "color": "#000000",
             "padding": 5,
@@ -1454,7 +1503,11 @@ exports[`datasource tests create chart with row datasets 1`] = `
         },
         "y": {
           "beginAtZero": true,
+          "grid": {
+            "display": true,
+          },
           "position": "left",
+          "stacked": false,
           "ticks": {
             "callback": [Function],
             "color": "#000000",
@@ -1594,6 +1647,7 @@ exports[`datasource tests create chart with row datasets with category title 1`]
       "responsive": true,
       "scales": {
         "x": {
+          "stacked": undefined,
           "ticks": {
             "color": "#000000",
             "padding": 5,
@@ -1602,7 +1656,11 @@ exports[`datasource tests create chart with row datasets with category title 1`]
         },
         "y": {
           "beginAtZero": true,
+          "grid": {
+            "display": true,
+          },
           "position": "left",
+          "stacked": false,
           "ticks": {
             "callback": [Function],
             "color": "#000000",
@@ -1743,6 +1801,7 @@ exports[`datasource tests create chart with row datasets without series title 1`
       "responsive": true,
       "scales": {
         "x": {
+          "stacked": undefined,
           "ticks": {
             "color": "#000000",
             "padding": 5,
@@ -1751,7 +1810,11 @@ exports[`datasource tests create chart with row datasets without series title 1`
         },
         "y": {
           "beginAtZero": true,
+          "grid": {
+            "display": true,
+          },
           "position": "left",
+          "stacked": false,
           "ticks": {
             "callback": [Function],
             "color": "#000000",

--- a/tests/figures/chart/bar_chart_plugin.test.ts
+++ b/tests/figures/chart/bar_chart_plugin.test.ts
@@ -89,7 +89,11 @@ describe("bar chart", () => {
       expect(options.scales.y.title.text).toBe("yAxis");
       expect(options.scales.y.ticks.callback).toBeUndefined();
 
-      const tooltipTestItem = { parsed: { x: 5, y: "label" }, label: "dataSetLabel" };
+      const tooltipTestItem = {
+        parsed: { x: 5, y: "label" },
+        label: "dataSetLabel",
+        dataset: { xAxisID: "x" },
+      };
       const tooltip = runtime.chartJsConfig.options?.plugins?.tooltip as any;
       expect(tooltip?.callbacks?.label(tooltipTestItem)).toBe("dataSetLabel: 5€");
     });
@@ -125,7 +129,7 @@ describe("bar chart", () => {
       );
       const runtime = model.getters.getChartRuntime("id") as any;
       expect(runtime.chartJsConfig.options?.scales?.y1).toBe(undefined);
-      expect(runtime.chartJsConfig.data.datasets[0].yAxisID).toBe(undefined);
+      expect(runtime.chartJsConfig.data.datasets[0].yAxisID).toBe("y");
     });
   });
 });

--- a/tests/figures/chart/bar_chart_plugin.test.ts
+++ b/tests/figures/chart/bar_chart_plugin.test.ts
@@ -49,8 +49,8 @@ describe("bar chart", () => {
   test("Stacked bar", () => {
     const model = new Model();
     createChart(model, { type: "bar", stacked: false }, "chartId");
-    expect(isChartAxisStacked(model, "chartId", "x")).toBeUndefined();
-    expect(isChartAxisStacked(model, "chartId", "y")).toBeUndefined();
+    expect(isChartAxisStacked(model, "chartId", "x")).toBeFalsy();
+    expect(isChartAxisStacked(model, "chartId", "y")).toBeFalsy();
 
     updateChart(model, "chartId", { stacked: true });
     expect(isChartAxisStacked(model, "chartId", "x")).toBe(true);

--- a/tests/figures/chart/chart_plugin.test.ts
+++ b/tests/figures/chart/chart_plugin.test.ts
@@ -2117,7 +2117,7 @@ describe("Chart design configuration", () => {
   });
 
   test.each(["line", "scatter", "bar", "combo"] as const)(
-    "%s chart correctly use right axis if set up in definition",
+    "%s chart correctly use right axis if set up in definition, and the grid lines are only displayed once",
     (chartType) => {
       setCellContent(model, "A1", "1");
       setCellContent(model, "A2", "2");
@@ -2139,8 +2139,14 @@ describe("Chart design configuration", () => {
       let config = getChartConfiguration(model, "43");
       expect(config.data?.datasets![0]["yAxisID"]).toEqual("y");
       expect(config.data?.datasets![1]["yAxisID"]).toEqual("y1");
-      expect(config.options?.scales?.y).toMatchObject({ position: "left" });
-      expect(config.options?.scales?.y1).toMatchObject({ position: "right" });
+      expect(config.options?.scales?.y).toMatchObject({
+        position: "left",
+        grid: { display: true },
+      });
+      expect(config.options?.scales?.y1).toMatchObject({
+        position: "right",
+        grid: { display: false },
+      });
       updateChart(model, "43", {
         dataSets: [
           { dataRange: "A1:A2", yAxisId: "y1" },
@@ -2150,8 +2156,11 @@ describe("Chart design configuration", () => {
       config = getChartConfiguration(model, "43");
       expect(config.data?.datasets![0]["yAxisID"]).toEqual("y1");
       expect(config.data?.datasets![1]["yAxisID"]).toEqual("y1");
-      expect(config.options?.scales?.y).not.toBeDefined();
-      expect(config.options?.scales?.y1).toMatchObject({ position: "right" });
+      expect(config.options?.scales?.y).toBeUndefined();
+      expect(config.options?.scales?.y1).toMatchObject({
+        position: "right",
+        grid: { display: true },
+      });
       updateChart(model, "43", {
         dataSets: [
           { dataRange: "A1:A2", yAxisId: "y" },
@@ -2161,8 +2170,11 @@ describe("Chart design configuration", () => {
       config = getChartConfiguration(model, "43");
       expect(config.data?.datasets![0]["yAxisID"]).toEqual("y");
       expect(config.data?.datasets![1]["yAxisID"]).toEqual("y");
-      expect(config.options?.scales?.y1).not.toBeDefined();
-      expect(config.options?.scales?.y).toMatchObject({ position: "left" });
+      expect(config.options?.scales?.y1).toBeUndefined();
+      expect(config.options?.scales?.y).toMatchObject({
+        position: "left",
+        grid: { display: true },
+      });
     }
   );
 

--- a/tests/figures/chart/chart_plugin.test.ts
+++ b/tests/figures/chart/chart_plugin.test.ts
@@ -3143,10 +3143,9 @@ describe("trending line", () => {
       offset: false,
       labels: range(0, 26).map((v) => v.toString()),
     });
-    const runtime = model.getters.getChartRuntime("1") as LineChartRuntime;
+    const runtime = model.getters.getChartRuntime("1") as any;
     const step = (6 - 1) / 25;
-    //@ts-ignore
-    const data = runtime.dataSetsValues[1].data;
+    const data = runtime.chartJsConfig.data.datasets[1].data;
     for (let i = 0; i < data.lenght; i++) {
       const value = data.lenght;
       const expectedValue = Math.pow(1 + i * step, 2);
@@ -3163,10 +3162,9 @@ describe("trending line", () => {
       offset: false,
       labels: range(0, 26).map((v) => v.toString()),
     });
-    const runtime = model.getters.getChartRuntime("1");
+    const runtime = model.getters.getChartRuntime("1") as any;
     const step = (5 - 1) / 25;
-    //@ts-ignore
-    const data = runtime.dataSetsValues[1].data;
+    const data = runtime.chartJsConfig.data.datasets[1].data;
     for (let i = 0; i < data.lenght; i++) {
       const value = data.lenght;
       const expectedValue = Math.pow(1 + i * step, 2);
@@ -3182,10 +3180,9 @@ describe("trending line", () => {
       offset: false,
       labels: range(0, 26).map((v) => v.toString()),
     });
-    const runtime = model.getters.getChartRuntime("1");
+    const runtime = model.getters.getChartRuntime("1") as any;
     const step = (5 - 1) / 25;
-    //@ts-ignore
-    const data = runtime.dataSetsValues[1].data;
+    const data = runtime.chartJsConfig.data.datasets[1].data;
     for (let i = 0; i < data.lenght; i++) {
       const value = data.lenght;
       const expectedValue = Math.pow(1 + i * step, 2);
@@ -3212,10 +3209,9 @@ describe("trending line", () => {
       offset: false,
       labels: range(0, 51).map((v) => v.toString()),
     });
-    const runtime = model.getters.getChartRuntime("1");
+    const runtime = model.getters.getChartRuntime("1") as any;
     const step = (10 - 1) / 25;
-    //@ts-ignore
-    const data = runtime.dataSetsValues[1].data;
+    const data = runtime.chartJsConfig.data.datasets[1].data;
     for (let i = 0; i < data.lenght; i++) {
       const value = data.lenght;
       const expectedValue = Math.pow(1 + i * step, 2);

--- a/tests/figures/chart/combo_chart_plugin.test.ts
+++ b/tests/figures/chart/combo_chart_plugin.test.ts
@@ -43,22 +43,11 @@ describe("combo chart", () => {
     });
   });
 
-  test("both axis formats are based on their data set", () => {
+  test("both axis and tooltips formats are based on their data set", () => {
     const model = new Model();
-    setCellContent(model, "A1", "Alice");
-    setCellContent(model, "A2", "Bob");
 
-    // first data set
-    setCellContent(model, "B1", "1");
-    setCellContent(model, "B2", "2");
-    setCellFormat(model, "B1", "0.00%");
-    setCellFormat(model, "B2", "0.00%");
-
-    // second data set
-    setCellContent(model, "C1", "10");
-    setCellContent(model, "C2", "20");
-    setCellFormat(model, "C1", "0.00[$$]");
-    setCellFormat(model, "C2", "0.00[$$]");
+    setCellFormat(model, "B1", "0.00%"); // first data set
+    setCellFormat(model, "C1", "0.00[$$]"); // second data set
 
     createChart(
       model,
@@ -74,14 +63,16 @@ describe("combo chart", () => {
       "1"
     );
     const runtime = model.getters.getChartRuntime("1") as ComboChartRuntime;
-    const index = 0; // because chart.js types expects an index
-    const ticks = []; // because chart.js types expects the ticks
-    expect(
-      runtime.chartJsConfig.options?.scales?.y?.ticks?.callback?.apply(null, [1, index, ticks])
-    ).toBe("100.00%");
-    expect(
-      runtime.chartJsConfig.options?.scales?.y1?.ticks?.callback?.apply(null, [1, index, ticks])
-    ).toBe("1.00$");
+    const scales = runtime.chartJsConfig.options?.scales as any;
+    expect(scales?.y?.ticks?.callback?.apply(null, [1])).toBe("100.00%");
+    expect(scales?.y1?.ticks?.callback?.apply(null, [1])).toBe("1.00$");
+
+    const tooltipCallbacks = runtime.chartJsConfig.options?.plugins?.tooltip?.callbacks as any;
+    let tooltipItem = { parsed: { y: 20 }, dataIndex: 0, dataset: { yAxisID: "y", label: "Ds 1" } };
+    expect(tooltipCallbacks?.label?.(tooltipItem)).toEqual("Ds 1: 2000.00%");
+
+    tooltipItem = { parsed: { y: 20 }, dataIndex: 1, dataset: { yAxisID: "y1", label: "Ds 2" } };
+    expect(tooltipCallbacks?.label?.(tooltipItem)).toEqual("Ds 2: 20.00$");
   });
 
   test("Can edit the type of the series", () => {

--- a/tests/figures/chart/line_chart_plugin.test.ts
+++ b/tests/figures/chart/line_chart_plugin.test.ts
@@ -60,8 +60,8 @@ describe("line chart", () => {
       ],
     });
     createChart(model, { type: "line", dataSets: [{ dataRange: "Sheet1!B1:B4" }] }, "chartId");
-    expect(isChartAxisStacked(model, "chartId", "x")).toBeUndefined();
-    expect(isChartAxisStacked(model, "chartId", "y")).toBeUndefined();
+    expect(isChartAxisStacked(model, "chartId", "x")).toBeFalsy();
+    expect(isChartAxisStacked(model, "chartId", "y")).toBeFalsy();
 
     updateChart(model, "chartId", { stacked: true });
     const runtime = model.getters.getChartRuntime("chartId") as any;
@@ -105,8 +105,8 @@ describe("line chart", () => {
     expect(runtime.chartJsConfig.data.datasets[0].backgroundColor).toBe("#4EA7F266");
     expect(runtime.chartJsConfig.data.datasets[1].fill).toBe("origin");
     expect(runtime.chartJsConfig.data.datasets[1].backgroundColor).toBe("#EA617566");
-    expect(isChartAxisStacked(model, "chartId", "x")).toBeUndefined();
-    expect(isChartAxisStacked(model, "chartId", "y")).toBeUndefined();
+    expect(isChartAxisStacked(model, "chartId", "x")).toBeFalsy();
+    expect(isChartAxisStacked(model, "chartId", "y")).toBeFalsy();
   });
 
   test("Stacked area chart", () => {

--- a/tests/figures/chart/pyramid_chart_plugin.test.ts
+++ b/tests/figures/chart/pyramid_chart_plugin.test.ts
@@ -97,7 +97,11 @@ describe("population pyramid chart", () => {
       // Second dataset is converted to negative values for chartJS display, but it should be invisible to the user
       expect(options.scales.x.ticks.callback(-10)).toBe("10€");
 
-      const tooltipTestItem = { parsed: { x: -10, y: "label" }, label: "dataSetLabel" };
+      const tooltipTestItem = {
+        parsed: { x: -10, y: "label" },
+        label: "dataSetLabel",
+        dataset: { xAxisID: "x" },
+      };
       const tooltip = runtime.chartJsConfig.options?.plugins?.tooltip as any;
       expect(tooltip?.callbacks?.label(tooltipTestItem)).toBe("dataSetLabel: 10€");
     });

--- a/tests/figures/chart/waterfall/waterfall_chart_plugin.test.ts
+++ b/tests/figures/chart/waterfall/waterfall_chart_plugin.test.ts
@@ -6,7 +6,12 @@ import {
 } from "../../../../src/constants";
 import { WaterfallChart } from "../../../../src/helpers/figures/charts";
 import { WaterfallChartRuntime } from "../../../../src/types/chart/waterfall_chart";
-import { createWaterfallChart, setCellContent, updateChart } from "../../../test_helpers";
+import {
+  createWaterfallChart,
+  setCellContent,
+  setFormat,
+  updateChart,
+} from "../../../test_helpers";
 
 let model: Model;
 
@@ -200,6 +205,7 @@ describe("Waterfall chart", () => {
     setCellContent(model, "A1", "Dataset 1");
     setCellContent(model, "B1", "Dataset 2");
     setCellContent(model, "A2", "30");
+    setFormat(model, "A2", "0[$€]");
     setCellContent(model, "B2", "-40");
     const chartId = createWaterfallChart(model, {
       dataSets: [{ dataRange: "A1:B2" }],
@@ -208,17 +214,12 @@ describe("Waterfall chart", () => {
     });
     const runtime = getWaterfallRuntime(chartId);
 
-    let tooltipItem = { raw: [0, 30], dataIndex: 0 };
-    expect(
-      // @ts-ignore
-      runtime.chartJsConfig.options?.plugins?.tooltip?.callbacks?.label?.(tooltipItem)
-    ).toEqual("Dataset 1: 30");
+    let tooltipItem = { raw: [0, 30], dataIndex: 0, dataset: { xAxisID: "x" } };
+    const tooltipCallbacks = runtime.chartJsConfig.options?.plugins?.tooltip?.callbacks as any;
+    expect(tooltipCallbacks?.label?.(tooltipItem)).toEqual("Dataset 1: 30€");
 
-    tooltipItem = { raw: [30, -10], dataIndex: 1 };
-    expect(
-      // @ts-ignore
-      runtime.chartJsConfig.options?.plugins?.tooltip?.callbacks?.label?.(tooltipItem)
-    ).toEqual("Dataset 2: -40");
+    tooltipItem = { raw: [30, -10], dataIndex: 1, dataset: { xAxisID: "x" } };
+    expect(tooltipCallbacks?.label?.(tooltipItem)).toEqual("Dataset 2: -40€");
   });
 
   test("Waterfall legend", () => {


### PR DESCRIPTION
## Description:

### [IMP] charts: show single grid line for y-axis

When a chart had 2 vertical axis (left & right), we showed grid lines
for both, which made the chart messy. Now we show only the grid lines
for the left axis (or the right axis if there is no left axis).

### [IMP] chart: multiple Y axis value formatting

Some chart support multiple Y axis, but the format of the values in
the ticks/tooltips was the same for both charts.

With this commit, each axis can have a different format, and this
format is applied to the ticks, the tooltips and the "show values"
option.

Task: [4153935](https://www.odoo.com/web#id=4153935&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo