### PR TITLE
[PERF] Actions: Fill missing ids with fast unique values

### DIFF
--- a/src/actions/action.ts
+++ b/src/actions/action.ts
@@ -1,4 +1,3 @@
-import { UuidGenerator } from "../helpers";
 import { Color, SpreadsheetChildEnv } from "../types";
 
 /*
@@ -91,7 +90,7 @@ export function createActions(menuItems: ActionSpec[]): Action[] {
   return menuItems.map(createAction).sort((a, b) => a.sequence - b.sequence);
 }
 
-const uuidGenerator = new UuidGenerator();
+let nextItemId = 1;
 
 export function createAction(item: ActionSpec): Action {
   const name = item.name;
@@ -99,8 +98,9 @@ export function createAction(item: ActionSpec): Action {
   const description = item.description;
   const icon = item.icon;
   const secondaryIcon = item.secondaryIcon;
+  const itemId = item.id || nextItemId++;
   return {
-    id: item.id || uuidGenerator.uuidv4(),
+    id: itemId.toString(),
     name: typeof name === "function" ? name : () => name,
     isVisible: item.isVisible ? item.isVisible : () => true,
     isEnabled: item.isEnabled ? item.isEnabled : () => true,

--- a/src/model.ts
+++ b/src/model.ts
@@ -231,8 +231,6 @@ export class Model extends EventBus<any> implements CommandDispatcher {
       isDashboard: () => this.config.mode === "dashboard",
     } as Getters;
 
-    this.uuidGenerator.setIsFastStrategy(true);
-
     // Initiate stream processor
     this.selection = new SelectionStreamProcessorImpl(this.getters);
 


### PR DESCRIPTION
The ActionsSpecs have a defaut behaviour where we are not obligated to provide an id in the actionSpec because "CreateAction" will end up generating it on demand with an uuidv4.

However, uuidv4 can become a problem if invoked to often and it so happens that some actionSpecs related to the topbar benefit from this automatic generation. Since the topbar items are regenerated at each rendering of a spreadsheet, they can become problematic.

For instance, in Odoo test suites, they take up to 2-3% of the computation time.

This revision bypasses the call to an actual uuidv4 by forcing a fast strategy in the uuidGenerator, which accomplishes the same result, having a unique identifier for each menu item generated.

Task: 4216427

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo