### PR TITLE
[IMP] chart: keep data series when switching chart types

### DIFF
--- a/tests/figures/chart/charts_component.test.ts
+++ b/tests/figures/chart/charts_component.test.ts
@@ -1596,6 +1596,51 @@ describe("charts", () => {
       checkbox = document.querySelector("input[name='dataSetsHaveTitle']") as HTMLInputElement;
       expect(checkbox.checked).toBe(true);
     });
+
+    test("Context creation is not shared between charts", async () => {
+      createChart(model, { type: "line" }, "chart1");
+      createTestChart("scorecard", "chart2");
+
+      await mountChartSidePanel("chart1");
+      await click(fixture, "input[name='cumulative']");
+      expect(model.getters.getChartDefinition("chart1")["cumulative"]).toBe(true);
+      await changeChartType("bar"); // save chart1 context creation the side panel store
+
+      model.dispatch("SELECT_FIGURE", { id: "chart2" });
+      await nextTick();
+      await changeChartType("line");
+      // check that chart2 cumulative option is the line chart default (undefined) and not the chart1 value
+      expect(model.getters.getChartDefinition("chart2")["cumulative"]).toBe(undefined);
+    });
+
+    test("Chart datasets are kept when switching from a bar to a chart accepting a single dataset then back to a bar chart", async () => {
+      createChart(model, { type: "bar", dataSets: [{ dataRange: "A1" }, { dataRange: "B1" }] });
+      const chartId = model.getters.getChartIds(sheetId)[0];
+      await mountChartSidePanel(chartId);
+
+      await changeChartType("gauge");
+      expect(model.getters.getChartDefinition(chartId)).toMatchObject({ dataRange: "A1" });
+
+      await changeChartType("bar");
+      expect(model.getters.getChartDefinition(chartId)).toMatchObject({
+        dataSets: [{ dataRange: "A1" }, { dataRange: "B1" }],
+      });
+    });
+
+    test("Chart datasets from old chart type are discarded as soon as a dataset is changed in the new type", async () => {
+      createChart(model, { type: "bar", dataSets: [{ dataRange: "A1" }, { dataRange: "B1" }] });
+      const chartId = model.getters.getChartIds(sheetId)[0];
+      await mountChartSidePanel(chartId);
+
+      await changeChartType("pie");
+      updateChart(model, chartId, { dataSets: [{ dataRange: "C1" }] });
+      await nextTick();
+
+      await changeChartType("bar");
+      expect(model.getters.getChartDefinition(chartId)).toMatchObject({
+        dataSets: [{ dataRange: "C1" }],
+      });
+    });
   });
 
   describe("trend line", () => {


### PR DESCRIPTION
## Description

Currently if you have a bar chart with 3 ranges, switch to a gauge chart that only accept a single range, then back to a bar chart you will lose the 2 other ranges.

This commit fixes that. The ranges are kept in the store so we can switch between chart types without losing data.

There is one issue however: we do not make any difference between ranges lost because the chart type changed, and ranges lost because the user manually removed them. So if a user change chart type => remove a range => change chart type again, the removed range will be back.

This commit also fixed another issue that the chart creation context was not dependant on which figure was edited.

Task: [4282798](https://www.odoo.com/odoo/2328/tasks/4282798)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo