### PR TITLE
[FIX] xlsx: fix table total row export

### DIFF
--- a/src/xlsx/functions/table.ts
+++ b/src/xlsx/functions/table.ts
@@ -76,6 +76,15 @@ function addTableColumns(table: ExcelTableData, sheetData: ExcelSheetData): XMLS
       ["id", i + 1], // id cannot be 0
       ["name", colName],
     ];
+    if (table.config.totalRow) {
+      // Note: To be 100% complete, we could also add a `totalsRowLabel` attribute for total strings, and a tag
+      // `<totalsRowFormula>` for the formula of the total. But those doesn't seem to be mandatory for Excel.
+      const colTotalXc = toXC(tableZone.left + i, tableZone.bottom);
+      const colTotalContent = sheetData.cells[colTotalXc]?.content;
+      if (colTotalContent?.startsWith("=")) {
+        colAttributes.push(["totalsRowFunction", "custom"]);
+      }
+    }
     columns.push(escapeXml/*xml*/ `<tableColumn ${formatAttributes(colAttributes)}/>`);
   }
 

--- a/src/xlsx/functions/worksheet.ts
+++ b/src/xlsx/functions/worksheet.ts
@@ -105,11 +105,12 @@ export function addRows(
           ({ attrs: additionalAttrs, node: cellNode } = addContent(label, construct.sharedStrings));
         } else if (cell.content && cell.content !== "") {
           const isTableHeader = isCellTableHeader(c, r, sheet);
+          const isTableTotal = isCellTableTotal(c, r, sheet);
           const isPlainText = !!(cell.format && data.formats[cell.format] === PLAIN_TEXT_FORMAT);
           ({ attrs: additionalAttrs, node: cellNode } = addContent(
             cell.content,
             construct.sharedStrings,
-            isTableHeader || isPlainText
+            isTableHeader || isTableTotal || isPlainText
           ));
         }
         attributes.push(...additionalAttrs);
@@ -145,6 +146,17 @@ function isCellTableHeader(col: HeaderIndex, row: HeaderIndex, sheet: ExcelSheet
     const zone = toZone(table.range);
     const headerZone = { ...zone, bottom: zone.top };
     return isInside(col, row, headerZone);
+  });
+}
+
+function isCellTableTotal(col: HeaderIndex, row: HeaderIndex, sheet: ExcelSheetData): boolean {
+  return sheet.tables.some((table) => {
+    if (!table.config.totalRow) {
+      return false;
+    }
+    const zone = toZone(table.range);
+    const totalZone = { ...zone, top: zone.bottom };
+    return isInside(col, row, totalZone);
   });
 }
 

--- a/tests/xlsx/__snapshots__/xlsx_export.test.ts.snap
+++ b/tests/xlsx/__snapshots__/xlsx_export.test.ts.snap
@@ -19095,11 +19095,12 @@ exports[`Test XLSX export Export data filters Export data filters snapshot 1`] =
 
 exports[`Test XLSX export Export data filters Table style is correctly exported 1`] = `
 {
-  "content": "<table id="1" name="Table1" displayName="Table1" ref="A1:A4" headerRowCount="1" totalsRowCount="1" xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xr="http://schemas.microsoft.com/office/spreadsheetml/2014/revision" xmlns:xr3="http://schemas.microsoft.com/office/spreadsheetml/2016/revision3" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006">
-    <autoFilter ref="A1:A4">
+  "content": "<table id="1" name="Table1" displayName="Table1" ref="A1:B4" headerRowCount="1" totalsRowCount="1" xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xr="http://schemas.microsoft.com/office/spreadsheetml/2014/revision" xmlns:xr3="http://schemas.microsoft.com/office/spreadsheetml/2016/revision3" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006">
+    <autoFilter ref="A1:B4">
     </autoFilter>
-    <tableColumns count="1">
+    <tableColumns count="2">
         <tableColumn id="1" name="Column0"/>
+        <tableColumn id="2" name="Column1" totalsRowFunction="custom"/>
     </tableColumns>
     <tableStyleInfo name="TableStyleMedium9" showFirstColumn="1" showLastColumn="1" showRowStripes="1" showColumnStripes="1"/>
 </table>",


### PR DESCRIPTION
## Description

In Excel, the total row of a table should only contain either:
- string cells
- formula cells, with an attribute table column to mark them as custom total formulas.

Task: [4206619](https://www.odoo.com/web#id=4206619&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo