### PR TITLE
[IMP] standalone_composer: change active border color

### DIFF
--- a/src/components/composer/standalone_composer/standalone_composer.ts
+++ b/src/components/composer/standalone_composer/standalone_composer.ts
@@ -1,5 +1,5 @@
 import { Component } from "@odoo/owl";
-import { GRAY_300, SELECTION_BORDER_COLOR } from "../../../constants";
+import { ACTION_COLOR, GRAY_300 } from "../../../constants";
 import { Token } from "../../../formulas";
 import { AutoCompleteProviderDefinition } from "../../../registries";
 import { Store, useLocalStore, useStore } from "../../../store_engine";
@@ -21,7 +21,7 @@ css/* scss */ `
       border-color: ${GRAY_300};
 
       &.active {
-        border-color: ${SELECTION_BORDER_COLOR};
+        border-color: ${ACTION_COLOR};
       }
 
       &.o-invalid {


### PR DESCRIPTION
The current bottom border color of the standalone composer is blue when the input is focused.

This commit changes the color to the blue-green color, like every other input

Task: 4380648

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo