### PR TITLE
[IMP] model: create snapshot when loading xlsx file

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -281,7 +281,7 @@ export class Model extends EventBus<any> implements CommandDispatcher {
 
     this.joinSession();
 
-    if (config.snapshotRequested) {
+    if (config.snapshotRequested || (data["[Content_Types].xml"] && !this.getters.isReadonly())) {
       const startSnapshot = performance.now();
       console.debug("Snapshot requested");
       this.session.snapshot(this.exportData());

--- a/tests/model/model.test.ts
+++ b/tests/model/model.test.ts
@@ -1,9 +1,12 @@
 import { CommandResult, CorePlugin } from "../../src";
+import { MESSAGE_VERSION } from "../../src/constants";
 import { toZone } from "../../src/helpers";
 import { Model, ModelConfig } from "../../src/model";
 import { corePluginRegistry, featurePluginRegistry } from "../../src/plugins/index";
 import { UIPlugin } from "../../src/plugins/ui_plugin";
 import { Command, CommandTypes, CoreCommand, DispatchResult, coreTypes } from "../../src/types";
+import { MockTransportService } from "../__mocks__/transport_service";
+import { getTextXlsxFiles } from "../__xlsx__/read_demo_xlsx";
 import { setupCollaborativeEnv } from "../collaborative/collaborative_helpers";
 import { copy, selectCell, setCellContent } from "../test_helpers/commands_helpers";
 import {
@@ -365,5 +368,34 @@ describe("Model", () => {
         },
       ],
     });
+  });
+
+  test("it should snapshot when importing xlsx file", async () => {
+    const transport = new MockTransportService();
+    const spy = jest.spyOn(transport, "sendMessage");
+    const xlsxData = await getTextXlsxFiles();
+    new Model(xlsxData, {
+      transportService: transport,
+      client: { id: "test", name: "Test" },
+    });
+    expect(spy).toHaveBeenCalledWith({
+      type: "SNAPSHOT",
+      version: MESSAGE_VERSION,
+      nextRevisionId: expect.any(String),
+      serverRevisionId: "START_REVISION",
+      data: expect.any(Object),
+    });
+  });
+
+  test("it should not snapshot when importing xlsx file in readonly mode", async () => {
+    const transport = new MockTransportService();
+    const spy = jest.spyOn(transport, "sendMessage");
+    const xlsxData = await getTextXlsxFiles();
+    new Model(xlsxData, {
+      transportService: transport,
+      client: { id: "test", name: "Test" },
+      mode: "readonly",
+    });
+    expect(spy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Before this commit, when uploading an XLSX file, the code in the Odoo repository would create a spreadsheet document with data that is encoded in xml. Whenever the file is loaded, we parse the stringified xml to convert it to the o-spreadsheet json structure. The problem is that this conversion can be quite slow and costly when the XLSX file is large.

This commit mitigates the issue by saving a snapshot once the XLSX file is loaded for the first time.

Task: [4080514](https://www.odoo.com/odoo/2328/tasks/4080514)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo