### PR TITLE
[IMP] pivot: disable automatic autofill

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -294,7 +294,7 @@ export const PIVOT_TABLE_CONFIG = {
   bandedRows: true,
   bandedColumns: false,
   styleId: "TableStyleMedium5",
-  automaticAutofill: true,
+  automaticAutofill: false,
 };
 
 export const DEFAULT_CURRENCY: Currency = {

--- a/tests/pivots/pivot_menu_items.test.ts
+++ b/tests/pivots/pivot_menu_items.test.ts
@@ -418,7 +418,7 @@ describe("Pivot reinsertion menu item", () => {
         })
       ).toMatchObject({
         range: { zone: toZone("B8") },
-        config: { numberOfHeaders: 1, automaticAutofill: true },
+        config: { numberOfHeaders: 1, automaticAutofill: false },
         type: "dynamic",
       });
     });
@@ -494,7 +494,7 @@ describe("Pivot reinsertion menu item", () => {
         })
       ).toMatchObject({
         range: { zone: toZone("B8:C11") },
-        config: { numberOfHeaders: 1, automaticAutofill: true },
+        config: { numberOfHeaders: 1, automaticAutofill: false },
         type: "static",
       });
     });


### PR DESCRIPTION


## Description:

FP request: when applying a data table automatically to pivots (and to lists), disable the "autofill formulas", this way when you copy/paste some of the data to a new column adjacent it doesn't mess everything up.

Task: [4256700](https://www.odoo.com/web#id=4256700&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo