### PR TITLE
[FIX] pivot: skip cells on manipulated pivot array formulas

### DIFF
--- a/src/plugins/ui_core_views/pivot_ui.ts
+++ b/src/plugins/ui_core_views/pivot_ui.ts
@@ -197,6 +197,12 @@ export class PivotUIPlugin extends UIPlugin {
     if (!pivot.isValid()) {
       return EMPTY_PIVOT_CELL;
     }
+    if (
+      functionName === "PIVOT" &&
+      !cell.content.replaceAll(" ", "").toUpperCase().startsWith("=PIVOT")
+    ) {
+      return EMPTY_PIVOT_CELL;
+    }
     if (functionName === "PIVOT") {
       const includeTotal = args[2] === false ? false : undefined;
       const includeColumnHeaders = args[3] === false ? false : undefined;

--- a/tests/pivots/pivot_plugin.test.ts
+++ b/tests/pivots/pivot_plugin.test.ts
@@ -50,6 +50,26 @@ describe("Pivot plugin", () => {
     );
   });
 
+  test("getPivotCellFromPosition cannot get the pivot cell when the table is manipulated by other functions", () => {
+    // prettier-ignore
+    const grid = {
+      A1: "Customer", B1: "Price", C1: '=PIVOT.VALUE(1,"Price","5","Bob")',
+      A2: "Alice",    B2: "10",
+      A3: "Bob",      B3: "30",
+      A4: "=TRANSPOSE(PIVOT(1))",
+    };
+    const model = createModelFromGrid(grid);
+    addPivot(model, "A1:B3", {
+      columns: [],
+      rows: [{ name: "Customer" }],
+      measures: [{ name: "Price", aggregator: "sum" }],
+    });
+    selectCell(model, "C5");
+    expect(model.getters.getPivotCellFromPosition(model.getters.getActivePosition())).toEqual(
+      EMPTY_PIVOT_CELL
+    );
+  });
+
   test("forbidden characters are removed from new sheet name when duplicating a pivot", () => {
     const grid = {
       A1: "Customer",


### PR DESCRIPTION
## Description:

Steps to reproduce in odoo:

- insert a pivot with more rows than columns
- write in a cell =TRANSPOSE(ODOO.PIVOT.TABLE(1))
- right-click on the grand total value

=> boom

When computing which cell of the pivot table is clicked, we assume the matrix comes directly from the ODOO.PIVOT.TABLE(...) function to compute the offsets from the array formula. But it's completely wrong as the cell could at a completely different place if the matrix is manipulated by other functions before being outputted to the grid.

Forward-port of https://github.com/odoo/odoo/commit/d33a9f3

Task: [4292134](https://www.odoo.com/web#id=4292134&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo