### PR TITLE
[FIX] spreadsheet: avoid parasitic renders

### DIFF
--- a/src/collaborative/session.ts
+++ b/src/collaborative/session.ts
@@ -319,6 +319,9 @@ export class Session extends EventBus<CollaborativeEvent> {
       }
     }
     this.acknowledge(message);
+    if (message.type === "REMOTE_REVISION" && message.clientId === this.clientId) {
+      return;
+    }
     this.trigger("collaborative-event-received");
   }
 

--- a/src/components/bottom_bar_sheet/bottom_bar_sheet.ts
+++ b/src/components/bottom_bar_sheet/bottom_bar_sheet.ts
@@ -150,11 +150,11 @@ export class BottomBarSheet extends Component<Props, SpreadsheetChildEnv> {
     if (ev.key === "Enter") {
       ev.preventDefault();
       this.stopEdition();
-      this.DOMFocusableElementStore.focus();
+      this.DOMFocusableElementStore.focusableElement?.focus();
     }
     if (ev.key === "Escape") {
       this.cancelEdition();
-      this.DOMFocusableElementStore.focus();
+      this.DOMFocusableElementStore.focusableElement?.focus();
     }
   }
 

--- a/src/components/composer/grid_composer/grid_composer.ts
+++ b/src/components/composer/grid_composer/grid_composer.ts
@@ -182,7 +182,7 @@ export class GridComposer extends Component<Props, SpreadsheetChildEnv> {
       this.isEditing = isEditing;
       if (!isEditing) {
         this.rect = this.defaultRect;
-        this.DOMFocusableElementStore.focus();
+        this.DOMFocusableElementStore.focusableElement?.focus();
         return;
       }
       const position = this.env.model.getters.getActivePosition();

--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -176,7 +176,7 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
     useEffect(
       () => {
         if (!this.sidePanel.isOpen) {
-          this.DOMFocusableElementStore.focus();
+          this.DOMFocusableElementStore.focusableElement?.focus();
         }
       },
       () => [this.sidePanel.isOpen]
@@ -400,7 +400,7 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
       !this.env.model.getters.getSelectedFigureId() &&
       this.composerStore.editionMode === "inactive"
     ) {
-      this.DOMFocusableElementStore.focus();
+      this.DOMFocusableElementStore.focusableElement?.focus();
     }
   }
 

--- a/src/stores/DOM_focus_store.ts
+++ b/src/stores/DOM_focus_store.ts
@@ -1,12 +1,8 @@
 export class DOMFocusableElementStore {
-  mutators = ["setFocusableElement", "focus"] as const;
-  private focusableElement: HTMLElement | undefined = undefined;
+  mutators = ["setFocusableElement"] as const;
+  focusableElement: HTMLElement | undefined = undefined;
 
   setFocusableElement(element: HTMLElement) {
     this.focusableElement = element;
-  }
-
-  focus() {
-    this.focusableElement?.focus();
   }
 }

--- a/tests/bottom_bar/bottom_bar_component.test.ts
+++ b/tests/bottom_bar/bottom_bar_component.test.ts
@@ -366,14 +366,20 @@ describe("BottomBar component", () => {
     test.each(["Enter", "Escape"])(
       "Pressing %s ends the edition and yields back the DOM focus",
       async (key) => {
+        const focusElement = jest.fn();
+        const focusableElementStore = env.getStore(DOMFocusableElementStore);
+        const defaultFocusElement = document.createElement("div");
+        defaultFocusElement.focus = focusElement;
+        focusableElementStore.setFocusableElement(defaultFocusElement);
+
         const sheetName = fixture.querySelector<HTMLElement>(".o-sheet-name")!;
         // will give focus back to the component main node
         triggerMouseEvent(sheetName, "dblclick");
         await nextTick();
         sheetName.textContent = "New name";
+        expect(focusElement).not.toHaveBeenCalled();
         await keyDown({ key });
-        const focusableElementStore = env.getStore(DOMFocusableElementStore);
-        expect(focusableElementStore.focus).toHaveBeenCalled();
+        expect(focusElement).toHaveBeenCalled();
       }
     );
   });


### PR DESCRIPTION
## Description

Clicking on a button on the topbar would trigger 3 renders:
- one on model update (expected)
- one because we received a collaborative event for our own revision (useless)
- one because the onClick of the topbar calls `DOMFocusableElementStore.focus`, which triggers a render because a store method was called (useless)

Task: [4373054](https://www.odoo.com/odoo/2328/tasks/4373054)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo