### PR TITLE
[IMP] data: bump version to 25

### DIFF
--- a/src/migrations/data.ts
+++ b/src/migrations/data.ts
@@ -19,7 +19,7 @@ import { migrationStepRegistry } from "./migration_steps";
  * a breaking change is made in the way the state is handled, and an upgrade
  * function should be defined
  */
-export const CURRENT_VERSION = 24;
+export const CURRENT_VERSION = 25;
 const INITIAL_SHEET_ID = "Sheet1";
 
 /**

--- a/src/migrations/migration_steps.ts
+++ b/src/migrations/migration_steps.ts
@@ -446,6 +446,13 @@ migrationStepRegistry
       }
       return data;
     },
+  })
+  .add("migration_24", {
+    // Empty migration to allow odoo migrate pivot custom sorting.
+    versionFrom: "24",
+    migrate(data: WorkbookData): any {
+      return data;
+    },
   });
 
 function fixOverlappingFilters(data: any): any {


### PR DESCRIPTION
The purpose of this commit is only to allow migration defined in odoo to be executed. This is not ideal but it is the only way to make it work with the current setup.

Ideally, the migration version should be bumped automatically when the freeze is done, but this part should be discussed.

See https://github.com/odoo/odoo/pull/191109/commits/80a18fa7fe870bad15f6a05abf3751d980b2f999#diff-96d495629fafbb1f70eb713faca6ec7b2c8416b4addb1fc53b798c1d8ab9fa42

Task: 0

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo