### PR TITLE
[FIX] pivots: don't translate pivot titles

### DIFF
--- a/src/plugins/core/pivot.ts
+++ b/src/plugins/core/pivot.ts
@@ -2,7 +2,6 @@ import { compile } from "../../formulas";
 import { deepCopy, deepEquals } from "../../helpers";
 import { createPivotFormula, getMaxObjectId } from "../../helpers/pivot/pivot_helpers";
 import { SpreadsheetPivotTable } from "../../helpers/pivot/table_spreadsheet_pivot";
-import { _t } from "../../translation";
 import {
   ApplyRangeChange,
   CellPosition,
@@ -162,7 +161,7 @@ export class PivotCorePlugin extends CorePlugin<CoreState> implements CoreState 
   }
 
   getPivotName(pivotId: UID) {
-    return _t(this.getPivotCore(pivotId).definition.name);
+    return this.getPivotCore(pivotId).definition.name;
   }
 
   /**


### PR DESCRIPTION
In standards dashboards, pivot titles are currently extracted from the json files to be translated. But those titles are not visible in dashboard mode (only in edit mode, in the side panels and menus). The cost of translating those titles is not worth it.

Task 4239967

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [4239967](https://www.odoo.com/web#id=4239967&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo