### PR TITLE
[sheet] prevent deletion of the last visible sheet

### DIFF
--- a/src/plugins/core/sheet.ts
+++ b/src/plugins/core/sheet.ts
@@ -122,7 +122,7 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
       case "RENAME_SHEET":
         return this.isRenameAllowed(cmd);
       case "DELETE_SHEET":
-        return this.orderedSheetIds.length > 1
+        return this.getVisibleSheetIds().length > 1
           ? CommandResult.Success
           : CommandResult.NotEnoughSheets;
       case "ADD_COLUMNS_ROWS":

--- a/src/registries/menus/sheet_menu_registry.ts
+++ b/src/registries/menus/sheet_menu_registry.ts
@@ -9,7 +9,7 @@ sheetMenuRegistry
     name: _lt("Delete"),
     sequence: 10,
     isVisible: (env) => {
-      return env.model.getters.getSheetIds().length > 1;
+      return env.model.getters.getVisibleSheetIds().length > 1;
     },
     action: (env) =>
       env.askConfirmation(_lt("Are you sure you want to delete this sheet ?"), () => {

--- a/tests/plugins/sheets.test.ts
+++ b/tests/plugins/sheets.test.ts
@@ -819,6 +819,15 @@ describe("sheets", () => {
     ).toBeCancelledBecause(CommandResult.NotEnoughSheets);
   });
 
+  test("Cannot delete sheet if it is the last visible one", () => {
+    const model = new Model();
+    createSheet(model, { sheetId: "Sheet2" });
+    hideSheet(model, "Sheet2");
+    expect(model.dispatch("DELETE_SHEET", { sheetId: "Sheet1" })).toBeCancelledBecause(
+      CommandResult.NotEnoughSheets
+    );
+  });
+
   test("Can undo-redo a sheet deletion", () => {
     const model = new Model();
     createSheet(model, { sheetId: "42" });


### PR DESCRIPTION
Prior to this commit, deleting the last visible sheet resulted in an error: "Sheet `<sheetId>` not found."

Steps to reproduce:
- Create a second sheet
- Hide a sheet
- Delete the last visible sheet

We address this by preventing deleting the last visible sheet, ensuring at least one sheet remains accessible.

Task: [4555893](https://www.odoo.com/odoo/2328/tasks/4555893)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo