### PR TITLE
[IMP] components: add Legend Component

### DIFF
--- a/src/components/side_panel/chart/building_blocks/legend/legend.ts
+++ b/src/components/side_panel/chart/building_blocks/legend/legend.ts
@@ -1,0 +1,32 @@
+import { Component } from "@odoo/owl";
+import {
+  ChartWithDataSetDefinition,
+  DispatchResult,
+  SpreadsheetChildEnv,
+  UID,
+} from "../../../../../types";
+import { Section } from "../../../components/section/section";
+
+interface Props {
+  figureId: UID;
+  definition: ChartWithDataSetDefinition;
+  updateChart: (figureId: UID, definition: Partial<ChartWithDataSetDefinition>) => DispatchResult;
+}
+
+export class ChartLegend extends Component<Props, SpreadsheetChildEnv> {
+  static template = "o-spreadsheet-ChartLegend";
+  static components = {
+    Section,
+  };
+  static props = {
+    figureId: String,
+    definition: Object,
+    updateChart: Function,
+  };
+
+  updateLegendPosition(ev) {
+    this.props.updateChart(this.props.figureId, {
+      legendPosition: ev.target.value,
+    });
+  }
+}

--- a/src/components/side_panel/chart/building_blocks/legend/legend.xml
+++ b/src/components/side_panel/chart/building_blocks/legend/legend.xml
@@ -1,0 +1,16 @@
+<templates>
+  <t t-name="o-spreadsheet-ChartLegend">
+    <Section class="'pt-0'" title.translate="Legend position">
+      <select
+        t-att-value="props.definition.legendPosition ?? 'top'"
+        class="o-input o-chart-legend-position"
+        t-on-change="this.updateLegendPosition">
+        <option value="none">None</option>
+        <option value="top">Top</option>
+        <option value="bottom">Bottom</option>
+        <option value="left">Left</option>
+        <option value="right">Right</option>
+      </select>
+    </Section>
+  </t>
+</templates>

--- a/src/components/side_panel/chart/chart_with_axis/design_panel.ts
+++ b/src/components/side_panel/chart/chart_with_axis/design_panel.ts
@@ -15,6 +15,7 @@ import {
   AxisDesignEditor,
 } from "../building_blocks/axis_design/axis_design_editor";
 import { GeneralDesignEditor } from "../building_blocks/general_design/general_design_editor";
+import { ChartLegend } from "../building_blocks/legend/legend";
 import { SeriesWithAxisDesignEditor } from "../building_blocks/series_design/series_with_axis_design_editor";
 
 interface Props {
@@ -39,6 +40,7 @@ export class ChartWithAxisDesignPanel<P extends Props = Props> extends Component
     AxisDesignEditor,
     Checkbox,
     SeriesWithAxisDesignEditor,
+    ChartLegend,
   };
   static props = {
     figureId: String,
@@ -57,11 +59,5 @@ export class ChartWithAxisDesignPanel<P extends Props = Props> extends Component
       axes.push({ id: "y1", name: useLeftAxis ? _t("Right axis") : _t("Vertical axis") });
     }
     return axes;
-  }
-
-  updateLegendPosition(ev) {
-    this.props.updateChart(this.props.figureId, {
-      legendPosition: ev.target.value,
-    });
   }
 }

--- a/src/components/side_panel/chart/chart_with_axis/design_panel.xml
+++ b/src/components/side_panel/chart/chart_with_axis/design_panel.xml
@@ -5,18 +5,11 @@
       definition="props.definition"
       updateChart="props.updateChart">
       <t t-set-slot="general-extension">
-        <Section class="'pt-0'" title.translate="Legend position">
-          <select
-            t-att-value="props.definition.legendPosition ?? 'top'"
-            class="o-input"
-            t-on-change="this.updateLegendPosition">
-            <option value="none">None</option>
-            <option value="top">Top</option>
-            <option value="bottom">Bottom</option>
-            <option value="left">Left</option>
-            <option value="right">Right</option>
-          </select>
-        </Section>
+        <ChartLegend
+          figureId="props.figureId"
+          definition="props.definition"
+          updateChart="props.updateChart"
+        />
         <Section class="'pt-0'" title.translate="Values">
           <Checkbox
             name="'showValues'"

--- a/src/components/side_panel/chart/combo_chart/combo_chart_design_panel.xml
+++ b/src/components/side_panel/chart/combo_chart/combo_chart_design_panel.xml
@@ -5,18 +5,11 @@
       definition="props.definition"
       updateChart="props.updateChart">
       <t t-set-slot="general-extension">
-        <Section class="'pt-0'" title.translate="Legend position">
-          <select
-            t-att-value="props.definition.legendPosition ?? 'top'"
-            class="o-input"
-            t-on-change="this.updateLegendPosition">
-            <option value="none">None</option>
-            <option value="top">Top</option>
-            <option value="bottom">Bottom</option>
-            <option value="left">Left</option>
-            <option value="right">Right</option>
-          </select>
-        </Section>
+        <ChartLegend
+          figureId="props.figureId"
+          definition="props.definition"
+          updateChart="props.updateChart"
+        />
         <Section class="'pt-0'" title.translate="Values">
           <Checkbox
             name="'showValues'"

--- a/src/components/side_panel/chart/pie_chart/pie_chart_design_panel.ts
+++ b/src/components/side_panel/chart/pie_chart/pie_chart_design_panel.ts
@@ -4,6 +4,7 @@ import { PieChartDefinition } from "../../../../types/chart";
 import { Checkbox } from "../../components/checkbox/checkbox";
 import { Section } from "../../components/section/section";
 import { GeneralDesignEditor } from "../building_blocks/general_design/general_design_editor";
+import { ChartLegend } from "../building_blocks/legend/legend";
 
 interface Props {
   figureId: UID;
@@ -18,6 +19,7 @@ export class PieChartDesignPanel extends Component<Props, SpreadsheetChildEnv> {
     GeneralDesignEditor,
     Section,
     Checkbox,
+    ChartLegend,
   };
   static props = {
     figureId: String,
@@ -25,10 +27,4 @@ export class PieChartDesignPanel extends Component<Props, SpreadsheetChildEnv> {
     updateChart: Function,
     canUpdateChart: { type: Function, optional: true },
   };
-
-  updateLegendPosition(ev) {
-    this.props.updateChart(this.props.figureId, {
-      legendPosition: ev.target.value,
-    });
-  }
 }

--- a/src/components/side_panel/chart/pie_chart/pie_chart_design_panel.xml
+++ b/src/components/side_panel/chart/pie_chart/pie_chart_design_panel.xml
@@ -5,18 +5,11 @@
       definition="props.definition"
       updateChart="props.updateChart">
       <t t-set-slot="general-extension">
-        <Section class="'pt-0'" title.translate="Legend position">
-          <select
-            t-att-value="props.definition.legendPosition ?? 'top'"
-            class="o-input"
-            t-on-change="(ev) => this.updateLegendPosition(ev)">
-            <option value="none">None</option>
-            <option value="top">Top</option>
-            <option value="bottom">Bottom</option>
-            <option value="left">Left</option>
-            <option value="right">Right</option>
-          </select>
-        </Section>
+        <ChartLegend
+          figureId="props.figureId"
+          definition="props.definition"
+          updateChart="props.updateChart"
+        />
         <Section title.translate="Values">
           <Checkbox
             name="'showValues'"

--- a/src/components/side_panel/chart/radar_chart/radar_chart_design_panel.ts
+++ b/src/components/side_panel/chart/radar_chart/radar_chart_design_panel.ts
@@ -4,6 +4,7 @@ import { DispatchResult, SpreadsheetChildEnv, UID } from "../../../../types/inde
 import { Checkbox } from "../../components/checkbox/checkbox";
 import { Section } from "../../components/section/section";
 import { GeneralDesignEditor } from "../building_blocks/general_design/general_design_editor";
+import { ChartLegend } from "../building_blocks/legend/legend";
 import { SeriesDesignEditor } from "../building_blocks/series_design/series_design_editor";
 
 interface Props {
@@ -20,6 +21,7 @@ export class RadarChartDesignPanel extends Component<Props, SpreadsheetChildEnv>
     SeriesDesignEditor,
     Section,
     Checkbox,
+    ChartLegend,
   };
   static props = {
     figureId: String,
@@ -27,10 +29,4 @@ export class RadarChartDesignPanel extends Component<Props, SpreadsheetChildEnv>
     canUpdateChart: Function,
     updateChart: Function,
   };
-
-  updateLegendPosition(ev) {
-    this.props.updateChart(this.props.figureId, {
-      legendPosition: ev.target.value,
-    });
-  }
 }

--- a/src/components/side_panel/chart/radar_chart/radar_chart_design_panel.xml
+++ b/src/components/side_panel/chart/radar_chart/radar_chart_design_panel.xml
@@ -5,18 +5,11 @@
       definition="props.definition"
       updateChart="props.updateChart">
       <t t-set-slot="general-extension">
-        <Section class="'pt-0'" title.translate="Legend Position">
-          <select
-            t-att-value="props.definition.legendPosition ?? 'top'"
-            class="o-input"
-            t-on-change="this.updateLegendPosition">
-            <option value="none">None</option>
-            <option value="top">Top</option>
-            <option value="bottom">Bottom</option>
-            <option value="left">Left</option>
-            <option value="right">Right</option>
-          </select>
-        </Section>
+        <ChartLegend
+          figureId="props.figureId"
+          definition="props.definition"
+          updateChart="props.updateChart"
+        />
       </t>
     </GeneralDesignEditor>
     <SeriesDesignEditor t-props="props"/>

--- a/src/components/side_panel/chart/waterfall_chart/waterfall_chart_design_panel.ts
+++ b/src/components/side_panel/chart/waterfall_chart/waterfall_chart_design_panel.ts
@@ -17,6 +17,7 @@ import {
   AxisDesignEditor,
 } from "../building_blocks/axis_design/axis_design_editor";
 import { GeneralDesignEditor } from "../building_blocks/general_design/general_design_editor";
+import { ChartLegend } from "../building_blocks/legend/legend";
 import { Checkbox } from "./../../components/checkbox/checkbox";
 
 interface Props {
@@ -36,6 +37,7 @@ export class WaterfallChartDesignPanel extends Component<Props, SpreadsheetChild
     RoundColorPicker,
     AxisDesignEditor,
     RadioSelection,
+    ChartLegend,
   };
   static props = {
     figureId: String,
@@ -88,12 +90,6 @@ export class WaterfallChartDesignPanel extends Component<Props, SpreadsheetChild
       (this.props.definition as WaterfallChartDefinition).subTotalValuesColor ||
       CHART_WATERFALL_SUBTOTAL_COLOR
     );
-  }
-
-  updateLegendPosition(ev) {
-    this.props.updateChart(this.props.figureId, {
-      legendPosition: ev.target.value,
-    });
   }
 
   updateVerticalAxisPosition(value: "left" | "right") {

--- a/src/components/side_panel/chart/waterfall_chart/waterfall_chart_design_panel.xml
+++ b/src/components/side_panel/chart/waterfall_chart/waterfall_chart_design_panel.xml
@@ -13,19 +13,12 @@
             onChange.bind="updateVerticalAxisPosition"
           />
         </Section>
-        <Section title.translate="Legend position">
-          <select
-            t-att-value="props.definition.legendPosition"
-            class="o-input o-chart-legend-position"
-            t-on-change="(ev) => this.updateLegendPosition(ev)">
-            <option value="none">None</option>
-            <option value="top">Top</option>
-            <option value="bottom">Bottom</option>
-            <option value="left">Left</option>
-            <option value="right">Right</option>
-          </select>
-        </Section>
-        <Section title.translate="Values">
+        <ChartLegend
+          figureId="props.figureId"
+          definition="props.definition"
+          updateChart="props.updateChart"
+        />
+        <Section class="'pt-0'" title.translate="Values">
           <Checkbox
             name="'showValues'"
             label.translate="Show values"


### PR DESCRIPTION
## Description:

This commit adds a new Component for handling the legend position of a chart

Task: [3633666](https://www.odoo.com/web#id=3633666&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo