### PR TITLE
[FIX] data_validation: don't prefilter on initial exact match

### DIFF
--- a/src/components/composer/composer/composer_store.ts
+++ b/src/components/composer/composer/composer_store.ts
@@ -832,6 +832,17 @@ export class ComposerStore extends SpreadsheetStore {
       const exactMatch = proposals?.find((p) => p.text === tokenAtCursor.value);
       // remove tokens that are likely to be other parts of the formula that slipped in the token if it's a string
       const searchTerm = tokenAtCursor.value.replace(/[ ,\(\)]/g, "");
+      if (
+        this._currentContent === this.initialContent &&
+        provider.displayAllOnInitialContent &&
+        proposals?.length
+      ) {
+        return {
+          proposals,
+          selectProposal: provider.selectProposal,
+          autoSelectFirstProposal: provider.autoSelectFirstProposal ?? false,
+        };
+      }
       if (exactMatch && this._currentContent !== this.initialContent) {
         // this means the user has chosen a proposal
         return;

--- a/src/registries/auto_completes/auto_complete_registry.ts
+++ b/src/registries/auto_completes/auto_complete_registry.ts
@@ -30,11 +30,12 @@ export interface AutoCompleteProvider {
  * We declare the providers in the registry as an object (rather than a class)
  * to allow a type-safe way to declare the provider.
  * We still want to be able to use `this` for the getters and dispatch for simplicity.
- * Binding happens at runtime in the edition plugin.
+ * Binding happens at runtime in the composer store.
  */
 export interface AutoCompleteProviderDefinition {
   sequence?: number;
   autoSelectFirstProposal?: boolean;
+  displayAllOnInitialContent?: boolean;
   maxDisplayedProposals?: number;
   getProposals(
     this: { composer: ComposerStore; getters: Getters },

--- a/src/registries/auto_completes/data_validation_auto_complete.ts
+++ b/src/registries/auto_completes/data_validation_auto_complete.ts
@@ -2,6 +2,7 @@ import { isNotNull } from "../../helpers";
 import { autoCompleteProviders } from "./auto_complete_registry";
 
 autoCompleteProviders.add("dataValidation", {
+  displayAllOnInitialContent: true,
   getProposals(tokenAtCursor, content) {
     if (content.startsWith("=")) {
       return [];

--- a/tests/composer/auto_complete/data_validation_auto_complete_store.test.ts
+++ b/tests/composer/auto_complete/data_validation_auto_complete_store.test.ts
@@ -1,0 +1,33 @@
+import { ComposerStore } from "../../../src/components/composer/composer/composer_store";
+import { addDataValidation, setCellContent } from "../../test_helpers/commands_helpers";
+import { makeStore } from "../../test_helpers/stores";
+
+describe("Data validation auto complete", () => {
+  test("start with exact match, but with other proposals", () => {
+    const { store: composer, model } = makeStore(ComposerStore);
+    addDataValidation(model, "A1", "id", {
+      type: "isValueInList",
+      values: ["XS", "S", "M", "L", "XL"],
+      displayStyle: "arrow",
+    });
+    setCellContent(model, "A1", "S");
+    composer.startEdition();
+    const autoComplete = composer.autocompleteProvider;
+    const proposals = autoComplete?.proposals;
+    expect(proposals).toHaveLength(5);
+  });
+
+  test("start with partial match displays all values", () => {
+    const { store: composer, model } = makeStore(ComposerStore);
+    addDataValidation(model, "A1", "id", {
+      type: "isValueInList",
+      values: ["XS", "XL", "L"],
+      displayStyle: "arrow",
+    });
+    setCellContent(model, "A1", "X");
+    composer.startEdition();
+    const autoComplete = composer.autocompleteProvider;
+    const proposals = autoComplete?.proposals;
+    expect(proposals).toHaveLength(3);
+  });
+});


### PR DESCRIPTION

## Description:

Steps to reproduce:
- Add dropdown list data validation with those options: XS, S, M, L
- select S
- double click the cell again to change the value

=> only S and XS are in the auto-complete dropdown

Task: [4518009](https://www.odoo.com/odoo/2328/tasks/4518009)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo