### PR TITLE
[IMP] CF: Add support for min and max in data bars

### DIFF
--- a/src/components/side_panel/conditional_formatting/cf_editor/cf_editor.ts
+++ b/src/components/side_panel/conditional_formatting/cf_editor/cf_editor.ts
@@ -635,4 +635,27 @@ export class ConditionalFormattingEditor extends Component<Props, SpreadsheetChi
   onDataBarRangeChange() {
     this.updateConditionalFormat({ rule: this.state.rules.dataBar });
   }
+
+  onDataBarFillingPercentageChange(target: "min" | "max", percentage: number) {
+    if (target == "min") {
+      this.state.rules.dataBar.minimum_filling = percentage;
+    } else {
+      this.state.rules.dataBar.maximum_filling = percentage;
+    }
+    this.updateConditionalFormat({ rule: this.state.rules.dataBar });
+  }
+
+  isDataBarFillingPercentageInvalid(target: "min" | "max") {
+    if (target == "min") {
+      return (
+        this.state.errors.includes(CommandResult.MinNotPercent) ||
+        this.state.errors.includes(CommandResult.MinBiggerThanMax)
+      );
+    } else {
+      return (
+        this.state.errors.includes(CommandResult.MaxNotPercent) ||
+        this.state.errors.includes(CommandResult.MinBiggerThanMax)
+      );
+    }
+  }
 }

--- a/src/components/side_panel/conditional_formatting/cf_editor/data_bar_rule_editor.xml
+++ b/src/components/side_panel/conditional_formatting/cf_editor/data_bar_rule_editor.xml
@@ -16,6 +16,36 @@
         onSelectionConfirmed.bind="onDataBarRangeChange"
         required="false"
       />
+      <div class="o-section-subtitle">Filling range</div>
+
+      <tr>
+        <td>Min percentage:</td>
+        <td>
+          <input
+            type="number"
+            class="o-input"
+            placeholder="10"
+            t-att-class="{ 'o-invalid': isDataBarFillingPercentageInvalid('min') }"
+            t-att-value="rule.minimum_filling"
+            t-on-change="(ev) => this.onDataBarFillingPercentageChange('min', ev.target.valueAsNumber)"
+            required="false"
+          />
+        </td>
+      </tr>
+      <tr>
+        <td>Max percentage:</td>
+        <td>
+          <input
+            type="number"
+            class="o-input"
+            placeholder="90"
+            t-att-class="{ 'o-invalid': isDataBarFillingPercentageInvalid('max') }"
+            t-att-value="rule.maximum_filling"
+            t-on-change="(ev) => this.onDataBarFillingPercentageChange('max', ev.target.valueAsNumber)"
+            required="false"
+          />
+        </td>
+      </tr>
     </div>
   </t>
 </templates>

--- a/src/components/translations_terms.ts
+++ b/src/components/translations_terms.ts
@@ -27,6 +27,8 @@ export const CfTerms = {
     [CommandResult.ValueCellIsInvalidFormula]: _t(
       "At least one of the provided values is an invalid formula"
     ),
+    [CommandResult.MinNotPercent]: _t("The minimum value must be between 0 and 100"),
+    [CommandResult.MaxNotPercent]: _t("The maximum value must be between 0 and 100"),
     Unexpected: _t("The rule is invalid for an unknown reason"),
   },
   ColorScale: _t("Color scale"),

--- a/src/plugins/core/conditional_format.ts
+++ b/src/plugins/core/conditional_format.ts
@@ -14,6 +14,7 @@ import {
   ConditionalFormatInternal,
   ConditionalFormattingOperatorValues,
   CoreCommand,
+  DataBarRule,
   ExcelWorkbookData,
   IconSetRule,
   IconThreshold,
@@ -436,6 +437,16 @@ export class ConditionalFormatPlugin
           this.chainValidations(this.checkInflectionPoints(this.checkFormulaCompilation))
         );
       }
+      case "DataBarRule": {
+        return this.checkValidations(
+          rule,
+          this.chainValidations(
+            this.checkBarMinMax,
+            this.checkBarMinPercent,
+            this.checkBarMaxPercent
+          )
+        );
+      }
     }
     return CommandResult.Success;
   }
@@ -591,6 +602,31 @@ export class ConditionalFormatPlugin
       stringToNumber(minValue) >= stringToNumber(midValue)
     ) {
       return CommandResult.MinBiggerThanMid;
+    }
+    return CommandResult.Success;
+  }
+
+  private checkBarMinPercent(rule: DataBarRule): CommandResult {
+    const min = rule?.minimum_filling === 0 ? 0 : rule?.minimum_filling || 10;
+    if (min < 0) {
+      return CommandResult.MinNotPercent;
+    }
+    return CommandResult.Success;
+  }
+
+  private checkBarMaxPercent(rule: DataBarRule): CommandResult {
+    const max = rule.maximum_filling || 90;
+    if (max > 100) {
+      return CommandResult.MaxNotPercent;
+    }
+    return CommandResult.Success;
+  }
+
+  private checkBarMinMax(rule: DataBarRule): CommandResult {
+    const min = rule?.minimum_filling === 0 ? 0 : rule?.minimum_filling || 10;
+    const max = rule.maximum_filling || 90;
+    if (min > max) {
+      return CommandResult.MinBiggerThanMax;
     }
     return CommandResult.Success;
   }

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -1255,6 +1255,8 @@ export const enum CommandResult {
   MaxInvalidFormula = "MaxInvalidFormula",
   ValueUpperInvalidFormula = "ValueUpperInvalidFormula",
   ValueLowerInvalidFormula = "ValueLowerInvalidFormula",
+  MinNotPercent = "MinNotPercent",
+  MaxNotPercent = "MaxNotPercent",
   InvalidSortAnchor = "InvalidSortAnchor",
   InvalidSortZone = "InvalidSortZone",
   SortZoneWithArrayFormulas = "SortZoneWithArrayFormulas",

--- a/src/types/conditional_formatting.ts
+++ b/src/types/conditional_formatting.ts
@@ -90,6 +90,8 @@ export interface DataBarRule {
   type: "DataBarRule";
   color: number;
   rangeValues?: string;
+  minimum_filling?: number;
+  maximum_filling?: number;
 }
 
 export interface DataBarRuleInternal extends Omit<DataBarRule, "rangeValues"> {

--- a/tests/conditional_formatting/conditional_formatting_plugin.test.ts
+++ b/tests/conditional_formatting/conditional_formatting_plugin.test.ts
@@ -2365,7 +2365,7 @@ describe("conditional formats types", () => {
     // prettier-ignore
     const grid = {
         A1: "2",
-        A2: "4",
+        A2: "5",
         A3: "8",
     };
     const model = createModelFromGrid(grid);
@@ -2375,12 +2375,14 @@ describe("conditional formats types", () => {
         rule: {
           type: "DataBarRule",
           color: 0xff0000,
+          minimum_filling: 0,
+          maximum_filling: 100,
         },
       },
       ranges: toRangesData(sheetId, "A1:A3"),
       sheetId,
     });
-    expect(getDataBarFill(model, "A1")?.percentage).toBe(25);
+    expect(getDataBarFill(model, "A1")?.percentage).toBe(0);
     expect(getDataBarFill(model, "A2")?.percentage).toBe(50);
     expect(getDataBarFill(model, "A3")?.percentage).toBe(100);
   });
@@ -2389,7 +2391,7 @@ describe("conditional formats types", () => {
     // prettier-ignore
     const grid = {
         A1: "2", B1: "Hello",
-        A2: "4", B2: "World",
+        A2: "5", B2: "World",
         A3: "8", B3: "!",
     };
     const model = createModelFromGrid(grid);
@@ -2400,12 +2402,14 @@ describe("conditional formats types", () => {
           type: "DataBarRule",
           color: 0xff0000,
           rangeValues: "A1:A3",
+          minimum_filling: 0,
+          maximum_filling: 100,
         },
       },
       ranges: toRangesData(sheetId, "B1:B3"),
       sheetId,
     });
-    expect(getDataBarFill(model, "B1")?.percentage).toBe(25);
+    expect(getDataBarFill(model, "B1")?.percentage).toBe(0);
     expect(getDataBarFill(model, "B2")?.percentage).toBe(50);
     expect(getDataBarFill(model, "B3")?.percentage).toBe(100);
   });
@@ -2425,12 +2429,14 @@ describe("conditional formats types", () => {
           type: "DataBarRule",
           color: 0xff0000,
           rangeValues: "B1:B2",
+          minimum_filling: 0,
+          maximum_filling: 100,
         },
       },
       ranges: toRangesData(sheetId, "A1:A3"),
       sheetId,
     });
-    expect(getDataBarFill(model, "A1")?.percentage).toBe(50);
+    expect(getDataBarFill(model, "A1")?.percentage).toBe(0);
     expect(getDataBarFill(model, "A2")?.percentage).toBe(100);
     expect(getDataBarFill(model, "A3")?.percentage).toBeUndefined();
   });
@@ -2439,7 +2445,7 @@ describe("conditional formats types", () => {
     // prettier-ignore
     const grid = {
       A1: "A", B1: "2",
-      A2: "B", B2: "4",
+      A2: "B", B2: "5",
       A3: "C", B3: "8",
   };
     const model = createModelFromGrid(grid);
@@ -2450,12 +2456,14 @@ describe("conditional formats types", () => {
           type: "DataBarRule",
           color: 0xff0000,
           rangeValues: "B1:B4",
+          minimum_filling: 0,
+          maximum_filling: 100,
         },
       },
       ranges: toRangesData(sheetId, "A1:A3"),
       sheetId,
     });
-    expect(getDataBarFill(model, "A1")?.percentage).toBe(25);
+    expect(getDataBarFill(model, "A1")?.percentage).toBe(0);
     expect(getDataBarFill(model, "A2")?.percentage).toBe(50);
     expect(getDataBarFill(model, "A3")?.percentage).toBe(100);
     expect(getDataBarFill(model, "A4")?.percentage).toBeUndefined();
@@ -2465,7 +2473,7 @@ describe("conditional formats types", () => {
     // prettier-ignore
     const grid = {
         A1: "-2",
-        A2: "-4",
+        A2: "-5",
         A3: "-8",
     };
     const model = createModelFromGrid(grid);
@@ -2475,14 +2483,16 @@ describe("conditional formats types", () => {
         rule: {
           type: "DataBarRule",
           color: 0xff0000,
+          minimum_filling: 0,
+          maximum_filling: 100,
         },
       },
       ranges: toRangesData(sheetId, "A1:A3"),
       sheetId,
     });
-    expect(getDataBarFill(model, "A1")).toBeUndefined();
-    expect(getDataBarFill(model, "A2")).toBeUndefined();
-    expect(getDataBarFill(model, "A3")).toBeUndefined();
+    expect(getDataBarFill(model, "A1")?.percentage).toBe(100);
+    expect(getDataBarFill(model, "A2")?.percentage).toBe(50);
+    expect(getDataBarFill(model, "A3")?.percentage).toBe(0);
   });
 
   test("Data bar CF with 0 values", () => {
@@ -2499,6 +2509,8 @@ describe("conditional formats types", () => {
         rule: {
           type: "DataBarRule",
           color: 0xff0000,
+          minimum_filling: 0,
+          maximum_filling: 100,
         },
       },
       ranges: toRangesData(sheetId, "A1:A3"),
@@ -2506,13 +2518,13 @@ describe("conditional formats types", () => {
     });
     expect(getDataBarFill(model, "A1")?.percentage).toBe(100);
     expect(getDataBarFill(model, "A2")?.percentage).toBe(50);
-    expect(getDataBarFill(model, "A3")).toBeUndefined();
+    expect(getDataBarFill(model, "A3")?.percentage).toBe(0);
   });
 
-  test("Data bar CF with 0 as maximum", () => {
+  test("Data bar CF with single value", () => {
     // prettier-ignore
     const grid = {
-        A1: "0",
+        A1: "2",
     };
     const model = createModelFromGrid(grid);
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
@@ -2526,15 +2538,16 @@ describe("conditional formats types", () => {
       ranges: toRangesData(sheetId, "A1"),
       sheetId,
     });
-    expect(getDataBarFill(model, "A1")).toBeUndefined();
+    expect(getDataBarFill(model, "A1")?.percentage).toBe(50);
   });
 
   test("Ignore not number cells", () => {
     // prettier-ignore
     const grid = {
         A1: "10",
-        A2: "Hello",
-        A3: "World",
+        A2: "5",
+        A3: "Hello",
+        A4: "World",
     };
     const model = createModelFromGrid(grid);
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
@@ -2543,43 +2556,50 @@ describe("conditional formats types", () => {
         rule: {
           type: "DataBarRule",
           color: 0xff0000,
+          minimum_filling: 0,
+          maximum_filling: 100,
+        },
+      },
+      ranges: toRangesData(sheetId, "A1:A4"),
+      sheetId,
+    });
+    expect(getDataBarFill(model, "A1")?.percentage).toBe(100);
+    expect(getDataBarFill(model, "A2")?.percentage).toBe(0);
+    expect(getDataBarFill(model, "A3")).toBeUndefined();
+    expect(getDataBarFill(model, "A4")).toBeUndefined();
+  });
+
+  test("Negative and positive number cells", () => {
+    // prettier-ignore
+    const grid = {
+        A1: "10",
+        A2: "0",
+        A3: "-10",
+    };
+    const model = createModelFromGrid(grid);
+    model.dispatch("ADD_CONDITIONAL_FORMAT", {
+      cf: {
+        id: "1",
+        rule: {
+          type: "DataBarRule",
+          color: 0xff0000,
+          minimum_filling: 0,
+          maximum_filling: 100,
         },
       },
       ranges: toRangesData(sheetId, "A1:A3"),
       sheetId,
     });
     expect(getDataBarFill(model, "A1")?.percentage).toBe(100);
-    expect(getDataBarFill(model, "A2")).toBeUndefined();
-    expect(getDataBarFill(model, "A3")).toBeUndefined();
-  });
-
-  test("Ignore negative number cells", () => {
-    // prettier-ignore
-    const grid = {
-        A1: "10",
-        A2: "-10",
-    };
-    const model = createModelFromGrid(grid);
-    model.dispatch("ADD_CONDITIONAL_FORMAT", {
-      cf: {
-        id: "1",
-        rule: {
-          type: "DataBarRule",
-          color: 0xff0000,
-        },
-      },
-      ranges: toRangesData(sheetId, "A1:A2"),
-      sheetId,
-    });
-    expect(getDataBarFill(model, "A1")?.percentage).toBe(100);
-    expect(getDataBarFill(model, "A2")).toBeUndefined();
+    expect(getDataBarFill(model, "A2")?.percentage).toBe(50);
+    expect(getDataBarFill(model, "A3")?.percentage).toBe(0);
   });
 
   test("range value range is adapted", () => {
     // prettier-ignore
     const grid = {
         B1: "2", C1: "Hello",
-        B2: "4", C2: "World",
+        B2: "5", C2: "World",
         B3: "8", C3: "!",
     };
     const model = createModelFromGrid(grid);
@@ -2590,14 +2610,68 @@ describe("conditional formats types", () => {
           type: "DataBarRule",
           color: 0xff0000,
           rangeValues: "B1:B3",
+          minimum_filling: 0,
+          maximum_filling: 100,
         },
       },
       ranges: toRangesData(sheetId, "C1:C3"),
       sheetId,
     });
     deleteColumns(model, ["A"]);
-    expect(getDataBarFill(model, "B1")?.percentage).toBe(25);
+    expect(getDataBarFill(model, "B1")?.percentage).toBe(0);
     expect(getDataBarFill(model, "B2")?.percentage).toBe(50);
     expect(getDataBarFill(model, "B3")?.percentage).toBe(100);
+  });
+
+  test("Custom filling value", () => {
+    // prettier-ignore
+    const grid = {
+        A1: "10",
+        A2: "0",
+        A3: "-10",
+    };
+    const model = createModelFromGrid(grid);
+    model.dispatch("ADD_CONDITIONAL_FORMAT", {
+      cf: {
+        id: "1",
+        rule: {
+          type: "DataBarRule",
+          color: 0xff0000,
+          minimum_filling: 10,
+          maximum_filling: 20,
+        },
+      },
+      ranges: toRangesData(sheetId, "A1:A3"),
+      sheetId,
+    });
+    expect(getDataBarFill(model, "A1")?.percentage).toBe(20);
+    expect(getDataBarFill(model, "A2")?.percentage).toBe(15);
+    expect(getDataBarFill(model, "A3")?.percentage).toBe(10);
+  });
+
+  test("Null filling delta", () => {
+    // prettier-ignore
+    const grid = {
+        A1: "10",
+        A2: "0",
+        A3: "-10",
+    };
+    const model = createModelFromGrid(grid);
+    model.dispatch("ADD_CONDITIONAL_FORMAT", {
+      cf: {
+        id: "1",
+        rule: {
+          type: "DataBarRule",
+          color: 0xff0000,
+          minimum_filling: 42,
+          maximum_filling: 42,
+        },
+      },
+      ranges: toRangesData(sheetId, "A1:A3"),
+      sheetId,
+    });
+    expect(getDataBarFill(model, "A1")?.percentage).toBe(42);
+    expect(getDataBarFill(model, "A2")?.percentage).toBe(42);
+    expect(getDataBarFill(model, "A3")?.percentage).toBe(42);
   });
 });


### PR DESCRIPTION
## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [4187950](https://www.odoo.com/odoo/2328/tasks/4187950)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo