### PR TITLE
[FIX] pivot: autocomplete dimension after positional

### DIFF
--- a/src/registries/auto_completes/pivot_auto_complete.ts
+++ b/src/registries/auto_completes/pivot_auto_complete.ts
@@ -120,9 +120,13 @@ autoCompleteProviders.add("pivot_group_fields", {
     const rowFields = rows.map((groupBy) => groupBy.nameWithGranularity);
 
     const proposals: string[] = [];
-    const previousGroupBy = ["ARG_SEPARATOR", "SPACE"].includes(tokenAtCursor.type)
+    let previousGroupBy = ["ARG_SEPARATOR", "SPACE"].includes(tokenAtCursor.type)
       ? argGroupBys.at(-1)
       : argGroupBys.at(-2);
+    const isPositionalSupported = supportedPivotPositionalFormulaRegistry.get(pivot.type);
+    if (isPositionalSupported && previousGroupBy?.startsWith("#")) {
+      previousGroupBy = previousGroupBy.slice(1);
+    }
     if (previousGroupBy === undefined) {
       proposals.push(colFields[0]);
       proposals.push(rowFields[0]);
@@ -145,7 +149,7 @@ autoCompleteProviders.add("pivot_group_fields", {
       })
       .concat(
         groupBys.map((groupBy) => {
-          if (!supportedPivotPositionalFormulaRegistry.get(pivot.type)) {
+          if (!isPositionalSupported) {
             return undefined;
           }
           const fieldName = groupBy.split(":")[0];

--- a/src/registries/auto_completes/pivot_dimension_auto_complete.ts
+++ b/src/registries/auto_completes/pivot_dimension_auto_complete.ts
@@ -12,7 +12,6 @@ export function createMeasureAutoComplete(
     sequence: 0,
     autoSelectFirstProposal: true,
     getProposals(tokenAtCursor) {
-      // return []
       const measureProposals = pivot.measures
         .filter((m) => m !== forComputedMeasure)
         .map((measure) => {


### PR DESCRIPTION
Steps to reproduce (in odoo)
- insert the default CRM pivot (grouped by date and stage)
- type in a cell =PIVOT.VALUE(1,"expected_revenue:sum","#create_date:month",1,

=> stage_id and #stage_id should be proposed.

A test is added with a PR in odoo ;)

Task: 4235329

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo