### PR TITLE
[FIX] chart: fix test clicking on wrong checkbox

### DIFF
--- a/tests/components/charts.test.ts
+++ b/tests/components/charts.test.ts
@@ -1267,13 +1267,20 @@ describe("figures", () => {
 
     test("Side panel correctly reacts to has_header checkbox check/uncheck (with only one point)", async () => {
       createTestChart("basicChart");
-      updateChart(model, chartId, { type: "line", labelRange: "C2", dataSets: ["A1"] });
+      updateChart(model, chartId, {
+        type: "line",
+        labelRange: "C2",
+        dataSets: ["A1"],
+        dataSetsHaveTitle: false,
+      });
       await nextTick();
       await simulateClick(".o-figure");
       await simulateClick(".o-chart-menu-item");
       await simulateClick(".o-menu div[data-name='edit']");
 
-      const checkbox = document.querySelector("input[name='labelsAsText']") as HTMLInputElement;
+      const checkbox = document.querySelector(
+        ".o-data-series input[type='checkbox']"
+      ) as HTMLInputElement;
       expect(checkbox.checked).toBe(false);
 
       await simulateClick(checkbox);
@@ -1282,13 +1289,20 @@ describe("figures", () => {
 
     test("Side panel correctly reacts to has_header checkbox check/uncheck (with two datasets)", async () => {
       createTestChart("basicChart");
-      updateChart(model, chartId, { type: "line", labelRange: "C2", dataSets: ["A1:A2", "A1"] });
+      updateChart(model, chartId, {
+        type: "line",
+        labelRange: "C2",
+        dataSets: ["A1:A2", "A1"],
+        dataSetsHaveTitle: false,
+      });
       await nextTick();
       await simulateClick(".o-figure");
       await simulateClick(".o-chart-menu-item");
       await simulateClick(".o-menu div[data-name='edit']");
 
-      const checkbox = document.querySelector("input[name='labelsAsText']") as HTMLInputElement;
+      const checkbox = document.querySelector(
+        ".o-data-series input[type='checkbox']"
+      ) as HTMLInputElement;
       expect(checkbox.checked).toBe(false);
 
       expect(checkbox.checked).toBe(false);


### PR DESCRIPTION
## Description

The tests introduced with 4199153 were meant to test that the chart's datasets didn't break when clicking on "use row X as header" checkbox. But they clicked on the "Treat labels as text" checkbox.

Task: [4543496](https://www.odoo.com/odoo/2328/tasks/4543496)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo