### PR TITLE
[FIX] pivot: prevent incorrect notification for pivot side panel

### DIFF
--- a/src/components/side_panel/pivot/pivot_side_panel/pivot_side_panel_store.ts
+++ b/src/components/side_panel/pivot/pivot_side_panel/pivot_side_panel_store.ts
@@ -141,11 +141,7 @@ export class PivotSidePanelStore extends SpreadsheetStore {
         pivot: this.draft,
       });
       this.draft = null;
-      if (
-        !this.alreadyNotified &&
-        !this.isDynamicPivotInViewport() &&
-        this.isStaticPivotInViewport()
-      ) {
+      if (!this.alreadyNotified && this.isUpdatedPivotVisibleInViewportOnlyAsStaticPivot()) {
         const formulaId = this.getters.getPivotFormulaId(this.pivotId);
         const pivotExample = `=PIVOT(${formulaId})`;
         this.alreadyNotified = true;
@@ -209,30 +205,32 @@ export class PivotSidePanelStore extends SpreadsheetStore {
     }
   }
 
-  private isDynamicPivotInViewport() {
-    const sheetId = this.getters.getActiveSheetId();
-    for (const col of this.getters.getSheetViewVisibleCols()) {
-      for (const row of this.getters.getSheetViewVisibleRows()) {
-        const isDynamicPivot = this.getters.isSpillPivotFormula({ sheetId, col, row });
-        if (isDynamicPivot) {
-          return true;
-        }
-      }
-    }
-    return false;
-  }
-
-  private isStaticPivotInViewport() {
+  /**
+   * @returns true if the updated pivot is visible in the viewport only as a
+   * static pivot and not as a dynamic pivot
+   */
+  private isUpdatedPivotVisibleInViewportOnlyAsStaticPivot() {
+    let staticPivotCount = 0;
+    const updatedPivotFormulaId = this.getters.getPivotFormulaId(this.pivotId);
     for (const position of this.getters.getVisibleCellPositions()) {
       const cell = this.getters.getCell(position);
       if (cell?.isFormula) {
         const pivotFunction = getFirstPivotFunction(cell.compiledFormula.tokens);
-        if (pivotFunction && pivotFunction.functionName !== "PIVOT") {
-          return true;
+        const pivotFormulaId = pivotFunction?.args[0]?.value;
+        if (pivotFunction && updatedPivotFormulaId === pivotFormulaId.toString()) {
+          if (pivotFunction.functionName === "PIVOT") {
+            // if we have at least one dynamic pivot visible inserted the viewport
+            // we return false
+            return false;
+          } else {
+            staticPivotCount++;
+          }
         }
       }
     }
-    return false;
+    // we return true if there are only static pivots visible inserted the viewport,
+    // otherwise false
+    return staticPivotCount > 0;
   }
 
   private addDefaultDateTimeGranularity(fields: PivotFields, definition: PivotCoreDefinition) {


### PR DESCRIPTION
Previously, the notification mechanism for the pivot side panel store only checked for the presence of a pivot formula in the viewport, without verifying if it was related to the currently opened pivot.

This caused misleading notifications when editing a pivot in the side panel that had no associated formulas in the viewport.

Steps to reproduce:
- Create two pivot tables.
- Add the first pivot as a static pivot in a new sheet.
- Open the side panel for the second pivot from that sheet.
- Edit the second pivot.
- A notification appears even though no formulas in the viewport reference it.

This fix ensures that notifications are only triggered when a formula in the viewport corresponds to the pivot currently open in the side panel.

Task: [4475744](https://www.odoo.com/odoo/2328/tasks/4475744)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo