### PR TITLE
[FIX] bottom_bar: ensure active sheet is scrolled into view

### DIFF
--- a/src/components/bottom_bar_sheet/bottom_bar_sheet.ts
+++ b/src/components/bottom_bar_sheet/bottom_bar_sheet.ts
@@ -1,4 +1,4 @@
-import { Component, onMounted, onPatched, useRef, useState } from "@odoo/owl";
+import { Component, onPatched, useEffect, useRef, useState } from "@odoo/owl";
 import { BOTTOMBAR_HEIGHT } from "../../constants";
 import { interactiveRenameSheet } from "../../helpers/ui/sheet_interactive";
 import { getSheetMenuRegistry } from "../../registries";
@@ -76,17 +76,21 @@ export class BottomBarSheet extends Component<Props, SpreadsheetChildEnv> {
   private editionState: "initializing" | "editing" = "initializing";
 
   setup() {
-    onMounted(() => {
-      if (this.isSheetActive) {
-        this.scrollToSheet();
-      }
-    });
     onPatched(() => {
       if (this.sheetNameRef.el && this.state.isEditing && this.editionState === "initializing") {
         this.editionState = "editing";
         this.focusInputAndSelectContent();
       }
     });
+
+    useEffect(
+      (sheetId) => {
+        if (this.props.sheetId === sheetId) {
+          this.scrollToSheet();
+        }
+      },
+      () => [this.env.model.getters.getActiveSheetId()]
+    );
   }
 
   private focusInputAndSelectContent() {
@@ -105,7 +109,10 @@ export class BottomBarSheet extends Component<Props, SpreadsheetChildEnv> {
   }
 
   private scrollToSheet() {
-    this.sheetDivRef.el?.scrollIntoView?.();
+    this.sheetDivRef.el?.scrollIntoView?.({
+      behavior: "smooth",
+      inline: "nearest",
+    });
   }
 
   onFocusOut() {

--- a/tests/bottom_bar/bottom_bar_component.test.ts
+++ b/tests/bottom_bar/bottom_bar_component.test.ts
@@ -604,6 +604,23 @@ describe("BottomBar component", () => {
       simulateClick(".o-bottom-bar-arrow-left");
       expect(scrollTo).toBe(200);
     });
+
+    test("Selecting a sheet from the context menu scrolls to that sheet", async () => {
+      const mockScrollIntoView = jest.fn();
+      HTMLElement.prototype.scrollIntoView = mockScrollIntoView;
+
+      expect(model.getters.getActiveSheetId()).toBe("Sheet1");
+
+      await click(fixture, ".o-list-sheets");
+      await click(fixture, ".o-menu-item[data-name='Sheet6']");
+
+      expect(model.getters.getActiveSheetId()).toBe("Sheet6");
+
+      const sheet6Element = fixture.querySelector(".o-sheet[data-id='Sheet6']");
+      expect(mockScrollIntoView).toHaveBeenCalledWith({ behavior: "smooth", inline: "nearest" });
+      expect(mockScrollIntoView).toHaveBeenCalledTimes(1);
+      expect(mockScrollIntoView.mock.instances[0]).toBe(sheet6Element);
+    });
   });
 
   test("Display the statistic button only if no-empty cells are selected", async () => {


### PR DESCRIPTION
## Description:

Previously, selecting a sheet from the menu did not scroll the bottom bar's sheet list to bring the active sheet into view if it was outside the visible area. This commit resolves the issue by automatically scrolling the sheet list to ensure the active sheet is visible.

Task: [4377840](https://www.odoo.com/odoo/2328/tasks/4377840)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo