### PR TITLE
[FIX] icons: Missing dimension on icon

### DIFF
--- a/src/components/icons/icons.xml
+++ b/src/components/icons/icons.xml
@@ -668,7 +668,13 @@
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.SMALL_DOT_RIGHT_ALIGN">
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18">
+    <svg
+      class="o-icon"
+      style="color: currentcolor;"
+      width="10"
+      height="10"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 18 18">
       <circle fill="currentColor" cx="14" cy="9" r="4"/>
     </svg>
   </t>


### PR DESCRIPTION
A bug similar to 3d5cb36d affects the Safari browser. If no dimension is set on an svg, it is not correctly rendered.

Task: 4461359

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo