### PR TITLE
[REF] pivot, clickable cells: iterate over visible positions

### DIFF
--- a/src/components/dashboard/clickable_cell_store.ts
+++ b/src/components/dashboard/clickable_cell_store.ts
@@ -65,23 +65,17 @@ export class ClickableCellsStore extends SpreadsheetStore {
     const cells: ClickableCell[] = [];
     const getters = this.getters;
     const sheetId = getters.getActiveSheetId();
-    for (const col of getters.getSheetViewVisibleCols()) {
-      for (const row of getters.getSheetViewVisibleRows()) {
-        const position = { sheetId, col, row };
-        if (!getters.isMainCellPosition(position)) {
-          continue;
-        }
-        const action = this.getClickableAction(position);
-        if (!action) {
-          continue;
-        }
-        const zone = getters.expandZone(sheetId, positionToZone(position));
-        cells.push({
-          coordinates: getters.getVisibleRect(zone),
-          position,
-          action,
-        });
+    for (const position of this.getters.getVisibleCellPositions()) {
+      const action = this.getClickableAction(position);
+      if (!action) {
+        continue;
       }
+      const zone = getters.expandZone(sheetId, positionToZone(position));
+      cells.push({
+        coordinates: getters.getVisibleRect(zone),
+        position,
+        action,
+      });
     }
     return cells;
   }

--- a/src/components/side_panel/pivot/pivot_side_panel/pivot_side_panel_store.ts
+++ b/src/components/side_panel/pivot/pivot_side_panel/pivot_side_panel_store.ts
@@ -211,13 +211,10 @@ export class PivotSidePanelStore extends SpreadsheetStore {
   }
 
   private isDynamicPivotInViewport() {
-    const sheetId = this.getters.getActiveSheetId();
-    for (const col of this.getters.getSheetViewVisibleCols()) {
-      for (const row of this.getters.getSheetViewVisibleRows()) {
-        const isDynamicPivot = this.getters.isSpillPivotFormula({ sheetId, col, row });
-        if (isDynamicPivot) {
-          return true;
-        }
+    for (const position of this.getters.getVisibleCellPositions()) {
+      const isDynamicPivot = this.getters.isSpillPivotFormula(position);
+      if (isDynamicPivot) {
+        return true;
       }
     }
     return false;


### PR DESCRIPTION
## Description:

Those 2 methods were iterating over all visible positions using 2 nested for loops, but there's a getter returning exactly those positions. Now it's only one for loop, which is simpler.

Task: [4453844](https://www.odoo.com/odoo/2328/tasks/4453844)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo