### PR TITLE
[PERF] tokenizer: work with slices

### DIFF
--- a/src/formulas/tokenizer.ts
+++ b/src/formulas/tokenizer.ts
@@ -169,20 +169,22 @@ function tokenizeSymbol(chars: TokenizingChars): Token | null {
   // there are two main cases to manage: either something which starts with
   // a ', like 'Sheet 2'A2, or a word-like element.
   if (chars.current === "'") {
-    let lastChar = chars.shift();
-    result += lastChar;
+    let lastChar = chars.current;
+    chars.beginSlice();
+    chars.advanceSliceEnd();
     while (chars.current) {
-      lastChar = chars.shift();
-      result += lastChar;
+      lastChar = chars.current;
+      chars.advanceSliceEnd();
       if (lastChar === "'") {
         if (chars.current && chars.current === "'") {
-          lastChar = chars.shift();
-          result += lastChar;
+          lastChar = chars.current;
+          chars.advanceSliceEnd();
         } else {
           break;
         }
       }
     }
+    result += chars.shiftSlice();
 
     if (lastChar !== "'") {
       return {
@@ -191,9 +193,11 @@ function tokenizeSymbol(chars: TokenizingChars): Token | null {
       };
     }
   }
+  chars.beginSlice();
   while (chars.current && SYMBOL_CHARS.has(chars.current)) {
-    result += chars.shift();
+    chars.advanceSliceEnd();
   }
+  result += chars.shiftSlice();
   if (result.length) {
     const value = result;
     const isReference = rangeReference.test(value);

--- a/src/helpers/misc.ts
+++ b/src/helpers/misc.ts
@@ -576,6 +576,7 @@ export class TokenizingChars {
   private text: string;
   private currentIndex: number = 0;
   current: string;
+  private sliceEndIndex = 0;
 
   constructor(text: string) {
     this.text = text;
@@ -612,6 +613,23 @@ export class TokenizingChars {
       }
     }
     return true;
+  }
+
+  beginSlice() {
+    this.sliceEndIndex = this.currentIndex;
+  }
+
+  advanceSliceEnd() {
+    this.sliceEndIndex++;
+    this.current = this.text[this.sliceEndIndex];
+  }
+
+  shiftSlice() {
+    const nextHead = this.sliceEndIndex;
+    const sliceString = this.text.slice(this.currentIndex, nextHead);
+    this.currentIndex = nextHead;
+    this.current = this.text[nextHead];
+    return sliceString;
   }
 }
 


### PR DESCRIPTION
With this commit, we try to avoid building tokens character by character, but rather by slice of string where it makes sense.

Specifically, we try to avoid the pattern `result += something`in loops where `something` is a single character.

Total memory allocation of `tokenize` (BE timesheet dashboard)

before: 201Mb
after:  128Mb (~36% less)

Total time to create the model:

before: 5003ms
after:  4931ms (~1.5% faster)
(average over 10 runs)

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo