### PR TITLE
[FIX] charts: do not show zero values in pie charts

### DIFF
--- a/src/components/figures/chart/chartJs/chartjs_show_values_plugin.ts
+++ b/src/components/figures/chart/chartJs/chartjs_show_values_plugin.ts
@@ -147,6 +147,10 @@ function drawPieChartValues(
 ) {
   for (const dataset of chart._metasets) {
     for (let i = 0; i < dataset._parsed.length; i++) {
+      const value = Number(dataset._parsed[i]);
+      if (isNaN(value) || value === 0) {
+        continue;
+      }
       const bar = dataset.data[i];
       const { startAngle, endAngle, innerRadius, outerRadius } = bar;
       const midAngle = (startAngle + endAngle) / 2;
@@ -157,8 +161,8 @@ function drawPieChartValues(
       ctx.fillStyle = chartFontColor(options.background);
       ctx.strokeStyle = options.background || "#ffffff";
 
-      const value = options.callback(dataset._parsed[i]);
-      drawTextWithBackground(value, x, y, ctx);
+      const displayValue = options.callback(value);
+      drawTextWithBackground(displayValue, x, y, ctx);
     }
   }
 }


### PR DESCRIPTION
## Description

In pie charts we do not want to display "0" when enabling the "show values" option. Nor do we want to display NaN for non-number values.

Task: [4277144](https://www.odoo.com/web#id=4277144&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo