### PR TITLE
[FIX] Datavalidation: coreView plugin should not dispatch

### DIFF
--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -36,6 +36,7 @@ import {
   SortPlugin,
   UIOptionsPlugin,
 } from "./ui_feature";
+import { DataValidationInsertionPlugin } from "./ui_feature/datavalidation_insertion";
 import { HistoryPlugin } from "./ui_feature/local_history";
 import { SplitToColumnsPlugin } from "./ui_feature/split_to_columns";
 import { TableAutofillPlugin } from "./ui_feature/table_autofill";
@@ -78,7 +79,8 @@ export const featurePluginRegistry = new Registry<UIPluginConstructor>()
   .add("collaborative", CollaborativePlugin)
   .add("history", HistoryPlugin)
   .add("data_cleanup", DataCleanupPlugin)
-  .add("table_autofill", TableAutofillPlugin);
+  .add("table_autofill", TableAutofillPlugin)
+  .add("datavalidation_insert", DataValidationInsertionPlugin);
 
 // Plugins which have a state, but which should not be shared in collaborative
 export const statefulUIPluginRegistry = new Registry<UIPluginConstructor>()

--- a/src/plugins/ui_core_views/evaluation_data_validation.ts
+++ b/src/plugins/ui_core_views/evaluation_data_validation.ts
@@ -56,24 +56,9 @@ export class EvaluationDataValidationPlugin extends UIPlugin {
     }
     switch (cmd.type) {
       case "ADD_DATA_VALIDATION_RULE":
-        const ranges = cmd.ranges.map((range) => this.getters.getRangeFromRangeData(range));
-        if (cmd.rule.criterion.type === "isBoolean") {
-          this.setContentToBooleanCells({ ...cmd.rule, ranges });
-        }
-        delete this.validationResults[cmd.sheetId];
-        break;
       case "REMOVE_DATA_VALIDATION_RULE":
         delete this.validationResults[cmd.sheetId];
         break;
-    }
-  }
-
-  private setContentToBooleanCells(rule: DataValidationRule) {
-    for (const position of getCellPositionsInRanges(rule.ranges)) {
-      const evaluatedCell = this.getters.getEvaluatedCell(position);
-      if (evaluatedCell.type !== CellValueType.boolean) {
-        this.dispatch("UPDATE_CELL", { ...position, content: "FALSE" });
-      }
     }
   }
 

--- a/src/plugins/ui_feature/datavalidation_insertion.ts
+++ b/src/plugins/ui_feature/datavalidation_insertion.ts
@@ -1,0 +1,37 @@
+import { getCellPositionsInRanges, isBoolean } from "../../helpers";
+import { CellValueType, Command, isMatrix } from "../../types/index";
+import { UIPlugin } from "../ui_plugin";
+
+export class DataValidationInsertionPlugin extends UIPlugin {
+  handle(cmd: Command) {
+    switch (cmd.type) {
+      case "ADD_DATA_VALIDATION_RULE":
+        if (cmd.rule.criterion.type === "isBoolean") {
+          const ranges = cmd.ranges.map((range) => this.getters.getRangeFromRangeData(range));
+          for (const position of getCellPositionsInRanges(ranges)) {
+            const cell = this.getters.getCell(position);
+            const evaluatedCell = this.getters.getEvaluatedCell(position);
+
+            if (!cell?.content) {
+              this.dispatch("UPDATE_CELL", { ...position, content: "FALSE" });
+              // In this case, a cell has been updated in the core plugin but
+              // not yet evaluated. This can occur after a paste operation.
+            } else if (cell?.content && evaluatedCell.type === CellValueType.empty) {
+              let value: string | undefined;
+              if (cell.content.startsWith("=")) {
+                const result = this.getters.evaluateFormula(position.sheetId, cell.content);
+                value = (isMatrix(result) ? result[0][0] : result)?.toString();
+              } else {
+                value = cell.content;
+              }
+              if (!value || !isBoolean(value)) {
+                this.dispatch("UPDATE_CELL", { ...position, content: "FALSE" });
+              }
+            } else if (evaluatedCell.type !== CellValueType.boolean) {
+              this.dispatch("UPDATE_CELL", { ...position, content: "FALSE" });
+            }
+          }
+        }
+    }
+  }
+}


### PR DESCRIPTION
See #5216 - CoreView plugins replay remote revisions and should not take the risk to dispatch during the replay. The code that was assigning arbitrary default values to the cells of a boolean datavalidation has been moved to a UI feature plugin, hence avoiding the problem raised in PR #5216.

Task: 4241141

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo