### PR TITLE
[IMP] CoreViewPlugin: Remove access to dispatch

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -209,6 +209,7 @@ export { findCellInNewZone } from "./helpers/zones";
 export { load } from "./migrations/data";
 export { Model } from "./model";
 export { CorePlugin } from "./plugins/core_plugin";
+export { CoreViewPlugin } from "./plugins/core_view_plugin";
 export { UIPlugin } from "./plugins/ui_plugin";
 export { Registry } from "./registries/registry";
 export { setTranslationMethod } from "./translation";

--- a/src/plugins/base_plugin.ts
+++ b/src/plugins/base_plugin.ts
@@ -1,6 +1,5 @@
 import { StateObserver } from "../state_observer";
 import {
-  CommandDispatcher,
   CommandHandler,
   CommandResult,
   ExcelWorkbookData,
@@ -25,20 +24,12 @@ export class BasePlugin<State = any, C = any> implements CommandHandler<C>, Vali
   static getters: readonly string[] = [];
 
   protected history: WorkbookHistory<State>;
-  protected dispatch: CommandDispatcher["dispatch"];
-  protected canDispatch: CommandDispatcher["dispatch"];
 
-  constructor(
-    stateObserver: StateObserver,
-    dispatch: CommandDispatcher["dispatch"],
-    canDispatch: CommandDispatcher["dispatch"]
-  ) {
+  constructor(stateObserver: StateObserver) {
     this.history = Object.assign(Object.create(stateObserver), {
       update: stateObserver.addChange.bind(stateObserver, this),
       selectCell: () => {},
     });
-    this.dispatch = dispatch;
-    this.canDispatch = canDispatch;
   }
 
   /**

--- a/src/plugins/core_plugin.ts
+++ b/src/plugins/core_plugin.ts
@@ -38,11 +38,15 @@ export class CorePlugin<State = any>
   implements RangeProvider
 {
   protected getters: CoreGetters;
+  protected dispatch: CoreCommandDispatcher["dispatch"];
+  protected canDispatch: CoreCommandDispatcher["dispatch"];
 
   constructor({ getters, stateObserver, range, dispatch, canDispatch }: CorePluginConfig) {
-    super(stateObserver, dispatch, canDispatch);
+    super(stateObserver);
     range.addRangeProvider(this.adaptRanges.bind(this));
     this.getters = getters;
+    this.dispatch = dispatch;
+    this.canDispatch = canDispatch;
   }
 
   // ---------------------------------------------------------------------------

--- a/src/plugins/core_view_plugin.ts
+++ b/src/plugins/core_view_plugin.ts
@@ -1,0 +1,37 @@
+import { Session } from "../collaborative/session";
+import { ModelConfig } from "../model";
+import { SelectionStreamProcessor } from "../selection_stream/selection_stream_processor";
+import { StateObserver } from "../state_observer";
+import { ClientPosition, Color, Command, Currency, Getters } from "../types/index";
+import { BasePlugin } from "./base_plugin";
+import { UIActions } from "./ui_plugin";
+
+export interface CoreViewPluginConfig {
+  readonly getters: Getters;
+  readonly stateObserver: StateObserver;
+  readonly selection: SelectionStreamProcessor;
+  readonly moveClient: (position: ClientPosition) => void;
+  readonly uiActions: UIActions;
+  readonly custom: ModelConfig["custom"];
+  readonly session: Session;
+  readonly defaultCurrency?: Partial<Currency>;
+  readonly customColors: Color[];
+  readonly external: ModelConfig["external"];
+}
+
+export interface CoreViewPluginConstructor {
+  new (config: CoreViewPluginConfig): CoreViewPlugin;
+  getters: readonly string[];
+}
+
+/**
+ * Core view plugins handle any data derived from core date (i.e. evaluation).
+ * They cannot impact the model data (i.e. cannot dispatch commands).
+ */
+export class CoreViewPlugin<State = any> extends BasePlugin<State, Command> {
+  protected getters: Getters;
+  constructor({ getters, stateObserver }: CoreViewPluginConfig) {
+    super(stateObserver);
+    this.getters = getters;
+  }
+}

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -19,6 +19,7 @@ import { SettingsPlugin } from "./core/settings";
 import { SpreadsheetPivotCorePlugin } from "./core/spreadsheet_pivot";
 import { TableStylePlugin } from "./core/table_style";
 import { CorePluginConstructor } from "./core_plugin";
+import { CoreViewPluginConstructor } from "./core_view_plugin";
 import {
   CustomColorsPlugin,
   EvaluationChartPlugin,
@@ -107,7 +108,7 @@ export const statefulUIPluginRegistry = new Registry<UIPluginConstructor>()
   .add("clipboard", ClipboardPlugin);
 
 // Plugins which have a derived state from core data
-export const coreViewsPluginRegistry = new Registry<UIPluginConstructor>()
+export const coreViewsPluginRegistry = new Registry<CoreViewPluginConstructor>()
   .add("evaluation", EvaluationPlugin)
   .add("evaluation_chart", EvaluationChartPlugin)
   .add("evaluation_cf", EvaluationConditionalFormatPlugin)

--- a/src/plugins/ui_core_views/cell_evaluation/evaluation_plugin.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluation_plugin.ts
@@ -22,7 +22,7 @@ import {
   isMatrix,
 } from "../../../types/index";
 import { FormulaCellWithDependencies } from "../../core";
-import { UIPlugin, UIPluginConfig } from "../../ui_plugin";
+import { CoreViewPlugin, CoreViewPluginConfig } from "../../core_view_plugin";
 import { CoreViewCommand, invalidateEvaluationCommands } from "./../../../types/commands";
 import { Evaluator } from "./evaluator";
 
@@ -141,7 +141,7 @@ import { Evaluator } from "./evaluator";
 // of other cells depending on it, at the next iteration.
 
 //#endregion
-export class EvaluationPlugin extends UIPlugin {
+export class EvaluationPlugin extends CoreViewPlugin {
   static getters = [
     "evaluateFormula",
     "evaluateFormulaResult",
@@ -164,7 +164,7 @@ export class EvaluationPlugin extends UIPlugin {
   private evaluator: Evaluator;
   private positionsToUpdate: CellPosition[] = [];
 
-  constructor(config: UIPluginConfig) {
+  constructor(config: CoreViewPluginConfig) {
     super(config);
     this.evaluator = new Evaluator(config.custom, this.getters);
   }

--- a/src/plugins/ui_core_views/custom_colors.ts
+++ b/src/plugins/ui_core_views/custom_colors.ts
@@ -10,7 +10,7 @@ import {
   toHex,
 } from "../../helpers";
 import { Color, Command, Immutable, RGBA, TableElementStyle, UID } from "../../types";
-import { UIPlugin, UIPluginConfig } from "../ui_plugin";
+import { CoreViewPlugin, CoreViewPluginConfig } from "../core_view_plugin";
 
 const chartColorRegex = /"(#[0-9a-fA-F]{6})"/g;
 
@@ -70,12 +70,12 @@ interface CustomColorState {
  * This plugins aims to compute and keep to custom colors used in the
  * current spreadsheet
  */
-export class CustomColorsPlugin extends UIPlugin<CustomColorState> {
+export class CustomColorsPlugin extends CoreViewPlugin<CustomColorState> {
   private readonly customColors: Immutable<Record<Color, true>> = {};
   private readonly shouldUpdateColors = true;
   static getters = ["getCustomColors"] as const;
 
-  constructor(config: UIPluginConfig) {
+  constructor(config: CoreViewPluginConfig) {
     super(config);
     this.tryToAddColors(config.customColors ?? []);
   }

--- a/src/plugins/ui_core_views/dynamic_tables.ts
+++ b/src/plugins/ui_core_views/dynamic_tables.ts
@@ -23,10 +23,9 @@ import {
   Zone,
   invalidateEvaluationCommands,
 } from "../../types/index";
+import { CoreViewPlugin } from "../core_view_plugin";
 
-import { UIPlugin } from "../ui_plugin";
-
-export class DynamicTablesPlugin extends UIPlugin {
+export class DynamicTablesPlugin extends CoreViewPlugin {
   static getters = [
     "canCreateDynamicTableOnZones",
     "doesZonesContainFilter",

--- a/src/plugins/ui_core_views/evaluation_chart.ts
+++ b/src/plugins/ui_core_views/evaluation_chart.ts
@@ -8,7 +8,7 @@ import {
   invalidateChartEvaluationCommands,
   invalidateEvaluationCommands,
 } from "../../types/commands";
-import { UIPlugin } from "../ui_plugin";
+import { CoreViewPlugin } from "../core_view_plugin";
 
 interface EvaluationChartStyle {
   background: Color;
@@ -19,7 +19,7 @@ interface EvaluationChartState {
   charts: Record<UID, ChartRuntime | undefined>;
 }
 
-export class EvaluationChartPlugin extends UIPlugin<EvaluationChartState> {
+export class EvaluationChartPlugin extends CoreViewPlugin<EvaluationChartState> {
   static getters = ["getChartRuntime", "getStyleOfSingleCellChart"] as const;
 
   charts: Record<UID, ChartRuntime | undefined> = {};

--- a/src/plugins/ui_core_views/evaluation_conditional_format.ts
+++ b/src/plugins/ui_core_views/evaluation_conditional_format.ts
@@ -25,14 +25,14 @@ import {
   invalidateCFEvaluationCommands,
   isMatrix,
 } from "../../types/index";
-import { UIPlugin } from "../ui_plugin";
+import { CoreViewPlugin } from "../core_view_plugin";
 import { CoreViewCommand, invalidateEvaluationCommands } from "./../../types/commands";
 
 type ComputedStyles = { [col: HeaderIndex]: (Style | undefined)[] };
 type ComputedIcons = { [col: HeaderIndex]: (string | undefined)[] };
 type ComputedDataBars = { [col: HeaderIndex]: (DataBarFill | undefined)[] };
 
-export class EvaluationConditionalFormatPlugin extends UIPlugin {
+export class EvaluationConditionalFormatPlugin extends CoreViewPlugin {
   static getters = [
     "getConditionalIcon",
     "getCellConditionalFormatStyle",

--- a/src/plugins/ui_core_views/evaluation_data_validation.ts
+++ b/src/plugins/ui_core_views/evaluation_data_validation.ts
@@ -16,7 +16,7 @@ import {
   isMatrix,
 } from "../../types";
 import { CoreViewCommand, invalidateEvaluationCommands } from "../../types/commands";
-import { UIPlugin } from "../ui_plugin";
+import { CoreViewPlugin } from "../core_view_plugin";
 import { _t } from "./../../translation";
 
 interface InvalidValidationResult {
@@ -35,7 +35,7 @@ type ValidationResult = ValidValidationResult | InvalidValidationResult;
 
 type SheetValidationResult = { [col: HeaderIndex]: Array<Lazy<ValidationResult>> };
 
-export class EvaluationDataValidationPlugin extends UIPlugin {
+export class EvaluationDataValidationPlugin extends CoreViewPlugin {
   static getters = [
     "getDataValidationInvalidCriterionValueMessage",
     "getInvalidDataValidationMessage",

--- a/src/plugins/ui_core_views/header_sizes_ui.ts
+++ b/src/plugins/ui_core_views/header_sizes_ui.ts
@@ -10,7 +10,7 @@ import {
 } from "../../helpers";
 import { Command } from "../../types";
 import { CellPosition, Dimension, HeaderIndex, Immutable, Pixel, UID } from "../../types/misc";
-import { UIPlugin } from "../ui_plugin";
+import { CoreViewPlugin } from "../core_view_plugin";
 
 interface HeaderSizeState {
   tallestCellInRow: Immutable<Record<UID, Array<CellWithSize | undefined>>>;
@@ -21,7 +21,7 @@ interface CellWithSize {
   size: Pixel;
 }
 
-export class HeaderSizeUIPlugin extends UIPlugin<HeaderSizeState> implements HeaderSizeState {
+export class HeaderSizeUIPlugin extends CoreViewPlugin<HeaderSizeState> implements HeaderSizeState {
   static getters = ["getRowSize", "getHeaderSize"] as const;
 
   readonly tallestCellInRow: Immutable<Record<UID, Array<CellWithSize | undefined>>> = {};

--- a/src/plugins/ui_core_views/pivot_ui.ts
+++ b/src/plugins/ui_core_views/pivot_ui.ts
@@ -25,7 +25,8 @@ import {
   invalidateEvaluationCommands,
 } from "../../types";
 import { Pivot } from "../../types/pivot_runtime";
-import { UIPlugin, UIPluginConfig } from "../ui_plugin";
+import { CoreViewPlugin, CoreViewPluginConfig } from "../core_view_plugin";
+import { UIPluginConfig } from "../ui_plugin";
 
 export const UNDO_REDO_PIVOT_COMMANDS = ["ADD_PIVOT", "UPDATE_PIVOT"];
 
@@ -33,7 +34,7 @@ function isPivotCommand(cmd: CoreCommand): cmd is AddPivotCommand | UpdatePivotC
   return UNDO_REDO_PIVOT_COMMANDS.includes(cmd.type);
 }
 
-export class PivotUIPlugin extends UIPlugin {
+export class PivotUIPlugin extends CoreViewPlugin {
   static getters = [
     "getPivot",
     "getFirstPivotFunction",
@@ -48,7 +49,7 @@ export class PivotUIPlugin extends UIPlugin {
   private unusedPivots?: UID[];
   private custom: UIPluginConfig["custom"];
 
-  constructor(config: UIPluginConfig) {
+  constructor(config: CoreViewPluginConfig) {
     super(config);
     this.custom = config.custom;
   }

--- a/src/plugins/ui_plugin.ts
+++ b/src/plugins/ui_plugin.ts
@@ -14,7 +14,7 @@ import {
 } from "../types/index";
 import { BasePlugin } from "./base_plugin";
 
-type UIActions = Pick<ModelConfig, "notifyUI" | "raiseBlockingErrorUI">;
+export type UIActions = Pick<ModelConfig, "notifyUI" | "raiseBlockingErrorUI">;
 
 export interface UIPluginConfig {
   readonly getters: Getters;
@@ -47,6 +47,8 @@ export class UIPlugin<State = any> extends BasePlugin<State, Command> {
   protected getters: Getters;
   protected ui: UIActions;
   protected selection: SelectionStreamProcessor;
+  protected dispatch: CommandDispatcher["dispatch"];
+  protected canDispatch: CommandDispatcher["dispatch"];
 
   constructor({
     getters,
@@ -56,10 +58,12 @@ export class UIPlugin<State = any> extends BasePlugin<State, Command> {
     uiActions,
     selection,
   }: UIPluginConfig) {
-    super(stateObserver, dispatch, canDispatch);
+    super(stateObserver);
     this.getters = getters;
     this.ui = uiActions;
     this.selection = selection;
+    this.dispatch = dispatch;
+    this.canDispatch = canDispatch;
   }
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
The CoreView plugins have a local state that is directly derived from the core data. As such, they should not have any impact on plugins other than themselves, especially not on core plugins.

This revision removes the dispatch fro the core view plugins altogether as they don't and should not dispatch anything.

Task: 4241403

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo