### PR TITLE
[IMP] charts: harmonize chart design panel paddings

### DIFF
--- a/src/components/side_panel/chart/pie_chart/pie_chart_design_panel.xml
+++ b/src/components/side_panel/chart/pie_chart/pie_chart_design_panel.xml
@@ -10,7 +10,7 @@
           definition="props.definition"
           updateChart="props.updateChart"
         />
-        <Section title.translate="Values">
+        <Section class="'pt-0'" title.translate="Values">
           <Checkbox
             name="'showValues'"
             label.translate="Show values"

--- a/src/components/side_panel/chart/scorecard_chart_panel/scorecard_chart_design_panel.xml
+++ b/src/components/side_panel/chart/scorecard_chart_panel/scorecard_chart_design_panel.xml
@@ -28,7 +28,7 @@
             placeholder="Baseline description"
           />
         </Section>
-        <Section class="'o-chart-baseline-color'" title="colorsSectionTitle">
+        <Section class="'o-chart-baseline-color pt-0'" title="colorsSectionTitle">
           <div class="d-flex align-items-center mb-2">
             <RoundColorPicker
               currentColor="props.definition.baselineColorUp"

--- a/src/components/side_panel/chart/waterfall_chart/waterfall_chart_design_panel.xml
+++ b/src/components/side_panel/chart/waterfall_chart/waterfall_chart_design_panel.xml
@@ -5,7 +5,7 @@
       definition="props.definition"
       updateChart="props.updateChart">
       <t t-set-slot="general-extension">
-        <Section class="'o-vertical-axis-selection'" title.translate="Vertical axis position">
+        <Section class="'o-vertical-axis-selection pt-0'" title.translate="Vertical axis position">
           <RadioSelection
             choices="axisChoices"
             selectedValue="props.definition.verticalAxisPosition"
@@ -55,7 +55,7 @@
             onChange.bind="onUpdateShowConnectorLines"
           />
         </Section>
-        <Section title.translate="Colors">
+        <Section class="'pt-0'" title.translate="Colors">
           <div class="o-waterfall-positive-color d-flex align-items-center mb-2">
             <RoundColorPicker
               currentColor="positiveValuesColor"


### PR DESCRIPTION
## Description

This commit aims to make all the section in the chart design panel to have the same padding between them.

Task: [4283611](https://www.odoo.com/web#id=4283611&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo