### PR TITLE
[FIX] format painter: use a single history step

### DIFF
--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -992,6 +992,10 @@ export interface SplitPivotFormulaCommand extends PositionDependentCommand {
   pivotId: UID;
 }
 
+export interface PaintFormat extends TargetDependentCommand {
+  type: "PAINT_FORMAT";
+}
+
 export type CoreCommand =
   // /** History */
   // | SelectiveUndoCommand
@@ -1139,7 +1143,8 @@ export type LocalCommand =
   | InsertNewPivotCommand
   | DuplicatePivotInNewSheetCommand
   | InsertPivotWithTableCommand
-  | SplitPivotFormulaCommand;
+  | SplitPivotFormulaCommand
+  | PaintFormat;
 
 export type Command = CoreCommand | LocalCommand;
 

--- a/tests/grid/grid_component.test.ts
+++ b/tests/grid/grid_component.test.ts
@@ -46,6 +46,7 @@ import {
   setCellFormat,
   setSelection,
   setStyle,
+  undo,
   updateFilter,
   updateTableConfig,
 } from "../test_helpers/commands_helpers";
@@ -961,6 +962,23 @@ describe("Grid component", () => {
       gridMouseEvent(model, "pointerdown", "D8");
       gridMouseEvent(model, "pointerup", "D8");
       expect(getCell(model, "D8")?.style).toEqual({ bold: true });
+    });
+
+    test("Paint format does a single history step", async () => {
+      selectCell(model, "B2");
+      setStyle(model, "B2", { bold: true });
+      setBorders(model, "B2", { top: DEFAULT_BORDER_DESC });
+
+      paintFormatStore.activate({ persistent: false });
+      gridMouseEvent(model, "pointerdown", "D8");
+      gridMouseEvent(model, "pointerup", "D8");
+
+      expect(getStyle(model, "D8")).toEqual({ bold: true });
+      expect(getBorder(model, "D8")).toEqual({ top: DEFAULT_BORDER_DESC });
+
+      undo(model);
+      expect(getStyle(model, "D8")).toEqual({});
+      expect(getBorder(model, "D8")).toEqual(null);
     });
   });
 


### PR DESCRIPTION
## Description

Since it was transformed into a store, the paint format tool would paste the style across multiple history steps. Oops.

Task: [4277362](https://www.odoo.com/web#id=4277362&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo