### PR TITLE
[FIX] Charts: Fix tooltip value when data is zero

### DIFF
--- a/src/helpers/figures/charts/chart_ui_common.ts
+++ b/src/helpers/figures/charts/chart_ui_common.ts
@@ -156,7 +156,7 @@ export function getDefaultChartJsRuntime(
             const xLabel = tooltipItem.dataset?.label || tooltipItem.label;
             // tooltipItem.parsed can be an object or a number for pie charts
             let yLabel = horizontalChart ? tooltipItem.parsed.x : tooltipItem.parsed.y;
-            if (!yLabel) {
+            if (yLabel === undefined || yLabel === null) {
               yLabel = tooltipItem.parsed;
             }
             const toolTipFormat = !format && Math.abs(yLabel) >= 1000 ? "#,##" : format;

--- a/tests/figures/chart/chart_plugin.test.ts
+++ b/tests/figures/chart/chart_plugin.test.ts
@@ -1913,6 +1913,18 @@ describe("Chart design configuration", () => {
       const label = getTooltipLabel(runtime, 0, 0);
       expect(label).toEqual("6,000");
     });
+
+    test.each(["bar", "line"])(
+      "Basic chart tooltip label, zero-values are properly displayed",
+      (chartType) => {
+        setCellContent(model, "A2", "0");
+        createChart(model, { ...defaultChart, type: chartType as "bar" | "line" }, "42");
+        const runtime = model.getters.getChartRuntime("42") as BarChartRuntime;
+        const label = getTooltipLabel(runtime, 0, 0);
+
+        expect(label).toEqual("0");
+      }
+    );
   });
 
   describe("Pie Chart tooltip", () => {


### PR DESCRIPTION
Following a refactoring of the charts, the tooltip would not display the data value when the data equalled zero.

How to reproduce:
- generate a line graph such that one of the dataset points is 0
- Hover the said data point

-> the tooltip will read something along "Series 1:" and no value afterwards.

Task: 4251681

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo