### PR TITLE
[FIX] pivot: date time measures are not supported

### DIFF
--- a/src/helpers/pivot/pivot_registry.ts
+++ b/src/helpers/pivot/pivot_registry.ts
@@ -55,6 +55,6 @@ pivotRegistry.add("SPREADSHEET", {
   onIterationEndEvaluation: (pivot: SpreadsheetPivot) => pivot.markAsDirtyForEvaluation(),
   dateGranularities: [...dateGranularities],
   datetimeGranularities: [...dateGranularities, "hour_number", "minute_number", "second_number"],
-  isMeasureCandidate: (field: PivotField) => !["date", "boolean"].includes(field.type),
+  isMeasureCandidate: (field: PivotField) => !["datetime", "boolean"].includes(field.type),
   isGroupable: () => true,
 });

--- a/tests/pivots/spreadsheet_pivot/spreadsheet_pivot_side_panel.test.ts
+++ b/tests/pivots/spreadsheet_pivot/spreadsheet_pivot_side_panel.test.ts
@@ -314,6 +314,29 @@ describe("Spreadsheet pivot side panel", () => {
     expect(fixture.querySelectorAll(".pivot-dimension")).toHaveLength(0);
   });
 
+  test("filter unsupported measures", async () => {
+    setCellContent(model, "A1", "integer");
+    setCellContent(model, "A2", "10");
+    setCellContent(model, "B1", "float");
+    setCellContent(model, "B2", "10.1");
+    setCellContent(model, "C1", "bool");
+    setCellContent(model, "C2", "true");
+    setCellContent(model, "D1", "date");
+    setCellContent(model, "D2", "2024/01/01");
+    setCellContent(model, "E1", "datetime");
+    setCellContent(model, "E2", "2024/01/01 08:00:00");
+    setCellContent(model, "F1", "text");
+    setCellContent(model, "F2", "hi");
+    addPivot(model, "A1:F2", {}, "3");
+    env.openSidePanel("PivotSidePanel", { pivotId: "3" });
+    await nextTick();
+    await click(fixture.querySelector(".o-pivot-measure .add-dimension")!);
+    const measures = [...fixture.querySelectorAll(".o-autocomplete-value")].map(
+      (el) => el.textContent
+    );
+    expect(measures).toEqual(["Count", "float", "integer", "text"]);
+  });
+
   test("Measures have the correct default aggregator", async () => {
     setCellContent(model, "A1", "amount");
     setCellContent(model, "A2", "10");


### PR DESCRIPTION
## Description:

Steps to reproduce:

- add a list of data in a spreadsheet, with at least one datetime field
- add a pivot based on this range
- add the data field as a measure => boom

Since 8421a7367c1068ae, all "date" fields are now "datetime".

Task: [4241036](https://www.odoo.com/web#id=4241036&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo