### PR TITLE
[FIX] GridComposer: Fix CellReference pill display

### DIFF
--- a/src/components/composer/grid_composer/grid_composer.ts
+++ b/src/components/composer/grid_composer/grid_composer.ts
@@ -190,7 +190,7 @@ export class GridComposer extends Component<Props, SpreadsheetChildEnv> {
       return;
     }
     const sheetId = this.env.model.getters.getActiveSheetId();
-    const zone = this.env.model.getters.getSelectedZone();
+    const zone = positionToZone(this.env.model.getters.getSelection().anchor.cell);
     const rect = this.env.model.getters.getVisibleRect(zone);
     if (
       !deepEquals(rect, this.rect) ||

--- a/tests/composer/composer_integration_component.test.ts
+++ b/tests/composer/composer_integration_component.test.ts
@@ -18,6 +18,7 @@ import {
   resizeRows,
   selectCell,
   setCellContent,
+  setSelection,
 } from "../test_helpers/commands_helpers";
 import {
   click,
@@ -246,6 +247,7 @@ describe("Composer interactions", () => {
   });
 
   test("Starting the edition should not display the cell reference", async () => {
+    setSelection(model, ["A1:A2"]);
     await startComposition();
     expect(fixture.querySelector(".o-grid div.o-cell-reference")).toBeNull();
   });


### PR DESCRIPTION
How to reproduce:
- Select a large zone (more than 1 cell) on the grid
- Hit enter to start the edition

=> the cell reference pill is visible even though it functionally should only be visible if we scrolled (changed sheet) while editing.

Task: 4501136

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo