### PR TITLE
[FIX] conditional format: huge revisions on copy/paste cf

### DIFF
--- a/src/clipboard_handlers/data_validation_clipboard.ts
+++ b/src/clipboard_handlers/data_validation_clipboard.ts
@@ -26,6 +26,10 @@ export class DataValidationClipboardHandler extends AbstractCellClipboardHandler
   Maybe<ClipboardDataValidationRule>
 > {
   private readonly uuidGenerator = new UuidGenerator();
+  private queuedChanges: Record<
+    UID,
+    { toAdd: Zone[]; toRemove: Zone[]; rule: DataValidationRule }[]
+  > = {};
 
   copy(data: ClipboardCellData): ClipboardContent | undefined {
     const { rowsIndexes, columnsIndexes } = data;
@@ -45,6 +49,7 @@ export class DataValidationClipboardHandler extends AbstractCellClipboardHandler
   }
 
   paste(target: ClipboardPasteTarget, clippedContent: ClipboardContent, options: ClipboardOptions) {
+    this.queuedChanges = {};
     if (options.pasteOption) {
       return;
     }
@@ -56,6 +61,7 @@ export class DataValidationClipboardHandler extends AbstractCellClipboardHandler
     } else {
       this.pasteFromCut(sheetId, zones, clippedContent);
     }
+    this.executeQueuedChanges();
   }
 
   private pasteFromCut(sheetId: UID, target: Zone[], content: ClipboardContent) {
@@ -119,7 +125,7 @@ export class DataValidationClipboardHandler extends AbstractCellClipboardHandler
     originRule: DataValidationRule,
     newId = true
   ): DataValidationRule {
-    const ruleInTargetSheet = this.getters
+    let targetRule = this.getters
       .getDataValidationRules(targetSheetId)
       .find(
         (rule) =>
@@ -127,9 +133,22 @@ export class DataValidationClipboardHandler extends AbstractCellClipboardHandler
           originRule.isBlocking === rule.isBlocking
       );
 
-    return ruleInTargetSheet
-      ? ruleInTargetSheet
-      : { ...originRule, id: newId ? this.uuidGenerator.uuidv4() : originRule.id, ranges: [] };
+    const queuedRules = this.queuedChanges[targetSheetId];
+    if (!targetRule && queuedRules) {
+      targetRule = queuedRules.find(
+        (queued) =>
+          deepEquals(originRule.criterion, queued.rule.criterion) &&
+          originRule.isBlocking === queued.rule.isBlocking
+      )?.rule;
+    }
+
+    return (
+      targetRule || {
+        ...originRule,
+        id: newId ? this.uuidGenerator.uuidv4() : originRule.id,
+        ranges: [],
+      }
+    );
   }
 
   /**
@@ -141,16 +160,36 @@ export class DataValidationClipboardHandler extends AbstractCellClipboardHandler
     toAdd: Zone[],
     toRemove: Zone[]
   ) {
-    const dvZones = rule.ranges.map((range) => range.zone);
-    const newDvZones = recomputeZones([...dvZones, ...toAdd], toRemove);
-    if (newDvZones.length === 0) {
-      this.dispatch("REMOVE_DATA_VALIDATION_RULE", { sheetId, id: rule.id });
-      return;
+    if (!this.queuedChanges[sheetId]) {
+      this.queuedChanges[sheetId] = [];
     }
-    this.dispatch("ADD_DATA_VALIDATION_RULE", {
-      rule,
-      ranges: newDvZones.map((zone) => this.getters.getRangeDataFromZone(sheetId, zone)),
-      sheetId,
-    });
+    const queuedChange = this.queuedChanges[sheetId].find((queued) => queued.rule.id === rule.id);
+    if (!queuedChange) {
+      this.queuedChanges[sheetId].push({ toAdd, toRemove, rule });
+    } else {
+      queuedChange.toAdd.push(...toAdd);
+      queuedChange.toRemove.push(...toRemove);
+    }
+  }
+
+  private executeQueuedChanges() {
+    for (const sheetId in this.queuedChanges) {
+      for (const { toAdd, toRemove, rule: dv } of this.queuedChanges[sheetId]) {
+        // Remove the zones first in case the same position is in toAdd and toRemove
+        const dvZones = dv.ranges.map((range) => range.zone);
+        const withRemovedZones = recomputeZones(dvZones, toRemove);
+        const newDvZones = recomputeZones([...withRemovedZones, ...toAdd], []);
+
+        if (newDvZones.length === 0) {
+          this.dispatch("REMOVE_DATA_VALIDATION_RULE", { sheetId, id: dv.id });
+          continue;
+        }
+        this.dispatch("ADD_DATA_VALIDATION_RULE", {
+          rule: dv,
+          ranges: newDvZones.map((zone) => this.getters.getRangeDataFromZone(sheetId, zone)),
+          sheetId,
+        });
+      }
+    }
   }
 }

--- a/src/plugins/core/conditional_format.ts
+++ b/src/plugins/core/conditional_format.ts
@@ -287,8 +287,9 @@ export class ConditionalFormatPlugin
       currentRanges = rules[replaceIndex].ranges.map(toUnboundedZone);
     }
 
-    currentRanges = currentRanges.concat(toAdd);
-    return recomputeZones(currentRanges, toRemove).map((zone) =>
+    // Remove the zones first in case the same position is in toAdd and toRemove
+    const withRemovedZones = recomputeZones(currentRanges, toRemove);
+    return recomputeZones([...toAdd, ...withRemovedZones], []).map((zone) =>
       this.getters.getRangeDataFromZone(sheetId, zone)
     );
   }


### PR DESCRIPTION
When copy/pasting a conditional format, the revision had one ADD_CONDITIONAL_FORMAT command per copied cell. That lead to huge revisions if, for example, a whole column with a CF was copied.

Now the revision only has a single ADD_CONDITIONAL_FORMAT command per modified CF.

The exact same work was done for data validation rules.

Benchmark:
-------------------
Copy/paste a column of 100 cells with a CF:
Before: 46.6KB revision
After: 526B revision (divided by 88!)

Task: [4240668](https://www.odoo.com/web#id=4240668&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo