### PR TITLE
[FIX] chart: filled radar chart with negative values

### DIFF
--- a/src/helpers/figures/charts/radar_chart.ts
+++ b/src/helpers/figures/charts/radar_chart.ts
@@ -280,7 +280,7 @@ export function createRadarChartRuntime(chart: RadarChart, getters: Getters): Ra
     };
     if (fill) {
       dataset.backgroundColor = setColorAlpha(borderColor, 0.3);
-      dataset["fill"] = true;
+      dataset["fill"] = "start"; // fills from the start of the axes (default is to start at 0)
     }
     config.data.datasets.push(dataset);
   }

--- a/tests/figures/chart/radar_chart_plugin.test.ts
+++ b/tests/figures/chart/radar_chart_plugin.test.ts
@@ -1,5 +1,7 @@
-import { ChartCreationContext } from "../../../src";
+import { ChartCreationContext, Model } from "../../../src";
 import { RadarChart } from "../../../src/helpers/figures/charts/radar_chart";
+import { RadarChartRuntime } from "../../../src/types/chart/radar_chart";
+import { createRadarChart, setCellContent, updateChart } from "../../test_helpers/commands_helpers";
 
 describe("radar chart", () => {
   test("create radar chart from creation context", () => {
@@ -34,5 +36,19 @@ describe("radar chart", () => {
       fillArea: true,
       stacked: true,
     });
+  });
+
+  test("Dataset is filled if fillArea is set to true", () => {
+    const model = new Model();
+    setCellContent(model, "A2", "1");
+    createRadarChart(model, { fillArea: false, dataSets: [{ dataRange: "A1:A2" }] }, "chartId");
+    let runtime = model.getters.getChartRuntime("chartId") as RadarChartRuntime;
+    expect(runtime.chartJsConfig.data.datasets[0]?.backgroundColor).toBeFalsy();
+    expect(runtime.chartJsConfig.data.datasets[0]?.["fill"]).toBeFalsy();
+
+    updateChart(model, "chartId", { fillArea: true });
+    runtime = model.getters.getChartRuntime("chartId") as RadarChartRuntime;
+    expect(runtime.chartJsConfig.data.datasets[0]?.backgroundColor).toEqual("#4EA7F24D");
+    expect(runtime.chartJsConfig.data.datasets[0]?.["fill"]).toEqual("start");
   });
 });

--- a/tests/test_helpers/commands_helpers.ts
+++ b/tests/test_helpers/commands_helpers.ts
@@ -32,6 +32,7 @@ import { target, toRangeData, toRangesData } from "./helpers";
 
 import { ComboChartDefinition } from "../../src/types/chart/combo_chart";
 import { GaugeChartDefinition } from "../../src/types/chart/gauge_chart";
+import { RadarChartDefinition } from "../../src/types/chart/radar_chart";
 import { ScorecardChartDefinition } from "../../src/types/chart/scorecard_chart";
 import { WaterfallChartDefinition } from "../../src/types/chart/waterfall_chart";
 import { Image } from "../../src/types/image";
@@ -203,6 +204,33 @@ export function createComboChart(
       background: data.background,
       legendPosition: data.legendPosition || "top",
       aggregated: ("aggregated" in data && data.aggregated) || false,
+    },
+  });
+}
+
+export function createRadarChart(
+  model: Model,
+  data: Partial<RadarChartDefinition>,
+  chartId?: UID,
+  sheetId?: UID
+) {
+  const id = chartId || model.uuidGenerator.uuidv4();
+  sheetId = sheetId || model.getters.getActiveSheetId();
+
+  return model.dispatch("CREATE_CHART", {
+    id,
+    sheetId,
+    definition: {
+      title: data.title || { text: "test" },
+      dataSets: data.dataSets || [],
+      dataSetsHaveTitle: data.dataSetsHaveTitle !== undefined ? data.dataSetsHaveTitle : true,
+      labelRange: data.labelRange,
+      type: "radar",
+      background: data.background,
+      legendPosition: data.legendPosition || "top",
+      aggregated: ("aggregated" in data && data.aggregated) || false,
+      fillArea: data.fillArea || false,
+      stacked: data.stacked || false,
     },
   });
 }


### PR DESCRIPTION
## Description

The filled radar chart is wrong with negative values: the fill area starts at "0" instead of the minimum value, which makes the chart very strange if there is negative values in the dataset.

Task: [4281116](https://www.odoo.com/web#id=4281116&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo