### PR TITLE
[FIX] pivot: remove forbidden chars when duplicating

### DIFF
--- a/src/plugins/ui_feature/insert_pivot.ts
+++ b/src/plugins/ui_feature/insert_pivot.ts
@@ -1,4 +1,4 @@
-import { PIVOT_TABLE_CONFIG } from "../../constants";
+import { FORBIDDEN_IN_EXCEL_REGEX, PIVOT_TABLE_CONFIG } from "../../constants";
 import { SpreadsheetPivotTable } from "../../helpers/pivot/table_spreadsheet_pivot";
 import { getZoneArea } from "../../helpers/zones";
 import { _t } from "../../translation";
@@ -72,7 +72,7 @@ export class InsertPivotPlugin extends UIPlugin {
     const position = this.getters.getSheetIds().indexOf(activeSheetId) + 1;
     const formulaId = this.getters.getPivotFormulaId(newPivotId);
     const newPivotName = this.getters.getPivotName(newPivotId);
-    this.dispatch("CREATE_SHEET", {
+    const result = this.dispatch("CREATE_SHEET", {
       sheetId: newSheetId,
       name: this.getPivotDuplicateSheetName(
         _t("%(newPivotName)s (Pivot #%(formulaId)s)", {
@@ -82,21 +82,24 @@ export class InsertPivotPlugin extends UIPlugin {
       ),
       position,
     });
-    this.dispatch("ACTIVATE_SHEET", { sheetIdFrom: activeSheetId, sheetIdTo: newSheetId });
-    this.dispatch("UPDATE_CELL", {
-      sheetId: newSheetId,
-      col: 0,
-      row: 0,
-      content: `=PIVOT(${formulaId})`,
-    });
+    if (result.isSuccessful) {
+      this.dispatch("ACTIVATE_SHEET", { sheetIdFrom: activeSheetId, sheetIdTo: newSheetId });
+      this.dispatch("UPDATE_CELL", {
+        sheetId: newSheetId,
+        col: 0,
+        row: 0,
+        content: `=PIVOT(${formulaId})`,
+      });
+    }
   }
 
   private getPivotDuplicateSheetName(pivotName: string) {
     let i = 1;
     const names = this.getters.getSheetIds().map((id) => this.getters.getSheetName(id));
-    let name = pivotName;
+    const sanitizedName = pivotName.replace(new RegExp(FORBIDDEN_IN_EXCEL_REGEX, "g"), " ");
+    let name = sanitizedName;
     while (names.includes(name)) {
-      name = `${pivotName} (${i})`;
+      name = `${sanitizedName} (${i})`;
       i++;
     }
     return name;


### PR DESCRIPTION
## Description:

Steps to reproduce:

- insert a new pivot
- rename the pivot with one of the following character in its name: ', *, ?, /, \, [, ]
- duplicate the pivot

=> boom

The command to create the new sheet is rejected (the name contains invalid characters). But we later tries to activate the sheet (which doesn doesn't exist since it was never created)

Task: [4221325](https://www.odoo.com/web#id=4221325&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo