### PR TITLE
[IMP] css: remove global `content-box` directive

### DIFF
--- a/src/components/action_button/action_button.ts
+++ b/src/components/action_button/action_button.ts
@@ -11,7 +11,7 @@ css/* scss */ `
     margin: 2px 1px;
     padding: 0px 1px;
     border-radius: 2px;
-    min-width: 20px;
+    min-width: 22px;
   }
   .o-disabled {
     opacity: 0.6;

--- a/src/components/autofill/autofill.ts
+++ b/src/components/autofill/autofill.ts
@@ -15,7 +15,6 @@ css/* scss */ `
     height: ${AUTOFILL_EDGE_LENGTH}px;
     width: ${AUTOFILL_EDGE_LENGTH}px;
     border: 1px solid white;
-    box-sizing: border-box !important;
     background-color: #1a73e8;
   }
 

--- a/src/components/border_editor/border_editor.ts
+++ b/src/components/border_editor/border_editor.ts
@@ -72,8 +72,8 @@ css/* scss */ `
         margin: 1px;
         .o-line-item {
           padding: 4px;
-          width: 18px;
-          height: 18px;
+          width: 26px;
+          height: 26px;
           &.active {
             background-color: ${BUTTON_ACTIVE_BG};
           }

--- a/src/components/color_picker/color_picker.ts
+++ b/src/components/color_picker/color_picker.ts
@@ -74,8 +74,8 @@ css/* scss */ `
       }
     }
     .o-color-picker-line-item {
-      width: ${ITEM_EDGE_LENGTH}px;
-      height: ${ITEM_EDGE_LENGTH}px;
+      width: ${ITEM_EDGE_LENGTH + 2 * ITEM_BORDER_WIDTH}px;
+      height: ${ITEM_EDGE_LENGTH + 2 * ITEM_BORDER_WIDTH}px;
       margin: 0px;
       border-radius: 50px;
       border: ${ITEM_BORDER_WIDTH}px solid #666666;
@@ -98,7 +98,6 @@ css/* scss */ `
         font-size: 14px;
         background: white;
         border-radius: 4px;
-        box-sizing: border-box;
         &:hover:enabled {
           background-color: rgba(0, 0, 0, 0.08);
         }
@@ -125,7 +124,6 @@ css/* scss */ `
       .o-gradient {
         margin-bottom: ${MAGNIFIER_EDGE / 2}px;
         border: ${ITEM_BORDER_WIDTH}px solid #c0c0c0;
-        box-sizing: border-box;
         width: ${INNER_GRADIENT_WIDTH + 2 * ITEM_BORDER_WIDTH}px;
         height: ${INNER_GRADIENT_HEIGHT + 2 * ITEM_BORDER_WIDTH}px;
         position: relative;
@@ -134,7 +132,6 @@ css/* scss */ `
       .magnifier {
         height: ${MAGNIFIER_EDGE}px;
         width: ${MAGNIFIER_EDGE}px;
-        box-sizing: border-box;
         border-radius: 50%;
         border: 2px solid #fff;
         box-shadow: 0px 0px 3px #c0c0c0;
@@ -149,7 +146,6 @@ css/* scss */ `
       }
       .o-hue-picker {
         border: ${ITEM_BORDER_WIDTH}px solid #c0c0c0;
-        box-sizing: border-box;
         width: 100%;
         height: 12px;
         border-radius: 4px;
@@ -176,7 +172,6 @@ css/* scss */ `
         padding: 2px 0px;
         display: flex;
         input {
-          box-sizing: border-box;
           width: 50%;
           border-radius: 4px;
           padding: 4px 23px 4px 10px;

--- a/src/components/color_picker/color_picker_widget.ts
+++ b/src/components/color_picker/color_picker_widget.ts
@@ -38,7 +38,7 @@ css/* scss */ `
     .o-color-picker-button {
       > span {
         border-bottom: 4px solid;
-        height: 16px;
+        height: 20px;
         margin-top: 2px;
         display: block;
       }

--- a/src/components/composer/composer/composer.ts
+++ b/src/components/composer/composer/composer.ts
@@ -51,8 +51,6 @@ css/* scss */ `
       word-break: break-all;
       padding-right: 2px;
 
-      box-sizing: border-box;
-
       caret-color: black;
       padding-left: 3px;
       padding-right: 3px;

--- a/src/components/composer/grid_composer/grid_composer.ts
+++ b/src/components/composer/grid_composer/grid_composer.ts
@@ -21,7 +21,6 @@ const GRID_CELL_REFERENCE_TOP_OFFSET = 28;
 css/* scss */ `
   div.o-grid-composer {
     z-index: ${ComponentsImportance.GridComposer};
-    box-sizing: border-box;
     position: absolute;
     border: ${COMPOSER_BORDER_WIDTH}px solid ${SELECTION_BORDER_COLOR};
     font-family: ${DEFAULT_FONT};

--- a/src/components/composer/standalone_composer/standalone_composer.ts
+++ b/src/components/composer/standalone_composer/standalone_composer.ts
@@ -15,7 +15,6 @@ css/* scss */ `
   .o-spreadsheet {
     .o-standalone-composer {
       min-height: 24px;
-      box-sizing: border-box;
 
       border-bottom: 1px solid;
       border-color: ${GRAY_300};

--- a/src/components/data_validation_overlay/dv_checkbox/dv_checkbox.ts
+++ b/src/components/data_validation_overlay/dv_checkbox/dv_checkbox.ts
@@ -8,8 +8,6 @@ const MARGIN = (GRID_ICON_EDGE_LENGTH - CHECKBOX_WIDTH) / 2;
 
 css/* scss */ `
   .o-dv-checkbox {
-    box-sizing: border-box !important;
-    accent-color: #808080;
     margin: ${MARGIN}px;
     /* required to prevent the checkbox position to be sensible to the font-size (affects Firefox) */
     position: absolute;

--- a/src/components/error_tooltip/error_tooltip.ts
+++ b/src/components/error_tooltip/error_tooltip.ts
@@ -14,7 +14,6 @@ css/* scss */ `
     border-left: 3px solid red;
     padding: 10px;
     width: ${ERROR_TOOLTIP_WIDTH}px;
-    box-sizing: border-box !important;
     overflow-wrap: break-word;
 
     .o-error-tooltip-message {

--- a/src/components/figures/chart/chartJs/chartjs.ts
+++ b/src/components/figures/chart/chartJs/chartjs.ts
@@ -21,9 +21,6 @@ css/* scss */ `
       font-size: 12px;
       background-color: #fff;
       z-index: ${ComponentsImportance.FigureTooltip};
-      table td span {
-        box-sizing: border-box;
-      }
     }
   }
 `;

--- a/src/components/figures/figure/figure.ts
+++ b/src/components/figures/figure/figure.ts
@@ -39,7 +39,6 @@ const ACTIVE_BORDER_WIDTH = 2;
 
 css/*SCSS*/ `
   div.o-figure {
-    box-sizing: border-box;
     position: absolute;
     width: 100%;
     height: 100%;
@@ -51,7 +50,6 @@ css/*SCSS*/ `
   }
 
   div.o-figure-border {
-    box-sizing: border-box;
     z-index: 1;
   }
 

--- a/src/components/filters/filter_menu/filter_menu.ts
+++ b/src/components/filters/filter_menu/filter_menu.ts
@@ -12,14 +12,12 @@ const FILTER_MENU_HEIGHT = 295;
 
 const CSS = css/* scss */ `
   .o-filter-menu {
-    box-sizing: border-box;
     padding: 8px 16px;
     height: ${FILTER_MENU_HEIGHT}px;
     line-height: 1;
 
     .o-filter-menu-item {
       display: flex;
-      box-sizing: border-box;
       cursor: pointer;
       user-select: none;
 

--- a/src/components/grid_add_rows_footer/grid_add_rows_footer.ts
+++ b/src/components/grid_add_rows_footer/grid_add_rows_footer.ts
@@ -7,7 +7,6 @@ import { ValidationMessages } from "../validation_messages/validation_messages";
 css/* scss */ `
   .o-grid-add-rows {
     input.o-input {
-      box-sizing: border-box;
       width: 60px;
       height: 30px;
     }

--- a/src/components/header_group/header_group.ts
+++ b/src/components/header_group/header_group.ts
@@ -31,8 +31,8 @@ css/* scss */ `
       z-index: ${ComponentsImportance.HeaderGroupingButton};
       .o-group-fold-button {
         cursor: pointer;
-        width: 13px;
-        height: 13px;
+        width: 15px;
+        height: 15px;
         border: 1px solid ${HEADER_GROUPING_BORDER_COLOR};
         .o-icon {
           width: 7px;
@@ -43,9 +43,6 @@ css/* scss */ `
           border-color: #777;
         }
       }
-    }
-    .o-group-border {
-      box-sizing: border-box;
     }
   }
 `;

--- a/src/components/link/link_display/link_display.ts
+++ b/src/components/link/link_display/link_display.ts
@@ -22,7 +22,6 @@ css/* scss */ `
     justify-content: space-between;
     height: ${LINK_TOOLTIP_HEIGHT}px;
     width: ${LINK_TOOLTIP_WIDTH}px;
-    box-sizing: border-box !important;
 
     img {
       margin-right: 3px;

--- a/src/components/link/link_editor/link_editor.ts
+++ b/src/components/link/link_editor/link_editor.ts
@@ -12,7 +12,7 @@ import { Menu } from "../../menu/menu";
 const MENU_OFFSET_X = 320;
 const MENU_OFFSET_Y = 100;
 const PADDING = 12;
-const LINK_EDITOR_WIDTH = 340;
+const LINK_EDITOR_WIDTH = 340 + 2 * PADDING;
 
 css/* scss */ `
   .o-link-editor {
@@ -37,7 +37,6 @@ css/* scss */ `
       text-align: right;
     }
     input.o-input {
-      box-sizing: border-box;
       width: 100%;
       padding: 0 23px 4px 0;
     }

--- a/src/components/menu/menu.ts
+++ b/src/components/menu/menu.ts
@@ -34,11 +34,9 @@ css/* scss */ `
     background-color: white;
     padding: ${MENU_VERTICAL_PADDING}px 0px;
     width: ${MENU_WIDTH}px;
-    box-sizing: border-box !important;
     user-select: none;
 
     .o-menu-item {
-      box-sizing: border-box;
       height: ${MENU_ITEM_HEIGHT}px;
       padding: ${MENU_ITEM_PADDING_VERTICAL}px ${MENU_ITEM_PADDING_HORIZONTAL}px;
       cursor: pointer;

--- a/src/components/scrollbar/scrollbar.ts
+++ b/src/components/scrollbar/scrollbar.ts
@@ -22,6 +22,7 @@ css/* scss */ `
     background-color: ${BACKGROUND_GRAY_COLOR};
 
     &.corner {
+      box-sizing: content-box;
       right: 0px;
       bottom: 0px;
       height: ${SCROLLBAR_WIDTH}px;

--- a/src/components/selection_input/selection_input.ts
+++ b/src/components/selection_input/selection_input.ts
@@ -24,7 +24,6 @@ css/* scss */ `
       }
     }
     .o-button {
-      height: 28px;
       flex-grow: 0;
     }
 

--- a/src/components/side_panel/chart/chart_type_picker/chart_type_picker.ts
+++ b/src/components/side_panel/chart/chart_type_picker/chart_type_picker.ts
@@ -28,7 +28,6 @@ css/* scss */ `
   }
 
   .o-popover .o-chart-select-popover {
-    box-sizing: border-box;
     background: #fff;
     .o-chart-type-item {
       cursor: pointer;

--- a/src/components/side_panel/chart/gauge_chart_panel/gauge_chart_design_panel.ts
+++ b/src/components/side_panel/chart/gauge_chart_panel/gauge_chart_design_panel.ts
@@ -30,7 +30,6 @@ css/* scss */ `
     }
 
     td {
-      box-sizing: border-box;
       height: 30px;
       padding: 6px 0;
     }
@@ -53,7 +52,6 @@ css/* scss */ `
     select {
       width: 100%;
       height: 100%;
-      box-sizing: border-box;
     }
   }
 `;

--- a/src/components/side_panel/components/checkbox/checkbox.ts
+++ b/src/components/side_panel/components/checkbox/checkbox.ts
@@ -31,7 +31,6 @@ css/* scss */ `
       width: ${CHECKBOX_WIDTH}px;
       height: ${CHECKBOX_WIDTH}px;
       vertical-align: top;
-      box-sizing: border-box;
       outline: none;
       border: 1px solid ${GRAY_300};
       cursor: pointer;

--- a/src/components/side_panel/components/radio_selection/radio_selection.ts
+++ b/src/components/side_panel/components/radio_selection/radio_selection.ts
@@ -31,7 +31,6 @@ css/* scss */ `
       width: 14px;
       height: 14px;
       border: 1px solid ${GRAY_300};
-      box-sizing: border-box;
       outline: none;
       border-radius: 8px;
 

--- a/src/components/side_panel/components/round_color_picker/round_color_picker.ts
+++ b/src/components/side_panel/components/round_color_picker/round_color_picker.ts
@@ -25,8 +25,8 @@ const TRANSPARENT_BACKGROUND_SVG = /*xml*/ `
 
 css/* scss */ `
   .o-round-color-picker-button {
-    width: 18px;
-    height: 18px;
+    width: 20px;
+    height: 20px;
     cursor: pointer;
     border: 1px solid ${GRAY_300};
     background-position: 1px 1px;

--- a/src/components/side_panel/conditional_formatting/cf_preview/cf_preview.ts
+++ b/src/components/side_panel/conditional_formatting/cf_preview/cf_preview.ts
@@ -15,7 +15,7 @@ css/* scss */ `
     }
 
     border-bottom: 1px solid ${GRAY_300};
-    height: 60px;
+    height: 80px;
     padding: 10px;
     position: relative;
     cursor: pointer;

--- a/src/components/side_panel/data_validation/dv_preview/dv_preview.ts
+++ b/src/components/side_panel/data_validation/dv_preview/dv_preview.ts
@@ -9,7 +9,6 @@ css/* scss */ `
   .o-sidePanel {
     .o-dv-preview {
       height: 70px;
-      box-sizing: border-box;
       cursor: pointer;
       border-bottom: 1px solid ${FIGURE_BORDER_COLOR};
 

--- a/src/components/side_panel/more_formats/more_formats.ts
+++ b/src/components/side_panel/more_formats/more_formats.ts
@@ -25,7 +25,7 @@ interface Props {
 css/* scss */ `
   .o-more-formats-panel {
     .format-preview {
-      height: 48px;
+      height: 49px;
       background-color: white;
       cursor: pointer;
 

--- a/src/components/side_panel/pivot/pivot_defer_update/pivot_defer_update.ts
+++ b/src/components/side_panel/pivot/pivot_defer_update/pivot_defer_update.ts
@@ -7,7 +7,7 @@ import { Section } from "../../components/section/section";
 
 css/* scss */ `
   .pivot-defer-update {
-    min-height: 35px;
+    min-height: 40px;
   }
 `;
 

--- a/src/components/side_panel/pivot/pivot_measure_display_panel/pivot_measure_display_panel.ts
+++ b/src/components/side_panel/pivot/pivot_measure_display_panel/pivot_measure_display_panel.ts
@@ -19,7 +19,6 @@ css/* scss */ `
   .o-sidePanel {
     .o-pivot-measure-display-field,
     .o-pivot-measure-display-value {
-      box-sizing: border-box;
       border: solid 1px ${GRAY_300};
       border-radius: 3px;
     }

--- a/src/components/side_panel/table_panel/table_panel.xml
+++ b/src/components/side_panel/table_panel/table_panel.xml
@@ -92,7 +92,7 @@
             disabled="!this.canBeDynamic"
           />
           <div
-            class="o-info-icon d-flex flex-row align-items-center text-muted ps-1"
+            class="o-info-icon d-flex flex-row align-items-center text-muted ms-1"
             t-att-title="dynamicTableTooltip">
             <t t-call="o-spreadsheet-Icon.CIRCLE_INFO"/>
           </div>

--- a/src/components/spreadsheet/spreadsheet.ts
+++ b/src/components/spreadsheet/spreadsheet.ts
@@ -33,7 +33,6 @@ import {
   PRIMARY_BUTTON_ACTIVE_BG,
   PRIMARY_BUTTON_BG,
   PRIMARY_BUTTON_HOVER_BG,
-  SCROLLBAR_WIDTH,
   SEPARATOR_COLOR,
   TEXT_BODY,
   TEXT_BODY_MUTED,
@@ -93,7 +92,6 @@ css/* scss */ `
     *,
     *:before,
     *:after {
-      box-sizing: content-box;
       /* rtl not supported ATM */
       direction: ltr;
     }
@@ -152,7 +150,6 @@ css/* scss */ `
     .o-input {
       min-width: 0px;
       padding: 1px 0;
-      box-sizing: border-box;
       width: 100%;
       outline: none;
       border-color: ${GRAY_300};
@@ -225,17 +222,8 @@ css/* scss */ `
     }
 
     > canvas {
+      box-sizing: content-box;
       border-bottom: 1px solid #e2e3e3;
-    }
-    .o-scrollbar {
-      &.corner {
-        right: 0px;
-        bottom: 0px;
-        height: ${SCROLLBAR_WIDTH}px;
-        width: ${SCROLLBAR_WIDTH}px;
-        border-top: 1px solid #e2e3e3;
-        border-left: 1px solid #e2e3e3;
-      }
     }
 
     .o-grid-overlay {
@@ -249,7 +237,7 @@ css/* scss */ `
     border-radius: 4px;
     font-weight: 500;
     font-size: 14px;
-    height: 30px;
+    height: 32px;
     line-height: 16px;
     flex-grow: 1;
     background-color: ${BUTTON_BG};

--- a/src/components/tables/table_resizer/table_resizer.ts
+++ b/src/components/tables/table_resizer/table_resizer.ts
@@ -9,8 +9,8 @@ const COLOR = "#777";
 
 css/* scss */ `
   .o-table-resizer {
-    width: ${SIZE}px;
-    height: ${SIZE}px;
+    width: ${SIZE * 2}px;
+    height: ${SIZE * 2}px;
     border-bottom: ${SIZE}px solid ${COLOR};
     border-right: ${SIZE}px solid ${COLOR};
     cursor: nwse-resize;

--- a/src/components/tables/table_style_picker/table_style_picker.ts
+++ b/src/components/tables/table_style_picker/table_style_picker.ts
@@ -20,7 +20,6 @@ interface TableStylePickerState {
 
 css/* scss */ `
   .o-table-style-picker {
-    box-sizing: border-box;
     border: 1px solid ${GRAY_300};
     border-radius: 3px;
 

--- a/src/components/text_input/text_input.ts
+++ b/src/components/text_input/text_input.ts
@@ -7,7 +7,6 @@ import { css } from "../helpers";
 css/* scss */ `
   .o-spreadsheet {
     .os-input {
-      box-sizing: border-box;
       border-width: 0 0 1px 0;
       border-color: transparent;
       outline: none;


### PR DESCRIPTION
## Description

We have a global css directive that sets `box-sizing: content-box` everywhere. This is a bit stupid, as it override bootstrap default `border-box` directive.

And it also make using `width/height` directive less intuitive, as the size you set does not includes border/padding.

We had 32 occurrences of `box-sizing: border-box` in our codebase, to override the global directive.

Task: [4550753](https://www.odoo.com/odoo/2328/tasks/4550753)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo