### PR TITLE
[FIX] charts: enable custom tooltip for geo chart

### DIFF
--- a/src/helpers/figures/charts/runtime/chartjs_tooltip.ts
+++ b/src/helpers/figures/charts/runtime/chartjs_tooltip.ts
@@ -204,6 +204,8 @@ export function getGeoChartTooltip(
   const { locale, axisFormats } = args;
   const format = axisFormats?.y || axisFormats?.y1;
   return {
+    enabled: false,
+    external: customTooltipHandler,
     filter: function (tooltipItem: TooltipItem<"choropleth">) {
       return (tooltipItem.raw as any).value !== undefined;
     },

--- a/tests/figures/chart/geochart/geo_chart_plugin.test.ts
+++ b/tests/figures/chart/geochart/geo_chart_plugin.test.ts
@@ -96,6 +96,15 @@ describe("Geo charts plugin tests", () => {
     expect(runtime.chartJsConfig.options?.scales?.color?.["ticks"]?.callback?.(20)).toBe("$20");
   });
 
+  test("Geo charts use custom tooltip", () => {
+    createGeoChart(model, {});
+    const runtime = model.getters.getChartRuntime("chartId") as any;
+    expect(runtime.chartJsConfig.options?.plugins?.tooltip).toMatchObject({
+      enabled: false,
+      external: expect.any(Function),
+    });
+  });
+
   test("Tooltip values have the same format as the data", () => {
     setCellContent(model, "A2", "France");
     setCellContent(model, "B2", "20");


### PR DESCRIPTION
## Description



Task: [4509160](https://www.odoo.com/odoo/2328/tasks/4509160)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo