### PR TITLE
[IMP] formulas: add a cache on linear search functions

### DIFF
--- a/src/functions/helpers.ts
+++ b/src/functions/helpers.ts
@@ -15,6 +15,7 @@ import {
   isMatrix,
 } from "../types";
 import { CellErrorType, EvaluationError, errorTypes } from "../types/errors";
+import { LookupCaches } from "../types/functions";
 
 const SORT_TYPES_ORDER = ["number", "string", "boolean", "undefined"];
 
@@ -846,6 +847,7 @@ export function linearSearch<T>(
   mode: LinearSearchMode,
   numberOfValues: number,
   getValueInData: (data: T, index: number) => CellValue | undefined,
+  lookupCaches?: LookupCaches,
   reverseSearch = false
 ): number {
   if (target === undefined || target.value === null) {
@@ -854,13 +856,59 @@ export function linearSearch<T>(
   if (isEvaluationError(target.value)) {
     throw target;
   }
+
   const _target = normalizeValue(target.value);
   const getValue = reverseSearch
-    ? (data: T, i: number) => getValueInData(data, numberOfValues - i - 1)
-    : getValueInData;
+    ? (data: T, i: number) => normalizeValue(getValueInData(data, numberOfValues - i - 1))
+    : (data: T, i: number) => normalizeValue(getValueInData(data, i));
 
+  // first check if the target is in the cache
+
+  const isNotWildcardTarget =
+    mode !== "wildcard" ||
+    typeof _target !== "string" ||
+    !(_target.includes("*") || _target.includes("?"));
+
+  if (lookupCaches && isNotWildcardTarget) {
+    const searchMode = reverseSearch ? "reverseSearch" : "forwardSearch";
+    let cache = lookupCaches[searchMode].get(data);
+    if (cache === undefined) {
+      // build the cache for all the values
+      cache = new Map<CellValue, number>();
+      for (let i = 0; i < numberOfValues; i++) {
+        const value = getValue(data, i) ?? null;
+        if (!cache.has(value)) {
+          cache.set(value, i);
+        }
+      }
+      lookupCaches[searchMode].set(data, cache);
+    }
+
+    if (cache.has(_target)) {
+      const resultIndex = cache.get(_target)!;
+      return reverseSearch ? numberOfValues - resultIndex - 1 : resultIndex;
+    }
+
+    if (mode === "strict") {
+      return -1;
+    }
+  }
+
+  // else perform the linear search
+
+  const resultIndex = _linearSearch(data, _target, mode, numberOfValues, getValue);
+  return reverseSearch && resultIndex !== -1 ? numberOfValues - resultIndex - 1 : resultIndex;
+}
+
+function _linearSearch<T>(
+  data: T,
+  _target: Exclude<CellValue, null>,
+  mode: LinearSearchMode,
+  numberOfValues: number,
+  getNormalizeValue: (data: T, index: number) => CellValue | undefined
+): number {
   let indexMatchTarget: (index: number) => boolean = (i) => {
-    return normalizeValue(getValue(data, i)) === _target;
+    return getNormalizeValue(data, i) === _target;
   };
 
   if (
@@ -870,7 +918,7 @@ export function linearSearch<T>(
   ) {
     const regExp = wildcardToRegExp(_target);
     indexMatchTarget = (i) => {
-      const value = normalizeValue(getValue(data, i));
+      const value = getNormalizeValue(data, i);
       if (typeof value === "string") {
         return regExp.test(value);
       }
@@ -883,7 +931,7 @@ export function linearSearch<T>(
 
   if (mode === "nextSmaller") {
     indexMatchTarget = (i) => {
-      const value = normalizeValue(getValue(data, i));
+      const value = getNormalizeValue(data, i);
       if (
         (!closestMatch && compareCellValues(_target, value) >= 0) ||
         (compareCellValues(_target, value) >= 0 && compareCellValues(value, closestMatch) > 0)
@@ -897,7 +945,7 @@ export function linearSearch<T>(
 
   if (mode === "nextGreater") {
     indexMatchTarget = (i) => {
-      const value = normalizeValue(getValue(data, i));
+      const value = getNormalizeValue(data, i);
       if (
         (!closestMatch && compareCellValues(_target, value) <= 0) ||
         (compareCellValues(_target, value) <= 0 && compareCellValues(value, closestMatch) < 0)
@@ -911,12 +959,11 @@ export function linearSearch<T>(
 
   for (let i = 0; i < numberOfValues; i++) {
     if (indexMatchTarget(i)) {
-      return reverseSearch ? numberOfValues - i - 1 : i;
+      return i;
     }
   }
-  return reverseSearch && closestMatchIndex !== -1
-    ? numberOfValues - closestMatchIndex - 1
-    : closestMatchIndex;
+
+  return closestMatchIndex;
 }
 
 /**

--- a/src/functions/module_lookup.ts
+++ b/src/functions/module_lookup.ts
@@ -200,7 +200,14 @@ export const HLOOKUP = {
     const _isSorted = toBoolean(isSorted.value);
     const colIndex = _isSorted
       ? dichotomicSearch(range, searchKey, "nextSmaller", "asc", range.length, getValueFromRange)
-      : linearSearch(range, searchKey, "wildcard", range.length, getValueFromRange);
+      : linearSearch(
+          range,
+          searchKey,
+          "wildcard",
+          range.length,
+          getValueFromRange,
+          this.lookupCaches
+        );
     const col = range[colIndex];
     if (col === undefined) {
       return valueNotAvailable(searchKey);
@@ -443,7 +450,7 @@ export const MATCH = {
         index = dichotomicSearch(range, searchKey, "nextSmaller", "asc", rangeLen, getElement);
         break;
       case 0:
-        index = linearSearch(range, searchKey, "wildcard", rangeLen, getElement);
+        index = linearSearch(range, searchKey, "wildcard", rangeLen, getElement, this.lookupCaches);
         break;
       case -1:
         index = dichotomicSearch(range, searchKey, "nextGreater", "desc", rangeLen, getElement);
@@ -556,7 +563,14 @@ export const VLOOKUP = {
     const _isSorted = toBoolean(isSorted.value);
     const rowIndex = _isSorted
       ? dichotomicSearch(range, searchKey, "nextSmaller", "asc", range[0].length, getValueFromRange)
-      : linearSearch(range, searchKey, "wildcard", range[0].length, getValueFromRange);
+      : linearSearch(
+          range,
+          searchKey,
+          "wildcard",
+          range[0].length,
+          getValueFromRange,
+          this.lookupCaches
+        );
 
     const value = range[_index - 1][rowIndex];
     if (value === undefined) {
@@ -671,7 +685,15 @@ export const XLOOKUP = {
             rangeLen,
             getElement
           )
-        : linearSearch(lookupRange, searchKey, mode, rangeLen, getElement, reverseSearch);
+        : linearSearch(
+            lookupRange,
+            searchKey,
+            mode,
+            rangeLen,
+            getElement,
+            this.lookupCaches,
+            reverseSearch
+          );
 
     if (index !== -1) {
       return lookupDirection === "col"

--- a/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
@@ -137,6 +137,10 @@ export class Evaluator {
     );
     this.compilationParams.evalContext.updateDependencies = this.updateDependencies.bind(this);
     this.compilationParams.evalContext.addDependencies = this.addDependencies.bind(this);
+    this.compilationParams.evalContext.lookupCaches = {
+      forwardSearch: new Map(),
+      reverseSearch: new Map(),
+    };
   }
 
   private createEmptyPositionSet() {

--- a/src/types/functions.ts
+++ b/src/types/functions.ts
@@ -60,4 +60,13 @@ export type EvalContext = {
   updateDependencies?: (position: CellPosition) => void;
   addDependencies?: (position: CellPosition, ranges: Range[]) => void;
   debug?: boolean;
+  lookupCaches?: LookupCaches;
+};
+
+/**
+ * used to cache lookup values for linear search
+ **/
+export type LookupCaches = {
+  forwardSearch: Map<any, Map<CellValue, number>>;
+  reverseSearch: Map<any, Map<CellValue, number>>;
 };


### PR DESCRIPTION
Benchmark for 10 000 Vlookup performed on a random array composed of integer values ​​between 1 and 10000
`=VLOOKUP(A1:A10000,A1:A10000,1,false)`

measures on "linearSearch" before the commit:
- 267 ms (48% of evaluateAllCells)
- 271 ms (48% of evaluateAllCells)
- 296 ms (50% of evaluateAllCells)

measures on "linearSearch" after the commit:
- 4 ms (2% of evaluateAllCells)
- 1 ms (0.5% of evalauteAllCells)
- 2 ms (3 % of evaluateAllCells)

Task: [4080146](https://www.odoo.com/odoo/2328/tasks/4080146)
