### PR TITLE
[FIX] Borders: Fix border continuity

### DIFF
--- a/src/plugins/core/borders.ts
+++ b/src/plugins/core/borders.ts
@@ -302,7 +302,7 @@ export class BordersPlugin extends CorePlugin<BordersPluginState> implements Bor
   private getCommonSides(border1: Border, border2: Border): Border {
     const commonBorder = {};
     for (let side of ["top", "bottom", "left", "right"]) {
-      if (border1[side] && border1[side] === border2[side]) {
+      if (border1[side] && deepEquals(border1[side], border2[side])) {
         commonBorder[side] = border1[side];
       }
     }

--- a/tests/borders/border_plugin.test.ts
+++ b/tests/borders/border_plugin.test.ts
@@ -741,6 +741,66 @@ describe("Grid manipulation", () => {
   });
 });
 
+describe("Border continuity", () => {
+  const border = {
+    top: DEFAULT_BORDER_DESC,
+    left: DEFAULT_BORDER_DESC,
+    right: DEFAULT_BORDER_DESC,
+    bottom: DEFAULT_BORDER_DESC,
+  };
+  test("border continuity is preserved when adding a row before", () => {
+    const model = new Model();
+    setZoneBorders(model, { position: "external" }, ["A1"]);
+    setZoneBorders(model, { position: "external" }, ["A2"]);
+    expect(getBorder(model, "A1")).toEqual(border);
+    expect(getBorder(model, "A2")).toEqual(border);
+    expect(getBorder(model, "A3")).toEqual({ top: DEFAULT_BORDER_DESC });
+    addRows(model, "before", 1, 1);
+    expect(getBorder(model, "A1")).toEqual(border);
+    expect(getBorder(model, "A2")).toEqual(border);
+    expect(getBorder(model, "A3")).toEqual(border);
+  });
+
+  test("border continuity is preserved when adding a row after", () => {
+    const model = new Model();
+    setZoneBorders(model, { position: "external" }, ["A1"]);
+    setZoneBorders(model, { position: "external" }, ["A2"]);
+    expect(getBorder(model, "A1")).toEqual(border);
+    expect(getBorder(model, "A2")).toEqual(border);
+    expect(getBorder(model, "A3")).toEqual({ top: DEFAULT_BORDER_DESC });
+    addRows(model, "after", 0, 1);
+    expect(getBorder(model, "A1")).toEqual(border);
+    expect(getBorder(model, "A2")).toEqual(border);
+    expect(getBorder(model, "A3")).toEqual(border);
+  });
+
+  test("border continuity is preserved when adding a column before", () => {
+    const model = new Model();
+    setZoneBorders(model, { position: "external" }, ["A1"]);
+    setZoneBorders(model, { position: "external" }, ["B1"]);
+    expect(getBorder(model, "A1")).toEqual(border);
+    expect(getBorder(model, "B1")).toEqual(border);
+    expect(getBorder(model, "C1")).toEqual({ left: DEFAULT_BORDER_DESC });
+    addColumns(model, "before", "B", 1);
+    expect(getBorder(model, "A1")).toEqual(border);
+    expect(getBorder(model, "B1")).toEqual(border);
+    expect(getBorder(model, "C1")).toEqual(border);
+  });
+
+  test("border continuity is preserved when adding a column after", () => {
+    const model = new Model();
+    setZoneBorders(model, { position: "external" }, ["A1"]);
+    setZoneBorders(model, { position: "external" }, ["B1"]);
+    expect(getBorder(model, "A1")).toEqual(border);
+    expect(getBorder(model, "B1")).toEqual(border);
+    expect(getBorder(model, "C1")).toEqual({ left: DEFAULT_BORDER_DESC });
+    addColumns(model, "after", "A", 1);
+    expect(getBorder(model, "A1")).toEqual(border);
+    expect(getBorder(model, "B1")).toEqual(border);
+    expect(getBorder(model, "C1")).toEqual(border);
+  });
+});
+
 test("Cells that have undefined borders don't override borders of neighboring cells at import", () => {
   const data = {
     sheets: [


### PR DESCRIPTION
The code that would compare the common sides of two borders was not adapted when we improved the border structure (from a single value to an object with color and style properties). It would make a reference comparison which would sometimes fail, sometimes succeed depending on how the borders were added in the first place.

Task: 4523890

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo