### PR TITLE
[FIX] xlsx: fix conversion of table formulas

### DIFF
--- a/tests/__xlsx__/xlsx_demo_data/[Content_Types].xml
+++ b/tests/__xlsx__/xlsx_demo_data/[Content_Types].xml
@@ -37,6 +37,7 @@
   <Override PartName="/xl/charts/chart2.xml" ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml"/>
   <Override PartName="/xl/charts/chart3.xml" ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml"/>
   <Override PartName="/xl/charts/chart4.xml" ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml"/>
+  <Override PartName="/xl/tables/table10.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.table+xml"/>
   <Override PartName="/xl/calcChain.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.calcChain+xml"/>
   <Override PartName="/docProps/core.xml" ContentType="application/vnd.openxmlformats-package.core-properties+xml"/>
   <Override PartName="/docProps/app.xml" ContentType="application/vnd.openxmlformats-officedocument.extended-properties+xml"/>

--- a/tests/__xlsx__/xlsx_demo_data/xl/sharedStrings.xml
+++ b/tests/__xlsx__/xlsx_demo_data/xl/sharedStrings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" count="457" uniqueCount="409">
+<sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" count="464" uniqueCount="414">
   <si>
     <t>CF =42</t>
   </si>
@@ -1227,5 +1227,20 @@
   </si>
   <si>
     <t>NotHidden</t>
+  </si>
+  <si>
+    <t>Total table</t>
+  </si>
+  <si>
+    <t>Column of table of other sheet</t>
+  </si>
+  <si>
+    <t>Multiple columns total</t>
+  </si>
+  <si>
+    <t>Multiple Columns</t>
+  </si>
+  <si>
+    <t>Multiple keywords</t>
   </si>
 </sst>

--- a/tests/__xlsx__/xlsx_demo_data/xl/tables/table10.xml
+++ b/tests/__xlsx__/xlsx_demo_data/xl/tables/table10.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<table xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:xr="http://schemas.microsoft.com/office/spreadsheetml/2014/revision" xmlns:xr3="http://schemas.microsoft.com/office/spreadsheetml/2016/revision3" mc:Ignorable="xr xr3" id="2" xr:uid="{891778F1-A351-4CCC-ACB3-96A88FAA5482}" name="Table2" displayName="Table2" ref="A7:B12" totalsRowShown="0">
+  <autoFilter ref="A7:B12" xr:uid="{891778F1-A351-4CCC-ACB3-96A88FAA5482}"/>
+  <tableColumns count="2">
+    <tableColumn id="1" xr3:uid="{615674DC-C015-4560-8605-1ABAF6C9942F}" name="Col1"/>
+    <tableColumn id="2" xr3:uid="{7A471A3C-3EBA-4B2E-A4F8-CA7E933722CF}" name="Col2"/>
+  </tableColumns>
+  <tableStyleInfo name="TableStyleLight10" showFirstColumn="0" showLastColumn="0" showRowStripes="1" showColumnStripes="0"/>
+</table>

--- a/tests/__xlsx__/xlsx_demo_data/xl/worksheets/_rels/sheet9.xml.rels
+++ b/tests/__xlsx__/xlsx_demo_data/xl/worksheets/_rels/sheet9.xml.rels
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/table" Target="../tables/table10.xml"/>
+</Relationships>

--- a/tests/__xlsx__/xlsx_demo_data/xl/worksheets/sheet6.xml
+++ b/tests/__xlsx__/xlsx_demo_data/xl/worksheets/sheet6.xml
@@ -2,8 +2,8 @@
 <worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:x14ac="http://schemas.microsoft.com/office/spreadsheetml/2009/9/ac" xmlns:xr="http://schemas.microsoft.com/office/spreadsheetml/2014/revision" xmlns:xr2="http://schemas.microsoft.com/office/spreadsheetml/2015/revision2" xmlns:xr3="http://schemas.microsoft.com/office/spreadsheetml/2016/revision3" mc:Ignorable="x14ac xr xr2 xr3" xr:uid="{1E6D1E5F-C597-4F2D-A80C-76EFDC57349F}">
   <dimension ref="A1:J32"/>
   <sheetViews>
-    <sheetView zoomScale="115" zoomScaleNormal="115" workbookViewId="0">
-      <selection activeCell="E29" sqref="E29"/>
+    <sheetView tabSelected="1" zoomScale="115" zoomScaleNormal="115" workbookViewId="0">
+      <selection activeCell="F16" sqref="F16"/>
     </sheetView>
   </sheetViews>
   <sheetFormatPr defaultColWidth="9.140625" defaultRowHeight="12.75" x14ac:dyDescent="0.2"/>
@@ -154,6 +154,21 @@
       <c r="D8">
         <v>2</v>
       </c>
+      <c r="F8" t="s">
+        <v>409</v>
+      </c>
+      <c r="G8" t="s">
+        <v>410</v>
+      </c>
+      <c r="H8" t="s">
+        <v>411</v>
+      </c>
+      <c r="I8" t="s">
+        <v>412</v>
+      </c>
+      <c r="J8" t="s">
+        <v>413</v>
+      </c>
     </row>
     <row r="9" spans="1:10" x14ac:dyDescent="0.2">
       <c r="C9">
@@ -161,6 +176,26 @@
       </c>
       <c r="D9">
         <v>4</v>
+      </c>
+      <c r="F9">
+        <f>SUM(Table3[#All])</f>
+        <v>396</v>
+      </c>
+      <c r="G9">
+        <f>SUM(Table2[Col2])</f>
+        <v>15</v>
+      </c>
+      <c r="H9">
+        <f>SUM(Table3[[#Totals],[Age]:[Rank]])</f>
+        <v>51</v>
+      </c>
+      <c r="I9">
+        <f>SUM(Table3[[Age]:[Rank]])</f>
+        <v>51</v>
+      </c>
+      <c r="J9">
+        <f>SUM(Table3[[#Data],[#Totals],[Rank]])</f>
+        <v>24</v>
       </c>
     </row>
     <row r="11" spans="1:10" x14ac:dyDescent="0.2">

--- a/tests/__xlsx__/xlsx_demo_data/xl/worksheets/sheet9.xml
+++ b/tests/__xlsx__/xlsx_demo_data/xl/worksheets/sheet9.xml
@@ -1,18 +1,69 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:x14ac="http://schemas.microsoft.com/office/spreadsheetml/2009/9/ac" xmlns:xr="http://schemas.microsoft.com/office/spreadsheetml/2014/revision" xmlns:xr2="http://schemas.microsoft.com/office/spreadsheetml/2015/revision2" xmlns:xr3="http://schemas.microsoft.com/office/spreadsheetml/2016/revision3" mc:Ignorable="x14ac xr xr2 xr3" xr:uid="{178A9C2C-69A0-49B9-B110-21B7CBF9C575}">
-  <dimension ref="A1"/>
+  <dimension ref="A1:B12"/>
   <sheetViews>
     <sheetView showGridLines="0" workbookViewId="0">
-      <selection activeCell="E29" sqref="E29"/>
+      <selection activeCell="D8" sqref="D8"/>
     </sheetView>
   </sheetViews>
   <sheetFormatPr defaultRowHeight="12.75" x14ac:dyDescent="0.2"/>
   <sheetData>
-    <row r="1" spans="1:1" ht="38.25" x14ac:dyDescent="0.2">
+    <row r="1" spans="1:2" ht="38.25" x14ac:dyDescent="0.2">
       <c r="A1" s="100" t="s">
         <v>399</v>
       </c>
     </row>
+    <row r="7" spans="1:2" x14ac:dyDescent="0.2">
+      <c r="A7" t="s">
+        <v>405</v>
+      </c>
+      <c r="B7" t="s">
+        <v>406</v>
+      </c>
+    </row>
+    <row r="8" spans="1:2" x14ac:dyDescent="0.2">
+      <c r="A8">
+        <v>1</v>
+      </c>
+      <c r="B8">
+        <v>1</v>
+      </c>
+    </row>
+    <row r="9" spans="1:2" x14ac:dyDescent="0.2">
+      <c r="A9">
+        <v>2</v>
+      </c>
+      <c r="B9">
+        <v>2</v>
+      </c>
+    </row>
+    <row r="10" spans="1:2" x14ac:dyDescent="0.2">
+      <c r="A10">
+        <v>3</v>
+      </c>
+      <c r="B10">
+        <v>3</v>
+      </c>
+    </row>
+    <row r="11" spans="1:2" x14ac:dyDescent="0.2">
+      <c r="A11">
+        <v>4</v>
+      </c>
+      <c r="B11">
+        <v>4</v>
+      </c>
+    </row>
+    <row r="12" spans="1:2" x14ac:dyDescent="0.2">
+      <c r="A12">
+        <v>5</v>
+      </c>
+      <c r="B12">
+        <v>5</v>
+      </c>
+    </row>
   </sheetData>
   <pageMargins left="0.7" right="0.7" top="0.75" bottom="0.75" header="0.3" footer="0.3"/>
+  <tableParts count="1">
+    <tablePart r:id="rId1"/>
+  </tableParts>
 </worksheet>


### PR DESCRIPTION
## Description

There was some issues with our conversion of table-specific formulas:

- the keyword #ALL didn't include the table headers
- we didn't support ranges with only a keyword (eg. tableName[#ALL])
- we didn't support range with multiple parts (eg. tableName[[#This Row],[Col1]:[Col2]])
- we didn't support ranges with multiple keywords (eg tableName[[#Data],[#Headers], [Col1]])
- we only converted formulas that were inside of tables, but there can be table formulas that are not in any table
- we didn't consider the case where the formula wasn't on the same
sheet as the referenced table

Task: [4095599](https://www.odoo.com/odoo/2328/tasks/4095599)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo