### PR TITLE
[FIX] clipboard: Fix clipboard cross-browser coverage

### DIFF
--- a/src/actions/menu_items_actions.ts
+++ b/src/actions/menu_items_actions.ts
@@ -1,5 +1,6 @@
 import { CellPopoverStore } from "../components/popover";
 import { DEFAULT_FIGURE_HEIGHT, DEFAULT_FIGURE_WIDTH } from "../constants";
+import { parseOSClipboardContent } from "../helpers/clipboard/clipboard_helpers";
 import {
   getChartPositionAtCenterOfViewport,
   getSmartChartDefinition,
@@ -54,20 +55,13 @@ async function paste(env: SpreadsheetChildEnv, pasteOption?: ClipboardPasteOptio
   const osClipboard = await env.clipboard.read();
   switch (osClipboard.status) {
     case "ok":
-      const htmlDocument = new DOMParser().parseFromString(
-        osClipboard.content[ClipboardMIMEType.Html] ?? "<div></div>",
-        "text/html"
-      );
-      const osClipboardSpreadsheetContent =
-        osClipboard.content[ClipboardMIMEType.OSpreadsheet] || "{}";
-      const clipboardId =
-        JSON.parse(osClipboardSpreadsheetContent).clipboardId ??
-        htmlDocument.querySelector("div")?.getAttribute("data-clipboard-id");
+      const clipboardContent = parseOSClipboardContent(osClipboard.content);
+      const clipboardId = clipboardContent.data?.clipboardId;
 
       const target = env.model.getters.getSelectedZones();
 
       if (env.model.getters.getClipboardId() !== clipboardId) {
-        interactivePasteFromOS(env, target, osClipboard.content, pasteOption);
+        interactivePasteFromOS(env, target, clipboardContent, pasteOption);
       } else {
         interactivePaste(env, target, pasteOption);
       }

--- a/src/clipboard_handlers/abstract_clipboard_handler.ts
+++ b/src/clipboard_handlers/abstract_clipboard_handler.ts
@@ -40,7 +40,7 @@ export class ClipboardHandler<T> {
     return { zones: [], sheetId };
   }
 
-  convertOSClipboardData(data: any): T | undefined {
+  convertTextToClipboardData(data: string): T | undefined {
     return;
   }
 }

--- a/src/clipboard_handlers/cell_clipboard.ts
+++ b/src/clipboard_handlers/cell_clipboard.ts
@@ -288,7 +288,7 @@ export class CellClipboardHandler extends AbstractCellClipboardHandler<
     }
   }
 
-  convertOSClipboardData(text: string): ClipboardContent {
+  convertTextToClipboardData(text: string): ClipboardContent {
     const locale = this.getters.getLocale();
     const copiedData: any = {
       cells: [],

--- a/src/helpers/clipboard/clipboard_helpers.ts
+++ b/src/helpers/clipboard/clipboard_helpers.ts
@@ -1,4 +1,11 @@
-import { ClipboardCellData, UID, Zone } from "../../types";
+import {
+  ClipboardCellData,
+  ClipboardMIMEType,
+  OSClipboardContent,
+  ParsedOSClipboardContent,
+  UID,
+  Zone,
+} from "../../types";
 import { mergeOverlappingZones, positions } from "../zones";
 
 export function getClipboardDataPositions(sheetId: UID, zones: Zone[]): ClipboardCellData {
@@ -53,4 +60,24 @@ export function getPasteZones<T>(target: Zone[], content: T[][]): Zone[] {
   const width = content[0].length,
     height = content.length;
   return target.map((t) => splitZoneForPaste(t, width, height)).flat();
+}
+
+export function parseOSClipboardContent(content: OSClipboardContent): ParsedOSClipboardContent {
+  if (!content[ClipboardMIMEType.Html]) {
+    return {
+      text: content[ClipboardMIMEType.PlainText],
+    };
+  }
+  const htmlDocument = new DOMParser().parseFromString(
+    content[ClipboardMIMEType.Html],
+    "text/html"
+  );
+  const oSheetClipboardData = htmlDocument
+    .querySelector("div")
+    ?.getAttribute("data-osheet-clipboard");
+  const spreadsheetContent = oSheetClipboardData && JSON.parse(oSheetClipboardData);
+  return {
+    text: content[ClipboardMIMEType.PlainText],
+    data: spreadsheetContent,
+  };
 }

--- a/src/helpers/ui/paste_interactive.ts
+++ b/src/helpers/ui/paste_interactive.ts
@@ -1,11 +1,10 @@
 import { CURRENT_VERSION } from "../../migrations/data";
 import { _t } from "../../translation";
 import {
-  ClipboardContent,
-  ClipboardMIMEType,
   ClipboardPasteOptions,
   CommandResult,
   DispatchResult,
+  ParsedOSClipboardContent,
   SpreadsheetChildEnv,
   Zone,
 } from "../../types";
@@ -45,7 +44,7 @@ export function interactivePaste(
 export function interactivePasteFromOS(
   env: SpreadsheetChildEnv,
   target: Zone[],
-  clipboardContent: ClipboardContent,
+  clipboardContent: ParsedOSClipboardContent,
   pasteOption?: ClipboardPasteOptions
 ) {
   let result: DispatchResult;
@@ -59,10 +58,9 @@ export function interactivePasteFromOS(
       pasteOption,
     });
   } catch (error) {
-    const parsedSpreadsheetContent = clipboardContent[ClipboardMIMEType.OSpreadsheet]
-      ? JSON.parse(clipboardContent[ClipboardMIMEType.OSpreadsheet])
-      : {};
-    if (parsedSpreadsheetContent.version && parsedSpreadsheetContent.version !== CURRENT_VERSION) {
+    const parsedSpreadsheetContent = clipboardContent.data;
+
+    if (parsedSpreadsheetContent?.version !== CURRENT_VERSION) {
       env.raiseError(
         _t(
           "An unexpected error occurred while pasting content.\
@@ -73,7 +71,7 @@ export function interactivePasteFromOS(
     result = env.model.dispatch("PASTE_FROM_OS_CLIPBOARD", {
       target,
       clipboardContent: {
-        [ClipboardMIMEType.PlainText]: clipboardContent[ClipboardMIMEType.PlainText],
+        text: clipboardContent.text,
       },
       pasteOption,
     });

--- a/src/types/clipboard.ts
+++ b/src/types/clipboard.ts
@@ -1,12 +1,17 @@
+import { SpreadsheetClipboardData } from "../plugins/ui_stateful";
 import { HeaderIndex, UID, Zone } from "./misc";
 
 export enum ClipboardMIMEType {
   PlainText = "text/plain",
   Html = "text/html",
-  OSpreadsheet = "web application/o-spreadsheet",
 }
 
-export type ClipboardContent = { [type in ClipboardMIMEType]?: string };
+export type OSClipboardContent = { [type in ClipboardMIMEType]?: string };
+
+export type ParsedOSClipboardContent = {
+  text?: string;
+  data?: SpreadsheetClipboardData;
+};
 
 export interface ClipboardOptions {
   isCutOperation: boolean;

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -22,7 +22,7 @@ import {
 } from "./misc";
 
 import { ChartDefinition } from "./chart/chart";
-import { ClipboardContent, ClipboardPasteOptions } from "./clipboard";
+import { ClipboardPasteOptions, ParsedOSClipboardContent } from "./clipboard";
 import { FigureSize } from "./figure";
 import { SearchOptions } from "./find_and_replace";
 import { Image } from "./image";
@@ -780,7 +780,7 @@ export interface AutoFillCellCommand {
 export interface PasteFromOSClipboardCommand {
   type: "PASTE_FROM_OS_CLIPBOARD";
   target: Zone[];
-  clipboardContent: ClipboardContent;
+  clipboardContent: ParsedOSClipboardContent;
   pasteOption?: ClipboardPasteOptions;
 }
 

--- a/tests/clipboard/clipboard_figure_plugin.test.ts
+++ b/tests/clipboard/clipboard_figure_plugin.test.ts
@@ -1,6 +1,7 @@
 import { CommandResult, Model } from "../../src";
 import { DEFAULT_CELL_HEIGHT, DEFAULT_CELL_WIDTH } from "../../src/constants";
-import { ClipboardMIMEType, UID } from "../../src/types";
+import { parseOSClipboardContent } from "../../src/helpers/clipboard/clipboard_helpers";
+import { UID } from "../../src/types";
 import { BarChartDefinition } from "../../src/types/chart";
 import {
   activateSheet,
@@ -179,9 +180,9 @@ describe.each(["chart", "image"])("Clipboard for %s figures", (type: string) => 
   test("Chart clipboard content is not serialized at copy", () => {
     model.dispatch("SELECT_FIGURE", { id: figureId });
     copy(model);
-    const clipboardSpreadsheetContent = JSON.parse(
-      model.getters.getClipboardContent()[ClipboardMIMEType.OSpreadsheet]!
-    );
+
+    const clipboardSpreadsheetContent = parseOSClipboardContent(model.getters.getClipboardContent())
+      .data!;
     expect(clipboardSpreadsheetContent.figureId).toBe(undefined);
     expect(clipboardSpreadsheetContent.copiedFigure).toBe(undefined);
     expect(clipboardSpreadsheetContent.copiedChart).toBe(undefined);

--- a/tests/clipboard/clipboard_plugin.test.ts
+++ b/tests/clipboard/clipboard_plugin.test.ts
@@ -1,9 +1,13 @@
 import { clipboardHandlersRegistries } from "../../src/clipboard_handlers";
 import { DEFAULT_BORDER_DESC, LINK_COLOR } from "../../src/constants";
 import { markdownLink, toCartesian, toZone, zoneToXc } from "../../src/helpers";
-import { getClipboardDataPositions } from "../../src/helpers/clipboard/clipboard_helpers";
+import {
+  getClipboardDataPositions,
+  parseOSClipboardContent,
+} from "../../src/helpers/clipboard/clipboard_helpers";
 import { urlRepresentation } from "../../src/helpers/links";
 import { Model } from "../../src/model";
+import { ClipboardPlugin } from "../../src/plugins/ui_stateful";
 import {
   ClipboardMIMEType,
   ClipboardPasteTarget,
@@ -63,6 +67,7 @@ import {
   createEqualCF,
   createModelFromGrid,
   getGrid,
+  getPlugin,
   target,
   toRangesData,
 } from "../test_helpers/helpers";
@@ -207,9 +212,9 @@ describe("clipboard", () => {
     clipboardData.setData(ClipboardMIMEType.PlainText, "Excalibur");
 
     const content = clipboardData.getData(ClipboardMIMEType.PlainText);
-    pasteFromOSClipboard(model, "C2", { [ClipboardMIMEType.PlainText]: content });
+    pasteFromOSClipboard(model, "C2", { text: content });
     expect(getCellContent(model, "C2")).toBe(content);
-    pasteFromOSClipboard(model, "C3", { [ClipboardMIMEType.PlainText]: content }, "onlyFormat");
+    pasteFromOSClipboard(model, "C3", { text: content }, "onlyFormat");
     expect(getCellContent(model, "C3")).toBe("");
   });
 
@@ -556,7 +561,11 @@ describe("clipboard", () => {
       setCellContent(model, "A2", "3");
       copy(model, "A1:B2");
       const htmlContent = model.getters.getClipboardContent()[ClipboardMIMEType.Html]!;
-      const expectedHtmlContent = `<div data-clipboard-id="${model.getters.getClipboardId()}"><table border="1" style="border-collapse:collapse"><tr><td style="">1</td><td style="">2</td></tr><tr><td style="">3</td><td style=""></td></tr></table></div>`;
+      const cbPlugin = getPlugin(model, ClipboardPlugin);
+      const clipboardData = JSON.stringify(cbPlugin["getSheetData"]());
+      const expectedHtmlContent = `<div data-osheet-clipboard='${xmlEscape(
+        clipboardData
+      )}'><table border="1" style="border-collapse:collapse"><tr><td style="">1</td><td style="">2</td></tr><tr><td style="">3</td><td style=""></td></tr></table></div>`;
       expect(htmlContent).toBe(expectedHtmlContent);
     });
 
@@ -625,8 +634,10 @@ describe("clipboard", () => {
       const model = new Model();
       setCellContent(model, "A1", "1");
       copy(model, "A1");
+      const cbPlugin = getPlugin(model, ClipboardPlugin);
+      const clipboardData = JSON.stringify(cbPlugin["getSheetData"]());
       expect(model.getters.getClipboardContent()[ClipboardMIMEType.Html]).toBe(
-        `<div data-clipboard-id="${model.getters.getClipboardId()}">1</div>`
+        `<div data-osheet-clipboard='${xmlEscape(clipboardData)}'>1</div>`
       );
     });
   });
@@ -670,7 +681,7 @@ describe("clipboard", () => {
 
   test("can paste multiple cells from os clipboard", () => {
     const model = new Model();
-    pasteFromOSClipboard(model, "C1", { [ClipboardMIMEType.PlainText]: "a\t1\nb\t2" });
+    pasteFromOSClipboard(model, "C1", { text: "a\t1\nb\t2" });
 
     expect(getCellContent(model, "C1")).toBe("a");
     expect(getCellContent(model, "C2")).toBe("b");
@@ -683,7 +694,7 @@ describe("clipboard", () => {
     const sheetId = model.getters.getActiveSheetId();
     merge(model, "B2:C3");
     const result = pasteFromOSClipboard(model, "B2", {
-      [ClipboardMIMEType.PlainText]: "a\t1\nb\t2",
+      text: "a\t1\nb\t2",
     });
     expect(result).toBeCancelledBecause(CommandResult.WillRemoveExistingMerge);
     expect(model.getters.getMerges(sheetId).map(zoneToXc)).toEqual(["B2:C3"]);
@@ -692,13 +703,13 @@ describe("clipboard", () => {
   test("pasting from OS will not change the viewport", () => {
     const model = new Model();
     const viewport = model.getters.getActiveMainViewport();
-    pasteFromOSClipboard(model, "C60", { [ClipboardMIMEType.PlainText]: "a\t1\nb\t2" });
+    pasteFromOSClipboard(model, "C60", { text: "a\t1\nb\t2" });
     expect(model.getters.getActiveMainViewport()).toEqual(viewport);
   });
 
   test("pasting numbers from windows clipboard => interpreted as number", () => {
     const model = new Model();
-    pasteFromOSClipboard(model, "C1", { [ClipboardMIMEType.PlainText]: "1\r\n2\r\n3" });
+    pasteFromOSClipboard(model, "C1", { text: "1\r\n2\r\n3" });
 
     expect(getCellContent(model, "C1")).toBe("1");
     expect(getEvaluatedCell(model, "C1").value).toBe(1);
@@ -2365,7 +2376,7 @@ describe("clipboard: pasting outside of sheet", () => {
   test("can paste multiple cells from os to outside of sheet", () => {
     const model = new Model();
     createSheet(model, { activate: true, sheetId: "2", rows: 2, cols: 2 });
-    pasteFromOSClipboard(model, "B2", { [ClipboardMIMEType.PlainText]: "A\nque\tcoucou\nBOB" });
+    pasteFromOSClipboard(model, "B2", { text: "A\nque\tcoucou\nBOB" });
     expect(getCellContent(model, "B2")).toBe("A");
     expect(getCellContent(model, "B3")).toBe("que");
     expect(getCellContent(model, "C3")).toBe("coucou");
@@ -2377,7 +2388,7 @@ describe("clipboard: pasting outside of sheet", () => {
       rows: 2,
       cols: 2,
     });
-    pasteFromOSClipboard(model, "B2", { [ClipboardMIMEType.PlainText]: "A\nque\tcoucou\tPatrick" });
+    pasteFromOSClipboard(model, "B2", { text: "A\nque\tcoucou\tPatrick" });
     expect(getCellContent(model, "B2")).toBe("A");
     expect(getCellContent(model, "B3")).toBe("que");
     expect(getCellContent(model, "C3")).toBe("coucou");
@@ -2392,7 +2403,7 @@ describe("clipboard: pasting outside of sheet", () => {
       formulaArgSeparator: ";",
       thousandsSeparator: " ",
     });
-    pasteFromOSClipboard(model, "A1", { [ClipboardMIMEType.PlainText]: "=SUM(5 ; 3,14)" });
+    pasteFromOSClipboard(model, "A1", { text: "=SUM(5 ; 3,14)" });
     expect(getCell(model, "A1")?.content).toBe("=SUM(5 , 3.14)");
     expect(getEvaluatedCell(model, "A1").value).toBe(8.14);
   });
@@ -2716,7 +2727,7 @@ describe("cross spreadsheet copy/paste", () => {
 
     expect(clipboardContent["text/plain"]).toBe("b2");
 
-    pasteFromOSClipboard(modelB, "D2", clipboardContent);
+    pasteFromOSClipboard(modelB, "D2", parseOSClipboardContent(clipboardContent));
 
     expect(getCell(modelA, "B2")?.content).toBe("b2");
     expect(getCell(modelB, "D2")?.content).toBe("b2");
@@ -2736,7 +2747,7 @@ describe("cross spreadsheet copy/paste", () => {
     copy(modelA, "B2");
     const clipboardContent = modelA.getters.getClipboardContent();
 
-    pasteFromOSClipboard(modelB, "D2", clipboardContent);
+    pasteFromOSClipboard(modelB, "D2", parseOSClipboardContent(clipboardContent));
 
     expect(getBorder(modelA, "B2")).toEqual({ top: DEFAULT_BORDER_DESC });
     expect(getBorder(modelB, "D2")).toEqual({ top: DEFAULT_BORDER_DESC });
@@ -2756,7 +2767,7 @@ describe("cross spreadsheet copy/paste", () => {
 
     copy(modelA, "A1:A5");
     const clipboardContent = modelA.getters.getClipboardContent();
-    pasteFromOSClipboard(modelB, "D1", clipboardContent);
+    pasteFromOSClipboard(modelB, "D1", parseOSClipboardContent(clipboardContent));
 
     expect(getCell(modelB, "D1")?.content).toBe("=SUM(1,2)");
     expect(getCell(modelB, "D2")?.content).toBe("=SUM(1,2)");
@@ -2774,7 +2785,7 @@ describe("cross spreadsheet copy/paste", () => {
     setCellContent(modelA, "A1", markdownLink(urlLabel, url));
     copy(modelA, "A1");
     const clipboardContent = modelA.getters.getClipboardContent();
-    pasteFromOSClipboard(modelB, "D1", clipboardContent);
+    pasteFromOSClipboard(modelB, "D1", parseOSClipboardContent(clipboardContent));
 
     const cell = getEvaluatedCell(modelB, "D1");
     expect(cell.link?.label).toBe(urlLabel);
@@ -2796,7 +2807,7 @@ describe("cross spreadsheet copy/paste", () => {
 
     copy(modelA, "A1:B2");
     const clipboardContent = modelA.getters.getClipboardContent();
-    pasteFromOSClipboard(modelB, "D1", clipboardContent);
+    pasteFromOSClipboard(modelB, "D1", parseOSClipboardContent(clipboardContent));
 
     const tableB = modelB.getters.getCoreTables(modelA.getters.getActiveSheetId())[0];
 
@@ -2827,16 +2838,9 @@ describe("cross spreadsheet copy/paste", () => {
     copy(modelB, "C1");
     copy(modelA, "A1");
     const clipboardContent = modelA.getters.getClipboardContent();
-
     expect(clipboardContent["text/plain"]).toBe("a1");
 
-    pasteFromOSClipboard(modelB, "B1", {
-      [ClipboardMIMEType.PlainText]: clipboardContent["text/plain"]
-        ? clipboardContent["text/plain"]
-        : "",
-      [ClipboardMIMEType.OSpreadsheet]: clipboardContent["web application/o-spreadsheet"],
-    });
-
+    pasteFromOSClipboard(modelB, "B1", parseOSClipboardContent(clipboardContent));
     expect(getCell(modelA, "A1")).toMatchObject({
       content: "a1",
     });
@@ -2856,11 +2860,31 @@ describe("cross spreadsheet copy/paste", () => {
     setCellContent(modelA, "C3", "=A3*B3");
 
     copy(modelA, "A1:C3");
-    pasteFromOSClipboard(modelB, "E1", modelA.getters.getClipboardContent());
+    pasteFromOSClipboard(
+      modelB,
+      "E1",
+      parseOSClipboardContent(modelA.getters.getClipboardContent())
+    );
 
     expect(getCell(modelB, "G1")?.content).toBe("=E1*F1");
     expect(getCell(modelB, "G2")?.content).toBe("=E2*F2");
     expect(getCell(modelB, "G3")?.content).toBe("=E3*F3");
+  });
+
+  test("can copy/paste cells with escapable content", () => {
+    const modelA = new Model();
+    const modelB = new Model();
+
+    const escapableString = ` & " < > / \ '`;
+    setCellContent(modelA, "A1", escapableString);
+    copy(modelA, "A1");
+    const clipboardContent = modelA.getters.getClipboardContent();
+
+    expect(clipboardContent["text/plain"]).toBe(escapableString);
+
+    pasteFromOSClipboard(modelB, "D2", parseOSClipboardContent(clipboardContent));
+    expect(getCell(modelA, "A1")?.content).toBe(escapableString);
+    expect(getCell(modelB, "D2")?.content).toBe(escapableString);
   });
 });
 

--- a/tests/grid/grid_component.test.ts
+++ b/tests/grid/grid_component.test.ts
@@ -18,9 +18,11 @@ import {
 import { buildSheetLink, toCartesian, toHex, toZone, zoneToXc } from "../../src/helpers";
 import { createEmptyWorkbookData } from "../../src/migrations/data";
 import { Model } from "../../src/model";
+import { ClipboardPlugin } from "../../src/plugins/ui_stateful";
 import { Store } from "../../src/store_engine";
 import { HighlightStore } from "../../src/stores/highlight_store";
 import { Align, ClipboardMIMEType, SpreadsheetChildEnv } from "../../src/types";
+import { xmlEscape } from "../../src/xlsx/helpers/xml_helpers";
 import { FileStore } from "../__mocks__/mock_file_store";
 import { MockTransportService } from "../__mocks__/transport_service";
 import { MockClipboardData, getClipboardEvent } from "../test_helpers/clipboard";
@@ -78,6 +80,7 @@ import {
 } from "../test_helpers/getters_helpers";
 import {
   createEqualCF,
+  getPlugin,
   mockChart,
   mountSpreadsheet,
   nextTick,
@@ -1470,9 +1473,12 @@ describe("Copy paste keyboard shortcut", () => {
     selectCell(model, "A1");
     document.body.dispatchEvent(getClipboardEvent("copy", clipboardData));
     const clipboardContent = clipboardData.content;
+    const cbPlugin = getPlugin(model, ClipboardPlugin);
+    //@ts-ignore
+    const clipboardHtmlData = JSON.stringify(cbPlugin.getSheetData());
     expect(clipboardContent).toMatchObject({
       "text/plain": "things",
-      "text/html": `<div data-clipboard-id="${model.getters.getClipboardId()}">things</div>`,
+      "text/html": `<div data-osheet-clipboard='${xmlEscape(clipboardHtmlData)}'>things</div>`,
     });
     selectCell(model, "A2");
     document.body.dispatchEvent(getClipboardEvent("paste", clipboardData));
@@ -1485,9 +1491,12 @@ describe("Copy paste keyboard shortcut", () => {
     selectCell(model, "A1");
     document.body.dispatchEvent(getClipboardEvent("cut", clipboardData));
     const clipboardContent = clipboardData.content;
+    const cbPlugin = getPlugin(model, ClipboardPlugin);
+    //@ts-ignore
+    const clipboardHtmlData = JSON.stringify(cbPlugin.getSheetData());
     expect(clipboardContent).toMatchObject({
       "text/plain": "things",
-      "text/html": `<div data-clipboard-id="${model.getters.getClipboardId()}">things</div>`,
+      "text/html": `<div data-osheet-clipboard='${xmlEscape(clipboardHtmlData)}'>things</div>`,
     });
     selectCell(model, "A2");
     document.body.dispatchEvent(getClipboardEvent("paste", clipboardData));

--- a/tests/helpers/ui_helpers.test.ts
+++ b/tests/helpers/ui_helpers.test.ts
@@ -252,9 +252,7 @@ describe("UI Helpers", () => {
       const clipboardString = "a\t1\nb\t2";
 
       test("Can interactive paste", () => {
-        interactivePasteFromOS(env, target("D2"), {
-          "text/plain": clipboardString,
-        });
+        interactivePasteFromOS(env, target("D2"), { text: clipboardString });
         expect(getCellContent(model, "D2")).toBe("a");
         expect(getCellContent(model, "E2")).toBe("1");
         expect(getCellContent(model, "D3")).toBe("b");
@@ -265,7 +263,7 @@ describe("UI Helpers", () => {
         merge(model, "B2:C3");
         selectCell(model, "A1");
         interactivePasteFromOS(env, model.getters.getSelectedZones(), {
-          "text/plain": clipboardString,
+          text: clipboardString,
         });
         expect(notifyUserTextSpy).toHaveBeenCalledWith(
           PasteInteractiveContent.willRemoveExistingMerge.toString()

--- a/tests/menus/menu_items_registry.test.ts
+++ b/tests/menus/menu_items_registry.test.ts
@@ -50,7 +50,6 @@ import {
 } from "../test_helpers/helpers";
 
 import { Currency, Model } from "../../src";
-import { ClipboardMIMEType } from "../../src/types";
 
 import { CellComposerStore } from "../../src/components/composer/composer/cell_composer_store";
 import { FONT_SIZES } from "../../src/constants";
@@ -230,11 +229,7 @@ describe("Menu Item actions", () => {
     selectCell(model, "A1");
     await doAction(["edit", "paste_special", "paste_special_format"], env);
     expect(dispatch).toHaveBeenCalledWith("PASTE_FROM_OS_CLIPBOARD", {
-      clipboardContent: {
-        [ClipboardMIMEType.PlainText]: "Copy in OS clipboard",
-        [ClipboardMIMEType.Html]: "",
-        [ClipboardMIMEType.OSpreadsheet]: "",
-      },
+      clipboardContent: { text: "Copy in OS clipboard" },
       target: target("A1"),
       pasteOption: "onlyFormat",
     });
@@ -278,11 +273,7 @@ describe("Menu Item actions", () => {
     await doAction(["edit", "paste_special", "paste_special_value"], env);
     expect(dispatch).toHaveBeenCalledWith("PASTE_FROM_OS_CLIPBOARD", {
       target: target("A1"),
-      clipboardContent: {
-        [ClipboardMIMEType.PlainText]: text,
-        [ClipboardMIMEType.Html]: "",
-        [ClipboardMIMEType.OSpreadsheet]: "",
-      },
+      clipboardContent: { text },
       pasteOption: "asValue",
     });
   });
@@ -302,11 +293,7 @@ describe("Menu Item actions", () => {
     await doAction(["edit", "paste_special", "paste_special_format"], env);
     expect(dispatch).toHaveBeenCalledWith("PASTE_FROM_OS_CLIPBOARD", {
       target: target("A1"),
-      clipboardContent: {
-        [ClipboardMIMEType.PlainText]: text,
-        [ClipboardMIMEType.Html]: "",
-        [ClipboardMIMEType.OSpreadsheet]: "",
-      },
+      clipboardContent: { text },
       pasteOption: "onlyFormat",
     });
   });

--- a/tests/test_helpers/clipboard.ts
+++ b/tests/test_helpers/clipboard.ts
@@ -2,10 +2,10 @@ import {
   ClipboardInterface,
   ClipboardReadResult,
 } from "../../src/helpers/clipboard/navigator_clipboard_wrapper";
-import { ClipboardContent, ClipboardMIMEType } from "../../src/types";
+import { ClipboardMIMEType, OSClipboardContent } from "../../src/types";
 
 export class MockClipboard implements ClipboardInterface {
-  private content: ClipboardContent = {};
+  private content: OSClipboardContent = {};
 
   async read(): Promise<ClipboardReadResult> {
     return {
@@ -13,7 +13,6 @@ export class MockClipboard implements ClipboardInterface {
       content: {
         [ClipboardMIMEType.PlainText]: this.content[ClipboardMIMEType.PlainText],
         [ClipboardMIMEType.Html]: this.content[ClipboardMIMEType.Html],
-        [ClipboardMIMEType.OSpreadsheet]: this.content[ClipboardMIMEType.OSpreadsheet],
       },
     };
   }
@@ -21,20 +20,18 @@ export class MockClipboard implements ClipboardInterface {
   async writeText(text: string): Promise<void> {
     this.content[ClipboardMIMEType.PlainText] = text;
     this.content[ClipboardMIMEType.Html] = "";
-    this.content[ClipboardMIMEType.OSpreadsheet] = "";
   }
 
-  async write(content: ClipboardContent) {
+  async write(content: OSClipboardContent) {
     this.content = {
       [ClipboardMIMEType.PlainText]: content[ClipboardMIMEType.PlainText],
       [ClipboardMIMEType.Html]: content[ClipboardMIMEType.Html],
-      [ClipboardMIMEType.OSpreadsheet]: content[ClipboardMIMEType.OSpreadsheet],
     };
   }
 }
 
 export class MockClipboardData {
-  content: ClipboardContent = {};
+  content: OSClipboardContent = {};
 
   setText(text: string) {
     this.content[ClipboardMIMEType.PlainText] = text;

--- a/tests/test_helpers/commands_helpers.ts
+++ b/tests/test_helpers/commands_helpers.ts
@@ -11,7 +11,6 @@ import {
   BorderData,
   ChartDefinition,
   ChartWithAxisDefinition,
-  ClipboardContent,
   ClipboardPasteOptions,
   Color,
   CreateSheetCommand,
@@ -21,6 +20,7 @@ import {
   Direction,
   DispatchResult,
   Locale,
+  ParsedOSClipboardContent,
   SelectionStep,
   SortDirection,
   SortOptions,
@@ -339,7 +339,7 @@ export function paste(
 export function pasteFromOSClipboard(
   model: Model,
   range: string,
-  content: ClipboardContent,
+  content: ParsedOSClipboardContent,
   pasteOption?: ClipboardPasteOptions
 ): DispatchResult {
   return model.dispatch("PASTE_FROM_OS_CLIPBOARD", {


### PR DESCRIPTION
The current implementation of the cross-browser clipboard relies heavily on an API that is currently only available on Chromium based browsers (see [table](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API#api.clipboarditem)).

There is currently no definitive announce that the feature will be adopted by other browsers (namely FF and Safari) and since the feature is still marked as experimental, it'd be better to rely on a more generic approach.

This revision changes the flow to rely entirely on the `text/html` mimetype as it is supported by all modern browsers.

Task: 4241877

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo