### PR TITLE
[FIX] xlsx: ignore charts without data set

### DIFF
--- a/src/xlsx/conversion/figure_conversion.ts
+++ b/src/xlsx/conversion/figure_conversion.ts
@@ -47,6 +47,9 @@ function convertFigure(
 }
 
 function convertChartData(chartData: ExcelChartDefinition): ChartDefinition | undefined {
+  if (chartData.dataSets.length === 0) {
+    return undefined;
+  }
   const labelRange = chartData.dataSets[0].label?.replace(/\$/g, "");
   let dataSets = chartData.dataSets.map((data) => data.range.replace(/\$/g, ""));
   // For doughnut charts, in chartJS first dataset = outer dataset, in excel first dataset = inner dataset


### PR DESCRIPTION
When we parse the XML and extract the data sets, we expect an element `c:val`. But this element is optional according to the spec.

It leads to a chart with a `dataSets` property being an empty array. It crashes (17.0) or the chart is ignored (18.0) later down the line because a chart without any data set makes no sense.

I must admit I do not fully understand what are those charts without data set in excel. When importing the file in Excel Online or Google Sheet, there's no chart...

With this commit, we ignore those charts as well.

opw: [4443811](https://www.odoo.com/odoo/2328/tasks/4443811)
Task: [4460515](https://www.odoo.com/odoo/2328/tasks/4460515)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo