### PR TITLE
[FIX] charts: translate gauge chart titles

### DIFF
--- a/src/helpers/figures/charts/gauge_chart.ts
+++ b/src/helpers/figures/charts/gauge_chart.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_GAUGE_UPPER_COLOR,
 } from "../../../constants";
 import { BasePlugin } from "../../../plugins/base_plugin";
+import { _t } from "../../../translation";
 import {
   AddColumnsRowsCommand,
   ApplyRangeChange,
@@ -317,7 +318,7 @@ export function createGaugeChartRuntime(chart: GaugeChart, getters: Getters): Ga
 
   return {
     background: getters.getStyleOfSingleCellChart(chart.background, dataRange).background,
-    title: chart.title,
+    title: _t(chart.title),
     minValue: {
       value: minValue,
       label: formatValue(minValue, { locale, format }),


### PR DESCRIPTION
## Description:

Currently the demo dashboards in Odoo have their gauge chart titles not translated, although they are exported for translation in the .pot file.

In this commit we make them go through the `_t()` function, just like the titles of the scorecard charts.

Task: [4421055](https://www.odoo.com/odoo/project.task/4421055)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo