### PR TITLE
[FIX] chart tooltip: create app only on demand

### DIFF
--- a/src/helpers/figures/charts/runtime/chart_custom_tooltip.ts
+++ b/src/helpers/figures/charts/runtime/chart_custom_tooltip.ts
@@ -50,13 +50,16 @@ const templates = /* xml */ `
 </templates>
 `;
 
-const app = new App(Component, { templates, translateFn: _t });
+let app: App | undefined;
 
 export function renderToString(templateName: string, context: any = {}) {
   return render(templateName, context).innerHTML;
 }
 
 function render(templateName: string, context: any = {}) {
+  if (!app) {
+    app = new App(Component, { templates, translateFn: _t });
+  }
   const templateFn = app.getTemplate(templateName);
   const bdom = templateFn(context, {});
   const div = document.createElement("div");


### PR DESCRIPTION
Before this commit, a new App was created even when `renderToString` was never called. `renderToString` is for now only called to render a custom tooltip on a chart.

This caused a memory leak in the tests of Odoo, as a new App was created for each test, but never destroyed.

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo