### PR TITLE
[FIX] ui_sheet: batch resize commands in `AUTORESIZE_ROWS`

### DIFF
--- a/src/plugins/ui/ui_sheet.ts
+++ b/src/plugins/ui/ui_sheet.ts
@@ -61,14 +61,12 @@ export class SheetUIPlugin extends UIPlugin {
         }
         break;
       case "AUTORESIZE_ROWS":
-        for (let row of cmd.rows) {
-          this.dispatch("RESIZE_COLUMNS_ROWS", {
-            elements: [row],
-            dimension: "ROW",
-            size: null,
-            sheetId: cmd.sheetId,
-          });
-        }
+        this.dispatch("RESIZE_COLUMNS_ROWS", {
+          elements: cmd.rows,
+          dimension: "ROW",
+          size: null,
+          sheetId: cmd.sheetId,
+        });
         break;
     }
   }

--- a/tests/plugins/formatting.test.ts
+++ b/tests/plugins/formatting.test.ts
@@ -36,6 +36,7 @@ import {
   setStyle,
 } from "../test_helpers/commands_helpers";
 import { getCell, getCellContent } from "../test_helpers/getters_helpers";
+import { spyUiPluginHandle } from "../test_helpers/helpers";
 
 function setDecimal(model: Model, step: SetDecimalStep) {
   model.dispatch("SET_DECIMAL", {
@@ -510,6 +511,22 @@ describe("Autoresize", () => {
     model.dispatch("AUTORESIZE_ROWS", { sheetId, rows: [0, 2] });
     expect(model.getters.getRowSize(sheetId, 0)).toBe(DEFAULT_CELL_HEIGHT);
     expect(model.getters.getRowSize(sheetId, 2)).toBe(fontSizeMap[24] + vPadding);
+  });
+
+  test("Only a single resize command is dispatched when auto-resizing multiple rows", () => {
+    const rows = [0, 1, 2];
+    resizeRows(model, rows, DEFAULT_CELL_HEIGHT + 30);
+    const handleCmd = spyUiPluginHandle(model);
+    model.dispatch("AUTORESIZE_ROWS", { sheetId, rows: [0, 1, 2] });
+    expect(handleCmd).toHaveBeenCalledTimes(2);
+    expect(handleCmd).toHaveBeenNthCalledWith(1, { type: "AUTORESIZE_ROWS", sheetId, rows });
+    expect(handleCmd).toHaveBeenNthCalledWith(2, {
+      type: "RESIZE_COLUMNS_ROWS",
+      elements: rows,
+      dimension: "ROW",
+      size: null,
+      sheetId,
+    });
   });
 
   test("Can autoresize a column in another sheet", () => {

--- a/tests/plugins/history.test.ts
+++ b/tests/plugins/history.test.ts
@@ -1,7 +1,5 @@
-import { UIPlugin } from "../../src";
 import { MAX_HISTORY_STEPS } from "../../src/constants";
 import { Model } from "../../src/model";
-import { uiPluginRegistry } from "../../src/plugins";
 import { StateObserver } from "../../src/state_observer";
 import { CommandResult, UpdateCellCommand } from "../../src/types/commands";
 import {
@@ -14,7 +12,7 @@ import {
 } from "../test_helpers/commands_helpers";
 import { getBorder, getCell, getCellContent } from "../test_helpers/getters_helpers"; // to have getcontext mocks
 import "../test_helpers/helpers";
-import { getPlugin } from "../test_helpers/helpers";
+import { spyUiPluginHandle } from "../test_helpers/helpers";
 
 // we test here the undo/redo feature
 
@@ -310,11 +308,8 @@ describe("Model history", () => {
   });
 
   test("undone & redone commands are part of the command", () => {
-    class TestPlugin extends UIPlugin {}
-    uiPluginRegistry.add("test-plugin", TestPlugin);
     const model = new Model();
-    const plugin = getPlugin(model, TestPlugin);
-    plugin.handle = jest.fn((cmd) => {});
+    const pluginHandle = spyUiPluginHandle(model);
     const command: UpdateCellCommand = {
       type: "UPDATE_CELL",
       col: 0,
@@ -324,15 +319,14 @@ describe("Model history", () => {
     };
     model.dispatch(command.type, command);
     undo(model);
-    expect(plugin.handle).toHaveBeenCalledWith({
+    expect(pluginHandle).toHaveBeenCalledWith({
       type: "UNDO",
       commands: [command],
     });
     redo(model);
-    expect(plugin.handle).toHaveBeenCalledWith({
+    expect(pluginHandle).toHaveBeenCalledWith({
       type: "REDO",
       commands: [command],
     });
-    uiPluginRegistry.remove("test-plugin");
   });
 });

--- a/tests/test_helpers/helpers.ts
+++ b/tests/test_helpers/helpers.ts
@@ -7,6 +7,7 @@ import { FocusableElement } from "../../src/helpers/focus_manager";
 import { toCartesian, toUnboundedZone, toXC, toZone } from "../../src/helpers/index";
 import { Model } from "../../src/model";
 import { MergePlugin } from "../../src/plugins/core/merge";
+import { SheetUIPlugin } from "../../src/plugins/ui/ui_sheet";
 import {
   ColorScaleMidPointThreshold,
   ColorScaleThreshold,
@@ -77,6 +78,10 @@ export function getChildFromComponent<T extends new (...args: any) => any>(
 
 export function spyModelDispatch(model: Model): jest.SpyInstance {
   return jest.spyOn(model, "dispatch");
+}
+
+export function spyUiPluginHandle(model: Model): jest.SpyInstance {
+  return jest.spyOn(getPlugin(model, SheetUIPlugin), "handle");
 }
 
 export function makeTestFixture() {


### PR DESCRIPTION
## Description

When auto-resizing rows, we would dispatch a `RESIZE_COLUMNS_ROWS` for each row in the selection. But we could simply be dispatching a single `RESIZE_COLUMNS_ROWS` command all the rows, since the size would be the same for all the rows (`null` to mark that they can resize dynamically). This lighten up the network load when auto-resizing multiple rows.

Note that the same cannot be done for columns, since the size of auto-resized columns can be different.

Task: [4504918](https://www.odoo.com/odoo/2328/tasks/4504918)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo