### PR TITLE
[FIX] table_style_editor_panel: disable "No Color" button

### DIFF
--- a/src/components/side_panel/table_style_editor_panel/table_style_editor_panel.ts
+++ b/src/components/side_panel/table_style_editor_panel/table_style_editor_panel.ts
@@ -1,4 +1,5 @@
 import { Component, useExternalListener, useState } from "@odoo/owl";
+import { isColorValid } from "../../../helpers";
 import { TABLE_STYLES_TEMPLATES, buildTableStyle } from "../../../helpers/table_presets";
 import {
   Color,
@@ -30,6 +31,8 @@ css/* scss */ `
     }
   }
 `;
+
+const DEFAULT_TABLE_STYLE_COLOR = "#3C78D8";
 
 export interface TableStyleEditorPanelProps {
   onCloseSidePanel: () => void;
@@ -68,7 +71,7 @@ export class TableStyleEditorPanel extends Component<
       : null;
     return {
       pickerOpened: false,
-      primaryColor: editedStyle?.primaryColor || "#3C78D8",
+      primaryColor: editedStyle?.primaryColor || DEFAULT_TABLE_STYLE_COLOR,
       selectedTemplateName: editedStyle?.templateName || "lightColoredText",
       styleName: editedStyle?.displayName || this.env.model.getters.getNewCustomTableStyleName(),
     };
@@ -79,7 +82,7 @@ export class TableStyleEditorPanel extends Component<
   }
 
   onColorPicked(color: Color) {
-    this.state.primaryColor = color;
+    this.state.primaryColor = isColorValid(color) ? color : DEFAULT_TABLE_STYLE_COLOR;
     this.state.pickerOpened = false;
   }
 

--- a/src/components/side_panel/table_style_editor_panel/table_style_editor_panel.xml
+++ b/src/components/side_panel/table_style_editor_panel/table_style_editor_panel.xml
@@ -9,7 +9,11 @@
         <t t-set-slot="title">Style color</t>
         <div class="d-flex align-items-center">
           <span class="pe-2">Primary table style color</span>
-          <RoundColorPicker currentColor="state.primaryColor" onColorPicked.bind="onColorPicked"/>
+          <RoundColorPicker
+            currentColor="state.primaryColor"
+            onColorPicked.bind="onColorPicked"
+            disableNoColor="true"
+          />
         </div>
       </Section>
       <Section class="'pt-1'">


### PR DESCRIPTION
## Description:

This PR introduces two changes:

1. Resolves a traceback error in the table style editor by disabling the "No Color" button when not applicable.

2. Prevents errors by validating color input earlier, ensuring that empty values are not processed when generating table color sets.

Task: [4102704](https://www.odoo.com/odoo/project/2328/tasks/4102704)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo