### PR TITLE
[FIX] sheet: Avoid divergent sheet names in collaborative

### DIFF
--- a/src/plugins/core/sheet.ts
+++ b/src/plugins/core/sheet.ts
@@ -249,7 +249,7 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
     }
 
     for (let sheetData of data.sheets) {
-      const name = sheetData.name || _t("Sheet") + (Object.keys(this.sheets).length + 1);
+      const name = sheetData.name || "Sheet" + (Object.keys(this.sheets).length + 1);
       const { colNumber, rowNumber } = this.getImportedSheetSize(sheetData);
       const sheet: Sheet = {
         id: sheetData.id,


### PR DESCRIPTION
Similar issue to the one raised in https://github.com/odoo/o-spreadsheet/pull/5010. If 2 userrs with different languages (i.e. different translation schemes), importing a sheet data without a name could result in different outcomes for both users.

Currently, this is not an issue because the sheet data are 'fixed' upstream by the migration mecanism but this might change/disappear in the future.

Task: 0

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo