### PR TITLE
[FIX] pivot: handle boolean-like function arguments in `getPivotCellF…

### DIFF
--- a/src/plugins/ui_core_views/pivot_ui.ts
+++ b/src/plugins/ui_core_views/pivot_ui.ts
@@ -1,5 +1,7 @@
 import { Token } from "../../formulas";
 import { astToFormula } from "../../formulas/parser";
+import { toScalar } from "../../functions/helper_matrices";
+import { toBoolean } from "../../functions/helpers";
 import {
   getFirstPivotFunction,
   getNumberOfPivotFunctions,
@@ -204,11 +206,14 @@ export class PivotUIPlugin extends UIPlugin {
       return EMPTY_PIVOT_CELL;
     }
     if (functionName === "PIVOT") {
-      const includeTotal = args[2] === false ? false : undefined;
-      const includeColumnHeaders = args[3] === false ? false : undefined;
+      const includeTotal = toScalar(args[2]);
+      const shouldIncludeTotal = includeTotal === undefined ? true : toBoolean(includeTotal);
+      const includeColumnHeaders = toScalar(args[3]);
+      const shouldIncludeColumnHeaders =
+        includeColumnHeaders === undefined ? true : toBoolean(includeColumnHeaders);
       const pivotCells = pivot
         .getTableStructure()
-        .getPivotCells(includeTotal, includeColumnHeaders);
+        .getPivotCells(shouldIncludeTotal, shouldIncludeColumnHeaders);
       const pivotCol = position.col - mainPosition.col;
       const pivotRow = position.row - mainPosition.row;
       return pivotCells[pivotCol][pivotRow];

--- a/tests/pivots/pivot_plugin.test.ts
+++ b/tests/pivots/pivot_plugin.test.ts
@@ -105,4 +105,47 @@ describe("Pivot plugin", () => {
     });
     expect(model.getters.getSheetName("Sheet2")).toEqual("forbidden:   (copy) (Pivot #2) (1)");
   });
+
+  test("getPivotCellFromPosition handles falsy arguments for includeColumnTitle", () => {
+    // prettier-ignore
+    const grid = {
+      A1: "Customer", B1: "Price",
+      A2: "Alice",    B2: "10",    
+      A3: "Bob",      B3: "30",
+    };
+    const model = createModelFromGrid(grid);
+    addPivot(model, "A1:B3", {
+      columns: [{ name: "Customer" }],
+      rows: [{ name: "Price" }],
+      measures: [{ name: "__count", aggregator: "sum" }],
+    });
+    const sheetId = model.getters.getActiveSheetId();
+    setCellContent(model, "C1", "=PIVOT(1,,,false)");
+    expect(model.getters.getPivotCellFromPosition(toCellPosition(sheetId, "D1"))).toMatchObject({
+      measure: "__count",
+      type: "VALUE",
+    });
+    setCellContent(model, "C1", "=PIVOT(1,,,0)");
+    expect(model.getters.getPivotCellFromPosition(toCellPosition(sheetId, "D1"))).toMatchObject({
+      measure: "__count",
+      type: "VALUE",
+    });
+    setCellContent(model, "C1", `=PIVOT(1,,,"FALSE")`);
+    expect(model.getters.getPivotCellFromPosition(toCellPosition(sheetId, "D1"))).toMatchObject({
+      measure: "__count",
+      type: "VALUE",
+    });
+    setCellContent(model, "C1", "=PIVOT(1,,,true)");
+    expect(model.getters.getPivotCellFromPosition(toCellPosition(sheetId, "D1"))).toMatchObject({
+      type: "HEADER",
+    });
+    setCellContent(model, "C1", "=PIVOT(1,,,1)");
+    expect(model.getters.getPivotCellFromPosition(toCellPosition(sheetId, "D1"))).toMatchObject({
+      type: "HEADER",
+    });
+    setCellContent(model, "C1", `=PIVOT(1,,,"TRUE")`);
+    expect(model.getters.getPivotCellFromPosition(toCellPosition(sheetId, "D1"))).toMatchObject({
+      type: "HEADER",
+    });
+  });
 });


### PR DESCRIPTION
…romPosition`

The getter would only detect the 'includeTotal' and 'includeColumnHeaders' arguments if they were explicitely written as boolean and not as boolean-like (i.e; 1,2, 0, -1) values.

Task: 4207502

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [4207502](https://www.odoo.com/odoo/2328/tasks/4207502)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo