### PR TITLE
[FIX] PivotDimension: Prevent DnD on dimension action buttons

### DIFF
--- a/src/components/side_panel/pivot/pivot_layout_configurator/pivot_dimension/pivot_dimension.xml
+++ b/src/components/side_panel/pivot/pivot_layout_configurator/pivot_dimension/pivot_dimension.xml
@@ -16,7 +16,7 @@
           />
           <span t-else="1" class="o-fw-bold" t-esc="props.dimension.displayName"/>
         </div>
-        <div class="d-flex flex-rows">
+        <div class="d-flex flex-rows" t-on-pointerdown.stop="">
           <t t-slot="upper-right-icons"/>
           <i
             class="o-button-icon fa fa-trash pe-1 ps-2"

--- a/src/components/side_panel/pivot/pivot_layout_configurator/pivot_measure/pivot_measure.xml
+++ b/src/components/side_panel/pivot/pivot_layout_configurator/pivot_measure/pivot_measure.xml
@@ -18,7 +18,7 @@
         />
       </t>
       <div t-if="measure.computedBy" class="d-flex flex-row small">
-        <div class="d-flex flex-column py-2 px-2 w-100">
+        <div class="d-flex flex-column py-2 px-2 w-100" t-on-pointerdown.stop="">
           <StandaloneComposer
             onConfirm.bind="updateMeasureFormula"
             composerContent="measure.computedBy.formula"

--- a/tests/pivots/spreadsheet_pivot/spreadsheet_pivot_side_panel.test.ts
+++ b/tests/pivots/spreadsheet_pivot/spreadsheet_pivot_side_panel.test.ts
@@ -546,4 +546,34 @@ describe("Spreadsheet pivot side panel", () => {
       { id: "amount:sum", fieldName: "amount", aggregator: "sum", isHidden: false },
     ]);
   });
+
+  test("Cannot drag a dimension when clicking its upper right icons", async () => {
+    mockGetBoundingClientRect({
+      /**
+       * 'pt-1' is the class of the main div of the pivot dimension
+       */
+      "pt-1": () => ({
+        height: 10,
+        y: 0,
+      }),
+      "o-section-title": () => ({
+        height: 10,
+        y: 10,
+      }),
+      "pivot-dimensions": () => ({
+        height: 40,
+        y: 0,
+      }),
+    });
+    await click(fixture.querySelector(".add-dimension")!);
+    await click(fixture.querySelectorAll(".o-autocomplete-value")[0]);
+    await setInputValueAndTrigger(fixture.querySelector(".pivot-dimension select"), "desc");
+    expect(model.getters.getPivotCoreDefinition("1").columns).toEqual([
+      { fieldName: "Amount", order: "desc" },
+    ]);
+    await dragElement(".pivot-dimension .fa-trash", { x: 0, y: 30 }, undefined, true);
+    expect(model.getters.getPivotCoreDefinition("1").columns).toEqual([
+      { fieldName: "Amount", order: "desc" },
+    ]);
+  });
 });


### PR DESCRIPTION
If we apply a mouse down on the action buttons of a pivot dimension (e.g. on the trash or hide/show icon) and move of a single pixel, the drag-n-drop of the dimension is triggered, which prevents the default action of the said action button.

This commit also prevents this behaviour when targeting the standalone composer of the computed measures.

Task: 4095643

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo