### PR TITLE
[FIX] paint format: copy conditional formats

### DIFF
--- a/src/components/paint_format_button/paint_format_store.ts
+++ b/src/components/paint_format_button/paint_format_store.ts
@@ -1,6 +1,7 @@
 import { ClipboardHandler } from "../../clipboard_handlers/abstract_clipboard_handler";
 import { BorderClipboardHandler } from "../../clipboard_handlers/borders_clipboard";
 import { CellClipboardHandler } from "../../clipboard_handlers/cell_clipboard";
+import { ConditionalFormatClipboardHandler } from "../../clipboard_handlers/conditional_format_clipboard";
 import { TableClipboardHandler } from "../../clipboard_handlers/tables_clipboard";
 import { SELECTION_BORDER_COLOR } from "../../constants";
 import { getClipboardDataPositions } from "../../helpers/clipboard/clipboard_helpers";
@@ -23,6 +24,7 @@ export class PaintFormatStore extends SpreadsheetStore {
     new CellClipboardHandler(this.getters, this.model.dispatch),
     new BorderClipboardHandler(this.getters, this.model.dispatch),
     new TableClipboardHandler(this.getters, this.model.dispatch),
+    new ConditionalFormatClipboardHandler(this.getters, this.model.dispatch),
   ];
 
   private status: "inactive" | "oneOff" | "persistent" = "inactive";

--- a/tests/grid/grid_component.test.ts
+++ b/tests/grid/grid_component.test.ts
@@ -75,7 +75,14 @@ import {
   getSelectionAnchorCellXc,
   getStyle,
 } from "../test_helpers/getters_helpers";
-import { mockChart, mountSpreadsheet, nextTick, typeInComposerGrid } from "../test_helpers/helpers";
+import {
+  createEqualCF,
+  mockChart,
+  mountSpreadsheet,
+  nextTick,
+  toRangesData,
+  typeInComposerGrid,
+} from "../test_helpers/helpers";
 import { mockGetBoundingClientRect } from "../test_helpers/mock_helpers";
 jest.mock("../../src/components/composer/content_editable_helper", () =>
   require("../__mocks__/content_editable_helper")
@@ -878,6 +885,21 @@ describe("Grid component", () => {
       gridMouseEvent(model, "pointerup", "C8");
 
       expect(getCell(model, "C8")?.style).toMatchObject({ fillColor: "#748747" });
+    });
+
+    test("Paste format works with conditional format", () => {
+      const sheetId = model.getters.getActiveSheetId();
+      model.dispatch("ADD_CONDITIONAL_FORMAT", {
+        cf: createEqualCF("1", { fillColor: "#0000FF" }, "cf2"),
+        sheetId,
+        ranges: toRangesData(sheetId, "A1"),
+      });
+      selectCell(model, "A1");
+      paintFormatStore.activate({ persistent: false });
+      gridMouseEvent(model, "pointerdown", "C8");
+      gridMouseEvent(model, "pointerup", "C8");
+
+      expect(model.getters.getConditionalFormats(sheetId)[0].ranges).toEqual(["A1", "C8"]);
     });
 
     test("can keep the paint format mode persistently", async () => {


### PR DESCRIPTION
## Description

The paint format tool should also copy the conditional formats of the source cells.

Task: [4226853](https://www.odoo.com/web#id=4226853&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo