### PR TITLE
[REF] range: rename useFixedReference

### DIFF
--- a/src/helpers/figures/charts/chart_common.ts
+++ b/src/helpers/figures/charts/chart_common.ts
@@ -268,14 +268,14 @@ export function toExcelDataset(getters: CoreGetters, ds: DataSet): ExcelChartDat
   } else if (ds.labelCell) {
     label = {
       reference: getters.getRangeString(ds.labelCell, "forceSheetReference", {
-        useFixedReference: true,
+        useBoundedReference: true,
       }),
     };
   }
 
   return {
     label,
-    range: getters.getRangeString(dataRange, "forceSheetReference", { useFixedReference: true }),
+    range: getters.getRangeString(dataRange, "forceSheetReference", { useBoundedReference: true }),
     backgroundColor: ds.backgroundColor,
     rightYAxis: ds.rightYAxis,
   };
@@ -294,7 +294,7 @@ export function toExcelLabelRange(
     zone.top = zone.top + 1;
   }
   const range = labelRange.clone({ zone });
-  return getters.getRangeString(range, "forceSheetReference", { useFixedReference: true });
+  return getters.getRangeString(range, "forceSheetReference", { useBoundedReference: true });
 }
 
 /**

--- a/src/plugins/core/cell.ts
+++ b/src/plugins/core/cell.ts
@@ -399,7 +399,7 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
     sheetId: UID,
     tokens: Token[],
     dependencies: Range[],
-    useFixedReference: boolean = false
+    useBoundedReference: boolean = false
   ): string {
     if (!dependencies.length) {
       return concat(tokens.map((token) => token.value));
@@ -409,7 +409,7 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
       tokens.map((token) => {
         if (token.type === "REFERENCE") {
           const range = dependencies[rangeIndex++];
-          return this.getters.getRangeString(range, sheetId, { useFixedReference });
+          return this.getters.getRangeString(range, sheetId, { useBoundedReference });
         }
         return token.value;
       })
@@ -740,7 +740,7 @@ export class FormulaCellWithDependencies implements FormulaCell {
     private readonly getRangeString: (
       range: Range,
       sheetId: UID,
-      option?: { useFixedReference: boolean }
+      option?: { useBoundedReference: boolean }
     ) => string
   ) {
     let rangeIndex = 0;
@@ -769,7 +769,7 @@ export class FormulaCellWithDependencies implements FormulaCell {
         if (token.type === "REFERENCE") {
           const index = rangeIndex++;
           return this.getRangeString(this.compiledFormula.dependencies[index], this.sheetId, {
-            useFixedReference: true,
+            useBoundedReference: true,
           });
         }
         return token.value;

--- a/src/plugins/core/conditional_format.ts
+++ b/src/plugins/core/conditional_format.ts
@@ -213,7 +213,7 @@ export class ConditionalFormatPlugin
       for (let sheet of data.sheets) {
         if (this.cfRules[sheet.id]) {
           sheet.conditionalFormats = this.cfRules[sheet.id].map((rule) =>
-            this.mapToConditionalFormat(sheet.id, rule, { useFixedReference: true })
+            this.mapToConditionalFormat(sheet.id, rule, { useBoundedReference: true })
           );
         }
       }
@@ -305,10 +305,10 @@ export class ConditionalFormatPlugin
   private mapToConditionalFormat(
     sheetId: UID,
     cf: ConditionalFormatInternal,
-    { useFixedReference } = { useFixedReference: false }
+    { useBoundedReference } = { useBoundedReference: false }
   ): ConditionalFormat {
     const ranges = cf.ranges.map((range) => {
-      return this.getters.getRangeString(range, sheetId, { useFixedReference });
+      return this.getters.getRangeString(range, sheetId, { useBoundedReference });
     });
     if (cf.rule.type !== "DataBarRule") {
       return {
@@ -324,7 +324,7 @@ export class ConditionalFormatPlugin
         rangeValues:
           cf.rule.rangeValues &&
           this.getters.getRangeString(cf.rule.rangeValues!, sheetId, {
-            useFixedReference,
+            useBoundedReference,
           }),
       },
       ranges,

--- a/src/plugins/core/data_validation.ts
+++ b/src/plugins/core/data_validation.ts
@@ -276,7 +276,7 @@ export class DataValidationPlugin
         sheet.dataValidationRules.push({
           ...rule,
           ranges: rule.ranges.map((range) =>
-            this.getters.getRangeString(range, sheet.id, { useFixedReference: true })
+            this.getters.getRangeString(range, sheet.id, { useBoundedReference: true })
           ),
         });
       }

--- a/src/plugins/core/range.ts
+++ b/src/plugins/core/range.ts
@@ -366,9 +366,9 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
    * @param range the range (received from getRangeFromXC or getRangeFromZone)
    * @param forSheetId the id of the sheet where the range string is supposed to be used.
    * @param options
-   * @param options.useFixedReference if true, the range will be returned with fixed row and column
+   * @param options.useBoundedReference if true, the range will be returned with fixed row and column
    */
-  getRangeString(range: Range, forSheetId: UID, options = { useFixedReference: false }): string {
+  getRangeString(range: Range, forSheetId: UID, options = { useBoundedReference: false }): string {
     if (!range) {
       return CellErrorType.InvalidReference;
     }
@@ -498,7 +498,7 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
   private getRangePartString(
     range: RangeImpl,
     part: 0 | 1,
-    options: { useFixedReference: boolean } = { useFixedReference: false }
+    options: { useBoundedReference: boolean } = { useBoundedReference: false }
   ): string {
     const colFixed = range.parts && range.parts[part]?.colFixed ? "$" : "";
     const col = part === 0 ? numberToLetters(range.zone.left) : numberToLetters(range.zone.right);
@@ -506,13 +506,13 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
     const row = part === 0 ? String(range.zone.top + 1) : String(range.zone.bottom + 1);
 
     let str = "";
-    if (range.isFullCol && !options.useFixedReference) {
+    if (range.isFullCol && !options.useBoundedReference) {
       if (part === 0 && range.unboundedZone.hasHeader) {
         str = colFixed + col + rowFixed + row;
       } else {
         str = colFixed + col;
       }
-    } else if (range.isFullRow && !options.useFixedReference) {
+    } else if (range.isFullRow && !options.useBoundedReference) {
       if (part === 0 && range.unboundedZone.hasHeader) {
         str = colFixed + col + rowFixed + row;
       } else {


### PR DESCRIPTION
## Description:

This commit renames `useFixedReference` to `useBoundedReference`.

"fixed" refers to $ like in $A$1

but the option `useFixedReference` doesn't have anything to do with $ but it makes sure the reference is bounded: A10:A -> A10:A100

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo