### PR TITLE
[FIX] popover: wrong position on updated popover

### DIFF
--- a/src/components/popover/popover.ts
+++ b/src/components/popover/popover.ts
@@ -81,6 +81,10 @@ export class Popover extends Component<PopoverProps, SpreadsheetChildEnv> {
       this.currentDisplayValue = newDisplay;
 
       if (!anchor) return;
+      el.style.top = "";
+      el.style.left = "";
+      el.style["max-height"] = "";
+      el.style["max-width"] = "";
 
       const propsMaxSize = { width: this.props.maxWidth, height: this.props.maxHeight };
       let elDims = {


### PR DESCRIPTION
## Description

If a popover has a change of props, we don't clean its style before computing its new height/width, leading to a wrong position sometimes.

Task: [3814260](https://www.odoo.com/odoo/2328/tasks/3814260)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo