### PR TITLE
[FIX] TextValueProvider: Avoid duplicate key in template

### DIFF
--- a/src/components/composer/autocomplete_dropdown/autocomplete_dropdown.xml
+++ b/src/components/composer/autocomplete_dropdown/autocomplete_dropdown.xml
@@ -4,7 +4,7 @@
       t-ref="autoCompleteList"
       t-att-class="{
           'o-autocomplete-dropdown': props.proposals.length}">
-      <t t-foreach="props.proposals" t-as="proposal" t-key="proposal.text">
+      <t t-foreach="props.proposals" t-as="proposal" t-key="proposal.text + proposal_index">
         <div
           class="d-flex flex-column text-start"
           t-att-class="{'o-autocomplete-value-focus': props.selectedIndex === proposal_index}"

--- a/tests/composer/autocomplete_dropdown_component.test.ts
+++ b/tests/composer/autocomplete_dropdown_component.test.ts
@@ -3,6 +3,7 @@ import { ComposerStore } from "../../src/components/composer/composer/composer_s
 import { DEFAULT_CELL_HEIGHT, DEFAULT_CELL_WIDTH } from "../../src/constants";
 import { functionRegistry } from "../../src/functions/index";
 import { Model } from "../../src/model";
+import { autoCompleteProviders } from "../../src/registries";
 import { Store } from "../../src/store_engine";
 import { ContentEditableHelper } from "../__mocks__/content_editable_helper";
 import { registerCleanup } from "../setup/jest.setup";
@@ -578,4 +579,27 @@ describe("composer entries", () => {
     expect(entries[5].textContent).toBe("SAPER");
     expect(entries[6].textContent).toBe("SUPER");
   });
+});
+
+test("aucomplete supports values with similar names", async () => {
+  autoCompleteProviders.add("test", {
+    sequence: 1,
+    getProposals() {
+      return [
+        { text: "SA", fuzzySearchKey: "s" },
+        { text: "SA", fuzzySearchKey: "s" },
+      ];
+    },
+    selectProposal() {},
+  });
+  ({ fixture, parent } = await mountComposerWrapper());
+  // start composition
+  parent.startComposition();
+  await nextTick();
+  composerEl = fixture.querySelector("div.o-composer")!;
+
+  composerStore = parent.env.getStore(ComposerStore);
+  await typeInComposer("=s");
+  expect(fixture.querySelectorAll(".o-autocomplete-value")).toHaveLength(2);
+  autoCompleteProviders.remove("test");
 });


### PR DESCRIPTION
The template of `TextValueProvider` would rely on proposal.text as an identification key but there are no unicity constraints on that value.

Task: 4483494

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo