### PR TITLE
[FIX] chart: trend line of area chart

### DIFF
--- a/src/helpers/figures/charts/chart_common.ts
+++ b/src/helpers/figures/charts/chart_common.ts
@@ -1,6 +1,5 @@
 import { ChartDataset } from "chart.js";
 import { transformZone } from "../../../collaborative/ot/ot_helpers";
-import { LINE_FILL_TRANSPARENCY } from "../../../constants";
 import {
   evaluatePolynomial,
   expM,
@@ -503,14 +502,8 @@ export function getFullTrendingLineDataSet(
   defaultBorderColor.a = 1;
 
   const borderColor = config.color || lightenColor(rgbaToHex(defaultBorderColor), 0.5);
-  const backgroundRGBA = colorToRGBA(borderColor);
-  // @ts-expect-error
-  if (dataset?.fill) {
-    backgroundRGBA.a = LINE_FILL_TRANSPARENCY; // to support area charts
-  }
 
   return {
-    ...dataset,
     type: "line",
     xAxisID: TREND_LINE_XAXIS_ID,
     label: dataset.label ? _t("Trend line for %s", dataset.label) : "",
@@ -518,10 +511,12 @@ export function getFullTrendingLineDataSet(
     order: -1,
     showLine: true,
     pointRadius: 0,
-    backgroundColor: rgbaToHex(backgroundRGBA),
+    backgroundColor: undefined,
     borderColor,
     borderDash: [5, 5],
     borderWidth: undefined,
+    fill: false,
+    pointBackgroundColor: borderColor,
   };
 }
 

--- a/tests/figures/chart/chart_plugin.test.ts
+++ b/tests/figures/chart/chart_plugin.test.ts
@@ -3230,4 +3230,35 @@ describe("trending line", () => {
       expect(value).toBeCloseTo(expectedValue);
     }
   });
+
+  test("Trend line dataset is correctly styled", () => {
+    let runtime = model.getters.getChartRuntime("1") as LineChartRuntime;
+    expect(runtime.chartJsConfig.data.datasets[1]).toMatchObject({
+      label: "Trend line for Series 1",
+      borderColor: "#A6D4F8",
+      pointBackgroundColor: "#A6D4F8",
+      backgroundColor: undefined,
+      fill: false,
+      pointRadius: 0,
+    });
+
+    updateChart(model, "1", {
+      dataSets: [
+        {
+          dataRange: "B1:B10",
+          trend: { display: true, type: "polynomial", order: 2, color: "#FF0000" },
+        },
+      ],
+    });
+
+    runtime = model.getters.getChartRuntime("1") as LineChartRuntime;
+    expect(runtime.chartJsConfig.data.datasets[1]).toMatchObject({
+      label: "Trend line for Series 1",
+      borderColor: "#FF0000",
+      pointBackgroundColor: "#FF0000",
+      backgroundColor: undefined,
+      fill: false,
+      pointRadius: 0,
+    });
+  });
 });

--- a/tests/figures/chart/charts_component.test.ts
+++ b/tests/figures/chart/charts_component.test.ts
@@ -1757,14 +1757,14 @@ describe("charts", () => {
         await openChartDesignSidePanel(model, env, fixture, chartId);
 
         let runtime = model.getters.getChartRuntime(chartId) as BarChartRuntime;
-        expect(runtime.chartJsConfig.data.datasets[1].backgroundColor).toBe("#FF8080");
+        expect(runtime.chartJsConfig.data.datasets[1].borderColor).toBe("#FF8080");
 
         let color_menu = fixture.querySelectorAll(".o-round-color-picker-button")[2];
         await click(color_menu);
         await click(fixture, ".o-color-picker-line-item[data-color='#EFEFEF'");
 
         runtime = model.getters.getChartRuntime(chartId) as BarChartRuntime;
-        expect(runtime.chartJsConfig.data.datasets[1].backgroundColor).toBe("#EFEFEF");
+        expect(runtime.chartJsConfig.data.datasets[1].borderColor).toBe("#EFEFEF");
       }
     );
   });

--- a/tests/figures/chart/line_chart_plugin.test.ts
+++ b/tests/figures/chart/line_chart_plugin.test.ts
@@ -148,7 +148,7 @@ describe("line chart", () => {
     expect(isChartAxisStacked(model, "chartId", "y")).toBe(true);
   });
 
-  test("trend line opacity is preserved when choosing a custom color", () => {
+  test("Trend lines have no fill color in area chart", () => {
     const model = new Model();
     setCellContent(model, "A1", "data");
     setCellContent(model, "A2", "3");
@@ -166,21 +166,7 @@ describe("line chart", () => {
     let runtime = model.getters.getChartRuntime("chartId") as any;
     expect(runtime.chartJsConfig.data.datasets[0].fill).toBe("origin");
     expect(runtime.chartJsConfig.data.datasets[0].backgroundColor).toBe("#4EA7F266");
-    expect(runtime.chartJsConfig.data.datasets[1].fill).toBe("origin");
-    expect(runtime.chartJsConfig.data.datasets[1].backgroundColor).toBe("#A6D4F866");
-
-    updateChart(model, "chartId", {
-      dataSets: [
-        {
-          dataRange: "A1:A3",
-          trend: { type: "polynomial", order: 1, display: true, color: "#112233" },
-        },
-      ],
-    });
-
-    runtime = model.getters.getChartRuntime("chartId") as any;
-    expect(runtime.chartJsConfig.data.datasets[1].fill).toBe("origin");
-    expect(runtime.chartJsConfig.data.datasets[1].borderColor).toBe("#112233");
-    expect(runtime.chartJsConfig.data.datasets[1].backgroundColor).toBe("#11223366");
+    expect(runtime.chartJsConfig.data.datasets[1].fill).toBe(false);
+    expect(runtime.chartJsConfig.data.datasets[1].backgroundColor).toBe(undefined);
   });
 });


### PR DESCRIPTION
## Description

The trend line of area charts should not have a filled area under the line.

Also the trend line configuration should probably not inherit all the values of their parent dataset, as it's easy to miss thing and have options that make no sense (pointBackgroundColor being the color of the parent dataset rather than the color of the trend line for example).

Task: [4274294](https://www.odoo.com/web#id=4274294&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo