### PR TITLE
[FIX] session: useless snapshot on leave

### DIFF
--- a/src/types/collaborative/transport_service.ts
+++ b/src/types/collaborative/transport_service.ts
@@ -59,7 +59,7 @@ interface SnapshotMessage extends AbstractMessage {
  * Notify all clients that the server has a new snapshot of the
  * spreadsheet and that the previous history may be lost.
  */
-interface SnapshotCreatedMessage extends AbstractMessage {
+export interface SnapshotCreatedMessage extends AbstractMessage {
   type: "SNAPSHOT_CREATED";
   serverRevisionId: UID;
   nextRevisionId: UID;


### PR DESCRIPTION
## Description

Since 18.0, we snapshot when the user leave the sessions. But we also snapshotted if there was no revisions since the last snapshot.

Task: [4356913](https://www.odoo.com/odoo/2328/tasks/4356913)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo