### PR TITLE
[FIX] logs: log performance information at debug level

### DIFF
--- a/src/collaborative/session.ts
+++ b/src/collaborative/session.ts
@@ -159,7 +159,7 @@ export class Session extends EventBus<CollaborativeEvent> {
       this.onMessageReceived(message);
     }
     this.isReplayingInitialRevisions = false;
-    console.info("Replayed", numberOfCommands, "commands in", performance.now() - start, "ms");
+    console.debug("Replayed", numberOfCommands, "commands in", performance.now() - start, "ms");
   }
 
   /**

--- a/src/migrations/data.ts
+++ b/src/migrations/data.ts
@@ -42,7 +42,7 @@ export function load(data?: any, verboseImport?: boolean): WorkbookData {
   if (!data) {
     return createEmptyWorkbookData();
   }
-  console.group("Loading data");
+  console.debug("### Loading data ###");
   const start = performance.now();
   if (data["[Content_Types].xml"]) {
     const reader = new XlsxReader(data);
@@ -57,13 +57,13 @@ export function load(data?: any, verboseImport?: boolean): WorkbookData {
   // apply migrations, if needed
   if ("version" in data) {
     if (data.version < CURRENT_VERSION) {
-      console.info("Migrating data from version", data.version);
+      console.debug("Migrating data from version", data.version);
       data = migrate(data);
     }
   }
   data = repairData(data);
-  console.info("Data loaded in", performance.now() - start, "ms");
-  console.groupEnd();
+  console.debug("Data loaded in", performance.now() - start, "ms");
+  console.debug("###");
   return data;
 }
 
@@ -84,7 +84,7 @@ function migrate(data: any): WorkbookData {
   for (let i = index; i < MIGRATIONS.length; i++) {
     data = MIGRATIONS[i].applyMigration(data);
   }
-  console.info("Data migrated in", performance.now() - start, "ms");
+  console.debug("Data migrated in", performance.now() - start, "ms");
   return data;
 }
 

--- a/src/model.ts
+++ b/src/model.ts
@@ -194,7 +194,7 @@ export class Model extends EventBus<any> implements CommandDispatcher {
     verboseImport = true
   ) {
     const start = performance.now();
-    console.group("Model creation");
+    console.debug("##### Model creation #####");
     super();
     setDefaultTranslationMethod();
 
@@ -284,16 +284,16 @@ export class Model extends EventBus<any> implements CommandDispatcher {
 
     if (config.snapshotRequested) {
       const startSnapshot = performance.now();
-      console.info("Snapshot requested");
+      console.debug("Snapshot requested");
       this.session.snapshot(this.exportData());
       this.garbageCollectExternalResources();
-      console.info("Snapshot taken in", performance.now() - startSnapshot, "ms");
+      console.debug("Snapshot taken in", performance.now() - startSnapshot, "ms");
     }
     // mark all models as "raw", so they will not be turned into reactive objects
     // by owl, since we do not rely on reactivity
     markRaw(this);
-    console.info("Model created in", performance.now() - start, "ms");
-    console.groupEnd();
+    console.debug("Model created in", performance.now() - start, "ms");
+    console.debug("######");
   }
 
   joinSession() {
@@ -538,7 +538,7 @@ export class Model extends EventBus<any> implements CommandDispatcher {
           this.finalize();
           const time = performance.now() - start;
           if (time > 5) {
-            console.info(type, time, "ms");
+            console.debug(type, time, "ms");
           }
         });
         this.session.save(command, commands, changes);

--- a/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
@@ -146,7 +146,7 @@ export class Evaluator {
     cellsToCompute.addMany(arrayFormulasPositions);
     cellsToCompute.addMany(this.getCellsDependingOn(arrayFormulasPositions));
     this.evaluate(cellsToCompute);
-    console.info("evaluate Cells", performance.now() - start, "ms");
+    console.debug("evaluate Cells", performance.now() - start, "ms");
   }
 
   private getArrayFormulasImpactedByChangesOf(
@@ -193,7 +193,7 @@ export class Evaluator {
     const start = performance.now();
     this.evaluatedCells = new PositionMap();
     this.evaluate(this.getAllCells());
-    console.info("evaluate all cells", performance.now() - start, "ms");
+    console.debug("evaluate all cells", performance.now() - start, "ms");
   }
 
   evaluateFormulaResult(

--- a/tests/setup/jest.setup.ts
+++ b/tests/setup/jest.setup.ts
@@ -38,9 +38,7 @@ beforeAll(() => {
     },
   });
 
-  console.info = () => {};
-  console.group = () => {};
-  console.groupEnd = () => {};
+  console.debug = () => {};
 });
 
 beforeEach(() => {


### PR DESCRIPTION
3b1657f introduced the logging of performance information in the logs. This could be useful in some case, but often flooded the console for nothing.

This commit changes the log level to debug, so that it is not displayed by default.

Unfortunately console.group is not meant for debug level (it still group the messages, but the group title is always displayed even if debug logs are not displayed). Replaced it by good'ol `console.debug("#####")` to mark sections.

Task: 0

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo