### PR TITLE
[REM] UUID: remove fast strategy

### DIFF
--- a/src/helpers/uuid.ts
+++ b/src/helpers/uuid.ts
@@ -3,20 +3,9 @@
  * */
 
 export class UuidGenerator {
-  private isFastIdStrategy = false;
-
-  private fastIdStart = 0;
-
-  setIsFastStrategy(isFast: boolean) {
-    this.isFastIdStrategy = isFast;
-  }
-
   uuidv4(): string {
-    if (this.isFastIdStrategy) {
-      this.fastIdStart++;
-      return String(this.fastIdStart);
-      //@ts-ignore
-    } else if (window.crypto && window.crypto.getRandomValues) {
+    //@ts-ignore
+    if (window.crypto && window.crypto.getRandomValues) {
       //@ts-ignore
       return ([1e7] + -1e3 + -4e3 + -8e3 + -1e11).replace(/[018]/g, (c) =>
         (c ^ (crypto.getRandomValues(new Uint8Array(1))[0] & (15 >> (c / 4)))).toString(16)

--- a/src/model.ts
+++ b/src/model.ts
@@ -430,7 +430,6 @@ export class Model extends EventBus<any> implements CommandDispatcher {
       range: this.range,
       dispatch: this.dispatchFromCorePlugin,
       canDispatch: this.canDispatch,
-      uuidGenerator: this.uuidGenerator,
       custom: this.config.custom,
       external: this.config.external,
     };

--- a/src/model.ts
+++ b/src/model.ts
@@ -230,8 +230,6 @@ export class Model extends EventBus<any> implements CommandDispatcher {
       isDashboard: () => this.config.mode === "dashboard",
     } as Getters;
 
-    this.uuidGenerator.setIsFastStrategy(true);
-
     // Initiate stream processor
     this.selection = new SelectionStreamProcessorImpl(this.getters);
 
@@ -268,7 +266,6 @@ export class Model extends EventBus<any> implements CommandDispatcher {
       this.handlers.push(plugin);
       this.uiHandlers.push(plugin);
     }
-    this.uuidGenerator.setIsFastStrategy(false);
 
     // starting plugins
     this.dispatch("START");

--- a/src/plugins/core/tables.ts
+++ b/src/plugins/core/tables.ts
@@ -41,6 +41,8 @@ import {
 
 import { CorePlugin } from "../core_plugin";
 
+let nextTableId = 1;
+
 interface TableState {
   tables: Record<UID, Record<TableId, CoreTable | undefined>>;
 }
@@ -126,7 +128,7 @@ export class TablePlugin extends CorePlugin<TableState> implements TableState {
         const mergesInTarget = this.getters.getMergesInZone(cmd.sheetId, union.zone);
         this.dispatch("REMOVE_MERGE", { sheetId: cmd.sheetId, target: mergesInTarget });
 
-        const id = this.uuidGenerator.uuidv4();
+        const id = `${nextTableId++}`;
         const config = cmd.config || DEFAULT_TABLE_CONFIG;
         const newTable =
           cmd.tableType === "dynamic"
@@ -310,7 +312,7 @@ export class TablePlugin extends CorePlugin<TableState> implements TableState {
       filters = [];
       for (const i of range(zone.left, zone.right + 1)) {
         const filterZone = { ...zone, left: i, right: i };
-        const uid = this.uuidGenerator.uuidv4();
+        const uid = `${nextTableId++}`;
         filters.push(this.createFilterFromZone(uid, tableRange.sheetId, filterZone, config));
       }
     }
@@ -391,7 +393,7 @@ export class TablePlugin extends CorePlugin<TableState> implements TableState {
             ? table.filters.find((f) => f.col === i)
             : undefined;
         const filterZone = { ...tableZone, left: i, right: i };
-        const filterId = oldFilter?.id || this.uuidGenerator.uuidv4();
+        const filterId = oldFilter?.id || `${nextTableId++}`;
         filters.push(this.createFilterFromZone(filterId, tableRange.sheetId, filterZone, config));
       }
     }
@@ -514,7 +516,7 @@ export class TablePlugin extends CorePlugin<TableState> implements TableState {
     if (filters.length < zoneToDimension(tableZone).numberOfCols) {
       for (let col = tableZone.left; col <= tableZone.right; col++) {
         if (!filters.find((filter) => filter.col === col)) {
-          const uid = this.uuidGenerator.uuidv4();
+          const uid = `${nextTableId++}`;
           const filterZone = { ...tableZone, left: col, right: col };
           filters.push(this.createFilterFromZone(uid, sheetId, filterZone, table.config));
         }
@@ -539,7 +541,7 @@ export class TablePlugin extends CorePlugin<TableState> implements TableState {
   import(data: WorkbookData) {
     for (const sheet of data.sheets) {
       for (const tableData of sheet.tables || []) {
-        const uuid = this.uuidGenerator.uuidv4();
+        const uuid = `${nextTableId++}`;
         const tableConfig = tableData.config || DEFAULT_TABLE_CONFIG;
         const range = this.getters.getRangeFromSheetXC(sheet.id, tableData.range);
         const tableType = tableData.type || "static";

--- a/src/plugins/core_plugin.ts
+++ b/src/plugins/core_plugin.ts
@@ -1,4 +1,3 @@
-import { UuidGenerator } from "../helpers";
 import { ModelConfig } from "../model";
 import { StateObserver } from "../state_observer";
 import {
@@ -19,7 +18,6 @@ export interface CorePluginConfig {
   readonly range: RangeAdapter;
   readonly dispatch: CoreCommandDispatcher["dispatch"];
   readonly canDispatch: CoreCommandDispatcher["dispatch"];
-  readonly uuidGenerator: UuidGenerator;
   readonly custom: ModelConfig["custom"];
   readonly external: ModelConfig["external"];
 }
@@ -40,20 +38,11 @@ export class CorePlugin<State = any>
   implements RangeProvider
 {
   protected getters: CoreGetters;
-  protected uuidGenerator: UuidGenerator;
 
-  constructor({
-    getters,
-    stateObserver,
-    range,
-    dispatch,
-    canDispatch,
-    uuidGenerator,
-  }: CorePluginConfig) {
+  constructor({ getters, stateObserver, range, dispatch, canDispatch }: CorePluginConfig) {
     super(stateObserver, dispatch, canDispatch);
     range.addRangeProvider(this.adaptRanges.bind(this));
     this.getters = getters;
-    this.uuidGenerator = uuidGenerator;
   }
 
   // ---------------------------------------------------------------------------

--- a/tests/__mocks__/uuid.ts
+++ b/tests/__mocks__/uuid.ts
@@ -1,8 +1,6 @@
 export class UuidGenerator {
   private nextId = 1;
 
-  setIsFastStrategy(isFast: boolean) {}
-
   uuidv4(): string {
     return String(this.nextId++);
   }


### PR DESCRIPTION
THe fast strategy for uuid generator was introduced to speed up the startup of a model, specifically when generating cells which could be numerous and the calls to crypto could become a hassle. However, we realised later on that a uuid was useless for that specific purpose. More specifically, a uuid is useful to generate unique identifiers that will be shared accross users to avoid collisions in multi-user context (i.e. concurrent updates).
In other cases, shortcutting the uuid generator to become a simple incremented integer value is either wrong or shows the uselessness of calling uuidGenerator in the first place.

Task: 4216816

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo