### PR TITLE
[FIX] xlsx: convert #REF at export to xlsx

### DIFF
--- a/src/formulas/parser.ts
+++ b/src/formulas/parser.ts
@@ -1,8 +1,7 @@
 import { DEFAULT_ERROR_MESSAGE } from "../constants";
 import { parseNumber, removeStringQuotes } from "../helpers/index";
 import { _lt } from "../translation";
-import { InvalidReferenceError } from "../types/errors";
-import { UnknownFunctionError } from "./../types/errors";
+import { CellErrorType, UnknownFunctionError } from "./../types/errors";
 import { rangeTokenize } from "./range_tokenizer";
 import { Token } from "./tokenizer";
 
@@ -152,7 +151,11 @@ function parsePrefix(current: Token, tokens: Token[]): AST {
         return { type: "FUNCALL", value: current.value, args };
       }
     case "INVALID_REFERENCE":
-      throw new InvalidReferenceError();
+      return {
+        type: "REFERENCE",
+        value: CellErrorType.InvalidReference,
+      };
+
     case "REFERENCE":
       if (tokens[0]?.value === ":" && tokens[1]?.type === "REFERENCE") {
         tokens.shift();

--- a/tests/__snapshots__/xlsx_export.test.ts.snap
+++ b/tests/__snapshots__/xlsx_export.test.ts.snap
@@ -10456,6 +10456,16 @@ Object {
                 </v>
             </c>
         </row>
+        <row r=\\"41\\" ht=\\"17.25\\" customHeight=\\"1\\" hidden=\\"0\\">
+            <c r=\\"A41\\" s=\\"3\\" t=\\"str\\">
+                <f>
+                    #REF!+5
+                </f>
+                <v>
+                    #REF!
+                </v>
+            </c>
+        </row>
     </sheetData>
 </worksheet>",
       "contentType": "sheet",

--- a/tests/formulas/parser.test.ts
+++ b/tests/formulas/parser.test.ts
@@ -1,5 +1,5 @@
 import { astToFormula, parse } from "../../src";
-import { InvalidReferenceError } from "../../src/types/errors";
+import { CellErrorType } from "../../src/types/errors";
 
 describe("parser", () => {
   test("can parse a function call with no argument", () => {
@@ -151,7 +151,10 @@ describe("parser", () => {
   });
 
   test("Can parse invalid references", () => {
-    expect(() => parse("#REF")).toThrowError(new InvalidReferenceError().message);
+    expect(parse("#REF")).toEqual({
+      type: "REFERENCE",
+      value: CellErrorType.InvalidReference,
+    });
   });
 
   test("Cannot parse empty string", () => {

--- a/tests/xlsx_export.test.ts
+++ b/tests/xlsx_export.test.ts
@@ -70,6 +70,7 @@ const simpleData = {
         A38: { content: `='<Sheet2>'!B2` },
         A39: { content: `=A39` },
         A40: { content: `=(1+2)/3` },
+        A41: { content: "=#REF + 5" },
         K3: { border: 5 },
         K4: { border: 4 },
         K5: { border: 4 },


### PR DESCRIPTION
### [FIX] xlsx: convert #REF at export to xlsx:

Reference errors in excel are #REF!, not #REF.

### [FIX] parser: inconsistent handling of #REF

Depending on how we get a formula with #REF, the parser can have
different behavior even if the formula is the same.

- If we write directly =#REF (or it comes from a snapshot), the parser
will throw an error.
- If we write =A1, then delete the row 1 to get =#REF, the parser will
return a REFERENCE token with an #REF value.

This is a bit of a problem when exporting the data to xlsx: since
we parse the formulas to know whether we need to export it, we get
a different result depending on how we got the #REF.

Task: [4207052](https://www.odoo.com/web#id=4207052&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo