### PR TITLE
[REF] pivot: adapt menu item to reflect odoo menu

### DIFF
--- a/src/helpers/pivot/pivot_menu_items.ts
+++ b/src/helpers/pivot/pivot_menu_items.ts
@@ -3,7 +3,7 @@ import { _t } from "../../translation";
 import { CellValueType } from "../../types";
 
 export const pivotProperties: ActionSpec = {
-  name: _t("Edit Pivot"),
+  name: _t("See pivot properties"),
   execute(env) {
     const position = env.model.getters.getActivePosition();
     const pivotId = env.model.getters.getPivotIdFromPosition(position);

--- a/src/registries/menus/cell_menu_registry.ts
+++ b/src/registries/menus/cell_menu_registry.ts
@@ -112,6 +112,5 @@ cellMenuRegistry
   })
   .add("pivot_properties", {
     ...ACTIONS_PIVOT.pivotProperties,
-    sequence: 160,
-    separator: true,
+    sequence: 170,
   });


### PR DESCRIPTION
## Description:

This menu item was duplicated and overwritten in odoo. The overwrite has been removed from odoo and this commit changes the menu here to reflect what was visible in odoo.
Task: [4242125](https://www.odoo.com/web#id=4242125&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo