### PR TITLE
[Find&Replace] A couple of imp

### DIFF
--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -347,6 +347,8 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
     },
     "Ctrl+D": async () => this.env.model.dispatch("COPY_PASTE_CELLS_ABOVE"),
     "Ctrl+R": async () => this.env.model.dispatch("COPY_PASTE_CELLS_ON_LEFT"),
+    "Ctrl+H": () => this.sidePanel.open("FindAndReplace", {}),
+    "Ctrl+F": () => this.sidePanel.open("FindAndReplace", {}),
     "Ctrl+Shift+E": () => this.setHorizontalAlign("center"),
     "Ctrl+Shift+L": () => this.setHorizontalAlign("left"),
     "Ctrl+Shift+R": () => this.setHorizontalAlign("right"),

--- a/src/components/side_panel/find_and_replace/find_and_replace.ts
+++ b/src/components/side_panel/find_and_replace/find_and_replace.ts
@@ -1,9 +1,17 @@
-import { Component, onMounted, onWillUnmount, useRef, useState } from "@odoo/owl";
+import {
+  Component,
+  onMounted,
+  onWillUnmount,
+  useExternalListener,
+  useRef,
+  useState,
+} from "@odoo/owl";
 import { debounce, zoneToXc } from "../../../helpers";
 import { Store, useLocalStore } from "../../../store_engine";
 import { _t } from "../../../translation";
 import { DebouncedFunction, SpreadsheetChildEnv } from "../../../types/index";
 import { css } from "../../helpers/css";
+import { keyboardEventToShortcutString } from "../../helpers/dom_helpers";
 import { SelectionInput } from "../../selection_input/selection_input";
 import { ValidationMessages } from "../../validation_messages/validation_messages";
 import { Checkbox } from "../components/checkbox/checkbox";
@@ -108,6 +116,19 @@ export class FindAndReplacePanel extends Component<Props, SpreadsheetChildEnv> {
     onMounted(() => this.searchInput.el?.focus());
     onWillUnmount(() => this.updateSearchContent.stopDebounce());
     this.updateSearchContent = debounce(this.store.updateSearchContent, 200);
+    useExternalListener(
+      window,
+      "keydown",
+      (ev: KeyboardEvent) => {
+        const code = keyboardEventToShortcutString(ev);
+        if (code === "Ctrl+F" || code === "Ctrl+H") {
+          this.searchInput.el?.focus();
+          ev.preventDefault();
+          ev.stopPropagation();
+        }
+      },
+      { capture: true }
+    );
   }
 
   onFocusSearch() {

--- a/src/components/side_panel/find_and_replace/find_and_replace_store.ts
+++ b/src/components/side_panel/find_and_replace/find_and_replace_store.ts
@@ -17,6 +17,11 @@ enum Direction {
   next = 1,
 }
 
+interface RefreshSearchOptions {
+  jumpToMatchSheet?: boolean;
+  updateSelection?: boolean;
+}
+
 export class FindAndReplaceStore extends SpreadsheetStore implements HighlightProvider {
   mutators = [
     "updateSearchOptions",
@@ -31,10 +36,12 @@ export class FindAndReplaceStore extends SpreadsheetStore implements HighlightPr
   private specificRangeMatches: CellPosition[] = [];
 
   private currentSearchRegex: RegExp | null = null;
-  private isSearchDirty = false;
   private initialShowFormulaState: boolean;
   private preserveSelectedMatchIndex: boolean = false;
   private irreplaceableMatchCount: number = 0;
+
+  private isSearchDirty = false;
+  private shouldFinalizeUpdateSelection = false;
 
   private notificationStore = this.get(NotificationStore);
 
@@ -89,11 +96,14 @@ export class FindAndReplaceStore extends SpreadsheetStore implements HighlightPr
   }
 
   selectPreviousMatch() {
-    this.selectNextCell(Direction.previous);
+    this.selectNextCell(Direction.previous, {
+      jumpToMatchSheet: true,
+      updateSelection: true,
+    });
   }
 
   selectNextMatch() {
-    this.selectNextCell(Direction.next);
+    this.selectNextCell(Direction.next, { jumpToMatchSheet: true, updateSelection: true });
   }
 
   handle(cmd: Command) {
@@ -111,8 +121,11 @@ export class FindAndReplaceStore extends SpreadsheetStore implements HighlightPr
       case "ADD_COLUMNS_ROWS":
       case "EVALUATE_CELLS":
       case "UPDATE_CELL":
+        this.isSearchDirty = true;
+        break;
       case "ACTIVATE_SHEET":
         this.isSearchDirty = true;
+        this.shouldFinalizeUpdateSelection = true;
         break;
       case "REPLACE_SEARCH":
         for (const match of cmd.matches) {
@@ -130,7 +143,11 @@ export class FindAndReplaceStore extends SpreadsheetStore implements HighlightPr
 
   finalize() {
     if (this.isSearchDirty) {
-      this.refreshSearch(false);
+      this.refreshSearch({
+        jumpToMatchSheet: false,
+        updateSelection: this.shouldFinalizeUpdateSelection,
+      });
+      this.shouldFinalizeUpdateSelection = false;
       this.isSearchDirty = false;
     }
   }
@@ -162,18 +179,18 @@ export class FindAndReplaceStore extends SpreadsheetStore implements HighlightPr
     }
     this.toSearch = toSearch;
     this.currentSearchRegex = getSearchRegex(this.toSearch, this.searchOptions);
-    this.refreshSearch();
+    this.refreshSearch({ jumpToMatchSheet: true, updateSelection: true });
   }
 
   /**
    * refresh the matches according to the current search options
    */
-  private refreshSearch(jumpToMatchSheet = true) {
+  private refreshSearch(options: RefreshSearchOptions) {
     if (!this.preserveSelectedMatchIndex) {
       this.selectedMatchIndex = null;
     }
     this.findMatches();
-    this.selectNextCell(Direction.current, jumpToMatchSheet);
+    this.selectNextCell(Direction.current, options);
   }
 
   private getSheetsInSearchOrder() {
@@ -254,7 +271,7 @@ export class FindAndReplaceStore extends SpreadsheetStore implements HighlightPr
    * It is also used to keep coherence between the selected searchMatch
    * and selectedMatchIndex.
    */
-  private selectNextCell(indexChange: Direction, jumpToMatchSheet = true) {
+  private selectNextCell(indexChange: Direction, options: RefreshSearchOptions) {
     const matches = this.searchMatches;
     if (!matches.length) {
       this.selectedMatchIndex = null;
@@ -280,7 +297,7 @@ export class FindAndReplaceStore extends SpreadsheetStore implements HighlightPr
     const selectedMatch = matches[nextIndex];
 
     // Switch to the sheet where the match is located
-    if (jumpToMatchSheet && this.getters.getActiveSheetId() !== selectedMatch.sheetId) {
+    if (options.jumpToMatchSheet && this.getters.getActiveSheetId() !== selectedMatch.sheetId) {
       // We set `preserveSelectedMatchIndex` to true to avoid resetting the selected search
       // index in the `refreshSearch` function when a new sheet is activated. The reason being
       // that, when we automatically go back to previous sheet while performing a search, the
@@ -296,7 +313,9 @@ export class FindAndReplaceStore extends SpreadsheetStore implements HighlightPr
     }
     // we want grid selection to capture the selection stream
     this.model.selection.getBackToDefault();
-    this.model.selection.selectCell(selectedMatch.col, selectedMatch.row);
+    if (options.updateSelection) {
+      this.model.selection.selectCell(selectedMatch.col, selectedMatch.row);
+    }
   }
 
   /**
@@ -313,7 +332,7 @@ export class FindAndReplaceStore extends SpreadsheetStore implements HighlightPr
       matches: [this.searchMatches[this.selectedMatchIndex]],
       searchOptions: this.searchOptions,
     });
-    this.selectNextCell(Direction.next);
+    this.selectNextCell(Direction.next, { jumpToMatchSheet: true, updateSelection: true });
   }
   /**
    * Apply the replace function to all the matches one time.

--- a/src/components/spreadsheet/spreadsheet.ts
+++ b/src/components/spreadsheet/spreadsheet.ts
@@ -59,7 +59,6 @@ import { SpreadsheetDashboard } from "../dashboard/dashboard";
 import { Grid } from "../grid/grid";
 import { HeaderGroupContainer } from "../header_group/header_group_container";
 import { css, cssPropertiesToCss } from "../helpers/css";
-import { isCtrlKey } from "../helpers/dom_helpers";
 import { useSpreadsheetRect } from "../helpers/position_hook";
 import { SidePanel } from "../side_panel/side_panel/side_panel";
 import { SidePanelStore } from "../side_panel/side_panel/side_panel_store";
@@ -353,8 +352,6 @@ export class Spreadsheet extends Component<SpreadsheetProps, SpreadsheetChildEnv
 
   private _focusGrid?: () => void;
 
-  private keyDownMapping!: { [key: string]: Function };
-
   private isViewportTooSmall: boolean = false;
   private notificationStore!: Store<NotificationStore>;
   private composerFocusStore!: Store<ComposerFocusStore>;
@@ -381,10 +378,6 @@ export class Spreadsheet extends Component<SpreadsheetProps, SpreadsheetChildEnv
     this.notificationStore = useStore(NotificationStore);
     this.composerFocusStore = useStore(ComposerFocusStore);
     this.sidePanel = useStore(SidePanelStore);
-    this.keyDownMapping = {
-      "CTRL+H": () => this.sidePanel.toggle("FindAndReplace", {}),
-      "CTRL+F": () => this.sidePanel.toggle("FindAndReplace", {}),
-    };
     const fileStore = this.model.config.external.fileStore;
     useSubEnv({
       model: this.model,
@@ -510,22 +503,6 @@ export class Spreadsheet extends Component<SpreadsheetProps, SpreadsheetChildEnv
       return;
     }
     this._focusGrid();
-  }
-
-  onKeydown(ev: KeyboardEvent) {
-    let keyDownString = "";
-    if (isCtrlKey(ev)) {
-      keyDownString += "CTRL+";
-    }
-    keyDownString += ev.key.toUpperCase();
-
-    let handler = this.keyDownMapping[keyDownString];
-    if (handler) {
-      ev.preventDefault();
-      ev.stopPropagation();
-      handler();
-      return;
-    }
   }
 
   get gridHeight(): Pixel {

--- a/src/components/spreadsheet/spreadsheet.xml
+++ b/src/components/spreadsheet/spreadsheet.xml
@@ -1,10 +1,6 @@
 <templates>
   <t t-name="o-spreadsheet-Spreadsheet">
-    <div
-      class="o-spreadsheet"
-      t-on-keydown="(ev) => !env.isDashboard() and this.onKeydown(ev)"
-      t-ref="spreadsheet"
-      t-att-style="getStyle()">
+    <div class="o-spreadsheet" t-ref="spreadsheet" t-att-style="getStyle()">
       <t t-if="env.isDashboard()">
         <SpreadsheetDashboard/>
       </t>

--- a/tests/find_and_replace/find_and_replace_store.test.ts
+++ b/tests/find_and_replace/find_and_replace_store.test.ts
@@ -1,7 +1,7 @@
 import { Model } from "../../src";
 import { FindAndReplaceStore } from "../../src/components/side_panel/find_and_replace/find_and_replace_store";
 import { functionRegistry } from "../../src/functions";
-import { toZone } from "../../src/helpers";
+import { toZone, zoneToXc } from "../../src/helpers";
 import { DependencyContainer } from "../../src/store_engine";
 import { NotificationStore } from "../../src/stores/notification_store";
 import { UID } from "../../src/types";
@@ -543,6 +543,13 @@ describe("next/previous with single match", () => {
     expect(model.getters.getSelectedZones()).toEqual([toZone("B3")]);
     updateSearch(model, "1");
     expect(model.getters.getSelectedZones()).toEqual([toZone("A1")]);
+  });
+
+  test("Updating search with external change will not re-select the match", () => {
+    setSelection(model, ["B3"]);
+    expect(zoneToXc(model.getters.getSelectedZone())).toEqual("B3");
+    setCellContent(model, "C9", "2");
+    expect(zoneToXc(model.getters.getSelectedZone())).toEqual("B3");
   });
 
   test.each(["selectNext", "selectPrevious"] as const)(

--- a/tests/spreadsheet/spreadsheet_component.test.ts
+++ b/tests/spreadsheet/spreadsheet_component.test.ts
@@ -231,19 +231,6 @@ describe("Simple Spreadsheet Component", () => {
     jest.useRealTimers();
   });
 
-  test("Keydown is ineffective in dashboard mode", async () => {
-    ({ model, parent, fixture } = await mountSpreadsheet());
-    const spreadsheetKeyDown = jest.spyOn(parent, "onKeydown");
-    // const spreadsheetDiv = fixture.querySelector(".o-spreadsheet")!;
-    keyDown({ key: "H", ctrlKey: true });
-    expect(spreadsheetKeyDown).toHaveBeenCalled();
-    jest.clearAllMocks();
-    model.updateMode("dashboard");
-    await nextTick();
-    keyDown({ key: "H", ctrlKey: true });
-    expect(spreadsheetKeyDown).not.toHaveBeenCalled();
-  });
-
   test("Insert a function properly sets the edition", async () => {
     ({ model, parent, fixture, env } = await mountSpreadsheet());
     const composerStore = env.getStore(CellComposerStore);

--- a/tests/spreadsheet/spreadsheet_component.test.ts
+++ b/tests/spreadsheet/spreadsheet_component.test.ts
@@ -137,21 +137,33 @@ describe("Simple Spreadsheet Component", () => {
     expect(composerStore.currentContent).toBe("d");
   });
 
-  test("can open/close search with ctrl+h", async () => {
+  test("can open search with ctrl+h", async () => {
     ({ model, parent, fixture } = await mountSpreadsheet());
     await keyDown({ key: "H", ctrlKey: true });
     expect(document.querySelectorAll(".o-sidePanel").length).toBe(1);
-    await keyDown({ key: "H", ctrlKey: true });
-    expect(document.querySelectorAll(".o-sidePanel").length).toBe(0);
   });
 
-  test("can open/close search with ctrl+f", async () => {
+  test("can open search with ctrl+f", async () => {
     ({ model, parent, fixture } = await mountSpreadsheet());
     await keyDown({ key: "F", ctrlKey: true });
     expect(document.querySelectorAll(".o-sidePanel").length).toBe(1);
-    await nextTick();
+  });
+
+  test("A second press of ctrl+f/ctrl+h will focus the search input", async () => {
+    ({ model, parent, fixture } = await mountSpreadsheet());
+    await keyDown({ key: "H", ctrlKey: true });
+    expect(document.querySelectorAll(".o-sidePanel").length).toBe(1);
+    expect(document.activeElement!.classList).toContain("o-search");
+
+    fixture.querySelector<HTMLElement>(".o-grid")!.focus();
+    expect(document.activeElement!.classList).not.toContain("o-search");
+    await keyDown({ key: "H", ctrlKey: true });
+    expect(document.activeElement!.classList).toContain("o-search");
+
+    fixture.querySelector<HTMLElement>(".o-grid")!.focus();
+    expect(document.activeElement!.classList).not.toContain("o-search");
     await keyDown({ key: "F", ctrlKey: true });
-    expect(document.querySelectorAll(".o-sidePanel").length).toBe(0);
+    expect(document.activeElement!.classList).toContain("o-search");
   });
 
   test("Mac user use metaKey, not CtrlKey", async () => {


### PR DESCRIPTION
## Description:

### [FIX] find and replace: do not update selection at each change

Previously, when doing any operation that would refresh the search
(eg. an update_cell), we would update the selection to the current
search result. This was preventing the user to have any work done
while the f&r panel was open.

This commit changes the behavior to only update the selection when
the user explicitly clicks on a search result or changes the sheet.

### [IMP] find and replace: focus search input on Ctrl+F

Pressing Ctrl+F with the f&r search panel open would close it. This
commit changes the behavior to focus the search input instead.

### [REF] spreadsheet: move Ctrl+F handling to Grid component

The handling of the Ctrl+F key combination was done in the Spreadsheet
component. This made no sense as:

- the Spreadsheet component never has the Dom focus
- we needed to explicitly disable the shortcuts in dashboard mode

This commit moves the handling of the Ctrl+F key combination to the Grid
along all the other keyboard shortcuts. It's less code, and the behavior
is now automatically disabled in dashboard mode (since there is no
Grid component in dashboard mode).


Task: [3973671](https://www.odoo.com/web#id=3973671&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo