### PR TITLE
[IMP] xlsx: support exporting array formulas

### DIFF
--- a/src/plugins/ui_core_views/cell_evaluation/evaluation_plugin.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluation_plugin.ts
@@ -345,8 +345,10 @@ export class EvaluationPlugin extends CoreViewPlugin {
 
       const formulaCell = this.getCorrespondingFormulaCell(position);
       if (formulaCell) {
+        const cell = this.getters.getCell(position);
+        isFormula = isExported && cell?.content === formulaCell.content;
         isExported = isExportableToExcel(formulaCell.compiledFormula.tokens);
-        isFormula = isExported;
+        // isFormula = isExported;
 
         // If the cell contains a non-exported formula and that is evaluates to
         // nothing* ,we don't export it.
@@ -374,7 +376,7 @@ export class EvaluationPlugin extends CoreViewPlugin {
       const spillZone = this.getSpreadZone(position);
       if (spillZone) {
         exportedSheetData.formulaSpillRanges[xc] = this.getters.getRangeString(
-          this.getters.getRangeFromZone(this.getters.getActiveSheetId(), spillZone),
+          this.getters.getRangeFromZone(position.sheetId, spillZone),
           position.sheetId
         );
       }

--- a/src/plugins/ui_core_views/cell_evaluation/evaluation_plugin.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluation_plugin.ts
@@ -331,10 +331,10 @@ export class EvaluationPlugin extends CoreViewPlugin {
   exportForExcel(data: ExcelWorkbookData) {
     for (const sheet of data.sheets) {
       sheet.cellValues = {};
+      sheet.formulaSpillRanges = {};
     }
     for (const position of this.evaluator.getEvaluatedPositions()) {
       const evaluatedCell = this.evaluator.getEvaluatedCell(position);
-
       const xc = toXC(position.col, position.row);
       const value = evaluatedCell.value;
       let isFormula = false;
@@ -361,7 +361,6 @@ export class EvaluationPlugin extends CoreViewPlugin {
           }
         }
       }
-
       const exportedCellData = exportedSheetData.cells[xc];
 
       let content: string | undefined;
@@ -372,6 +371,13 @@ export class EvaluationPlugin extends CoreViewPlugin {
       }
       exportedSheetData.cells[xc] = content;
       exportedSheetData.cellValues[xc] = value;
+      const spillZone = this.getSpreadZone(position);
+      if (spillZone) {
+        exportedSheetData.formulaSpillRanges[xc] = this.getters.getRangeString(
+          this.getters.getRangeFromZone(this.getters.getActiveSheetId(), spillZone),
+          position.sheetId
+        );
+      }
     }
   }
 

--- a/src/types/workbook_data.ts
+++ b/src/types/workbook_data.ts
@@ -76,6 +76,7 @@ export interface ExcelWorkbookData extends WorkbookData {
 
 export interface ExcelSheetData extends Omit<SheetData, "figureTables" | "cols" | "rows"> {
   cellValues: { [xc: string]: CellValue | undefined };
+  formulaSpillRanges: { [xc: string]: string };
   charts: FigureData<ExcelChartDefinition>[];
   images: FigureData<Image>[];
   tables: ExcelTableData[];

--- a/src/xlsx/constants.ts
+++ b/src/xlsx/constants.ts
@@ -33,6 +33,7 @@ export const CONTENT_TYPES = {
   macroEnabledTemplateWorkbook: "application/vnd.ms-excel.template.macroEnabled.main+xml",
   excelAddInWorkbook: "application/vnd.ms-excel.addin.macroEnabled.main+xml",
   sheet: "application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml",
+  metadata: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml",
   sharedStrings: "application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml",
   styles: "application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml",
   drawing: "application/vnd.openxmlformats-officedocument.drawing+xml",
@@ -46,6 +47,7 @@ export const CONTENT_TYPES = {
 export const XLSX_RELATION_TYPE = {
   document: "http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument",
   sheet: "http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet",
+  metadata: "http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata",
   sharedStrings:
     "http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings",
   styles: "http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles",

--- a/src/xlsx/functions/cells.ts
+++ b/src/xlsx/functions/cells.ts
@@ -19,7 +19,8 @@ import { DEFAULT_LOCALE } from "./../../types/locale";
 
 export function addFormula(
   formula: string | undefined,
-  value: CellValue
+  value: CellValue,
+  arrayFormulaRange: string
 ): {
   attrs: XMLAttributes;
   node: XMLString;
@@ -33,11 +34,13 @@ export function addFormula(
     return { attrs: [], node: escapeXml`` };
   }
 
-  const attrs: XMLAttributes = [["t", type]];
+  const attrs: XMLAttributes = [["cm", "1"]];
   const XlsxFormula = adaptFormulaToExcel(formula);
-
   const exportedValue = adaptFormulaValueToExcel(value);
-  const node = escapeXml/*xml*/ `<f>${XlsxFormula}</f><v>${exportedValue}</v>`;
+  // We treat all formulas as array formulas (a simple formula
+  // is an array formula that spills on only one cell) to avoid
+  // trying to detect spilling sub-formulas which is not a trivial task.
+  const node = escapeXml/*xml*/ `<f t="array" ref="${arrayFormulaRange}">${XlsxFormula}</f><v>${exportedValue}</v>`;
   return { attrs, node };
 }
 

--- a/src/xlsx/functions/cells.ts
+++ b/src/xlsx/functions/cells.ts
@@ -34,7 +34,10 @@ export function addFormula(
     return { attrs: [], node: escapeXml`` };
   }
 
-  const attrs: XMLAttributes = [["cm", "1"]];
+  const attrs: XMLAttributes = [
+    ["cm", "1"],
+    ["t", type],
+  ];
   const XlsxFormula = adaptFormulaToExcel(formula);
   const exportedValue = adaptFormulaValueToExcel(value);
   // We treat all formulas as array formulas (a simple formula

--- a/src/xlsx/functions/worksheet.ts
+++ b/src/xlsx/functions/worksheet.ts
@@ -110,7 +110,7 @@ export function addRows(
         let cellNode = escapeXml``;
         // Either formula or static value inside the cell
         if (content?.startsWith("=") && value !== undefined) {
-          const res = addFormula(content, value);
+          const res = addFormula(content, value, sheet.formulaSpillRanges[xc] ?? xc);
           if (!res) {
             continue;
           }

--- a/src/xlsx/xlsx_writer.ts
+++ b/src/xlsx/xlsx_writer.ts
@@ -207,6 +207,31 @@ function createWorksheets(data: ExcelWorkbookData, construct: XLSXStructure): XL
     `;
     files.push(createXMLFile(parseXML(sheetXml), `xl/worksheets/sheet${sheetIndex}.xml`, "sheet"));
   }
+  const sheetMetadataXml = escapeXml/*xml*/ `
+    <metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+        <metadataTypes count="1">
+            <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1"
+                pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1"
+                clearComments="1" assign="1" coerce="1" cellMeta="1" />
+        </metadataTypes>
+        <futureMetadata name="XLDAPR" count="1">
+            <bk>
+                <extLst>
+                    <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                        <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0" />
+                    </ext>
+                </extLst>
+            </bk>
+        </futureMetadata>
+        <cellMetadata count="1">
+            <bk>
+                <rc t="1" v="0" />
+            </bk>
+        </cellMetadata>
+    </metadata>
+  `;
+  files.push(createXMLFile(parseXML(sheetMetadataXml), "xl/metadata.xml", "metadata"));
+
   addRelsToFile(construct.relsFiles, "xl/_rels/workbook.xml.rels", {
     type: XLSX_RELATION_TYPE.sharedStrings,
     target: "sharedStrings.xml",
@@ -214,6 +239,10 @@ function createWorksheets(data: ExcelWorkbookData, construct: XLSXStructure): XL
   addRelsToFile(construct.relsFiles, "xl/_rels/workbook.xml.rels", {
     type: XLSX_RELATION_TYPE.styles,
     target: "styles.xml",
+  });
+  addRelsToFile(construct.relsFiles, "xl/_rels/workbook.xml.rels", {
+    type: XLSX_RELATION_TYPE.metadata,
+    target: "metadata.xml",
   });
   return files;
 }

--- a/tests/xlsx/__snapshots__/xlsx_export.test.ts.snap
+++ b/tests/xlsx/__snapshots__/xlsx_export.test.ts.snap
@@ -470,6 +470,29 @@ exports[`Test XLSX export Charts Chart legend is set to none position 1`] = `
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -552,6 +575,7 @@ exports[`Test XLSX export Charts Chart legend is set to none position 1`] = `
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -586,6 +610,7 @@ exports[`Test XLSX export Charts Chart legend is set to none position 1`] = `
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml" PartName="/xl/charts/chart1.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawing+xml" PartName="/xl/drawings/drawing0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -1060,6 +1085,29 @@ exports[`Test XLSX export Charts Export chart overflowing outside the sheet 1`] 
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -1142,6 +1190,7 @@ exports[`Test XLSX export Charts Export chart overflowing outside the sheet 1`] 
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -1176,6 +1225,7 @@ exports[`Test XLSX export Charts Export chart overflowing outside the sheet 1`] 
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml" PartName="/xl/charts/chart1.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawing+xml" PartName="/xl/drawings/drawing0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -1650,6 +1700,29 @@ exports[`Test XLSX export Charts chart dataset without title 1`] = `
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -1732,6 +1805,7 @@ exports[`Test XLSX export Charts chart dataset without title 1`] = `
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -1766,6 +1840,7 @@ exports[`Test XLSX export Charts chart dataset without title 1`] = `
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml" PartName="/xl/charts/chart1.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawing+xml" PartName="/xl/drawings/drawing0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -3742,6 +3817,29 @@ exports[`Test XLSX export Charts chart font color is white with a dark backgroun
       "path": "xl/worksheets/sheet1.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -3825,6 +3923,7 @@ exports[`Test XLSX export Charts chart font color is white with a dark backgroun
     <Relationship Id="rId2" Target="worksheets/sheet1.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId3" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId4" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId5" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -3870,6 +3969,7 @@ exports[`Test XLSX export Charts chart font color is white with a dark backgroun
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawing+xml" PartName="/xl/drawings/drawing0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet1.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -4760,6 +4860,29 @@ exports[`Test XLSX export Charts charts in different sheets 1`] = `
       "path": "xl/worksheets/sheet1.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -4843,6 +4966,7 @@ exports[`Test XLSX export Charts charts in different sheets 1`] = `
     <Relationship Id="rId2" Target="worksheets/sheet1.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId3" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId4" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId5" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -4894,6 +5018,7 @@ exports[`Test XLSX export Charts charts in different sheets 1`] = `
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml" PartName="/xl/charts/chart2.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawing+xml" PartName="/xl/drawings/drawing1.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet1.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -5735,6 +5860,29 @@ exports[`Test XLSX export Charts multiple charts in the same sheet 1`] = `
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -5817,6 +5965,7 @@ exports[`Test XLSX export Charts multiple charts in the same sheet 1`] = `
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -5853,6 +6002,7 @@ exports[`Test XLSX export Charts multiple charts in the same sheet 1`] = `
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml" PartName="/xl/charts/chart2.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawing+xml" PartName="/xl/drawings/drawing0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -6065,6 +6215,29 @@ exports[`Test XLSX export Charts pie chart with only title dataset 1`] = `
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -6117,6 +6290,7 @@ exports[`Test XLSX export Charts pie chart with only title dataset 1`] = `
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -6151,6 +6325,7 @@ exports[`Test XLSX export Charts pie chart with only title dataset 1`] = `
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml" PartName="/xl/charts/chart1.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawing+xml" PartName="/xl/drawings/drawing0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -6605,6 +6780,29 @@ exports[`Test XLSX export Charts simple bar chart with customized axis 1`] = `
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -6687,6 +6885,7 @@ exports[`Test XLSX export Charts simple bar chart with customized axis 1`] = `
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -6721,6 +6920,7 @@ exports[`Test XLSX export Charts simple bar chart with customized axis 1`] = `
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml" PartName="/xl/charts/chart1.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawing+xml" PartName="/xl/drawings/drawing0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -7169,6 +7369,29 @@ exports[`Test XLSX export Charts simple bar chart with customized dataset 1`] = 
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -7251,6 +7474,7 @@ exports[`Test XLSX export Charts simple bar chart with customized dataset 1`] = 
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -7285,6 +7509,7 @@ exports[`Test XLSX export Charts simple bar chart with customized dataset 1`] = 
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml" PartName="/xl/charts/chart1.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawing+xml" PartName="/xl/drawings/drawing0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -7735,6 +7960,29 @@ exports[`Test XLSX export Charts simple bar chart with customized title 1`] = `
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -7817,6 +8065,7 @@ exports[`Test XLSX export Charts simple bar chart with customized title 1`] = `
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -7851,6 +8100,7 @@ exports[`Test XLSX export Charts simple bar chart with customized title 1`] = `
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml" PartName="/xl/charts/chart1.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawing+xml" PartName="/xl/drawings/drawing0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -8301,6 +8551,29 @@ exports[`Test XLSX export Charts simple bar chart with dataset [ [Object] ] 1`] 
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -8383,6 +8656,7 @@ exports[`Test XLSX export Charts simple bar chart with dataset [ [Object] ] 1`] 
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -8417,6 +8691,7 @@ exports[`Test XLSX export Charts simple bar chart with dataset [ [Object] ] 1`] 
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml" PartName="/xl/charts/chart1.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawing+xml" PartName="/xl/drawings/drawing0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -8905,6 +9180,29 @@ exports[`Test XLSX export Charts simple bar chart with dataset [ [Object], [Obje
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -8987,6 +9285,7 @@ exports[`Test XLSX export Charts simple bar chart with dataset [ [Object], [Obje
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -9021,6 +9320,7 @@ exports[`Test XLSX export Charts simple bar chart with dataset [ [Object], [Obje
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml" PartName="/xl/charts/chart1.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawing+xml" PartName="/xl/drawings/drawing0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -9474,6 +9774,29 @@ exports[`Test XLSX export Charts simple combo chart with customized axis 1`] = `
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -9556,6 +9879,7 @@ exports[`Test XLSX export Charts simple combo chart with customized axis 1`] = `
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -9590,6 +9914,7 @@ exports[`Test XLSX export Charts simple combo chart with customized axis 1`] = `
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml" PartName="/xl/charts/chart1.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawing+xml" PartName="/xl/drawings/drawing0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -10037,6 +10362,29 @@ exports[`Test XLSX export Charts simple combo chart with customized dataset 1`] 
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -10119,6 +10467,7 @@ exports[`Test XLSX export Charts simple combo chart with customized dataset 1`] 
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -10153,6 +10502,7 @@ exports[`Test XLSX export Charts simple combo chart with customized dataset 1`] 
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml" PartName="/xl/charts/chart1.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawing+xml" PartName="/xl/drawings/drawing0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -10602,6 +10952,29 @@ exports[`Test XLSX export Charts simple combo chart with customized title 1`] = 
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -10684,6 +11057,7 @@ exports[`Test XLSX export Charts simple combo chart with customized title 1`] = 
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -10718,6 +11092,7 @@ exports[`Test XLSX export Charts simple combo chart with customized title 1`] = 
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml" PartName="/xl/charts/chart1.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawing+xml" PartName="/xl/drawings/drawing0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -11167,6 +11542,29 @@ exports[`Test XLSX export Charts simple combo chart with dataset [ [Object] ] 1`
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -11249,6 +11647,7 @@ exports[`Test XLSX export Charts simple combo chart with dataset [ [Object] ] 1`
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -11283,6 +11682,7 @@ exports[`Test XLSX export Charts simple combo chart with dataset [ [Object] ] 1`
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml" PartName="/xl/charts/chart1.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawing+xml" PartName="/xl/drawings/drawing0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -11791,6 +12191,29 @@ exports[`Test XLSX export Charts simple combo chart with dataset [ [Object], [Ob
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -11873,6 +12296,7 @@ exports[`Test XLSX export Charts simple combo chart with dataset [ [Object], [Ob
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -11907,6 +12331,7 @@ exports[`Test XLSX export Charts simple combo chart with dataset [ [Object], [Ob
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml" PartName="/xl/charts/chart1.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawing+xml" PartName="/xl/drawings/drawing0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -12371,6 +12796,29 @@ exports[`Test XLSX export Charts simple line chart with customized axis 1`] = `
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -12453,6 +12901,7 @@ exports[`Test XLSX export Charts simple line chart with customized axis 1`] = `
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -12487,6 +12936,7 @@ exports[`Test XLSX export Charts simple line chart with customized axis 1`] = `
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml" PartName="/xl/charts/chart1.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawing+xml" PartName="/xl/drawings/drawing0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -12945,6 +13395,29 @@ exports[`Test XLSX export Charts simple line chart with customized dataset 1`] =
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -13027,6 +13500,7 @@ exports[`Test XLSX export Charts simple line chart with customized dataset 1`] =
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -13061,6 +13535,7 @@ exports[`Test XLSX export Charts simple line chart with customized dataset 1`] =
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml" PartName="/xl/charts/chart1.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawing+xml" PartName="/xl/drawings/drawing0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -13521,6 +13996,29 @@ exports[`Test XLSX export Charts simple line chart with customized title 1`] = `
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -13603,6 +14101,7 @@ exports[`Test XLSX export Charts simple line chart with customized title 1`] = `
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -13637,6 +14136,7 @@ exports[`Test XLSX export Charts simple line chart with customized title 1`] = `
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml" PartName="/xl/charts/chart1.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawing+xml" PartName="/xl/drawings/drawing0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -14097,6 +14597,29 @@ exports[`Test XLSX export Charts simple line chart with dataset [ [Object] ] 1`]
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -14179,6 +14702,7 @@ exports[`Test XLSX export Charts simple line chart with dataset [ [Object] ] 1`]
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -14213,6 +14737,7 @@ exports[`Test XLSX export Charts simple line chart with dataset [ [Object] ] 1`]
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml" PartName="/xl/charts/chart1.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawing+xml" PartName="/xl/drawings/drawing0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -14724,6 +15249,29 @@ exports[`Test XLSX export Charts simple line chart with dataset [ [Object], [Obj
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -14806,6 +15354,7 @@ exports[`Test XLSX export Charts simple line chart with dataset [ [Object], [Obj
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -14840,6 +15389,7 @@ exports[`Test XLSX export Charts simple line chart with dataset [ [Object], [Obj
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml" PartName="/xl/charts/chart1.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawing+xml" PartName="/xl/drawings/drawing0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -15205,6 +15755,29 @@ exports[`Test XLSX export Charts simple pie chart with dataset [ [Object] ] 1`] 
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -15287,6 +15860,7 @@ exports[`Test XLSX export Charts simple pie chart with dataset [ [Object] ] 1`] 
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -15321,6 +15895,7 @@ exports[`Test XLSX export Charts simple pie chart with dataset [ [Object] ] 1`] 
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml" PartName="/xl/charts/chart1.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawing+xml" PartName="/xl/drawings/drawing0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -15760,6 +16335,29 @@ exports[`Test XLSX export Charts simple pie chart with dataset [ [Object], [Obje
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -15842,6 +16440,7 @@ exports[`Test XLSX export Charts simple pie chart with dataset [ [Object], [Obje
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -15876,6 +16475,7 @@ exports[`Test XLSX export Charts simple pie chart with dataset [ [Object], [Obje
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml" PartName="/xl/charts/chart1.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawing+xml" PartName="/xl/drawings/drawing0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -16335,6 +16935,29 @@ exports[`Test XLSX export Charts simple radar chart with customized axis 1`] = `
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -16417,6 +17040,7 @@ exports[`Test XLSX export Charts simple radar chart with customized axis 1`] = `
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -16451,6 +17075,7 @@ exports[`Test XLSX export Charts simple radar chart with customized axis 1`] = `
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml" PartName="/xl/charts/chart1.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawing+xml" PartName="/xl/drawings/drawing0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -16908,6 +17533,29 @@ exports[`Test XLSX export Charts simple radar chart with customized dataset 1`] 
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -16990,6 +17638,7 @@ exports[`Test XLSX export Charts simple radar chart with customized dataset 1`] 
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -17024,6 +17673,7 @@ exports[`Test XLSX export Charts simple radar chart with customized dataset 1`] 
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml" PartName="/xl/charts/chart1.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawing+xml" PartName="/xl/drawings/drawing0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -17483,6 +18133,29 @@ exports[`Test XLSX export Charts simple radar chart with customized title 1`] = 
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -17565,6 +18238,7 @@ exports[`Test XLSX export Charts simple radar chart with customized title 1`] = 
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -17599,6 +18273,7 @@ exports[`Test XLSX export Charts simple radar chart with customized title 1`] = 
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml" PartName="/xl/charts/chart1.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawing+xml" PartName="/xl/drawings/drawing0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -18058,6 +18733,29 @@ exports[`Test XLSX export Charts simple radar chart with dataset [ [Object] ] 1`
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -18140,6 +18838,7 @@ exports[`Test XLSX export Charts simple radar chart with dataset [ [Object] ] 1`
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -18174,6 +18873,7 @@ exports[`Test XLSX export Charts simple radar chart with dataset [ [Object] ] 1`
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml" PartName="/xl/charts/chart1.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawing+xml" PartName="/xl/drawings/drawing0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -18684,6 +19384,29 @@ exports[`Test XLSX export Charts simple radar chart with dataset [ [Object], [Ob
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -18766,6 +19489,7 @@ exports[`Test XLSX export Charts simple radar chart with dataset [ [Object], [Ob
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -18800,6 +19524,7 @@ exports[`Test XLSX export Charts simple radar chart with dataset [ [Object], [Ob
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml" PartName="/xl/charts/chart1.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawing+xml" PartName="/xl/drawings/drawing0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -19264,6 +19989,29 @@ exports[`Test XLSX export Charts simple scatter chart with customized axis 1`] =
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -19346,6 +20094,7 @@ exports[`Test XLSX export Charts simple scatter chart with customized axis 1`] =
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -19380,6 +20129,7 @@ exports[`Test XLSX export Charts simple scatter chart with customized axis 1`] =
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml" PartName="/xl/charts/chart1.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawing+xml" PartName="/xl/drawings/drawing0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -19838,6 +20588,29 @@ exports[`Test XLSX export Charts simple scatter chart with customized dataset 1`
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -19920,6 +20693,7 @@ exports[`Test XLSX export Charts simple scatter chart with customized dataset 1`
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -19954,6 +20728,7 @@ exports[`Test XLSX export Charts simple scatter chart with customized dataset 1`
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml" PartName="/xl/charts/chart1.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawing+xml" PartName="/xl/drawings/drawing0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -20414,6 +21189,29 @@ exports[`Test XLSX export Charts simple scatter chart with customized title 1`] 
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -20496,6 +21294,7 @@ exports[`Test XLSX export Charts simple scatter chart with customized title 1`] 
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -20530,6 +21329,7 @@ exports[`Test XLSX export Charts simple scatter chart with customized title 1`] 
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml" PartName="/xl/charts/chart1.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawing+xml" PartName="/xl/drawings/drawing0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -20990,6 +21790,29 @@ exports[`Test XLSX export Charts simple scatter chart with dataset [ [Object] ] 
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -21072,6 +21895,7 @@ exports[`Test XLSX export Charts simple scatter chart with dataset [ [Object] ] 
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -21106,6 +21930,7 @@ exports[`Test XLSX export Charts simple scatter chart with dataset [ [Object] ] 
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml" PartName="/xl/charts/chart1.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawing+xml" PartName="/xl/drawings/drawing0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -21617,6 +22442,29 @@ exports[`Test XLSX export Charts simple scatter chart with dataset [ [Object], [
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -21699,6 +22547,7 @@ exports[`Test XLSX export Charts simple scatter chart with dataset [ [Object], [
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -21733,6 +22582,7 @@ exports[`Test XLSX export Charts simple scatter chart with dataset [ [Object], [
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml" PartName="/xl/charts/chart1.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawing+xml" PartName="/xl/drawings/drawing0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -22221,6 +23071,29 @@ exports[`Test XLSX export Charts stacked bar chart 1`] = `
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -22303,6 +23176,7 @@ exports[`Test XLSX export Charts stacked bar chart 1`] = `
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -22337,6 +23211,7 @@ exports[`Test XLSX export Charts stacked bar chart 1`] = `
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml" PartName="/xl/charts/chart1.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawing+xml" PartName="/xl/drawings/drawing0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -22453,8 +23328,8 @@ exports[`Test XLSX export Export data filters Export data filters snapshot 1`] =
                     5
                 </v>
             </c>
-            <c r="B2" t="str">
-                <f>
+            <c r="B2" cm="1">
+                <f t="array" ref="B2">
                     ""
                 </f>
                 <v/>
@@ -22491,6 +23366,29 @@ exports[`Test XLSX export Export data filters Export data filters snapshot 1`] =
 </worksheet>",
       "contentType": "sheet",
       "path": "xl/worksheets/sheet0.xml",
+    },
+    {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
     },
     {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
@@ -22560,6 +23458,7 @@ exports[`Test XLSX export Export data filters Export data filters snapshot 1`] =
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -22586,6 +23485,7 @@ exports[`Test XLSX export Export data filters Export data filters snapshot 1`] =
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml" PartName="/xl/workbook.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.table+xml" PartName="/xl/tables/table1.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -22871,6 +23771,29 @@ exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Conditional f
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -22947,6 +23870,7 @@ exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Conditional f
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -22965,6 +23889,7 @@ exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Conditional f
     <Default Extension="xml" ContentType="application/xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml" PartName="/xl/workbook.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -23022,6 +23947,29 @@ exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Conditional f
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -23074,6 +24022,7 @@ exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Conditional f
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -23092,6 +24041,7 @@ exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Conditional f
     <Default Extension="xml" ContentType="application/xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml" PartName="/xl/workbook.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -23140,6 +24090,29 @@ exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Conditional f
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -23192,6 +24165,7 @@ exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Conditional f
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -23210,6 +24184,7 @@ exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Conditional f
     <Default Extension="xml" ContentType="application/xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml" PartName="/xl/workbook.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -23312,6 +24287,29 @@ exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Data validati
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -23364,6 +24362,7 @@ exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Data validati
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -23382,6 +24381,7 @@ exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Data validati
     <Default Extension="xml" ContentType="application/xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml" PartName="/xl/workbook.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -23459,6 +24459,29 @@ exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Merges 1`] = 
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -23511,6 +24534,7 @@ exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Merges 1`] = 
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -23529,6 +24553,7 @@ exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Merges 1`] = 
     <Default Extension="xml" ContentType="application/xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml" PartName="/xl/workbook.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -23809,8 +24834,8 @@ exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Simple model 
             </c>
         </row>
         <row r="37">
-            <c r="A37" t="str">
-                <f>
+            <c r="A37" cm="1">
+                <f t="array" ref="A37">
                     "this is a quote: """
                 </f>
                 <v>
@@ -23819,8 +24844,8 @@ exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Simple model 
             </c>
         </row>
         <row r="38">
-            <c r="A38" t="n">
-                <f>
+            <c r="A38" cm="1">
+                <f t="array" ref="A38">
                     '&lt;Sheet2&gt;'!B2
                 </f>
                 <v>
@@ -23829,8 +24854,8 @@ exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Simple model 
             </c>
         </row>
         <row r="39">
-            <c r="A39" t="str">
-                <f>
+            <c r="A39" cm="1">
+                <f t="array" ref="A39">
                     A39
                 </f>
                 <v>
@@ -23839,8 +24864,8 @@ exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Simple model 
             </c>
         </row>
         <row r="40">
-            <c r="A40" t="n">
-                <f>
+            <c r="A40" cm="1">
+                <f t="array" ref="A40">
                     (1+2)/3
                 </f>
                 <v>
@@ -23849,8 +24874,8 @@ exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Simple model 
             </c>
         </row>
         <row r="41">
-            <c r="A41" t="str">
-                <f>
+            <c r="A41" cm="1">
+                <f t="array" ref="A41">
                     #REF!+5
                 </f>
                 <v>
@@ -23910,6 +24935,29 @@ exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Simple model 
 </worksheet>",
       "contentType": "sheet",
       "path": "xl/worksheets/sheet1.xml",
+    },
+    {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
     },
     {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
@@ -24239,6 +25287,7 @@ exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Simple model 
     <Relationship Id="rId2" Target="worksheets/sheet1.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId3" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId4" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId5" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -24258,6 +25307,7 @@ exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Simple model 
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml" PartName="/xl/workbook.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet1.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -24330,6 +25380,29 @@ exports[`Test XLSX export Header grouping export Nested grouped headers 1`] = `
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -24382,6 +25455,7 @@ exports[`Test XLSX export Header grouping export Nested grouped headers 1`] = `
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -24400,6 +25474,7 @@ exports[`Test XLSX export Header grouping export Nested grouped headers 1`] = `
     <Default Extension="xml" ContentType="application/xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml" PartName="/xl/workbook.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -24486,6 +25561,29 @@ exports[`Test XLSX export Header grouping export Nested grouped headers 2`] = `
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -24538,6 +25636,7 @@ exports[`Test XLSX export Header grouping export Nested grouped headers 2`] = `
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -24556,6 +25655,7 @@ exports[`Test XLSX export Header grouping export Nested grouped headers 2`] = `
     <Default Extension="xml" ContentType="application/xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml" PartName="/xl/workbook.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -24636,6 +25736,29 @@ exports[`Test XLSX export Header grouping export Simple grouped headers 1`] = `
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -24688,6 +25811,7 @@ exports[`Test XLSX export Header grouping export Simple grouped headers 1`] = `
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -24706,6 +25830,7 @@ exports[`Test XLSX export Header grouping export Simple grouped headers 1`] = `
     <Default Extension="xml" ContentType="application/xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml" PartName="/xl/workbook.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -24778,6 +25903,29 @@ exports[`Test XLSX export Header grouping export Simple grouped headers 2`] = `
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -24830,6 +25978,7 @@ exports[`Test XLSX export Header grouping export Simple grouped headers 2`] = `
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -24848,6 +25997,7 @@ exports[`Test XLSX export Header grouping export Simple grouped headers 2`] = `
     <Default Extension="xml" ContentType="application/xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml" PartName="/xl/workbook.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -24982,6 +26132,29 @@ exports[`Test XLSX export Images image larger than the sheet 1`] = `
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -25034,6 +26207,7 @@ exports[`Test XLSX export Images image larger than the sheet 1`] = `
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -25067,6 +26241,7 @@ exports[`Test XLSX export Images image larger than the sheet 1`] = `
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml" PartName="/xl/workbook.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawing+xml" PartName="/xl/drawings/drawing0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -25201,6 +26376,29 @@ exports[`Test XLSX export Images image overflowing outside the sheet 1`] = `
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -25253,6 +26451,7 @@ exports[`Test XLSX export Images image overflowing outside the sheet 1`] = `
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -25286,6 +26485,7 @@ exports[`Test XLSX export Images image overflowing outside the sheet 1`] = `
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml" PartName="/xl/workbook.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawing+xml" PartName="/xl/drawings/drawing0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -25525,6 +26725,29 @@ exports[`Test XLSX export Images images in different sheets 1`] = `
       "path": "xl/worksheets/sheet1.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -25578,6 +26801,7 @@ exports[`Test XLSX export Images images in different sheets 1`] = `
     <Relationship Id="rId2" Target="worksheets/sheet1.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId3" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId4" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId5" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -25627,6 +26851,7 @@ exports[`Test XLSX export Images images in different sheets 1`] = `
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawing+xml" PartName="/xl/drawings/drawing1.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet1.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -25817,6 +27042,29 @@ exports[`Test XLSX export Images multiple images in the same sheet 1`] = `
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -25869,6 +27117,7 @@ exports[`Test XLSX export Images multiple images in the same sheet 1`] = `
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -25903,6 +27152,7 @@ exports[`Test XLSX export Images multiple images in the same sheet 1`] = `
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml" PartName="/xl/workbook.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawing+xml" PartName="/xl/drawings/drawing0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -26037,6 +27287,29 @@ exports[`Test XLSX export Images simple image 1`] = `
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -26089,6 +27362,7 @@ exports[`Test XLSX export Images simple image 1`] = `
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -26122,6 +27396,7 @@ exports[`Test XLSX export Images simple image 1`] = `
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml" PartName="/xl/workbook.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawing+xml" PartName="/xl/drawings/drawing0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -26240,6 +27515,29 @@ exports[`Test XLSX export Sheet with frozen panes 1`] = `
       "path": "xl/worksheets/sheet1.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -26293,6 +27591,7 @@ exports[`Test XLSX export Sheet with frozen panes 1`] = `
     <Relationship Id="rId2" Target="worksheets/sheet1.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId3" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId4" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId5" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -26312,6 +27611,7 @@ exports[`Test XLSX export Sheet with frozen panes 1`] = `
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml" PartName="/xl/workbook.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet1.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -26426,6 +27726,29 @@ exports[`Test XLSX export Sheet with hide gridlines 1`] = `
       "path": "xl/worksheets/sheet1.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -26479,6 +27802,7 @@ exports[`Test XLSX export Sheet with hide gridlines 1`] = `
     <Relationship Id="rId2" Target="worksheets/sheet1.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId3" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId4" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId5" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -26498,6 +27822,7 @@ exports[`Test XLSX export Sheet with hide gridlines 1`] = `
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml" PartName="/xl/workbook.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet1.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -26615,6 +27940,29 @@ exports[`Test XLSX export Workbook with colored sheet 1`] = `
       "path": "xl/worksheets/sheet1.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -26668,6 +28016,7 @@ exports[`Test XLSX export Workbook with colored sheet 1`] = `
     <Relationship Id="rId2" Target="worksheets/sheet1.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId3" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId4" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId5" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -26687,6 +28036,7 @@ exports[`Test XLSX export Workbook with colored sheet 1`] = `
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml" PartName="/xl/workbook.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet1.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -26801,6 +28151,29 @@ exports[`Test XLSX export Workbook with hidden sheet 1`] = `
       "path": "xl/worksheets/sheet1.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -26854,6 +28227,7 @@ exports[`Test XLSX export Workbook with hidden sheet 1`] = `
     <Relationship Id="rId2" Target="worksheets/sheet1.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId3" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId4" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId5" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -26873,6 +28247,7 @@ exports[`Test XLSX export Workbook with hidden sheet 1`] = `
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml" PartName="/xl/workbook.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet1.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -26977,8 +28352,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="2">
-            <c r="A2" t="n">
-                <f>
+            <c r="A2" cm="1">
+                <f t="array" ref="A2">
                     ABS(-5.5)
                 </f>
                 <v>
@@ -27017,8 +28392,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="3">
-            <c r="A3" t="n">
-                <f>
+            <c r="A3" cm="1">
+                <f t="array" ref="A3">
                     ACOS(1)
                 </f>
                 <v>
@@ -27057,8 +28432,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="4">
-            <c r="A4" t="n">
-                <f>
+            <c r="A4" cm="1">
+                <f t="array" ref="A4">
                     ACOSH(2)
                 </f>
                 <v>
@@ -27097,16 +28472,16 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="5">
-            <c r="A5" t="n">
-                <f>
+            <c r="A5" cm="1">
+                <f t="array" ref="A5">
                     _xlfn.ACOT(1)
                 </f>
                 <v>
                     0.7853981633974483
                 </v>
             </c>
-            <c r="B5" t="n">
-                <f>
+            <c r="B5" cm="1">
+                <f t="array" ref="B5">
                     _xlfn.ACOT(_xlfn.ACOT(1))
                 </f>
                 <v>
@@ -27145,8 +28520,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="6">
-            <c r="A6" t="n">
-                <f>
+            <c r="A6" cm="1">
+                <f t="array" ref="A6">
                     _xlfn.ACOTH(2)
                 </f>
                 <v>
@@ -27185,8 +28560,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="7">
-            <c r="A7" t="b">
-                <f>
+            <c r="A7" cm="1">
+                <f t="array" ref="A7">
                     AND(TRUE,TRUE)
                 </f>
                 <v>
@@ -27225,8 +28600,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="8">
-            <c r="A8" t="n">
-                <f>
+            <c r="A8" cm="1">
+                <f t="array" ref="A8">
                     ASIN(0.5)
                 </f>
                 <v>
@@ -27265,8 +28640,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="9">
-            <c r="A9" t="n">
-                <f>
+            <c r="A9" cm="1">
+                <f t="array" ref="A9">
                     ASINH(2)
                 </f>
                 <v>
@@ -27300,8 +28675,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="10">
-            <c r="A10" t="n">
-                <f>
+            <c r="A10" cm="1">
+                <f t="array" ref="A10">
                     ATAN(1)
                 </f>
                 <v>
@@ -27310,8 +28685,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="11">
-            <c r="A11" t="n">
-                <f>
+            <c r="A11" cm="1">
+                <f t="array" ref="A11">
                     ATAN2(-1,0)
                 </f>
                 <v>
@@ -27325,8 +28700,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="12">
-            <c r="A12" t="n">
-                <f>
+            <c r="A12" cm="1">
+                <f t="array" ref="A12">
                     ATANH(0.7)
                 </f>
                 <v>
@@ -27360,8 +28735,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="13">
-            <c r="A13" t="n">
-                <f>
+            <c r="A13" cm="1">
+                <f t="array" ref="A13">
                     AVEDEV(I2:I9)
                 </f>
                 <v>
@@ -27395,8 +28770,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="14">
-            <c r="A14" t="n">
-                <f>
+            <c r="A14" cm="1">
+                <f t="array" ref="A14">
                     AVERAGE(H2:H9)
                 </f>
                 <v>
@@ -27405,8 +28780,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="15">
-            <c r="A15" t="n">
-                <f>
+            <c r="A15" cm="1">
+                <f t="array" ref="A15">
                     AVERAGEA(G2:H9)
                 </f>
                 <v>
@@ -27415,8 +28790,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="16">
-            <c r="A16" t="n">
-                <f>
+            <c r="A16" cm="1">
+                <f t="array" ref="A16">
                     AVERAGEIF(J2:J9,"&gt;150000")
                 </f>
                 <v>
@@ -27425,8 +28800,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="17">
-            <c r="A17" t="n">
-                <f>
+            <c r="A17" cm="1">
+                <f t="array" ref="A17">
                     AVERAGEIFS(I2:I9,H2:H9,"&gt;=30",K2:K9,"&lt;10")
                 </f>
                 <v>
@@ -27435,8 +28810,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="18">
-            <c r="A18" t="n">
-                <f>
+            <c r="A18" cm="1">
+                <f t="array" ref="A18">
                     CEILING(20.4,1)
                 </f>
                 <v>
@@ -27445,8 +28820,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="19">
-            <c r="A19" t="n">
-                <f>
+            <c r="A19" cm="1">
+                <f t="array" ref="A19">
                     _xlfn.CEILING.MATH(-5.5,1,0)
                 </f>
                 <v>
@@ -27455,8 +28830,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="20">
-            <c r="A20" t="n">
-                <f>
+            <c r="A20" cm="1">
+                <f t="array" ref="A20">
                     _xlfn.CEILING.PRECISE(230,100)
                 </f>
                 <v>
@@ -27465,8 +28840,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="21">
-            <c r="A21" t="str">
-                <f>
+            <c r="A21" cm="1">
+                <f t="array" ref="A21">
                     CHAR(74)
                 </f>
                 <v>
@@ -27475,8 +28850,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="22">
-            <c r="A22" t="n">
-                <f>
+            <c r="A22" cm="1">
+                <f t="array" ref="A22">
                     COLUMN(C4)
                 </f>
                 <v>
@@ -27485,8 +28860,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="23">
-            <c r="A23" t="n">
-                <f>
+            <c r="A23" cm="1">
+                <f t="array" ref="A23">
                     COLUMNS(A5:D12)
                 </f>
                 <v>
@@ -27495,8 +28870,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="24">
-            <c r="A24" t="str">
-                <f>
+            <c r="A24" cm="1">
+                <f t="array" ref="A24">
                     _xlfn.CONCAT(1,23)
                 </f>
                 <v>
@@ -27505,8 +28880,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="25">
-            <c r="A25" t="str">
-                <f>
+            <c r="A25" cm="1">
+                <f t="array" ref="A25">
                     CONCATENATE("BUT, ","MICHEL")
                 </f>
                 <v>
@@ -27515,8 +28890,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="26">
-            <c r="A26" t="n">
-                <f>
+            <c r="A26" cm="1">
+                <f t="array" ref="A26">
                     COS(PI()/3)
                 </f>
                 <v>
@@ -27525,8 +28900,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="27">
-            <c r="A27" t="n">
-                <f>
+            <c r="A27" cm="1">
+                <f t="array" ref="A27">
                     COSH(2)
                 </f>
                 <v>
@@ -27535,8 +28910,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="28">
-            <c r="A28" t="n">
-                <f>
+            <c r="A28" cm="1">
+                <f t="array" ref="A28">
                     _xlfn.COT(PI()/6)
                 </f>
                 <v>
@@ -27545,8 +28920,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="29">
-            <c r="A29" t="n">
-                <f>
+            <c r="A29" cm="1">
+                <f t="array" ref="A29">
                     _xlfn.COTH(0.5)
                 </f>
                 <v>
@@ -27555,8 +28930,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="30">
-            <c r="A30" t="n">
-                <f>
+            <c r="A30" cm="1">
+                <f t="array" ref="A30">
                     COUNT(1,"a","5","2021-03-14")
                 </f>
                 <v>
@@ -27565,8 +28940,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="31">
-            <c r="A31" t="n">
-                <f>
+            <c r="A31" cm="1">
+                <f t="array" ref="A31">
                     COUNTA(1,"a","5","2021-03-14")
                 </f>
                 <v>
@@ -27575,8 +28950,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="32">
-            <c r="A32" t="n">
-                <f>
+            <c r="A32" cm="1">
+                <f t="array" ref="A32">
                     COUNTBLANK("","1",3,FALSE)
                 </f>
                 <v>
@@ -27585,8 +28960,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="33">
-            <c r="A33" t="n">
-                <f>
+            <c r="A33" cm="1">
+                <f t="array" ref="A33">
                     COUNTIF(H2:H9,"&gt;30")
                 </f>
                 <v>
@@ -27595,8 +28970,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="34">
-            <c r="A34" t="n">
-                <f>
+            <c r="A34" cm="1">
+                <f t="array" ref="A34">
                     COUNTIFS(H2:H9,"&gt;25",K2:K9,"&lt;4")
                 </f>
                 <v>
@@ -27605,8 +28980,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="35">
-            <c r="A35" t="n">
-                <f>
+            <c r="A35" cm="1">
+                <f t="array" ref="A35">
                     COVAR(H2:H9,K2:K9)
                 </f>
                 <v>
@@ -27615,8 +28990,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="36">
-            <c r="A36" t="n">
-                <f>
+            <c r="A36" cm="1">
+                <f t="array" ref="A36">
                     _xlfn.COVARIANCE.P(K2:K9,H2:H9)
                 </f>
                 <v>
@@ -27625,8 +29000,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="37">
-            <c r="A37" t="n">
-                <f>
+            <c r="A37" cm="1">
+                <f t="array" ref="A37">
                     _xlfn.COVARIANCE.P(I2:I9,J2:J9)
                 </f>
                 <v>
@@ -27635,8 +29010,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="38">
-            <c r="A38" t="n">
-                <f>
+            <c r="A38" cm="1">
+                <f t="array" ref="A38">
                     _xlfn.CSC(PI()/4)
                 </f>
                 <v>
@@ -27645,8 +29020,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="39">
-            <c r="A39" t="n">
-                <f>
+            <c r="A39" cm="1">
+                <f t="array" ref="A39">
                     _xlfn.CSCH(PI()/3)
                 </f>
                 <v>
@@ -27655,8 +29030,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="40">
-            <c r="A40" t="n">
-                <f>
+            <c r="A40" cm="1">
+                <f t="array" ref="A40">
                     DATE(2020,5,25)
                 </f>
                 <v>
@@ -27665,8 +29040,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="41">
-            <c r="A41" t="n">
-                <f>
+            <c r="A41" cm="1">
+                <f t="array" ref="A41">
                     DATEVALUE("1969-08-15")
                 </f>
                 <v>
@@ -27675,8 +29050,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="42">
-            <c r="A42" t="n">
-                <f>
+            <c r="A42" cm="1">
+                <f t="array" ref="A42">
                     DAVERAGE(G1:K9,"Tot. Score",J12:J13)
                 </f>
                 <v>
@@ -27685,8 +29060,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="43">
-            <c r="A43" t="n">
-                <f>
+            <c r="A43" cm="1">
+                <f t="array" ref="A43">
                     DAY("2020-03-17")
                 </f>
                 <v>
@@ -27695,8 +29070,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="44">
-            <c r="A44" t="n">
-                <f>
+            <c r="A44" cm="1">
+                <f t="array" ref="A44">
                     _xlfn.DAYS("2022-03-17","2021-03-17")
                 </f>
                 <v>
@@ -27705,8 +29080,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="45">
-            <c r="A45" t="n">
-                <f>
+            <c r="A45" cm="1">
+                <f t="array" ref="A45">
                     DCOUNT(G1:K9,"Name",H12:H13)
                 </f>
                 <v>
@@ -27715,8 +29090,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="46">
-            <c r="A46" t="n">
-                <f>
+            <c r="A46" cm="1">
+                <f t="array" ref="A46">
                     DCOUNTA(G1:K9,"Name",H12:H13)
                 </f>
                 <v>
@@ -27725,8 +29100,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="47">
-            <c r="A47" t="n">
-                <f>
+            <c r="A47" cm="1">
+                <f t="array" ref="A47">
                     _xlfn.DECIMAL(20,16)
                 </f>
                 <v>
@@ -27735,8 +29110,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="48">
-            <c r="A48" t="n">
-                <f>
+            <c r="A48" cm="1">
+                <f t="array" ref="A48">
                     DEGREES(PI()/4)
                 </f>
                 <v>
@@ -27745,8 +29120,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="49">
-            <c r="A49" t="n">
-                <f>
+            <c r="A49" cm="1">
+                <f t="array" ref="A49">
                     DGET(G1:K9,"Hours Played",G12:G13)
                 </f>
                 <v>
@@ -27755,8 +29130,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="50">
-            <c r="A50" t="n">
-                <f>
+            <c r="A50" cm="1">
+                <f t="array" ref="A50">
                     DMAX(G1:K9,"Tot. Score",I12:I13)
                 </f>
                 <v>
@@ -27765,8 +29140,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="51">
-            <c r="A51" t="n">
-                <f>
+            <c r="A51" cm="1">
+                <f t="array" ref="A51">
                     DMIN(G1:K9,"Tot. Score",H12:H13)
                 </f>
                 <v>
@@ -27775,8 +29150,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="52">
-            <c r="A52" t="n">
-                <f>
+            <c r="A52" cm="1">
+                <f t="array" ref="A52">
                     DPRODUCT(G1:K9,"Age",K12:K13)
                 </f>
                 <v>
@@ -27785,8 +29160,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="53">
-            <c r="A53" t="n">
-                <f>
+            <c r="A53" cm="1">
+                <f t="array" ref="A53">
                     DSTDEV(G1:K9,"Age",H12:H13)
                 </f>
                 <v>
@@ -27795,8 +29170,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="54">
-            <c r="A54" t="n">
-                <f>
+            <c r="A54" cm="1">
+                <f t="array" ref="A54">
                     DSTDEVP(G1:K9,"Age",H12:H13)
                 </f>
                 <v>
@@ -27805,8 +29180,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="55">
-            <c r="A55" t="n">
-                <f>
+            <c r="A55" cm="1">
+                <f t="array" ref="A55">
                     DSUM(G1:K9,"Age",I12:I13)
                 </f>
                 <v>
@@ -27815,8 +29190,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="56">
-            <c r="A56" t="n">
-                <f>
+            <c r="A56" cm="1">
+                <f t="array" ref="A56">
                     DVAR(G1:K9,"Hours Played",H12:H13)
                 </f>
                 <v>
@@ -27825,8 +29200,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="57">
-            <c r="A57" t="n">
-                <f>
+            <c r="A57" cm="1">
+                <f t="array" ref="A57">
                     DVARP(G1:K9,"Hours Played",H12:H13)
                 </f>
                 <v>
@@ -27835,8 +29210,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="58">
-            <c r="A58" t="n">
-                <f>
+            <c r="A58" cm="1">
+                <f t="array" ref="A58">
                     EDATE("1969-07-22",-2)
                 </f>
                 <v>
@@ -27845,8 +29220,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="59">
-            <c r="A59" t="n">
-                <f>
+            <c r="A59" cm="1">
+                <f t="array" ref="A59">
                     EOMONTH("2020-07-21",1)
                 </f>
                 <v>
@@ -27855,8 +29230,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="60">
-            <c r="A60" t="b">
-                <f>
+            <c r="A60" cm="1">
+                <f t="array" ref="A60">
                     EXACT("AbsSdf%","AbsSdf%")
                 </f>
                 <v>
@@ -27865,8 +29240,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="61">
-            <c r="A61" t="n">
-                <f>
+            <c r="A61" cm="1">
+                <f t="array" ref="A61">
                     EXP(4)
                 </f>
                 <v>
@@ -27875,8 +29250,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="62">
-            <c r="A62" t="n">
-                <f>
+            <c r="A62" cm="1">
+                <f t="array" ref="A62">
                     FIND("A","qbdahbaazo A")
                 </f>
                 <v>
@@ -27885,8 +29260,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="63">
-            <c r="A63" t="n">
-                <f>
+            <c r="A63" cm="1">
+                <f t="array" ref="A63">
                     FLOOR(5.5,2)
                 </f>
                 <v>
@@ -27895,8 +29270,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="64">
-            <c r="A64" t="n">
-                <f>
+            <c r="A64" cm="1">
+                <f t="array" ref="A64">
                     _xlfn.FLOOR.MATH(-5.55,2,1)
                 </f>
                 <v>
@@ -27905,8 +29280,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="65">
-            <c r="A65" t="n">
-                <f>
+            <c r="A65" cm="1">
+                <f t="array" ref="A65">
                     _xlfn.FLOOR.PRECISE(199,100)
                 </f>
                 <v>
@@ -27915,8 +29290,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="66">
-            <c r="A66" t="n">
-                <f>
+            <c r="A66" cm="1">
+                <f t="array" ref="A66">
                     HLOOKUP("Tot. Score",H1:K9,4,FALSE)
                 </f>
                 <v>
@@ -27925,8 +29300,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="67">
-            <c r="A67" t="n">
-                <f>
+            <c r="A67" cm="1">
+                <f t="array" ref="A67">
                     HOUR("02:14:56")
                 </f>
                 <v>
@@ -27935,8 +29310,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="68">
-            <c r="A68" t="str">
-                <f>
+            <c r="A68" cm="1">
+                <f t="array" ref="A68">
                     IF(TRUE,"TABOURET","JAMBON")
                 </f>
                 <v>
@@ -27945,8 +29320,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="69">
-            <c r="A69" t="str">
-                <f>
+            <c r="A69" cm="1">
+                <f t="array" ref="A69">
                     IFERROR(0/0,"no diving by zero.")
                 </f>
                 <v>
@@ -27955,8 +29330,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="70">
-            <c r="A70" t="str">
-                <f>
+            <c r="A70" cm="1">
+                <f t="array" ref="A70">
                     _xlfn.IFS($H2&gt;$H3,"first player is older",$H3&gt;$H2,"second player is older")
                 </f>
                 <v>
@@ -27965,8 +29340,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="71">
-            <c r="A71" t="b">
-                <f>
+            <c r="A71" cm="1">
+                <f t="array" ref="A71">
                     ISERROR(0/0)
                 </f>
                 <v>
@@ -27975,8 +29350,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="72">
-            <c r="A72" t="b">
-                <f>
+            <c r="A72" cm="1">
+                <f t="array" ref="A72">
                     ISEVEN(3)
                 </f>
                 <v>
@@ -27985,8 +29360,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="73">
-            <c r="A73" t="b">
-                <f>
+            <c r="A73" cm="1">
+                <f t="array" ref="A73">
                     ISLOGICAL("TRUE")
                 </f>
                 <v>
@@ -27995,8 +29370,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="74">
-            <c r="A74" t="b">
-                <f>
+            <c r="A74" cm="1">
+                <f t="array" ref="A74">
                     ISNONTEXT(TRUE)
                 </f>
                 <v>
@@ -28005,8 +29380,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="75">
-            <c r="A75" t="b">
-                <f>
+            <c r="A75" cm="1">
+                <f t="array" ref="A75">
                     ISNUMBER(1231.5)
                 </f>
                 <v>
@@ -28015,8 +29390,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="76">
-            <c r="A76" t="n">
-                <f>
+            <c r="A76" cm="1">
+                <f t="array" ref="A76">
                     ISO.CEILING(-7.89)
                 </f>
                 <v>
@@ -28025,8 +29400,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="77">
-            <c r="A77" t="b">
-                <f>
+            <c r="A77" cm="1">
+                <f t="array" ref="A77">
                     ISODD(4)
                 </f>
                 <v>
@@ -28035,8 +29410,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="78">
-            <c r="A78" t="n">
-                <f>
+            <c r="A78" cm="1">
+                <f t="array" ref="A78">
                     _xlfn.ISOWEEKNUM("2016-01-03")
                 </f>
                 <v>
@@ -28045,8 +29420,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="79">
-            <c r="A79" t="b">
-                <f>
+            <c r="A79" cm="1">
+                <f t="array" ref="A79">
                     ISTEXT("123")
                 </f>
                 <v>
@@ -28055,8 +29430,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="80">
-            <c r="A80" t="n">
-                <f>
+            <c r="A80" cm="1">
+                <f t="array" ref="A80">
                     LARGE(H2:H9,3)
                 </f>
                 <v>
@@ -28065,8 +29440,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="81">
-            <c r="A81" t="str">
-                <f>
+            <c r="A81" cm="1">
+                <f t="array" ref="A81">
                     LEFT("Mich",4)
                 </f>
                 <v>
@@ -28075,8 +29450,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="82">
-            <c r="A82" t="n">
-                <f>
+            <c r="A82" cm="1">
+                <f t="array" ref="A82">
                     LEN("anticonstitutionnellement")
                 </f>
                 <v>
@@ -28085,8 +29460,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="83">
-            <c r="A83" t="n">
-                <f>
+            <c r="A83" cm="1">
+                <f t="array" ref="A83">
                     ROUND(LN(2),5)
                 </f>
                 <v>
@@ -28095,8 +29470,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="84">
-            <c r="A84" t="n">
-                <f>
+            <c r="A84" cm="1">
+                <f t="array" ref="A84">
                     LOOKUP(42,H2:J9)
                 </f>
                 <v>
@@ -28105,8 +29480,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="85">
-            <c r="A85" t="str">
-                <f>
+            <c r="A85" cm="1">
+                <f t="array" ref="A85">
                     LOWER("オAドB")
                 </f>
                 <v>
@@ -28115,8 +29490,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="86">
-            <c r="A86" t="n">
-                <f>
+            <c r="A86" cm="1">
+                <f t="array" ref="A86">
                     MATCH(42,H2:H9,0)
                 </f>
                 <v>
@@ -28125,8 +29500,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="87">
-            <c r="A87" t="n">
-                <f>
+            <c r="A87" cm="1">
+                <f t="array" ref="A87">
                     MAX(N1:N8)
                 </f>
                 <v>
@@ -28135,8 +29510,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="88">
-            <c r="A88" t="n">
-                <f>
+            <c r="A88" cm="1">
+                <f t="array" ref="A88">
                     MAXA(N1:N8)
                 </f>
                 <v>
@@ -28145,8 +29520,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="89">
-            <c r="A89" t="n">
-                <f>
+            <c r="A89" cm="1">
+                <f t="array" ref="A89">
                     _xlfn.MAXIFS(H2:H9,K2:K9,"&lt;20",K2:K9,"&lt;&gt;4")
                 </f>
                 <v>
@@ -28155,8 +29530,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="90">
-            <c r="A90" t="n">
-                <f>
+            <c r="A90" cm="1">
+                <f t="array" ref="A90">
                     MEDIAN(-1,6,7,234,163845)
                 </f>
                 <v>
@@ -28165,8 +29540,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="91">
-            <c r="A91" t="n">
-                <f>
+            <c r="A91" cm="1">
+                <f t="array" ref="A91">
                     MIN(N1:N8)
                 </f>
                 <v>
@@ -28175,8 +29550,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="92">
-            <c r="A92" t="n">
-                <f>
+            <c r="A92" cm="1">
+                <f t="array" ref="A92">
                     MINA(N1:N8)
                 </f>
                 <v>
@@ -28185,8 +29560,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="93">
-            <c r="A93" t="n">
-                <f>
+            <c r="A93" cm="1">
+                <f t="array" ref="A93">
                     _xlfn.MINIFS(J2:J9,H2:H9,"&gt;20")
                 </f>
                 <v>
@@ -28195,8 +29570,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="94">
-            <c r="A94" t="n">
-                <f>
+            <c r="A94" cm="1">
+                <f t="array" ref="A94">
                     MINUTE(0.126)
                 </f>
                 <v>
@@ -28205,8 +29580,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="95">
-            <c r="A95" t="n">
-                <f>
+            <c r="A95" cm="1">
+                <f t="array" ref="A95">
                     MOD(42,12)
                 </f>
                 <v>
@@ -28215,8 +29590,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="96">
-            <c r="A96" t="n">
-                <f>
+            <c r="A96" cm="1">
+                <f t="array" ref="A96">
                     MONTH("1954-05-02")
                 </f>
                 <v>
@@ -28225,8 +29600,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="97">
-            <c r="A97" t="n">
-                <f>
+            <c r="A97" cm="1">
+                <f t="array" ref="A97">
                     NETWORKDAYS("2013-01-01","2013-02-01")
                 </f>
                 <v>
@@ -28235,8 +29610,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="98">
-            <c r="A98" t="n">
-                <f>
+            <c r="A98" cm="1">
+                <f t="array" ref="A98">
                     NETWORKDAYS.INTL("2013-01-01","2013-02-01","0000111")
                 </f>
                 <v>
@@ -28245,8 +29620,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="99">
-            <c r="A99" t="b">
-                <f>
+            <c r="A99" cm="1">
+                <f t="array" ref="A99">
                     NOT(FALSE)
                 </f>
                 <v>
@@ -28255,8 +29630,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="100">
-            <c r="A100" t="n">
-                <f>
+            <c r="A100" cm="1">
+                <f t="array" ref="A100">
                     NOW()
                 </f>
                 <v>
@@ -28265,8 +29640,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="101">
-            <c r="A101" t="n">
-                <f>
+            <c r="A101" cm="1">
+                <f t="array" ref="A101">
                     ODD(4)
                 </f>
                 <v>
@@ -28275,8 +29650,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="102">
-            <c r="A102" t="b">
-                <f>
+            <c r="A102" cm="1">
+                <f t="array" ref="A102">
                     OR("true",FALSE)
                 </f>
                 <v>
@@ -28285,8 +29660,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="103">
-            <c r="A103" t="n">
-                <f>
+            <c r="A103" cm="1">
+                <f t="array" ref="A103">
                     PERCENTILE(N1:N5,1)
                 </f>
                 <v>
@@ -28295,8 +29670,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="104">
-            <c r="A104" t="n">
-                <f>
+            <c r="A104" cm="1">
+                <f t="array" ref="A104">
                     _xlfn.PERCENTILE.EXC(N1:N5,0.5)
                 </f>
                 <v>
@@ -28305,8 +29680,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="105">
-            <c r="A105" t="n">
-                <f>
+            <c r="A105" cm="1">
+                <f t="array" ref="A105">
                     _xlfn.PERCENTILE.INC(N1:N5,0)
                 </f>
                 <v>
@@ -28315,8 +29690,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="106">
-            <c r="A106" t="n">
-                <f>
+            <c r="A106" cm="1">
+                <f t="array" ref="A106">
                     PI()
                 </f>
                 <v>
@@ -28325,8 +29700,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="107">
-            <c r="A107" t="n">
-                <f>
+            <c r="A107" cm="1">
+                <f t="array" ref="A107">
                     POWER(42,2)
                 </f>
                 <v>
@@ -28335,8 +29710,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="108">
-            <c r="A108" t="n">
-                <f>
+            <c r="A108" cm="1">
+                <f t="array" ref="A108">
                     PRODUCT(1,2,3)
                 </f>
                 <v>
@@ -28345,8 +29720,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="109">
-            <c r="A109" t="n">
-                <f>
+            <c r="A109" cm="1">
+                <f t="array" ref="A109">
                     QUARTILE(N1:N5,0)
                 </f>
                 <v>
@@ -28355,8 +29730,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="110">
-            <c r="A110" t="n">
-                <f>
+            <c r="A110" cm="1">
+                <f t="array" ref="A110">
                     _xlfn.QUARTILE.EXC(N1:N5,1)
                 </f>
                 <v>
@@ -28365,8 +29740,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="111">
-            <c r="A111" t="n">
-                <f>
+            <c r="A111" cm="1">
+                <f t="array" ref="A111">
                     _xlfn.QUARTILE.INC(N1:N5,4)
                 </f>
                 <v>
@@ -28375,8 +29750,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="112">
-            <c r="A112" t="n">
-                <f>
+            <c r="A112" cm="1">
+                <f t="array" ref="A112">
                     RAND()
                 </f>
                 <v>
@@ -28385,8 +29760,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="113">
-            <c r="A113" t="n">
-                <f>
+            <c r="A113" cm="1">
+                <f t="array" ref="A113">
                     RANDBETWEEN(1.1,2)
                 </f>
                 <v>
@@ -28395,8 +29770,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="114">
-            <c r="A114" t="str">
-                <f>
+            <c r="A114" cm="1">
+                <f t="array" ref="A114">
                     REPLACE("ABZ",2,1,"Y")
                 </f>
                 <v>
@@ -28405,8 +29780,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="115">
-            <c r="A115" t="str">
-                <f>
+            <c r="A115" cm="1">
+                <f t="array" ref="A115">
                     RIGHT("kikou",2)
                 </f>
                 <v>
@@ -28415,8 +29790,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="116">
-            <c r="A116" t="n">
-                <f>
+            <c r="A116" cm="1">
+                <f t="array" ref="A116">
                     ROUND(49.9,1)
                 </f>
                 <v>
@@ -28425,8 +29800,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="117">
-            <c r="A117" t="n">
-                <f>
+            <c r="A117" cm="1">
+                <f t="array" ref="A117">
                     ROUNDDOWN(42,-1)
                 </f>
                 <v>
@@ -28435,8 +29810,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="118">
-            <c r="A118" t="n">
-                <f>
+            <c r="A118" cm="1">
+                <f t="array" ref="A118">
                     ROUNDUP(-1.6,0)
                 </f>
                 <v>
@@ -28445,8 +29820,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="119">
-            <c r="A119" t="n">
-                <f>
+            <c r="A119" cm="1">
+                <f t="array" ref="A119">
                     ROW(A234)
                 </f>
                 <v>
@@ -28455,8 +29830,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="120">
-            <c r="A120" t="n">
-                <f>
+            <c r="A120" cm="1">
+                <f t="array" ref="A120">
                     ROWS(B3:C40)
                 </f>
                 <v>
@@ -28465,8 +29840,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="121">
-            <c r="A121" t="n">
-                <f>
+            <c r="A121" cm="1">
+                <f t="array" ref="A121">
                     SEARCH("C","ABCD")
                 </f>
                 <v>
@@ -28475,8 +29850,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="122">
-            <c r="A122" t="n">
-                <f>
+            <c r="A122" cm="1">
+                <f t="array" ref="A122">
                     _xlfn.SEC(PI()/3)
                 </f>
                 <v>
@@ -28485,8 +29860,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="123">
-            <c r="A123" t="n">
-                <f>
+            <c r="A123" cm="1">
+                <f t="array" ref="A123">
                     _xlfn.SECH(1)
                 </f>
                 <v>
@@ -28495,8 +29870,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="124">
-            <c r="A124" t="n">
-                <f>
+            <c r="A124" cm="1">
+                <f t="array" ref="A124">
                     SECOND("00:21:42")
                 </f>
                 <v>
@@ -28505,8 +29880,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="125">
-            <c r="A125" t="n">
-                <f>
+            <c r="A125" cm="1">
+                <f t="array" ref="A125">
                     SIN(PI()/6)
                 </f>
                 <v>
@@ -28515,8 +29890,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="126">
-            <c r="A126" t="n">
-                <f>
+            <c r="A126" cm="1">
+                <f t="array" ref="A126">
                     SINH(1)
                 </f>
                 <v>
@@ -28525,8 +29900,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="127">
-            <c r="A127" t="n">
-                <f>
+            <c r="A127" cm="1">
+                <f t="array" ref="A127">
                     SMALL(H2:H9,3)
                 </f>
                 <v>
@@ -28535,8 +29910,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="128">
-            <c r="A128" t="n">
-                <f>
+            <c r="A128" cm="1">
+                <f t="array" ref="A128">
                     SQRT(4)
                 </f>
                 <v>
@@ -28545,8 +29920,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="129">
-            <c r="A129" t="n">
-                <f>
+            <c r="A129" cm="1">
+                <f t="array" ref="A129">
                     STDEV(-2,0,2)
                 </f>
                 <v>
@@ -28555,8 +29930,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="130">
-            <c r="A130" t="n">
-                <f>
+            <c r="A130" cm="1">
+                <f t="array" ref="A130">
                     _xlfn.STDEV.P(2,4)
                 </f>
                 <v>
@@ -28565,8 +29940,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="131">
-            <c r="A131" t="n">
-                <f>
+            <c r="A131" cm="1">
+                <f t="array" ref="A131">
                     _xlfn.STDEV.S(2,4,6)
                 </f>
                 <v>
@@ -28575,8 +29950,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="132">
-            <c r="A132" t="n">
-                <f>
+            <c r="A132" cm="1">
+                <f t="array" ref="A132">
                     STDEVA(TRUE,3,5)
                 </f>
                 <v>
@@ -28585,8 +29960,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="133">
-            <c r="A133" t="n">
-                <f>
+            <c r="A133" cm="1">
+                <f t="array" ref="A133">
                     STDEVP(2,5,8)
                 </f>
                 <v>
@@ -28595,8 +29970,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="134">
-            <c r="A134" t="n">
-                <f>
+            <c r="A134" cm="1">
+                <f t="array" ref="A134">
                     STDEVPA(TRUE,4,7)
                 </f>
                 <v>
@@ -28605,8 +29980,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="135">
-            <c r="A135" t="str">
-                <f>
+            <c r="A135" cm="1">
+                <f t="array" ref="A135">
                     SUBSTITUTE("SAP is best","SAP","Odoo")
                 </f>
                 <v>
@@ -28615,8 +29990,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="136">
-            <c r="A136" t="n">
-                <f>
+            <c r="A136" cm="1">
+                <f t="array" ref="A136">
                     SUM(1,2,3,4,5)
                 </f>
                 <v>
@@ -28625,8 +30000,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="137">
-            <c r="A137" t="n">
-                <f>
+            <c r="A137" cm="1">
+                <f t="array" ref="A137">
                     SUMIF(K2:K9,"&lt;100")
                 </f>
                 <v>
@@ -28635,8 +30010,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="138">
-            <c r="A138" t="n">
-                <f>
+            <c r="A138" cm="1">
+                <f t="array" ref="A138">
                     SUMIFS(H2:H9,K2:K9,"&lt;100")
                 </f>
                 <v>
@@ -28645,8 +30020,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="139">
-            <c r="A139" t="n">
-                <f>
+            <c r="A139" cm="1">
+                <f t="array" ref="A139">
                     TAN(PI()/4)
                 </f>
                 <v>
@@ -28655,8 +30030,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="140">
-            <c r="A140" t="n">
-                <f>
+            <c r="A140" cm="1">
+                <f t="array" ref="A140">
                     TANH(1)
                 </f>
                 <v>
@@ -28665,8 +30040,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="141">
-            <c r="A141" t="str">
-                <f>
+            <c r="A141" cm="1">
+                <f t="array" ref="A141">
                     _xlfn.TEXTJOIN("-",TRUE,"","1","A","%")
                 </f>
                 <v>
@@ -28675,8 +30050,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="142">
-            <c r="A142" t="n">
-                <f>
+            <c r="A142" cm="1">
+                <f t="array" ref="A142">
                     TIME(9,11,31)
                 </f>
                 <v>
@@ -28685,8 +30060,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="143">
-            <c r="A143" t="n">
-                <f>
+            <c r="A143" cm="1">
+                <f t="array" ref="A143">
                     TIMEVALUE("18:00:00")
                 </f>
                 <v>
@@ -28695,8 +30070,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="144">
-            <c r="A144" t="n">
-                <f>
+            <c r="A144" cm="1">
+                <f t="array" ref="A144">
                     TODAY()
                 </f>
                 <v>
@@ -28705,8 +30080,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="145">
-            <c r="A145" t="str">
-                <f>
+            <c r="A145" cm="1">
+                <f t="array" ref="A145">
                     TRIM(" Jean Ticonstitutionnalise ")
                 </f>
                 <v>
@@ -28715,8 +30090,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="146">
-            <c r="A146" t="n">
-                <f>
+            <c r="A146" cm="1">
+                <f t="array" ref="A146">
                     TRUNC(42.42,1)
                 </f>
                 <v>
@@ -28725,8 +30100,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="147">
-            <c r="A147" t="str">
-                <f>
+            <c r="A147" cm="1">
+                <f t="array" ref="A147">
                     UPPER("grrrr !")
                 </f>
                 <v>
@@ -28735,8 +30110,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="148">
-            <c r="A148" t="n">
-                <f>
+            <c r="A148" cm="1">
+                <f t="array" ref="A148">
                     VAR(K1:K5)
                 </f>
                 <v>
@@ -28745,8 +30120,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="149">
-            <c r="A149" t="n">
-                <f>
+            <c r="A149" cm="1">
+                <f t="array" ref="A149">
                     _xlfn.VAR.P(K1:K5)
                 </f>
                 <v>
@@ -28755,8 +30130,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="150">
-            <c r="A150" t="n">
-                <f>
+            <c r="A150" cm="1">
+                <f t="array" ref="A150">
                     _xlfn.VAR.S(2,5,8)
                 </f>
                 <v>
@@ -28765,8 +30140,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="151">
-            <c r="A151" t="n">
-                <f>
+            <c r="A151" cm="1">
+                <f t="array" ref="A151">
                     VARA(K1:K5)
                 </f>
                 <v>
@@ -28775,8 +30150,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="152">
-            <c r="A152" t="n">
-                <f>
+            <c r="A152" cm="1">
+                <f t="array" ref="A152">
                     VARP(K1:K5)
                 </f>
                 <v>
@@ -28785,8 +30160,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="153">
-            <c r="A153" t="n">
-                <f>
+            <c r="A153" cm="1">
+                <f t="array" ref="A153">
                     VARPA(K1:K5)
                 </f>
                 <v>
@@ -28795,8 +30170,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="154">
-            <c r="A154" t="n">
-                <f>
+            <c r="A154" cm="1">
+                <f t="array" ref="A154">
                     VLOOKUP("NotACheater",G1:K9,3,FALSE)
                 </f>
                 <v>
@@ -28805,8 +30180,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="155">
-            <c r="A155" t="n">
-                <f>
+            <c r="A155" cm="1">
+                <f t="array" ref="A155">
                     WEEKDAY("2021-06-12")
                 </f>
                 <v>
@@ -28815,8 +30190,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="156">
-            <c r="A156" t="n">
-                <f>
+            <c r="A156" cm="1">
+                <f t="array" ref="A156">
                     WEEKNUM("2021-06-29")
                 </f>
                 <v>
@@ -28825,8 +30200,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="157">
-            <c r="A157" t="n">
-                <f>
+            <c r="A157" cm="1">
+                <f t="array" ref="A157">
                     WORKDAY("2021-03-15",6)
                 </f>
                 <v>
@@ -28835,8 +30210,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="158">
-            <c r="A158" t="n">
-                <f>
+            <c r="A158" cm="1">
+                <f t="array" ref="A158">
                     WORKDAY.INTL("2021-03-15",6,"0111111")
                 </f>
                 <v>
@@ -28845,8 +30220,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="159">
-            <c r="A159" t="b">
-                <f>
+            <c r="A159" cm="1">
+                <f t="array" ref="A159">
                     _xlfn.XOR(FALSE,TRUE,FALSE,FALSE)
                 </f>
                 <v>
@@ -28855,8 +30230,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="160">
-            <c r="A160" t="n">
-                <f>
+            <c r="A160" cm="1">
+                <f t="array" ref="A160">
                     YEAR("2012-03-12")
                 </f>
                 <v>
@@ -28865,8 +30240,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="161">
-            <c r="A161" t="n">
-                <f>
+            <c r="A161" cm="1">
+                <f t="array" ref="A161">
                     DELTA(1,1)
                 </f>
                 <v>
@@ -28875,8 +30250,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="162">
-            <c r="A162" t="str">
-                <f>
+            <c r="A162" cm="1">
+                <f t="array" ref="A162">
                     NA()
                 </f>
                 <v>
@@ -28885,8 +30260,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="163">
-            <c r="A163" t="b">
-                <f>
+            <c r="A163" cm="1">
+                <f t="array" ref="A163">
                     ISNA(A162)
                 </f>
                 <v>
@@ -28895,8 +30270,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="164">
-            <c r="A164" t="b">
-                <f>
+            <c r="A164" cm="1">
+                <f t="array" ref="A164">
                     ISERR(A162)
                 </f>
                 <v>
@@ -28905,8 +30280,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="165">
-            <c r="A165" t="str">
-                <f>
+            <c r="A165" cm="1">
+                <f t="array" ref="A165">
                     HYPERLINK("https://www.odoo.com","Odoo")
                 </f>
                 <v>
@@ -28915,8 +30290,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="166">
-            <c r="A166" t="str">
-                <f>
+            <c r="A166" cm="1">
+                <f t="array" ref="A166">
                     ADDRESS(27,53,4,FALSE,"sheet!")
                 </f>
                 <v>
@@ -28925,8 +30300,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="167">
-            <c r="A167" t="n">
-                <f>
+            <c r="A167" cm="1">
+                <f t="array" ref="A167">
                     DATEDIF("2002-01-01","2002-01-02","D")
                 </f>
                 <v>
@@ -28935,8 +30310,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="168">
-            <c r="A168" t="n">
-                <f>
+            <c r="A168" cm="1">
+                <f t="array" ref="A168:B169">
                     _xlfn.RANDARRAY(2,2)
                 </f>
                 <v>
@@ -28956,6 +30331,29 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
 </worksheet>",
       "contentType": "sheet",
       "path": "xl/worksheets/sheet0.xml",
+    },
+    {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
     },
     {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
@@ -29110,6 +30508,7 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -29128,6 +30527,7 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
     <Default Extension="xml" ContentType="application/xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml" PartName="/xl/workbook.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -29206,8 +30606,8 @@ exports[`Test XLSX export formulas All non-exportable formulas 1`] = `
             </c>
         </row>
         <row r="3">
-            <c r="A3" t="n">
-                <f>
+            <c r="A3" cm="1">
+                <f t="array" ref="A3">
                     SUM(A1,ABS(100))
                 </f>
                 <v>
@@ -29392,8 +30792,8 @@ exports[`Test XLSX export formulas All non-exportable formulas 1`] = `
             </c>
         </row>
         <row r="22">
-            <c r="A22" t="n">
-                <f>
+            <c r="A22" cm="1">
+                <f t="array" ref="A22">
                     SUM(A3:Z3)
                 </f>
                 <v>
@@ -29402,8 +30802,8 @@ exports[`Test XLSX export formulas All non-exportable formulas 1`] = `
             </c>
         </row>
         <row r="23">
-            <c r="A23" t="str">
-                <f>
+            <c r="A23" cm="1">
+                <f t="array" ref="A23">
                     SUM(A3:A100)
                 </f>
                 <v>
@@ -29728,6 +31128,29 @@ exports[`Test XLSX export formulas All non-exportable formulas 1`] = `
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="1">
         <numFmt numFmtId="164" formatCode="#,##0,[$k]"/>
@@ -29782,6 +31205,7 @@ exports[`Test XLSX export formulas All non-exportable formulas 1`] = `
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -29800,6 +31224,7 @@ exports[`Test XLSX export formulas All non-exportable formulas 1`] = `
     <Default Extension="xml" ContentType="application/xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml" PartName="/xl/workbook.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -29868,8 +31293,8 @@ exports[`Test XLSX export formulas Multi-Sheet export functions with cross refer
     </cols>
     <sheetData>
         <row r="1">
-            <c r="A1" t="n">
-                <f>
+            <c r="A1" cm="1">
+                <f t="array" ref="A1">
                     SUM(Sheet2!A1)
                 </f>
                 <v>
@@ -29933,8 +31358,8 @@ exports[`Test XLSX export formulas Multi-Sheet export functions with cross refer
             </c>
         </row>
         <row r="2">
-            <c r="A2" t="n">
-                <f>
+            <c r="A2" cm="1">
+                <f t="array" ref="A2">
                     SUM(Sheet1!A2)
                 </f>
                 <v>
@@ -29946,6 +31371,29 @@ exports[`Test XLSX export formulas Multi-Sheet export functions with cross refer
 </worksheet>",
       "contentType": "sheet",
       "path": "xl/worksheets/sheet1.xml",
+    },
+    {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
     },
     {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
@@ -30001,6 +31449,7 @@ exports[`Test XLSX export formulas Multi-Sheet export functions with cross refer
     <Relationship Id="rId2" Target="worksheets/sheet1.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId3" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId4" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId5" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -30020,6 +31469,7 @@ exports[`Test XLSX export formulas Multi-Sheet export functions with cross refer
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml" PartName="/xl/workbook.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet1.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -30125,8 +31575,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="2">
-            <c r="A2" t="n">
-                <f>
+            <c r="A2" cm="1">
+                <f t="array" ref="A2">
                     ABS(-5.5)
                 </f>
                 <v>
@@ -30165,8 +31615,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="3">
-            <c r="A3" t="n">
-                <f>
+            <c r="A3" cm="1">
+                <f t="array" ref="A3">
                     ACOS(1)
                 </f>
                 <v>
@@ -30205,8 +31655,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="4">
-            <c r="A4" t="n">
-                <f>
+            <c r="A4" cm="1">
+                <f t="array" ref="A4">
                     ACOSH(2)
                 </f>
                 <v>
@@ -30245,16 +31695,16 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="5">
-            <c r="A5" t="n">
-                <f>
+            <c r="A5" cm="1">
+                <f t="array" ref="A5">
                     _xlfn.ACOT(1)
                 </f>
                 <v>
                     0.7853981633974483
                 </v>
             </c>
-            <c r="B5" t="n">
-                <f>
+            <c r="B5" cm="1">
+                <f t="array" ref="B5">
                     _xlfn.ACOT(_xlfn.ACOT(1))
                 </f>
                 <v>
@@ -30293,8 +31743,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="6">
-            <c r="A6" t="n">
-                <f>
+            <c r="A6" cm="1">
+                <f t="array" ref="A6">
                     _xlfn.ACOTH(2)
                 </f>
                 <v>
@@ -30333,8 +31783,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="7">
-            <c r="A7" t="b">
-                <f>
+            <c r="A7" cm="1">
+                <f t="array" ref="A7">
                     AND(TRUE,TRUE)
                 </f>
                 <v>
@@ -30373,8 +31823,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="8">
-            <c r="A8" t="n">
-                <f>
+            <c r="A8" cm="1">
+                <f t="array" ref="A8">
                     ASIN(0.5)
                 </f>
                 <v>
@@ -30413,8 +31863,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="9">
-            <c r="A9" t="n">
-                <f>
+            <c r="A9" cm="1">
+                <f t="array" ref="A9">
                     ASINH(2)
                 </f>
                 <v>
@@ -30448,8 +31898,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="10">
-            <c r="A10" t="n">
-                <f>
+            <c r="A10" cm="1">
+                <f t="array" ref="A10">
                     ATAN(1)
                 </f>
                 <v>
@@ -30458,8 +31908,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="11">
-            <c r="A11" t="n">
-                <f>
+            <c r="A11" cm="1">
+                <f t="array" ref="A11">
                     ATAN2(-1,0)
                 </f>
                 <v>
@@ -30473,8 +31923,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="12">
-            <c r="A12" t="n">
-                <f>
+            <c r="A12" cm="1">
+                <f t="array" ref="A12">
                     ATANH(0.7)
                 </f>
                 <v>
@@ -30508,8 +31958,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="13">
-            <c r="A13" t="n">
-                <f>
+            <c r="A13" cm="1">
+                <f t="array" ref="A13">
                     AVEDEV(I2:I9)
                 </f>
                 <v>
@@ -30543,8 +31993,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="14">
-            <c r="A14" t="n">
-                <f>
+            <c r="A14" cm="1">
+                <f t="array" ref="A14">
                     AVERAGE(H2:H9)
                 </f>
                 <v>
@@ -30553,8 +32003,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="15">
-            <c r="A15" t="n">
-                <f>
+            <c r="A15" cm="1">
+                <f t="array" ref="A15">
                     AVERAGEA(G2:H9)
                 </f>
                 <v>
@@ -30563,8 +32013,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="16">
-            <c r="A16" t="n">
-                <f>
+            <c r="A16" cm="1">
+                <f t="array" ref="A16">
                     AVERAGEIF(J2:J9,"&gt;150000")
                 </f>
                 <v>
@@ -30573,8 +32023,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="17">
-            <c r="A17" t="n">
-                <f>
+            <c r="A17" cm="1">
+                <f t="array" ref="A17">
                     AVERAGEIFS(I2:I9,H2:H9,"&gt;=30",K2:K9,"&lt;10")
                 </f>
                 <v>
@@ -30583,8 +32033,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="18">
-            <c r="A18" t="n">
-                <f>
+            <c r="A18" cm="1">
+                <f t="array" ref="A18">
                     CEILING(20.4,1)
                 </f>
                 <v>
@@ -30593,8 +32043,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="19">
-            <c r="A19" t="n">
-                <f>
+            <c r="A19" cm="1">
+                <f t="array" ref="A19">
                     _xlfn.CEILING.MATH(-5.5,1,0)
                 </f>
                 <v>
@@ -30603,8 +32053,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="20">
-            <c r="A20" t="n">
-                <f>
+            <c r="A20" cm="1">
+                <f t="array" ref="A20">
                     _xlfn.CEILING.PRECISE(230,100)
                 </f>
                 <v>
@@ -30613,8 +32063,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="21">
-            <c r="A21" t="str">
-                <f>
+            <c r="A21" cm="1">
+                <f t="array" ref="A21">
                     CHAR(74)
                 </f>
                 <v>
@@ -30623,8 +32073,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="22">
-            <c r="A22" t="n">
-                <f>
+            <c r="A22" cm="1">
+                <f t="array" ref="A22">
                     COLUMN(C4)
                 </f>
                 <v>
@@ -30633,8 +32083,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="23">
-            <c r="A23" t="n">
-                <f>
+            <c r="A23" cm="1">
+                <f t="array" ref="A23">
                     COLUMNS(A5:D12)
                 </f>
                 <v>
@@ -30643,8 +32093,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="24">
-            <c r="A24" t="str">
-                <f>
+            <c r="A24" cm="1">
+                <f t="array" ref="A24">
                     _xlfn.CONCAT(1,23)
                 </f>
                 <v>
@@ -30653,8 +32103,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="25">
-            <c r="A25" t="str">
-                <f>
+            <c r="A25" cm="1">
+                <f t="array" ref="A25">
                     CONCATENATE("BUT, ","MICHEL")
                 </f>
                 <v>
@@ -30663,8 +32113,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="26">
-            <c r="A26" t="n">
-                <f>
+            <c r="A26" cm="1">
+                <f t="array" ref="A26">
                     COS(PI()/3)
                 </f>
                 <v>
@@ -30673,8 +32123,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="27">
-            <c r="A27" t="n">
-                <f>
+            <c r="A27" cm="1">
+                <f t="array" ref="A27">
                     COSH(2)
                 </f>
                 <v>
@@ -30683,8 +32133,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="28">
-            <c r="A28" t="n">
-                <f>
+            <c r="A28" cm="1">
+                <f t="array" ref="A28">
                     _xlfn.COT(PI()/6)
                 </f>
                 <v>
@@ -30693,8 +32143,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="29">
-            <c r="A29" t="n">
-                <f>
+            <c r="A29" cm="1">
+                <f t="array" ref="A29">
                     _xlfn.COTH(0.5)
                 </f>
                 <v>
@@ -30703,8 +32153,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="30">
-            <c r="A30" t="n">
-                <f>
+            <c r="A30" cm="1">
+                <f t="array" ref="A30">
                     COUNT(1,"a","5","2021-03-14")
                 </f>
                 <v>
@@ -30713,8 +32163,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="31">
-            <c r="A31" t="n">
-                <f>
+            <c r="A31" cm="1">
+                <f t="array" ref="A31">
                     COUNTA(1,"a","5","2021-03-14")
                 </f>
                 <v>
@@ -30723,8 +32173,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="32">
-            <c r="A32" t="n">
-                <f>
+            <c r="A32" cm="1">
+                <f t="array" ref="A32">
                     COUNTBLANK("","1",3,FALSE)
                 </f>
                 <v>
@@ -30733,8 +32183,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="33">
-            <c r="A33" t="n">
-                <f>
+            <c r="A33" cm="1">
+                <f t="array" ref="A33">
                     COUNTIF(H2:H9,"&gt;30")
                 </f>
                 <v>
@@ -30743,8 +32193,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="34">
-            <c r="A34" t="n">
-                <f>
+            <c r="A34" cm="1">
+                <f t="array" ref="A34">
                     COUNTIFS(H2:H9,"&gt;25",K2:K9,"&lt;4")
                 </f>
                 <v>
@@ -30753,8 +32203,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="35">
-            <c r="A35" t="n">
-                <f>
+            <c r="A35" cm="1">
+                <f t="array" ref="A35">
                     COVAR(H2:H9,K2:K9)
                 </f>
                 <v>
@@ -30763,8 +32213,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="36">
-            <c r="A36" t="n">
-                <f>
+            <c r="A36" cm="1">
+                <f t="array" ref="A36">
                     _xlfn.COVARIANCE.P(K2:K9,H2:H9)
                 </f>
                 <v>
@@ -30773,8 +32223,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="37">
-            <c r="A37" t="n">
-                <f>
+            <c r="A37" cm="1">
+                <f t="array" ref="A37">
                     _xlfn.COVARIANCE.P(I2:I9,J2:J9)
                 </f>
                 <v>
@@ -30783,8 +32233,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="38">
-            <c r="A38" t="n">
-                <f>
+            <c r="A38" cm="1">
+                <f t="array" ref="A38">
                     _xlfn.CSC(PI()/4)
                 </f>
                 <v>
@@ -30793,8 +32243,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="39">
-            <c r="A39" t="n">
-                <f>
+            <c r="A39" cm="1">
+                <f t="array" ref="A39">
                     _xlfn.CSCH(PI()/3)
                 </f>
                 <v>
@@ -30803,8 +32253,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="40">
-            <c r="A40" t="n">
-                <f>
+            <c r="A40" cm="1">
+                <f t="array" ref="A40">
                     DATE(2020,5,25)
                 </f>
                 <v>
@@ -30813,8 +32263,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="41">
-            <c r="A41" t="n">
-                <f>
+            <c r="A41" cm="1">
+                <f t="array" ref="A41">
                     DATEVALUE("1969-08-15")
                 </f>
                 <v>
@@ -30823,8 +32273,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="42">
-            <c r="A42" t="n">
-                <f>
+            <c r="A42" cm="1">
+                <f t="array" ref="A42">
                     DAVERAGE(G1:K9,"Tot. Score",J12:J13)
                 </f>
                 <v>
@@ -30833,8 +32283,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="43">
-            <c r="A43" t="n">
-                <f>
+            <c r="A43" cm="1">
+                <f t="array" ref="A43">
                     DAY("2020-03-17")
                 </f>
                 <v>
@@ -30843,8 +32293,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="44">
-            <c r="A44" t="n">
-                <f>
+            <c r="A44" cm="1">
+                <f t="array" ref="A44">
                     _xlfn.DAYS("2022-03-17","2021-03-17")
                 </f>
                 <v>
@@ -30853,8 +32303,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="45">
-            <c r="A45" t="n">
-                <f>
+            <c r="A45" cm="1">
+                <f t="array" ref="A45">
                     DCOUNT(G1:K9,"Name",H12:H13)
                 </f>
                 <v>
@@ -30863,8 +32313,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="46">
-            <c r="A46" t="n">
-                <f>
+            <c r="A46" cm="1">
+                <f t="array" ref="A46">
                     DCOUNTA(G1:K9,"Name",H12:H13)
                 </f>
                 <v>
@@ -30873,8 +32323,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="47">
-            <c r="A47" t="n">
-                <f>
+            <c r="A47" cm="1">
+                <f t="array" ref="A47">
                     _xlfn.DECIMAL(20,16)
                 </f>
                 <v>
@@ -30883,8 +32333,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="48">
-            <c r="A48" t="n">
-                <f>
+            <c r="A48" cm="1">
+                <f t="array" ref="A48">
                     DEGREES(PI()/4)
                 </f>
                 <v>
@@ -30893,8 +32343,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="49">
-            <c r="A49" t="n">
-                <f>
+            <c r="A49" cm="1">
+                <f t="array" ref="A49">
                     DGET(G1:K9,"Hours Played",G12:G13)
                 </f>
                 <v>
@@ -30903,8 +32353,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="50">
-            <c r="A50" t="n">
-                <f>
+            <c r="A50" cm="1">
+                <f t="array" ref="A50">
                     DMAX(G1:K9,"Tot. Score",I12:I13)
                 </f>
                 <v>
@@ -30913,8 +32363,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="51">
-            <c r="A51" t="n">
-                <f>
+            <c r="A51" cm="1">
+                <f t="array" ref="A51">
                     DMIN(G1:K9,"Tot. Score",H12:H13)
                 </f>
                 <v>
@@ -30923,8 +32373,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="52">
-            <c r="A52" t="n">
-                <f>
+            <c r="A52" cm="1">
+                <f t="array" ref="A52">
                     DPRODUCT(G1:K9,"Age",K12:K13)
                 </f>
                 <v>
@@ -30933,8 +32383,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="53">
-            <c r="A53" t="n">
-                <f>
+            <c r="A53" cm="1">
+                <f t="array" ref="A53">
                     DSTDEV(G1:K9,"Age",H12:H13)
                 </f>
                 <v>
@@ -30943,8 +32393,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="54">
-            <c r="A54" t="n">
-                <f>
+            <c r="A54" cm="1">
+                <f t="array" ref="A54">
                     DSTDEVP(G1:K9,"Age",H12:H13)
                 </f>
                 <v>
@@ -30953,8 +32403,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="55">
-            <c r="A55" t="n">
-                <f>
+            <c r="A55" cm="1">
+                <f t="array" ref="A55">
                     DSUM(G1:K9,"Age",I12:I13)
                 </f>
                 <v>
@@ -30963,8 +32413,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="56">
-            <c r="A56" t="n">
-                <f>
+            <c r="A56" cm="1">
+                <f t="array" ref="A56">
                     DVAR(G1:K9,"Hours Played",H12:H13)
                 </f>
                 <v>
@@ -30973,8 +32423,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="57">
-            <c r="A57" t="n">
-                <f>
+            <c r="A57" cm="1">
+                <f t="array" ref="A57">
                     DVARP(G1:K9,"Hours Played",H12:H13)
                 </f>
                 <v>
@@ -30983,8 +32433,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="58">
-            <c r="A58" t="n">
-                <f>
+            <c r="A58" cm="1">
+                <f t="array" ref="A58">
                     EDATE("1969-07-22",-2)
                 </f>
                 <v>
@@ -30993,8 +32443,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="59">
-            <c r="A59" t="n">
-                <f>
+            <c r="A59" cm="1">
+                <f t="array" ref="A59">
                     EOMONTH("2020-07-21",1)
                 </f>
                 <v>
@@ -31003,8 +32453,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="60">
-            <c r="A60" t="b">
-                <f>
+            <c r="A60" cm="1">
+                <f t="array" ref="A60">
                     EXACT("AbsSdf%","AbsSdf%")
                 </f>
                 <v>
@@ -31013,8 +32463,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="61">
-            <c r="A61" t="n">
-                <f>
+            <c r="A61" cm="1">
+                <f t="array" ref="A61">
                     EXP(4)
                 </f>
                 <v>
@@ -31023,8 +32473,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="62">
-            <c r="A62" t="n">
-                <f>
+            <c r="A62" cm="1">
+                <f t="array" ref="A62">
                     FIND("A","qbdahbaazo A")
                 </f>
                 <v>
@@ -31033,8 +32483,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="63">
-            <c r="A63" t="n">
-                <f>
+            <c r="A63" cm="1">
+                <f t="array" ref="A63">
                     FLOOR(5.5,2)
                 </f>
                 <v>
@@ -31043,8 +32493,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="64">
-            <c r="A64" t="n">
-                <f>
+            <c r="A64" cm="1">
+                <f t="array" ref="A64">
                     _xlfn.FLOOR.MATH(-5.55,2,1)
                 </f>
                 <v>
@@ -31053,8 +32503,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="65">
-            <c r="A65" t="n">
-                <f>
+            <c r="A65" cm="1">
+                <f t="array" ref="A65">
                     _xlfn.FLOOR.PRECISE(199,100)
                 </f>
                 <v>
@@ -31063,8 +32513,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="66">
-            <c r="A66" t="n">
-                <f>
+            <c r="A66" cm="1">
+                <f t="array" ref="A66">
                     HLOOKUP("Tot. Score",H1:K9,4,FALSE)
                 </f>
                 <v>
@@ -31073,8 +32523,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="67">
-            <c r="A67" t="n">
-                <f>
+            <c r="A67" cm="1">
+                <f t="array" ref="A67">
                     HOUR("02:14:56")
                 </f>
                 <v>
@@ -31083,8 +32533,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="68">
-            <c r="A68" t="str">
-                <f>
+            <c r="A68" cm="1">
+                <f t="array" ref="A68">
                     IF(TRUE,"TABOURET","JAMBON")
                 </f>
                 <v>
@@ -31093,8 +32543,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="69">
-            <c r="A69" t="str">
-                <f>
+            <c r="A69" cm="1">
+                <f t="array" ref="A69">
                     IFERROR(0/0,"no diving by zero.")
                 </f>
                 <v>
@@ -31103,8 +32553,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="70">
-            <c r="A70" t="str">
-                <f>
+            <c r="A70" cm="1">
+                <f t="array" ref="A70">
                     _xlfn.IFS($H2&gt;$H3,"first player is older",$H3&gt;$H2,"second player is older")
                 </f>
                 <v>
@@ -31113,8 +32563,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="71">
-            <c r="A71" t="b">
-                <f>
+            <c r="A71" cm="1">
+                <f t="array" ref="A71">
                     ISERROR(0/0)
                 </f>
                 <v>
@@ -31123,8 +32573,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="72">
-            <c r="A72" t="b">
-                <f>
+            <c r="A72" cm="1">
+                <f t="array" ref="A72">
                     ISEVEN(3)
                 </f>
                 <v>
@@ -31133,8 +32583,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="73">
-            <c r="A73" t="b">
-                <f>
+            <c r="A73" cm="1">
+                <f t="array" ref="A73">
                     ISLOGICAL("TRUE")
                 </f>
                 <v>
@@ -31143,8 +32593,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="74">
-            <c r="A74" t="b">
-                <f>
+            <c r="A74" cm="1">
+                <f t="array" ref="A74">
                     ISNONTEXT(TRUE)
                 </f>
                 <v>
@@ -31153,8 +32603,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="75">
-            <c r="A75" t="b">
-                <f>
+            <c r="A75" cm="1">
+                <f t="array" ref="A75">
                     ISNUMBER(1231.5)
                 </f>
                 <v>
@@ -31163,8 +32613,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="76">
-            <c r="A76" t="n">
-                <f>
+            <c r="A76" cm="1">
+                <f t="array" ref="A76">
                     ISO.CEILING(-7.89)
                 </f>
                 <v>
@@ -31173,8 +32623,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="77">
-            <c r="A77" t="b">
-                <f>
+            <c r="A77" cm="1">
+                <f t="array" ref="A77">
                     ISODD(4)
                 </f>
                 <v>
@@ -31183,8 +32633,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="78">
-            <c r="A78" t="n">
-                <f>
+            <c r="A78" cm="1">
+                <f t="array" ref="A78">
                     _xlfn.ISOWEEKNUM("2016-01-03")
                 </f>
                 <v>
@@ -31193,8 +32643,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="79">
-            <c r="A79" t="b">
-                <f>
+            <c r="A79" cm="1">
+                <f t="array" ref="A79">
                     ISTEXT("123")
                 </f>
                 <v>
@@ -31203,8 +32653,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="80">
-            <c r="A80" t="n">
-                <f>
+            <c r="A80" cm="1">
+                <f t="array" ref="A80">
                     LARGE(H2:H9,3)
                 </f>
                 <v>
@@ -31213,8 +32663,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="81">
-            <c r="A81" t="str">
-                <f>
+            <c r="A81" cm="1">
+                <f t="array" ref="A81">
                     LEFT("Mich",4)
                 </f>
                 <v>
@@ -31223,8 +32673,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="82">
-            <c r="A82" t="n">
-                <f>
+            <c r="A82" cm="1">
+                <f t="array" ref="A82">
                     LEN("anticonstitutionnellement")
                 </f>
                 <v>
@@ -31233,8 +32683,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="83">
-            <c r="A83" t="n">
-                <f>
+            <c r="A83" cm="1">
+                <f t="array" ref="A83">
                     ROUND(LN(2),5)
                 </f>
                 <v>
@@ -31243,8 +32693,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="84">
-            <c r="A84" t="n">
-                <f>
+            <c r="A84" cm="1">
+                <f t="array" ref="A84">
                     LOOKUP(42,H2:J9)
                 </f>
                 <v>
@@ -31253,8 +32703,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="85">
-            <c r="A85" t="str">
-                <f>
+            <c r="A85" cm="1">
+                <f t="array" ref="A85">
                     LOWER("オAドB")
                 </f>
                 <v>
@@ -31263,8 +32713,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="86">
-            <c r="A86" t="n">
-                <f>
+            <c r="A86" cm="1">
+                <f t="array" ref="A86">
                     MATCH(42,H2:H9,0)
                 </f>
                 <v>
@@ -31273,8 +32723,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="87">
-            <c r="A87" t="n">
-                <f>
+            <c r="A87" cm="1">
+                <f t="array" ref="A87">
                     MAX(N1:N8)
                 </f>
                 <v>
@@ -31283,8 +32733,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="88">
-            <c r="A88" t="n">
-                <f>
+            <c r="A88" cm="1">
+                <f t="array" ref="A88">
                     MAXA(N1:N8)
                 </f>
                 <v>
@@ -31293,8 +32743,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="89">
-            <c r="A89" t="n">
-                <f>
+            <c r="A89" cm="1">
+                <f t="array" ref="A89">
                     _xlfn.MAXIFS(H2:H9,K2:K9,"&lt;20",K2:K9,"&lt;&gt;4")
                 </f>
                 <v>
@@ -31303,8 +32753,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="90">
-            <c r="A90" t="n">
-                <f>
+            <c r="A90" cm="1">
+                <f t="array" ref="A90">
                     MEDIAN(-1,6,7,234,163845)
                 </f>
                 <v>
@@ -31313,8 +32763,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="91">
-            <c r="A91" t="n">
-                <f>
+            <c r="A91" cm="1">
+                <f t="array" ref="A91">
                     MIN(N1:N8)
                 </f>
                 <v>
@@ -31323,8 +32773,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="92">
-            <c r="A92" t="n">
-                <f>
+            <c r="A92" cm="1">
+                <f t="array" ref="A92">
                     MINA(N1:N8)
                 </f>
                 <v>
@@ -31333,8 +32783,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="93">
-            <c r="A93" t="n">
-                <f>
+            <c r="A93" cm="1">
+                <f t="array" ref="A93">
                     _xlfn.MINIFS(J2:J9,H2:H9,"&gt;20")
                 </f>
                 <v>
@@ -31343,8 +32793,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="94">
-            <c r="A94" t="n">
-                <f>
+            <c r="A94" cm="1">
+                <f t="array" ref="A94">
                     MINUTE(0.126)
                 </f>
                 <v>
@@ -31353,8 +32803,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="95">
-            <c r="A95" t="n">
-                <f>
+            <c r="A95" cm="1">
+                <f t="array" ref="A95">
                     MOD(42,12)
                 </f>
                 <v>
@@ -31363,8 +32813,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="96">
-            <c r="A96" t="n">
-                <f>
+            <c r="A96" cm="1">
+                <f t="array" ref="A96">
                     MONTH("1954-05-02")
                 </f>
                 <v>
@@ -31373,8 +32823,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="97">
-            <c r="A97" t="n">
-                <f>
+            <c r="A97" cm="1">
+                <f t="array" ref="A97">
                     NETWORKDAYS("2013-01-01","2013-02-01")
                 </f>
                 <v>
@@ -31383,8 +32833,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="98">
-            <c r="A98" t="n">
-                <f>
+            <c r="A98" cm="1">
+                <f t="array" ref="A98">
                     NETWORKDAYS.INTL("2013-01-01","2013-02-01","0000111")
                 </f>
                 <v>
@@ -31393,8 +32843,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="99">
-            <c r="A99" t="b">
-                <f>
+            <c r="A99" cm="1">
+                <f t="array" ref="A99">
                     NOT(FALSE)
                 </f>
                 <v>
@@ -31403,8 +32853,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="100">
-            <c r="A100" t="n">
-                <f>
+            <c r="A100" cm="1">
+                <f t="array" ref="A100">
                     NOW()
                 </f>
                 <v>
@@ -31413,8 +32863,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="101">
-            <c r="A101" t="n">
-                <f>
+            <c r="A101" cm="1">
+                <f t="array" ref="A101">
                     ODD(4)
                 </f>
                 <v>
@@ -31423,8 +32873,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="102">
-            <c r="A102" t="b">
-                <f>
+            <c r="A102" cm="1">
+                <f t="array" ref="A102">
                     OR("true",FALSE)
                 </f>
                 <v>
@@ -31433,8 +32883,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="103">
-            <c r="A103" t="n">
-                <f>
+            <c r="A103" cm="1">
+                <f t="array" ref="A103">
                     PERCENTILE(N1:N5,1)
                 </f>
                 <v>
@@ -31443,8 +32893,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="104">
-            <c r="A104" t="n">
-                <f>
+            <c r="A104" cm="1">
+                <f t="array" ref="A104">
                     _xlfn.PERCENTILE.EXC(N1:N5,0.5)
                 </f>
                 <v>
@@ -31453,8 +32903,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="105">
-            <c r="A105" t="n">
-                <f>
+            <c r="A105" cm="1">
+                <f t="array" ref="A105">
                     _xlfn.PERCENTILE.INC(N1:N5,0)
                 </f>
                 <v>
@@ -31463,8 +32913,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="106">
-            <c r="A106" t="n">
-                <f>
+            <c r="A106" cm="1">
+                <f t="array" ref="A106">
                     PI()
                 </f>
                 <v>
@@ -31473,8 +32923,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="107">
-            <c r="A107" t="n">
-                <f>
+            <c r="A107" cm="1">
+                <f t="array" ref="A107">
                     POWER(42,2)
                 </f>
                 <v>
@@ -31483,8 +32933,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="108">
-            <c r="A108" t="n">
-                <f>
+            <c r="A108" cm="1">
+                <f t="array" ref="A108">
                     PRODUCT(1,2,3)
                 </f>
                 <v>
@@ -31493,8 +32943,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="109">
-            <c r="A109" t="n">
-                <f>
+            <c r="A109" cm="1">
+                <f t="array" ref="A109">
                     QUARTILE(N1:N5,0)
                 </f>
                 <v>
@@ -31503,8 +32953,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="110">
-            <c r="A110" t="n">
-                <f>
+            <c r="A110" cm="1">
+                <f t="array" ref="A110">
                     _xlfn.QUARTILE.EXC(N1:N5,1)
                 </f>
                 <v>
@@ -31513,8 +32963,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="111">
-            <c r="A111" t="n">
-                <f>
+            <c r="A111" cm="1">
+                <f t="array" ref="A111">
                     _xlfn.QUARTILE.INC(N1:N5,4)
                 </f>
                 <v>
@@ -31523,8 +32973,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="112">
-            <c r="A112" t="n">
-                <f>
+            <c r="A112" cm="1">
+                <f t="array" ref="A112">
                     RAND()
                 </f>
                 <v>
@@ -31533,8 +32983,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="113">
-            <c r="A113" t="n">
-                <f>
+            <c r="A113" cm="1">
+                <f t="array" ref="A113">
                     RANDBETWEEN(1.1,2)
                 </f>
                 <v>
@@ -31543,8 +32993,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="114">
-            <c r="A114" t="str">
-                <f>
+            <c r="A114" cm="1">
+                <f t="array" ref="A114">
                     REPLACE("ABZ",2,1,"Y")
                 </f>
                 <v>
@@ -31553,8 +33003,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="115">
-            <c r="A115" t="str">
-                <f>
+            <c r="A115" cm="1">
+                <f t="array" ref="A115">
                     RIGHT("kikou",2)
                 </f>
                 <v>
@@ -31563,8 +33013,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="116">
-            <c r="A116" t="n">
-                <f>
+            <c r="A116" cm="1">
+                <f t="array" ref="A116">
                     ROUND(49.9,1)
                 </f>
                 <v>
@@ -31573,8 +33023,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="117">
-            <c r="A117" t="n">
-                <f>
+            <c r="A117" cm="1">
+                <f t="array" ref="A117">
                     ROUNDDOWN(42,-1)
                 </f>
                 <v>
@@ -31583,8 +33033,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="118">
-            <c r="A118" t="n">
-                <f>
+            <c r="A118" cm="1">
+                <f t="array" ref="A118">
                     ROUNDUP(-1.6,0)
                 </f>
                 <v>
@@ -31593,8 +33043,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="119">
-            <c r="A119" t="n">
-                <f>
+            <c r="A119" cm="1">
+                <f t="array" ref="A119">
                     ROW(A234)
                 </f>
                 <v>
@@ -31603,8 +33053,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="120">
-            <c r="A120" t="n">
-                <f>
+            <c r="A120" cm="1">
+                <f t="array" ref="A120">
                     ROWS(B3:C40)
                 </f>
                 <v>
@@ -31613,8 +33063,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="121">
-            <c r="A121" t="n">
-                <f>
+            <c r="A121" cm="1">
+                <f t="array" ref="A121">
                     SEARCH("C","ABCD")
                 </f>
                 <v>
@@ -31623,8 +33073,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="122">
-            <c r="A122" t="n">
-                <f>
+            <c r="A122" cm="1">
+                <f t="array" ref="A122">
                     _xlfn.SEC(PI()/3)
                 </f>
                 <v>
@@ -31633,8 +33083,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="123">
-            <c r="A123" t="n">
-                <f>
+            <c r="A123" cm="1">
+                <f t="array" ref="A123">
                     _xlfn.SECH(1)
                 </f>
                 <v>
@@ -31643,8 +33093,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="124">
-            <c r="A124" t="n">
-                <f>
+            <c r="A124" cm="1">
+                <f t="array" ref="A124">
                     SECOND("00:21:42")
                 </f>
                 <v>
@@ -31653,8 +33103,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="125">
-            <c r="A125" t="n">
-                <f>
+            <c r="A125" cm="1">
+                <f t="array" ref="A125">
                     SIN(PI()/6)
                 </f>
                 <v>
@@ -31663,8 +33113,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="126">
-            <c r="A126" t="n">
-                <f>
+            <c r="A126" cm="1">
+                <f t="array" ref="A126">
                     SINH(1)
                 </f>
                 <v>
@@ -31673,8 +33123,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="127">
-            <c r="A127" t="n">
-                <f>
+            <c r="A127" cm="1">
+                <f t="array" ref="A127">
                     SMALL(H2:H9,3)
                 </f>
                 <v>
@@ -31683,8 +33133,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="128">
-            <c r="A128" t="n">
-                <f>
+            <c r="A128" cm="1">
+                <f t="array" ref="A128">
                     SQRT(4)
                 </f>
                 <v>
@@ -31693,8 +33143,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="129">
-            <c r="A129" t="n">
-                <f>
+            <c r="A129" cm="1">
+                <f t="array" ref="A129">
                     STDEV(-2,0,2)
                 </f>
                 <v>
@@ -31703,8 +33153,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="130">
-            <c r="A130" t="n">
-                <f>
+            <c r="A130" cm="1">
+                <f t="array" ref="A130">
                     _xlfn.STDEV.P(2,4)
                 </f>
                 <v>
@@ -31713,8 +33163,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="131">
-            <c r="A131" t="n">
-                <f>
+            <c r="A131" cm="1">
+                <f t="array" ref="A131">
                     _xlfn.STDEV.S(2,4,6)
                 </f>
                 <v>
@@ -31723,8 +33173,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="132">
-            <c r="A132" t="n">
-                <f>
+            <c r="A132" cm="1">
+                <f t="array" ref="A132">
                     STDEVA(TRUE,3,5)
                 </f>
                 <v>
@@ -31733,8 +33183,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="133">
-            <c r="A133" t="n">
-                <f>
+            <c r="A133" cm="1">
+                <f t="array" ref="A133">
                     STDEVP(2,5,8)
                 </f>
                 <v>
@@ -31743,8 +33193,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="134">
-            <c r="A134" t="n">
-                <f>
+            <c r="A134" cm="1">
+                <f t="array" ref="A134">
                     STDEVPA(TRUE,4,7)
                 </f>
                 <v>
@@ -31753,8 +33203,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="135">
-            <c r="A135" t="str">
-                <f>
+            <c r="A135" cm="1">
+                <f t="array" ref="A135">
                     SUBSTITUTE("SAP is best","SAP","Odoo")
                 </f>
                 <v>
@@ -31763,8 +33213,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="136">
-            <c r="A136" t="n">
-                <f>
+            <c r="A136" cm="1">
+                <f t="array" ref="A136">
                     SUM(1,2,3,4,5)
                 </f>
                 <v>
@@ -31773,8 +33223,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="137">
-            <c r="A137" t="n">
-                <f>
+            <c r="A137" cm="1">
+                <f t="array" ref="A137">
                     SUMIF(K2:K9,"&lt;100")
                 </f>
                 <v>
@@ -31783,8 +33233,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="138">
-            <c r="A138" t="n">
-                <f>
+            <c r="A138" cm="1">
+                <f t="array" ref="A138">
                     SUMIFS(H2:H9,K2:K9,"&lt;100")
                 </f>
                 <v>
@@ -31793,8 +33243,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="139">
-            <c r="A139" t="n">
-                <f>
+            <c r="A139" cm="1">
+                <f t="array" ref="A139">
                     TAN(PI()/4)
                 </f>
                 <v>
@@ -31803,8 +33253,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="140">
-            <c r="A140" t="n">
-                <f>
+            <c r="A140" cm="1">
+                <f t="array" ref="A140">
                     TANH(1)
                 </f>
                 <v>
@@ -31813,8 +33263,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="141">
-            <c r="A141" t="str">
-                <f>
+            <c r="A141" cm="1">
+                <f t="array" ref="A141">
                     _xlfn.TEXTJOIN("-",TRUE,"","1","A","%")
                 </f>
                 <v>
@@ -31823,8 +33273,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="142">
-            <c r="A142" t="n">
-                <f>
+            <c r="A142" cm="1">
+                <f t="array" ref="A142">
                     TIME(9,11,31)
                 </f>
                 <v>
@@ -31833,8 +33283,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="143">
-            <c r="A143" t="n">
-                <f>
+            <c r="A143" cm="1">
+                <f t="array" ref="A143">
                     TIMEVALUE("18:00:00")
                 </f>
                 <v>
@@ -31843,8 +33293,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="144">
-            <c r="A144" t="n">
-                <f>
+            <c r="A144" cm="1">
+                <f t="array" ref="A144">
                     TODAY()
                 </f>
                 <v>
@@ -31853,8 +33303,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="145">
-            <c r="A145" t="str">
-                <f>
+            <c r="A145" cm="1">
+                <f t="array" ref="A145">
                     TRIM(" Jean Ticonstitutionnalise ")
                 </f>
                 <v>
@@ -31863,8 +33313,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="146">
-            <c r="A146" t="n">
-                <f>
+            <c r="A146" cm="1">
+                <f t="array" ref="A146">
                     TRUNC(42.42,1)
                 </f>
                 <v>
@@ -31873,8 +33323,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="147">
-            <c r="A147" t="str">
-                <f>
+            <c r="A147" cm="1">
+                <f t="array" ref="A147">
                     UPPER("grrrr !")
                 </f>
                 <v>
@@ -31883,8 +33333,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="148">
-            <c r="A148" t="n">
-                <f>
+            <c r="A148" cm="1">
+                <f t="array" ref="A148">
                     VAR(K1:K5)
                 </f>
                 <v>
@@ -31893,8 +33343,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="149">
-            <c r="A149" t="n">
-                <f>
+            <c r="A149" cm="1">
+                <f t="array" ref="A149">
                     _xlfn.VAR.P(K1:K5)
                 </f>
                 <v>
@@ -31903,8 +33353,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="150">
-            <c r="A150" t="n">
-                <f>
+            <c r="A150" cm="1">
+                <f t="array" ref="A150">
                     _xlfn.VAR.S(2,5,8)
                 </f>
                 <v>
@@ -31913,8 +33363,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="151">
-            <c r="A151" t="n">
-                <f>
+            <c r="A151" cm="1">
+                <f t="array" ref="A151">
                     VARA(K1:K5)
                 </f>
                 <v>
@@ -31923,8 +33373,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="152">
-            <c r="A152" t="n">
-                <f>
+            <c r="A152" cm="1">
+                <f t="array" ref="A152">
                     VARP(K1:K5)
                 </f>
                 <v>
@@ -31933,8 +33383,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="153">
-            <c r="A153" t="n">
-                <f>
+            <c r="A153" cm="1">
+                <f t="array" ref="A153">
                     VARPA(K1:K5)
                 </f>
                 <v>
@@ -31943,8 +33393,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="154">
-            <c r="A154" t="n">
-                <f>
+            <c r="A154" cm="1">
+                <f t="array" ref="A154">
                     VLOOKUP("NotACheater",G1:K9,3,FALSE)
                 </f>
                 <v>
@@ -31953,8 +33403,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="155">
-            <c r="A155" t="n">
-                <f>
+            <c r="A155" cm="1">
+                <f t="array" ref="A155">
                     WEEKDAY("2021-06-12")
                 </f>
                 <v>
@@ -31963,8 +33413,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="156">
-            <c r="A156" t="n">
-                <f>
+            <c r="A156" cm="1">
+                <f t="array" ref="A156">
                     WEEKNUM("2021-06-29")
                 </f>
                 <v>
@@ -31973,8 +33423,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="157">
-            <c r="A157" t="n">
-                <f>
+            <c r="A157" cm="1">
+                <f t="array" ref="A157">
                     WORKDAY("2021-03-15",6)
                 </f>
                 <v>
@@ -31983,8 +33433,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="158">
-            <c r="A158" t="n">
-                <f>
+            <c r="A158" cm="1">
+                <f t="array" ref="A158">
                     WORKDAY.INTL("2021-03-15",6,"0111111")
                 </f>
                 <v>
@@ -31993,8 +33443,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="159">
-            <c r="A159" t="b">
-                <f>
+            <c r="A159" cm="1">
+                <f t="array" ref="A159">
                     _xlfn.XOR(FALSE,TRUE,FALSE,FALSE)
                 </f>
                 <v>
@@ -32003,8 +33453,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="160">
-            <c r="A160" t="n">
-                <f>
+            <c r="A160" cm="1">
+                <f t="array" ref="A160">
                     YEAR("2012-03-12")
                 </f>
                 <v>
@@ -32013,8 +33463,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="161">
-            <c r="A161" t="n">
-                <f>
+            <c r="A161" cm="1">
+                <f t="array" ref="A161">
                     DELTA(1,1)
                 </f>
                 <v>
@@ -32023,8 +33473,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="162">
-            <c r="A162" t="str">
-                <f>
+            <c r="A162" cm="1">
+                <f t="array" ref="A162">
                     NA()
                 </f>
                 <v>
@@ -32033,8 +33483,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="163">
-            <c r="A163" t="b">
-                <f>
+            <c r="A163" cm="1">
+                <f t="array" ref="A163">
                     ISNA(A162)
                 </f>
                 <v>
@@ -32043,8 +33493,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="164">
-            <c r="A164" t="b">
-                <f>
+            <c r="A164" cm="1">
+                <f t="array" ref="A164">
                     ISERR(A162)
                 </f>
                 <v>
@@ -32053,8 +33503,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="165">
-            <c r="A165" t="str">
-                <f>
+            <c r="A165" cm="1">
+                <f t="array" ref="A165">
                     HYPERLINK("https://www.odoo.com","Odoo")
                 </f>
                 <v>
@@ -32063,8 +33513,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="166">
-            <c r="A166" t="str">
-                <f>
+            <c r="A166" cm="1">
+                <f t="array" ref="A166">
                     ADDRESS(27,53,4,FALSE,"sheet!")
                 </f>
                 <v>
@@ -32073,8 +33523,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="167">
-            <c r="A167" t="n">
-                <f>
+            <c r="A167" cm="1">
+                <f t="array" ref="A167">
                     DATEDIF("2002-01-01","2002-01-02","D")
                 </f>
                 <v>
@@ -32083,8 +33533,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="168">
-            <c r="A168" t="n">
-                <f>
+            <c r="A168" cm="1">
+                <f t="array" ref="A168:B169">
                     _xlfn.RANDARRAY(2,2)
                 </f>
                 <v>
@@ -32142,8 +33592,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
     </cols>
     <sheetData>
         <row r="1">
-            <c r="A1" t="n">
-                <f>
+            <c r="A1" cm="1">
+                <f t="array" ref="A1">
                     ABS(10)
                 </f>
                 <v>
@@ -32155,6 +33605,29 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
 </worksheet>",
       "contentType": "sheet",
       "path": "xl/worksheets/sheet1.xml",
+    },
+    {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
     },
     {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
@@ -32310,6 +33783,7 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
     <Relationship Id="rId2" Target="worksheets/sheet1.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId3" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId4" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId5" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -32329,6 +33803,7 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml" PartName="/xl/workbook.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet1.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -32415,6 +33890,29 @@ exports[`Test XLSX export formulas Non exportable formulas are exported even wit
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -32467,6 +33965,7 @@ exports[`Test XLSX export formulas Non exportable formulas are exported even wit
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -32485,6 +33984,7 @@ exports[`Test XLSX export formulas Non exportable formulas are exported even wit
     <Default Extension="xml" ContentType="application/xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml" PartName="/xl/workbook.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -32544,6 +34044,29 @@ exports[`Test XLSX export formulas Non exportable functions that is evaluated as
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -32596,6 +34119,7 @@ exports[`Test XLSX export formulas Non exportable functions that is evaluated as
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -32614,6 +34138,7 @@ exports[`Test XLSX export formulas Non exportable functions that is evaluated as
     <Default Extension="xml" ContentType="application/xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml" PartName="/xl/workbook.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -32728,6 +34253,29 @@ exports[`Test XLSX export link cells 1`] = `
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -32795,6 +34343,7 @@ exports[`Test XLSX export link cells 1`] = `
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -32821,6 +34370,7 @@ exports[`Test XLSX export link cells 1`] = `
     <Default Extension="xml" ContentType="application/xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml" PartName="/xl/workbook.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -33236,6 +34786,29 @@ exports[`Test XLSX export multiple elements are exported in the correct order 1`
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -33298,6 +34871,7 @@ exports[`Test XLSX export multiple elements are exported in the correct order 1`
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -33333,6 +34907,7 @@ exports[`Test XLSX export multiple elements are exported in the correct order 1`
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml" PartName="/xl/charts/chart1.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawing+xml" PartName="/xl/drawings/drawing0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -36576,6 +38151,29 @@ exports[`Test XLSX export references with headers should be converted to referen
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -36628,6 +38226,7 @@ exports[`Test XLSX export references with headers should be converted to referen
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -36670,6 +38269,7 @@ exports[`Test XLSX export references with headers should be converted to referen
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml" PartName="/xl/charts/chart5.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawing+xml" PartName="/xl/drawings/drawing0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -36713,8 +38313,8 @@ exports[`Test XLSX export references with headers should be converted to referen
     </cols>
     <sheetData>
         <row r="2">
-            <c r="A2" t="n">
-                <f>
+            <c r="A2" cm="1">
+                <f t="array" ref="A2">
                     SUM(B3:B5)
                 </f>
                 <v>
@@ -36752,6 +38352,29 @@ exports[`Test XLSX export references with headers should be converted to referen
 </worksheet>",
       "contentType": "sheet",
       "path": "xl/worksheets/sheet0.xml",
+    },
+    {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
     },
     {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
@@ -36813,6 +38436,7 @@ exports[`Test XLSX export references with headers should be converted to referen
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -36831,6 +38455,7 @@ exports[`Test XLSX export references with headers should be converted to referen
     <Default Extension="xml" ContentType="application/xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml" PartName="/xl/workbook.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",


### PR DESCRIPTION
This commit improves the export of vectorized & array formulas, including those that spill across cells, ensuring better compatibility with other spreadsheet applications. The adopted approach is to treat all formulas as array formulas & to add an additional xml file that contains metadata about array formula properties. As a result, we improve the integrity & usability of our generated XLSX files.

Task: [4134347](https://www.odoo.com/odoo/2328/tasks/4134347)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo