### PR TITLE
[FIX] xlsx: export data validation with unbounded range

### DIFF
--- a/src/helpers/figures/charts/chart_common.ts
+++ b/src/helpers/figures/charts/chart_common.ts
@@ -279,14 +279,14 @@ export function toExcelDataset(getters: CoreGetters, ds: DataSet): ExcelChartDat
   } else if (ds.labelCell) {
     label = {
       reference: getters.getRangeString(ds.labelCell, "forceSheetReference", {
-        useFixedReference: true,
+        useBoundedReference: true,
       }),
     };
   }
 
   return {
     label,
-    range: getters.getRangeString(dataRange, "forceSheetReference", { useFixedReference: true }),
+    range: getters.getRangeString(dataRange, "forceSheetReference", { useBoundedReference: true }),
     backgroundColor: ds.backgroundColor,
     rightYAxis: ds.rightYAxis,
   };
@@ -305,7 +305,7 @@ export function toExcelLabelRange(
     zone.top = zone.top + 1;
   }
   const range = labelRange.clone({ zone });
-  return getters.getRangeString(range, "forceSheetReference", { useFixedReference: true });
+  return getters.getRangeString(range, "forceSheetReference", { useBoundedReference: true });
 }
 
 /**

--- a/src/plugins/core/cell.ts
+++ b/src/plugins/core/cell.ts
@@ -426,7 +426,7 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
     sheetId: UID,
     tokens: Token[],
     dependencies: Range[],
-    useFixedReference: boolean = false
+    useBoundedReference: boolean = false
   ): string {
     if (!dependencies.length) {
       return concat(tokens.map((token) => token.value));
@@ -436,7 +436,7 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
       tokens.map((token) => {
         if (token.type === "REFERENCE") {
           const range = dependencies[rangeIndex++];
-          return this.getters.getRangeString(range, sheetId, { useFixedReference });
+          return this.getters.getRangeString(range, sheetId, { useBoundedReference });
         }
         return token.value;
       })
@@ -767,7 +767,7 @@ export class FormulaCellWithDependencies implements FormulaCell {
     private readonly getRangeString: (
       range: Range,
       sheetId: UID,
-      option?: { useFixedReference: boolean }
+      option?: { useBoundedReference: boolean }
     ) => string
   ) {
     let rangeIndex = 0;
@@ -796,7 +796,7 @@ export class FormulaCellWithDependencies implements FormulaCell {
         if (token.type === "REFERENCE") {
           const index = rangeIndex++;
           return this.getRangeString(this.compiledFormula.dependencies[index], this.sheetId, {
-            useFixedReference: true,
+            useBoundedReference: true,
           });
         }
         return token.value;

--- a/src/plugins/core/conditional_format.ts
+++ b/src/plugins/core/conditional_format.ts
@@ -208,7 +208,7 @@ export class ConditionalFormatPlugin
       for (let sheet of data.sheets) {
         if (this.cfRules[sheet.id]) {
           sheet.conditionalFormats = this.cfRules[sheet.id].map((rule) =>
-            this.mapToConditionalFormat(sheet.id, rule, { useFixedReference: true })
+            this.mapToConditionalFormat(sheet.id, rule, { useBoundedReference: true })
           );
         }
       }
@@ -300,10 +300,10 @@ export class ConditionalFormatPlugin
   private mapToConditionalFormat(
     sheetId: UID,
     cf: ConditionalFormatInternal,
-    { useFixedReference } = { useFixedReference: false }
+    { useBoundedReference } = { useBoundedReference: false }
   ): ConditionalFormat {
     const ranges = cf.ranges.map((range) => {
-      return this.getters.getRangeString(range, sheetId, { useFixedReference });
+      return this.getters.getRangeString(range, sheetId, { useBoundedReference });
     });
     if (cf.rule.type !== "DataBarRule") {
       return {
@@ -319,7 +319,7 @@ export class ConditionalFormatPlugin
         rangeValues:
           cf.rule.rangeValues &&
           this.getters.getRangeString(cf.rule.rangeValues!, sheetId, {
-            useFixedReference,
+            useBoundedReference,
           }),
       },
       ranges,

--- a/src/plugins/core/data_validation.ts
+++ b/src/plugins/core/data_validation.ts
@@ -271,12 +271,19 @@ export class DataValidationPlugin
     for (const sheet of data.sheets) {
       sheet.dataValidationRules = [];
       for (const rule of this.rules[sheet.id]) {
-        sheet.dataValidationRules.push({
-          ...rule,
+        const excelRule = {
+          ...deepCopy(rule),
           ranges: rule.ranges.map((range) =>
             this.getters.getRangeString(range, sheet.id, { useFixedReference: true })
           ),
-        });
+        };
+        if (rule.criterion.type === "isValueInRange") {
+          excelRule.criterion.values = rule.criterion.values.map((value) => {
+            const range = this.getters.getRangeFromSheetXC(sheet.id, value);
+            return this.getters.getRangeString(range, sheet.id, { useFixedReference: true });
+          });
+        }
+        sheet.dataValidationRules.push(excelRule);
       }
     }
   }

--- a/src/plugins/core/data_validation.ts
+++ b/src/plugins/core/data_validation.ts
@@ -274,13 +274,13 @@ export class DataValidationPlugin
         const excelRule = {
           ...deepCopy(rule),
           ranges: rule.ranges.map((range) =>
-            this.getters.getRangeString(range, sheet.id, { useFixedReference: true })
+            this.getters.getRangeString(range, sheet.id, { useBoundedReference: true })
           ),
         };
         if (rule.criterion.type === "isValueInRange") {
           excelRule.criterion.values = rule.criterion.values.map((value) => {
             const range = this.getters.getRangeFromSheetXC(sheet.id, value);
-            return this.getters.getRangeString(range, sheet.id, { useFixedReference: true });
+            return this.getters.getRangeString(range, sheet.id, { useBoundedReference: true });
           });
         }
         sheet.dataValidationRules.push(excelRule);

--- a/src/plugins/core/data_validation.ts
+++ b/src/plugins/core/data_validation.ts
@@ -280,7 +280,10 @@ export class DataValidationPlugin
         if (rule.criterion.type === "isValueInRange") {
           excelRule.criterion.values = rule.criterion.values.map((value) => {
             const range = this.getters.getRangeFromSheetXC(sheet.id, value);
-            return this.getters.getRangeString(range, sheet.id, { useBoundedReference: true });
+            return this.getters.getRangeString(range, sheet.id, {
+              useBoundedReference: true,
+              useFixedReference: true,
+            });
           });
         }
         sheet.dataValidationRules.push(excelRule);

--- a/src/plugins/core/range.ts
+++ b/src/plugins/core/range.ts
@@ -366,9 +366,9 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
    * @param range the range (received from getRangeFromXC or getRangeFromZone)
    * @param forSheetId the id of the sheet where the range string is supposed to be used.
    * @param options
-   * @param options.useFixedReference if true, the range will be returned with fixed row and column
+   * @param options.useBoundedReference if true, the range will be returned with fixed row and column
    */
-  getRangeString(range: Range, forSheetId: UID, options = { useFixedReference: false }): string {
+  getRangeString(range: Range, forSheetId: UID, options = { useBoundedReference: false }): string {
     if (!range) {
       return CellErrorType.InvalidReference;
     }
@@ -498,7 +498,7 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
   private getRangePartString(
     range: RangeImpl,
     part: 0 | 1,
-    options: { useFixedReference: boolean } = { useFixedReference: false }
+    options: { useBoundedReference: boolean } = { useBoundedReference: false }
   ): string {
     const colFixed = range.parts && range.parts[part]?.colFixed ? "$" : "";
     const col = part === 0 ? numberToLetters(range.zone.left) : numberToLetters(range.zone.right);
@@ -506,13 +506,13 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
     const row = part === 0 ? String(range.zone.top + 1) : String(range.zone.bottom + 1);
 
     let str = "";
-    if (range.isFullCol && !options.useFixedReference) {
+    if (range.isFullCol && !options.useBoundedReference) {
       if (part === 0 && range.unboundedZone.hasHeader) {
         str = colFixed + col + rowFixed + row;
       } else {
         str = colFixed + col;
       }
-    } else if (range.isFullRow && !options.useFixedReference) {
+    } else if (range.isFullRow && !options.useBoundedReference) {
       if (part === 0 && range.unboundedZone.hasHeader) {
         str = colFixed + col + rowFixed + row;
       } else {

--- a/src/plugins/core/range.ts
+++ b/src/plugins/core/range.ts
@@ -33,6 +33,11 @@ import {
   Zone,
 } from "../../types/index";
 
+interface RangeStringOptions {
+  useBoundedReference?: boolean;
+  useFixedReference?: boolean;
+}
+
 export class RangeAdapter implements CommandHandler<CoreCommand> {
   private getters: CoreGetters;
   private providers: Array<RangeProvider["adaptRanges"]> = [];
@@ -366,9 +371,14 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
    * @param range the range (received from getRangeFromXC or getRangeFromZone)
    * @param forSheetId the id of the sheet where the range string is supposed to be used.
    * @param options
-   * @param options.useBoundedReference if true, the range will be returned with fixed row and column
+   * @param options.useBoundedReference if true, the range will be returned with bounded row and column
+   * @param options.useFixedReference if true, the range will be returned with fixed row and column
    */
-  getRangeString(range: Range, forSheetId: UID, options = { useBoundedReference: false }): string {
+  getRangeString(
+    range: Range,
+    forSheetId: UID,
+    options: RangeStringOptions = { useBoundedReference: false, useFixedReference: false }
+  ): string {
     if (!range) {
       return CellErrorType.InvalidReference;
     }
@@ -498,11 +508,11 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
   private getRangePartString(
     range: RangeImpl,
     part: 0 | 1,
-    options: { useBoundedReference: boolean } = { useBoundedReference: false }
+    options: RangeStringOptions = { useBoundedReference: false, useFixedReference: false }
   ): string {
-    const colFixed = range.parts && range.parts[part]?.colFixed ? "$" : "";
+    const colFixed = range.parts[part]?.colFixed || options.useFixedReference ? "$" : "";
     const col = part === 0 ? numberToLetters(range.zone.left) : numberToLetters(range.zone.right);
-    const rowFixed = range.parts && range.parts[part]?.rowFixed ? "$" : "";
+    const rowFixed = range.parts[part]?.rowFixed || options.useFixedReference ? "$" : "";
     const row = part === 0 ? String(range.zone.top + 1) : String(range.zone.bottom + 1);
 
     let str = "";

--- a/tests/xlsx/__snapshots__/xlsx_export.test.ts.snap
+++ b/tests/xlsx/__snapshots__/xlsx_export.test.ts.snap
@@ -19639,10 +19639,15 @@ exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Data validati
     </cols>
     <sheetData>
     </sheetData>
-    <dataValidations count="4">
+    <dataValidations count="5">
         <dataValidation allowBlank="1" showInputMessage="1" showErrorMessage="1" errorStyle="warning" sqref="A1:A5" type="list">
             <formula1>
                 A1:A5
+            </formula1>
+        </dataValidation>
+        <dataValidation allowBlank="1" showInputMessage="1" showErrorMessage="1" errorStyle="warning" sqref="A1:A100" type="list">
+            <formula1>
+                A1:A100
             </formula1>
         </dataValidation>
         <dataValidation allowBlank="1" showInputMessage="1" showErrorMessage="1" errorStyle="warning" sqref="B1:B5" type="decimal" operator="greaterThan">

--- a/tests/xlsx/__snapshots__/xlsx_export.test.ts.snap
+++ b/tests/xlsx/__snapshots__/xlsx_export.test.ts.snap
@@ -19642,12 +19642,12 @@ exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Data validati
     <dataValidations count="5">
         <dataValidation allowBlank="1" showInputMessage="1" showErrorMessage="1" errorStyle="warning" sqref="A1:A5" type="list">
             <formula1>
-                A1:A5
+                $A$1:$A$5
             </formula1>
         </dataValidation>
         <dataValidation allowBlank="1" showInputMessage="1" showErrorMessage="1" errorStyle="warning" sqref="A1:A100" type="list">
             <formula1>
-                A1:A100
+                $A$1:$A$100
             </formula1>
         </dataValidation>
         <dataValidation allowBlank="1" showInputMessage="1" showErrorMessage="1" errorStyle="warning" sqref="B1:B5" type="decimal" operator="greaterThan">

--- a/tests/xlsx/xlsx_export.test.ts
+++ b/tests/xlsx/xlsx_export.test.ts
@@ -653,6 +653,14 @@ describe("Test XLSX export", () => {
                 },
               },
               {
+                ranges: ["A1:A"],
+                criterion: {
+                  type: "isValueInRange",
+                  values: ["A1:A"],
+                  isBlocking: true,
+                },
+              },
+              {
                 ranges: ["B1:B5"],
                 criterion: {
                   type: "isGreaterThan",


### PR DESCRIPTION

## Description:

Steps to reproduce:
- Create a data validation with the criterion "value in range"
- use an unbounded range
- export to xlsx

=> the values from the range aren't showing up in Libre Office. In Gsheet, the value is marked as being invalid (little error triangle)

Task: [4505771](https://www.odoo.com/odoo/2328/tasks/4505771)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo