### PR TITLE
[REF] charts: rename copyForSheetId method

### DIFF
--- a/src/helpers/figures/charts/abstract_chart.ts
+++ b/src/helpers/figures/charts/abstract_chart.ts
@@ -78,10 +78,10 @@ export abstract class AbstractChart {
   abstract updateRanges(applyChange: ApplyRangeChange): AbstractChart;
 
   /**
-   * Get a copy a the chart adapted to the given sheetId.
-   * The ranges that are in the same sheet as the chart will be adapted to the given sheetId.
+   * Duplicate the chart when a sheet is duplicated.
+   * The ranges that are in the same sheet as the chart are adapted to the new sheetId.
    */
-  abstract copyForSheetId(sheetId: UID): AbstractChart;
+  abstract duplicateInDuplicatedSheet(newSheetId: UID): AbstractChart;
 
   /**
    * Get a copy a the chart in the given sheetId.

--- a/src/helpers/figures/charts/bar_chart.ts
+++ b/src/helpers/figures/charts/bar_chart.ts
@@ -31,9 +31,9 @@ import {
   chartFontColor,
   checkDataset,
   checkLabelRange,
-  copyDataSetsWithNewSheetId,
-  copyLabelRangeWithNewSheetId,
   createDataSets,
+  duplicateDataSetsInDuplicatedSheet,
+  duplicateLabelRangeInDuplicatedSheet,
   getDefinedAxis,
   shouldRemoveFirstLabel,
   toExcelDataset,
@@ -134,11 +134,15 @@ export class BarChart extends AbstractChart {
     };
   }
 
-  copyForSheetId(sheetId: UID): BarChart {
-    const dataSets = copyDataSetsWithNewSheetId(this.sheetId, sheetId, this.dataSets);
-    const labelRange = copyLabelRangeWithNewSheetId(this.sheetId, sheetId, this.labelRange);
-    const definition = this.getDefinitionWithSpecificDataSets(dataSets, labelRange, sheetId);
-    return new BarChart(definition, sheetId, this.getters);
+  duplicateInDuplicatedSheet(newSheetId: UID): BarChart {
+    const dataSets = duplicateDataSetsInDuplicatedSheet(this.sheetId, newSheetId, this.dataSets);
+    const labelRange = duplicateLabelRangeInDuplicatedSheet(
+      this.sheetId,
+      newSheetId,
+      this.labelRange
+    );
+    const definition = this.getDefinitionWithSpecificDataSets(dataSets, labelRange, newSheetId);
+    return new BarChart(definition, newSheetId, this.getters);
   }
 
   copyInSheetId(sheetId: UID): BarChart {

--- a/src/helpers/figures/charts/chart_common.ts
+++ b/src/helpers/figures/charts/chart_common.ts
@@ -30,7 +30,7 @@ import { CellErrorType } from "../../../types/errors";
 import { ColorGenerator, relativeLuminance } from "../../color";
 import { formatValue } from "../../format/format";
 import { isDefined, largeMax } from "../../misc";
-import { copyRangeWithNewSheetId } from "../../range";
+import { duplicateRangeInDuplicatedSheet } from "../../range";
 import { rangeReference } from "../../references";
 import { getZoneArea, isFullRow, toUnboundedZone, zoneToDimension, zoneToXc } from "../../zones";
 
@@ -95,34 +95,34 @@ export function updateChartRangesWithDataSets(
 }
 
 /**
- * Copy the dataSets given. All the ranges which are on sheetIdFrom will target
+ * Duplicate the dataSets. All ranges on sheetIdFrom are adapted to target
  * sheetIdTo.
  */
-export function copyDataSetsWithNewSheetId(
+export function duplicateDataSetsInDuplicatedSheet(
   sheetIdFrom: UID,
   sheetIdTo: UID,
   dataSets: DataSet[]
 ): DataSet[] {
   return dataSets.map((ds) => {
     return {
-      dataRange: copyRangeWithNewSheetId(sheetIdFrom, sheetIdTo, ds.dataRange),
+      dataRange: duplicateRangeInDuplicatedSheet(sheetIdFrom, sheetIdTo, ds.dataRange),
       labelCell: ds.labelCell
-        ? copyRangeWithNewSheetId(sheetIdFrom, sheetIdTo, ds.labelCell)
+        ? duplicateRangeInDuplicatedSheet(sheetIdFrom, sheetIdTo, ds.labelCell)
         : undefined,
     };
   });
 }
 
 /**
- * Copy a range. If the range is on the sheetIdFrom, the range will target
+ * Duplicate a range. If the range is on the sheetIdFrom, the range will target
  * sheetIdTo.
  */
-export function copyLabelRangeWithNewSheetId(
+export function duplicateLabelRangeInDuplicatedSheet(
   sheetIdFrom: UID,
   sheetIdTo: UID,
   range?: Range
 ): Range | undefined {
-  return range ? copyRangeWithNewSheetId(sheetIdFrom, sheetIdTo, range) : undefined;
+  return range ? duplicateRangeInDuplicatedSheet(sheetIdFrom, sheetIdTo, range) : undefined;
 }
 
 /**

--- a/src/helpers/figures/charts/combo_chart.ts
+++ b/src/helpers/figures/charts/combo_chart.ts
@@ -34,9 +34,9 @@ import {
   chartFontColor,
   checkDataset,
   checkLabelRange,
-  copyDataSetsWithNewSheetId,
-  copyLabelRangeWithNewSheetId,
   createDataSets,
+  duplicateDataSetsInDuplicatedSheet,
+  duplicateLabelRangeInDuplicatedSheet,
   getDefinedAxis,
   shouldRemoveFirstLabel,
   toExcelDataset,
@@ -207,11 +207,15 @@ export class ComboChart extends AbstractChart {
     };
   }
 
-  copyForSheetId(sheetId: UID): ComboChart {
-    const dataSets = copyDataSetsWithNewSheetId(this.sheetId, sheetId, this.dataSets);
-    const labelRange = copyLabelRangeWithNewSheetId(this.sheetId, sheetId, this.labelRange);
-    const definition = this.getDefinitionWithSpecificDataSets(dataSets, labelRange, sheetId);
-    return new ComboChart(definition, sheetId, this.getters);
+  duplicateInDuplicatedSheet(newSheetId: UID): ComboChart {
+    const dataSets = duplicateDataSetsInDuplicatedSheet(this.sheetId, newSheetId, this.dataSets);
+    const labelRange = duplicateLabelRangeInDuplicatedSheet(
+      this.sheetId,
+      newSheetId,
+      this.labelRange
+    );
+    const definition = this.getDefinitionWithSpecificDataSets(dataSets, labelRange, newSheetId);
+    return new ComboChart(definition, newSheetId, this.getters);
   }
 
   copyInSheetId(sheetId: UID): ComboChart {

--- a/src/helpers/figures/charts/gauge_chart.ts
+++ b/src/helpers/figures/charts/gauge_chart.ts
@@ -34,7 +34,7 @@ import { createValidRange } from "../../range";
 import { rangeReference } from "../../references";
 import { toUnboundedZone, zoneToXc } from "../../zones";
 import { AbstractChart } from "./abstract_chart";
-import { adaptChartRange, copyLabelRangeWithNewSheetId } from "./chart_common";
+import { adaptChartRange, duplicateLabelRangeInDuplicatedSheet } from "./chart_common";
 
 type RangeLimitsValidation = (rangeLimit: string, rangeLimitName: string) => CommandResult;
 type InflectionPointValueValidation = (
@@ -203,10 +203,14 @@ export class GaugeChart extends AbstractChart {
     };
   }
 
-  copyForSheetId(sheetId: UID): GaugeChart {
-    const dataRange = copyLabelRangeWithNewSheetId(this.sheetId, sheetId, this.dataRange);
-    const definition = this.getDefinitionWithSpecificRanges(dataRange, sheetId);
-    return new GaugeChart(definition, sheetId, this.getters);
+  duplicateInDuplicatedSheet(newSheetId: UID): GaugeChart {
+    const dataRange = duplicateLabelRangeInDuplicatedSheet(
+      this.sheetId,
+      newSheetId,
+      this.dataRange
+    );
+    const definition = this.getDefinitionWithSpecificRanges(dataRange, newSheetId);
+    return new GaugeChart(definition, newSheetId, this.getters);
   }
 
   copyInSheetId(sheetId: UID): GaugeChart {

--- a/src/helpers/figures/charts/geo_chart.ts
+++ b/src/helpers/figures/charts/geo_chart.ts
@@ -30,9 +30,9 @@ import { AbstractChart } from "./abstract_chart";
 import {
   checkDataset,
   checkLabelRange,
-  copyDataSetsWithNewSheetId,
-  copyLabelRangeWithNewSheetId,
   createDataSets,
+  duplicateDataSetsInDuplicatedSheet,
+  duplicateLabelRangeInDuplicatedSheet,
   transformChartDefinitionWithDataSetsWithZone,
   updateChartRangesWithDataSets,
 } from "./chart_common";
@@ -120,11 +120,15 @@ export class GeoChart extends AbstractChart {
     };
   }
 
-  copyForSheetId(sheetId: UID): GeoChart {
-    const dataSets = copyDataSetsWithNewSheetId(this.sheetId, sheetId, this.dataSets);
-    const labelRange = copyLabelRangeWithNewSheetId(this.sheetId, sheetId, this.labelRange);
-    const definition = this.getDefinitionWithSpecificDataSets(dataSets, labelRange, sheetId);
-    return new GeoChart(definition, sheetId, this.getters);
+  duplicateInDuplicatedSheet(newSheetId: UID): GeoChart {
+    const dataSets = duplicateDataSetsInDuplicatedSheet(this.sheetId, newSheetId, this.dataSets);
+    const labelRange = duplicateLabelRangeInDuplicatedSheet(
+      this.sheetId,
+      newSheetId,
+      this.labelRange
+    );
+    const definition = this.getDefinitionWithSpecificDataSets(dataSets, labelRange, newSheetId);
+    return new GeoChart(definition, newSheetId, this.getters);
   }
 
   copyInSheetId(sheetId: UID): GeoChart {

--- a/src/helpers/figures/charts/line_chart.ts
+++ b/src/helpers/figures/charts/line_chart.ts
@@ -32,9 +32,9 @@ import {
   chartFontColor,
   checkDataset,
   checkLabelRange,
-  copyDataSetsWithNewSheetId,
-  copyLabelRangeWithNewSheetId,
   createDataSets,
+  duplicateDataSetsInDuplicatedSheet,
+  duplicateLabelRangeInDuplicatedSheet,
   getDefinedAxis,
   shouldRemoveFirstLabel,
   toExcelDataset,
@@ -214,11 +214,15 @@ export class LineChart extends AbstractChart {
     };
   }
 
-  copyForSheetId(sheetId: UID): LineChart {
-    const dataSets = copyDataSetsWithNewSheetId(this.sheetId, sheetId, this.dataSets);
-    const labelRange = copyLabelRangeWithNewSheetId(this.sheetId, sheetId, this.labelRange);
-    const definition = this.getDefinitionWithSpecificDataSets(dataSets, labelRange, sheetId);
-    return new LineChart(definition, sheetId, this.getters);
+  duplicateInDuplicatedSheet(newSheetId: UID): LineChart {
+    const dataSets = duplicateDataSetsInDuplicatedSheet(this.sheetId, newSheetId, this.dataSets);
+    const labelRange = duplicateLabelRangeInDuplicatedSheet(
+      this.sheetId,
+      newSheetId,
+      this.labelRange
+    );
+    const definition = this.getDefinitionWithSpecificDataSets(dataSets, labelRange, newSheetId);
+    return new LineChart(definition, newSheetId, this.getters);
   }
 
   copyInSheetId(sheetId: UID): LineChart {

--- a/src/helpers/figures/charts/pie_chart.ts
+++ b/src/helpers/figures/charts/pie_chart.ts
@@ -28,9 +28,9 @@ import {
   chartFontColor,
   checkDataset,
   checkLabelRange,
-  copyDataSetsWithNewSheetId,
-  copyLabelRangeWithNewSheetId,
   createDataSets,
+  duplicateDataSetsInDuplicatedSheet,
+  duplicateLabelRangeInDuplicatedSheet,
   shouldRemoveFirstLabel,
   toExcelDataset,
   toExcelLabelRange,
@@ -144,11 +144,15 @@ export class PieChart extends AbstractChart {
     };
   }
 
-  copyForSheetId(sheetId: UID): PieChart {
-    const dataSets = copyDataSetsWithNewSheetId(this.sheetId, sheetId, this.dataSets);
-    const labelRange = copyLabelRangeWithNewSheetId(this.sheetId, sheetId, this.labelRange);
-    const definition = this.getDefinitionWithSpecificDataSets(dataSets, labelRange, sheetId);
-    return new PieChart(definition, sheetId, this.getters);
+  duplicateInDuplicatedSheet(newSheetId: UID): PieChart {
+    const dataSets = duplicateDataSetsInDuplicatedSheet(this.sheetId, newSheetId, this.dataSets);
+    const labelRange = duplicateLabelRangeInDuplicatedSheet(
+      this.sheetId,
+      newSheetId,
+      this.labelRange
+    );
+    const definition = this.getDefinitionWithSpecificDataSets(dataSets, labelRange, newSheetId);
+    return new PieChart(definition, newSheetId, this.getters);
   }
 
   copyInSheetId(sheetId: UID): PieChart {

--- a/src/helpers/figures/charts/pyramid_chart.ts
+++ b/src/helpers/figures/charts/pyramid_chart.ts
@@ -27,9 +27,9 @@ import { AbstractChart } from "./abstract_chart";
 import {
   checkDataset,
   checkLabelRange,
-  copyDataSetsWithNewSheetId,
-  copyLabelRangeWithNewSheetId,
   createDataSets,
+  duplicateDataSetsInDuplicatedSheet,
+  duplicateLabelRangeInDuplicatedSheet,
   transformChartDefinitionWithDataSetsWithZone,
   updateChartRangesWithDataSets,
 } from "./chart_common";
@@ -125,11 +125,15 @@ export class PyramidChart extends AbstractChart {
     };
   }
 
-  copyForSheetId(sheetId: UID): PyramidChart {
-    const dataSets = copyDataSetsWithNewSheetId(this.sheetId, sheetId, this.dataSets);
-    const labelRange = copyLabelRangeWithNewSheetId(this.sheetId, sheetId, this.labelRange);
-    const definition = this.getDefinitionWithSpecificDataSets(dataSets, labelRange, sheetId);
-    return new PyramidChart(definition, sheetId, this.getters);
+  duplicateInDuplicatedSheet(newSheetId: UID): PyramidChart {
+    const dataSets = duplicateDataSetsInDuplicatedSheet(this.sheetId, newSheetId, this.dataSets);
+    const labelRange = duplicateLabelRangeInDuplicatedSheet(
+      this.sheetId,
+      newSheetId,
+      this.labelRange
+    );
+    const definition = this.getDefinitionWithSpecificDataSets(dataSets, labelRange, newSheetId);
+    return new PyramidChart(definition, newSheetId, this.getters);
   }
 
   copyInSheetId(sheetId: UID): PyramidChart {

--- a/src/helpers/figures/charts/radar_chart.ts
+++ b/src/helpers/figures/charts/radar_chart.ts
@@ -30,9 +30,9 @@ import {
   chartFontColor,
   checkDataset,
   checkLabelRange,
-  copyDataSetsWithNewSheetId,
-  copyLabelRangeWithNewSheetId,
   createDataSets,
+  duplicateDataSetsInDuplicatedSheet,
+  duplicateLabelRangeInDuplicatedSheet,
   shouldRemoveFirstLabel,
   toExcelDataset,
   toExcelLabelRange,
@@ -130,11 +130,15 @@ export class RadarChart extends AbstractChart {
     };
   }
 
-  copyForSheetId(sheetId: UID): RadarChart {
-    const dataSets = copyDataSetsWithNewSheetId(this.sheetId, sheetId, this.dataSets);
-    const labelRange = copyLabelRangeWithNewSheetId(this.sheetId, sheetId, this.labelRange);
-    const definition = this.getDefinitionWithSpecificDataSets(dataSets, labelRange, sheetId);
-    return new RadarChart(definition, sheetId, this.getters);
+  duplicateInDuplicatedSheet(newSheetId: UID): RadarChart {
+    const dataSets = duplicateDataSetsInDuplicatedSheet(this.sheetId, newSheetId, this.dataSets);
+    const labelRange = duplicateLabelRangeInDuplicatedSheet(
+      this.sheetId,
+      newSheetId,
+      this.labelRange
+    );
+    const definition = this.getDefinitionWithSpecificDataSets(dataSets, labelRange, newSheetId);
+    return new RadarChart(definition, newSheetId, this.getters);
   }
 
   copyInSheetId(sheetId: UID): RadarChart {

--- a/src/helpers/figures/charts/scatter_chart.ts
+++ b/src/helpers/figures/charts/scatter_chart.ts
@@ -30,9 +30,9 @@ import {
   chartFontColor,
   checkDataset,
   checkLabelRange,
-  copyDataSetsWithNewSheetId,
-  copyLabelRangeWithNewSheetId,
   createDataSets,
+  duplicateDataSetsInDuplicatedSheet,
+  duplicateLabelRangeInDuplicatedSheet,
   getDefinedAxis,
   shouldRemoveFirstLabel,
   toExcelDataset,
@@ -202,11 +202,15 @@ export class ScatterChart extends AbstractChart {
     };
   }
 
-  copyForSheetId(sheetId: UID): ScatterChart {
-    const dataSets = copyDataSetsWithNewSheetId(this.sheetId, sheetId, this.dataSets);
-    const labelRange = copyLabelRangeWithNewSheetId(this.sheetId, sheetId, this.labelRange);
-    const definition = this.getDefinitionWithSpecificDataSets(dataSets, labelRange, sheetId);
-    return new ScatterChart(definition, sheetId, this.getters);
+  duplicateInDuplicatedSheet(newSheetId: UID): ScatterChart {
+    const dataSets = duplicateDataSetsInDuplicatedSheet(this.sheetId, newSheetId, this.dataSets);
+    const labelRange = duplicateLabelRangeInDuplicatedSheet(
+      this.sheetId,
+      newSheetId,
+      this.labelRange
+    );
+    const definition = this.getDefinitionWithSpecificDataSets(dataSets, labelRange, newSheetId);
+    return new ScatterChart(definition, newSheetId, this.getters);
   }
 
   copyInSheetId(sheetId: UID): ScatterChart {

--- a/src/helpers/figures/charts/scorecard_chart.ts
+++ b/src/helpers/figures/charts/scorecard_chart.ts
@@ -37,7 +37,7 @@ import { rangeReference } from "../../references";
 import { clipTextWithEllipsis, drawDecoratedText } from "../../text_helper";
 import { toUnboundedZone, zoneToXc } from "../../zones";
 import { AbstractChart } from "./abstract_chart";
-import { adaptChartRange, copyLabelRangeWithNewSheetId } from "./chart_common";
+import { adaptChartRange, duplicateLabelRangeInDuplicatedSheet } from "./chart_common";
 import { ScorecardChartConfig } from "./scorecard_chart_config_builder";
 
 function getBaselineText(
@@ -225,11 +225,11 @@ export class ScorecardChart extends AbstractChart {
     };
   }
 
-  copyForSheetId(sheetId: UID): ScorecardChart {
-    const baseline = copyLabelRangeWithNewSheetId(this.sheetId, sheetId, this.baseline);
-    const keyValue = copyLabelRangeWithNewSheetId(this.sheetId, sheetId, this.keyValue);
-    const definition = this.getDefinitionWithSpecificRanges(baseline, keyValue, sheetId);
-    return new ScorecardChart(definition, sheetId, this.getters);
+  duplicateInDuplicatedSheet(newSheetId: UID): ScorecardChart {
+    const baseline = duplicateLabelRangeInDuplicatedSheet(this.sheetId, newSheetId, this.baseline);
+    const keyValue = duplicateLabelRangeInDuplicatedSheet(this.sheetId, newSheetId, this.keyValue);
+    const definition = this.getDefinitionWithSpecificRanges(baseline, keyValue, newSheetId);
+    return new ScorecardChart(definition, newSheetId, this.getters);
   }
 
   copyInSheetId(sheetId: UID): ScorecardChart {

--- a/src/helpers/figures/charts/waterfall_chart.ts
+++ b/src/helpers/figures/charts/waterfall_chart.ts
@@ -29,9 +29,9 @@ import { AbstractChart } from "./abstract_chart";
 import {
   checkDataset,
   checkLabelRange,
-  copyDataSetsWithNewSheetId,
-  copyLabelRangeWithNewSheetId,
   createDataSets,
+  duplicateDataSetsInDuplicatedSheet,
+  duplicateLabelRangeInDuplicatedSheet,
   transformChartDefinitionWithDataSetsWithZone,
   updateChartRangesWithDataSets,
 } from "./chart_common";
@@ -141,11 +141,15 @@ export class WaterfallChart extends AbstractChart {
     };
   }
 
-  copyForSheetId(sheetId: UID): WaterfallChart {
-    const dataSets = copyDataSetsWithNewSheetId(this.sheetId, sheetId, this.dataSets);
-    const labelRange = copyLabelRangeWithNewSheetId(this.sheetId, sheetId, this.labelRange);
-    const definition = this.getDefinitionWithSpecificDataSets(dataSets, labelRange, sheetId);
-    return new WaterfallChart(definition, sheetId, this.getters);
+  duplicateInDuplicatedSheet(newSheetId: UID): WaterfallChart {
+    const dataSets = duplicateDataSetsInDuplicatedSheet(this.sheetId, newSheetId, this.dataSets);
+    const labelRange = duplicateLabelRangeInDuplicatedSheet(
+      this.sheetId,
+      newSheetId,
+      this.labelRange
+    );
+    const definition = this.getDefinitionWithSpecificDataSets(dataSets, labelRange, newSheetId);
+    return new WaterfallChart(definition, newSheetId, this.getters);
   }
 
   copyInSheetId(sheetId: UID): WaterfallChart {

--- a/src/helpers/range.ts
+++ b/src/helpers/range.ts
@@ -188,10 +188,14 @@ export class RangeImpl implements Range {
 }
 
 /**
- * Copy a range. If the range is on the sheetIdFrom, the range will target
+ * Duplicate a range. If the range is on the sheetIdFrom, the range will target
  * sheetIdTo.
  */
-export function copyRangeWithNewSheetId(sheetIdFrom: UID, sheetIdTo: UID, range: Range): Range {
+export function duplicateRangeInDuplicatedSheet(
+  sheetIdFrom: UID,
+  sheetIdTo: UID,
+  range: Range
+): Range {
   const sheetId = range.sheetId === sheetIdFrom ? sheetIdTo : range.sheetId;
   return range.clone({ sheetId });
 }

--- a/src/plugins/core/chart.ts
+++ b/src/plugins/core/chart.ts
@@ -87,7 +87,7 @@ export class ChartPlugin extends CorePlugin<ChartState> implements ChartState {
           if (fig.tag === "chart") {
             const figureIdBase = fig.id.split(FIGURE_ID_SPLITTER).pop();
             const duplicatedFigureId = `${cmd.sheetIdTo}${FIGURE_ID_SPLITTER}${figureIdBase}`;
-            const chart = this.charts[fig.id]?.copyForSheetId(cmd.sheetIdTo);
+            const chart = this.charts[fig.id]?.duplicateInDuplicatedSheet(cmd.sheetIdTo);
             if (chart) {
               this.dispatch("CREATE_CHART", {
                 id: duplicatedFigureId,

--- a/src/plugins/core/data_validation.ts
+++ b/src/plugins/core/data_validation.ts
@@ -1,7 +1,7 @@
 import { compile } from "../../formulas";
 import {
-  copyRangeWithNewSheetId,
   deepCopy,
+  duplicateRangeInDuplicatedSheet,
   getCellPositionsInRanges,
   isInside,
   recomputeZones,
@@ -106,7 +106,7 @@ export class DataValidationPlugin
         const rules = deepCopy(this.rules[cmd.sheetId]).map((rule) => ({
           ...rule,
           ranges: rule.ranges.map((range) =>
-            copyRangeWithNewSheetId(cmd.sheetId, cmd.sheetIdTo, range)
+            duplicateRangeInDuplicatedSheet(cmd.sheetId, cmd.sheetIdTo, range)
           ),
         }));
         this.history.update("rules", cmd.sheetIdTo, rules);

--- a/tests/range_plugin.test.ts
+++ b/tests/range_plugin.test.ts
@@ -1,5 +1,5 @@
 import { CorePlugin, coreTypes, Model } from "../src";
-import { copyRangeWithNewSheetId } from "../src/helpers";
+import { duplicateRangeInDuplicatedSheet } from "../src/helpers";
 import { corePluginRegistry } from "../src/plugins";
 import { ApplyRangeChange, Command, Range, UID } from "../src/types";
 import { CellErrorType } from "../src/types/errors";
@@ -603,7 +603,7 @@ describe("Helpers", () => {
     ["A1:B1", "s1", "s2", "s2"],
     ["Sheet1!A1:B1", "s1", "s2", "s2"],
     ["Sheet2!A1:B1", "s1", "s2", "s2"],
-  ])("copyRangeWithNewSheetId", (xc, sheetIdFrom, sheetIdTo, result) => {
+  ])("duplicateRangeInDuplicatedSheet", (xc, sheetIdFrom, sheetIdTo, result) => {
     const model = new Model({
       sheets: [
         { id: "s1", name: "Sheet1" },
@@ -611,7 +611,7 @@ describe("Helpers", () => {
       ],
     });
     const range = model.getters.getRangeFromSheetXC(sheetIdFrom, xc);
-    const updated = copyRangeWithNewSheetId(sheetIdFrom, sheetIdTo, range);
+    const updated = duplicateRangeInDuplicatedSheet(sheetIdFrom, sheetIdTo, range);
     expect(updated.sheetId).toBe(result);
   });
 });


### PR DESCRIPTION
The difference between both methods `copyForSheetId` and `copyInSheetId` has always been confusing to me.

This commits attemps to make it clearer by renaming one of the method.

Task: 0

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo