### PR TITLE
[FIX] selection: drag and drop resized cols and rows

### DIFF
--- a/src/plugins/ui/selection.ts
+++ b/src/plugins/ui/selection.ts
@@ -645,7 +645,7 @@ export class GridSelectionPlugin extends UIPlugin {
     state.paste(pasteTarget, { selectTarget: true });
 
     const toRemove = isBasedBefore ? cmd.elements.map((el) => el + thickness) : cmd.elements;
-    let currentIndex = cmd.base;
+    let currentIndex = isBasedBefore ? cmd.base : cmd.base + 1;
     for (const element of toRemove) {
       const size =
         cmd.dimension === "COL"

--- a/tests/plugins/selection.test.ts
+++ b/tests/plugins/selection.test.ts
@@ -1072,22 +1072,30 @@ describe("move elements(s)", () => {
     const model = new Model();
     resizeColumns(model, ["A"], 10);
     resizeColumns(model, ["C"], 20);
-    moveColumns(model, "D", ["A"]);
+    moveColumns(model, "C", ["A"], "after");
     const sheetId = model.getters.getActiveSheetId();
     expect(model.getters.getColSize(sheetId, 0)).toEqual(DEFAULT_CELL_WIDTH);
     expect(model.getters.getColSize(sheetId, 1)).toEqual(20);
     expect(model.getters.getColSize(sheetId, 2)).toEqual(10);
+    moveColumns(model, "A", ["C"], "before");
+    expect(model.getters.getColSize(sheetId, 0)).toEqual(10);
+    expect(model.getters.getColSize(sheetId, 1)).toEqual(DEFAULT_CELL_WIDTH);
+    expect(model.getters.getColSize(sheetId, 2)).toEqual(20);
   });
 
   test("Move a resized row preserves its size", () => {
     const model = new Model();
     resizeRows(model, [0], 10);
     resizeRows(model, [2], 20);
-    moveRows(model, 3, [0]);
+    moveRows(model, 2, [0], "after");
     const sheetId = model.getters.getActiveSheetId();
     expect(model.getters.getRowSize(sheetId, 0)).toEqual(DEFAULT_CELL_HEIGHT);
     expect(model.getters.getRowSize(sheetId, 1)).toEqual(20);
     expect(model.getters.getRowSize(sheetId, 2)).toEqual(10);
+    moveRows(model, 0, [2], "before");
+    expect(model.getters.getRowSize(sheetId, 0)).toEqual(10);
+    expect(model.getters.getRowSize(sheetId, 1)).toEqual(DEFAULT_CELL_HEIGHT);
+    expect(model.getters.getRowSize(sheetId, 2)).toEqual(20);
   });
 
   test("Can move a column to the end of the sheet", () => {


### PR DESCRIPTION
## Description:

Previously, resizing a column or row and then dragging it to a new position (right or down) did not correctly resize the dropped column/row

This issue occurred because the resizing logic incorrectly used the original index of the column or row instead of adjusting for its new position. The correct approach requires using `index + 1` for "after" operations to account for the updated position, but the implementation used the unadjusted index, leading to the bug.

Task: [4454025](https://www.odoo.com/odoo/2328/tasks/4454025)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo