### PR TITLE
[FIX] pivot: notify only with static formulas

### DIFF
--- a/tests/pivots/spreadsheet_pivot/spreadsheet_pivot_side_panel.test.ts
+++ b/tests/pivots/spreadsheet_pivot/spreadsheet_pivot_side_panel.test.ts
@@ -472,6 +472,12 @@ describe("Spreadsheet pivot side panel", () => {
     setViewportOffset(model, 0, 1000);
     await click(fixture.querySelector(".o-pivot-measure .add-dimension")!);
     await click(fixture.querySelectorAll(".o-autocomplete-value")[1]);
+    expect(mockNotify).toHaveBeenCalledTimes(0);
+
+    // add a static pivot in the viewport
+    setCellContent(model, "A50", "=PIVOT.VALUE(1)");
+    await click(fixture.querySelector(".o-pivot-measure .add-dimension")!);
+    await click(fixture.querySelectorAll(".o-autocomplete-value")[1]);
     expect(mockNotify).toHaveBeenCalledWith({
       text: "Pivot updates only work with dynamic pivot tables. Use =PIVOT(1) or re-insert the static pivot from the Data menu.",
       sticky: false,


### PR DESCRIPTION
## Description:

When we update a pivot from it's side panel with a static pivot present in the viewport, we have the warning "Pivot updates only work with dynamic pivot tables". But the warning is also present if you have no static pivot anywhere, but that there is no dynamic pivot in the viewport (eg. you scolled a bit after opening the pivot side panel).

The warning should only be displayed if you have a static pivot somewhere in the viewport.

Task: [4453844](https://www.odoo.com/odoo/2328/tasks/4453844)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo