### PR TITLE
[FIX] charts: correct stacked checkbox label

### DIFF
--- a/src/components/side_panel/chart/bar_chart/bar_chart_config_panel.ts
+++ b/src/components/side_panel/chart/bar_chart/bar_chart_config_panel.ts
@@ -1,7 +1,15 @@
+import { BarChartDefinition } from "../../../../types/chart";
 import { GenericChartConfigPanel } from "../building_blocks/generic_side_panel/config_panel";
 
 export class BarConfigPanel extends GenericChartConfigPanel {
   static template = "o-spreadsheet-BarConfigPanel";
+
+  get stackedLabel(): string {
+    const definition = this.props.definition as BarChartDefinition;
+    return definition.horizontal
+      ? this.chartTerms.StackedBarChart
+      : this.chartTerms.StackedColumnChart;
+  }
 
   onUpdateStacked(stacked: boolean) {
     this.props.updateChart(this.props.figureId, {

--- a/src/components/side_panel/chart/bar_chart/bar_chart_config_panel.xml
+++ b/src/components/side_panel/chart/bar_chart/bar_chart_config_panel.xml
@@ -4,7 +4,7 @@
       <Section class="'pt-0'">
         <Checkbox
           name="'stacked'"
-          label="chartTerms.StackedBarChart"
+          label="stackedLabel"
           value="props.definition.stacked"
           onChange.bind="onUpdateStacked"
         />

--- a/src/components/side_panel/chart/line_chart/line_chart_config_panel.ts
+++ b/src/components/side_panel/chart/line_chart/line_chart_config_panel.ts
@@ -16,7 +16,9 @@ export class LineConfigPanel extends GenericChartConfigPanel {
 
   get stackedLabel(): string {
     const definition = this.props.definition as LineChartDefinition;
-    return definition.fillArea ? this.chartTerms.StackedAreaChart : this.chartTerms.StackedBarChart;
+    return definition.fillArea
+      ? this.chartTerms.StackedAreaChart
+      : this.chartTerms.StackedLineChart;
   }
 
   getLabelRangeOptions() {

--- a/src/components/translations_terms.ts
+++ b/src/components/translations_terms.ts
@@ -53,6 +53,7 @@ export const ChartTerms = {
   StackedBarChart: _t("Stacked bar chart"),
   StackedLineChart: _t("Stacked line chart"),
   StackedAreaChart: _t("Stacked area chart"),
+  StackedColumnChart: _t("Stacked column chart"),
   CumulativeData: _t("Cumulative data"),
   TreatLabelsAsText: _t("Treat labels as text"),
   AggregatedChart: _t("Aggregate"),

--- a/tests/figures/chart/charts_component.test.ts
+++ b/tests/figures/chart/charts_component.test.ts
@@ -1861,4 +1861,22 @@ describe("Change chart type", () => {
     });
     expect(select.value).toBe("stacked_line");
   });
+
+  test("Changing chart type updates the stacked checkbox label accordingly", async () => {
+    createChart(model, { type: "line" }, chartId);
+    await mountChartSidePanel(chartId);
+
+    expect(fixture.querySelector("label.o-checkbox")!.textContent).toBe("Stacked line chart");
+
+    updateChart(model, chartId, { fillArea: true }, sheetId);
+    await nextTick();
+    expect(fixture.querySelector("label.o-checkbox")!.textContent).toBe("Stacked area chart");
+
+    await changeChartType("bar");
+    expect(fixture.querySelector("label.o-checkbox")!.textContent).toBe("Stacked bar chart");
+
+    updateChart(model, chartId, { horizontal: false }, sheetId);
+    await nextTick();
+    expect(fixture.querySelector("label.o-checkbox")!.textContent).toBe("Stacked column chart");
+  });
 });


### PR DESCRIPTION
## Description:

This PR addresses an issue where the stacked checkbox label in the chart config panel was not updating when the chart type was changed.

Task: [4251670](https://www.odoo.com/web#id=4251670&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo