### PR TITLE
[FIX] auto_complete: search pivot value with quotes

### DIFF
--- a/src/registries/auto_completes/pivot_auto_complete.ts
+++ b/src/registries/auto_completes/pivot_auto_complete.ts
@@ -291,7 +291,7 @@ autoCompleteProviders.add("pivot_group_values", {
         text,
         description: usedLabel,
         htmlContent: [{ value: text, color }],
-        fuzzySearchKey: value + usedLabel,
+        fuzzySearchKey: text + usedLabel,
       };
     });
   },

--- a/tests/composer/auto_complete/pivot_auto_complete_store.test.ts
+++ b/tests/composer/auto_complete/pivot_auto_complete_store.test.ts
@@ -300,13 +300,13 @@ describe("spreadsheet pivot auto complete", () => {
     expect(autoComplete?.proposals).toEqual([
       {
         description: "",
-        fuzzySearchKey: "New",
+        fuzzySearchKey: '"New"',
         htmlContent: [{ color: "#00a82d", value: '"New"' }],
         text: '"New"',
       },
       {
         description: "",
-        fuzzySearchKey: "Won",
+        fuzzySearchKey: '"Won"',
         htmlContent: [{ color: "#00a82d", value: '"Won"' }],
         text: '"Won"',
       },
@@ -314,6 +314,26 @@ describe("spreadsheet pivot auto complete", () => {
     autoComplete?.selectProposal(autoComplete?.proposals[0].text);
     expect(composer.currentContent).toBe('=PIVOT.VALUE(1,"Expected Revenue","Stage","New"');
     expect(composer.autocompleteProvider).toBeUndefined();
+  });
+
+  test.each(['"Ne', "Ne"])("PIVOT.VALUE search text field for group value", async (searchTerm) => {
+    const model = createModelWithPivot("A1:I5");
+    updatePivot(model, "1", {
+      columns: [],
+      rows: [{ fieldName: "Stage" }],
+      measures: [{ id: "Expected Revenue:sum", fieldName: "Expected Revenue", aggregator: "sum" }],
+    });
+    const { store: composer } = makeStoreWithModel(model, CellComposerStore);
+    composer.startEdition(`=PIVOT.VALUE(1,"Expected Revenue","Stage",${searchTerm}`);
+    const autoComplete = composer.autocompleteProvider;
+    expect(autoComplete?.proposals).toEqual([
+      {
+        description: "",
+        fuzzySearchKey: '"New"',
+        htmlContent: [{ color: "#00a82d", value: '"New"' }],
+        text: '"New"',
+      },
+    ]);
   });
 
   test("PIVOT.VALUE autocomplete date month_number field for group value", async () => {


### PR DESCRIPTION
## Description:

In the demo sheet, When typing =PIVOT.VALUE(1,"Expected Revenue","Stage", "Ne), we are not getting any suggestions.

The reason is the double quotes, which is not part of the value fuzzy search key and hence the value is filtered out.

Task: [4061068](https://www.odoo.com/odoo/2328/tasks/4061068)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo