### PR TITLE
[REF] viewport: rename getter isPositionVisible

### DIFF
--- a/src/components/helpers/figure_snap_helper.ts
+++ b/src/components/helpers/figure_snap_helper.ts
@@ -192,7 +192,7 @@ function isAxisVisible<T extends HFigureAxisType | VFigureAxisType>(
       break;
   }
 
-  return axisStartEndPositions.some(getters.isPositionVisible);
+  return axisStartEndPositions.some(getters.isPixelPositionVisible);
 }
 
 /**

--- a/src/plugins/ui_stateful/sheetview.ts
+++ b/src/plugins/ui_stateful/sheetview.ts
@@ -101,7 +101,7 @@ export class SheetViewPlugin extends UIPlugin {
     "getSheetViewVisibleCols",
     "getSheetViewVisibleRows",
     "getFrozenSheetViewRatio",
-    "isPositionVisible",
+    "isPixelPositionVisible",
     "getColDimensionsInViewport",
     "getRowDimensionsInViewport",
     "getAllActiveViewportsZones",
@@ -854,7 +854,7 @@ export class SheetViewPlugin extends UIPlugin {
     return result;
   }
 
-  isPositionVisible(position: PixelPosition): boolean {
+  isPixelPositionVisible(position: PixelPosition): boolean {
     const { scrollX, scrollY } = this.getters.getActiveSheetScrollInfo();
     const { x: mainViewportX, y: mainViewportY } = this.getters.getMainViewportCoordinates();
     const { width, height } = this.getters.getSheetViewDimension();


### PR DESCRIPTION
There are two getters that can be confused.
`isPositionVisible` and `isVisibleInViewport`.

By looking at their names, it's hard to know the difference.

`isPositionVisible` expectings a pixel position { x, y }.

If proof is needed that this naming is misleading, `isPositionVisible` is
used only once in Odoo—and it's incorrect! The correct getter to use in that
case is `isVisibleInViewport`.

Task: 0

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo