### PR TITLE
[FIX] custom currency: panel on very long currency code

### DIFF
--- a/src/components/side_panel/custom_currency/custom_currency.ts
+++ b/src/components/side_panel/custom_currency/custom_currency.ts
@@ -26,6 +26,10 @@ css/* scss */ `
       border: 1px solid #d8dadd;
       color: #374151;
     }
+
+    table {
+      table-layout: fixed;
+    }
   }
 `;
 

--- a/src/components/side_panel/custom_currency/custom_currency.xml
+++ b/src/components/side_panel/custom_currency/custom_currency.xml
@@ -59,11 +59,11 @@
           onChange.bind="toggleAccountingFormat"
         />
         <div class="o-format-examples mt-4" t-if="selectedFormat">
-          <table>
+          <table class="w-100">
             <t t-foreach="getFormatExamples()" t-as="example" t-key="example_index">
               <tr>
-                <td class="pe-3 o-fw-bold" t-esc="example.label"/>
-                <td t-esc="example.value"/>
+                <td class="w-25 pe-3 o-fw-bold" t-esc="example.label"/>
+                <td class="w-75 text-truncate" t-esc="example.value"/>
               </tr>
             </t>
           </table>


### PR DESCRIPTION
## Description

The custom currency panel was not displaying correctly when the
 currency code was very long. This commit fixes the CSS.

Task: [4402647](https://www.odoo.com/odoo/2328/tasks/4402647)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo