### PR TITLE
[IMP] pivot: allow to open side panel in readonly mode

### DIFF
--- a/src/components/side_panel/pivot/pivot_side_panel/pivot_spreadsheet_side_panel/pivot_spreadsheet_side_panel.xml
+++ b/src/components/side_panel/pivot/pivot_side_panel/pivot_spreadsheet_side_panel/pivot_spreadsheet_side_panel.xml
@@ -1,6 +1,10 @@
 <templates>
   <t t-name="o-spreadsheet-PivotSpreadsheetSidePanel">
-    <div class="d-flex flex-column h-100 justify-content-between overflow-hidden">
+    <t t-set="isReadonly" t-value="env.model.getters.isReadonly()"/>
+    <div
+      class="d-flex flex-column h-100 justify-content-between overflow-hidden"
+      t-att="isReadonly ? ['inert', 1] : []"
+      t-att-class="{ 'pe-none': isReadonly, 'opacity-50': isReadonly }">
       <div class="h-100 position-relative overflow-x-hidden overflow-y-auto">
         <PivotTitleSection pivotId="props.pivotId" flipAxis.bind="flipAxis"/>
         <Section title.translate="Range">

--- a/src/helpers/pivot/pivot_menu_items.ts
+++ b/src/helpers/pivot/pivot_menu_items.ts
@@ -14,6 +14,7 @@ export const pivotProperties: ActionSpec = {
     const pivotId = env.model.getters.getPivotIdFromPosition(position);
     return (pivotId && env.model.getters.isExistingPivot(pivotId)) || false;
   },
+  isReadonlyAllowed: true,
   icon: "o-spreadsheet-Icon.PIVOT",
 };
 

--- a/src/registries/menus/topbar_menu_registry.ts
+++ b/src/registries/menus/topbar_menu_registry.ts
@@ -473,6 +473,7 @@ topbarMenuRegistry
         id: `item_pivot_${env.model.getters.getPivotFormulaId(pivotId)}`,
         name: env.model.getters.getPivotDisplayName(pivotId),
         sequence: sequence + index,
+        isReadonlyAllowed: true,
         execute: (env) => env.openSidePanel("PivotSidePanel", { pivotId }),
         onStartHover: (env) => env.getStore(HighlightStore).register(highlightProvider),
         onStopHover: (env) => env.getStore(HighlightStore).unRegister(highlightProvider),

--- a/tests/pivots/pivot_side_panel.test.ts
+++ b/tests/pivots/pivot_side_panel.test.ts
@@ -25,6 +25,19 @@ describe("Pivot side panel", () => {
     addPivot(model, "A1:B2", {}, "2");
   });
 
+  test("readonly panel is not clickable and greyed", async () => {
+    env.openSidePanel("PivotSidePanel", { pivotId: "2" });
+    await nextTick();
+    const panel = fixture.querySelector(".o-sidePanelBody > div");
+    expect(panel?.classList).not.toContain("pe-none");
+    expect(panel?.classList).not.toContain("opacity-50");
+    model.updateMode("readonly");
+    await nextTick();
+    expect(panel?.classList).toContain("pe-none");
+    expect(panel?.classList).toContain("opacity-50");
+    expect(panel?.getAttribute("inert")).toBe("1");
+  });
+
   test("It should open the pivot editor when pivotId is provided", async () => {
     env.openSidePanel("PivotSidePanel", { pivotId: "2" });
     await nextTick();


### PR DESCRIPTION


## Description:

In read-only mode, you can't open the pivots/lists/charts side panels. It's useful to know what you're looking at (range, domain, sorting, etc.), even if you can't edit anything.

Task: [4187705](https://www.odoo.com/web#id=4187705&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo