### PR TITLE
[FIX] UUID: Reduce uuid size everywhere except revisions

### DIFF
--- a/src/components/bottom_bar/bottom_bar.ts
+++ b/src/components/bottom_bar/bottom_bar.ts
@@ -142,7 +142,7 @@ export class BottomBar extends Component<Props, SpreadsheetChildEnv> {
     const activeSheetId = this.env.model.getters.getActiveSheetId();
     const position =
       this.env.model.getters.getSheetIds().findIndex((sheetId) => sheetId === activeSheetId) + 1;
-    const sheetId = this.env.model.uuidGenerator.uuidv4();
+    const sheetId = this.env.model.uuidGenerator.smallUuid();
     const name = this.env.model.getters.getNextSheetName(this.env._t("Sheet"));
     this.env.model.dispatch("CREATE_SHEET", { sheetId, position, name });
     this.env.model.dispatch("ACTIVATE_SHEET", { sheetIdFrom: activeSheetId, sheetIdTo: sheetId });

--- a/src/components/selection_input/selection_input.ts
+++ b/src/components/selection_input/selection_input.ts
@@ -83,7 +83,7 @@ interface SelectionRange extends Omit<RangeInputValue, "color"> {
  */
 export class SelectionInput extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-SelectionInput";
-  private id = uuidGenerator.uuidv4();
+  private id = uuidGenerator.smallUuid();
   private previousRanges: string[] = this.props.ranges || [];
   private originSheet = this.env.model.getters.getActiveSheetId();
   private state = useState({

--- a/src/components/side_panel/conditional_formatting/conditional_formatting.ts
+++ b/src/components/side_panel/conditional_formatting/conditional_formatting.ts
@@ -458,7 +458,7 @@ export class ConditionalFormattingPanel extends Component<Props, SpreadsheetChil
           id:
             this.state.mode === "edit"
               ? this.state.currentCF.id
-              : this.env.model.uuidGenerator.uuidv4(),
+              : this.env.model.uuidGenerator.smallUuid(),
         },
         ranges: this.state.currentCF.ranges.map((xc) =>
           this.env.model.getters.getRangeDataFromXc(sheetId, xc)
@@ -530,7 +530,7 @@ export class ConditionalFormattingPanel extends Component<Props, SpreadsheetChil
     this.state.mode = "add";
     this.state.currentCFType = "CellIsRule";
     this.state.currentCF = {
-      id: this.env.model.uuidGenerator.uuidv4(),
+      id: this.env.model.uuidGenerator.smallUuid(),
       ranges: this.env.model.getters
         .getSelectedZones()
         .map((zone) =>

--- a/src/helpers/clipboard/clipboard_figure_state.ts
+++ b/src/helpers/clipboard/clipboard_figure_state.ts
@@ -70,7 +70,7 @@ export class ClipboardFigureState implements ClipboardState {
     };
 
     const newChart = this.copiedChart.copyInSheetId(sheetId);
-    const newId = new UuidGenerator().uuidv4();
+    const newId = new UuidGenerator().smallUuid();
 
     this.dispatch("CREATE_CHART", {
       id: newId,

--- a/src/helpers/filters.ts
+++ b/src/helpers/filters.ts
@@ -10,10 +10,10 @@ export class FilterTable implements Cloneable<FilterTable> {
     this.filters = [];
     this.zone = zone;
     const uuid = new UuidGenerator();
-    this.id = uuid.uuidv4();
+    this.id = uuid.smallUuid();
     for (const i of range(zone.left, zone.right + 1)) {
       const filterZone = { ...this.zone, left: i, right: i };
-      this.filters.push(new Filter(uuid.uuidv4(), filterZone));
+      this.filters.push(new Filter(uuid.smallUuid(), filterZone));
     }
   }
 

--- a/src/helpers/uuid.ts
+++ b/src/helpers/uuid.ts
@@ -11,6 +11,39 @@ export class UuidGenerator {
     this.isFastIdStrategy = isFast;
   }
 
+  /**
+   * Generates a custom UUID using a simple 26^8 method (8-character alphanumeric string with lowercase letters)
+   * This has a higher chance of collision than a UUIDv4, but not only faster to generate than an UUIDV4,
+   * it also has a smaller size, which is preferable to alleviate the overall data size.
+   *
+   * This method is preferable when generating uuids for the core data (sheetId, figureId, etc)
+   * as they will appear several times in the revisions and local history.
+   *
+   */
+  smallUuid(): string {
+    if (this.isFastIdStrategy) {
+      this.fastIdStart++;
+      return String(this.fastIdStart);
+      //@ts-ignore
+    } else if (window.crypto && window.crypto.getRandomValues) {
+      return (1e7).toString().replace(/[018]/g, (c) =>
+        //@ts-ignore
+        (c ^ (crypto.getRandomValues(new Uint8Array(1))[0] & (15 >> (c / 4)))).toString(16)
+      );
+    } else {
+      // mainly for jest and other browsers that do not have the crypto functionality
+      return "xxxxxxxx".replace(/[xy]/g, function (c) {
+        var r = (Math.random() * 16) | 0,
+          v = c == "x" ? r : (r & 0x3) | 0x8;
+        return v.toString(16);
+      });
+    }
+  }
+
+  /**
+   * Generates an UUIDV4, has astronomically low chance of collision, but is larger in size than the smallUuid.
+   * This method should be used when you need to avoid collisions at all costs, like the id of a revision.
+   */
   uuidv4(): string {
     if (this.isFastIdStrategy) {
       this.fastIdStart++;

--- a/src/migrations/data.ts
+++ b/src/migrations/data.ts
@@ -364,7 +364,7 @@ function forceUnicityOfFigure(data: Partial<WorkbookData>): Partial<WorkbookData
   for (const sheet of data.sheets || []) {
     for (const figure of sheet.figures || []) {
       if (figureIds.has(figure.id)) {
-        figure.id += uuidGenerator.uuidv4();
+        figure.id += uuidGenerator.smallUuid();
       }
       figureIds.add(figure.id);
     }

--- a/src/model.ts
+++ b/src/model.ts
@@ -346,7 +346,7 @@ export class Model extends EventBus<any> implements CommandDispatcher {
 
   private setupConfig(config: Partial<ModelConfig>): ModelConfig {
     const client = config.client || {
-      id: this.uuidGenerator.uuidv4(),
+      id: this.uuidGenerator.smallUuid(),
       name: _lt("Anonymous").toString(),
     };
     const transportService = config.transportService || new LocalTransportService();

--- a/src/plugins/core/filters.ts
+++ b/src/plugins/core/filters.ts
@@ -210,7 +210,7 @@ export class FiltersPlugin extends CorePlugin<FiltersState> implements FiltersSt
         for (let col = zone.left; col <= zone.right; col++) {
           if (!filters.find((filter) => filter.col === col)) {
             filters.push(
-              new Filter(this.uuidGenerator.uuidv4(), { ...zone, left: col, right: col })
+              new Filter(this.uuidGenerator.smallUuid(), { ...zone, left: col, right: col })
             );
           }
         }

--- a/src/plugins/ui/evaluation_conditional_format.ts
+++ b/src/plugins/ui/evaluation_conditional_format.ts
@@ -516,6 +516,8 @@ export class EvaluationConditionalFormatPlugin extends UIPlugin {
       .getConditionalFormats(targetSheetId)
       .find((cf) => cf.stopIfTrue === originCF.stopIfTrue && deepEquals(cf.rule, originCF.rule));
 
-    return cfInTarget ? cfInTarget : { ...originCF, id: this.uuidGenerator.uuidv4(), ranges: [] };
+    return cfInTarget
+      ? cfInTarget
+      : { ...originCF, id: this.uuidGenerator.smallUuid(), ranges: [] };
   }
 }

--- a/src/plugins/ui/selection_input.ts
+++ b/src/plugins/ui/selection_input.ts
@@ -181,7 +181,7 @@ export class SelectionInputPlugin extends UIPlugin implements StreamCallbacks<Se
   private setContent(index: number, xc: string) {
     this.ranges[index] = {
       ...this.ranges[index],
-      id: uuidGenerator.uuidv4(),
+      id: uuidGenerator.smallUuid(),
       xc,
     };
   }

--- a/src/registries/menus/menu_items_actions.ts
+++ b/src/registries/menus/menu_items_actions.ts
@@ -570,7 +570,7 @@ export const UNHIDE_ROWS_ACTION = (env: SpreadsheetChildEnv) => {
 export const CREATE_SHEET_ACTION = (env: SpreadsheetChildEnv) => {
   const activeSheetId = env.model.getters.getActiveSheetId();
   const position = env.model.getters.getSheetIds().indexOf(activeSheetId) + 1;
-  const sheetId = env.model.uuidGenerator.uuidv4();
+  const sheetId = env.model.uuidGenerator.smallUuid();
   env.model.dispatch("CREATE_SHEET", { sheetId, position });
   env.model.dispatch("ACTIVATE_SHEET", { sheetIdFrom: activeSheetId, sheetIdTo: sheetId });
 };
@@ -583,7 +583,7 @@ export const CREATE_CHART = (env: SpreadsheetChildEnv) => {
   const getters = env.model.getters;
   const zone = getters.getSelectedZone();
   let dataSetZone = zone;
-  const id = env.model.uuidGenerator.uuidv4();
+  const id = env.model.uuidGenerator.smallUuid();
   let labelRange: string | undefined;
   if (zone.left !== zone.right) {
     dataSetZone = { ...zone, left: zone.left + 1 };

--- a/src/registries/menus/sheet_menu_registry.ts
+++ b/src/registries/menus/sheet_menu_registry.ts
@@ -21,7 +21,7 @@ sheetMenuRegistry
     sequence: 20,
     action: (env) => {
       const sheetIdFrom = env.model.getters.getActiveSheetId();
-      const sheetIdTo = env.model.uuidGenerator.uuidv4();
+      const sheetIdTo = env.model.uuidGenerator.smallUuid();
       env.model.dispatch("DUPLICATE_SHEET", {
         sheetId: sheetIdFrom,
         sheetIdTo,

--- a/src/registries/topbar_component_registry.ts
+++ b/src/registries/topbar_component_registry.ts
@@ -17,7 +17,7 @@ class TopBarComponentRegistry extends Registry<TopbarComponent> {
   uuidGenerator = new UuidGenerator();
 
   add(name: string, value: Omit<TopbarComponent, "id">) {
-    const component: TopbarComponent = { ...value, id: this.uuidGenerator.uuidv4() };
+    const component: TopbarComponent = { ...value, id: this.uuidGenerator.smallUuid() };
     return super.add(name, component);
   }
 }

--- a/tests/__mocks__/uuid.ts
+++ b/tests/__mocks__/uuid.ts
@@ -7,6 +7,10 @@ export class UuidGenerator {
     return String(this.nextId++);
   }
 
+  smallUuid(): string {
+    return String(this.nextId++);
+  }
+
   setNextId(i: number) {
     this.nextId = i;
   }


### PR DESCRIPTION
Long uuids are not necessary for standard identifiers (like sheet,cf, figure) as they are only meaningful when two users will try to create them at the exact same time. A string with 8 random alphanumeric values gives have 36^8 to 1 chance to collide, which is clearly enough. The strong uuids are still necessary in the case of revisions as they can come way more often.

On a spreadsheet 112mb of revisions, it reduces the size of all the revisions by 15mb, -> 13.4% size gained.

Co-authored-by: Vincent Schippefilt <vsc@odoo.com>
Task: 4532659

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo