### PR TITLE
[IMP] selection: alleviate size of revision on 'move header'

### DIFF
--- a/src/plugins/ui_stateful/selection.ts
+++ b/src/plugins/ui_stateful/selection.ts
@@ -580,15 +580,26 @@ export class GridSelectionPlugin extends UIPlugin {
 
     const toRemove = isBasedBefore ? cmd.elements.map((el) => el + thickness) : cmd.elements;
     let currentIndex = cmd.base;
+
+    const resizingGroups: Record<number, number[]> = {};
+
     for (const element of toRemove) {
       const size = this.getters.getHeaderSize(cmd.sheetId, cmd.dimension, element);
+      const currentSize = this.getters.getHeaderSize(cmd.sheetId, cmd.dimension, currentIndex);
+      if (size != currentSize) {
+        resizingGroups[size] ??= [];
+        resizingGroups[size].push(currentIndex);
+        currentIndex += 1;
+      }
+    }
+
+    for (const size in resizingGroups) {
       this.dispatch("RESIZE_COLUMNS_ROWS", {
         dimension: cmd.dimension,
         sheetId: cmd.sheetId,
-        size,
-        elements: [currentIndex],
+        size: parseInt(size, 10),
+        elements: resizingGroups[size],
       });
-      currentIndex += 1;
     }
 
     this.dispatch("REMOVE_COLUMNS_ROWS", {


### PR DESCRIPTION
Aleviate the size  of the message dispatched on the server by grouping the dispatch per size and only if it's different from the current size.

Task: 4378896

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [4378896](https://www.odoo.com/odoo/2328/tasks/4378896)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo