### PR TITLE
[FIX] chart: show values with hidden dataset

### DIFF
--- a/src/components/figures/chart/chartJs/chartjs_show_values_plugin.ts
+++ b/src/components/figures/chart/chartJs/chartjs_show_values_plugin.ts
@@ -72,8 +72,8 @@ function drawLineOrBarOrRadarChartValues(
   const textsPositions: Record<number, number[]> = {};
 
   for (const dataset of chart._metasets) {
-    if (dataset.xAxisID === TREND_LINE_XAXIS_ID) {
-      return; // ignore trend lines
+    if (dataset.xAxisID === TREND_LINE_XAXIS_ID || dataset.hidden) {
+      continue;
     }
 
     for (let i = 0; i < dataset._parsed.length; i++) {


### PR DESCRIPTION
## Description

Now we can hide a dataset by clicking on the legend. But the "Show values" are still shown on the chart even if the dataset is hidden.

Task: [4334865](https://www.odoo.com/web#id=4334865&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo