### PR TITLE
[FIX] charts: fix logarithmic dataset trendline

### DIFF
--- a/src/helpers/figures/charts/runtime/chart_data_extractor.ts
+++ b/src/helpers/figures/charts/runtime/chart_data_extractor.ts
@@ -369,10 +369,18 @@ function interpolateData(
         )[0];
       }
       case "logarithmic": {
+        const positiveLogValues: number[] = [];
+        const filteredLabels: number[] = [];
+        for (let i = 0; i < values.length; i++) {
+          if (normalizedLabels[i] > 0) {
+            positiveLogValues.push(values[i]);
+            filteredLabels.push(Math.log(normalizedLabels[i]));
+          }
+        }
         return predictLinearValues(
-          [values],
-          logM([normalizedLabels]),
-          logM([normalizedNewLabels]),
+          [positiveLogValues],
+          [filteredLabels],
+          logM([normalizedNewLabels.slice(1)]), // We remove the first element to avoid log(0)
           true
         )[0];
       }

--- a/tests/figures/chart/chart_plugin.test.ts
+++ b/tests/figures/chart/chart_plugin.test.ts
@@ -3472,6 +3472,42 @@ describe("trending line", () => {
   });
 });
 
+test("logarithmic trending line", () => {
+  // prettier-ignore
+  setGrid(model, {
+      B1: "12", C1: "34",
+      B2: "45", C2: "23",
+      B3: "32", C3: "31",
+      B4: "29", C4: "54",
+      B5: "16", C5: "11",
+      B6: "19", C6: "89",
+      B7: "23", C7: "43",
+      B8: "64", C8: "42",
+    });
+  createChart(
+    model,
+    {
+      type: "scatter",
+      dataSets: [{ dataRange: "C1:C8", trend: { display: true, type: "logarithmic" } }],
+      labelRange: "B1:B8",
+      labelsAsText: false,
+      dataSetsHaveTitle: false,
+    },
+    "1"
+  );
+  function roundToFourDecimals(value) {
+    return Math.round(value * 10000) / 10000;
+  }
+  let runtime = model.getters.getChartRuntime("1") as LineChartRuntime;
+  // We round up to 4 decimals to avoid floating point errors
+  expect(runtime.chartJsConfig.data.datasets[1].data.map(roundToFourDecimals)).toEqual([
+    48.0254, 46.2824, 45.2628, 44.5393, 43.9782, 43.5197, 43.1321, 42.7963, 42.5001, 42.2351,
+    41.9954, 41.7766, 41.5754, 41.389, 41.2155, 41.0532, 40.9007, 40.757, 40.621, 40.4921, 40.3694,
+    40.2524, 40.1406, 40.0336, 39.9309, 39.8323, 39.7374, 39.6459, 39.5577, 39.4724, 39.39, 39.3101,
+    39.2328, 39.1577, 39.0848, 39.014, 38.945, 38.878, 38.8127, 38.749,
+  ]);
+});
+
 test("moving average trending line", () => {
   // prettier-ignore
   setGrid(model, {


### PR DESCRIPTION
Logarithmic trendline in charts was calculated incorrectly for datasets with null values. This commit fixes the issue by ensuring that only valid, positive values are considered for logarithmic dataset trend computation.

Task: [4385057](https://www.odoo.com/odoo/2328/tasks/4385057)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo