### PR TITLE
[REF] cleanup o-spreadsheet code a bit

### DIFF
--- a/demo/data.js
+++ b/demo/data.js
@@ -2757,7 +2757,7 @@ function computeStringCells(cols, rows) {
   for (let col = 0; col < cols; col++) {
     const letter = _getColumnLetter(col);
     for (let index = 1; index < rows; index++) {
-      cells[letter + index] = { content: Math.random().toString(36).substr(2) };
+      cells[letter + index] = { content: Math.random().toString(36).slice(2) };
     }
   }
   return cells;

--- a/demo/index.html
+++ b/demo/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
     <link rel="icon" type="image/png" href="./favicon.png" />
+    <title>O-spreadsheet Dev</title>
   </head>
   <body>
     <script src="../node_modules/@odoo/owl/dist/owl.iife.js"></script>
@@ -17,6 +18,5 @@
     <link rel="stylesheet" href="../node_modules/bootstrap/dist/css/bootstrap.min.css" />
     <link rel="stylesheet" href="../node_modules/font-awesome/css/font-awesome.min.css" />
     <script src="../node_modules/bootstrap/dist/js/bootstrap.min.js"></script>
-    <title>O-spreadsheet Dev</title>
   </body>
 </html>

--- a/doc/extending/command.md
+++ b/doc/extending/command.md
@@ -34,7 +34,7 @@ Core commands should be device-agnostic and include all necessary information to
 
 To declare a new `CoreCommands`, its type should be added to `coreTypes`:
 
-```js
+```ts
 import { coreTypes } from "@odoo/o-spreadsheet";
 
 coreTypes.add("MY_COMMAND_NAME");
@@ -46,7 +46,7 @@ In read-only mode, all core commands are cancelled with the `CommandResult` `Rea
 However, some locale commands still need to be executed, such as updating the active sheet.
 To allow a new local command in read-only mode, add its type to `readonlyAllowedCommands`:
 
-```js
+```ts
 import { readonlyAllowedCommands } from "@odoo/o-spreadsheet";
 
 readonlyAllowedCommands.add("MY_COMMAND_NAME");
@@ -72,7 +72,7 @@ Some commands can be repeated with CTRL+Y (redo) when the redo stack is empty. T
 
 To declare a repeatable core command, add it to the `repeatCommandTransformRegistry`
 
-```js
+```ts
 import { repeatCommandTransformRegistry, genericRepeat } from "@odoo/o-spreadsheet";
 
 repeatCommandTransformRegistry.add("MY_CORE_COMMAND", genericRepeat);
@@ -105,7 +105,7 @@ repeatCommandTransformRegistry.add("ADD_COL_ROW_COMMAND", repeatAddColumnsRowsCo
 
 Local commands can also be repeated. To declare a repeatable local command, add it to the `repeatLocalCommandTransformRegistry`:
 
-```js
+```ts
 import { repeatLocalCommandTransformRegistry, genericRepeat } from "@odoo/o-spreadsheet";
 
 repeatLocalCommandTransformRegistry.add("MY_LOCAL_COMMAND", genericRepeat);
@@ -113,7 +113,7 @@ repeatLocalCommandTransformRegistry.add("MY_LOCAL_COMMAND", genericRepeat);
 
 For local commands, the transformation function includes a third argument: the core (sub)commands dispatched during the handling of the root local command. This is useful if the result depends on the UI plugins' state, as there is no guarantee that the UI plugins' state will be the same when the command is repeated. Adapting the child core commands can be a valid way to adjust the local command, as they do not depend on any internal state.
 
-```js
+```ts
 type LocalRepeatTransform = (
   getters: Getters,
   cmd: LocalCommand,

--- a/doc/integrating/collaborative/collaborative.md
+++ b/doc/integrating/collaborative/collaborative.md
@@ -119,7 +119,7 @@ To extend o-spreadsheet without breaking realtime collaborative edition, there a
 There are two types of [commands](add_command.md): `CoreCommands` and `Commands`. Only `CoreCommands` are synchronized.
 Here is the way to register a `CoreCommand` to o-spreadsheet.
 
-```js
+```ts
 const { coreTypes } = o_spreadsheet;
 
 coreTypes.add("MY_COMMAND_NAME");
@@ -133,7 +133,7 @@ A transformation function takes as arguments the already executed command, and t
 
 If a transformation is required, here is the way to declare it. The transformation check that the command is on the same sheet of the deleted sheet. If true, the command should be skipped.
 
-```js
+```ts
 const { otRegistry } = o_spreadsheet.registries;
 
 otRegistry.addTransformation("DELETE_SHEET", ["MY_COMMAND"], (myCommand, deleteSheet) => {
@@ -165,7 +165,7 @@ The inverse function is used during a selective undo to transform commands execu
 
 Here is the way to declare it.
 
-```js
+```ts
 const { inverseCommandRegistry } = o_spreadsheet.registries;
 
 inverseCommandRegistry.add("CREATE_SHEET", (cmd) => {

--- a/src/clipboard_handlers/tables_clipboard.ts
+++ b/src/clipboard_handlers/tables_clipboard.ts
@@ -1,4 +1,4 @@
-import { isZoneInside, range, removeFalsyAttributes, zoneToDimension } from "../helpers";
+import { isZoneInside, removeFalsyAttributes, zoneToDimension } from "../helpers";
 import {
   Border,
   CellPosition,
@@ -69,10 +69,6 @@ export class TableClipboardHandler extends AbstractCellClipboardHandler<
           zones.some((z) => isZoneInside(tableZone, z))
         ) {
           copiedTablesIds.add(table.id);
-          const values: Array<string[]> = [];
-          for (const col of range(tableZone.left, tableZone.right + 1)) {
-            values.push(this.getters.getFilterHiddenValues({ sheetId, col, row: tableZone.top }));
-          }
           copiedTable = {
             range: coreTable.range.rangeData,
             config: coreTable.config,

--- a/src/components/composer/grid_composer/grid_composer.ts
+++ b/src/components/composer/grid_composer/grid_composer.ts
@@ -114,11 +114,9 @@ export class GridComposer extends Component<Props, SpreadsheetChildEnv> {
   }
 
   get focus(): ComposerFocusType {
-    const focus =
-      this.composerFocusStore.activeComposer === this.composerInterface
-        ? this.composerFocusStore.focusMode
-        : "inactive";
-    return focus;
+    return this.composerFocusStore.activeComposer === this.composerInterface
+      ? this.composerFocusStore.focusMode
+      : "inactive";
   }
 
   get composerProps(): CellComposerProps {

--- a/src/components/headers_overlay/headers_overlay.ts
+++ b/src/components/headers_overlay/headers_overlay.ts
@@ -209,7 +209,7 @@ abstract class AbstractResizer extends Component<ResizerProps, SpreadsheetChildE
     if (index < 0) {
       return;
     }
-    if (this.state.waitingForMove === true) {
+    if (this.state.waitingForMove) {
       if (!this.env.model.getters.isGridSelectionActive()) {
         this._selectElement(index, false);
       } else {

--- a/src/components/helpers/css.ts
+++ b/src/components/helpers/css.ts
@@ -153,11 +153,10 @@ export function cssPropertiesToCss(attributes: CSSProperties): string {
 
 export function getElementMargins(el: Element) {
   const style = window.getComputedStyle(el);
-  const margins = {
+  return {
     top: parseInt(style.marginTop, 10) || 0,
     bottom: parseInt(style.marginBottom, 10) || 0,
     left: parseInt(style.marginLeft, 10) || 0,
     right: parseInt(style.marginRight, 10) || 0,
   };
-  return margins;
 }

--- a/src/components/helpers/drag_and_drop_hook.ts
+++ b/src/components/helpers/drag_and_drop_hook.ts
@@ -268,12 +268,6 @@ class DOMDndHelper {
     if (this.edgeScrollIntervalId) return;
     this.edgeScrollIntervalId = window.setInterval(() => {
       const offset = direction * 3;
-      let newPosition = this.currentMousePosition + offset;
-      if (newPosition < Math.min(this.container.start, this.minPosition)) {
-        newPosition = Math.min(this.container.start, this.minPosition);
-      } else if (newPosition > Math.max(this.container.end, this.maxPosition)) {
-        newPosition = Math.max(this.container.end, this.maxPosition);
-      }
       this.container.scroll += offset;
     }, 5);
   }

--- a/src/components/helpers/html_content_helpers.ts
+++ b/src/components/helpers/html_content_helpers.ts
@@ -22,7 +22,5 @@ export function getHtmlContentFromPattern(
   }
 
   pendingHtmlContent.push({ value });
-  const htmlContent = pendingHtmlContent.filter((content) => content.value);
-
-  return htmlContent;
+  return pendingHtmlContent.filter((content) => content.value);
 }

--- a/src/components/popover/popover.ts
+++ b/src/components/popover/popover.ts
@@ -199,7 +199,7 @@ abstract class PopoverPositionContext {
     const shouldRenderAtRight = this.shouldRenderAtRight(elDims.width);
 
     verticalOffset = shouldRenderAtBottom ? verticalOffset : -verticalOffset;
-    const cssProperties: CSSProperties = {
+    return {
       top:
         this.getTopCoordinate(actualHeight, shouldRenderAtBottom) -
         this.spreadsheetOffset.y -
@@ -208,8 +208,6 @@ abstract class PopoverPositionContext {
       left:
         this.getLeftCoordinate(actualWidth, shouldRenderAtRight) - this.spreadsheetOffset.x + "px",
     };
-
-    return cssProperties;
   }
 
   getCurrentPosition(elDims: DOMDimension): PopoverPosition {

--- a/src/components/side_panel/chart/building_blocks/axis_design/axis_design_editor.ts
+++ b/src/components/side_panel/chart/building_blocks/axis_design/axis_design_editor.ts
@@ -99,8 +99,7 @@ export class AxisDesignEditor extends Component<Props, SpreadsheetChildEnv> {
   }
 
   updateAxisEditor(ev) {
-    const axis = ev.target.value;
-    this.state.currentAxis = axis;
+    this.state.currentAxis = ev.target.value;
   }
 
   getAxisTitle() {

--- a/src/components/side_panel/conditional_formatting/cf_editor/cf_editor.ts
+++ b/src/components/side_panel/conditional_formatting/cf_editor/cf_editor.ts
@@ -425,7 +425,7 @@ export class ConditionalFormattingEditor extends Component<Props, SpreadsheetChi
   setColorScaleColor(target: string, color: Color) {
     const point = this.state.rules.colorScale[target];
     if (point) {
-      point.color = Number.parseInt(color.substr(1), 16);
+      point.color = Number.parseInt(color.slice(1), 16);
     }
     this.closeMenus();
   }
@@ -559,7 +559,7 @@ export class ConditionalFormattingEditor extends Component<Props, SpreadsheetChi
   }
 
   updateDataBarColor(color: Color) {
-    this.state.rules.dataBar.color = Number.parseInt(color.substr(1), 16);
+    this.state.rules.dataBar.color = Number.parseInt(color.slice(1), 16);
   }
 
   onDataBarRangeUpdate(ranges: string[]) {

--- a/src/components/side_panel/find_and_replace/find_and_replace_store.ts
+++ b/src/components/side_panel/find_and_replace/find_and_replace_store.ts
@@ -186,7 +186,6 @@ export class FindAndReplaceStore extends SpreadsheetStore implements HighlightPr
           ...sheetIds.slice(activeSheetIndex + 1),
           ...sheetIds.slice(0, activeSheetIndex),
         ];
-        break;
       case "activeSheet":
         return [this.getters.getActiveSheetId()];
       case "specificRange":

--- a/src/components/side_panel/remove_duplicates/remove_duplicates.ts
+++ b/src/components/side_panel/remove_duplicates/remove_duplicates.ts
@@ -73,7 +73,7 @@ export class RemoveDuplicatesPanel extends Component<Props, SpreadsheetChildEnv>
   }
 
   get isEveryColumnSelected(): boolean {
-    return Object.values(this.state.columns).every((value) => value === true);
+    return Object.values(this.state.columns).every((value) => value);
   }
 
   get errorMessages(): string[] {

--- a/src/components/side_panel/settings/settings_panel.ts
+++ b/src/components/side_panel/settings/settings_panel.ts
@@ -80,10 +80,7 @@ export class SettingsPanel extends Component<Props, SpreadsheetChildEnv> {
     const localeInLoadedLocales = this.loadedLocales.find((l) => l.code === currentLocale.code);
 
     if (!localeInLoadedLocales) {
-      const locales = [...this.loadedLocales, currentLocale].sort((a, b) =>
-        a.name.localeCompare(b.name)
-      );
-      return locales;
+      return [...this.loadedLocales, currentLocale].sort((a, b) => a.name.localeCompare(b.name));
     } else if (!deepEquals(currentLocale, localeInLoadedLocales)) {
       const index = this.loadedLocales.indexOf(localeInLoadedLocales);
       const locales = [...this.loadedLocales];

--- a/src/components/side_panel/side_panel/side_panel_store.ts
+++ b/src/components/side_panel/side_panel/side_panel_store.ts
@@ -52,7 +52,7 @@ export class SidePanelStore extends SpreadsheetStore {
 
   open(componentTag: string, panelProps: SidePanelProps = {}) {
     const state = this.computeState(componentTag, panelProps);
-    if (state.isOpen === false) {
+    if (!state.isOpen) {
       return;
     }
     if (this.isOpen && componentTag !== this.componentTag) {

--- a/src/formulas/composer_tokenizer.ts
+++ b/src/formulas/composer_tokenizer.ts
@@ -110,7 +110,7 @@ function mapParentFunction(tokens: EnrichedToken[]): EnrichedToken[] {
     }
   }
 
-  const res = tokens.map((token, i) => {
+  return tokens.map((token, i) => {
     if (!["SPACE", "LEFT_PAREN"].includes(token.type)) {
       functionStarted = "";
     }
@@ -150,7 +150,6 @@ function mapParentFunction(tokens: EnrichedToken[]): EnrichedToken[] {
     }
     return token;
   });
-  return res;
 }
 
 /**

--- a/src/functions/module_database.ts
+++ b/src/functions/module_database.ts
@@ -140,10 +140,8 @@ function getMatchingCells(
 
   const fieldCol = database[index];
   // Example continuation:: fieldCol = ["C", "j", "k", 7]
-  const matchingCells = [...matchingRows].map((x) => fieldCol[x + 1]);
   // Example continuation:: matchingCells = ["j", 7]
-
-  return matchingCells;
+  return [...matchingRows].map((x) => fieldCol[x + 1]);
 }
 
 const databaseArgs = [

--- a/src/functions/module_lookup.ts
+++ b/src/functions/module_lookup.ts
@@ -88,8 +88,8 @@ export const ADDRESS = {
     let cellReference: string;
     if (_useA1Notation) {
       const rangePart = {
-        rowFixed: [1, 2].includes(_absoluteRelativeMode) ? true : false,
-        colFixed: [1, 3].includes(_absoluteRelativeMode) ? true : false,
+        rowFixed: [1, 2].includes(_absoluteRelativeMode),
+        colFixed: [1, 3].includes(_absoluteRelativeMode),
       };
       cellReference = toXC(colNumber - 1, rowNumber - 1, rangePart);
     } else {

--- a/src/functions/module_math.ts
+++ b/src/functions/module_math.ts
@@ -618,7 +618,7 @@ export const DECIMAL = {
      * Remove '-?' in the next regex to catch this error.
      */
     assert(
-      () => !!DECIMAL_REPRESENTATION.test(_value),
+      () => DECIMAL_REPRESENTATION.test(_value),
       _t("The value (%s) must be a valid base %s representation.", _value, _base.toString())
     );
 

--- a/src/functions/module_statistical.ts
+++ b/src/functions/module_statistical.ts
@@ -108,10 +108,9 @@ function covariance(dataY: Arg, dataX: Arg, isSample: boolean): number {
 
 function variance(args: Arg[], isSample: boolean, textAs0: boolean, locale: Locale): number {
   let count = 0;
-  let sum = 0;
   const reduceFunction = textAs0 ? reduceNumbersTextAs0 : reduceNumbers;
 
-  sum = reduceFunction(
+  const sum = reduceFunction(
     args,
     (acc, a) => {
       count += 1;

--- a/src/helpers/cells/cell_evaluation.ts
+++ b/src/helpers/cells/cell_evaluation.ts
@@ -50,7 +50,7 @@ export function parseLiteral(content: string, locale: Locale): CellValue {
     return internalDate.value;
   }
   if (isBoolean(content)) {
-    return content.toUpperCase() === "TRUE" ? true : false;
+    return content.toUpperCase() === "TRUE";
   }
   return content;
 }

--- a/src/helpers/clipboard/navigator_clipboard_wrapper.ts
+++ b/src/helpers/clipboard/navigator_clipboard_wrapper.ts
@@ -64,8 +64,7 @@ class WebClipboardWrapper implements ClipboardInterface {
         for (const item of clipboardItems) {
           for (const type of item.types) {
             const blob = await item.getType(type);
-            const text = await blob.text();
-            clipboardContent[type as ClipboardMIMEType] = text;
+            clipboardContent[type as ClipboardMIMEType] = await blob.text();
           }
         }
         return { status: "ok", content: clipboardContent };

--- a/src/helpers/figures/charts/bar_chart.ts
+++ b/src/helpers/figures/charts/bar_chart.ts
@@ -310,8 +310,7 @@ export function createBarChartRuntime(chart: BarChart, getters: Getters): BarCha
     config.data.datasets.push(dataset);
 
     if (definition.dataSets?.[index]?.label) {
-      const label = definition.dataSets[index].label;
-      dataset.label = label;
+      dataset.label = definition.dataSets[index].label;
     }
 
     dataset.yAxisID = chart.horizontal ? "y" : definition.dataSets[index].yAxisId || "y";

--- a/src/helpers/figures/charts/chart_common.ts
+++ b/src/helpers/figures/charts/chart_common.ts
@@ -398,12 +398,10 @@ export function getChartPositionAtCenterOfViewport(
   const { scrollX, scrollY } = getters.getActiveSheetScrollInfo();
   const { width, height } = getters.getVisibleRect(getters.getActiveMainViewport());
 
-  const position = {
+  return {
     x: x + scrollX + Math.max(0, (width - chartSize.width) / 2),
     y: y + scrollY + Math.max(0, (height - chartSize.height) / 2),
   }; // Position at the center of the scrollable viewport
-
-  return position;
 }
 
 export function getChartAxisTitleRuntime(design?: AxisDesign):

--- a/src/helpers/figures/charts/chart_common_line_scatter.ts
+++ b/src/helpers/figures/charts/chart_common_line_scatter.ts
@@ -345,8 +345,7 @@ export function createLineOrScatterChartRuntime(
 
   for (const [index, dataset] of config.data.datasets.entries()) {
     if (definition.dataSets?.[index]?.label) {
-      const label = definition.dataSets[index].label;
-      dataset.label = label;
+      dataset.label = definition.dataSets[index].label;
     }
     dataset["yAxisID"] = definition.dataSets[index].yAxisId || "y";
 

--- a/src/helpers/figures/figure/figure.ts
+++ b/src/helpers/figures/figure/figure.ts
@@ -10,11 +10,10 @@ export function centerFigurePosition(getters: Getters, size: FigureSize) {
   const scrollableViewportWidth = Math.min(rect.width, dim.width - offsetCorrectionX);
   const scrollableViewportHeight = Math.min(rect.height, dim.height - offsetCorrectionY);
 
-  const position = {
+  return {
     x: offsetCorrectionX + scrollX + Math.max(0, (scrollableViewportWidth - size.width) / 2),
     y: offsetCorrectionY + scrollY + Math.max(0, (scrollableViewportHeight - size.height) / 2),
   }; // Position at the center of the scrollable viewport
-  return position;
 }
 
 export function getMaxFigureSize(getters: Getters, figureSize: FigureSize): FigureSize {

--- a/src/helpers/locale.ts
+++ b/src/helpers/locale.ts
@@ -201,10 +201,9 @@ function localizeNumberLiteral(literal: string, locale: Locale): string {
   }
 
   const decimalNumberRegex = getDecimalNumberRegex(DEFAULT_LOCALE);
-  const localized = literal.replace(decimalNumberRegex, (match) => {
+  return literal.replace(decimalNumberRegex, (match) => {
     return match.replace(".", locale.decimalSeparator);
   });
-  return localized;
 }
 
 /**

--- a/src/helpers/misc.ts
+++ b/src/helpers/misc.ts
@@ -233,7 +233,7 @@ export function buildSheetLink(sheetId: UID) {
  */
 export function parseSheetUrl(sheetLink: string) {
   if (sheetLink.startsWith(O_SPREADSHEET_LINK_PREFIX)) {
-    return sheetLink.substr(O_SPREADSHEET_LINK_PREFIX.length);
+    return sheetLink.slice(O_SPREADSHEET_LINK_PREFIX.length);
   }
   throw new Error(`${sheetLink} is not a valid sheet link`);
 }

--- a/src/helpers/numbers.ts
+++ b/src/helpers/numbers.ts
@@ -43,9 +43,7 @@ const getNumberRegex = memoize(function getNumberRegex(locale: Locale) {
 
   const pNumberExp = "^(?:(?:" + [p1, p2, p3].join(")|(?:") + "))$";
 
-  const numberRegexp = new RegExp(pNumberExp, "i");
-
-  return numberRegexp;
+  return new RegExp(pNumberExp, "i");
 });
 
 /**

--- a/src/helpers/pivot/pivot_helpers.ts
+++ b/src/helpers/pivot/pivot_helpers.ts
@@ -94,8 +94,7 @@ export function getMaxObjectId(o: object) {
     return 0;
   }
   const nums = keys.map((id) => parseInt(id, 10));
-  const max = Math.max(...nums);
-  return max;
+  return Math.max(...nums);
 }
 
 export const ALL_PERIODS = {

--- a/src/helpers/pivot/pivot_presentation.ts
+++ b/src/helpers/pivot/pivot_presentation.ts
@@ -699,8 +699,7 @@ export default function (PivotClass: PivotUIConstructor) {
       }
 
       const comparedValue = this._getPivotCellValueAndFormat(measure.id, comparedDomain);
-      const comparedValueNumber = this.strictMeasureValueToNumber(comparedValue);
-      return comparedValueNumber;
+      return this.strictMeasureValueToNumber(comparedValue);
     }
 
     private getPivotValueCells(measureId: string): PivotValueCell[][] {

--- a/src/helpers/text_helper.ts
+++ b/src/helpers/text_helper.ts
@@ -68,8 +68,7 @@ export function computeCachedTextWidth(context: CanvasRenderingContext2D, text: 
     textWidthCache[font] = {};
   }
   if (textWidthCache[font][text] === undefined) {
-    const textWidth = context.measureText(text).width;
-    textWidthCache[font][text] = textWidth;
+    textWidthCache[font][text] = context.measureText(text).width;
   }
   return textWidthCache[font][text];
 }

--- a/src/helpers/uuid.ts
+++ b/src/helpers/uuid.ts
@@ -13,7 +13,7 @@ export class UuidGenerator {
     } else {
       // mainly for jest and other browsers that do not have the crypto functionality
       return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, function (c) {
-        var r = (Math.random() * 16) | 0,
+        const r = (Math.random() * 16) | 0,
           v = c === "x" ? r : (r & 0x3) | 0x8;
         return v.toString(16);
       });

--- a/src/migrations/data.ts
+++ b/src/migrations/data.ts
@@ -289,7 +289,7 @@ export function createEmptySheet(sheetId: UID, name: string): SheetData {
 }
 
 export function createEmptyWorkbookData(sheetName = "Sheet1"): WorkbookData {
-  const data = {
+  return {
     version: CURRENT_VERSION,
     sheets: [createEmptySheet(INITIAL_SHEET_ID, sheetName)],
     styles: {},
@@ -302,7 +302,6 @@ export function createEmptyWorkbookData(sheetName = "Sheet1"): WorkbookData {
     pivotNextId: 1,
     customTableStyles: {},
   };
-  return data;
 }
 
 export function createEmptyExcelSheet(sheetId: UID, name: string): ExcelSheetData {

--- a/src/model.ts
+++ b/src/model.ts
@@ -356,7 +356,7 @@ export class Model extends EventBus<any> implements CommandDispatcher {
   }
 
   private setupSession(revisionId: UID): Session {
-    const session = new Session(
+    return new Session(
       buildRevisionLog({
         initialRevisionId: revisionId,
         recordChanges: this.state.recordChanges.bind(this.state),
@@ -373,7 +373,6 @@ export class Model extends EventBus<any> implements CommandDispatcher {
       this.config.transportService,
       revisionId
     );
-    return session;
   }
 
   private setupSessionEvents() {
@@ -475,8 +474,7 @@ export class Model extends EventBus<any> implements CommandDispatcher {
   }
 
   private checkDispatchAllowedLocalCommand(command: LocalCommand) {
-    const results = this.uiHandlers.map((handler) => handler.allowDispatch(command));
-    return results;
+    return this.uiHandlers.map((handler) => handler.allowDispatch(command));
   }
 
   private finalize() {

--- a/src/model.ts
+++ b/src/model.ts
@@ -124,12 +124,7 @@ const enum Status {
 
 export class Model extends EventBus<any> implements CommandDispatcher {
   private corePlugins: CorePlugin[] = [];
-
-  private featurePlugins: UIPlugin[] = [];
-
   private statefulUIPlugins: UIPlugin[] = [];
-
-  private coreViewsPlugins: UIPlugin[] = [];
 
   private range: RangeAdapter;
 
@@ -249,7 +244,6 @@ export class Model extends EventBus<any> implements CommandDispatcher {
 
     for (let Plugin of coreViewsPluginRegistry.getAll()) {
       const plugin = this.setupUiPlugin(Plugin);
-      this.coreViewsPlugins.push(plugin);
       this.handlers.push(plugin);
       this.uiHandlers.push(plugin);
       this.coreHandlers.push(plugin);
@@ -262,7 +256,6 @@ export class Model extends EventBus<any> implements CommandDispatcher {
     }
     for (let Plugin of featurePluginRegistry.getAll()) {
       const plugin = this.setupUiPlugin(Plugin);
-      this.featurePlugins.push(plugin);
       this.handlers.push(plugin);
       this.uiHandlers.push(plugin);
     }

--- a/src/plugins/ui_core_views/evaluation_conditional_format.ts
+++ b/src/plugins/ui_core_views/evaluation_conditional_format.ts
@@ -187,8 +187,7 @@ export class EvaluationConditionalFormatPlugin extends UIPlugin {
       .map((cell) => cell.value);
     switch (threshold.type) {
       case "value":
-        const result = functionName === "max" ? largeMax(rangeValues) : largeMin(rangeValues);
-        return result;
+        return functionName === "max" ? largeMax(rangeValues) : largeMin(rangeValues);
       case "number":
         return Number(threshold.value);
       case "percentage":

--- a/src/plugins/ui_feature/collaborative.ts
+++ b/src/plugins/ui_feature/collaborative.ts
@@ -126,8 +126,7 @@ export class CollaborativePlugin extends UIPlugin {
       }
       const color = client.color;
       /* Cell background */
-      const cellBackgroundColor = `${color}10`;
-      ctx.fillStyle = cellBackgroundColor;
+      ctx.fillStyle = `${color}10`;
       ctx.lineWidth = 4 * thinLineWidth;
       ctx.strokeStyle = color;
       ctx.globalCompositeOperation = "multiply";

--- a/src/plugins/ui_feature/header_visibility_ui.ts
+++ b/src/plugins/ui_feature/header_visibility_ui.ts
@@ -100,8 +100,7 @@ export class HeaderVisibilityUIPlugin extends UIPlugin {
   exportForExcel(data: ExcelWorkbookData) {
     for (const sheetData of data.sheets) {
       for (const [row, rowData] of Object.entries(sheetData.rows)) {
-        const isHidden = this.isRowHidden(sheetData.id, Number(row));
-        rowData.isHidden = isHidden;
+        rowData.isHidden = this.isRowHidden(sheetData.id, Number(row));
       }
     }
   }

--- a/src/plugins/ui_feature/ui_sheet.ts
+++ b/src/plugins/ui_feature/ui_sheet.ts
@@ -201,7 +201,6 @@ export class SheetUIPlugin extends UIPlugin {
       if (!isEqual(zone, newZone)) {
         hasExpanded = true;
         zone = newZone;
-        continue;
       }
     } while (hasExpanded);
 

--- a/src/plugins/ui_stateful/clipboard.ts
+++ b/src/plugins/ui_stateful/clipboard.ts
@@ -216,7 +216,7 @@ export class ClipboardPlugin extends UIPlugin {
         this.status = "invisible";
 
         // If we add a col/row inside or before the cut area, we invalidate the clipboard
-        if (this._isCutOperation !== true || cmd.sheetId !== this.copiedData?.sheetId) {
+        if (!this._isCutOperation || cmd.sheetId !== this.copiedData?.sheetId) {
           return;
         }
         const isClipboardDirty = this.isColRowDirtyingClipboard(
@@ -232,7 +232,7 @@ export class ClipboardPlugin extends UIPlugin {
         this.status = "invisible";
 
         // If we remove a col/row inside or before the cut area, we invalidate the clipboard
-        if (this._isCutOperation !== true || cmd.sheetId !== this.copiedData?.sheetId) {
+        if (!this._isCutOperation || cmd.sheetId !== this.copiedData?.sheetId) {
           return;
         }
         for (let el of cmd.elements) {
@@ -254,7 +254,7 @@ export class ClipboardPlugin extends UIPlugin {
         break;
       }
       case "DELETE_SHEET":
-        if (this._isCutOperation !== true) {
+        if (!this._isCutOperation) {
           return;
         }
         if (this.originSheetId === cmd.sheetId) {

--- a/src/plugins/ui_stateful/selection.ts
+++ b/src/plugins/ui_stateful/selection.ts
@@ -463,8 +463,7 @@ export class GridSelectionPlugin extends UIPlugin {
   }
 
   private setActiveSheet(id: UID) {
-    const sheet = this.getters.getSheet(id);
-    this.activeSheet = sheet;
+    this.activeSheet = this.getters.getSheet(id);
   }
 
   private activateNextSheet(direction: "left" | "right") {

--- a/src/plugins/ui_stateful/sheetview.ts
+++ b/src/plugins/ui_stateful/sheetview.ts
@@ -252,9 +252,6 @@ export class SheetViewPlugin extends UIPlugin {
       case "UNFREEZE_COLUMNS_ROWS":
         this.resetViewports(this.getters.getActiveSheetId());
         break;
-      case "DELETE_SHEET":
-        this.sheetsWithDirtyViewports.delete(cmd.sheetId);
-        break;
       case "SCROLL_TO_CELL":
         this.refreshViewport(this.getters.getActiveSheetId(), { col: cmd.col, row: cmd.row });
         break;

--- a/src/registries/auto_completes/pivot_auto_complete.ts
+++ b/src/registries/auto_completes/pivot_auto_complete.ts
@@ -158,14 +158,13 @@ autoCompleteProviders.add("pivot_group_fields", {
             return undefined;
           }
           const positionalFieldArg = `"#${groupBy}"`;
-          const positionalProposal = {
+          return {
             text: positionalFieldArg,
             description:
               _t("%s (positional)", field.string) + (field.help ? ` (${field.help})` : ""),
             htmlContent: [{ value: positionalFieldArg, color: tokenColors.STRING }],
             fuzzySearchKey: field.string + positionalFieldArg, // search on translated name and on technical name
           };
-          return positionalProposal;
         })
       )
       .filter(isDefined);

--- a/src/registries/autofill_rules.ts
+++ b/src/registries/autofill_rules.ts
@@ -154,8 +154,7 @@ function calculateDateIncrementBasedOnGroup(group: number[]) {
           return 0;
         }
         const previous = jsDates[index - 1];
-        const days = Math.floor(date.getTime()) - Math.floor(previous.getTime());
-        return days;
+        return Math.floor(date.getTime()) - Math.floor(previous.getTime());
       })
       .slice(1);
     const equidistantDates = timeIntervals.every((interval) => interval === timeIntervals[0]);

--- a/src/selection_stream/selection_stream_processor.ts
+++ b/src/selection_stream/selection_stream_processor.ts
@@ -641,12 +641,11 @@ export class SelectionStreamProcessorImpl implements SelectionStreamProcessor {
     const dimOfInterest = dimension === "cols" ? "col" : "row";
     const startingPosition = { ...currentPosition };
 
-    const nextCoord =
+    startingPosition[dimOfInterest] =
       dimension === "cols"
         ? this.getNextAvailableCol(direction, startingPosition.col, startingPosition.row)
         : this.getNextAvailableRow(direction, startingPosition.col, startingPosition.row);
 
-    startingPosition[dimOfInterest] = nextCoord;
     return { col: startingPosition.col, row: startingPosition.row };
   }
 

--- a/src/xlsx/extraction/base_extractor.ts
+++ b/src/xlsx/extraction/base_extractor.ts
@@ -110,12 +110,11 @@ export class XlsxBaseExtractor {
    * Get the list of all the XLSX files in the XLSX file structure
    */
   protected getListOfXMLFiles(): XLSXImportFile[] {
-    const XMLFiles = Object.entries(this.xlsxFileStructure)
+    return Object.entries(this.xlsxFileStructure)
       .filter(([key]) => key !== "images")
       .map(([_, value]) => value)
       .flat()
       .filter(isDefined);
-    return XMLFiles;
   }
 
   /**
@@ -330,13 +329,12 @@ export class XlsxBaseExtractor {
       rgb = this.extractAttr(colorElement, "rgb")?.asString();
       rgb = rgb === DEFAULT_SYSTEM_COLOR ? undefined : rgb;
     }
-    const color = {
+    return {
       rgb: rgb || defaultColor,
       auto: this.extractAttr(colorElement, "auto")?.asBool(),
       indexed: this.extractAttr(colorElement, "indexed")?.asNum(),
       tint: this.extractAttr(colorElement, "tint")?.asNum(),
     };
-    return color;
   }
 
   /**

--- a/src/xlsx/extraction/sheet_extractor.ts
+++ b/src/xlsx/extraction/sheet_extractor.ts
@@ -61,7 +61,7 @@ export class XlsxSheetExtractor extends XlsxBaseExtractor {
           hyperlinks: this.extractHyperLinks(sheetElement),
           tables: this.extractTables(sheetElement),
           pivotTables: this.extractPivotTables(),
-          isVisible: sheetWorkbookInfo.state === "visible" ? true : false,
+          isVisible: sheetWorkbookInfo.state === "visible",
         };
       }
     )[0];

--- a/src/xlsx/extraction/sheet_extractor.ts
+++ b/src/xlsx/extraction/sheet_extractor.ts
@@ -164,12 +164,11 @@ export class XlsxSheetExtractor extends XlsxBaseExtractor {
         const drawingId = this.extractAttr(drawingElement, "r:id", { required: true })?.asString();
         const drawingFile = this.getTargetXmlFile(this.relationships[drawingId])!;
 
-        const figures = new XlsxFigureExtractor(
+        return new XlsxFigureExtractor(
           drawingFile,
           this.xlsxFileStructure,
           this.warningManager
         ).extractFigures();
-        return figures;
       }
     )[0];
 
@@ -199,12 +198,11 @@ export class XlsxSheetExtractor extends XlsxBaseExtractor {
         .filter((relationship) => relationship.type.endsWith("pivotTable"))
         .map((pivotRelationship) => {
           const pivotFile = this.getTargetXmlFile(pivotRelationship)!;
-          const pivot = new XlsxPivotExtractor(
+          return new XlsxPivotExtractor(
             pivotFile,
             this.xlsxFileStructure,
             this.warningManager
           ).getPivotTable();
-          return pivot;
         });
     } catch (e) {
       this.catchErrorOnElement(e);

--- a/src/xlsx/functions/worksheet.ts
+++ b/src/xlsx/functions/worksheet.ts
@@ -258,14 +258,13 @@ export function addSheetViews(sheet: ExcelSheetData) {
     ["workbookViewId", 0],
   ];
 
-  let sheetView = escapeXml/*xml*/ `
+  return escapeXml/*xml*/ `
       <sheetViews>
         <sheetView ${formatAttributes(sheetViewAttrs)}>
           ${splitPanes}
         </sheetView>
       </sheetViews>
     `;
-  return sheetView;
 }
 
 export function addSheetProperties(sheet: ExcelSheetData) {
@@ -273,10 +272,9 @@ export function addSheetProperties(sheet: ExcelSheetData) {
     return "";
   }
 
-  let sheetView = escapeXml/*xml*/ `
+  return escapeXml/*xml*/ `
       <sheetPr>
         <tabColor ${formatAttributes([["rgb", toXlsxHexColor(sheet.color)]])} />
       </sheetPr>
     `;
-  return sheetView;
 }

--- a/src/xlsx/xlsx_reader.ts
+++ b/src/xlsx/xlsx_reader.ts
@@ -55,8 +55,7 @@ export class XlsxReader {
 
   convertXlsx(): WorkbookData {
     const xlsxData = this.getXlsxData();
-    const convertedData = this.convertImportedData(xlsxData);
-    return convertedData;
+    return this.convertImportedData(xlsxData);
   }
 
   // ---------------------------------------------------------------------------

--- a/tests/bottom_bar/bottom_bar_component.test.ts
+++ b/tests/bottom_bar/bottom_bar_component.test.ts
@@ -501,10 +501,6 @@ describe("BottomBar component", () => {
       };
     });
 
-    afterEach(() => {
-      parent;
-    });
-
     test("Can scroll on the list of sheets", async () => {
       expect(sheetListEl.scrollLeft).toBe(0);
       triggerWheelEvent(sheetListEl, { deltaY: 100 });

--- a/tests/bottom_bar/bottom_bar_component.test.ts
+++ b/tests/bottom_bar/bottom_bar_component.test.ts
@@ -229,8 +229,8 @@ describe("BottomBar component", () => {
 
     triggerMouseEvent(".o-sheet", "contextmenu");
     await nextTick();
-    expect(fixture.querySelector(".o-menu-item[data-name='move_left'")).toBeNull();
-    expect(fixture.querySelector(".o-menu-item[data-name='move_right'")).toBeNull();
+    expect(fixture.querySelector(".o-menu-item[data-name='move_left']")).toBeNull();
+    expect(fixture.querySelector(".o-menu-item[data-name='move_right']")).toBeNull();
   });
 
   describe("Rename a sheet", () => {
@@ -411,7 +411,7 @@ describe("BottomBar component", () => {
 
     triggerMouseEvent(".o-sheet", "contextmenu");
     await nextTick();
-    expect(fixture.querySelector(".o-menu-item[data-name='delete'")).toBeNull();
+    expect(fixture.querySelector(".o-menu-item[data-name='delete']")).toBeNull();
   });
 
   test("Can open the list of sheets", async () => {
@@ -454,7 +454,7 @@ describe("BottomBar component", () => {
     const { model } = await mountBottomBar();
     createSheet(model, { sheetId: "42", hidden: true });
     await click(fixture, ".o-list-sheets");
-    const menuItem = fixture.querySelector<HTMLElement>(".o-menu-item[data-name='42'")!;
+    const menuItem = fixture.querySelector<HTMLElement>(".o-menu-item[data-name='42']")!;
     expect(toHex(menuItem.style.color)).toEqual("#808080");
     await click(menuItem);
     expect(model.getters.getActiveSheetId()).toBe("42");
@@ -466,7 +466,7 @@ describe("BottomBar component", () => {
     createSheet(model, { sheetId: "42", hidden: true });
     model.updateMode("readonly");
     await click(fixture, ".o-list-sheets");
-    const menuItem = fixture.querySelector<HTMLElement>(".o-menu-item[data-name='42'");
+    const menuItem = fixture.querySelector<HTMLElement>(".o-menu-item[data-name='42']");
     expect(menuItem!.classList).toContain("disabled");
   });
 

--- a/tests/composer/composer_store.test.ts
+++ b/tests/composer/composer_store.test.ts
@@ -1112,7 +1112,6 @@ describe("edition", () => {
     expect(gridHighlights[0]).toMatchObject({ zone: toZone("A2"), color: colors[1] });
     const composerHighlights = composerStore.highlights;
     expect(composerHighlights).toHaveLength(2);
-    colors;
     expect(composerHighlights[0]).toMatchObject({ zone: toZone("A1"), color: colors[0] });
     expect(composerHighlights[1]).toMatchObject({ zone: toZone("A2"), color: colors[1] });
   });

--- a/tests/figures/chart/chart_plugin.test.ts
+++ b/tests/figures/chart/chart_plugin.test.ts
@@ -2476,10 +2476,6 @@ describe("Linear/Time charts", () => {
     );
     let config = getChartConfiguration(model, chartId);
     expect(config.options?.scales?.x?.type).toEqual("time");
-
-    updateChart(model, chartId, { type: "bar" });
-    model.getters.getChartRuntime(chartId)!; //ANHE : this test doesn't seems to update anything ...
-    expect(config.options?.scales?.x?.type).toEqual("time");
   });
 
   test("time axis for line/bar chart with formulas w/ date format as labels", () => {
@@ -2498,10 +2494,6 @@ describe("Linear/Time charts", () => {
       chartId
     );
     let chart = model.getters.getChartRuntime(chartId) as LineChartRuntime;
-    expect(chart.chartJsConfig.options?.scales?.x?.type).toEqual("time");
-
-    updateChart(model, chartId, { type: "bar" });
-    model.getters.getChartRuntime(chartId)!;
     expect(chart.chartJsConfig.options?.scales?.x?.type).toEqual("time");
   });
 

--- a/tests/figures/figure_component.test.ts
+++ b/tests/figures/figure_component.test.ts
@@ -160,7 +160,6 @@ describe("figures", () => {
     setCellContent(model, "A1", "content");
     selectCell(model, "A1");
     await nextTick();
-    fixture.querySelector(".o-figure")!;
     await simulateClick(".o-figure");
     await keyDown({ key: "Delete" });
     expect(fixture.querySelector(".o-figure")).toBeNull();
@@ -170,7 +169,6 @@ describe("figures", () => {
   test("Can delete a figure with `Backspace`", async () => {
     createFigure(model);
     await nextTick();
-    fixture.querySelector(".o-figure")!;
     await simulateClick(".o-figure");
     await keyDown({ key: "Backspace" });
     expect(fixture.querySelector(".o-figure")).toBeNull();
@@ -192,7 +190,6 @@ describe("figures", () => {
     let figure = model.getters.getFigure(sheetId, "someuuid");
     expect(figure).toMatchObject({ id: "someuuid", x: 1, y: 1 });
     await nextTick();
-    fixture.querySelector(".o-figure")!;
     await simulateClick(".o-figure");
     await nextTick();
     const selectedFigure = model.getters.getSelectedFigureId();

--- a/tests/functions/functions.test.ts
+++ b/tests/functions/functions.test.ts
@@ -252,10 +252,7 @@ describe("functions", () => {
       functionRegistry.add("FORMULA_TROWING_ERROR", {
         description: "function trowing error",
         compute: () => {
-          if (!false) {
-            throw new EvaluationError("NOP");
-          }
-          return 42;
+          throw new EvaluationError("NOP");
         },
         args: [],
       });
@@ -271,10 +268,7 @@ describe("functions", () => {
       functionRegistry.add("FORMULA_RETURNING_RANGE_TROWING_ERROR", {
         description: "function returning range",
         compute: () => {
-          if (!false) {
-            throw new EvaluationError("NOP");
-          }
-          return [["cucumber"]];
+          throw new EvaluationError("NOP");
         },
         args: [],
       });

--- a/tests/functions/functions.test.ts
+++ b/tests/functions/functions.test.ts
@@ -71,7 +71,7 @@ describe("functions", () => {
     functionRegistry.add("RETURN.VALUE.DEPENDING.ON.INPUT.ERROR", {
       description: "return value depending on input error",
       compute: function (arg: Arg) {
-        return isEvaluationError(toScalar(arg)?.value) ? true : false;
+        return isEvaluationError(toScalar(arg)?.value);
       },
       args: [arg("arg (any)", "blabla")],
     });

--- a/tests/link/link_editor_component.test.ts
+++ b/tests/link/link_editor_component.test.ts
@@ -34,12 +34,10 @@ describe("link editor component", () => {
   }
 
   function labelInput(): HTMLInputElement {
-    const inputs = fixture?.querySelector('input[title="Link label"]')! as HTMLInputElement;
-    return inputs;
+    return fixture?.querySelector('input[title="Link label"]')! as HTMLInputElement;
   }
   function urlInput(): HTMLInputElement {
-    const inputs = fixture?.querySelector('input[title="Link URL"]')! as HTMLInputElement;
-    return inputs;
+    return fixture?.querySelector('input[title="Link URL"]')! as HTMLInputElement;
   }
 
   beforeEach(async () => {

--- a/tests/renderer_store.test.ts
+++ b/tests/renderer_store.test.ts
@@ -1920,19 +1920,19 @@ describe("renderer", () => {
     expect(renderedBorders).toEqual({
       [colors.left]: {
         start: [0, 0],
-        end: [0, 0 + DEFAULT_CELL_HEIGHT],
+        end: [0, DEFAULT_CELL_HEIGHT],
       },
       [colors.top]: {
         start: [0, 0],
-        end: [0 + DEFAULT_CELL_WIDTH, 0],
+        end: [DEFAULT_CELL_WIDTH, 0],
       },
       [colors.right]: {
-        start: [0 + DEFAULT_CELL_WIDTH, 0],
-        end: [0 + DEFAULT_CELL_WIDTH, 0 + DEFAULT_CELL_HEIGHT],
+        start: [DEFAULT_CELL_WIDTH, 0],
+        end: [DEFAULT_CELL_WIDTH, DEFAULT_CELL_HEIGHT],
       },
       [colors.bottom]: {
-        start: [0, 0 + DEFAULT_CELL_HEIGHT],
-        end: [0 + DEFAULT_CELL_WIDTH, 0 + DEFAULT_CELL_HEIGHT],
+        start: [0, DEFAULT_CELL_HEIGHT],
+        end: [DEFAULT_CELL_WIDTH, DEFAULT_CELL_HEIGHT],
       },
     });
   });

--- a/tests/sheet/selection_plugin.test.ts
+++ b/tests/sheet/selection_plugin.test.ts
@@ -963,6 +963,7 @@ describe("move elements(s)", () => {
       position: "after",
       dimension: "COL",
     });
+    expect(result).toBeCancelledBecause(CommandResult.InvalidHeaderIndex);
   });
 
   test("cannot move row out of bound", () => {

--- a/tests/sheet/sheets_plugin.test.ts
+++ b/tests/sheet/sheets_plugin.test.ts
@@ -299,8 +299,6 @@ describe("sheets", () => {
     });
 
     expect(model.getters.getSheetName(model.getters.getActiveSheetId())).toBe("ABC");
-    const B2 = getCell(model, "B2", "DEF");
-    B2;
     expect(getEvaluatedCell(model, "B1").value).toBe(3);
   });
 

--- a/tests/table/table_resizer_component.test.ts
+++ b/tests/table/table_resizer_component.test.ts
@@ -10,13 +10,11 @@ import { getHighlightsFromStore, mountComponent, nextTick } from "../test_helper
 describe("Table resizer component", () => {
   let model: Model;
   let sheetId: UID;
-  let fixture: HTMLElement;
   let env: SpreadsheetChildEnv;
 
   beforeEach(async () => {
-    ({ model, fixture, env } = await mountComponent(Grid, { props: { exposeFocus: () => {} } }));
+    ({ model, env } = await mountComponent(Grid, { props: { exposeFocus: () => {} } }));
     sheetId = model.getters.getActiveSheetId();
-    fixture.style ? "ok" : "ko";
   });
 
   test("Can resize a table with drag & drop", async () => {

--- a/tests/test_helpers/commands_helpers.ts
+++ b/tests/test_helpers/commands_helpers.ts
@@ -307,8 +307,7 @@ export function copy(model: Model, ...ranges: string[]): DispatchResult {
   if (ranges && ranges.length) {
     setSelection(model, ranges);
   }
-  const result = model.dispatch("COPY");
-  return result;
+  return model.dispatch("COPY");
 }
 
 /**
@@ -318,8 +317,7 @@ export function cut(model: Model, ...ranges: string[]): DispatchResult {
   if (ranges && ranges.length) {
     setSelection(model, ranges);
   }
-  const result = model.dispatch("CUT");
-  return result;
+  return model.dispatch("CUT");
 }
 
 /**
@@ -353,16 +351,14 @@ export function pasteFromOSClipboard(
  * Copy cells above a zone and paste on zone
  */
 export function copyPasteAboveCells(model: Model): DispatchResult {
-  const result = model.dispatch("COPY_PASTE_CELLS_ABOVE");
-  return result;
+  return model.dispatch("COPY_PASTE_CELLS_ABOVE");
 }
 
 /**
  * Copy cells to the left of a zone and paste on zone
  */
 export function copyPasteCellsOnLeft(model: Model): DispatchResult {
-  const result = model.dispatch("COPY_PASTE_CELLS_ON_LEFT");
-  return result;
+  return model.dispatch("COPY_PASTE_CELLS_ON_LEFT");
 }
 
 /**

--- a/tests/test_helpers/getters_helpers.ts
+++ b/tests/test_helpers/getters_helpers.ts
@@ -206,9 +206,6 @@ export function automaticSumMulti(
   { anchor }: { anchor?: string } = {},
   sheetId?: UID
 ) {
-  if (!sheetId) {
-    sheetId = model.getters.getActiveSheetId();
-  }
   setSelection(model, xcs, { anchor });
   return model.dispatch("SUM_SELECTION");
 }

--- a/tests/test_helpers/helpers.ts
+++ b/tests/test_helpers/helpers.ts
@@ -348,8 +348,7 @@ function getCellGrid(model: Model): { [xc: string]: EvaluatedCell } {
   const sheetId = model.getters.getActiveSheetId();
   for (const position of model.getters.getEvaluatedCellsPositions(sheetId)) {
     const { col, row } = position;
-    const cell = model.getters.getEvaluatedCell(position);
-    result[toXC(col, row)] = cell;
+    result[toXC(col, row)] = model.getters.getEvaluatedCell(position);
   }
   return result;
 }

--- a/tests/top_bar_component.test.ts
+++ b/tests/top_bar_component.test.ts
@@ -568,7 +568,7 @@ describe("TopBar component", () => {
     // Won't update the current content
     const content = composerStore.currentContent;
     expect(content).toBe("");
-    composerEl = await typeInComposerTopBar("tabouret", false);
+    await typeInComposerTopBar("tabouret", false);
     expect(composerStore.currentContent).toBe(content);
   });
 

--- a/tests/xlsx/xlsx_import_export.test.ts
+++ b/tests/xlsx/xlsx_import_export.test.ts
@@ -57,8 +57,7 @@ function exportToXlsxThenImport(model: Model) {
       imageSrc: file.imageSrc,
     };
   }
-  const imported = new Model(dataToImport, undefined, undefined, undefined, false);
-  return imported;
+  return new Model(dataToImport, undefined, undefined, undefined, false);
 }
 
 describe("Export data to xlsx then import it", () => {

--- a/tools/bundle_xml/bundle_xml_templates.cjs
+++ b/tools/bundle_xml/bundle_xml_templates.cjs
@@ -91,7 +91,6 @@ function writeToFile(filepath, data) {
   fs.writeFile(filepath, data, (err) => {
     if (err) {
       process.stdout.write(`Error while writing file ${filepath}: ${err}`);
-      return;
     }
   });
 }

--- a/tools/bundle_xml/bundle_xml_templates.cjs
+++ b/tools/bundle_xml/bundle_xml_templates.cjs
@@ -10,8 +10,7 @@ const config = require("../../package.json");
 function getParsedOwlTemplateBundle() {
   const xml = getOwlTemplatesBundle();
   const parser = new DOMParser();
-  const doc = parser.parseFromString(xml, "text/xml");
-  return doc;
+  return parser.parseFromString(xml, "text/xml");
 }
 
 /**
@@ -22,8 +21,7 @@ function getParsedOwlTemplateBundle() {
 function getOwlTemplatesBundle(removeRootTags = false) {
   const srcPath = path.join(__dirname, "../../src");
   const files = getXmlTemplatesFiles(srcPath);
-  const templateBundle = createOwlTemplateBundle(files, removeRootTags);
-  return templateBundle;
+  return createOwlTemplateBundle(files, removeRootTags);
 }
 
 function getXmlTemplatesFiles(dir) {

--- a/tools/owl_templates/compile_templates.cjs
+++ b/tools/owl_templates/compile_templates.cjs
@@ -47,8 +47,7 @@ function compileTemplates() {
   const compiledTemplates = {};
   for (const template of parsedXMl.querySelectorAll("[t-name]")) {
     const name = template.getAttribute("t-name");
-    const fn = app._compileTemplate(name, template);
-    compiledTemplates[name] = fn;
+    compiledTemplates[name] = app._compileTemplate(name, template);
   }
 
   return compiledTemplates;


### PR DESCRIPTION
## Description:

I ran JetBrain's code inspection on the o-spreadhseet code. It listed a bunch of issues that I fixed.  Probably some of these commits are kinda useless.

Task: [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo