### PR TITLE
[FIX] chart: cleanup tooltip title code

### DIFF
--- a/src/helpers/figures/charts/bar_chart.ts
+++ b/src/helpers/figures/charts/bar_chart.ts
@@ -365,13 +365,10 @@ export function createBarChartRuntime(chart: BarChart, getters: Getters): BarCha
      */
     trendDatasets.forEach((x) => config.data.datasets!.push(x));
 
-    const originalTooltipTitle = config.options.plugins!.tooltip!.callbacks!.title;
     config.options.plugins!.tooltip!.callbacks!.title = function (tooltipItems) {
-      if (tooltipItems.some((item) => item.dataset.xAxisID !== TREND_LINE_XAXIS_ID)) {
-        // @ts-expect-error
-        return originalTooltipTitle?.(tooltipItems);
-      }
-      return "";
+      return tooltipItems.some((item) => item.dataset.xAxisID !== TREND_LINE_XAXIS_ID)
+        ? undefined
+        : "";
     };
   }
 

--- a/src/helpers/figures/charts/chart_common_line_scatter.ts
+++ b/src/helpers/figures/charts/chart_common_line_scatter.ts
@@ -326,7 +326,6 @@ export function createLineOrScatterChartRuntime(
     config.options.scales!.x!.type = "linear";
     config.options.scales!.x!.ticks!.callback = (value) =>
       formatValue(value, { format: labelFormat, locale });
-    config.options.plugins!.tooltip!.callbacks!.title = () => "";
     config.options.plugins!.tooltip!.callbacks!.label = (tooltipItem) => {
       const dataSetPoint = dataSetsValues[tooltipItem.datasetIndex!].data![tooltipItem.dataIndex!];
       let label: string | number = tooltipItem.label || labelValues.values[tooltipItem.dataIndex!];
@@ -422,16 +421,13 @@ export function createLineOrScatterChartRuntime(
      * distinguish the originals and trendLine datasets after
      */
     trendDatasets.forEach((x) => config.data.datasets!.push(x));
-
-    const originalTooltipTitle = config.options.plugins!.tooltip!.callbacks!.title;
-    config.options.plugins!.tooltip!.callbacks!.title = function (tooltipItems) {
-      if (tooltipItems.some((item) => item.dataset.xAxisID !== TREND_LINE_XAXIS_ID)) {
-        // @ts-expect-error
-        return originalTooltipTitle?.(tooltipItems);
-      }
-      return "";
-    };
   }
+  config.options.plugins!.tooltip!.callbacks!.title = function (tooltipItems) {
+    const displayTooltipTitle =
+      axisType !== "linear" &&
+      tooltipItems.some((item) => item.dataset.xAxisID !== TREND_LINE_XAXIS_ID);
+    return displayTooltipTitle ? undefined : "";
+  };
 
   return {
     chartJsConfig: config,

--- a/src/helpers/figures/charts/combo_chart.ts
+++ b/src/helpers/figures/charts/combo_chart.ts
@@ -365,13 +365,10 @@ export function createComboChartRuntime(chart: ComboChart, getters: Getters): Co
      */
     trendDatasets.forEach((x) => config.data.datasets!.push(x));
 
-    const originalTooltipTitle = config.options.plugins!.tooltip!.callbacks!.title;
     config.options.plugins!.tooltip!.callbacks!.title = function (tooltipItems) {
-      if (tooltipItems.some((item) => item.dataset.xAxisID !== TREND_LINE_XAXIS_ID)) {
-        // @ts-expect-error
-        return originalTooltipTitle?.(tooltipItems);
-      }
-      return "";
+      return tooltipItems.some((item) => item.dataset.xAxisID !== TREND_LINE_XAXIS_ID)
+        ? undefined
+        : "";
     };
   }
 

--- a/tests/figures/chart/__snapshots__/chart_plugin.test.ts.snap
+++ b/tests/figures/chart/__snapshots__/chart_plugin.test.ts.snap
@@ -227,6 +227,7 @@ exports[`Linear/Time charts snapshot test of chartJS configuration for date char
         "tooltip": {
           "callbacks": {
             "label": [Function],
+            "title": [Function],
           },
         },
       },
@@ -609,6 +610,7 @@ exports[`datasource tests create chart with a dataset of one cell (no title) 1`]
         "tooltip": {
           "callbacks": {
             "label": [Function],
+            "title": [Function],
           },
         },
       },
@@ -743,6 +745,7 @@ exports[`datasource tests create chart with column datasets 1`] = `
         "tooltip": {
           "callbacks": {
             "label": [Function],
+            "title": [Function],
           },
         },
       },
@@ -891,6 +894,7 @@ exports[`datasource tests create chart with column datasets with category title 
         "tooltip": {
           "callbacks": {
             "label": [Function],
+            "title": [Function],
           },
         },
       },
@@ -1040,6 +1044,7 @@ exports[`datasource tests create chart with column datasets without series title
         "tooltip": {
           "callbacks": {
             "label": [Function],
+            "title": [Function],
           },
         },
       },
@@ -1161,6 +1166,7 @@ exports[`datasource tests create chart with only the dataset title (no data) 1`]
         "tooltip": {
           "callbacks": {
             "label": [Function],
+            "title": [Function],
           },
         },
       },
@@ -1292,6 +1298,7 @@ exports[`datasource tests create chart with rectangle dataset 1`] = `
         "tooltip": {
           "callbacks": {
             "label": [Function],
+            "title": [Function],
           },
         },
       },
@@ -1440,6 +1447,7 @@ exports[`datasource tests create chart with row datasets 1`] = `
         "tooltip": {
           "callbacks": {
             "label": [Function],
+            "title": [Function],
           },
         },
       },
@@ -1588,6 +1596,7 @@ exports[`datasource tests create chart with row datasets with category title 1`]
         "tooltip": {
           "callbacks": {
             "label": [Function],
+            "title": [Function],
           },
         },
       },
@@ -1737,6 +1746,7 @@ exports[`datasource tests create chart with row datasets without series title 1`
         "tooltip": {
           "callbacks": {
             "label": [Function],
+            "title": [Function],
           },
         },
       },

--- a/tests/figures/chart/chart_plugin.test.ts
+++ b/tests/figures/chart/chart_plugin.test.ts
@@ -406,7 +406,7 @@ describe("datasource tests", function () {
       "1"
     );
     const title = getChartConfiguration(model, "1").options?.plugins?.tooltip?.callbacks?.title;
-    expect(title).toBeUndefined();
+    expect(title?.([{ dataset: { axisId: "y" } }])).toBeUndefined();
   });
 
   test("can delete an imported chart", () => {


### PR DESCRIPTION
## Description

The code that ensure that the the trend lines points in a chart have no tooltip title is uselessly complex, with reference to some "originalTooltipTitle" and a //@ts-expect-error.

In fact, originalTooltipTitle is almost always undefined, except for linear charts where it's a simple callback that return an empty string.

This commit simplifies the code, removing the obscure reference to "originalTooltipTitle" and the //@ts-expect-error. The callback now simply returns an empty string where we do not want a title, and undefined if we want to let ChartJs do it's thing.

Task: [4269632](https://www.odoo.com/web#id=4269632&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo