### PR TITLE
[IMP] CellPlugin: Avoid useless UPDATE_CELL

### DIFF
--- a/src/plugins/core/cell.ts
+++ b/src/plugins/core/cell.ts
@@ -162,7 +162,7 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
       for (let col = zone.left; col <= zone.right; col++) {
         for (let row = zone.top; row <= zone.bottom; row++) {
           const cell = this.getters.getCell({ sheetId, col, row });
-          if (cell) {
+          if (cell?.isFormula || cell?.content) {
             this.dispatch("UPDATE_CELL", {
               sheetId: sheetId,
               content: "",
@@ -200,7 +200,6 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
     for (let zone of recomputeZones(zones)) {
       for (let col = zone.left; col <= zone.right; col++) {
         for (let row = zone.top; row <= zone.bottom; row++) {
-          // commandHelpers.updateCell(sheetId, col, row, { style: undefined});
           this.dispatch("UPDATE_CELL", {
             sheetId,
             col,


### PR DESCRIPTION
The CellPlugin handler for "DELETE_CONTENT" will dispatch an UPDATE_CELL to empty its content regardless of the cell. On a big zone this can end up being quite costly as we pass for no reason in all the plugins and stores to apply 0 changes, it only adds some overhead.

the allowDispatch of UPDATE_CELL handles this case but in this case it's a subcommand and the allowDispatch is bypassed.


Benchmark
=========

Measure of the execution time of `model.Dispatch` on a 26x100 cells
sheet with **styled** cells.

cells with content (formula or text)
- before: 120~140ms
- after: 120~140ms

cells without content
- before 120~140ms
- 4~9ms

Task: 4367772

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [4367772](https://www.odoo.com/odoo/2328/tasks/4367772)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo