### PR TITLE
Master tree map chart adrm

### DIFF
--- a/demo/data.js
+++ b/demo/data.js
@@ -806,6 +806,29 @@ export const demoData = {
             cumulative: true,
           },
         },
+        {
+          id: "13",
+          x: 550,
+          y: 1800,
+          height: 400,
+          width: 900,
+          tag: "chart",
+          data: {
+            type: "treemap",
+            dataSetsHaveTitle: true,
+            dataSets: [
+              {
+                dataRange: "V1:V23",
+              },
+              {
+                dataRange: "W1:W23",
+              },
+            ],
+            legendPosition: "top",
+            labelRange: "X1:X23",
+            title: { text: "Movie Revenue by Genre" },
+          },
+        },
       ],
       tables: [
         {

--- a/demo/index.html
+++ b/demo/index.html
@@ -17,6 +17,7 @@
     <script src="../node_modules/chartjs-chart-geo/build/index.umd.js"></script>
     <script src="../node_modules/luxon/build/global/luxon.js"></script>
     <script src="../node_modules/chartjs-adapter-luxon/dist/chartjs-adapter-luxon.umd.js"></script>
+    <script src="lib/chart_js_treemap.js"></script>
     <script src="../build/o_spreadsheet.iife.js"></script>
     <script src="main.js" type="module"></script>
   </body>

--- a/demo/lib/chart_js_treemap.js
+++ b/demo/lib/chart_js_treemap.js
@@ -1,0 +1,1298 @@
+/*!
+ * chartjs-chart-treemap v3.1.0
+ * https://chartjs-chart-treemap.pages.dev/
+ * (c) 2025 Jukka Kurkela
+ * Released under the MIT license
+ */
+(function (global, factory) {
+  typeof exports === "object" && typeof module !== "undefined"
+    ? factory(exports, require("chart.js"), require("chart.js/helpers"))
+    : typeof define === "function" && define.amd
+    ? define(["exports", "chart.js", "chart.js/helpers"], factory)
+    : ((global = typeof globalThis !== "undefined" ? globalThis : global || self),
+      factory((global["chartjs-chart-treemap"] = {}), global.Chart, global.Chart.helpers));
+})(this, function (exports, chart_js, helpers) {
+  "use strict";
+
+  const isOlderPart = (act, req) =>
+    req > act || (act.length > req.length && act.slice(0, req.length) === req);
+
+  const getGroupKey = (lvl) => "" + lvl;
+
+  function scanTreeObject(keys, treeLeafKey, obj, tree = [], lvl = 0, result = []) {
+    const objIndex = lvl - 1;
+    if (keys[0] in obj && lvl > 0) {
+      const record = tree.reduce(function (reduced, item, i) {
+        if (i !== objIndex) {
+          reduced[getGroupKey(i)] = item;
+        }
+        return reduced;
+      }, {});
+      record[treeLeafKey] = tree[objIndex];
+      keys.forEach(function (k) {
+        record[k] = obj[k];
+      });
+      result.push(record);
+    } else {
+      for (const childKey of Object.keys(obj)) {
+        const child = obj[childKey];
+        if (helpers.isObject(child)) {
+          tree.push(childKey);
+          scanTreeObject(keys, treeLeafKey, child, tree, lvl + 1, result);
+        }
+      }
+    }
+    tree.splice(objIndex, 1);
+    return result;
+  }
+
+  function normalizeTreeToArray(keys, treeLeafKey, obj) {
+    const data = scanTreeObject(keys, treeLeafKey, obj);
+    if (!data.length) {
+      return data;
+    }
+    const max = data.reduce(function (maxVal, element) {
+      // minus 2 because _leaf and value properties are added
+      // on top to groups ones
+      const ikeys = Object.keys(element).length - 2;
+      return maxVal > ikeys ? maxVal : ikeys;
+    });
+    data.forEach(function (element) {
+      for (let i = 0; i < max; i++) {
+        const groupKey = getGroupKey(i);
+        if (!element[groupKey]) {
+          element[groupKey] = "";
+        }
+      }
+    });
+    return data;
+  }
+
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat
+  function flatten(input) {
+    const stack = [...input];
+    const res = [];
+    while (stack.length) {
+      // pop value from stack
+      const next = stack.pop();
+      if (Array.isArray(next)) {
+        // push back array items, won't modify the original input
+        stack.push(...next);
+      } else {
+        res.push(next);
+      }
+    }
+    // reverse to restore input order
+    return res.reverse();
+  }
+
+  function getPath(groups, value, defaultValue) {
+    if (!groups.length) {
+      return;
+    }
+    const path = [];
+    for (const grp of groups) {
+      const item = value[grp];
+      if (item === "") {
+        path.push(defaultValue);
+        break;
+      }
+      path.push(item);
+    }
+    return path.length ? path.join(".") : defaultValue;
+  }
+
+  /**
+   * @param {[]} values
+   * @param {string} grp
+   * @param {[string]} keys
+   * @param {string} treeeLeafKey
+   * @param {string} [mainGrp]
+   * @param {*} [mainValue]
+   * @param {[]} groups
+   */
+  function group(values, grp, keys, treeLeafKey, mainGrp, mainValue, groups = []) {
+    const key = keys[0];
+    const addKeys = keys.slice(1);
+    const tmp = Object.create(null);
+    const data = Object.create(null);
+    const ret = [];
+    let g, i, n;
+    for (i = 0, n = values.length; i < n; ++i) {
+      const v = values[i];
+      if (mainGrp && v[mainGrp] !== mainValue) {
+        continue;
+      }
+      g = v[grp] || v[treeLeafKey] || "";
+      if (!g) {
+        return [];
+      }
+      if (!(g in tmp)) {
+        const tmpRef = (tmp[g] = { value: 0 });
+        addKeys.forEach(function (k) {
+          tmpRef[k] = 0;
+        });
+        data[g] = [];
+      }
+      tmp[g].value += +v[key];
+      tmp[g].label = v[grp] || "";
+      const tmpRef = tmp[g];
+      addKeys.forEach(function (k) {
+        tmpRef[k] += v[k];
+      });
+      tmp[g].path = getPath(groups, v, g);
+      data[g].push(v);
+    }
+
+    Object.keys(tmp).forEach((k) => {
+      const v = { children: data[k] };
+      v[key] = +tmp[k].value;
+      addKeys.forEach(function (ak) {
+        v[ak] = +tmp[k][ak];
+      });
+      v[grp] = tmp[k].label;
+      v.label = k;
+      v.path = tmp[k].path;
+
+      if (mainGrp) {
+        v[mainGrp] = mainValue;
+      }
+      ret.push(v);
+    });
+
+    return ret;
+  }
+
+  function index(values, key) {
+    let n = values.length;
+    let i;
+
+    if (!n) {
+      return key;
+    }
+
+    const obj = helpers.isObject(values[0]);
+    key = obj ? key : "v";
+
+    for (i = 0, n = values.length; i < n; ++i) {
+      if (obj) {
+        values[i]._idx = i;
+      } else {
+        values[i] = { v: values[i], _idx: i };
+      }
+    }
+    return key;
+  }
+
+  function sort(values, key) {
+    if (key) {
+      values.sort((a, b) => +b[key] - +a[key]);
+    } else {
+      values.sort((a, b) => +b - +a);
+    }
+  }
+
+  function sum(values, key) {
+    let s, i, n;
+
+    for (s = 0, i = 0, n = values.length; i < n; ++i) {
+      s += key ? +values[i][key] : +values[i];
+    }
+
+    return s;
+  }
+
+  /**
+   * @param {string} pkg
+   * @param {string} min
+   * @param {string} ver
+   * @param {boolean} [strict=true]
+   * @returns {boolean}
+   */
+  function requireVersion(pkg, min, ver, strict = true) {
+    const parts = ver.split(".");
+    let i = 0;
+    for (const req of min.split(".")) {
+      const act = parts[i++];
+      if (parseInt(req, 10) < parseInt(act, 10)) {
+        break;
+      }
+      if (isOlderPart(act, req)) {
+        if (strict) {
+          throw new Error(`${pkg} v${ver} is not supported. v${min} or newer is required.`);
+        } else {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  const widthCache = new Map();
+
+  /**
+   * Helper function to get the bounds of the rect
+   * @param {TreemapElement} rect the rect
+   * @param {boolean} [useFinalPosition]
+   * @return {object} bounds of the rect
+   * @private
+   */
+  function getBounds(rect, useFinalPosition) {
+    const { x, y, width, height } = rect.getProps(["x", "y", "width", "height"], useFinalPosition);
+    return { left: x, top: y, right: x + width, bottom: y + height };
+  }
+
+  function limit(value, min, max) {
+    return Math.max(Math.min(value, max), min);
+  }
+
+  function parseBorderWidth(value, maxW, maxH) {
+    const o = helpers.toTRBL(value);
+
+    return {
+      t: limit(o.top, 0, maxH),
+      r: limit(o.right, 0, maxW),
+      b: limit(o.bottom, 0, maxH),
+      l: limit(o.left, 0, maxW),
+    };
+  }
+
+  function parseBorderRadius(value, maxW, maxH) {
+    const o = helpers.toTRBLCorners(value);
+    const maxR = Math.min(maxW, maxH);
+
+    return {
+      topLeft: limit(o.topLeft, 0, maxR),
+      topRight: limit(o.topRight, 0, maxR),
+      bottomLeft: limit(o.bottomLeft, 0, maxR),
+      bottomRight: limit(o.bottomRight, 0, maxR),
+    };
+  }
+
+  function boundingRects(rect) {
+    const bounds = getBounds(rect);
+    const width = bounds.right - bounds.left;
+    const height = bounds.bottom - bounds.top;
+    const border = parseBorderWidth(rect.options.borderWidth, width / 2, height / 2);
+    const radius = parseBorderRadius(rect.options.borderRadius, width / 2, height / 2);
+    const outer = {
+      x: bounds.left,
+      y: bounds.top,
+      w: width,
+      h: height,
+      active: rect.active,
+      radius,
+    };
+
+    return {
+      outer,
+      inner: {
+        x: outer.x + border.l,
+        y: outer.y + border.t,
+        w: outer.w - border.l - border.r,
+        h: outer.h - border.t - border.b,
+        active: rect.active,
+        radius: {
+          topLeft: Math.max(0, radius.topLeft - Math.max(border.t, border.l)),
+          topRight: Math.max(0, radius.topRight - Math.max(border.t, border.r)),
+          bottomLeft: Math.max(0, radius.bottomLeft - Math.max(border.b, border.l)),
+          bottomRight: Math.max(0, radius.bottomRight - Math.max(border.b, border.r)),
+        },
+      },
+    };
+  }
+
+  function inRange(rect, x, y, useFinalPosition) {
+    const skipX = x === null;
+    const skipY = y === null;
+    const bounds = !rect || (skipX && skipY) ? false : getBounds(rect, useFinalPosition);
+
+    return (
+      bounds &&
+      (skipX || (x >= bounds.left && x <= bounds.right)) &&
+      (skipY || (y >= bounds.top && y <= bounds.bottom))
+    );
+  }
+
+  function hasRadius(radius) {
+    return radius.topLeft || radius.topRight || radius.bottomLeft || radius.bottomRight;
+  }
+
+  /**
+   * Add a path of a rectangle to the current sub-path
+   * @param {CanvasRenderingContext2D} ctx Context
+   * @param {*} rect Bounding rect
+   */
+  function addNormalRectPath(ctx, rect) {
+    ctx.rect(rect.x, rect.y, rect.w, rect.h);
+  }
+
+  function shouldDrawCaption(displayMode, rect, options) {
+    if (!options || options.display === false) {
+      return false;
+    }
+    if (displayMode === "headerBoxes") {
+      return true;
+    }
+    const { w, h } = rect;
+    const font = helpers.toFont(options.font);
+    const min = font.lineHeight;
+    const padding = limit(helpers.valueOrDefault(options.padding, 3) * 2, 0, Math.min(w, h));
+    return w - padding > min && h - padding > min;
+  }
+
+  function getCaptionHeight(displayMode, rect, font, padding) {
+    if (displayMode !== "headerBoxes") {
+      return font.lineHeight + padding * 2;
+    }
+    const captionHeight = font.lineHeight + padding * 2;
+    return rect.h < 2 * captionHeight ? rect.h / 3 : captionHeight;
+  }
+
+  function drawText(ctx, rect, options, item) {
+    const { captions, labels, displayMode } = options;
+    ctx.save();
+    ctx.beginPath();
+    ctx.rect(rect.x, rect.y, rect.w, rect.h);
+    ctx.clip();
+    const isLeaf = item && (!helpers.defined(item.l) || item.isLeaf);
+    if (isLeaf && labels.display) {
+      drawLabel(ctx, rect, options);
+    } else if (!isLeaf && shouldDrawCaption(displayMode, rect, captions)) {
+      drawCaption(ctx, rect, options, item);
+    }
+    ctx.restore();
+  }
+
+  function drawCaption(ctx, rect, options, item) {
+    const { captions, spacing, rtl, displayMode } = options;
+    const { color, hoverColor, font, hoverFont, padding, align, formatter } = captions;
+    const oColor = (rect.active ? hoverColor : color) || color;
+    const oAlign = align || (rtl ? "right" : "left");
+    const optFont = (rect.active ? hoverFont : font) || font;
+    const oFont = helpers.toFont(optFont);
+    const fonts = [oFont];
+    if (oFont.lineHeight > rect.h) {
+      return;
+    }
+    let text = formatter || item.g;
+    const captionSize = measureLabelSize(ctx, [formatter], fonts);
+    if (captionSize.width + 2 * padding > rect.w) {
+      text = sliceTextToFitWidth(ctx, text, rect.w - 2 * padding, fonts);
+    }
+
+    const lh = oFont.lineHeight / 2;
+    const x = calculateX(rect, oAlign, padding);
+    ctx.fillStyle = oColor;
+    ctx.font = oFont.string;
+    ctx.textAlign = oAlign;
+    ctx.textBaseline = "middle";
+    const y = displayMode === "headerBoxes" ? rect.y + rect.h / 2 : rect.y + padding + spacing + lh;
+    ctx.fillText(text, x, y);
+  }
+
+  function sliceTextToFitWidth(ctx, text, width, fonts) {
+    const ellipsis = "...";
+    const ellipsisWidth = measureLabelSize(ctx, [ellipsis], fonts).width;
+    if (ellipsisWidth >= width) {
+      return "";
+    }
+    let lowerBoundLen = 1;
+    let upperBoundLen = text.length;
+    let currentWidth;
+    while (lowerBoundLen <= upperBoundLen) {
+      const currentLen = Math.floor((lowerBoundLen + upperBoundLen) / 2);
+      const currentText = text.slice(0, currentLen);
+      currentWidth = measureLabelSize(ctx, [currentText], fonts).width;
+      if (currentWidth + ellipsisWidth > width) {
+        upperBoundLen = currentLen - 1;
+      } else {
+        lowerBoundLen = currentLen + 1;
+      }
+    }
+    const slicedText = text.slice(0, Math.max(0, lowerBoundLen - 1));
+    return slicedText ? slicedText + ellipsis : "";
+  }
+
+  function measureLabelSize(ctx, lines, fonts) {
+    const fontsKey = fonts.reduce(function (prev, item) {
+      prev += item.string;
+      return prev;
+    }, "");
+    const mapKey = lines.join() + fontsKey + (ctx._measureText ? "-spriting" : "");
+    if (!widthCache.has(mapKey)) {
+      ctx.save();
+      const count = lines.length;
+      let width = 0;
+      let height = 0;
+      for (let i = 0; i < count; i++) {
+        const font = fonts[Math.min(i, fonts.length - 1)];
+        ctx.font = font.string;
+        const text = lines[i];
+        width = Math.max(width, ctx.measureText(text).width);
+        height += font.lineHeight;
+      }
+      ctx.restore();
+      widthCache.set(mapKey, { width, height });
+    }
+    return widthCache.get(mapKey);
+  }
+
+  function toFonts(fonts, fitRatio) {
+    return fonts.map(function (f) {
+      f.size = Math.floor(f.size * fitRatio);
+      f.lineHeight = undefined;
+      return helpers.toFont(f);
+    });
+  }
+
+  function labelToDraw(ctx, rect, options, labelSize) {
+    const { overflow, padding } = options;
+    const { width, height } = labelSize;
+    if (overflow === "hidden") {
+      return !(width + padding * 2 > rect.w || height + padding * 2 > rect.h);
+    } else if (overflow === "fit") {
+      const ratio = Math.min(rect.w / (width + padding * 2), rect.h / (height + padding * 2));
+      if (ratio < 1) {
+        return ratio;
+      }
+    }
+    return true;
+  }
+
+  function getFontFromOptions(rect, labels) {
+    const { font, hoverFont } = labels;
+    const optFont = (rect.active ? hoverFont : font) || font;
+    return helpers.isArray(optFont)
+      ? optFont.map((f) => helpers.toFont(f))
+      : [helpers.toFont(optFont)];
+  }
+
+  function drawLabel(ctx, rect, options) {
+    const labels = options.labels;
+    const content = labels.formatter;
+    if (!content) {
+      return;
+    }
+    const contents = helpers.isArray(content) ? content : [content];
+    let fonts = getFontFromOptions(rect, labels);
+    let labelSize = measureLabelSize(ctx, contents, fonts);
+    const lblToDraw = labelToDraw(ctx, rect, labels, labelSize);
+    if (!lblToDraw) {
+      return;
+    }
+    if (helpers.isNumber(lblToDraw)) {
+      labelSize = { width: labelSize.width * lblToDraw, height: labelSize.height * lblToDraw };
+      fonts = toFonts(fonts, lblToDraw);
+    }
+    const { color, hoverColor, align } = labels;
+    const optColor = (rect.active ? hoverColor : color) || color;
+    const colors = helpers.isArray(optColor) ? optColor : [optColor];
+    const xyPoint = calculateXYLabel(rect, labels, labelSize);
+    ctx.textAlign = align;
+    ctx.textBaseline = "middle";
+    let lhs = 0;
+    contents.forEach(function (l, i) {
+      const c = colors[Math.min(i, colors.length - 1)];
+      const f = fonts[Math.min(i, fonts.length - 1)];
+      const lh = f.lineHeight;
+      ctx.font = f.string;
+      ctx.fillStyle = c;
+      ctx.fillText(l, xyPoint.x, xyPoint.y + lh / 2 + lhs);
+      lhs += lh;
+    });
+  }
+
+  function drawDivider(ctx, rect, options, item) {
+    const dividers = options.dividers;
+    if (!dividers.display || !item._data.children.length) {
+      return;
+    }
+    const { x, y, w, h } = rect;
+    const { lineColor, lineCapStyle, lineDash, lineDashOffset, lineWidth } = dividers;
+    ctx.save();
+    ctx.strokeStyle = lineColor;
+    ctx.lineCap = lineCapStyle;
+    ctx.setLineDash(lineDash);
+    ctx.lineDashOffset = lineDashOffset;
+    ctx.lineWidth = lineWidth;
+    ctx.beginPath();
+    if (w > h) {
+      const w2 = w / 2;
+      ctx.moveTo(x + w2, y);
+      ctx.lineTo(x + w2, y + h);
+    } else {
+      const h2 = h / 2;
+      ctx.moveTo(x, y + h2);
+      ctx.lineTo(x + w, y + h2);
+    }
+    ctx.stroke();
+    ctx.restore();
+  }
+
+  function calculateXYLabel(rect, options, labelSize) {
+    const { align, position, padding } = options;
+    let x, y;
+    x = calculateX(rect, align, padding);
+    if (position === "top") {
+      y = rect.y + padding;
+    } else if (position === "bottom") {
+      y = rect.y + rect.h - padding - labelSize.height;
+    } else {
+      y = rect.y + (rect.h - labelSize.height) / 2 + padding;
+    }
+    return { x, y };
+  }
+
+  function calculateX(rect, align, padding) {
+    if (align === "left") {
+      return rect.x + padding;
+    } else if (align === "right") {
+      return rect.x + rect.w - padding;
+    }
+    return rect.x + rect.w / 2;
+  }
+
+  class TreemapElement extends chart_js.Element {
+    constructor(cfg) {
+      super();
+
+      this.options = undefined;
+      this.width = undefined;
+      this.height = undefined;
+
+      if (cfg) {
+        Object.assign(this, cfg);
+      }
+    }
+
+    draw(ctx, data) {
+      if (!data) {
+        return;
+      }
+      const options = this.options;
+      const { inner, outer } = boundingRects(this);
+
+      const addRectPath = hasRadius(outer.radius) ? helpers.addRoundedRectPath : addNormalRectPath;
+
+      ctx.save();
+
+      if (outer.w !== inner.w || outer.h !== inner.h) {
+        ctx.beginPath();
+        addRectPath(ctx, outer);
+        ctx.clip();
+        addRectPath(ctx, inner);
+        ctx.fillStyle = options.borderColor;
+        ctx.fill("evenodd");
+      }
+
+      ctx.beginPath();
+      addRectPath(ctx, inner);
+      ctx.fillStyle = options.backgroundColor;
+      ctx.fill();
+
+      drawDivider(ctx, inner, options, data);
+      drawText(ctx, inner, options, data);
+      ctx.restore();
+    }
+
+    inRange(mouseX, mouseY, useFinalPosition) {
+      return inRange(this, mouseX, mouseY, useFinalPosition);
+    }
+
+    inXRange(mouseX, useFinalPosition) {
+      return inRange(this, mouseX, null, useFinalPosition);
+    }
+
+    inYRange(mouseY, useFinalPosition) {
+      return inRange(this, null, mouseY, useFinalPosition);
+    }
+
+    getCenterPoint(useFinalPosition) {
+      const { x, y, width, height } = this.getProps(
+        ["x", "y", "width", "height"],
+        useFinalPosition
+      );
+      return {
+        x: x + width / 2,
+        y: y + height / 2,
+      };
+    }
+
+    tooltipPosition() {
+      return this.getCenterPoint();
+    }
+
+    /**
+     * @todo: remove this unused function in v3
+     */
+    getRange(axis) {
+      return axis === "x" ? this.width / 2 : this.height / 2;
+    }
+  }
+
+  TreemapElement.id = "treemap";
+
+  TreemapElement.defaults = {
+    borderRadius: 0,
+    borderWidth: 0,
+    captions: {
+      align: undefined,
+      color: "black",
+      display: true,
+      font: {},
+      formatter: (ctx) => ctx.raw.g || ctx.raw._data.label || "",
+      padding: 3,
+    },
+    dividers: {
+      display: false,
+      lineCapStyle: "butt",
+      lineColor: "black",
+      lineDash: [],
+      lineDashOffset: 0,
+      lineWidth: 1,
+    },
+    label: undefined,
+    labels: {
+      align: "center",
+      color: "black",
+      display: false,
+      font: {},
+      formatter(ctx) {
+        if (ctx.raw.g) {
+          return [ctx.raw.g, ctx.raw.v + ""];
+        }
+        return ctx.raw._data.label ? [ctx.raw._data.label, ctx.raw.v + ""] : ctx.raw.v + "";
+      },
+      overflow: "cut",
+      position: "middle",
+      padding: 3,
+    },
+    rtl: false,
+    spacing: 0.5,
+    unsorted: false,
+    displayMode: "containerBoxes",
+  };
+
+  TreemapElement.descriptors = {
+    captions: {
+      _fallback: true,
+    },
+    labels: {
+      _fallback: true,
+    },
+    _scriptable: true,
+    _indexable: false,
+  };
+
+  TreemapElement.defaultRoutes = {
+    backgroundColor: "backgroundColor",
+    borderColor: "borderColor",
+  };
+
+  function getDims(itm, w2, s2, key) {
+    const a = itm._normalized;
+    const ar = (w2 * a) / s2;
+    const d1 = Math.sqrt(a * ar);
+    const d2 = a / d1;
+    const w = key === "_ix" ? d1 : d2;
+    const h = key === "_ix" ? d2 : d1;
+
+    return { d1, d2, w, h };
+  }
+
+  const getX = (rect, w) => (rect.rtl ? rect.x + rect.iw - w : rect.x + rect._ix);
+
+  function buildRow(rect, itm, dims, sum) {
+    const r = {
+      x: getX(rect, dims.w),
+      y: rect.y + rect._iy,
+      w: dims.w,
+      h: dims.h,
+      a: itm._normalized,
+      v: itm.value,
+      vs: itm.values,
+      s: sum,
+      _data: itm._data,
+    };
+    if (itm.group) {
+      r.g = itm.group;
+      r.l = itm.level;
+      r.gs = itm.groupSum;
+    }
+    return r;
+  }
+
+  class Rect {
+    constructor(r) {
+      r = r || { w: 1, h: 1 };
+      this.rtl = !!r.rtl;
+      this.unsorted = !!r.unsorted;
+      this.x = r.x || r.left || 0;
+      this.y = r.y || r.top || 0;
+      this._ix = 0;
+      this._iy = 0;
+      this.w = r.w || r.width || r.right - r.left;
+      this.h = r.h || r.height || r.bottom - r.top;
+    }
+
+    get area() {
+      return this.w * this.h;
+    }
+
+    get iw() {
+      return this.w - this._ix;
+    }
+
+    get ih() {
+      return this.h - this._iy;
+    }
+
+    get dir() {
+      const ih = this.ih;
+      return ih <= this.iw && ih > 0 ? "y" : "x";
+    }
+
+    get side() {
+      return this.dir === "x" ? this.iw : this.ih;
+    }
+
+    map(arr) {
+      const { dir, side } = this;
+      const key = dir === "x" ? "_ix" : "_iy";
+      const sum = arr.nsum;
+      const row = arr.get();
+      const w2 = side * side;
+      const s2 = sum * sum;
+      const ret = [];
+      let maxd2 = 0;
+      let totd1 = 0;
+      for (const itm of row) {
+        const dims = getDims(itm, w2, s2, key);
+        totd1 += dims.d1;
+        maxd2 = Math.max(maxd2, dims.d2);
+        ret.push(buildRow(this, itm, dims, arr.sum));
+        this[key] += dims.d1;
+      }
+
+      this[dir === "x" ? "_iy" : "_ix"] += maxd2;
+      this[key] -= totd1;
+      return ret;
+    }
+  }
+
+  const min = Math.min;
+  const max = Math.max;
+
+  function getStat(sa) {
+    return {
+      min: sa.min,
+      max: sa.max,
+      sum: sa.sum,
+      nmin: sa.nmin,
+      nmax: sa.nmax,
+      nsum: sa.nsum,
+    };
+  }
+
+  function getNewStat(sa, o) {
+    const v = +o[sa.key];
+    const n = v * sa.ratio;
+    o._normalized = n;
+
+    return {
+      min: min(sa.min, v),
+      max: max(sa.max, v),
+      sum: sa.sum + v,
+      nmin: min(sa.nmin, n),
+      nmax: max(sa.nmax, n),
+      nsum: sa.nsum + n,
+    };
+  }
+
+  function setStat(sa, stat) {
+    Object.assign(sa, stat);
+  }
+
+  function push(sa, o, stat) {
+    sa._arr.push(o);
+    setStat(sa, stat);
+  }
+
+  class StatArray {
+    constructor(key, ratio) {
+      const me = this;
+      me.key = key;
+      me.ratio = ratio;
+      me.reset();
+    }
+
+    get length() {
+      return this._arr.length;
+    }
+
+    reset() {
+      const me = this;
+      me._arr = [];
+      me._hist = [];
+      me.sum = 0;
+      me.nsum = 0;
+      me.min = Infinity;
+      me.max = -Infinity;
+      me.nmin = Infinity;
+      me.nmax = -Infinity;
+    }
+
+    push(o) {
+      push(this, o, getNewStat(this, o));
+    }
+
+    pushIf(o, fn, ...args) {
+      const nstat = getNewStat(this, o);
+      if (!fn(getStat(this), nstat, args)) {
+        return o;
+      }
+      push(this, o, nstat);
+    }
+
+    get() {
+      return this._arr;
+    }
+  }
+
+  function compareAspectRatio(oldStat, newStat, args) {
+    if (oldStat.sum === 0) {
+      return true;
+    }
+
+    const [length] = args;
+    const os2 = oldStat.nsum * oldStat.nsum;
+    const ns2 = newStat.nsum * newStat.nsum;
+    const l2 = length * length;
+    const or = Math.max((l2 * oldStat.nmax) / os2, os2 / (l2 * oldStat.nmin));
+    const nr = Math.max((l2 * newStat.nmax) / ns2, ns2 / (l2 * newStat.nmin));
+    return nr <= or;
+  }
+
+  /**
+   *
+   * @param {number[]|object[]} values
+   * @param {object} rectangle
+   * @param {string} [key]
+   * @param {string} [grp]
+   * @param {number} [lvl]
+   * @param {number} [gsum]
+   */
+  function squarify(values, rectangle, keys = [], grp, lvl, gsum) {
+    values = values || [];
+    const rows = [];
+    const rect = new Rect(rectangle);
+    const row = new StatArray("value", rect.area / sum(values, keys[0]));
+    let length = rect.side;
+    const n = values.length;
+    let i, o;
+
+    if (!n) {
+      return rows;
+    }
+
+    const tmp = values.slice();
+    let key = index(tmp, keys[0]);
+
+    if (!rectangle?.unsorted) {
+      sort(tmp, key);
+    }
+
+    const val = (idx) => (key ? +tmp[idx][key] : +tmp[idx]);
+    const gval = (idx) => grp && tmp[idx][grp];
+
+    for (i = 0; i < n; ++i) {
+      o = {
+        value: val(i),
+        groupSum: gsum,
+        _data: values[tmp[i]._idx],
+        level: undefined,
+        group: undefined,
+      };
+      if (grp) {
+        o.level = lvl;
+        o.group = gval(i);
+        const tmpRef = tmp[i];
+        o.values = keys.reduce(function (obj, k) {
+          obj[k] = +tmpRef[k];
+          return obj;
+        }, {});
+      }
+      o = row.pushIf(o, compareAspectRatio, length);
+      if (o) {
+        rows.push(rect.map(row));
+        length = rect.side;
+        row.reset();
+        row.push(o);
+      }
+    }
+    if (row.length) {
+      rows.push(rect.map(row));
+    }
+    return flatten(rows);
+  }
+
+  var version = "3.1.0";
+
+  function scaleRect(sq, xScale, yScale, sp) {
+    const sp2 = sp * 2;
+    const x = xScale.getPixelForValue(sq.x);
+    const y = yScale.getPixelForValue(sq.y);
+    const w = xScale.getPixelForValue(sq.x + sq.w) - x;
+    const h = yScale.getPixelForValue(sq.y + sq.h) - y;
+    return {
+      x: x + sp,
+      y: y + sp,
+      width: w - sp2,
+      height: h - sp2,
+      hidden: sp2 > w || sp2 > h,
+    };
+  }
+
+  function rectNotEqual(r1, r2) {
+    return (
+      !r1 ||
+      !r2 ||
+      r1.x !== r2.x ||
+      r1.y !== r2.y ||
+      r1.w !== r2.w ||
+      r1.h !== r2.h ||
+      r1.rtl !== r2.rtl ||
+      r1.unsorted !== r2.unsorted
+    );
+  }
+
+  function arrayNotEqual(a, b) {
+    let i, n;
+
+    if (!a || !b) {
+      return true;
+    }
+
+    if (a === b) {
+      return false;
+    }
+
+    if (a.length !== b.length) {
+      return true;
+    }
+
+    for (i = 0, n = a.length; i < n; ++i) {
+      if (a[i] !== b[i]) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  function buildData(tree, dataset, keys, mainRect) {
+    const treeLeafKey = dataset.treeLeafKey || "_leaf";
+    if (helpers.isObject(tree)) {
+      tree = normalizeTreeToArray(keys, treeLeafKey, tree);
+    }
+    const groups = dataset.groups || [];
+    const glen = groups.length;
+    const sp =
+      dataset.displayMode === "headerBoxes" ? 0 : helpers.valueOrDefault(dataset.spacing, 0);
+    const captions = dataset.captions || {};
+    const font = helpers.toFont(captions.font);
+    const padding = helpers.valueOrDefault(captions.padding, 3);
+
+    function recur(treeElements, gidx, rect, parent, gs) {
+      const g = getGroupKey(groups[gidx]);
+      const pg = gidx > 0 && getGroupKey(groups[gidx - 1]);
+      const gdata = group(
+        treeElements,
+        g,
+        keys,
+        treeLeafKey,
+        pg,
+        parent,
+        groups.filter((item, index) => index <= gidx)
+      );
+      const gsq = squarify(gdata, rect, keys, g, gidx, gs);
+      const ret = gsq.slice();
+      if (gidx < glen - 1) {
+        gsq.forEach((sq) => {
+          const bw =
+            dataset.displayMode === "headerBoxes"
+              ? { l: 0, r: 0, t: 0, b: 0 }
+              : parseBorderWidth(dataset.borderWidth, sq.w / 2, sq.h / 2);
+          const subRect = {
+            ...rect,
+            x: sq.x + sp + bw.l,
+            y: sq.y + sp + bw.t,
+            w: sq.w - 2 * sp - bw.l - bw.r,
+            h: sq.h - 2 * sp - bw.t - bw.b,
+          };
+          if (shouldDrawCaption(dataset.displayMode, subRect, captions)) {
+            const captionHeight = getCaptionHeight(dataset.displayMode, subRect, font, padding);
+            subRect.y += captionHeight;
+            subRect.h -= captionHeight;
+          }
+          const children = [];
+          gdata.forEach((gEl) => {
+            children.push(...recur(gEl.children, gidx + 1, subRect, sq.g, sq.s));
+          });
+          ret.push(...children);
+          sq.isLeaf = !children.length;
+        });
+      } else {
+        gsq.forEach((sq) => {
+          sq.isLeaf = true;
+        });
+      }
+      return ret;
+    }
+
+    const result = glen ? recur(tree, 0, mainRect) : squarify(tree, mainRect, keys);
+    return result
+      .map((d) => {
+        if (dataset.displayMode !== "headerBoxes" || d.isLeaf) {
+          return d;
+        }
+        if (!shouldDrawCaption(dataset.displayMode, d, captions)) {
+          return undefined;
+        }
+        const captionHeight = getCaptionHeight(dataset.displayMode, d, font, padding);
+        return { ...d, h: captionHeight };
+      })
+      .filter((d) => d);
+  }
+
+  class TreemapController extends chart_js.DatasetController {
+    constructor(chart, datasetIndex) {
+      super(chart, datasetIndex);
+
+      this._groups = undefined;
+      this._keys = undefined;
+      this._rect = undefined;
+      this._rectChanged = true;
+    }
+
+    initialize() {
+      this.enableOptionSharing = true;
+      super.initialize();
+    }
+
+    getMinMax(scale) {
+      return {
+        min: 0,
+        max: scale.axis === "x" ? scale.right - scale.left : scale.bottom - scale.top,
+      };
+    }
+
+    configure() {
+      super.configure();
+      const { xScale, yScale } = this.getMeta();
+      if (!xScale || !yScale) {
+        // configure is called once before `linkScales`, and at that call we don't have any scales linked yet
+        return;
+      }
+
+      const w = xScale.right - xScale.left;
+      const h = yScale.bottom - yScale.top;
+      const rect = { x: 0, y: 0, w, h, rtl: !!this.options.rtl, unsorted: !!this.options.unsorted };
+
+      if (rectNotEqual(this._rect, rect)) {
+        this._rect = rect;
+        this._rectChanged = true;
+      }
+
+      if (this._rectChanged) {
+        xScale.max = w;
+        xScale.configure();
+        yScale.max = h;
+        yScale.configure();
+      }
+    }
+
+    update(mode) {
+      const dataset = this.getDataset();
+      const { data } = this.getMeta();
+      const groups = dataset.groups || [];
+      const keys = [dataset.key || ""].concat(dataset.sumKeys || []);
+      const tree = (dataset.tree = dataset.tree || dataset.data || []);
+
+      if (mode === "reset") {
+        // reset is called before 2nd configure and is only called if animations are enabled. So wen need an extra configure call here.
+        this.configure();
+      }
+
+      if (
+        this._rectChanged ||
+        arrayNotEqual(this._keys, keys) ||
+        arrayNotEqual(this._groups, groups) ||
+        this._prevTree !== tree
+      ) {
+        this._groups = groups.slice();
+        this._keys = keys.slice();
+        this._prevTree = tree;
+        this._rectChanged = false;
+
+        dataset.data = buildData(tree, dataset, this._keys, this._rect);
+        // @ts-ignore using private stuff
+        this._dataCheck();
+        // @ts-ignore using private stuff
+        this._resyncElements();
+      }
+
+      this.updateElements(data, 0, data.length, mode);
+    }
+
+    updateElements(rects, start, count, mode) {
+      const reset = mode === "reset";
+      const dataset = this.getDataset();
+      const firstOpts = (this._rect.options = this.resolveDataElementOptions(start, mode));
+      const sharedOptions = this.getSharedOptions(firstOpts);
+      const includeOptions = this.includeOptions(mode, sharedOptions);
+      const { xScale, yScale } = this.getMeta(this.index);
+
+      for (let i = start; i < start + count; i++) {
+        const options = sharedOptions || this.resolveDataElementOptions(i, mode);
+        const properties = scaleRect(dataset.data[i], xScale, yScale, options.spacing);
+        if (reset) {
+          properties.width = 0;
+          properties.height = 0;
+        }
+
+        if (includeOptions) {
+          properties.options = options;
+        }
+        this.updateElement(rects[i], i, properties, mode);
+      }
+
+      this.updateSharedOptions(sharedOptions, mode, firstOpts);
+    }
+
+    draw() {
+      const { ctx, chartArea } = this.chart;
+      const metadata = this.getMeta().data || [];
+      const dataset = this.getDataset();
+      const data = dataset.data;
+
+      helpers.clipArea(ctx, chartArea);
+      for (let i = 0, ilen = metadata.length; i < ilen; ++i) {
+        const rect = metadata[i];
+        if (!rect.hidden) {
+          rect.draw(ctx, data[i]);
+        }
+      }
+      helpers.unclipArea(ctx);
+    }
+  }
+
+  TreemapController.id = "treemap";
+
+  TreemapController.version = version;
+
+  TreemapController.defaults = {
+    dataElementType: "treemap",
+
+    animations: {
+      numbers: {
+        type: "number",
+        properties: ["x", "y", "width", "height"],
+      },
+    },
+  };
+
+  TreemapController.descriptors = {
+    _scriptable: true,
+    _indexable: false,
+  };
+
+  TreemapController.overrides = {
+    interaction: {
+      mode: "point",
+      includeInvisible: true,
+      intersect: true,
+    },
+
+    hover: {},
+
+    plugins: {
+      tooltip: {
+        position: "treemap",
+        intersect: true,
+        callbacks: {
+          title(items) {
+            if (items.length) {
+              const item = items[0];
+              return item.dataset.key || "";
+            }
+            return "";
+          },
+          label(item) {
+            const dataset = item.dataset;
+            const dataItem = dataset.data[item.dataIndex];
+            const label = dataItem.g || dataItem._data.label || dataset.label;
+            return (label ? label + ": " : "") + dataItem.v;
+          },
+        },
+      },
+    },
+    scales: {
+      x: {
+        type: "linear",
+        alignToPixels: true,
+        bounds: "data",
+        display: false,
+      },
+      y: {
+        type: "linear",
+        alignToPixels: true,
+        bounds: "data",
+        display: false,
+        reverse: true,
+      },
+    },
+  };
+
+  TreemapController.beforeRegister = function () {
+    requireVersion("chart.js", "3.8", chart_js.Chart.version);
+  };
+
+  TreemapController.afterRegister = function () {
+    const tooltipPlugin = chart_js.registry.plugins.get("tooltip");
+    if (tooltipPlugin) {
+      tooltipPlugin.positioners.treemap = function (active) {
+        if (!active.length) {
+          return false;
+        }
+
+        const item = active[active.length - 1];
+        const el = item.element;
+
+        return el.tooltipPosition();
+      };
+    } else {
+      console.warn(
+        "Unable to register the treemap positioner because tooltip plugin is not registered"
+      );
+    }
+  };
+
+  TreemapController.afterUnregister = function () {
+    const tooltipPlugin = chart_js.registry.plugins.get("tooltip");
+    if (tooltipPlugin) {
+      delete tooltipPlugin.positioners.treemap;
+    }
+  };
+
+  chart_js.Chart.register(TreemapController, TreemapElement);
+
+  exports.flatten = flatten;
+  exports.getGroupKey = getGroupKey;
+  exports.group = group;
+  exports.index = index;
+  exports.normalizeTreeToArray = normalizeTreeToArray;
+  exports.requireVersion = requireVersion;
+  exports.sort = sort;
+  exports.sum = sum;
+});

--- a/src/components/side_panel/chart/chart_type_picker/chart_previews.xml
+++ b/src/components/side_panel/chart/chart_type_picker/chart_previews.xml
@@ -283,4 +283,19 @@
       />
     </svg>
   </t>
+  <t t-name="o-spreadsheet-ChartPreview.TREE_MAP_CHART">
+    <svg viewBox="0 0 48 48" class="o-chart-preview" xmlns="http://www.w3.org/2000/svg">
+      <path fill="#444" d="M2,4 h44 v5 h-44"/>
+      <path fill="#444" d="M2,10 h28 v5 h-28"/>
+      <path fill="#444" d="M31,10 h15 v5 h-15"/>
+      <path fill="#0074d9" d="M2,16 h28 v14 h-28"/>
+      <path fill="#c4e4ff" d="M3,17 h26 v12 h-26"/>
+      <path fill="#0074d9" d="M2,31 h15 v12 h-15"/>
+      <path fill="#c4e4ff" d="M3,32 h13 v10 h-13"/>
+      <path fill="#0074d9" d="M18,31 h12 v12 h-12"/>
+      <path fill="#c4e4ff" d="M19,32 h10 v10 h-10"/>
+      <path fill="#eb6d00" d="M31,16 h15 v27 h-15"/>
+      <path fill="#ffe1c8" d="M32,17 h13 v25 h-13"/>
+    </svg>
+  </t>
 </templates>

--- a/src/components/side_panel/chart/hierarchical_chart/hierarchical_chart_config_panel.ts
+++ b/src/components/side_panel/chart/hierarchical_chart/hierarchical_chart_config_panel.ts
@@ -1,7 +1,7 @@
 import { GenericChartConfigPanel } from "../building_blocks/generic_side_panel/config_panel";
 
-export class SunburstChartConfigPanel extends GenericChartConfigPanel {
-  static template = "o-spreadsheet-SunburstChartConfigPanel";
+export class HierarchicalChartConfigPanel extends GenericChartConfigPanel {
+  static template = "o-spreadsheet-HierarchicalChartConfigPanel";
   static components = { ...GenericChartConfigPanel.components };
 
   getLabelRangeOptions() {

--- a/src/components/side_panel/chart/hierarchical_chart/hierarchical_chart_config_panel.xml
+++ b/src/components/side_panel/chart/hierarchical_chart/hierarchical_chart_config_panel.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet-SunburstChartConfigPanel">
+  <t t-name="o-spreadsheet-HierarchicalChartConfigPanel">
     <div>
       <ChartDataSeries
         ranges="this.getDataSeriesRanges()"

--- a/src/components/side_panel/chart/index.ts
+++ b/src/components/side_panel/chart/index.ts
@@ -10,14 +10,15 @@ import { GaugeChartConfigPanel } from "./gauge_chart_panel/gauge_chart_config_pa
 import { GaugeChartDesignPanel } from "./gauge_chart_panel/gauge_chart_design_panel";
 import { GeoChartConfigPanel } from "./geo_chart_panel/geo_chart_config_panel";
 import { GeoChartDesignPanel } from "./geo_chart_panel/geo_chart_design_panel";
+import { HierarchicalChartConfigPanel } from "./hierarchical_chart/hierarchical_chart_config_panel";
 import { LineConfigPanel } from "./line_chart/line_chart_config_panel";
 import { PieChartDesignPanel } from "./pie_chart/pie_chart_design_panel";
 import { RadarChartDesignPanel } from "./radar_chart/radar_chart_design_panel";
 import { ScatterConfigPanel } from "./scatter_chart/scatter_chart_config_panel";
 import { ScorecardChartConfigPanel } from "./scorecard_chart_panel/scorecard_chart_config_panel";
 import { ScorecardChartDesignPanel } from "./scorecard_chart_panel/scorecard_chart_design_panel";
-import { SunburstChartConfigPanel } from "./sunburst_chart/sunburst_chart_config_panel";
 import { SunburstChartDesignPanel } from "./sunburst_chart/sunburst_chart_design_panel";
+import { TreeMapChartDesignPanel } from "./treemap_chart/treemap_chart_design_panel";
 import { WaterfallChartDesignPanel } from "./waterfall_chart/waterfall_chart_design_panel";
 
 export { BarConfigPanel } from "./bar_chart/bar_chart_config_panel";
@@ -78,7 +79,7 @@ chartSidePanelComponentRegistry
     design: RadarChartDesignPanel,
   })
   .add("sunburst", {
-    configuration: SunburstChartConfigPanel,
+    configuration: HierarchicalChartConfigPanel,
     design: SunburstChartDesignPanel,
   })
   .add("geo", {
@@ -88,4 +89,8 @@ chartSidePanelComponentRegistry
   .add("funnel", {
     configuration: FunnelChartConfigPanel,
     design: FunnelChartDesignPanel,
+  })
+  .add("treemap", {
+    configuration: HierarchicalChartConfigPanel,
+    design: TreeMapChartDesignPanel,
   });

--- a/src/components/side_panel/chart/treemap_chart/treemap_category_color/treemap_category_color.ts
+++ b/src/components/side_panel/chart/treemap_chart/treemap_category_color/treemap_category_color.ts
@@ -1,0 +1,62 @@
+import { Component } from "@odoo/owl";
+import { ChartConfiguration } from "chart.js";
+import { DispatchResult, UID } from "../../../../..";
+import { deepCopy } from "../../../../../helpers";
+import { SpreadsheetChildEnv } from "../../../../../types";
+import {
+  TreeMapCategoryColorOptions,
+  TreeMapChartDefaults,
+  TreeMapChartDefinition,
+  TreeMapChartRuntime,
+} from "../../../../../types/chart/tree_map_chart";
+import { Checkbox } from "../../../components/checkbox/checkbox";
+import { RoundColorPicker } from "../../../components/round_color_picker/round_color_picker";
+
+interface Props {
+  figureId: UID;
+  definition: TreeMapChartDefinition;
+  onColorChanged: (colors: TreeMapCategoryColorOptions) => DispatchResult;
+}
+
+export class TreeMapCategoryColors extends Component<Props, SpreadsheetChildEnv> {
+  static template = "o-spreadsheet-TreeMapCategoryColors";
+  static components = {
+    Checkbox,
+    RoundColorPicker,
+  };
+  static props = {
+    figureId: String,
+    definition: Object,
+    onColorChanged: Function,
+  };
+
+  get coloringOptions() {
+    const coloringOptions =
+      this.props.definition.coloringOptions ?? TreeMapChartDefaults.coloringOptions;
+    if (coloringOptions.type !== "categoryColor") {
+      throw new Error("Coloring options is not solid color");
+    }
+    return coloringOptions;
+  }
+
+  getTreeGroupAndColors() {
+    const runtime = this.env.model.getters.getChartRuntime(
+      this.props.figureId
+    ) as TreeMapChartRuntime;
+    const config = runtime.chartJsConfig as ChartConfiguration<"treemap">;
+    return config.data.datasets[0]?.groupColors || [];
+  }
+
+  onGroupColorChanged(index: number, color: string) {
+    const coloringOptions = deepCopy(this.coloringOptions);
+    coloringOptions.colors[index] = color || undefined; // color picker returns empty string for no color
+    this.props.onColorChanged(coloringOptions);
+  }
+
+  useValueBasedGradient(useValueBasedGradient: boolean) {
+    if (this.coloringOptions.type !== "categoryColor") {
+      throw new Error("Coloring options is not solid color");
+    }
+    this.props.onColorChanged({ ...this.coloringOptions, useValueBasedGradient });
+  }
+}

--- a/src/components/side_panel/chart/treemap_chart/treemap_category_color/treemap_category_color.xml
+++ b/src/components/side_panel/chart/treemap_chart/treemap_category_color/treemap_category_color.xml
@@ -1,0 +1,27 @@
+<templates>
+  <t t-name="o-spreadsheet-TreeMapCategoryColors">
+    <div class="mt-3">
+      <div class="o-fw-bold mb-2">Category</div>
+      <t t-foreach="getTreeGroupAndColors()" t-as="group" t-key="group_index">
+        <div class="d-flex align-items-center mb-2" t-att-data-id="group.label">
+          <RoundColorPicker
+            currentColor="group.color"
+            onColorPicked="(color) => this.onGroupColorChanged(group_index, color)"
+          />
+          <span class="ps-2">
+            <span t-esc="'(#' + (group_index +1 ) + ')'" class="o-text-bolder pe-1"/>
+            <span class="text-muted" t-esc="group.label"/>
+          </span>
+        </div>
+      </t>
+
+      <Checkbox
+        name="'useValueBasedGradient'"
+        label.translate="Use value-based gradient"
+        value="coloringOptions.useValueBasedGradient"
+        onChange.bind="useValueBasedGradient"
+        className="'mt-4'"
+      />
+    </div>
+  </t>
+</templates>

--- a/src/components/side_panel/chart/treemap_chart/treemap_chart_design_panel.ts
+++ b/src/components/side_panel/chart/treemap_chart/treemap_chart_design_panel.ts
@@ -1,0 +1,105 @@
+import { Component } from "@odoo/owl";
+import { _t } from "../../../../translation";
+import {
+  TreeMapCategoryColorOptions,
+  TreeMapChartDefaults,
+  TreeMapChartDefinition,
+  TreeMapColorScaleOptions,
+} from "../../../../types/chart/tree_map_chart";
+import { DispatchResult, SpreadsheetChildEnv, UID } from "../../../../types/index";
+import { BadgeSelection } from "../../components/badge_selection/badge_selection";
+import { Checkbox } from "../../components/checkbox/checkbox";
+import { SidePanelCollapsible } from "../../components/collapsible/side_panel_collapsible";
+import { RoundColorPicker } from "../../components/round_color_picker/round_color_picker";
+import { Section } from "../../components/section/section";
+import { GeneralDesignEditor } from "../building_blocks/general_design/general_design_editor";
+import { TextStyler } from "../building_blocks/text_styler/text_styler";
+import { TreeMapCategoryColors } from "./treemap_category_color/treemap_category_color";
+import { TreeMapColorScale } from "./treemap_color_scale/treemap_color_scale";
+
+interface Props {
+  figureId: UID;
+  definition: TreeMapChartDefinition;
+  canUpdateChart: (figureID: UID, definition: Partial<TreeMapChartDefinition>) => DispatchResult;
+  updateChart: (figureId: UID, definition: Partial<TreeMapChartDefinition>) => DispatchResult;
+}
+
+const DEFAULT_COLOR_SCALE: TreeMapColorScaleOptions = {
+  type: "colorScale",
+  minColor: "#FFF5EB",
+  midColor: "#FD8D3C",
+  maxColor: "#7F2704",
+};
+
+const DEFAULT_SOLID_COLOR: TreeMapCategoryColorOptions = {
+  type: "categoryColor",
+  colors: [],
+  useValueBasedGradient: true,
+};
+
+export class TreeMapChartDesignPanel extends Component<Props, SpreadsheetChildEnv> {
+  static template = "o-spreadsheet-TreeMapChartDesignPanel";
+  static components = {
+    GeneralDesignEditor,
+    Section,
+    SidePanelCollapsible,
+    Checkbox,
+    TextStyler,
+    RoundColorPicker,
+    BadgeSelection,
+    TreeMapCategoryColors,
+    TreeMapColorScale,
+  };
+  static props = {
+    figureId: String,
+    definition: Object,
+    updateChart: Function,
+    canUpdateChart: { type: Function, optional: true },
+  };
+
+  private savedColors = {
+    categoryColors: DEFAULT_SOLID_COLOR,
+    colorScale: DEFAULT_COLOR_SCALE,
+  };
+
+  defaults = TreeMapChartDefaults;
+
+  get showHeaders() {
+    return this.props.definition.showHeaders ?? TreeMapChartDefaults.showHeaders;
+  }
+
+  get showValues() {
+    return this.props.definition.showValues ?? TreeMapChartDefaults.showValues;
+  }
+
+  get showLabels() {
+    return this.props.definition.showLabels ?? TreeMapChartDefaults.showLabels;
+  }
+
+  get coloringOptions() {
+    return this.props.definition.coloringOptions ?? TreeMapChartDefaults.coloringOptions;
+  }
+
+  changeColoringOption(option: "categoryColor" | "colorScale") {
+    const coloringOptions =
+      option === "categoryColor" ? this.savedColors.categoryColors : this.savedColors.colorScale;
+    this.props.updateChart(this.props.figureId, { coloringOptions });
+  }
+
+  onCategoryColorChange(coloringOptions: TreeMapCategoryColorOptions) {
+    this.savedColors.categoryColors = coloringOptions;
+    this.props.updateChart(this.props.figureId, { coloringOptions });
+  }
+
+  onColorScaleChange(coloringOptions: TreeMapColorScaleOptions) {
+    this.savedColors.colorScale = coloringOptions;
+    this.props.updateChart(this.props.figureId, { coloringOptions });
+  }
+
+  get coloringOptionChoices() {
+    return [
+      { label: _t("Category color"), value: "categoryColor" },
+      { label: _t("Color scale"), value: "colorScale" },
+    ];
+  }
+}

--- a/src/components/side_panel/chart/treemap_chart/treemap_chart_design_panel.xml
+++ b/src/components/side_panel/chart/treemap_chart/treemap_chart_design_panel.xml
@@ -1,0 +1,84 @@
+<templates>
+  <t t-name="o-spreadsheet-TreeMapChartDesignPanel">
+    <GeneralDesignEditor
+      figureId="props.figureId"
+      definition="props.definition"
+      updateChart="props.updateChart"
+    />
+
+    <SidePanelCollapsible isInitiallyCollapsed="false" title.translate="Tree map colors">
+      <t t-set-slot="content">
+        <Section class="'pt-0'">
+          <BadgeSelection
+            choices="coloringOptionChoices"
+            onChange.bind="changeColoringOption"
+            selectedValue="coloringOptions.type"
+          />
+
+          <t t-if="coloringOptions.type === 'categoryColor'">
+            <TreeMapCategoryColors
+              figureId="props.figureId"
+              definition="props.definition"
+              onColorChanged.bind="onCategoryColorChange"
+            />
+          </t>
+          <t t-else="">
+            <TreeMapColorScale
+              figureId="props.figureId"
+              definition="props.definition"
+              onColorChanged.bind="onColorScaleChange"
+            />
+          </t>
+        </Section>
+      </t>
+    </SidePanelCollapsible>
+
+    <SidePanelCollapsible isInitiallyCollapsed="false" title.translate="Headers and labels">
+      <t t-set-slot="content">
+        <Section title.translate="Headers" class="'pt-0 pb-0'">
+          <Checkbox
+            name="'showHeaders'"
+            label.translate="Show headers"
+            value="showHeaders"
+            onChange="(showHeaders) => props.updateChart(this.props.figureId, { showHeaders })"
+          />
+        </Section>
+        <Section class="'pt-0'" t-if="showHeaders">
+          <TextStyler
+            class="'pt-0 o-header-style'"
+            updateStyle="(headerDesign) => props.updateChart(this.props.figureId, { headerDesign })"
+            style="props.definition.headerDesign || {}"
+            defaultStyle="defaults.headerDesign"
+            hasBackgroundColor="true"
+          />
+        </Section>
+
+        <Section title.translate="Labels" class="'pt-0 pb-0'">
+          <div class="d-flex flex-row gap-4">
+            <Checkbox
+              name="'showLabels'"
+              label.translate="Show labels"
+              value="showLabels"
+              onChange="(showLabels) => props.updateChart(this.props.figureId, { showLabels })"
+            />
+            <Checkbox
+              name="'showValues'"
+              label.translate="Show values"
+              value="showValues"
+              onChange="(showValues) => props.updateChart(this.props.figureId, { showValues })"
+            />
+          </div>
+        </Section>
+        <Section class="'pt-0'" t-if="showValues || showLabels">
+          <TextStyler
+            class="'pt-0 o-values-style'"
+            updateStyle="(valuesDesign) => props.updateChart(this.props.figureId, { valuesDesign })"
+            style="props.definition.valuesDesign || {}"
+            defaultStyle="defaults.valuesDesign"
+            hasVerticalAlign="true"
+          />
+        </Section>
+      </t>
+    </SidePanelCollapsible>
+  </t>
+</templates>

--- a/src/components/side_panel/chart/treemap_chart/treemap_color_scale/treemap_color_scale.ts
+++ b/src/components/side_panel/chart/treemap_chart/treemap_color_scale/treemap_color_scale.ts
@@ -1,0 +1,38 @@
+import { Component } from "@odoo/owl";
+import { DispatchResult, UID } from "../../../../..";
+import { SpreadsheetChildEnv } from "../../../../../types";
+import {
+  TreeMapChartDefaults,
+  TreeMapChartDefinition,
+  TreeMapColorScaleOptions,
+} from "../../../../../types/chart/tree_map_chart";
+import { RoundColorPicker } from "../../../components/round_color_picker/round_color_picker";
+
+interface Props {
+  figureId: UID;
+  definition: TreeMapChartDefinition;
+  onColorChanged: (colors: TreeMapColorScaleOptions) => DispatchResult;
+}
+
+export class TreeMapColorScale extends Component<Props, SpreadsheetChildEnv> {
+  static template = "o-spreadsheet-TreeMapColorScale";
+  static components = { RoundColorPicker };
+  static props = {
+    figureId: String,
+    definition: Object,
+    onColorChanged: Function,
+  };
+
+  get coloringOptions() {
+    const coloringOptions =
+      this.props.definition.coloringOptions ?? TreeMapChartDefaults.coloringOptions;
+    if (coloringOptions.type !== "colorScale") {
+      throw new Error("Coloring options is not a color scale");
+    }
+    return coloringOptions;
+  }
+
+  setColorScaleColor(point: "minColor" | "midColor" | "maxColor", color: string) {
+    this.props.onColorChanged({ ...this.coloringOptions, [point]: color });
+  }
+}

--- a/src/components/side_panel/chart/treemap_chart/treemap_color_scale/treemap_color_scale.xml
+++ b/src/components/side_panel/chart/treemap_chart/treemap_color_scale/treemap_color_scale.xml
@@ -1,0 +1,27 @@
+<templates>
+  <t t-name="o-spreadsheet-TreeMapColorScale">
+    <div class="o-min-color d-flex align-items-center mb-2 mt-4">
+      <RoundColorPicker
+        currentColor="coloringOptions.minColor"
+        onColorPicked="(color) => this.setColorScaleColor('minColor', color)"
+        disableNoColor="true"
+      />
+      <span class="ps-2">Color of minimum values</span>
+    </div>
+    <div class="o-mid-color d-flex align-items-center mb-2">
+      <RoundColorPicker
+        currentColor="coloringOptions.midColor"
+        onColorPicked="(color) => this.setColorScaleColor('midColor', color)"
+      />
+      <span class="ps-2">Color of middle values</span>
+    </div>
+    <div class="o-max-color d-flex align-items-center">
+      <RoundColorPicker
+        currentColor="coloringOptions.maxColor"
+        onColorPicked="(color) => this.setColorScaleColor('maxColor', color)"
+        disableNoColor="true"
+      />
+      <span class="ps-2">Color of maximum values</span>
+    </div>
+  </t>
+</templates>

--- a/src/helpers/figures/charts/runtime/chart_data_extractor.ts
+++ b/src/helpers/figures/charts/runtime/chart_data_extractor.ts
@@ -38,6 +38,7 @@ import {
   GeoChartRuntimeGenerationArgs,
 } from "../../../../types/chart/geo_chart";
 import { RadarChartDefinition } from "../../../../types/chart/radar_chart";
+import { TreeMapChartDefinition } from "../../../../types/chart/tree_map_chart";
 import { timeFormatLuxonCompatible } from "../../../chart_date";
 import { isDateTimeFormat } from "../../../format/format";
 import { deepCopy, findNextDefinedValue, range } from "../../../misc";
@@ -301,13 +302,13 @@ export function getFunnelChartData(
   };
 }
 
-export function getSunburstChartData(
-  definition: SunburstChartDefinition,
+export function getHierarchalChartData(
+  definition: SunburstChartDefinition | TreeMapChartDefinition,
   dataSets: DataSet[],
   labelRange: Range | undefined,
   getters: Getters
 ): ChartRuntimeGenerationArgs {
-  // In Sunburst, labels are the leaf values (numbers), and the hierarchy is defined in the dataSets (strings)
+  // In hierarchical charts, labels are the leaf values (numbers), and the hierarchy is defined in the dataSets (strings)
   let labels = getChartLabelValues(getters, dataSets, labelRange).values;
   let dataSetsValues = getHierarchicalDatasetValues(getters, dataSets);
   const removeFirstLabel = shouldRemoveFirstLabel(

--- a/src/helpers/figures/charts/runtime/chartjs_tooltip.ts
+++ b/src/helpers/figures/charts/runtime/chartjs_tooltip.ts
@@ -15,6 +15,7 @@ import {
 } from "../../../../types/chart";
 import { GeoChartDefinition } from "../../../../types/chart/geo_chart";
 import { RadarChartDefinition } from "../../../../types/chart/radar_chart";
+import { TreeMapChartDefinition } from "../../../../types/chart/tree_map_chart";
 import { setColorAlpha } from "../../../color";
 import { formatValue } from "../../../format/format";
 import { isNumber } from "../../../numbers";
@@ -258,6 +259,40 @@ export function getSunburstChartTooltip(
       label: function (tooltipItem) {
         const data = tooltipItem.raw as SunburstChartRawData;
         const yLabel = data.value;
+        const toolTipFormat = !format && yLabel >= 1000 ? "#,##" : format;
+        return formatValue(yLabel, { format: toolTipFormat, locale });
+      },
+    },
+  };
+}
+
+export function getTreeMapChartTooltip(
+  definition: TreeMapChartDefinition,
+  args: ChartRuntimeGenerationArgs
+): ChartTooltip {
+  const { locale, axisFormats } = args;
+  const format = axisFormats?.y;
+  return {
+    enabled: false,
+    external: customTooltipHandler,
+    filter: (tooltipItem: any, index: number, tooltipItems: any[]) => {
+      return index === tooltipItems.length - 1;
+    },
+    callbacks: {
+      title: () => "",
+      beforeLabel: (tooltipItem: any) => {
+        const childElement = tooltipItem.raw._data.children[0];
+        if (!childElement) {
+          return "";
+        }
+        const path: string[] = [];
+        for (let i = 0; i <= tooltipItem.raw.l; i++) {
+          path.push(childElement[i]);
+        }
+        return path.join(" / ");
+      },
+      label: (tooltipItem: any) => {
+        const yLabel = tooltipItem.raw.v;
         const toolTipFormat = !format && yLabel >= 1000 ? "#,##" : format;
         return formatValue(yLabel, { format: toolTipFormat, locale });
       },

--- a/src/registries/chart_types.ts
+++ b/src/registries/chart_types.ts
@@ -21,6 +21,7 @@ import {
   SunburstChart,
   createSunburstChartRuntime,
 } from "../helpers/figures/charts/sunburst_chart";
+import { TreeMapChart, createTreeMapChartRuntime } from "../helpers/figures/charts/tree_map_chart";
 import {
   WaterfallChart,
   createWaterfallChartRuntime,
@@ -54,6 +55,7 @@ import { GeoChartDefinition } from "../types/chart/geo_chart";
 import { PyramidChartDefinition } from "../types/chart/pyramid_chart";
 import { RadarChartDefinition } from "../types/chart/radar_chart";
 import { ScatterChartDefinition } from "../types/chart/scatter_chart";
+import { TreeMapChartDefinition } from "../types/chart/tree_map_chart";
 import { WaterfallChartDefinition } from "../types/chart/waterfall_chart";
 import { Validator } from "../types/validator";
 import { Registry } from "./registry";
@@ -219,6 +221,16 @@ chartRegistry.add("sunburst", {
   getChartDefinitionFromContextCreation: SunburstChart.getDefinitionFromContextCreation,
   sequence: 30,
 });
+chartRegistry.add("treemap", {
+  match: (type) => type === "treemap",
+  createChart: (definition, sheetId, getters) =>
+    new TreeMapChart(definition as TreeMapChartDefinition, sheetId, getters),
+  getChartRuntime: createTreeMapChartRuntime,
+  validateChartDefinition: TreeMapChart.validateChartDefinition,
+  transformDefinition: TreeMapChart.transformDefinition,
+  getChartDefinitionFromContextCreation: TreeMapChart.getDefinitionFromContextCreation,
+  sequence: 100,
+});
 
 export const chartComponentRegistry = new Registry<new (...args: any) => Component>();
 chartComponentRegistry.add("line", ChartJsComponent);
@@ -234,6 +246,7 @@ chartComponentRegistry.add("radar", ChartJsComponent);
 chartComponentRegistry.add("geo", ChartJsComponent);
 chartComponentRegistry.add("funnel", ChartJsComponent);
 chartComponentRegistry.add("sunburst", ChartJsComponent);
+chartComponentRegistry.add("treemap", ChartJsComponent);
 
 type ChartUICategory = keyof typeof chartCategories;
 
@@ -243,6 +256,7 @@ export const chartCategories = {
   bar: _t("Bar"),
   area: _t("Area"),
   pie: _t("Pie"),
+  hierarchical: _t("Hierarchical"),
   misc: _t("Miscellaneous"),
 };
 
@@ -440,6 +454,14 @@ chartSubtypeRegistry
     displayName: _t("Sunburst"),
     chartSubtype: "sunburst",
     chartType: "sunburst",
-    category: "misc",
+    category: "hierarchical",
     preview: "o-spreadsheet-ChartPreview.SUNBURST_CHART",
+  })
+  .add("treemap", {
+    matcher: (definition) => definition.type === "treemap",
+    displayName: _t("Tree Map"),
+    chartType: "treemap",
+    chartSubtype: "treemap",
+    category: "hierarchical",
+    preview: "o-spreadsheet-ChartPreview.TREE_MAP_CHART",
   });

--- a/src/types/chart/chart.ts
+++ b/src/types/chart/chart.ts
@@ -14,6 +14,11 @@ import { RadarChartDefinition, RadarChartRuntime } from "./radar_chart";
 import { ScatterChartDefinition, ScatterChartRuntime } from "./scatter_chart";
 import { ScorecardChartDefinition, ScorecardChartRuntime } from "./scorecard_chart";
 import { SunburstChartDefinition, SunburstChartRuntime } from "./sunburst_chart";
+import {
+  TreeMapChartDefinition,
+  TreeMapChartRuntime,
+  TreeMapColoringOptions,
+} from "./tree_map_chart";
 import { WaterfallChartDefinition, WaterfallChartRuntime } from "./waterfall_chart";
 
 export const CHART_TYPES = [
@@ -30,6 +35,7 @@ export const CHART_TYPES = [
   "geo",
   "funnel",
   "sunburst",
+  "treemap",
 ] as const;
 export type ChartType = (typeof CHART_TYPES)[number];
 
@@ -46,7 +52,8 @@ export type ChartDefinition =
   | RadarChartDefinition
   | GeoChartDefinition
   | FunnelChartDefinition
-  | SunburstChartDefinition;
+  | SunburstChartDefinition
+  | TreeMapChartDefinition;
 
 export type ChartWithDataSetDefinition = Extract<
   ChartDefinition,
@@ -69,7 +76,8 @@ export type ChartJSRuntime =
   | RadarChartRuntime
   | GeoChartRuntime
   | FunnelChartRuntime
-  | SunburstChartRuntime;
+  | SunburstChartRuntime
+  | TreeMapChartRuntime;
 
 export type ChartRuntime = ChartJSRuntime | ScorecardChartRuntime | GaugeChartRuntime;
 
@@ -165,8 +173,9 @@ export interface ExcelChartDefinition {
 
 export interface ChartCreationContext {
   readonly range?: CustomizedDataSet[];
+  readonly hierarchicalRanges?: CustomizedDataSet[];
   readonly title?: TitleDesign;
-  readonly background?: string;
+  readonly background?: Color;
   readonly auxiliaryRange?: string;
   readonly aggregated?: boolean;
   readonly stacked?: boolean;
@@ -184,6 +193,9 @@ export interface ChartCreationContext {
   readonly showLabels?: boolean;
   readonly valuesDesign?: ChartStyle;
   readonly groupColors?: (Color | undefined | null)[];
+  readonly showHeaders?: boolean;
+  readonly headerDesign?: TitleDesign;
+  readonly treemapColoringOptions?: TreeMapColoringOptions;
 }
 
 export type ChartAxisFormats = { [axisId: string]: Format | undefined } | undefined;

--- a/src/types/chart/chartjs_tree_map_type.ts
+++ b/src/types/chart/chartjs_tree_map_type.ts
@@ -15,6 +15,7 @@ import {
   ScriptableContext,
   VisualElement,
 } from "chart.js";
+import { TreeMapGroupColor } from "./tree_map_chart";
 
 type AnyObject = Record<string, unknown>;
 
@@ -87,6 +88,9 @@ export interface TreemapControllerDatasetOptions<DType> {
   hidden?: boolean;
 
   displayMode?: "containerBoxes" | "headerBoxes";
+
+  /* Groups and their colors. Not present in original library*/
+  groupColors?: TreeMapGroupColor[];
 }
 
 export interface TreemapDataPoint {

--- a/src/types/chart/chartjs_tree_map_type.ts
+++ b/src/types/chart/chartjs_tree_map_type.ts
@@ -1,0 +1,164 @@
+/*!
+ * chartjs-chart-treemap v3.1.0
+ * https://chartjs-chart-treemap.pages.dev/
+ * (c) 2024 Jukka Kurkela
+ * Released under the MIT license
+ */
+
+import {
+  Color,
+  CoreChartOptions,
+  DatasetController,
+  Element,
+  FontSpec,
+  Scriptable,
+  ScriptableContext,
+  VisualElement,
+} from "chart.js";
+
+type AnyObject = Record<string, unknown>;
+
+type TreemapScriptableContext = ScriptableContext<"treemap"> & {
+  raw: TreemapDataPoint;
+};
+
+type TreemapControllerDatasetCaptionsOptions = {
+  align?: Scriptable<LabelAlign, TreemapScriptableContext>;
+  color?: Scriptable<Color, TreemapScriptableContext>;
+  display?: boolean;
+  formatter?: Scriptable<string, TreemapScriptableContext>;
+  font?: FontSpec;
+  hoverColor?: Scriptable<Color, TreemapScriptableContext>;
+  hoverFont?: FontSpec;
+  padding?: number;
+};
+
+type TreemapControllerDatasetLabelsOptions = {
+  align?: Scriptable<LabelAlign, TreemapScriptableContext>;
+  color?: Scriptable<Color | Color[], TreemapScriptableContext>;
+  display?: boolean;
+  formatter?: Scriptable<string | Array<string>, TreemapScriptableContext>;
+  font?: Scriptable<FontSpec | FontSpec[], TreemapScriptableContext>;
+  hoverColor?: Scriptable<Color | Color[], TreemapScriptableContext>;
+  hoverFont?: Scriptable<FontSpec | FontSpec[], TreemapScriptableContext>;
+  overflow?: Scriptable<LabelOverflow, TreemapScriptableContext>;
+  padding?: number;
+  position?: Scriptable<LabelPosition, TreemapScriptableContext>;
+};
+
+export type LabelPosition = "top" | "middle" | "bottom";
+
+export type LabelAlign = "left" | "center" | "right";
+
+export type LabelOverflow = "cut" | "hidden" | "fit";
+
+type TreemapControllerDatasetDividersOptions = {
+  display?: boolean;
+  lineCapStyle?: string;
+  lineColor?: string;
+  lineDash?: number[];
+  lineDashOffset?: number;
+  lineWidth?: number;
+};
+
+export interface TreemapControllerDatasetOptions<DType> {
+  spacing?: number;
+  rtl?: boolean;
+
+  backgroundColor?: Scriptable<Color, TreemapScriptableContext>;
+  borderColor?: Scriptable<Color, TreemapScriptableContext>;
+  borderWidth?: number;
+
+  hoverBackgroundColor?: Scriptable<Color, TreemapScriptableContext>;
+  hoverBorderColor?: Scriptable<Color, TreemapScriptableContext>;
+  hoverBorderWidth?: number;
+
+  captions?: TreemapControllerDatasetCaptionsOptions;
+  dividers?: TreemapControllerDatasetDividersOptions;
+  labels?: TreemapControllerDatasetLabelsOptions;
+  label?: string;
+
+  data: TreemapDataPoint[]; // This will be auto-generated from `tree`
+  groups?: Array<keyof DType>;
+  sumKeys?: Array<keyof DType>;
+  tree: number[] | DType[] | AnyObject;
+  treeLeafKey?: keyof DType;
+  key?: keyof DType;
+  hidden?: boolean;
+
+  displayMode?: "containerBoxes" | "headerBoxes";
+}
+
+export interface TreemapDataPoint {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  /**
+   * Value
+   */
+  v: number;
+  /**
+   * Sum
+   */
+  s: number;
+  /**
+   * Depth, only available if grouping
+   */
+  l?: number;
+  /**
+   * Group name, only available if grouping
+   */
+  g?: string;
+  /**
+   * Group Sum, only available if grouping
+   */
+  gs?: number;
+  /**
+   * additonal keys sums, only available if grouping
+   */
+  vs?: AnyObject;
+  isLeaf?: boolean;
+}
+
+/*
+  export interface TreemapInteractionOptions {
+    position: Scriptable<"treemap", ScriptableTooltipContext<"treemap">>
+  }*/
+
+declare module "chart.js" {
+  export interface ChartTypeRegistry {
+    treemap: {
+      chartOptions: CoreChartOptions<"treemap">;
+      datasetOptions: TreemapControllerDatasetOptions<Record<string, unknown>>;
+      defaultDataPoint: TreemapDataPoint;
+      metaExtensions: AnyObject;
+      parsedDataType: unknown;
+      scales: never;
+    };
+  }
+
+  // interface TooltipOptions<TType extends ChartType> extends CoreInteractionOptions, TreemapInteractionOptions {
+  // }
+}
+
+export interface TreemapOptions {
+  backgroundColor: Color;
+  borderColor: Color;
+  borderWidth: number | { top?: number; right?: number; bottom?: number; left?: number };
+}
+
+export interface TreemapConfig {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export type TreemapController = DatasetController;
+
+export interface TreemapElement<
+  T extends TreemapConfig = TreemapConfig,
+  O extends TreemapOptions = TreemapOptions
+> extends Element<T, O>,
+    VisualElement {}

--- a/src/types/chart/index.ts
+++ b/src/types/chart/index.ts
@@ -1,5 +1,6 @@
 export * from "./bar_chart";
 export * from "./chart";
+export * from "./chartjs_tree_map_type";
 export * from "./common_chart";
 export * from "./funnel_chart";
 export * from "./gauge_chart";

--- a/src/types/chart/tree_map_chart.ts
+++ b/src/types/chart/tree_map_chart.ts
@@ -1,0 +1,74 @@
+import { ChartConfiguration } from "chart.js";
+import { Color } from "../misc";
+import { CustomizedDataSet, TitleDesign } from "./chart";
+import { TreemapDataPoint } from "./chartjs_tree_map_type";
+import { LegendPosition } from "./common_chart";
+
+export interface TreeMapChartDefinition {
+  readonly type: "treemap";
+  readonly dataSets: CustomizedDataSet[];
+  readonly dataSetsHaveTitle: boolean;
+  readonly labelRange?: string;
+  readonly title: TitleDesign;
+  readonly background?: Color;
+  readonly legendPosition: LegendPosition;
+  readonly showHeaders?: boolean;
+  readonly headerDesign?: TitleDesign;
+  readonly showValues?: boolean;
+  readonly showLabels?: boolean;
+  readonly valuesDesign?: TitleDesign;
+  readonly coloringOptions?: TreeMapColoringOptions;
+}
+
+export type TreeMapCategoryColorOptions = {
+  type: "categoryColor";
+  colors: (Color | undefined | null)[];
+  useValueBasedGradient: boolean;
+};
+
+export type TreeMapColorScaleOptions = {
+  type: "colorScale";
+  minColor: Color;
+  midColor?: Color;
+  maxColor: Color;
+};
+
+export interface TreeMapGroupColor {
+  label: string;
+  color: Color;
+}
+
+export type TreeMapDataset = Record<string, string | number | undefined>[];
+
+export type TreeMapColoringOptions = TreeMapCategoryColorOptions | TreeMapColorScaleOptions;
+
+export type TreeMapChartRuntime = {
+  chartJsConfig: ChartConfiguration;
+  background: Color;
+};
+
+export type TreeMapItem = {
+  raw: TreemapDataPoint;
+};
+
+export const TreeMapChartDefaults = {
+  showHeaders: true,
+  headerDesign: {
+    align: "center",
+    fillColor: "#808080",
+    bold: true,
+    fontSize: 15,
+  } as TitleDesign,
+  showValues: true,
+  showLabels: true,
+  valuesDesign: {
+    align: "left",
+    verticalAlign: "bottom",
+    fontSize: 12,
+  } as TitleDesign,
+  coloringOptions: {
+    type: "categoryColor",
+    colors: [],
+    useValueBasedGradient: true,
+  } as TreeMapCategoryColorOptions,
+};

--- a/tests/figures/chart/geochart/geo_chart_panel_component.test.ts
+++ b/tests/figures/chart/geochart/geo_chart_panel_component.test.ts
@@ -2,14 +2,14 @@ import { Model, SpreadsheetChildEnv, UID } from "../../../../src";
 import { SidePanel } from "../../../../src/components/side_panel/side_panel/side_panel";
 import { GeoChartDefinition } from "../../../../src/types/chart/geo_chart";
 import {
+  changeRoundColorPickerColor,
   createGeoChart,
   getHTMLCheckboxValue,
+  getRoundColorPickerValue,
   setInputValueAndTrigger,
   simulateClick,
 } from "../../../test_helpers";
 import {
-  editColorPicker,
-  getColorPickerValue,
   openChartConfigSidePanel,
   openChartDesignSidePanel,
 } from "../../../test_helpers/chart_helpers";
@@ -94,7 +94,7 @@ describe("Geo chart side panel", () => {
       });
       await openChartDesignSidePanel(model, env, fixture, chartId);
 
-      expect(getColorPickerValue(fixture, ".o-chart-background-color")).toEqual("#000000");
+      expect(getRoundColorPickerValue(".o-chart-background-color")).toEqual("#000000");
       expect(".o-chart-title input").toHaveValue("Title");
       expect(".o-chart-legend-position").toHaveValue("right");
       expect("span[title=Bold]").toHaveClass("active");
@@ -115,9 +115,9 @@ describe("Geo chart side panel", () => {
       await openChartDesignSidePanel(model, env, fixture, chartId);
 
       await setInputValueAndTrigger(".o-color-scale select", "custom");
-      await editColorPicker(fixture, ".o-min-color", "#FF0000");
-      await editColorPicker(fixture, ".o-mid-color", "#00FF00");
-      await editColorPicker(fixture, ".o-max-color", "#0000FF");
+      await changeRoundColorPickerColor(".o-min-color", "#FF0000");
+      await changeRoundColorPickerColor(".o-mid-color", "#00FF00");
+      await changeRoundColorPickerColor(".o-max-color", "#0000FF");
 
       expect(getGeoChartDefinition(chartId)?.colorScale).toMatchObject({
         minColor: "#FF0000",
@@ -130,9 +130,9 @@ describe("Geo chart side panel", () => {
       createGeoChart(model, { missingValueColor: "#f00" });
       await openChartDesignSidePanel(model, env, fixture, chartId);
 
-      await editColorPicker(fixture, ".o-missing-value", "#FF9900");
+      await changeRoundColorPickerColor(".o-missing-value", "#FF9900");
       expect(getGeoChartDefinition(chartId)?.missingValueColor).toEqual("#FF9900");
-      expect(getColorPickerValue(fixture, ".o-missing-value")).toEqual("#FF9900");
+      expect(getRoundColorPickerValue(".o-missing-value")).toEqual("#FF9900");
     });
   });
 });

--- a/tests/figures/chart/pyramid_chart/pyramid_chart_plugin.test.ts
+++ b/tests/figures/chart/pyramid_chart/pyramid_chart_plugin.test.ts
@@ -9,7 +9,7 @@ import { createChart, setCellContent, setFormat } from "../../../test_helpers/co
 
 let model: Model;
 describe("population pyramid chart", () => {
-  test("create bar chart from creation context", () => {
+  test("create pyramid chart from creation context", () => {
     const context: Required<ChartCreationContext> = {
       ...GENERAL_CHART_CREATION_CONTEXT,
       range: [{ dataRange: "Sheet1!B1:B4", yAxisId: "y1" }],

--- a/tests/figures/chart/sunburst/sunburst_chart_plugin.test.ts
+++ b/tests/figures/chart/sunburst/sunburst_chart_plugin.test.ts
@@ -12,6 +12,7 @@ import {
 import { GENERAL_CHART_CREATION_CONTEXT } from "../../../test_helpers/chart_helpers";
 import {
   createSunburstChart,
+  createTreeMapChart,
   setCellContent,
   setFormat,
 } from "../../../test_helpers/commands_helpers";
@@ -85,6 +86,20 @@ describe("Sunburst chart chart", () => {
     expect(chart.getContextCreation()).toMatchObject({
       range: [{ dataRange: "Sheet1!B1:B4" }],
       auxiliaryRange: "A1:A4",
+    });
+  });
+
+  test("Labels and datasets are not swapped from a TreeMap chart creation context", () => {
+    const model = new Model();
+    const chartId = createTreeMapChart(model, {
+      dataSets: [{ dataRange: "A1:A4" }],
+      labelRange: "B1:B4",
+    });
+    const context = model.getters.getChart(chartId)!.getContextCreation();
+    const definition = SunburstChart.getDefinitionFromContextCreation(context);
+    expect(definition).toMatchObject({
+      dataSets: [{ dataRange: "A1:A4" }],
+      labelRange: "B1:B4",
     });
   });
 

--- a/tests/figures/chart/treemap/treemap_chart_plugin.test.ts
+++ b/tests/figures/chart/treemap/treemap_chart_plugin.test.ts
@@ -1,0 +1,434 @@
+import { ChartCreationContext, Model, UID } from "../../../../src";
+import { ColorGenerator, lightenColor } from "../../../../src/helpers";
+import { TreeMapChart } from "../../../../src/helpers/figures/charts/tree_map_chart";
+import { TreeMapChartRuntime } from "../../../../src/types/chart/tree_map_chart";
+import {
+  createSunburstChart,
+  createTreeMapChart,
+  setCellContent,
+  setFormat,
+  updateChart,
+} from "../../../test_helpers";
+import { GENERAL_CHART_CREATION_CONTEXT } from "../../../test_helpers/chart_helpers";
+import { setGrid } from "../../../test_helpers/helpers";
+
+interface TreeMapElementCtx {
+  type: "data";
+  raw: {
+    v: number; // value
+    g: string; // group
+    l: number; // depth
+    _data: { children: Record<string, number | string | undefined>[]; path: string };
+    isLeaf: boolean;
+  };
+}
+
+let model: Model;
+
+function getTreeMapDatasetConfig(chartId: UID) {
+  return (model.getters.getChartRuntime(chartId) as any).chartJsConfig.data.datasets[0];
+}
+
+function getTreeMapConfig(chartId: UID) {
+  return (model.getters.getChartRuntime(chartId) as any).chartJsConfig;
+}
+
+function getTreeMapElement(args: {
+  value?: number;
+  group?: string;
+  depth?: number;
+  path?: string;
+  isLeaf?: boolean;
+}): TreeMapElementCtx {
+  const path = args.path || args.group || "";
+  const child: Record<string, number | string | undefined> = { value: args.value || 0 };
+  path.split(".").forEach((group, index) => (child[index] = group));
+
+  return {
+    type: "data",
+    raw: {
+      v: args.value || 0,
+      g: args.group || path.split(".")[args.depth || 0] || "",
+      l: args.depth || 0,
+      _data: {
+        children: [child],
+        path,
+      },
+      isLeaf: args.isLeaf || false,
+    },
+  };
+}
+
+describe("TreeMap chart", () => {
+  beforeEach(() => {
+    model = new Model();
+  });
+
+  test("Labels and datasets are swapped from the creation context", () => {
+    // In TreeMap, the labels are the values (numbers) and the datasets are the categories (strings). This is the inverse
+    // of the usual chart structure.
+    const context: Required<ChartCreationContext> = {
+      ...GENERAL_CHART_CREATION_CONTEXT,
+      range: [{ dataRange: "Sheet1!B1:B4" }, { dataRange: "Sheet1!C1:C4" }],
+      auxiliaryRange: "Sheet1!A1:A4",
+    };
+    const definition = TreeMapChart.getDefinitionFromContextCreation(context);
+    expect(definition).toMatchObject({
+      dataSets: [{ dataRange: "Sheet1!A1:A4" }],
+      labelRange: "Sheet1!B1:B4",
+    });
+    const chart = new TreeMapChart(definition, "Sheet1", model.getters);
+    expect(chart.getContextCreation()).toMatchObject({
+      range: [{ dataRange: "Sheet1!B1:B4" }],
+      auxiliaryRange: "A1:A4",
+    });
+  });
+
+  test("Labels and datasets are not swapped from a Sunburst chart creation context", () => {
+    const model = new Model();
+    const chartId = createSunburstChart(model, {
+      dataSets: [{ dataRange: "A1:A4" }],
+      labelRange: "B1:B4",
+    });
+    const context = model.getters.getChart(chartId)!.getContextCreation();
+    const definition = TreeMapChart.getDefinitionFromContextCreation(context);
+    expect(definition).toMatchObject({
+      dataSets: [{ dataRange: "A1:A4" }],
+      labelRange: "B1:B4",
+    });
+  });
+
+  test("create TreeMap chart from creation context", () => {
+    const context: Required<ChartCreationContext> = {
+      ...GENERAL_CHART_CREATION_CONTEXT,
+      background: "#123456",
+      title: { text: "hello there" },
+      range: [{ dataRange: "Sheet1!B1:B4", yAxisId: "y1" }],
+      auxiliaryRange: "Sheet1!A1:A4",
+      dataSetsHaveTitle: true,
+      aggregated: true,
+      showValues: false,
+      headerDesign: { bold: false },
+      showHeaders: true,
+      showLabels: false,
+      valuesDesign: { italic: true },
+      treemapColoringOptions: { type: "categoryColor", colors: [], useValueBasedGradient: true },
+    };
+    const definition = TreeMapChart.getDefinitionFromContextCreation(context);
+    expect(definition).toEqual({
+      type: "treemap",
+      background: "#123456",
+      title: { text: "hello there" },
+      dataSets: [{ dataRange: "Sheet1!A1:A4", yAxisId: "y1" }],
+      labelRange: "Sheet1!B1:B4",
+      legendPosition: "bottom",
+      dataSetsHaveTitle: true,
+      showValues: false,
+      headerDesign: { bold: false },
+      showHeaders: true,
+      showLabels: false,
+      valuesDesign: { italic: true },
+      coloringOptions: { type: "categoryColor", colors: [], useValueBasedGradient: true },
+    });
+  });
+
+  test("TreeMap dataset", () => {
+    // prettier-ignore
+    setGrid(model, {
+      A1: "Year", B1: "Quarter", C1: "Sales",
+      A2: "2024", B2: "Q1",      C2: "100",
+      A3: "2024", B3: "Q2",      C3: "200",
+    });
+
+    const chartId = createTreeMapChart(model, {
+      dataSets: [{ dataRange: "A1:A3" }, { dataRange: "B1:B3" }],
+      labelRange: "C1:C3",
+      dataSetsHaveTitle: true,
+    });
+    const datasetConfig = getTreeMapDatasetConfig(chartId);
+    expect(datasetConfig).toMatchObject({
+      tree: [
+        { 0: "2024", 1: "Q1", value: 100 },
+        { 0: "2024", 1: "Q2", value: 200 },
+      ],
+      groups: ["0", "1"],
+      key: "value",
+    });
+  });
+
+  test("Can have a hierarchical dataset with some categories more detailed that others", () => {
+    // prettier-ignore
+    setGrid(model, {
+      A1: "Year", B1: "Quarter", C1: "Sales",
+      A2: "2024", B2: "Q1",      C2: "100",
+      A3: "2024", B3: "Q2",      C3: "200",
+      A4: "2024", B4: "Q3",      C4: "300",
+      A5: "2025", B5: "",        C5: "600",
+    });
+
+    const chartId = createTreeMapChart(model, {
+      dataSets: [{ dataRange: "A1:A5" }, { dataRange: "B1:B5" }],
+      labelRange: "C1:C5",
+      dataSetsHaveTitle: true,
+    });
+    const datasetConfig = getTreeMapDatasetConfig(chartId);
+    expect(datasetConfig).toMatchObject({
+      tree: [
+        { 0: "2024", 1: "Q1", value: 100 },
+        { 0: "2024", 1: "Q2", value: 200 },
+        { 0: "2024", 1: "Q3", value: 300 },
+        { 0: "2025", 1: undefined, value: 600 },
+      ],
+      groups: ["0", "1"],
+      key: "value",
+    });
+  });
+
+  test("Can define TreeMap dataset in a tree-like manner", () => {
+    // prettier-ignore
+    const grid = {
+      A1: "Year", B1: "Quarter", C1: "Week", D1: "Sales",
+      A2: "2024", B2: "Q1",      C2: "W1",   D2: "100",
+                                 C3: "W2",   D3: "200",
+                  B4: "Q2",      C4: "W1",   D4: "300",
+                                 C5: "W2",   D5: "400",
+      A6: "2025", B6: "Q1",      C6: "W1",   D6: "500",
+                                 C7: "W2",   D7: "600",
+    };
+    setGrid(model, grid);
+
+    const chartId = createTreeMapChart(model, {
+      dataSets: [{ dataRange: "A1:A7" }, { dataRange: "B1:B7" }, { dataRange: "C1:C7" }],
+      labelRange: "D1:D7",
+      dataSetsHaveTitle: true,
+    });
+    const datasetConfig = getTreeMapDatasetConfig(chartId);
+    expect(datasetConfig).toMatchObject({
+      tree: [
+        { 0: "2024", 1: "Q1", 2: "W1", value: 100 },
+        { 0: "2024", 1: "Q1", 2: "W2", value: 200 },
+        { 0: "2024", 1: "Q2", 2: "W1", value: 300 },
+        { 0: "2024", 1: "Q2", 2: "W2", value: 400 },
+        { 0: "2025", 1: "Q1", 2: "W1", value: 500 },
+        { 0: "2025", 1: "Q1", 2: "W2", value: 600 },
+      ],
+    });
+  });
+
+  test("Invalid values are filtered out", () => {
+    // prettier-ignore
+    const grid = {
+      A1: "",     B1: "Q1",      C1: "",     D1: "50",         // No root group value
+      A2: "2024", B2: "Q1",      C2: "W1",   D2: "100",
+                  B4: "Q2",      C4: "W1",   D4: "notANumber", // Invalid value
+                                 C5: "W2",   D5: "400",
+      A7: "2025", B7: "Q1",      C7: "W1",   D7: "",           // No data value
+    };
+    setGrid(model, grid);
+
+    const chartId = createTreeMapChart(model, {
+      dataSets: [{ dataRange: "A1:A7" }, { dataRange: "B1:B7" }, { dataRange: "C1:C7" }],
+      labelRange: "D1:D7",
+      dataSetsHaveTitle: false,
+    });
+    const datasetConfig = getTreeMapDatasetConfig(chartId);
+    expect(datasetConfig.tree).toEqual([
+      { 0: "2024", 1: "Q1", 2: "W1", value: 100 },
+      { 0: "2024", 1: "Q2", 2: "W2", value: 400 },
+    ]);
+  });
+
+  test("TreeMap background", () => {
+    setCellContent(model, "A1", "45");
+    const chartId = createTreeMapChart(model, {
+      background: "#123456",
+      dataSets: [{ dataRange: "A1" }],
+    });
+    expect(model.getters.getChartRuntime(chartId)?.background).toEqual("#123456");
+  });
+
+  test("TreeMap header style", () => {
+    setCellContent(model, "A1", "45");
+    const chartId = createTreeMapChart(model, {
+      dataSetsHaveTitle: false,
+      dataSets: [{ dataRange: "A1" }],
+      headerDesign: { bold: false, italic: true, align: "right" },
+    });
+    const datasetConfig = getTreeMapDatasetConfig(chartId);
+    expect(datasetConfig.captions).toMatchObject({
+      display: true,
+      align: "right",
+      font: { weight: "normal" },
+    });
+  });
+
+  test("TreeMap tooltip value", () => {
+    // prettier-ignore
+    const grid = {
+      A1: "Year", B1: "Quarter", C1: "Week", D1: "Sales",
+      A2: "2024", B2: "Q1",      C2: "W1",   D2: "100",
+      A3: "2024", B3: "Q2",      C3: "W2",   D3: "200",
+    };
+    setGrid(model, grid);
+    setFormat(model, "D1:D3", "#,##0[$€]");
+    const chartId = createTreeMapChart(model, {
+      dataSets: [{ dataRange: "A1:A3" }, { dataRange: "B1:B3" }, { dataRange: "C1:C3" }],
+      labelRange: "D1:D3",
+    });
+    const config = getTreeMapConfig(chartId);
+
+    const tooltipBeforeLabel = config.options?.plugins?.tooltip?.callbacks?.beforeLabel;
+    const tooltipLabel = config.options?.plugins?.tooltip?.callbacks?.label;
+    const tooltipTitle = config.options?.plugins?.tooltip?.callbacks?.title;
+
+    const leafItem = getTreeMapElement({ value: 25, depth: 2, path: "2025.Q2.W1", group: "W1" });
+    expect(tooltipTitle([leafItem])).toBe("");
+    expect(tooltipBeforeLabel(leafItem)).toBe("2025 / Q2 / W1");
+    expect(tooltipLabel(leafItem)).toBe("25€");
+
+    const parentItem = getTreeMapElement({ value: 100, depth: 1, group: "Q2", path: "2024.Q2" });
+    expect(tooltipTitle([parentItem])).toBe("");
+    expect(tooltipBeforeLabel(parentItem)).toBe("2024 / Q2");
+    expect(tooltipLabel(parentItem)).toBe("100€");
+  });
+
+  test("TreeMap label & value style", () => {
+    // prettier-ignore
+    setGrid(model, {
+      A1: "Year", B1: "Quarter", C1: "Sales",
+      A2: "2024", B2: "Q1",      C2: "100",
+      A3: "2024", B3: "Q2",      C3: "200",
+    });
+
+    const chartId = createTreeMapChart(model, {
+      dataSets: [{ dataRange: "A1:A2" }, { dataRange: "B1:B2" }],
+      labelRange: "C1:C2",
+      valuesDesign: { bold: true, italic: true, align: "right", color: "#123456" },
+    });
+    let labelConfig = getTreeMapDatasetConfig(chartId).labels as any;
+    expect(labelConfig).toMatchObject({
+      display: true,
+      align: "right",
+      color: "#123456",
+      font: { weight: "bold" },
+    });
+    expect(labelConfig?.formatter?.(getTreeMapElement({ value: 45, group: "Parent" }))).toEqual([
+      "Parent",
+      "45",
+    ]);
+
+    updateChart(model, chartId, { showLabels: false });
+    labelConfig = getTreeMapDatasetConfig(chartId).labels as any;
+    expect(labelConfig?.formatter?.(getTreeMapElement({ value: 45, group: "Parent" }))).toEqual([
+      "45",
+    ]);
+
+    updateChart(model, chartId, { showValues: false });
+    labelConfig = getTreeMapDatasetConfig(chartId).labels as any;
+    expect(labelConfig?.display).toEqual(false);
+  });
+
+  describe("TreeMap background colors", () => {
+    function getBackgroundColorCallback(chartId: UID) {
+      const runtime = model.getters.getChartRuntime(chartId) as TreeMapChartRuntime;
+      return runtime.chartJsConfig.data.datasets[0].backgroundColor as (
+        ctx: TreeMapElementCtx
+      ) => string;
+    }
+
+    test("TreeMap category colors without highlight", () => {
+      // prettier-ignore
+      const grid = {
+            A1: "Year", B1: "Quarter", C1: "Sales",
+            A2: "2023", B2: "Q1",      C2: "20",
+            A3: "2024", B3: "Q2",      C3: "100",
+            A4: "2025", B4: "Q2",      C4: "200",
+      };
+      setGrid(model, grid);
+      const chartId = createTreeMapChart(model, {
+        dataSets: [{ dataRange: "A1:A4" }, { dataRange: "B1:B4" }],
+        labelRange: "C1:C4",
+        coloringOptions: {
+          type: "categoryColor",
+          useValueBasedGradient: false,
+          colors: ["#778899", undefined, "#112233"],
+        },
+      });
+      const getColor = getBackgroundColorCallback(chartId);
+
+      expect(getColor(getTreeMapElement({ depth: 1, path: "2023.Q1", isLeaf: true }))).toEqual(
+        "#112233"
+      );
+      const colorGenerator = new ColorGenerator(3);
+      colorGenerator.next();
+      expect(getColor(getTreeMapElement({ depth: 1, path: "2024.Q2", isLeaf: true }))).toEqual(
+        colorGenerator.next()
+      );
+      expect(getColor(getTreeMapElement({ depth: 1, path: "2025.Q2", isLeaf: true }))).toEqual(
+        "#778899"
+      );
+    });
+
+    test("TreeMap category colors with highlight of bigger values", () => {
+      // prettier-ignore
+      const grid = {
+            A1: "Year", B1: "Quarter", C1: "Sales",
+            A2: "2023", B2: "Q1",      C2: "100",
+            A3: "2023", B3: "Q2",      C3: "200",
+            A4: "2023", B4: "Q3",      C4: "300",
+      };
+      setGrid(model, grid);
+      const chartId = createTreeMapChart(model, {
+        dataSets: [{ dataRange: "A1:A4" }, { dataRange: "B1:B4" }],
+        labelRange: "C1:C4",
+        coloringOptions: {
+          type: "categoryColor",
+          useValueBasedGradient: true,
+          colors: ["#112233"],
+        },
+      });
+      const getColor = getBackgroundColorCallback(chartId);
+
+      expect(
+        getColor(getTreeMapElement({ depth: 1, path: "2023.Q1", value: 100, isLeaf: true }))
+      ).toEqual(lightenColor("#112233", 0.5));
+      expect(
+        getColor(getTreeMapElement({ depth: 1, path: "2023.Q2", value: 200, isLeaf: true }))
+      ).toEqual(lightenColor("#112233", 0.25));
+      expect(
+        getColor(getTreeMapElement({ depth: 1, path: "2023.Q3", value: 300, isLeaf: true }))
+      ).toEqual("#112233");
+    });
+
+    test("TreeMap color scale", () => {
+      // prettier-ignore
+      const grid = {
+            A1: "Year", B1: "Quarter", C1: "Sales",
+            A2: "2024", B2: "Q1",      C2: "100",
+            A3: "2024", B3: "Q2",      C3: "200",
+            A4: "2025", B4: "Q2",      C4: "300",
+      };
+      setGrid(model, grid);
+      const chartId = createTreeMapChart(model, {
+        dataSets: [{ dataRange: "A1:A4" }, { dataRange: "B1:B4" }],
+        labelRange: "C1:C4",
+        coloringOptions: {
+          type: "colorScale",
+          minColor: "#112233",
+          midColor: "#445566",
+          maxColor: "#778899",
+        },
+      });
+      const getColor = getBackgroundColorCallback(chartId);
+      expect(getColor(getTreeMapElement({ value: 100, depth: 1, isLeaf: true }))).toEqual(
+        "#112233"
+      );
+      expect(getColor(getTreeMapElement({ value: 200, depth: 1, isLeaf: true }))).toEqual(
+        "#445566"
+      );
+      expect(getColor(getTreeMapElement({ value: 3000, depth: 1, isLeaf: true }))).toEqual(
+        "#778899"
+      );
+    });
+  });
+});

--- a/tests/figures/chart/treemap/treemap_panel_component.test.ts
+++ b/tests/figures/chart/treemap/treemap_panel_component.test.ts
@@ -1,0 +1,251 @@
+import { Model, SpreadsheetChildEnv, UID } from "../../../../src";
+import { SidePanel } from "../../../../src/components/side_panel/side_panel/side_panel";
+import { ColorGenerator } from "../../../../src/helpers";
+import { TreeMapChartDefinition } from "../../../../src/types/chart/tree_map_chart";
+import {
+  changeColorPickerWidgetColor,
+  changeRoundColorPickerColor,
+  click,
+  createTreeMapChart,
+  getColorPickerWidgetColor,
+  getHTMLCheckboxValue,
+  getHTMLInputValue,
+  getRoundColorPickerValue,
+  setInputValueAndTrigger,
+  simulateClick,
+} from "../../../test_helpers";
+import {
+  openChartConfigSidePanel,
+  openChartDesignSidePanel,
+} from "../../../test_helpers/chart_helpers";
+import { mountComponentWithPortalTarget, setGrid } from "../../../test_helpers/helpers";
+
+let model: Model;
+let fixture: HTMLElement;
+let env: SpreadsheetChildEnv;
+
+function getTreeMapChartDefinition(chartId: UID): TreeMapChartDefinition {
+  return model.getters.getChartDefinition(chartId) as TreeMapChartDefinition;
+}
+
+describe("TreeMap chart side panel", () => {
+  beforeEach(async () => {
+    model = new Model();
+    ({ fixture, env } = await mountComponentWithPortalTarget(SidePanel, { model }));
+  });
+
+  describe("Config panel", () => {
+    test("TreeMap config panel is correctly initialized", async () => {
+      const chartId = createTreeMapChart(model, {
+        dataSets: [{ dataRange: "A1:A3" }],
+        labelRange: "B1:B3",
+        dataSetsHaveTitle: true,
+      });
+      await openChartConfigSidePanel(model, env, chartId);
+
+      expect(getHTMLInputValue(".o-data-series input")).toEqual("A1:A3");
+      expect(getHTMLInputValue(".o-data-labels input")).toEqual("B1:B3");
+      expect(getHTMLCheckboxValue('input[name="dataSetsHaveTitle"]')).toBe(true);
+    });
+
+    test("Can change chart values in config side panel", async () => {
+      const chartId = createTreeMapChart(model, {
+        dataSets: [{ dataRange: "A1:A3" }],
+        labelRange: "B1:B3",
+        dataSetsHaveTitle: true,
+      });
+      await openChartConfigSidePanel(model, env, chartId);
+
+      await setInputValueAndTrigger(".o-data-labels input", "C1:C3");
+      await simulateClick(".o-data-labels .o-selection-ok");
+      expect(getTreeMapChartDefinition(chartId)?.labelRange).toEqual("C1:C3");
+
+      await setInputValueAndTrigger(".o-data-series input", "B1:B3");
+      await simulateClick(".o-data-series .o-selection-ok");
+      expect(getTreeMapChartDefinition(chartId)?.dataSets).toEqual([{ dataRange: "B1:B3" }]);
+
+      await simulateClick('input[name="dataSetsHaveTitle"]');
+      expect(getTreeMapChartDefinition(chartId)?.dataSetsHaveTitle).toEqual(false);
+    });
+  });
+
+  describe("Design panel", () => {
+    test("TreeMap design panel is correctly initialized", async () => {
+      setGrid(model, {
+        A1: "Category",
+        A2: "Category1",
+        A3: "Category2",
+        B1: "Value",
+        B2: "30",
+        B3: "20",
+      });
+      const chartId = createTreeMapChart(model, {
+        dataSets: [{ dataRange: "A1:A3" }],
+        labelRange: "B1:B3",
+        title: { text: "My TreeMap chart" },
+        background: "#00FF00",
+        showHeaders: true,
+        headerDesign: { fillColor: "#0000FF", italic: true },
+        showLabels: false,
+        valuesDesign: { bold: false, color: "#FF0000" },
+        coloringOptions: {
+          type: "categoryColor",
+          colors: ["#FFFFFF"],
+          useValueBasedGradient: true,
+        },
+      });
+      await openChartDesignSidePanel(model, env, fixture, chartId);
+
+      expect(getHTMLInputValue(".o-chart-title input")).toEqual("My TreeMap chart");
+
+      expect(getRoundColorPickerValue(".o-chart-background-color")).toEqual("#00FF00");
+      expect(getColorPickerWidgetColor(".o-header-style", "Fill color")).toEqual("#0000FF");
+      expect(".o-header-style [title=Italic]").toHaveClass("active");
+      expect(".o-header-style [title=Bold]").toHaveClass("active");
+
+      expect(getHTMLCheckboxValue('input[name="showLabels"]')).toBe(false);
+      expect(getColorPickerWidgetColor(".o-values-style", "Text color")).toEqual("#FF0000");
+      expect(".o-values-style [title=Bold]").not.toHaveClass("active");
+
+      const chartColorGenerator = new ColorGenerator(2);
+      expect(getRoundColorPickerValue("[data-id=Category1]")).toEqual("#FFFFFF");
+      chartColorGenerator.next(); // Skip the first color which would have been used for Category1
+      expect(getRoundColorPickerValue("[data-id=Category2]")).toEqual(chartColorGenerator.next());
+    });
+
+    test("Can change headers style", async () => {
+      const chartId = createTreeMapChart(model, {});
+      await openChartDesignSidePanel(model, env, fixture, chartId);
+
+      await simulateClick(".o-header-style [title=Italic]");
+      await changeColorPickerWidgetColor(".o-header-style", "Text color", "#FF0000");
+
+      expect(getTreeMapChartDefinition(chartId)?.headerDesign).toMatchObject({
+        italic: true,
+        color: "#FF0000",
+      });
+
+      await click(fixture, "input[name='showHeaders']");
+      expect(getTreeMapChartDefinition(chartId)?.showHeaders).toBe(false);
+      expect(".o-header-style").toHaveCount(0);
+    });
+
+    test("Can change values style", async () => {
+      const chartId = createTreeMapChart(model, {});
+      await openChartDesignSidePanel(model, env, fixture, chartId);
+
+      await simulateClick(".o-values-style [title=Italic]");
+      await changeColorPickerWidgetColor(".o-values-style", "Text color", "#FF0000");
+      await click(fixture, ".o-values-style .o-menu-item-button[title='Vertical alignment']");
+      await click(fixture, ".o-values-style .o-menu-item-button[title='Top']");
+
+      expect(getTreeMapChartDefinition(chartId)?.valuesDesign).toMatchObject({
+        italic: true,
+        color: "#FF0000",
+        verticalAlign: "top",
+      });
+
+      await click(fixture, "input[name='showValues']");
+      await click(fixture, "input[name='showLabels']");
+      expect(getTreeMapChartDefinition(chartId)?.showValues).toBe(false);
+      expect(getTreeMapChartDefinition(chartId)?.showLabels).toBe(false);
+      expect(".o-values-style").toHaveCount(0);
+    });
+
+    test("Can change categories colors", async () => {
+      setGrid(model, {
+        A1: "Category",
+        A2: "Category1",
+        A3: "Category2",
+        B1: "Value",
+        B2: "30",
+        B3: "20",
+      });
+      const chartId = createTreeMapChart(model, {
+        dataSets: [{ dataRange: "A1:A3" }],
+        labelRange: "B1:B3",
+      });
+      await openChartDesignSidePanel(model, env, fixture, chartId);
+
+      await changeRoundColorPickerColor("[data-id=Category1]", "#000000");
+      expect(getTreeMapChartDefinition(chartId)?.coloringOptions).toMatchObject({
+        colors: ["#000000"],
+      });
+
+      await changeRoundColorPickerColor("[data-id=Category2]", "#FFFFFF");
+      expect(getTreeMapChartDefinition(chartId)?.coloringOptions).toMatchObject({
+        colors: ["#000000", "#FFFFFF"],
+      });
+
+      await changeRoundColorPickerColor("[data-id=Category1]", undefined);
+      expect(getTreeMapChartDefinition(chartId)?.coloringOptions).toMatchObject({
+        colors: [undefined, "#FFFFFF"],
+      });
+    });
+
+    test("Can highlight bigger values", async () => {
+      setGrid(model, { A1: "Category", A2: "Category1", B1: "Value", B3: "20" });
+      const chartId = createTreeMapChart(model, {
+        dataSets: [{ dataRange: "A1:A2" }],
+        labelRange: "B1:B2",
+        coloringOptions: { type: "categoryColor", useValueBasedGradient: false, colors: [] },
+      });
+      await openChartDesignSidePanel(model, env, fixture, chartId);
+
+      await click(fixture, "input[name='useValueBasedGradient']");
+      expect(getTreeMapChartDefinition(chartId)?.coloringOptions).toMatchObject({
+        useValueBasedGradient: true,
+      });
+    });
+
+    test("Can change color scale colors", async () => {
+      const chartId = createTreeMapChart(model, {});
+      await openChartDesignSidePanel(model, env, fixture, chartId);
+      await click(fixture, "button[data-id='colorScale']");
+
+      await changeRoundColorPickerColor(".o-min-color", "#000000");
+      await changeRoundColorPickerColor(".o-mid-color", "#666666");
+      await changeRoundColorPickerColor(".o-max-color", "#FFFFFF");
+
+      expect(getTreeMapChartDefinition(chartId)?.coloringOptions).toMatchObject({
+        type: "colorScale",
+        minColor: "#000000",
+        midColor: "#666666",
+        maxColor: "#FFFFFF",
+      });
+    });
+
+    test("changes are kept when switching back and forth between coloring options types", async () => {
+      setGrid(model, { A2: "Category1", B2: "10" });
+      const chartId = createTreeMapChart(model, {
+        dataSets: [{ dataRange: "A1:A2" }],
+        labelRange: "B1:B2",
+      });
+      await openChartDesignSidePanel(model, env, fixture, chartId);
+
+      await changeRoundColorPickerColor("[data-id=Category1]", "#000000");
+      expect(getTreeMapChartDefinition(chartId)?.coloringOptions).toMatchObject({
+        colors: ["#000000"],
+      });
+
+      await click(fixture, "button[data-id='colorScale']");
+      await changeRoundColorPickerColor(".o-min-color", "#FF0000");
+      expect(getTreeMapChartDefinition(chartId)?.coloringOptions).toMatchObject({
+        type: "colorScale",
+        minColor: "#FF0000",
+      });
+
+      await click(fixture, "button[data-id='categoryColor']");
+      expect(getTreeMapChartDefinition(chartId)?.coloringOptions).toMatchObject({
+        type: "categoryColor",
+        colors: ["#000000"],
+      });
+
+      await click(fixture, "button[data-id='colorScale']");
+      expect(getTreeMapChartDefinition(chartId)?.coloringOptions).toMatchObject({
+        type: "colorScale",
+        minColor: "#FF0000",
+      });
+    });
+  });
+});

--- a/tests/figures/chart/waterfall/waterfall_panel_component.test.ts
+++ b/tests/figures/chart/waterfall/waterfall_panel_component.test.ts
@@ -2,20 +2,17 @@ import { Model, SpreadsheetChildEnv, UID } from "../../../../src";
 import { SidePanel } from "../../../../src/components/side_panel/side_panel/side_panel";
 import { WaterfallChartDefinition } from "../../../../src/types/chart/waterfall_chart";
 import {
+  changeRoundColorPickerColor,
   click,
-  createTable,
   createWaterfallChart,
   getHTMLCheckboxValue,
   getHTMLInputValue,
   getHTMLRadioValue,
+  getRoundColorPickerValue,
   setInputValueAndTrigger,
   simulateClick,
 } from "../../../test_helpers";
-import {
-  editColorPicker,
-  getColorPickerValue,
-  openChartConfigSidePanel,
-} from "../../../test_helpers/chart_helpers";
+import { openChartConfigSidePanel } from "../../../test_helpers/chart_helpers";
 import { mountComponentWithPortalTarget } from "../../../test_helpers/helpers";
 
 let model: Model;
@@ -29,7 +26,6 @@ function getWaterfallDefinition(chartId: UID): WaterfallChartDefinition {
 describe("Waterfall chart side panel", () => {
   beforeEach(async () => {
     model = new Model();
-    createTable(model, "A1:C3");
     ({ fixture, env } = await mountComponentWithPortalTarget(SidePanel, { model }));
   });
 
@@ -98,10 +94,10 @@ describe("Waterfall chart side panel", () => {
       expect(getHTMLCheckboxValue('input[name="showConnectorLines"]')).toBe(true);
       expect(getHTMLCheckboxValue('input[name="firstValueAsSubtotal"]')).toBe(true);
 
-      expect(getColorPickerValue(fixture, ".o-chart-background-color")).toEqual("#00FF00");
-      expect(getColorPickerValue(fixture, ".o-waterfall-positive-color")).toEqual("#0000FF");
-      expect(getColorPickerValue(fixture, ".o-waterfall-negative-color")).toEqual("#FFFF00");
-      expect(getColorPickerValue(fixture, ".o-waterfall-subtotal-color")).toEqual("#FF0000");
+      expect(getRoundColorPickerValue(".o-chart-background-color")).toEqual("#00FF00");
+      expect(getRoundColorPickerValue(".o-waterfall-positive-color")).toEqual("#0000FF");
+      expect(getRoundColorPickerValue(".o-waterfall-negative-color")).toEqual("#FFFF00");
+      expect(getRoundColorPickerValue(".o-waterfall-subtotal-color")).toEqual("#FF0000");
     });
 
     test("Can change basic chart options", async () => {
@@ -143,16 +139,16 @@ describe("Waterfall chart side panel", () => {
       await openChartConfigSidePanel(model, env, chartId);
       await click(fixture, ".o-panel-design");
 
-      await editColorPicker(fixture, ".o-chart-background-color", "#A64D79");
+      await changeRoundColorPickerColor(".o-chart-background-color", "#A64D79");
       expect(getWaterfallDefinition(chartId)?.background).toEqual("#A64D79");
 
-      await editColorPicker(fixture, ".o-waterfall-positive-color", "#BF9000");
+      await changeRoundColorPickerColor(".o-waterfall-positive-color", "#BF9000");
       expect(getWaterfallDefinition(chartId)?.positiveValuesColor).toEqual("#BF9000");
 
-      await editColorPicker(fixture, ".o-waterfall-negative-color", "#FF9900");
+      await changeRoundColorPickerColor(".o-waterfall-negative-color", "#FF9900");
       expect(getWaterfallDefinition(chartId)?.negativeValuesColor).toEqual("#FF9900");
 
-      await editColorPicker(fixture, ".o-waterfall-subtotal-color", "#0C343D");
+      await changeRoundColorPickerColor(".o-waterfall-subtotal-color", "#0C343D");
       expect(getWaterfallDefinition(chartId)?.subTotalValuesColor).toEqual("#0C343D");
     });
   });

--- a/tests/setup/jest.setup.ts
+++ b/tests/setup/jest.setup.ts
@@ -4,6 +4,7 @@
 import { App } from "@odoo/owl";
 import * as Chart from "chart.js";
 import { setDefaultSheetViewSize } from "../../src/constants";
+import "../../src/types/chart/chartjs_tree_map_type";
 import { getCompiledTemplates } from "../../tools/owl_templates/compile_templates.cjs";
 import "./canvas.mock";
 import "./jest_extend";

--- a/tests/test_helpers/chart_helpers.ts
+++ b/tests/test_helpers/chart_helpers.ts
@@ -100,6 +100,7 @@ export const GENERAL_CHART_CREATION_CONTEXT: Required<ChartCreationContext> = {
   background: "#123456",
   title: { text: "hello there" },
   range: [{ dataRange: "Sheet1!B1:B4" }],
+  hierarchicalRanges: [],
   auxiliaryRange: "Sheet1!A1:A4",
   legendPosition: "bottom",
   cumulative: true,
@@ -117,4 +118,7 @@ export const GENERAL_CHART_CREATION_CONTEXT: Required<ChartCreationContext> = {
   showLabels: false,
   valuesDesign: {},
   groupColors: [],
+  headerDesign: { bold: false },
+  treemapColoringOptions: { type: "categoryColor", colors: [], useValueBasedGradient: true },
+  showHeaders: true,
 };

--- a/tests/test_helpers/commands_helpers.ts
+++ b/tests/test_helpers/commands_helpers.ts
@@ -43,6 +43,7 @@ import { GaugeChartDefinition } from "../../src/types/chart/gauge_chart";
 import { GeoChartDefinition } from "../../src/types/chart/geo_chart";
 import { RadarChartDefinition } from "../../src/types/chart/radar_chart";
 import { ScorecardChartDefinition } from "../../src/types/chart/scorecard_chart";
+import { TreeMapChartDefinition } from "../../src/types/chart/tree_map_chart";
 import { WaterfallChartDefinition } from "../../src/types/chart/waterfall_chart";
 import { Image } from "../../src/types/image";
 import { CoreTableType, TableConfig } from "../../src/types/table";
@@ -319,6 +320,12 @@ export function createFunnelChart(model: Model, def?: Partial<FunnelChartDefinit
 export function createSunburstChart(model: Model, def?: Partial<SunburstChartDefinition>): UID {
   createChart(model, { ...def, type: "sunburst" });
   return model.getters.getChartIds(model.getters.getActiveSheetId())[0];
+}
+
+export function createTreeMapChart(model: Model, def?: Partial<TreeMapChartDefinition>): UID {
+  createChart(model, { ...def, type: "treemap" });
+  const sheetId = model.getters.getActiveSheetId();
+  return model.getters.getChartIds(sheetId)[0];
 }
 
 export function createScorecardChart(


### PR DESCRIPTION
### [IMP] charts: add tree map chart

This commits adds the "treemap" chart type to display hierarchical data.

We use the library `https://chartjs-chart-treemap.pages.dev/` that we
patch a bit to have the render that we want.


### [IMP] chart: add functionalities to `TextStyler`

Add the possibility of having a `TextStyler` that:

- has no text input
- can edit vertical algin
- can edit text background color
- made label optional


### [REF] chart: simplify `TextStyler` component

This commit simplifies the `TextStyler` by

- delete all the props `updateColor`, `toggleBold`, ... in favor of a
single callback `updateStyle`
- rename `name` props to `label` to be more explicit
- use `ActionButton` components instead of custom HTML that looks like
an action button


### [MOV] chart: rename `ChartTitle` to `TextStyler`

Rename the `ChartTitle` component to `TextStyler` to make it sounds
more generic and to prepare for the next commits.

Task: [4364295](https://www.odoo.com/odoo/2328/tasks/4364295)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo