### PR TITLE
[FIX] pivot: apply format on measure only a basic formula

### DIFF
--- a/src/plugins/ui_feature/format.ts
+++ b/src/plugins/ui_feature/format.ts
@@ -11,6 +11,8 @@ import {
   CellValueType,
   Command,
   Format,
+  PivotTableCell,
+  PivotValueCell,
   Position,
   SetDecimalStep,
   UID,
@@ -43,7 +45,7 @@ export class FormatPlugin extends UIPlugin {
         for (let row = zone.top; row <= zone.bottom; row++) {
           const position = { sheetId, col, row };
           const pivotCell = this.getters.getPivotCellFromPosition(position);
-          if (pivotCell.type === "VALUE") {
+          if (this.isSpilledPivotValueFormula(position, pivotCell)) {
             measurePositions.push(position);
             const pivotId = this.getters.getPivotIdFromPosition(position) || "";
             measuresByPivotId[pivotId] ??= new Set();
@@ -81,6 +83,13 @@ export class FormatPlugin extends UIPlugin {
     });
   }
 
+  private isSpilledPivotValueFormula(
+    position: CellPosition,
+    pivotCell: PivotTableCell
+  ): pivotCell is PivotValueCell {
+    const cell = this.getters.getCell(position);
+    return pivotCell.type === "VALUE" && !cell?.isFormula;
+  }
   /**
    * This function allows to adjust the quantity of decimal places after a decimal
    * point on cells containing number value. It does this by changing the cells

--- a/tests/formats/formatting_plugin.test.ts
+++ b/tests/formats/formatting_plugin.test.ts
@@ -371,6 +371,22 @@ describe("pivot contextual formatting", () => {
       ["Total",      "$1.00"],
     ]);
   });
+
+  test("format is not applied on the measure with fixed pivot values", () => {
+    // prettier-ignore
+    const grid = {
+      A1: "Customer", B1: "Price",  C1: '=PIVOT.VALUE(1, "Price")',
+      A2: "Alice",    B2: "10",
+    };
+    const model = createModelFromGrid(grid);
+    addPivot(model, "A1:B2", {
+      rows: [{ fieldName: "Customer" }],
+      measures: [{ id: "Price", fieldName: "Price", aggregator: "count" }],
+    });
+    setContextualFormat(model, "C1", "[$$]#,##0.00");
+    expect(model.getters.getPivotCoreDefinition("1")?.measures[0].format).toBeUndefined();
+    expect(getCell(model, "C1")?.format).toBe("[$$]#,##0.00");
+  });
 });
 
 describe("formatting values (when change decimal)", () => {


### PR DESCRIPTION
## Description:

Let's say I have a computed measure "weighted delay:sum", on which I applied an integer format.

I later use it in a formula such as:

=PIVOT.VALUE(1,"weighted delay:sum","#user_id",A3)/PIVOT.VALUE(1,"__count:sum","#user_id",A3)

This is no longer an integer. If I change the format on this formula ☝️, the format is applied on the entire measure, which is not what I want.

With this commit, we apply the format on the measure (rather than on the cell)
if and only if the value comes from a spilled PIVOT formula.

Task: [4377411](https://www.odoo.com/odoo/2328/tasks/4377411)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo