### PR TITLE
[IMP] Spreadsheet: middle-click opens records in a new tab

### DIFF
--- a/src/actions/action.ts
+++ b/src/actions/action.ts
@@ -49,7 +49,7 @@ export interface ActionSpec {
    * Execute the action. The action can return a result.
    * The result will be carried by a `menu-clicked` event to the menu parent component.
    */
-  execute?: (env: SpreadsheetChildEnv) => unknown;
+  execute?: (env: SpreadsheetChildEnv, isMiddleClick?: boolean) => unknown;
   /**
    * subitems associated to this item
    * NB: an action without an execute function or children is not displayed !
@@ -77,7 +77,7 @@ export interface Action {
   iconColor?: Color;
   secondaryIcon: (env: SpreadsheetChildEnv) => string;
   isReadonlyAllowed: boolean;
-  execute?: (env: SpreadsheetChildEnv) => unknown;
+  execute?: (env: SpreadsheetChildEnv, isMiddleClick?: boolean) => unknown;
   children: (env: SpreadsheetChildEnv) => Action[];
   separator: boolean;
   textColor?: Color;

--- a/src/components/dashboard/clickable_cell_store.ts
+++ b/src/components/dashboard/clickable_cell_store.ts
@@ -15,7 +15,7 @@ export interface ClickableCell {
   coordinates: Rect;
   position: CellPosition;
   title: string;
-  action: (position: CellPosition, env: SpreadsheetChildEnv) => void;
+  action: (position: CellPosition, env: SpreadsheetChildEnv, isMiddleClick?: boolean) => void;
 }
 
 export class ClickableCellsStore extends SpreadsheetStore {

--- a/src/components/dashboard/dashboard.ts
+++ b/src/components/dashboard/dashboard.ts
@@ -5,6 +5,7 @@ import { HoveredCellStore } from "../grid/hovered_cell_store";
 import { GridOverlay } from "../grid_overlay/grid_overlay";
 import { GridPopover } from "../grid_popover/grid_popover";
 import { css, cssPropertiesToCss } from "../helpers/css";
+import { isMiddleClickOrCtrlClick } from "../helpers/dom_helpers";
 import { useGridDrawing } from "../helpers/draw_grid_hook";
 import { useAbsoluteBoundingRect } from "../helpers/position_hook";
 import { useWheelHandler } from "../helpers/wheel_hook";
@@ -92,9 +93,9 @@ export class SpreadsheetDashboard extends Component<Props, SpreadsheetChildEnv> 
     return toRaw(this.clickableCellsStore.clickableCells);
   }
 
-  selectClickableCell(clickableCell: ClickableCell) {
+  selectClickableCell(ev: MouseEvent, clickableCell: ClickableCell) {
     const { position, action } = clickableCell;
-    action(position, this.env);
+    action(position, this.env, isMiddleClickOrCtrlClick(ev));
   }
 
   onClosePopover() {

--- a/src/components/dashboard/dashboard.xml
+++ b/src/components/dashboard/dashboard.xml
@@ -20,7 +20,8 @@
           t-key="clickableCell_index"
           class="o-dashboard-clickable-cell"
           t-att-title="clickableCell.title"
-          t-on-click="() => this.selectClickableCell(clickableCell)"
+          t-on-click="(ev) => this.selectClickableCell(ev, clickableCell)"
+          t-on-auxclick="(ev) => this.selectClickableCell(ev, clickableCell)"
           t-on-contextmenu.prevent=""
           t-att-style="getCellClickableStyle(clickableCell.coordinates)"
         />

--- a/src/components/helpers/dom_helpers.ts
+++ b/src/components/helpers/dom_helpers.ts
@@ -185,3 +185,12 @@ export function isMacOS(): boolean {
 export function isCtrlKey(ev: KeyboardEvent | MouseEvent): boolean {
   return isMacOS() ? ev.metaKey : ev.ctrlKey;
 }
+
+/**
+ * @param {MouseEvent} ev - The mouse event.
+ * @returns {boolean} Returns true if the event was triggered by a middle-click
+ * or a Ctrl + Click (Cmd + Click on Mac).
+ */
+export function isMiddleClickOrCtrlClick(ev: MouseEvent): boolean {
+  return ev.button === 1 || (isCtrlKey(ev) && ev.button === 0);
+}

--- a/src/components/link/link_display/link_display.ts
+++ b/src/components/link/link_display/link_display.ts
@@ -6,6 +6,7 @@ import { Store, useStore } from "../../../store_engine";
 import { EvaluatedCell, Link, Position, SpreadsheetChildEnv } from "../../../types";
 import { CellPopoverComponent, PopoverBuilders } from "../../../types/cell_popovers";
 import { css } from "../../helpers/css";
+import { isMiddleClickOrCtrlClick } from "../../helpers/dom_helpers";
 import { CellPopoverStore } from "../../popover/cell_popover_store";
 
 const LINK_TOOLTIP_HEIGHT = 32;
@@ -97,8 +98,8 @@ export class LinkDisplay extends Component<LinkDisplayProps, SpreadsheetChildEnv
     return urlRepresentation(link, this.env.model.getters);
   }
 
-  openLink() {
-    openLink(this.link, this.env);
+  openLink(ev: MouseEvent) {
+    openLink(this.link, this.env, isMiddleClickOrCtrlClick(ev));
   }
 
   edit() {

--- a/src/components/link/link_display/link_display.xml
+++ b/src/components/link/link_display/link_display.xml
@@ -21,6 +21,7 @@
         t-else=""
         class="o-link"
         t-on-click.prevent="openLink"
+        t-on-auxclick.prevent="openLink"
         t-att-title="getUrlRepresentation(link)">
         <t t-esc="getUrlRepresentation(link)"/>
       </a>

--- a/src/components/menu/menu.ts
+++ b/src/components/menu/menu.ts
@@ -20,7 +20,7 @@ import {
 } from "../../constants";
 import { DOMCoordinates, MenuMouseEvent, Pixel, SpreadsheetChildEnv, UID } from "../../types";
 import { css, cssPropertiesToCss } from "../helpers/css";
-import { getOpenedMenus, isChildEvent } from "../helpers/dom_helpers";
+import { getOpenedMenus, isChildEvent, isMiddleClickOrCtrlClick } from "../helpers/dom_helpers";
 import { useAbsoluteBoundingRect } from "../helpers/position_hook";
 import { useTimeOut } from "../helpers/time_hooks";
 import { Popover, PopoverProps } from "../popover/popover";
@@ -217,8 +217,8 @@ export class Menu extends Component<Props, SpreadsheetChildEnv> {
     return cssPropertiesToCss({ color: menu.iconColor });
   }
 
-  async activateMenu(menu: Action) {
-    const result = await menu.execute?.(this.env);
+  async activateMenu(menu: Action, isMiddleClick?: boolean) {
+    const result = await menu.execute?.(this.env, isMiddleClick);
     this.close();
     this.props.onMenuClicked?.({ detail: result } as CustomEvent);
   }
@@ -293,12 +293,14 @@ export class Menu extends Component<Props, SpreadsheetChildEnv> {
   }
 
   onClickMenu(menu: Action, ev: MouseEvent) {
-    if (this.isEnabled(menu)) {
-      if (this.isRoot(menu)) {
-        this.openSubMenu(menu, ev.currentTarget as HTMLElement);
-      } else {
-        this.activateMenu(menu);
-      }
+    if (!this.isEnabled(menu)) {
+      return;
+    }
+
+    if (this.isRoot(menu)) {
+      this.openSubMenu(menu, ev.currentTarget as HTMLElement);
+    } else {
+      this.activateMenu(menu, isMiddleClickOrCtrlClick(ev));
     }
   }
 

--- a/src/components/menu/menu.xml
+++ b/src/components/menu/menu.xml
@@ -19,6 +19,7 @@
               t-att-title="getName(menuItem)"
               t-att-data-name="menuItem.id"
               t-on-click="(ev) => this.onClickMenu(menuItem, ev)"
+              t-on-auxclick="(ev) => this.onClickMenu(menuItem, ev)"
               t-on-mouseenter="(ev) => this.onMouseEnter(menuItem, ev)"
               t-on-mouseover="(ev) => this.onMouseOver(menuItem, ev)"
               t-on-mouseleave="(ev) => this.onMouseLeave(menuItem)"

--- a/src/helpers/links.ts
+++ b/src/helpers/links.ts
@@ -24,7 +24,7 @@ export interface LinkSpec {
    * - a link to a sheet displays the sheet name
    */
   readonly urlRepresentation: (url: string, getters: Getters) => string;
-  readonly open: (url: string, env: SpreadsheetChildEnv) => void;
+  readonly open: (url: string, env: SpreadsheetChildEnv, isMiddleClick?: boolean) => void;
   readonly sequence: number;
 }
 
@@ -92,8 +92,8 @@ export function urlRepresentation(link: Link, getters: Getters): string {
   return findMatchingSpec(link.url).urlRepresentation(link.url, getters);
 }
 
-export function openLink(link: Link, env: SpreadsheetChildEnv) {
-  findMatchingSpec(link.url).open(link.url, env);
+export function openLink(link: Link, env: SpreadsheetChildEnv, isMiddleClick?: boolean) {
+  findMatchingSpec(link.url).open(link.url, env, isMiddleClick);
 }
 
 export function detectLink(value: CellValue | null): Link | undefined {

--- a/src/registries/cell_clickable_registry.ts
+++ b/src/registries/cell_clickable_registry.ts
@@ -4,7 +4,7 @@ import { Registry } from "./registry";
 
 export interface CellClickableItem {
   condition: (position: CellPosition, getters: Getters) => boolean;
-  execute: (position: CellPosition, env: SpreadsheetChildEnv) => void;
+  execute: (position: CellPosition, env: SpreadsheetChildEnv, isMiddleClick?: boolean) => void;
   title?: string;
   sequence: number;
 }
@@ -15,7 +15,7 @@ clickableCellRegistry.add("link", {
   condition: (position: CellPosition, getters: Getters) => {
     return !!getters.getEvaluatedCell(position).link;
   },
-  execute: (position: CellPosition, env: SpreadsheetChildEnv) =>
-    openLink(env.model.getters.getEvaluatedCell(position).link!, env),
+  execute: (position: CellPosition, env: SpreadsheetChildEnv, isMiddleClick?: boolean) =>
+    openLink(env.model.getters.getEvaluatedCell(position).link!, env, isMiddleClick),
   sequence: 5,
 });

--- a/tests/grid/dashboard_grid_component.test.ts
+++ b/tests/grid/dashboard_grid_component.test.ts
@@ -149,6 +149,25 @@ describe("Grid component in dashboard mode", () => {
     clickableCellRegistry.remove("fake");
   });
 
+  test("Triggers clickable cell actions with correct params on left-click and middle-click", async () => {
+    const fn = jest.fn();
+    clickableCellRegistry.add("fake", {
+      condition: (position, getters) => {
+        return !!getters.getCell(position)?.content.startsWith("__");
+      },
+      execute: (_, __, isMiddleClick) => fn(isMiddleClick),
+      sequence: 5,
+    });
+    setCellContent(model, "A1", "__test1");
+    model.updateMode("dashboard");
+    await nextTick();
+    await simulateClick("div.o-dashboard-clickable-cell", 10, 10, { bubbles: true, button: 0 });
+    expect(fn).toHaveBeenCalledWith(false);
+    await simulateClick("div.o-dashboard-clickable-cell", 10, 10, { bubbles: true, button: 1 });
+    expect(fn).toHaveBeenCalledWith(true);
+    clickableCellRegistry.remove("fake");
+  });
+
   test("Clickable cells actions can have a tooltip", async () => {
     clickableCellRegistry.add("fake", {
       condition: () => true,

--- a/tests/menus/context_menu_component.test.ts
+++ b/tests/menus/context_menu_component.test.ts
@@ -713,6 +713,22 @@ describe("Context Menu internal tests", () => {
     const childMenu = fixture.querySelectorAll<HTMLElement>(".o-menu")[1]!;
     expect(getStylePropertyInPx(childMenu, "width")).toBe(100);
   });
+
+  test("Triggers menu item action with correct params on left-click and middle-click", async () => {
+    const mockCallback = jest.fn();
+    const menuItems: Action[] = createActions([
+      {
+        id: "menuItem",
+        name: "menuItem",
+        execute: (_, isMiddleClick) => mockCallback(isMiddleClick),
+      },
+    ]);
+    await renderContextMenu(300, 300, { menuItems });
+    await simulateClick(".o-menu div[data-name='menuItem']", 10, 10, { button: 0 });
+    expect(mockCallback).toHaveBeenCalledWith(false);
+    await simulateClick(".o-menu div[data-name='menuItem']", 10, 10, { button: 1 });
+    expect(mockCallback).toHaveBeenCalledWith(true);
+  });
 });
 
 describe("Context Menu position on large screen 1000px/1000px", () => {


### PR DESCRIPTION
## Description:

This PR allows users to open records in a new tab by middle-clicking or Ctrl+Clicking in the following places:

- See Record(s) (in Pivot/List view)
- Clickable cells in the Dashboard view
- Dashboard charts
- Odoo menu links

Task: [4373367](https://www.odoo.com/odoo/2328/tasks/4373367)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo