### PR TITLE
[IMP] function: add a debugger just before the compute function

### DIFF
--- a/src/formulas/compiler.ts
+++ b/src/formulas/compiler.ts
@@ -161,6 +161,7 @@ function compileTokensOrThrow(tokens: Token[]): CompiledFormula {
       }
       if (ast.debug) {
         code.append("debugger;");
+        code.append(`ctx["debug"] = true;`);
       }
       switch (ast.type) {
         case "BOOLEAN":

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -226,6 +226,9 @@ function createComputeFunction(
     this: EvalContext,
     ...args: Arg[]
   ): FunctionResultObject | Matrix<FunctionResultObject> {
+    if (this.debug) {
+      debugger;
+    }
     const result = descr.compute.apply(this, args);
 
     if (!isMatrix(result)) {

--- a/src/types/functions.ts
+++ b/src/types/functions.ts
@@ -58,4 +58,5 @@ export type EvalContext = {
   [key: string]: any;
   updateDependencies?: (position: CellPosition) => void;
   addDependencies?: (position: CellPosition, ranges: Range[]) => void;
+  debug?: boolean;
 };

--- a/tests/evaluation/__snapshots__/compiler.test.ts.snap
+++ b/tests/evaluation/__snapshots__/compiler.test.ts.snap
@@ -105,6 +105,7 @@ exports[`expression compiler expressions with a debugger 1`] = `
 ) {
 // =?C|0|/|N0|
 debugger;
+ctx["debug"] = true;
 const _1 = ref(deps[0], false);
 const _2 = { value: this.constantValues.numbers[0] };
 return ctx['DIVIDE'](_1, _2);


### PR DESCRIPTION
Since the introduction of array formulas and vectorization, one who adds a `?` in a formula to debug it will have to go through all the process needed for array formulas and vectorization. This is not convenient. This commit adds a debugger just before the compute function to make it easier to debug a formula.

Note that it does not remove the debugger from the compiled formula, in order to still be able to debug the formula from start.

Task: /

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo