### PR TITLE
[IMP] spreadsheet: Operation value transform

### DIFF
--- a/doc/integrating/collaborative/collaborative.md
+++ b/doc/integrating/collaborative/collaborative.md
@@ -169,6 +169,6 @@ Here is the way to declare it.
 const { inverseCommandRegistry } = o_spreadsheet.registries;
 
 inverseCommandRegistry.add("CREATE_SHEET", (cmd) => {
-  return [{ type: "DELETE_SHEET", sheetId: cmd.sheetId }];
+  return [{ type: "DELETE_SHEET", sheetId: cmd.sheetId, sheetName: cmd.sheetName }];
 });
 ```

--- a/src/actions/insert_actions.ts
+++ b/src/actions/insert_actions.ts
@@ -328,7 +328,11 @@ export const insertSheet: ActionSpec = {
     const activeSheetId = env.model.getters.getActiveSheetId();
     const position = env.model.getters.getSheetIds().indexOf(activeSheetId) + 1;
     const sheetId = env.model.uuidGenerator.smallUuid();
-    env.model.dispatch("CREATE_SHEET", { sheetId, position });
+    env.model.dispatch("CREATE_SHEET", {
+      sheetId,
+      position,
+      name: env.model.getters.getNextSheetName(),
+    });
     env.model.dispatch("ACTIVATE_SHEET", { sheetIdFrom: activeSheetId, sheetIdTo: sheetId });
   },
   icon: "o-spreadsheet-Icon.INSERT_SHEET",

--- a/src/actions/menu_items_actions.ts
+++ b/src/actions/menu_items_actions.ts
@@ -188,6 +188,7 @@ export const REMOVE_ROWS_ACTION = (env: SpreadsheetChildEnv) => {
   }
   env.model.dispatch("REMOVE_COLUMNS_ROWS", {
     sheetId: env.model.getters.getActiveSheetId(),
+    sheetName: env.model.getters.getActiveSheetName(),
     dimension: "ROW",
     elements: rows,
   });
@@ -251,6 +252,7 @@ export const REMOVE_COLUMNS_ACTION = (env: SpreadsheetChildEnv) => {
   }
   env.model.dispatch("REMOVE_COLUMNS_ROWS", {
     sheetId: env.model.getters.getActiveSheetId(),
+    sheetName: env.model.getters.getActiveSheetName(),
     dimension: "COL",
     elements: columns,
   });
@@ -276,6 +278,7 @@ export const INSERT_ROWS_BEFORE_ACTION = (env: SpreadsheetChildEnv) => {
   }
   env.model.dispatch("ADD_COLUMNS_ROWS", {
     sheetId: env.model.getters.getActiveSheetId(),
+    sheetName: env.model.getters.getActiveSheetName(),
     position: "before",
     base: row,
     quantity,
@@ -297,6 +300,7 @@ export const INSERT_ROWS_AFTER_ACTION = (env: SpreadsheetChildEnv) => {
   }
   env.model.dispatch("ADD_COLUMNS_ROWS", {
     sheetId: env.model.getters.getActiveSheetId(),
+    sheetName: env.model.getters.getActiveSheetName(),
     position: "after",
     base: row,
     quantity,
@@ -318,6 +322,7 @@ export const INSERT_COLUMNS_BEFORE_ACTION = (env: SpreadsheetChildEnv) => {
   }
   env.model.dispatch("ADD_COLUMNS_ROWS", {
     sheetId: env.model.getters.getActiveSheetId(),
+    sheetName: env.model.getters.getActiveSheetName(),
     position: "before",
     dimension: "COL",
     base: column,
@@ -339,6 +344,7 @@ export const INSERT_COLUMNS_AFTER_ACTION = (env: SpreadsheetChildEnv) => {
   }
   env.model.dispatch("ADD_COLUMNS_ROWS", {
     sheetId: env.model.getters.getActiveSheetId(),
+    sheetName: env.model.getters.getActiveSheetName(),
     position: "after",
     dimension: "COL",
     base: column,

--- a/src/actions/sheet_actions.ts
+++ b/src/actions/sheet_actions.ts
@@ -25,7 +25,10 @@ export const deleteSheet: ActionSpec = {
   },
   execute: (env) =>
     env.askConfirmation(_t("Are you sure you want to delete this sheet?"), () => {
-      env.model.dispatch("DELETE_SHEET", { sheetId: env.model.getters.getActiveSheetId() });
+      env.model.dispatch("DELETE_SHEET", {
+        sheetId: env.model.getters.getActiveSheetId(),
+        sheetName: env.model.getters.getActiveSheetName(),
+      });
     }),
   icon: "o-spreadsheet-Icon.TRASH",
 };

--- a/src/clipboard_handlers/references_clipboard.ts
+++ b/src/clipboard_handlers/references_clipboard.ts
@@ -20,6 +20,7 @@ export class ReferenceClipboardHandler extends AbstractCellClipboardHandler<Clip
       this.dispatch("MOVE_RANGES", {
         target: content.zones,
         sheetId: content.sheetId,
+        sheetName: this.getters.getSheetName(content.sheetId),
         targetSheetId: target.sheetId,
         col: selection.left,
         row: selection.top,

--- a/src/collaborative/ot/srt_specific.ts
+++ b/src/collaborative/ot/srt_specific.ts
@@ -1,0 +1,103 @@
+import { deepCopy } from "../../helpers";
+import { adaptFormulaStringRanges, adaptStringRange } from "../../helpers/formulas";
+import { specificRangeTransformRegistry } from "../../registries/srt_registry";
+import {
+  AddConditionalFormatCommand,
+  AddDataValidationCommand,
+  AddPivotCommand,
+  UpdateCellCommand,
+  UpdatePivotCommand,
+} from "../../types/commands";
+import { RangeAdapter } from "../../types/misc";
+
+function updateCellCommandAdaptRange(
+  cmd: UpdateCellCommand,
+  applyChange: RangeAdapter
+): UpdateCellCommand {
+  const content = cmd.content && adaptFormulaStringRanges(cmd.sheetId, cmd.content, applyChange);
+  return { ...cmd, content };
+}
+specificRangeTransformRegistry.add("UPDATE_CELL", updateCellCommandAdaptRange);
+
+function addConditionalFormatCommandAdaptRange(
+  cmd: AddConditionalFormatCommand,
+  applyChange: RangeAdapter
+): AddConditionalFormatCommand {
+  const rule = cmd.cf.rule;
+  cmd = { ...cmd, cf: { ...cmd.cf } };
+  if (rule.type == "CellIsRule") {
+    cmd.cf.rule = {
+      ...rule,
+      values: rule.values.map((val) => adaptFormulaStringRanges(cmd.sheetId, val, applyChange)),
+    };
+  } else if (rule.type === "ColorScaleRule") {
+    const { minimum: min, maximum: max, midpoint: mid } = rule;
+    cmd.cf.rule = {
+      ...rule,
+      minimum: {
+        ...min,
+        value: min.value && adaptFormulaStringRanges(cmd.sheetId, min.value, applyChange),
+      },
+      maximum: {
+        ...max,
+        value: max.value && adaptFormulaStringRanges(cmd.sheetId, max.value, applyChange),
+      },
+      midpoint: mid
+        ? { ...mid, value: adaptFormulaStringRanges(cmd.sheetId, mid.value, applyChange) }
+        : undefined,
+    };
+  } else if (rule.type === "IconSetRule") {
+    const { upperInflectionPoint: uip, lowerInflectionPoint: lip } = rule;
+    cmd.cf.rule = {
+      ...rule,
+      upperInflectionPoint: {
+        ...uip,
+        value: adaptFormulaStringRanges(cmd.sheetId, uip.value, applyChange),
+      },
+      lowerInflectionPoint: {
+        ...lip,
+        value: adaptFormulaStringRanges(cmd.sheetId, lip.value, applyChange),
+      },
+    };
+  } else if (rule.type === "DataBarRule") {
+    cmd.cf.rule = {
+      ...rule,
+      rangeValues: rule.rangeValues
+        ? adaptStringRange(cmd.sheetId, rule.rangeValues, applyChange)
+        : undefined,
+    };
+  }
+  return cmd;
+}
+specificRangeTransformRegistry.add("ADD_CONDITIONAL_FORMAT", addConditionalFormatCommandAdaptRange);
+
+function addDataValidationCommandAdaptRange(
+  cmd: AddDataValidationCommand,
+  applyChange: RangeAdapter
+): AddDataValidationCommand {
+  cmd = { ...cmd, rule: { ...cmd.rule, criterion: { ...cmd.rule.criterion } } };
+  cmd.rule.criterion.values = cmd.rule.criterion.values.map((val) =>
+    adaptFormulaStringRanges(cmd.sheetId, val, applyChange)
+  );
+  return cmd;
+}
+specificRangeTransformRegistry.add("ADD_DATA_VALIDATION_RULE", addDataValidationCommandAdaptRange);
+
+function addPivotCommandAdaptRange<Cmd extends AddPivotCommand | UpdatePivotCommand>(
+  cmd: Cmd,
+  applyChange: RangeAdapter
+): Cmd {
+  cmd = deepCopy(cmd);
+  cmd.pivot.measures.map((measure) => {
+    if (measure.computedBy) {
+      measure.computedBy.formula = adaptFormulaStringRanges(
+        measure.computedBy.sheetId,
+        measure.computedBy.formula,
+        applyChange
+      );
+    }
+  });
+  return cmd;
+}
+specificRangeTransformRegistry.add("ADD_PIVOT", addPivotCommandAdaptRange);
+specificRangeTransformRegistry.add("UPDATE_PIVOT", addPivotCommandAdaptRange);

--- a/src/components/composer/composer/cell_composer_store.ts
+++ b/src/components/composer/composer/cell_composer_store.ts
@@ -260,6 +260,7 @@ export class CellComposerStore extends AbstractComposerStore {
     if (missingCols > 0) {
       this.model.dispatch("ADD_COLUMNS_ROWS", {
         sheetId: this.sheetId,
+        sheetName: this.getters.getSheetName(this.sheetId),
         dimension: "COL",
         base: numberOfCols - 1,
         position: "after",
@@ -269,6 +270,7 @@ export class CellComposerStore extends AbstractComposerStore {
     if (missingRows > 0) {
       this.model.dispatch("ADD_COLUMNS_ROWS", {
         sheetId: this.sheetId,
+        sheetName: this.getters.getSheetName(this.sheetId),
         dimension: "ROW",
         base: numberOfRows - 1,
         position: "after",

--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -378,12 +378,14 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
       if (columns.length > 0 && rows.length === 0) {
         this.env.model.dispatch("REMOVE_COLUMNS_ROWS", {
           sheetId: this.env.model.getters.getActiveSheetId(),
+          sheetName: this.env.model.getters.getActiveSheetName(),
           dimension: "COL",
           elements: columns,
         });
       } else if (rows.length > 0 && columns.length === 0) {
         this.env.model.dispatch("REMOVE_COLUMNS_ROWS", {
           sheetId: this.env.model.getters.getActiveSheetId(),
+          sheetName: this.env.model.getters.getActiveSheetName(),
           dimension: "ROW",
           elements: rows,
         });

--- a/src/components/grid_add_rows_footer/grid_add_rows_footer.ts
+++ b/src/components/grid_add_rows_footer/grid_add_rows_footer.ts
@@ -79,6 +79,7 @@ export class GridAddRowsFooter extends Component<Props, SpreadsheetChildEnv> {
     const rowNumber = this.env.model.getters.getNumberRows(activeSheetId);
     this.env.model.dispatch("ADD_COLUMNS_ROWS", {
       sheetId: activeSheetId,
+      sheetName: this.env.model.getters.getSheetName(activeSheetId),
       position: "after",
       base: rowNumber - 1,
       quantity,

--- a/src/components/headers_overlay/headers_overlay.ts
+++ b/src/components/headers_overlay/headers_overlay.ts
@@ -445,6 +445,7 @@ export class ColResizer extends AbstractResizer {
     }
     const result = this.env.model.dispatch("MOVE_COLUMNS_ROWS", {
       sheetId: this.sheetId,
+      sheetName: this.env.model.getters.getActiveSheetName(),
       dimension: "COL",
       base: this.state.base,
       elements,
@@ -670,6 +671,7 @@ export class RowResizer extends AbstractResizer {
     }
     const result = this.env.model.dispatch("MOVE_COLUMNS_ROWS", {
       sheetId: this.sheetId,
+      sheetName: this.env.model.getters.getActiveSheetName(),
       dimension: "ROW",
       base: this.state.base,
       elements,

--- a/src/helpers/formulas.ts
+++ b/src/helpers/formulas.ts
@@ -1,0 +1,104 @@
+import { rangeTokenize } from "../formulas";
+import { Range, RangeAdapter, UID, ZoneDimension } from "../types";
+import { CellErrorType } from "../types/errors";
+import { concat } from "./misc";
+import { RangeImpl } from "./range";
+import { rangeReference, splitReference } from "./references";
+import { toUnboundedZone } from "./zones";
+
+export function adaptFormulaStringRanges(
+  defaultSheetId: string,
+  formula: string,
+  applyChange: RangeAdapter
+): string {
+  if (!formula.startsWith("=")) {
+    return formula;
+  }
+  const tokens = rangeTokenize(formula);
+  for (let tokenIdx = 1; tokenIdx < tokens.length; tokenIdx++) {
+    if (tokens[tokenIdx].type != "REFERENCE") {
+      continue;
+    }
+    const sheetXC = tokens[tokenIdx].value;
+    const newSheetXC = adaptStringRange(defaultSheetId, sheetXC, applyChange);
+
+    if (sheetXC !== newSheetXC) {
+      tokens[tokenIdx] = {
+        value: newSheetXC,
+        type: "REFERENCE",
+      };
+    }
+  }
+  return concat(tokens.map((token) => token.value));
+}
+
+export function adaptStringRange(
+  defaultSheetId: string,
+  sheetXC: string,
+  applyChange: RangeAdapter
+): string {
+  const sheetName = splitReference(sheetXC).sheetName;
+  if (sheetName ? sheetName !== applyChange.sheetName : defaultSheetId !== applyChange.sheetId) {
+    return sheetXC;
+  }
+  const sheetId = sheetName ? applyChange.sheetId : defaultSheetId;
+
+  const range = getRange(sheetXC, sheetId);
+  if (range.invalidXc) {
+    return sheetXC;
+  }
+
+  const change = applyChange.applyChange(range);
+  if (change.changeType === "NONE" || change.changeType === "REMOVE") {
+    return sheetXC;
+  }
+
+  const newSheetXC = change.range.getRangeString(defaultSheetId, getSheetNameGetter(applyChange));
+  return newSheetXC === CellErrorType.InvalidReference ? sheetXC : newSheetXC;
+}
+
+function getSheetNameGetter(applyChange: RangeAdapter) {
+  return (sheetId: UID): string => {
+    return sheetId === applyChange.sheetId ? applyChange.sheetName : "";
+  };
+}
+
+function defaultGetSheetSize(sheetId: UID) {
+  return { numberOfRows: Number.MAX_SAFE_INTEGER, numberOfCols: Number.MAX_SAFE_INTEGER };
+}
+
+function getRange(sheetXC: string, sheetId: UID): Range {
+  if (!rangeReference.test(sheetXC)) {
+    return invalidRange(sheetXC, defaultGetSheetSize);
+  }
+
+  let sheetName: string | undefined;
+  let xc = sheetXC;
+  let prefixSheet = false;
+  if (sheetXC.includes("!")) {
+    ({ xc, sheetName } = splitReference(sheetXC));
+    if (sheetName) {
+      prefixSheet = true;
+    }
+  }
+
+  const unboundedZone = toUnboundedZone(xc);
+  const parts = RangeImpl.getRangeParts(xc, unboundedZone);
+
+  const rangeInterface = { prefixSheet, unboundedZone, sheetId, invalidSheetName: "", parts };
+
+  return new RangeImpl(rangeInterface, defaultGetSheetSize).orderZone();
+}
+
+function invalidRange(sheetXC: string, getSheetSize: (sheetId: UID) => ZoneDimension): Range {
+  return new RangeImpl(
+    {
+      sheetId: "",
+      unboundedZone: { left: -1, top: -1, right: -1, bottom: -1 },
+      parts: [],
+      invalidXc: sheetXC,
+      prefixSheet: false,
+    },
+    getSheetSize
+  );
+}

--- a/src/helpers/range.ts
+++ b/src/helpers/range.ts
@@ -1,18 +1,37 @@
 import {
+  AddColumnsRowsCommand,
+  ApplyRangeChange,
+  ApplyRangeChangeSheet,
   CellPosition,
+  ChangeType,
+  Command,
   CoreGetters,
   CustomizedDataSet,
+  DeleteSheetCommand,
   Getters,
+  MoveRangeCommand,
   Range,
   RangeData,
   RangePart,
+  RemoveColumnsRowsCommand,
+  RenameSheetCommand,
   UID,
   UnboundedZone,
   Zone,
   ZoneDimension,
 } from "../types";
+import { CellErrorType } from "../types/errors";
+import { groupConsecutive, largeMax, largeMin } from "./misc";
 import { isRowReference, splitReference } from "./references";
-import { getZoneArea, isZoneOrdered, positions, toUnboundedZone, zoneToXc } from "./zones";
+import {
+  createAdaptedZone,
+  getZoneArea,
+  isZoneInside,
+  isZoneOrdered,
+  positions,
+  toUnboundedZone,
+  zoneToXc,
+} from "./zones";
 
 interface ConstructorArgs {
   readonly zone: Readonly<Zone | UnboundedZone>;
@@ -274,4 +293,176 @@ export function getCellPositionsInRanges(ranges: Range[]): CellPosition[] {
     }
   }
   return cellPositions;
+}
+
+export function getApplyRangeChange(
+  cmd: Command,
+  getters: CoreGetters
+): ApplyRangeChangeSheet | undefined {
+  switch (cmd.type) {
+    case "REMOVE_COLUMNS_ROWS":
+      return { applyChange: getApplyRangeChangeRemoveColRow(cmd), sheetId: cmd.sheetId };
+    case "ADD_COLUMNS_ROWS":
+      return { applyChange: getApplyRangeChangeAddColRow(cmd), sheetId: cmd.sheetId };
+    case "DELETE_SHEET":
+      return { applyChange: getApplyRangeChangeDeleteSheet(cmd, getters), sheetId: cmd.sheetId };
+    case "RENAME_SHEET":
+      return { applyChange: getApplyRangeChangeRenameSheet(cmd) };
+    case "MOVE_RANGES":
+      return { applyChange: getApplyRangeChangeMoveRange(cmd) };
+  }
+  return undefined;
+}
+
+function getApplyRangeChangeRemoveColRow(cmd: RemoveColumnsRowsCommand): ApplyRangeChange {
+  let start: "left" | "top" = cmd.dimension === "COL" ? "left" : "top";
+  let end: "right" | "bottom" = cmd.dimension === "COL" ? "right" : "bottom";
+  let dimension: "columns" | "rows" = cmd.dimension === "COL" ? "columns" : "rows";
+
+  const elements = [...cmd.elements];
+  elements.sort((a, b) => b - a);
+
+  const groups = groupConsecutive(elements);
+  return (range: RangeImpl) => {
+    if (range.sheetId !== cmd.sheetId) {
+      return { changeType: "NONE" };
+    }
+    let newRange = range;
+    let changeType: ChangeType = "NONE";
+    for (let group of groups) {
+      const min = largeMin(group);
+      const max = largeMax(group);
+      if (range.zone[start] <= min && min <= range.zone[end]) {
+        const toRemove = Math.min(range.zone[end], max) - min + 1;
+        changeType = "RESIZE";
+        newRange = createAdaptedRange(newRange, dimension, changeType, -toRemove);
+      } else if (range.zone[start] >= min && range.zone[end] <= max) {
+        changeType = "REMOVE";
+        newRange = range.clone({ ...getInvalidRange() });
+      } else if (range.zone[start] <= max && range.zone[end] >= max) {
+        const toRemove = max - range.zone[start] + 1;
+        changeType = "RESIZE";
+        newRange = createAdaptedRange(newRange, dimension, changeType, -toRemove);
+        newRange = createAdaptedRange(newRange, dimension, "MOVE", -(range.zone[start] - min));
+      } else if (min < range.zone[start]) {
+        changeType = "MOVE";
+        newRange = createAdaptedRange(newRange, dimension, changeType, -(max - min + 1));
+      }
+    }
+    if (changeType !== "NONE") {
+      return { changeType, range: newRange };
+    }
+    return { changeType: "NONE" };
+  };
+}
+
+function getApplyRangeChangeAddColRow(cmd: AddColumnsRowsCommand): ApplyRangeChange {
+  let start: "left" | "top" = cmd.dimension === "COL" ? "left" : "top";
+  let end: "right" | "bottom" = cmd.dimension === "COL" ? "right" : "bottom";
+  let dimension: "columns" | "rows" = cmd.dimension === "COL" ? "columns" : "rows";
+
+  return (range: RangeImpl) => {
+    if (range.sheetId !== cmd.sheetId) {
+      return { changeType: "NONE" };
+    }
+    if (cmd.position === "after") {
+      if (range.zone[start] <= cmd.base && cmd.base < range.zone[end]) {
+        return {
+          changeType: "RESIZE",
+          range: createAdaptedRange(range, dimension, "RESIZE", cmd.quantity),
+        };
+      }
+      if (cmd.base < range.zone[start]) {
+        return {
+          changeType: "MOVE",
+          range: createAdaptedRange(range, dimension, "MOVE", cmd.quantity),
+        };
+      }
+    } else {
+      if (range.zone[start] < cmd.base && cmd.base <= range.zone[end]) {
+        return {
+          changeType: "RESIZE",
+          range: createAdaptedRange(range, dimension, "RESIZE", cmd.quantity),
+        };
+      }
+      if (cmd.base <= range.zone[start]) {
+        return {
+          changeType: "MOVE",
+          range: createAdaptedRange(range, dimension, "MOVE", cmd.quantity),
+        };
+      }
+    }
+    return { changeType: "NONE" };
+  };
+}
+
+function getApplyRangeChangeDeleteSheet(
+  cmd: DeleteSheetCommand,
+  getters: CoreGetters
+): ApplyRangeChange {
+  return (range: RangeImpl) => {
+    if (range.sheetId !== cmd.sheetId) {
+      return { changeType: "NONE" };
+    }
+    const invalidSheetName = getters.getSheetName(cmd.sheetId);
+    range = range.clone({
+      ...getInvalidRange(),
+      invalidSheetName,
+    });
+    return { changeType: "REMOVE", range };
+  };
+}
+
+function getApplyRangeChangeRenameSheet(cmd: RenameSheetCommand): ApplyRangeChange {
+  return (range: RangeImpl) => {
+    if (range.sheetId === cmd.sheetId) {
+      return { changeType: "CHANGE", range };
+    }
+    if (cmd.name && range.invalidSheetName === cmd.name) {
+      const invalidSheetName = undefined;
+      const sheetId = cmd.sheetId;
+      const newRange = range.clone({ sheetId, invalidSheetName });
+      return { changeType: "CHANGE", range: newRange };
+    }
+    return { changeType: "NONE" };
+  };
+}
+
+function getApplyRangeChangeMoveRange(cmd: MoveRangeCommand): ApplyRangeChange {
+  const originZone = cmd.target[0];
+  return (range: RangeImpl) => {
+    if (range.sheetId !== cmd.sheetId || !isZoneInside(range.zone, originZone)) {
+      return { changeType: "NONE" };
+    }
+    const targetSheetId = cmd.targetSheetId;
+    const offsetX = cmd.col - originZone.left;
+    const offsetY = cmd.row - originZone.top;
+    const adaptedRange = createAdaptedRange(range, "both", "MOVE", [offsetX, offsetY]);
+    const prefixSheet = cmd.sheetId === targetSheetId ? adaptedRange.prefixSheet : true;
+    return {
+      changeType: "MOVE",
+      range: adaptedRange.clone({ sheetId: targetSheetId, prefixSheet }),
+    };
+  };
+}
+
+function createAdaptedRange<Dimension extends "columns" | "rows" | "both">(
+  range: RangeImpl,
+  dimension: Dimension,
+  operation: "MOVE" | "RESIZE",
+  by: Dimension extends "both" ? [number, number] : number
+) {
+  const zone = createAdaptedZone(range.unboundedZone, dimension, operation, by);
+  const adaptedRange = range.clone({ zone });
+  return adaptedRange;
+}
+
+function getInvalidRange() {
+  return {
+    parts: [],
+    prefixSheet: false,
+    zone: { left: -1, top: -1, right: -1, bottom: -1 },
+    sheetId: "",
+    invalidXc: CellErrorType.InvalidReference,
+  };
 }

--- a/src/helpers/ui/sheet_interactive.ts
+++ b/src/helpers/ui/sheet_interactive.ts
@@ -8,7 +8,11 @@ export function interactiveRenameSheet(
   name: string,
   errorCallback: () => void
 ) {
-  const result = env.model.dispatch("RENAME_SHEET", { sheetId, name });
+  const result = env.model.dispatch("RENAME_SHEET", {
+    sheetId,
+    newName: name,
+    oldName: env.model.getters.getSheetName(sheetId),
+  });
   if (result.reasons.includes(CommandResult.MissingSheetName)) {
     env.raiseError(_t("The sheet name cannot be empty."), errorCallback);
   } else if (result.reasons.includes(CommandResult.DuplicatedSheetName)) {

--- a/src/plugins/core/cell.ts
+++ b/src/plugins/core/cell.ts
@@ -72,12 +72,16 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
   readonly nextId = 1;
   public readonly cells: { [sheetId: string]: { [id: string]: Cell } } = {};
 
-  adaptRanges(applyChange: ApplyRangeChange, sheetId?: UID) {
+  adaptRanges(applyChange: ApplyRangeChange, sheetId?: UID, sheetName?: string) {
     for (const sheet of Object.keys(this.cells)) {
       for (const cell of Object.values(this.cells[sheet] || {})) {
         if (cell.isFormula) {
           for (const range of cell.compiledFormula.dependencies) {
-            if (!sheetId || range.sheetId === sheetId) {
+            if (
+              !sheetId ||
+              range.sheetId === sheetId ||
+              (sheetName && range.invalidSheetName === sheetName)
+            ) {
               const change = applyChange(range);
               if (change.changeType !== "NONE") {
                 this.history.update(

--- a/src/plugins/core/conditional_format.ts
+++ b/src/plugins/core/conditional_format.ts
@@ -180,7 +180,7 @@ export class ConditionalFormatPlugin
     }
   }
 
-  adaptRanges(applyChange: ApplyRangeChange, sheetId?: UID) {
+  adaptRanges(applyChange: ApplyRangeChange, sheetId?: UID, sheetName?: string) {
     const sheetIds = sheetId ? [sheetId] : Object.keys(this.cfRules);
     for (const sheetId of sheetIds) {
       this.adaptCFRanges(sheetId, applyChange);

--- a/src/plugins/core/data_validation.ts
+++ b/src/plugins/core/data_validation.ts
@@ -41,7 +41,7 @@ export class DataValidationPlugin
 
   readonly rules: { [sheet: string]: DataValidationRule[] } = {};
 
-  adaptRanges(applyChange: ApplyRangeChange, sheetId?: UID) {
+  adaptRanges(applyChange: ApplyRangeChange, sheetId?: UID, sheetName?: string) {
     const sheetIds = sheetId ? [sheetId] : Object.keys(this.rules);
     for (const sheetId of sheetIds) {
       this.adaptDVRanges(sheetId, applyChange);

--- a/src/plugins/core/merge.ts
+++ b/src/plugins/core/merge.ts
@@ -120,7 +120,7 @@ export class MergePlugin extends CorePlugin<MergeState> implements MergeState {
     }
   }
 
-  adaptRanges(applyChange: ApplyRangeChange, sheetId?: UID) {
+  adaptRanges(applyChange: ApplyRangeChange, sheetId?: UID, sheetName?: string) {
     const sheetIds = sheetId ? [sheetId] : Object.keys(this.merges);
     for (const sheetId of sheetIds) {
       this.applyRangeChangeOnSheet(sheetId, applyChange);
@@ -166,10 +166,10 @@ export class MergePlugin extends CorePlugin<MergeState> implements MergeState {
    * Same as `getRangeString` but add all necessary merge to the range to make it a valid selection
    */
   getSelectionRangeString(range: Range, forSheetId: UID): string {
-    const rangeImpl = RangeImpl.fromRange(range, this.getters);
+    const rangeImpl = RangeImpl.fromRange(range, this.getters.getSheetSize);
     const expandedZone = this.getters.expandZone(rangeImpl.sheetId, rangeImpl.zone);
     const expandedRange = rangeImpl.clone({
-      zone: {
+      unboundedZone: {
         ...expandedZone,
         bottom: rangeImpl.isFullCol ? undefined : expandedZone.bottom,
         right: rangeImpl.isFullRow ? undefined : expandedZone.right,

--- a/src/plugins/core/pivot.ts
+++ b/src/plugins/core/pivot.ts
@@ -131,7 +131,7 @@ export class PivotCorePlugin extends CorePlugin<CoreState> implements CoreState 
     }
   }
 
-  adaptRanges(applyChange: ApplyRangeChange) {
+  adaptRanges(applyChange: ApplyRangeChange, sheetId?: UID, sheetName?: string) {
     for (const sheetId in this.compiledMeasureFormulas) {
       for (const formulaString in this.compiledMeasureFormulas[sheetId]) {
         const compiledFormula = this.compiledMeasureFormulas[sheetId][formulaString];
@@ -264,6 +264,7 @@ export class PivotCorePlugin extends CorePlugin<CoreState> implements CoreState 
         dimension: "COL",
         base: numberCols - 1,
         sheetId: sheetId,
+        sheetName: this.getters.getSheetName(sheetId),
         quantity: colLimit - deltaCol,
         position: "after",
       });
@@ -276,6 +277,7 @@ export class PivotCorePlugin extends CorePlugin<CoreState> implements CoreState 
         dimension: "ROW",
         base: numberRows - 1,
         sheetId: sheetId,
+        sheetName: this.getters.getSheetName(sheetId),
         quantity: rowLimit - deltaRow,
         position: "after",
       });

--- a/src/plugins/core/range.ts
+++ b/src/plugins/core/range.ts
@@ -1,10 +1,8 @@
 import { compile } from "../../formulas";
 import {
   duplicateRangeInDuplicatedSheet,
-  getApplyRangeChange,
-  getCanonicalSymbolName,
+  getRangeAdapter,
   isZoneValid,
-  numberToLetters,
   RangeImpl,
   rangeReference,
   recomputeZones,
@@ -25,15 +23,11 @@ import {
   Range,
   RangeData,
   RangeProvider,
+  RangeStringOptions,
   UID,
   UnboundedZone,
   Zone,
 } from "../../types/index";
-
-interface RangeStringOptions {
-  useBoundedReference?: boolean;
-  useFixedReference?: boolean;
-}
 
 export class RangeAdapter implements CommandHandler<CoreCommand> {
   private getters: CoreGetters;
@@ -71,9 +65,13 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
   beforeHandle(command: Command) {}
 
   handle(cmd: Command) {
-    const arc = getApplyRangeChange(cmd, this.getters);
-    if (arc?.applyChange) {
-      this.executeOnAllRanges(arc.applyChange, arc.sheetId);
+    const rangeAdapter = getRangeAdapter(cmd);
+    if (rangeAdapter?.applyChange) {
+      this.executeOnAllRanges(
+        rangeAdapter.applyChange,
+        rangeAdapter.sheetId,
+        rangeAdapter.sheetName
+      );
     }
   }
 
@@ -95,10 +93,10 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
     };
   }
 
-  private executeOnAllRanges(adaptRange: ApplyRangeChange, sheetId?: UID) {
+  private executeOnAllRanges(adaptRange: ApplyRangeChange, sheetId?: UID, sheetName?: string) {
     const func = this.verifyRangeRemoved(adaptRange);
     for (const provider of this.providers) {
-      provider(func, sheetId);
+      provider(func, sheetId, sheetName);
     }
   }
 
@@ -119,7 +117,7 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
   // ---------------------------------------------------------------------------
 
   createAdaptedRanges(ranges: Range[], offsetX: number, offsetY: number, sheetId: UID): Range[] {
-    const rangesImpl = ranges.map((range) => RangeImpl.fromRange(range, this.getters));
+    const rangesImpl = ranges.map((range) => RangeImpl.fromRange(range, this.getters.getSheetSize));
     return rangesImpl.map((range) => {
       if (!isZoneValid(range.zone)) {
         return range;
@@ -148,7 +146,7 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
           : range.unboundedZone.bottom! +
             ((range.parts[1] || range.parts[0]).rowFixed ? 0 : offsetY),
       };
-      return range.clone({ sheetId: copySheetId, zone: unboundZone }).orderZone();
+      return range.clone({ sheetId: copySheetId, unboundedZone: unboundZone }).orderZone();
     });
   }
 
@@ -157,7 +155,7 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
    */
   removeRangesSheetPrefix(sheetId: UID, ranges: Range[]): Range[] {
     return ranges.map((range) => {
-      const rangeImpl = RangeImpl.fromRange(range, this.getters);
+      const rangeImpl = RangeImpl.fromRange(range, this.getters.getSheetSize);
       if (rangeImpl.prefixSheet && rangeImpl.sheetId === sheetId) {
         return rangeImpl.clone({ prefixSheet: false });
       }
@@ -166,16 +164,16 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
   }
 
   extendRange(range: Range, dimension: Dimension, quantity: number): Range {
-    const rangeImpl = RangeImpl.fromRange(range, this.getters);
+    const rangeImpl = RangeImpl.fromRange(range, this.getters.getSheetSize);
     const right = dimension === "COL" ? rangeImpl.zone.right + quantity : rangeImpl.zone.right;
     const bottom = dimension === "ROW" ? rangeImpl.zone.bottom + quantity : rangeImpl.zone.bottom;
-    const zone = {
+    const unboundedZone = {
       left: rangeImpl.zone.left,
       top: rangeImpl.zone.top,
       right: rangeImpl.isFullRow ? undefined : right,
       bottom: rangeImpl.isFullCol ? undefined : bottom,
     };
-    return new RangeImpl({ ...rangeImpl, zone }, this.getters.getSheetSize).orderZone();
+    return new RangeImpl({ ...rangeImpl, unboundedZone }, this.getters.getSheetSize).orderZone();
   }
 
   /**
@@ -188,7 +186,7 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
       return new RangeImpl(
         {
           sheetId: "",
-          zone: { left: -1, top: -1, right: -1, bottom: -1 },
+          unboundedZone: { left: -1, top: -1, right: -1, bottom: -1 },
           parts: [],
           invalidXc: sheetXC,
           prefixSheet: false,
@@ -206,13 +204,13 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
         prefixSheet = true;
       }
     }
-    const zone = toUnboundedZone(xc);
-    const parts = RangeImpl.getRangeParts(xc, zone);
+    const unboundedZone = toUnboundedZone(xc);
+    const parts = RangeImpl.getRangeParts(xc, unboundedZone);
     const invalidSheetName =
       sheetName && !this.getters.getSheetIdByName(sheetName) ? sheetName : undefined;
     const sheetId = this.getters.getSheetIdByName(sheetName) || defaultSheetId;
 
-    const rangeInterface = { prefixSheet, zone, sheetId, invalidSheetName, parts };
+    const rangeInterface = { prefixSheet, unboundedZone, sheetId, invalidSheetName, parts };
 
     return new RangeImpl(rangeInterface, this.getters.getSheetSize).orderZone();
   }
@@ -242,45 +240,7 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
     if (!this.getters.tryGetSheet(range.sheetId)) {
       return CellErrorType.InvalidReference;
     }
-    if (range.zone.bottom - range.zone.top < 0 || range.zone.right - range.zone.left < 0) {
-      return CellErrorType.InvalidReference;
-    }
-    if (range.zone.left < 0 || range.zone.top < 0) {
-      return CellErrorType.InvalidReference;
-    }
-    const rangeImpl = RangeImpl.fromRange(range, this.getters);
-    let prefixSheet =
-      rangeImpl.sheetId !== forSheetId || rangeImpl.invalidSheetName || rangeImpl.prefixSheet;
-    let sheetName: string = "";
-    if (prefixSheet) {
-      if (rangeImpl.invalidSheetName) {
-        sheetName = rangeImpl.invalidSheetName;
-      } else {
-        sheetName = getCanonicalSymbolName(this.getters.getSheetName(rangeImpl.sheetId));
-      }
-    }
-
-    if (prefixSheet && !sheetName) {
-      return CellErrorType.InvalidReference;
-    }
-
-    let rangeString = this.getRangePartString(rangeImpl, 0, options);
-    if (rangeImpl.parts && rangeImpl.parts.length === 2) {
-      // this if converts A2:A2 into A2 except if any part of the original range had fixed row or column (with $)
-      if (
-        rangeImpl.zone.top !== rangeImpl.zone.bottom ||
-        rangeImpl.zone.left !== rangeImpl.zone.right ||
-        rangeImpl.parts[0].rowFixed ||
-        rangeImpl.parts[0].colFixed ||
-        rangeImpl.parts[1].rowFixed ||
-        rangeImpl.parts[1].colFixed
-      ) {
-        rangeString += ":";
-        rangeString += this.getRangePartString(rangeImpl, 1, options);
-      }
-    }
-
-    return `${prefixSheet ? sheetName + "!" : ""}${rangeString}`;
+    return range.getRangeString(forSheetId, this.getters.getSheetName, options);
   }
 
   getRangeDataFromXc(sheetId: UID, xc: string): RangeData {
@@ -296,7 +256,7 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
     return new RangeImpl(
       {
         sheetId,
-        zone,
+        unboundedZone: zone,
         parts: [
           { colFixed: false, rowFixed: false },
           { colFixed: false, rowFixed: false },
@@ -311,9 +271,11 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
    * Allows you to recompute ranges from the same sheet
    */
   recomputeRanges(ranges: Range[], rangesToRemove: Range[]): Range[] {
-    const zones = ranges.map((range) => RangeImpl.fromRange(range, this.getters).unboundedZone);
+    const zones = ranges.map(
+      (range) => RangeImpl.fromRange(range, this.getters.getSheetSize).unboundedZone
+    );
     const zonesToRemove = rangesToRemove.map(
-      (range) => RangeImpl.fromRange(range, this.getters).unboundedZone
+      (range) => RangeImpl.fromRange(range, this.getters.getSheetSize).unboundedZone
     );
     return recomputeZones(zones, zonesToRemove).map((zone) =>
       this.getRangeFromZone(ranges[0].sheetId, zone)
@@ -323,7 +285,7 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
   getRangeFromRangeData(data: RangeData): Range {
     const rangeInterface = {
       prefixSheet: false,
-      zone: data._zone,
+      unboundedZone: data._zone,
       sheetId: data._sheetId,
       invalidSheetName: undefined,
       parts: [
@@ -347,7 +309,9 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
   }
 
   getRangesUnion(ranges: Range[]): Range {
-    const zones = ranges.map((range) => RangeImpl.fromRange(range, this.getters).unboundedZone);
+    const zones = ranges.map(
+      (range) => RangeImpl.fromRange(range, this.getters.getSheetSize).unboundedZone
+    );
     const unionOfZones = unionUnboundedZones(...zones);
     return this.getRangeFromZone(ranges[0].sheetId, unionOfZones);
   }
@@ -395,42 +359,5 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
         : duplicateRangeInDuplicatedSheet(sheetIdFrom, sheetIdTo, range);
     });
     return this.getters.getFormulaString(sheetIdTo, compiledFormula.tokens, updatedDependencies);
-  }
-
-  // ---------------------------------------------------------------------------
-  // Private
-  // ---------------------------------------------------------------------------
-
-  /**
-   * Get a Xc string that represent a part of a range
-   */
-  private getRangePartString(
-    range: RangeImpl,
-    part: 0 | 1,
-    options: RangeStringOptions = { useBoundedReference: false, useFixedReference: false }
-  ): string {
-    const colFixed = range.parts[part]?.colFixed || options.useFixedReference ? "$" : "";
-    const col = part === 0 ? numberToLetters(range.zone.left) : numberToLetters(range.zone.right);
-    const rowFixed = range.parts[part]?.rowFixed || options.useFixedReference ? "$" : "";
-    const row = part === 0 ? String(range.zone.top + 1) : String(range.zone.bottom + 1);
-
-    let str = "";
-    if (range.isFullCol && !options.useBoundedReference) {
-      if (part === 0 && range.unboundedZone.hasHeader) {
-        str = colFixed + col + rowFixed + row;
-      } else {
-        str = colFixed + col;
-      }
-    } else if (range.isFullRow && !options.useBoundedReference) {
-      if (part === 0 && range.unboundedZone.hasHeader) {
-        str = colFixed + col + rowFixed + row;
-      } else {
-        str = rowFixed + row;
-      }
-    } else {
-      str = colFixed + col + rowFixed + row;
-    }
-
-    return str;
   }
 }

--- a/src/plugins/core/sheet.ts
+++ b/src/plugins/core/sheet.ts
@@ -187,7 +187,7 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
         this.moveSheet(cmd.sheetId, cmd.delta);
         break;
       case "RENAME_SHEET":
-        this.renameSheet(this.sheets[cmd.sheetId]!, cmd.name!);
+        this.renameSheet(this.sheets[cmd.sheetId]!, cmd.newName);
         break;
       case "COLOR_SHEET":
         this.history.update("sheets", cmd.sheetId, "color", cmd.color);
@@ -642,12 +642,13 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
 
   private checkSheetName(cmd: RenameSheetCommand | CreateSheetCommand): CommandResult {
     const originalSheetName = this.getters.tryGetSheetName(cmd.sheetId);
-    if (originalSheetName !== undefined && cmd.name === originalSheetName) {
+    const sheetName = cmd.type === "RENAME_SHEET" ? cmd.newName : cmd.name;
+    if (originalSheetName !== undefined && sheetName === originalSheetName) {
       return CommandResult.UnchangedSheetName;
     }
 
     const { orderedSheetIds, sheets } = this;
-    const name = cmd.name && cmd.name.trim().toLowerCase();
+    const name = sheetName && sheetName.trim().toLowerCase();
     if (
       orderedSheetIds.find((id) => sheets[id]?.name.toLowerCase() === name && id !== cmd.sheetId)
     ) {
@@ -700,7 +701,7 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
   }
 
   private isRenameAllowed(cmd: RenameSheetCommand): CommandResult {
-    const name = cmd.name && cmd.name.trim().toLowerCase();
+    const name = cmd.newName && cmd.newName.trim().toLowerCase();
     if (!name) {
       return CommandResult.MissingSheetName;
     }

--- a/src/plugins/core/tables.ts
+++ b/src/plugins/core/tables.ts
@@ -52,7 +52,7 @@ export class TablePlugin extends CorePlugin<TableState> implements TableState {
   readonly tables: Record<UID, Record<TableId, CoreTable | undefined>> = {};
   readonly nextTableId: number = 1;
 
-  adaptRanges(applyChange: ApplyRangeChange, sheetId?: UID) {
+  adaptRanges(applyChange: ApplyRangeChange, sheetId?: UID, sheetName?: string) {
     const sheetIds = sheetId ? [sheetId] : this.getters.getSheetIds();
     for (const sheetId of sheetIds) {
       for (const table of this.getCoreTables(sheetId)) {

--- a/src/plugins/core_plugin.ts
+++ b/src/plugins/core_plugin.ts
@@ -66,7 +66,7 @@ export class CorePlugin<State = any>
    * @param applyChange a function that, when called, will adapt the range according to the change on the grid
    * @param sheetId an optional sheetId to adapt either range of that sheet specifically, or ranges pointing to that sheet
    */
-  adaptRanges(applyChange: ApplyRangeChange, sheetId?: UID): void {}
+  adaptRanges(applyChange: ApplyRangeChange, sheetId?: UID, sheetName?: string): void {}
 
   /**
    * Implement this method to clean unused external resources, such as images

--- a/src/plugins/ui_feature/insert_pivot.ts
+++ b/src/plugins/ui_feature/insert_pivot.ts
@@ -198,6 +198,7 @@ export class InsertPivotPlugin extends UIPlugin {
         dimension: "COL",
         base: numberCols - 1,
         sheetId: sheetId,
+        sheetName: this.getters.getSheetName(sheetId),
         quantity: colLimit - deltaCol,
         position: "after",
       });
@@ -210,6 +211,7 @@ export class InsertPivotPlugin extends UIPlugin {
         dimension: "ROW",
         base: numberRows - 1,
         sheetId: sheetId,
+        sheetName: this.getters.getSheetName(sheetId),
         quantity: rowLimit - deltaRow,
         position: "after",
       });

--- a/src/plugins/ui_feature/split_to_columns.ts
+++ b/src/plugins/ui_feature/split_to_columns.ts
@@ -154,6 +154,7 @@ export class SplitToColumnsPlugin extends UIPlugin {
         dimension: "COL",
         base: selection.left,
         sheetId,
+        sheetName: this.getters.getSheetName(sheetId),
         quantity: colsToAdd,
         position: "after",
       });
@@ -183,6 +184,7 @@ export class SplitToColumnsPlugin extends UIPlugin {
         dimension: "COL",
         base: maxColIndex,
         sheetId,
+        sheetName: this.getters.getSheetName(sheetId),
         quantity: selection.left + maxColumnsToSpread - maxColIndex,
         position: "after",
       });

--- a/src/plugins/ui_stateful/clipboard.ts
+++ b/src/plugins/ui_stateful/clipboard.ts
@@ -472,6 +472,7 @@ export class ClipboardPlugin extends UIPlugin {
         dimension: "ROW",
         base: this.getters.getNumberRows(sheetId) - 1,
         sheetId,
+        sheetName: this.getters.getSheetName(sheetId),
         quantity: missingRows,
         position: "after",
       });
@@ -482,6 +483,7 @@ export class ClipboardPlugin extends UIPlugin {
         dimension: "COL",
         base: this.getters.getNumberCols(sheetId) - 1,
         sheetId,
+        sheetName: this.getters.getSheetName(sheetId),
         quantity: missingCols,
         position: "after",
       });

--- a/src/plugins/ui_stateful/selection.ts
+++ b/src/plugins/ui_stateful/selection.ts
@@ -45,6 +45,7 @@ export class GridSelectionPlugin extends UIPlugin {
   static getters = [
     "getActiveSheet",
     "getActiveSheetId",
+    "getActiveSheetName",
     "getActiveCell",
     "getActiveCols",
     "getActiveRows",
@@ -267,6 +268,10 @@ export class GridSelectionPlugin extends UIPlugin {
 
   getActiveSheetId(): UID {
     return this.activeSheet.id;
+  }
+
+  getActiveSheetName(): string {
+    return this.activeSheet.name;
   }
 
   tryGetActiveSheetId(): UID | undefined {
@@ -523,6 +528,7 @@ export class GridSelectionPlugin extends UIPlugin {
     this.dispatch("ADD_COLUMNS_ROWS", {
       dimension: cmd.dimension,
       sheetId: cmd.sheetId,
+      sheetName: cmd.sheetName,
       base: cmd.base,
       quantity: thickness,
       position: cmd.position,
@@ -593,6 +599,7 @@ export class GridSelectionPlugin extends UIPlugin {
     this.dispatch("REMOVE_COLUMNS_ROWS", {
       dimension: cmd.dimension,
       sheetId: cmd.sheetId,
+      sheetName: cmd.sheetName,
       elements: toRemove,
     });
   }

--- a/src/registries/inverse_command_registry.ts
+++ b/src/registries/inverse_command_registry.ts
@@ -73,6 +73,7 @@ function inverseAddColumnsRows(cmd: AddColumnsRowsCommand): RemoveColumnsRowsCom
       dimension: cmd.dimension,
       elements,
       sheetId: cmd.sheetId,
+      sheetName: cmd.sheetName,
     },
   ];
 }
@@ -86,11 +87,11 @@ function inverseRemoveMerge(cmd: RemoveMergeCommand): AddMergeCommand[] {
 }
 
 function inverseCreateSheet(cmd: CreateSheetCommand): DeleteSheetCommand[] {
-  return [{ type: "DELETE_SHEET", sheetId: cmd.sheetId }];
+  return [{ type: "DELETE_SHEET", sheetId: cmd.sheetId, sheetName: cmd.name }];
 }
 
 function inverseDuplicateSheet(cmd: DuplicateSheetCommand): DeleteSheetCommand[] {
-  return [{ type: "DELETE_SHEET", sheetId: cmd.sheetIdTo }];
+  return [{ type: "DELETE_SHEET", sheetId: cmd.sheetIdTo, sheetName: "" }];
 }
 
 function inverseRemoveColumnsRows(cmd: RemoveColumnsRowsCommand): AddColumnsRowsCommand[] {
@@ -105,6 +106,7 @@ function inverseRemoveColumnsRows(cmd: RemoveColumnsRowsCommand): AddColumnsRows
       quantity: group.length,
       base: column,
       sheetId: cmd.sheetId,
+      sheetName: cmd.sheetName,
       position,
     });
   }
@@ -112,7 +114,7 @@ function inverseRemoveColumnsRows(cmd: RemoveColumnsRowsCommand): AddColumnsRows
 }
 
 function inverseDeleteSheet(cmd: DeleteSheetCommand): CreateSheetCommand[] {
-  return [{ type: "CREATE_SHEET", sheetId: cmd.sheetId, position: 1 }];
+  return [{ type: "CREATE_SHEET", sheetId: cmd.sheetId, position: 1, name: cmd.sheetName }];
 }
 
 function inverseCreateFigure(cmd: CreateFigureCommand): DeleteFigureCommand[] {

--- a/src/registries/srt_registry.ts
+++ b/src/registries/srt_registry.ts
@@ -1,0 +1,32 @@
+import { CoreCommand, RangeAdapter } from "../types";
+import { Registry } from "./registry";
+
+/*
+ * Specific Ranges Transform Registry
+ * ====================================
+ *
+ * This registry contains all the transformations functions to adapt commands'
+ * ranges to preserve the intention of the users and consistency during a
+ * collaborative session.
+ *
+ */
+
+export type CommandAdaptRangeFunction<C extends CoreCommand> = (
+  cmd: C,
+  applyChange: RangeAdapter
+) => C;
+
+export class SpecificRangeTransformRegistry extends Registry<
+  CommandAdaptRangeFunction<CoreCommand>
+> {
+  add<C extends CoreCommand>(cmdType: C["type"], fn: CommandAdaptRangeFunction<C>): this {
+    super.add(cmdType, fn);
+    return this;
+  }
+
+  get<C extends CoreCommand>(cmdType: C["type"]): CommandAdaptRangeFunction<CoreCommand> {
+    return this.content[cmdType];
+  }
+}
+
+export const specificRangeTransformRegistry = new SpecificRangeTransformRegistry();

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -78,6 +78,10 @@ export function isHeadersDependant(
   return "dimension" in cmd && "sheetId" in cmd && "elements" in cmd;
 }
 
+export interface SheetEditingCommand {
+  sheetName: string;
+}
+
 export interface TargetDependentCommand {
   sheetId: UID;
   target: Zone[];
@@ -322,7 +326,7 @@ export interface UpdateCellPositionCommand extends PositionDependentCommand {
 // Grid Shape
 //------------------------------------------------------------------------------
 
-export interface AddColumnsRowsCommand extends SheetDependentCommand {
+export interface AddColumnsRowsCommand extends SheetDependentCommand, SheetEditingCommand {
   type: "ADD_COLUMNS_ROWS";
   dimension: Dimension;
   base: HeaderIndex;
@@ -330,12 +334,12 @@ export interface AddColumnsRowsCommand extends SheetDependentCommand {
   position: "before" | "after";
 }
 
-export interface RemoveColumnsRowsCommand extends HeadersDependentCommand {
+export interface RemoveColumnsRowsCommand extends HeadersDependentCommand, SheetEditingCommand {
   type: "REMOVE_COLUMNS_ROWS";
   elements: HeaderIndex[];
 }
 
-export interface MoveColumnsRowsCommand extends HeadersDependentCommand {
+export interface MoveColumnsRowsCommand extends HeadersDependentCommand, SheetEditingCommand {
   type: "MOVE_COLUMNS_ROWS";
   base: HeaderIndex;
   elements: HeaderIndex[];
@@ -414,12 +418,12 @@ export interface RemoveMergeCommand extends TargetDependentCommand {
 export interface CreateSheetCommand extends SheetDependentCommand {
   type: "CREATE_SHEET";
   position: number;
-  name?: string; // should be required in master
+  name: string;
   cols?: number;
   rows?: number;
 }
 
-export interface DeleteSheetCommand extends SheetDependentCommand {
+export interface DeleteSheetCommand extends SheetDependentCommand, SheetEditingCommand {
   type: "DELETE_SHEET";
 }
 
@@ -435,7 +439,8 @@ export interface MoveSheetCommand extends SheetDependentCommand {
 
 export interface RenameSheetCommand extends SheetDependentCommand {
   type: "RENAME_SHEET";
-  name?: string;
+  newName: string;
+  oldName: string;
 }
 
 export interface ColorSheetCommand extends SheetDependentCommand {
@@ -460,7 +465,10 @@ export interface ShowSheetCommand extends SheetDependentCommand {
  * to cells/ranges within a specific zone.
  * Command particularly useful during CUT / PATE.
  */
-export interface MoveRangeCommand extends PositionDependentCommand, TargetDependentCommand {
+export interface MoveRangeCommand
+  extends PositionDependentCommand,
+    TargetDependentCommand,
+    SheetEditingCommand {
   type: "MOVE_RANGES";
   targetSheetId: string;
 }

--- a/src/types/misc.ts
+++ b/src/types/misc.ts
@@ -293,6 +293,10 @@ export type ApplyRangeChangeResult =
   | { changeType: Exclude<ChangeType, "NONE">; range: Range }
   | { changeType: "NONE" };
 export type ApplyRangeChange = (range: Range) => ApplyRangeChangeResult;
+export type ApplyRangeChangeSheet = {
+  sheetId?: UID;
+  applyChange: ApplyRangeChange;
+};
 
 export type Dimension = "COL" | "ROW";
 

--- a/src/types/misc.ts
+++ b/src/types/misc.ts
@@ -293,8 +293,10 @@ export type ApplyRangeChangeResult =
   | { changeType: Exclude<ChangeType, "NONE">; range: Range }
   | { changeType: "NONE" };
 export type ApplyRangeChange = (range: Range) => ApplyRangeChangeResult;
-export type ApplyRangeChangeSheet = {
-  sheetId?: UID;
+
+export type RangeAdapter = {
+  sheetId: UID;
+  sheetName: string;
   applyChange: ApplyRangeChange;
 };
 
@@ -303,7 +305,7 @@ export type Dimension = "COL" | "ROW";
 export type ConsecutiveIndexes = HeaderIndex[];
 
 export interface RangeProvider {
-  adaptRanges: (applyChange: ApplyRangeChange, sheetId?: UID) => void;
+  adaptRanges: (applyChange: ApplyRangeChange, sheetId?: UID, sheetName?: string) => void;
 }
 
 export type Validation<T> = (toValidate: T) => CommandResult | CommandResult[];

--- a/src/types/range.ts
+++ b/src/types/range.ts
@@ -7,6 +7,7 @@ export interface RangePart {
 
 export interface Range extends Cloneable<Range> {
   readonly zone: Readonly<Zone>;
+  readonly unboundedZone: Readonly<UnboundedZone>;
   readonly parts: readonly RangePart[];
   readonly invalidXc?: string;
   /** true if the user provided the range with the sheet name */
@@ -16,6 +17,17 @@ export interface Range extends Cloneable<Range> {
   /** the sheet on which the range is defined */
   readonly sheetId: UID;
   readonly rangeData: RangeData;
+
+  getRangeString: (
+    forSheetId: UID,
+    getSheetName: (sheetId: UID) => string,
+    options?: RangeStringOptions
+  ) => string;
+}
+
+export interface RangeStringOptions {
+  useBoundedReference?: boolean;
+  useFixedReference?: boolean;
 }
 
 export interface RangeData {

--- a/tests/bottom_bar/bottom_bar_component.test.ts
+++ b/tests/bottom_bar/bottom_bar_component.test.ts
@@ -400,8 +400,9 @@ describe("BottomBar component", () => {
     triggerMouseEvent(".o-sheet", "contextmenu");
     await nextTick();
     const sheetId = model.getters.getActiveSheetId();
+    const sheetName = model.getters.getActiveSheetName();
     await click(fixture, ".o-menu-item[data-name='delete'");
-    expect(dispatch).toHaveBeenCalledWith("DELETE_SHEET", { sheetId });
+    expect(dispatch).toHaveBeenCalledWith("DELETE_SHEET", { sheetId, sheetName });
   });
 
   test("Delete sheet is not visible when there is only one sheet", async () => {

--- a/tests/clipboard/clipboard_figure_plugin.test.ts
+++ b/tests/clipboard/clipboard_figure_plugin.test.ts
@@ -10,6 +10,7 @@ import {
   createImage,
   createSheet,
   cut,
+  deleteSheet,
   paste,
   setCellContent,
   setSelection,
@@ -168,7 +169,7 @@ describe.each(["chart", "image"])("Clipboard for %s figures", (type: string) => 
     );
     model.dispatch("SELECT_FIGURE", { id: chartId });
     copy(model);
-    model.dispatch("DELETE_SHEET", { sheetId: "Sheet1" });
+    deleteSheet(model, "Sheet1");
     paste(model, "A1");
     expect(model.getters.getFigures("sheet2Id")).toHaveLength(1);
     const newChartId = model.getters.getFigures("sheet2Id")[0].id;

--- a/tests/collaborative/collaborative.test.ts
+++ b/tests/collaborative/collaborative.test.ts
@@ -201,7 +201,7 @@ describe("Multi users synchronisation", () => {
       nextRevisionId: "1",
       serverRevisionId: DEFAULT_REVISION_ID,
       clientId: "alice",
-      commands: [{ type: "DELETE_SHEET", sheetId }],
+      commands: [{ type: "DELETE_SHEET", sheetId, sheetName: "" }],
     };
     const model = new Model(
       {
@@ -557,6 +557,7 @@ describe("Multi users synchronisation", () => {
         sheetId: alice.getters.getActiveSheetId(),
         base: 1,
         quantity: 50,
+        sheetName: "",
       },
     ];
     const message: CollaborationMessage = {
@@ -827,7 +828,7 @@ describe("Multi users synchronisation", () => {
         sheetId: firstSheetId,
         sheetIdTo: "sheet2",
       });
-      charlie.dispatch("DELETE_SHEET", { sheetId: firstSheetId });
+      deleteSheet(charlie, firstSheetId);
     });
     const colSize = alice.getters.getColSize("sheet2", 0);
     const ctx = document.createElement("canvas").getContext("2d")!;

--- a/tests/collaborative/collaborative_helpers.ts
+++ b/tests/collaborative/collaborative_helpers.ts
@@ -17,9 +17,9 @@ interface CollaborativeEnv {
  * first, meaning she will also resend her pending messages first.
  * Similarly, Bob's messages are resent before Charlie's.
  */
-export function setupCollaborativeEnv(): CollaborativeEnv {
+export function setupCollaborativeEnv(modelData?: any): CollaborativeEnv {
   const network = new MockTransportService();
-  const emptySheetData = new Model().exportData();
+  const emptySheetData = new Model(modelData).exportData();
   const alice = new Model(deepCopy(emptySheetData), {
     transportService: network,
     client: { id: "alice", name: "Alice" },

--- a/tests/collaborative/collaborative_history.test.ts
+++ b/tests/collaborative/collaborative_history.test.ts
@@ -231,7 +231,9 @@ describe("Collaborative local history", () => {
         nextRevisionId: "2",
         version: MESSAGE_VERSION,
         clientId: "bob",
-        commands: [{ type: "CREATE_SHEET", sheetId: "newSheetId", position: 1 }],
+        commands: [
+          { type: "CREATE_SHEET", sheetId: "newSheetId", name: "newSheetName", position: 1 },
+        ],
       },
       {
         type: "REMOTE_REVISION",
@@ -564,7 +566,7 @@ describe("Collaborative local history", () => {
     expect(all).toHaveSynchronizedExportedData();
     setCellContent(alice, "A1", "hello", sheetId);
     undo(alice);
-    bob.dispatch("DELETE_SHEET", { sheetId });
+    deleteSheet(bob, sheetId);
     redo(alice);
     expect(all).toHaveSynchronizedExportedData();
   });
@@ -632,7 +634,7 @@ describe("Collaborative local history", () => {
   test("Undo a create sheet command", () => {
     const sheet1Id = alice.getters.getActiveSheetId();
     const sheetId = "42";
-    alice.dispatch("CREATE_SHEET", { sheetId, position: 0 });
+    createSheet(alice, { sheetId, position: 0 });
     setCellContent(bob, "A1", "Hello in A1", sheetId);
     expect(all).toHaveSynchronizedValue(
       (user) => getCellContent(user, "A1", sheetId),
@@ -1046,7 +1048,7 @@ describe("Collaborative local history", () => {
 
       // DELETE_SHEET is initially accepted (there's 2 sheets) but later
       // rejected because there's only one sheet left when DUPLICATE_SHEET is undone
-      bob.dispatch("DELETE_SHEET", { sheetId: "Sheet1" });
+      bob.dispatch("DELETE_SHEET", { sheetId: "Sheet1", sheetName: "Sheet1" });
     });
     network.concurrent(() => {
       undo(bob);
@@ -1059,6 +1061,7 @@ describe("Collaborative local history", () => {
         base: 0,
         quantity: 1,
         sheetId: "Sheet1",
+        sheetName: "Sheet1",
       });
     });
     expect([alice, bob, charlie]).toHaveSynchronizedValue(

--- a/tests/collaborative/collaborative_selection.test.ts
+++ b/tests/collaborative/collaborative_selection.test.ts
@@ -4,6 +4,7 @@ import { MockTransportService } from "../__mocks__/transport_service";
 import {
   addColumns,
   createSheet,
+  deleteSheet,
   moveAnchorCell,
   selectCell,
   selectColumn,
@@ -244,7 +245,7 @@ describe("Collaborative selection", () => {
   test("client positions are updated with fallback sheet", () => {
     const sheetId = alice.getters.getActiveSheetId();
     createSheet(alice, { sheetId: "42" });
-    alice.dispatch("DELETE_SHEET", { sheetId });
+    deleteSheet(alice, sheetId);
     jest.advanceTimersByTime(DEBOUNCE_TIME + 100);
     expect([alice, bob, charlie]).toHaveSynchronizedValue(
       (user) => user.getters.getConnectedClients(),

--- a/tests/collaborative/inverses.test.ts
+++ b/tests/collaborative/inverses.test.ts
@@ -33,6 +33,7 @@ describe("Inverses commands", () => {
       quantity: 2,
       base: 1,
       sheetId: "1",
+      sheetName: "Sheet42",
     };
 
     test("Inverse with position = after", () => {
@@ -42,6 +43,7 @@ describe("Inverses commands", () => {
           sheetId: "1",
           elements: [2, 3],
           dimension: "COL",
+          sheetName: "Sheet42",
         },
       ]);
     });
@@ -53,6 +55,7 @@ describe("Inverses commands", () => {
           sheetId: "1",
           elements: [1, 2],
           dimension: "COL",
+          sheetName: "Sheet42",
         },
       ]);
     });
@@ -65,11 +68,18 @@ describe("Inverses commands", () => {
       quantity: 2,
       base: 1,
       sheetId: "1",
+      sheetName: "Sheet42",
     };
 
     test("Inverse with position = after", () => {
       expect(inverseCommand(addRows)).toEqual([
-        { type: "REMOVE_COLUMNS_ROWS", sheetId: "1", elements: [2, 3], dimension: "ROW" },
+        {
+          type: "REMOVE_COLUMNS_ROWS",
+          sheetId: "1",
+          elements: [2, 3],
+          dimension: "ROW",
+          sheetName: "Sheet42",
+        },
       ]);
     });
 
@@ -80,6 +90,7 @@ describe("Inverses commands", () => {
           sheetId: "1",
           elements: [1, 2],
           dimension: "ROW",
+          sheetName: "Sheet42",
         },
       ]);
     });
@@ -108,8 +119,11 @@ describe("Inverses commands", () => {
       type: "CREATE_SHEET",
       position: 1,
       sheetId: "1",
+      name: "SheetName",
     };
-    expect(inverseCommand(createSheet)).toEqual([{ type: "DELETE_SHEET", sheetId: "1" }]);
+    expect(inverseCommand(createSheet)).toEqual([
+      { type: "DELETE_SHEET", sheetId: "1", sheetName: "SheetName" },
+    ]);
   });
 
   test("Duplicate Sheet", () => {
@@ -118,7 +132,9 @@ describe("Inverses commands", () => {
       sheetId: "1",
       sheetIdTo: "2",
     };
-    expect(inverseCommand(duplicateSheet)).toEqual([{ type: "DELETE_SHEET", sheetId: "2" }]);
+    expect(inverseCommand(duplicateSheet)).toEqual([
+      { type: "DELETE_SHEET", sheetId: "2", sheetName: "" },
+    ]);
   });
 
   describe("Remove columns", () => {
@@ -127,6 +143,7 @@ describe("Inverses commands", () => {
       dimension: "COL",
       elements: [0],
       sheetId: "42",
+      sheetName: "Sheet42",
     };
     test("Inverse with column = 0", () => {
       expect(inverseCommand(removeColumns)).toEqual([
@@ -137,6 +154,7 @@ describe("Inverses commands", () => {
           quantity: 1,
           base: 0,
           sheetId: "42",
+          sheetName: "Sheet42",
         },
       ]);
     });
@@ -149,6 +167,7 @@ describe("Inverses commands", () => {
           quantity: 2,
           base: 0,
           sheetId: "42",
+          sheetName: "Sheet42",
         },
         {
           type: "ADD_COLUMNS_ROWS",
@@ -157,6 +176,7 @@ describe("Inverses commands", () => {
           quantity: 2,
           base: 3,
           sheetId: "42",
+          sheetName: "Sheet42",
         },
         {
           type: "ADD_COLUMNS_ROWS",
@@ -165,6 +185,7 @@ describe("Inverses commands", () => {
           quantity: 1,
           base: 8,
           sheetId: "42",
+          sheetName: "Sheet42",
         },
       ]);
     });
@@ -176,6 +197,7 @@ describe("Inverses commands", () => {
       dimension: "ROW",
       elements: [0],
       sheetId: "42",
+      sheetName: "SheetName",
     };
     test("Inverse with row = 0", () => {
       expect(inverseCommand(removeRows)).toEqual([
@@ -186,6 +208,7 @@ describe("Inverses commands", () => {
           quantity: 1,
           base: 0,
           sheetId: "42",
+          sheetName: "SheetName",
         },
       ]);
     });
@@ -198,6 +221,7 @@ describe("Inverses commands", () => {
           quantity: 2,
           base: 0,
           sheetId: "42",
+          sheetName: "SheetName",
         },
         {
           type: "ADD_COLUMNS_ROWS",
@@ -206,6 +230,7 @@ describe("Inverses commands", () => {
           quantity: 2,
           base: 3,
           sheetId: "42",
+          sheetName: "SheetName",
         },
         {
           type: "ADD_COLUMNS_ROWS",
@@ -214,6 +239,7 @@ describe("Inverses commands", () => {
           quantity: 1,
           base: 8,
           sheetId: "42",
+          sheetName: "SheetName",
         },
       ]);
     });
@@ -223,9 +249,10 @@ describe("Inverses commands", () => {
     const deleteSheet: DeleteSheetCommand = {
       type: "DELETE_SHEET",
       sheetId: "42",
+      sheetName: "Sheet42",
     };
     expect(inverseCommand(deleteSheet)).toEqual([
-      { type: "CREATE_SHEET", position: 1, sheetId: "42" },
+      { type: "CREATE_SHEET", position: 1, sheetId: "42", name: "Sheet42" },
     ]);
   });
 

--- a/tests/collaborative/ot/ot.test.ts
+++ b/tests/collaborative/ot/ot.test.ts
@@ -24,7 +24,10 @@ describe("OT with DELETE_FIGURE", () => {
     });
 
     test("distinct ID", () => {
-      expect(transform({ ...cmd, id: "otherId" }, deleteFigure)).toEqual({ ...cmd, id: "otherId" });
+      expect(transform({ ...cmd, id: "otherId" }, deleteFigure)).toEqual({
+        ...cmd,
+        id: "otherId",
+      });
     });
   });
 });

--- a/tests/collaborative/ot/ot_helper.ts
+++ b/tests/collaborative/ot/ot_helper.ts
@@ -1,0 +1,62 @@
+import {
+  AddConditionalFormatCommand,
+  AddDataValidationCommand,
+  AddPivotCommand,
+  CoreCommand,
+  UID,
+  UpdateCellCommand,
+} from "../../../src";
+import { deepCopy } from "../../../src/helpers";
+import { TEST_COMMANDS } from "../../test_helpers/constants";
+
+export function getFormulaStringCommands(
+  sheetId: UID,
+  formulaBefore: string,
+  formulaAfter: string
+): CoreCommand[][] {
+  return [
+    [getUpdateCellCommand(sheetId, formulaBefore), getUpdateCellCommand(sheetId, formulaAfter)],
+    [getCFCommand(sheetId, formulaBefore), getCFCommand(sheetId, formulaAfter)],
+    [getDVCommand(sheetId, formulaBefore), getDVCommand(sheetId, formulaAfter)],
+    [getPivotCommand(sheetId, formulaBefore), getPivotCommand(sheetId, formulaAfter)],
+  ];
+}
+
+function getUpdateCellCommand(sheetId: UID, formula: string): UpdateCellCommand {
+  return { ...TEST_COMMANDS.UPDATE_CELL, sheetId, content: formula };
+}
+
+function getCFCommand(sheetId: UID, formula: string): AddConditionalFormatCommand {
+  const cmd = deepCopy(TEST_COMMANDS.ADD_CONDITIONAL_FORMAT);
+  cmd.cf.rule = {
+    values: [formula],
+    operator: "Equal",
+    type: "CellIsRule",
+    style: { fillColor: "#FF0000" },
+  };
+  cmd.sheetId = sheetId;
+  return cmd;
+}
+
+function getDVCommand(sheetId: UID, formula: string): AddDataValidationCommand {
+  const cmd = deepCopy(TEST_COMMANDS.ADD_DATA_VALIDATION_RULE);
+  cmd.rule.criterion = {
+    type: "isEqual",
+    values: [formula],
+  };
+  cmd.sheetId = sheetId;
+  return cmd;
+}
+
+function getPivotCommand(sheetId: UID, formula: string): AddPivotCommand {
+  const cmd = deepCopy(TEST_COMMANDS.ADD_PIVOT);
+  cmd.pivot.measures = [
+    {
+      id: "",
+      fieldName: "",
+      aggregator: "",
+      computedBy: { sheetId, formula },
+    },
+  ];
+  return cmd;
+}

--- a/tests/collaborative/ot/ot_sheet_deleted.test.ts
+++ b/tests/collaborative/ot/ot_sheet_deleted.test.ts
@@ -17,11 +17,16 @@ import {
   TEST_COMMANDS,
 } from "../../test_helpers/constants";
 import { toRangesData } from "../../test_helpers/helpers";
+import { getFormulaStringCommands } from "./ot_helper";
 
 describe("OT with DELETE_SHEET", () => {
   const deletedSheetId = "deletedSheet";
   const sheetId = "stillPresent";
-  const deleteSheet: DeleteSheetCommand = { type: "DELETE_SHEET", sheetId: deletedSheetId };
+  const deleteSheet: DeleteSheetCommand = {
+    type: "DELETE_SHEET",
+    sheetId: deletedSheetId,
+    sheetName: "Sheet Name",
+  };
 
   const addColumns: Omit<AddColumnsRowsCommand, "sheetId"> = {
     ...TEST_COMMANDS.ADD_COLUMNS_ROWS,
@@ -115,6 +120,7 @@ describe("OT with DELETE_SHEET", () => {
       col: 0,
       row: 0,
       target: [toZone("A1")],
+      sheetName: "",
     };
 
     test("Delete the sheet on which the command is triggered", () => {
@@ -160,6 +166,21 @@ describe("OT with DELETE_SHEET", () => {
       };
       const result = transform(cmd, deleteSheet);
       expect(result).toEqual({ ...cmd, ranges: toRangesData(sheetId, "A1:B1") });
+    });
+  });
+
+  describe("Delete sheed with string formula dependant command", () => {
+    const deletedSheetName = "DeletedSheetName";
+
+    const cmds = getFormulaStringCommands(
+      sheetId,
+      "=" + deletedSheetName + "!A1",
+      "=" + deletedSheetName + "!A1"
+    );
+
+    test.each(cmds)("%s", (cmd, expected) => {
+      const result = transform(cmd, deleteSheet);
+      expect(result).toEqual(expected);
     });
   });
 });

--- a/tests/composer/composer_sheet_transform_plugin.test.ts
+++ b/tests/composer/composer_sheet_transform_plugin.test.ts
@@ -9,6 +9,7 @@ import {
   createSheet,
   deleteColumns,
   deleteRows,
+  deleteSheet,
   redo,
   selectCell,
   setCellContent,
@@ -152,7 +153,7 @@ describe("describe", () => {
     createSheet(model, { sheetId: "42" });
     selectCell(model, "A4");
     composerStore.startEdition("hello");
-    model.dispatch("DELETE_SHEET", { sheetId: activeSheetId });
+    deleteSheet(model, activeSheetId);
     expect(raiseErrorSpy).toHaveBeenCalled();
     expect(composerStore.editionMode).toBe("inactive");
   });
@@ -181,7 +182,7 @@ describe("describe", () => {
     selectCell(model, "A4");
     composerStore.startEdition("hello");
     composerStore.stopEdition();
-    model.dispatch("DELETE_SHEET", { sheetId: activeSheetId });
+    deleteSheet(model, activeSheetId);
     expect(raiseErrorSpy).not.toHaveBeenCalled();
     expect(composerStore.editionMode).toBe("inactive");
   });
@@ -192,7 +193,7 @@ describe("describe", () => {
     selectCell(model, "A4");
     setCellContent(model, "A4", "=A1+");
     composerStore.startEdition();
-    model.dispatch("DELETE_SHEET", { sheetId: activeSheetId });
+    deleteSheet(model, activeSheetId);
     expect(composerStore.editionMode).toBe("inactive");
   });
 
@@ -201,7 +202,7 @@ describe("describe", () => {
     activateSheet(model, "42");
     selectCell(model, "A4");
     composerStore.startEdition("hello");
-    model.dispatch("DELETE_SHEET", { sheetId: "42" });
+    deleteSheet(model, "42");
     expect(raiseErrorSpy).toHaveBeenCalled();
     expect(composerStore.editionMode).toBe("inactive");
   });
@@ -209,7 +210,7 @@ describe("describe", () => {
   test("Composing in a sheet when a sheet deletion is redone", () => {
     createSheet(model, { sheetId: "42" });
     selectCell(model, "A4");
-    model.dispatch("DELETE_SHEET", { sheetId: "42" });
+    deleteSheet(model, "42");
     undo(model);
     activateSheet(model, "42");
     composerStore.startEdition("hello");

--- a/tests/figures/chart/chart_plugin.test.ts
+++ b/tests/figures/chart/chart_plugin.test.ts
@@ -1006,7 +1006,7 @@ describe("datasource tests", function () {
   });
 
   test("Chart is deleted on sheet deletion", () => {
-    model.dispatch("CREATE_SHEET", { sheetId: "2", position: 1 });
+    createSheet(model, { sheetId: "2", position: 1 });
     createChart(
       model,
       {
@@ -1018,7 +1018,7 @@ describe("datasource tests", function () {
       "2"
     );
     expect(model.getters.getChartRuntime("1")).not.toBeUndefined();
-    model.dispatch("DELETE_SHEET", { sheetId: "2" });
+    deleteSheet(model, "2");
     expect(() => model.getters.getChartRuntime("1")).toThrow();
   });
 
@@ -1632,7 +1632,7 @@ describe("multiple sheets", function () {
       },
       "28"
     );
-    model.dispatch("DELETE_SHEET", { sheetId: originSheet });
+    deleteSheet(model, originSheet);
     const exportedData = model.exportData();
     const newModel = new Model(exportedData);
     const chart = newModel.getters.getChartRuntime("28")!;

--- a/tests/figures/chart/charts_component.test.ts
+++ b/tests/figures/chart/charts_component.test.ts
@@ -28,6 +28,7 @@ import {
   createGaugeChart,
   createScorecardChart,
   createSheet,
+  deleteSheet,
   paste,
   selectCell,
   setCellContent,
@@ -2092,7 +2093,8 @@ describe("charts with multiple sheets", () => {
 
   test("delete sheet containing chart data does not crash", async () => {
     expect(model.getters.getSheetName(model.getters.getActiveSheetId())).toBe("Sheet1");
-    model.dispatch("DELETE_SHEET", { sheetId: model.getters.getActiveSheetId() });
+    const sheetId = model.getters.getActiveSheetId();
+    deleteSheet(model, sheetId);
     const runtimeChart = model.getters.getChartRuntime(chartId);
     expect(runtimeChart).toBeDefined();
     await nextTick();

--- a/tests/figures/chart/gauge/gauge_chart_plugin.test.ts
+++ b/tests/figures/chart/gauge/gauge_chart_plugin.test.ts
@@ -375,10 +375,10 @@ describe("datasource tests", function () {
   });
 
   test("Gauge Chart is deleted on sheet deletion", () => {
-    model.dispatch("CREATE_SHEET", { sheetId: "sheet2", position: 1 });
+    createSheet(model, { sheetId: "sheet2", position: 1 });
     createGaugeChart(model, { dataRange: "Sheet1!B1:B4" }, "chartId", "sheet2");
     expect(model.getters.getChartRuntime("chartId") as GaugeChartRuntime).not.toBeUndefined();
-    model.dispatch("DELETE_SHEET", { sheetId: "sheet2" });
+    deleteSheet(model, "sheet2");
     expect(() => model.getters.getChartRuntime("chartId")).toThrow();
   });
 

--- a/tests/figures/chart/scorecard/scorecard_chart_plugin.test.ts
+++ b/tests/figures/chart/scorecard/scorecard_chart_plugin.test.ts
@@ -192,7 +192,7 @@ describe("datasource tests", function () {
   });
 
   test("Scorecard Chart is deleted on sheet deletion", () => {
-    model.dispatch("CREATE_SHEET", { sheetId: "2", position: 1 });
+    createSheet(model, { sheetId: "2", position: 1 });
     createScorecardChart(
       model,
       {
@@ -202,7 +202,7 @@ describe("datasource tests", function () {
       "2"
     );
     expect(model.getters.getChartRuntime("1")).not.toBeUndefined();
-    model.dispatch("DELETE_SHEET", { sheetId: "2" });
+    deleteSheet(model, "2");
     expect(() => model.getters.getChartRuntime("1")).toThrow();
   });
 

--- a/tests/figures/image/image_file_store.test.ts
+++ b/tests/figures/image/image_file_store.test.ts
@@ -227,7 +227,7 @@ describe("image file store", () => {
           nextRevisionId: "2",
           version: 1,
           commands: [
-            { type: "CREATE_SHEET", position: 1, sheetId: "sheet_2" },
+            { type: "CREATE_SHEET", position: 1, sheetId: "sheet_2", name: "Sheet2" },
             {
               type: "CREATE_IMAGE",
               definition: { path: "/image/1", size, mimetype: "image/jpeg" },
@@ -236,7 +236,7 @@ describe("image file store", () => {
               sheetId: "sheet_2",
               size,
             },
-            { type: "DELETE_SHEET", sheetId: "sheet_2" },
+            { type: "DELETE_SHEET", sheetId: "sheet_2", sheetName: "Sheet2" },
           ],
         },
       ]
@@ -263,7 +263,7 @@ describe("image file store", () => {
           nextRevisionId: "2",
           version: 1,
           commands: [
-            { type: "CREATE_SHEET", position: 1, sheetId: "sheet_2" },
+            { type: "CREATE_SHEET", position: 1, sheetId: "sheet_2", name: "Sheet2" },
             {
               type: "CREATE_IMAGE",
               definition: { path: "/image/1", size, mimetype: "image/jpeg" },

--- a/tests/figures/image/image_plugin.test.ts
+++ b/tests/figures/image/image_plugin.test.ts
@@ -1,6 +1,13 @@
 import { Model } from "../../../src";
 import { FIGURE_ID_SPLITTER } from "../../../src/constants";
-import { createImage, paste, redo, undo } from "../../test_helpers/commands_helpers";
+import {
+  createImage,
+  createSheet,
+  deleteSheet,
+  paste,
+  redo,
+  undo,
+} from "../../test_helpers/commands_helpers";
 import { getFigureIds } from "../../test_helpers/helpers";
 
 describe("image plugin", function () {
@@ -89,9 +96,9 @@ describe("test image in sheet", function () {
     const model = new Model();
     const imageId = "Image1";
     const newSheetId = "Sheet2";
-    model.dispatch("CREATE_SHEET", { sheetId: newSheetId, position: 2 });
+    createSheet(model, { sheetId: newSheetId, position: 2 });
     createImage(model, { sheetId: newSheetId, figureId: imageId });
-    model.dispatch("DELETE_SHEET", { sheetId: newSheetId });
+    deleteSheet(model, newSheetId);
     const images = getFigureIds(model, newSheetId);
     expect(images).toHaveLength(0);
   });

--- a/tests/history/history_plugin.test.ts
+++ b/tests/history/history_plugin.test.ts
@@ -272,7 +272,7 @@ describe("Model history", () => {
   test("undo a sheet creation changes the active sheet", () => {
     const model = new Model();
     const sheetId = model.getters.getActiveSheetId();
-    model.dispatch("CREATE_SHEET", { sheetId: "42", position: 1 });
+    createSheet(model, { sheetId: "42", position: 1 });
     model.dispatch("ACTIVATE_SHEET", { sheetIdFrom: sheetId, sheetIdTo: "42" });
     undo(model);
     expect(model.getters.getActiveSheetId()).toBe(sheetId);

--- a/tests/menus/menu_items_registry.test.ts
+++ b/tests/menus/menu_items_registry.test.ts
@@ -323,6 +323,7 @@ describe("Menu Item actions", () => {
       doAction(path, env);
       expect(dispatch).toHaveBeenLastCalledWith("REMOVE_COLUMNS_ROWS", {
         sheetId: env.model.getters.getActiveSheetId(),
+        sheetName: env.model.getters.getActiveSheetName(),
         dimension: "ROW",
         elements: [4, 5],
       });
@@ -335,6 +336,7 @@ describe("Menu Item actions", () => {
       doAction(path, env);
       expect(dispatch).toHaveBeenLastCalledWith("REMOVE_COLUMNS_ROWS", {
         sheetId: env.model.getters.getActiveSheetId(),
+        sheetName: env.model.getters.getActiveSheetName(),
         dimension: "ROW",
         elements: [4, 5],
       });
@@ -352,6 +354,7 @@ describe("Menu Item actions", () => {
       doAction(path, env);
       expect(dispatch).toHaveBeenLastCalledWith("REMOVE_COLUMNS_ROWS", {
         sheetId: env.model.getters.getActiveSheetId(),
+        sheetName: env.model.getters.getActiveSheetName(),
         dimension: "ROW",
         elements: [3, 4],
       });
@@ -389,6 +392,7 @@ describe("Menu Item actions", () => {
       doAction(path, env);
       expect(dispatch).toHaveBeenLastCalledWith("REMOVE_COLUMNS_ROWS", {
         sheetId: env.model.getters.getActiveSheetId(),
+        sheetName: env.model.getters.getActiveSheetName(),
         dimension: "COL",
         elements: [4],
       });
@@ -401,6 +405,7 @@ describe("Menu Item actions", () => {
       doAction(path, env);
       expect(dispatch).toHaveBeenLastCalledWith("REMOVE_COLUMNS_ROWS", {
         sheetId: env.model.getters.getActiveSheetId(),
+        sheetName: env.model.getters.getActiveSheetName(),
         dimension: "COL",
         elements: [4, 5],
       });
@@ -413,6 +418,7 @@ describe("Menu Item actions", () => {
       doAction(path, env);
       expect(dispatch).toHaveBeenLastCalledWith("REMOVE_COLUMNS_ROWS", {
         sheetId: env.model.getters.getActiveSheetId(),
+        sheetName: env.model.getters.getActiveSheetName(),
         dimension: "COL",
         elements: [4, 5],
       });
@@ -424,6 +430,7 @@ describe("Menu Item actions", () => {
       doAction(path, env);
       expect(dispatch).toHaveBeenLastCalledWith("REMOVE_COLUMNS_ROWS", {
         sheetId: env.model.getters.getActiveSheetId(),
+        sheetName: env.model.getters.getActiveSheetName(),
         dimension: "COL",
         elements: [3],
       });
@@ -436,6 +443,7 @@ describe("Menu Item actions", () => {
       doAction(path, env);
       expect(dispatch).toHaveBeenLastCalledWith("REMOVE_COLUMNS_ROWS", {
         sheetId: env.model.getters.getActiveSheetId(),
+        sheetName: env.model.getters.getActiveSheetName(),
         dimension: "COL",
         elements: [3, 4],
       });
@@ -469,6 +477,7 @@ describe("Menu Item actions", () => {
       doAction(insertRowBeforePath, env);
       expect(dispatch).toHaveBeenLastCalledWith("ADD_COLUMNS_ROWS", {
         sheetId: env.model.getters.getActiveSheetId(),
+        sheetName: env.model.getters.getActiveSheetName(),
         dimension: "ROW",
         base: 4,
         quantity: 2,
@@ -501,6 +510,7 @@ describe("Menu Item actions", () => {
       doAction(insertRowBeforePath, env);
       expect(dispatch).toHaveBeenLastCalledWith("ADD_COLUMNS_ROWS", {
         sheetId: env.model.getters.getActiveSheetId(),
+        sheetName: env.model.getters.getActiveSheetName(),
         dimension: "ROW",
         base: 3,
         quantity: 2,
@@ -526,6 +536,7 @@ describe("Menu Item actions", () => {
       doAction(addRowBeforePath, env, rowMenuRegistry);
       expect(dispatch).toHaveBeenLastCalledWith("ADD_COLUMNS_ROWS", {
         sheetId: env.model.getters.getActiveSheetId(),
+        sheetName: env.model.getters.getActiveSheetName(),
         dimension: "ROW",
         base: 4,
         quantity: 2,
@@ -562,6 +573,7 @@ describe("Menu Item actions", () => {
       doAction(insertRowAfterPath, env);
       expect(dispatch).toHaveBeenLastCalledWith("ADD_COLUMNS_ROWS", {
         sheetId: env.model.getters.getActiveSheetId(),
+        sheetName: env.model.getters.getActiveSheetName(),
         dimension: "ROW",
         base: 5,
         quantity: 2,
@@ -594,6 +606,7 @@ describe("Menu Item actions", () => {
       doAction(insertRowAfterPath, env);
       expect(dispatch).toHaveBeenLastCalledWith("ADD_COLUMNS_ROWS", {
         sheetId: env.model.getters.getActiveSheetId(),
+        sheetName: env.model.getters.getActiveSheetName(),
         dimension: "ROW",
         base: 4,
         quantity: 2,
@@ -619,6 +632,7 @@ describe("Menu Item actions", () => {
       doAction(addRowAfterPath, env, rowMenuRegistry);
       expect(dispatch).toHaveBeenLastCalledWith("ADD_COLUMNS_ROWS", {
         sheetId: env.model.getters.getActiveSheetId(),
+        sheetName: env.model.getters.getActiveSheetName(),
         dimension: "ROW",
         base: 5,
         quantity: 2,
@@ -655,6 +669,7 @@ describe("Menu Item actions", () => {
       doAction(insertColBeforePath, env);
       expect(dispatch).toHaveBeenLastCalledWith("ADD_COLUMNS_ROWS", {
         sheetId: env.model.getters.getActiveSheetId(),
+        sheetName: env.model.getters.getActiveSheetName(),
         base: 4,
         dimension: "COL",
         quantity: 2,
@@ -687,6 +702,7 @@ describe("Menu Item actions", () => {
       doAction(insertColBeforePath, env);
       expect(dispatch).toHaveBeenLastCalledWith("ADD_COLUMNS_ROWS", {
         sheetId: env.model.getters.getActiveSheetId(),
+        sheetName: env.model.getters.getActiveSheetName(),
         base: 3,
         dimension: "COL",
         quantity: 2,
@@ -712,6 +728,7 @@ describe("Menu Item actions", () => {
       doAction(addColBeforePath, env, colMenuRegistry);
       expect(dispatch).toHaveBeenLastCalledWith("ADD_COLUMNS_ROWS", {
         sheetId: env.model.getters.getActiveSheetId(),
+        sheetName: env.model.getters.getActiveSheetName(),
         base: 4,
         dimension: "COL",
         quantity: 2,
@@ -748,6 +765,7 @@ describe("Menu Item actions", () => {
       doAction(insertColAfterPath, env);
       expect(dispatch).toHaveBeenLastCalledWith("ADD_COLUMNS_ROWS", {
         sheetId: env.model.getters.getActiveSheetId(),
+        sheetName: env.model.getters.getActiveSheetName(),
         base: 5,
         dimension: "COL",
         quantity: 2,
@@ -780,6 +798,7 @@ describe("Menu Item actions", () => {
       doAction(insertColAfterPath, env);
       expect(dispatch).toHaveBeenLastCalledWith("ADD_COLUMNS_ROWS", {
         sheetId: env.model.getters.getActiveSheetId(),
+        sheetName: env.model.getters.getActiveSheetName(),
         base: 4,
         dimension: "COL",
         quantity: 2,
@@ -805,6 +824,7 @@ describe("Menu Item actions", () => {
       doAction(addColAfterPath, env, colMenuRegistry);
       expect(dispatch).toHaveBeenLastCalledWith("ADD_COLUMNS_ROWS", {
         sheetId: env.model.getters.getActiveSheetId(),
+        sheetName: env.model.getters.getActiveSheetName(),
         base: 5,
         dimension: "COL",
         quantity: 2,
@@ -953,6 +973,7 @@ describe("Menu Item actions", () => {
     const newSheetId = env.model.getters.getSheetIds()[1];
     expect(dispatch).toHaveBeenNthCalledWith(1, "CREATE_SHEET", {
       sheetId: newSheetId,
+      name: "Sheet2",
       position: 1,
     });
     expect(dispatch).toHaveBeenNthCalledWith(2, "ACTIVATE_SHEET", {

--- a/tests/model/model.test.ts
+++ b/tests/model/model.test.ts
@@ -8,7 +8,7 @@ import { Command, CommandTypes, CoreCommand, DispatchResult, coreTypes } from ".
 import { MockTransportService } from "../__mocks__/transport_service";
 import { getTextXlsxFiles } from "../__xlsx__/read_demo_xlsx";
 import { setupCollaborativeEnv } from "../collaborative/collaborative_helpers";
-import { copy, selectCell, setCellContent } from "../test_helpers/commands_helpers";
+import { copy, createSheet, selectCell, setCellContent } from "../test_helpers/commands_helpers";
 import {
   getCell,
   getCellContent,
@@ -69,7 +69,7 @@ describe("Model", () => {
     }
     addTestPlugin(corePluginRegistry, MyCorePlugin);
     const model = new Model();
-    model.dispatch("CREATE_SHEET", { sheetId: "42", position: 1 });
+    createSheet(model, { sheetId: "42", position: 1 });
     expect(result).toBeSuccessfullyDispatched();
     expect(getCellText(model, "A1", "42")).toBe("Hello");
   });
@@ -153,12 +153,12 @@ describe("Model", () => {
     }
     addTestPlugin(corePluginRegistry, MyCorePlugin);
     const model = new Model();
-    expect(model.canDispatch("CREATE_SHEET", { sheetId: "42", position: 1 })).toBeCancelledBecause(
-      CommandResult.CancelledForUnknownReason
-    );
-    expect(model.dispatch("CREATE_SHEET", { sheetId: "42", position: 1 })).toBeCancelledBecause(
-      CommandResult.CancelledForUnknownReason
-    );
+    expect(
+      model.canDispatch("CREATE_SHEET", { sheetId: "42", position: 1, name: "Sheet42" })
+    ).toBeCancelledBecause(CommandResult.CancelledForUnknownReason);
+    expect(
+      model.dispatch("CREATE_SHEET", { sheetId: "42", position: 1, name: "Sheet42" })
+    ).toBeCancelledBecause(CommandResult.CancelledForUnknownReason);
 
     const sheetId = model.getters.getActiveSheetId();
     expect(

--- a/tests/repeat_commands_plugin.test.ts
+++ b/tests/repeat_commands_plugin.test.ts
@@ -316,6 +316,7 @@ describe("Repeat command transform specifics", () => {
       dimension: args.dim as Dimension,
       sheetId,
       elements: [0, 1],
+      sheetName: "42",
     };
     activateSheet(model, "42");
     setSelection(model, [args.selection]);

--- a/tests/sheet/selection_plugin.test.ts
+++ b/tests/sheet/selection_plugin.test.ts
@@ -19,6 +19,7 @@ import {
   createSheet,
   deleteColumns,
   deleteRows,
+  deleteSheet,
   hideColumns,
   hideRows,
   merge,
@@ -388,6 +389,7 @@ describe("simple selection", () => {
             position: "before",
             base: 0,
             quantity: 1,
+            sheetName: "Sheet1",
           },
         ],
         clientId: "1",
@@ -496,7 +498,7 @@ describe("multiple sheets", () => {
     createSheet(model, { sheetId: secondSheetId, activate: true });
     selectCell(model, "C4");
     activateSheet(model, firstSheetId);
-    model.dispatch("DELETE_SHEET", { sheetId: firstSheetId });
+    deleteSheet(model, firstSheetId);
     expect(model.getters.getSelectedZone()).toEqual(toZone("C4"));
     expect(model.getters.getActiveSheetId()).toBe(secondSheetId);
     moveAnchorCell(model, "right");
@@ -1038,6 +1040,7 @@ describe("move elements(s)", () => {
     expect(result).toBeCancelledBecause(CommandResult.InvalidHeaderIndex);
     result = model.dispatch("MOVE_COLUMNS_ROWS", {
       sheetId: model.getters.getActiveSheetId(),
+      sheetName: model.getters.getActiveSheetName(),
       base: -1,
       elements: [0],
       position: "after",

--- a/tests/sheet/sheet_manipulation_component.test.ts
+++ b/tests/sheet/sheet_manipulation_component.test.ts
@@ -110,6 +110,7 @@ describe("Context Menu add/remove row/col", () => {
       elements: [3],
       dimension: "COL",
       sheetId: model.getters.getActiveSheetId(),
+      sheetName: model.getters.getActiveSheetName(),
     });
   });
 
@@ -140,6 +141,7 @@ describe("Context Menu add/remove row/col", () => {
       elements: [4],
       dimension: "ROW",
       sheetId: model.getters.getActiveSheetId(),
+      sheetName: model.getters.getActiveSheetName(),
     });
   });
 
@@ -172,6 +174,7 @@ describe("Context Menu add/remove row/col", () => {
       base: 3,
       quantity: 1,
       sheetId: model.getters.getActiveSheetId(),
+      sheetName: model.getters.getActiveSheetName(),
     });
   });
 
@@ -186,6 +189,7 @@ describe("Context Menu add/remove row/col", () => {
       dimension: "ROW",
       quantity: 1,
       sheetId: model.getters.getActiveSheetId(),
+      sheetName: model.getters.getActiveSheetName(),
     });
   });
 
@@ -200,6 +204,7 @@ describe("Context Menu add/remove row/col", () => {
       base: 3,
       quantity: 1,
       sheetId: model.getters.getActiveSheetId(),
+      sheetName: model.getters.getActiveSheetName(),
     });
   });
 
@@ -214,6 +219,7 @@ describe("Context Menu add/remove row/col", () => {
       dimension: "ROW",
       quantity: 1,
       sheetId: model.getters.getActiveSheetId(),
+      sheetName: model.getters.getActiveSheetName(),
     });
   });
 });

--- a/tests/sheet/sheets_plugin.test.ts
+++ b/tests/sheet/sheets_plugin.test.ts
@@ -176,16 +176,16 @@ describe("sheets", () => {
 
   test("Cannot create a sheet with a position > length of sheets", () => {
     const model = new Model();
-    expect(model.dispatch("CREATE_SHEET", { sheetId: "42", position: 54 })).toBeCancelledBecause(
-      CommandResult.WrongSheetPosition
-    );
+    expect(
+      model.dispatch("CREATE_SHEET", { sheetId: "42", position: 54, name: "S42" })
+    ).toBeCancelledBecause(CommandResult.WrongSheetPosition);
   });
 
   test("Cannot create a sheet with a negative position", () => {
     const model = new Model();
-    expect(model.dispatch("CREATE_SHEET", { sheetId: "42", position: -1 })).toBeCancelledBecause(
-      CommandResult.WrongSheetPosition
-    );
+    expect(
+      model.dispatch("CREATE_SHEET", { sheetId: "42", position: -1, name: "S42" })
+    ).toBeCancelledBecause(CommandResult.WrongSheetPosition);
   });
 
   test("Name is correctly generated when creating a sheet without given name", () => {
@@ -196,7 +196,7 @@ describe("sheets", () => {
     expect(model.getters.getSheetName(model.getters.getActiveSheetId())).toBe("Sheet2");
     createSheet(model, { sheetId: "43", activate: true });
     expect(model.getters.getSheetName(model.getters.getActiveSheetId())).toBe("Sheet3");
-    model.dispatch("DELETE_SHEET", { sheetId: "42" });
+    deleteSheet(model, "42");
     expect(model.getters.getSheetIds().map(model.getters.getSheetName)[0]).toBe("Sheet1");
     expect(model.getters.getSheetIds().map(model.getters.getSheetName)[1]).toBe("Sheet3");
     createSheet(model, { sheetId: "44", activate: true });
@@ -205,9 +205,9 @@ describe("sheets", () => {
 
   test("Cannot delete an invalid sheet", async () => {
     const model = new Model();
-    expect(model.dispatch("DELETE_SHEET", { sheetId: "invalid" })).toBeCancelledBecause(
-      CommandResult.InvalidSheetId
-    );
+    expect(
+      model.dispatch("DELETE_SHEET", { sheetId: "invalid", sheetName: "invalid2" })
+    ).toBeCancelledBecause(CommandResult.InvalidSheetId);
   });
 
   test("Cannot create a sheet with an already existent id", () => {
@@ -227,9 +227,7 @@ describe("sheets", () => {
 
   test("Cannot delete an invalid sheet; confirmation", async () => {
     const model = new Model();
-    expect(model.dispatch("DELETE_SHEET", { sheetId: "invalid" })).toBeCancelledBecause(
-      CommandResult.InvalidSheetId
-    );
+    expect(deleteSheet(model, "invalid")).toBeCancelledBecause(CommandResult.InvalidSheetId);
   });
 
   test("can read a value in same sheet", () => {
@@ -794,7 +792,7 @@ describe("sheets", () => {
     const sheet1 = model.getters.getActiveSheetId();
     createSheet(model, { sheetId: "42", activate: true });
     const sheet2 = model.getters.getActiveSheetId();
-    model.dispatch("DELETE_SHEET", { sheetId: sheet2 });
+    deleteSheet(model, sheet2);
     expect(model.getters.getSheetIds()).toHaveLength(1);
     expect(model.getters.getSheetIds()[0]).toEqual(sheet1);
     expect(model.getters.getActiveSheetId()).toEqual(sheet1);
@@ -812,7 +810,7 @@ describe("sheets", () => {
     const sheet2 = "Sheet2";
     createSheet(model, { sheetId: sheet2 });
     setCellContent(model, "A1", "Hello in Sheet2", sheet2);
-    model.dispatch("DELETE_SHEET", { sheetId: sheet1 });
+    deleteSheet(model, sheet1);
     expect(model.getters.getActiveSheetId()).toBe(sheet2);
     expect(getCellContent(model, "A1")).toBe("Hello in Sheet2");
   });
@@ -822,7 +820,7 @@ describe("sheets", () => {
     const sheet1 = model.getters.getActiveSheetId();
     createSheet(model, { sheetId: "42", activate: true });
     const sheet2 = model.getters.getSheetIds()[1];
-    model.dispatch("DELETE_SHEET", { sheetId: sheet1 });
+    deleteSheet(model, sheet1);
     expect(model.getters.getSheetIds()).toHaveLength(1);
     expect(model.getters.getSheetIds()[0]).toEqual(sheet2);
     expect(model.getters.getActiveSheetId()).toEqual(sheet2);
@@ -831,7 +829,10 @@ describe("sheets", () => {
   test("Cannot delete sheet if there is only one", () => {
     const model = new Model();
     expect(
-      model.dispatch("DELETE_SHEET", { sheetId: model.getters.getActiveSheetId() })
+      model.dispatch("DELETE_SHEET", {
+        sheetId: model.getters.getActiveSheetId(),
+        sheetName: model.getters.getActiveSheetName(),
+      })
     ).toBeCancelledBecause(CommandResult.NotEnoughSheets);
   });
 
@@ -839,9 +840,9 @@ describe("sheets", () => {
     const model = new Model();
     createSheet(model, { sheetId: "Sheet2" });
     hideSheet(model, "Sheet2");
-    expect(model.dispatch("DELETE_SHEET", { sheetId: "Sheet1" })).toBeCancelledBecause(
-      CommandResult.NotEnoughSheets
-    );
+    expect(
+      model.dispatch("DELETE_SHEET", { sheetId: "Sheet1", sheetName: "Sheet1" })
+    ).toBeCancelledBecause(CommandResult.NotEnoughSheets);
   });
 
   test("Can undo-redo a sheet deletion", () => {
@@ -854,7 +855,7 @@ describe("sheets", () => {
     const model = new Model();
     testUndoRedo(model, expect, "RENAME_SHEET", {
       sheetId: model.getters.getActiveSheetId(),
-      name: "New name",
+      newName: "New name",
     });
   });
 
@@ -870,13 +871,19 @@ describe("sheets", () => {
     const model = new Model();
     const name = "NEW_NAME";
     const sheet1 = model.getters.getActiveSheetId();
-    setCellContent(model, "A1", "=NEW_NAME!A1");
-    createSheetWithName(model, { sheetId: "42", activate: true }, name);
+    createSheetWithName(model, { sheetId: "sheet2", activate: true }, name);
     const sheet2 = model.getters.getActiveSheetId();
+
+    setCellContent(model, "A1", "=NEW_NAME!A1", sheet1);
     setCellContent(model, "A1", "42");
-    model.dispatch("DELETE_SHEET", { sheetId: sheet2 });
+
+    expect(getCellText(model, "A1", sheet1)).toBe("=NEW_NAME!A1");
+    expect(getEvaluatedCell(model, "A1", sheet1).value).toBe(42);
+
+    deleteSheet(model, sheet2);
     expect(getCellText(model, "A1")).toBe("=#REF");
     expect(getEvaluatedCell(model, "A1").value).toBe("#REF");
+
     undo(model);
     activateSheet(model, sheet1);
     expect(getCellText(model, "A1")).toBe("=NEW_NAME!A1");

--- a/tests/sheet/sheetview_plugin.test.ts
+++ b/tests/sheet/sheetview_plugin.test.ts
@@ -1035,9 +1035,9 @@ describe("Viewport of Simple sheet", () => {
         version: MESSAGE_VERSION,
         clientId: "bob",
         commands: [
-          { type: "CREATE_SHEET", position: 1, sheetId: "newSheetId" },
+          { type: "CREATE_SHEET", position: 1, sheetId: "newSheetId", name: "newSheetName" },
           { type: "UPDATE_CELL", sheetId: "newSheetId", col: 0, row: 0, content: "1" },
-          { type: "DELETE_SHEET", sheetId: "newSheetId" },
+          { type: "DELETE_SHEET", sheetId: "newSheetId", sheetName: "newSheetName" },
         ],
       },
     ];

--- a/tests/test_helpers/constants.ts
+++ b/tests/test_helpers/constants.ts
@@ -202,11 +202,13 @@ export const TEST_COMMANDS: CommandMapping = {
   DELETE_SHEET: {
     type: "DELETE_SHEET",
     sheetId: "Sheet1",
+    sheetName: "newSheetName",
   },
   RENAME_SHEET: {
     type: "RENAME_SHEET",
     sheetId: "Sheet1",
-    name: "newName",
+    newName: "newName",
+    oldName: "newSheetName",
   },
   COLOR_SHEET: {
     type: "COLOR_SHEET",
@@ -299,12 +301,14 @@ export const TEST_COMMANDS: CommandMapping = {
     base: 0,
     quantity: 1,
     sheetId: "Sheet1",
+    sheetName: "newSheetName",
   },
   REMOVE_COLUMNS_ROWS: {
     type: "REMOVE_COLUMNS_ROWS",
     dimension: "ROW",
     elements: [0],
     sheetId: "Sheet1",
+    sheetName: "newSheetName",
   },
   FREEZE_COLUMNS: {
     type: "FREEZE_COLUMNS",
@@ -350,6 +354,7 @@ export const TEST_COMMANDS: CommandMapping = {
     target: target("A1"),
     sheetId: "Sheet1",
     targetSheetId: "Sheet1",
+    sheetName: "Sheet1",
     col: 0,
     row: 0,
   },


### PR DESCRIPTION
## Description:

This task add an adaptRange-like feature to command operational transform.
The goal is to simplify the adaptability of formulas and range in OT and avoid the
N² function required in the current OT for range adaptation using the same ApplyRangeChange
method.

This require the name of the modified sheet and thus, it has now become an argument of sheet-altering command.
On top of that to reuse the applyRangeChange interface and provide a similar modification to command in OT and history, all the related code has been moved to helpers files and stripped of getter necessity.

This commit also modify the range Interface and rangeImpl object to all to remove the use of RangeImpl type in argument and allow the creation of ranges without the use of getters.

Task: [4319840](https://www.odoo.com/odoo/2328/tasks/4319840)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo