### PR TITLE
[FIX] charts: disable waterfall legend onClick

### DIFF
--- a/src/helpers/figures/charts/runtime/chartjs_legend.ts
+++ b/src/helpers/figures/charts/runtime/chartjs_legend.ts
@@ -160,6 +160,7 @@ export function getWaterfallChartLegend(
         return legendValues;
       },
     },
+    onClick: () => {}, // Disables click interaction with the waterfall chart legend items
   };
 }
 


### PR DESCRIPTION
## Description:

The onClick handler for the waterfall chart legend was explicitly set to `undefined` to prevent interactions with legend items. This was done to disable the default Chart.js behavior that toggles the visibility of chart series when a legend item is clicked.

Task: [4413802](https://www.odoo.com/odoo/2328/tasks/4413802)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo