### PR TITLE
[IMP] model: create snapshot when loading xlsx file

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -233,7 +233,7 @@ export class Model extends EventBus<any> implements CommandDispatcher {
     this.session.loadInitialMessages(stateUpdateMessages);
     this.joinSession();
 
-    if (config.snapshotRequested) {
+    if (config.snapshotRequested || data["[Content_Types].xml"]) {
       this.session.snapshot(this.exportData());
     }
     // mark all models as "raw", so they will not be turned into reactive objects


### PR DESCRIPTION
Before this commit, when uploading an XLSX file, the code in the Odoo repository would create a spreadsheet document with data that is encoded in xml. Whenever the file is loaded, we parse the stringified xml to convert it to the o-spreadsheet json structure. The problem is that this conversion can be quite slow and costly when the XLSX file is large.

This commit mitigates the issue by saving a snapshot once the XLSX file is loaded for the first time.

Task: [4080514](https://www.odoo.com/odoo/project/2328/tasks/4080514)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo