### PR TITLE
[FIX] pivot: use displayed value in computed measure

### DIFF
--- a/src/helpers/pivot/pivot_presentation.ts
+++ b/src/helpers/pivot/pivot_presentation.ts
@@ -131,7 +131,7 @@ export default function (PivotClass: PivotUIConstructor) {
           const symbolIndex = rowDomain.findIndex((row) => row.field === symbolName);
           return this.getPivotHeaderValueAndFormat(rowDomain.slice(0, symbolIndex + 1));
         }
-        return this._getPivotCellValueAndFormat(symbolName, domain);
+        return this.getPivotCellValueAndFormat(symbolName, domain);
       };
       const result = this.getters.evaluateCompiledFormula(
         measure.computedBy.sheetId,

--- a/tests/pivots/pivot_measure/pivot_measure_display_model.test.ts
+++ b/tests/pivots/pivot_measure/pivot_measure_display_model.test.ts
@@ -1589,6 +1589,43 @@ describe("Measure display", () => {
     });
   });
 
+  test("calculated measure uses the displayed values", () => {
+    const measureDisplay: PivotMeasureDisplay = {
+      type: "%_of_grand_total",
+      fieldNameWithGranularity: "Created on:month_number",
+      value: 2,
+    };
+    const model = createModelWithTestPivot();
+    const sheetId = model.getters.getActiveSheetId();
+    updatePivot(model, pivotId, {
+      measures: [
+        {
+          fieldName: "Expected Revenue",
+          userDefinedName: "m1",
+          aggregator: "sum",
+          id: measureId,
+          display: measureDisplay,
+        },
+        {
+          fieldName: "Expected Revenue + 10%",
+          userDefinedName: "m2",
+          aggregator: "sum",
+          id: "calculated",
+          computedBy: { formula: "='m1' + 10%", sheetId },
+        },
+      ],
+    });
+    // prettier-ignore
+    expect(getFormattedGrid(model)).toMatchObject({
+      A20:"(#1) Pivot",  B20: "Alice",   C20: "",        D20: "Bob",     E20: "",        F20: "Total",    G20: "",
+      A21: "",           B21: "m1",      C21: "m2",      D21: "m1",      E21: "m2",      F21: "m1",       G21: "m2",
+      A22: "February",   B22: "7.03%",   C22: "17.03%",  D22: "0.00%",   E22: "10.00%",  F22: "7.03%",    G22: "27.03%",
+      A23: "March",      B23: "39.16%",  C23: "49.16%",  D23: "19.99%",  E23: "29.99%",  F23: "59.15%",   G23: "79.15%",
+      A24: "April",      B24: "25.70%",  C24: "35.70%",  D24: "8.12%",   E24: "18.12%",  F24: "33.82%",   G24: "53.82%",
+      A25: "Total",      B25: "71.89%",  C25: "101.89%", D25: "28.11%",  E25: "58.11%",  F25: "100.00%",  G25: "160.00%",
+    });
+  });
+
   test("Can change measure display with calculated measure", () => {
     const measureDisplay: PivotMeasureDisplay = {
       type: "%_of_grand_total",
@@ -1607,11 +1644,11 @@ describe("Measure display", () => {
           display: measureDisplay,
         },
         {
-          fieldName: "Expected Revenue + 1000",
+          fieldName: "Expected Revenue + 10%",
           userDefinedName: "m2",
           aggregator: "sum",
           id: "calculated",
-          computedBy: { formula: "='m1' + 1000", sheetId },
+          computedBy: { formula: "='m1' + 10%", sheetId },
           display: measureDisplay,
         },
       ],
@@ -1620,10 +1657,10 @@ describe("Measure display", () => {
     expect(getFormattedGrid(model)).toMatchObject({
       A20:"(#1) Pivot",  B20: "Alice",   C20: "",        D20: "Bob",     E20: "",        F20: "Total",    G20: "",
       A21: "",           B21: "m1",      C21: "m2",      D21: "m1",      E21: "m2",      F21: "m1",       G21: "m2",
-      A22: "February",   B22: "7.03%",   C22: "7.20%",   D22: "0.00%",   E22: "0.31%",   F22: "7.03%",    G22: "7.51%",
-      A23: "March",      B23: "39.16%",  C23: "38.75%",  D23: "19.99%",  E23: "19.93%",  F23: "59.15%",   G23: "58.68%",
-      A24: "April",      B24: "25.70%",  C24: "25.54%",  D24: "8.12%",   E24: "8.28%",   F24: "33.82%",   G24: "33.81%",
-      A25: "Total",      B25: "71.89%",  C25: "71.49%",  D25: "28.11%",  E25: "28.51%",  F25: "100.00%",  G25: "100.00%",
+      A22: "February",   B22: "7.03%",   C22: "10.64%",  D22: "0.00%",   E22: "6.25%",   F22: "7.03%",    G22: "16.89%",
+      A23: "March",      B23: "39.16%",  C23: "30.73%",  D23: "19.99%",  E23: "18.74%",  F23: "59.15%",   G23: "49.47%",
+      A24: "April",      B24: "25.70%",  C24: "22.31%",  D24: "8.12%",   E24: "11.32%",  F24: "33.82%",   G24: "33.64%",
+      A25: "Total",      B25: "71.89%",  C25: "63.68%",  D25: "28.11%",  E25: "36.32%",  F25: "100.00%",  G25: "100.00%",
     });
   });
 });


### PR DESCRIPTION

## Description:

Computed measures do not take into account the "Display as". It means the value of a measure within a the formula computation is not the expected value (e.g. 'price_total:sum' in =MIN(50000, 'price_total:sum')). The user would expect the value to be the value he sees in the pivot, not the underlying raw value (before applying the "Display as").

This is confusing.

With this task, the values within computed measures are taken with "Display as" taken into account.
The previous behavior is still achievable
by inserting the referenced measure a second time (without "Display as"), and optionally hide it.

With this change, computed measures are strictly more powerful.

Stable or master?

This is a breaking change if someone uses the current behavior (change of behavior). Should we break it right now in 18.0, or break it later for more users, at upgrade ? Our guess is that it's a niche use case that is most probably not used a lot (or not used at all). We tend to prefer to fix/break it early, and favor stability at upgrade. It's easy to fix spreadsheets if we have tickets

Task: [4517312](https://www.odoo.com/odoo/2328/tasks/4517312)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo