### PR TITLE
[FIX] side_panel_collapsible: title is not visible

### DIFF
--- a/src/components/side_panel/components/collapsible/side_panel_collapsible.xml
+++ b/src/components/side_panel/components/collapsible/side_panel_collapsible.xml
@@ -11,9 +11,7 @@
           <span class="collapsor-arrow">
             <t t-call="o-spreadsheet-Icon.ANGLE_DOWN"/>
           </span>
-          <div class="ps-2">
-            <t t-slot="title"/>
-          </div>
+          <div class="ps-2" t-esc="props.title"/>
         </div>
       </div>
       <div


### PR DESCRIPTION
## Description:

With PR #5052 , the title will now be passed as a prop to the SidePanelCollapsible component instead of being provided via a slot. The component needs to be updated accordingly to use the title prop.

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo