### PR TITLE
[FIX] composer: long composer asisstant breaks the layout

### DIFF
--- a/src/components/composer/composer/composer.ts
+++ b/src/components/composer/composer/composer.ts
@@ -172,7 +172,8 @@ export class Composer extends Component<ComposerProps, SpreadsheetChildEnv> {
     const composerRect = this.composerRef.el!.getBoundingClientRect();
     const assistantStyle: CSSProperties = {};
 
-    assistantStyle["min-width"] = `${this.props.rect?.width || ASSISTANT_WIDTH}px`;
+    const minWidth = Math.min(this.props.rect?.width || Infinity, ASSISTANT_WIDTH);
+    assistantStyle["min-width"] = `${minWidth}px`;
     if (this.autoCompleteState.type === "function") {
       assistantStyle.width = `${ASSISTANT_WIDTH}px`;
     }

--- a/src/components/composer/composer/composer.xml
+++ b/src/components/composer/composer/composer.xml
@@ -22,29 +22,32 @@
         t-on-contextmenu="onContextMenu"
       />
 
-      <div
-        t-if="props.focus !== 'inactive' and (autoCompleteState.showProvider or functionDescriptionState.showDescription)"
-        class="o-composer-assistant shadow"
-        t-att-style="assistantStyle"
-        t-on-wheel.stop=""
-        t-on-mousedown.prevent.stop=""
-        t-on-click.prevent.stop=""
-        t-on-mouseup.prevent.stop="">
-        <TextValueProvider
-          t-if="autoCompleteState.showProvider"
-          values="autoCompleteState.values"
-          selectedIndex="autoCompleteState.selectedIndex"
-          onValueSelected.bind="this.autoComplete"
-          onValueHovered.bind="this.updateAutoCompleteIndex"
-          getHtmlContent="autoCompleteState.getHtmlContent"
-        />
-        <FunctionDescriptionProvider
-          t-if="functionDescriptionState.showDescription"
-          functionName="functionDescriptionState.functionName"
-          functionDescription="functionDescriptionState.functionDescription"
-          argToFocus="functionDescriptionState.argToFocus"
-        />
-      </div>
+      <Popover
+        t-props="popoverProps"
+        t-if="props.focus !== 'inactive' and (autoCompleteState.showProvider or functionDescriptionState.showDescription)">
+        <div
+          class="o-composer-assistant"
+          t-att-style="assistantStyle"
+          t-on-wheel.stop=""
+          t-on-mousedown.prevent.stop=""
+          t-on-click.prevent.stop=""
+          t-on-mouseup.prevent.stop="">
+          <TextValueProvider
+            t-if="autoCompleteState.showProvider"
+            values="autoCompleteState.values"
+            selectedIndex="autoCompleteState.selectedIndex"
+            onValueSelected.bind="this.autoComplete"
+            onValueHovered.bind="this.updateAutoCompleteIndex"
+            getHtmlContent="autoCompleteState.getHtmlContent"
+          />
+          <FunctionDescriptionProvider
+            t-if="functionDescriptionState.showDescription"
+            functionName="functionDescriptionState.functionName"
+            functionDescription="functionDescriptionState.functionDescription"
+            argToFocus="functionDescriptionState.argToFocus"
+          />
+        </div>
+      </Popover>
     </div>
   </t>
 </templates>

--- a/src/components/composer/grid_composer/grid_composer.ts
+++ b/src/components/composer/grid_composer/grid_composer.ts
@@ -94,13 +94,7 @@ export class GridComposer extends Component<Props, SpreadsheetChildEnv> {
   }
 
   get composerProps(): ComposerProps {
-    const { width, height } = this.env.model.getters.getSheetViewDimensionWithHeaders();
     return {
-      rect: { ...this.rect },
-      delimitation: {
-        width,
-        height,
-      },
       focus: this.props.focus,
       isDefaultFocus: true,
       onComposerContentFocused: this.props.onComposerContentFocused,

--- a/src/components/menu/menu.xml
+++ b/src/components/menu/menu.xml
@@ -44,6 +44,7 @@
       </div>
       <Menu
         t-if="subMenu.isOpen"
+        t-key="subMenu.parentMenu.id"
         position="subMenuPosition"
         menuItems="subMenu.menuItems"
         depth="props.depth + 1"

--- a/src/components/popover/popover.ts
+++ b/src/components/popover/popover.ts
@@ -81,10 +81,6 @@ export class Popover extends Component<PopoverProps, SpreadsheetChildEnv> {
       this.currentDisplayValue = newDisplay;
 
       if (!anchor) return;
-      el.style.top = "";
-      el.style.left = "";
-      el.style["max-height"] = "";
-      el.style["max-width"] = "";
 
       const propsMaxSize = { width: this.props.maxWidth, height: this.props.maxHeight };
       let elDims = {

--- a/tests/composer/__snapshots__/autocomplete_dropdown_component.test.ts.snap
+++ b/tests/composer/__snapshots__/autocomplete_dropdown_component.test.ts.snap
@@ -57,124 +57,134 @@ exports[`Functions autocomplete autocomplete simple snapshot with =S 1`] = `
 
 exports[`composer Assistant render above the cell when not enough place below 1`] = `
 <div
-  class="o-composer-assistant shadow"
-  style="min-width:96px; width:300px; max-height:150px; top:-3px; transform:translate(0, -100%); right:0px; "
+  class="o-popover"
+  style="z-index: 35; display: block; max-height: 600px; max-width: 900px; top: 100px; left: 100px;"
 >
   <div
-    class="o-autocomplete-dropdown"
+    class="o-composer-assistant"
+    style="min-width:300px; width:300px; "
   >
     <div
-      class="d-flex flex-column text-start o-autocomplete-value-focus"
+      class="o-autocomplete-dropdown"
     >
       <div
-        class="o-autocomplete-value text-truncate"
+        class="d-flex flex-column text-start o-autocomplete-value-focus"
       >
-        <span
-          class="o-semi-bold"
-          style="color: #9B359B;"
+        <div
+          class="o-autocomplete-value text-truncate"
         >
-          S
-        </span>
-        <span
-          style="color: inherit;"
+          <span
+            class="o-semi-bold"
+            style="color: #9B359B;"
+          >
+            S
+          </span>
+          <span
+            style="color: inherit;"
+          >
+            UM
+          </span>
+          
+        </div>
+        <div
+          class="o-autocomplete-description text-truncate"
         >
-          UM
-        </span>
+          do sum
+        </div>
         
       </div>
       <div
-        class="o-autocomplete-description text-truncate"
+        class="d-flex flex-column text-start"
       >
-        do sum
-      </div>
-      
-    </div>
-    <div
-      class="d-flex flex-column text-start"
-    >
-      <div
-        class="o-autocomplete-value text-truncate"
-      >
-        <span
-          class="o-semi-bold"
-          style="color: #9B359B;"
+        <div
+          class="o-autocomplete-value text-truncate"
         >
-          S
-        </span>
-        <span
-          style="color: inherit;"
-        >
-          ZZ
-        </span>
+          <span
+            class="o-semi-bold"
+            style="color: #9B359B;"
+          >
+            S
+          </span>
+          <span
+            style="color: inherit;"
+          >
+            ZZ
+          </span>
+          
+        </div>
         
       </div>
       
     </div>
     
+    
   </div>
-  
-  
 </div>
 `;
 
 exports[`composer Assistant render below the cell by default 1`] = `
 <div
-  class="o-composer-assistant shadow"
-  style="min-width:300px; width:300px; "
+  class="o-popover"
+  style="z-index: 35; display: block; max-height: 850px; max-width: 900px; top: 150px; left: 100px;"
 >
   <div
-    class="o-autocomplete-dropdown"
+    class="o-composer-assistant"
+    style="min-width:300px; width:300px; "
   >
     <div
-      class="d-flex flex-column text-start o-autocomplete-value-focus"
+      class="o-autocomplete-dropdown"
     >
       <div
-        class="o-autocomplete-value text-truncate"
+        class="d-flex flex-column text-start o-autocomplete-value-focus"
       >
-        <span
-          class="o-semi-bold"
-          style="color: #9B359B;"
+        <div
+          class="o-autocomplete-value text-truncate"
         >
-          S
-        </span>
-        <span
-          style="color: inherit;"
+          <span
+            class="o-semi-bold"
+            style="color: #9B359B;"
+          >
+            S
+          </span>
+          <span
+            style="color: inherit;"
+          >
+            UM
+          </span>
+          
+        </div>
+        <div
+          class="o-autocomplete-description text-truncate"
         >
-          UM
-        </span>
+          do sum
+        </div>
         
       </div>
       <div
-        class="o-autocomplete-description text-truncate"
+        class="d-flex flex-column text-start"
       >
-        do sum
-      </div>
-      
-    </div>
-    <div
-      class="d-flex flex-column text-start"
-    >
-      <div
-        class="o-autocomplete-value text-truncate"
-      >
-        <span
-          class="o-semi-bold"
-          style="color: #9B359B;"
+        <div
+          class="o-autocomplete-value text-truncate"
         >
-          S
-        </span>
-        <span
-          style="color: inherit;"
-        >
-          ZZ
-        </span>
+          <span
+            class="o-semi-bold"
+            style="color: #9B359B;"
+          >
+            S
+          </span>
+          <span
+            style="color: inherit;"
+          >
+            ZZ
+          </span>
+          
+        </div>
         
       </div>
       
     </div>
     
+    
   </div>
-  
-  
 </div>
 `;

--- a/tests/composer/autocomplete_dropdown_component.test.ts
+++ b/tests/composer/autocomplete_dropdown_component.test.ts
@@ -5,6 +5,7 @@ import { ContentEditableHelper } from "../__mocks__/content_editable_helper";
 import { selectCell } from "../test_helpers/commands_helpers";
 import {
   click,
+  getElStyle,
   keyDown,
   keyUp,
   simulateClick,
@@ -402,6 +403,22 @@ describe("composer Assistant", () => {
     expect(assistantEL.style.width).toBe("300px");
     expect(assistantEL.style.top).toBe("-3px");
     expect(assistantEL.style.transform).toBe("translate(0, -100%)");
+  });
+
+  test("composer assistant min-width is the same as the underlying cell", async () => {
+    ({ model, fixture, parent } = await mountComposerWrapper(new Model(), {
+      rect: { width: 60, height: DEFAULT_CELL_HEIGHT, x: 150, y: 150 },
+    }));
+    await typeInComposer("=s");
+    expect(getElStyle(".o-composer-assistant", "min-width")).toBe("60px");
+  });
+
+  test("composer assistant min-width is capped for large cells", async () => {
+    ({ model, fixture, parent } = await mountComposerWrapper(new Model(), {
+      rect: { width: 1000, height: DEFAULT_CELL_HEIGHT, x: 150, y: 150 },
+    }));
+    await typeInComposer("=s");
+    expect(getElStyle(".o-composer-assistant", "min-width")).toBe("300px");
   });
 });
 

--- a/tests/composer/composer_component.test.ts
+++ b/tests/composer/composer_component.test.ts
@@ -2,14 +2,12 @@ import {
   selectionIndicatorClass,
   tokenColors,
 } from "../../src/components/composer/composer/composer";
-import { DEFAULT_CELL_HEIGHT, DEFAULT_CELL_WIDTH } from "../../src/constants";
 import { colors, toCartesian, toZone } from "../../src/helpers/index";
 import { Model } from "../../src/model";
 import { Highlight } from "../../src/types";
 import { ContentEditableHelper } from "../__mocks__/content_editable_helper";
 import { MockClipboardData, getClipboardEvent } from "../test_helpers/clipboard";
 import {
-  createFilter,
   createSheet,
   createSheetWithName,
   merge,
@@ -30,13 +28,11 @@ import {
   getCellContent,
   getCellText,
   getEvaluatedCell,
-  getFilterTable,
   getSelectionAnchorCellXc,
 } from "../test_helpers/getters_helpers";
 import {
   ComposerWrapper,
   mountComposerWrapper,
-  mountSpreadsheet,
   nextTick,
   typeInComposerHelper,
 } from "../test_helpers/helpers";
@@ -511,19 +507,6 @@ describe("composer", () => {
     expect(model.getters.getEditionMode()).toBe("inactive");
   });
 
-  test("should create a table when a cell is double clicked in edit mode", async () => {
-    ({ model, fixture } = await mountSpreadsheet());
-    selectCell(model, "A1");
-    triggerMouseEvent(
-      ".o-grid-overlay",
-      "dblclick",
-      0.5 * DEFAULT_CELL_WIDTH,
-      0.5 * DEFAULT_CELL_HEIGHT
-    );
-    createFilter(model, "A1");
-    expect(getFilterTable(model, "A1")).toBeTruthy();
-  });
-
   test("edit link cell changes the label", async () => {
     setCellContent(model, "A1", "[label](http://odoo.com)");
     composerEl = await startComposition();
@@ -532,20 +515,6 @@ describe("composer", () => {
     const link = getEvaluatedCell(model, "A1").link;
     expect(link?.label).toBe("label updated");
     expect(link?.url).toBe("http://odoo.com");
-  });
-
-  test("Pressing Enter while editing a label does not open grid composer", async () => {
-    ({ model, fixture } = await mountSpreadsheet());
-    setCellContent(model, "A1", "[label](http://odoo.com)");
-    await simulateClick(".o-topbar-menu[data-id='insert']");
-    await simulateClick(".o-menu-item[data-name='insert_link']");
-    const editor = fixture.querySelector(".o-link-editor");
-    expect(editor).toBeTruthy();
-
-    editor!.querySelectorAll("input")[0].focus();
-    await keyDown({ key: "Enter" });
-    expect(fixture.querySelector(".o-link-editor")).toBeFalsy();
-    expect(model.getters.getEditionMode()).toBe("inactive");
   });
 
   describe("change selecting mode when typing specific token value", () => {

--- a/tests/composer/composer_integration_component.test.ts
+++ b/tests/composer/composer_integration_component.test.ts
@@ -11,6 +11,7 @@ import { ContentEditableHelper } from "../__mocks__/content_editable_helper";
 import {
   activateSheet,
   copy,
+  createFilter,
   createSheet,
   paste,
   renameSheet,
@@ -29,6 +30,7 @@ import {
   rightClickCell,
   selectColumnByClicking,
   simulateClick,
+  triggerMouseEvent,
   triggerWheelEvent,
 } from "../test_helpers/dom_helper";
 import {
@@ -36,6 +38,7 @@ import {
   getActiveSheetFullScrollInfo,
   getCellContent,
   getCellText,
+  getFilterTable,
   getSelectionAnchorCellXc,
 } from "../test_helpers/getters_helpers";
 import {
@@ -451,6 +454,31 @@ describe("Composer interactions", () => {
     await typeInComposerGrid("=sum(sum(1,2");
     await clickCell(model, "B2");
     expect(getCellText(model, "A1")).toBe("=sum(sum(1,2))");
+  });
+
+  test("Pressing Enter while editing a label does not open grid composer", async () => {
+    setCellContent(model, "A1", "[label](http://odoo.com)");
+    await simulateClick(".o-topbar-menu[data-id='insert']");
+    await simulateClick(".o-menu-item[data-name='insert_link']");
+    const editor = fixture.querySelector(".o-link-editor");
+    expect(editor).toBeTruthy();
+
+    editor!.querySelectorAll("input")[0].focus();
+    await keyDown({ key: "Enter" });
+    expect(fixture.querySelector(".o-link-editor")).toBeFalsy();
+    expect(model.getters.getEditionMode()).toBe("inactive");
+  });
+
+  test("should create a table when a cell is double clicked in edit mode", async () => {
+    selectCell(model, "A1");
+    triggerMouseEvent(
+      ".o-grid-overlay",
+      "dblclick",
+      0.5 * DEFAULT_CELL_WIDTH,
+      0.5 * DEFAULT_CELL_HEIGHT
+    );
+    createFilter(model, "A1");
+    expect(getFilterTable(model, "A1")).toBeTruthy();
   });
 });
 

--- a/tests/composer/composer_integration_component.test.ts
+++ b/tests/composer/composer_integration_component.test.ts
@@ -149,11 +149,10 @@ describe("Composer interactions", () => {
 
   test("autocomplete disappear when grid composer is blurred", async () => {
     await keyDown({ key: "Enter" });
-    const topBarComposer = document.querySelector(".o-spreadsheet-topbar .o-composer")!;
     await typeInComposerGrid("=SU");
-    expect(fixture.querySelector(".o-grid .o-autocomplete-dropdown")).not.toBeNull();
-    await click(topBarComposer);
-    expect(fixture.querySelector(".o-grid .o-autocomplete-dropdown")).toBeNull();
+    expect(fixture.querySelector(".o-popover .o-autocomplete-dropdown")).not.toBeNull();
+    await simulateClick(".o-grid-overlay");
+    expect(fixture.querySelector(".o-popover .o-autocomplete-dropdown")).toBeNull();
   });
 
   test("focus top bar composer does not resize grid composer when autocomplete is displayed", async () => {

--- a/tests/test_helpers/helpers.ts
+++ b/tests/test_helpers/helpers.ts
@@ -739,6 +739,7 @@ type ComposerWrapperProps = {
 export class ComposerWrapper extends Component<ComposerWrapperProps, SpreadsheetChildEnv> {
   static components = { Composer };
   static template = xml/*xml*/ `
+    <div class="o-spreadsheet"/>
     <Composer t-props="composerProps"/>
   `;
   state = useState({ focusComposer: <ComposerFocusType>"inactive" });


### PR DESCRIPTION
### [FIX] composer: broken layout for long list suggestions

If the composer TextProvider displayed a very long list of possible
values, it broke the spreadsheet layout.

This commit changes the composer assistant to a Popover component,
which have build-in code to be limited by the spreadsheet size.

The assistant was also positioned relative to the `o-composer` element,
where it should have been positioned relative to the parent element,
because it's the one that has the borders/padding.


### [FIX] composer: wrong size for autocomplete dropdown

In the grid composer we pass a `rect` props to the composer to make
the formula assistant have the same size as the underlying cell.

This makes:
1) the FunctionDescriptionProvider ugly for large cells
2) the TextValueProvider buggy for large cells, as its CSS define a
`max-width` that conflicts with the `min-width` that the composer sets.

This commit caps the `min-width` of the composer to `ASSISTANT_WIDTH`.


### [FIX] popover: scroll lost on re-render

The commit c49ed07780 tried to fix the positioning of the `Popover`
when it was re-rendered with possibly different props. But setting the
`max-height` of the popover to undefined, even temporarily, was causing
the scroll to be lost.

This reverts the changes of c49ed07780, and adds a `t-key` to the
`Popover` in the `Menu` to fix the original issue by forcing a
total re-render of the `Popover` when the user opens a different menu.


### [MOV] test: move some composer tests in correct files

Some tests in the `composer_component.test.ts` were mounting a
spreadsheet after a ComposerWrapper was already mounted in the
beforeEach.

It caused issue with the following commit that adds a Portal target in
the ComposerWrapper. This led to two Portal targets in the document and
a test failing.

This commit moves these tests to the `composer_integration_component.test.ts`
file where they belong.

Task: [4456224](https://www.odoo.com/odoo/2328/tasks/4456224)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo