### PR TITLE
[FIX] font_size_editor: dropdown and outline issues

### DIFF
--- a/src/components/font_size_editor/font_size_editor.ts
+++ b/src/components/font_size_editor/font_size_editor.ts
@@ -1,6 +1,6 @@
 import { Component, useExternalListener, useRef, useState } from "@odoo/owl";
 import { setStyle } from "../../actions/menu_items_actions";
-import { DEFAULT_FONT_SIZE, FONT_SIZES, SELECTION_BORDER_COLOR } from "../../constants";
+import { DEFAULT_FONT_SIZE, FONT_SIZES } from "../../constants";
 import { clip } from "../../helpers/index";
 import { SpreadsheetChildEnv } from "../../types/index";
 import { css } from "../helpers/css";
@@ -20,7 +20,7 @@ css/* scss */ `
   .o-font-size-editor {
     height: calc(100% - 4px);
     input.o-font-size {
-      outline-color: ${SELECTION_BORDER_COLOR};
+      outline: none;
       height: 20px;
       width: 23px;
     }

--- a/src/components/font_size_editor/font_size_editor.xml
+++ b/src/components/font_size_editor/font_size_editor.xml
@@ -12,6 +12,7 @@
           max="400"
           class="o-font-size bg-transparent border-0"
           t-on-keydown="onInputKeydown"
+          t-on-wheel.prevent.stop=""
           t-on-click.stop=""
           t-on-focus.stop="onInputFocused"
           t-att-value="currentFontSize"

--- a/tests/top_bar_component.test.ts
+++ b/tests/top_bar_component.test.ts
@@ -340,6 +340,18 @@ describe("TopBar component", () => {
     expect(getStyle(model, "A1").fontSize).toBe(8);
   });
 
+  test("prevents default behavior of mouse wheel event on font size input", async () => {
+    await mountParent();
+    const fontSizeInput = fixture.querySelector("input.o-font-size") as HTMLInputElement;
+
+    const event = new WheelEvent("wheel", { deltaY: 100 });
+    const preventDefaultSpy = jest.spyOn(event, "preventDefault");
+
+    fontSizeInput.dispatchEvent(event);
+
+    expect(preventDefaultSpy).toHaveBeenCalled();
+  });
+
   describe("horizontal align", () => {
     test.each([
       ["Left (Ctrl+Shift+L)", { align: "left" }],


### PR DESCRIPTION
## Description:

### Issue 1:

Adjusting the font size with the **mouse wheel** while the dropdown was open caused unexpected behavior:
- Clicking a font size applied the **wheel-adjusted** value instead of the selected one, closing the dropdown.
- Keeping the dropdown open resulted in the font size being set twice.
- Disabled the **mouse wheel event** to prevent accidental changes.

### Issue 2:
The focus outline for the font size editor was not visible due to a global CSS reset in Odoo.
- To align with the design, the outline has been removed in o-spreadsheet.

Task: [4357023](https://www.odoo.com/odoo/2328/tasks/4357023)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo