### PR TITLE
[ADD] Paste toolbox: a post-paste correction tool

### DIFF
--- a/src/components/autofill/autofill.ts
+++ b/src/components/autofill/autofill.ts
@@ -1,7 +1,7 @@
 import { Component, useState, xml } from "@odoo/owl";
 import { AUTOFILL_EDGE_LENGTH } from "../../constants";
 import { clip } from "../../helpers";
-import { HeaderIndex, SpreadsheetChildEnv } from "../../types";
+import { DOMCoordinates, HeaderIndex, SpreadsheetChildEnv } from "../../types";
 import { css, cssPropertiesToCss } from "../helpers/css";
 import { dragAndDropBeyondTheViewport } from "../helpers/drag_and_drop";
 
@@ -41,16 +41,11 @@ css/* scss */ `
 
 interface Props {
   isVisible: boolean;
-  position: Position;
-}
-
-interface Position {
-  top: HeaderIndex;
-  left: HeaderIndex;
+  position: DOMCoordinates;
 }
 
 interface State {
-  position: Position;
+  position: DOMCoordinates;
   handler: boolean;
 }
 
@@ -61,31 +56,31 @@ export class Autofill extends Component<Props, SpreadsheetChildEnv> {
     isVisible: Boolean,
   };
   state: State = useState({
-    position: { left: 0, top: 0 },
+    position: { x: 0, y: 0 },
     handler: false,
   });
 
   get style() {
-    const { left, top } = this.props.position;
+    const { x, y } = this.props.position;
     return cssPropertiesToCss({
-      top: `${top}px`,
-      left: `${left}px`,
+      top: `${y}px`,
+      left: `${x}px`,
       visibility: this.props.isVisible ? "visible" : "hidden",
     });
   }
   get handlerStyle() {
-    const { left, top } = this.state.handler ? this.state.position : this.props.position;
+    const { x, y } = this.state.handler ? this.state.position : this.props.position;
     return cssPropertiesToCss({
-      top: `${top}px`,
-      left: `${left}px`,
+      top: `${y}px`,
+      left: `${x}px`,
     });
   }
 
   get styleNextValue() {
-    const { left, top } = this.state.position;
+    const { x, y } = this.state.position;
     return cssPropertiesToCss({
-      top: `${top + 5}px`,
-      left: `${left + 15}px`,
+      top: `${y + 5}px`,
+      left: `${x + 15}px`,
     });
   }
 
@@ -103,8 +98,8 @@ export class Autofill extends Component<Props, SpreadsheetChildEnv> {
     let lastCol: HeaderIndex | undefined;
     let lastRow: HeaderIndex | undefined;
     const start = {
-      left: ev.clientX - this.props.position.left,
-      top: ev.clientY - this.props.position.top,
+      left: ev.clientX - this.props.position.x,
+      top: ev.clientY - this.props.position.y,
     };
     const onMouseUp = () => {
       this.state.handler = false;
@@ -114,8 +109,8 @@ export class Autofill extends Component<Props, SpreadsheetChildEnv> {
 
     const onMouseMove = (col: HeaderIndex, row: HeaderIndex, ev: MouseEvent) => {
       this.state.position = {
-        left: ev.clientX - start.left,
-        top: ev.clientY - start.top,
+        x: ev.clientX - start.left,
+        y: ev.clientY - start.top,
       };
       if (lastCol !== col || lastRow !== row) {
         const activeSheetId = this.env.model.getters.getActiveSheetId();

--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -73,6 +73,7 @@ import { useWheelHandler } from "../helpers/wheel_hook";
 import { Highlight } from "../highlight/highlight/highlight";
 import { Menu, MenuState } from "../menu/menu";
 import { PaintFormatStore } from "../paint_format_button/paint_format_store";
+import { PasteToolbox } from "../paste_toolbox/paste_toolbox";
 import { CellPopoverStore } from "../popover";
 import { Popover } from "../popover/popover";
 import { HorizontalScrollBar, VerticalScrollBar } from "../scrollbar/";
@@ -126,6 +127,7 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
     HeadersOverlay,
     Menu,
     Autofill,
+    PasteToolbox,
     ClientTag,
     Highlight,
     Popover,
@@ -251,7 +253,7 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
       } else if (this.paintFormatStore.isActive) {
         this.paintFormatStore.cancel();
       } else {
-        this.env.model.dispatch("CLEAN_CLIPBOARD_HIGHLIGHT");
+        this.env.model.dispatch("CLEAR_CLIPBOARD_HIGHLIGHT");
       }
     },
     "Ctrl+A": () => this.env.model.selection.loopSelection(),
@@ -419,12 +421,20 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
     return this.gridRef.el;
   }
 
-  getAutofillPosition() {
+  getBottomSelectionPosition(): DOMCoordinates {
     const zone = this.env.model.getters.getSelectedZone();
     const rect = this.env.model.getters.getVisibleRect(zone);
     return {
-      left: rect.x + rect.width - AUTOFILL_EDGE_LENGTH / 2,
-      top: rect.y + rect.height - AUTOFILL_EDGE_LENGTH / 2,
+      x: rect.x + rect.width,
+      y: rect.y + rect.height,
+    };
+  }
+
+  getAutofillPosition(): DOMCoordinates {
+    const { x, y } = this.getBottomSelectionPosition();
+    return {
+      x: x - AUTOFILL_EDGE_LENGTH / 2,
+      y: y - AUTOFILL_EDGE_LENGTH / 2,
     };
   }
 
@@ -437,6 +447,10 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
       bottom: zone.bottom,
     });
     return !(rect.width === 0 || rect.height === 0);
+  }
+
+  get isPasteToolboxVisible(): boolean {
+    return this.env.model.getters.canModifyPaste();
   }
 
   onGridResized({ height, width }: DOMDimension) {

--- a/src/components/grid/grid.xml
+++ b/src/components/grid/grid.xml
@@ -44,6 +44,11 @@
       />
       <t t-if="env.model.getters.isGridSelectionActive()">
         <Autofill position="getAutofillPosition()" isVisible="isAutofillVisible"/>
+        <PasteToolbox
+          t-if="isPasteToolboxVisible"
+          position="getBottomSelectionPosition()"
+          onClosed.bind="focusDefaultElement"
+        />
       </t>
       <t t-foreach="highlights" t-as="highlight" t-key="highlight_index">
         <t

--- a/src/components/paste_toolbox/paste_toolbox.ts
+++ b/src/components/paste_toolbox/paste_toolbox.ts
@@ -1,0 +1,96 @@
+import { Component, useRef, useState } from "@odoo/owl";
+import { createActions } from "../../actions/action";
+import { paste, pasteSpecialFormat, pasteSpecialValue } from "../../actions/edit_actions";
+import { ComponentsImportance, ICON_EDGE_LENGTH } from "../../constants";
+import { DOMCoordinates, SpreadsheetChildEnv } from "../../types";
+import { css, cssPropertiesToCss } from "../helpers/css";
+import { Menu, MenuState } from "../menu/menu";
+
+css/* scss */ `
+  .o-paste {
+    position: absolute;
+    height: ${ICON_EDGE_LENGTH + 10}px;
+    border: 1px solid lightgrey;
+    box-sizing: border-box !important;
+    background-color: white;
+    cursor: pointer;
+    z-index: ${ComponentsImportance.Clipboard};
+    align-content: center;
+
+    .o-icon {
+      margin: auto;
+    }
+  }
+`;
+
+interface Props {
+  position: DOMCoordinates;
+  onClosed: () => void;
+}
+
+export class PasteToolbox extends Component<Props, SpreadsheetChildEnv> {
+  static template = "o-spreadsheet-PasteToolbox";
+  static props = {
+    position: Object,
+    onClosed: Function,
+  };
+  static components = { Menu };
+
+  private menuState: MenuState = useState({
+    isOpen: false,
+    position: { x: 0, y: 0 },
+    menuItems: [],
+  });
+
+  private toolboxRef = useRef("toolboxButton");
+
+  get style() {
+    const { x, y } = this.props.position;
+    return cssPropertiesToCss({
+      left: `${x}px`,
+      top: `${y + 5}px`,
+    });
+  }
+
+  showMenu() {
+    this.menuState.isOpen = true;
+    const { x, y } = this.toolboxRef.el!.getBoundingClientRect();
+    this.menuState.menuItems = this.getMenuItems();
+    this.menuState.position = { x, y };
+  }
+
+  onMenuClosed() {
+    this.menuState.isOpen = false;
+    this.props.onClosed();
+  }
+
+  private getMenuItems() {
+    return createActions([
+      {
+        ...paste,
+        icon: undefined,
+        id: "paste",
+        execute: (env) => {
+          env.model.dispatch("REQUEST_UNDO");
+          paste.execute?.(this.env);
+        },
+      },
+      {
+        name: pasteSpecialValue.name,
+        id: "paste_special_value",
+        execute: (env) => {
+          env.model.dispatch("REQUEST_UNDO");
+          pasteSpecialValue.execute?.(env);
+        },
+      },
+      {
+        name: pasteSpecialFormat.name,
+        id: "paste_special_format",
+        execute: (env) => {
+          env.model.dispatch("REQUEST_UNDO");
+          pasteSpecialFormat.execute?.(env);
+        },
+      },
+    ]);
+  }
+}

--- a/src/components/paste_toolbox/paste_toolbox.xml
+++ b/src/components/paste_toolbox/paste_toolbox.xml
@@ -1,0 +1,18 @@
+<templates>
+  <t t-name="o-spreadsheet-PasteToolbox">
+    <div
+      t-ref="toolboxButton"
+      class="o-paste d-flex ps-1"
+      t-att-style="style"
+      t-on-click="showMenu">
+      <t t-call="o-spreadsheet-Icon.PASTE"/>
+      <t t-call="o-spreadsheet-Icon.CARET_DOWN"/>
+    </div>
+    <Menu
+      t-if="menuState.isOpen"
+      position="menuState.position"
+      menuItems="menuState.menuItems"
+      onClose.bind="onMenuClosed"
+    />
+  </t>
+</templates>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -261,6 +261,7 @@ export const LOADING = "Loading...";
 export enum ComponentsImportance {
   Grid = 0,
   Highlight = 5,
+  Clipboard = 6,
   HeaderGroupingButton = 6,
   Figure = 10,
   ScrollBar = 15,

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -761,8 +761,12 @@ export interface RepeatPasteCommand {
   pasteOption?: ClipboardPasteOptions;
 }
 
-export interface CleanClipBoardHighlightCommand {
-  type: "CLEAN_CLIPBOARD_HIGHLIGHT";
+export interface ClearClipBoardHighlightCommand {
+  type: "CLEAR_CLIPBOARD_HIGHLIGHT";
+}
+
+export interface ClearPasteHander {
+  type: "CLEAR_PASTE_HANDLER";
 }
 
 export interface AutoFillCellCommand {
@@ -1104,7 +1108,7 @@ export type LocalCommand =
   | CopyPasteCellsAboveCommand
   | CopyPasteCellsOnLeftCommand
   | RepeatPasteCommand
-  | CleanClipBoardHighlightCommand
+  | ClearClipBoardHighlightCommand
   | AutoFillCellCommand
   | PasteFromOSClipboardCommand
   | AutoresizeColumnsCommand
@@ -1144,7 +1148,8 @@ export type LocalCommand =
   | DuplicatePivotInNewSheetCommand
   | InsertPivotWithTableCommand
   | SplitPivotFormulaCommand
-  | PaintFormat;
+  | PaintFormat
+  | ClearPasteHander;
 
 export type Command = CoreCommand | LocalCommand;
 

--- a/tests/grid/__snapshots__/grid_component.test.ts.snap
+++ b/tests/grid/__snapshots__/grid_component.test.ts.snap
@@ -122,6 +122,7 @@ exports[`Grid component simple rendering snapshot 1`] = `
   
   
   
+  
   <div
     class="o-scrollbar vertical"
     style="top:26px; right:0px; width:15px; bottom:0px; "

--- a/tests/paste_toolbox/__snapshots__/paste_toolbox_component.test.ts.snap
+++ b/tests/paste_toolbox/__snapshots__/paste_toolbox_component.test.ts.snap
@@ -1,0 +1,78 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Paste toolbox Menu items are correct 1`] = `
+<div
+  class="o-menu"
+  style=""
+>
+  
+  <div
+    class="o-menu-item d-flex justify-content-between align-items-center"
+    data-name="paste"
+    style=""
+    title="Paste"
+  >
+    <div
+      class="d-flex w-100"
+    >
+      
+      <div
+        class="o-menu-item-name align-middle text-truncate"
+      >
+        Paste
+      </div>
+      <div
+        class="o-menu-item-description ms-auto text-truncate"
+      >
+        Ctrl+V
+      </div>
+      
+      
+      
+    </div>
+  </div>
+  
+  <div
+    class="o-menu-item d-flex justify-content-between align-items-center"
+    data-name="paste_special_value"
+    style=""
+    title="Paste as value"
+  >
+    <div
+      class="d-flex w-100"
+    >
+      
+      <div
+        class="o-menu-item-name align-middle text-truncate"
+      >
+        Paste as value
+      </div>
+      
+      
+      
+    </div>
+  </div>
+  
+  <div
+    class="o-menu-item d-flex justify-content-between align-items-center"
+    data-name="paste_special_format"
+    style=""
+    title="Paste format only"
+  >
+    <div
+      class="d-flex w-100"
+    >
+      
+      <div
+        class="o-menu-item-name align-middle text-truncate"
+      >
+        Paste format only
+      </div>
+      
+      
+      
+    </div>
+  </div>
+  
+</div>
+`;

--- a/tests/paste_toolbox/paste_toolbox_component.test.ts
+++ b/tests/paste_toolbox/paste_toolbox_component.test.ts
@@ -1,0 +1,126 @@
+import { Model, Spreadsheet } from "../../src";
+import { PASTE_ACTION as pasteAction } from "../../src/actions/menu_items_actions";
+import { MockClipboardData, getClipboardEvent } from "../test_helpers/clipboard";
+import {
+  copy,
+  paste,
+  pasteFromOSClipboard,
+  setCellContent,
+  setSelection,
+} from "../test_helpers/commands_helpers";
+import { click } from "../test_helpers/dom_helper";
+import { getCell } from "../test_helpers/getters_helpers";
+import { mountSpreadsheet, nextTick } from "../test_helpers/helpers";
+
+describe("Paste toolbox", () => {
+  let model: Model;
+  let fixture: HTMLElement;
+  let parent: Spreadsheet;
+  beforeEach(async () => {
+    // mount a spreadsheet with a paste toolbox
+    ({ model, fixture, parent } = await mountSpreadsheet());
+  });
+
+  test("Activates on paste", async () => {
+    setCellContent(model, "A1", "1");
+    copy(model, "A1");
+    paste(model, "A2");
+    await nextTick();
+    expect(fixture.querySelector(".o-paste")).not.toBeNull();
+  });
+
+  test("Activates on OS paste", async () => {
+    pasteFromOSClipboard(model, "A2", { text: "1\n2" });
+    await nextTick();
+    expect(fixture.querySelector(".o-paste")).not.toBeNull();
+  });
+
+  test("Clicking the paste toolbox opens a menu", async () => {
+    setCellContent(model, "A1", "1");
+    copy(model, "A1");
+    paste(model, "A2");
+    await nextTick();
+    await click(fixture, ".o-paste");
+    expect(fixture.querySelector(".o-menu")).not.toBeNull();
+  });
+
+  test("closes when changing paste target (i.e. the selection)", async () => {
+    setCellContent(model, "A1", "1");
+    copy(model, "A1");
+    paste(model, "A2");
+    await nextTick();
+    expect(fixture.querySelector(".o-paste")).not.toBeNull();
+    model.selection.selectCell(1, 1);
+    await nextTick();
+    expect(fixture.querySelector(".o-paste")).toBeNull();
+    paste(model, "A2");
+    await nextTick();
+    await click(fixture, ".o-paste");
+    expect(fixture.querySelector(".o-menu")).not.toBeNull();
+    model.selection.selectCell(1, 1);
+    await nextTick();
+    expect(fixture.querySelector(".o-menu")).toBeNull();
+  });
+
+  test("Menu items are correct", async () => {
+    setCellContent(model, "A1", "1");
+    copy(model, "A1");
+    paste(model, "A2");
+    await nextTick();
+    await click(fixture, ".o-paste");
+    expect(fixture.querySelector(".o-menu")).toMatchSnapshot();
+  });
+
+  test("Can cycle through the paste options", async () => {
+    model.dispatch("UPDATE_CELL", {
+      sheetId: model.getters.getActiveSheetId(),
+      col: 0,
+      row: 0,
+      style: { bold: true },
+      content: "1",
+      format: "m/d/yyyy",
+    });
+
+    // required to polulate the os clipboard
+    const clipboardData = new MockClipboardData();
+    document.body.dispatchEvent(getClipboardEvent("copy", clipboardData));
+    parent.env.clipboard.write(clipboardData.content);
+
+    setSelection(model, ["A3"]);
+    await pasteAction(parent.env);
+    expect(getCell(model, "A3")).toMatchObject({
+      content: "1",
+      style: { bold: true },
+      format: "m/d/yyyy",
+    });
+    await nextTick();
+
+    // as Value
+    await click(fixture, ".o-paste");
+    await click(fixture, ".o-menu-item[data-name=paste_special_value]");
+    expect(getCell(model, "A3")).toMatchObject({
+      content: "1",
+      style: undefined,
+      format: "m/d/yyyy",
+    });
+    // as format only
+    await nextTick();
+    await click(fixture, ".o-paste");
+    await click(fixture, ".o-menu-item[data-name=paste_special_format]");
+    expect(getCell(model, "A3")).toMatchObject({
+      content: "",
+      style: { bold: true },
+      format: "m/d/yyyy",
+    });
+
+    // as normal paste
+    await nextTick();
+    await click(fixture, ".o-paste");
+    await click(fixture, ".o-menu-item[data-name=paste]");
+    expect(getCell(model, "A3")).toMatchObject({
+      content: "1",
+      style: { bold: true },
+      format: "m/d/yyyy",
+    });
+  });
+});

--- a/tests/spreadsheet/__snapshots__/spreadsheet_component.test.ts.snap
+++ b/tests/spreadsheet/__snapshots__/spreadsheet_component.test.ts.snap
@@ -756,6 +756,7 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
         
         
         
+        
         <div
           class="o-scrollbar vertical"
           style="top:26px; right:0px; width:15px; bottom:0px; "

--- a/tests/test_helpers/commands_helpers.ts
+++ b/tests/test_helpers/commands_helpers.ts
@@ -393,7 +393,7 @@ export function copyPasteCellsOnLeft(model: Model): DispatchResult {
  * Clean clipboard highlight selection.
  */
 export function cleanClipBoardHighlight(model: Model): DispatchResult {
-  return model.dispatch("CLEAN_CLIPBOARD_HIGHLIGHT");
+  return model.dispatch("CLEAR_CLIPBOARD_HIGHLIGHT");
 }
 
 /**


### PR DESCRIPTION
## Description:

After pasting, a user might want to change the type of pasting they do:
- only paste the value
- only paste the format
- ...

This revision adds a 'paste toolbox' to allow the user to alter the type
of paste they want to do.


Task: [4385451](https://www.odoo.com/odoo/2328/tasks/4385451)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo