### PR TITLE
[FIX] chart: radar chart axis do not start at zero

### DIFF
--- a/src/helpers/figures/charts/runtime/chartjs_scales.ts
+++ b/src/helpers/figures/charts/runtime/chartjs_scales.ts
@@ -170,14 +170,19 @@ export function getRadarChartScales(
   definition: GenericDefinition<RadarChartDefinition>,
   args: ChartRuntimeGenerationArgs
 ): ChartScales {
-  const { locale, axisFormats } = args;
+  const { locale, axisFormats, dataSetsValues } = args;
+  const minValue = Math.min(
+    ...dataSetsValues.map((ds) => Math.min(...ds.data.filter((x) => !isNaN(x))))
+  );
   return {
     r: {
+      beginAtZero: true,
       ticks: {
         callback: formatTickValue({ format: axisFormats?.r, locale }),
         backdropColor: definition.background || "#FFFFFF",
       },
       pointLabels: { color: chartFontColor(definition.background) },
+      suggestedMin: minValue < 0 ? minValue - 1 : 0,
     },
   };
 }

--- a/tests/figures/chart/radar_chart_plugin.test.ts
+++ b/tests/figures/chart/radar_chart_plugin.test.ts
@@ -127,4 +127,24 @@ describe("radar chart", () => {
     runtime = model.getters.getChartRuntime("chartId") as RadarChartRuntime;
     expect(runtime.chartJsConfig.options?.scales?.r?.["pointLabels"]?.color).toBe("#FFFFFF");
   });
+
+  test("Radar scale starts at zero for positive numbers", () => {
+    const model = new Model();
+    setCellContent(model, "A2", "1");
+    setCellContent(model, "A3", "1");
+    createRadarChart(model, { dataSets: [{ dataRange: "A1:A3" }] }, "chartId");
+    const runtime = model.getters.getChartRuntime("chartId") as RadarChartRuntime;
+    expect(runtime.chartJsConfig.options?.scales?.r?.["beginAtZero"]).toBe(true);
+  });
+
+  test("Radar scale starts below the minimum for negative values", () => {
+    const model = new Model();
+    setCellContent(model, "A2", "4");
+    setCellContent(model, "A3", "-7");
+    setCellContent(model, "A4", "-1");
+
+    createRadarChart(model, { dataSets: [{ dataRange: "A1:A4" }] }, "chartId");
+    const runtime = model.getters.getChartRuntime("chartId") as RadarChartRuntime;
+    expect(runtime.chartJsConfig.options?.scales?.r?.suggestedMin).toBe(-8);
+  });
 });


### PR DESCRIPTION
## Description

The axis of the radar chart did not start at zero for some datasets values (eg. [4, 4, 8] would start at 4 instead of 0).

Task: [4319641](https://www.odoo.com/web#id=4319641&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo