### PR TITLE
[FIX] SheetPlugin: Fix handling of unbounded zones

### DIFF
--- a/src/plugins/core/sheet.ts
+++ b/src/plugins/core/sheet.ts
@@ -442,6 +442,9 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
   }
 
   getUnboundedZone(sheetId: UID, zone: Zone | UnboundedZone): UnboundedZone {
+    if (zone.bottom === undefined || zone.right === undefined) {
+      return zone;
+    }
     const isFullRow = zone.left === 0 && zone.right === this.getNumberCols(sheetId) - 1;
     const isFullCol = zone.top === 0 && zone.bottom === this.getNumberRows(sheetId) - 1;
     return {

--- a/tests/sheet/sheets_plugin.test.ts
+++ b/tests/sheet/sheets_plugin.test.ts
@@ -1,5 +1,5 @@
 import { FORBIDDEN_SHEETNAME_CHARS } from "../../src/constants";
-import { getCanonicalSheetName, numberToLetters, toZone } from "../../src/helpers";
+import { getCanonicalSheetName, numberToLetters, toUnboundedZone, toZone } from "../../src/helpers";
 import { Model } from "../../src/model";
 import { CommandResult } from "../../src/types";
 import {
@@ -1075,4 +1075,14 @@ describe("sheets", () => {
     const zone = toZone("A1:J1");
     expect(model.getters.getUnboundedZone(sheetId, zone)).toEqual({ ...zone, right: undefined });
   });
+
+  test.each<string>(["A1:Z", "A2:Z", "B2:26", "B1:26", "A:A", "A:A3"])(
+    "GetUnboundedZone : Unbounded range '%s' is unaffected",
+    (xc) => {
+      const model = new Model();
+      const sheetId = model.getters.getActiveSheetId();
+      const zone = toUnboundedZone(xc);
+      expect(model.getters.getUnboundedZone(sheetId, zone)).toEqual(zone);
+    }
+  );
 });


### PR DESCRIPTION
The getter `getUnboundedZone` did not properly support unbounded zones as arguments.

Task: 4397745

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo