### PR TITLE
[IMP] data_validation: add formula autocomplete and validation

### DIFF
--- a/src/components/side_panel/data_validation/dv_criterion_form/dv_input/dv_input.ts
+++ b/src/components/side_panel/data_validation/dv_criterion_form/dv_input/dv_input.ts
@@ -3,6 +3,7 @@ import { canonicalizeContent } from "../../../../../helpers/locale";
 import { dataValidationEvaluatorRegistry } from "../../../../../registries/data_validation_registry";
 import { _t } from "../../../../../translation";
 import { DataValidationCriterionType, SpreadsheetChildEnv } from "../../../../../types";
+import { StandaloneComposer } from "../../../../composer/standalone_composer/standalone_composer";
 import { css } from "../../../../helpers";
 
 interface Props {
@@ -43,6 +44,7 @@ export class DataValidationInput extends Component<Props, SpreadsheetChildEnv> {
     focused: false,
     onBlur: () => {},
   };
+  static components = { StandaloneComposer: StandaloneComposer };
 
   inputRef = useRef("input");
 
@@ -61,11 +63,6 @@ export class DataValidationInput extends Component<Props, SpreadsheetChildEnv> {
     shouldDisplayError: !!this.props.value, // Don't display error if user inputted nothing yet
   });
 
-  onValueChanged(ev: Event) {
-    this.state.shouldDisplayError = true;
-    this.props.onValueChanged((ev.target as HTMLInputElement).value);
-  }
-
   get placeholder(): string {
     const evaluator = dataValidationEvaluatorRegistry.get(this.props.criterionType);
 
@@ -76,6 +73,31 @@ export class DataValidationInput extends Component<Props, SpreadsheetChildEnv> {
     }
 
     return _t("Value or formula");
+  }
+
+  get allowedValues(): string {
+    const evaluator = dataValidationEvaluatorRegistry.get(this.props.criterionType);
+    return evaluator.allowedValues ?? "any";
+  }
+
+  onInputValueChanged(ev: Event) {
+    this.state.shouldDisplayError = true;
+    this.props.onValueChanged((ev.target as HTMLInputElement).value);
+  }
+
+  onChangeComposerValue(str: string) {
+    this.state.shouldDisplayError = true;
+    this.props.onValueChanged(str);
+  }
+
+  getDataValidationRuleInputComposerProps(): StandaloneComposer["props"] {
+    return {
+      onConfirm: (str: string) => this.onChangeComposerValue(str),
+      composerContent: this.props.value,
+      placeholder: this.placeholder,
+      class: "o-sidePanel-composer",
+      defaultRangeSheetId: this.env.model.getters.getActiveSheetId(),
+    };
   }
 
   get errorMessage(): string | undefined {

--- a/src/components/side_panel/data_validation/dv_criterion_form/dv_input/dv_input.xml
+++ b/src/components/side_panel/data_validation/dv_criterion_form/dv_input/dv_input.xml
@@ -1,20 +1,25 @@
 <templates>
   <t t-name="o-spreadsheet-DataValidationInput">
-    <div class="o-dv-input position-relative w-100">
-      <input
-        type="text"
-        t-ref="input"
-        t-on-input="onValueChanged"
-        t-att-value="props.value"
-        class="o-input"
-        t-att-class="{
-            'o-invalid border-danger position-relative': errorMessage,
-          }"
-        t-att-title="errorMessage"
-        t-att-placeholder="placeholder"
-        t-on-keydown="props.onKeyDown"
-        t-on-blur="props.onBlur"
-      />
+    <div class="o-dv-input position-relative w-100 p-1">
+      <t t-if="allowedValues === 'onlyLiterals'">
+        <input
+          type="text"
+          t-ref="input"
+          t-on-input="onInputValueChanged"
+          t-att-value="props.value"
+          class="o-input"
+          t-att-class="{
+              'o-invalid border-danger position-relative': errorMessage,
+            }"
+          t-att-title="errorMessage"
+          t-att-placeholder="placeholder"
+          t-on-keydown="props.onKeyDown"
+          t-on-blur="props.onBlur"
+        />
+      </t>
+      <t t-else="">
+        <StandaloneComposer t-props="getDataValidationRuleInputComposerProps()"/>
+      </t>
       <span
         t-if="errorMessage"
         class="error-icon text-danger position-absolute d-flex align-items-center"

--- a/src/components/side_panel/data_validation/dv_editor/dv_editor.xml
+++ b/src/components/side_panel/data_validation/dv_editor/dv_editor.xml
@@ -37,13 +37,11 @@
       <Section>
         <div class="o-sidePanelButtons">
           <button t-on-click="props.onExit" class="o-dv-cancel o-button">Cancel</button>
-          <button
-            t-on-click="onSave"
-            class="o-dv-save o-button primary"
-            t-att-class="{'o-disabled': !canSave }">
-            Save
-          </button>
+          <button t-on-click="onSave" class="o-dv-save o-button primary">Save</button>
         </div>
+      </Section>
+      <Section>
+        <ValidationMessages messages="errorMessages" msgType="'error'"/>
       </Section>
     </div>
   </t>

--- a/src/components/translations_terms.ts
+++ b/src/components/translations_terms.ts
@@ -144,6 +144,17 @@ export const DVTerms = {
     numberValue: _t("The value must be a number"),
     dateValue: _t("The value must be a date"),
     validRange: _t("The value must be a valid range"),
+    validFormula: _t("The formula must be valid"),
+  },
+  Errors: {
+    [CommandResult.InvalidRange]: _t("The range is invalid."),
+    [CommandResult.InvalidDataValidationCriterionValue]: _t(
+      "One or more of the provided criteria values are invalid. Please review and correct them."
+    ),
+    [CommandResult.InvalidNumberOfCriterionValues]: _t(
+      "One or more of the provided criteria values are missing."
+    ),
+    Unexpected: _t("The rule is invalid for an unknown reason."),
   },
 };
 

--- a/src/plugins/ui_core_views/evaluation_data_validation.ts
+++ b/src/plugins/ui_core_views/evaluation_data_validation.ts
@@ -1,3 +1,4 @@
+import { DVTerms } from "../../components/translations_terms";
 import { compile } from "../../formulas";
 import { getCellPositionsInRanges, isInside, lazy } from "../../helpers";
 import { dataValidationEvaluatorRegistry } from "../../registries/data_validation_registry";
@@ -82,9 +83,10 @@ export class EvaluationDataValidationPlugin extends UIPlugin {
   ): string | undefined {
     const evaluator = dataValidationEvaluatorRegistry.get(criterionType);
     if (value.startsWith("=")) {
-      return evaluator.allowedValues === "onlyLiterals"
-        ? _t("The value must not be a formula")
-        : undefined;
+      if (evaluator.allowedValues === "onlyLiterals") {
+        return _t("The value must not be a formula");
+      }
+      return this.isValidFormula(value) ? undefined : DVTerms.CriterionError.validFormula;
     } else if (evaluator.allowedValues === "onlyFormulas") {
       return _t("The value must be a formula");
     }
@@ -117,6 +119,10 @@ export class EvaluationDataValidationPlugin extends UIPlugin {
     const error = this.getRuleErrorForCellValue(cellValue, cellPosition, rule);
 
     return error ? { error, rule, isValid: false } : VALID_RESULT;
+  }
+
+  private isValidFormula(value: string): boolean {
+    return !compile(value).isBadExpression;
   }
 
   private getValidationResultForCell(cellPosition: CellPosition): ValidationResult {

--- a/src/registries/data_validation_registry.ts
+++ b/src/registries/data_validation_registry.ts
@@ -78,7 +78,6 @@ export type DataValidationCriterionEvaluator = {
    * The value should be in canonical form (non-localized).
    */
   isCriterionValueValid: (value: string) => boolean;
-
   /** Return the number of values that the criterion must contains. Return undefined if the criterion can have any number of values */
   numberOfValues: (criterion: DataValidationCriterion) => number | undefined;
   name: string;

--- a/tests/data_validation/data_validation_list_component.test.ts
+++ b/tests/data_validation/data_validation_list_component.test.ts
@@ -51,7 +51,7 @@ describe("Edit criterion in side panel", () => {
       await click(fixture, ".o-dv-preview");
     });
 
-    test("Side panel is correctly pre-filled", () => {
+    test("Side panel is correctly pre-filled for isValueInList criterion", () => {
       const inputs = fixture.querySelectorAll<HTMLInputElement>(".o-dv-list-values .o-input");
       expect(inputs).toHaveLength(3);
       expect(inputs[0].value).toBe("ok");
@@ -60,6 +60,18 @@ describe("Edit criterion in side panel", () => {
 
       const displayStyleInput = fixture.querySelector<HTMLInputElement>(".o-dv-display-style");
       expect(displayStyleInput?.value).toBe("arrow");
+    });
+
+    test("Side panel is correctly pre-filled for composer criterion", async () => {
+      addDataValidation(model, "A1", "id", {
+        type: "textContains",
+        values: ["hola"],
+      });
+      ({ fixture } = await mountDataValidationPanel(model));
+      await click(fixture, ".o-dv-preview");
+      const inputs = fixture.querySelectorAll<HTMLInputElement>(".o-dv-input .o-composer");
+      expect(inputs).toHaveLength(1);
+      expect(inputs[0].innerText).toBe("hola");
     });
 
     test("Can add a new value", async () => {

--- a/tests/data_validation/data_validation_registry.test.ts
+++ b/tests/data_validation/data_validation_registry.test.ts
@@ -82,7 +82,7 @@ describe("Data validation registry", () => {
     test("Error string", () =>
       testErrorStringEqual(criterion, 'The value must be a text that contains "test"'));
 
-    test("Valid criterion values", () => testValidTextCriterionValues(evaluator));
+    test("Valid criterion text values", () => testValidTextCriterionValues(evaluator));
   });
 
   describe("Text not contains", () => {


### PR DESCRIPTION
This commit adds autocomplete and validation checks for formulas used in data validation rules.

Task: [4084829](https://www.odoo.com/odoo/project/2328/tasks/4084829)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo