### PR TITLE
[IMP] xlsx: support exporting array formulas

### DIFF
--- a/src/plugins/ui_core_views/cell_evaluation/evaluation_plugin.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluation_plugin.ts
@@ -1,7 +1,7 @@
 import { compileTokens } from "../../../formulas/compiler";
 import { Token, isExportableToExcel } from "../../../formulas/index";
 import { matrixMap } from "../../../functions/helpers";
-import { getItemId, positions, toXC } from "../../../helpers/index";
+import { getItemId, positionToZone, positions, toXC, union } from "../../../helpers/index";
 import {
   CellPosition,
   CellValue,
@@ -295,6 +295,9 @@ export class EvaluationPlugin extends UIPlugin {
   // ---------------------------------------------------------------------------
 
   exportForExcel(data: ExcelWorkbookData) {
+    for (const sheet of data.sheets) {
+      sheet.formulaSpillRanges = {};
+    }
     for (const position of this.evaluator.getEvaluatedPositions()) {
       const evaluatedCell = this.evaluator.getEvaluatedCell(position);
 
@@ -309,8 +312,9 @@ export class EvaluationPlugin extends UIPlugin {
 
       const formulaCell = this.getCorrespondingFormulaCell(position);
       if (formulaCell) {
+        const cell = this.getters.getCell(position);
         isExported = isExportableToExcel(formulaCell.compiledFormula.tokens);
-        isFormula = isExported;
+        isFormula = isExported && cell?.content === formulaCell.content;
 
         if (!isExported) {
           // If the cell contains a non-exported formula and that is evaluates to
@@ -341,6 +345,18 @@ export class EvaluationPlugin extends UIPlugin {
         content = !isExported ? newContent : exportedCellData.content;
       }
       exportedSheetData.cells[xc] = { ...exportedCellData, value, isFormula, content, format };
+
+      const spillCells = this.getSpreadPositionsOf(position);
+      spillCells.push(position);
+      const spillZones = spillCells.map((cell) => positionToZone(cell));
+      const spillZone = union(...spillZones);
+      const spillZoneXc = this.getters.getRangeString(
+        this.getters.getRangeFromZone(position.sheetId, spillZone),
+        position.sheetId
+      );
+      if (spillZoneXc && spillZoneXc !== "#REF") {
+        exportedSheetData.formulaSpillRanges[xc] = spillZoneXc;
+      }
     }
   }
 

--- a/src/types/workbook_data.ts
+++ b/src/types/workbook_data.ts
@@ -78,6 +78,7 @@ export interface ExcelCellData extends CellData {
 }
 export interface ExcelSheetData extends Omit<SheetData, "figureTables"> {
   cells: { [key: string]: ExcelCellData | undefined };
+  formulaSpillRanges: { [xc: string]: string };
   charts: FigureData<ExcelChartDefinition>[];
   images: FigureData<Image>[];
   filterTables: ExcelFilterTableData[];

--- a/src/xlsx/constants.ts
+++ b/src/xlsx/constants.ts
@@ -29,6 +29,7 @@ export const DRAWING_NS_C = "http://schemas.openxmlformats.org/drawingml/2006/ch
 export const CONTENT_TYPES = {
   workbook: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml",
   sheet: "application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml",
+  metadata: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml",
   sharedStrings: "application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml",
   styles: "application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml",
   drawing: "application/vnd.openxmlformats-officedocument.drawing+xml",
@@ -42,6 +43,7 @@ export const CONTENT_TYPES = {
 export const XLSX_RELATION_TYPE = {
   document: "http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument",
   sheet: "http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet",
+  metadata: "http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata",
   sharedStrings:
     "http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings",
   styles: "http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles",
@@ -52,6 +54,8 @@ export const XLSX_RELATION_TYPE = {
   hyperlink: "http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink",
   image: "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image",
 } as const;
+
+export const ARRAY_FORMULA_URI = "bdbb8cdc-fa1e-496e-a857-3c3f30c029c3";
 
 export const RELATIONSHIP_NSR =
   "http://schemas.openxmlformats.org/officeDocument/2006/relationships";

--- a/src/xlsx/functions/cells.ts
+++ b/src/xlsx/functions/cells.ts
@@ -17,7 +17,10 @@ import { getCellType, pushElement } from "../helpers/content_helpers";
 import { escapeXml } from "../helpers/xml_helpers";
 import { DEFAULT_LOCALE } from "./../../types/locale";
 
-export function addFormula(cell: ExcelCellData): {
+export function addFormula(
+  cell: ExcelCellData,
+  formulaSpillRange: string
+): {
   attrs: XMLAttributes;
   node: XMLString;
 } {
@@ -31,11 +34,18 @@ export function addFormula(cell: ExcelCellData): {
     return { attrs: [], node: escapeXml`` };
   }
 
-  const attrs: XMLAttributes = [["t", type]];
+  const attrs: XMLAttributes = [
+    ["cm", "1"],
+    ["t", type],
+  ];
   const XlsxFormula = adaptFormulaToExcel(formula);
 
   const exportedValue = adaptFormulaValueToExcel(cell.value);
-  const node = escapeXml/*xml*/ `<f>${XlsxFormula}</f><v>${exportedValue}</v>`;
+  // We treat all formulas as array formulas (a simple formula
+  // is an array formula that spills on only one cell) to avoid
+  // trying to detect spilling sub-formulas which is not a trivial task.
+  let node: XMLString;
+  node = escapeXml/*xml*/ `<f t="array" ref="${formulaSpillRange}">${XlsxFormula}</f><v>${exportedValue}</v>`;
   return { attrs, node };
 }
 

--- a/src/xlsx/functions/worksheet.ts
+++ b/src/xlsx/functions/worksheet.ts
@@ -78,7 +78,7 @@ export function addRows(
         let cellNode = escapeXml``;
         // Either formula or static value inside the cell
         if (cell.isFormula) {
-          const res = addFormula(cell);
+          const res = addFormula(cell, sheet.formulaSpillRanges[xc] ?? xc);
           if (!res) {
             continue;
           }

--- a/src/xlsx/xlsx_writer.ts
+++ b/src/xlsx/xlsx_writer.ts
@@ -9,7 +9,13 @@ import {
   XMLString,
 } from "../types/xlsx";
 import { XLSXExportXMLFile } from "./../types/xlsx";
-import { CONTENT_TYPES, NAMESPACE, RELATIONSHIP_NSR, XLSX_RELATION_TYPE } from "./constants";
+import {
+  ARRAY_FORMULA_URI,
+  CONTENT_TYPES,
+  NAMESPACE,
+  RELATIONSHIP_NSR,
+  XLSX_RELATION_TYPE,
+} from "./constants";
 import { IMAGE_MIMETYPE_TO_EXTENSION_MAPPING } from "./conversion";
 import { createChart } from "./functions/charts";
 import { addConditionalFormatting } from "./functions/conditional_formatting";
@@ -200,6 +206,30 @@ function createWorksheets(data: ExcelWorkbookData, construct: XLSXStructure): XL
     `;
     files.push(createXMLFile(parseXML(sheetXml), `xl/worksheets/sheet${sheetIndex}.xml`, "sheet"));
   }
+  const sheetMetadataXml = escapeXml/*xml*/ `
+    <metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+        <metadataTypes count="1">
+            <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1"
+                pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1"
+                clearComments="1" assign="1" coerce="1" cellMeta="1" />
+        </metadataTypes>
+        <futureMetadata name="XLDAPR" count="1">
+            <bk>
+                <extLst>
+                    <ext uri="{${ARRAY_FORMULA_URI}}">
+                        <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0" />
+                    </ext>
+                </extLst>
+            </bk>
+        </futureMetadata>
+        <cellMetadata count="1">
+            <bk>
+                <rc t="1" v="0" />
+            </bk>
+        </cellMetadata>
+    </metadata>
+  `;
+  files.push(createXMLFile(parseXML(sheetMetadataXml), "xl/metadata.xml", "metadata"));
   addRelsToFile(construct.relsFiles, "xl/_rels/workbook.xml.rels", {
     type: XLSX_RELATION_TYPE.sharedStrings,
     target: "sharedStrings.xml",
@@ -207,6 +237,10 @@ function createWorksheets(data: ExcelWorkbookData, construct: XLSXStructure): XL
   addRelsToFile(construct.relsFiles, "xl/_rels/workbook.xml.rels", {
     type: XLSX_RELATION_TYPE.styles,
     target: "styles.xml",
+  });
+  addRelsToFile(construct.relsFiles, "xl/_rels/workbook.xml.rels", {
+    type: XLSX_RELATION_TYPE.metadata,
+    target: "metadata.xml",
   });
   return files;
 }

--- a/tests/xlsx/__snapshots__/xlsx_export.test.ts.snap
+++ b/tests/xlsx/__snapshots__/xlsx_export.test.ts.snap
@@ -468,6 +468,29 @@ exports[`Test XLSX export Charts Chart legend is set to none position 1`] = `
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -558,6 +581,7 @@ exports[`Test XLSX export Charts Chart legend is set to none position 1`] = `
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -592,6 +616,7 @@ exports[`Test XLSX export Charts Chart legend is set to none position 1`] = `
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml" PartName="/xl/charts/chart1.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawing+xml" PartName="/xl/drawings/drawing0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -1064,6 +1089,29 @@ exports[`Test XLSX export Charts Export chart overflowing outside the sheet 1`] 
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -1154,6 +1202,7 @@ exports[`Test XLSX export Charts Export chart overflowing outside the sheet 1`] 
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -1188,6 +1237,7 @@ exports[`Test XLSX export Charts Export chart overflowing outside the sheet 1`] 
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml" PartName="/xl/charts/chart1.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawing+xml" PartName="/xl/drawings/drawing0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -1660,6 +1710,29 @@ exports[`Test XLSX export Charts chart dataset without title 1`] = `
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -1750,6 +1823,7 @@ exports[`Test XLSX export Charts chart dataset without title 1`] = `
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -1784,6 +1858,7 @@ exports[`Test XLSX export Charts chart dataset without title 1`] = `
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml" PartName="/xl/charts/chart1.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawing+xml" PartName="/xl/drawings/drawing0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -3153,6 +3228,29 @@ exports[`Test XLSX export Charts chart font color is white with a dark backgroun
       "path": "xl/worksheets/sheet1.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -3244,6 +3342,7 @@ exports[`Test XLSX export Charts chart font color is white with a dark backgroun
     <Relationship Id="rId2" Target="worksheets/sheet1.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId3" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId4" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId5" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -3285,6 +3384,7 @@ exports[`Test XLSX export Charts chart font color is white with a dark backgroun
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawing+xml" PartName="/xl/drawings/drawing0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet1.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -4151,6 +4251,29 @@ exports[`Test XLSX export Charts charts in different sheets 1`] = `
       "path": "xl/worksheets/sheet1.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -4242,6 +4365,7 @@ exports[`Test XLSX export Charts charts in different sheets 1`] = `
     <Relationship Id="rId2" Target="worksheets/sheet1.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId3" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId4" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId5" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -4293,6 +4417,7 @@ exports[`Test XLSX export Charts charts in different sheets 1`] = `
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml" PartName="/xl/charts/chart2.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawing+xml" PartName="/xl/drawings/drawing1.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet1.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -5110,6 +5235,29 @@ exports[`Test XLSX export Charts multiple charts in the same sheet 1`] = `
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -5200,6 +5348,7 @@ exports[`Test XLSX export Charts multiple charts in the same sheet 1`] = `
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -5236,6 +5385,7 @@ exports[`Test XLSX export Charts multiple charts in the same sheet 1`] = `
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml" PartName="/xl/charts/chart2.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawing+xml" PartName="/xl/drawings/drawing0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -5448,6 +5598,29 @@ exports[`Test XLSX export Charts pie chart with only title dataset 1`] = `
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -5502,6 +5675,7 @@ exports[`Test XLSX export Charts pie chart with only title dataset 1`] = `
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -5536,6 +5710,7 @@ exports[`Test XLSX export Charts pie chart with only title dataset 1`] = `
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml" PartName="/xl/charts/chart1.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawing+xml" PartName="/xl/drawings/drawing0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -5984,6 +6159,29 @@ exports[`Test XLSX export Charts simple bar chart with dataset [ 'Sheet1!B1:B4' 
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -6074,6 +6272,7 @@ exports[`Test XLSX export Charts simple bar chart with dataset [ 'Sheet1!B1:B4' 
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -6108,6 +6307,7 @@ exports[`Test XLSX export Charts simple bar chart with dataset [ 'Sheet1!B1:B4' 
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml" PartName="/xl/charts/chart1.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawing+xml" PartName="/xl/drawings/drawing0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -6594,6 +6794,29 @@ exports[`Test XLSX export Charts simple bar chart with dataset [ 'Sheet1!B1:B4',
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -6684,6 +6907,7 @@ exports[`Test XLSX export Charts simple bar chart with dataset [ 'Sheet1!B1:B4',
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -6718,6 +6942,7 @@ exports[`Test XLSX export Charts simple bar chart with dataset [ 'Sheet1!B1:B4',
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml" PartName="/xl/charts/chart1.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawing+xml" PartName="/xl/drawings/drawing0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -7166,6 +7391,29 @@ exports[`Test XLSX export Charts simple line chart with dataset [ 'Sheet1!B1:B4'
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -7256,6 +7504,7 @@ exports[`Test XLSX export Charts simple line chart with dataset [ 'Sheet1!B1:B4'
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -7290,6 +7539,7 @@ exports[`Test XLSX export Charts simple line chart with dataset [ 'Sheet1!B1:B4'
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml" PartName="/xl/charts/chart1.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawing+xml" PartName="/xl/drawings/drawing0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -7779,6 +8029,29 @@ exports[`Test XLSX export Charts simple line chart with dataset [ 'Sheet1!B1:B4'
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -7869,6 +8142,7 @@ exports[`Test XLSX export Charts simple line chart with dataset [ 'Sheet1!B1:B4'
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -7903,6 +8177,7 @@ exports[`Test XLSX export Charts simple line chart with dataset [ 'Sheet1!B1:B4'
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml" PartName="/xl/charts/chart1.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawing+xml" PartName="/xl/drawings/drawing0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -8268,6 +8543,29 @@ exports[`Test XLSX export Charts simple pie chart with dataset [ 'Sheet1!B1:B4' 
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -8358,6 +8656,7 @@ exports[`Test XLSX export Charts simple pie chart with dataset [ 'Sheet1!B1:B4' 
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -8392,6 +8691,7 @@ exports[`Test XLSX export Charts simple pie chart with dataset [ 'Sheet1!B1:B4' 
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml" PartName="/xl/charts/chart1.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawing+xml" PartName="/xl/drawings/drawing0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -8831,6 +9131,29 @@ exports[`Test XLSX export Charts simple pie chart with dataset [ 'Sheet1!B1:B4',
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -8921,6 +9244,7 @@ exports[`Test XLSX export Charts simple pie chart with dataset [ 'Sheet1!B1:B4',
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -8955,6 +9279,7 @@ exports[`Test XLSX export Charts simple pie chart with dataset [ 'Sheet1!B1:B4',
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml" PartName="/xl/charts/chart1.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawing+xml" PartName="/xl/drawings/drawing0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -9441,6 +9766,29 @@ exports[`Test XLSX export Charts stacked bar chart 1`] = `
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -9531,6 +9879,7 @@ exports[`Test XLSX export Charts stacked bar chart 1`] = `
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -9565,6 +9914,7 @@ exports[`Test XLSX export Charts stacked bar chart 1`] = `
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml" PartName="/xl/charts/chart1.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawing+xml" PartName="/xl/drawings/drawing0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -9681,8 +10031,8 @@ exports[`Test XLSX export Export data filters Export data filters snapshot 1`] =
                     5
                 </v>
             </c>
-            <c r="B2" s="1" t="str">
-                <f>
+            <c r="B2" s="1" cm="1" t="str">
+                <f t="array" ref="B2">
                     ""
                 </f>
                 <v/>
@@ -9719,6 +10069,29 @@ exports[`Test XLSX export Export data filters Export data filters snapshot 1`] =
 </worksheet>",
       "contentType": "sheet",
       "path": "xl/worksheets/sheet0.xml",
+    },
+    {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
     },
     {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
@@ -9796,6 +10169,7 @@ exports[`Test XLSX export Export data filters Export data filters snapshot 1`] =
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -9822,6 +10196,7 @@ exports[`Test XLSX export Export data filters Export data filters snapshot 1`] =
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml" PartName="/xl/workbook.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.table+xml" PartName="/xl/tables/table1.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -10091,6 +10466,29 @@ exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Conditional f
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -10175,6 +10573,7 @@ exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Conditional f
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -10193,6 +10592,7 @@ exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Conditional f
     <Default Extension="xml" ContentType="application/xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml" PartName="/xl/workbook.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -10239,6 +10639,29 @@ exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Conditional f
 </worksheet>",
       "contentType": "sheet",
       "path": "xl/worksheets/sheet0.xml",
+    },
+    {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
     },
     {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
@@ -10295,6 +10718,7 @@ exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Conditional f
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -10313,6 +10737,7 @@ exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Conditional f
     <Default Extension="xml" ContentType="application/xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml" PartName="/xl/workbook.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -10390,6 +10815,29 @@ exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Merges 1`] = 
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -10444,6 +10892,7 @@ exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Merges 1`] = 
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -10462,6 +10911,7 @@ exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Merges 1`] = 
     <Default Extension="xml" ContentType="application/xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml" PartName="/xl/workbook.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -10786,8 +11236,8 @@ exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Simple model 
             </c>
         </row>
         <row r="37" ht="17.25" customHeight="1" hidden="0">
-            <c r="A37" s="3" t="str">
-                <f>
+            <c r="A37" s="3" cm="1" t="str">
+                <f t="array" ref="A37">
                     "this is a quote: """
                 </f>
                 <v>
@@ -10796,8 +11246,8 @@ exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Simple model 
             </c>
         </row>
         <row r="38" ht="17.25" customHeight="1" hidden="0">
-            <c r="A38" s="3" t="n">
-                <f>
+            <c r="A38" s="3" cm="1" t="n">
+                <f t="array" ref="A38">
                     '&lt;Sheet2&gt;'!B2
                 </f>
                 <v>
@@ -10806,8 +11256,8 @@ exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Simple model 
             </c>
         </row>
         <row r="39" ht="17.25" customHeight="1" hidden="0">
-            <c r="A39" s="3" t="str">
-                <f>
+            <c r="A39" s="3" cm="1" t="str">
+                <f t="array" ref="A39">
                     A39
                 </f>
                 <v>
@@ -10816,8 +11266,8 @@ exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Simple model 
             </c>
         </row>
         <row r="40" ht="17.25" customHeight="1" hidden="0">
-            <c r="A40" s="3" t="n">
-                <f>
+            <c r="A40" s="3" cm="1" t="n">
+                <f t="array" ref="A40">
                     (1+2)/3
                 </f>
                 <v>
@@ -10826,8 +11276,8 @@ exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Simple model 
             </c>
         </row>
         <row r="41" ht="17.25" customHeight="1" hidden="0">
-            <c r="A41" s="3" t="str">
-                <f>
+            <c r="A41" s="3" cm="1" t="str">
+                <f t="array" ref="A41">
                     #REF!+5
                 </f>
                 <v>
@@ -10887,6 +11337,29 @@ exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Simple model 
 </worksheet>",
       "contentType": "sheet",
       "path": "xl/worksheets/sheet1.xml",
+    },
+    {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
     },
     {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
@@ -11308,6 +11781,7 @@ exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Simple model 
     <Relationship Id="rId2" Target="worksheets/sheet1.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId3" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId4" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId5" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -11327,6 +11801,7 @@ exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Simple model 
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml" PartName="/xl/workbook.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet1.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -11461,6 +11936,29 @@ exports[`Test XLSX export Images image larger than the sheet 1`] = `
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -11515,6 +12013,7 @@ exports[`Test XLSX export Images image larger than the sheet 1`] = `
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -11548,6 +12047,7 @@ exports[`Test XLSX export Images image larger than the sheet 1`] = `
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml" PartName="/xl/workbook.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawing+xml" PartName="/xl/drawings/drawing0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -11682,6 +12182,29 @@ exports[`Test XLSX export Images image overflowing outside the sheet 1`] = `
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -11736,6 +12259,7 @@ exports[`Test XLSX export Images image overflowing outside the sheet 1`] = `
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -11769,6 +12293,7 @@ exports[`Test XLSX export Images image overflowing outside the sheet 1`] = `
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml" PartName="/xl/workbook.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawing+xml" PartName="/xl/drawings/drawing0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -12008,6 +12533,29 @@ exports[`Test XLSX export Images images in different sheets 1`] = `
       "path": "xl/worksheets/sheet1.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -12063,6 +12611,7 @@ exports[`Test XLSX export Images images in different sheets 1`] = `
     <Relationship Id="rId2" Target="worksheets/sheet1.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId3" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId4" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId5" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -12112,6 +12661,7 @@ exports[`Test XLSX export Images images in different sheets 1`] = `
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawing+xml" PartName="/xl/drawings/drawing1.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet1.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -12302,6 +12852,29 @@ exports[`Test XLSX export Images multiple images in the same sheet 1`] = `
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -12356,6 +12929,7 @@ exports[`Test XLSX export Images multiple images in the same sheet 1`] = `
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -12390,6 +12964,7 @@ exports[`Test XLSX export Images multiple images in the same sheet 1`] = `
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml" PartName="/xl/workbook.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawing+xml" PartName="/xl/drawings/drawing0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -12524,6 +13099,29 @@ exports[`Test XLSX export Images simple image 1`] = `
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -12578,6 +13176,7 @@ exports[`Test XLSX export Images simple image 1`] = `
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -12611,6 +13210,7 @@ exports[`Test XLSX export Images simple image 1`] = `
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml" PartName="/xl/workbook.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawing+xml" PartName="/xl/drawings/drawing0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -12729,6 +13329,29 @@ exports[`Test XLSX export Sheet with frozen panes 1`] = `
       "path": "xl/worksheets/sheet1.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -12784,6 +13407,7 @@ exports[`Test XLSX export Sheet with frozen panes 1`] = `
     <Relationship Id="rId2" Target="worksheets/sheet1.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId3" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId4" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId5" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -12803,6 +13427,7 @@ exports[`Test XLSX export Sheet with frozen panes 1`] = `
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml" PartName="/xl/workbook.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet1.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -12917,6 +13542,29 @@ exports[`Test XLSX export Sheet with hide gridlines 1`] = `
       "path": "xl/worksheets/sheet1.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -12972,6 +13620,7 @@ exports[`Test XLSX export Sheet with hide gridlines 1`] = `
     <Relationship Id="rId2" Target="worksheets/sheet1.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId3" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId4" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId5" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -12991,6 +13640,7 @@ exports[`Test XLSX export Sheet with hide gridlines 1`] = `
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml" PartName="/xl/workbook.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet1.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -13105,6 +13755,29 @@ exports[`Test XLSX export Workbook with hidden sheet 1`] = `
       "path": "xl/worksheets/sheet1.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -13160,6 +13833,7 @@ exports[`Test XLSX export Workbook with hidden sheet 1`] = `
     <Relationship Id="rId2" Target="worksheets/sheet1.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId3" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId4" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId5" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -13179,6 +13853,7 @@ exports[`Test XLSX export Workbook with hidden sheet 1`] = `
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml" PartName="/xl/workbook.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet1.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -13283,8 +13958,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="2" ht="17.25" customHeight="1" hidden="0">
-            <c r="A2" s="1" t="n">
-                <f>
+            <c r="A2" s="1" cm="1" t="n">
+                <f t="array" ref="A2">
                     ABS(-5.5)
                 </f>
                 <v>
@@ -13323,8 +13998,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="3" ht="17.25" customHeight="1" hidden="0">
-            <c r="A3" s="1" t="n">
-                <f>
+            <c r="A3" s="1" cm="1" t="n">
+                <f t="array" ref="A3">
                     ACOS(1)
                 </f>
                 <v>
@@ -13363,8 +14038,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="4" ht="17.25" customHeight="1" hidden="0">
-            <c r="A4" s="1" t="n">
-                <f>
+            <c r="A4" s="1" cm="1" t="n">
+                <f t="array" ref="A4">
                     ACOSH(2)
                 </f>
                 <v>
@@ -13403,16 +14078,16 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="5" ht="17.25" customHeight="1" hidden="0">
-            <c r="A5" s="1" t="n">
-                <f>
+            <c r="A5" s="1" cm="1" t="n">
+                <f t="array" ref="A5">
                     _xlfn.ACOT(1)
                 </f>
                 <v>
                     0.7853981633974483
                 </v>
             </c>
-            <c r="B5" s="1" t="n">
-                <f>
+            <c r="B5" s="1" cm="1" t="n">
+                <f t="array" ref="B5">
                     _xlfn.ACOT(_xlfn.ACOT(1))
                 </f>
                 <v>
@@ -13451,8 +14126,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="6" ht="17.25" customHeight="1" hidden="0">
-            <c r="A6" s="1" t="n">
-                <f>
+            <c r="A6" s="1" cm="1" t="n">
+                <f t="array" ref="A6">
                     _xlfn.ACOTH(2)
                 </f>
                 <v>
@@ -13491,8 +14166,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="7" ht="17.25" customHeight="1" hidden="0">
-            <c r="A7" s="1" t="b">
-                <f>
+            <c r="A7" s="1" cm="1" t="b">
+                <f t="array" ref="A7">
                     AND(TRUE,TRUE)
                 </f>
                 <v>
@@ -13531,8 +14206,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="8" ht="17.25" customHeight="1" hidden="0">
-            <c r="A8" s="1" t="n">
-                <f>
+            <c r="A8" s="1" cm="1" t="n">
+                <f t="array" ref="A8">
                     ASIN(0.5)
                 </f>
                 <v>
@@ -13571,8 +14246,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="9" ht="17.25" customHeight="1" hidden="0">
-            <c r="A9" s="1" t="n">
-                <f>
+            <c r="A9" s="1" cm="1" t="n">
+                <f t="array" ref="A9">
                     ASINH(2)
                 </f>
                 <v>
@@ -13606,8 +14281,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="10" ht="17.25" customHeight="1" hidden="0">
-            <c r="A10" s="1" t="n">
-                <f>
+            <c r="A10" s="1" cm="1" t="n">
+                <f t="array" ref="A10">
                     ATAN(1)
                 </f>
                 <v>
@@ -13616,8 +14291,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="11" ht="17.25" customHeight="1" hidden="0">
-            <c r="A11" s="1" t="n">
-                <f>
+            <c r="A11" s="1" cm="1" t="n">
+                <f t="array" ref="A11">
                     ATAN2(-1,0)
                 </f>
                 <v>
@@ -13631,8 +14306,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="12" ht="17.25" customHeight="1" hidden="0">
-            <c r="A12" s="1" t="n">
-                <f>
+            <c r="A12" s="1" cm="1" t="n">
+                <f t="array" ref="A12">
                     ATANH(0.7)
                 </f>
                 <v>
@@ -13666,8 +14341,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="13" ht="17.25" customHeight="1" hidden="0">
-            <c r="A13" s="1" t="n">
-                <f>
+            <c r="A13" s="1" cm="1" t="n">
+                <f t="array" ref="A13">
                     AVEDEV(I2:I9)
                 </f>
                 <v>
@@ -13701,8 +14376,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="14" ht="17.25" customHeight="1" hidden="0">
-            <c r="A14" s="1" t="n">
-                <f>
+            <c r="A14" s="1" cm="1" t="n">
+                <f t="array" ref="A14">
                     AVERAGE(H2:H9)
                 </f>
                 <v>
@@ -13711,8 +14386,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="15" ht="17.25" customHeight="1" hidden="0">
-            <c r="A15" s="1" t="n">
-                <f>
+            <c r="A15" s="1" cm="1" t="n">
+                <f t="array" ref="A15">
                     AVERAGEA(G2:H9)
                 </f>
                 <v>
@@ -13721,8 +14396,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="16" ht="17.25" customHeight="1" hidden="0">
-            <c r="A16" s="1" t="n">
-                <f>
+            <c r="A16" s="1" cm="1" t="n">
+                <f t="array" ref="A16">
                     AVERAGEIF(J2:J9,"&gt;150000")
                 </f>
                 <v>
@@ -13731,8 +14406,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="17" ht="17.25" customHeight="1" hidden="0">
-            <c r="A17" s="1" t="n">
-                <f>
+            <c r="A17" s="1" cm="1" t="n">
+                <f t="array" ref="A17">
                     AVERAGEIFS(I2:I9,H2:H9,"&gt;=30",K2:K9,"&lt;10")
                 </f>
                 <v>
@@ -13741,8 +14416,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="18" ht="17.25" customHeight="1" hidden="0">
-            <c r="A18" s="1" t="n">
-                <f>
+            <c r="A18" s="1" cm="1" t="n">
+                <f t="array" ref="A18">
                     CEILING(20.4,1)
                 </f>
                 <v>
@@ -13751,8 +14426,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="19" ht="17.25" customHeight="1" hidden="0">
-            <c r="A19" s="1" t="n">
-                <f>
+            <c r="A19" s="1" cm="1" t="n">
+                <f t="array" ref="A19">
                     _xlfn.CEILING.MATH(-5.5,1,0)
                 </f>
                 <v>
@@ -13761,8 +14436,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="20" ht="17.25" customHeight="1" hidden="0">
-            <c r="A20" s="1" t="n">
-                <f>
+            <c r="A20" s="1" cm="1" t="n">
+                <f t="array" ref="A20">
                     _xlfn.CEILING.PRECISE(230,100)
                 </f>
                 <v>
@@ -13771,8 +14446,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="21" ht="17.25" customHeight="1" hidden="0">
-            <c r="A21" s="1" t="str">
-                <f>
+            <c r="A21" s="1" cm="1" t="str">
+                <f t="array" ref="A21">
                     CHAR(74)
                 </f>
                 <v>
@@ -13781,8 +14456,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="22" ht="17.25" customHeight="1" hidden="0">
-            <c r="A22" s="1" t="n">
-                <f>
+            <c r="A22" s="1" cm="1" t="n">
+                <f t="array" ref="A22">
                     COLUMN(C4)
                 </f>
                 <v>
@@ -13791,8 +14466,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="23" ht="17.25" customHeight="1" hidden="0">
-            <c r="A23" s="1" t="n">
-                <f>
+            <c r="A23" s="1" cm="1" t="n">
+                <f t="array" ref="A23">
                     COLUMNS(A5:D12)
                 </f>
                 <v>
@@ -13801,8 +14476,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="24" ht="17.25" customHeight="1" hidden="0">
-            <c r="A24" s="1" t="str">
-                <f>
+            <c r="A24" s="1" cm="1" t="str">
+                <f t="array" ref="A24">
                     _xlfn.CONCAT(1,23)
                 </f>
                 <v>
@@ -13811,8 +14486,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="25" ht="17.25" customHeight="1" hidden="0">
-            <c r="A25" s="1" t="str">
-                <f>
+            <c r="A25" s="1" cm="1" t="str">
+                <f t="array" ref="A25">
                     CONCATENATE("BUT, ","MICHEL")
                 </f>
                 <v>
@@ -13821,8 +14496,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="26" ht="17.25" customHeight="1" hidden="0">
-            <c r="A26" s="1" t="n">
-                <f>
+            <c r="A26" s="1" cm="1" t="n">
+                <f t="array" ref="A26">
                     COS(PI()/3)
                 </f>
                 <v>
@@ -13831,8 +14506,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="27" ht="17.25" customHeight="1" hidden="0">
-            <c r="A27" s="1" t="n">
-                <f>
+            <c r="A27" s="1" cm="1" t="n">
+                <f t="array" ref="A27">
                     COSH(2)
                 </f>
                 <v>
@@ -13841,8 +14516,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="28" ht="17.25" customHeight="1" hidden="0">
-            <c r="A28" s="1" t="n">
-                <f>
+            <c r="A28" s="1" cm="1" t="n">
+                <f t="array" ref="A28">
                     _xlfn.COT(PI()/6)
                 </f>
                 <v>
@@ -13851,8 +14526,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="29" ht="17.25" customHeight="1" hidden="0">
-            <c r="A29" s="1" t="n">
-                <f>
+            <c r="A29" s="1" cm="1" t="n">
+                <f t="array" ref="A29">
                     _xlfn.COTH(0.5)
                 </f>
                 <v>
@@ -13861,8 +14536,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="30" ht="17.25" customHeight="1" hidden="0">
-            <c r="A30" s="1" t="n">
-                <f>
+            <c r="A30" s="1" cm="1" t="n">
+                <f t="array" ref="A30">
                     COUNT(1,"a","5","2021-03-14")
                 </f>
                 <v>
@@ -13871,8 +14546,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="31" ht="17.25" customHeight="1" hidden="0">
-            <c r="A31" s="1" t="n">
-                <f>
+            <c r="A31" s="1" cm="1" t="n">
+                <f t="array" ref="A31">
                     COUNTA(1,"a","5","2021-03-14")
                 </f>
                 <v>
@@ -13881,8 +14556,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="32" ht="17.25" customHeight="1" hidden="0">
-            <c r="A32" s="1" t="n">
-                <f>
+            <c r="A32" s="1" cm="1" t="n">
+                <f t="array" ref="A32">
                     COUNTBLANK("","1",3,FALSE)
                 </f>
                 <v>
@@ -13891,8 +14566,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="33" ht="17.25" customHeight="1" hidden="0">
-            <c r="A33" s="1" t="n">
-                <f>
+            <c r="A33" s="1" cm="1" t="n">
+                <f t="array" ref="A33">
                     COUNTIF(H2:H9,"&gt;30")
                 </f>
                 <v>
@@ -13901,8 +14576,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="34" ht="17.25" customHeight="1" hidden="0">
-            <c r="A34" s="1" t="n">
-                <f>
+            <c r="A34" s="1" cm="1" t="n">
+                <f t="array" ref="A34">
                     COUNTIFS(H2:H9,"&gt;25",K2:K9,"&lt;4")
                 </f>
                 <v>
@@ -13911,8 +14586,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="35" ht="17.25" customHeight="1" hidden="0">
-            <c r="A35" s="1" t="n">
-                <f>
+            <c r="A35" s="1" cm="1" t="n">
+                <f t="array" ref="A35">
                     COVAR(H2:H9,K2:K9)
                 </f>
                 <v>
@@ -13921,8 +14596,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="36" ht="17.25" customHeight="1" hidden="0">
-            <c r="A36" s="1" t="n">
-                <f>
+            <c r="A36" s="1" cm="1" t="n">
+                <f t="array" ref="A36">
                     _xlfn.COVARIANCE.P(K2:K9,H2:H9)
                 </f>
                 <v>
@@ -13931,8 +14606,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="37" ht="17.25" customHeight="1" hidden="0">
-            <c r="A37" s="1" t="n">
-                <f>
+            <c r="A37" s="1" cm="1" t="n">
+                <f t="array" ref="A37">
                     _xlfn.COVARIANCE.P(I2:I9,J2:J9)
                 </f>
                 <v>
@@ -13941,8 +14616,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="38" ht="17.25" customHeight="1" hidden="0">
-            <c r="A38" s="1" t="n">
-                <f>
+            <c r="A38" s="1" cm="1" t="n">
+                <f t="array" ref="A38">
                     _xlfn.CSC(PI()/4)
                 </f>
                 <v>
@@ -13951,8 +14626,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="39" ht="17.25" customHeight="1" hidden="0">
-            <c r="A39" s="1" t="n">
-                <f>
+            <c r="A39" s="1" cm="1" t="n">
+                <f t="array" ref="A39">
                     _xlfn.CSCH(PI()/3)
                 </f>
                 <v>
@@ -13961,8 +14636,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="40" ht="17.25" customHeight="1" hidden="0">
-            <c r="A40" s="1" t="n">
-                <f>
+            <c r="A40" s="1" cm="1" t="n">
+                <f t="array" ref="A40">
                     DATE(2020,5,25)
                 </f>
                 <v>
@@ -13971,8 +14646,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="41" ht="17.25" customHeight="1" hidden="0">
-            <c r="A41" s="1" t="n">
-                <f>
+            <c r="A41" s="1" cm="1" t="n">
+                <f t="array" ref="A41">
                     DATEVALUE("1969-08-15")
                 </f>
                 <v>
@@ -13981,8 +14656,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="42" ht="17.25" customHeight="1" hidden="0">
-            <c r="A42" s="1" t="n">
-                <f>
+            <c r="A42" s="1" cm="1" t="n">
+                <f t="array" ref="A42">
                     DAVERAGE(G1:K9,"Tot. Score",J12:J13)
                 </f>
                 <v>
@@ -13991,8 +14666,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="43" ht="17.25" customHeight="1" hidden="0">
-            <c r="A43" s="1" t="n">
-                <f>
+            <c r="A43" s="1" cm="1" t="n">
+                <f t="array" ref="A43">
                     DAY("2020-03-17")
                 </f>
                 <v>
@@ -14001,8 +14676,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="44" ht="17.25" customHeight="1" hidden="0">
-            <c r="A44" s="1" t="n">
-                <f>
+            <c r="A44" s="1" cm="1" t="n">
+                <f t="array" ref="A44">
                     _xlfn.DAYS("2022-03-17","2021-03-17")
                 </f>
                 <v>
@@ -14011,8 +14686,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="45" ht="17.25" customHeight="1" hidden="0">
-            <c r="A45" s="1" t="n">
-                <f>
+            <c r="A45" s="1" cm="1" t="n">
+                <f t="array" ref="A45">
                     DCOUNT(G1:K9,"Name",H12:H13)
                 </f>
                 <v>
@@ -14021,8 +14696,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="46" ht="17.25" customHeight="1" hidden="0">
-            <c r="A46" s="1" t="n">
-                <f>
+            <c r="A46" s="1" cm="1" t="n">
+                <f t="array" ref="A46">
                     DCOUNTA(G1:K9,"Name",H12:H13)
                 </f>
                 <v>
@@ -14031,8 +14706,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="47" ht="17.25" customHeight="1" hidden="0">
-            <c r="A47" s="1" t="n">
-                <f>
+            <c r="A47" s="1" cm="1" t="n">
+                <f t="array" ref="A47">
                     _xlfn.DECIMAL(20,16)
                 </f>
                 <v>
@@ -14041,8 +14716,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="48" ht="17.25" customHeight="1" hidden="0">
-            <c r="A48" s="1" t="n">
-                <f>
+            <c r="A48" s="1" cm="1" t="n">
+                <f t="array" ref="A48">
                     DEGREES(PI()/4)
                 </f>
                 <v>
@@ -14051,8 +14726,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="49" ht="17.25" customHeight="1" hidden="0">
-            <c r="A49" s="1" t="n">
-                <f>
+            <c r="A49" s="1" cm="1" t="n">
+                <f t="array" ref="A49">
                     DGET(G1:K9,"Hours Played",G12:G13)
                 </f>
                 <v>
@@ -14061,8 +14736,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="50" ht="17.25" customHeight="1" hidden="0">
-            <c r="A50" s="1" t="n">
-                <f>
+            <c r="A50" s="1" cm="1" t="n">
+                <f t="array" ref="A50">
                     DMAX(G1:K9,"Tot. Score",I12:I13)
                 </f>
                 <v>
@@ -14071,8 +14746,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="51" ht="17.25" customHeight="1" hidden="0">
-            <c r="A51" s="1" t="n">
-                <f>
+            <c r="A51" s="1" cm="1" t="n">
+                <f t="array" ref="A51">
                     DMIN(G1:K9,"Tot. Score",H12:H13)
                 </f>
                 <v>
@@ -14081,8 +14756,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="52" ht="17.25" customHeight="1" hidden="0">
-            <c r="A52" s="1" t="n">
-                <f>
+            <c r="A52" s="1" cm="1" t="n">
+                <f t="array" ref="A52">
                     DPRODUCT(G1:K9,"Age",K12:K13)
                 </f>
                 <v>
@@ -14091,8 +14766,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="53" ht="17.25" customHeight="1" hidden="0">
-            <c r="A53" s="1" t="n">
-                <f>
+            <c r="A53" s="1" cm="1" t="n">
+                <f t="array" ref="A53">
                     DSTDEV(G1:K9,"Age",H12:H13)
                 </f>
                 <v>
@@ -14101,8 +14776,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="54" ht="17.25" customHeight="1" hidden="0">
-            <c r="A54" s="1" t="n">
-                <f>
+            <c r="A54" s="1" cm="1" t="n">
+                <f t="array" ref="A54">
                     DSTDEVP(G1:K9,"Age",H12:H13)
                 </f>
                 <v>
@@ -14111,8 +14786,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="55" ht="17.25" customHeight="1" hidden="0">
-            <c r="A55" s="1" t="n">
-                <f>
+            <c r="A55" s="1" cm="1" t="n">
+                <f t="array" ref="A55">
                     DSUM(G1:K9,"Age",I12:I13)
                 </f>
                 <v>
@@ -14121,8 +14796,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="56" ht="17.25" customHeight="1" hidden="0">
-            <c r="A56" s="1" t="n">
-                <f>
+            <c r="A56" s="1" cm="1" t="n">
+                <f t="array" ref="A56">
                     DVAR(G1:K9,"Hours Played",H12:H13)
                 </f>
                 <v>
@@ -14131,8 +14806,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="57" ht="17.25" customHeight="1" hidden="0">
-            <c r="A57" s="1" t="n">
-                <f>
+            <c r="A57" s="1" cm="1" t="n">
+                <f t="array" ref="A57">
                     DVARP(G1:K9,"Hours Played",H12:H13)
                 </f>
                 <v>
@@ -14141,8 +14816,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="58" ht="17.25" customHeight="1" hidden="0">
-            <c r="A58" s="1" t="n">
-                <f>
+            <c r="A58" s="1" cm="1" t="n">
+                <f t="array" ref="A58">
                     EDATE("1969-07-22",-2)
                 </f>
                 <v>
@@ -14151,8 +14826,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="59" ht="17.25" customHeight="1" hidden="0">
-            <c r="A59" s="1" t="n">
-                <f>
+            <c r="A59" s="1" cm="1" t="n">
+                <f t="array" ref="A59">
                     EOMONTH("2020-07-21",1)
                 </f>
                 <v>
@@ -14161,8 +14836,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="60" ht="17.25" customHeight="1" hidden="0">
-            <c r="A60" s="1" t="b">
-                <f>
+            <c r="A60" s="1" cm="1" t="b">
+                <f t="array" ref="A60">
                     EXACT("AbsSdf%","AbsSdf%")
                 </f>
                 <v>
@@ -14171,8 +14846,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="61" ht="17.25" customHeight="1" hidden="0">
-            <c r="A61" s="1" t="n">
-                <f>
+            <c r="A61" s="1" cm="1" t="n">
+                <f t="array" ref="A61">
                     EXP(4)
                 </f>
                 <v>
@@ -14181,8 +14856,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="62" ht="17.25" customHeight="1" hidden="0">
-            <c r="A62" s="1" t="n">
-                <f>
+            <c r="A62" s="1" cm="1" t="n">
+                <f t="array" ref="A62">
                     FIND("A","qbdahbaazo A")
                 </f>
                 <v>
@@ -14191,8 +14866,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="63" ht="17.25" customHeight="1" hidden="0">
-            <c r="A63" s="1" t="n">
-                <f>
+            <c r="A63" s="1" cm="1" t="n">
+                <f t="array" ref="A63">
                     FLOOR(5.5,2)
                 </f>
                 <v>
@@ -14201,8 +14876,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="64" ht="17.25" customHeight="1" hidden="0">
-            <c r="A64" s="1" t="n">
-                <f>
+            <c r="A64" s="1" cm="1" t="n">
+                <f t="array" ref="A64">
                     _xlfn.FLOOR.MATH(-5.55,2,1)
                 </f>
                 <v>
@@ -14211,8 +14886,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="65" ht="17.25" customHeight="1" hidden="0">
-            <c r="A65" s="1" t="n">
-                <f>
+            <c r="A65" s="1" cm="1" t="n">
+                <f t="array" ref="A65">
                     _xlfn.FLOOR.PRECISE(199,100)
                 </f>
                 <v>
@@ -14221,8 +14896,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="66" ht="17.25" customHeight="1" hidden="0">
-            <c r="A66" s="1" t="n">
-                <f>
+            <c r="A66" s="1" cm="1" t="n">
+                <f t="array" ref="A66">
                     HLOOKUP("Tot. Score",H1:K9,4,FALSE)
                 </f>
                 <v>
@@ -14231,8 +14906,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="67" ht="17.25" customHeight="1" hidden="0">
-            <c r="A67" s="1" t="n">
-                <f>
+            <c r="A67" s="1" cm="1" t="n">
+                <f t="array" ref="A67">
                     HOUR("02:14:56")
                 </f>
                 <v>
@@ -14241,8 +14916,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="68" ht="17.25" customHeight="1" hidden="0">
-            <c r="A68" s="1" t="str">
-                <f>
+            <c r="A68" s="1" cm="1" t="str">
+                <f t="array" ref="A68">
                     IF(TRUE,"TABOURET","JAMBON")
                 </f>
                 <v>
@@ -14251,8 +14926,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="69" ht="17.25" customHeight="1" hidden="0">
-            <c r="A69" s="1" t="str">
-                <f>
+            <c r="A69" s="1" cm="1" t="str">
+                <f t="array" ref="A69">
                     IFERROR(0/0,"no diving by zero.")
                 </f>
                 <v>
@@ -14261,8 +14936,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="70" ht="17.25" customHeight="1" hidden="0">
-            <c r="A70" s="1" t="str">
-                <f>
+            <c r="A70" s="1" cm="1" t="str">
+                <f t="array" ref="A70">
                     _xlfn.IFS($H2&gt;$H3,"first player is older",$H3&gt;$H2,"second player is older")
                 </f>
                 <v>
@@ -14271,8 +14946,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="71" ht="17.25" customHeight="1" hidden="0">
-            <c r="A71" s="1" t="b">
-                <f>
+            <c r="A71" s="1" cm="1" t="b">
+                <f t="array" ref="A71">
                     ISERROR(0/0)
                 </f>
                 <v>
@@ -14281,8 +14956,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="72" ht="17.25" customHeight="1" hidden="0">
-            <c r="A72" s="1" t="b">
-                <f>
+            <c r="A72" s="1" cm="1" t="b">
+                <f t="array" ref="A72">
                     ISEVEN(3)
                 </f>
                 <v>
@@ -14291,8 +14966,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="73" ht="17.25" customHeight="1" hidden="0">
-            <c r="A73" s="1" t="b">
-                <f>
+            <c r="A73" s="1" cm="1" t="b">
+                <f t="array" ref="A73">
                     ISLOGICAL("TRUE")
                 </f>
                 <v>
@@ -14301,8 +14976,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="74" ht="17.25" customHeight="1" hidden="0">
-            <c r="A74" s="1" t="b">
-                <f>
+            <c r="A74" s="1" cm="1" t="b">
+                <f t="array" ref="A74">
                     ISNONTEXT(TRUE)
                 </f>
                 <v>
@@ -14311,8 +14986,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="75" ht="17.25" customHeight="1" hidden="0">
-            <c r="A75" s="1" t="b">
-                <f>
+            <c r="A75" s="1" cm="1" t="b">
+                <f t="array" ref="A75">
                     ISNUMBER(1231.5)
                 </f>
                 <v>
@@ -14321,8 +14996,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="76" ht="17.25" customHeight="1" hidden="0">
-            <c r="A76" s="1" t="n">
-                <f>
+            <c r="A76" s="1" cm="1" t="n">
+                <f t="array" ref="A76">
                     ISO.CEILING(-7.89)
                 </f>
                 <v>
@@ -14331,8 +15006,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="77" ht="17.25" customHeight="1" hidden="0">
-            <c r="A77" s="1" t="b">
-                <f>
+            <c r="A77" s="1" cm="1" t="b">
+                <f t="array" ref="A77">
                     ISODD(4)
                 </f>
                 <v>
@@ -14341,8 +15016,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="78" ht="17.25" customHeight="1" hidden="0">
-            <c r="A78" s="1" t="n">
-                <f>
+            <c r="A78" s="1" cm="1" t="n">
+                <f t="array" ref="A78">
                     _xlfn.ISOWEEKNUM("2016-01-03")
                 </f>
                 <v>
@@ -14351,8 +15026,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="79" ht="17.25" customHeight="1" hidden="0">
-            <c r="A79" s="1" t="b">
-                <f>
+            <c r="A79" s="1" cm="1" t="b">
+                <f t="array" ref="A79">
                     ISTEXT("123")
                 </f>
                 <v>
@@ -14361,8 +15036,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="80" ht="17.25" customHeight="1" hidden="0">
-            <c r="A80" s="1" t="n">
-                <f>
+            <c r="A80" s="1" cm="1" t="n">
+                <f t="array" ref="A80">
                     LARGE(H2:H9,3)
                 </f>
                 <v>
@@ -14371,8 +15046,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="81" ht="17.25" customHeight="1" hidden="0">
-            <c r="A81" s="1" t="str">
-                <f>
+            <c r="A81" s="1" cm="1" t="str">
+                <f t="array" ref="A81">
                     LEFT("Mich",4)
                 </f>
                 <v>
@@ -14381,8 +15056,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="82" ht="17.25" customHeight="1" hidden="0">
-            <c r="A82" s="1" t="n">
-                <f>
+            <c r="A82" s="1" cm="1" t="n">
+                <f t="array" ref="A82">
                     LEN("anticonstitutionnellement")
                 </f>
                 <v>
@@ -14391,8 +15066,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="83" ht="17.25" customHeight="1" hidden="0">
-            <c r="A83" s="1" t="n">
-                <f>
+            <c r="A83" s="1" cm="1" t="n">
+                <f t="array" ref="A83">
                     ROUND(LN(2),5)
                 </f>
                 <v>
@@ -14401,8 +15076,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="84" ht="17.25" customHeight="1" hidden="0">
-            <c r="A84" s="1" t="n">
-                <f>
+            <c r="A84" s="1" cm="1" t="n">
+                <f t="array" ref="A84">
                     LOOKUP(42,H2:J9)
                 </f>
                 <v>
@@ -14411,8 +15086,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="85" ht="17.25" customHeight="1" hidden="0">
-            <c r="A85" s="1" t="str">
-                <f>
+            <c r="A85" s="1" cm="1" t="str">
+                <f t="array" ref="A85">
                     LOWER("オAドB")
                 </f>
                 <v>
@@ -14421,8 +15096,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="86" ht="17.25" customHeight="1" hidden="0">
-            <c r="A86" s="1" t="n">
-                <f>
+            <c r="A86" s="1" cm="1" t="n">
+                <f t="array" ref="A86">
                     MATCH(42,H2:H9,0)
                 </f>
                 <v>
@@ -14431,8 +15106,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="87" ht="17.25" customHeight="1" hidden="0">
-            <c r="A87" s="1" t="n">
-                <f>
+            <c r="A87" s="1" cm="1" t="n">
+                <f t="array" ref="A87">
                     MAX(N1:N8)
                 </f>
                 <v>
@@ -14441,8 +15116,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="88" ht="17.25" customHeight="1" hidden="0">
-            <c r="A88" s="1" t="n">
-                <f>
+            <c r="A88" s="1" cm="1" t="n">
+                <f t="array" ref="A88">
                     MAXA(N1:N8)
                 </f>
                 <v>
@@ -14451,8 +15126,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="89" ht="17.25" customHeight="1" hidden="0">
-            <c r="A89" s="1" t="n">
-                <f>
+            <c r="A89" s="1" cm="1" t="n">
+                <f t="array" ref="A89">
                     _xlfn.MAXIFS(H2:H9,K2:K9,"&lt;20",K2:K9,"&lt;&gt;4")
                 </f>
                 <v>
@@ -14461,8 +15136,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="90" ht="17.25" customHeight="1" hidden="0">
-            <c r="A90" s="1" t="n">
-                <f>
+            <c r="A90" s="1" cm="1" t="n">
+                <f t="array" ref="A90">
                     MEDIAN(-1,6,7,234,163845)
                 </f>
                 <v>
@@ -14471,8 +15146,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="91" ht="17.25" customHeight="1" hidden="0">
-            <c r="A91" s="1" t="n">
-                <f>
+            <c r="A91" s="1" cm="1" t="n">
+                <f t="array" ref="A91">
                     MIN(N1:N8)
                 </f>
                 <v>
@@ -14481,8 +15156,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="92" ht="17.25" customHeight="1" hidden="0">
-            <c r="A92" s="1" t="n">
-                <f>
+            <c r="A92" s="1" cm="1" t="n">
+                <f t="array" ref="A92">
                     MINA(N1:N8)
                 </f>
                 <v>
@@ -14491,8 +15166,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="93" ht="17.25" customHeight="1" hidden="0">
-            <c r="A93" s="1" t="n">
-                <f>
+            <c r="A93" s="1" cm="1" t="n">
+                <f t="array" ref="A93">
                     _xlfn.MINIFS(J2:J9,H2:H9,"&gt;20")
                 </f>
                 <v>
@@ -14501,8 +15176,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="94" ht="17.25" customHeight="1" hidden="0">
-            <c r="A94" s="1" t="n">
-                <f>
+            <c r="A94" s="1" cm="1" t="n">
+                <f t="array" ref="A94">
                     MINUTE(0.126)
                 </f>
                 <v>
@@ -14511,8 +15186,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="95" ht="17.25" customHeight="1" hidden="0">
-            <c r="A95" s="1" t="n">
-                <f>
+            <c r="A95" s="1" cm="1" t="n">
+                <f t="array" ref="A95">
                     MOD(42,12)
                 </f>
                 <v>
@@ -14521,8 +15196,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="96" ht="17.25" customHeight="1" hidden="0">
-            <c r="A96" s="1" t="n">
-                <f>
+            <c r="A96" s="1" cm="1" t="n">
+                <f t="array" ref="A96">
                     MONTH("1954-05-02")
                 </f>
                 <v>
@@ -14531,8 +15206,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="97" ht="17.25" customHeight="1" hidden="0">
-            <c r="A97" s="1" t="n">
-                <f>
+            <c r="A97" s="1" cm="1" t="n">
+                <f t="array" ref="A97">
                     NETWORKDAYS("2013-01-01","2013-02-01")
                 </f>
                 <v>
@@ -14541,8 +15216,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="98" ht="17.25" customHeight="1" hidden="0">
-            <c r="A98" s="1" t="n">
-                <f>
+            <c r="A98" s="1" cm="1" t="n">
+                <f t="array" ref="A98">
                     NETWORKDAYS.INTL("2013-01-01","2013-02-01","0000111")
                 </f>
                 <v>
@@ -14551,8 +15226,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="99" ht="17.25" customHeight="1" hidden="0">
-            <c r="A99" s="1" t="b">
-                <f>
+            <c r="A99" s="1" cm="1" t="b">
+                <f t="array" ref="A99">
                     NOT(FALSE)
                 </f>
                 <v>
@@ -14561,8 +15236,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="100" ht="17.25" customHeight="1" hidden="0">
-            <c r="A100" s="1" t="n">
-                <f>
+            <c r="A100" s="1" cm="1" t="n">
+                <f t="array" ref="A100">
                     NOW()
                 </f>
                 <v>
@@ -14571,8 +15246,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="101" ht="17.25" customHeight="1" hidden="0">
-            <c r="A101" s="1" t="n">
-                <f>
+            <c r="A101" s="1" cm="1" t="n">
+                <f t="array" ref="A101">
                     ODD(4)
                 </f>
                 <v>
@@ -14581,8 +15256,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="102" ht="17.25" customHeight="1" hidden="0">
-            <c r="A102" s="1" t="b">
-                <f>
+            <c r="A102" s="1" cm="1" t="b">
+                <f t="array" ref="A102">
                     OR("true",FALSE)
                 </f>
                 <v>
@@ -14591,8 +15266,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="103" ht="17.25" customHeight="1" hidden="0">
-            <c r="A103" s="1" t="n">
-                <f>
+            <c r="A103" s="1" cm="1" t="n">
+                <f t="array" ref="A103">
                     PERCENTILE(N1:N5,1)
                 </f>
                 <v>
@@ -14601,8 +15276,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="104" ht="17.25" customHeight="1" hidden="0">
-            <c r="A104" s="1" t="n">
-                <f>
+            <c r="A104" s="1" cm="1" t="n">
+                <f t="array" ref="A104">
                     _xlfn.PERCENTILE.EXC(N1:N5,0.5)
                 </f>
                 <v>
@@ -14611,8 +15286,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="105" ht="17.25" customHeight="1" hidden="0">
-            <c r="A105" s="1" t="n">
-                <f>
+            <c r="A105" s="1" cm="1" t="n">
+                <f t="array" ref="A105">
                     _xlfn.PERCENTILE.INC(N1:N5,0)
                 </f>
                 <v>
@@ -14621,8 +15296,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="106" ht="17.25" customHeight="1" hidden="0">
-            <c r="A106" s="1" t="n">
-                <f>
+            <c r="A106" s="1" cm="1" t="n">
+                <f t="array" ref="A106">
                     PI()
                 </f>
                 <v>
@@ -14631,8 +15306,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="107" ht="17.25" customHeight="1" hidden="0">
-            <c r="A107" s="1" t="n">
-                <f>
+            <c r="A107" s="1" cm="1" t="n">
+                <f t="array" ref="A107">
                     POWER(42,2)
                 </f>
                 <v>
@@ -14641,8 +15316,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="108" ht="17.25" customHeight="1" hidden="0">
-            <c r="A108" s="1" t="n">
-                <f>
+            <c r="A108" s="1" cm="1" t="n">
+                <f t="array" ref="A108">
                     PRODUCT(1,2,3)
                 </f>
                 <v>
@@ -14651,8 +15326,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="109" ht="17.25" customHeight="1" hidden="0">
-            <c r="A109" s="1" t="n">
-                <f>
+            <c r="A109" s="1" cm="1" t="n">
+                <f t="array" ref="A109">
                     QUARTILE(N1:N5,0)
                 </f>
                 <v>
@@ -14661,8 +15336,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="110" ht="17.25" customHeight="1" hidden="0">
-            <c r="A110" s="1" t="n">
-                <f>
+            <c r="A110" s="1" cm="1" t="n">
+                <f t="array" ref="A110">
                     _xlfn.QUARTILE.EXC(N1:N5,1)
                 </f>
                 <v>
@@ -14671,8 +15346,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="111" ht="17.25" customHeight="1" hidden="0">
-            <c r="A111" s="1" t="n">
-                <f>
+            <c r="A111" s="1" cm="1" t="n">
+                <f t="array" ref="A111">
                     _xlfn.QUARTILE.INC(N1:N5,4)
                 </f>
                 <v>
@@ -14681,8 +15356,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="112" ht="17.25" customHeight="1" hidden="0">
-            <c r="A112" s="1" t="n">
-                <f>
+            <c r="A112" s="1" cm="1" t="n">
+                <f t="array" ref="A112">
                     RAND()
                 </f>
                 <v>
@@ -14691,8 +15366,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="113" ht="17.25" customHeight="1" hidden="0">
-            <c r="A113" s="1" t="n">
-                <f>
+            <c r="A113" s="1" cm="1" t="n">
+                <f t="array" ref="A113">
                     RANDBETWEEN(1.1,2)
                 </f>
                 <v>
@@ -14701,8 +15376,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="114" ht="17.25" customHeight="1" hidden="0">
-            <c r="A114" s="1" t="str">
-                <f>
+            <c r="A114" s="1" cm="1" t="str">
+                <f t="array" ref="A114">
                     REPLACE("ABZ",2,1,"Y")
                 </f>
                 <v>
@@ -14711,8 +15386,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="115" ht="17.25" customHeight="1" hidden="0">
-            <c r="A115" s="1" t="str">
-                <f>
+            <c r="A115" s="1" cm="1" t="str">
+                <f t="array" ref="A115">
                     RIGHT("kikou",2)
                 </f>
                 <v>
@@ -14721,8 +15396,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="116" ht="17.25" customHeight="1" hidden="0">
-            <c r="A116" s="1" t="n">
-                <f>
+            <c r="A116" s="1" cm="1" t="n">
+                <f t="array" ref="A116">
                     ROUND(49.9,1)
                 </f>
                 <v>
@@ -14731,8 +15406,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="117" ht="17.25" customHeight="1" hidden="0">
-            <c r="A117" s="1" t="n">
-                <f>
+            <c r="A117" s="1" cm="1" t="n">
+                <f t="array" ref="A117">
                     ROUNDDOWN(42,-1)
                 </f>
                 <v>
@@ -14741,8 +15416,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="118" ht="17.25" customHeight="1" hidden="0">
-            <c r="A118" s="1" t="n">
-                <f>
+            <c r="A118" s="1" cm="1" t="n">
+                <f t="array" ref="A118">
                     ROUNDUP(-1.6,0)
                 </f>
                 <v>
@@ -14751,8 +15426,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="119" ht="17.25" customHeight="1" hidden="0">
-            <c r="A119" s="1" t="n">
-                <f>
+            <c r="A119" s="1" cm="1" t="n">
+                <f t="array" ref="A119">
                     ROW(A234)
                 </f>
                 <v>
@@ -14761,8 +15436,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="120" ht="17.25" customHeight="1" hidden="0">
-            <c r="A120" s="1" t="n">
-                <f>
+            <c r="A120" s="1" cm="1" t="n">
+                <f t="array" ref="A120">
                     ROWS(B3:C40)
                 </f>
                 <v>
@@ -14771,8 +15446,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="121" ht="17.25" customHeight="1" hidden="0">
-            <c r="A121" s="1" t="n">
-                <f>
+            <c r="A121" s="1" cm="1" t="n">
+                <f t="array" ref="A121">
                     SEARCH("C","ABCD")
                 </f>
                 <v>
@@ -14781,8 +15456,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="122" ht="17.25" customHeight="1" hidden="0">
-            <c r="A122" s="1" t="n">
-                <f>
+            <c r="A122" s="1" cm="1" t="n">
+                <f t="array" ref="A122">
                     _xlfn.SEC(PI()/3)
                 </f>
                 <v>
@@ -14791,8 +15466,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="123" ht="17.25" customHeight="1" hidden="0">
-            <c r="A123" s="1" t="n">
-                <f>
+            <c r="A123" s="1" cm="1" t="n">
+                <f t="array" ref="A123">
                     _xlfn.SECH(1)
                 </f>
                 <v>
@@ -14801,8 +15476,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="124" ht="17.25" customHeight="1" hidden="0">
-            <c r="A124" s="1" t="n">
-                <f>
+            <c r="A124" s="1" cm="1" t="n">
+                <f t="array" ref="A124">
                     SECOND("00:21:42")
                 </f>
                 <v>
@@ -14811,8 +15486,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="125" ht="17.25" customHeight="1" hidden="0">
-            <c r="A125" s="1" t="n">
-                <f>
+            <c r="A125" s="1" cm="1" t="n">
+                <f t="array" ref="A125">
                     SIN(PI()/6)
                 </f>
                 <v>
@@ -14821,8 +15496,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="126" ht="17.25" customHeight="1" hidden="0">
-            <c r="A126" s="1" t="n">
-                <f>
+            <c r="A126" s="1" cm="1" t="n">
+                <f t="array" ref="A126">
                     SINH(1)
                 </f>
                 <v>
@@ -14831,8 +15506,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="127" ht="17.25" customHeight="1" hidden="0">
-            <c r="A127" s="1" t="n">
-                <f>
+            <c r="A127" s="1" cm="1" t="n">
+                <f t="array" ref="A127">
                     SMALL(H2:H9,3)
                 </f>
                 <v>
@@ -14841,8 +15516,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="128" ht="17.25" customHeight="1" hidden="0">
-            <c r="A128" s="1" t="n">
-                <f>
+            <c r="A128" s="1" cm="1" t="n">
+                <f t="array" ref="A128">
                     SQRT(4)
                 </f>
                 <v>
@@ -14851,8 +15526,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="129" ht="17.25" customHeight="1" hidden="0">
-            <c r="A129" s="1" t="n">
-                <f>
+            <c r="A129" s="1" cm="1" t="n">
+                <f t="array" ref="A129">
                     STDEV(-2,0,2)
                 </f>
                 <v>
@@ -14861,8 +15536,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="130" ht="17.25" customHeight="1" hidden="0">
-            <c r="A130" s="1" t="n">
-                <f>
+            <c r="A130" s="1" cm="1" t="n">
+                <f t="array" ref="A130">
                     _xlfn.STDEV.P(2,4)
                 </f>
                 <v>
@@ -14871,8 +15546,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="131" ht="17.25" customHeight="1" hidden="0">
-            <c r="A131" s="1" t="n">
-                <f>
+            <c r="A131" s="1" cm="1" t="n">
+                <f t="array" ref="A131">
                     _xlfn.STDEV.S(2,4,6)
                 </f>
                 <v>
@@ -14881,8 +15556,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="132" ht="17.25" customHeight="1" hidden="0">
-            <c r="A132" s="1" t="n">
-                <f>
+            <c r="A132" s="1" cm="1" t="n">
+                <f t="array" ref="A132">
                     STDEVA(TRUE,3,5)
                 </f>
                 <v>
@@ -14891,8 +15566,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="133" ht="17.25" customHeight="1" hidden="0">
-            <c r="A133" s="1" t="n">
-                <f>
+            <c r="A133" s="1" cm="1" t="n">
+                <f t="array" ref="A133">
                     STDEVP(2,5,8)
                 </f>
                 <v>
@@ -14901,8 +15576,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="134" ht="17.25" customHeight="1" hidden="0">
-            <c r="A134" s="1" t="n">
-                <f>
+            <c r="A134" s="1" cm="1" t="n">
+                <f t="array" ref="A134">
                     STDEVPA(TRUE,4,7)
                 </f>
                 <v>
@@ -14911,8 +15586,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="135" ht="17.25" customHeight="1" hidden="0">
-            <c r="A135" s="1" t="str">
-                <f>
+            <c r="A135" s="1" cm="1" t="str">
+                <f t="array" ref="A135">
                     SUBSTITUTE("SAP is best","SAP","Odoo")
                 </f>
                 <v>
@@ -14921,8 +15596,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="136" ht="17.25" customHeight="1" hidden="0">
-            <c r="A136" s="1" t="n">
-                <f>
+            <c r="A136" s="1" cm="1" t="n">
+                <f t="array" ref="A136">
                     SUM(1,2,3,4,5)
                 </f>
                 <v>
@@ -14931,8 +15606,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="137" ht="17.25" customHeight="1" hidden="0">
-            <c r="A137" s="1" t="n">
-                <f>
+            <c r="A137" s="1" cm="1" t="n">
+                <f t="array" ref="A137">
                     SUMIF(K2:K9,"&lt;100")
                 </f>
                 <v>
@@ -14941,8 +15616,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="138" ht="17.25" customHeight="1" hidden="0">
-            <c r="A138" s="1" t="n">
-                <f>
+            <c r="A138" s="1" cm="1" t="n">
+                <f t="array" ref="A138">
                     SUMIFS(H2:H9,K2:K9,"&lt;100")
                 </f>
                 <v>
@@ -14951,8 +15626,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="139" ht="17.25" customHeight="1" hidden="0">
-            <c r="A139" s="1" t="n">
-                <f>
+            <c r="A139" s="1" cm="1" t="n">
+                <f t="array" ref="A139">
                     TAN(PI()/4)
                 </f>
                 <v>
@@ -14961,8 +15636,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="140" ht="17.25" customHeight="1" hidden="0">
-            <c r="A140" s="1" t="n">
-                <f>
+            <c r="A140" s="1" cm="1" t="n">
+                <f t="array" ref="A140">
                     TANH(1)
                 </f>
                 <v>
@@ -14971,8 +15646,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="141" ht="17.25" customHeight="1" hidden="0">
-            <c r="A141" s="1" t="str">
-                <f>
+            <c r="A141" s="1" cm="1" t="str">
+                <f t="array" ref="A141">
                     _xlfn.TEXTJOIN("-",TRUE,"","1","A","%")
                 </f>
                 <v>
@@ -14981,8 +15656,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="142" ht="17.25" customHeight="1" hidden="0">
-            <c r="A142" s="1" t="n">
-                <f>
+            <c r="A142" s="1" cm="1" t="n">
+                <f t="array" ref="A142">
                     TIME(9,11,31)
                 </f>
                 <v>
@@ -14991,8 +15666,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="143" ht="17.25" customHeight="1" hidden="0">
-            <c r="A143" s="1" t="n">
-                <f>
+            <c r="A143" s="1" cm="1" t="n">
+                <f t="array" ref="A143">
                     TIMEVALUE("18:00:00")
                 </f>
                 <v>
@@ -15001,8 +15676,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="144" ht="17.25" customHeight="1" hidden="0">
-            <c r="A144" s="1" t="n">
-                <f>
+            <c r="A144" s="1" cm="1" t="n">
+                <f t="array" ref="A144">
                     TODAY()
                 </f>
                 <v>
@@ -15011,8 +15686,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="145" ht="17.25" customHeight="1" hidden="0">
-            <c r="A145" s="1" t="str">
-                <f>
+            <c r="A145" s="1" cm="1" t="str">
+                <f t="array" ref="A145">
                     TRIM(" Jean Ticonstitutionnalise ")
                 </f>
                 <v>
@@ -15021,8 +15696,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="146" ht="17.25" customHeight="1" hidden="0">
-            <c r="A146" s="1" t="n">
-                <f>
+            <c r="A146" s="1" cm="1" t="n">
+                <f t="array" ref="A146">
                     TRUNC(42.42,1)
                 </f>
                 <v>
@@ -15031,8 +15706,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="147" ht="17.25" customHeight="1" hidden="0">
-            <c r="A147" s="1" t="str">
-                <f>
+            <c r="A147" s="1" cm="1" t="str">
+                <f t="array" ref="A147">
                     UPPER("grrrr !")
                 </f>
                 <v>
@@ -15041,8 +15716,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="148" ht="17.25" customHeight="1" hidden="0">
-            <c r="A148" s="1" t="n">
-                <f>
+            <c r="A148" s="1" cm="1" t="n">
+                <f t="array" ref="A148">
                     VAR(K1:K5)
                 </f>
                 <v>
@@ -15051,8 +15726,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="149" ht="17.25" customHeight="1" hidden="0">
-            <c r="A149" s="1" t="n">
-                <f>
+            <c r="A149" s="1" cm="1" t="n">
+                <f t="array" ref="A149">
                     _xlfn.VAR.P(K1:K5)
                 </f>
                 <v>
@@ -15061,8 +15736,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="150" ht="17.25" customHeight="1" hidden="0">
-            <c r="A150" s="1" t="n">
-                <f>
+            <c r="A150" s="1" cm="1" t="n">
+                <f t="array" ref="A150">
                     _xlfn.VAR.S(2,5,8)
                 </f>
                 <v>
@@ -15071,8 +15746,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="151" ht="17.25" customHeight="1" hidden="0">
-            <c r="A151" s="1" t="n">
-                <f>
+            <c r="A151" s="1" cm="1" t="n">
+                <f t="array" ref="A151">
                     VARA(K1:K5)
                 </f>
                 <v>
@@ -15081,8 +15756,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="152" ht="17.25" customHeight="1" hidden="0">
-            <c r="A152" s="1" t="n">
-                <f>
+            <c r="A152" s="1" cm="1" t="n">
+                <f t="array" ref="A152">
                     VARP(K1:K5)
                 </f>
                 <v>
@@ -15091,8 +15766,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="153" ht="17.25" customHeight="1" hidden="0">
-            <c r="A153" s="1" t="n">
-                <f>
+            <c r="A153" s="1" cm="1" t="n">
+                <f t="array" ref="A153">
                     VARPA(K1:K5)
                 </f>
                 <v>
@@ -15101,8 +15776,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="154" ht="17.25" customHeight="1" hidden="0">
-            <c r="A154" s="1" t="n">
-                <f>
+            <c r="A154" s="1" cm="1" t="n">
+                <f t="array" ref="A154">
                     VLOOKUP("NotACheater",G1:K9,3,FALSE)
                 </f>
                 <v>
@@ -15111,8 +15786,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="155" ht="17.25" customHeight="1" hidden="0">
-            <c r="A155" s="1" t="n">
-                <f>
+            <c r="A155" s="1" cm="1" t="n">
+                <f t="array" ref="A155">
                     WEEKDAY("2021-06-12")
                 </f>
                 <v>
@@ -15121,8 +15796,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="156" ht="17.25" customHeight="1" hidden="0">
-            <c r="A156" s="1" t="n">
-                <f>
+            <c r="A156" s="1" cm="1" t="n">
+                <f t="array" ref="A156">
                     WEEKNUM("2021-06-29")
                 </f>
                 <v>
@@ -15131,8 +15806,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="157" ht="17.25" customHeight="1" hidden="0">
-            <c r="A157" s="1" t="n">
-                <f>
+            <c r="A157" s="1" cm="1" t="n">
+                <f t="array" ref="A157">
                     WORKDAY("2021-03-15",6)
                 </f>
                 <v>
@@ -15141,8 +15816,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="158" ht="17.25" customHeight="1" hidden="0">
-            <c r="A158" s="1" t="n">
-                <f>
+            <c r="A158" s="1" cm="1" t="n">
+                <f t="array" ref="A158">
                     WORKDAY.INTL("2021-03-15",6,"0111111")
                 </f>
                 <v>
@@ -15151,8 +15826,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="159" ht="17.25" customHeight="1" hidden="0">
-            <c r="A159" s="1" t="b">
-                <f>
+            <c r="A159" s="1" cm="1" t="b">
+                <f t="array" ref="A159">
                     _xlfn.XOR(FALSE,TRUE,FALSE,FALSE)
                 </f>
                 <v>
@@ -15161,8 +15836,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="160" ht="17.25" customHeight="1" hidden="0">
-            <c r="A160" s="1" t="n">
-                <f>
+            <c r="A160" s="1" cm="1" t="n">
+                <f t="array" ref="A160">
                     YEAR("2012-03-12")
                 </f>
                 <v>
@@ -15171,8 +15846,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="161" ht="17.25" customHeight="1" hidden="0">
-            <c r="A161" s="1" t="n">
-                <f>
+            <c r="A161" s="1" cm="1" t="n">
+                <f t="array" ref="A161">
                     DELTA(1,1)
                 </f>
                 <v>
@@ -15181,8 +15856,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="162" ht="17.25" customHeight="1" hidden="0">
-            <c r="A162" s="1" t="str">
-                <f>
+            <c r="A162" s="1" cm="1" t="str">
+                <f t="array" ref="A162">
                     NA()
                 </f>
                 <v>
@@ -15191,8 +15866,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="163" ht="17.25" customHeight="1" hidden="0">
-            <c r="A163" s="1" t="b">
-                <f>
+            <c r="A163" s="1" cm="1" t="b">
+                <f t="array" ref="A163">
                     ISNA(A162)
                 </f>
                 <v>
@@ -15201,8 +15876,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="164" ht="17.25" customHeight="1" hidden="0">
-            <c r="A164" s="1" t="b">
-                <f>
+            <c r="A164" s="1" cm="1" t="b">
+                <f t="array" ref="A164">
                     ISERR(A162)
                 </f>
                 <v>
@@ -15211,8 +15886,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="165" ht="17.25" customHeight="1" hidden="0">
-            <c r="A165" s="1" t="str">
-                <f>
+            <c r="A165" s="1" cm="1" t="str">
+                <f t="array" ref="A165">
                     HYPERLINK("https://www.odoo.com","Odoo")
                 </f>
                 <v>
@@ -15221,8 +15896,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="166" ht="17.25" customHeight="1" hidden="0">
-            <c r="A166" s="1" t="str">
-                <f>
+            <c r="A166" s="1" cm="1" t="str">
+                <f t="array" ref="A166">
                     ADDRESS(27,53,4,FALSE,"sheet!")
                 </f>
                 <v>
@@ -15231,8 +15906,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="167" ht="17.25" customHeight="1" hidden="0">
-            <c r="A167" s="1" t="n">
-                <f>
+            <c r="A167" s="1" cm="1" t="n">
+                <f t="array" ref="A167">
                     DATEDIF("2002-01-01","2002-01-02","D")
                 </f>
                 <v>
@@ -15241,8 +15916,8 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="168" ht="17.25" customHeight="1" hidden="0">
-            <c r="A168" s="1" t="n">
-                <f>
+            <c r="A168" s="1" cm="1" t="n">
+                <f t="array" ref="A168:B169">
                     _xlfn.RANDARRAY(2,2)
                 </f>
                 <v>
@@ -15262,6 +15937,29 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
 </worksheet>",
       "contentType": "sheet",
       "path": "xl/worksheets/sheet0.xml",
+    },
+    {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
     },
     {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
@@ -15424,6 +16122,7 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -15442,6 +16141,7 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
     <Default Extension="xml" ContentType="application/xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml" PartName="/xl/workbook.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -15656,8 +16356,8 @@ exports[`Test XLSX export formulas All non-exportable formulas 1`] = `
             </c>
         </row>
         <row r="22" ht="17.25" customHeight="1" hidden="0">
-            <c r="A22" s="1" t="str">
-                <f>
+            <c r="A22" s="1" cm="1" t="str">
+                <f t="array" ref="A22">
                     SUM(A3:Z3)
                 </f>
                 <v>
@@ -15666,8 +16366,8 @@ exports[`Test XLSX export formulas All non-exportable formulas 1`] = `
             </c>
         </row>
         <row r="23" ht="17.25" customHeight="1" hidden="0">
-            <c r="A23" s="1" t="str">
-                <f>
+            <c r="A23" s="1" cm="1" t="str">
+                <f t="array" ref="A23">
                     SUM(A3:A100)
                 </f>
                 <v>
@@ -15686,6 +16386,29 @@ exports[`Test XLSX export formulas All non-exportable formulas 1`] = `
 </worksheet>",
       "contentType": "sheet",
       "path": "xl/worksheets/sheet0.xml",
+    },
+    {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
     },
     {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
@@ -15765,6 +16488,7 @@ exports[`Test XLSX export formulas All non-exportable formulas 1`] = `
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -15783,6 +16507,7 @@ exports[`Test XLSX export formulas All non-exportable formulas 1`] = `
     <Default Extension="xml" ContentType="application/xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml" PartName="/xl/workbook.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -15904,6 +16629,29 @@ exports[`Test XLSX export formulas Multi-Sheet export async functions without cr
       "path": "xl/worksheets/sheet1.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -15965,6 +16713,7 @@ exports[`Test XLSX export formulas Multi-Sheet export async functions without cr
     <Relationship Id="rId2" Target="worksheets/sheet1.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId3" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId4" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId5" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -15984,6 +16733,7 @@ exports[`Test XLSX export formulas Multi-Sheet export async functions without cr
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml" PartName="/xl/workbook.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet1.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -16052,8 +16802,8 @@ exports[`Test XLSX export formulas Multi-Sheet export functions with cross refer
     </cols>
     <sheetData>
         <row r="1" ht="17.25" customHeight="1" hidden="0">
-            <c r="A1" s="1" t="n">
-                <f>
+            <c r="A1" s="1" cm="1" t="n">
+                <f t="array" ref="A1">
                     SUM(Sheet2!A1)
                 </f>
                 <v>
@@ -16113,6 +16863,29 @@ exports[`Test XLSX export formulas Multi-Sheet export functions with cross refer
 </worksheet>",
       "contentType": "sheet",
       "path": "xl/worksheets/sheet1.xml",
+    },
+    {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
     },
     {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
@@ -16176,6 +16949,7 @@ exports[`Test XLSX export formulas Multi-Sheet export functions with cross refer
     <Relationship Id="rId2" Target="worksheets/sheet1.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId3" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId4" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId5" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -16195,6 +16969,7 @@ exports[`Test XLSX export formulas Multi-Sheet export functions with cross refer
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml" PartName="/xl/workbook.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet1.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -16300,8 +17075,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="2" ht="17.25" customHeight="1" hidden="0">
-            <c r="A2" s="1" t="n">
-                <f>
+            <c r="A2" s="1" cm="1" t="n">
+                <f t="array" ref="A2">
                     ABS(-5.5)
                 </f>
                 <v>
@@ -16340,8 +17115,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="3" ht="17.25" customHeight="1" hidden="0">
-            <c r="A3" s="1" t="n">
-                <f>
+            <c r="A3" s="1" cm="1" t="n">
+                <f t="array" ref="A3">
                     ACOS(1)
                 </f>
                 <v>
@@ -16380,8 +17155,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="4" ht="17.25" customHeight="1" hidden="0">
-            <c r="A4" s="1" t="n">
-                <f>
+            <c r="A4" s="1" cm="1" t="n">
+                <f t="array" ref="A4">
                     ACOSH(2)
                 </f>
                 <v>
@@ -16420,16 +17195,16 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="5" ht="17.25" customHeight="1" hidden="0">
-            <c r="A5" s="1" t="n">
-                <f>
+            <c r="A5" s="1" cm="1" t="n">
+                <f t="array" ref="A5">
                     _xlfn.ACOT(1)
                 </f>
                 <v>
                     0.7853981633974483
                 </v>
             </c>
-            <c r="B5" s="1" t="n">
-                <f>
+            <c r="B5" s="1" cm="1" t="n">
+                <f t="array" ref="B5">
                     _xlfn.ACOT(_xlfn.ACOT(1))
                 </f>
                 <v>
@@ -16468,8 +17243,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="6" ht="17.25" customHeight="1" hidden="0">
-            <c r="A6" s="1" t="n">
-                <f>
+            <c r="A6" s="1" cm="1" t="n">
+                <f t="array" ref="A6">
                     _xlfn.ACOTH(2)
                 </f>
                 <v>
@@ -16508,8 +17283,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="7" ht="17.25" customHeight="1" hidden="0">
-            <c r="A7" s="1" t="b">
-                <f>
+            <c r="A7" s="1" cm="1" t="b">
+                <f t="array" ref="A7">
                     AND(TRUE,TRUE)
                 </f>
                 <v>
@@ -16548,8 +17323,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="8" ht="17.25" customHeight="1" hidden="0">
-            <c r="A8" s="1" t="n">
-                <f>
+            <c r="A8" s="1" cm="1" t="n">
+                <f t="array" ref="A8">
                     ASIN(0.5)
                 </f>
                 <v>
@@ -16588,8 +17363,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="9" ht="17.25" customHeight="1" hidden="0">
-            <c r="A9" s="1" t="n">
-                <f>
+            <c r="A9" s="1" cm="1" t="n">
+                <f t="array" ref="A9">
                     ASINH(2)
                 </f>
                 <v>
@@ -16623,8 +17398,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="10" ht="17.25" customHeight="1" hidden="0">
-            <c r="A10" s="1" t="n">
-                <f>
+            <c r="A10" s="1" cm="1" t="n">
+                <f t="array" ref="A10">
                     ATAN(1)
                 </f>
                 <v>
@@ -16633,8 +17408,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="11" ht="17.25" customHeight="1" hidden="0">
-            <c r="A11" s="1" t="n">
-                <f>
+            <c r="A11" s="1" cm="1" t="n">
+                <f t="array" ref="A11">
                     ATAN2(-1,0)
                 </f>
                 <v>
@@ -16648,8 +17423,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="12" ht="17.25" customHeight="1" hidden="0">
-            <c r="A12" s="1" t="n">
-                <f>
+            <c r="A12" s="1" cm="1" t="n">
+                <f t="array" ref="A12">
                     ATANH(0.7)
                 </f>
                 <v>
@@ -16683,8 +17458,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="13" ht="17.25" customHeight="1" hidden="0">
-            <c r="A13" s="1" t="n">
-                <f>
+            <c r="A13" s="1" cm="1" t="n">
+                <f t="array" ref="A13">
                     AVEDEV(I2:I9)
                 </f>
                 <v>
@@ -16718,8 +17493,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="14" ht="17.25" customHeight="1" hidden="0">
-            <c r="A14" s="1" t="n">
-                <f>
+            <c r="A14" s="1" cm="1" t="n">
+                <f t="array" ref="A14">
                     AVERAGE(H2:H9)
                 </f>
                 <v>
@@ -16728,8 +17503,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="15" ht="17.25" customHeight="1" hidden="0">
-            <c r="A15" s="1" t="n">
-                <f>
+            <c r="A15" s="1" cm="1" t="n">
+                <f t="array" ref="A15">
                     AVERAGEA(G2:H9)
                 </f>
                 <v>
@@ -16738,8 +17513,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="16" ht="17.25" customHeight="1" hidden="0">
-            <c r="A16" s="1" t="n">
-                <f>
+            <c r="A16" s="1" cm="1" t="n">
+                <f t="array" ref="A16">
                     AVERAGEIF(J2:J9,"&gt;150000")
                 </f>
                 <v>
@@ -16748,8 +17523,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="17" ht="17.25" customHeight="1" hidden="0">
-            <c r="A17" s="1" t="n">
-                <f>
+            <c r="A17" s="1" cm="1" t="n">
+                <f t="array" ref="A17">
                     AVERAGEIFS(I2:I9,H2:H9,"&gt;=30",K2:K9,"&lt;10")
                 </f>
                 <v>
@@ -16758,8 +17533,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="18" ht="17.25" customHeight="1" hidden="0">
-            <c r="A18" s="1" t="n">
-                <f>
+            <c r="A18" s="1" cm="1" t="n">
+                <f t="array" ref="A18">
                     CEILING(20.4,1)
                 </f>
                 <v>
@@ -16768,8 +17543,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="19" ht="17.25" customHeight="1" hidden="0">
-            <c r="A19" s="1" t="n">
-                <f>
+            <c r="A19" s="1" cm="1" t="n">
+                <f t="array" ref="A19">
                     _xlfn.CEILING.MATH(-5.5,1,0)
                 </f>
                 <v>
@@ -16778,8 +17553,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="20" ht="17.25" customHeight="1" hidden="0">
-            <c r="A20" s="1" t="n">
-                <f>
+            <c r="A20" s="1" cm="1" t="n">
+                <f t="array" ref="A20">
                     _xlfn.CEILING.PRECISE(230,100)
                 </f>
                 <v>
@@ -16788,8 +17563,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="21" ht="17.25" customHeight="1" hidden="0">
-            <c r="A21" s="1" t="str">
-                <f>
+            <c r="A21" s="1" cm="1" t="str">
+                <f t="array" ref="A21">
                     CHAR(74)
                 </f>
                 <v>
@@ -16798,8 +17573,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="22" ht="17.25" customHeight="1" hidden="0">
-            <c r="A22" s="1" t="n">
-                <f>
+            <c r="A22" s="1" cm="1" t="n">
+                <f t="array" ref="A22">
                     COLUMN(C4)
                 </f>
                 <v>
@@ -16808,8 +17583,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="23" ht="17.25" customHeight="1" hidden="0">
-            <c r="A23" s="1" t="n">
-                <f>
+            <c r="A23" s="1" cm="1" t="n">
+                <f t="array" ref="A23">
                     COLUMNS(A5:D12)
                 </f>
                 <v>
@@ -16818,8 +17593,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="24" ht="17.25" customHeight="1" hidden="0">
-            <c r="A24" s="1" t="str">
-                <f>
+            <c r="A24" s="1" cm="1" t="str">
+                <f t="array" ref="A24">
                     _xlfn.CONCAT(1,23)
                 </f>
                 <v>
@@ -16828,8 +17603,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="25" ht="17.25" customHeight="1" hidden="0">
-            <c r="A25" s="1" t="str">
-                <f>
+            <c r="A25" s="1" cm="1" t="str">
+                <f t="array" ref="A25">
                     CONCATENATE("BUT, ","MICHEL")
                 </f>
                 <v>
@@ -16838,8 +17613,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="26" ht="17.25" customHeight="1" hidden="0">
-            <c r="A26" s="1" t="n">
-                <f>
+            <c r="A26" s="1" cm="1" t="n">
+                <f t="array" ref="A26">
                     COS(PI()/3)
                 </f>
                 <v>
@@ -16848,8 +17623,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="27" ht="17.25" customHeight="1" hidden="0">
-            <c r="A27" s="1" t="n">
-                <f>
+            <c r="A27" s="1" cm="1" t="n">
+                <f t="array" ref="A27">
                     COSH(2)
                 </f>
                 <v>
@@ -16858,8 +17633,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="28" ht="17.25" customHeight="1" hidden="0">
-            <c r="A28" s="1" t="n">
-                <f>
+            <c r="A28" s="1" cm="1" t="n">
+                <f t="array" ref="A28">
                     _xlfn.COT(PI()/6)
                 </f>
                 <v>
@@ -16868,8 +17643,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="29" ht="17.25" customHeight="1" hidden="0">
-            <c r="A29" s="1" t="n">
-                <f>
+            <c r="A29" s="1" cm="1" t="n">
+                <f t="array" ref="A29">
                     _xlfn.COTH(0.5)
                 </f>
                 <v>
@@ -16878,8 +17653,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="30" ht="17.25" customHeight="1" hidden="0">
-            <c r="A30" s="1" t="n">
-                <f>
+            <c r="A30" s="1" cm="1" t="n">
+                <f t="array" ref="A30">
                     COUNT(1,"a","5","2021-03-14")
                 </f>
                 <v>
@@ -16888,8 +17663,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="31" ht="17.25" customHeight="1" hidden="0">
-            <c r="A31" s="1" t="n">
-                <f>
+            <c r="A31" s="1" cm="1" t="n">
+                <f t="array" ref="A31">
                     COUNTA(1,"a","5","2021-03-14")
                 </f>
                 <v>
@@ -16898,8 +17673,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="32" ht="17.25" customHeight="1" hidden="0">
-            <c r="A32" s="1" t="n">
-                <f>
+            <c r="A32" s="1" cm="1" t="n">
+                <f t="array" ref="A32">
                     COUNTBLANK("","1",3,FALSE)
                 </f>
                 <v>
@@ -16908,8 +17683,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="33" ht="17.25" customHeight="1" hidden="0">
-            <c r="A33" s="1" t="n">
-                <f>
+            <c r="A33" s="1" cm="1" t="n">
+                <f t="array" ref="A33">
                     COUNTIF(H2:H9,"&gt;30")
                 </f>
                 <v>
@@ -16918,8 +17693,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="34" ht="17.25" customHeight="1" hidden="0">
-            <c r="A34" s="1" t="n">
-                <f>
+            <c r="A34" s="1" cm="1" t="n">
+                <f t="array" ref="A34">
                     COUNTIFS(H2:H9,"&gt;25",K2:K9,"&lt;4")
                 </f>
                 <v>
@@ -16928,8 +17703,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="35" ht="17.25" customHeight="1" hidden="0">
-            <c r="A35" s="1" t="n">
-                <f>
+            <c r="A35" s="1" cm="1" t="n">
+                <f t="array" ref="A35">
                     COVAR(H2:H9,K2:K9)
                 </f>
                 <v>
@@ -16938,8 +17713,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="36" ht="17.25" customHeight="1" hidden="0">
-            <c r="A36" s="1" t="n">
-                <f>
+            <c r="A36" s="1" cm="1" t="n">
+                <f t="array" ref="A36">
                     _xlfn.COVARIANCE.P(K2:K9,H2:H9)
                 </f>
                 <v>
@@ -16948,8 +17723,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="37" ht="17.25" customHeight="1" hidden="0">
-            <c r="A37" s="1" t="n">
-                <f>
+            <c r="A37" s="1" cm="1" t="n">
+                <f t="array" ref="A37">
                     _xlfn.COVARIANCE.P(I2:I9,J2:J9)
                 </f>
                 <v>
@@ -16958,8 +17733,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="38" ht="17.25" customHeight="1" hidden="0">
-            <c r="A38" s="1" t="n">
-                <f>
+            <c r="A38" s="1" cm="1" t="n">
+                <f t="array" ref="A38">
                     _xlfn.CSC(PI()/4)
                 </f>
                 <v>
@@ -16968,8 +17743,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="39" ht="17.25" customHeight="1" hidden="0">
-            <c r="A39" s="1" t="n">
-                <f>
+            <c r="A39" s="1" cm="1" t="n">
+                <f t="array" ref="A39">
                     _xlfn.CSCH(PI()/3)
                 </f>
                 <v>
@@ -16978,8 +17753,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="40" ht="17.25" customHeight="1" hidden="0">
-            <c r="A40" s="1" t="n">
-                <f>
+            <c r="A40" s="1" cm="1" t="n">
+                <f t="array" ref="A40">
                     DATE(2020,5,25)
                 </f>
                 <v>
@@ -16988,8 +17763,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="41" ht="17.25" customHeight="1" hidden="0">
-            <c r="A41" s="1" t="n">
-                <f>
+            <c r="A41" s="1" cm="1" t="n">
+                <f t="array" ref="A41">
                     DATEVALUE("1969-08-15")
                 </f>
                 <v>
@@ -16998,8 +17773,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="42" ht="17.25" customHeight="1" hidden="0">
-            <c r="A42" s="1" t="n">
-                <f>
+            <c r="A42" s="1" cm="1" t="n">
+                <f t="array" ref="A42">
                     DAVERAGE(G1:K9,"Tot. Score",J12:J13)
                 </f>
                 <v>
@@ -17008,8 +17783,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="43" ht="17.25" customHeight="1" hidden="0">
-            <c r="A43" s="1" t="n">
-                <f>
+            <c r="A43" s="1" cm="1" t="n">
+                <f t="array" ref="A43">
                     DAY("2020-03-17")
                 </f>
                 <v>
@@ -17018,8 +17793,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="44" ht="17.25" customHeight="1" hidden="0">
-            <c r="A44" s="1" t="n">
-                <f>
+            <c r="A44" s="1" cm="1" t="n">
+                <f t="array" ref="A44">
                     _xlfn.DAYS("2022-03-17","2021-03-17")
                 </f>
                 <v>
@@ -17028,8 +17803,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="45" ht="17.25" customHeight="1" hidden="0">
-            <c r="A45" s="1" t="n">
-                <f>
+            <c r="A45" s="1" cm="1" t="n">
+                <f t="array" ref="A45">
                     DCOUNT(G1:K9,"Name",H12:H13)
                 </f>
                 <v>
@@ -17038,8 +17813,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="46" ht="17.25" customHeight="1" hidden="0">
-            <c r="A46" s="1" t="n">
-                <f>
+            <c r="A46" s="1" cm="1" t="n">
+                <f t="array" ref="A46">
                     DCOUNTA(G1:K9,"Name",H12:H13)
                 </f>
                 <v>
@@ -17048,8 +17823,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="47" ht="17.25" customHeight="1" hidden="0">
-            <c r="A47" s="1" t="n">
-                <f>
+            <c r="A47" s="1" cm="1" t="n">
+                <f t="array" ref="A47">
                     _xlfn.DECIMAL(20,16)
                 </f>
                 <v>
@@ -17058,8 +17833,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="48" ht="17.25" customHeight="1" hidden="0">
-            <c r="A48" s="1" t="n">
-                <f>
+            <c r="A48" s="1" cm="1" t="n">
+                <f t="array" ref="A48">
                     DEGREES(PI()/4)
                 </f>
                 <v>
@@ -17068,8 +17843,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="49" ht="17.25" customHeight="1" hidden="0">
-            <c r="A49" s="1" t="n">
-                <f>
+            <c r="A49" s="1" cm="1" t="n">
+                <f t="array" ref="A49">
                     DGET(G1:K9,"Hours Played",G12:G13)
                 </f>
                 <v>
@@ -17078,8 +17853,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="50" ht="17.25" customHeight="1" hidden="0">
-            <c r="A50" s="1" t="n">
-                <f>
+            <c r="A50" s="1" cm="1" t="n">
+                <f t="array" ref="A50">
                     DMAX(G1:K9,"Tot. Score",I12:I13)
                 </f>
                 <v>
@@ -17088,8 +17863,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="51" ht="17.25" customHeight="1" hidden="0">
-            <c r="A51" s="1" t="n">
-                <f>
+            <c r="A51" s="1" cm="1" t="n">
+                <f t="array" ref="A51">
                     DMIN(G1:K9,"Tot. Score",H12:H13)
                 </f>
                 <v>
@@ -17098,8 +17873,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="52" ht="17.25" customHeight="1" hidden="0">
-            <c r="A52" s="1" t="n">
-                <f>
+            <c r="A52" s="1" cm="1" t="n">
+                <f t="array" ref="A52">
                     DPRODUCT(G1:K9,"Age",K12:K13)
                 </f>
                 <v>
@@ -17108,8 +17883,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="53" ht="17.25" customHeight="1" hidden="0">
-            <c r="A53" s="1" t="n">
-                <f>
+            <c r="A53" s="1" cm="1" t="n">
+                <f t="array" ref="A53">
                     DSTDEV(G1:K9,"Age",H12:H13)
                 </f>
                 <v>
@@ -17118,8 +17893,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="54" ht="17.25" customHeight="1" hidden="0">
-            <c r="A54" s="1" t="n">
-                <f>
+            <c r="A54" s="1" cm="1" t="n">
+                <f t="array" ref="A54">
                     DSTDEVP(G1:K9,"Age",H12:H13)
                 </f>
                 <v>
@@ -17128,8 +17903,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="55" ht="17.25" customHeight="1" hidden="0">
-            <c r="A55" s="1" t="n">
-                <f>
+            <c r="A55" s="1" cm="1" t="n">
+                <f t="array" ref="A55">
                     DSUM(G1:K9,"Age",I12:I13)
                 </f>
                 <v>
@@ -17138,8 +17913,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="56" ht="17.25" customHeight="1" hidden="0">
-            <c r="A56" s="1" t="n">
-                <f>
+            <c r="A56" s="1" cm="1" t="n">
+                <f t="array" ref="A56">
                     DVAR(G1:K9,"Hours Played",H12:H13)
                 </f>
                 <v>
@@ -17148,8 +17923,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="57" ht="17.25" customHeight="1" hidden="0">
-            <c r="A57" s="1" t="n">
-                <f>
+            <c r="A57" s="1" cm="1" t="n">
+                <f t="array" ref="A57">
                     DVARP(G1:K9,"Hours Played",H12:H13)
                 </f>
                 <v>
@@ -17158,8 +17933,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="58" ht="17.25" customHeight="1" hidden="0">
-            <c r="A58" s="1" t="n">
-                <f>
+            <c r="A58" s="1" cm="1" t="n">
+                <f t="array" ref="A58">
                     EDATE("1969-07-22",-2)
                 </f>
                 <v>
@@ -17168,8 +17943,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="59" ht="17.25" customHeight="1" hidden="0">
-            <c r="A59" s="1" t="n">
-                <f>
+            <c r="A59" s="1" cm="1" t="n">
+                <f t="array" ref="A59">
                     EOMONTH("2020-07-21",1)
                 </f>
                 <v>
@@ -17178,8 +17953,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="60" ht="17.25" customHeight="1" hidden="0">
-            <c r="A60" s="1" t="b">
-                <f>
+            <c r="A60" s="1" cm="1" t="b">
+                <f t="array" ref="A60">
                     EXACT("AbsSdf%","AbsSdf%")
                 </f>
                 <v>
@@ -17188,8 +17963,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="61" ht="17.25" customHeight="1" hidden="0">
-            <c r="A61" s="1" t="n">
-                <f>
+            <c r="A61" s="1" cm="1" t="n">
+                <f t="array" ref="A61">
                     EXP(4)
                 </f>
                 <v>
@@ -17198,8 +17973,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="62" ht="17.25" customHeight="1" hidden="0">
-            <c r="A62" s="1" t="n">
-                <f>
+            <c r="A62" s="1" cm="1" t="n">
+                <f t="array" ref="A62">
                     FIND("A","qbdahbaazo A")
                 </f>
                 <v>
@@ -17208,8 +17983,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="63" ht="17.25" customHeight="1" hidden="0">
-            <c r="A63" s="1" t="n">
-                <f>
+            <c r="A63" s="1" cm="1" t="n">
+                <f t="array" ref="A63">
                     FLOOR(5.5,2)
                 </f>
                 <v>
@@ -17218,8 +17993,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="64" ht="17.25" customHeight="1" hidden="0">
-            <c r="A64" s="1" t="n">
-                <f>
+            <c r="A64" s="1" cm="1" t="n">
+                <f t="array" ref="A64">
                     _xlfn.FLOOR.MATH(-5.55,2,1)
                 </f>
                 <v>
@@ -17228,8 +18003,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="65" ht="17.25" customHeight="1" hidden="0">
-            <c r="A65" s="1" t="n">
-                <f>
+            <c r="A65" s="1" cm="1" t="n">
+                <f t="array" ref="A65">
                     _xlfn.FLOOR.PRECISE(199,100)
                 </f>
                 <v>
@@ -17238,8 +18013,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="66" ht="17.25" customHeight="1" hidden="0">
-            <c r="A66" s="1" t="n">
-                <f>
+            <c r="A66" s="1" cm="1" t="n">
+                <f t="array" ref="A66">
                     HLOOKUP("Tot. Score",H1:K9,4,FALSE)
                 </f>
                 <v>
@@ -17248,8 +18023,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="67" ht="17.25" customHeight="1" hidden="0">
-            <c r="A67" s="1" t="n">
-                <f>
+            <c r="A67" s="1" cm="1" t="n">
+                <f t="array" ref="A67">
                     HOUR("02:14:56")
                 </f>
                 <v>
@@ -17258,8 +18033,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="68" ht="17.25" customHeight="1" hidden="0">
-            <c r="A68" s="1" t="str">
-                <f>
+            <c r="A68" s="1" cm="1" t="str">
+                <f t="array" ref="A68">
                     IF(TRUE,"TABOURET","JAMBON")
                 </f>
                 <v>
@@ -17268,8 +18043,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="69" ht="17.25" customHeight="1" hidden="0">
-            <c r="A69" s="1" t="str">
-                <f>
+            <c r="A69" s="1" cm="1" t="str">
+                <f t="array" ref="A69">
                     IFERROR(0/0,"no diving by zero.")
                 </f>
                 <v>
@@ -17278,8 +18053,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="70" ht="17.25" customHeight="1" hidden="0">
-            <c r="A70" s="1" t="str">
-                <f>
+            <c r="A70" s="1" cm="1" t="str">
+                <f t="array" ref="A70">
                     _xlfn.IFS($H2&gt;$H3,"first player is older",$H3&gt;$H2,"second player is older")
                 </f>
                 <v>
@@ -17288,8 +18063,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="71" ht="17.25" customHeight="1" hidden="0">
-            <c r="A71" s="1" t="b">
-                <f>
+            <c r="A71" s="1" cm="1" t="b">
+                <f t="array" ref="A71">
                     ISERROR(0/0)
                 </f>
                 <v>
@@ -17298,8 +18073,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="72" ht="17.25" customHeight="1" hidden="0">
-            <c r="A72" s="1" t="b">
-                <f>
+            <c r="A72" s="1" cm="1" t="b">
+                <f t="array" ref="A72">
                     ISEVEN(3)
                 </f>
                 <v>
@@ -17308,8 +18083,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="73" ht="17.25" customHeight="1" hidden="0">
-            <c r="A73" s="1" t="b">
-                <f>
+            <c r="A73" s="1" cm="1" t="b">
+                <f t="array" ref="A73">
                     ISLOGICAL("TRUE")
                 </f>
                 <v>
@@ -17318,8 +18093,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="74" ht="17.25" customHeight="1" hidden="0">
-            <c r="A74" s="1" t="b">
-                <f>
+            <c r="A74" s="1" cm="1" t="b">
+                <f t="array" ref="A74">
                     ISNONTEXT(TRUE)
                 </f>
                 <v>
@@ -17328,8 +18103,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="75" ht="17.25" customHeight="1" hidden="0">
-            <c r="A75" s="1" t="b">
-                <f>
+            <c r="A75" s="1" cm="1" t="b">
+                <f t="array" ref="A75">
                     ISNUMBER(1231.5)
                 </f>
                 <v>
@@ -17338,8 +18113,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="76" ht="17.25" customHeight="1" hidden="0">
-            <c r="A76" s="1" t="n">
-                <f>
+            <c r="A76" s="1" cm="1" t="n">
+                <f t="array" ref="A76">
                     ISO.CEILING(-7.89)
                 </f>
                 <v>
@@ -17348,8 +18123,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="77" ht="17.25" customHeight="1" hidden="0">
-            <c r="A77" s="1" t="b">
-                <f>
+            <c r="A77" s="1" cm="1" t="b">
+                <f t="array" ref="A77">
                     ISODD(4)
                 </f>
                 <v>
@@ -17358,8 +18133,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="78" ht="17.25" customHeight="1" hidden="0">
-            <c r="A78" s="1" t="n">
-                <f>
+            <c r="A78" s="1" cm="1" t="n">
+                <f t="array" ref="A78">
                     _xlfn.ISOWEEKNUM("2016-01-03")
                 </f>
                 <v>
@@ -17368,8 +18143,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="79" ht="17.25" customHeight="1" hidden="0">
-            <c r="A79" s="1" t="b">
-                <f>
+            <c r="A79" s="1" cm="1" t="b">
+                <f t="array" ref="A79">
                     ISTEXT("123")
                 </f>
                 <v>
@@ -17378,8 +18153,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="80" ht="17.25" customHeight="1" hidden="0">
-            <c r="A80" s="1" t="n">
-                <f>
+            <c r="A80" s="1" cm="1" t="n">
+                <f t="array" ref="A80">
                     LARGE(H2:H9,3)
                 </f>
                 <v>
@@ -17388,8 +18163,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="81" ht="17.25" customHeight="1" hidden="0">
-            <c r="A81" s="1" t="str">
-                <f>
+            <c r="A81" s="1" cm="1" t="str">
+                <f t="array" ref="A81">
                     LEFT("Mich",4)
                 </f>
                 <v>
@@ -17398,8 +18173,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="82" ht="17.25" customHeight="1" hidden="0">
-            <c r="A82" s="1" t="n">
-                <f>
+            <c r="A82" s="1" cm="1" t="n">
+                <f t="array" ref="A82">
                     LEN("anticonstitutionnellement")
                 </f>
                 <v>
@@ -17408,8 +18183,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="83" ht="17.25" customHeight="1" hidden="0">
-            <c r="A83" s="1" t="n">
-                <f>
+            <c r="A83" s="1" cm="1" t="n">
+                <f t="array" ref="A83">
                     ROUND(LN(2),5)
                 </f>
                 <v>
@@ -17418,8 +18193,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="84" ht="17.25" customHeight="1" hidden="0">
-            <c r="A84" s="1" t="n">
-                <f>
+            <c r="A84" s="1" cm="1" t="n">
+                <f t="array" ref="A84">
                     LOOKUP(42,H2:J9)
                 </f>
                 <v>
@@ -17428,8 +18203,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="85" ht="17.25" customHeight="1" hidden="0">
-            <c r="A85" s="1" t="str">
-                <f>
+            <c r="A85" s="1" cm="1" t="str">
+                <f t="array" ref="A85">
                     LOWER("オAドB")
                 </f>
                 <v>
@@ -17438,8 +18213,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="86" ht="17.25" customHeight="1" hidden="0">
-            <c r="A86" s="1" t="n">
-                <f>
+            <c r="A86" s="1" cm="1" t="n">
+                <f t="array" ref="A86">
                     MATCH(42,H2:H9,0)
                 </f>
                 <v>
@@ -17448,8 +18223,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="87" ht="17.25" customHeight="1" hidden="0">
-            <c r="A87" s="1" t="n">
-                <f>
+            <c r="A87" s="1" cm="1" t="n">
+                <f t="array" ref="A87">
                     MAX(N1:N8)
                 </f>
                 <v>
@@ -17458,8 +18233,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="88" ht="17.25" customHeight="1" hidden="0">
-            <c r="A88" s="1" t="n">
-                <f>
+            <c r="A88" s="1" cm="1" t="n">
+                <f t="array" ref="A88">
                     MAXA(N1:N8)
                 </f>
                 <v>
@@ -17468,8 +18243,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="89" ht="17.25" customHeight="1" hidden="0">
-            <c r="A89" s="1" t="n">
-                <f>
+            <c r="A89" s="1" cm="1" t="n">
+                <f t="array" ref="A89">
                     _xlfn.MAXIFS(H2:H9,K2:K9,"&lt;20",K2:K9,"&lt;&gt;4")
                 </f>
                 <v>
@@ -17478,8 +18253,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="90" ht="17.25" customHeight="1" hidden="0">
-            <c r="A90" s="1" t="n">
-                <f>
+            <c r="A90" s="1" cm="1" t="n">
+                <f t="array" ref="A90">
                     MEDIAN(-1,6,7,234,163845)
                 </f>
                 <v>
@@ -17488,8 +18263,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="91" ht="17.25" customHeight="1" hidden="0">
-            <c r="A91" s="1" t="n">
-                <f>
+            <c r="A91" s="1" cm="1" t="n">
+                <f t="array" ref="A91">
                     MIN(N1:N8)
                 </f>
                 <v>
@@ -17498,8 +18273,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="92" ht="17.25" customHeight="1" hidden="0">
-            <c r="A92" s="1" t="n">
-                <f>
+            <c r="A92" s="1" cm="1" t="n">
+                <f t="array" ref="A92">
                     MINA(N1:N8)
                 </f>
                 <v>
@@ -17508,8 +18283,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="93" ht="17.25" customHeight="1" hidden="0">
-            <c r="A93" s="1" t="n">
-                <f>
+            <c r="A93" s="1" cm="1" t="n">
+                <f t="array" ref="A93">
                     _xlfn.MINIFS(J2:J9,H2:H9,"&gt;20")
                 </f>
                 <v>
@@ -17518,8 +18293,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="94" ht="17.25" customHeight="1" hidden="0">
-            <c r="A94" s="1" t="n">
-                <f>
+            <c r="A94" s="1" cm="1" t="n">
+                <f t="array" ref="A94">
                     MINUTE(0.126)
                 </f>
                 <v>
@@ -17528,8 +18303,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="95" ht="17.25" customHeight="1" hidden="0">
-            <c r="A95" s="1" t="n">
-                <f>
+            <c r="A95" s="1" cm="1" t="n">
+                <f t="array" ref="A95">
                     MOD(42,12)
                 </f>
                 <v>
@@ -17538,8 +18313,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="96" ht="17.25" customHeight="1" hidden="0">
-            <c r="A96" s="1" t="n">
-                <f>
+            <c r="A96" s="1" cm="1" t="n">
+                <f t="array" ref="A96">
                     MONTH("1954-05-02")
                 </f>
                 <v>
@@ -17548,8 +18323,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="97" ht="17.25" customHeight="1" hidden="0">
-            <c r="A97" s="1" t="n">
-                <f>
+            <c r="A97" s="1" cm="1" t="n">
+                <f t="array" ref="A97">
                     NETWORKDAYS("2013-01-01","2013-02-01")
                 </f>
                 <v>
@@ -17558,8 +18333,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="98" ht="17.25" customHeight="1" hidden="0">
-            <c r="A98" s="1" t="n">
-                <f>
+            <c r="A98" s="1" cm="1" t="n">
+                <f t="array" ref="A98">
                     NETWORKDAYS.INTL("2013-01-01","2013-02-01","0000111")
                 </f>
                 <v>
@@ -17568,8 +18343,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="99" ht="17.25" customHeight="1" hidden="0">
-            <c r="A99" s="1" t="b">
-                <f>
+            <c r="A99" s="1" cm="1" t="b">
+                <f t="array" ref="A99">
                     NOT(FALSE)
                 </f>
                 <v>
@@ -17578,8 +18353,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="100" ht="17.25" customHeight="1" hidden="0">
-            <c r="A100" s="1" t="n">
-                <f>
+            <c r="A100" s="1" cm="1" t="n">
+                <f t="array" ref="A100">
                     NOW()
                 </f>
                 <v>
@@ -17588,8 +18363,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="101" ht="17.25" customHeight="1" hidden="0">
-            <c r="A101" s="1" t="n">
-                <f>
+            <c r="A101" s="1" cm="1" t="n">
+                <f t="array" ref="A101">
                     ODD(4)
                 </f>
                 <v>
@@ -17598,8 +18373,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="102" ht="17.25" customHeight="1" hidden="0">
-            <c r="A102" s="1" t="b">
-                <f>
+            <c r="A102" s="1" cm="1" t="b">
+                <f t="array" ref="A102">
                     OR("true",FALSE)
                 </f>
                 <v>
@@ -17608,8 +18383,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="103" ht="17.25" customHeight="1" hidden="0">
-            <c r="A103" s="1" t="n">
-                <f>
+            <c r="A103" s="1" cm="1" t="n">
+                <f t="array" ref="A103">
                     PERCENTILE(N1:N5,1)
                 </f>
                 <v>
@@ -17618,8 +18393,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="104" ht="17.25" customHeight="1" hidden="0">
-            <c r="A104" s="1" t="n">
-                <f>
+            <c r="A104" s="1" cm="1" t="n">
+                <f t="array" ref="A104">
                     _xlfn.PERCENTILE.EXC(N1:N5,0.5)
                 </f>
                 <v>
@@ -17628,8 +18403,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="105" ht="17.25" customHeight="1" hidden="0">
-            <c r="A105" s="1" t="n">
-                <f>
+            <c r="A105" s="1" cm="1" t="n">
+                <f t="array" ref="A105">
                     _xlfn.PERCENTILE.INC(N1:N5,0)
                 </f>
                 <v>
@@ -17638,8 +18413,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="106" ht="17.25" customHeight="1" hidden="0">
-            <c r="A106" s="1" t="n">
-                <f>
+            <c r="A106" s="1" cm="1" t="n">
+                <f t="array" ref="A106">
                     PI()
                 </f>
                 <v>
@@ -17648,8 +18423,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="107" ht="17.25" customHeight="1" hidden="0">
-            <c r="A107" s="1" t="n">
-                <f>
+            <c r="A107" s="1" cm="1" t="n">
+                <f t="array" ref="A107">
                     POWER(42,2)
                 </f>
                 <v>
@@ -17658,8 +18433,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="108" ht="17.25" customHeight="1" hidden="0">
-            <c r="A108" s="1" t="n">
-                <f>
+            <c r="A108" s="1" cm="1" t="n">
+                <f t="array" ref="A108">
                     PRODUCT(1,2,3)
                 </f>
                 <v>
@@ -17668,8 +18443,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="109" ht="17.25" customHeight="1" hidden="0">
-            <c r="A109" s="1" t="n">
-                <f>
+            <c r="A109" s="1" cm="1" t="n">
+                <f t="array" ref="A109">
                     QUARTILE(N1:N5,0)
                 </f>
                 <v>
@@ -17678,8 +18453,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="110" ht="17.25" customHeight="1" hidden="0">
-            <c r="A110" s="1" t="n">
-                <f>
+            <c r="A110" s="1" cm="1" t="n">
+                <f t="array" ref="A110">
                     _xlfn.QUARTILE.EXC(N1:N5,1)
                 </f>
                 <v>
@@ -17688,8 +18463,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="111" ht="17.25" customHeight="1" hidden="0">
-            <c r="A111" s="1" t="n">
-                <f>
+            <c r="A111" s="1" cm="1" t="n">
+                <f t="array" ref="A111">
                     _xlfn.QUARTILE.INC(N1:N5,4)
                 </f>
                 <v>
@@ -17698,8 +18473,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="112" ht="17.25" customHeight="1" hidden="0">
-            <c r="A112" s="1" t="n">
-                <f>
+            <c r="A112" s="1" cm="1" t="n">
+                <f t="array" ref="A112">
                     RAND()
                 </f>
                 <v>
@@ -17708,8 +18483,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="113" ht="17.25" customHeight="1" hidden="0">
-            <c r="A113" s="1" t="n">
-                <f>
+            <c r="A113" s="1" cm="1" t="n">
+                <f t="array" ref="A113">
                     RANDBETWEEN(1.1,2)
                 </f>
                 <v>
@@ -17718,8 +18493,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="114" ht="17.25" customHeight="1" hidden="0">
-            <c r="A114" s="1" t="str">
-                <f>
+            <c r="A114" s="1" cm="1" t="str">
+                <f t="array" ref="A114">
                     REPLACE("ABZ",2,1,"Y")
                 </f>
                 <v>
@@ -17728,8 +18503,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="115" ht="17.25" customHeight="1" hidden="0">
-            <c r="A115" s="1" t="str">
-                <f>
+            <c r="A115" s="1" cm="1" t="str">
+                <f t="array" ref="A115">
                     RIGHT("kikou",2)
                 </f>
                 <v>
@@ -17738,8 +18513,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="116" ht="17.25" customHeight="1" hidden="0">
-            <c r="A116" s="1" t="n">
-                <f>
+            <c r="A116" s="1" cm="1" t="n">
+                <f t="array" ref="A116">
                     ROUND(49.9,1)
                 </f>
                 <v>
@@ -17748,8 +18523,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="117" ht="17.25" customHeight="1" hidden="0">
-            <c r="A117" s="1" t="n">
-                <f>
+            <c r="A117" s="1" cm="1" t="n">
+                <f t="array" ref="A117">
                     ROUNDDOWN(42,-1)
                 </f>
                 <v>
@@ -17758,8 +18533,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="118" ht="17.25" customHeight="1" hidden="0">
-            <c r="A118" s="1" t="n">
-                <f>
+            <c r="A118" s="1" cm="1" t="n">
+                <f t="array" ref="A118">
                     ROUNDUP(-1.6,0)
                 </f>
                 <v>
@@ -17768,8 +18543,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="119" ht="17.25" customHeight="1" hidden="0">
-            <c r="A119" s="1" t="n">
-                <f>
+            <c r="A119" s="1" cm="1" t="n">
+                <f t="array" ref="A119">
                     ROW(A234)
                 </f>
                 <v>
@@ -17778,8 +18553,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="120" ht="17.25" customHeight="1" hidden="0">
-            <c r="A120" s="1" t="n">
-                <f>
+            <c r="A120" s="1" cm="1" t="n">
+                <f t="array" ref="A120">
                     ROWS(B3:C40)
                 </f>
                 <v>
@@ -17788,8 +18563,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="121" ht="17.25" customHeight="1" hidden="0">
-            <c r="A121" s="1" t="n">
-                <f>
+            <c r="A121" s="1" cm="1" t="n">
+                <f t="array" ref="A121">
                     SEARCH("C","ABCD")
                 </f>
                 <v>
@@ -17798,8 +18573,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="122" ht="17.25" customHeight="1" hidden="0">
-            <c r="A122" s="1" t="n">
-                <f>
+            <c r="A122" s="1" cm="1" t="n">
+                <f t="array" ref="A122">
                     _xlfn.SEC(PI()/3)
                 </f>
                 <v>
@@ -17808,8 +18583,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="123" ht="17.25" customHeight="1" hidden="0">
-            <c r="A123" s="1" t="n">
-                <f>
+            <c r="A123" s="1" cm="1" t="n">
+                <f t="array" ref="A123">
                     _xlfn.SECH(1)
                 </f>
                 <v>
@@ -17818,8 +18593,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="124" ht="17.25" customHeight="1" hidden="0">
-            <c r="A124" s="1" t="n">
-                <f>
+            <c r="A124" s="1" cm="1" t="n">
+                <f t="array" ref="A124">
                     SECOND("00:21:42")
                 </f>
                 <v>
@@ -17828,8 +18603,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="125" ht="17.25" customHeight="1" hidden="0">
-            <c r="A125" s="1" t="n">
-                <f>
+            <c r="A125" s="1" cm="1" t="n">
+                <f t="array" ref="A125">
                     SIN(PI()/6)
                 </f>
                 <v>
@@ -17838,8 +18613,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="126" ht="17.25" customHeight="1" hidden="0">
-            <c r="A126" s="1" t="n">
-                <f>
+            <c r="A126" s="1" cm="1" t="n">
+                <f t="array" ref="A126">
                     SINH(1)
                 </f>
                 <v>
@@ -17848,8 +18623,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="127" ht="17.25" customHeight="1" hidden="0">
-            <c r="A127" s="1" t="n">
-                <f>
+            <c r="A127" s="1" cm="1" t="n">
+                <f t="array" ref="A127">
                     SMALL(H2:H9,3)
                 </f>
                 <v>
@@ -17858,8 +18633,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="128" ht="17.25" customHeight="1" hidden="0">
-            <c r="A128" s="1" t="n">
-                <f>
+            <c r="A128" s="1" cm="1" t="n">
+                <f t="array" ref="A128">
                     SQRT(4)
                 </f>
                 <v>
@@ -17868,8 +18643,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="129" ht="17.25" customHeight="1" hidden="0">
-            <c r="A129" s="1" t="n">
-                <f>
+            <c r="A129" s="1" cm="1" t="n">
+                <f t="array" ref="A129">
                     STDEV(-2,0,2)
                 </f>
                 <v>
@@ -17878,8 +18653,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="130" ht="17.25" customHeight="1" hidden="0">
-            <c r="A130" s="1" t="n">
-                <f>
+            <c r="A130" s="1" cm="1" t="n">
+                <f t="array" ref="A130">
                     _xlfn.STDEV.P(2,4)
                 </f>
                 <v>
@@ -17888,8 +18663,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="131" ht="17.25" customHeight="1" hidden="0">
-            <c r="A131" s="1" t="n">
-                <f>
+            <c r="A131" s="1" cm="1" t="n">
+                <f t="array" ref="A131">
                     _xlfn.STDEV.S(2,4,6)
                 </f>
                 <v>
@@ -17898,8 +18673,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="132" ht="17.25" customHeight="1" hidden="0">
-            <c r="A132" s="1" t="n">
-                <f>
+            <c r="A132" s="1" cm="1" t="n">
+                <f t="array" ref="A132">
                     STDEVA(TRUE,3,5)
                 </f>
                 <v>
@@ -17908,8 +18683,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="133" ht="17.25" customHeight="1" hidden="0">
-            <c r="A133" s="1" t="n">
-                <f>
+            <c r="A133" s="1" cm="1" t="n">
+                <f t="array" ref="A133">
                     STDEVP(2,5,8)
                 </f>
                 <v>
@@ -17918,8 +18693,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="134" ht="17.25" customHeight="1" hidden="0">
-            <c r="A134" s="1" t="n">
-                <f>
+            <c r="A134" s="1" cm="1" t="n">
+                <f t="array" ref="A134">
                     STDEVPA(TRUE,4,7)
                 </f>
                 <v>
@@ -17928,8 +18703,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="135" ht="17.25" customHeight="1" hidden="0">
-            <c r="A135" s="1" t="str">
-                <f>
+            <c r="A135" s="1" cm="1" t="str">
+                <f t="array" ref="A135">
                     SUBSTITUTE("SAP is best","SAP","Odoo")
                 </f>
                 <v>
@@ -17938,8 +18713,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="136" ht="17.25" customHeight="1" hidden="0">
-            <c r="A136" s="1" t="n">
-                <f>
+            <c r="A136" s="1" cm="1" t="n">
+                <f t="array" ref="A136">
                     SUM(1,2,3,4,5)
                 </f>
                 <v>
@@ -17948,8 +18723,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="137" ht="17.25" customHeight="1" hidden="0">
-            <c r="A137" s="1" t="n">
-                <f>
+            <c r="A137" s="1" cm="1" t="n">
+                <f t="array" ref="A137">
                     SUMIF(K2:K9,"&lt;100")
                 </f>
                 <v>
@@ -17958,8 +18733,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="138" ht="17.25" customHeight="1" hidden="0">
-            <c r="A138" s="1" t="n">
-                <f>
+            <c r="A138" s="1" cm="1" t="n">
+                <f t="array" ref="A138">
                     SUMIFS(H2:H9,K2:K9,"&lt;100")
                 </f>
                 <v>
@@ -17968,8 +18743,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="139" ht="17.25" customHeight="1" hidden="0">
-            <c r="A139" s="1" t="n">
-                <f>
+            <c r="A139" s="1" cm="1" t="n">
+                <f t="array" ref="A139">
                     TAN(PI()/4)
                 </f>
                 <v>
@@ -17978,8 +18753,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="140" ht="17.25" customHeight="1" hidden="0">
-            <c r="A140" s="1" t="n">
-                <f>
+            <c r="A140" s="1" cm="1" t="n">
+                <f t="array" ref="A140">
                     TANH(1)
                 </f>
                 <v>
@@ -17988,8 +18763,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="141" ht="17.25" customHeight="1" hidden="0">
-            <c r="A141" s="1" t="str">
-                <f>
+            <c r="A141" s="1" cm="1" t="str">
+                <f t="array" ref="A141">
                     _xlfn.TEXTJOIN("-",TRUE,"","1","A","%")
                 </f>
                 <v>
@@ -17998,8 +18773,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="142" ht="17.25" customHeight="1" hidden="0">
-            <c r="A142" s="1" t="n">
-                <f>
+            <c r="A142" s="1" cm="1" t="n">
+                <f t="array" ref="A142">
                     TIME(9,11,31)
                 </f>
                 <v>
@@ -18008,8 +18783,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="143" ht="17.25" customHeight="1" hidden="0">
-            <c r="A143" s="1" t="n">
-                <f>
+            <c r="A143" s="1" cm="1" t="n">
+                <f t="array" ref="A143">
                     TIMEVALUE("18:00:00")
                 </f>
                 <v>
@@ -18018,8 +18793,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="144" ht="17.25" customHeight="1" hidden="0">
-            <c r="A144" s="1" t="n">
-                <f>
+            <c r="A144" s="1" cm="1" t="n">
+                <f t="array" ref="A144">
                     TODAY()
                 </f>
                 <v>
@@ -18028,8 +18803,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="145" ht="17.25" customHeight="1" hidden="0">
-            <c r="A145" s="1" t="str">
-                <f>
+            <c r="A145" s="1" cm="1" t="str">
+                <f t="array" ref="A145">
                     TRIM(" Jean Ticonstitutionnalise ")
                 </f>
                 <v>
@@ -18038,8 +18813,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="146" ht="17.25" customHeight="1" hidden="0">
-            <c r="A146" s="1" t="n">
-                <f>
+            <c r="A146" s="1" cm="1" t="n">
+                <f t="array" ref="A146">
                     TRUNC(42.42,1)
                 </f>
                 <v>
@@ -18048,8 +18823,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="147" ht="17.25" customHeight="1" hidden="0">
-            <c r="A147" s="1" t="str">
-                <f>
+            <c r="A147" s="1" cm="1" t="str">
+                <f t="array" ref="A147">
                     UPPER("grrrr !")
                 </f>
                 <v>
@@ -18058,8 +18833,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="148" ht="17.25" customHeight="1" hidden="0">
-            <c r="A148" s="1" t="n">
-                <f>
+            <c r="A148" s="1" cm="1" t="n">
+                <f t="array" ref="A148">
                     VAR(K1:K5)
                 </f>
                 <v>
@@ -18068,8 +18843,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="149" ht="17.25" customHeight="1" hidden="0">
-            <c r="A149" s="1" t="n">
-                <f>
+            <c r="A149" s="1" cm="1" t="n">
+                <f t="array" ref="A149">
                     _xlfn.VAR.P(K1:K5)
                 </f>
                 <v>
@@ -18078,8 +18853,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="150" ht="17.25" customHeight="1" hidden="0">
-            <c r="A150" s="1" t="n">
-                <f>
+            <c r="A150" s="1" cm="1" t="n">
+                <f t="array" ref="A150">
                     _xlfn.VAR.S(2,5,8)
                 </f>
                 <v>
@@ -18088,8 +18863,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="151" ht="17.25" customHeight="1" hidden="0">
-            <c r="A151" s="1" t="n">
-                <f>
+            <c r="A151" s="1" cm="1" t="n">
+                <f t="array" ref="A151">
                     VARA(K1:K5)
                 </f>
                 <v>
@@ -18098,8 +18873,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="152" ht="17.25" customHeight="1" hidden="0">
-            <c r="A152" s="1" t="n">
-                <f>
+            <c r="A152" s="1" cm="1" t="n">
+                <f t="array" ref="A152">
                     VARP(K1:K5)
                 </f>
                 <v>
@@ -18108,8 +18883,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="153" ht="17.25" customHeight="1" hidden="0">
-            <c r="A153" s="1" t="n">
-                <f>
+            <c r="A153" s="1" cm="1" t="n">
+                <f t="array" ref="A153">
                     VARPA(K1:K5)
                 </f>
                 <v>
@@ -18118,8 +18893,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="154" ht="17.25" customHeight="1" hidden="0">
-            <c r="A154" s="1" t="n">
-                <f>
+            <c r="A154" s="1" cm="1" t="n">
+                <f t="array" ref="A154">
                     VLOOKUP("NotACheater",G1:K9,3,FALSE)
                 </f>
                 <v>
@@ -18128,8 +18903,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="155" ht="17.25" customHeight="1" hidden="0">
-            <c r="A155" s="1" t="n">
-                <f>
+            <c r="A155" s="1" cm="1" t="n">
+                <f t="array" ref="A155">
                     WEEKDAY("2021-06-12")
                 </f>
                 <v>
@@ -18138,8 +18913,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="156" ht="17.25" customHeight="1" hidden="0">
-            <c r="A156" s="1" t="n">
-                <f>
+            <c r="A156" s="1" cm="1" t="n">
+                <f t="array" ref="A156">
                     WEEKNUM("2021-06-29")
                 </f>
                 <v>
@@ -18148,8 +18923,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="157" ht="17.25" customHeight="1" hidden="0">
-            <c r="A157" s="1" t="n">
-                <f>
+            <c r="A157" s="1" cm="1" t="n">
+                <f t="array" ref="A157">
                     WORKDAY("2021-03-15",6)
                 </f>
                 <v>
@@ -18158,8 +18933,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="158" ht="17.25" customHeight="1" hidden="0">
-            <c r="A158" s="1" t="n">
-                <f>
+            <c r="A158" s="1" cm="1" t="n">
+                <f t="array" ref="A158">
                     WORKDAY.INTL("2021-03-15",6,"0111111")
                 </f>
                 <v>
@@ -18168,8 +18943,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="159" ht="17.25" customHeight="1" hidden="0">
-            <c r="A159" s="1" t="b">
-                <f>
+            <c r="A159" s="1" cm="1" t="b">
+                <f t="array" ref="A159">
                     _xlfn.XOR(FALSE,TRUE,FALSE,FALSE)
                 </f>
                 <v>
@@ -18178,8 +18953,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="160" ht="17.25" customHeight="1" hidden="0">
-            <c r="A160" s="1" t="n">
-                <f>
+            <c r="A160" s="1" cm="1" t="n">
+                <f t="array" ref="A160">
                     YEAR("2012-03-12")
                 </f>
                 <v>
@@ -18188,8 +18963,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="161" ht="17.25" customHeight="1" hidden="0">
-            <c r="A161" s="1" t="n">
-                <f>
+            <c r="A161" s="1" cm="1" t="n">
+                <f t="array" ref="A161">
                     DELTA(1,1)
                 </f>
                 <v>
@@ -18198,8 +18973,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="162" ht="17.25" customHeight="1" hidden="0">
-            <c r="A162" s="1" t="str">
-                <f>
+            <c r="A162" s="1" cm="1" t="str">
+                <f t="array" ref="A162">
                     NA()
                 </f>
                 <v>
@@ -18208,8 +18983,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="163" ht="17.25" customHeight="1" hidden="0">
-            <c r="A163" s="1" t="b">
-                <f>
+            <c r="A163" s="1" cm="1" t="b">
+                <f t="array" ref="A163">
                     ISNA(A162)
                 </f>
                 <v>
@@ -18218,8 +18993,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="164" ht="17.25" customHeight="1" hidden="0">
-            <c r="A164" s="1" t="b">
-                <f>
+            <c r="A164" s="1" cm="1" t="b">
+                <f t="array" ref="A164">
                     ISERR(A162)
                 </f>
                 <v>
@@ -18228,8 +19003,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="165" ht="17.25" customHeight="1" hidden="0">
-            <c r="A165" s="1" t="str">
-                <f>
+            <c r="A165" s="1" cm="1" t="str">
+                <f t="array" ref="A165">
                     HYPERLINK("https://www.odoo.com","Odoo")
                 </f>
                 <v>
@@ -18238,8 +19013,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="166" ht="17.25" customHeight="1" hidden="0">
-            <c r="A166" s="1" t="str">
-                <f>
+            <c r="A166" s="1" cm="1" t="str">
+                <f t="array" ref="A166">
                     ADDRESS(27,53,4,FALSE,"sheet!")
                 </f>
                 <v>
@@ -18248,8 +19023,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="167" ht="17.25" customHeight="1" hidden="0">
-            <c r="A167" s="1" t="n">
-                <f>
+            <c r="A167" s="1" cm="1" t="n">
+                <f t="array" ref="A167">
                     DATEDIF("2002-01-01","2002-01-02","D")
                 </f>
                 <v>
@@ -18258,8 +19033,8 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="168" ht="17.25" customHeight="1" hidden="0">
-            <c r="A168" s="1" t="n">
-                <f>
+            <c r="A168" s="1" cm="1" t="n">
+                <f t="array" ref="A168:B169">
                     _xlfn.RANDARRAY(2,2)
                 </f>
                 <v>
@@ -18327,6 +19102,29 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
 </worksheet>",
       "contentType": "sheet",
       "path": "xl/worksheets/sheet1.xml",
+    },
+    {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
     },
     {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
@@ -18495,6 +19293,7 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
     <Relationship Id="rId2" Target="worksheets/sheet1.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId3" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId4" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId5" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -18514,6 +19313,7 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml" PartName="/xl/workbook.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet1.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -18600,6 +19400,29 @@ exports[`Test XLSX export formulas Non exportable formulas are exported even wit
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -18660,6 +19483,7 @@ exports[`Test XLSX export formulas Non exportable formulas are exported even wit
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -18678,6 +19502,7 @@ exports[`Test XLSX export formulas Non exportable formulas are exported even wit
     <Default Extension="xml" ContentType="application/xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml" PartName="/xl/workbook.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -18737,6 +19562,29 @@ exports[`Test XLSX export formulas Non exportable functions that is evaluated as
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -18797,6 +19645,7 @@ exports[`Test XLSX export formulas Non exportable functions that is evaluated as
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -18815,6 +19664,7 @@ exports[`Test XLSX export formulas Non exportable functions that is evaluated as
     <Default Extension="xml" ContentType="application/xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml" PartName="/xl/workbook.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -18929,6 +19779,29 @@ exports[`Test XLSX export link cells 1`] = `
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -19004,6 +19877,7 @@ exports[`Test XLSX export link cells 1`] = `
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -19030,6 +19904,7 @@ exports[`Test XLSX export link cells 1`] = `
     <Default Extension="xml" ContentType="application/xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml" PartName="/xl/workbook.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -19443,6 +20318,29 @@ exports[`Test XLSX export multiple elements are exported in the correct order 1`
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -19513,6 +20411,7 @@ exports[`Test XLSX export multiple elements are exported in the correct order 1`
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -19548,6 +20447,7 @@ exports[`Test XLSX export multiple elements are exported in the correct order 1`
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml" PartName="/xl/charts/chart1.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawing+xml" PartName="/xl/drawings/drawing0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -22062,6 +22962,29 @@ exports[`Test XLSX export references with headers should be converted to referen
       "path": "xl/worksheets/sheet0.xml",
     },
     {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
@@ -22116,6 +23039,7 @@ exports[`Test XLSX export references with headers should be converted to referen
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -22154,6 +23078,7 @@ exports[`Test XLSX export references with headers should be converted to referen
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml" PartName="/xl/charts/chart3.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.drawing+xml" PartName="/xl/drawings/drawing0.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",
@@ -22197,8 +23122,8 @@ exports[`Test XLSX export references with headers should be converted to referen
     </cols>
     <sheetData>
         <row r="2" ht="17.25" customHeight="1" hidden="0">
-            <c r="A2" s="1" t="n">
-                <f>
+            <c r="A2" s="1" cm="1" t="n">
+                <f t="array" ref="A2">
                     SUM(B3:B5)
                 </f>
                 <v>
@@ -22236,6 +23161,29 @@ exports[`Test XLSX export references with headers should be converted to referen
 </worksheet>",
       "contentType": "sheet",
       "path": "xl/worksheets/sheet0.xml",
+    },
+    {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
     },
     {
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
@@ -22305,6 +23253,7 @@ exports[`Test XLSX export references with headers should be converted to referen
     <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
     <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
     <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -22323,6 +23272,7 @@ exports[`Test XLSX export references with headers should be converted to referen
     <Default Extension="xml" ContentType="application/xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml" PartName="/xl/workbook.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
     <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
 </Types>",


### PR DESCRIPTION
This commit improves the export of vectorized & array formulas, including those that spill across cells, ensuring better compatibility with other spreadsheet applications. The adopted approach is to treat all formulas as array formulas & to add an additional xml file that contains metadata about array formula properties. As a result, we improve the integrity & usability of our generated XLSX files.

Task: [4134347](https://www.odoo.com/odoo/2328/tasks/4134347)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo