### PR TITLE
[FIX] Evaluation: Remove old spreaded cells from spread relations

### DIFF
--- a/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
@@ -450,6 +450,7 @@ export class Evaluator {
       this.evaluatedCells.delete(child);
       this.nextPositionsToUpdate.addMany(this.getCellsDependingOn([child]));
       this.nextPositionsToUpdate.addMany(this.getArrayFormulasBlockedBy(child));
+      this.spreadingRelations.removeNode(child);
     }
     this.spreadingRelations.removeNode(positionId);
   }

--- a/tests/evaluation/evaluation_formula_array.test.ts
+++ b/tests/evaluation/evaluation_formula_array.test.ts
@@ -1,5 +1,6 @@
 import { arg, functionRegistry } from "../../src/functions";
 import { toNumber } from "../../src/functions/helpers";
+import { toCartesian } from "../../src/helpers";
 import { Model } from "../../src/model";
 import {
   Arg,
@@ -745,6 +746,21 @@ describe("evaluate formulas that return an array", () => {
       expect(c).toEqual(1);
       setCellContent(model, "A2", "2");
       expect(c).toEqual(2);
+    });
+
+    test("Cells that no longer depend on the array formula are removed from the spreading dependencies", () => {
+      setCellContent(model, "A1", "=TRANSPOSE(A3:A4)");
+      setCellContent(model, "A3", "3");
+      setCellContent(model, "A4", "4");
+      expect(getEvaluatedCell(model, "B1").value).toEqual(4);
+      const sheetId = model.getters.getActiveSheetId();
+      expect(model.getters.getCorrespondingFormulaCell({ sheetId, ...toCartesian("B1") })).toBe(
+        model.getters.getCorrespondingFormulaCell({ sheetId, ...toCartesian("A1") })
+      );
+      setCellContent(model, "A1", "=TRANSPOSE(A3)");
+      expect(
+        model.getters.getCorrespondingFormulaCell({ sheetId, ...toCartesian("B1") })
+      ).toBeUndefined();
     });
 
     test("have collision when spread size zone change", () => {


### PR DESCRIPTION
Currently, the spread relations of a spreaded formula are not invalidated. The evaluated value of the relation is currently properly invalidated so it's not posing any problem during the evaluation/display phase but some features rely specifically on the spreading relation (e.g. the pivot cells highlighting in the top bar) and the current situation leads to false positives (see attached test).

Task: 4342240

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo