### PR TITLE
[FIX] css: use correct CSS comment syntax

### DIFF
--- a/src/components/color_picker/color_picker.ts
+++ b/src/components/color_picker/color_picker.ts
@@ -42,7 +42,7 @@ const CONTAINER_WIDTH = CONTENT_WIDTH + 2 * PICKER_PADDING;
 css/* scss */ `
   .o-color-picker {
     padding: ${PICKER_PADDING}px 0;
-    /** FIXME: this is useless, overiden by the popover container */
+    /* FIXME: this is useless, overiden by the popover container */
     box-shadow: 1px 2px 5px 2px rgba(51, 51, 51, 0.15);
     background-color: white;
     line-height: 1.2;
@@ -185,7 +185,7 @@ css/* scss */ `
           margin-right: 2px;
         }
         .o-wrong-color {
-          /** FIXME bootstrap class instead? */
+          /* FIXME bootstrap class instead? */
           outline-color: red;
           border-color: red;
           &:focus {

--- a/src/components/composer/composer/composer.ts
+++ b/src/components/composer/composer/composer.ts
@@ -106,7 +106,7 @@ css/* scss */ `
       margin: 1px 4px;
 
       .o-semi-bold {
-        /** FIXME: to remove in favor of Bootstrap
+        /* FIXME: to remove in favor of Bootstrap
         * 'fw-semibold' when we upgrade to Bootstrap 5.2
         */
         font-weight: 600 !important;

--- a/src/components/data_validation_overlay/dv_checkbox/dv_checkbox.ts
+++ b/src/components/data_validation_overlay/dv_checkbox/dv_checkbox.ts
@@ -11,7 +11,7 @@ css/* scss */ `
     box-sizing: border-box !important;
     accent-color: #808080;
     margin: ${MARGIN}px;
-    /** required to prevent the checkbox position to be sensible to the font-size (affects Firefox) */
+    /* required to prevent the checkbox position to be sensible to the font-size (affects Firefox) */
     position: absolute;
   }
 `;

--- a/src/components/figures/figure_container/figure_container.ts
+++ b/src/components/figures/figure_container/figure_container.ts
@@ -59,7 +59,7 @@ css/*SCSS*/ `
     }
   }
   .o-figure-container {
-    -webkit-user-select: none; // safari
+    -webkit-user-select: none; /* safari */
     user-select: none;
   }
 `;

--- a/src/components/header_group/header_group_container.ts
+++ b/src/components/header_group/header_group_container.ts
@@ -28,7 +28,7 @@ css/* scss */ `
 
   .o-header-group-main-pane {
     &.o-group-rows {
-      margin-top: -2px; // Counteract o-header-group-frozen-pane-border offset
+      margin-top: -2px; /* Counteract o-header-group-frozen-pane-border offset */
     }
     &.o-group-columns {
       margin-left: -2px;

--- a/src/components/selection_input/selection_input.ts
+++ b/src/components/selection_input/selection_input.ts
@@ -24,7 +24,7 @@ css/* scss */ `
       flex-grow: 0;
     }
 
-    /** Make the character a bit bigger
+    /* Make the character a bit bigger
     compared to its neighbor INPUT box  */
     .o-remove-selection {
       font-size: calc(100% + 4px);

--- a/src/components/side_panel/conditional_formatting/cf_editor/cf_editor.ts
+++ b/src/components/side_panel/conditional_formatting/cf_editor/cf_editor.ts
@@ -62,7 +62,7 @@ css/* scss */ `
         .o-threshold-value {
           flex-grow: 1;
           flex-basis: 60%;
-          min-width: 0px; // input overflows in Firefox otherwise
+          min-width: 0px; /* input overflows in Firefox otherwise */
         }
         .o-threshold-value input:disabled {
           background-color: #edebed;

--- a/src/components/side_panel/data_validation/dv_preview/dv_preview.ts
+++ b/src/components/side_panel/data_validation/dv_preview/dv_preview.ts
@@ -14,7 +14,7 @@ css/* scss */ `
       border-bottom: 1px solid ${FIGURE_BORDER_COLOR};
 
       .o-dv-container {
-        min-width: 0; // otherwise flex won't shrink correctly
+        min-width: 0; /* otherwise flex won't shrink correctly */
       }
 
       .o-dv-preview-description {

--- a/src/components/spreadsheet/spreadsheet.ts
+++ b/src/components/spreadsheet/spreadsheet.ts
@@ -99,7 +99,7 @@ css/* scss */ `
     *:before,
     *:after {
       box-sizing: content-box;
-      /** rtl not supported ATM */
+      /* rtl not supported ATM */
       direction: ltr;
     }
     .o-separator {

--- a/src/components/tables/table_styles_popover/table_styles_popover.ts
+++ b/src/components/tables/table_styles_popover/table_styles_popover.ts
@@ -19,7 +19,7 @@ export interface TableStylesPopoverProps {
 
 css/* scss */ `
   .o-table-style-popover {
-    /** 7 tables preview + padding by line */
+    /* 7 tables preview + padding by line */
     width: calc((66px + 4px * 2) * 7 + 1.5rem * 2);
     background: #fff;
     font-size: 14px;


### PR DESCRIPTION
## Description

Comments in CSS use `/* */`. Not `/** */` nor `//`.

`/** */` seems to work in browsers (second asterisk is probably ignored), but it's not standard.

 `//` is not valid CSS, and it can break the CSS if we're not careful.
`border: 1px; // comment` seems to work correctly
`// comment\n
border: 1px;` disable the border property

Task: [4353310](https://www.odoo.com/odoo/2328/tasks/4353310)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo