### PR TITLE
[FIX] cell: keep non-breaking spaces

### DIFF
--- a/src/formulas/tokenizer.ts
+++ b/src/formulas/tokenizer.ts
@@ -199,14 +199,13 @@ function tokenizeSymbol(chars: string[]): Token | null {
 const whiteSpaceRegexp = /\s/;
 
 function tokenizeSpace(chars: string[]): Token | null {
-  let length = 0;
+  let spaces = "";
   while (chars[0] && chars[0].match(whiteSpaceRegexp)) {
-    length++;
-    chars.shift();
+    spaces += chars.shift();
   }
 
-  if (length) {
-    return { type: "SPACE", value: " ".repeat(length) };
+  if (spaces) {
+    return { type: "SPACE", value: spaces };
   }
   return null;
 }

--- a/src/plugins/core/cell.ts
+++ b/src/plugins/core/cell.ts
@@ -34,8 +34,6 @@ import {
 } from "../../types/index";
 import { CorePlugin } from "../core_plugin";
 
-const nbspRegexp = new RegExp(String.fromCharCode(160), "g");
-
 const LINK_STYLE = { textColor: LINK_COLOR };
 
 interface CoreState {
@@ -452,9 +450,7 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
     const hasContent = "content" in after || "formula" in after;
 
     // Compute the new cell properties
-    const afterContent = hasContent
-      ? after.content?.replace(nbspRegexp, "") || ""
-      : before?.content || "";
+    const afterContent = (hasContent ? after.content : before?.content) || "";
     let style: Style | undefined;
     if (after.style !== undefined) {
       style = after.style || undefined;

--- a/tests/formulas/tokenizer.test.ts
+++ b/tests/formulas/tokenizer.test.ts
@@ -253,4 +253,8 @@ describe("tokenizer", () => {
       { type: "NUMBER", value: "4" },
     ]);
   });
+
+  test("Space characters", () => {
+    expect(tokenize(" \u00A0 \u00A0")).toEqual([{ type: "SPACE", value: " \u00A0 \u00A0" }]);
+  });
 });

--- a/tests/plugins/cell.test.ts
+++ b/tests/plugins/cell.test.ts
@@ -189,6 +189,12 @@ describe("getCellText", () => {
     setCellContent(model, "A1", '="hello \\"world\\""');
     expect(getCell(model, "A1")?.formattedValue).toBe('hello "world"');
   });
+
+  test("Non breaking spaces are kept on cell insertion", () => {
+    const model = new Model();
+    setCellContent(model, "A1", "hello\u00A0world");
+    expect(getCellText(model, "A1")).toBe("hello\u00A0world");
+  });
 });
 
 describe("link cell", () => {


### PR DESCRIPTION
## Description

The non-breaking spaces were removed when updating a cell. This caused issues is odoo pivots, since the formula contained a group name with the non-breaking space removed, but the data was still using the non-breaking space.

Task: [4403607](https://www.odoo.com/odoo/2328/tasks/4403607)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo