### PR TITLE
[IMP] OT: add registry for operation values transform

### DIFF
--- a/src/collaborative/ot/ot.ts
+++ b/src/collaborative/ot/ot.ts
@@ -6,6 +6,7 @@ import {
   moveHeaderIndexesOnHeaderAddition,
   moveHeaderIndexesOnHeaderDeletion,
 } from "../../helpers/index";
+import { deepCopy } from "../../helpers/misc";
 import { otRegistry } from "../../registries/ot_registry";
 import { ovtRegistry } from "../../registries/ovt_registry";
 import {
@@ -103,7 +104,7 @@ export function transformAll(
   let transformedCommands = [...toTransform];
   for (const executedCommand of executed) {
     transformedCommands = transformedCommands
-      .map((cmd) => transform(cmd, executedCommand, coreGetters))
+      .map((cmd) => transform(deepCopy(cmd), executedCommand, coreGetters))
       .filter(isDefined);
   }
   return transformedCommands;

--- a/src/collaborative/ot/ovt_specific.ts
+++ b/src/collaborative/ot/ovt_specific.ts
@@ -1,0 +1,65 @@
+import { ovtRegistry } from "../../registries/ovt_registry";
+import {
+  AddConditionalFormatCommand,
+  AddDataValidationCommand,
+  AddPivotCommand,
+  UpdateCellCommand,
+} from "../../types/commands";
+import { CoreGetters } from "../../types/getters";
+import { ApplyRangeChangeSheet } from "../../types/misc";
+
+function updateCellCommandAdaptRange(
+  cmd: UpdateCellCommand,
+  getters: CoreGetters,
+  applyChange: ApplyRangeChangeSheet
+): UpdateCellCommand {
+  cmd.content =
+    cmd.content &&
+    getters.adaptFormulaStringDependencies(cmd.sheetId, cmd.content, applyChange.applyChange);
+  return cmd;
+}
+ovtRegistry.addValue("UPDATE_CELL", updateCellCommandAdaptRange);
+
+function addConditionalFormatCommandAdaptRange(
+  cmd: AddConditionalFormatCommand,
+  getters: CoreGetters,
+  applyChange: ApplyRangeChangeSheet
+): AddConditionalFormatCommand {
+  if (cmd.cf.rule.type == "CellIsRule") {
+    cmd.cf.rule.values = cmd.cf.rule.values.map((val) =>
+      getters.adaptFormulaStringDependencies(cmd.sheetId, val, applyChange.applyChange)
+    );
+  }
+  return cmd;
+}
+ovtRegistry.addValue("ADD_CONDITIONAL_FORMAT", addConditionalFormatCommandAdaptRange);
+
+function addDataValidationCommandAdaptRange(
+  cmd: AddDataValidationCommand,
+  getters: CoreGetters,
+  applyChange: ApplyRangeChangeSheet
+): AddDataValidationCommand {
+  cmd.rule.criterion.values = cmd.rule.criterion.values.map((val) =>
+    getters.adaptFormulaStringDependencies(cmd.sheetId, val, applyChange.applyChange)
+  );
+  return cmd;
+}
+ovtRegistry.addValue("ADD_DATA_VALIDATION_RULE", addDataValidationCommandAdaptRange);
+
+function addPivotCommandAdaptRange(
+  cmd: AddPivotCommand,
+  getters: CoreGetters,
+  applyChange: ApplyRangeChangeSheet
+): AddPivotCommand {
+  cmd.pivot.measures.map((msr) => {
+    if (msr.computedBy) {
+      msr.computedBy.formula = getters.adaptFormulaStringDependencies(
+        msr.computedBy.sheetId,
+        msr.computedBy.formula,
+        applyChange.applyChange
+      );
+    }
+  });
+  return cmd;
+}
+ovtRegistry.addValue("ADD_PIVOT", addPivotCommandAdaptRange);

--- a/src/collaborative/session.ts
+++ b/src/collaborative/session.ts
@@ -19,6 +19,7 @@ import {
   StateUpdateMessage,
   TransportService,
 } from "../types/collaborative/transport_service";
+import { CoreGetters } from "../types/getters";
 import { Command } from "./../types/commands";
 import { transformAll } from "./ot/ot";
 import { Revision } from "./revisions";
@@ -66,7 +67,8 @@ export class Session extends EventBus<CollaborativeEvent> {
   constructor(
     private revisions: RevisionLog<Revision>,
     private transportService: TransportService<CollaborationMessage>,
-    private serverRevisionId: UID = DEFAULT_REVISION_ID
+    private serverRevisionId: UID = DEFAULT_REVISION_ID,
+    private CoreGetters: CoreGetters
   ) {
     super();
 
@@ -304,7 +306,7 @@ export class Session extends EventBus<CollaborativeEvent> {
             .map((msg) => (msg as RemoteRevisionMessage).commands)
             .flat();
           this.trigger("remote-revision-received", {
-            commands: transformAll(commands, pendingCommands),
+            commands: transformAll(commands, pendingCommands, this.CoreGetters),
           });
         }
         break;

--- a/src/helpers/range.ts
+++ b/src/helpers/range.ts
@@ -1,19 +1,38 @@
 import { _t } from "../translation";
 import {
+  AddColumnsRowsCommand,
+  ApplyRangeChange,
+  ApplyRangeChangeSheet,
   CellPosition,
+  ChangeType,
+  Command,
   CoreGetters,
   CustomizedDataSet,
+  DeleteSheetCommand,
   Getters,
+  MoveRangeCommand,
   Range,
   RangeData,
   RangePart,
+  RemoveColumnsRowsCommand,
+  RenameSheetCommand,
   UID,
   UnboundedZone,
   Zone,
   ZoneDimension,
 } from "../types";
+import { CellErrorType } from "../types/errors";
+import { groupConsecutive, largeMax, largeMin } from "./misc";
 import { isRowReference, splitReference } from "./references";
-import { getZoneArea, isZoneOrdered, positions, toUnboundedZone, zoneToXc } from "./zones";
+import {
+  createAdaptedZone,
+  getZoneArea,
+  isZoneInside,
+  isZoneOrdered,
+  positions,
+  toUnboundedZone,
+  zoneToXc,
+} from "./zones";
 
 interface ConstructorArgs {
   readonly zone: Readonly<Zone | UnboundedZone>;
@@ -273,4 +292,176 @@ export function getCellPositionsInRanges(ranges: Range[]): CellPosition[] {
     }
   }
   return cellPositions;
+}
+
+export function getApplyRangeChange(
+  cmd: Command,
+  getters: CoreGetters
+): ApplyRangeChangeSheet | undefined {
+  switch (cmd.type) {
+    case "REMOVE_COLUMNS_ROWS":
+      return { applyChange: getApplyRangeChangeRemoveColRow(cmd), sheetId: cmd.sheetId };
+    case "ADD_COLUMNS_ROWS":
+      return { applyChange: getApplyRangeChangeAddColRow(cmd), sheetId: cmd.sheetId };
+    case "DELETE_SHEET":
+      return { applyChange: getApplyRangeChangeDeleteSheet(cmd, getters), sheetId: cmd.sheetId };
+    case "RENAME_SHEET":
+      return { applyChange: getApplyRangeChangeRenameSheet(cmd) };
+    case "MOVE_RANGES":
+      return { applyChange: getApplyRangeChangeMoveRange(cmd) };
+  }
+  return undefined;
+}
+
+function getApplyRangeChangeRemoveColRow(cmd: RemoveColumnsRowsCommand): ApplyRangeChange {
+  let start: "left" | "top" = cmd.dimension === "COL" ? "left" : "top";
+  let end: "right" | "bottom" = cmd.dimension === "COL" ? "right" : "bottom";
+  let dimension: "columns" | "rows" = cmd.dimension === "COL" ? "columns" : "rows";
+
+  const elements = [...cmd.elements];
+  elements.sort((a, b) => b - a);
+
+  const groups = groupConsecutive(elements);
+  return (range: RangeImpl) => {
+    if (range.sheetId !== cmd.sheetId) {
+      return { changeType: "NONE" };
+    }
+    let newRange = range;
+    let changeType: ChangeType = "NONE";
+    for (let group of groups) {
+      const min = largeMin(group);
+      const max = largeMax(group);
+      if (range.zone[start] <= min && min <= range.zone[end]) {
+        const toRemove = Math.min(range.zone[end], max) - min + 1;
+        changeType = "RESIZE";
+        newRange = createAdaptedRange(newRange, dimension, changeType, -toRemove);
+      } else if (range.zone[start] >= min && range.zone[end] <= max) {
+        changeType = "REMOVE";
+        newRange = range.clone({ ...getInvalidRange() });
+      } else if (range.zone[start] <= max && range.zone[end] >= max) {
+        const toRemove = max - range.zone[start] + 1;
+        changeType = "RESIZE";
+        newRange = createAdaptedRange(newRange, dimension, changeType, -toRemove);
+        newRange = createAdaptedRange(newRange, dimension, "MOVE", -(range.zone[start] - min));
+      } else if (min < range.zone[start]) {
+        changeType = "MOVE";
+        newRange = createAdaptedRange(newRange, dimension, changeType, -(max - min + 1));
+      }
+    }
+    if (changeType !== "NONE") {
+      return { changeType, range: newRange };
+    }
+    return { changeType: "NONE" };
+  };
+}
+
+function getApplyRangeChangeAddColRow(cmd: AddColumnsRowsCommand): ApplyRangeChange {
+  let start: "left" | "top" = cmd.dimension === "COL" ? "left" : "top";
+  let end: "right" | "bottom" = cmd.dimension === "COL" ? "right" : "bottom";
+  let dimension: "columns" | "rows" = cmd.dimension === "COL" ? "columns" : "rows";
+
+  return (range: RangeImpl) => {
+    if (range.sheetId !== cmd.sheetId) {
+      return { changeType: "NONE" };
+    }
+    if (cmd.position === "after") {
+      if (range.zone[start] <= cmd.base && cmd.base < range.zone[end]) {
+        return {
+          changeType: "RESIZE",
+          range: createAdaptedRange(range, dimension, "RESIZE", cmd.quantity),
+        };
+      }
+      if (cmd.base < range.zone[start]) {
+        return {
+          changeType: "MOVE",
+          range: createAdaptedRange(range, dimension, "MOVE", cmd.quantity),
+        };
+      }
+    } else {
+      if (range.zone[start] < cmd.base && cmd.base <= range.zone[end]) {
+        return {
+          changeType: "RESIZE",
+          range: createAdaptedRange(range, dimension, "RESIZE", cmd.quantity),
+        };
+      }
+      if (cmd.base <= range.zone[start]) {
+        return {
+          changeType: "MOVE",
+          range: createAdaptedRange(range, dimension, "MOVE", cmd.quantity),
+        };
+      }
+    }
+    return { changeType: "NONE" };
+  };
+}
+
+function getApplyRangeChangeDeleteSheet(
+  cmd: DeleteSheetCommand,
+  getters: CoreGetters
+): ApplyRangeChange {
+  return (range: RangeImpl) => {
+    if (range.sheetId !== cmd.sheetId) {
+      return { changeType: "NONE" };
+    }
+    const invalidSheetName = getters.getSheetName(cmd.sheetId);
+    range = range.clone({
+      ...getInvalidRange(),
+      invalidSheetName,
+    });
+    return { changeType: "REMOVE", range };
+  };
+}
+
+function getApplyRangeChangeRenameSheet(cmd: RenameSheetCommand): ApplyRangeChange {
+  return (range: RangeImpl) => {
+    if (range.sheetId === cmd.sheetId) {
+      return { changeType: "CHANGE", range };
+    }
+    if (cmd.name && range.invalidSheetName === cmd.name) {
+      const invalidSheetName = undefined;
+      const sheetId = cmd.sheetId;
+      const newRange = range.clone({ sheetId, invalidSheetName });
+      return { changeType: "CHANGE", range: newRange };
+    }
+    return { changeType: "NONE" };
+  };
+}
+
+function getApplyRangeChangeMoveRange(cmd: MoveRangeCommand): ApplyRangeChange {
+  const originZone = cmd.target[0];
+  return (range: RangeImpl) => {
+    if (range.sheetId !== cmd.sheetId || !isZoneInside(range.zone, originZone)) {
+      return { changeType: "NONE" };
+    }
+    const targetSheetId = cmd.targetSheetId;
+    const offsetX = cmd.col - originZone.left;
+    const offsetY = cmd.row - originZone.top;
+    const adaptedRange = createAdaptedRange(range, "both", "MOVE", [offsetX, offsetY]);
+    const prefixSheet = cmd.sheetId === targetSheetId ? adaptedRange.prefixSheet : true;
+    return {
+      changeType: "MOVE",
+      range: adaptedRange.clone({ sheetId: targetSheetId, prefixSheet }),
+    };
+  };
+}
+
+function createAdaptedRange<Dimension extends "columns" | "rows" | "both">(
+  range: RangeImpl,
+  dimension: Dimension,
+  operation: "MOVE" | "RESIZE",
+  by: Dimension extends "both" ? [number, number] : number
+) {
+  const zone = createAdaptedZone(range.unboundedZone, dimension, operation, by);
+  const adaptedRange = range.clone({ zone });
+  return adaptedRange;
+}
+
+function getInvalidRange() {
+  return {
+    parts: [],
+    prefixSheet: false,
+    zone: { left: -1, top: -1, right: -1, bottom: -1 },
+    sheetId: "",
+    invalidXc: CellErrorType.InvalidReference,
+  };
 }

--- a/src/history/factory.ts
+++ b/src/history/factory.ts
@@ -3,12 +3,14 @@ import { Revision } from "../collaborative/revisions";
 import { inverseCommand } from "../helpers/inverse_commands";
 import { StateObserver } from "../state_observer";
 import { CoreCommand, HistoryChange, UID } from "../types";
+import { CoreGetters } from "../types/getters";
 import { SelectiveHistory } from "./selective_history";
 
 export function buildRevisionLog(args: {
   initialRevisionId: UID;
   recordChanges: StateObserver["recordChanges"];
   dispatch: (command: CoreCommand) => void;
+  coreGetters: CoreGetters;
 }) {
   return new SelectiveHistory<Revision>({
     initialOperationId: args.initialRevisionId,
@@ -28,7 +30,7 @@ export function buildRevisionLog(args: {
         return new Revision(
           toTransform.id,
           toTransform.clientId,
-          transformAll(toTransform.commands, revision.commands),
+          transformAll(toTransform.commands, revision.commands, args.coreGetters),
           toTransform.rootCommand,
           undefined,
           toTransform.timestamp
@@ -38,7 +40,11 @@ export function buildRevisionLog(args: {
         return new Revision(
           toTransform.id,
           toTransform.clientId,
-          transformAll(toTransform.commands, revision.commands.map(inverseCommand).flat()),
+          transformAll(
+            toTransform.commands,
+            revision.commands.map(inverseCommand).flat(),
+            args.coreGetters
+          ),
           toTransform.rootCommand,
           undefined,
           toTransform.timestamp

--- a/src/model.ts
+++ b/src/model.ts
@@ -212,8 +212,6 @@ export class Model extends EventBus<any> implements CommandDispatcher {
 
     this.config = this.setupConfig(config);
 
-    this.session = this.setupSession(workbookData.revisionId);
-
     this.coreGetters = {} as CoreGetters;
 
     this.range = new RangeAdapter(this.coreGetters);
@@ -236,6 +234,8 @@ export class Model extends EventBus<any> implements CommandDispatcher {
       isReadonly: () => this.config.mode === "readonly" || this.config.mode === "dashboard",
       isDashboard: () => this.config.mode === "dashboard",
     } as Getters;
+
+    this.session = this.setupSession(workbookData.revisionId, this.coreGetters);
 
     // Initiate stream processor
     this.selection = new SelectionStreamProcessorImpl(this.getters);
@@ -376,7 +376,7 @@ export class Model extends EventBus<any> implements CommandDispatcher {
     this.finalize();
   }
 
-  private setupSession(revisionId: UID): Session {
+  private setupSession(revisionId: UID, coreGetters: CoreGetters): Session {
     return new Session(
       buildRevisionLog({
         initialRevisionId: revisionId,
@@ -390,9 +390,11 @@ export class Model extends EventBus<any> implements CommandDispatcher {
           this.dispatchToHandlers(this.coreHandlers, command);
           this.isReplayingCommand = false;
         },
+        coreGetters,
       }),
       this.config.transportService,
-      revisionId
+      revisionId,
+      coreGetters
     );
   }
 

--- a/src/model.ts
+++ b/src/model.ts
@@ -229,6 +229,8 @@ export class Model extends EventBus<any> implements CommandDispatcher {
     this.coreGetters.extendRange = this.range.extendRange.bind(this.range);
     this.coreGetters.getRangesUnion = this.range.getRangesUnion.bind(this.range);
     this.coreGetters.removeRangesSheetPrefix = this.range.removeRangesSheetPrefix.bind(this.range);
+    this.coreGetters.adaptFormulaStringDependencies =
+      this.range.adaptFormulaStringDependencies.bind(this.range);
 
     this.getters = {
       isReadonly: () => this.config.mode === "readonly" || this.config.mode === "dashboard",

--- a/src/plugins/core/range.ts
+++ b/src/plugins/core/range.ts
@@ -353,7 +353,9 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
     const updatedDependencies = compiledFormula.dependencies.map((dep) => {
       const range = this.getters.getRangeFromSheetXC(sheetId, dep);
       const changedRange = applyChange(range);
-      return changedRange.changeType === "NONE" ? range : changedRange.range;
+      return changedRange.changeType === "NONE" || changedRange.changeType === "REMOVE"
+        ? range
+        : changedRange.range;
     });
     return this.getters.getFormulaString(sheetId, compiledFormula.tokens, updatedDependencies);
   }

--- a/src/plugins/core/range.ts
+++ b/src/plugins/core/range.ts
@@ -1,12 +1,8 @@
 import { compile } from "../../formulas";
 import {
-  createAdaptedZone,
+  getApplyRangeChange,
   getCanonicalSymbolName,
-  groupConsecutive,
-  isZoneInside,
   isZoneValid,
-  largeMax,
-  largeMin,
   numberToLetters,
   RangeImpl,
   rangeReference,
@@ -19,7 +15,6 @@ import { CellErrorType } from "../../types/errors";
 import {
   ApplyRangeChange,
   ApplyRangeChangeResult,
-  ChangeType,
   Command,
   CommandHandler,
   CommandResult,
@@ -69,143 +64,9 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
   beforeHandle(command: Command) {}
 
   handle(cmd: Command) {
-    switch (cmd.type) {
-      case "REMOVE_COLUMNS_ROWS": {
-        let start: "left" | "top" = cmd.dimension === "COL" ? "left" : "top";
-        let end: "right" | "bottom" = cmd.dimension === "COL" ? "right" : "bottom";
-        let dimension: "columns" | "rows" = cmd.dimension === "COL" ? "columns" : "rows";
-
-        const elements = [...cmd.elements];
-        elements.sort((a, b) => b - a);
-
-        const groups = groupConsecutive(elements);
-        this.executeOnAllRanges((range: RangeImpl) => {
-          if (range.sheetId !== cmd.sheetId) {
-            return { changeType: "NONE" };
-          }
-          let newRange = range;
-          let changeType: ChangeType = "NONE";
-          for (let group of groups) {
-            const min = largeMin(group);
-            const max = largeMax(group);
-            if (range.zone[start] <= min && min <= range.zone[end]) {
-              const toRemove = Math.min(range.zone[end], max) - min + 1;
-              changeType = "RESIZE";
-              newRange = this.createAdaptedRange(newRange, dimension, changeType, -toRemove);
-            } else if (range.zone[start] >= min && range.zone[end] <= max) {
-              changeType = "REMOVE";
-              newRange = range.clone({ ...this.getInvalidRange() });
-            } else if (range.zone[start] <= max && range.zone[end] >= max) {
-              const toRemove = max - range.zone[start] + 1;
-              changeType = "RESIZE";
-              newRange = this.createAdaptedRange(newRange, dimension, changeType, -toRemove);
-              newRange = this.createAdaptedRange(
-                newRange,
-                dimension,
-                "MOVE",
-                -(range.zone[start] - min)
-              );
-            } else if (min < range.zone[start]) {
-              changeType = "MOVE";
-              newRange = this.createAdaptedRange(newRange, dimension, changeType, -(max - min + 1));
-            }
-          }
-          if (changeType !== "NONE") {
-            return { changeType, range: newRange };
-          }
-          return { changeType: "NONE" };
-        }, cmd.sheetId);
-        break;
-      }
-      case "ADD_COLUMNS_ROWS": {
-        let start: "left" | "top" = cmd.dimension === "COL" ? "left" : "top";
-        let end: "right" | "bottom" = cmd.dimension === "COL" ? "right" : "bottom";
-        let dimension: "columns" | "rows" = cmd.dimension === "COL" ? "columns" : "rows";
-
-        this.executeOnAllRanges((range: RangeImpl) => {
-          if (range.sheetId !== cmd.sheetId) {
-            return { changeType: "NONE" };
-          }
-          if (cmd.position === "after") {
-            if (range.zone[start] <= cmd.base && cmd.base < range.zone[end]) {
-              return {
-                changeType: "RESIZE",
-                range: this.createAdaptedRange(range, dimension, "RESIZE", cmd.quantity),
-              };
-            }
-            if (cmd.base < range.zone[start]) {
-              return {
-                changeType: "MOVE",
-                range: this.createAdaptedRange(range, dimension, "MOVE", cmd.quantity),
-              };
-            }
-          } else {
-            if (range.zone[start] < cmd.base && cmd.base <= range.zone[end]) {
-              return {
-                changeType: "RESIZE",
-                range: this.createAdaptedRange(range, dimension, "RESIZE", cmd.quantity),
-              };
-            }
-            if (cmd.base <= range.zone[start]) {
-              return {
-                changeType: "MOVE",
-                range: this.createAdaptedRange(range, dimension, "MOVE", cmd.quantity),
-              };
-            }
-          }
-          return { changeType: "NONE" };
-        }, cmd.sheetId);
-
-        break;
-      }
-      case "DELETE_SHEET": {
-        this.executeOnAllRanges((range: RangeImpl) => {
-          if (range.sheetId !== cmd.sheetId) {
-            return { changeType: "NONE" };
-          }
-          const invalidSheetName = this.getters.getSheetName(cmd.sheetId);
-          range = range.clone({
-            ...this.getInvalidRange(),
-            invalidSheetName,
-          });
-          return { changeType: "REMOVE", range };
-        }, cmd.sheetId);
-
-        break;
-      }
-      case "RENAME_SHEET": {
-        this.executeOnAllRanges((range: RangeImpl) => {
-          if (range.sheetId === cmd.sheetId) {
-            return { changeType: "CHANGE", range };
-          }
-          if (cmd.name && range.invalidSheetName === cmd.name) {
-            const invalidSheetName = undefined;
-            const sheetId = cmd.sheetId;
-            const newRange = range.clone({ sheetId, invalidSheetName });
-            return { changeType: "CHANGE", range: newRange };
-          }
-          return { changeType: "NONE" };
-        });
-        break;
-      }
-      case "MOVE_RANGES": {
-        const originZone = cmd.target[0];
-        this.executeOnAllRanges((range: RangeImpl) => {
-          if (range.sheetId !== cmd.sheetId || !isZoneInside(range.zone, originZone)) {
-            return { changeType: "NONE" };
-          }
-          const targetSheetId = cmd.targetSheetId;
-          const offsetX = cmd.col - originZone.left;
-          const offsetY = cmd.row - originZone.top;
-          const adaptedRange = this.createAdaptedRange(range, "both", "MOVE", [offsetX, offsetY]);
-          const prefixSheet = cmd.sheetId === targetSheetId ? adaptedRange.prefixSheet : true;
-          return {
-            changeType: "MOVE",
-            range: adaptedRange.clone({ sheetId: targetSheetId, prefixSheet }),
-          };
-        });
-        break;
-      }
+    const arc = getApplyRangeChange(cmd, this.getters);
+    if (arc?.applyChange) {
+      this.executeOnAllRanges(arc.applyChange, arc.sheetId);
     }
   }
 
@@ -225,17 +86,6 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
       }
       return result;
     };
-  }
-
-  private createAdaptedRange<Dimension extends "columns" | "rows" | "both">(
-    range: RangeImpl,
-    dimension: Dimension,
-    operation: "MOVE" | "RESIZE",
-    by: Dimension extends "both" ? [number, number] : number
-  ) {
-    const zone = createAdaptedZone(range.unboundedZone, dimension, operation, by);
-    const adaptedRange = range.clone({ zone });
-    return adaptedRange;
   }
 
   private executeOnAllRanges(adaptRange: ApplyRangeChange, sheetId?: UID) {
@@ -543,15 +393,5 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
     }
 
     return str;
-  }
-
-  private getInvalidRange() {
-    return {
-      parts: [],
-      prefixSheet: false,
-      zone: { left: -1, top: -1, right: -1, bottom: -1 },
-      sheetId: "",
-      invalidXc: CellErrorType.InvalidReference,
-    };
   }
 }

--- a/src/registries/ovt_registry.ts
+++ b/src/registries/ovt_registry.ts
@@ -1,0 +1,31 @@
+import { ApplyRangeChangeSheet, CoreCommand, CoreGetters } from "../types";
+import { Registry } from "./registry";
+
+/*
+ * Operation Value Transform Registry
+ * ==================================
+ *
+ * This registry contains all the transformations functions to adapt on command ranges
+ * to preserve the intention of the users and consistency during a collaborative
+ * session.
+ *
+ */
+
+export type CommandAdaptRangeFunction<C extends CoreCommand> = (
+  cmd: C,
+  getters: CoreGetters,
+  applyChange: ApplyRangeChangeSheet
+) => C;
+
+export class OVTRegistry extends Registry<CommandAdaptRangeFunction<CoreCommand>> {
+  addValue<C extends CoreCommand>(cmdType: C["type"], fn: CommandAdaptRangeFunction<C>): this {
+    this.content[cmdType] = fn;
+    return this;
+  }
+
+  getValues<C extends CoreCommand>(cmdType: C["type"]): CommandAdaptRangeFunction<CoreCommand> {
+    return this.content[cmdType];
+  }
+}
+
+export const ovtRegistry = new OVTRegistry();

--- a/src/types/misc.ts
+++ b/src/types/misc.ts
@@ -288,6 +288,10 @@ export type ApplyRangeChangeResult =
   | { changeType: Exclude<ChangeType, "NONE">; range: Range }
   | { changeType: "NONE" };
 export type ApplyRangeChange = (range: Range) => ApplyRangeChangeResult;
+export type ApplyRangeChangeSheet = {
+  sheetId?: UID;
+  applyChange: ApplyRangeChange;
+};
 
 export type Dimension = "COL" | "ROW";
 

--- a/tests/collaborative/collaborative_helpers.ts
+++ b/tests/collaborative/collaborative_helpers.ts
@@ -17,9 +17,9 @@ interface CollaborativeEnv {
  * first, meaning she will also resend her pending messages first.
  * Similarly, Bob's messages are resent before Charlie's.
  */
-export function setupCollaborativeEnv(): CollaborativeEnv {
+export function setupCollaborativeEnv(modelData?: any): CollaborativeEnv {
   const network = new MockTransportService();
-  const emptySheetData = new Model().exportData();
+  const emptySheetData = new Model(modelData).exportData();
   const alice = new Model(deepCopy(emptySheetData), {
     transportService: network,
     client: { id: "alice", name: "Alice" },

--- a/tests/collaborative/collaborative_session.test.ts
+++ b/tests/collaborative/collaborative_session.test.ts
@@ -3,7 +3,7 @@ import { Session } from "../../src/collaborative/session";
 import { DEBOUNCE_TIME, MESSAGE_VERSION } from "../../src/constants";
 import { lazy } from "../../src/helpers";
 import { buildRevisionLog } from "../../src/history/factory";
-import { Client, CommandResult, WorkbookData } from "../../src/types";
+import { Client, CommandResult, CoreGetters, WorkbookData } from "../../src/types";
 import { MockTransportService } from "../__mocks__/transport_service";
 import { selectCell, setCellContent } from "../test_helpers/commands_helpers";
 import { nextTick } from "../test_helpers/helpers";
@@ -21,12 +21,14 @@ describe("Collaborative session", () => {
       id: "alice",
       name: "Alice",
     };
+    const coreGetters = {} as CoreGetters;
     const revisionLog = buildRevisionLog({
       initialRevisionId: "START_REVISION",
       recordChanges: () => ({ changes: [], commands: [] }),
       dispatch: () => CommandResult.Success,
+      coreGetters,
     });
-    session = new Session(revisionLog, transport);
+    session = new Session(revisionLog, transport, undefined, coreGetters);
     session.join(client);
   });
 

--- a/tests/collaborative/ot/ot.test.ts
+++ b/tests/collaborative/ot/ot.test.ts
@@ -1,5 +1,11 @@
+import { Model } from "../../../src";
 import { transform } from "../../../src/collaborative/ot/ot";
-import { DeleteFigureCommand, UpdateChartCommand, UpdateFigureCommand } from "../../../src/types";
+import {
+  CoreGetters,
+  DeleteFigureCommand,
+  UpdateChartCommand,
+  UpdateFigureCommand,
+} from "../../../src/types";
 import { LineChartDefinition } from "../../../src/types/chart/line_chart";
 
 describe("OT with DELETE_FIGURE", () => {
@@ -17,14 +23,27 @@ describe("OT with DELETE_FIGURE", () => {
     type: "UPDATE_FIGURE",
     sheetId: "42",
   };
+  let sheetId = "sheetId";
+  let model: Model;
+  let getters: CoreGetters;
+
+  beforeEach(() => {
+    model = new Model({
+      sheets: [{ id: sheetId, name: "Sheet Name" }],
+    });
+    getters = model.getters;
+  });
 
   describe.each([updateChart, updateFigure])("UPDATE_CHART & UPDATE_FIGURE", (cmd) => {
     test("Same ID", () => {
-      expect(transform({ ...cmd, id: "42" }, deleteFigure)).toBeUndefined();
+      expect(transform({ ...cmd, id: "42" }, deleteFigure, getters)).toBeUndefined();
     });
 
     test("distinct ID", () => {
-      expect(transform({ ...cmd, id: "otherId" }, deleteFigure)).toEqual({ ...cmd, id: "otherId" });
+      expect(transform({ ...cmd, id: "otherId" }, deleteFigure, getters)).toEqual({
+        ...cmd,
+        id: "otherId",
+      });
     });
   });
 });

--- a/tests/collaborative/ot/ot_columns_removed.test.ts
+++ b/tests/collaborative/ot/ot_columns_removed.test.ts
@@ -1,7 +1,9 @@
+import { Model } from "../../../src";
 import { transform } from "../../../src/collaborative/ot/ot";
 import { toZone } from "../../../src/helpers";
 import {
   AddColumnsRowsCommand,
+  CoreGetters,
   FreezeColumnsCommand,
   FreezeRowsCommand,
   RemoveColumnsRowsCommand,
@@ -17,6 +19,7 @@ import {
   TEST_COMMANDS,
 } from "../../test_helpers/constants";
 import { target, toRangeData, toRangesData } from "../../test_helpers/helpers";
+import { getFormulaStringCommands } from "./ot_helper";
 
 describe("OT with REMOVE_COLUMN", () => {
   const sheetId = "Sheet1";
@@ -26,36 +29,45 @@ describe("OT with REMOVE_COLUMN", () => {
     elements: [2, 5, 3],
     sheetId,
   };
+  let model: Model;
+  let getters: CoreGetters;
+
+  beforeEach(() => {
+    model = new Model({
+      sheets: [{ id: sheetId, name: "Sheet Name" }],
+    });
+    getters = model.getters;
+  });
 
   describe.each(OT_TESTS_SINGLE_CELL_COMMANDS)("single cell commands", (cmd) => {
     test(`remove columns before ${cmd.type}`, () => {
       const command = { ...cmd, sheetId, col: 10 };
-      const result = transform(command, removeColumns);
+      const result = transform(command, removeColumns, getters);
       expect(result).toEqual({ ...command, col: 7 });
     });
     test(`remove columns after ${cmd.type}`, () => {
       const command = { ...cmd, sheetId, col: 1 };
-      const result = transform(command, removeColumns);
+      const result = transform(command, removeColumns, getters);
       expect(result).toEqual(command);
     });
     test(`remove columns before and after ${cmd.type}`, () => {
       const command = { ...cmd, sheetId, col: 4 };
-      const result = transform(command, removeColumns);
+      const result = transform(command, removeColumns, getters);
       expect(result).toEqual({ ...command, col: 2 });
     });
     test(`${cmd.type} in removed columns`, () => {
       const command = { ...cmd, sheetId, col: 2 };
-      const result = transform(command, removeColumns);
+      const result = transform(command, removeColumns, getters);
       expect(result).toBeUndefined();
     });
     test(`${cmd.type} and columns removed in different sheets`, () => {
       const command = { ...cmd, col: 10, sheetId: "42" };
-      const result = transform(command, removeColumns);
+      const result = transform(command, removeColumns, getters);
       expect(result).toEqual(command);
     });
     test(`with many col elements in growing order`, () => {
       const command = { ...cmd, sheetId, col: 8 };
-      const result = transform(command, { ...removeColumns, elements: [2, 3, 4, 5, 6] });
+      const result = transform(command, { ...removeColumns, elements: [2, 3, 4, 5, 6] }, getters);
       expect(result).toEqual({ ...command, col: 3 });
     });
   });
@@ -63,37 +75,37 @@ describe("OT with REMOVE_COLUMN", () => {
   describe.each(OT_TESTS_TARGET_DEPENDANT_COMMANDS)("target commands", (cmd) => {
     test(`remove columns after ${cmd.type}`, () => {
       const command = { ...cmd, sheetId, target: [toZone("A1:A3")] };
-      const result = transform(command, removeColumns);
+      const result = transform(command, removeColumns, getters);
       expect(result).toEqual(command);
     });
     test(`remove columns before ${cmd.type}`, () => {
       const command = { ...cmd, sheetId, target: [toZone("M1:O2")] };
-      const result = transform(command, removeColumns);
+      const result = transform(command, removeColumns, getters);
       expect(result).toEqual({ ...command, target: [toZone("J1:L2")] });
     });
     test(`remove columns before and after ${cmd.type}`, () => {
       const command = { ...cmd, sheetId, target: [toZone("E1:E2")] };
-      const result = transform(command, removeColumns);
+      const result = transform(command, removeColumns, getters);
       expect(result).toEqual({ ...command, target: [toZone("C1:C2")] });
     });
     test(`${cmd.type} in removed columns`, () => {
       const command = { ...cmd, sheetId, target: [toZone("F1:G2")] };
-      const result = transform(command, removeColumns);
+      const result = transform(command, removeColumns, getters);
       expect(result).toEqual({ ...command, target: [toZone("D1:D2")] });
     });
     test(`${cmd.type} and columns removed in different sheets`, () => {
       const command = { ...cmd, target: [toZone("A1:F3")], sheetId: "42" };
-      const result = transform(command, removeColumns);
+      const result = transform(command, removeColumns, getters);
       expect(result).toEqual(command);
     });
     test(`${cmd.type} with a target removed`, () => {
       const command = { ...cmd, sheetId, target: [toZone("C1:D2")] };
-      const result = transform(command, removeColumns);
+      const result = transform(command, removeColumns, getters);
       expect(result).toBeUndefined();
     });
     test(`${cmd.type} with a target removed, but another valid`, () => {
       const command = { ...cmd, sheetId, target: [toZone("C1:D2"), toZone("A1")] };
-      const result = transform(command, removeColumns);
+      const result = transform(command, removeColumns, getters);
       expect(result).toEqual({ ...command, target: [toZone("A1")] });
     });
   });
@@ -101,27 +113,27 @@ describe("OT with REMOVE_COLUMN", () => {
   describe.each(OT_TESTS_ZONE_DEPENDANT_COMMANDS)("zone dependant commands", (cmd) => {
     test(`remove columns after ${cmd.type}`, () => {
       const command = { ...cmd, sheetId, zone: toZone("A1:A3") };
-      const result = transform(command, removeColumns);
+      const result = transform(command, removeColumns, getters);
       expect(result).toEqual(command);
     });
     test(`remove columns before ${cmd.type}`, () => {
       const command = { ...cmd, sheetId, zone: toZone("M1:O2") };
-      const result = transform(command, removeColumns);
+      const result = transform(command, removeColumns, getters);
       expect(result).toEqual({ ...command, zone: toZone("J1:L2") });
     });
     test(`remove columns before and after ${cmd.type}`, () => {
       const command = { ...cmd, sheetId, zone: toZone("E1:E2") };
-      const result = transform(command, removeColumns);
+      const result = transform(command, removeColumns, getters);
       expect(result).toEqual({ ...command, zone: toZone("C1:C2") });
     });
     test(`${cmd.type} in removed columns`, () => {
       const command = { ...cmd, sheetId, zone: toZone("F1:G2") };
-      const result = transform(command, removeColumns);
+      const result = transform(command, removeColumns, getters);
       expect(result).toEqual({ ...command, zone: toZone("D1:D2") });
     });
     test(`${cmd.type} and columns removed in different sheets`, () => {
       const command = { ...cmd, zone: toZone("A1:F3"), sheetId: "42" };
-      const result = transform(command, removeColumns);
+      const result = transform(command, removeColumns, getters);
       expect(result).toEqual(command);
     });
   });
@@ -129,12 +141,12 @@ describe("OT with REMOVE_COLUMN", () => {
   describe.each(OT_TESTS_RANGE_DEPENDANT_COMMANDS)("ranges dependant commands", (cmd) => {
     test(`remove columns after ${cmd.type}`, () => {
       const command = { ...cmd, sheetId, ranges: toRangesData(sheetId, "A1:A3") };
-      const result = transform(command, removeColumns);
+      const result = transform(command, removeColumns, getters);
       expect(result).toEqual(command);
     });
     test(`remove columns before ${cmd.type}`, () => {
       const command = { ...cmd, sheetId, ranges: toRangesData(sheetId, "M1:O2") };
-      const result = transform(command, removeColumns);
+      const result = transform(command, removeColumns, getters);
       expect(result).toEqual({ ...command, ranges: toRangesData(sheetId, "J1:L2") });
     });
     test(`remove columns before in the shhet of the range ${cmd.type}`, () => {
@@ -143,59 +155,59 @@ describe("OT with REMOVE_COLUMN", () => {
         ranges: toRangesData(sheetId, "M1:O2"),
         sheetId: "42",
       };
-      const result = transform(command, removeColumns);
+      const result = transform(command, removeColumns, getters);
       expect(result).toEqual({ ...command, ranges: toRangesData(sheetId, "J1:L2") });
     });
     test(`remove columns before and after ${cmd.type}`, () => {
       const command = { ...cmd, sheetId, ranges: toRangesData(sheetId, "E1:E2") };
-      const result = transform(command, removeColumns);
+      const result = transform(command, removeColumns, getters);
       expect(result).toEqual({ ...command, ranges: toRangesData(sheetId, "C1:C2") });
     });
     test(`${cmd.type} in removed columns`, () => {
       const command = { ...cmd, sheetId, ranges: toRangesData(sheetId, "F1:G2") };
-      const result = transform(command, removeColumns);
+      const result = transform(command, removeColumns, getters);
       expect(result).toEqual({ ...command, ranges: toRangesData(sheetId, "D1:D2") });
     });
     test(`${cmd.type} and columns removed in different sheets`, () => {
       const command = { ...cmd, ranges: toRangesData("42", "A1:F3"), sheetId: "42" };
-      const result = transform(command, removeColumns);
+      const result = transform(command, removeColumns, getters);
       expect(result).toEqual(command);
     });
     test(`${cmd.type} with a target removed`, () => {
       const command = { ...cmd, sheetId, ranges: toRangesData(sheetId, "C1:D2") };
-      const result = transform(command, removeColumns);
+      const result = transform(command, removeColumns, getters);
       expect(result).toBeUndefined();
     });
     test(`${cmd.type} with a target removed, but another valid`, () => {
       const command = { ...cmd, sheetId, ranges: toRangesData(sheetId, "C1:D2,A1") };
-      const result = transform(command, removeColumns);
+      const result = transform(command, removeColumns, getters);
       expect(result).toEqual({ ...command, ranges: toRangesData(sheetId, "A1") });
     });
 
     describe("With unbounded ranges", () => {
       test(`remove columns after ${cmd.type}`, () => {
         const command = { ...cmd, sheetId, ranges: toRangesData(sheetId, "A:A") };
-        const result = transform(command, removeColumns);
+        const result = transform(command, removeColumns, getters);
         expect(result).toEqual(command);
       });
       test(`remove columns before ${cmd.type}`, () => {
         const command = { ...cmd, sheetId, ranges: toRangesData(sheetId, "M5:O") };
-        const result = transform(command, removeColumns);
+        const result = transform(command, removeColumns, getters);
         expect(result).toEqual({ ...command, ranges: toRangesData(sheetId, "J5:L") });
       });
       test(`${cmd.type} in removed columns`, () => {
         const command = { ...cmd, sheetId, ranges: toRangesData(sheetId, "F:G") };
-        const result = transform(command, removeColumns);
+        const result = transform(command, removeColumns, getters);
         expect(result).toEqual({ ...command, ranges: toRangesData(sheetId, "D:D") });
       });
       test(`${cmd.type} with a target removed`, () => {
         const command = { ...cmd, sheetId, ranges: toRangesData(sheetId, "C:D") };
-        const result = transform(command, removeColumns);
+        const result = transform(command, removeColumns, getters);
         expect(result).toBeUndefined();
       });
       test(`${cmd.type} with a target removed, but another valid`, () => {
         const command = { ...cmd, sheetId, ranges: toRangesData(sheetId, "C:D,A2:A") };
-        const result = transform(command, removeColumns);
+        const result = transform(command, removeColumns, getters);
         expect(result).toEqual({ ...command, ranges: toRangesData(sheetId, "A2:A") });
       });
     });
@@ -212,25 +224,25 @@ describe("OT with REMOVE_COLUMN", () => {
 
     test("Add a removed columns", () => {
       const command = { ...toTransform, base: 2 };
-      const result = transform(command, removeColumns);
+      const result = transform(command, removeColumns, getters);
       expect(result).toBeUndefined();
     });
 
     test("Add a column after the removed ones", () => {
       const command = { ...toTransform, base: 10 };
-      const result = transform(command, removeColumns);
+      const result = transform(command, removeColumns, getters);
       expect(result).toEqual({ ...command, base: 7 });
     });
 
     test("Add a column before the removed ones", () => {
       const command = { ...toTransform, base: 0 };
-      const result = transform(command, removeColumns);
+      const result = transform(command, removeColumns, getters);
       expect(result).toEqual(command);
     });
 
     test("Add on another sheet", () => {
       const command = { ...toTransform, base: 2, sheetId: "42" };
-      const result = transform(command, removeColumns);
+      const result = transform(command, removeColumns, getters);
       expect(result).toEqual(command);
     });
   });
@@ -244,43 +256,43 @@ describe("OT with REMOVE_COLUMN", () => {
 
     test("Remove a column which is in the removed columns", () => {
       const command = { ...toTransform, elements: [2] };
-      const result = transform(command, removeColumns);
+      const result = transform(command, removeColumns, getters);
       expect(result).toBeUndefined();
     });
 
     test("Remove columns with one in the removed columns", () => {
       const command = { ...toTransform, elements: [0, 2] };
-      const result = transform(command, removeColumns);
+      const result = transform(command, removeColumns, getters);
       expect(result).toEqual({ ...command, elements: [0] });
     });
 
     test("Remove a column before removed columns", () => {
       const command = { ...toTransform, elements: [0] };
-      const result = transform(command, removeColumns);
+      const result = transform(command, removeColumns, getters);
       expect(result).toEqual(command);
     });
 
     test("Remove a column after removed columns", () => {
       const command = { ...toTransform, elements: [8] };
-      const result = transform(command, removeColumns);
+      const result = transform(command, removeColumns, getters);
       expect(result).toEqual({ ...command, elements: [5] });
     });
 
     test("Remove a column inside removed columns", () => {
       const command = { ...toTransform, elements: [4] };
-      const result = transform(command, removeColumns);
+      const result = transform(command, removeColumns, getters);
       expect(result).toEqual({ ...command, elements: [2] });
     });
 
     test("Remove a column on another sheet", () => {
       const command = { ...toTransform, elements: [4], sheetId: "42" };
-      const result = transform(command, removeColumns);
+      const result = transform(command, removeColumns, getters);
       expect(result).toEqual(command);
     });
 
     test("Remove a column adjacent to removed columns", () => {
       const command = { ...toTransform, elements: [2] };
-      const result = transform(command, { ...removeColumns, elements: [0, 1] });
+      const result = transform(command, { ...removeColumns, elements: [0, 1] }, getters);
       expect(result).toEqual({ ...command, elements: [0] });
     });
   });
@@ -294,25 +306,25 @@ describe("OT with REMOVE_COLUMN", () => {
 
     test("Resize columns which are positioned before the removed columns", () => {
       const command = { ...resizeColumnsCommand, elements: [0, 1] };
-      const result = transform(command, removeColumns);
+      const result = transform(command, removeColumns, getters);
       expect(result).toEqual(command);
     });
 
     test("Resize columns which are positioned before AND after the removed columns", () => {
       const command = { ...resizeColumnsCommand, elements: [0, 10] };
-      const result = transform(command, removeColumns);
+      const result = transform(command, removeColumns, getters);
       expect(result).toEqual({ ...command, elements: [0, 7] });
     });
 
     test("Resize a column which is a deleted column", () => {
       const command = { ...resizeColumnsCommand, elements: [5] };
-      const result = transform(command, removeColumns);
+      const result = transform(command, removeColumns, getters);
       expect(result).toBeUndefined();
     });
 
     test("Resize columns one of which is a deleted column", () => {
       const command = { ...resizeColumnsCommand, elements: [0, 5] };
-      const result = transform(command, removeColumns);
+      const result = transform(command, removeColumns, getters);
       expect(result).toEqual({ ...command, elements: [0] });
     });
   });
@@ -322,32 +334,32 @@ describe("OT with REMOVE_COLUMN", () => {
     (cmd) => {
       test(`remove columns before merge`, () => {
         const command = { ...cmd, sheetId, target: target("A1:A3") };
-        const result = transform(command, removeColumns);
+        const result = transform(command, removeColumns, getters);
         expect(result).toEqual(command);
       });
       test(`remove columns after merge`, () => {
         const command = { ...cmd, sheetId, target: target("M1:O2") };
-        const result = transform(command, removeColumns);
+        const result = transform(command, removeColumns, getters);
         expect(result).toEqual({ ...command, target: target("J1:L2") });
       });
       test(`remove columns before and after merge`, () => {
         const command = { ...cmd, sheetId, target: target("E1:E2") };
-        const result = transform(command, removeColumns);
+        const result = transform(command, removeColumns, getters);
         expect(result).toEqual({ ...command, target: target("C1:C2") });
       });
       test(`merge in removed columns`, () => {
         const command = { ...cmd, sheetId, target: target("F1:G2") };
-        const result = transform(command, removeColumns);
+        const result = transform(command, removeColumns, getters);
         expect(result).toEqual({ ...command, target: target("D1:D2") });
       });
       test(`merge and columns removed in different sheets`, () => {
         const command = { ...cmd, target: target("A1:F3"), sheetId: "42" };
-        const result = transform(command, removeColumns);
+        const result = transform(command, removeColumns, getters);
         expect(result).toEqual(command);
       });
       test(`merge with a target removed`, () => {
         const command = { ...cmd, sheetId, target: target("C1:D2") };
-        const result = transform(command, removeColumns);
+        const result = transform(command, removeColumns, getters);
         expect(result).toBeUndefined();
       });
     }
@@ -372,11 +384,11 @@ describe("OT with REMOVE_COLUMN", () => {
     };
 
     test("Add rows (after) after delete columns", () => {
-      const result = transform(addRowsAfter, removeColumns);
+      const result = transform(addRowsAfter, removeColumns, getters);
       expect(result).toEqual(addRowsAfter);
     });
     test("Add rows (before) after delete columns", () => {
-      const result = transform(addRowsBefore, removeColumns);
+      const result = transform(addRowsBefore, removeColumns, getters);
       expect(result).toEqual(addRowsBefore);
     });
   });
@@ -389,31 +401,31 @@ describe("OT with REMOVE_COLUMN", () => {
 
     test("freeze a column before the left-most deleted column", () => {
       const command = { ...toTransform, quantity: 2 };
-      const result = transform(command, removeColumns);
+      const result = transform(command, removeColumns, getters);
       expect(result).toEqual(command);
     });
 
     test("Freeze a removed column", () => {
       const command = { ...toTransform, quantity: 3 };
-      const result = transform(command, removeColumns);
+      const result = transform(command, removeColumns, getters);
       expect(result).toEqual({ ...command, quantity: 2 });
     });
 
     test("Freeze column after the removed ones", () => {
       const command = { ...toTransform, quantity: 10 };
-      const result = transform(command, removeColumns);
+      const result = transform(command, removeColumns, getters);
       expect(result).toEqual({ ...command, quantity: 7 });
     });
 
     test("Freeze a column before the removed ones", () => {
       const command = { ...toTransform, quantity: 1 };
-      const result = transform(command, removeColumns);
+      const result = transform(command, removeColumns, getters);
       expect(result).toEqual(command);
     });
 
     test("Freeze column on another sheet", () => {
       const command = { ...toTransform, quantity: 2, sheetId: "42" };
-      const result = transform(command, removeColumns);
+      const result = transform(command, removeColumns, getters);
       expect(result).toEqual(command);
     });
   });
@@ -426,7 +438,7 @@ describe("OT with REMOVE_COLUMN", () => {
 
     test("freeze a row after added after column", () => {
       const command = { ...toTransform, quantity: 3 };
-      const result = transform(command, removeColumns);
+      const result = transform(command, removeColumns, getters);
       expect(result).toEqual({ ...command });
     });
   });
@@ -445,28 +457,38 @@ describe.each(OT_TESTS_HEADER_GROUP_COMMANDS)(
       start: 5,
       end: 7,
     };
+    let sheetId = "sheetId";
+    let model: Model;
+    let getters: CoreGetters;
+
+    beforeEach(() => {
+      model = new Model({
+        sheets: [{ id: sheetId, name: "Sheet Name" }],
+      });
+      getters = model.getters;
+    });
 
     test("Remove columns before the group", () => {
       const executed: RemoveColumnsRowsCommand = { ...removeColumnsCmd, elements: [0, 1] };
-      const result = transform(toTransform, executed);
+      const result = transform(toTransform, executed, getters);
       expect(result).toEqual({ ...toTransform, start: 3, end: 5 });
     });
 
     test("Remove some columns of the group", () => {
       const executed: RemoveColumnsRowsCommand = { ...removeColumnsCmd, elements: [6, 1] };
-      const result = transform(toTransform, executed);
+      const result = transform(toTransform, executed, getters);
       expect(result).toEqual({ ...toTransform, start: 4, end: 5 });
     });
 
     test("Remove all columns of the group", () => {
       const executed: RemoveColumnsRowsCommand = { ...removeColumnsCmd, elements: [5, 6, 7] };
-      const result = transform(toTransform, executed);
+      const result = transform(toTransform, executed, getters);
       expect(result).toEqual(undefined);
     });
 
     test("Remove columns after the group", () => {
       const executed: RemoveColumnsRowsCommand = { ...removeColumnsCmd, elements: [8, 9] };
-      const result = transform(toTransform, executed);
+      const result = transform(toTransform, executed, getters);
       expect(result).toEqual({ ...toTransform, start: 5, end: 7 });
     });
 
@@ -476,7 +498,7 @@ describe.each(OT_TESTS_HEADER_GROUP_COMMANDS)(
         elements: [0],
         sheetId: "42",
       };
-      const result = transform(toTransform, executed);
+      const result = transform(toTransform, executed, getters);
       expect(result).toEqual(toTransform);
     });
   }
@@ -493,10 +515,19 @@ describe("Transform of UPDATE_TABLE when removing cols", () => {
     zone: toZone("B2:C3"),
     newTableRange: toRangeData(sheetId, "B2:D4"),
   };
+  let model: Model;
+  let getters: CoreGetters;
+
+  beforeEach(() => {
+    model = new Model({
+      sheets: [{ id: sheetId, name: "Sheet Name" }],
+    });
+    getters = model.getters;
+  });
 
   test("Add cols before the zones", () => {
     const executed: RemoveColumnsRowsCommand = { ...removeColsCmd, elements: [0] };
-    const result = transform(updateFilterCmd, executed);
+    const result = transform(updateFilterCmd, executed, getters);
     expect(result).toEqual({
       ...updateFilterCmd,
       zone: toZone("A2:B3"),
@@ -506,7 +537,7 @@ describe("Transform of UPDATE_TABLE when removing cols", () => {
 
   test("Add cols inside the zones", () => {
     const executed: RemoveColumnsRowsCommand = { ...removeColsCmd, elements: [2] };
-    const result = transform(updateFilterCmd, executed);
+    const result = transform(updateFilterCmd, executed, getters);
     expect(result).toEqual({
       ...updateFilterCmd,
       zone: toZone("B2:B3"),
@@ -516,13 +547,80 @@ describe("Transform of UPDATE_TABLE when removing cols", () => {
 
   test("Add cols after the zones", () => {
     const executed: RemoveColumnsRowsCommand = { ...removeColsCmd, elements: [7] };
-    const result = transform(updateFilterCmd, executed);
+    const result = transform(updateFilterCmd, executed, getters);
     expect(result).toEqual(updateFilterCmd);
   });
 
   test("Add cols in another sheet", () => {
     const executed: RemoveColumnsRowsCommand = { ...removeColsCmd, elements: [0], sheetId: "42" };
-    const result = transform(updateFilterCmd, executed);
+    const result = transform(updateFilterCmd, executed, getters);
     expect(result).toEqual(updateFilterCmd);
+  });
+});
+
+describe("Transform adapt string formulas on row deletion", () => {
+  const sheetId = "mainSheetId";
+  const sheetName = "MainSheetName";
+  const otherSheetId = "otherSheetId";
+  const otherSheetName = "OtherSheetName";
+
+  let model: Model;
+
+  beforeEach(() => {
+    model = new Model({
+      sheets: [
+        { id: sheetId, name: sheetName },
+        { id: otherSheetId, name: otherSheetName },
+      ],
+    });
+  });
+
+  describe("on the same sheet", () => {
+    const cmds = getFormulaStringCommands(sheetId, "=SUM(A1:F1)", "=SUM(A1:E1)");
+    const removeRowsCmd: RemoveColumnsRowsCommand = {
+      ...TEST_COMMANDS.REMOVE_COLUMNS_ROWS,
+      dimension: "COL",
+      elements: [2],
+      sheetId,
+    };
+
+    test.each(cmds)("%s", (cmd, expected) => {
+      const result = transform(cmd, removeRowsCmd, model.getters);
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe("on another sheet", () => {
+    const cmds = getFormulaStringCommands(
+      sheetId,
+      "=SUM(" + otherSheetName + "!A1:F1)",
+      "=SUM(" + otherSheetName + "!A1:E1)"
+    );
+    const removeRowsCmd: RemoveColumnsRowsCommand = {
+      ...TEST_COMMANDS.REMOVE_COLUMNS_ROWS,
+      dimension: "COL",
+      elements: [2],
+      sheetId: otherSheetId,
+    };
+
+    test.each(cmds)("%s", (cmd, expected) => {
+      const result = transform(cmd, removeRowsCmd, model.getters);
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe("do not adapt strings", () => {
+    const cmds = getFormulaStringCommands(sheetId, "hello in F1", "hello in F1");
+    const removeRowsCmd: RemoveColumnsRowsCommand = {
+      ...TEST_COMMANDS.REMOVE_COLUMNS_ROWS,
+      dimension: "COL",
+      elements: [2],
+      sheetId: otherSheetId,
+    };
+
+    test.each(cmds)("%s", (cmd, expected) => {
+      const result = transform(cmd, removeRowsCmd, model.getters);
+      expect(result).toEqual(expected);
+    });
   });
 });

--- a/tests/collaborative/ot/ot_helper.ts
+++ b/tests/collaborative/ot/ot_helper.ts
@@ -1,0 +1,62 @@
+import {
+  AddConditionalFormatCommand,
+  AddDataValidationCommand,
+  AddPivotCommand,
+  CoreCommand,
+  UID,
+  UpdateCellCommand,
+} from "../../../src";
+import { deepCopy } from "../../../src/helpers";
+import { TEST_COMMANDS } from "../../test_helpers/constants";
+
+export function getFormulaStringCommands(
+  sheetId: UID,
+  formulaBefore: string,
+  formulaAfter: string
+): CoreCommand[][] {
+  return [
+    [getUpdateCellCommand(sheetId, formulaBefore), getUpdateCellCommand(sheetId, formulaAfter)],
+    [getCFCommand(sheetId, formulaBefore), getCFCommand(sheetId, formulaAfter)],
+    [getDVCommand(sheetId, formulaBefore), getDVCommand(sheetId, formulaAfter)],
+    [getPivotCommand(sheetId, formulaBefore), getPivotCommand(sheetId, formulaAfter)],
+  ];
+}
+
+function getUpdateCellCommand(sheetId: UID, formula: string): UpdateCellCommand {
+  return { ...TEST_COMMANDS.UPDATE_CELL, sheetId, content: formula };
+}
+
+function getCFCommand(sheetId: UID, formula: string): AddConditionalFormatCommand {
+  const cmd = deepCopy(TEST_COMMANDS.ADD_CONDITIONAL_FORMAT);
+  cmd.cf.rule = {
+    values: [formula],
+    operator: "Equal",
+    type: "CellIsRule",
+    style: { fillColor: "#FF0000" },
+  };
+  cmd.sheetId = sheetId;
+  return cmd;
+}
+
+function getDVCommand(sheetId: UID, formula: string): AddDataValidationCommand {
+  const cmd = deepCopy(TEST_COMMANDS.ADD_DATA_VALIDATION_RULE);
+  cmd.rule.criterion = {
+    type: "isEqual",
+    values: [formula],
+  };
+  cmd.sheetId = sheetId;
+  return cmd;
+}
+
+function getPivotCommand(sheetId: UID, formula: string): AddPivotCommand {
+  const cmd = deepCopy(TEST_COMMANDS.ADD_PIVOT);
+  cmd.pivot.measures = [
+    {
+      id: "",
+      fieldName: "",
+      aggregator: "",
+      computedBy: { sheetId, formula },
+    },
+  ];
+  return cmd;
+}

--- a/tests/collaborative/ot/ot_merged.test.ts
+++ b/tests/collaborative/ot/ot_merged.test.ts
@@ -1,6 +1,7 @@
+import { Model } from "../../../src";
 import { transform } from "../../../src/collaborative/ot/ot";
 import { toZone } from "../../../src/helpers";
-import { AddMergeCommand } from "../../../src/types";
+import { AddMergeCommand, CoreGetters } from "../../../src/types";
 import { OT_TESTS_SINGLE_CELL_COMMANDS, TEST_COMMANDS } from "../../test_helpers/constants";
 import { target } from "../../test_helpers/helpers";
 
@@ -11,27 +12,36 @@ describe("OT with ADD_MERGE", () => {
     target: target("B2:C3"),
     sheetId,
   };
+  let model: Model;
+  let getters: CoreGetters;
+
+  beforeEach(() => {
+    model = new Model({
+      sheets: [{ id: sheetId, name: "Sheet Name" }],
+    });
+    getters = model.getters;
+  });
 
   describe.each(OT_TESTS_SINGLE_CELL_COMMANDS)("single cell commands", (cmd) => {
     test(`${cmd.type} inside the merge`, () => {
       const command = { ...cmd, sheetId, col: 2, row: 2 };
-      const result = transform(command, addMerge);
+      const result = transform(command, addMerge, getters);
       expect(result).toBeUndefined();
     });
     test(`${cmd.type} = the top-left of the merge`, () => {
       const command = { ...cmd, sheetId, col: 1, row: 1 };
-      const result = transform(command, addMerge);
+      const result = transform(command, addMerge, getters);
       expect(result).toEqual(command);
     });
     test(`${cmd.type} outside the merge`, () => {
       const command = { ...cmd, sheetId, col: 10, row: 10 };
-      const result = transform(command, addMerge);
+      const result = transform(command, addMerge, getters);
       expect(result).toEqual(command);
     });
 
     test(`${cmd.type} in another sheet`, () => {
       const command = { ...cmd, col: 2, row: 1, sheetId: "42" };
-      const result = transform(command, addMerge);
+      const result = transform(command, addMerge, getters);
       expect(result).toEqual(command);
     });
   });
@@ -43,7 +53,7 @@ describe("OT with ADD_MERGE", () => {
   ])("target commands", (cmd) => {
     test(`${cmd.type} outside merge`, () => {
       const command = { ...cmd, sheetId, target: [toZone("E1:F2")] };
-      const result = transform(command, addMerge);
+      const result = transform(command, addMerge, getters);
       expect(result).toEqual(command);
     });
   });
@@ -53,17 +63,17 @@ describe("OT with ADD_MERGE", () => {
     (cmd) => {
       test("two distinct merges", () => {
         const command = { ...cmd, sheetId, target: target("E1:F2") };
-        const result = transform(command, addMerge);
+        const result = transform(command, addMerge, getters);
         expect(result).toEqual(command);
       });
       test("two overlapping merges", () => {
         const command = { ...cmd, sheetId, target: target("C3:D5") };
-        const result = transform(command, addMerge);
+        const result = transform(command, addMerge, getters);
         expect(result).toBeUndefined();
       });
       test("two overlapping merges in different sheets", () => {
         const command = { ...cmd, target: target("C3:D5"), sheetId: "another sheet" };
-        const result = transform(command, addMerge);
+        const result = transform(command, addMerge, getters);
         expect(result).toEqual(command);
       });
     }


### PR DESCRIPTION
## Description:

This task add an adaptRange-like feature to command operational transform.
The goal is to simplify the adaptability of formulas and range in OT and avoid the 
N² function required in the current OT for range adaptation using the same ApplyRangeChange
method.

Task: [4319840](https://www.odoo.com/odoo/2328/tasks/4319840)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo