### PR TITLE
[FIX] renderer: Re-fix box rendering

### DIFF
--- a/src/helpers/internal_viewport.ts
+++ b/src/helpers/internal_viewport.ts
@@ -98,10 +98,10 @@ export class InternalViewport {
         Math.min(topRowSize, this.viewportHeight - lastRowSize) // Add pixels that allows the snapping at maximum vertical scroll
       );
       height = Math.max(height, this.viewportHeight); // if the viewport grid size is smaller than its client height, return client height
-    }
 
-    if (lastRowEnd + FOOTER_HEIGHT > height && !this.getters.isReadonly()) {
-      height += FOOTER_HEIGHT;
+      if (lastRowEnd + FOOTER_HEIGHT > height && !this.getters.isReadonly()) {
+        height += FOOTER_HEIGHT;
+      }
     }
 
     return { width, height };

--- a/src/plugins/ui_feature/renderer.ts
+++ b/src/plugins/ui_feature/renderer.ts
@@ -120,11 +120,10 @@ export class RendererPlugin extends UIPlugin {
     switch (layer) {
       case LAYERS.Background:
         this.drawGlobalBackground(renderingContext);
-        for (const zone of this.getters.getAllActiveViewportsZones()) {
+        for (const { zone, rect } of this.getters.getAllActiveViewportsZonesAndRect()) {
           const { ctx } = renderingContext;
           ctx.save();
           ctx.beginPath();
-          const rect = this.getters.getVisibleRect(zone);
           ctx.rect(rect.x, rect.y, rect.width, rect.height);
           ctx.clip();
           this.boxes = this.getGridBoxes(zone);

--- a/src/plugins/ui_stateful/sheetview.ts
+++ b/src/plugins/ui_stateful/sheetview.ts
@@ -101,7 +101,7 @@ export class SheetViewPlugin extends UIPlugin {
     "getSheetViewVisibleRows",
     "getFrozenSheetViewRatio",
     "isPositionVisible",
-    "getAllActiveViewportsZones",
+    "getAllActiveViewportsZonesAndRect",
     "getRect",
   ] as const;
 
@@ -569,9 +569,18 @@ export class SheetViewPlugin extends UIPlugin {
     return { x, y };
   }
 
-  getAllActiveViewportsZones(): Zone[] {
+  getAllActiveViewportsZonesAndRect(): { zone: Zone; rect: Rect }[] {
     const sheetId = this.getters.getActiveSheetId();
-    return this.getSubViewports(sheetId);
+    return this.getSubViewports(sheetId).map((viewport) => {
+      return {
+        zone: viewport,
+        rect: {
+          x: viewport.offsetCorrectionX + this.gridOffsetX,
+          y: viewport.offsetCorrectionY + this.gridOffsetY,
+          ...viewport.getMaxSize(),
+        },
+      };
+    });
   }
 
   // ---------------------------------------------------------------------------

--- a/tests/__snapshots__/renderer_plugin.test.ts.snap
+++ b/tests/__snapshots__/renderer_plugin.test.ts.snap
@@ -7,7 +7,7 @@ exports[`renderer snapshot for a simple grid rendering 1`] = `
   "context.fillRect(0, 0, 952.5, 974.5)",
   "context.save()",
   "context.beginPath()",
-  "context.rect(0, 0, 952, 974)",
+  "context.rect(0, 0, 2592, 2374)",
   "context.clip()",
   "context.strokeStyle="#E2E3E3";",
   "context.lineWidth=0.4;",

--- a/tests/renderer_plugin.test.ts
+++ b/tests/renderer_plugin.test.ts
@@ -2070,7 +2070,7 @@ describe("renderer", () => {
   });
 
   test("Each frozen pane is clipped in the grid", () => {
-    const model = new Model();
+    const model = new Model({ sheets: [{ colNumber: 7, rowNumber: 7 }] });
 
     setCellContent(model, "A1", "1");
     freezeColumns(model, 2);


### PR DESCRIPTION
The fix introduced in 44979e28 failed to take the trait width to clip the viewports. As a side effect, the borders and grid traits of the last row and columns are partially cropped.

Task: 4526742

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo