### PR TITLE
[IMP] charts: filter invalid values from charts

### DIFF
--- a/tests/figures/chart/pie_chart_plugin.test.ts
+++ b/tests/figures/chart/pie_chart_plugin.test.ts
@@ -40,24 +40,24 @@ describe("pie chart", () => {
   });
 
   test("Pie chart legend", () => {
+    // prettier-ignore
     const model = createModelFromGrid({
-      A1: "1",
-      A2: "2",
-      A3: "3",
-      A4: "4",
+      A1: "P1",  B1: "1",  C1: "3",
+      A2: "P2",  B2: "2",  C2: "4",
     });
     createChart(
       model,
       {
-        dataSets: [{ dataRange: "Sheet1!A1:A2" }, { dataRange: "Sheet1!A3:A4" }],
-        labelRange: "Sheet1!A2:A4",
+        dataSets: [{ dataRange: "Sheet1!B1:B2" }, { dataRange: "Sheet1!C1:C2" }],
+        labelRange: "Sheet1!A1:A2",
+        dataSetsHaveTitle: false,
         type: "pie",
       },
       "1"
     );
     expect(getChartLegendLabels(model, "1")).toEqual([
       {
-        text: "3",
+        text: "P1",
         fillStyle: "#4EA7F2",
         hidden: false,
         lineWidth: 2,
@@ -65,7 +65,7 @@ describe("pie chart", () => {
         strokeStyle: "#4EA7F2",
       },
       {
-        text: "4",
+        text: "P2",
         fillStyle: "#EA6175",
         hidden: false,
         lineWidth: 2,


### PR DESCRIPTION
## Description:

In pie chart, it's useless to keep zero values and non-numeric values,
as they won't be displayed in the pie and will take space in the legend.

In line/bars it make some sense to keep the non-number values that
have a label, as they will show in the chart as an empty bar/ a break in
the line. Non-number values without a label are still filtered out.

Task: [4313528](https://www.odoo.com/web#id=4313528&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo