### PR TITLE
[PERF] formulas: add a cache on linear search functions

### DIFF
--- a/src/functions/module_lookup.ts
+++ b/src/functions/module_lookup.ts
@@ -200,7 +200,14 @@ export const HLOOKUP = {
     const _isSorted = toBoolean(isSorted.value);
     const colIndex = _isSorted
       ? dichotomicSearch(range, searchKey, "nextSmaller", "asc", range.length, getValueFromRange)
-      : linearSearch(range, searchKey, "wildcard", range.length, getValueFromRange);
+      : linearSearch(
+          range,
+          searchKey,
+          "wildcard",
+          range.length,
+          getValueFromRange,
+          this.lookupCaches
+        );
     const col = range[colIndex];
     if (col === undefined) {
       return valueNotAvailable(searchKey);
@@ -443,7 +450,7 @@ export const MATCH = {
         index = dichotomicSearch(range, searchKey, "nextSmaller", "asc", rangeLen, getElement);
         break;
       case 0:
-        index = linearSearch(range, searchKey, "wildcard", rangeLen, getElement);
+        index = linearSearch(range, searchKey, "wildcard", rangeLen, getElement, this.lookupCaches);
         break;
       case -1:
         index = dichotomicSearch(range, searchKey, "nextGreater", "desc", rangeLen, getElement);
@@ -556,7 +563,14 @@ export const VLOOKUP = {
     const _isSorted = toBoolean(isSorted.value);
     const rowIndex = _isSorted
       ? dichotomicSearch(range, searchKey, "nextSmaller", "asc", range[0].length, getValueFromRange)
-      : linearSearch(range, searchKey, "wildcard", range[0].length, getValueFromRange);
+      : linearSearch(
+          range,
+          searchKey,
+          "wildcard",
+          range[0].length,
+          getValueFromRange,
+          this.lookupCaches
+        );
 
     const value = range[_index - 1][rowIndex];
     if (value === undefined) {
@@ -671,7 +685,15 @@ export const XLOOKUP = {
             rangeLen,
             getElement
           )
-        : linearSearch(lookupRange, searchKey, mode, rangeLen, getElement, reverseSearch);
+        : linearSearch(
+            lookupRange,
+            searchKey,
+            mode,
+            rangeLen,
+            getElement,
+            this.lookupCaches,
+            reverseSearch
+          );
 
     if (index !== -1) {
       return lookupDirection === "col"

--- a/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
@@ -137,6 +137,10 @@ export class Evaluator {
     );
     this.compilationParams.evalContext.updateDependencies = this.updateDependencies.bind(this);
     this.compilationParams.evalContext.addDependencies = this.addDependencies.bind(this);
+    this.compilationParams.evalContext.lookupCaches = {
+      forwardSearch: new Map(),
+      reverseSearch: new Map(),
+    };
   }
 
   private createEmptyPositionSet() {

--- a/src/types/functions.ts
+++ b/src/types/functions.ts
@@ -59,4 +59,13 @@ export type EvalContext = {
   [key: string]: any;
   updateDependencies?: (position: CellPosition) => void;
   addDependencies?: (position: CellPosition, ranges: Range[]) => void;
+  lookupCaches?: LookupCaches;
+};
+
+/**
+ * used to cache lookup values for linear search
+ **/
+export type LookupCaches = {
+  forwardSearch: Map<unknown, Map<CellValue, number>>;
+  reverseSearch: Map<unknown, Map<CellValue, number>>;
 };


### PR DESCRIPTION
Benchmark for 10 000 Vlookup performed on a random array composed of integer values ​​between 1 and 10000
`=VLOOKUP(A1:A10000,A1:A10000,1,false)`

measures on "linearSearch" before the commit:
- 267 ms (48% of evaluateAllCells)
- 271 ms (48% of evaluateAllCells)
- 296 ms (50% of evaluateAllCells)

measures on "linearSearch" after the commit:
- 4 ms (2% of evaluateAllCells)
- 1 ms (0.5% of evalauteAllCells)
- 2 ms (3 % of evaluateAllCells)

Task: [4080146](https://www.odoo.com/odoo/2328/tasks/4080146)
