### PR TITLE
[FIX] chart: date line chart

### DIFF
--- a/src/helpers/figures/charts/chart_ui_common.ts
+++ b/src/helpers/figures/charts/chart_ui_common.ts
@@ -160,11 +160,19 @@ export function getChartLabelFormat(
   range: Range | undefined
 ): Format | undefined {
   if (!range) return undefined;
-  return getters.getEvaluatedCell({
-    sheetId: range.sheetId,
-    col: range.zone.left,
-    row: range.zone.top,
-  }).format;
+
+  const {
+    sheetId,
+    zone: { left, top, bottom },
+  } = range;
+  for (let row = top; row <= bottom; row++) {
+    const format = getters.getEvaluatedCell({ sheetId, col: left, row }).format;
+    if (format) {
+      return format;
+    }
+  }
+
+  return undefined;
 }
 
 export function getChartLabelValues(

--- a/src/helpers/figures/charts/line_chart.ts
+++ b/src/helpers/figures/charts/line_chart.ts
@@ -262,11 +262,7 @@ function canBeDateChart(labelRange: Range | undefined, getters: Getters): boolea
   if (!labelRange || !canBeLinearChart(labelRange, getters)) {
     return false;
   }
-  const labelFormat = getters.getEvaluatedCell({
-    sheetId: labelRange.sheetId,
-    col: labelRange.zone.left,
-    row: labelRange.zone.top,
-  }).format;
+  const labelFormat = getChartLabelFormat(getters, labelRange);
   return Boolean(labelFormat && timeFormatLuxonCompatible.test(labelFormat));
 }
 

--- a/tests/figures/chart/chart_plugin.test.ts
+++ b/tests/figures/chart/chart_plugin.test.ts
@@ -2120,6 +2120,27 @@ describe("Linear/Time charts", () => {
     );
     expect(model.getters.getChartRuntime(chartId)).toMatchSnapshot();
   });
+
+  test("Displays date labels correctly when 'Use row X as labels' is checked", () => {
+    setCellContent(model, "A2", "2024-01-01");
+    setCellContent(model, "B1", "first dataset");
+    setCellContent(model, "B2", "10");
+
+    createChart(
+      model,
+      {
+        type: "line",
+        dataSets: ["B1:B2"],
+        labelRange: "A1:A2",
+        labelsAsText: false,
+        dataSetsHaveTitle: true,
+      },
+      chartId
+    );
+
+    const chart = (model.getters.getChartRuntime(chartId) as LineChartRuntime).chartJsConfig;
+    expect(chart.data!.labels).toEqual(["2024-01-01"]);
+  });
 });
 
 describe("Chart evaluation", () => {


### PR DESCRIPTION
## Description:

When creating a line chart with date labels, if 'Use row X as headers' is enabled, the first cell is empty. Currently, we're checking the format of this empty cell to determine if the labels are dates.

Task: [4268977](https://www.odoo.com/odoo/project/2328/tasks/4268977)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo