### PR TITLE
[PERF] evaluation: early return errors

### DIFF
--- a/src/functions/arguments.ts
+++ b/src/functions/arguments.ts
@@ -55,6 +55,10 @@ function makeArg(str: string, description: string): ArgDefinition {
     description,
     type: types,
   };
+  const acceptErrors = types.includes("ANY") || types.includes("RANGE");
+  if (acceptErrors) {
+    result.acceptErrors = true;
+  }
   if (isOptional) {
     result.optional = true;
   }

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -215,6 +215,17 @@ function createComputeFunction(
     this: EvalContext,
     ...args: Arg[]
   ): Matrix<FunctionResultObject> | FunctionResultObject {
+    for (let i = 0; i < args.length; i++) {
+      const arg = args[i];
+      const argDefinition = descr.args[descr.getArgToFocus(i + 1) - 1];
+
+      // Early exit if the argument is an error and the function does not accept errors
+      // We only check scalar arguments, not matrix arguments for performance reasons.
+      // Casting helpers are responsible for handling errors in matrix arguments.
+      if (!argDefinition.acceptErrors && !isMatrix(arg) && isEvaluationError(arg?.value)) {
+        return arg;
+      }
+    }
     try {
       return computeFunctionToObject.apply(this, args);
     } catch (e) {

--- a/src/functions/module_database.ts
+++ b/src/functions/module_database.ts
@@ -154,7 +154,7 @@ const databaseArgs = [
     )
   ),
   arg(
-    "field (any)",
+    "field (number, string)",
     _t("Indicates which column in database contains the values to be extracted and operated on.")
   ),
   arg(

--- a/src/functions/module_logical.ts
+++ b/src/functions/module_logical.ts
@@ -147,7 +147,7 @@ export const IFS = {
     ),
     arg("value1 (any)", _t("The returned value if condition1 is TRUE.")),
     arg(
-      "condition2 (boolean, repeating)",
+      "condition2 (boolean, any, repeating)",
       _t("Additional conditions to be evaluated if the previous ones are FALSE.")
     ),
     arg(

--- a/src/functions/module_lookup.ts
+++ b/src/functions/module_lookup.ts
@@ -160,7 +160,10 @@ export const COLUMNS = {
 export const HLOOKUP = {
   description: _t("Horizontal lookup"),
   args: [
-    arg("search_key (any)", _t("The value to search for. For example, 42, 'Cats', or I24.")),
+    arg(
+      "search_key (string, number, boolean)",
+      _t("The value to search for. For example, 42, 'Cats', or I24.")
+    ),
     arg(
       "range (range)",
       _t(
@@ -190,9 +193,6 @@ export const HLOOKUP = {
       () => 1 <= _index && _index <= range[0].length,
       _t("[[FUNCTION_NAME]] evaluates to an out of bounds range.")
     );
-    if (searchKey && isEvaluationError(searchKey.value)) {
-      return searchKey;
-    }
 
     const getValueFromRange = (range: Matrix<FunctionResultObject>, index: number) =>
       range[index][0].value;
@@ -320,7 +320,10 @@ export const INDIRECT: AddFunctionDescription = {
 export const LOOKUP = {
   description: _t("Look up a value."),
   args: [
-    arg("search_key (any)", _t("The value to search for. For example, 42, 'Cats', or I24.")),
+    arg(
+      "search_key (string, number, boolean)",
+      _t("The value to search for. For example, 42, 'Cats', or I24.")
+    ),
     arg(
       "search_array (range)",
       _t(
@@ -400,7 +403,10 @@ const DEFAULT_SEARCH_TYPE = 1;
 export const MATCH = {
   description: _t("Position of item in range that matches value."),
   args: [
-    arg("search_key (any)", _t("The value to search for. For example, 42, 'Cats', or I24.")),
+    arg(
+      "search_key (string, number, boolean)",
+      _t("The value to search for. For example, 42, 'Cats', or I24.")
+    ),
     arg("range (any, range)", _t("The one-dimensional array to be searched.")),
     arg(
       `search_type (number, default=${DEFAULT_SEARCH_TYPE})`,
@@ -509,7 +515,10 @@ export const ROWS = {
 export const VLOOKUP = {
   description: _t("Vertical lookup."),
   args: [
-    arg("search_key (any)", _t("The value to search for. For example, 42, 'Cats', or I24.")),
+    arg(
+      "search_key (string, number, boolean)",
+      _t("The value to search for. For example, 42, 'Cats', or I24.")
+    ),
     arg(
       "range (any, range)",
       _t(
@@ -540,9 +549,6 @@ export const VLOOKUP = {
       () => 1 <= _index && _index <= range.length,
       _t("[[FUNCTION_NAME]] evaluates to an out of bounds range.")
     );
-    if (searchKey && isEvaluationError(searchKey.value)) {
-      return searchKey;
-    }
 
     const getValueFromRange = (range: Matrix<FunctionResultObject>, index: number) =>
       range[0][index].value;
@@ -577,7 +583,7 @@ export const XLOOKUP = {
     "Search a range for a match and return the corresponding item from a second range."
   ),
   args: [
-    arg("search_key (any)", _t("The value to search for.")),
+    arg("search_key (string,number,boolean)", _t("The value to search for.")),
     arg(
       "lookup_range (any, range)",
       _t("The range to consider for the search. Should be a single column or a single row.")
@@ -646,10 +652,6 @@ export const XLOOKUP = {
       _t("return_range should have the same dimensions as lookup_range.")
     );
 
-    if (searchKey && isEvaluationError(searchKey.value)) {
-      return [[searchKey]];
-    }
-
     const getElement =
       lookupDirection === "col"
         ? (range: Matrix<FunctionResultObject>, index: number) => range[0][index].value
@@ -688,13 +690,15 @@ export const XLOOKUP = {
 // Pivot functions
 //--------------------------------------------------------------------------
 
+// PIVOT.VALUE
+
 export const PIVOT_VALUE = {
   description: _t("Get the value from a pivot."),
   args: [
-    arg("pivot_id (string)", _t("ID of the pivot.")),
+    arg("pivot_id (number,string)", _t("ID of the pivot.")),
     arg("measure_name (string)", _t("Name of the measure.")),
     arg("domain_field_name (string,optional,repeating)", _t("Field name.")),
-    arg("domain_value (string,optional,repeating)", _t("Value.")),
+    arg("domain_value (number,string,boolean,optional,repeating)", _t("Value.")),
   ],
   compute: function (
     formulaId: Maybe<FunctionResultObject>,
@@ -735,12 +739,14 @@ export const PIVOT_VALUE = {
   },
 } satisfies AddFunctionDescription;
 
+// PIVOT.HEADER
+
 export const PIVOT_HEADER = {
   description: _t("Get the header of a pivot."),
   args: [
-    arg("pivot_id (string)", _t("ID of the pivot.")),
+    arg("pivot_id (number,string)", _t("ID of the pivot.")),
     arg("domain_field_name (string,optional,repeating)", _t("Field name.")),
-    arg("domain_value (string,optional,repeating)", _t("Value.")),
+    arg("domain_value (number,string,value,optional,repeating)", _t("Value.")),
   ],
   compute: function (
     pivotId: Maybe<FunctionResultObject>,

--- a/src/functions/module_operators.ts
+++ b/src/functions/module_operators.ts
@@ -86,8 +86,8 @@ const getNeutral = { number: 0, string: "", boolean: false };
 export const EQ = {
   description: _t("Equal."),
   args: [
-    arg("value1 (any)", _t("The first value.")),
-    arg("value2 (any)", _t("The value to test against value1 for equality.")),
+    arg("value1 (string, number, boolean)", _t("The first value.")),
+    arg("value2 (string, number, boolean)", _t("The value to test against value1 for equality.")),
   ],
   compute: function (
     value1: Maybe<FunctionResultObject>,
@@ -100,12 +100,6 @@ export const EQ = {
     }
     if (typeof _value2 === "string") {
       _value2 = _value2.toUpperCase();
-    }
-    if (isEvaluationError(_value1)) {
-      throw value1;
-    }
-    if (isEvaluationError(_value2)) {
-      throw value2;
     }
     return _value1 === _value2;
   },
@@ -147,8 +141,8 @@ function applyRelationalOperator(
 export const GT = {
   description: _t("Strictly greater than."),
   args: [
-    arg("value1 (any)", _t("The value to test as being greater than value2.")),
-    arg("value2 (any)", _t("The second value.")),
+    arg("value1 (number, string, boolean)", _t("The value to test as being greater than value2.")),
+    arg("value2 (number, string, boolean)", _t("The second value.")),
   ],
   compute: function (
     value1: Maybe<FunctionResultObject>,
@@ -166,8 +160,11 @@ export const GT = {
 export const GTE = {
   description: _t("Greater than or equal to."),
   args: [
-    arg("value1 (any)", _t("The value to test as being greater than or equal to value2.")),
-    arg("value2 (any)", _t("The second value.")),
+    arg(
+      "value1 (number, string, boolean)",
+      _t("The value to test as being greater than or equal to value2.")
+    ),
+    arg("value2 (number, string, boolean)", _t("The second value.")),
   ],
   compute: function (
     value1: Maybe<FunctionResultObject>,
@@ -185,8 +182,8 @@ export const GTE = {
 export const LT = {
   description: _t("Less than."),
   args: [
-    arg("value1 (any)", _t("The value to test as being less than value2.")),
-    arg("value2 (any)", _t("The second value.")),
+    arg("value1 (number, string, boolean)", _t("The value to test as being less than value2.")),
+    arg("value2 (number, string, boolean)", _t("The second value.")),
   ],
   compute: function (
     value1: Maybe<FunctionResultObject>,
@@ -202,8 +199,11 @@ export const LT = {
 export const LTE = {
   description: _t("Less than or equal to."),
   args: [
-    arg("value1 (any)", _t("The value to test as being less than or equal to value2.")),
-    arg("value2 (any)", _t("The second value.")),
+    arg(
+      "value1 (number, string, boolean)",
+      _t("The value to test as being less than or equal to value2.")
+    ),
+    arg("value2 (number, string, boolean)", _t("The second value.")),
   ],
   compute: function (
     value1: Maybe<FunctionResultObject>,
@@ -259,8 +259,8 @@ export const MULTIPLY = {
 export const NE = {
   description: _t("Not equal."),
   args: [
-    arg("value1 (any)", _t("The first value.")),
-    arg("value2 (any)", _t("The value to test against value1 for inequality.")),
+    arg("value1 (string, number, boolean)", _t("The first value.")),
+    arg("value2 (string, number, boolean)", _t("The value to test against value1 for inequality.")),
   ],
   compute: function (
     value1: Maybe<FunctionResultObject>,

--- a/src/functions/module_statistical.ts
+++ b/src/functions/module_statistical.ts
@@ -411,11 +411,11 @@ export const COUNT = {
   description: _t("The number of numeric values in dataset."),
   args: [
     arg(
-      "value1 (number, range<number>)",
+      "value1 (number, any, range<number>)",
       _t("The first value or range to consider when counting.")
     ),
     arg(
-      "value2 (number, range<number>, repeating)",
+      "value2 (number, any, range<number>, repeating)",
       _t("Additional values or ranges to consider when counting.")
     ),
   ],
@@ -1057,6 +1057,8 @@ export const PEARSON: AddFunctionDescription = {
   },
   isExported: true,
 };
+
+// CORREL
 // In GSheet, CORREL is just an alias to PEARSON
 export const CORREL: AddFunctionDescription = PEARSON;
 

--- a/src/types/functions.ts
+++ b/src/types/functions.ts
@@ -21,6 +21,7 @@ export type ArgType =
 export interface ArgDefinition {
   acceptMatrix?: boolean;
   acceptMatrixOnly?: boolean;
+  acceptErrors?: boolean;
   repeating?: boolean;
   optional?: boolean;
   description: string;

--- a/tests/functions/functions.test.ts
+++ b/tests/functions/functions.test.ts
@@ -214,15 +214,7 @@ describe("functions", () => {
         compute: (arg) => {
           return true;
         },
-        args: [
-          {
-            name: "arg1",
-            description: "",
-            type: ["RANGE"],
-            acceptMatrix: true,
-            acceptMatrixOnly: true,
-          },
-        ],
+        args: [arg("arg1 (range<any>)", "1st argument")],
       });
 
       functionRegistry.add("FORMULA_RETURNING_RANGE", {

--- a/tests/functions/module_filter.test.ts
+++ b/tests/functions/module_filter.test.ts
@@ -709,6 +709,27 @@ describe("SORT function", () => {
     ]);
   });
 
+  test("Sorting columns specifying range with strings or errors", () => {
+    const grid = {
+      C1: "=10",
+      C2: "=0",
+      C3: "=EQ(A1, 4)", // FALSE
+      C4: '=CONCAT("ki", "kou")',
+      C5: "=BADBUNNY", // #BAD_EXPR
+      C6: "=0/0",
+    };
+    const model = createModelFromGrid(grid);
+    setCellContent(model, "A11", "=SORT(C1:C6,C1:C6,TRUE)");
+    expect(getRangeValuesAsMatrix(model, "A11:A16")).toEqual([
+      [0],
+      [10],
+      ["#BAD_EXPR"],
+      ["#DIV/0!"],
+      ["kikou"],
+      [false],
+    ]);
+  });
+
   test("Sorting multiple columns specifying multiple ranges to base to sorting on", () => {
     //prettier-ignore
     const grid = {
@@ -1048,6 +1069,27 @@ describe("SORTN function", () => {
       [3, 4, 4],
       [2, 1, 2],
       [null, null, null],
+    ]);
+  });
+
+  test("Sorting based on strings or errors", () => {
+    const grid = {
+      C1: "=10",
+      C2: "=0",
+      C3: "=EQ(A1, 4)", // FALSE
+      C4: '=CONCAT("ki", "kou")',
+      C5: "=BADBUNNY", // #BAD_EXPR
+      C6: "=0/0",
+    };
+    const model = createModelFromGrid(grid);
+    setCellContent(model, "A11", "=SORTN(C1:C6,6,0,C1:C6,TRUE)");
+    expect(getRangeValuesAsMatrix(model, "A11:A16")).toEqual([
+      [0],
+      [10],
+      ["#BAD_EXPR"],
+      ["#DIV/0!"],
+      ["kikou"],
+      [false],
     ]);
   });
 


### PR DESCRIPTION
## Description:

Throwing errors is super slow but the evaluation uses throw in many
places when the formula result is an error (historic). Returning
the error result is better than throwing.

Extensive work has been done in the past year to reduce `throw`, especially
the "Loading..." errors.

But if a function receives an error object as an argument and the
function uses one of the casting helpers (`toNumber`, `toString`, etc.)
the error is still thrown.

With this commit, if a function argument is an error, we by pass the
function `compute` and the error is directly returned.

That is unless the argument is declared as accepting the type `any`,
in which case it can use the error argument as part of its business logic.

We currently only check simple scalar arguments (and not matrices) for
performance reasons. Iterating over all matrices to check if there's any
error is costly and probably outweights the benefits (especially when there
isn't any error)

On one of the dashboard on odoo.com (id=116), the evaluation triggered by
setting a global filter is reduced by ~70% (when setting a filter,
everything is reloading and hence there are "Loading..." everywhere

before: 1707ms
after:   533ms

There's no significant performance hit on regular evaluations (when there's
no errors)

Many types of many function arguments had to be changed to remove `any`
where the function doesn't need to handle errors itself.

For some function expecting an matrix of a given type (let's say
`range<number>`), we added `range<any>`. The real type of those arguments
is `range<any>` but from a functional POV, they expect `range<number>` and
ignore any other values. We leave the `range<number>` only for an informative
reason.

Task: [4328215](https://www.odoo.com/web#id=4328215&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo