### PR TITLE
[FIX] formula : fix SORT formula error

### DIFF
--- a/src/functions/module_filter.ts
+++ b/src/functions/module_filter.ts
@@ -27,8 +27,8 @@ function sortMatrix(
     assert(
       () => value !== undefined,
       _t(
-        "Value for parameter %d is missing, while the function [[FUNCTION_NAME]] expect a number or a range.",
-        i + 1
+        "Value for parameter %s is missing, while the function [[FUNCTION_NAME]] expect a number or a range.",
+        (i + 1).toString()
       )
     );
   }

--- a/tests/functions/module_filter.test.ts
+++ b/tests/functions/module_filter.test.ts
@@ -806,11 +806,29 @@ describe("SORT function", () => {
     ]);
   });
 
-  test("Sorting with missing 'order' argument", () => {
+  test("Sorting with missing 'is_ascending' argument", () => {
     const model = new Model();
     setCellContent(model, "B1", "=SORT(A1:A2, 1)");
     expect(getRangeValuesAsMatrix(model, "B1")).toEqual([["#BAD_EXPR"]]);
     expect(checkFunctionDoesntSpreadBeyondRange(model, "B1")).toBeTruthy();
+  });
+
+  test("Sorting with undefined 'sort_column' argument", () => {
+    const model = new Model();
+    setCellContent(model, "B1", "=SORT(A1:A2, , 1)");
+    expect(getRangeValuesAsMatrix(model, "B1")).toEqual([["#ERROR"]]);
+    expect(getCellError(model, "B1")).toBe(
+      "Value for parameter 1 is missing, while the function SORT expect a number or a range."
+    );
+  });
+
+  test("Sorting with undefined 'is_ascending' argument", () => {
+    const model = new Model();
+    setCellContent(model, "B1", "=SORT(A1:A2, 1,)");
+    expect(getRangeValuesAsMatrix(model, "B1")).toEqual([["#ERROR"]]);
+    expect(getCellError(model, "B1")).toBe(
+      "Value for parameter 2 is missing, while the function SORT expect a number or a range."
+    );
   });
 });
 


### PR DESCRIPTION
## Description

This commit aims to fix the error message of the SORT formula when one of the repeatable parameter is undefined. This issue was using "%d" instead of "%s" in _t

Task: 0