### PR TITLE
[IMP] cf: apply panel update immediately

### DIFF
--- a/src/components/side_panel/conditional_formatting/cf_editor/cell_is_rule_editor.xml
+++ b/src/components/side_panel/conditional_formatting/cf_editor/cell_is_rule_editor.xml
@@ -17,9 +17,15 @@
     <t t-set="text_color">Text Color</t>
     <div class="o-cf-cell-is-rule">
       <div class="o-section-subtitle">Format cells if...</div>
-      <select t-model="rule.operator" class="o-input o-cell-is-operator mb-3">
-        <t t-foreach="Object.keys(cellIsOperators)" t-as="op" t-key="op_index">
-          <option t-att-value="op" t-esc="cellIsOperators[op]"/>
+      <select
+        class="o-input o-cell-is-operator mb-3"
+        t-on-change="(ev) => this.editOperator(ev.target.value)">
+        <t t-foreach="cellIsOperators" t-as="op" t-key="op_index">
+          <option
+            t-att-value="op"
+            t-esc="cellIsOperators[op]"
+            t-att-selected="rule.operator === op"
+          />
         </t>
       </select>
       <t t-if="rule.operator !== 'IsEmpty' and rule.operator !== 'IsNotEmpty'">

--- a/src/components/side_panel/conditional_formatting/cf_editor/cf_editor.xml
+++ b/src/components/side_panel/conditional_formatting/cf_editor/cf_editor.xml
@@ -4,10 +4,11 @@
       <Section class="'o-cf-range pb-0'" title.translate="Apply to range">
         <div class="o-selection-cf">
           <SelectionInput
-            ranges="state.currentCF.ranges"
+            ranges="state.ranges"
             class="'o-range'"
             isInvalid="isRangeValid"
-            onSelectionChanged="(ranges) => this.onRangesChanged(ranges)"
+            onSelectionChanged.bind="onRangeUpdate"
+            onSelectionConfirmed.bind="onRangeConfirmed"
             required="true"
           />
         </div>
@@ -39,8 +40,11 @@
       </Section>
       <Section class="'pt-1'">
         <div class="o-sidePanelButtons">
-          <button t-on-click="props.onExitEdition" class="o-button o-cf-cancel">Cancel</button>
-          <button t-on-click="saveConditionalFormat" class="o-button primary o-cf-save">
+          <button t-on-click="props.onCancel" class="o-button o-cf-cancel">Cancel</button>
+          <button
+            t-on-click="onSave"
+            class="o-button primary o-cf-save"
+            t-att-disabled="state.errors.length !== 0">
             Save
           </button>
         </div>

--- a/src/components/side_panel/conditional_formatting/cf_editor/color_scale_rule_editor.xml
+++ b/src/components/side_panel/conditional_formatting/cf_editor/color_scale_rule_editor.xml
@@ -22,14 +22,18 @@
         <select
           class="o-input me-2"
           name="valueType"
-          t-model="threshold.type"
+          t-on-change="(ev) => this.updateThresholdType(thresholdType, ev.target.value)"
           t-on-click="closeMenus"
           t-att-class="{ 'o-select-with-input': threshold?.type !== 'value' }">
-          <option value="value">Cell values</option>
-          <option value="number">Number</option>
-          <option value="percentage">Percentage</option>
-          <option value="percentile">Percentile</option>
-          <option value="formula">Formula</option>
+          <option value="value" t-att-selected="threshold.type === 'value'">Cell values</option>
+          <option value="number" t-att-selected="threshold.type === 'number'">Number</option>
+          <option value="percentage" t-att-selected="threshold.type === 'percentage'">
+            Percentage
+          </option>
+          <option value="percentile" t-att-selected="threshold.type === 'percentile'">
+            Percentile
+          </option>
+          <option value="formula" t-att-selected="threshold.type === 'formula'">Formula</option>
         </select>
       </t>
       <div class="o-threshold-value me-2" t-if="threshold and threshold.type !== 'value'">
@@ -37,7 +41,8 @@
           t-if="threshold.type !== 'formula'"
           type="text"
           class="o-input"
-          t-model="rule[thresholdType].value"
+          t-att-value="threshold.value"
+          t-on-change="(ev) => this.updateThresholdValue(thresholdType, ev.target.value)"
           t-att-class="{ 'o-invalid': isValueInvalid(thresholdType), 'invisible': threshold === undefined }"
         />
         <StandaloneComposer t-else="" t-props="getColorScaleComposerProps(thresholdType)"/>

--- a/src/components/side_panel/conditional_formatting/cf_editor/data_bar_rule_editor.xml
+++ b/src/components/side_panel/conditional_formatting/cf_editor/data_bar_rule_editor.xml
@@ -12,7 +12,8 @@
         class="'o-range'"
         isInvalid="false"
         hasSingleRange="true"
-        onSelectionChanged="(ranges) => this.onDataBarRangeUpdate(ranges)"
+        onSelectionChanged.bind="onDataBarRangeUpdate"
+        onSelectionConfirmed.bind="onDataBarRangeChange"
         required="false"
       />
     </div>

--- a/src/components/side_panel/conditional_formatting/cf_editor/icon_set_rule_editor.xml
+++ b/src/components/side_panel/conditional_formatting/cf_editor/icon_set_rule_editor.xml
@@ -38,11 +38,14 @@
       </td>
       <td>When value is</td>
       <td>
-        <select class="o-input" name="valueType" t-model="inflectionPointValue.operator">
-          <option value="gt">
+        <select
+          class="o-input"
+          name="valueType"
+          t-on-change="(ev) => this.setInflectionOperator(inflectionPoint, ev.target.value)">
+          <option value="gt" t-att-selected="inflectionPointValue.operator === 'gt'">
             <span>&#62;</span>
           </option>
-          <option value="ge">
+          <option value="ge" t-att-selected="inflectionPointValue.operator === 'ge'">
             <span>&#8805;</span>
           </option>
         </select>
@@ -54,17 +57,29 @@
             t-if="inflectionPointValue.type !== 'formula'"
             class="o-input"
             t-att-class="{ 'o-invalid': isInflectionPointInvalid(inflectionPoint) }"
-            t-model="rule[inflectionPoint].value"
+            t-att-value="rule[inflectionPoint].value"
+            t-on-change="(ev) => this.setInflectionValue(inflectionPoint, ev.target.value)"
           />
           <StandaloneComposer t-else="" t-props="getColorIconSetComposerProps(inflectionPoint)"/>
         </div>
       </td>
       <td>
-        <select class="o-input" name="valueType" t-model="inflectionPointValue.type">
-          <option value="number">Number</option>
-          <option value="percentage">Percentage</option>
-          <option value="percentile">Percentile</option>
-          <option value="formula">Formula</option>
+        <select
+          class="o-input"
+          name="valueType"
+          t-on-change="(ev) => this.setInflectionType(inflectionPoint, ev.target.value, ev)">
+          <option value="number" t-att-selected="inflectionPointValue.type === 'number'">
+            Number
+          </option>
+          <option value="percentage" t-att-selected="inflectionPointValue.type === 'percentage'">
+            Percentage
+          </option>
+          <option value="percentile" t-att-selected="inflectionPointValue.type === 'percentile'">
+            Percentile
+          </option>
+          <option value="formula" t-att-selected="inflectionPointValue.type === 'formula'">
+            Formula
+          </option>
         </select>
       </td>
     </tr>

--- a/src/components/side_panel/conditional_formatting/conditional_formatting.xml
+++ b/src/components/side_panel/conditional_formatting/conditional_formatting.xml
@@ -9,7 +9,11 @@
         />
       </t>
       <t t-if="state.mode === 'edit'">
-        <ConditionalFormattingEditor editedCf="state.editedCf" onExitEdition.bind="switchToList"/>
+        <ConditionalFormattingEditor
+          editedCf="editedCF"
+          onSave.bind="switchToList"
+          onCancel.bind="cancelEdition"
+        />
       </t>
     </div>
   </t>

--- a/tests/conditional_formatting/conditional_formatting_plugin.test.ts
+++ b/tests/conditional_formatting/conditional_formatting_plugin.test.ts
@@ -216,6 +216,21 @@ describe("conditional format", () => {
     ).toBeCancelledBecause(CommandResult.TargetOutOfSheet);
   });
 
+  test("Dispatch is refused if no changes are made", () => {
+    model = new Model();
+    createSheet(model, { sheetId: "42" });
+    const sheetId = model.getters.getActiveSheetId();
+    const cmd = {
+      cf: createEqualCF("4", { fillColor: "#0000FF" }, "2"),
+      ranges: toRangesData(sheetId, "A1:A4"),
+      sheetId: sheetId,
+    };
+    expect(model.dispatch("ADD_CONDITIONAL_FORMAT", cmd)).toBeSuccessfullyDispatched();
+    expect(model.dispatch("ADD_CONDITIONAL_FORMAT", cmd)).toBeCancelledBecause(
+      CommandResult.NoChanges
+    );
+  });
+
   test("remove a conditional format rule", () => {
     setCellContent(model, "A1", "1");
     setCellContent(model, "A2", "2");

--- a/tests/selection_input/selection_input_component.test.ts
+++ b/tests/selection_input/selection_input_component.test.ts
@@ -396,7 +396,7 @@ describe("Selection Input", () => {
     await simulateClick(".o-cf-add");
     await nextTick();
     let input = fixture.querySelector(".o-selection-input input") as HTMLInputElement;
-    expect(input.value).toBe("B1:B100");
+    expect(input.value).toBe("B:B");
 
     await simulateClick(input);
     await selectColumnByClicking(model, "C");


### PR DESCRIPTION
## Description

The previous workflow of the CF side panel was to edit the conditional format, then click on save to confirm. This wasn't the greatest, as it meant that you wouldn't see the result of your changes until you saved. And if you didn't like the change, you then needed to re-click on the CF to re-open its editor, and do the changes.

With this commit, the CF side panel now updates immediately when you change a value. This also mean that a new CF is created immediately when you click on the "Add" button. The changes made can be discarded by clicking on the "Cancel" button.

Task: [3720877](https://www.odoo.com/web#id=3720877&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo