### PR TITLE
[FIX] collaborative: don't snapshot in read-only mode

### DIFF
--- a/src/collaborative/session.ts
+++ b/src/collaborative/session.ts
@@ -159,8 +159,8 @@ export class Session extends EventBus<CollaborativeEvent> {
   /**
    * Notify the server that the user client left the collaborative session
    */
-  async leave(data: Lazy<WorkbookData>) {
-    if (Object.keys(this.clients).length === 1 && this.processedRevisions.size) {
+  async leave(data?: Lazy<WorkbookData>) {
+    if (data && Object.keys(this.clients).length === 1 && this.processedRevisions.size) {
       await this.snapshot(data());
     }
     delete this.clients[this.clientId];

--- a/src/model.ts
+++ b/src/model.ts
@@ -289,7 +289,8 @@ export class Model extends EventBus<any> implements CommandDispatcher {
   }
 
   async leaveSession() {
-    await this.session.leave(lazy(() => this.exportData()));
+    const snapshot = this.getters.isReadonly() ? undefined : lazy(() => this.exportData());
+    await this.session.leave(snapshot);
   }
 
   private setupUiPlugin(Plugin: UIPluginConstructor) {

--- a/tests/collaborative/collaborative_session.test.ts
+++ b/tests/collaborative/collaborative_session.test.ts
@@ -105,6 +105,31 @@ describe("Collaborative session", () => {
     expect(spy).toHaveBeenCalledWith(expect.objectContaining({ type: "CLIENT_LEFT" }));
   });
 
+  test("do not snapshot when leaving in read-only mode", async () => {
+    const model = new Model(
+      {},
+      {
+        mode: "readonly",
+        transportService: transport,
+        client: { id: "alice", name: "Alice" },
+      }
+    );
+    transport.sendMessage({
+      type: "REMOTE_REVISION",
+      version: MESSAGE_VERSION,
+      nextRevisionId: "42",
+      clientId: "client_42",
+      commands: [],
+      serverRevisionId: transport["serverRevisionId"],
+    });
+    const spy = jest.spyOn(transport, "sendMessage");
+    model.leaveSession();
+    await nextTick();
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).not.toHaveBeenCalledWith(expect.objectContaining({ type: "SNAPSHOT" }));
+    expect(spy).toHaveBeenCalledWith(expect.objectContaining({ type: "CLIENT_LEFT" }));
+  });
+
   test("local client leaves with other connected clients and changes", () => {
     transport.sendMessage({
       type: "CLIENT_JOINED",


### PR DESCRIPTION



## Description:

Steps to reproduce:

- open two browser windows with 2 different users: Alice and Bob. Alice has write access and Bob have only read-only access
- open the same spreadsheet with both users
- Alice updates a few cells
- Alice leaves the spreadsheet
- Bob leaves the spreadsheet

=> Bob is faced with an access error because he is trying to snapshot
   the spreadsheet.

Task: [4344187](https://www.odoo.com/web#id=4344187&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo