### PR TITLE
[IMP] Clipboard: support images in the clipboard

### DIFF
--- a/demo/file_store.js
+++ b/demo/file_store.js
@@ -21,4 +21,9 @@ export class FileStore {
   async delete(path) {
     console.warn("cannot delete file. Not implemented");
   }
+
+  async getFile(path) {
+    const response = await fetch(path);
+    return await response.blob();
+  }
 }

--- a/src/actions/edit_actions.ts
+++ b/src/actions/edit_actions.ts
@@ -29,7 +29,7 @@ export const copy: ActionSpec = {
   isReadonlyAllowed: true,
   execute: async (env) => {
     env.model.dispatch("COPY");
-    await env.clipboard.write(env.model.getters.getClipboardContent());
+    await env.clipboard.write(await env.model.getters.getClipboardTextAndImageContent());
   },
   icon: "o-spreadsheet-Icon.CLIPBOARD",
 };
@@ -39,7 +39,7 @@ export const cut: ActionSpec = {
   description: "Ctrl+X",
   execute: async (env) => {
     interactiveCut(env);
-    await env.clipboard.write(env.model.getters.getClipboardContent());
+    await env.clipboard.write(await env.model.getters.getClipboardTextAndImageContent());
   },
   icon: "o-spreadsheet-Icon.CUT",
 };

--- a/src/components/helpers/dom_helpers.ts
+++ b/src/components/helpers/dom_helpers.ts
@@ -194,3 +194,29 @@ export function isCtrlKey(ev: KeyboardEvent | MouseEvent): boolean {
 export function isMiddleClickOrCtrlClick(ev: MouseEvent): boolean {
   return ev.button === 1 || (isCtrlKey(ev) && ev.button === 0);
 }
+
+export async function convertImageToPng(imageUrl: string): Promise<Blob | null> {
+  return new Promise((resolve, reject) => {
+    const image = new Image();
+    image.addEventListener("load", () => {
+      const canvas = document.createElement("canvas");
+      canvas.width = image.width;
+      canvas.height = image.height;
+
+      const ctx = canvas.getContext("2d");
+      ctx?.drawImage(image, 0, 0);
+      canvas.toBlob(resolve, "image/png");
+    });
+    image.addEventListener("error", reject);
+    image.src = imageUrl;
+  });
+}
+
+export function downloadFile(dataUrl: string, fileName: string) {
+  const a = document.createElement("a");
+  a.href = dataUrl;
+  a.download = fileName;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+}

--- a/src/components/icons/icons.xml
+++ b/src/components/icons/icons.xml
@@ -82,6 +82,19 @@
       />
     </svg>
   </t>
+  <t t-name="o-spreadsheet-Icon.COPY_AS_IMAGE">
+    <svg class="o-icon">
+      <path
+        fill="currentColor"
+        d="m 14,15 v 1.5 H 2.5147386 c -0.5522847,0 -1,-0.447715 -1,-1 V 3 H 3 V 14 c 0,0.552285 0.4477153,1 1,1 h 10"
+      />
+      <path
+        fill="currentColor"
+        d="M 3.8194506,2.0480809 A 1.1084934,1.1763958 0 0 1 4.927944,0.87168505 H 15.273882 A 1.1084934,1.1763958 0 0 1 16.382375,2.0480809 V 13.027775 a 1.1084934,1.1763958 0 0 1 -1.108493,1.176396 H 4.927944 A 1.1084934,1.1763958 0 0 1 3.8194506,13.027775 V 2.0480809 H 4.927944 V 13.027775 H 15.273882 V 2.0480809 H 4.927944 M 12.3179,5.5772683 10.839908,9.1064553 9.7314149,7.93006 8.2534245,9.8907193 7.1449309,8.7143233 5.6669395,11.067114 H 14.534886 M 6.0364374,4.4008725 a 1.1084936,1.176396 0 0 1 2.2169871,0 1.1084936,1.176396 0 0 1 -2.2169871,0"
+        id="path1-5"
+      />
+    </svg>
+  </t>
   <t t-name="o-spreadsheet-Icon.PASTE">
     <svg class="o-icon">
       <path
@@ -969,6 +982,11 @@
   <t t-name="o-spreadsheet-Icon.HIDE_SHEET">
     <div class="o-icon">
       <i class="fa fa-eye-slash"/>
+    </div>
+  </t>
+  <t t-name="o-spreadsheet-Icon.DOWNLOAD">
+    <div class="o-icon">
+      <i class="fa fa-download"/>
     </div>
   </t>
 </templates>

--- a/src/helpers/figures/images/image_provider.ts
+++ b/src/helpers/figures/images/image_provider.ts
@@ -10,13 +10,19 @@ export class ImageProvider implements ImageProviderInterface {
   }
 
   async requestImage(): Promise<Image> {
-    const file = await this.getImageFromUser();
+    const file = await this.userImageUpload();
     const path = await this.fileStore.upload(file);
     const size = await this.getImageOriginalSize(path);
     return { path, size, mimetype: file.type };
   }
 
-  private getImageFromUser(): Promise<File> {
+  async uploadFile(file: File): Promise<Image> {
+    const path = await this.fileStore.upload(file);
+    const size = await this.getImageOriginalSize(path);
+    return { path, size, mimetype: file.type };
+  }
+
+  private userImageUpload(): Promise<File> {
     return new Promise((resolve, reject) => {
       const input = document.createElement("input");
       input.setAttribute("type", "file");
@@ -35,12 +41,12 @@ export class ImageProvider implements ImageProviderInterface {
   getImageOriginalSize(path: string): Promise<FigureSize> {
     return new Promise((resolve, reject) => {
       const image = new Image();
-      image.src = path;
       image.addEventListener("load", () => {
         const size = { width: image.width, height: image.height };
         resolve(size);
       });
       image.addEventListener("error", reject);
+      image.src = path;
     });
   }
 }

--- a/src/plugins/ui_core_views/evaluation_chart.ts
+++ b/src/plugins/ui_core_views/evaluation_chart.ts
@@ -1,5 +1,5 @@
 import { BACKGROUND_CHART_COLOR } from "../../constants";
-import { chartFontColor, chartRuntimeFactory, chartToImage } from "../../helpers/figures/charts";
+import { chartFontColor, chartRuntimeFactory, chartToImageUrl } from "../../helpers/figures/charts";
 import { Color, ExcelWorkbookData, FigureData, Range, UID } from "../../types";
 import { ChartRuntime, ExcelChartDefinition } from "../../types/chart/chart";
 import {
@@ -115,7 +115,7 @@ export class EvaluationChartPlugin extends CoreViewPlugin<EvaluationChartState> 
           }
           const type = this.getters.getChartType(figureId);
           const runtime = this.getters.getChartRuntime(figureId);
-          const img = chartToImage(runtime, figure, type);
+          const img = chartToImageUrl(runtime, figure, type);
           if (img) {
             sheet.images.push({
               ...figure,

--- a/src/types/clipboard.ts
+++ b/src/types/clipboard.ts
@@ -1,16 +1,28 @@
 import { SpreadsheetClipboardData } from "../plugins/ui_stateful";
+import { AllowedImageMimeTypes, Image } from "./image";
 import { HeaderIndex, UID, Zone } from "./misc";
 
 export enum ClipboardMIMEType {
   PlainText = "text/plain",
   Html = "text/html",
+  Image = "image",
 }
 
-export type OSClipboardContent = { [type in ClipboardMIMEType]?: string };
+export type OSClipboardContent = {
+  [key in (typeof AllowedImageMimeTypes)[number]]?: Blob;
+} & {
+  [ClipboardMIMEType.PlainText]?: string;
+  [ClipboardMIMEType.Html]?: string;
+};
 
 export type ParsedOSClipboardContent = {
   text?: string;
   data?: SpreadsheetClipboardData;
+  imageBlob?: Blob;
+};
+
+export type ParsedOsClipboardContentWithImageData = ParsedOSClipboardContent & {
+  imageData?: Image;
 };
 
 export interface ClipboardOptions {

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -1,7 +1,7 @@
 import {
   ConditionalFormat,
-  DOMCoordinates,
   DataValidationRule,
+  DOMCoordinates,
   Figure,
   Format,
   Locale,
@@ -23,7 +23,7 @@ import {
 } from "./misc";
 
 import { ChartDefinition } from "./chart/chart";
-import { ClipboardPasteOptions, ParsedOSClipboardContent } from "./clipboard";
+import { ClipboardPasteOptions, ParsedOsClipboardContentWithImageData } from "./clipboard";
 import { FigureSize } from "./figure";
 import { SearchOptions } from "./find_and_replace";
 import { Image } from "./image";
@@ -795,7 +795,7 @@ export interface AutoFillCellCommand {
 export interface PasteFromOSClipboardCommand {
   type: "PASTE_FROM_OS_CLIPBOARD";
   target: Zone[];
-  clipboardContent: ParsedOSClipboardContent;
+  clipboardContent: ParsedOsClipboardContentWithImageData;
   pasteOption?: ClipboardPasteOptions;
 }
 

--- a/src/types/files.ts
+++ b/src/types/files.ts
@@ -16,6 +16,11 @@ export interface FileStore {
    * Delete a file from the server
    */
   delete(filePath: FilePath): Promise<void>;
+
+  /**
+   * get File from the server
+   */
+  getFile(filePath: FilePath): Promise<File | Blob>;
 }
 
 /**
@@ -26,5 +31,6 @@ export interface ImageProviderInterface {
    * RequestImage ask the user to input an image file. Then send it to a server trough an FileStore. Finally it return the path and the size of the image in the server.
    */
   requestImage(): Promise<Image>;
+  uploadFile(file: File | Blob): Promise<Image>;
   getImageOriginalSize(path: string): Promise<FigureSize>;
 }

--- a/src/types/image.ts
+++ b/src/types/image.ts
@@ -1,10 +1,11 @@
+import { Alias } from "..";
 import { FigureSize } from "./figure";
 import { XLSXFigureSize } from "./xlsx";
 
 /**
  * Image source given to <img src="..."/>
  */
-export type ImageSrc = string;
+export type ImageSrc = string & Alias;
 
 export interface Image {
   path: string;
@@ -17,3 +18,14 @@ export interface ExcelImage {
   size: XLSXFigureSize;
   mimetype?: string;
 }
+
+export const AllowedImageMimeTypes = [
+  "image/avif",
+  "image/bmp",
+  "image/gif",
+  "image/vnd.microsoft.icon",
+  "image/jpeg",
+  "image/png",
+  "image/tiff",
+  "image/webp",
+] as const;

--- a/src/xlsx/conversion/conversion_maps.ts
+++ b/src/xlsx/conversion/conversion_maps.ts
@@ -8,6 +8,7 @@ import {
   VerticalAlign,
 } from "../../types";
 import { LegendPosition } from "../../types/chart/common_chart";
+import { AllowedImageMimeTypes } from "../../types/image";
 import {
   ExcelIconSet,
   XLSXBorderStyle,
@@ -372,7 +373,11 @@ export const XLSX_INDEXED_COLORS = {
   65: "FFFFFF", // system background
 };
 
-export const IMAGE_MIMETYPE_TO_EXTENSION_MAPPING = {
+type MimeExtensionMap = {
+  [key in (typeof AllowedImageMimeTypes)[number]]: string;
+};
+
+export const IMAGE_MIMETYPE_TO_EXTENSION_MAPPING: MimeExtensionMap = {
   "image/avif": "avif",
   "image/bmp": "bmp",
   "image/gif": "gif",
@@ -381,9 +386,11 @@ export const IMAGE_MIMETYPE_TO_EXTENSION_MAPPING = {
   "image/png": "png",
   "image/tiff": "tiff",
   "image/webp": "webp",
-};
+} as const;
 
-export const IMAGE_EXTENSION_TO_MIMETYPE_MAPPING = {
+export const IMAGE_EXTENSION_TO_MIMETYPE_MAPPING: {
+  [K in keyof MimeExtensionMap as MimeExtensionMap[K]]: K;
+} = {
   avif: "image/avif",
   bmp: "image/bmp",
   gif: "image/gif",

--- a/tests/__mocks__/mock_file_store.ts
+++ b/tests/__mocks__/mock_file_store.ts
@@ -7,4 +7,8 @@ export class FileStore implements FileStoreInterface {
   }
 
   async delete() {}
+
+  async getFile(fileUrl) {
+    return new File([], "mock", { type: "image/png" });
+  }
 }

--- a/tests/__mocks__/mock_image_provider.ts
+++ b/tests/__mocks__/mock_image_provider.ts
@@ -19,4 +19,8 @@ export class ImageProvider implements ImageProviderInterface {
   async getImageOriginalSize(path: string): Promise<FigureSize> {
     return this.size;
   }
+
+  async uploadFile(file: File | Blob): Promise<Image> {
+    return { path: this.path, size: this.size, mimetype: this.mimetype };
+  }
 }

--- a/tests/figures/image/image_component.test.ts
+++ b/tests/figures/image/image_component.test.ts
@@ -1,0 +1,25 @@
+import { Model } from "../../../src";
+import { createImage } from "../../test_helpers/commands_helpers";
+import { simulateClick } from "../../test_helpers/dom_helper";
+import { mountSpreadsheet } from "../../test_helpers/helpers";
+
+describe("Image component", () => {
+  test("Can reset the image size", async () => {
+    const model = new Model({});
+    const sheetId = model.getters.getActiveSheetId();
+    createImage(model, { sheetId, figureId: "test", size: { width: 200, height: 200 } });
+    await mountSpreadsheet({ model });
+    model.dispatch("UPDATE_FIGURE", {
+      sheetId,
+      id: "test",
+      x: 0,
+      y: 0,
+      width: 300,
+      height: 300,
+    });
+    await simulateClick(".o-figure");
+    await simulateClick(".o-figure-menu-item");
+    await simulateClick(".o-menu div[data-name='reset_size']");
+    expect(model.getters.getFigure(sheetId, "test")).toMatchObject({ width: 200, height: 200 });
+  });
+});

--- a/tests/menus/menu_items_registry.test.ts
+++ b/tests/menus/menu_items_registry.test.ts
@@ -177,24 +177,28 @@ describe("Menu Item actions", () => {
     expect(dispatch).toHaveBeenCalledWith("REQUEST_REDO");
   });
 
-  test("Edit -> copy", () => {
+  test("Edit -> copy", async () => {
     const spyWriteClipboard = jest.spyOn(env.clipboard!, "write");
     doAction(["edit", "copy"], env);
     expect(dispatch).toHaveBeenCalledWith("COPY");
-    expect(spyWriteClipboard).toHaveBeenCalledWith(model.getters.getClipboardContent());
+    expect(spyWriteClipboard).toHaveBeenCalledWith(
+      await model.getters.getClipboardTextAndImageContent()
+    );
   });
 
-  test("Edit -> cut", () => {
+  test("Edit -> cut", async () => {
     const spyWriteClipboard = jest.spyOn(env.clipboard!, "write");
     doAction(["edit", "cut"], env);
     expect(dispatch).toHaveBeenCalledWith("CUT");
-    expect(spyWriteClipboard).toHaveBeenCalledWith(model.getters.getClipboardContent());
+    expect(spyWriteClipboard).toHaveBeenCalledWith(
+      await model.getters.getClipboardTextAndImageContent()
+    );
   });
 
   test("Edit -> paste from OS clipboard if copied from outside world last", async () => {
     setCellContent(model, "A1", "a1");
     selectCell(model, "A1");
-    doAction(["edit", "copy"], env); // first copy from grid
+    await doAction(["edit", "copy"], env); // first copy from grid
     await env.clipboard!.writeText("Then copy in OS clipboard");
     selectCell(model, "C3");
     await doAction(["edit", "paste"], env);
@@ -203,7 +207,7 @@ describe("Menu Item actions", () => {
 
   test("Edit -> paste if copied from grid last", async () => {
     await env.clipboard!.writeText("First copy in OS clipboard");
-    doAction(["edit", "copy"], env); // then copy from grid
+    await doAction(["edit", "copy"], env); // then copy from grid
     await doAction(["edit", "paste"], env);
     interactivePaste(env, target("A1"));
     expect(getCellContent(model, "A1")).toEqual("");
@@ -211,7 +215,7 @@ describe("Menu Item actions", () => {
 
   test("'Edit -> paste' if copied from grid and content altered before paste", async () => {
     setCellContent(model, "A1", "a1");
-    doAction(["edit", "copy"], env); // first copy from grid
+    await doAction(["edit", "copy"], env); // first copy from grid
     setCellContent(model, "A1", "os clipboard");
     selectCell(model, "C3");
     await doAction(["edit", "paste"], env);
@@ -238,7 +242,7 @@ describe("Menu Item actions", () => {
     setCellContent(model, "C1", "c1");
     setStyle(model, "C1", { fillColor: "#FA0000" });
     selectCell(model, "C1");
-    doAction(["edit", "copy"], env); // first copy from grid
+    await doAction(["edit", "copy"], env); // first copy from grid
     await env.clipboard!.writeText("Then copy in OS clipboard");
     selectCell(model, "A1");
     await doAction(["edit", "paste_special", "paste_special_format"], env);
@@ -257,7 +261,7 @@ describe("Menu Item actions", () => {
   });
 
   test("Edit -> paste_special -> paste_special_value", async () => {
-    doAction(["edit", "copy"], env);
+    await doAction(["edit", "copy"], env);
     await doAction(["edit", "paste_special", "paste_special_value"], env);
     expect(dispatch).toHaveBeenCalledWith("PASTE", {
       target: env.model.getters.getSelectedZones(),
@@ -277,7 +281,7 @@ describe("Menu Item actions", () => {
   });
 
   test("Edit -> paste_special -> paste_special_format", async () => {
-    doAction(["edit", "copy"], env);
+    await doAction(["edit", "copy"], env);
     await doAction(["edit", "paste_special", "paste_special_format"], env);
     expect(dispatch).toHaveBeenCalledWith("PASTE", {
       target: env.model.getters.getSelectedZones(),

--- a/tests/setup/jest.setup.ts
+++ b/tests/setup/jest.setup.ts
@@ -60,6 +60,13 @@ beforeEach(() => {
       }
       return 0;
     });
+  jest
+    .spyOn(HTMLCanvasElement.prototype, "toBlob")
+    .mockImplementation(function (callback: BlobCallback, type?: string) {
+      const data = new Uint8Array(length);
+      const blob = new window.Blob([data], { type });
+      setTimeout(() => callback(blob), 0);
+    });
 });
 
 afterEach(() => {

--- a/tests/test_helpers/commands_helpers.ts
+++ b/tests/test_helpers/commands_helpers.ts
@@ -20,7 +20,7 @@ import {
   Direction,
   DispatchResult,
   Locale,
-  ParsedOSClipboardContent,
+  ParsedOsClipboardContentWithImageData,
   SelectionStep,
   SortDirection,
   SortOptions,
@@ -399,7 +399,7 @@ export function paste(
 export function pasteFromOSClipboard(
   model: Model,
   range: string,
-  content: ParsedOSClipboardContent,
+  content: ParsedOsClipboardContentWithImageData,
   pasteOption?: ClipboardPasteOptions
 ): DispatchResult {
   return model.dispatch("PASTE_FROM_OS_CLIPBOARD", {

--- a/tools/server/main.cjs
+++ b/tools/server/main.cjs
@@ -6,6 +6,7 @@ const formData = require("express-form-data");
 const express = require("express");
 const cors = require("cors");
 const fs = require("fs");
+const path = require("path"); // magic
 const expressWS = require("express-ws")(express());
 const app = expressWS.app;
 
@@ -102,12 +103,14 @@ app.post("/upload-image", function (req, res) {
     }
     const formeData = req.files;
     const readStream = formeData["image"];
+    const inputFileName = path.basename(readStream.path);
+
     // We use the number of files in the images folder to determined the next file name.
     fs.readdir(imagesDirectory, (err, files) => {
       if (err) {
         log(err);
       } else {
-        const file_name = files.length.toString();
+        const file_name = files.length.toString() + inputFileName;
         const output = imagesDirectory + "/" + file_name;
         // This opens up the writeable stream to `output`
         const writeStream = fs.createWriteStream(output);


### PR DESCRIPTION
## Description:
This commit adds the support of images in the clipboard. Namely,
- Pasting an image from the OS clipboard will automatically upload it to
  the filestore and dispatch a CREATE_IMAGE accordingly.
- Copying a chart or an image from the spreadsheet will add it to the
  oOS clipboard. It can then be pasted somewhere else, like a discuss
app, a text editor maybe?.

TODO
- [ ] support multi type of images (not just png) It technically works
  because we never check agains the actual type of the file we upload
but it's wrong. Maybe use a generic `image/*` mimetype instead of using
png. We still need to purge out dangerous mimetypes like image/svg(+xml)
- [ ] Currently uploads the image from the clipboard THEN only checks if the
  we are copy pasting from the same spreadsheet clipboard (potential
useless upload)
- [ ] Not supported by some apps like Office 365 online (word & powerpoint tested). Supposedly because our
  clipboard has some text/* types along the image/* so it ignores the
later. for a fully integrated feature, we should probably decorrelate it
from the standard copy paste and make a  menu "copy image to os
clipboard" ? tbd
- [ ] works on discord at least
- [ ] No test whatsoever
Task: [4235104](https://www.odoo.com/web#id=4235104&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo