### PR TITLE
[FIX] action button: use nextProps instead of this.props

### DIFF
--- a/src/components/action_button/action_button.ts
+++ b/src/components/action_button/action_button.ts
@@ -32,9 +32,9 @@ export class ActionButton extends Component<Props, SpreadsheetChildEnv> {
   private actionButton = createAction(this.props.action);
 
   setup() {
-    onWillUpdateProps((nextProps) => {
+    onWillUpdateProps((nextProps: Props) => {
       if (nextProps.action !== this.props.action) {
-        this.actionButton = createAction(this.props.action);
+        this.actionButton = createAction(nextProps.action);
       }
     });
   }

--- a/tests/action_button.test.ts
+++ b/tests/action_button.test.ts
@@ -1,0 +1,28 @@
+import { Component, xml } from "@odoo/owl";
+import { ActionSpec } from "../src/actions/action";
+import { ActionButton } from "../src/components/action_button/action_button";
+import { SpreadsheetChildEnv } from "../src/types";
+import { mountComponent, nextTick } from "./test_helpers/helpers";
+
+interface ParentProps {
+  getAction: () => ActionSpec;
+}
+
+class Parent extends Component<ParentProps, SpreadsheetChildEnv> {
+  static components = { ActionButton };
+  static template = xml/*xml*/ `
+      <ActionButton action="props.getAction()"/>
+    `;
+}
+
+test("ActionButton is updated when its props are updated", async () => {
+  let action = { isActive: () => true, name: "TestAction" };
+  const { parent, fixture } = await mountComponent(Parent, { props: { getAction: () => action } });
+  const actionButton = fixture.querySelector(".o-menu-item-button")!;
+  expect(actionButton.classList).toContain("active");
+
+  action = { isActive: () => false, name: "TestAction" };
+  parent.render(true);
+  await nextTick();
+  expect(actionButton.classList).not.toContain("active");
+});


### PR DESCRIPTION
## Description

In the `onWillUpdateProps` of the action button component, we used this.props instead of nextProps, which is very wrong.

Task: [0](https://www.odoo.com/odoo/2328/tasks/0)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo