### PR TITLE
[FIX] test: skipped test in `renderer_plugin.test.ts`

### DIFF
--- a/tests/renderer_plugin.test.ts
+++ b/tests/renderer_plugin.test.ts
@@ -1274,39 +1274,32 @@ describe("renderer", () => {
   );
 
   test("Cell overflowing text centered is cut correctly when there's a border", () => {
-    () => {
-      const borders = ["right"];
-      const cellContent = "This is a long text larger than a cell";
-      const model = new Model({
-        sheets: [
-          { id: "sheet1", colNumber: 3, rowNumber: 3, cells: { B2: { content: cellContent } } },
-        ],
-      });
+    const cellContent = "This is a long text larger than a cell";
 
-      setStyle(model, "B2", { align: "center" });
+    const model = new Model();
+    resizeColumns(model, ["B"], 10);
+    setCellContent(model, "B2", cellContent);
+    setStyle(model, "B2", { align: "center" });
+    setZoneBorders(model, { position: "right" }, ["B2"]);
 
-      for (const border of borders) {
-        setZoneBorders(model, { position: border as BorderPosition }, ["B2"]);
-      }
-
-      let ctx = new MockGridRenderingContext(model, 1000, 1000, {});
-      model.drawGrid(ctx);
-      const box = getBoxFromText(model, cellContent);
-      const cell = getCell(model, "B2")!;
-      const textWidth = model.getters.getTextWidth(cell.content, cell.style || {});
-      const expectedClipRect = model.getters.getVisibleRect({
-        left: 0,
-        right: 1,
-        top: 1,
-        bottom: 1,
-      });
-      const expectedCLipX = box.x + box.width / 2 - textWidth / 2;
-      expect(box.clipRect).toEqual({
-        ...expectedClipRect,
-        x: expectedCLipX,
-        width: expectedClipRect.x + expectedClipRect.width - expectedCLipX,
-      });
-    };
+    let ctx = new MockGridRenderingContext(model, 1000, 1000, {});
+    model.drawGrid(ctx);
+    const box = getBoxFromText(model, cellContent);
+    const cell = getCell(model, "B2")!;
+    const textWidth =
+      model.getters.getTextWidth(cell.content, cell.style || {}) + MIN_CELL_TEXT_MARGIN;
+    const expectedClipRect = model.getters.getVisibleRect({
+      left: 0,
+      right: 1,
+      top: 1,
+      bottom: 1,
+    });
+    const expectedCLipX = box.x + box.width / 2 - textWidth / 2;
+    expect(box.clipRect).toEqual({
+      ...expectedClipRect,
+      x: expectedCLipX,
+      width: expectedClipRect.x + expectedClipRect.width - expectedCLipX,
+    });
   });
 
   test.each([


### PR DESCRIPTION
## Description

A test was skipped in `renderer_plugin.test.ts` because it didn't contain code instructions, but it contained a callback with those instructions. And the callback was never called.

This commit unskips the test and fixes it, it was wrong because it was forgetting to add `MIN_CELL_TEXT_MARGIN` to the width of the text.

Task: [4276968](https://www.odoo.com/web#id=4276968&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo