### PR TITLE
[FIX] pivot: prevent duplicating pivot in error

### DIFF
--- a/src/components/side_panel/pivot/pivot_title_section/pivot_title_section.ts
+++ b/src/components/side_panel/pivot/pivot_title_section/pivot_title_section.ts
@@ -1,7 +1,7 @@
 import { Component } from "@odoo/owl";
 import { ActionSpec } from "../../../../actions/action";
 import { _t } from "../../../../translation";
-import { SpreadsheetChildEnv, UID } from "../../../../types";
+import { CommandResult, SpreadsheetChildEnv, UID } from "../../../../types";
 import { TextInput } from "../../../text_input/text_input";
 import { CogWheelMenu } from "../../components/cog_wheel_menu/cog_wheel_menu";
 import { Section } from "../../components/section/section";
@@ -55,7 +55,14 @@ export class PivotTitleSection extends Component<Props, SpreadsheetChildEnv> {
       newPivotId,
       newSheetId,
     });
-    const text = result.isSuccessful ? _t("Pivot duplicated.") : _t("Pivot duplication failed");
+    let text: string;
+    if (result.isSuccessful) {
+      text = _t("Pivot duplicated.");
+    } else if (result.isCancelledBecause(CommandResult.PivotInError)) {
+      text = _t("Cannot duplicate a pivot in error.");
+    } else {
+      text = _t("Pivot duplication failed.");
+    }
     const type = result.isSuccessful ? "success" : "danger";
     this.env.notifyUser({
       text,

--- a/src/plugins/ui_feature/insert_pivot.ts
+++ b/src/plugins/ui_feature/insert_pivot.ts
@@ -5,11 +5,25 @@ import { SpreadsheetPivotTable } from "../../helpers/pivot/table_spreadsheet_piv
 import { getZoneArea, positionToZone } from "../../helpers/zones";
 import { _t } from "../../translation";
 import { CellPosition, HeaderIndex, PivotTableCell, PivotTableData, UID, Zone } from "../../types";
-import { Command } from "../../types/commands";
+import { Command, CommandResult } from "../../types/commands";
 import { UIPlugin } from "../ui_plugin";
 
 export class InsertPivotPlugin extends UIPlugin {
   static getters = [] as const;
+
+  allowDispatch(cmd: Command) {
+    switch (cmd.type) {
+      case "DUPLICATE_PIVOT_IN_NEW_SHEET":
+        if (!this.getters.isExistingPivot(cmd.pivotId)) {
+          return CommandResult.PivotIdNotFound;
+        }
+        if (!this.getters.getPivot(cmd.pivotId).isValid()) {
+          return CommandResult.PivotInError;
+        }
+        break;
+    }
+    return CommandResult.Success;
+  }
 
   handle(cmd: Command) {
     switch (cmd.type) {

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -1307,6 +1307,7 @@ export const enum CommandResult {
   SheetIsHidden = "SheetIsHidden",
   InvalidTableResize = "InvalidTableResize",
   PivotIdNotFound = "PivotIdNotFound",
+  PivotInError = "PivotInError",
   EmptyName = "EmptyName",
   ValueCellIsInvalidFormula = "ValueCellIsInvalidFormula",
   InvalidDefinition = "InvalidDefinition",

--- a/tests/pivots/pivot_plugin.test.ts
+++ b/tests/pivots/pivot_plugin.test.ts
@@ -1,4 +1,4 @@
-import { CommandResult } from "../../src";
+import { CommandResult, Model } from "../../src";
 import { FORBIDDEN_SHEETNAME_CHARS } from "../../src/constants";
 import { EMPTY_PIVOT_CELL } from "../../src/helpers/pivot/table_spreadsheet_pivot";
 import { renameSheet, selectCell, setCellContent } from "../test_helpers/commands_helpers";
@@ -262,5 +262,16 @@ describe("Pivot plugin", () => {
     expect(model.getters.getPivotCellFromPosition(toCellPosition(sheetId, "D1"))).toMatchObject({
       type: "HEADER",
     });
+  });
+
+  test("DUPLICATE_PIVOT_IN_NEW_SHEET is prevented if the pivot is in error", () => {
+    const model = new Model();
+    addPivot(model, "A1:A2", {}, "pivot1");
+    const result = model.dispatch("DUPLICATE_PIVOT_IN_NEW_SHEET", {
+      newPivotId: "pivot2",
+      newSheetId: "Sheet2",
+      pivotId: "pivot1",
+    });
+    expect(result).toBeCancelledBecause(CommandResult.PivotInError);
   });
 });

--- a/tests/pivots/spreadsheet_pivot/spreadsheet_pivot_side_panel.test.ts
+++ b/tests/pivots/spreadsheet_pivot/spreadsheet_pivot_side_panel.test.ts
@@ -30,9 +30,11 @@ describe("Spreadsheet pivot side panel", () => {
   let model: Model;
   let fixture: HTMLElement;
   let env: SpreadsheetChildEnv;
+  let notifyUser: jest.Mock;
 
   beforeEach(async () => {
-    ({ env, model, fixture } = await mountSpreadsheet());
+    notifyUser = jest.fn();
+    ({ env, model, fixture } = await mountSpreadsheet(undefined, { notifyUser }));
     setCellContent(model, "A1", "Customer");
     setCellContent(model, "B1", "Product");
     setCellContent(model, "C1", "Amount");
@@ -229,6 +231,19 @@ describe("Spreadsheet pivot side panel", () => {
     await nextTick();
     expect((fixture.querySelector(".os-pivot-title") as HTMLInputElement).value).toEqual(name);
     expect(model.getters.getPivotName("1")).toEqual(name);
+  });
+
+  test("Cannot duplicate a pivot in error", async () => {
+    updatePivot(model, "1", { dataSet: undefined });
+    expect(model.getters.getPivot("1").isValid()).toBe(false);
+
+    await click(fixture, SELECTORS.COG_WHEEL);
+    await click(fixture, SELECTORS.DUPLICATE_PIVOT);
+    expect(notifyUser).toHaveBeenCalledWith({
+      sticky: false,
+      text: "Cannot duplicate a pivot in error.",
+      type: "danger",
+    });
   });
 
   test("Can duplicate a pivot and undo the whole action with one step backward", async () => {


### PR DESCRIPTION
## Description

Trying to duplicate a pivot in error would raise a traceback when trying to call pivot.getTableStructure().

Task: [4361353](https://www.odoo.com/odoo/2328/tasks/4361353)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo