### PR TITLE
[FIX] chart: pyramid chart datasets are wrong in the panel

### DIFF
--- a/src/components/side_panel/chart/building_blocks/generic_side_panel/config_panel.ts
+++ b/src/components/side_panel/chart/building_blocks/generic_side_panel/config_panel.ts
@@ -118,6 +118,11 @@ export class GenericChartConfigPanel extends Component<Props, SpreadsheetChildEn
     this.state.datasetDispatchResult = this.props.updateChart(this.props.figureId, {
       dataSets: this.dataSeriesRanges,
     });
+    if (this.state.datasetDispatchResult.isSuccessful) {
+      this.dataSeriesRanges = (
+        this.env.model.getters.getChartDefinition(this.props.figureId) as ChartWithAxisDefinition
+      ).dataSets;
+    }
   }
 
   getDataSeriesRanges() {

--- a/tests/figures/chart/pyramid_chart/pyramid_chart_component.test.ts
+++ b/tests/figures/chart/pyramid_chart/pyramid_chart_component.test.ts
@@ -1,0 +1,42 @@
+import { Model, SpreadsheetChildEnv, UID } from "../../../../src";
+import { SidePanel } from "../../../../src/components/side_panel/side_panel/side_panel";
+import { PyramidChartDefinition } from "../../../../src/types/chart/pyramid_chart";
+import { createChart } from "../../../test_helpers";
+import { openChartConfigSidePanel } from "../../../test_helpers/chart_helpers";
+import { setInputValueAndTrigger, simulateClick } from "../../../test_helpers/dom_helper";
+import { mountComponentWithPortalTarget, nextTick } from "../../../test_helpers/helpers";
+
+let model: Model;
+let fixture: HTMLElement;
+let env: SpreadsheetChildEnv;
+
+function getPyramidDefinition(chartId: UID): PyramidChartDefinition {
+  return model.getters.getChartDefinition(chartId) as PyramidChartDefinition;
+}
+
+describe("Pyramid chart side panel", () => {
+  beforeEach(async () => {
+    model = new Model();
+    ({ fixture, env } = await mountComponentWithPortalTarget(SidePanel, { model }));
+  });
+
+  test("Only first 2 ranges are kept when changing the selection input", async () => {
+    createChart(model, { type: "pyramid", dataSets: [] }, "id");
+    await openChartConfigSidePanel(model, env, "id");
+
+    const dataSeries = fixture.querySelector<HTMLInputElement>(".o-chart .o-data-series input")!;
+    setInputValueAndTrigger(dataSeries, "A1:D5");
+    await nextTick();
+    await simulateClick(".o-data-series .o-selection-ok");
+
+    expect(getPyramidDefinition("id").dataSets).toEqual([
+      { dataRange: "A1:A5" },
+      { dataRange: "B1:B5" },
+    ]);
+
+    const inputs = fixture.querySelectorAll<HTMLInputElement>(".o-chart .o-data-series input");
+    expect(inputs).toHaveLength(2);
+    expect(inputs[0].value).toBe("A1:A5");
+    expect(inputs[1].value).toBe("B1:B5");
+  });
+});

--- a/tests/figures/chart/pyramid_chart/pyramid_chart_plugin.test.ts
+++ b/tests/figures/chart/pyramid_chart/pyramid_chart_plugin.test.ts
@@ -1,7 +1,7 @@
-import { ChartCreationContext, ChartJSRuntime, Model } from "../../../src";
-import { PyramidChart } from "../../../src/helpers/figures/charts/pyramid_chart";
-import { PyramidChartDefinition } from "../../../src/types/chart/pyramid_chart";
-import { createChart, setCellContent, setFormat } from "../../test_helpers/commands_helpers";
+import { ChartCreationContext, ChartJSRuntime, Model } from "../../../../src";
+import { PyramidChart } from "../../../../src/helpers/figures/charts/pyramid_chart";
+import { PyramidChartDefinition } from "../../../../src/types/chart/pyramid_chart";
+import { createChart, setCellContent, setFormat } from "../../../test_helpers/commands_helpers";
 
 let model: Model;
 describe("population pyramid chart", () => {

--- a/tests/test_helpers/chart_helpers.ts
+++ b/tests/test_helpers/chart_helpers.ts
@@ -1,4 +1,5 @@
-import { Model, UID } from "../../src";
+import { Model, SpreadsheetChildEnv, UID } from "../../src";
+import { nextTick } from "./helpers";
 
 export function isChartAxisStacked(model: Model, chartId: UID, axis: "x" | "y"): boolean {
   return getChartConfiguration(model, chartId).options?.scales?.[axis]?.stacked;
@@ -7,4 +8,10 @@ export function isChartAxisStacked(model: Model, chartId: UID, axis: "x" | "y"):
 export function getChartConfiguration(model: Model, chartId: UID) {
   const runtime = model.getters.getChartRuntime(chartId) as any;
   return runtime.chartJsConfig;
+}
+
+export async function openChartConfigSidePanel(model: Model, env: SpreadsheetChildEnv, id: UID) {
+  model.dispatch("SELECT_FIGURE", { id });
+  env.openSidePanel("ChartPanel");
+  await nextTick();
 }


### PR DESCRIPTION
## Description

Bug:
- Create a pyramid chart
- Set it's ranges to A1: C3
- In the side panel the ranges are [A1:A3, B1:B3, C1:C3]
- But only the first two ranges are actually in the chart definition, C1:C3 is dropped
- Closing and re-opening the panel display the correct ranges

Task: [4517138](https://www.odoo.com/odoo/2328/tasks/4517138)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo