### PR TITLE
[FIX] chart: label header prevents creating linear/time charts

### DIFF
--- a/src/components/side_panel/chart/line_chart/line_chart_config_panel.ts
+++ b/src/components/side_panel/chart/line_chart/line_chart_config_panel.ts
@@ -7,7 +7,7 @@ export class LineConfigPanel extends LineBarPieConfigPanel {
   get canTreatLabelsAsText() {
     const chart = this.env.model.getters.getChart(this.props.figureId);
     if (chart && chart instanceof LineChart) {
-      return canChartParseLabels(chart.labelRange, this.env.model.getters);
+      return canChartParseLabels(chart, this.env.model.getters);
     }
     return false;
   }

--- a/src/helpers/figures/charts/bar_chart.ts
+++ b/src/helpers/figures/charts/bar_chart.ts
@@ -254,11 +254,7 @@ export function createBarChartRuntime(chart: BarChart, getters: Getters): BarCha
   const labelValues = getChartLabelValues(getters, chart.dataSets, chart.labelRange);
   let labels = labelValues.formattedValues;
   let dataSetsValues = getChartDatasetValues(getters, chart.dataSets);
-  if (
-    chart.dataSetsHaveTitle &&
-    dataSetsValues[0] &&
-    labels.length > dataSetsValues[0].data.length
-  ) {
+  if (shouldRemoveFirstLabel(chart.labelRange, chart.dataSets[0], chart.dataSetsHaveTitle)) {
     labels.shift();
   }
 

--- a/src/helpers/figures/charts/chart_factory.ts
+++ b/src/helpers/figures/charts/chart_factory.ts
@@ -13,6 +13,7 @@ import {
   UID,
   Zone,
 } from "../../../types";
+import { LineChartDefinition } from "../../../types/chart";
 import {
   ChartCreationContext,
   ChartDefinition,
@@ -23,7 +24,7 @@ import { CoreGetters, Getters } from "../../../types/getters";
 import { Validator } from "../../../types/validator";
 import { getZoneArea, zoneToXc } from "../../zones";
 import { AbstractChart } from "./abstract_chart";
-import { canChartParseLabels } from "./line_chart";
+import { LineChart, canChartParseLabels } from "./line_chart";
 
 /**
  * Create a function used to create a Chart based on the definition
@@ -168,21 +169,22 @@ export function getSmartChartDefinition(zone: Zone, getters: Getters): ChartDefi
   // Only display legend for several datasets.
   const newLegendPos = dataSetZone.right === dataSetZone.left ? "none" : "top";
 
-  const labelRange = labelRangeXc ? getters.getRangeFromSheetXC(sheetId, labelRangeXc) : undefined;
-  if (canChartParseLabels(labelRange, getters)) {
-    return {
-      title,
-      dataSets,
-      labelsAsText: false,
-      stacked: false,
-      aggregated: false,
-      cumulative: false,
-      labelRange: labelRangeXc,
-      type: "line",
-      dataSetsHaveTitle,
-      verticalAxisPosition: "left",
-      legendPosition: newLegendPos,
-    };
+  const lineChartDefinition: LineChartDefinition = {
+    title,
+    dataSets,
+    labelsAsText: false,
+    stacked: false,
+    aggregated: false,
+    cumulative: false,
+    labelRange: labelRangeXc,
+    type: "line",
+    dataSetsHaveTitle,
+    verticalAxisPosition: "left",
+    legendPosition: newLegendPos,
+  };
+  const chart = new LineChart(lineChartDefinition, sheetId, getters);
+  if (canChartParseLabels(chart, getters)) {
+    return lineChartDefinition;
   }
   return {
     title,

--- a/src/helpers/figures/charts/chart_ui_common.ts
+++ b/src/helpers/figures/charts/chart_ui_common.ts
@@ -6,7 +6,7 @@ import { Color, Figure, Format, Getters, LocaleFormat, Range } from "../../../ty
 import { ChartRuntime, DataSet, DatasetValues, LabelValues } from "../../../types/chart/chart";
 import { formatValue, isDateTimeFormat } from "../../format";
 import { deepCopy, range } from "../../misc";
-import { recomputeZones, zoneToXc } from "../../zones";
+import { positions, recomputeZones, zoneToXc } from "../../zones";
 import { AbstractChart } from "./abstract_chart";
 import { drawScoreChart } from "./scorecard_chart";
 import { getScorecardConfiguration } from "./scorecard_chart_config_builder";
@@ -157,22 +157,21 @@ export function getDefaultChartJsRuntime(
 
 export function getChartLabelFormat(
   getters: Getters,
-  range: Range | undefined
+  range: Range | undefined,
+  shouldRemoveFirstLabel: boolean
 ): Format | undefined {
   if (!range) return undefined;
 
-  const {
-    sheetId,
-    zone: { left, top, bottom },
-  } = range;
-  for (let row = top; row <= bottom; row++) {
-    const format = getters.getEvaluatedCell({ sheetId, col: left, row }).format;
-    if (format) {
-      return format;
-    }
+  const { sheetId, zone } = range;
+
+  const formats = positions(zone).map(
+    (position) => getters.getEvaluatedCell({ sheetId, ...position }).format
+  );
+  if (shouldRemoveFirstLabel) {
+    formats.shift();
   }
 
-  return undefined;
+  return formats.find((format) => format !== undefined);
 }
 
 export function getChartLabelValues(

--- a/src/helpers/figures/charts/pie_chart.ts
+++ b/src/helpers/figures/charts/pie_chart.ts
@@ -265,11 +265,7 @@ export function createPieChartRuntime(chart: PieChart, getters: Getters): PieCha
   const labelValues = getChartLabelValues(getters, chart.dataSets, chart.labelRange);
   let labels = labelValues.formattedValues;
   let dataSetsValues = getChartDatasetValues(getters, chart.dataSets);
-  if (
-    chart.dataSetsHaveTitle &&
-    dataSetsValues[0] &&
-    labels.length > dataSetsValues[0].data.length
-  ) {
+  if (shouldRemoveFirstLabel(chart.labelRange, chart.dataSets[0], chart.dataSetsHaveTitle)) {
     labels.shift();
   }
 

--- a/tests/figures/chart/charts_component.test.ts
+++ b/tests/figures/chart/charts_component.test.ts
@@ -1056,13 +1056,18 @@ describe("charts", () => {
 
     test("Side panel correctly reacts to has_header checkbox check/uncheck (with only one point)", async () => {
       createTestChart("basicChart");
-      updateChart(model, chartId, { type: "line", labelRange: "C2", dataSets: ["A1"] });
+      updateChart(model, chartId, {
+        type: "line",
+        labelRange: "C2",
+        dataSets: ["A1"],
+        dataSetsHaveTitle: false,
+      });
       await nextTick();
       await simulateClick(".o-figure");
       await simulateClick(".o-figure-menu-item");
       await simulateClick(".o-menu div[data-name='edit']");
 
-      const checkbox = document.querySelector("input[name='labelsAsText']") as HTMLInputElement;
+      const checkbox = document.querySelector(".o-use-row-as-headers input") as HTMLInputElement;
       expect(checkbox.checked).toBe(false);
 
       await simulateClick(checkbox);
@@ -1071,13 +1076,18 @@ describe("charts", () => {
 
     test("Side panel correctly reacts to has_header checkbox check/uncheck (with two datasets)", async () => {
       createTestChart("basicChart");
-      updateChart(model, chartId, { type: "line", labelRange: "C2", dataSets: ["A1:A2", "A1"] });
+      updateChart(model, chartId, {
+        type: "line",
+        labelRange: "C2",
+        dataSets: ["A1:A2", "A1"],
+        dataSetsHaveTitle: false,
+      });
       await nextTick();
       await simulateClick(".o-figure");
       await simulateClick(".o-figure-menu-item");
       await simulateClick(".o-menu div[data-name='edit']");
 
-      const checkbox = document.querySelector("input[name='labelsAsText']") as HTMLInputElement;
+      const checkbox = document.querySelector(".o-use-row-as-headers input") as HTMLInputElement;
       expect(checkbox.checked).toBe(false);
 
       expect(checkbox.checked).toBe(false);


### PR DESCRIPTION
## Description

The helpers to check if the labels of a chart can be used to create a linear/time axis weren't taking into account that the first label should sometimes be ignored because of `chart.dataSetsHaveTitle`.

It was impossible to create a linear/time chart when the first label was a (non-number) title.

Also the helper `getChartLabelFormat` only supported columns as label ranges, where the label range can be rows as well.

Task: [4543496](https://www.odoo.com/odoo/2328/tasks/4543496)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo