### PR TITLE
[IMP] chart: improve bar chart borders

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -14,7 +14,6 @@ export const SELECTION_BORDER_COLOR = "#3266ca";
 export const HEADER_BORDER_COLOR = "#C0C0C0";
 export const CELL_BORDER_COLOR = "#E2E3E3";
 export const BACKGROUND_CHART_COLOR = "#FFFFFF";
-export const BORDER_CHART_COLOR = "#FFFFFF";
 export const DISABLED_TEXT_COLOR = "#CACACA";
 export const DEFAULT_COLOR_SCALE_MIDPOINT_COLOR = 0xb6d7a8;
 export const LINK_COLOR = "#017E84";

--- a/src/helpers/figures/charts/bar_chart.ts
+++ b/src/helpers/figures/charts/bar_chart.ts
@@ -1,6 +1,6 @@
 import type { ChartDataset, LegendOptions } from "chart.js";
 import { DeepPartial } from "chart.js/dist/types/utils";
-import { BACKGROUND_CHART_COLOR, BORDER_CHART_COLOR } from "../../../constants";
+import { BACKGROUND_CHART_COLOR } from "../../../constants";
 import {
   AddColumnsRowsCommand,
   ApplyRangeChange,
@@ -325,8 +325,8 @@ export function createBarChartRuntime(chart: BarChart, getters: Getters): BarCha
     const dataset: ChartDataset<"bar", number[]> = {
       label,
       data,
-      borderColor: BORDER_CHART_COLOR,
-      borderWidth: 1,
+      borderColor: definition.background || BACKGROUND_CHART_COLOR,
+      borderWidth: definition.stacked ? 1 : 0,
       backgroundColor: color,
     };
     config.data.datasets.push(dataset);

--- a/tests/figures/chart/bar_chart_plugin.test.ts
+++ b/tests/figures/chart/bar_chart_plugin.test.ts
@@ -1,4 +1,5 @@
 import { ChartCreationContext, Model } from "../../../src";
+import { BACKGROUND_CHART_COLOR } from "../../../src/constants";
 import { BarChart } from "../../../src/helpers/figures/charts";
 import { BarChartRuntime } from "../../../src/types/chart";
 import { isChartAxisStacked } from "../../test_helpers/chart_helpers";
@@ -8,6 +9,7 @@ import {
   setFormat,
   updateChart,
 } from "../../test_helpers/commands_helpers";
+import { createModelFromGrid } from "../../test_helpers/helpers";
 
 let model: Model;
 describe("bar chart", () => {
@@ -127,5 +129,55 @@ describe("bar chart", () => {
       expect(runtime.chartJsConfig.options?.scales?.y1).toBe(undefined);
       expect(runtime.chartJsConfig.data.datasets[0].yAxisID).toBe(undefined);
     });
+  });
+
+  test("Bar chart border are only shown for stacked chart", () => {
+    const model = createModelFromGrid({
+      A1: "first column dataset",
+      A2: "0",
+      A3: "1",
+      B1: "second column dataset",
+      B2: "10",
+      B3: "11",
+    });
+    createChart(
+      model,
+      {
+        type: "bar",
+        dataSets: [{ dataRange: "A1:B3" }, { dataRange: "B1:B3" }],
+      },
+      "chartId"
+    );
+    let runtime = model.getters.getChartRuntime("chartId") as BarChartRuntime;
+    expect(runtime.chartJsConfig.data.datasets[0].borderWidth).toBe(0);
+
+    updateChart(model, "chartId", { stacked: true });
+    runtime = model.getters.getChartRuntime("chartId") as BarChartRuntime;
+    expect(runtime.chartJsConfig.data.datasets[0].borderWidth).toBe(1);
+  });
+
+  test("Stacked Bar chart border are drawn with the chart background color", () => {
+    const model = createModelFromGrid({
+      A1: "first column dataset",
+      A2: "0",
+      A3: "1",
+      B1: "second column dataset",
+      B2: "10",
+      B3: "11",
+    });
+    createChart(
+      model,
+      {
+        type: "bar",
+        dataSets: [{ dataRange: "A1:B3" }, { dataRange: "B1:B3" }],
+      },
+      "chartId"
+    );
+    let runtime = model.getters.getChartRuntime("chartId") as BarChartRuntime;
+    expect(runtime.chartJsConfig.data.datasets[0].borderColor).toBe(BACKGROUND_CHART_COLOR);
+
+    updateChart(model, "chartId", { background: "#f00" });
+    runtime = model.getters.getChartRuntime("chartId") as BarChartRuntime;
+    expect(runtime.chartJsConfig.data.datasets[0].borderColor).toBe("#f00");
   });
 });


### PR DESCRIPTION
## Task Description

Since the new design of chart color, when we try to draw a bar chart, we have a small difference between a classical bar chart and a combo bar where every series is a bar. This is due to the border of the bar in a bar chart that are drawn in a whitish color, while the border are still in the same color as the bar in a combo chart. This task aims to change the way we draw the border of a bar chart, only drawing a small white border between two stacked bar.

## Related Task
- Task: 4283212

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo