### PR TITLE
[FIX] paint format: properly paint borders and tables

### DIFF
--- a/tests/grid/grid_component.test.ts
+++ b/tests/grid/grid_component.test.ts
@@ -5,6 +5,7 @@ import { PaintFormatStore } from "../../src/components/paint_format_button/paint
 import { CellPopoverStore } from "../../src/components/popover";
 import {
   BACKGROUND_GRAY_COLOR,
+  DEFAULT_BORDER_DESC,
   DEFAULT_CELL_HEIGHT,
   DEFAULT_CELL_WIDTH,
   GRID_ICON_EDGE_LENGTH,
@@ -40,6 +41,7 @@ import {
   selectColumn,
   selectHeader,
   selectRow,
+  setBorders,
   setCellContent,
   setCellFormat,
   setSelection,
@@ -64,6 +66,7 @@ import {
 } from "../test_helpers/dom_helper";
 import {
   getActiveSheetFullScrollInfo,
+  getBorder,
   getCell,
   getCellContent,
   getCellText,
@@ -849,20 +852,32 @@ describe("Grid component", () => {
       highlightStore = env.getStore(HighlightStore);
     });
 
-    test("can paste format with mouse once", async () => {
+    test("can paste format and borders with mouse once", async () => {
       setCellContent(model, "B2", "b2");
       selectCell(model, "B2");
       setStyle(model, "B2", { bold: true });
+      setBorders(model, "B2", { top: DEFAULT_BORDER_DESC });
       paintFormatStore.activate({ persistent: false });
       gridMouseEvent(model, "pointerdown", "C8");
       expect(getCell(model, "C8")).toBeUndefined();
       gridMouseEvent(model, "pointerup", "C8");
       expect(getCell(model, "C8")!.style).toEqual({ bold: true });
+      expect(getBorder(model, "C8")).toEqual({ top: DEFAULT_BORDER_DESC });
 
       gridMouseEvent(model, "pointerdown", "D8");
       expect(getCell(model, "D8")).toBeUndefined();
       gridMouseEvent(model, "pointerup", "D8");
       expect(getCell(model, "D8")).toBeUndefined();
+    });
+
+    test("Paste format works with table style", () => {
+      createTable(model, "A1:B2", { styleId: "TableStyleLight11" });
+      selectCell(model, "A1");
+      paintFormatStore.activate({ persistent: false });
+      gridMouseEvent(model, "pointerdown", "C8");
+      gridMouseEvent(model, "pointerup", "C8");
+
+      expect(getCell(model, "C8")?.style).toMatchObject({ fillColor: "#748747" });
     });
 
     test("can keep the paint format mode persistently", async () => {


### PR DESCRIPTION
## Description

Since the paint format tool was moved from the clipboard plugin to its own store, it didn't handle the borders and tables properly. This commit fixes that by adding the two ClipboardHandlers to the PaintFormatStore.

Task: [4213894](https://www.odoo.com/web#id=4213894&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo