### PR TITLE
[FIX] pivot_side_panel: drag and drop of dimensions

### DIFF
--- a/src/components/bottom_bar/bottom_bar.ts
+++ b/src/components/bottom_bar/bottom_bar.ts
@@ -254,7 +254,7 @@ export class BottomBar extends Component<Props, SpreadsheetChildEnv> {
       draggedItemId: sheetId,
       initialMousePosition: event.clientX,
       items: sheets,
-      containerEl: this.sheetListRef.el!,
+      scrollableContainerEl: this.sheetListRef.el!,
       onDragEnd: (sheetId: UID, finalIndex: number) => this.onDragEnd(sheetId, finalIndex),
     });
   }

--- a/src/components/helpers/drag_and_drop_hook.ts
+++ b/src/components/helpers/drag_and_drop_hook.ts
@@ -19,13 +19,13 @@ interface DndPartialArgs {
   draggedItemId: UID;
   initialMousePosition: Pixel;
   items: DragAndDropItemsPartial[];
-  containerEl: HTMLElement;
+  scrollableContainerEl: HTMLElement;
   onChange?: () => void;
   onCancel?: () => void;
   onDragEnd?: (itemId: UID, indexAtEnd: Pixel) => void;
 }
 
-interface DOMDndHelperArgs extends Omit<Required<DndPartialArgs>, "containerEl"> {
+interface DOMDndHelperArgs extends Omit<Required<DndPartialArgs>, "scrollableContainerEl"> {
   container: ContainerWrapper;
 }
 
@@ -75,8 +75,8 @@ export function useDragAndDropListItems() {
     state.draggedItemId = args.draggedItemId;
     const container =
       direction === "horizontal"
-        ? new HorizontalContainer(args.containerEl)
-        : new VerticalContainer(args.containerEl);
+        ? new HorizontalContainer(args.scrollableContainerEl)
+        : new VerticalContainer(args.scrollableContainerEl);
     dndHelper = new DOMDndHelper({
       ...args,
       container,
@@ -91,8 +91,8 @@ export function useDragAndDropListItems() {
     cleanupFns.push(stopListening);
 
     const onScroll = dndHelper.onScroll.bind(dndHelper);
-    args.containerEl.addEventListener("scroll", onScroll);
-    cleanupFns.push(() => args.containerEl.removeEventListener("scroll", onScroll));
+    args.scrollableContainerEl.addEventListener("scroll", onScroll);
+    cleanupFns.push(() => args.scrollableContainerEl.removeEventListener("scroll", onScroll));
 
     cleanupFns.push(dndHelper.destroy.bind(dndHelper));
   };

--- a/src/components/side_panel/conditional_formatting/cf_preview_list/cf_preview_list.ts
+++ b/src/components/side_panel/conditional_formatting/cf_preview_list/cf_preview_list.ts
@@ -52,7 +52,7 @@ export class ConditionalFormatPreviewList extends Component<Props, SpreadsheetCh
       draggedItemId: cf.id,
       initialMousePosition: event.clientY,
       items: items,
-      containerEl: this.cfListRef.el!,
+      scrollableContainerEl: this.cfListRef.el!,
       onDragEnd: (cfId: UID, finalIndex: number) => this.onDragEnd(cfId, finalIndex),
     });
   }

--- a/src/components/side_panel/pivot/pivot_layout_configurator/pivot_layout_configurator.ts
+++ b/src/components/side_panel/pivot/pivot_layout_configurator/pivot_layout_configurator.ts
@@ -26,6 +26,7 @@ interface Props {
   unusedMeasureFields: PivotField[];
   unusedDateTimeGranularities: Record<string, Set<string>>;
   allGranularities: string[];
+  getScrollableContainerEl?: () => HTMLElement;
 }
 
 export class PivotLayoutConfigurator extends Component<Props, SpreadsheetChildEnv> {
@@ -43,6 +44,7 @@ export class PivotLayoutConfigurator extends Component<Props, SpreadsheetChildEn
     unusedMeasureFields: Array,
     unusedDateTimeGranularities: Object,
     allGranularities: Array,
+    getScrollableContainerEl: { type: Function, optional: true },
   };
 
   private dimensionsRef = useRef("pivot-dimensions");
@@ -74,7 +76,7 @@ export class PivotLayoutConfigurator extends Component<Props, SpreadsheetChildEn
       draggedItemId: dimension.nameWithGranularity,
       initialMousePosition: event.clientY,
       items: draggableItems,
-      scrollableContainerEl: this.dimensionsRef.el!,
+      scrollableContainerEl: this.props.getScrollableContainerEl?.() || this.dimensionsRef.el!,
       onDragEnd: (dimensionName, finalIndex) => {
         const originalIndex = draggableIds.findIndex((id) => id === dimensionName);
         if (originalIndex === finalIndex) {
@@ -124,7 +126,7 @@ export class PivotLayoutConfigurator extends Component<Props, SpreadsheetChildEn
       draggedItemId: measure.name,
       initialMousePosition: event.clientY,
       items: draggableItems,
-      scrollableContainerEl: this.dimensionsRef.el!,
+      scrollableContainerEl: this.props.getScrollableContainerEl?.() || this.dimensionsRef.el!,
       onDragEnd: (measureName, finalIndex) => {
         const originalIndex = draggableIds.findIndex((id) => id === measureName);
         if (originalIndex === finalIndex) {

--- a/src/components/side_panel/pivot/pivot_layout_configurator/pivot_layout_configurator.ts
+++ b/src/components/side_panel/pivot/pivot_layout_configurator/pivot_layout_configurator.ts
@@ -74,7 +74,7 @@ export class PivotLayoutConfigurator extends Component<Props, SpreadsheetChildEn
       draggedItemId: dimension.nameWithGranularity,
       initialMousePosition: event.clientY,
       items: draggableItems,
-      containerEl: this.dimensionsRef.el!,
+      scrollableContainerEl: this.dimensionsRef.el!,
       onDragEnd: (dimensionName, finalIndex) => {
         const originalIndex = draggableIds.findIndex((id) => id === dimensionName);
         if (originalIndex === finalIndex) {
@@ -124,7 +124,7 @@ export class PivotLayoutConfigurator extends Component<Props, SpreadsheetChildEn
       draggedItemId: measure.name,
       initialMousePosition: event.clientY,
       items: draggableItems,
-      containerEl: this.dimensionsRef.el!,
+      scrollableContainerEl: this.dimensionsRef.el!,
       onDragEnd: (measureName, finalIndex) => {
         const originalIndex = draggableIds.findIndex((id) => id === measureName);
         if (originalIndex === finalIndex) {

--- a/src/components/side_panel/pivot/pivot_side_panel/pivot_spreadsheet_side_panel/pivot_spreadsheet_side_panel.ts
+++ b/src/components/side_panel/pivot/pivot_side_panel/pivot_spreadsheet_side_panel/pivot_spreadsheet_side_panel.ts
@@ -1,8 +1,8 @@
-import { Component, useState } from "@odoo/owl";
+import { Component, useRef, useState } from "@odoo/owl";
 import { SpreadsheetPivotRuntimeDefinition } from "../../../../../helpers/pivot/spreadsheet_pivot/runtime_definition_spreadsheet_pivot";
 import { SpreadsheetPivot } from "../../../../../helpers/pivot/spreadsheet_pivot/spreadsheet_pivot";
 import { Store, useLocalStore } from "../../../../../store_engine";
-import { SpreadsheetChildEnv, UID } from "../../../../../types";
+import { Ref, SpreadsheetChildEnv, UID } from "../../../../../types";
 import { SpreadsheetPivotCoreDefinition } from "../../../../../types/pivot";
 import { SelectionInput } from "../../../../selection_input/selection_input";
 import { Checkbox } from "../../../components/checkbox/checkbox";
@@ -35,6 +35,8 @@ export class PivotSpreadsheetSidePanel extends Component<Props, SpreadsheetChild
 
   state!: { range?: string; rangeHasChanged: boolean };
 
+  pivotSidePanelRef: Ref<HTMLElement> = useRef("pivotSidePanel");
+
   setup() {
     this.store = useLocalStore(PivotSidePanelStore, this.props.pivotId);
     this.state = useState({
@@ -66,6 +68,10 @@ export class PivotSpreadsheetSidePanel extends Component<Props, SpreadsheetChild
 
   get definition(): SpreadsheetPivotRuntimeDefinition {
     return this.store.definition as SpreadsheetPivotRuntimeDefinition;
+  }
+
+  getScrollableContainerEl() {
+    return this.pivotSidePanelRef.el;
   }
 
   onSelectionChanged(ranges: string[]) {

--- a/src/components/side_panel/pivot/pivot_side_panel/pivot_spreadsheet_side_panel/pivot_spreadsheet_side_panel.xml
+++ b/src/components/side_panel/pivot/pivot_side_panel/pivot_spreadsheet_side_panel/pivot_spreadsheet_side_panel.xml
@@ -1,7 +1,7 @@
 <templates>
   <t t-name="o-spreadsheet-PivotSpreadsheetSidePanel">
     <div class="d-flex flex-column h-100 justify-content-between overflow-hidden">
-      <div class="h-100 overflow-auto">
+      <div class="h-100 overflow-auto" t-ref="pivotSidePanel">
         <PivotTitleSection pivotId="props.pivotId" flipAxis.bind="flipAxis"/>
         <Section>
           <t t-set-slot="title">Range</t>
@@ -28,6 +28,7 @@
           allGranularities="store.allGranularities"
           definition="definition"
           onDimensionsUpdated.bind="onDimensionsUpdated"
+          getScrollableContainerEl.bind="getScrollableContainerEl"
         />
       </div>
       <PivotDeferUpdate

--- a/tests/pivots/spreadsheet_pivot/spreadsheet_pivot_side_panel.test.ts
+++ b/tests/pivots/spreadsheet_pivot/spreadsheet_pivot_side_panel.test.ts
@@ -213,6 +213,10 @@ describe("Spreadsheet pivot side panel", () => {
 
   test("should preserve the sorting of the dimension after ordering is changed", async () => {
     mockGetBoundingClientRect({
+      "h-100": () => ({
+        height: 100,
+        y: 0,
+      }),
       /**
        * 'pt-1' is the class of the main div of the pivot dimension
        */


### PR DESCRIPTION
## Description:

The pivot side panel did not scroll during drag-and-drop of dimensions when multiple dimensions were present.

This occurred because the dimensions container lacked a specific height. Adding a height to fill the available space would only enable scrolling within the dimensions list, not the entire side panel.

This fix resolves the issue by passing the pivot side panel's reference as the container to drag and drop hook for it's calculations, leveraging its `100vh` height. This approach ensures that scrolling affects the entire side panel, allowing drag-and-drop to function correctly.

Task: [3817565](https://www.odoo.com/odoo/2328/tasks/3817565)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo