### PR TITLE
[FIX] spreadsheet: localize chart scale ticks

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,7 @@ import { arg, functionRegistry } from "./functions/index";
 import {
   ChartColors,
   chartFontColor,
+  getChartDatasetFormat,
   getDefaultChartJsRuntime,
   getFillingMode,
 } from "./helpers/figures/charts";
@@ -214,6 +215,7 @@ export const helpers = {
   EvaluationError,
   CellErrorLevel,
   getFillingMode,
+  getChartDatasetFormat,
   rgbaToHex,
   colorToRGBA,
   positionToZone,


### PR DESCRIPTION
## Description:

Previously, the scale ticks in Odoo charts did not respect localization settings. This commit resolves the issue by leveraging the formatValue method within the scale tick callback function.

Task: [4273769](https://www.odoo.com/odoo/2328/tasks/4273769)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo