### PR TITLE
[FIX] table: insert table without filters

### DIFF
--- a/src/helpers/table_presets.ts
+++ b/src/helpers/table_presets.ts
@@ -11,7 +11,7 @@ export const TABLE_STYLE_CATEGORIES = {
 };
 
 export const DEFAULT_TABLE_CONFIG: TableConfig = {
-  hasFilters: true,
+  hasFilters: false,
   totalRow: false,
   firstColumn: false,
   lastColumn: false,

--- a/src/migrations/data.ts
+++ b/src/migrations/data.ts
@@ -19,7 +19,7 @@ import { migrationStepRegistry } from "./migration_steps";
  * a breaking change is made in the way the state is handled, and an upgrade
  * function should be defined
  */
-export const CURRENT_VERSION = 22;
+export const CURRENT_VERSION = 23;
 const INITIAL_SHEET_ID = "Sheet1";
 
 /**

--- a/src/migrations/migration_steps.ts
+++ b/src/migrations/migration_steps.ts
@@ -6,6 +6,7 @@ import {
 import { getItemId } from "../helpers";
 import { toXC } from "../helpers/coordinates";
 import { getMaxObjectId } from "../helpers/pivot/pivot_helpers";
+import { DEFAULT_TABLE_CONFIG } from "../helpers/table_presets";
 import { overlap, toZone, zoneToXc } from "../helpers/zones";
 import { Registry } from "../registries/registry";
 import { CustomizedDataSet, DEFAULT_LOCALE, Format, WorkbookData, Zone } from "../types";
@@ -415,6 +416,20 @@ migrationStepRegistry
           }
           if (gaugeData?.sectionRule?.upperInflectionPoint) {
             gaugeData.sectionRule.upperInflectionPoint.operator = "<=";
+          }
+        }
+      }
+      return data;
+    },
+  })
+  .add("migration_22", {
+    // "tables are no longer inserted with filters by default",
+    versionFrom: "22",
+    migrate(data: WorkbookData): any {
+      for (const sheet of data.sheets || []) {
+        for (const table of sheet.tables || []) {
+          if (!table.config) {
+            table.config = { ...DEFAULT_TABLE_CONFIG, hasFilters: true };
           }
         }
       }

--- a/tests/collaborative/collaborative.test.ts
+++ b/tests/collaborative/collaborative.test.ts
@@ -18,6 +18,7 @@ import {
   createSheet,
   createTable,
   createTableStyle,
+  createTableWithFilter,
   deleteRows,
   deleteSheet,
   groupHeaders,
@@ -749,7 +750,7 @@ describe("Multi users synchronisation", () => {
         sheetId: "Sheet1",
         sheetIdTo: "sheet2",
       });
-      createTable(charlie, "A1:B4", undefined, undefined, firstSheetId);
+      createTableWithFilter(charlie, "A1:B4", undefined, undefined, firstSheetId);
     });
     expect([alice, bob, charlie]).toHaveSynchronizedValue(
       (user) => user.getters.getTables("sheet2"),

--- a/tests/data_validation/data_validation_checkbox_component.test.ts
+++ b/tests/data_validation/data_validation_checkbox_component.test.ts
@@ -1,7 +1,7 @@
 import { Model } from "../../src";
 import {
   addDataValidation,
-  createTable,
+  createTableWithFilter,
   setCellContent,
   setStyle,
 } from "../test_helpers/commands_helpers";
@@ -59,7 +59,7 @@ describe("Checkbox component", () => {
   test("Icon is not displayed if there is a filter icon", async () => {
     const model = new Model();
     addDataValidation(model, "A1", "id", { type: "isBoolean", values: [] });
-    createTable(model, "A1:A4");
+    createTableWithFilter(model, "A1:A4");
 
     const { fixture } = await mountSpreadsheet({ model });
     expect(fixture.querySelector(".o-dv-checkbox")).toBeNull();

--- a/tests/data_validation/data_validation_list_component.test.ts
+++ b/tests/data_validation/data_validation_list_component.test.ts
@@ -9,7 +9,7 @@ import {
 import { IsValueInListCriterion, SpreadsheetChildEnv, UID } from "../../src/types";
 import {
   addDataValidation,
-  createTable,
+  createTableWithFilter,
   setCellContent,
   setSelection,
 } from "../test_helpers/commands_helpers";
@@ -371,7 +371,7 @@ describe("Selection arrow icon in grid", () => {
       values: ["ok", "hello", "okay"],
       displayStyle: "arrow",
     });
-    createTable(model, "A1:A4");
+    createTableWithFilter(model, "A1:A4");
 
     ({ fixture } = await mountSpreadsheet({ model }));
     expect(fixture.querySelector(".o-dv-list-icon")).toBeNull();

--- a/tests/figures/chart/chart_plugin.test.ts
+++ b/tests/figures/chart/chart_plugin.test.ts
@@ -17,7 +17,7 @@ import {
   createComboChart,
   createSheet,
   createSheetWithName,
-  createTable,
+  createTableWithFilter,
   deleteColumns,
   deleteRows,
   deleteSheet,
@@ -2790,7 +2790,7 @@ describe("Chart evaluation", () => {
       let chart = model.getters.getChartRuntime("1")! as LineChartRuntime;
       expect(chart.chartJsConfig.data.datasets![0].data?.length).toEqual(4);
       expect(chart.chartJsConfig.data.labels).toEqual(["P1", "P2", "P3", "P4"]);
-      createTable(model, "A1:C5");
+      createTableWithFilter(model, "A1:C5");
       updateFilter(model, "B3", ["11"]);
       chart = model.getters.getChartRuntime("1")! as LineChartRuntime;
       expect(chart.chartJsConfig.data.datasets![0].data?.length).toEqual(3);

--- a/tests/find_and_replace/find_and_replace_store.test.ts
+++ b/tests/find_and_replace/find_and_replace_store.test.ts
@@ -11,7 +11,7 @@ import {
   activateSheet,
   addRows,
   createSheet,
-  createTable,
+  createTableWithFilter,
   deleteRows,
   deleteTable,
   hideRows,
@@ -308,7 +308,7 @@ describe("basic search", () => {
   test("Need to update search if updating or removing the filter", () => {
     setCellContent(model, "A2", "1");
     setCellContent(model, "A3", "=111");
-    createTable(model, "A1:A6");
+    createTableWithFilter(model, "A1:A6");
     updateSearch(model, "1");
     expect(store.searchMatches).toHaveLength(2);
     expect(store.selectedMatchIndex).toStrictEqual(0);

--- a/tests/formats/formatting_plugin.test.ts
+++ b/tests/formats/formatting_plugin.test.ts
@@ -16,7 +16,7 @@ import { Model } from "../../src/model";
 import { CommandResult, Format, SetDecimalStep, UID } from "../../src/types";
 import {
   createSheet,
-  createTable,
+  createTableWithFilter,
   resizeColumns,
   resizeRows,
   selectCell,
@@ -652,7 +652,7 @@ describe("Autoresize", () => {
 
   test("Autoresize includes filter icon to compute the size", () => {
     setCellContent(model, "A1", TEXT);
-    createTable(model, "A1");
+    createTableWithFilter(model, "A1");
     model.dispatch("AUTORESIZE_COLUMNS", { sheetId, cols: [0] });
     expect(model.getters.getColSize(sheetId, 0)).toBe(
       sizes[0] + hPadding + ICON_EDGE_LENGTH + GRID_ICON_MARGIN
@@ -660,7 +660,7 @@ describe("Autoresize", () => {
   });
 
   test("Autoresize includes cells with only a filter icon", () => {
-    createTable(model, "A1");
+    createTableWithFilter(model, "A1");
     model.dispatch("AUTORESIZE_COLUMNS", { sheetId, cols: [0] });
     expect(model.getters.getColSize(sheetId, 0)).toBe(
       hPadding + ICON_EDGE_LENGTH + GRID_ICON_MARGIN

--- a/tests/grid/dashboard_grid_component.test.ts
+++ b/tests/grid/dashboard_grid_component.test.ts
@@ -8,7 +8,7 @@ import {
 import { Model } from "../../src/model";
 import { clickableCellRegistry } from "../../src/registries/cell_clickable_registry";
 import {
-  createTable,
+  createTableWithFilter,
   selectCell,
   setCellContent,
   setViewportOffset,
@@ -64,7 +64,7 @@ describe("Grid component in dashboard mode", () => {
   });
 
   test("Filter icon is correctly rendered", async () => {
-    createTable(model, "B2:C3");
+    createTableWithFilter(model, "B2:C3");
     model.updateMode("dashboard");
     await nextTick();
     const icons = fixture.querySelectorAll(".o-grid-cell-icon");
@@ -77,7 +77,7 @@ describe("Grid component in dashboard mode", () => {
   });
 
   test("Clicking on a filter icon correctly open the filter popover", async () => {
-    createTable(model, "A1:A2");
+    createTableWithFilter(model, "A1:A2");
     model.updateMode("dashboard");
     await nextTick();
     await simulateClick(".o-filter-icon");
@@ -85,7 +85,7 @@ describe("Grid component in dashboard mode", () => {
   });
 
   test("Clicking on a filter icon correctly closes the filter popover", async () => {
-    createTable(model, "A1:A2");
+    createTableWithFilter(model, "A1:A2");
     model.updateMode("dashboard");
     await nextTick();
     await simulateClick(".o-filter-icon");
@@ -97,7 +97,7 @@ describe("Grid component in dashboard mode", () => {
   });
 
   test("When filter menu is open, clicking on a random grid correctly closes filter popover", async () => {
-    createTable(model, "A1:A2");
+    createTableWithFilter(model, "A1:A2");
     model.updateMode("dashboard");
     await nextTick();
     await simulateClick(".o-filter-icon");

--- a/tests/grid/grid_component.test.ts
+++ b/tests/grid/grid_component.test.ts
@@ -28,7 +28,7 @@ import {
   copy,
   createChart,
   createSheet,
-  createTable,
+  createTableWithFilter,
   cut,
   foldHeaderGroup,
   freezeColumns,
@@ -739,7 +739,7 @@ describe("Grid component", () => {
     });
 
     test("Filter icon is correctly rendered", async () => {
-      createTable(model, "B2:C3");
+      createTableWithFilter(model, "B2:C3");
       await nextTick();
 
       const icons = fixture.querySelectorAll(".o-grid-cell-icon");
@@ -752,7 +752,7 @@ describe("Grid component", () => {
     });
 
     test("Filter icon change when filter is active", async () => {
-      createTable(model, "A1:A2");
+      createTableWithFilter(model, "A1:A2");
       await nextTick();
       const grid = fixture.querySelector(".o-grid")!;
       expect(grid.querySelectorAll(".filter-icon")).toHaveLength(1);
@@ -767,7 +767,7 @@ describe("Grid component", () => {
     });
 
     test("Filter icon changes color on high contrast background", async () => {
-      createTable(model, "A1:A2");
+      createTableWithFilter(model, "A1:A2");
       updateTableConfig(model, "A1", { styleId: "None" });
       await nextTick();
       const icon = fixture.querySelector(".o-grid .o-filter-icon");
@@ -783,7 +783,7 @@ describe("Grid component", () => {
     });
 
     test("Clicking on a filter icon correctly open context menu", async () => {
-      createTable(model, "A1:A2");
+      createTableWithFilter(model, "A1:A2");
       await nextTick();
       await simulateClick(".o-filter-icon");
       expect(fixture.querySelectorAll(".o-filter-menu")).toHaveLength(1);
@@ -871,7 +871,7 @@ describe("Grid component", () => {
     });
 
     test("Paste format works with table style", () => {
-      createTable(model, "A1:B2", { styleId: "TableStyleLight11" });
+      createTableWithFilter(model, "A1:B2", { styleId: "TableStyleLight11" });
       selectCell(model, "A1");
       paintFormatStore.activate({ persistent: false });
       gridMouseEvent(model, "pointerdown", "C8");
@@ -1583,7 +1583,7 @@ describe("Copy paste keyboard shortcut", () => {
 
   test("When there is a opened cell popover, hitting esc key will only close the popover and not clean the clipboard visible zones", async () => {
     setCellContent(model, "A1", "things");
-    createTable(model, "A1:A2");
+    createTableWithFilter(model, "A1:A2");
     selectCell(model, "A1");
     copy(model, "A1");
     selectCell(model, "A2");

--- a/tests/menus/menu_items_registry.test.ts
+++ b/tests/menus/menu_items_registry.test.ts
@@ -10,6 +10,7 @@ import {
   copy,
   createDynamicTable,
   createTable,
+  createTableWithFilter,
   foldHeaderGroup,
   freezeColumns,
   freezeRows,
@@ -1728,7 +1729,7 @@ describe("Menu Item actions", () => {
       });
 
       test("Filters -> Remove filter", () => {
-        createTable(model, "A1:A5");
+        createTableWithFilter(model, "A1:A5");
         setSelection(model, ["A1:A5"]);
         expect(getName(filterPath, env)).toBe("Remove selected filters");
         doAction(filterPath, env);
@@ -1772,7 +1773,7 @@ describe("Menu Item actions", () => {
         setSelection(model, ["A1:A5"]);
         expect(getName(filterPath, env)).toBe("Add filters");
 
-        createTable(model, "A1:B5");
+        createTableWithFilter(model, "A1:B5");
         expect(getName(filterPath, env)).toBe("Remove selected filters");
 
         setSelection(model, ["A1:B9"]);

--- a/tests/model/model_import_export.test.ts
+++ b/tests/model/model_import_export.test.ts
@@ -7,6 +7,7 @@ import {
   FORBIDDEN_SHEET_CHARS,
 } from "../../src/constants";
 import { toCartesian, toZone } from "../../src/helpers";
+import { DEFAULT_TABLE_CONFIG } from "../../src/helpers/table_presets";
 import { CURRENT_VERSION } from "../../src/migrations/data";
 import {
   BorderDescr,
@@ -395,7 +396,13 @@ describe("Migrations", () => {
       ],
     });
     const data = model.exportData();
-    expect(data.sheets[0].tables).toEqual([{ range: "A1:C2", type: "static" }]);
+    expect(data.sheets[0].tables).toEqual([
+      {
+        range: "A1:C2",
+        type: "static",
+        config: { ...DEFAULT_TABLE_CONFIG, hasFilters: true },
+      },
+    ]);
   });
 
   test("migrate version 12.5: update border description structure", () => {
@@ -445,7 +452,13 @@ describe("Migrations", () => {
       ],
     });
     const data = model.exportData();
-    expect(data.sheets[0].tables).toEqual([{ range: "A1:C2", type: "static" }]);
+    expect(data.sheets[0].tables).toEqual([
+      {
+        range: "A1:C2",
+        type: "static",
+        config: { ...DEFAULT_TABLE_CONFIG, hasFilters: true },
+      },
+    ]);
   });
 
   test("migrate version 15: filterTables are renamed into tables", () => {
@@ -461,7 +474,13 @@ describe("Migrations", () => {
     expect(model.getters.getTables("1")).toMatchObject([{ range: { zone: toZone("A1:B2") } }]);
     let data = model.exportData();
     expect(data.version).toBe(CURRENT_VERSION);
-    expect(data.sheets[0].tables).toEqual([{ range: "A1:B2", type: "static" }]);
+    expect(data.sheets[0].tables).toEqual([
+      {
+        range: "A1:B2",
+        type: "static",
+        config: { ...DEFAULT_TABLE_CONFIG, hasFilters: true },
+      },
+    ]);
   });
 
   test("migrate version 21: style,format and borders by zones", () => {
@@ -532,6 +551,28 @@ describe("Migrations", () => {
         upperInflectionPoint: { type: "percentage", value: "40", operator: "<=" },
       },
     });
+  });
+
+  test("migrate version 23: tables no longer have filters by default", () => {
+    const model = new Model({
+      version: 22,
+      sheets: [
+        {
+          id: "1",
+          tables: [{ range: "A1:B2" }],
+        },
+      ],
+    });
+    expect(model.getters.getTables("1")).toMatchObject([{ range: { zone: toZone("A1:B2") } }]);
+    const data = model.exportData();
+    expect(data.version).toBe(CURRENT_VERSION);
+    expect(data.sheets[0].tables).toEqual([
+      {
+        range: "A1:B2",
+        type: "static",
+        config: { ...DEFAULT_TABLE_CONFIG, hasFilters: true },
+      },
+    ]);
   });
 });
 

--- a/tests/repeat_commands_plugin.test.ts
+++ b/tests/repeat_commands_plugin.test.ts
@@ -24,7 +24,7 @@ import {
   activateSheet,
   copy,
   createSheet,
-  createTable,
+  createTableWithFilter,
   deleteCells,
   insertCells,
   paste,
@@ -392,7 +392,7 @@ describe("Repeat local commands", () => {
       ...TEST_COMMANDS.ADD_CONDITIONAL_FORMAT,
       ranges: toRangesData(sheetId, "A1:A2"),
     });
-    createTable(model, "A1:A2");
+    createTableWithFilter(model, "A1:A2");
 
     setSelection(model, ["A1:A2"]);
     copy(model);

--- a/tests/sheet/sheetview_plugin.test.ts
+++ b/tests/sheet/sheetview_plugin.test.ts
@@ -14,7 +14,7 @@ import {
   addColumns,
   addRows,
   createSheet,
-  createTable,
+  createTableWithFilter,
   deleteColumns,
   deleteRows,
   foldHeaderGroup,
@@ -847,7 +847,7 @@ describe("Viewport of Simple sheet", () => {
 
   test("Viewport is updated when updating a data filter", () => {
     model = new Model();
-    createTable(model, "A1:A10");
+    createTableWithFilter(model, "A1:A10");
     setCellContent(model, "A2", "5");
     setCellContent(model, "A2", "5");
 
@@ -861,7 +861,7 @@ describe("Viewport of Simple sheet", () => {
 
   test("Viewport is updated when updating a cell that change the evaluation of filtered rows", () => {
     model = new Model();
-    createTable(model, "A1:A10");
+    createTableWithFilter(model, "A1:A10");
     setCellContent(model, "A2", "=B1");
     setCellContent(model, "A2", "=B1");
     setCellContent(model, "A3", "=B1");
@@ -1106,7 +1106,7 @@ describe("Multi Panes viewport", () => {
     setCellContent(model, "A1", "Hi");
     setCellContent(model, "A2", "Hello");
 
-    createTable(model, "A1:A3");
+    createTableWithFilter(model, "A1:A3");
 
     updateFilter(model, "A1", ["Hello"]);
     expect(model.getters.isRowHidden(sheetId, 1)).toEqual(true);
@@ -1130,7 +1130,7 @@ describe("Multi Panes viewport", () => {
     setCellContent(model, "A2", "2808");
     setCellContent(model, "A3", "2808");
 
-    createTable(model, "A1:A3");
+    createTableWithFilter(model, "A1:A3");
     freezeRows(model, 2, sheetId);
 
     const originalActiveMainViewport = model.getters.getActiveMainViewport();

--- a/tests/table/dynamic_table_plugin.test.ts
+++ b/tests/table/dynamic_table_plugin.test.ts
@@ -126,7 +126,7 @@ describe("Dynamic tables", () => {
 
   test("Can update the filter of a dynamic table", () => {
     setCellContent(model, "A1", "=MUNIT(2)");
-    createDynamicTable(model, "A1");
+    createDynamicTable(model, "A1", { hasFilters: true });
     updateFilter(model, "A1", ["0"]);
     updateFilter(model, "B1", ["1"]);
     expect(getFilterHiddenValues(model)).toMatchObject([

--- a/tests/table/filter_icon_overlay.test.ts
+++ b/tests/table/filter_icon_overlay.test.ts
@@ -1,7 +1,7 @@
 import { Model } from "../../src";
 import { DEFAULT_CELL_HEIGHT, DEFAULT_CELL_WIDTH } from "../../src/constants";
 import { toZone } from "../../src/helpers";
-import { createTable } from "../test_helpers/commands_helpers";
+import { createTableWithFilter } from "../test_helpers/commands_helpers";
 import { edgeScrollDelay, simulateClick, triggerMouseEvent } from "../test_helpers/dom_helper";
 import { mountSpreadsheet, nextTick } from "../test_helpers/helpers";
 
@@ -24,7 +24,7 @@ describe("Filter Icon Overlay component", () => {
   test("MouseEvent on filter icon bubbles and selects the underlying cell", async () => {
     jest.useFakeTimers();
     const model = new Model();
-    createTable(model, "B2:B3");
+    createTableWithFilter(model, "B2:B3");
     const sheetId = model.getters.getActiveSheetId();
     const {} = await mountSpreadsheet({ model });
     expect(model.getters.getActivePosition()).toEqual({ sheetId, col: 0, row: 0 });

--- a/tests/table/filter_menu_component.test.ts
+++ b/tests/table/filter_menu_component.test.ts
@@ -2,7 +2,7 @@ import { Model } from "../../src";
 import { UID } from "../../src/types";
 import {
   createDynamicTable,
-  createTable,
+  createTableWithFilter,
   hideRows,
   setCellContent,
   setFormat,
@@ -44,13 +44,13 @@ describe("Filter menu component", () => {
 
   describe("Filter Tests", () => {
     beforeEach(async () => {
-      createTable(model, "A1:A5");
+      createTableWithFilter(model, "A1:A5");
       setCellContent(model, "A1", "header");
       setCellContent(model, "A2", "1");
       setCellContent(model, "A3", "1");
       setCellContent(model, "A4", "2");
 
-      createTable(model, "B1:B4");
+      createTableWithFilter(model, "B1:B4");
       setCellContent(model, "B2", "B2");
       setCellContent(model, "B3", "B3");
       setCellContent(model, "B4", "B4");
@@ -289,7 +289,7 @@ describe("Filter menu component", () => {
   });
 
   test("Sort filter", async () => {
-    createTable(model, "A10:B15");
+    createTableWithFilter(model, "A10:B15");
     setCellContent(model, "A10", "header");
     setCellContent(model, "A11", "olà");
     setCellContent(model, "A12", "1");
@@ -334,7 +334,7 @@ describe("Filter menu component", () => {
   });
 
   test("cannot sort filter table in readonly mode", async () => {
-    createTable(model, "A10:B15");
+    createTableWithFilter(model, "A10:B15");
     await nextTick();
     await openFilterMenu();
     expect(
@@ -349,7 +349,7 @@ describe("Filter menu component", () => {
 
   test("cannot sort dynamic table", async () => {
     setCellContent(model, "A10", "=MUNIT(2)");
-    createDynamicTable(model, "A10");
+    createDynamicTable(model, "A10", { hasFilters: true });
     await nextTick();
     await openFilterMenu();
     expect(

--- a/tests/table/table_computed_style_plugin.test.ts
+++ b/tests/table/table_computed_style_plugin.test.ts
@@ -4,6 +4,7 @@ import { TABLE_PRESETS } from "../../src/helpers/table_presets";
 import { Style, UID } from "../../src/types";
 import {
   createTable,
+  createTableWithFilter,
   deleteContent,
   deleteTable,
   foldAllHeaderGroups,
@@ -242,6 +243,8 @@ describe("Table style", () => {
     });
 
     test("Table style is updated when (un)filtering headers", () => {
+      model = new Model();
+      createTableWithFilter(model, "A1:B4");
       const tableStyle = getFullTableStyle("A1:B4");
       setCellContent(model, "A2", "test");
       updateFilter(model, "A1", ["test"]);

--- a/tests/table/table_panel_component.test.ts
+++ b/tests/table/table_panel_component.test.ts
@@ -86,6 +86,7 @@ describe("Table side panel", () => {
 
   test("Disabling then re-enabling the headers saves the state of the hasFilters checkbox", async () => {
     const hasFilters = fixture.querySelector<HTMLInputElement>("input[name='hasFilters']")!;
+    await click(fixture, "input[name='hasFilters']");
     expect(hasFilters.checked).toBe(true);
     await click(fixture, "input[name='headerRow']");
     expect(hasFilters.checked).toBe(false);

--- a/tests/test_helpers/commands_helpers.ts
+++ b/tests/test_helpers/commands_helpers.ts
@@ -978,6 +978,16 @@ export function createDynamicTable(
   return createTable(model, range, config, "dynamic", sheetId);
 }
 
+export function createTableWithFilter(
+  model: Model,
+  range: string,
+  config?: Partial<TableConfig>,
+  tableType: CoreTableType = "static",
+  sheetId: UID = model.getters.getActiveSheetId()
+) {
+  return createTable(model, range, { hasFilters: true, ...config }, tableType, sheetId);
+}
+
 export function updateTableConfig(
   model: Model,
   range: string,

--- a/tests/top_bar_component.test.ts
+++ b/tests/top_bar_component.test.ts
@@ -10,7 +10,7 @@ import { ConditionalFormat, Currency, Pixel, SpreadsheetChildEnv, Style } from "
 import { FileStore } from "./__mocks__/mock_file_store";
 import {
   addCellToSelection,
-  createTable,
+  createTableWithFilter,
   selectCell,
   setAnchorCorner,
   setCellContent,
@@ -272,7 +272,7 @@ describe("TopBar component", () => {
     });
 
     test("Filter tool change from create filter to remove filter when a filter is selected", async () => {
-      createTable(model, "A2:B3");
+      createTableWithFilter(model, "A2:B3");
       await nextTick();
       expect(fixture.querySelectorAll(removeFilterTool).length).toEqual(0);
       expect(fixture.querySelectorAll(createFilterTool).length).toEqual(1);

--- a/tests/xlsx/xlsx_export.test.ts
+++ b/tests/xlsx/xlsx_export.test.ts
@@ -15,7 +15,7 @@ import {
   createImage,
   createScorecardChart,
   createSheet,
-  createTable,
+  createTableWithFilter,
   foldHeaderGroup,
   groupHeaders,
   merge,
@@ -1464,7 +1464,7 @@ describe("Test XLSX export", () => {
   describe("Export data filters", () => {
     test("Table headers formula are replaced with their evaluated formatted value", () => {
       const model = new Model();
-      createTable(model, "A1:A4");
+      createTableWithFilter(model, "A1:A4");
       setCellContent(model, "A1", "=DATE(1,1,1)");
       setCellContent(model, "A2", "=DATE(1,1,1)");
       const exported = getExportedExcelData(model);
@@ -1479,7 +1479,7 @@ describe("Test XLSX export", () => {
 
     test("Table headers are replaced by unique value", () => {
       const model = new Model();
-      createTable(model, "A1:B4");
+      createTableWithFilter(model, "A1:B4");
       setCellContent(model, "A1", "Hello");
       setCellContent(model, "B1", "Hello");
       const exported = getExportedExcelData(model);
@@ -1492,7 +1492,7 @@ describe("Test XLSX export", () => {
 
     test("Table headers are replaced by unique formatted value even if table has no filters", () => {
       const model = new Model();
-      createTable(model, "A1:A4", { ...DEFAULT_TABLE_CONFIG, hasFilters: false });
+      createTableWithFilter(model, "A1:A4", { ...DEFAULT_TABLE_CONFIG, hasFilters: false });
       setCellContent(model, "A1", "=DATE(1,1,1)");
       const exported = getExportedExcelData(model);
       expect(exported.sheets[0].cells["A1"]?.content).toEqual("1/1/1901");
@@ -1500,7 +1500,7 @@ describe("Test XLSX export", () => {
 
     test("Table style is correctly exported", async () => {
       const model = new Model();
-      createTable(model, "A1:B4", {
+      createTableWithFilter(model, "A1:B4", {
         totalRow: true,
         firstColumn: true,
         lastColumn: true,
@@ -1538,7 +1538,7 @@ describe("Test XLSX export", () => {
 
     test("Filtered values are exported and rows are hidden", () => {
       const model = new Model();
-      createTable(model, "A1:B4");
+      createTableWithFilter(model, "A1:B4");
       setCellContent(model, "A2", "Hello");
       setCellContent(model, "A3", "Konnichiwa");
       setCellContent(model, "A4", '=CONCAT("Bon", "jour")');
@@ -1551,7 +1551,7 @@ describe("Test XLSX export", () => {
 
     test("Empty filters aren't exported", () => {
       const model = new Model();
-      createTable(model, "A1:B4");
+      createTableWithFilter(model, "A1:B4");
       setCellContent(model, "A2", "Hello");
       setCellContent(model, "B2", "Hello");
       const exported = getExportedExcelData(model);
@@ -1562,14 +1562,14 @@ describe("Test XLSX export", () => {
       const model = new Model();
       setCellContent(model, "A1", "Hello");
       setCellContent(model, "B1", "Hello");
-      createTable(model, "A1:B1");
+      createTableWithFilter(model, "A1:B1");
       const exported = getExportedExcelData(model);
       expect(exported.sheets[0].tables).toHaveLength(0);
     });
 
     test("Filtered values are not duplicated", () => {
       const model = new Model();
-      createTable(model, "A1:B4");
+      createTableWithFilter(model, "A1:B4");
       setCellContent(model, "A2", "Konnichiwa");
       setCellContent(model, "A3", "Konnichiwa");
       setCellContent(model, "A4", "5");
@@ -1580,7 +1580,7 @@ describe("Test XLSX export", () => {
 
     test("Empty cells are not added to displayedValues", () => {
       const model = new Model();
-      createTable(model, "A1:B4");
+      createTableWithFilter(model, "A1:B4");
       setCellContent(model, "A2", "5");
       updateFilter(model, "A1", ["5"]);
       const exported = getExportedExcelData(model);
@@ -1589,7 +1589,7 @@ describe("Test XLSX export", () => {
 
     test("Formulas evaluated to empty string are not added to displayedValues", () => {
       const model = new Model();
-      createTable(model, "A1:B4");
+      createTableWithFilter(model, "A1:B4");
       setCellContent(model, "A2", "5");
       updateFilter(model, "A1", ["5"]);
       setCellContent(model, "A3", '=""');
@@ -1600,7 +1600,7 @@ describe("Test XLSX export", () => {
 
     test("Export data filters snapshot", async () => {
       const model = new Model();
-      createTable(model, "A1:C4");
+      createTableWithFilter(model, "A1:C4");
 
       setCellContent(model, "A1", "Hello");
       setCellContent(model, "A2", "5");


### PR DESCRIPTION

## Description:

When inserting a table, it is inserted with the filter. It takes place on the cell and is only useful in a handful of use cases. It's very frequent that the very next step after inserting a table is to remove it.

So let's insert the table without the filter by default.

Feedback from RNG

Task: [4235172](https://www.odoo.com/web#id=4235172&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo