### PR TITLE
[FIX] data_bar_rule_editor: disable "No Color" button

### DIFF
--- a/src/components/side_panel/conditional_formatting/cf_editor/cf_editor.ts
+++ b/src/components/side_panel/conditional_formatting/cf_editor/cf_editor.ts
@@ -563,6 +563,10 @@ export class ConditionalFormattingEditor extends Component<Props, SpreadsheetChi
   }
 
   updateDataBarColor(color: Color) {
+    if (!isColorValid(color)) {
+      return;
+    }
+
     this.state.rules.dataBar.color = Number.parseInt(color.substr(1), 16);
   }
 

--- a/src/components/side_panel/conditional_formatting/cf_editor/data_bar_rule_editor.xml
+++ b/src/components/side_panel/conditional_formatting/cf_editor/data_bar_rule_editor.xml
@@ -5,6 +5,7 @@
       <RoundColorPicker
         currentColor="colorNumberString(rule.color)"
         onColorPicked.bind="updateDataBarColor"
+        disableNoColor="true"
       />
       <div class="o-section-subtitle">Range of values</div>
       <SelectionInput


### PR DESCRIPTION
## Description:

This PR introduces two changes:

1. Fixes a traceback error in the Conditional Formatting Databar editor by hiding the "Reset" button when not applicable.

2. Prevents errors by validating color input earlier to avoid empty string parsing issues.

Task: [4102704](https://www.odoo.com/odoo/project/2328/tasks/4102704)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo