### PR TITLE
[FIX] charts: non-invertible matrix returns NaN as predicted data

### DIFF
--- a/src/components/side_panel/chart/chart_with_axis/design_panel.ts
+++ b/src/components/side_panel/chart/chart_with_axis/design_panel.ts
@@ -195,7 +195,7 @@ export class ChartWithAxisDesignPanel<P extends Props = Props> extends Component
       case "polynomial":
         config = {
           type: "polynomial",
-          order: type === "linear" ? 1 : 2,
+          order: type === "linear" ? 1 : this.getMaxPolynomialDegree(),
         };
         break;
       case "exponential":

--- a/tests/figures/chart/chart_plugin.test.ts
+++ b/tests/figures/chart/chart_plugin.test.ts
@@ -3209,6 +3209,20 @@ describe("trending line", () => {
     }
   });
 
+  test("non-invertible matrix doesn't throw error", () => {
+    // prettier-ignore
+    setGrid(model, {
+      A1: "label",
+      A2: "0",
+      A3: "1",
+    });
+    updateChart(model, "1", {
+      dataSets: [{ dataRange: "A1:A3", trend: { display: true, type: "polynomial", order: 2 } }],
+    });
+    const runtime = model.getters.getChartRuntime("1") as LineChartRuntime;
+    expect(runtime.chartJsConfig.data.datasets[1].data.every((x) => isNaN(Number(x)))).toBeTruthy();
+  });
+
   test("trend line works with real date values as labels", () => {
     setGrid(model, {
       B1: "1",


### PR DESCRIPTION
## Task Description

When trying to make a trending line, almost all model use matrix computation to get the predicted data, with some matrix multiplications and inversions. When the matrix aren't inversibles, the user get a traceback, which is not fine.
This PR aims to fix these issues by returning an array of NaN when there is an error in the computation of the predicted dataset.

## Related Task
- Task: 4328743

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo