### PR TITLE
[IMP] icons : use fa-clipboard icon for copy-to-clipboard buttons

### DIFF
--- a/src/actions/edit_actions.ts
+++ b/src/actions/edit_actions.ts
@@ -31,7 +31,7 @@ export const copy: ActionSpec = {
     env.model.dispatch("COPY");
     await env.clipboard.write(env.model.getters.getClipboardContent());
   },
-  icon: "o-spreadsheet-Icon.COPY",
+  icon: "o-spreadsheet-Icon.CLIPBOARD",
 };
 
 export const cut: ActionSpec = {

--- a/src/components/icons/icons.xml
+++ b/src/components/icons/icons.xml
@@ -64,6 +64,11 @@
       />
     </svg>
   </t>
+  <t t-name="o-spreadsheet-Icon.CLIPBOARD">
+    <div class="o-icon">
+      <i class="fa fa-clipboard"/>
+    </div>
+  </t>
   <t t-name="o-spreadsheet-Icon.COPY">
     <div class="o-icon">
       <i class="fa fa-clone"/>

--- a/src/registries/figure_registry.ts
+++ b/src/registries/figure_registry.ts
@@ -110,7 +110,7 @@ function getCopyMenuItem(figureId: UID, env: SpreadsheetChildEnv): ActionSpec {
       env.model.dispatch("COPY");
       await env.clipboard.write(env.model.getters.getClipboardContent());
     },
-    icon: "o-spreadsheet-Icon.COPY",
+    icon: "o-spreadsheet-Icon.CLIPBOARD",
   };
 }
 

--- a/tests/menus/__snapshots__/context_menu_component.test.ts.snap
+++ b/tests/menus/__snapshots__/context_menu_component.test.ts.snap
@@ -63,7 +63,7 @@ exports[`Context Menu integration tests context menu simple rendering 1`] = `
           class="o-icon"
         >
           <i
-            class="fa fa-clone"
+            class="fa fa-clipboard"
           />
         </div>
       </div>


### PR DESCRIPTION
## Description:

Buttons that copy text to the clipboard were previously using the fa-clone icon, which was incorrect. Updated these icons to fa-clipboard.

Task: [3181092](https://www.odoo.com/web#id=3181092&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo