### PR TITLE
[FIX] locale: wrong parsing with "." thousand separator

### DIFF
--- a/src/helpers/numbers.ts
+++ b/src/helpers/numbers.ts
@@ -64,11 +64,12 @@ const getInvaluableSymbolsRegexp = memoize(function getInvaluableSymbolsRegexp(l
  * number from the point of view of the isNumber function.
  */
 export function parseNumber(str: string, locale: Locale): number {
+  // remove invaluable characters
+  str = str.replace(getInvaluableSymbolsRegexp(locale), "");
+
   if (locale.decimalSeparator !== ".") {
     str = str.replace(locale.decimalSeparator, ".");
   }
-  // remove invaluable characters
-  str = str.replace(getInvaluableSymbolsRegexp(locale), "");
   let n = Number(str);
   if (isNaN(n) && str.includes("%")) {
     n = Number(str.split("%")[0]);

--- a/tests/settings/settings_plugin.test.ts
+++ b/tests/settings/settings_plugin.test.ts
@@ -9,7 +9,7 @@ import {
   updateLocale,
 } from "../test_helpers/commands_helpers";
 import { CUSTOM_LOCALE, FR_LOCALE } from "../test_helpers/constants";
-import { getCell, getCellContent } from "../test_helpers/getters_helpers";
+import { getCell, getCellContent, getEvaluatedCell } from "../test_helpers/getters_helpers";
 import { target } from "../test_helpers/helpers";
 
 describe("Settings plugin", () => {
@@ -114,6 +114,22 @@ describe("Settings plugin", () => {
       expect(getCell(model, "A1")?.format).toEqual("yyyy/mm/dd");
       expect(getCell(model, "A2")?.format).toEqual("hh:mm");
       expect(getCell(model, "A3")?.format).toEqual("yyyy/mm/dd hh:mm");
+    });
+
+    test("can use dot as thousand separator", () => {
+      const locale = { ...CUSTOM_LOCALE, decimalSeparator: ",", thousandsSeparator: "." };
+      updateLocale(model, locale);
+      setCellContent(model, "A1", "1000000");
+      setFormat(model, "#,##0.00", target("A1"));
+      expect(getCellContent(model, "A1")).toEqual("1.000.000,00");
+
+      setCellContent(model, "A2", '="1,2" + 1');
+      expect(getEvaluatedCell(model, "A2")?.value).toEqual(2.2);
+      expect(getCellContent(model, "A2")).toEqual("2,2");
+
+      setCellContent(model, "A2", '="1.000,2" + 1');
+      expect(getEvaluatedCell(model, "A2")?.value).toEqual(1001.2);
+      expect(getCellContent(model, "A2")).toEqual("1001,2");
     });
   });
 });


### PR DESCRIPTION
## Description

The parsing of strings to number was wrong if the thousand separator was a ".". We would first replace the locale's thousand separator with JS's thousand separator ("."), and then remove all thousand separators in the string. Thus removing the actual decimal separator.

Task: [4525746](https://www.odoo.com/odoo/2328/tasks/4525746)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo