### PR TITLE
[FIX] model: CoreViewPlugin leaves core on revision replay

### DIFF
--- a/tests/collaborative/collaborative_helpers.ts
+++ b/tests/collaborative/collaborative_helpers.ts
@@ -17,8 +17,9 @@ interface CollaborativeEnv {
  * first, meaning she will also resend her pending messages first.
  * Similarly, Bob's messages are resent before Charlie's.
  */
-export function setupCollaborativeEnv(): CollaborativeEnv {
-  const network = new MockTransportService();
+export function setupCollaborativeEnv(
+  network: MockTransportService = new MockTransportService()
+): CollaborativeEnv {
   const emptySheetData = new Model().exportData();
   const alice = new Model(deepCopy(emptySheetData), {
     transportService: network,


### PR DESCRIPTION
CoreViewPlugins receive remote messages and while replaying them locally, they can re-dispatch sub-commands. Currently, the plugin will re-dispatch using the 'global' `Model.dispatch` method which is the external entry point of Model and creates a new local history step when called.

This means that the coreViewPlugin can create new history steps when replaying a remote command, which ends up with their local changes sent to the network.

Two notes on that subject:
- the local change will be sent before the revision is completely replayed, which means the revision ids of the messages are faulty and the message will be rejected by the server at first,
- Having messages sent to the network upon reception of another message could lead to infinite loop of messages.

This revision adapts the dispatch of CoreViewPlugin such that they bypass the local history (and thus revision creation) when replaying remote revisions.

Task: 4241403

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo