### PR TITLE
[FIX] sheet view: DELETE_SHEET in initial revisions

### DIFF
--- a/src/plugins/ui/sheetview.ts
+++ b/src/plugins/ui/sheetview.ts
@@ -202,6 +202,7 @@ export class SheetViewPlugin extends UIPlugin {
         break;
       case "DELETE_SHEET":
         this.cleanViewports();
+        this.sheetsWithDirtyViewports.delete(cmd.sheetId);
         break;
       case "ACTIVATE_SHEET":
         this.setViewports();
@@ -611,6 +612,9 @@ export class SheetViewPlugin extends UIPlugin {
   }
 
   private resetViewports(sheetId: UID) {
+    if (!this.getters.tryGetSheet(sheetId)) {
+      return;
+    }
     const { xSplit, ySplit } = this.getters.getPaneDivisions(sheetId);
     const nCols = this.getters.getNumberCols(sheetId);
     const nRows = this.getters.getNumberRows(sheetId);

--- a/tests/plugins/sheetview.test.ts
+++ b/tests/plugins/sheetview.test.ts
@@ -2,12 +2,15 @@ import { CommandResult } from "../../src";
 import {
   DEFAULT_CELL_HEIGHT,
   DEFAULT_CELL_WIDTH,
+  DEFAULT_REVISION_ID,
   DEFAULT_SHEETVIEW_SIZE,
+  MESSAGE_VERSION,
 } from "../../src/constants";
 import { isDefined, numberToLetters, range, toXC, toZone, zoneToXc } from "../../src/helpers";
 import { Model } from "../../src/model";
 import { SheetViewPlugin } from "../../src/plugins/ui/sheetview";
 import { Zone } from "../../src/types";
+import { StateUpdateMessage } from "../../src/types/collaborative/transport_service";
 import {
   activateSheet,
   addColumns,
@@ -908,6 +911,25 @@ describe("Viewport of Simple sheet", () => {
       width: 3.5 * DEFAULT_CELL_WIDTH,
       height: 4.5 * DEFAULT_CELL_HEIGHT,
     });
+  });
+
+  test("Loading a model with initial revisions in sheet that is deleted doesn't crash", () => {
+    const initialMessages: StateUpdateMessage[] = [
+      {
+        type: "REMOTE_REVISION",
+        serverRevisionId: DEFAULT_REVISION_ID,
+        nextRevisionId: "1",
+        version: MESSAGE_VERSION,
+        clientId: "bob",
+        commands: [
+          { type: "CREATE_SHEET", position: 1, sheetId: "newSheetId" },
+          { type: "UPDATE_CELL", sheetId: "newSheetId", col: 0, row: 0, content: "1" },
+          { type: "DELETE_SHEET", sheetId: "newSheetId" },
+        ],
+      },
+    ];
+
+    expect(() => new Model({}, {}, initialMessages)).not.toThrow();
   });
 });
 


### PR DESCRIPTION
## Description

If a revision contains a `UPDATE_CELL`, the sheet is added to the `sheetsWithDirtyViewports` set. But the sheet isn't when deleting the sheet. So if the initial revisions a sheet is updated then deleted, we'll try to update its viewport in the `finalize` and crash.

Task: [4405573](https://www.odoo.com/odoo/2328/tasks/4405573)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo