### PR TITLE
[IMP] charts: allow chart insertion with unbounded zone

### DIFF
--- a/src/helpers/figures/charts/chart_factory.ts
+++ b/src/helpers/figures/charts/chart_factory.ts
@@ -95,14 +95,14 @@ export function transformDefinition(
  * - Else returns a bar chart
  */
 export function getSmartChartDefinition(zone: Zone, getters: Getters): ChartDefinition {
+  const sheetId = getters.getActiveSheetId();
   let dataSetZone = zone;
   const singleColumn = zoneToDimension(zone).numberOfCols === 1;
   if (!singleColumn) {
     dataSetZone = { ...zone, left: zone.left + 1 };
   }
-  const dataRange = zoneToXc(dataSetZone);
+  const dataRange = zoneToXc(getters.getUnboundedZone(sheetId, dataSetZone));
   const dataSets = [{ dataRange, yAxisId: "y" }];
-  const sheetId = getters.getActiveSheetId();
 
   const topLeftCell = getters.getCell({ sheetId, col: zone.left, row: zone.top });
   if (getZoneArea(zone) === 1 && topLeftCell?.content) {
@@ -127,10 +127,7 @@ export function getSmartChartDefinition(zone: Zone, getters: Getters): ChartDefi
 
   let labelRangeXc: string | undefined;
   if (!singleColumn) {
-    labelRangeXc = zoneToXc({
-      ...zone,
-      right: zone.left,
-    });
+    labelRangeXc = zoneToXc(getters.getUnboundedZone(sheetId, { ...zone, right: zone.left }));
   }
   // Only display legend for several datasets.
   const newLegendPos = dataSetZone.right === dataSetZone.left ? "none" : "top";

--- a/tests/figures/chart/menu_item_insert_chart.test.ts
+++ b/tests/figures/chart/menu_item_insert_chart.test.ts
@@ -493,4 +493,14 @@ describe("Insert chart menu item", () => {
     };
     expect(dispatchSpy).toHaveBeenCalledWith("CREATE_CHART", payload);
   });
+
+  test("Chart can be inserted with unbounded ranges", () => {
+    setSelection(model, ["A1:B100"], { unbounded: true });
+    insertChart();
+    const chartId = model.getters.getChartIds(model.getters.getActiveSheetId())[0];
+    expect(model.getters.getChartDefinition(chartId)).toMatchObject({
+      dataSets: [{ dataRange: "B:B" }],
+      labelRange: "A:A",
+    });
+  });
 });

--- a/tests/test_helpers/commands_helpers.ts
+++ b/tests/test_helpers/commands_helpers.ts
@@ -728,6 +728,7 @@ export function setSelection(
   options: {
     anchor?: string | undefined;
     strict?: boolean;
+    unbounded?: boolean;
   } = { anchor: undefined, strict: false }
 ) {
   const sheetId = model.getters.getActiveSheetId();
@@ -766,7 +767,10 @@ export function setSelection(
 
   if (zones.length !== 0) {
     const z1 = zones.splice(0, 1)[0];
-    model.selection.selectZone({ cell: { col: z1.left, row: z1.top }, zone: z1 });
+    model.selection.selectZone(
+      { cell: { col: z1.left, row: z1.top }, zone: z1 },
+      { unbounded: options.unbounded }
+    );
     for (const zone of zones) {
       model.selection.addCellToSelection(zone.left, zone.top);
       model.selection.setAnchorCorner(zone.right, zone.bottom);
@@ -774,7 +778,7 @@ export function setSelection(
     model.selection.addCellToSelection(anchor.zone.left, anchor.zone.top);
     model.selection.setAnchorCorner(anchor.zone.right, anchor.zone.bottom);
   } else {
-    model.selection.selectZone(anchor);
+    model.selection.selectZone(anchor, { scrollIntoView: true, unbounded: options.unbounded });
   }
 }
 


### PR DESCRIPTION
## Description

This commit make it so that if a chart is inserted when the whole column A is selected, the chart will be inserted with A:A as data set instead of A1:A100.

Task: [3502197](https://www.odoo.com/web#id=3502197&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo