### PR TITLE
[FIX] clipboard: cannot paste whole table style

### DIFF
--- a/tests/table/tables_plugin.test.ts
+++ b/tests/table/tables_plugin.test.ts
@@ -2,7 +2,7 @@ import { CommandResult, Model } from "../../src";
 import { DEFAULT_BORDER_DESC } from "../../src/constants";
 import { toUnboundedZone, toZone, zoneToXc } from "../../src/helpers";
 import { TABLE_PRESETS } from "../../src/helpers/table_presets";
-import { ClipboardPasteOptions, UID } from "../../src/types";
+import { UID } from "../../src/types";
 import {
   addColumns,
   addRows,
@@ -803,17 +803,25 @@ describe("Table plugin", () => {
       expect(getCell(model, "B1")?.style?.fillColor).not.toEqual("#FF0000");
     });
 
-    test.each(["onlyFormat", "asValue"] as ClipboardPasteOptions[])(
-      "Special paste %s don't paste whole tables",
-      (pasteOption: ClipboardPasteOptions) => {
-        createTable(model, "A1:B4");
-        updateFilter(model, "A1", ["thisIsAValue"]);
+    test("Paste as value do not copy the table", () => {
+      createTable(model, "A1:B4", { styleId: "TestStyleAllRed" });
 
-        copy(model, "A1:B4");
-        paste(model, "A5", pasteOption);
-        expect(getTable(model, "A5")).toBeFalsy();
-      }
-    );
+      copy(model, "A1:B4");
+      paste(model, "A5", "asValue");
+      expect(getTable(model, "A5")).toBeFalsy();
+      expect(getCell(model, "A5")?.style).toBeUndefined();
+    });
+
+    test("Can copy/paste the whole table formatting", () => {
+      createTable(model, "A1:A2", { styleId: "TestStyleAllRed" });
+
+      copy(model, "A1:A2");
+      paste(model, "A5", "onlyFormat");
+      expect(getTable(model, "A5")).toBeFalsy();
+      expect(getCell(model, "A5")?.style).toEqual({ fillColor: "#FF0000", bold: true });
+      expect(getBorder(model, "A5")).toEqual({ top: DEFAULT_BORDER_DESC });
+      expect(getCell(model, "A6")?.style).toEqual({ fillColor: "#FF0000" });
+    });
 
     test("Pasting onlyFormat with a partial table copied paste the table style, not asValue", () => {
       createTable(model, "A1:B4");


### PR DESCRIPTION
## Description

Trying to copy a whole table, and then paste only the formatting didn't work and nothing was pasted. This commit fixes the issue.

Task: [4218988](https://www.odoo.com/web#id=4218988&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo