### PR TITLE
[FIX] pivot: ensure correct format status in menu

### DIFF
--- a/src/actions/format_actions.ts
+++ b/src/actions/format_actions.ts
@@ -396,13 +396,21 @@ function fontSizeMenuBuilder(): ActionSpec[] {
 }
 
 function isAutomaticFormatSelected(env: SpreadsheetChildEnv): boolean {
-  const activeCell = env.model.getters.getCell(env.model.getters.getActivePosition());
-  return !activeCell || !activeCell.format;
+  const activePosition = env.model.getters.getActivePosition();
+  const pivotCell = env.model.getters.getPivotCellFromPosition(activePosition);
+  if (pivotCell.type === "VALUE") {
+    return !env.model.getters.getEvaluatedCell(activePosition).format;
+  }
+  return !env.model.getters.getCell(activePosition)?.format;
 }
 
 function isFormatSelected(env: SpreadsheetChildEnv, format: string): boolean {
-  const activeCell = env.model.getters.getCell(env.model.getters.getActivePosition());
-  return activeCell?.format === format;
+  const activePosition = env.model.getters.getActivePosition();
+  const pivotCell = env.model.getters.getPivotCellFromPosition(activePosition);
+  if (pivotCell.type === "VALUE") {
+    return env.model.getters.getEvaluatedCell(activePosition).format === format;
+  }
+  return env.model.getters.getCell(activePosition)?.format === format;
 }
 
 function isFontSizeSelected(env: SpreadsheetChildEnv, fontSize: number): boolean {

--- a/tests/formats/formatting_plugin.test.ts
+++ b/tests/formats/formatting_plugin.test.ts
@@ -31,7 +31,7 @@ import {
   getEvaluatedCell,
   getEvaluatedGrid,
 } from "../test_helpers/getters_helpers";
-import { createModelFromGrid, target } from "../test_helpers/helpers";
+import { createModelFromGrid, getNode, makeTestEnv, target } from "../test_helpers/helpers";
 import { addPivot } from "../test_helpers/pivot_helpers";
 
 function setDecimal(model: Model, targetXc: string, step: SetDecimalStep) {
@@ -386,6 +386,24 @@ describe("pivot contextual formatting", () => {
     setContextualFormat(model, "C1", "[$$]#,##0.00");
     expect(model.getters.getPivotCoreDefinition("1")?.measures[0].format).toBeUndefined();
     expect(getCell(model, "C1")?.format).toBe("[$$]#,##0.00");
+  });
+
+  test("topbar menu correctly indicates the format of the selected pivot cell", () => {
+    const env = makeTestEnv();
+    const { model } = env;
+
+    setCellContent(model, "A1", "Price");
+    setCellContent(model, "A2", "10");
+    setCellContent(model, "B1", "=PIVOT(1)");
+
+    addPivot(model, "A1:A2", {
+      measures: [{ id: "Price", fieldName: "Price", aggregator: "sum" }],
+    });
+    setContextualFormat(model, "C3", "[$$]#,##0.00");
+    selectCell(model, "C3");
+
+    const action = getNode(["format", "format_number", "format_number_currency"], env);
+    expect(action.isActive?.(env)).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Description:

Since PR #4657, users can define a custom format for pivot measures by selecting a cell with a measure value and applying a format.

However, the format menu's tick status incorrectly displayed "Automatic" even after applying a custom format. This was caused by the getCell method fetching the cell format, which does not account for pivot measure-specific formats.

This fix ensures the format menu reflects the correct status by properly handling pivot cell measure formats.

Task: [4373606](https://www.odoo.com/odoo/2328/tasks/4373606)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo