### PR TITLE
[FIX] Selection: selection follows the moved header

### DIFF
--- a/src/plugins/ui_stateful/selection.ts
+++ b/src/plugins/ui_stateful/selection.ts
@@ -683,6 +683,11 @@ export class GridSelectionPlugin extends UIPlugin {
     ];
     handler.paste({ zones: pasteTarget }, data, { isCutOperation: true });
 
+    const selection = pasteTarget[0];
+    const col = selection.left;
+    const row = selection.top;
+    this.setSelectionMixin({ zone: selection, cell: { col, row } }, [selection]);
+
     const toRemove = isBasedBefore ? cmd.elements.map((el) => el + thickness) : cmd.elements;
     let currentIndex = cmd.base;
     for (const element of toRemove) {

--- a/tests/sheet/selection_plugin.test.ts
+++ b/tests/sheet/selection_plugin.test.ts
@@ -971,6 +971,20 @@ describe("move elements(s)", () => {
     result = moveRows(model, -1, [0]);
     expect(result).toBeCancelledBecause(CommandResult.InvalidHeaderIndex);
   });
+
+  test("Selection stays on the moved column", () => {
+    const model = new Model();
+    selectColumn(model, 1, "overrideSelection");
+    moveColumns(model, "D", ["B"]);
+    expect(model.getters.getSelectedZone()).toEqual(toZone("D1:D100"));
+  });
+
+  test("Selection stays on the moved row", () => {
+    const model = new Model();
+    selectRow(model, 1, "overrideSelection");
+    moveRows(model, 3, [1]);
+    expect(model.getters.getSelectedZone()).toEqual(toZone("A4:Z4"));
+  });
 });
 
 describe("Selection loop (ctrl + a)", () => {


### PR DESCRIPTION
Following the refactoring of the clipboard in #2857, we also isolated the flow of `MOVE_COLUMNS_ROWS` so it would not interfere with the clipboard. By doing so, we lost the capacity to select the moved header during the handling of the command.

How to reproduce:
- select row 2
- paint it red to identify it
- move it to row 4

The selection is still on row 2 and not on row 4 as expected.

Task: 4461901

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo