### PR TITLE
[FIX] charts: Account for correct locale when filtering empty datasets

### DIFF
--- a/src/helpers/figures/charts/chart_ui_common.ts
+++ b/src/helpers/figures/charts/chart_ui_common.ts
@@ -3,7 +3,16 @@ import { ChartTerms } from "../../../components/translations_terms";
 import { DEFAULT_CHART_FONT_SIZE, DEFAULT_CHART_PADDING, MAX_CHAR_LABEL } from "../../../constants";
 import { isEvaluationError } from "../../../functions/helpers";
 import { _t } from "../../../translation";
-import { CellValue, Color, Figure, Format, Getters, LocaleFormat, Range } from "../../../types";
+import {
+  CellValue,
+  Color,
+  DEFAULT_LOCALE,
+  Figure,
+  Format,
+  Getters,
+  LocaleFormat,
+  Range,
+} from "../../../types";
 import { GaugeChartRuntime, ScorecardChartRuntime } from "../../../types/chart";
 import { ChartRuntime, DataSet, DatasetValues, LabelValues } from "../../../types/chart/chart";
 import { formatValue, isDateTimeFormat } from "../../format/format";
@@ -288,8 +297,7 @@ export function getChartDatasetValues(getters: Getters, dataSets: DataSet[]): Da
       data.fill(1);
     } else if (
       data.every(
-        (cell) =>
-          cell === undefined || cell === null || !isNumber(cell.toString(), getters.getLocale())
+        (cell) => cell === undefined || cell === null || !isNumber(cell.toString(), DEFAULT_LOCALE)
       )
     ) {
       continue;

--- a/tests/figures/chart/chart_plugin.test.ts
+++ b/tests/figures/chart/chart_plugin.test.ts
@@ -346,6 +346,43 @@ describe("datasource tests", function () {
     expect(chart.chartJsConfig.data!.datasets?.length).toEqual(1);
   });
 
+  test("empty datasets are filtered in different locales", () => {
+    model = new Model({
+      sheets: [
+        {
+          name: "Sheet1",
+          colNumber: 10,
+          rowNumber: 10,
+          rows: {},
+          cells: {
+            A2: { content: "P1" },
+            A3: { content: "P2" },
+            A4: { content: "P3" },
+            B1: { content: "first column dataset" },
+            B2: { content: "10.1" },
+            C1: { content: "second dataset" },
+            C2: { content: "" },
+          },
+        },
+      ],
+      settings: {
+        locale: FR_LOCALE,
+      },
+    });
+    createChart(
+      model,
+      {
+        dataSets: [{ dataRange: "Sheet1!B1:B2" }, { dataRange: "Sheet1!C1:C2" }],
+        labelRange: "Sheet1!A2",
+        dataSetsHaveTitle: true,
+        type: "line",
+      },
+      "1"
+    );
+    const chart = model.getters.getChartRuntime("1")! as LineChartRuntime;
+    expect(chart.chartJsConfig.data!.datasets?.length).toEqual(1);
+  });
+
   test("create a chart with stacked bar", () => {
     createChart(
       model,


### PR DESCRIPTION
The filtering of empty datasets did not use the correct locale to evaluate the nature of a dataset value. Since it evaluates the actual stored data, it is based on the default locale (i.e. a dot as a decimal separator).

Task: 4465324

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo