### PR TITLE
[IMP] sort: prevent sorting on range with array formula

### DIFF
--- a/src/components/filters/filter_menu/filter_menu.ts
+++ b/src/components/filters/filter_menu/filter_menu.ts
@@ -2,6 +2,7 @@ import { Component, onWillUpdateProps, useRef, useState } from "@odoo/owl";
 import { MENU_ITEM_HEIGHT } from "../../../constants";
 import { deepEquals, positions, toLowerCase } from "../../../helpers";
 import { fuzzyLookup } from "../../../helpers/search";
+import { interactiveSort } from "../../../helpers/sort";
 import { Position, SortDirection, SpreadsheetChildEnv } from "../../../types";
 import { CellPopoverComponent, PopoverBuilders } from "../../../types/cell_popovers";
 import { css } from "../../helpers/css";
@@ -287,14 +288,9 @@ export class FilterMenu extends Component<Props, SpreadsheetChildEnv> {
     }
     const sheetId = this.env.model.getters.getActiveSheetId();
     const contentZone = { ...tableZone, top: tableZone.top + 1 };
-    this.env.model.dispatch("SORT_CELLS", {
-      sheetId,
-      col: filterPosition.col,
-      row: contentZone.top,
-      zone: contentZone,
-      sortDirection,
-      sortOptions: { emptyCellAsZero: true, sortHeaders: true },
-    });
+    const sortAnchor = { col: filterPosition.col, row: contentZone.top };
+    const sortOptions = { emptyCellAsZero: true, sortHeaders: true };
+    interactiveSort(this.env, sheetId, sortAnchor, contentZone, sortDirection, sortOptions);
     this.props.onClosed?.();
   }
 }

--- a/src/plugins/ui_feature/sort.ts
+++ b/src/plugins/ui_feature/sort.ts
@@ -24,7 +24,12 @@ export class SortPlugin extends UIPlugin {
         if (!isInside(cmd.col, cmd.row, cmd.zone)) {
           return CommandResult.InvalidSortAnchor;
         }
-        return this.checkValidations(cmd, this.checkMerge, this.checkMergeSizes);
+        return this.checkValidations(
+          cmd,
+          this.checkMerge,
+          this.checkMergeSizes,
+          this.checkArrayFormulaInSortZone
+        );
     }
     return CommandResult.Success;
   }
@@ -71,6 +76,13 @@ export class SortPlugin extends UIPlugin {
       return CommandResult.InvalidSortZone;
     }
     return CommandResult.Success;
+  }
+
+  private checkArrayFormulaInSortZone({ sheetId, zone }: SortCommand): CommandResult {
+    const arrayFormulaInZone = positions(zone).some(({ col, row }) =>
+      this.getters.getArrayFormulaSpreadingOn({ sheetId, col, row })
+    );
+    return arrayFormulaInZone ? CommandResult.SortZoneWithArrayFormulas : CommandResult.Success;
   }
 
   /**

--- a/src/plugins/ui_feature/sort.ts
+++ b/src/plugins/ui_feature/sort.ts
@@ -1,6 +1,5 @@
 import { isInside, overlap, positions, range, zoneToDimension } from "../../helpers/index";
 import { sortCells } from "../../helpers/sort";
-import { _t } from "../../translation";
 import {
   CellPosition,
   CellValueType,
@@ -23,7 +22,7 @@ export class SortPlugin extends UIPlugin {
     switch (cmd.type) {
       case "SORT_CELLS":
         if (!isInside(cmd.col, cmd.row, cmd.zone)) {
-          throw new Error(_t("The anchor must be part of the provided zone"));
+          return CommandResult.InvalidSortAnchor;
         }
         return this.checkValidations(cmd, this.checkMerge, this.checkMergeSizes);
     }

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -1257,6 +1257,7 @@ export const enum CommandResult {
   ValueLowerInvalidFormula = "ValueLowerInvalidFormula",
   InvalidSortAnchor = "InvalidSortAnchor",
   InvalidSortZone = "InvalidSortZone",
+  SortZoneWithArrayFormulas = "SortZoneWithArrayFormulas",
   WaitingSessionConfirmation = "WaitingSessionConfirmation",
   MergeOverlap = "MergeOverlap",
   TooManyHiddenElements = "TooManyHiddenElements",

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -1255,6 +1255,7 @@ export const enum CommandResult {
   MaxInvalidFormula = "MaxInvalidFormula",
   ValueUpperInvalidFormula = "ValueUpperInvalidFormula",
   ValueLowerInvalidFormula = "ValueLowerInvalidFormula",
+  InvalidSortAnchor = "InvalidSortAnchor",
   InvalidSortZone = "InvalidSortZone",
   WaitingSessionConfirmation = "WaitingSessionConfirmation",
   MergeOverlap = "MergeOverlap",

--- a/tests/helpers/ui_helpers.test.ts
+++ b/tests/helpers/ui_helpers.test.ts
@@ -38,7 +38,7 @@ import {
   undo,
 } from "../test_helpers/commands_helpers";
 import { getCell, getCellContent, getCellText } from "../test_helpers/getters_helpers";
-import { makeTestEnv, target } from "../test_helpers/helpers";
+import { createModelFromGrid, makeTestEnv, target } from "../test_helpers/helpers";
 
 function getCellsObject(model: Model, sheetId: UID) {
   const cells = {};
@@ -446,6 +446,15 @@ describe("UI Helpers", () => {
         D5: { content: "6" },
       });
     });
+  });
+
+  test("Cannot sort on zone with array formulas", () => {
+    const raiseError = jest.fn();
+    model = createModelFromGrid({ A1: "9", A2: "8", A3: "=CHOOSECOLS(A1:A2, 1)" });
+    const env = makeTestEnv({ model, raiseError });
+
+    interactiveSortSelection(env, sheetId, toCartesian("A1"), toZone("A1:A4"), "ascending");
+    expect(raiseError).toHaveBeenCalledWith("Cannot sort a zone with array formulas.");
   });
 
   describe("Sort Merges", () => {

--- a/tests/sort_plugin.test.ts
+++ b/tests/sort_plugin.test.ts
@@ -400,6 +400,15 @@ describe("Sorting allowDispatch", () => {
       sort(model, { zone: "A1:A5", anchor: "A1", direction: "ascending" })
     ).toBeCancelledBecause(CommandResult.InvalidSortZone);
   });
+
+  test("Sort with array formula", () => {
+    setCellContent(model, "A1", "8");
+    setCellContent(model, "A2", "4");
+    setCellContent(model, "A3", "=FILTER(A1:A2, A1:A2 > 1)");
+    expect(
+      sort(model, { zone: "A1:A4", anchor: "A1", direction: "ascending" })
+    ).toBeCancelledBecause(CommandResult.SortZoneWithArrayFormulas);
+  });
 });
 
 describe("Sort multi adjacent columns", () => {


### PR DESCRIPTION
## Description:

### [IMP] sort: prevent sorting on range with array formula

Sorting on an array formula does not work since the spreaded values
cannot be reordered. But the "sort" button was still enabled,
leading to cases where the user tried to sort on an array formula,
which would fail without any feedback.

This commits displays a warning message when the user tries to sort
on a range with an array formula.


### [FIX] sort: use allowDispatch instead of throwing

The sort plugin would throw an error if the sort anchor wasn't in the
sort zone, instead of using the standard allowDispatch behaviour of
returning a DispatchResult.

Task: [4342539](https://www.odoo.com/web#id=4342539&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo