### PR TITLE
[FIX] chart: fix trend line axis alignment

### DIFF
--- a/src/helpers/figures/charts/chart_common_line_scatter.ts
+++ b/src/helpers/figures/charts/chart_common_line_scatter.ts
@@ -405,10 +405,11 @@ export function createLineOrScatterChartRuntime(
       ...xAxis,
       display: false,
     };
-    if (axisType === "category") {
+    if (axisType === "category" || axisType === "time") {
       /* We add a second x axis here to draw the trend lines, with the labels length being
        * set so that the second axis points match the classical x axis
        */
+      config.options.scales[TREND_LINE_XAXIS_ID]["type"] = "category";
       config.options.scales[TREND_LINE_XAXIS_ID]["labels"] = range(0, maxLength).map((x) =>
         x.toString()
       );


### PR DESCRIPTION
## Task Description

Following https://github.com/odoo/o-spreadsheet/pull/5282, we now have the trend line data as an array of Point, and try to align the trend line axis to the real x-axis. This can't be done for categorical axis and time axis without treating the trend axis as a category axis, for both.

This PR aims to fix the axis for the datetime data, where the axis was considered as a datetime axis but can't be anymore. As this is caused by the way chartJs decides to align the axis, we don't have any other solution, neither have we a possibility to test the fix.
