### PR TITLE
[FIX] chart: trend line legend is wrong

### DIFF
--- a/tests/figures/chart/bar_chart_plugin.test.ts
+++ b/tests/figures/chart/bar_chart_plugin.test.ts
@@ -163,6 +163,7 @@ describe("bar chart", () => {
         lineWidth: 3,
         pointStyle: "rect",
         strokeStyle: "#FFFFFF",
+        datasetIndex: 0,
       },
       {
         fontColor: "#000000",
@@ -172,6 +173,7 @@ describe("bar chart", () => {
         lineWidth: 3,
         pointStyle: "rect",
         strokeStyle: "#FFFFFF",
+        datasetIndex: 1,
       },
     ]);
   });
@@ -224,5 +226,29 @@ describe("bar chart", () => {
     updateChart(model, "chartId", { background: "#f00" });
     runtime = model.getters.getChartRuntime("chartId") as BarChartRuntime;
     expect(runtime.chartJsConfig.data.datasets[0].borderColor).toBe("#f00");
+  });
+
+  test("Bar chart trend line legend", () => {
+    const model = createModelFromGrid({ A1: "1", A2: "2" });
+    createChart(
+      model,
+      {
+        dataSets: [
+          {
+            dataRange: "Sheet1!A1:A2",
+            backgroundColor: "#f00",
+            label: "serie_1",
+            trend: { type: "polynomial", order: 1, color: "#f0f", display: true },
+          },
+        ],
+        dataSetsHaveTitle: false,
+        type: "bar",
+      },
+      "1"
+    );
+    expect(getChartLegendLabels(model, "1")).toMatchObject([
+      { text: "serie_1", fillStyle: "#f00", pointStyle: "rect" },
+      { text: "Trend line for serie_1", strokeStyle: "#f0f", pointStyle: "line" },
+    ]);
   });
 });

--- a/tests/figures/chart/combo_chart_plugin.test.ts
+++ b/tests/figures/chart/combo_chart_plugin.test.ts
@@ -134,6 +134,7 @@ describe("combo chart", () => {
         pointStyle: "rect",
         strokeStyle: "#f00",
         fillStyle: "#f00",
+        datasetIndex: 0,
       },
       {
         fontColor: "#000000",
@@ -143,6 +144,7 @@ describe("combo chart", () => {
         pointStyle: "line",
         strokeStyle: "#00f",
         fillStyle: "#00f",
+        datasetIndex: 1,
       },
     ]);
   });

--- a/tests/figures/chart/line_chart_plugin.test.ts
+++ b/tests/figures/chart/line_chart_plugin.test.ts
@@ -197,6 +197,7 @@ describe("line chart", () => {
         lineWidth: 3,
         pointStyle: "line",
         strokeStyle: "#f00",
+        datasetIndex: 0,
       },
       {
         fontColor: "#000000",
@@ -206,6 +207,7 @@ describe("line chart", () => {
         lineWidth: 3,
         pointStyle: "line",
         strokeStyle: "#00f",
+        datasetIndex: 1,
       },
     ]);
   });

--- a/tests/figures/chart/radar_chart_plugin.test.ts
+++ b/tests/figures/chart/radar_chart_plugin.test.ts
@@ -88,6 +88,7 @@ describe("radar chart", () => {
         lineWidth: 3,
         pointStyle: "line",
         strokeStyle: "#f00",
+        datasetIndex: 0,
       },
       {
         fontColor: "#000000",
@@ -97,6 +98,7 @@ describe("radar chart", () => {
         lineWidth: 3,
         pointStyle: "line",
         strokeStyle: "#00f",
+        datasetIndex: 1,
       },
     ]);
   });


### PR DESCRIPTION
## Description

The trend line legend is a circle instead of a line in scatter charts. And it's a rectangle in bar chart.

Also the onClick of the legend was slightly wrong: we used the index of the legend item to check which dataset to hide. Which didn't work if for whatever reason ChartJs decided to change the order of the legend items.

Task: [4342471](https://www.odoo.com/web#id=4342471&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo