### PR TITLE
[FIX] helpers: Add generic helper to sanitize sheet names

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -215,8 +215,8 @@ export const DEBOUNCE_TIME = 200;
 export const MESSAGE_VERSION = 1;
 
 // Sheets
-export const FORBIDDEN_SHEET_CHARS = ["'", "*", "?", "/", "\\", "[", "]"] as const;
-export const FORBIDDEN_IN_EXCEL_REGEX = /'|\*|\?|\/|\\|\[|\]/;
+export const FORBIDDEN_SHEETNAME_CHARS = ["'", "*", "?", "/", "\\", "[", "]"] as const;
+export const FORBIDDEN_SHEETNAME_CHARS_IN_EXCEL_REGEX = /'|\*|\?|\/|\\|\[|\]/;
 
 // Cells
 export const FORMULA_REF_IDENTIFIER = "|";

--- a/src/helpers/misc.ts
+++ b/src/helpers/misc.ts
@@ -1,10 +1,12 @@
 //------------------------------------------------------------------------------
 // Miscellaneous
 //------------------------------------------------------------------------------
-import { NEWLINE } from "../constants";
+import { FORBIDDEN_SHEETNAME_CHARS_IN_EXCEL_REGEX, NEWLINE } from "../constants";
 import { ConsecutiveIndexes, Lazy, UID } from "../types";
 import { SearchOptions } from "../types/find_and_replace";
 import { Cloneable, DebouncedFunction } from "./../types/misc";
+
+const sanitizeSheetNameRegex = new RegExp(FORBIDDEN_SHEETNAME_CHARS_IN_EXCEL_REGEX, "g");
 
 /**
  * Remove quotes from a quoted string
@@ -107,6 +109,11 @@ export function getCanonicalSheetName(sheetName: string): string {
     sheetName = `'${sheetName}'`;
   }
   return sheetName;
+}
+
+/** Replace the excel-excluded characters of a sheetName */
+export function sanitizeSheetName(sheetName: string, replacementChar: string = " "): string {
+  return sheetName.replace(sanitizeSheetNameRegex, replacementChar);
 }
 
 export function clip(val: number, min: number, max: number): number {

--- a/src/helpers/ui/sheet_interactive.ts
+++ b/src/helpers/ui/sheet_interactive.ts
@@ -1,4 +1,4 @@
-import { FORBIDDEN_SHEET_CHARS } from "../../constants";
+import { FORBIDDEN_SHEETNAME_CHARS } from "../../constants";
 import { _t } from "../../translation";
 import { CommandResult, SpreadsheetChildEnv, UID } from "../../types";
 
@@ -20,7 +20,7 @@ export function interactiveRenameSheet(
     env.raiseError(
       _t(
         "Some used characters are not allowed in a sheet name (Forbidden characters are %s).",
-        FORBIDDEN_SHEET_CHARS.join(" ")
+        FORBIDDEN_SHEETNAME_CHARS.join(" ")
       ),
       errorCallback
     );

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,6 +98,7 @@ import {
   positionToZone,
   reduceZoneOnDeletion,
   rgbaToHex,
+  sanitizeSheetName,
   toCartesian,
   toUnboundedZone,
   toXC,
@@ -340,6 +341,7 @@ export const helpers = {
   createPivotFormula,
   areDomainArgsFieldsValid,
   formatTickValue,
+  sanitizeSheetName,
 };
 
 export const links = {

--- a/src/migrations/data.ts
+++ b/src/migrations/data.ts
@@ -1,10 +1,13 @@
+import { BACKGROUND_CHART_COLOR, DEFAULT_REVISION_ID, FORMULA_REF_IDENTIFIER } from "../constants";
 import {
-  BACKGROUND_CHART_COLOR,
-  DEFAULT_REVISION_ID,
-  FORBIDDEN_IN_EXCEL_REGEX,
-  FORMULA_REF_IDENTIFIER,
-} from "../constants";
-import { UuidGenerator, getItemId, overlap, toXC, toZone, zoneToXc } from "../helpers/index";
+  UuidGenerator,
+  getItemId,
+  overlap,
+  sanitizeSheetName,
+  toXC,
+  toZone,
+  zoneToXc,
+} from "../helpers/index";
 import { isValidLocale } from "../helpers/locale";
 import { getMaxObjectId } from "../helpers/pivot/pivot_helpers";
 import { StateUpdateMessage } from "../types/collaborative/transport_service";
@@ -185,13 +188,12 @@ const MIGRATIONS: Migration[] = [
     to: 8,
     applyMigration(data: any): any {
       const namesTaken: string[] = [];
-      const globalForbiddenInExcel = new RegExp(FORBIDDEN_IN_EXCEL_REGEX, "g");
       for (let sheet of data.sheets || []) {
         if (!sheet.name) {
           continue;
         }
         const oldName = sheet.name;
-        const escapedName: string = oldName.replace(globalForbiddenInExcel, "_");
+        const escapedName: string = sanitizeSheetName(oldName, "_");
         let i = 1;
         let newName = escapedName;
         while (namesTaken.includes(newName)) {

--- a/src/plugins/core/sheet.ts
+++ b/src/plugins/core/sheet.ts
@@ -1,4 +1,4 @@
-import { FORBIDDEN_IN_EXCEL_REGEX } from "../../constants";
+import { FORBIDDEN_SHEETNAME_CHARS_IN_EXCEL_REGEX } from "../../constants";
 import {
   createDefaultRows,
   deepCopy,
@@ -635,7 +635,7 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
     ) {
       return CommandResult.DuplicatedSheetName;
     }
-    if (FORBIDDEN_IN_EXCEL_REGEX.test(name!)) {
+    if (FORBIDDEN_SHEETNAME_CHARS_IN_EXCEL_REGEX.test(name!)) {
       return CommandResult.ForbiddenCharactersInSheetName;
     }
     return CommandResult.Success;

--- a/src/plugins/ui_feature/insert_pivot.ts
+++ b/src/plugins/ui_feature/insert_pivot.ts
@@ -1,4 +1,5 @@
-import { FORBIDDEN_IN_EXCEL_REGEX, PIVOT_TABLE_CONFIG } from "../../constants";
+import { PIVOT_TABLE_CONFIG } from "../../constants";
+import { sanitizeSheetName } from "../../helpers";
 import { SpreadsheetPivotTable } from "../../helpers/pivot/table_spreadsheet_pivot";
 import { getZoneArea } from "../../helpers/zones";
 import { _t } from "../../translation";
@@ -104,7 +105,7 @@ export class InsertPivotPlugin extends UIPlugin {
   private getPivotDuplicateSheetName(pivotName: string) {
     let i = 1;
     const names = this.getters.getSheetIds().map((id) => this.getters.getSheetName(id));
-    const sanitizedName = pivotName.replace(new RegExp(FORBIDDEN_IN_EXCEL_REGEX, "g"), " ");
+    const sanitizedName = sanitizeSheetName(pivotName);
     let name = sanitizedName;
     while (names.includes(name)) {
       name = `${sanitizedName} (${i})`;

--- a/tests/model/model_import_export.test.ts
+++ b/tests/model/model_import_export.test.ts
@@ -4,7 +4,7 @@ import {
   DEFAULT_CELL_HEIGHT,
   DEFAULT_CELL_WIDTH,
   DEFAULT_REVISION_ID,
-  FORBIDDEN_SHEET_CHARS,
+  FORBIDDEN_SHEETNAME_CHARS,
 } from "../../src/constants";
 import { toCartesian, toZone } from "../../src/helpers";
 import { CURRENT_VERSION } from "../../src/migrations/data";
@@ -204,7 +204,7 @@ describe("Migrations", () => {
       stacked: false,
     });
   });
-  test.each(FORBIDDEN_SHEET_CHARS)("migrate version 7: sheet Names", (char) => {
+  test.each(FORBIDDEN_SHEETNAME_CHARS)("migrate version 7: sheet Names", (char) => {
     const model = new Model({
       version: 7,
       sheets: [

--- a/tests/pivots/pivot_plugin.test.ts
+++ b/tests/pivots/pivot_plugin.test.ts
@@ -1,4 +1,4 @@
-import { FORBIDDEN_SHEET_CHARS } from "../../src/constants";
+import { FORBIDDEN_SHEETNAME_CHARS } from "../../src/constants";
 import { EMPTY_PIVOT_CELL } from "../../src/helpers/pivot/table_spreadsheet_pivot";
 import { renameSheet, selectCell, setCellContent } from "../test_helpers/commands_helpers";
 import { createModelFromGrid, toCellPosition } from "../test_helpers/helpers";
@@ -76,7 +76,7 @@ describe("Pivot plugin", () => {
       A2: "Alice",
     };
     const model = createModelFromGrid(grid);
-    addPivot(model, "A1:A2", { name: `forbidden: ${FORBIDDEN_SHEET_CHARS}` }, "pivot1");
+    addPivot(model, "A1:A2", { name: `forbidden: ${FORBIDDEN_SHEETNAME_CHARS}` }, "pivot1");
     model.dispatch("DUPLICATE_PIVOT_IN_NEW_SHEET", {
       newPivotId: "pivot2",
       newSheetId: "Sheet2",

--- a/tests/sheet/sheets_plugin.test.ts
+++ b/tests/sheet/sheets_plugin.test.ts
@@ -1,4 +1,4 @@
-import { FORBIDDEN_SHEET_CHARS } from "../../src/constants";
+import { FORBIDDEN_SHEETNAME_CHARS } from "../../src/constants";
 import { getCanonicalSheetName, numberToLetters, toZone } from "../../src/helpers";
 import { Model } from "../../src/model";
 import { CommandResult } from "../../src/types";
@@ -140,7 +140,7 @@ describe("sheets", () => {
     ).toBeCancelledBecause(CommandResult.DuplicatedSheetName);
   });
 
-  test.each(FORBIDDEN_SHEET_CHARS)("Cannot rename a sheet with a %s in the name", (char) => {
+  test.each(FORBIDDEN_SHEETNAME_CHARS)("Cannot rename a sheet with a %s in the name", (char) => {
     const model = new Model();
     expect(
       renameSheet(model, model.getters.getActiveSheetId(), `my life ${char}`)


### PR DESCRIPTION
Some commands or functionalities can dispatch the creation of new sheets. Unfortunately, the sheet names cannot contain specific characters. This revision introduces a generic helper to sanitize the names before using it inside the CREATE_SHEET command.

Task: 4347719

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [4347719](https://www.odoo.com/odoo/2328/tasks/4347719)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo