### PR TITLE
[FIX] composer: overflow on composer at end of screen

### DIFF
--- a/src/components/composer/composer/composer.ts
+++ b/src/components/composer/composer/composer.ts
@@ -92,10 +92,10 @@ css/* scss */ `
     }
 
     .fa-stack {
-      // reset stack size which is doubled by default
-      width: 1em;
-      height: 1em;
-      line-height: 1em;
+      /* reset stack size which is doubled by default */
+      width: ${CLOSE_ICON_RADIUS * 2}px;
+      height: ${CLOSE_ICON_RADIUS * 2}px;
+      line-height: ${CLOSE_ICON_RADIUS * 2}px;
     }
 
     .force-open-assistant {


### PR DESCRIPTION
## Description

The button to close the composer's formula assistant would overflow for the viewport and make an additional scrollbar appear when it's at the end of the screen (eg. standalone composer in the CF color scale panel).

This was due to two things:
1) there was a comment with `//`, which is invalid css and disabled the `width` property of the button
2) we were using a `CLOSE_ICON_RADIUS` to compute the position of the formula assistant. But this constant wasn't actually used in the CSS, so the button could have an arbitrary width unrelated to the constant. (in practice it was 18.4px vs 18px, but this would change if we changed the font size).

Task: [4315958](https://www.odoo.com/odoo/2328/tasks/4315958)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo