### PR TITLE
[IMP] charts: enable "Show Values" on radar chart

### DIFF
--- a/src/components/figures/chart/chartJs/chartjs_show_values_plugin.ts
+++ b/src/components/figures/chart/chartJs/chartjs_show_values_plugin.ts
@@ -44,9 +44,10 @@ export const chartShowValuesPlugin: Plugin = {
         break;
       case "bar":
       case "line":
+      case "radar":
         options.horizontal
           ? drawHorizontalBarChartValues(chart, options, ctx)
-          : drawLineOrBarChartValues(chart, options, ctx);
+          : drawLineOrBarOrRadarChartValues(chart, options, ctx);
         break;
     }
 
@@ -61,7 +62,7 @@ function drawTextWithBackground(text: string, x: number, y: number, ctx: CanvasR
   ctx.fillText(text, x, y);
 }
 
-function drawLineOrBarChartValues(
+function drawLineOrBarOrRadarChartValues(
   chart: any,
   options: ChartShowValuesPluginOptions,
   ctx: CanvasRenderingContext2D
@@ -76,14 +77,20 @@ function drawLineOrBarChartValues(
     }
 
     for (let i = 0; i < dataset._parsed.length; i++) {
-      const value = dataset._parsed[i].y;
-      const displayValue = options.callback(value - 0, dataset.yAxisID);
-      const point = dataset.data[i];
+      const parsedValue = dataset._parsed[i];
+      const value = Number(chart.config.type === "radar" ? parsedValue.r : parsedValue.y);
+      if (isNaN(value)) {
+        continue;
+      }
 
+      const axisId = chart.config.type === "radar" ? dataset.rAxisID : dataset.yAxisID;
+      const displayValue = options.callback(Number(value), axisId);
+
+      const point = dataset.data[i];
       const xPosition = point.x;
 
       let yPosition = 0;
-      if (chart.config.type === "line") {
+      if (chart.config.type === "line" || chart.config.type === "radar") {
         yPosition = point.y - 10;
       } else {
         yPosition = value < 0 ? point.y - point.height / 2 : point.y + point.height / 2;
@@ -124,8 +131,11 @@ function drawHorizontalBarChartValues(
     }
 
     for (let i = 0; i < dataset._parsed.length; i++) {
-      const value = dataset._parsed[i].x;
-      const displayValue = options.callback(value - 0, dataset.xAxisID);
+      const value = Number(dataset._parsed[i].x);
+      if (isNaN(value)) {
+        continue;
+      }
+      const displayValue = options.callback(value, dataset.xAxisID);
       const point = dataset.data[i];
 
       const yPosition = point.y;

--- a/src/components/side_panel/chart/chart_with_axis/design_panel.xml
+++ b/src/components/side_panel/chart/chart_with_axis/design_panel.xml
@@ -15,7 +15,7 @@
             name="'showValues'"
             label.translate="Show values"
             value="props.definition.showValues"
-            onChange="showValues => props.updateChart(this.props.figureId, {showValues})"
+            onChange="(showValues) => props.updateChart(this.props.figureId, { showValues })"
           />
         </Section>
       </t>

--- a/src/components/side_panel/chart/pie_chart/pie_chart_design_panel.xml
+++ b/src/components/side_panel/chart/pie_chart/pie_chart_design_panel.xml
@@ -15,7 +15,7 @@
             name="'showValues'"
             label.translate="Show values"
             value="props.definition.showValues"
-            onChange="showValues => props.updateChart(this.props.figureId, {showValues})"
+            onChange="(showValues) => props.updateChart(this.props.figureId, { showValues })"
           />
         </Section>
       </t>

--- a/src/components/side_panel/chart/radar_chart/radar_chart_design_panel.xml
+++ b/src/components/side_panel/chart/radar_chart/radar_chart_design_panel.xml
@@ -10,6 +10,14 @@
           definition="props.definition"
           updateChart="props.updateChart"
         />
+        <Section class="'pt-0'" title.translate="Values">
+          <Checkbox
+            name="'showValues'"
+            label.translate="Show values"
+            value="props.definition.showValues"
+            onChange="(showValues) => props.updateChart(this.props.figureId, { showValues })"
+          />
+        </Section>
       </t>
     </GeneralDesignEditor>
     <SeriesDesignEditor t-props="props"/>

--- a/src/components/side_panel/chart/waterfall_chart/waterfall_chart_design_panel.xml
+++ b/src/components/side_panel/chart/waterfall_chart/waterfall_chart_design_panel.xml
@@ -23,7 +23,7 @@
             name="'showValues'"
             label.translate="Show values"
             value="props.definition.showValues"
-            onChange="showValues => props.updateChart(this.props.figureId, {showValues})"
+            onChange="(showValues) => props.updateChart(this.props.figureId, { showValues })"
           />
         </Section>
       </t>

--- a/src/helpers/figures/charts/radar_chart.ts
+++ b/src/helpers/figures/charts/radar_chart.ts
@@ -42,6 +42,7 @@ import {
 import { CHART_COMMON_OPTIONS, truncateLabel } from "./chart_ui_common";
 import {
   getBarChartLayout,
+  getChartShowValues,
   getChartTitle,
   getRadarChartData,
   getRadarChartDatasets,
@@ -61,6 +62,7 @@ export class RadarChart extends AbstractChart {
   readonly dataSetsHaveTitle: boolean;
   readonly dataSetDesign?: DatasetDesign[];
   readonly fillArea?: boolean;
+  readonly showValues?: boolean;
 
   constructor(definition: RadarChartDefinition, sheetId: UID, getters: CoreGetters) {
     super(definition, sheetId, getters);
@@ -78,6 +80,7 @@ export class RadarChart extends AbstractChart {
     this.dataSetsHaveTitle = definition.dataSetsHaveTitle;
     this.dataSetDesign = definition.dataSets;
     this.fillArea = definition.fillArea;
+    this.showValues = definition.showValues;
   }
 
   static transformDefinition(
@@ -106,6 +109,7 @@ export class RadarChart extends AbstractChart {
       type: "radar",
       labelRange: context.auxiliaryRange || undefined,
       fillArea: context.fillArea ?? false,
+      showValues: context.showValues ?? false,
     };
   }
 
@@ -171,6 +175,7 @@ export class RadarChart extends AbstractChart {
       stacked: this.stacked,
       aggregated: this.aggregated,
       fillArea: this.fillArea,
+      showValues: this.showValues,
     };
   }
 
@@ -229,6 +234,7 @@ export function createRadarChartRuntime(chart: RadarChart, getters: Getters): Ra
         title: getChartTitle(definition),
         legend: getRadarChartLegend(definition, chartData),
         tooltip: getRadarChartTooltip(definition, chartData),
+        chartShowValuesPlugin: getChartShowValues(definition, chartData),
       },
     },
   };

--- a/src/types/chart/radar_chart.ts
+++ b/src/types/chart/radar_chart.ts
@@ -15,6 +15,7 @@ export interface RadarChartDefinition {
   readonly stacked: boolean;
   readonly axesDesign?: AxesDesign;
   readonly fillArea?: boolean;
+  readonly showValues?: boolean;
 }
 
 export type RadarChartRuntime = {

--- a/tests/figures/chart/charts_component.test.ts
+++ b/tests/figures/chart/charts_component.test.ts
@@ -1521,31 +1521,25 @@ describe("charts", () => {
     });
   });
 
-  test("showValues checkbox updates the chart", async () => {
-    createTestChart("basicChart");
-    updateChart(model, chartId, {
-      type: "line",
-      labelRange: "C2:C4",
-      dataSets: [{ dataRange: "B2:B4" }],
-    });
-    await mountChartSidePanel();
-    await openChartDesignSidePanel(model, env, fixture, chartId);
+  test.each<ChartType>(["bar", "line", "waterfall", "radar"])(
+    "showValues checkbox updates the chart",
+    async (type: ChartType) => {
+      createTestChart(type);
+      await mountChartSidePanel();
+      await openChartDesignSidePanel(model, env, fixture, chartId);
 
-    expect(
-      (model.getters.getChartDefinition(chartId) as LineChartDefinition).showValues
-    ).toBeFalsy();
+      expect(model.getters.getChartDefinition(chartId)["showValues"]).toBeFalsy();
 
-    let options = getChartConfiguration(model, chartId).options;
-    expect(options.plugins.chartShowValuesPlugin.showValues).toBeFalsy();
+      let options = getChartConfiguration(model, chartId).options;
+      expect(options.plugins.chartShowValuesPlugin.showValues).toBeFalsy();
 
-    await simulateClick("input[name='showValues']");
-    expect(
-      (model.getters.getChartDefinition(chartId) as LineChartDefinition).showValues
-    ).toBeTruthy();
+      await simulateClick("input[name='showValues']");
+      expect(model.getters.getChartDefinition(chartId)["showValues"]).toBeTruthy();
 
-    options = getChartConfiguration(model, chartId).options;
-    expect(options.plugins.chartShowValuesPlugin.showValues).toBeTruthy();
-  });
+      options = getChartConfiguration(model, chartId).options;
+      expect(options.plugins.chartShowValuesPlugin.showValues).toBeTruthy();
+    }
+  );
 
   describe("aggregate", () => {
     test.each(["bar", "pie", "line", "scatter", "combo"] as const)(

--- a/tests/figures/chart/radar_chart_plugin.test.ts
+++ b/tests/figures/chart/radar_chart_plugin.test.ts
@@ -29,7 +29,7 @@ describe("radar chart", () => {
       showSubTotals: true,
       axesDesign: {},
       fillArea: true,
-      showValues: false,
+      showValues: true,
     };
     const definition = RadarChart.getDefinitionFromContextCreation(context);
     expect(definition).toEqual({
@@ -43,6 +43,7 @@ describe("radar chart", () => {
       aggregated: true,
       fillArea: true,
       stacked: true,
+      showValues: true,
     });
   });
 


### PR DESCRIPTION
## Description

This enable the "Show Values" option on radar chart. It will display the values labels on the chart.

Also the radar points were missing a background color.

Task: [4282824](https://www.odoo.com/web#id=4282824&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo