### PR TITLE
[FIX] CoreViewPlugin: Remove access to dispatch

### DIFF
--- a/src/plugins/base_plugin.ts
+++ b/src/plugins/base_plugin.ts
@@ -1,6 +1,5 @@
 import { StateObserver } from "../state_observer";
 import {
-  CommandDispatcher,
   CommandHandler,
   CommandResult,
   ExcelWorkbookData,
@@ -25,14 +24,12 @@ export class BasePlugin<State = any, C = any> implements CommandHandler<C>, Vali
   static getters: readonly string[] = [];
 
   protected history: WorkbookHistory<State>;
-  protected dispatch: CommandDispatcher["dispatch"];
 
-  constructor(stateObserver: StateObserver, dispatch: CommandDispatcher["dispatch"]) {
+  constructor(stateObserver: StateObserver) {
     this.history = Object.assign(Object.create(stateObserver), {
       update: stateObserver.addChange.bind(stateObserver, this),
       selectCell: () => {},
     });
-    this.dispatch = dispatch;
   }
 
   /**

--- a/src/plugins/core_plugin.ts
+++ b/src/plugins/core_plugin.ts
@@ -40,12 +40,14 @@ export class CorePlugin<State = any>
 {
   protected getters: CoreGetters;
   protected uuidGenerator: UuidGenerator;
+  protected dispatch: CoreCommandDispatcher["dispatch"];
 
   constructor({ getters, stateObserver, range, dispatch, uuidGenerator }: CorePluginConfig) {
-    super(stateObserver, dispatch);
+    super(stateObserver);
     range.addRangeProvider(this.adaptRanges.bind(this));
     this.getters = getters;
     this.uuidGenerator = uuidGenerator;
+    this.dispatch = dispatch;
   }
 
   // ---------------------------------------------------------------------------

--- a/src/plugins/core_view_plugin.ts
+++ b/src/plugins/core_view_plugin.ts
@@ -1,0 +1,24 @@
+import { Command, Getters, LAYERS } from "../types/index";
+import { BasePlugin } from "./base_plugin";
+import { UIPluginConfig } from "./ui_plugin";
+
+export type CoreViewPluginConfig = Omit<UIPluginConfig, "dispatch">;
+
+export interface CoreViewPluginConstructor {
+  new (config: CoreViewPluginConfig): CoreViewPlugin;
+  getters: readonly string[];
+}
+
+/**
+ * Core view plugins handle any data derived from core date (i.e. evaluation).
+ * They cannot impact the model data (i.e. cannot dispatch commands).
+ */
+export class CoreViewPlugin<State = any> extends BasePlugin<State, Command> {
+  static layers: LAYERS[] = [];
+
+  protected getters: Getters;
+  constructor({ getters, stateObserver }: CoreViewPluginConfig) {
+    super(stateObserver);
+    this.getters = getters;
+  }
+}

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -16,6 +16,7 @@ import {
 import { HeaderGroupingPlugin } from "./core/header_grouping";
 import { SettingsPlugin } from "./core/settings";
 import { CorePluginConstructor } from "./core_plugin";
+import { CoreViewPluginConstructor } from "./core_view_plugin";
 import {
   CustomColorsPlugin,
   EvaluationChartPlugin,
@@ -97,7 +98,7 @@ export const statefulUIPluginRegistry = new Registry<UIPluginConstructor>()
   .add("edition", EditionPlugin);
 
 // Plugins which have a derived state from core data
-export const coreViewsPluginRegistry = new Registry<UIPluginConstructor>()
+export const coreViewsPluginRegistry = new Registry<CoreViewPluginConstructor>()
   .add("evaluation", EvaluationPlugin)
   .add("evaluation_chart", EvaluationChartPlugin)
   .add("evaluation_cf", EvaluationConditionalFormatPlugin)

--- a/src/plugins/ui_core_views/cell_evaluation/evaluation_plugin.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluation_plugin.ts
@@ -21,7 +21,7 @@ import {
   invalidateDependenciesCommands,
   isMatrix,
 } from "../../../types/index";
-import { UIPlugin, UIPluginConfig } from "../../ui_plugin";
+import { CoreViewPlugin, CoreViewPluginConfig } from "../../core_view_plugin";
 import { CoreViewCommand } from "./../../../types/commands";
 import { Evaluator } from "./evaluator";
 
@@ -140,7 +140,7 @@ import { Evaluator } from "./evaluator";
 // of other cells depending on it, at the next iteration.
 
 //#endregion
-export class EvaluationPlugin extends UIPlugin {
+export class EvaluationPlugin extends CoreViewPlugin {
   static getters = [
     "evaluateFormula",
     "evaluateFormulaResult",
@@ -161,7 +161,7 @@ export class EvaluationPlugin extends UIPlugin {
   private evaluator: Evaluator;
   private positionsToUpdate: CellPosition[] = [];
 
-  constructor(config: UIPluginConfig) {
+  constructor(config: CoreViewPluginConfig) {
     super(config);
     this.evaluator = new Evaluator(config.custom, this.getters);
   }

--- a/src/plugins/ui_core_views/custom_colors.ts
+++ b/src/plugins/ui_core_views/custom_colors.ts
@@ -11,7 +11,7 @@ import {
 } from "../../helpers";
 import { GaugeChart, ScorecardChart } from "../../helpers/figures/charts";
 import { Color, CoreViewCommand, Immutable, RGBA, UID } from "../../types";
-import { UIPlugin } from "../ui_plugin";
+import { CoreViewPlugin } from "../core_view_plugin";
 
 /**
  * https://tomekdev.com/posts/sorting-colors-in-js
@@ -69,7 +69,7 @@ interface CustomColorState {
  * This plugins aims to compute and keep to custom colors used in the
  * current spreadsheet
  */
-export class CustomColorsPlugin extends UIPlugin<CustomColorState> {
+export class CustomColorsPlugin extends CoreViewPlugin<CustomColorState> {
   private readonly customColors: Immutable<Record<Color, true>> = {};
   private readonly shouldUpdateColors = false;
   static getters = ["getCustomColors"] as const;

--- a/src/plugins/ui_core_views/evaluation_chart.ts
+++ b/src/plugins/ui_core_views/evaluation_chart.ts
@@ -7,7 +7,7 @@ import {
   invalidateCFEvaluationCommands,
   invalidateEvaluationCommands,
 } from "../../types/commands";
-import { UIPlugin } from "../ui_plugin";
+import { CoreViewPlugin } from "../core_view_plugin";
 
 interface EvaluationChartStyle {
   background: Color;
@@ -18,7 +18,7 @@ interface EvaluationChartState {
   charts: Record<UID, ChartRuntime | undefined>;
 }
 
-export class EvaluationChartPlugin extends UIPlugin<EvaluationChartState> {
+export class EvaluationChartPlugin extends CoreViewPlugin<EvaluationChartState> {
   static getters = ["getChartRuntime", "getStyleOfSingleCellChart"] as const;
 
   charts: Record<UID, ChartRuntime | undefined> = {};

--- a/src/plugins/ui_core_views/evaluation_conditional_format.ts
+++ b/src/plugins/ui_core_views/evaluation_conditional_format.ts
@@ -24,13 +24,13 @@ import {
   invalidateCFEvaluationCommands,
   isMatrix,
 } from "../../types/index";
-import { UIPlugin } from "../ui_plugin";
+import { CoreViewPlugin } from "../core_view_plugin";
 import { CoreViewCommand } from "./../../types/commands";
 
 type ComputedStyles = { [col: HeaderIndex]: (Style | undefined)[] };
 type ComputedIcons = { [col: HeaderIndex]: (string | undefined)[] };
 
-export class EvaluationConditionalFormatPlugin extends UIPlugin {
+export class EvaluationConditionalFormatPlugin extends CoreViewPlugin {
   static getters = ["getConditionalIcon", "getCellComputedStyle"] as const;
   private isStale: boolean = true;
   // stores the computed styles in the format of computedStyles.sheetName[col][row] = Style

--- a/src/plugins/ui_core_views/evaluation_data_validation.ts
+++ b/src/plugins/ui_core_views/evaluation_data_validation.ts
@@ -16,7 +16,7 @@ import {
 } from "../../types";
 import { CoreViewCommand, invalidateEvaluationCommands } from "../../types/commands";
 import { CellErrorType, EvaluationError } from "../../types/errors";
-import { UIPlugin } from "../ui_plugin";
+import { CoreViewPlugin } from "../core_view_plugin";
 import { _t } from "./../../translation";
 
 interface InvalidValidationResult {
@@ -35,7 +35,7 @@ type ValidationResult = ValidValidationResult | InvalidValidationResult;
 
 type SheetValidationResult = { [col: HeaderIndex]: Array<Lazy<ValidationResult>> };
 
-export class EvaluationDataValidationPlugin extends UIPlugin {
+export class EvaluationDataValidationPlugin extends CoreViewPlugin {
   static getters = [
     "getDataValidationInvalidCriterionValueMessage",
     "getInvalidDataValidationMessage",

--- a/src/plugins/ui_core_views/header_sizes_ui.ts
+++ b/src/plugins/ui_core_views/header_sizes_ui.ts
@@ -10,7 +10,7 @@ import {
 } from "../../helpers";
 import { Command } from "../../types";
 import { CellPosition, Dimension, HeaderIndex, Immutable, Pixel, UID } from "../../types/misc";
-import { UIPlugin } from "../ui_plugin";
+import { CoreViewPlugin } from "../core_view_plugin";
 
 interface HeaderSizeState {
   tallestCellInRow: Immutable<Record<UID, Array<CellWithSize | undefined>>>;
@@ -21,7 +21,7 @@ interface CellWithSize {
   size: Pixel;
 }
 
-export class HeaderSizeUIPlugin extends UIPlugin<HeaderSizeState> implements HeaderSizeState {
+export class HeaderSizeUIPlugin extends CoreViewPlugin<HeaderSizeState> implements HeaderSizeState {
   static getters = ["getRowSize", "getHeaderSize"] as const;
 
   readonly tallestCellInRow: Immutable<Record<UID, Array<CellWithSize | undefined>>> = {};

--- a/src/plugins/ui_plugin.ts
+++ b/src/plugins/ui_plugin.ts
@@ -43,11 +43,13 @@ export class UIPlugin<State = any> extends BasePlugin<State, Command> {
   protected getters: Getters;
   protected ui: UIActions;
   protected selection: SelectionStreamProcessor;
+  protected dispatch: CommandDispatcher["dispatch"];
   constructor({ getters, stateObserver, dispatch, uiActions, selection }: UIPluginConfig) {
-    super(stateObserver, dispatch);
+    super(stateObserver);
     this.getters = getters;
     this.ui = uiActions;
     this.selection = selection;
+    this.dispatch = dispatch;
   }
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
The CoreView plugins have a local state that is directly derived from the core data. As such, they should not have any impact on plugins other than themselves, especially not on core plugins.

This revision removes the dispatch fro the core view plugins altogether as they don't and should not dispatch anything.

Task: 4241403

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo