### PR TITLE
[FIX] spreadsheet: handle inverse increment when autofilling upwards/left

### DIFF
--- a/src/plugins/ui_feature/autofill.ts
+++ b/src/plugins/ui_feature/autofill.ts
@@ -356,7 +356,7 @@ export class AutofillPlugin extends UIPlugin {
   private getRule(cell: Cell, cells: (Cell | undefined)[]): AutofillModifier | undefined {
     const rules = autofillRulesRegistry.getAll().sort((a, b) => a.sequence - b.sequence);
     const rule = rules.find((rule) => rule.condition(cell, cells));
-    return rule && rule.generateRule(cell, cells);
+    return rule && this.direction && rule.generateRule(cell, cells, this.direction);
   }
 
   /**

--- a/src/registries/autofill_rules.ts
+++ b/src/registries/autofill_rules.ts
@@ -7,7 +7,7 @@ import {
   isDateTimeFormat,
 } from "../helpers";
 import { evaluateLiteral } from "../helpers/cells";
-import { AutofillModifier, Cell, CellValueType, DEFAULT_LOCALE } from "../types/index";
+import { AutofillModifier, Cell, CellValueType, DEFAULT_LOCALE, DIRECTION } from "../types/index";
 import { EvaluatedCell, LiteralCell } from "./../types/cells";
 import { Registry } from "./registry";
 
@@ -20,7 +20,7 @@ import { Registry } from "./registry";
  */
 export interface AutofillRule {
   condition: (cell: Cell, cells: (Cell | undefined)[]) => boolean;
-  generateRule: (cell: Cell, cells: (Cell | undefined)[]) => AutofillModifier;
+  generateRule: (cell: Cell, cells: (Cell | undefined)[], direction: DIRECTION) => AutofillModifier;
   sequence: number;
 }
 
@@ -188,7 +188,7 @@ autofillRulesRegistry
       !cell.isFormula &&
       evaluateLiteral(cell, { locale: DEFAULT_LOCALE }).type === CellValueType.text &&
       alphaNumericValueRegExp.test(cell.content),
-    generateRule: (cell: Cell, cells: Cell[]) => {
+    generateRule: (cell: Cell, cells: Cell[], direction: DIRECTION) => {
       const numberPostfix = parseInt(cell.content.match(numberPostfixRegExp)![0]);
       const prefix = cell.content.match(stringPrefixRegExp)![0];
       const numberPostfixLength = cell.content.length - prefix.length;
@@ -201,7 +201,10 @@ autofillRulesRegistry
       ) // get consecutive alphanumeric cells, no matter what the prefix is
         .filter((cell) => prefix === (cell.value ?? "").toString().match(stringPrefixRegExp)![0])
         .map((cell) => parseInt((cell.value ?? "").toString().match(numberPostfixRegExp)![0]));
-      const increment = calculateIncrementBasedOnGroup(group);
+      let increment = calculateIncrementBasedOnGroup(group);
+      if (["up", "left"].includes(direction) && group.length === 1) {
+        increment = -increment;
+      }
       return {
         type: "ALPHANUMERIC_INCREMENT_MODIFIER",
         prefix,
@@ -273,7 +276,7 @@ autofillRulesRegistry
     condition: (cell: Cell) =>
       !cell.isFormula &&
       evaluateLiteral(cell, { locale: DEFAULT_LOCALE }).type === CellValueType.number,
-    generateRule: (cell: LiteralCell, cells: (Cell | undefined)[]) => {
+    generateRule: (cell: LiteralCell, cells: (Cell | undefined)[], direction: DIRECTION) => {
       const group = getGroup(
         cell,
         cells,
@@ -281,7 +284,10 @@ autofillRulesRegistry
           evaluatedCell.type === CellValueType.number &&
           !isDateTimeFormat(evaluatedCell.format || "")
       ).map((cell) => Number(cell.value));
-      const increment = calculateIncrementBasedOnGroup(group);
+      let increment = calculateIncrementBasedOnGroup(group);
+      if (["up", "left"].includes(direction) && group.length === 1) {
+        increment = -increment;
+      }
       const evaluation = evaluateLiteral(cell, { locale: DEFAULT_LOCALE });
       return {
         type: "INCREMENT_MODIFIER",

--- a/tests/autofill/autofill_plugin.test.ts
+++ b/tests/autofill/autofill_plugin.test.ts
@@ -607,6 +607,38 @@ describe("Autofill", () => {
       expect(getCellContent(model, "A10")).toBe("-6");
     });
 
+    test("Autofill mixed-mixed values UP", () => {
+      setCellContent(model, "A10", "test");
+      setCellContent(model, "A11", "test1");
+      setCellContent(model, "A12", "4");
+      autofill("A10:A12", "A1");
+      expect(getCellContent(model, "A9")).toBe("3");
+      expect(getCellContent(model, "A8")).toBe("test0");
+      expect(getCellContent(model, "A7")).toBe("test");
+      expect(getCellContent(model, "A6")).toBe("2");
+      expect(getCellContent(model, "A5")).toBe("test-1");
+      expect(getCellContent(model, "A4")).toBe("test");
+      expect(getCellContent(model, "A3")).toBe("1");
+      expect(getCellContent(model, "A2")).toBe("test-2");
+      expect(getCellContent(model, "A1")).toBe("test");
+    });
+
+    test("Autofill mixed-mixed values LEFT", () => {
+      setCellContent(model, "J1", "test");
+      setCellContent(model, "K1", "test1");
+      setCellContent(model, "L1", "4");
+      autofill("J1:L1", "A1");
+      expect(getCellContent(model, "I1")).toBe("3");
+      expect(getCellContent(model, "H1")).toBe("test0");
+      expect(getCellContent(model, "G1")).toBe("test");
+      expect(getCellContent(model, "F1")).toBe("2");
+      expect(getCellContent(model, "E1")).toBe("test-1");
+      expect(getCellContent(model, "D1")).toBe("test");
+      expect(getCellContent(model, "C1")).toBe("1");
+      expect(getCellContent(model, "B1")).toBe("test-2");
+      expect(getCellContent(model, "A1")).toBe("test");
+    });
+
     test("Autofill should override selected zone", () => {
       setCellContent(model, "A1", "1");
       const sheetId = model.getters.getActiveSheetId();


### PR DESCRIPTION
Prior to this commit, autofilling upwards or to the left only correctly inverted the increment for numbers, but not when given a group of cells. This led to incorrect results when autofilling mixed content.

The issue occurred because the rule generator always processed values in the same order, regardless of the autofill direction. When a single numeric value was present in a group of cells, the autofill logic failed to apply a negative increment when filling upwards.

To address this, the rule generator now considers the autofill direction.

Steps to reproduce:
1. Insert the following values in a column:
   - A10: 'test'
   - A11: 'test2'
   - A12: '4'
2. Select A10:A12 and autofill upwards.
3. Expected: A9 should be '3'. Before this fix, it incorrectly showed '5'.

Task: [4199568](https://www.odoo.com/odoo/2328/tasks/4199568)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo