### PR TITLE
[FIX] chart: trend line tooltip for scatter/line charts

### DIFF
--- a/src/helpers/figures/charts/chart_common_line_scatter.ts
+++ b/src/helpers/figures/charts/chart_common_line_scatter.ts
@@ -315,7 +315,10 @@ export function createLineOrScatterChartRuntime(
       formatValue(value, { format: labelFormat, locale });
     config.options.plugins!.tooltip!.callbacks!.label = (tooltipItem) => {
       const dataSetPoint = dataSetsValues[tooltipItem.datasetIndex!].data![tooltipItem.dataIndex!];
-      let label: string | number = tooltipItem.label || labelValues.values[tooltipItem.dataIndex!];
+      let label: string | number =
+        tooltipItem.dataset.xAxisID === TREND_LINE_XAXIS_ID
+          ? ""
+          : tooltipItem.label || labelValues.values[tooltipItem.dataIndex!];
       if (isNumber(label, locale)) {
         label = toNumber(label, locale);
       }

--- a/tests/figures/chart/chart_plugin.test.ts
+++ b/tests/figures/chart/chart_plugin.test.ts
@@ -2128,6 +2128,25 @@ describe("Chart design configuration", () => {
     expect(label).toBe("Dataset 1: (500%, $6,000.00)");
   });
 
+  test("scatter chart trend line tooltip label", () => {
+    setGrid(model, { A1: "1", A2: "2", B1: "12", B2: "15" });
+
+    createChart(
+      model,
+      {
+        labelRange: "A1:A2",
+        dataSets: [{ dataRange: "B1:B2", trend: { type: "polynomial", order: 1, display: true } }],
+        type: "scatter",
+        dataSetsHaveTitle: false,
+      },
+      "1"
+    );
+    const chart = model.getters.getChartRuntime("1") as ScatterChartRuntime;
+    const label = getTooltipLabel(chart, 1, 0);
+
+    expect(label).toBe("Trend line for Series 1: 12");
+  });
+
   test.each(["line", "scatter", "bar", "combo"] as const)(
     "%s chart correctly use right axis if set up in definition",
     (chartType) => {


### PR DESCRIPTION
## Description

For scatter/line chart whose labels were numbers, the trend line tooltip was showing something like `(15, 9)`. 9 was the correct Y value, but the 15 was referring to the fact that it was the 15th point in the generated trend line. Which made no sense to the user.

This commit changes the tooltip to show only the Y value.

Task: [4279972](https://www.odoo.com/odoo/2328/tasks/4279972)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo