### PR TITLE
[FIX] pivot: display column values in sorted pivot

### DIFF
--- a/src/helpers/pivot/spreadsheet_pivot/data_entry_spreadsheet_pivot.ts
+++ b/src/helpers/pivot/spreadsheet_pivot/data_entry_spreadsheet_pivot.ts
@@ -73,7 +73,7 @@ function dataEntriesToRows(
     pivotTableRows.push({
       fields: _fields,
       values: _values,
-      indent: index,
+      indent: index + 1,
     });
     const record = groups[value];
     if (record) {

--- a/src/helpers/pivot/table_spreadsheet_pivot.ts
+++ b/src/helpers/pivot/table_spreadsheet_pivot.ts
@@ -340,7 +340,7 @@ export class SpreadsheetPivotTable {
   private rowTreeToRows(tree: DimensionTree, parentRow?: PivotTableRow): PivotTableRow[] {
     return tree.flatMap((node) => {
       const row: PivotTableRow = {
-        indent: parentRow ? parentRow.indent + 1 : 0,
+        indent: parentRow ? parentRow.indent + 1 : 1,
         fields: [...(parentRow?.fields || []), node.field],
         values: [...(parentRow?.values || []), node.value],
       };

--- a/tests/pivots/spreadsheet_pivot/spreadsheet_pivot.test.ts
+++ b/tests/pivots/spreadsheet_pivot/spreadsheet_pivot.test.ts
@@ -660,6 +660,33 @@ describe("Spreadsheet Pivot", () => {
     );
   });
 
+  test("sorted PIVOT include_total=FALSE with no column groups includes column data", () => {
+    // prettier-ignore
+    const grid = {
+      A1: "Person", B1: "Price", C1: "=PIVOT(1,,FALSE)",
+      A2: "Alice",  B2: "10",
+      A3: "Bob",    B3: "20",
+    };
+    const model = createModelFromGrid(grid);
+    addPivot(model, "A1:B3", {
+      rows: [{ fieldName: "Person" }],
+      measures: [{ id: "Price:sum", fieldName: "Price", aggregator: "sum" }],
+      sortedColumn: {
+        domain: [],
+        order: "desc",
+        measure: "Price:sum",
+      },
+    });
+    // prettier-ignore
+    expect(getEvaluatedGrid(model, "C1:D5")).toEqual([
+      ["(#1) Pivot", "Total"],
+      ["",           "Price"],
+      ["Bob",        "20"],
+      ["Alice",      "10"],
+      ["",           ""],
+    ]);
+  });
+
   test("PIVOT with limited columns count.", () => {
     // prettier-ignore
     const grid = {


### PR DESCRIPTION
## Description:

Steps to reproduce:

- Insert an odoo pivot with row groups, but no column group.
- sort the measure on one column => the formula =PIVOT(1,,FALSE) doesn't show any data, even though it should show the column

Task: [4536075](https://www.odoo.com/odoo/2328/tasks/4536075)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo