### PR TITLE
[FIX] functions: FILTER with strings and errors

### DIFF
--- a/src/functions/module_filter.ts
+++ b/src/functions/module_filter.ts
@@ -146,7 +146,9 @@ export const FILTER = {
     const result: Matrix<FunctionResultObject> = [];
     for (let i = 0; i < _array.length; i++) {
       const row = _array[i];
-      if (_conditions.every((c) => c[i])) {
+      if (
+        _conditions.every((c) => (typeof c[i] === "boolean" || typeof c[i] === "number") && c[i])
+      ) {
         result.push(row);
       }
     }

--- a/tests/functions/module_filter.test.ts
+++ b/tests/functions/module_filter.test.ts
@@ -109,6 +109,17 @@ describe("FILTER function", () => {
     expect(checkFunctionDoesntSpreadBeyondRange(model, "D1")).toBeTruthy();
   });
 
+  test("FILTER by string ignores the value", () => {
+    // prettier-ignore
+    const grid = {
+      A1: "Alice", B1: "yes",
+      A2: "Bob",   B2: "TRUE",
+    };
+    const model = createModelFromGrid(grid);
+    setCellContent(model, "A6", "=FILTER(A1:A2, B1:B2)");
+    expect(getRangeValuesAsMatrix(model, "A6:A7")).toEqual([["Bob"], [null]]);
+  });
+
   test("FILTER accepts errors in first argument", () => {
     // prettier-ignore
     const grid = {
@@ -119,6 +130,18 @@ describe("FILTER function", () => {
     const model = createModelFromGrid(grid);
     setCellContent(model, "A6", "=FILTER(A1:A3, B1:B3)");
     expect(getRangeValuesAsMatrix(model, "A6:A7")).toEqual([["#BAD_EXPR"], ["John"]]);
+  });
+
+  test("FILTER accepts errors in condition arguments", () => {
+    // prettier-ignore
+    const grid = {
+      A1: "Alice",  B1: "TRUE",     C1: "TRUE",
+      A2: "Peter",  B2: "=KABOUM",  C2: "TRUE",
+      A3: "John",   B3: "TRUE",     C3: "=KABOUM",
+    };
+    const model = createModelFromGrid(grid);
+    setCellContent(model, "A6", "=FILTER(A1:A3, B1:B3, C1:C3)");
+    expect(getRangeValuesAsMatrix(model, "A6:A8")).toEqual([["Alice"], [null], [null]]);
   });
 });
 


### PR DESCRIPTION
The FILTER function should only consider numbers and booleans as the conditions but it currently only accepts all types of values (strings, errors) as long as the value is "truthy".

Steps to reproduce:

Let's consider this grid
	A	B
1     Alice  coucou
2      Bob    TRUE

The formula =FILTER(A1:A2, B1:B2) should only yield Bob and not Alice.

Note that this is a breaking change since the behavior is different. That's why I'm not backporting the fix.

Task: 4307604

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo