### PR TITLE
[IMP] pivot: highlight pivot cells on panel open

### DIFF
--- a/src/components/side_panel/pivot/pivot_side_panel/pivot_side_panel.ts
+++ b/src/components/side_panel/pivot/pivot_side_panel/pivot_side_panel.ts
@@ -1,6 +1,8 @@
 import { Component } from "@odoo/owl";
+import { getPivotHighlights } from "../../../../helpers/pivot/pivot_highlight";
 import { pivotSidePanelRegistry } from "../../../../helpers/pivot/pivot_side_panel_registry";
 import { SpreadsheetChildEnv, UID } from "../../../../types";
+import { useHighlights } from "../../../helpers/highlight_hook";
 import { Section } from "../../components/section/section";
 import { PivotLayoutConfigurator } from "../pivot_layout_configurator/pivot_layout_configurator";
 
@@ -20,11 +22,19 @@ export class PivotSidePanel extends Component<Props, SpreadsheetChildEnv> {
     Section,
   };
 
+  setup() {
+    useHighlights(this);
+  }
+
   get sidePanelEditor() {
     const pivot = this.env.model.getters.getPivotCoreDefinition(this.props.pivotId);
     if (!pivot) {
       throw new Error("pivotId does not correspond to a pivot.");
     }
     return pivotSidePanelRegistry.get(pivot.type).editor;
+  }
+
+  get highlights() {
+    return getPivotHighlights(this.env.model.getters, this.props.pivotId);
   }
 }


### PR DESCRIPTION
## Description

The pivot cells should be highlighted when the pivot side panel for this pivot is open.

Task: [4341467](https://www.odoo.com/web#id=4341467&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo