### PR TITLE
Master composer hover result adrm

### DIFF
--- a/src/components/composer/autocomplete_dropdown/autocomplete_dropdown.xml
+++ b/src/components/composer/autocomplete_dropdown/autocomplete_dropdown.xml
@@ -16,7 +16,7 @@
               t-foreach="htmlContent"
               t-as="content"
               t-key="content_index"
-              t-att-class="content.class"
+              t-att-class="content.classes?.join(' ')"
               t-attf-style="color: {{content.color || 'inherit'}};"
               t-esc="content.value"
             />

--- a/src/components/composer/composer/composer.xml
+++ b/src/components/composer/composer/composer.xml
@@ -31,6 +31,7 @@
           t-on-mousewheel.stop=""
           t-on-input="onInput"
           t-on-pointerdown="onMousedown"
+          t-on-pointerup="onMouseup"
           t-on-click="onClick"
           t-on-keyup="onKeyup"
           t-on-paste="onPaste"
@@ -77,6 +78,11 @@
           />
         </div>
       </div>
+      <SpeechBubble
+        t-if="displaySpeechBubble"
+        content="props.composerStore.hoveredContentEvaluation"
+        anchorRect="composerState.hoveredRect"
+      />
     </div>
   </t>
 </templates>

--- a/src/components/composer/speech_bubble/speech_bubble.ts
+++ b/src/components/composer/speech_bubble/speech_bubble.ts
@@ -1,0 +1,69 @@
+import { Component, useEffect, useRef } from "@odoo/owl";
+import { ComponentsImportance } from "../../../constants";
+import { Rect, SpreadsheetChildEnv } from "../../../types";
+import { css } from "../../helpers";
+import { getBoundingRectAsPOJO } from "../../helpers/dom_helpers";
+import { useSpreadsheetRect } from "../../helpers/position_hook";
+import { Popover } from "../../popover";
+
+const BUBBLE_ARROW_SIZE = 7;
+
+css/* scss */ `
+  .o-spreadsheet {
+    .o-speech-bubble {
+      background-color: white;
+      box-sizing: border-box;
+      box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
+      border: 1px solid #ccc;
+      z-index: ${ComponentsImportance.Popover};
+
+      &::after {
+        content: "";
+        position: absolute;
+        top: 100%;
+        left: 50%;
+        background-color: white;
+        height: ${BUBBLE_ARROW_SIZE}px;
+        width: ${BUBBLE_ARROW_SIZE}px;
+        transform-origin: top left;
+        transform: translate(0, -67%) rotate(45deg);
+        border-right: 1px solid #ccc;
+        border-bottom: 1px solid #ccc;
+        box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
+      }
+    }
+
+    .o-speech-content {
+      max-width: 300px;
+    }
+  }
+`;
+
+export interface Props {
+  anchorRect: Rect;
+  content: string;
+}
+
+export class SpeechBubble extends Component<Props, SpreadsheetChildEnv> {
+  static template = "o-spreadsheet-SpeechBubble";
+  static props = { content: String, anchorRect: Object };
+  static components = { Popover };
+
+  private spreadsheetRect = useSpreadsheetRect();
+  private bubbleRef = useRef("bubble");
+
+  setup(): void {
+    useEffect(() => {
+      const el = this.bubbleRef.el;
+      if (!el) {
+        return;
+      }
+      const anchorRect = this.props.anchorRect;
+      const rect = getBoundingRectAsPOJO(el);
+      const x = anchorRect.x + anchorRect.width / 2 - rect.width / 2 - this.spreadsheetRect.x;
+      const y = anchorRect.y - rect.height - BUBBLE_ARROW_SIZE - this.spreadsheetRect.y;
+      el.style.left = `${x}px`;
+      el.style.top = `${y}px`;
+    });
+  }
+}

--- a/src/components/composer/speech_bubble/speech_bubble.xml
+++ b/src/components/composer/speech_bubble/speech_bubble.xml
@@ -1,0 +1,9 @@
+<templates>
+  <t t-name="o-spreadsheet-SpeechBubble">
+    <t t-portal="'.o-spreadsheet'">
+      <div class="o-speech-bubble position-absolute px-3" t-ref="bubble">
+        <div class="o-speech-content text-truncate pb-1" t-esc="props.content"/>
+      </div>
+    </t>
+  </t>
+</templates>

--- a/src/components/helpers/html_content_helpers.ts
+++ b/src/components/helpers/html_content_helpers.ts
@@ -16,7 +16,7 @@ export function getHtmlContentFromPattern(
     }
     pendingHtmlContent.push(
       { value: value.slice(0, index), color: "" },
-      { value: value[index], color: highlightColor, class: className }
+      { value: value[index], color: highlightColor, classes: [className] }
     );
     value = value.slice(index + 1);
   }

--- a/src/formulas/composer_tokenizer.ts
+++ b/src/formulas/composer_tokenizer.ts
@@ -46,6 +46,7 @@ export interface EnrichedToken extends Token {
   color?: Color;
   isBlurred?: boolean;
   isParenthesisLinkedToCursor?: boolean;
+  isInHoverContext?: boolean;
 }
 
 /**

--- a/src/xlsx/functions/cells.ts
+++ b/src/xlsx/functions/cells.ts
@@ -113,7 +113,12 @@ function addMissingRequiredArgs(ast: ASTFuncall): ASTFuncall {
       // We know that we have at least 1 default Value missing
       for (let i = ast.args.length; i < requiredArgs.length; i++) {
         const currentDefaultArg = exportDefaultArgs[i - diffArgs];
-        args.push({ type: currentDefaultArg.type, value: currentDefaultArg.value });
+        args.push({
+          type: currentDefaultArg.type,
+          value: currentDefaultArg.value,
+          tokenEndIndex: 0,
+          tokenStartIndex: 0,
+        });
       }
     }
   }

--- a/tests/__snapshots__/top_bar_component.test.ts.snap
+++ b/tests/__snapshots__/top_bar_component.test.ts.snap
@@ -691,6 +691,7 @@ exports[`TopBar component can set cell format 1`] = `
                 />
               </div>
               
+              
             </div>
           </div>
         </div>
@@ -1798,6 +1799,7 @@ exports[`TopBar component simple rendering 1`] = `
               tabindex="1"
             />
           </div>
+          
           
         </div>
       </div>

--- a/tests/composer/__snapshots__/composer_component.test.ts.snap
+++ b/tests/composer/__snapshots__/composer_component.test.ts.snap
@@ -46,7 +46,7 @@ exports[`Composer string is correctly translated to DOM Multi-line formula 1`] =
       SUM
     </span>
     <span
-      class="background-flag"
+      class="highlight-parenthesis-flag"
       style="color: rgb(0, 0, 0);"
     >
       (
@@ -59,7 +59,7 @@ exports[`Composer string is correctly translated to DOM Multi-line formula 1`] =
       5
     </span>
     <span
-      class="background-flag"
+      class="highlight-parenthesis-flag"
       style="color: rgb(0, 0, 0);"
     >
       )

--- a/tests/composer/__snapshots__/composer_integration_component.test.ts.snap
+++ b/tests/composer/__snapshots__/composer_integration_component.test.ts.snap
@@ -27,6 +27,7 @@ exports[`Grid composer grid composer basic style Grid composer snapshot 1`] = `
       </div>
     </div>
     
+    
   </div>
 </div>
 `;

--- a/tests/composer/composer_hover.test.ts
+++ b/tests/composer/composer_hover.test.ts
@@ -1,0 +1,357 @@
+import { SpreadsheetChildEnv } from "../../src";
+import { CellComposerStore } from "../../src/components/composer/composer/cell_composer_store";
+import { Model } from "../../src/model";
+import { Store } from "../../src/store_engine";
+import { setCellContent, setFormat, updateLocale } from "../test_helpers/commands_helpers";
+import { FR_LOCALE } from "../test_helpers/constants";
+import { getElStyle, keyDown, triggerMouseEvent } from "../test_helpers/dom_helper";
+import { getEvaluatedCell } from "../test_helpers/getters_helpers";
+import {
+  ComposerWrapper,
+  mountComposerWrapper,
+  mountSpreadsheet,
+  nextTick,
+  typeInComposerGrid,
+  typeInComposerHelper,
+} from "../test_helpers/helpers";
+
+let model: Model;
+let fixture: HTMLElement;
+let composerStore: Store<CellComposerStore>;
+let env: SpreadsheetChildEnv;
+
+export async function hoverComposerContent(content: string) {
+  const spans = fixture.querySelectorAll(".o-composer span");
+  const matchingSpans = Array.from(spans).filter((s) => s.textContent === content);
+  const hoveredSpan = matchingSpans[0];
+  if (!hoveredSpan) {
+    throw new Error(`Span with text ${content} not found`);
+  }
+  triggerMouseEvent(hoveredSpan, "mousemove");
+  jest.runAllTimers();
+  await nextTick();
+}
+
+async function stopHoverComposerContent(content: string) {
+  const composerEl = fixture.querySelector(".o-composer")!;
+  const spans = composerEl.querySelectorAll("span");
+  const hoveredSpan = Array.from(spans).find((s) => s.textContent === content);
+  if (!hoveredSpan) {
+    throw new Error(`Span with text ${content} not found`);
+  }
+  triggerMouseEvent(hoveredSpan, "mouseleave");
+  jest.runAllTimers();
+  await nextTick();
+}
+
+function getHighlightedContent() {
+  const composerEl = fixture.querySelector(".o-composer")!;
+  const spans = composerEl.querySelectorAll("span");
+  return Array.from(spans)
+    .filter((s) => s.classList.contains("highlight-flag"))
+    .map((s) => s.textContent)
+    .join("");
+}
+
+describe("Composer hover", () => {
+  let parent: ComposerWrapper;
+
+  beforeEach(async () => {
+    ({ model, parent, fixture, env } = await mountComposerWrapper());
+    jest.useFakeTimers();
+    composerStore = parent.env.getStore(CellComposerStore);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  async function typeInComposer(text: string, fromScratch: boolean = true) {
+    if (fromScratch) {
+      parent.startComposition();
+    }
+    const composerEl = await typeInComposerHelper("div.o-composer", text, false);
+    return composerEl;
+  }
+
+  test("Hovering a composer token will spawn a speech bubble with the evaluation result", async () => {
+    setCellContent(model, "B1", "56");
+    await typeInComposer("=B1");
+    await hoverComposerContent("=");
+    expect(composerStore.hoveredContentEvaluation).toEqual("56");
+    expect(".o-speech-bubble").toHaveText("56");
+  });
+
+  test("Speech bubble disappear when stopping the hover", async () => {
+    await typeInComposer("=12");
+    await hoverComposerContent("=");
+    expect(".o-speech-bubble").toHaveText("12");
+
+    await stopHoverComposerContent("=");
+    expect(".o-speech-bubble").toHaveCount(0);
+  });
+
+  test("Hovered content is highlighted", async () => {
+    await typeInComposer("=SUM(A1+2) * 8");
+    await hoverComposerContent("SUM");
+    expect(getHighlightedContent()).toEqual("SUM(A1+2)");
+
+    await stopHoverComposerContent("SUM");
+    expect(getHighlightedContent()).toEqual("");
+
+    await hoverComposerContent("*");
+    expect(getHighlightedContent()).toEqual("=SUM(A1+2) * 8");
+  });
+
+  test("Hovering a space or a argument separator does nothing", async () => {
+    await typeInComposer("=SUM(8, 2)");
+    await hoverComposerContent(" ");
+    expect(".o-speech-bubble").toHaveCount(0);
+
+    await hoverComposerContent(",");
+    expect(".o-speech-bubble").toHaveCount(0);
+  });
+
+  test("Can hover primitive types", async () => {
+    await typeInComposer('=CONCAT(1, "hello", TRue)');
+
+    await hoverComposerContent("1");
+    expect(".o-speech-bubble").toHaveText("1");
+
+    await hoverComposerContent('"hello"');
+    expect(".o-speech-bubble").toHaveText('"hello"');
+
+    await hoverComposerContent("TRue");
+    expect(".o-speech-bubble").toHaveText("TRUE");
+  });
+
+  test("Can hover an error", async () => {
+    setCellContent(model, "B1", "=SUM(");
+    await typeInComposer("=B1 + DIVIDE(1, 0)");
+
+    await hoverComposerContent("=");
+    expect(".o-speech-bubble").toHaveText("#BAD_EXPR");
+
+    await hoverComposerContent("B1");
+    expect(".o-speech-bubble").toHaveText("#BAD_EXPR");
+
+    await hoverComposerContent("DIVIDE");
+    expect(".o-speech-bubble").toHaveText("#DIV/0!");
+  });
+
+  test("Can hover a reference", async () => {
+    setCellContent(model, "B1", "128");
+    await typeInComposer("=B1");
+    await hoverComposerContent("B1");
+
+    expect(".o-speech-bubble").toHaveText("128");
+  });
+
+  test("Can hover a range", async () => {
+    setCellContent(model, "B1", "128");
+    setCellContent(model, "C2", "256");
+
+    await typeInComposer("=SUM(B1:C2)");
+    await hoverComposerContent("B1:C2");
+
+    expect(".o-speech-bubble").toHaveText("{128,0;0,256}");
+  });
+
+  test("Can hover any token to get an evaluation result", async () => {
+    setCellContent(model, "B1", "10");
+    await typeInComposer("=SUM(B1 + B1)");
+
+    await hoverComposerContent("=");
+    expect(".o-speech-bubble").toHaveText("20");
+
+    await hoverComposerContent("SUM");
+    expect(".o-speech-bubble").toHaveText("20");
+
+    await hoverComposerContent("(");
+    expect(".o-speech-bubble").toHaveText("20");
+
+    await hoverComposerContent("B1");
+    expect(".o-speech-bubble").toHaveText("10");
+
+    await hoverComposerContent("+");
+    expect(".o-speech-bubble").toHaveText("20");
+
+    await hoverComposerContent(")");
+    expect(".o-speech-bubble").toHaveText("20");
+  });
+
+  test("Hovered tokens take operation priority into account", async () => {
+    await typeInComposer("=SUM(5 * 5 + 6) - 12 / SUM(6)");
+
+    await hoverComposerContent("*");
+    expect(getHighlightedContent()).toEqual("5 * 5");
+    expect(".o-speech-bubble").toHaveText("25");
+
+    await hoverComposerContent("+");
+    expect(getHighlightedContent()).toEqual("5 * 5 + 6");
+    expect(".o-speech-bubble").toHaveText("31");
+
+    await hoverComposerContent("-");
+    expect(getHighlightedContent()).toEqual("=SUM(5 * 5 + 6) - 12 / SUM(6)");
+    expect(".o-speech-bubble").toHaveText("29");
+
+    await hoverComposerContent("/");
+    expect(getHighlightedContent()).toEqual("12 / SUM(6)");
+    expect(".o-speech-bubble").toHaveText("2");
+  });
+
+  test("Speech bubble content is formatted", async () => {
+    setCellContent(model, "B1", "5");
+    setFormat(model, "B1", "0.0$");
+
+    setCellContent(model, "C1", "1.1000000001");
+    expect(getEvaluatedCell(model, "C1").formattedValue).toEqual("1.1"); // default format
+
+    await typeInComposer("=B1+DATE(2025,1,1)+C1");
+    await hoverComposerContent("B1");
+    expect(".o-speech-bubble").toHaveText("5.0$");
+
+    await hoverComposerContent("DATE");
+    expect(".o-speech-bubble").toHaveText("1/1/2025");
+
+    await hoverComposerContent("C1");
+    expect(".o-speech-bubble").toHaveText("1.1");
+  });
+
+  test("Can hover localized content", async () => {
+    setCellContent(model, "B1", "1.5");
+    updateLocale(model, FR_LOCALE);
+    await typeInComposer("=B1 + SUM(1,5;12)");
+
+    await hoverComposerContent("=");
+    expect(".o-speech-bubble").toHaveText("15");
+
+    await hoverComposerContent("B1");
+    expect(".o-speech-bubble").toHaveText("1,5");
+
+    await hoverComposerContent("SUM");
+    expect(".o-speech-bubble").toHaveText("13,5");
+
+    await hoverComposerContent("1,5");
+    expect(".o-speech-bubble").toHaveText("1,5");
+  });
+
+  test("Can hover formula starting with +", async () => {
+    await typeInComposer("+9 - SUM(1,3)");
+    await hoverComposerContent("+");
+    expect(".o-speech-bubble").toHaveText("5");
+  });
+
+  test("Hovering an unfinished formula add the missing parenthesis before evaluating", async () => {
+    await typeInComposer("=MINUS(8,7)+SUM(5");
+    await hoverComposerContent("=");
+    expect(".o-speech-bubble").toHaveText("6");
+
+    await hoverComposerContent("MINUS");
+    expect(".o-speech-bubble").toHaveText("1");
+  });
+
+  test("Hovering elements do nothing if the selection start and end are different", async () => {
+    await typeInComposer("=12");
+    composerStore.changeComposerCursorSelection(0, 2);
+    await nextTick();
+    await hoverComposerContent("=");
+    expect(".o-speech-bubble").toHaveCount(0);
+  });
+
+  test("Bubble disappear when selecting a text with the mouse", async () => {
+    await typeInComposer("=12");
+    await hoverComposerContent("=");
+    expect(".o-speech-bubble").toHaveText("12");
+
+    const spans = fixture.querySelectorAll(".o-composer span");
+    triggerMouseEvent(spans[0], "pointerdown");
+    const selection = document.getSelection()!;
+    const range = document.createRange();
+    range.setStart(spans[0].childNodes[0], 0);
+    range.setEnd(spans[1].childNodes[0], 1);
+    selection.addRange(range);
+    triggerMouseEvent(spans[1], "pointerup");
+    await nextTick();
+
+    expect(".o-speech-bubble").toHaveCount(0);
+  });
+
+  test("Speech bubble is positioned in the middle of the hovered token", async () => {
+    const originalGetBoundingClientRect = HTMLElement.prototype.getBoundingClientRect;
+    jest
+      .spyOn(HTMLElement.prototype, "getBoundingClientRect")
+      .mockImplementation(function (this: HTMLElement) {
+        if (this.classList.contains("o-spreadsheet")) {
+          return { left: 66, top: 66, width: 555, height: 555 } as DOMRect;
+        }
+        if (this.classList.contains("o-speech-bubble")) {
+          return { x: 0, y: 0, width: 100, height: 50 } as DOMRect;
+        } else if (this.textContent === "=") {
+          return { x: 10, y: 10, width: 20, height: 20 } as DOMRect;
+        }
+        return originalGetBoundingClientRect.call(this);
+      });
+
+    await typeInComposer("=50");
+    await hoverComposerContent("=");
+
+    // center of bubble at the center of the hovered token
+    expect(getElStyle(".o-speech-bubble", "left")).toEqual(10 + 20 / 2 - 100 / 2 - 66 + "px");
+    // top above the hovered token + BUBBLE_ARROW_SIZE (7px)
+    expect(getElStyle(".o-speech-bubble", "top")).toEqual(10 - 50 - 7 - 66 + "px");
+    jest.restoreAllMocks();
+  });
+
+  test("Speech bubble do not move if hovering another token within the same evaluation context", async () => {
+    const originalGetBoundingClientRect = HTMLElement.prototype.getBoundingClientRect;
+    jest
+      .spyOn(HTMLElement.prototype, "getBoundingClientRect")
+      .mockImplementation(function (this: HTMLElement) {
+        if (this.classList.contains("o-speech-bubble")) {
+          return { x: 0, y: 0, width: 100, height: 50 } as DOMRect;
+        } else if (this.textContent === "SUM") {
+          return { x: 10, y: 10, width: 20, height: 20 } as DOMRect;
+        } else if (this.textContent === "(") {
+          return { x: 20, y: 10, width: 20, height: 20 } as DOMRect;
+        }
+        return originalGetBoundingClientRect.call(this);
+      });
+
+    await typeInComposer("=SUM(A1)");
+
+    await hoverComposerContent("SUM");
+    expect(getElStyle(".o-speech-bubble", "left")).toEqual("-30px");
+
+    await hoverComposerContent("(");
+    expect(getElStyle(".o-speech-bubble", "left")).toEqual("-30px");
+    jest.restoreAllMocks();
+  });
+});
+
+describe("Composer hover integration test", () => {
+  beforeEach(async () => {
+    ({ model, fixture, env } = await mountSpreadsheet());
+    composerStore = env.getStore(CellComposerStore);
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test("Speech bubble disappear when opening another grid composer", async () => {
+    await typeInComposerGrid("=12");
+    await hoverComposerContent("=");
+    expect(".o-grid-composer .o-composer.active").toHaveCount(1);
+    expect(".o-speech-bubble").toHaveText("12");
+
+    await keyDown({ key: "Enter" });
+    expect(".o-grid-composer .o-composer.active").toHaveCount(0);
+    expect(".o-speech-bubble").toHaveCount(0);
+
+    await keyDown({ key: "Enter" });
+    expect(".o-grid-composer .o-composer.active").toHaveCount(1);
+    expect(".o-speech-bubble").toHaveCount(0);
+  });
+});

--- a/tests/evaluation/__snapshots__/composer_tokenizer.test.ts.snap
+++ b/tests/evaluation/__snapshots__/composer_tokenizer.test.ts.snap
@@ -40,6 +40,8 @@ exports[`composerTokenizer = SUM ( C4 : C5 ) 1`] = `
       "argPosition": 0,
       "args": [
         {
+          "tokenEndIndex": 1,
+          "tokenStartIndex": 1,
           "type": "REFERENCE",
           "value": "C4 : C5",
         },
@@ -58,6 +60,8 @@ exports[`composerTokenizer = SUM ( C4 : C5 ) 1`] = `
       "argPosition": 0,
       "args": [
         {
+          "tokenEndIndex": 1,
+          "tokenStartIndex": 1,
           "type": "REFERENCE",
           "value": "C4 : C5",
         },
@@ -76,6 +80,8 @@ exports[`composerTokenizer = SUM ( C4 : C5 ) 1`] = `
       "argPosition": 0,
       "args": [
         {
+          "tokenEndIndex": 1,
+          "tokenStartIndex": 1,
           "type": "REFERENCE",
           "value": "C4 : C5",
         },
@@ -94,6 +100,8 @@ exports[`composerTokenizer = SUM ( C4 : C5 ) 1`] = `
       "argPosition": 0,
       "args": [
         {
+          "tokenEndIndex": 1,
+          "tokenStartIndex": 1,
           "type": "REFERENCE",
           "value": "C4 : C5",
         },
@@ -141,10 +149,14 @@ exports[`composerTokenizer base tests Boolean 1`] = `
       "argPosition": 0,
       "args": [
         {
+          "tokenEndIndex": 0,
+          "tokenStartIndex": 0,
           "type": "BOOLEAN",
           "value": true,
         },
         {
+          "tokenEndIndex": 0,
+          "tokenStartIndex": 0,
           "type": "BOOLEAN",
           "value": false,
         },
@@ -163,10 +175,14 @@ exports[`composerTokenizer base tests Boolean 1`] = `
       "argPosition": 0,
       "args": [
         {
+          "tokenEndIndex": 0,
+          "tokenStartIndex": 0,
           "type": "BOOLEAN",
           "value": true,
         },
         {
+          "tokenEndIndex": 0,
+          "tokenStartIndex": 0,
           "type": "BOOLEAN",
           "value": false,
         },
@@ -185,10 +201,14 @@ exports[`composerTokenizer base tests Boolean 1`] = `
       "argPosition": 1,
       "args": [
         {
+          "tokenEndIndex": 0,
+          "tokenStartIndex": 0,
           "type": "BOOLEAN",
           "value": true,
         },
         {
+          "tokenEndIndex": 0,
+          "tokenStartIndex": 0,
           "type": "BOOLEAN",
           "value": false,
         },
@@ -207,10 +227,14 @@ exports[`composerTokenizer base tests Boolean 1`] = `
       "argPosition": 1,
       "args": [
         {
+          "tokenEndIndex": 0,
+          "tokenStartIndex": 0,
           "type": "BOOLEAN",
           "value": true,
         },
         {
+          "tokenEndIndex": 0,
+          "tokenStartIndex": 0,
           "type": "BOOLEAN",
           "value": false,
         },
@@ -258,36 +282,52 @@ exports[`composerTokenizer base tests formula token 1`] = `
       "argPosition": 0,
       "args": [
         {
+          "tokenEndIndex": 0,
+          "tokenStartIndex": 0,
           "type": "NUMBER",
           "value": 1,
         },
         {
           "left": {
+            "tokenEndIndex": 1,
+            "tokenStartIndex": 1,
             "type": "NUMBER",
             "value": 1,
           },
           "right": {
+            "tokenEndIndex": 3,
+            "tokenStartIndex": 3,
             "type": "NUMBER",
             "value": 2,
           },
+          "tokenEndIndex": 4,
+          "tokenStartIndex": 0,
           "type": "BIN_OPERATION",
           "value": "+",
         },
         {
           "args": [
             {
+              "tokenEndIndex": 3,
+              "tokenStartIndex": 3,
               "type": "NUMBER",
               "value": 2,
             },
             {
+              "tokenEndIndex": 6,
+              "tokenStartIndex": 6,
               "type": "NUMBER",
               "value": 3,
             },
           ],
+          "tokenEndIndex": 7,
+          "tokenStartIndex": 0,
           "type": "FUNCALL",
           "value": "ADD",
         },
         {
+          "tokenEndIndex": 0,
+          "tokenStartIndex": 0,
           "type": "NUMBER",
           "value": 4,
         },
@@ -306,36 +346,52 @@ exports[`composerTokenizer base tests formula token 1`] = `
       "argPosition": 0,
       "args": [
         {
+          "tokenEndIndex": 0,
+          "tokenStartIndex": 0,
           "type": "NUMBER",
           "value": 1,
         },
         {
           "left": {
+            "tokenEndIndex": 1,
+            "tokenStartIndex": 1,
             "type": "NUMBER",
             "value": 1,
           },
           "right": {
+            "tokenEndIndex": 3,
+            "tokenStartIndex": 3,
             "type": "NUMBER",
             "value": 2,
           },
+          "tokenEndIndex": 4,
+          "tokenStartIndex": 0,
           "type": "BIN_OPERATION",
           "value": "+",
         },
         {
           "args": [
             {
+              "tokenEndIndex": 3,
+              "tokenStartIndex": 3,
               "type": "NUMBER",
               "value": 2,
             },
             {
+              "tokenEndIndex": 6,
+              "tokenStartIndex": 6,
               "type": "NUMBER",
               "value": 3,
             },
           ],
+          "tokenEndIndex": 7,
+          "tokenStartIndex": 0,
           "type": "FUNCALL",
           "value": "ADD",
         },
         {
+          "tokenEndIndex": 0,
+          "tokenStartIndex": 0,
           "type": "NUMBER",
           "value": 4,
         },
@@ -354,36 +410,52 @@ exports[`composerTokenizer base tests formula token 1`] = `
       "argPosition": 0,
       "args": [
         {
+          "tokenEndIndex": 0,
+          "tokenStartIndex": 0,
           "type": "NUMBER",
           "value": 1,
         },
         {
           "left": {
+            "tokenEndIndex": 1,
+            "tokenStartIndex": 1,
             "type": "NUMBER",
             "value": 1,
           },
           "right": {
+            "tokenEndIndex": 3,
+            "tokenStartIndex": 3,
             "type": "NUMBER",
             "value": 2,
           },
+          "tokenEndIndex": 4,
+          "tokenStartIndex": 0,
           "type": "BIN_OPERATION",
           "value": "+",
         },
         {
           "args": [
             {
+              "tokenEndIndex": 3,
+              "tokenStartIndex": 3,
               "type": "NUMBER",
               "value": 2,
             },
             {
+              "tokenEndIndex": 6,
+              "tokenStartIndex": 6,
               "type": "NUMBER",
               "value": 3,
             },
           ],
+          "tokenEndIndex": 7,
+          "tokenStartIndex": 0,
           "type": "FUNCALL",
           "value": "ADD",
         },
         {
+          "tokenEndIndex": 0,
+          "tokenStartIndex": 0,
           "type": "NUMBER",
           "value": 4,
         },
@@ -402,36 +474,52 @@ exports[`composerTokenizer base tests formula token 1`] = `
       "argPosition": 1,
       "args": [
         {
+          "tokenEndIndex": 0,
+          "tokenStartIndex": 0,
           "type": "NUMBER",
           "value": 1,
         },
         {
           "left": {
+            "tokenEndIndex": 1,
+            "tokenStartIndex": 1,
             "type": "NUMBER",
             "value": 1,
           },
           "right": {
+            "tokenEndIndex": 3,
+            "tokenStartIndex": 3,
             "type": "NUMBER",
             "value": 2,
           },
+          "tokenEndIndex": 4,
+          "tokenStartIndex": 0,
           "type": "BIN_OPERATION",
           "value": "+",
         },
         {
           "args": [
             {
+              "tokenEndIndex": 3,
+              "tokenStartIndex": 3,
               "type": "NUMBER",
               "value": 2,
             },
             {
+              "tokenEndIndex": 6,
+              "tokenStartIndex": 6,
               "type": "NUMBER",
               "value": 3,
             },
           ],
+          "tokenEndIndex": 7,
+          "tokenStartIndex": 0,
           "type": "FUNCALL",
           "value": "ADD",
         },
         {
+          "tokenEndIndex": 0,
+          "tokenStartIndex": 0,
           "type": "NUMBER",
           "value": 4,
         },
@@ -482,36 +570,52 @@ exports[`composerTokenizer base tests formula token 1`] = `
       "argPosition": 1,
       "args": [
         {
+          "tokenEndIndex": 0,
+          "tokenStartIndex": 0,
           "type": "NUMBER",
           "value": 1,
         },
         {
           "left": {
+            "tokenEndIndex": 1,
+            "tokenStartIndex": 1,
             "type": "NUMBER",
             "value": 1,
           },
           "right": {
+            "tokenEndIndex": 3,
+            "tokenStartIndex": 3,
             "type": "NUMBER",
             "value": 2,
           },
+          "tokenEndIndex": 4,
+          "tokenStartIndex": 0,
           "type": "BIN_OPERATION",
           "value": "+",
         },
         {
           "args": [
             {
+              "tokenEndIndex": 3,
+              "tokenStartIndex": 3,
               "type": "NUMBER",
               "value": 2,
             },
             {
+              "tokenEndIndex": 6,
+              "tokenStartIndex": 6,
               "type": "NUMBER",
               "value": 3,
             },
           ],
+          "tokenEndIndex": 7,
+          "tokenStartIndex": 0,
           "type": "FUNCALL",
           "value": "ADD",
         },
         {
+          "tokenEndIndex": 0,
+          "tokenStartIndex": 0,
           "type": "NUMBER",
           "value": 4,
         },
@@ -530,36 +634,52 @@ exports[`composerTokenizer base tests formula token 1`] = `
       "argPosition": 2,
       "args": [
         {
+          "tokenEndIndex": 0,
+          "tokenStartIndex": 0,
           "type": "NUMBER",
           "value": 1,
         },
         {
           "left": {
+            "tokenEndIndex": 1,
+            "tokenStartIndex": 1,
             "type": "NUMBER",
             "value": 1,
           },
           "right": {
+            "tokenEndIndex": 3,
+            "tokenStartIndex": 3,
             "type": "NUMBER",
             "value": 2,
           },
+          "tokenEndIndex": 4,
+          "tokenStartIndex": 0,
           "type": "BIN_OPERATION",
           "value": "+",
         },
         {
           "args": [
             {
+              "tokenEndIndex": 3,
+              "tokenStartIndex": 3,
               "type": "NUMBER",
               "value": 2,
             },
             {
+              "tokenEndIndex": 6,
+              "tokenStartIndex": 6,
               "type": "NUMBER",
               "value": 3,
             },
           ],
+          "tokenEndIndex": 7,
+          "tokenStartIndex": 0,
           "type": "FUNCALL",
           "value": "ADD",
         },
         {
+          "tokenEndIndex": 0,
+          "tokenStartIndex": 0,
           "type": "NUMBER",
           "value": 4,
         },
@@ -578,36 +698,52 @@ exports[`composerTokenizer base tests formula token 1`] = `
       "argPosition": 2,
       "args": [
         {
+          "tokenEndIndex": 0,
+          "tokenStartIndex": 0,
           "type": "NUMBER",
           "value": 1,
         },
         {
           "left": {
+            "tokenEndIndex": 1,
+            "tokenStartIndex": 1,
             "type": "NUMBER",
             "value": 1,
           },
           "right": {
+            "tokenEndIndex": 3,
+            "tokenStartIndex": 3,
             "type": "NUMBER",
             "value": 2,
           },
+          "tokenEndIndex": 4,
+          "tokenStartIndex": 0,
           "type": "BIN_OPERATION",
           "value": "+",
         },
         {
           "args": [
             {
+              "tokenEndIndex": 3,
+              "tokenStartIndex": 3,
               "type": "NUMBER",
               "value": 2,
             },
             {
+              "tokenEndIndex": 6,
+              "tokenStartIndex": 6,
               "type": "NUMBER",
               "value": 3,
             },
           ],
+          "tokenEndIndex": 7,
+          "tokenStartIndex": 0,
           "type": "FUNCALL",
           "value": "ADD",
         },
         {
+          "tokenEndIndex": 0,
+          "tokenStartIndex": 0,
           "type": "NUMBER",
           "value": 4,
         },
@@ -626,36 +762,52 @@ exports[`composerTokenizer base tests formula token 1`] = `
       "argPosition": 2,
       "args": [
         {
+          "tokenEndIndex": 0,
+          "tokenStartIndex": 0,
           "type": "NUMBER",
           "value": 1,
         },
         {
           "left": {
+            "tokenEndIndex": 1,
+            "tokenStartIndex": 1,
             "type": "NUMBER",
             "value": 1,
           },
           "right": {
+            "tokenEndIndex": 3,
+            "tokenStartIndex": 3,
             "type": "NUMBER",
             "value": 2,
           },
+          "tokenEndIndex": 4,
+          "tokenStartIndex": 0,
           "type": "BIN_OPERATION",
           "value": "+",
         },
         {
           "args": [
             {
+              "tokenEndIndex": 3,
+              "tokenStartIndex": 3,
               "type": "NUMBER",
               "value": 2,
             },
             {
+              "tokenEndIndex": 6,
+              "tokenStartIndex": 6,
               "type": "NUMBER",
               "value": 3,
             },
           ],
+          "tokenEndIndex": 7,
+          "tokenStartIndex": 0,
           "type": "FUNCALL",
           "value": "ADD",
         },
         {
+          "tokenEndIndex": 0,
+          "tokenStartIndex": 0,
           "type": "NUMBER",
           "value": 4,
         },
@@ -674,10 +826,14 @@ exports[`composerTokenizer base tests formula token 1`] = `
       "argPosition": 0,
       "args": [
         {
+          "tokenEndIndex": 0,
+          "tokenStartIndex": 0,
           "type": "NUMBER",
           "value": 2,
         },
         {
+          "tokenEndIndex": 1,
+          "tokenStartIndex": 1,
           "type": "NUMBER",
           "value": 3,
         },
@@ -696,10 +852,14 @@ exports[`composerTokenizer base tests formula token 1`] = `
       "argPosition": 0,
       "args": [
         {
+          "tokenEndIndex": 0,
+          "tokenStartIndex": 0,
           "type": "NUMBER",
           "value": 2,
         },
         {
+          "tokenEndIndex": 1,
+          "tokenStartIndex": 1,
           "type": "NUMBER",
           "value": 3,
         },
@@ -718,10 +878,14 @@ exports[`composerTokenizer base tests formula token 1`] = `
       "argPosition": 1,
       "args": [
         {
+          "tokenEndIndex": 0,
+          "tokenStartIndex": 0,
           "type": "NUMBER",
           "value": 2,
         },
         {
+          "tokenEndIndex": 1,
+          "tokenStartIndex": 1,
           "type": "NUMBER",
           "value": 3,
         },
@@ -740,10 +904,14 @@ exports[`composerTokenizer base tests formula token 1`] = `
       "argPosition": 1,
       "args": [
         {
+          "tokenEndIndex": 0,
+          "tokenStartIndex": 0,
           "type": "NUMBER",
           "value": 2,
         },
         {
+          "tokenEndIndex": 1,
+          "tokenStartIndex": 1,
           "type": "NUMBER",
           "value": 3,
         },
@@ -762,10 +930,14 @@ exports[`composerTokenizer base tests formula token 1`] = `
       "argPosition": 1,
       "args": [
         {
+          "tokenEndIndex": 0,
+          "tokenStartIndex": 0,
           "type": "NUMBER",
           "value": 2,
         },
         {
+          "tokenEndIndex": 1,
+          "tokenStartIndex": 1,
           "type": "NUMBER",
           "value": 3,
         },
@@ -784,36 +956,52 @@ exports[`composerTokenizer base tests formula token 1`] = `
       "argPosition": 2,
       "args": [
         {
+          "tokenEndIndex": 0,
+          "tokenStartIndex": 0,
           "type": "NUMBER",
           "value": 1,
         },
         {
           "left": {
+            "tokenEndIndex": 1,
+            "tokenStartIndex": 1,
             "type": "NUMBER",
             "value": 1,
           },
           "right": {
+            "tokenEndIndex": 3,
+            "tokenStartIndex": 3,
             "type": "NUMBER",
             "value": 2,
           },
+          "tokenEndIndex": 4,
+          "tokenStartIndex": 0,
           "type": "BIN_OPERATION",
           "value": "+",
         },
         {
           "args": [
             {
+              "tokenEndIndex": 3,
+              "tokenStartIndex": 3,
               "type": "NUMBER",
               "value": 2,
             },
             {
+              "tokenEndIndex": 6,
+              "tokenStartIndex": 6,
               "type": "NUMBER",
               "value": 3,
             },
           ],
+          "tokenEndIndex": 7,
+          "tokenStartIndex": 0,
           "type": "FUNCALL",
           "value": "ADD",
         },
         {
+          "tokenEndIndex": 0,
+          "tokenStartIndex": 0,
           "type": "NUMBER",
           "value": 4,
         },
@@ -832,36 +1020,52 @@ exports[`composerTokenizer base tests formula token 1`] = `
       "argPosition": 3,
       "args": [
         {
+          "tokenEndIndex": 0,
+          "tokenStartIndex": 0,
           "type": "NUMBER",
           "value": 1,
         },
         {
           "left": {
+            "tokenEndIndex": 1,
+            "tokenStartIndex": 1,
             "type": "NUMBER",
             "value": 1,
           },
           "right": {
+            "tokenEndIndex": 3,
+            "tokenStartIndex": 3,
             "type": "NUMBER",
             "value": 2,
           },
+          "tokenEndIndex": 4,
+          "tokenStartIndex": 0,
           "type": "BIN_OPERATION",
           "value": "+",
         },
         {
           "args": [
             {
+              "tokenEndIndex": 3,
+              "tokenStartIndex": 3,
               "type": "NUMBER",
               "value": 2,
             },
             {
+              "tokenEndIndex": 6,
+              "tokenStartIndex": 6,
               "type": "NUMBER",
               "value": 3,
             },
           ],
+          "tokenEndIndex": 7,
+          "tokenStartIndex": 0,
           "type": "FUNCALL",
           "value": "ADD",
         },
         {
+          "tokenEndIndex": 0,
+          "tokenStartIndex": 0,
           "type": "NUMBER",
           "value": 4,
         },
@@ -880,36 +1084,52 @@ exports[`composerTokenizer base tests formula token 1`] = `
       "argPosition": 3,
       "args": [
         {
+          "tokenEndIndex": 0,
+          "tokenStartIndex": 0,
           "type": "NUMBER",
           "value": 1,
         },
         {
           "left": {
+            "tokenEndIndex": 1,
+            "tokenStartIndex": 1,
             "type": "NUMBER",
             "value": 1,
           },
           "right": {
+            "tokenEndIndex": 3,
+            "tokenStartIndex": 3,
             "type": "NUMBER",
             "value": 2,
           },
+          "tokenEndIndex": 4,
+          "tokenStartIndex": 0,
           "type": "BIN_OPERATION",
           "value": "+",
         },
         {
           "args": [
             {
+              "tokenEndIndex": 3,
+              "tokenStartIndex": 3,
               "type": "NUMBER",
               "value": 2,
             },
             {
+              "tokenEndIndex": 6,
+              "tokenStartIndex": 6,
               "type": "NUMBER",
               "value": 3,
             },
           ],
+          "tokenEndIndex": 7,
+          "tokenStartIndex": 0,
           "type": "FUNCALL",
           "value": "ADD",
         },
         {
+          "tokenEndIndex": 0,
+          "tokenStartIndex": 0,
           "type": "NUMBER",
           "value": 4,
         },

--- a/tests/evaluation/parser.test.ts
+++ b/tests/evaluation/parser.test.ts
@@ -1,9 +1,9 @@
-import { astToFormula, parse } from "../../src";
+import { astToFormula, parse, tokenize } from "../../src";
 import { CellErrorType } from "../../src/types/errors";
 
 describe("parser", () => {
   test("can parse a function call with no argument", () => {
-    expect(parse("RAND()")).toEqual({ type: "FUNCALL", value: "RAND", args: [] });
+    expect(parse("RAND()")).toMatchObject({ type: "FUNCALL", value: "RAND", args: [] });
   });
 
   test("cannot parse a quoted function call", () => {
@@ -11,7 +11,7 @@ describe("parser", () => {
   });
 
   test("can parse a function call with one argument", () => {
-    expect(parse("SUM(1)")).toEqual({
+    expect(parse("SUM(1)")).toMatchObject({
       type: "FUNCALL",
       value: "SUM",
       args: [{ type: "NUMBER", value: 1 }],
@@ -19,7 +19,7 @@ describe("parser", () => {
   });
 
   test("can parse a function call with sub expressions as argument", () => {
-    expect(parse("IF(A1 > 0, 1, 2)")).toEqual({
+    expect(parse("IF(A1 > 0, 1, 2)")).toMatchObject({
       type: "FUNCALL",
       value: "IF",
       args: [
@@ -56,7 +56,7 @@ describe("parser", () => {
   });
 
   test("add a EMPTY token for empty arguments", () => {
-    expect(parse("SUM(1,)")).toEqual({
+    expect(parse("SUM(1,)")).toMatchObject({
       type: "FUNCALL",
       value: "SUM",
       args: [
@@ -64,7 +64,7 @@ describe("parser", () => {
         { type: "EMPTY", value: "" },
       ],
     });
-    expect(parse("SUM(,1)")).toEqual({
+    expect(parse("SUM(,1)")).toMatchObject({
       type: "FUNCALL",
       value: "SUM",
       args: [
@@ -72,7 +72,7 @@ describe("parser", () => {
         { type: "NUMBER", value: 1 },
       ],
     });
-    expect(parse("SUM(,)")).toEqual({
+    expect(parse("SUM(,)")).toMatchObject({
       type: "FUNCALL",
       value: "SUM",
       args: [
@@ -80,7 +80,7 @@ describe("parser", () => {
         { type: "EMPTY", value: "" },
       ],
     });
-    expect(parse("SUM(,,)")).toEqual({
+    expect(parse("SUM(,,)")).toMatchObject({
       type: "FUNCALL",
       value: "SUM",
       args: [
@@ -89,7 +89,7 @@ describe("parser", () => {
         { type: "EMPTY", value: "" },
       ],
     });
-    expect(parse("SUM(,,,1)")).toEqual({
+    expect(parse("SUM(,,,1)")).toMatchObject({
       type: "FUNCALL",
       value: "SUM",
       args: [
@@ -102,12 +102,12 @@ describe("parser", () => {
   });
 
   test("can parse unary operations", () => {
-    expect(parse("-1")).toEqual({
+    expect(parse("-1")).toMatchObject({
       type: "UNARY_OPERATION",
       value: "-",
       operand: { type: "NUMBER", value: 1 },
     });
-    expect(parse("+1")).toEqual({
+    expect(parse("+1")).toMatchObject({
       type: "UNARY_OPERATION",
       value: "+",
       operand: { type: "NUMBER", value: 1 },
@@ -115,13 +115,13 @@ describe("parser", () => {
   });
 
   test("can parse % operator", () => {
-    expect(parse("1%")).toEqual({
+    expect(parse("1%")).toMatchObject({
       type: "UNARY_OPERATION",
       value: "%",
       operand: { type: "NUMBER", value: 1 },
       postfix: true,
     });
-    expect(parse("100 %")).toEqual({
+    expect(parse("100 %")).toMatchObject({
       type: "UNARY_OPERATION",
       value: "%",
       operand: { type: "NUMBER", value: 100 },
@@ -130,18 +130,18 @@ describe("parser", () => {
   });
 
   test("can parse numeric values", () => {
-    expect(parse("1")).toEqual({ type: "NUMBER", value: 1 });
-    expect(parse("1.5")).toEqual({ type: "NUMBER", value: 1.5 });
-    expect(parse("1.")).toEqual({ type: "NUMBER", value: 1 });
-    expect(parse(".5")).toEqual({ type: "NUMBER", value: 0.5 });
+    expect(parse("1")).toMatchObject({ type: "NUMBER", value: 1 });
+    expect(parse("1.5")).toMatchObject({ type: "NUMBER", value: 1.5 });
+    expect(parse("1.")).toMatchObject({ type: "NUMBER", value: 1 });
+    expect(parse(".5")).toMatchObject({ type: "NUMBER", value: 0.5 });
   });
 
   test("can parse string without ending double quotes", () => {
-    expect(parse('"hello')).toEqual({ type: "STRING", value: "hello" });
+    expect(parse('"hello')).toMatchObject({ type: "STRING", value: "hello" });
   });
 
   test("can parse binary operations", () => {
-    expect(parse("2-3")).toEqual({
+    expect(parse("2-3")).toMatchObject({
       type: "BIN_OPERATION",
       value: "-",
       left: { type: "NUMBER", value: 2 },
@@ -150,7 +150,7 @@ describe("parser", () => {
   });
 
   test("can parse expression with parenthesis", () => {
-    expect(parse("(2+3)")).toEqual({
+    expect(parse("(2+3)")).toMatchObject({
       type: "BIN_OPERATION",
       value: "+",
       left: { type: "NUMBER", value: 2 },
@@ -163,7 +163,7 @@ describe("parser", () => {
   });
 
   test("can parse concat operator", () => {
-    expect(parse("A1&A2")).toEqual({
+    expect(parse("A1&A2")).toMatchObject({
       type: "BIN_OPERATION",
       value: "&",
       left: { type: "REFERENCE", value: "A1" },
@@ -172,7 +172,7 @@ describe("parser", () => {
   });
 
   test("Can parse invalid references", () => {
-    expect(parse("#REF")).toEqual({
+    expect(parse("#REF")).toMatchObject({
       type: "REFERENCE",
       value: CellErrorType.InvalidReference,
     });
@@ -183,7 +183,7 @@ describe("parser", () => {
   });
 
   test("AND", () => {
-    expect(parse("=AND(true, false)")).toEqual({
+    expect(parse("=AND(true, false)")).toMatchObject({
       type: "FUNCALL",
       value: "AND",
       args: [
@@ -191,7 +191,7 @@ describe("parser", () => {
         { type: "BOOLEAN", value: false },
       ],
     });
-    expect(parse("=AND(0, tRuE)")).toEqual({
+    expect(parse("=AND(0, tRuE)")).toMatchObject({
       type: "FUNCALL",
       value: "AND",
       args: [
@@ -202,14 +202,14 @@ describe("parser", () => {
   });
 
   test("can parse simple symbol", () => {
-    expect(parse("Hello")).toEqual({
+    expect(parse("Hello")).toMatchObject({
       type: "SYMBOL",
       value: "Hello",
     });
   });
 
   test("can parse quoted symbol", () => {
-    expect(parse("'Hello world'")).toEqual({
+    expect(parse("'Hello world'")).toMatchObject({
       type: "SYMBOL",
       value: "Hello world",
     });
@@ -217,6 +217,212 @@ describe("parser", () => {
 
   test("cannot parse unquoted symbol with space", () => {
     expect(() => parse("Hello world")).toThrow("Invalid expression");
+  });
+
+  describe("Parser saves the token indexes in the AST", () => {
+    test("Simple formula", () => {
+      const formula = "SUM(A1)";
+      const tokens = tokenize(formula);
+
+      expect(parse(formula)).toMatchObject({
+        type: "FUNCALL",
+        value: "SUM",
+        tokenStartIndex: 0,
+        tokenEndIndex: tokens.findIndex((t) => t.value === ")"),
+        args: [
+          {
+            type: "REFERENCE",
+            value: "A1",
+            tokenStartIndex: tokens.findIndex((t) => t.value === "A1"),
+            tokenEndIndex: tokens.findIndex((t) => t.value === "A1"),
+          },
+        ],
+      });
+    });
+
+    test("Simple prefix unary operator", () => {
+      const formula = "-A1";
+      const tokens = tokenize(formula);
+
+      expect(parse(formula)).toMatchObject({
+        type: "UNARY_OPERATION",
+        value: "-",
+        tokenStartIndex: 0,
+        tokenEndIndex: tokens.findIndex((t) => t.value === "A1"),
+        operand: {
+          type: "REFERENCE",
+          value: "A1",
+          tokenStartIndex: tokens.findIndex((t) => t.value === "A1"),
+          tokenEndIndex: tokens.findIndex((t) => t.value === "A1"),
+        },
+      });
+    });
+
+    test("Simple suffix unary operator", () => {
+      const formula = "12%";
+      const tokens = tokenize(formula);
+
+      expect(parse(formula)).toMatchObject({
+        type: "UNARY_OPERATION",
+        value: "%",
+        tokenStartIndex: 0,
+        tokenEndIndex: tokens.findIndex((t) => t.value === "%"),
+        operand: {
+          type: "NUMBER",
+          value: 12,
+          tokenStartIndex: 0,
+          tokenEndIndex: 0,
+        },
+        postfix: true,
+      });
+    });
+
+    test("Simple binary operator", () => {
+      const formula = "A1+B2";
+      const tokens = tokenize(formula);
+
+      expect(parse(formula)).toMatchObject({
+        type: "BIN_OPERATION",
+        value: "+",
+        tokenStartIndex: tokens.findIndex((t) => t.value === "A1"),
+        tokenEndIndex: tokens.findIndex((t) => t.value === "B2"),
+        left: {
+          type: "REFERENCE",
+          value: "A1",
+          tokenStartIndex: tokens.findIndex((t) => t.value === "A1"),
+          tokenEndIndex: tokens.findIndex((t) => t.value === "A1"),
+        },
+        right: {
+          type: "REFERENCE",
+          value: "B2",
+          tokenStartIndex: tokens.findIndex((t) => t.value === "B2"),
+          tokenEndIndex: tokens.findIndex((t) => t.value === "B2"),
+        },
+      });
+    });
+
+    test("With parenthesis", () => {
+      const formula = "((A1+B2))";
+      const tokens = tokenize(formula);
+
+      expect(parse(formula)).toMatchObject({
+        type: "BIN_OPERATION",
+        value: "+",
+        tokenStartIndex: 0,
+        tokenEndIndex: 6,
+        left: {
+          type: "REFERENCE",
+          value: "A1",
+          tokenStartIndex: tokens.findIndex((t) => t.value === "A1"),
+          tokenEndIndex: tokens.findIndex((t) => t.value === "A1"),
+        },
+        right: {
+          type: "REFERENCE",
+          value: "B2",
+          tokenStartIndex: tokens.findIndex((t) => t.value === "B2"),
+          tokenEndIndex: tokens.findIndex((t) => t.value === "B2"),
+        },
+      });
+    });
+
+    test("Complex formula", () => {
+      const formula = "SUM(A1+(-B2),12%)+15";
+      const tokens = tokenize(formula);
+
+      expect(parse(formula)).toMatchObject({
+        type: "BIN_OPERATION",
+        value: "+",
+        tokenStartIndex: 0,
+        tokenEndIndex: tokens.length - 1,
+        left: {
+          type: "FUNCALL",
+          value: "SUM",
+          tokenStartIndex: 0,
+          tokenEndIndex: 11,
+          args: [
+            {
+              type: "BIN_OPERATION",
+              value: "+",
+              tokenStartIndex: 2,
+              tokenEndIndex: 7,
+              left: {
+                type: "REFERENCE",
+                value: "A1",
+                tokenStartIndex: 2,
+                tokenEndIndex: 2,
+              },
+              right: {
+                type: "UNARY_OPERATION",
+                value: "-",
+                tokenStartIndex: 4,
+                tokenEndIndex: 7,
+                operand: {
+                  type: "REFERENCE",
+                  value: "B2",
+                  tokenStartIndex: 6,
+                  tokenEndIndex: 6,
+                },
+              },
+            },
+            {
+              type: "UNARY_OPERATION",
+              value: "%",
+              tokenStartIndex: 9,
+              tokenEndIndex: 10,
+              operand: {
+                type: "NUMBER",
+                value: 12,
+                tokenStartIndex: 9,
+                tokenEndIndex: 9,
+              },
+              postfix: true,
+            },
+          ],
+        },
+        right: {
+          type: "NUMBER",
+          value: 15,
+          tokenStartIndex: 13,
+          tokenEndIndex: 13,
+        },
+      });
+    });
+
+    test("With = at the start", () => {
+      const formula = "=A1";
+      const tokens = tokenize(formula);
+
+      expect(parse(formula)).toMatchObject({
+        type: "REFERENCE",
+        value: "A1",
+        tokenStartIndex: tokens.findIndex((t) => t.value === "A1"),
+        tokenEndIndex: tokens.findIndex((t) => t.value === "A1"),
+      });
+    });
+
+    test("With spaces", () => {
+      const formula = "  A1  +  B2  ";
+      const tokens = tokenize(formula);
+
+      expect(parse(formula)).toMatchObject({
+        type: "BIN_OPERATION",
+        value: "+",
+        tokenStartIndex: tokens.findIndex((t) => t.value === "A1"),
+        tokenEndIndex: tokens.findIndex((t) => t.value === "B2"),
+        left: {
+          type: "REFERENCE",
+          value: "A1",
+          tokenStartIndex: tokens.findIndex((t) => t.value === "A1"),
+          tokenEndIndex: tokens.findIndex((t) => t.value === "A1"),
+        },
+        right: {
+          type: "REFERENCE",
+          value: "B2",
+          tokenStartIndex: tokens.findIndex((t) => t.value === "B2"),
+          tokenEndIndex: tokens.findIndex((t) => t.value === "B2"),
+        },
+      });
+    });
   });
 });
 

--- a/tests/grid/__snapshots__/grid_component.test.ts.snap
+++ b/tests/grid/__snapshots__/grid_component.test.ts.snap
@@ -93,6 +93,7 @@ exports[`Grid component simple rendering snapshot 1`] = `
         />
       </div>
       
+      
     </div>
   </div>
   

--- a/tests/spreadsheet/__snapshots__/spreadsheet_component.test.ts.snap
+++ b/tests/spreadsheet/__snapshots__/spreadsheet_component.test.ts.snap
@@ -691,6 +691,7 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
               />
             </div>
             
+            
           </div>
         </div>
       </div>
@@ -811,6 +812,7 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
                 tabindex="1"
               />
             </div>
+            
             
           </div>
         </div>
@@ -1695,6 +1697,7 @@ exports[`components take the small screen into account 1`] = `
               />
             </div>
             
+            
           </div>
         </div>
       </div>
@@ -1815,6 +1818,7 @@ exports[`components take the small screen into account 1`] = `
                 tabindex="1"
               />
             </div>
+            
             
           </div>
         </div>

--- a/tests/test_helpers/helpers.ts
+++ b/tests/test_helpers/helpers.ts
@@ -1024,6 +1024,7 @@ type ComposerWrapperProps = {
 export class ComposerWrapper extends Component<ComposerWrapperProps, SpreadsheetChildEnv> {
   static components = { Composer };
   static template = xml/*xml*/ `
+    <div class="o-spreadsheet"/>
     <Composer t-props="composerProps"/>
   `;
   static props = { composerProps: Object, focusComposer: String };


### PR DESCRIPTION
## Description:

### [IMP] composer: preview formula expressions result

This commit adds a preview of the formula expression result in the
composer when hovering over a formula token. We can hover any part of
the formula (a range, a primitive, a sub-formula, etc.) and see the
result of the expression in a speech bubble. This allows for easy
debugging of complex formulas.


### [MOV] test: move some composer tests in correct files

Some tests in the `composer_component.test.ts` were mounting a
spreadsheet after a ComposerWrapper was already mounted in the
beforeEach.

It caused issue with the following commit that adds a Portal target in
the ComposerWrapper. This led to two Portal targets in the document and
a test failing.

This commit moves these tests to the `composer_integration_component.test.ts`
file where they belong.

Task: [4471274](https://www.odoo.com/odoo/2328/tasks/4471274)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo