### PR TITLE
[FIX] pivot: finer grained cycle detection

### DIFF
--- a/src/functions/helper_lookup.ts
+++ b/src/functions/helper_lookup.ts
@@ -2,7 +2,7 @@ import { zoneToXc } from "../helpers";
 import { _t } from "../translation";
 import { EvalContext, FunctionResultObject, Getters, Maybe, Range, UID } from "../types";
 import { EvaluationError, InvalidReferenceError } from "../types/errors";
-import { PivotCoreDefinition } from "../types/pivot";
+import { PivotCoreDefinition, PivotCoreMeasure } from "../types/pivot";
 
 /**
  * Get the pivot ID from the formula pivot ID.
@@ -37,7 +37,8 @@ export function assertDomainLength(domain: Maybe<FunctionResultObject>[]) {
 
 export function addPivotDependencies(
   evalContext: EvalContext,
-  coreDefinition: PivotCoreDefinition
+  coreDefinition: PivotCoreDefinition,
+  forMeasures: PivotCoreMeasure[]
 ) {
   //TODO This function can be very costly when used with PIVOT.VALUE and PIVOT.HEADER
   const dependencies: Range[] = [];
@@ -52,7 +53,7 @@ export function addPivotDependencies(
     dependencies.push(range);
   }
 
-  for (const measure of coreDefinition.measures) {
+  for (const measure of forMeasures) {
     if (measure.computedBy) {
       const formula = evalContext.getters.getMeasureCompiledFormula(measure);
       dependencies.push(...formula.dependencies.filter((range) => !range.invalidXc));

--- a/src/functions/module_lookup.ts
+++ b/src/functions/module_lookup.ts
@@ -709,7 +709,11 @@ export const PIVOT_VALUE = {
     const pivot = this.getters.getPivot(pivotId);
     const coreDefinition = this.getters.getPivotCoreDefinition(pivotId);
 
-    addPivotDependencies(this, coreDefinition);
+    addPivotDependencies(
+      this,
+      coreDefinition,
+      coreDefinition.measures.filter((m) => m.id === _measure)
+    );
     pivot.init({ reload: pivot.needsReevaluation });
     const error = pivot.assertIsValid({ throwOnError: false });
     if (error) {
@@ -747,7 +751,7 @@ export const PIVOT_HEADER = {
     assertDomainLength(domainArgs);
     const pivot = this.getters.getPivot(_pivotId);
     const coreDefinition = this.getters.getPivotCoreDefinition(_pivotId);
-    addPivotDependencies(this, coreDefinition);
+    addPivotDependencies(this, coreDefinition, []);
     pivot.init({ reload: pivot.needsReevaluation });
     const error = pivot.assertIsValid({ throwOnError: false });
     if (error) {
@@ -813,7 +817,7 @@ export const PIVOT = {
     const pivotId = getPivotId(_pivotFormulaId, this.getters);
     const pivot = this.getters.getPivot(pivotId);
     const coreDefinition = this.getters.getPivotCoreDefinition(pivotId);
-    addPivotDependencies(this, coreDefinition);
+    addPivotDependencies(this, coreDefinition, coreDefinition.measures);
     pivot.init({ reload: pivot.needsReevaluation });
     const error = pivot.assertIsValid({ throwOnError: false });
     if (error) {


### PR DESCRIPTION
## Description:

Steps to reproduce:

- insert a fixed pivot (not dynamic!)
- insert a new calculated measure
- in the calculated measure formula, reference one of a cell which contains a header formula

=> the cell becomes a #CYCLE even though there's no circular dependendy
   between the calculated measure and the other dimension header

Task: [4214188](https://www.odoo.com/web#id=4214188&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo