### PR TITLE
[FIX] collaborative: fix undo concurrence issues

### DIFF
--- a/src/history/tree.ts
+++ b/src/history/tree.ts
@@ -164,7 +164,7 @@ export class Tree<T = unknown> {
 
   /**
    * Drop the operation and all following operations in every
-   * branch
+   * branches
    */
   drop(operationId: UID) {
     for (const branch of this.branches) {

--- a/tests/collaborative/collaborative_history.test.ts
+++ b/tests/collaborative/collaborative_history.test.ts
@@ -7,11 +7,13 @@ import { LineChartDefinition } from "../../src/types/chart/line_chart";
 import { StateUpdateMessage } from "../../src/types/collaborative/transport_service";
 import {
   addColumns,
+  addRows,
   createSheet,
   deleteColumns,
   deleteRows,
   deleteSheet,
   redo,
+  resizeColumns,
   setCellContent,
   snapshot,
   undo,
@@ -88,6 +90,17 @@ describe("Collaborative local history", () => {
   test("Undo a pending revision", () => {
     network.concurrent(() => {
       setCellContent(alice, "A1", "hello");
+      undo(alice);
+      setCellContent(bob, "B1", "hello");
+    });
+    expect(all).toHaveSynchronizedValue((user) => getCell(user, "A1"), undefined);
+    expect(all).toHaveSynchronizedValue((user) => getCellContent(user, "B1"), "hello");
+    expect(all).toHaveSynchronizedExportedData();
+  });
+
+  test("Concurrent undo and a non-related pending revision", () => {
+    setCellContent(alice, "A1", "hello");
+    network.concurrent(() => {
       undo(alice);
       setCellContent(bob, "B1", "hello");
     });
@@ -279,6 +292,16 @@ describe("Collaborative local history", () => {
     );
     expect(getCell(model, "B1")).toBeUndefined();
     expect(model.exportData().revisionId).toBe("2");
+  });
+
+  test("Only the revisions **after** the first transformed one are dropped", () => {
+    addRows(alice, "after", 11, 1);
+    network.concurrent(() => {
+      undo(alice);
+      setCellContent(charlie, "A1", "Hello"); // This command is not transformed, so transferred to others users
+      setCellContent(charlie, "A13", "Hello"); // This command is transformed, hence dropped when receiveing the concurrent undo
+    });
+    expect([alice, bob, charlie]).toHaveSynchronizedExportedData();
   });
 
   test("Load model with initial messages, with redo", () => {
@@ -514,7 +537,7 @@ describe("Collaborative local history", () => {
       undo(alice);
       setCellContent(bob, "B1", "hello");
     });
-    expect(all).toHaveSynchronizedValue((user) => getCellContent(user, "A1"), "hello");
+    expect(all).toHaveSynchronizedValue((user) => getCell(user, "A1"), undefined);
     expect(all).toHaveSynchronizedValue((user) => getCell(user, "B1"), undefined);
   });
 
@@ -935,6 +958,16 @@ describe("Collaborative local history", () => {
     expect([alice, bob, charlie]).toHaveSynchronizedExportedData();
   });
 
+  test("Concurrent undo where the transformation partially destroys the other", () => {
+    addColumns(alice, "before", "C", 3);
+    network.concurrent(() => {
+      undo(alice);
+      resizeColumns(bob, ["A", "B", "C", "D", "E"], 20);
+    });
+    redo(alice);
+    expect([alice, bob, charlie]).toHaveSynchronizedExportedData();
+  });
+
   test("Transform command with preceding concurrent command when previous command is redone", () => {
     setCellContent(alice, "E10", "hello");
     addColumns(alice, "before", "F", 3);
@@ -964,10 +997,7 @@ describe("Collaborative local history", () => {
       setCellContent(alice, "C4", "hello");
     });
     redo(bob);
-    expect([alice, bob, charlie]).toHaveSynchronizedValue(
-      (user) => getCellContent(user, "C4"),
-      "hello"
-    );
+    expect([alice, bob, charlie]).toHaveSynchronizedValue((user) => getCell(user, "C4"), undefined);
     expect([alice, bob, charlie]).toHaveSynchronizedExportedData();
   });
 


### PR DESCRIPTION
Some revisions undergo transformations that may cause issues with undo/redo if the transformation is destructive (we don't get back the original command by transforming it with the inverse). To prevent these problems, we must discard all subsequent local revisions.

Here is a simple example to illustrate the issue:
- Alice add some columns before "C"
- Concurrently, Alice undo her action, Bob resize columns A to E
- Alice's command is committed before Bob's command => The state is synchronized
- Alice redo her action

=> The state is not synchronized anymore, as Bob contains in his history the resize command with columns A to E, but Alice has the resize command without the columns that has been removed by the undo.

Co-authored-by: Lucas Lefèvre <lul@odoo.com>
Co-authored-by: Pierre Rousseau <pro@odoo.com>

Task: 4558024

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo