### PR TITLE
[IMP] DV, CF: Enforce range on CF & DV

### DIFF
--- a/packages/o-spreadsheet-engine/src/components/translations_terms.ts
+++ b/packages/o-spreadsheet-engine/src/components/translations_terms.ts
@@ -6,30 +6,36 @@ import { Locale } from "../types/locale";
 
 export const CfTerms = {
   Errors: {
-    [CommandResult.InvalidRange]: _t("The range is invalid"),
-    [CommandResult.FirstArgMissing]: _t("The argument is missing. Please provide a value"),
-    [CommandResult.SecondArgMissing]: _t("The second argument is missing. Please provide a value"),
-    [CommandResult.MinNaN]: _t("The minpoint must be a number"),
-    [CommandResult.MidNaN]: _t("The midpoint must be a number"),
-    [CommandResult.MaxNaN]: _t("The maxpoint must be a number"),
-    [CommandResult.ValueUpperInflectionNaN]: _t("The first value must be a number"),
-    [CommandResult.ValueLowerInflectionNaN]: _t("The second value must be a number"),
-    [CommandResult.MinBiggerThanMax]: _t("Minimum must be smaller then Maximum"),
-    [CommandResult.MinBiggerThanMid]: _t("Minimum must be smaller then Midpoint"),
-    [CommandResult.MidBiggerThanMax]: _t("Midpoint must be smaller then Maximum"),
-    [CommandResult.LowerBiggerThanUpper]: _t(
-      "Lower inflection point must be smaller than upper inflection point"
-    ),
-    [CommandResult.MinInvalidFormula]: _t("Invalid Minpoint formula"),
-    [CommandResult.MaxInvalidFormula]: _t("Invalid Maxpoint formula"),
-    [CommandResult.MidInvalidFormula]: _t("Invalid Midpoint formula"),
-    [CommandResult.ValueUpperInvalidFormula]: _t("Invalid upper inflection point formula"),
-    [CommandResult.ValueLowerInvalidFormula]: _t("Invalid lower inflection point formula"),
-    [CommandResult.EmptyRange]: _t("A range needs to be defined"),
-    [CommandResult.ValueCellIsInvalidFormula]: _t(
-      "At least one of the provided values is an invalid formula"
-    ),
-    Unexpected: _t("The rule is invalid for an unknown reason"),
+    [CommandResult.InvalidRange]: (range: string[]) =>
+      _t('Invalid ranges: "%s"', range.join('", "')),
+    [CommandResult.FirstArgMissing]: () => _t("The argument is missing. Please provide a value"),
+    [CommandResult.SecondArgMissing]: () =>
+      _t("The second argument is missing. Please provide a value"),
+    [CommandResult.MinNaN]: () => _t("The minpoint must be a number"),
+    [CommandResult.MidNaN]: () => _t("The midpoint must be a number"),
+    [CommandResult.MaxNaN]: () => _t("The maxpoint must be a number"),
+    [CommandResult.ValueUpperInflectionNaN]: () => _t("The first value must be a number"),
+    [CommandResult.ValueLowerInflectionNaN]: () => _t("The second value must be a number"),
+    [CommandResult.MinBiggerThanMax]: () => _t("Minimum must be smaller than maximum"),
+    [CommandResult.MinBiggerThanMid]: () => _t("Minimum must be smaller than midpoint"),
+    [CommandResult.MidBiggerThanMax]: () => _t("Midpoint must be smaller than maximum"),
+    [CommandResult.LowerBiggerThanUpper]: () =>
+      _t("Lower inflection point must be smaller than upper inflection point"),
+    [CommandResult.MinInvalidFormula]: () => _t("Invalid minpoint formula"),
+    [CommandResult.MaxInvalidFormula]: () => _t("Invalid maxpoint formula"),
+    [CommandResult.MidInvalidFormula]: () => _t("Invalid midpoint formula"),
+    [CommandResult.ValueUpperInvalidFormula]: () => _t("Invalid upper inflection point formula"),
+    [CommandResult.ValueLowerInvalidFormula]: () => _t("Invalid lower inflection point formula"),
+    [CommandResult.EmptyRange]: () => _t("A range needs to be defined"),
+    [CommandResult.ValueCellIsInvalidFormula]: (formula: string[]) =>
+      _t('Invalid formulas: "%s"', formula.join('", "')),
+    [CommandResult.TargetOutOfSheet]: (sheetName: string, ranges: string[]) =>
+      _t(
+        'Ranges "%s" should target the sheet on which the conditional format is defined (%s)',
+        ranges.join('", "'),
+        sheetName
+      ),
+    Unexpected: () => _t("The rule is invalid for an unknown reason"),
   },
   ColorScale: _t("Color scale"),
   IconSet: _t("Icon set"),
@@ -148,14 +154,21 @@ export const DVTerms = {
     validFormula: _t("The formula must be valid"),
   },
   Errors: {
-    [CommandResult.InvalidRange]: _t("The range is invalid."),
-    [CommandResult.InvalidDataValidationCriterionValue]: _t(
-      "One or more of the provided criteria values are invalid. Please review and correct them."
-    ),
-    [CommandResult.InvalidNumberOfCriterionValues]: _t(
-      "One or more of the provided criteria values are missing."
-    ),
-    Unexpected: _t("The rule is invalid for an unknown reason."),
+    [CommandResult.InvalidRange]: (range: string[]) =>
+      _t('Invalid ranges: "%s"', range.join('", "')),
+    [CommandResult.InvalidDataValidationCriterionValue]: () =>
+      _t(
+        "One or more of the provided criteria values are invalid. Please review and correct them."
+      ),
+    [CommandResult.InvalidNumberOfCriterionValues]: () =>
+      _t("One or more of the provided criteria values are missing."),
+    [CommandResult.TargetOutOfSheet]: (sheetName: string, ranges: string[]) =>
+      _t(
+        'Ranges "%s" should target the sheet on which the conditional format is defined (%s)',
+        ranges.join('", "'),
+        sheetName
+      ),
+    Unexpected: () => _t("The rule is invalid for an unknown reason."),
   },
 };
 

--- a/packages/o-spreadsheet-engine/src/helpers/range.ts
+++ b/packages/o-spreadsheet-engine/src/helpers/range.ts
@@ -438,19 +438,19 @@ function getApplyRangeChangeDeleteSheet(cmd: DeleteSheetCommand): ApplyRangeChan
 function getApplyRangeChangeRenameSheet(cmd: RenameSheetCommand): ApplyRangeChange {
   return (range: Range) => {
     if (range.sheetId === cmd.sheetId) {
-      return { changeType: "CHANGE", range };
+      return { changeType: "CHANGE", range, newName: cmd.newName };
     }
     if (cmd.newName && range.invalidSheetName === cmd.newName) {
       const invalidSheetName = undefined;
       const sheetId = cmd.sheetId;
       const newRange = { ...range, sheetId, invalidSheetName };
-      return { changeType: "CHANGE", range: newRange };
+      return { changeType: "CHANGE", range: newRange, newName: cmd.newName };
     }
     if (cmd.oldName && range.invalidSheetName === cmd.oldName) {
       const invalidSheetName = undefined;
       const sheetId = cmd.sheetId;
       const newRange = { ...range, sheetId, invalidSheetName };
-      return { changeType: "CHANGE", range: newRange };
+      return { changeType: "CHANGE", range: newRange, newName: cmd.newName };
     }
     return { changeType: "NONE" };
   };

--- a/packages/o-spreadsheet-engine/src/helpers/range.ts
+++ b/packages/o-spreadsheet-engine/src/helpers/range.ts
@@ -438,19 +438,19 @@ function getApplyRangeChangeDeleteSheet(cmd: DeleteSheetCommand): ApplyRangeChan
 function getApplyRangeChangeRenameSheet(cmd: RenameSheetCommand): ApplyRangeChange {
   return (range: Range) => {
     if (range.sheetId === cmd.sheetId) {
-      return { changeType: "CHANGE", range, newName: cmd.newName };
+      return { changeType: "RENAME", range, newName: cmd.newName };
     }
     if (cmd.newName && range.invalidSheetName === cmd.newName) {
       const invalidSheetName = undefined;
       const sheetId = cmd.sheetId;
       const newRange = { ...range, sheetId, invalidSheetName };
-      return { changeType: "CHANGE", range: newRange, newName: cmd.newName };
+      return { changeType: "RENAME", range: newRange, newName: cmd.newName };
     }
     if (cmd.oldName && range.invalidSheetName === cmd.oldName) {
       const invalidSheetName = undefined;
       const sheetId = cmd.sheetId;
       const newRange = { ...range, sheetId, invalidSheetName };
-      return { changeType: "CHANGE", range: newRange, newName: cmd.newName };
+      return { changeType: "RENAME", range: newRange, newName: cmd.newName };
     }
     return { changeType: "NONE" };
   };

--- a/packages/o-spreadsheet-engine/src/plugins/core/borders.ts
+++ b/packages/o-spreadsheet-engine/src/plugins/core/borders.ts
@@ -134,7 +134,7 @@ export class BordersPlugin extends CorePlugin<BordersPluginState> implements Bor
       const change = applyChange(this.getters.getRangeFromZone(sheetId, border.zone));
       switch (change.changeType) {
         case "RESIZE":
-        case "CHANGE":
+        case "RENAME":
         case "MOVE":
           newBorders.push({ ...border, zone: change.range.unboundedZone });
           break;

--- a/packages/o-spreadsheet-engine/src/plugins/core/cell.ts
+++ b/packages/o-spreadsheet-engine/src/plugins/core/cell.ts
@@ -371,7 +371,8 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
     sheetId: UID,
     tokens: Token[],
     dependencies: Range[],
-    useBoundedReference: boolean = false
+    useBoundedReference: boolean = false,
+    newSheetNames?: Record<UID, string>
   ): string {
     if (!dependencies.length) {
       return concat(tokens.map((token) => token.value));
@@ -381,7 +382,12 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
       tokens.map((token) => {
         if (token.type === "REFERENCE") {
           const range = dependencies[rangeIndex++];
-          return this.getters.getRangeString(range, sheetId, { useBoundedReference });
+          return this.getters.getRangeString(
+            range,
+            sheetId,
+            { useBoundedReference },
+            newSheetNames
+          );
         }
         return token.value;
       })

--- a/packages/o-spreadsheet-engine/src/plugins/core/conditional_format.ts
+++ b/packages/o-spreadsheet-engine/src/plugins/core/conditional_format.ts
@@ -199,6 +199,7 @@ export class ConditionalFormatPlugin
         }
         return this.checkValidations(
           cmd,
+          this.checkValidRange,
           this.checkCFRule,
           this.checkEmptyRange,
           this.checkCFHasChanged
@@ -442,6 +443,14 @@ export class ConditionalFormatPlugin
 
   private checkEmptyRange(cmd: AddConditionalFormatCommand) {
     return cmd.ranges.length ? CommandResult.Success : CommandResult.EmptyRange;
+  }
+
+  private checkValidRange(cmd: AddConditionalFormatCommand): CommandResult {
+    const ranges = cmd.ranges.map((range) => this.getters.getRangeFromRangeData(range));
+    if (ranges.some((range) => range.sheetId !== cmd.sheetId)) {
+      return CommandResult.TargetOutOfSheet;
+    }
+    return CommandResult.Success;
   }
 
   private checkCFRule(cmd: AddConditionalFormatCommand) {

--- a/packages/o-spreadsheet-engine/src/plugins/core/conditional_format.ts
+++ b/packages/o-spreadsheet-engine/src/plugins/core/conditional_format.ts
@@ -76,7 +76,7 @@ export class ConditionalFormatPlugin
               break;
             case "RESIZE":
             case "MOVE":
-            case "CHANGE":
+            case "RENAME":
               this.history.update(
                 "cfRules",
                 sheetId,
@@ -164,7 +164,7 @@ export class ConditionalFormatPlugin
             break;
           case "RESIZE":
           case "MOVE":
-          case "CHANGE":
+          case "RENAME":
             this.history.update(
               "cfRules",
               sheetId,

--- a/packages/o-spreadsheet-engine/src/plugins/core/data_validation.ts
+++ b/packages/o-spreadsheet-engine/src/plugins/core/data_validation.ts
@@ -365,9 +365,8 @@ export class DataValidationPlugin
 
   private checkValidRange(cmd: AddDataValidationCommand): CommandResult {
     const ranges = cmd.ranges.map((range) => this.getters.getRangeFromRangeData(range));
-    const stringRanges = ranges.map((range) => this.getters.getRangeString(range, cmd.sheetId));
-    if (stringRanges.some((xc) => !this.getters.isRangeValid(xc))) {
-      return CommandResult.InvalidRange;
+    if (ranges.some((range) => range.sheetId !== cmd.sheetId)) {
+      return CommandResult.TargetOutOfSheet;
     }
     return CommandResult.Success;
   }

--- a/packages/o-spreadsheet-engine/src/plugins/core/data_validation.ts
+++ b/packages/o-spreadsheet-engine/src/plugins/core/data_validation.ts
@@ -83,7 +83,7 @@ export class DataValidationPlugin
             break;
           case "RESIZE":
           case "MOVE":
-          case "CHANGE":
+          case "RENAME":
             this.history.update("rules", sheetId, ruleIndex, "ranges", rangeIndex, change.range);
             break;
         }

--- a/packages/o-spreadsheet-engine/src/plugins/core/range.ts
+++ b/packages/o-spreadsheet-engine/src/plugins/core/range.ts
@@ -217,7 +217,8 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
   getRangeString(
     range: Range,
     forSheetId: UID,
-    options: RangeStringOptions = { useBoundedReference: false, useFixedReference: false }
+    options: RangeStringOptions = { useBoundedReference: false, useFixedReference: false },
+    newSheetNames?: Record<UID, string>
   ): string {
     if (!range) {
       return CellErrorType.InvalidReference;
@@ -228,7 +229,15 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
     if (!this.getters.tryGetSheet(range.sheetId)) {
       return CellErrorType.InvalidReference;
     }
-    return getRangeString(range, forSheetId, this.getters.getSheetName, options);
+    return getRangeString(range, forSheetId, this.sheetNameGetter(newSheetNames), options);
+  }
+
+  sheetNameGetter(newSheetNames?: Record<UID, string>) {
+    if (!newSheetNames) return this.getters.getSheetName;
+    return (sheetId: UID): string => {
+      if (newSheetNames[sheetId]) return newSheetNames[sheetId];
+      return this.getters.getSheetName(sheetId);
+    };
   }
 
   getRangeDataFromXc(sheetId: UID, xc: string): RangeData {
@@ -313,14 +322,24 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
     if (!formula.startsWith("=")) {
       return formula;
     }
-
+    const newSheetNames: Record<UID, string> = {};
     const compiledFormula = compile(formula);
     const updatedDependencies = compiledFormula.dependencies.map((dep) => {
       const range = this.getters.getRangeFromSheetXC(sheetId, dep);
       const changedRange = applyChange(range);
+      if (changedRange.changeType === "CHANGE" && "newName" in changedRange) {
+        newSheetNames[range.sheetId] = changedRange.newName;
+      }
       return changedRange.changeType === "NONE" ? range : changedRange.range;
     });
-    return this.getters.getFormulaString(sheetId, compiledFormula.tokens, updatedDependencies);
+
+    return this.getters.getFormulaString(
+      sheetId,
+      compiledFormula.tokens,
+      updatedDependencies,
+      false,
+      newSheetNames
+    );
   }
 
   /**

--- a/packages/o-spreadsheet-engine/src/plugins/core/range.ts
+++ b/packages/o-spreadsheet-engine/src/plugins/core/range.ts
@@ -327,7 +327,7 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
     const updatedDependencies = compiledFormula.dependencies.map((dep) => {
       const range = this.getters.getRangeFromSheetXC(sheetId, dep);
       const changedRange = applyChange(range);
-      if (changedRange.changeType === "CHANGE" && "newName" in changedRange) {
+      if (changedRange.changeType === "RENAME" && "newName" in changedRange) {
         newSheetNames[range.sheetId] = changedRange.newName;
       }
       return changedRange.changeType === "NONE" ? range : changedRange.range;

--- a/packages/o-spreadsheet-engine/src/plugins/core/style.ts
+++ b/packages/o-spreadsheet-engine/src/plugins/core/style.ts
@@ -113,7 +113,7 @@ export class StylePlugin extends CorePlugin<StylePluginState> implements StylePl
       const change = applyChange(this.getters.getRangeFromZone(sheetId, style.zone));
       switch (change.changeType) {
         case "RESIZE":
-        case "CHANGE":
+        case "RENAME":
         case "MOVE":
           newStyles.push({ style: style.style, zone: change.range.unboundedZone });
           break;

--- a/packages/o-spreadsheet-engine/src/types/misc.ts
+++ b/packages/o-spreadsheet-engine/src/types/misc.ts
@@ -294,10 +294,10 @@ export const enum DIRECTION {
   RIGHT = "right",
 }
 
-export type ChangeType = "REMOVE" | "RESIZE" | "MOVE" | "CHANGE" | "NONE";
+export type ChangeType = "REMOVE" | "RESIZE" | "MOVE" | "RENAME" | "NONE";
 export type ApplyRangeChangeResult =
-  | { changeType: Exclude<ChangeType, "NONE" | "CHANGE">; range: Range }
-  | { changeType: "CHANGE"; range: Range; newName: string }
+  | { changeType: Exclude<ChangeType, "NONE" | "RENAME">; range: Range }
+  | { changeType: "RENAME"; range: Range; newName: string }
   | { changeType: "NONE" };
 export type ApplyRangeChange = (range: Range) => ApplyRangeChangeResult;
 

--- a/packages/o-spreadsheet-engine/src/types/misc.ts
+++ b/packages/o-spreadsheet-engine/src/types/misc.ts
@@ -296,7 +296,8 @@ export const enum DIRECTION {
 
 export type ChangeType = "REMOVE" | "RESIZE" | "MOVE" | "CHANGE" | "NONE";
 export type ApplyRangeChangeResult =
-  | { changeType: Exclude<ChangeType, "NONE">; range: Range }
+  | { changeType: Exclude<ChangeType, "NONE" | "CHANGE">; range: Range }
+  | { changeType: "CHANGE"; range: Range; newName: string }
   | { changeType: "NONE" };
 export type ApplyRangeChange = (range: Range) => ApplyRangeChangeResult;
 

--- a/src/components/composer/composer/abstract_composer_store.ts
+++ b/src/components/composer/composer/abstract_composer_store.ts
@@ -177,9 +177,21 @@ export abstract class AbstractComposerStore extends SpreadsheetStore {
     this.updateAutoCompleteProvider();
   }
 
-  cancelEdition() {
-    this.resetContent();
-    this.cancelEditionAndActivateSheet();
+  cancelEdition({ resetContent = true, activateSheet = true } = {}) {
+    if (resetContent) {
+      this.resetContent();
+    }
+    if (this.editionMode === "inactive") {
+      return;
+    }
+    this._cancelEdition();
+    const sheetId = this.getters.getActiveSheetId();
+    if (activateSheet && sheetId !== this.sheetId) {
+      this.model.dispatch("ACTIVATE_SHEET", {
+        sheetIdFrom: sheetId,
+        sheetIdTo: this.sheetId,
+      });
+    }
   }
 
   setCurrentContent(content: string, selection?: ComposerSelection) {
@@ -201,8 +213,7 @@ export abstract class AbstractComposerStore extends SpreadsheetStore {
     switch (cmd.type) {
       case "SELECT_FIGURE":
         if (cmd.figureId) {
-          this.resetContent();
-          this.cancelEditionAndActivateSheet();
+          this.cancelEdition();
         }
         break;
       case "START_CHANGE_HIGHLIGHT":
@@ -460,9 +471,9 @@ export abstract class AbstractComposerStore extends SpreadsheetStore {
     this.captureSelection(zone, col, row);
   }
 
-  protected _stopEdition() {
+  protected _stopEdition({ resetContent = false, activateSheet = true } = {}) {
     if (this.editionMode !== "inactive") {
-      this.cancelEditionAndActivateSheet();
+      this.cancelEdition({ resetContent, activateSheet });
       let content = this.getCurrentCanonicalContent();
       const didChange = this.initialContent !== content;
       if (!didChange) {
@@ -482,20 +493,6 @@ export abstract class AbstractComposerStore extends SpreadsheetStore {
 
   protected getCurrentCanonicalContent(): string {
     return canonicalizeNumberContent(this._currentContent, this.getters.getLocale());
-  }
-
-  protected cancelEditionAndActivateSheet() {
-    if (this.editionMode === "inactive") {
-      return;
-    }
-    this._cancelEdition();
-    const sheetId = this.getters.getActiveSheetId();
-    if (sheetId !== this.sheetId) {
-      this.model.dispatch("ACTIVATE_SHEET", {
-        sheetIdFrom: this.getters.getActiveSheetId(),
-        sheetIdTo: this.sheetId,
-      });
-    }
   }
 
   protected _cancelEdition() {

--- a/src/components/composer/composer/cell_composer_store.ts
+++ b/src/components/composer/composer/cell_composer_store.ts
@@ -111,8 +111,7 @@ export class CellComposerStore extends AbstractComposerStore {
         const sheetIdExists = !!this.getters.tryGetSheet(this.sheetId);
         if (!sheetIdExists && this.editionMode !== "inactive") {
           this.sheetId = this.getters.getActiveSheetId();
-          this.resetContent();
-          this.cancelEditionAndActivateSheet();
+          this.cancelEdition();
           this.notificationStore.raiseError(CELL_DELETED_MESSAGE);
         }
         break;

--- a/src/components/composer/standalone_composer/standalone_composer_store.ts
+++ b/src/components/composer/standalone_composer/standalone_composer_store.ts
@@ -67,7 +67,7 @@ export class StandaloneComposerStore extends AbstractComposerStore {
   }
 
   stopEdition() {
-    this._stopEdition();
+    this._stopEdition({ activateSheet: false });
   }
 
   protected confirmEdition(content: string) {

--- a/src/components/composer/standalone_composer/standalone_composer_store.ts
+++ b/src/components/composer/standalone_composer/standalone_composer_store.ts
@@ -5,6 +5,7 @@ import { localizeContent } from "@odoo/o-spreadsheet-engine/helpers/locale";
 import { AutoCompleteProviderDefinition } from "../../../registries/auto_completes";
 import { Get } from "../../../store_engine";
 import { Color, UID, UnboundedZone, Zone } from "../../../types";
+import { adaptFormulaToSheet } from "../../helpers/formulas";
 import { AbstractComposerStore } from "../composer/abstract_composer_store";
 
 export interface StandaloneComposerArgs {
@@ -71,6 +72,12 @@ export class StandaloneComposerStore extends AbstractComposerStore {
   }
 
   protected confirmEdition(content: string) {
+    content = adaptFormulaToSheet(
+      this.getters,
+      content,
+      this.getters.getActiveSheetId(),
+      this.sheetId
+    );
     this.args().onConfirm(content);
   }
 

--- a/src/components/helpers/formulas.ts
+++ b/src/components/helpers/formulas.ts
@@ -1,0 +1,22 @@
+import { rangeTokenize } from "@odoo/o-spreadsheet-engine";
+import { Getters, UID } from "../..";
+
+export function adaptFormulaToSheet(
+  getters: Getters,
+  formula: string,
+  toSheetId: UID,
+  fromSheetId?: UID
+) {
+  return rangeTokenize(formula)
+    .map((token) => {
+      if (token.type === "REFERENCE") {
+        const range = getters.getRangeFromSheetXC(
+          fromSheetId ?? getters.getActiveSheetId(),
+          token.value
+        );
+        return getters.getRangeString(range, toSheetId);
+      }
+      return token.value;
+    })
+    .join("");
+}

--- a/src/components/selection_input/selection_input.ts
+++ b/src/components/selection_input/selection_input.ts
@@ -3,7 +3,7 @@ import { SpreadsheetChildEnv } from "@odoo/o-spreadsheet-engine/types/spreadshee
 import { Component, onWillUpdateProps, useEffect, useRef, useState } from "@odoo/owl";
 import { deepEquals, range } from "../../helpers";
 import { Store, useLocalStore } from "../../store_engine";
-import { Color } from "../../types";
+import { Color, UID } from "../../types";
 import { useDragAndDropListItems } from "../helpers/drag_and_drop_dom_items_hook";
 import { updateSelectionWithArrowKeys } from "../helpers/selection_helpers";
 import { RangeInputValue, SelectionInputStore } from "./selection_input_store";
@@ -13,6 +13,7 @@ interface Props {
   hasSingleRange?: boolean;
   required?: boolean;
   autofocus?: boolean;
+  availableOnSheetId?: UID;
   isInvalid?: boolean;
   class?: string;
   onSelectionChanged?: (ranges: string[]) => void;
@@ -52,6 +53,7 @@ export class SelectionInput extends Component<Props, SpreadsheetChildEnv> {
     hasSingleRange: { type: Boolean, optional: true },
     required: { type: Boolean, optional: true },
     autofocus: { type: Boolean, optional: true },
+    availableOnSheetId: { type: String, optional: true },
     isInvalid: { type: Boolean, optional: true },
     class: { type: String, optional: true },
     onSelectionChanged: { type: Function, optional: true },
@@ -62,6 +64,7 @@ export class SelectionInput extends Component<Props, SpreadsheetChildEnv> {
     disabledRanges: { type: Array, optional: true, default: [] },
     disabledRangeTitle: { type: String, optional: true },
   };
+
   private state: State = useState({
     isMissing: false,
     mode: "select-range",
@@ -76,7 +79,7 @@ export class SelectionInput extends Component<Props, SpreadsheetChildEnv> {
   }
 
   get canAddRange(): boolean {
-    return !this.props.hasSingleRange;
+    return !this.props.hasSingleRange && !this.isReadonly;
   }
 
   get isInvalid(): boolean {
@@ -84,11 +87,17 @@ export class SelectionInput extends Component<Props, SpreadsheetChildEnv> {
   }
 
   get isConfirmable(): boolean {
-    return this.store.isConfirmable;
+    return this.store.isConfirmable && !this.isReadonly;
   }
 
   get isResettable(): boolean {
-    return this.store.isResettable;
+    return this.store.isResettable && !this.isReadonly;
+  }
+
+  get isReadonly(): boolean {
+    return this.props.availableOnSheetId
+      ? this.env.model.getters.getActiveSheetId() !== this.props.availableOnSheetId
+      : false;
   }
 
   get hasDisabledRanges(): boolean {
@@ -105,7 +114,8 @@ export class SelectionInput extends Component<Props, SpreadsheetChildEnv> {
       this.props.ranges,
       this.props.hasSingleRange || false,
       this.props.colors,
-      this.props.disabledRanges
+      this.props.disabledRanges,
+      this.props.availableOnSheetId
     );
     if (this.props.autofocus) {
       this.store.focusById(this.store.selectionInputs[0]?.id);
@@ -172,7 +182,7 @@ export class SelectionInput extends Component<Props, SpreadsheetChildEnv> {
   }
 
   getColor(range: SelectionRange) {
-    if (!range.color) {
+    if (!range.color || this.isReadonly) {
       return "";
     }
     return cssPropertiesToCss({ color: range.color });

--- a/src/components/selection_input/selection_input.xml
+++ b/src/components/selection_input/selection_input.xml
@@ -7,7 +7,8 @@
         t-key="range.id"
         class="o-selection-input d-flex flex-row"
         t-att-style="dragAndDrop.itemsStyle[range.id]"
-        t-att-class="props.class">
+        t-att-class="props.class"
+        t-if="!isReadonly || range.xc">
         <span
           t-if="ranges.length > 1 and props.onSelectionReordered"
           title="Reorder range"
@@ -23,14 +24,15 @@
             t-on-input="(ev) => this.onInputChanged(range.id, ev)"
             t-on-focus="() => this.focus(range.id)"
             t-on-keydown="onKeydown"
+            t-att-disabled="isReadonly"
             t-att-value="range.xc"
             t-att-style="getColor(range)"
             class="o-input mb-2"
             t-att-class="{
               'o-disabled-ranges' : range.disabled and !range.isFocused,
-              'o-focused' : range.isFocused,
+              'o-focused' : range.isFocused and !isReadonly,
               'o-invalid border-danger position-relative': isInvalid || !range.isValidRange,
-              'text-decoration-underline': range.xc and range.isFocused and state.mode === 'select-range'
+              'text-decoration-underline': range.xc and range.isFocused and state.mode === 'select-range' and !isReadonly
             }"
             t-ref="{{range.isFocused ? 'focusedInput' : 'unfocusedInput' + range_index}}"
           />
@@ -49,12 +51,13 @@
         </div>
         <button
           class="border-0 bg-transparent fw-bold o-remove-selection o-button-icon pe-0"
-          t-if="ranges.length > 1"
+          t-if="ranges.length > 1 and !isReadonly"
           t-on-click="() => this.removeInput(range.id)">
           <t t-call="o-spreadsheet-Icon.TRASH_FILLED"/>
         </button>
       </div>
-      <div class="d-flex flex-row w-100 o-selection-input">
+
+      <div t-if="!isReadonly" class="d-flex flex-row w-100 o-selection-input">
         <button class="o-button o-add-selection" t-if="canAddRange" t-on-click="addEmptyInput">
           Add range
         </button>

--- a/src/components/selection_input/selection_input_store.ts
+++ b/src/components/selection_input/selection_input_store.ts
@@ -43,7 +43,8 @@ export class SelectionInputStore extends SpreadsheetStore {
     private initialRanges: string[] = [],
     private readonly inputHasSingleRange: boolean = false,
     public colors: Color[] = [],
-    public disabledRanges: boolean[] = []
+    public disabledRanges: boolean[] = [],
+    public availableOnSheetId: UID = ""
   ) {
     super(get);
     if (inputHasSingleRange && initialRanges.length > 1) {
@@ -64,7 +65,6 @@ export class SelectionInputStore extends SpreadsheetStore {
     if (this.focusedRangeIndex === null) {
       return;
     }
-
     const inputSheetId = this.inputSheetId;
     const activeSheetId = this.getters.getActiveSheetId();
     const zone = event.options.unbounded
@@ -248,9 +248,13 @@ export class SelectionInputStore extends SpreadsheetStore {
     return this.selectionInputs.some((i) => i.isFocused);
   }
 
-  private get hasMainFocus() {
+  private get hasMainFocus(): boolean {
     const focusedElement = this.focusStore.focusedElement;
     return !!focusedElement && focusedElement === this;
+  }
+
+  get isReadonly(): boolean {
+    return this.availableOnSheetId && this.availableOnSheetId !== this.getters.getActiveSheetId();
   }
 
   get highlights(): Highlight[] {
@@ -349,6 +353,9 @@ export class SelectionInputStore extends SpreadsheetStore {
    * new inputs will be added.
    */
   private setRange(index: number, values: string[]) {
+    if (this.isReadonly) {
+      return;
+    }
     const [, ...additionalValues] = values;
     this.setContent(index, values[0]);
     this.insertNewRange(index + 1, additionalValues);

--- a/src/components/side_panel/conditional_formatting/cf_editor/cf_editor.xml
+++ b/src/components/side_panel/conditional_formatting/cf_editor/cf_editor.xml
@@ -1,12 +1,13 @@
 <templates>
   <t t-name="o-spreadsheet-ConditionalFormattingEditor">
     <div class="o-cf-ruleEditor">
-      <Section class="'o-cf-range pb-0'" title.translate="Apply to range">
+      <Section class="'o-cf-range pb-0'" title="this.rangeTitle">
         <div class="o-selection-cf">
           <SelectionInput
             ranges="state.ranges"
             class="'o-range'"
             isInvalid="isRangeValid"
+            availableOnSheetId="this.props.sheetId"
             onSelectionChanged.bind="onRangeUpdate"
             onSelectionConfirmed.bind="onRangeConfirmed"
             required="true"

--- a/src/components/side_panel/conditional_formatting/conditional_formatting.ts
+++ b/src/components/side_panel/conditional_formatting/conditional_formatting.ts
@@ -38,7 +38,7 @@ export class ConditionalFormattingPanel extends Component<Props, SpreadsheetChil
 
   setup() {
     this.activeSheetId = this.env.model.getters.getActiveSheetId();
-    const sheetId = this.env.model.getters.getActiveSheetId();
+    const sheetId = this.activeSheetId;
     const rules = this.env.model.getters.getRulesSelection(sheetId, this.props.selection || []);
     if (rules.length === 1) {
       const cf = this.conditionalFormats.find((c) => c.id === rules[0]);
@@ -47,18 +47,18 @@ export class ConditionalFormattingPanel extends Component<Props, SpreadsheetChil
       }
     }
     onWillUpdateProps((nextProps: Props) => {
-      const newActiveSheetId = this.env.model.getters.getActiveSheetId();
-      if (newActiveSheetId !== this.activeSheetId) {
-        this.activeSheetId = newActiveSheetId;
-        this.switchToList();
-      } else if (nextProps.selection !== this.props.selection) {
-        const sheetId = this.env.model.getters.getActiveSheetId();
-        const rules = this.env.model.getters.getRulesSelection(sheetId, nextProps.selection || []);
-        if (rules.length === 1) {
-          const cf = this.conditionalFormats.find((c) => c.id === rules[0]);
-          if (cf) {
-            this.editConditionalFormat(cf);
-          }
+      if (this.state.mode === "list") {
+        this.activeSheetId = this.env.model.getters.getActiveSheetId();
+      }
+      if (nextProps.selection !== this.props.selection) {
+        const rules = this.env.model.getters.getRulesSelection(
+          this.activeSheetId,
+          nextProps.selection || []
+        );
+        const cf =
+          rules.length === 1 ? this.conditionalFormats.find((c) => c.id === rules[0]) : undefined;
+        if (cf) {
+          this.editConditionalFormat(cf);
         } else {
           this.switchToList();
         }
@@ -69,9 +69,7 @@ export class ConditionalFormattingPanel extends Component<Props, SpreadsheetChil
   }
 
   get conditionalFormats(): ConditionalFormat[] {
-    const cfs = this.env.model.getters.getConditionalFormats(
-      this.env.model.getters.getActiveSheetId()
-    );
+    const cfs = this.env.model.getters.getConditionalFormats(this.activeSheetId);
     return cfs.map((cf) => ({
       ...cf,
       rule: localizeCFRule(cf.rule, this.env.model.getters.getLocale()),
@@ -79,6 +77,7 @@ export class ConditionalFormattingPanel extends Component<Props, SpreadsheetChil
   }
 
   private switchToList() {
+    this.activeSheetId = this.env.model.getters.getActiveSheetId();
     this.state.mode = "list";
     this.state.editedCfId = undefined;
     this.originalEditedCf = undefined;

--- a/src/components/side_panel/conditional_formatting/conditional_formatting.xml
+++ b/src/components/side_panel/conditional_formatting/conditional_formatting.xml
@@ -1,16 +1,17 @@
 <templates>
   <t t-name="o-spreadsheet-ConditionalFormattingPanel">
     <div class="o-cf h-100">
-      <t t-if="state.mode === 'list'">
+      <t t-if="state.mode === 'list' || !editedCF">
         <ConditionalFormatPreviewList
           conditionalFormats="conditionalFormats"
           onPreviewClick.bind="editConditionalFormat"
           onAddConditionalFormat.bind="addConditionalFormat"
         />
       </t>
-      <t t-if="state.mode === 'edit'">
+      <t t-else="">
         <ConditionalFormattingEditor
           editedCf="editedCF"
+          sheetId="activeSheetId"
           onExit.bind="switchToList"
           onCancel.bind="cancelEdition"
           isNewCf="originalEditedCf === undefined"

--- a/src/components/side_panel/criterion_form/criterion_form.ts
+++ b/src/components/side_panel/criterion_form/criterion_form.ts
@@ -1,7 +1,7 @@
 import { SpreadsheetChildEnv } from "@odoo/o-spreadsheet-engine/types/spreadsheet_env";
 import { Component } from "@odoo/owl";
 import { useStore } from "../../../store_engine";
-import { GenericCriterion } from "../../../types";
+import { GenericCriterion, UID } from "../../../types";
 import { ComposerFocusStore } from "../../composer/composer_focus_store";
 
 interface Props<T extends GenericCriterion> {
@@ -9,6 +9,7 @@ interface Props<T extends GenericCriterion> {
   onCriterionChanged: (criterion: T) => void;
   disableFormulas?: boolean;
   autofocus?: boolean;
+  sheetId: UID;
 }
 
 export abstract class CriterionForm<
@@ -19,6 +20,7 @@ export abstract class CriterionForm<
     onCriterionChanged: Function,
     disableFormulas: { type: Boolean, optional: true },
     autofocus: { type: Boolean, optional: true },
+    sheetId: { type: String, optional: true },
   };
   setup() {
     const composerFocusStore = useStore(ComposerFocusStore);

--- a/src/components/side_panel/criterion_form/criterion_input/criterion_input.ts
+++ b/src/components/side_panel/criterion_form/criterion_input/criterion_input.ts
@@ -3,12 +3,14 @@ import { criterionEvaluatorRegistry } from "@odoo/o-spreadsheet-engine/registrie
 import { _t } from "@odoo/o-spreadsheet-engine/translation";
 import { SpreadsheetChildEnv } from "@odoo/o-spreadsheet-engine/types/spreadsheet_env";
 import { Component, useEffect, useRef, useState } from "@odoo/owl";
-import { DataValidationCriterionType } from "../../../../types";
+import { DataValidationCriterionType, UID } from "../../../../types";
 import { StandaloneComposer } from "../../../composer/standalone_composer/standalone_composer";
+import { adaptFormulaToSheet } from "../../../helpers/formulas";
 
 interface Props {
   value: string;
   criterionType: DataValidationCriterionType;
+  sheetId: UID;
   onValueChanged: (value: string) => void;
   onKeyDown?: (ev: KeyboardEvent) => void;
   focused: boolean;
@@ -22,6 +24,7 @@ export class CriterionInput extends Component<Props, SpreadsheetChildEnv> {
     value: { type: String, optional: true },
     criterionType: String,
     onValueChanged: Function,
+    sheetId: { type: String, optional: true },
     onKeyDown: { type: Function, optional: true },
     focused: { type: Boolean, optional: true },
     onBlur: { type: Function, optional: true },
@@ -82,6 +85,7 @@ export class CriterionInput extends Component<Props, SpreadsheetChildEnv> {
 
   onChangeComposerValue(str: string) {
     this.state.shouldDisplayError = true;
+    str = adaptFormulaToSheet(this.env.model.getters, str, this.props.sheetId);
     this.props.onValueChanged(str);
   }
 
@@ -91,7 +95,7 @@ export class CriterionInput extends Component<Props, SpreadsheetChildEnv> {
       composerContent: this.props.value,
       placeholder: this.placeholder,
       class: "o-sidePanel-composer",
-      defaultRangeSheetId: this.env.model.getters.getActiveSheetId(),
+      defaultRangeSheetId: this.props.sheetId,
       invalid: this.state.shouldDisplayError && !!this.errorMessage,
       defaultStatic: true,
       autofocus: this.props.focused,

--- a/src/components/side_panel/criterion_form/date_criterion/date_criterion.xml
+++ b/src/components/side_panel/criterion_form/date_criterion/date_criterion.xml
@@ -18,6 +18,7 @@
       criterionType="props.criterion.type"
       disableFormulas="props.disableFormulas"
       focused="props.autofocus"
+      sheetId="props.sheetId"
     />
   </t>
 </templates>

--- a/src/components/side_panel/criterion_form/double_input_criterion/double_input_criterion.xml
+++ b/src/components/side_panel/criterion_form/double_input_criterion/double_input_criterion.xml
@@ -6,12 +6,14 @@
       criterionType="props.criterion.type"
       disableFormulas="props.disableFormulas"
       focused="props.autofocus"
+      sheetId="props.sheetId"
     />
     <CriterionInput
       value="props.criterion.values[1]"
       onValueChanged.bind="onSecondValueChanged"
       criterionType="props.criterion.type"
       disableFormulas="props.disableFormulas"
+      sheetId="props.sheetId"
     />
   </t>
 </templates>

--- a/src/components/side_panel/criterion_form/single_input_criterion/single_input_criterion.xml
+++ b/src/components/side_panel/criterion_form/single_input_criterion/single_input_criterion.xml
@@ -6,6 +6,7 @@
       criterionType="props.criterion.type"
       disableFormulas="props.disableFormulas"
       focused="props.autofocus"
+      sheetId="props.sheetId"
     />
   </t>
 </templates>

--- a/src/components/side_panel/criterion_form/value_in_list_criterion/value_in_list_criterion.xml
+++ b/src/components/side_panel/criterion_form/value_in_list_criterion/value_in_list_criterion.xml
@@ -16,6 +16,7 @@
           focused="value_index === state.focusedValueIndex"
           onBlur.bind="onBlurInput"
           disableFormulas="props.disableFormulas"
+          sheetId="props.sheetId"
         />
         <div
           class="o-dv-list-item-delete ms-2 o-button-icon"

--- a/src/components/side_panel/data_validation/data_validation_panel.ts
+++ b/src/components/side_panel/data_validation/data_validation_panel.ts
@@ -12,6 +12,7 @@ interface Props {
 interface State {
   mode: "list" | "edit";
   activeRule: DataValidationRule | undefined;
+  sheetId: UID | undefined;
 }
 
 export class DataValidationPanel extends Component<Props, SpreadsheetChildEnv> {
@@ -21,12 +22,13 @@ export class DataValidationPanel extends Component<Props, SpreadsheetChildEnv> {
   };
   static components = { DataValidationPreview, DataValidationEditor };
 
-  state = useState<State>({ mode: "list", activeRule: undefined });
+  state = useState<State>({ mode: "list", activeRule: undefined, sheetId: undefined });
 
   onPreviewClick(id: UID) {
     const sheetId = this.env.model.getters.getActiveSheetId();
     const rule = this.env.model.getters.getDataValidationRule(sheetId, id);
     if (rule) {
+      this.state.sheetId = sheetId;
       this.state.mode = "edit";
       this.state.activeRule = rule;
     }
@@ -34,18 +36,29 @@ export class DataValidationPanel extends Component<Props, SpreadsheetChildEnv> {
 
   addDataValidationRule() {
     this.state.mode = "edit";
+    this.state.sheetId = this.env.model.getters.getActiveSheetId();
     this.state.activeRule = undefined;
   }
 
   onExitEditMode() {
     this.state.mode = "list";
     this.state.activeRule = undefined;
+    this.state.sheetId = undefined;
   }
 
   localizeDVRule(rule?: DataValidationRule): DataValidationRule | undefined {
     if (!rule) return rule;
     const locale = this.env.model.getters.getLocale();
     return localizeDataValidationRule(rule, locale);
+  }
+
+  ruleExist(rule?: DataValidationRule): boolean {
+    if (!rule || !this.state.sheetId) {
+      return true;
+    }
+    return !!this.localizeDVRule(
+      this.env.model.getters.getDataValidationRule(this.state.sheetId, rule.id)
+    );
   }
 
   get validationRules() {

--- a/src/components/side_panel/data_validation/data_validation_panel.xml
+++ b/src/components/side_panel/data_validation/data_validation_panel.xml
@@ -1,7 +1,7 @@
 <templates>
   <t t-name="o-spreadsheet-DataValidationPanel">
     <div class="o-data-validation">
-      <t t-if="state.mode === 'list'">
+      <t t-if="state.mode === 'list' || !ruleExist(state.activeRule)">
         <div class="o-dv-preview-list">
           <t t-foreach="validationRules" t-as="rule" t-key="rule.id">
             <DataValidationPreview
@@ -15,7 +15,11 @@
         </div>
       </t>
       <t t-else="">
-        <DataValidationEditor rule="localizeDVRule(state.activeRule)" onExit.bind="onExitEditMode"/>
+        <DataValidationEditor
+          rule="localizeDVRule(state.activeRule)"
+          onExit.bind="onExitEditMode"
+          sheetId="state.sheetId"
+        />
       </t>
     </div>
   </t>

--- a/src/components/side_panel/data_validation/dv_editor/dv_editor.xml
+++ b/src/components/side_panel/data_validation/dv_editor/dv_editor.xml
@@ -1,11 +1,12 @@
 <templates>
   <t t-name="o-spreadsheet-DataValidationEditor">
     <div class="o-dv-form w-100 h-100">
-      <Section class="'o-dv-range'" title.translate="Apply to range">
+      <Section class="'o-dv-range'" title="rangeTitle">
         <SelectionInput
           ranges="state.rule.ranges"
           onSelectionChanged="(ranges) => this.onRangesChanged(ranges)"
           required="true"
+          availableOnSheetId="props.sheetId"
         />
       </Section>
       <Section class="'pt-0'">
@@ -24,6 +25,7 @@
             criterion="state.rule.criterion"
             onCriterionChanged.bind="onCriterionChanged"
             autofocus="state.isTypeUpdated"
+            sheetId="props.sheetId"
           />
         </div>
       </Section>
@@ -37,7 +39,7 @@
 
       <Section>
         <div class="o-sidePanelButtons">
-          <button t-on-click="props.onExit" class="o-dv-cancel o-button">Cancel</button>
+          <button t-on-click="onCancel" class="o-dv-cancel o-button">Cancel</button>
           <button t-on-click="onSave" class="o-dv-save o-button primary">Save</button>
         </div>
       </Section>

--- a/tests/conditional_formatting/conditional_formatting_panel_component.test.ts
+++ b/tests/conditional_formatting/conditional_formatting_panel_component.test.ts
@@ -2,7 +2,6 @@ import { ConditionalFormatPlugin } from "@odoo/o-spreadsheet-engine/plugins/core
 import { SpreadsheetChildEnv } from "@odoo/o-spreadsheet-engine/types/spreadsheet_env";
 import { Component } from "@odoo/owl";
 import { Model } from "../../src";
-import { ComposerFocusStore } from "../../src/components/composer/composer_focus_store";
 import { ConditionalFormattingPanel } from "../../src/components/side_panel/conditional_formatting/conditional_formatting";
 import { toHex, toZone } from "../../src/helpers";
 import {
@@ -24,6 +23,7 @@ import {
   DOMTarget,
   click,
   clickAndDrag,
+  clickCell,
   getTarget,
   keyDown,
   setInputValueAndTrigger,
@@ -442,8 +442,70 @@ describe("UI of conditional formats", () => {
       await click(fixture, selectors.buttonSave);
       expect(dispatch).not.toHaveBeenCalledWith("ADD_CONDITIONAL_FORMAT");
       const errorString = document.querySelector(selectors.error);
-      expect(errorString!.textContent).toBe("The range is invalid");
+      expect(errorString!.textContent).toBe('Invalid ranges: "hello"');
     });
+
+    test("cannot create a new CF with out of sheet range", async () => {
+      createSheet(model, { sheetId: "s2", name: "Sheet2", activate: false });
+      await click(fixture, selectors.buttonAdd);
+      await nextTick();
+
+      setInputValueAndTrigger(selectors.ruleEditor.range, "Sheet2!A1");
+
+      const dispatch = spyModelDispatch(model);
+      await click(fixture, selectors.buttonSave);
+      expect(dispatch).not.toHaveBeenCalledWith("ADD_CONDITIONAL_FORMAT");
+      const errorString = document.querySelector(selectors.error);
+      expect(errorString).toBeTruthy();
+      expect(errorString?.textContent).toContain(
+        'Ranges "Sheet2!A1" should target the sheet on which the conditional format is defined (Sheet1)'
+      );
+    });
+
+    test("cannot edit a CF range on another sheet", async () => {
+      createSheet(model, { sheetId: "s2", name: "Sheet2", activate: false });
+      await click(fixture, selectors.buttonAdd);
+      await nextTick();
+
+      model.dispatch("ACTIVATE_NEXT_SHEET");
+      await nextTick();
+
+      const range = fixture.querySelector<HTMLInputElement>(selectors.ruleEditor.range);
+      expect(range?.disabled).toBeTruthy();
+    });
+
+    test("Edit a CF formula on another sheet is properly adapted on confirm", async () => {
+      createSheet(model, { sheetId: "s2", name: "Sheet2", activate: false });
+
+      await click(fixture, selectors.buttonAdd);
+      await nextTick();
+      setInputValueAndTrigger(selectors.ruleEditor.range, "A1");
+
+      model.dispatch("ACTIVATE_NEXT_SHEET");
+      await nextTick();
+
+      await changeRuleOperatorType(fixture, "beginsWithText");
+      editStandaloneComposer(selectors.ruleEditor.editor.valueInput, "=A1");
+      await nextTick();
+
+      const dispatch = spyModelDispatch(model);
+
+      await click(fixture, selectors.buttonSave);
+      expect(dispatch).toHaveBeenNthCalledWith(1, "ADD_CONDITIONAL_FORMAT", {
+        cf: {
+          id: expect.any(String),
+          rule: {
+            operator: "beginsWithText",
+            style: expect.anything(),
+            type: "CellIsRule",
+            values: ["=Sheet2!A1"],
+          },
+        },
+        ranges: toRangesData(sheetId, "A1"),
+        sheetId,
+      });
+    });
+
     test("displayed range is updated if range changes", async () => {
       const previews = document.querySelectorAll(selectors.listPreview);
       expect(previews[0].querySelector(selectors.description.range)!.textContent).toBe("A1:A2");
@@ -888,7 +950,7 @@ describe("UI of conditional formats", () => {
     await setInputValueAndTrigger(selectors.colorScaleEditor.maxType, "number");
     await setInputValueAndTrigger(selectors.colorScaleEditor.maxValue, "10");
 
-    expect(errorMessages()).toEqual(["Minimum must be smaller then Maximum"]);
+    expect(errorMessages()).toEqual(["Minimum must be smaller than maximum"]);
     expect(fixture.querySelector(selectors.colorScaleEditor.minValue)?.className).toContain(
       "o-invalid"
     );
@@ -916,9 +978,9 @@ describe("UI of conditional formats", () => {
     await setInputValueAndTrigger(selectors.colorScaleEditor.maxValue, "10");
 
     expect(errorMessages()).toEqual([
-      "Minimum must be smaller then Maximum",
-      "Minimum must be smaller then Midpoint",
-      "Midpoint must be smaller then Maximum",
+      "Minimum must be smaller than maximum",
+      "Minimum must be smaller than midpoint",
+      "Midpoint must be smaller than maximum",
     ]);
     expect(fixture.querySelector(selectors.colorScaleEditor.minValue)?.className).toContain(
       "o-invalid"
@@ -946,7 +1008,7 @@ describe("UI of conditional formats", () => {
     setInputValueAndTrigger(selectors.colorScaleEditor.midValue, "50");
     await setInputValueAndTrigger(selectors.colorScaleEditor.maxValue, "25");
 
-    expect(errorMessages()).toEqual(["Midpoint must be smaller then Maximum"]);
+    expect(errorMessages()).toEqual(["Midpoint must be smaller than maximum"]);
     expect(fixture.querySelector(selectors.colorScaleEditor.minValue)?.className).not.toContain(
       "o-invalid"
     );
@@ -1056,7 +1118,7 @@ describe("UI of conditional formats", () => {
     await editStandaloneComposer(selectors.colorScaleEditor.minValueComposer, "=hello()");
     await editStandaloneComposer(selectors.colorScaleEditor.maxValueComposer, "=SUM(1,2)");
 
-    expect(errorMessages()).toEqual(["Invalid Minpoint formula"]);
+    expect(errorMessages()).toEqual(["Invalid minpoint formula"]);
     expect(isInputInvalid(selectors.colorScaleEditor.minValueComposer)).toBe(true);
     expect(fixture.querySelector(selectors.colorScaleEditor.midValue)).toBe(null);
     expect(isInputInvalid(selectors.colorScaleEditor.maxValueComposer)).toBe(false);
@@ -1077,7 +1139,7 @@ describe("UI of conditional formats", () => {
     editStandaloneComposer(selectors.colorScaleEditor.midValueComposer, "=hello()");
     await setInputValueAndTrigger(selectors.colorScaleEditor.maxValue, "3");
 
-    expect(errorMessages()).toEqual(["Invalid Midpoint formula"]);
+    expect(errorMessages()).toEqual(["Invalid midpoint formula"]);
     expect(isInputInvalid(selectors.colorScaleEditor.minValue)).toBe(false);
     expect(isInputInvalid(selectors.colorScaleEditor.midValueComposer)).toBe(true);
     expect(isInputInvalid(selectors.colorScaleEditor.maxValue)).toBe(false);
@@ -1112,7 +1174,7 @@ describe("UI of conditional formats", () => {
     await editStandaloneComposer(selectors.ruleEditor.editor.valueInput, "=suùù(");
     await click(fixture, selectors.buttonSave);
     expect(fixture.querySelector(".o-invalid")).not.toBeNull();
-    expect(errorMessages()).toEqual(["At least one of the provided values is an invalid formula"]);
+    expect(errorMessages()).toEqual(['Invalid formulas: "=suùù()"']);
   });
 
   test("changing rule type resets errors", async () => {
@@ -1158,7 +1220,7 @@ describe("UI of conditional formats", () => {
     await editStandaloneComposer(selectors.colorScaleEditor.maxValueComposer, "=hello()");
     await editStandaloneComposer(selectors.colorScaleEditor.minValueComposer, "=SUM(1,2)");
 
-    expect(errorMessages()).toEqual(["Invalid Maxpoint formula"]);
+    expect(errorMessages()).toEqual(["Invalid maxpoint formula"]);
   });
 
   test("Hides the 'No Color' button when the color picker is opened for the color scale", async () => {
@@ -1562,7 +1624,7 @@ describe("Integration tests", () => {
     expect(ranges[1]["value"]).toBe("C3");
   });
 
-  test("switching sheet resets CF Editor to list", async () => {
+  test("switching sheet doesn't resets CF Editor to list", async () => {
     const sheetId = model.getters.getActiveSheetId();
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: createEqualCF("2", { bold: true, fillColor: "#ff0000" }, "99"),
@@ -1578,29 +1640,31 @@ describe("Integration tests", () => {
     expect(fixture.querySelector(selectors.ruleEditor.range! as "input")!.value).toBe("A1:A2");
     activateSheet(model, "42");
     await nextTick();
-    expect(fixture.querySelector(selectors.ruleEditor.range)).toBeNull();
-    expect(fixture.querySelector(selectors.listPreview)).toBeDefined();
+    expect(fixture.querySelector(selectors.ruleEditor.range)).toBeDefined();
+    expect(fixture.querySelector(selectors.listPreview)).toBeNull();
   });
 
-  test("CF standalone composer becomes inactive on sheet change", async () => {
-    const sheetId = model.getters.getActiveSheetId();
-    model.dispatch("ADD_CONDITIONAL_FORMAT", {
-      cf: createEqualCF("2", { bold: true, fillColor: "#ff0000" }, "99"),
-      ranges: toRangesData(sheetId, "A1:A2"),
-      sheetId,
-    });
-    createSheet(model, { sheetId: "42" });
+  test("cannot edit a range on another sheet", async () => {
+    createSheet(model, { sheetId: "s2", name: "Sheet2", activate: false });
+
     const zone = toZone("A1:A2");
     parent.env.openSidePanel("ConditionalFormatting", { selection: [zone] });
     await nextTick();
-    await editStandaloneComposer(selectors.ruleEditor.editor.valueInput, "=", {
-      confirm: false,
-    });
-    const composerFocusStore = parent.env.getStore(ComposerFocusStore);
-    expect(composerFocusStore.activeComposer.id).toBe("standaloneComposer");
-    expect(composerFocusStore.activeComposer.editionMode).toBe("selecting");
-    activateSheet(model, "42");
+
+    await click(fixture, selectors.buttonAdd);
     await nextTick();
-    expect(composerFocusStore.activeComposer.editionMode).toBe("inactive");
+
+    clickCell(model, "A1");
+    await nextTick();
+
+    fixture.querySelector<HTMLInputElement>(selectors.ruleEditor.range)?.focus();
+
+    model.dispatch("ACTIVATE_NEXT_SHEET");
+    await nextTick();
+
+    clickCell(model, "C5");
+    await nextTick();
+    const range = fixture.querySelector<HTMLInputElement>(selectors.ruleEditor.range);
+    expect(range?.value).toBe("A1");
   });
 });

--- a/tests/data_validation/data_validation_list_component.test.ts
+++ b/tests/data_validation/data_validation_list_component.test.ts
@@ -8,6 +8,7 @@ import {
 import { SpreadsheetChildEnv } from "@odoo/o-spreadsheet-engine/types/spreadsheet_env";
 import { Model } from "../../src";
 import { CellComposerStore } from "../../src/components/composer/composer/cell_composer_store";
+import { DataValidationPanel } from "../../src/components/side_panel/data_validation/data_validation_panel";
 import { toZone } from "../../src/helpers";
 import { IsValueInListCriterion, UID } from "../../src/types";
 import {
@@ -30,12 +31,12 @@ import { getCellContent, getCellIcons } from "../test_helpers/getters_helpers";
 import {
   ComposerWrapper,
   getDataValidationRules,
+  mountComponentWithPortalTarget,
   mountComposerWrapper,
   mountSpreadsheet,
   nextTick,
   typeInComposerHelper,
 } from "../test_helpers/helpers";
-import { mountDataValidationPanel } from "./data_validation_generics_side_panel_component.test";
 
 let model: Model;
 let fixture: HTMLElement;
@@ -46,6 +47,13 @@ beforeEach(async () => {
   model = new Model();
   sheetId = model.getters.getActiveSheetId();
 });
+
+async function mountDataValidationPanel(model?: Model) {
+  return mountComponentWithPortalTarget(DataValidationPanel, {
+    model: model || new Model(),
+    props: { onCloseSidePanel: () => {} },
+  });
+}
 
 describe("Edit criterion in side panel", () => {
   describe("Value in list", () => {

--- a/tests/pivots/spreadsheet_pivot/__snapshots__/spreadsheet_pivot_side_panel.test.ts.snap
+++ b/tests/pivots/spreadsheet_pivot/__snapshots__/spreadsheet_pivot_side_panel.test.ts.snap
@@ -185,6 +185,7 @@ exports[`Spreadsheet pivot side panel It should correctly be displayed 1`] = `
                         
                         
                       </div>
+                      
                     </div>
                     
                     
@@ -618,6 +619,7 @@ exports[`Spreadsheet pivot side panel It should display only the selection input
                         </div>
                         
                       </div>
+                      
                     </div>
                     <span
                       class="text-danger sp_range_error_message"

--- a/tests/pivots/spreadsheet_pivot/spreadsheet_pivot_side_panel.test.ts
+++ b/tests/pivots/spreadsheet_pivot/spreadsheet_pivot_side_panel.test.ts
@@ -233,12 +233,6 @@ describe("Spreadsheet pivot side panel", () => {
       "=A1+Sheet2!A1"
     );
     await keyDown({ key: "Enter" });
-
-    activateSheet(model, sheet2Id);
-    // close the side panel and reopen it while the second sheet is active
-    await click(fixture.querySelector(".o-sidePanelClose")!);
-    env.openSidePanel("PivotSidePanel", { pivotId: "3" });
-    await nextTick();
     expect(fixture.querySelector(".pivot-dimension .o-composer")?.textContent).toEqual(
       "=Sheet1!A1+Sheet2!A1"
     );
@@ -249,7 +243,7 @@ describe("Spreadsheet pivot side panel", () => {
     env.openSidePanel("PivotSidePanel", { pivotId: "3" });
     await nextTick();
     expect(fixture.querySelector(".pivot-dimension .o-composer")?.textContent).toEqual(
-      "=A1+Sheet2!A1"
+      "=Sheet1!A1+Sheet2!A1"
     );
   });
 

--- a/tests/range_plugin.test.ts
+++ b/tests/range_plugin.test.ts
@@ -48,7 +48,7 @@ class PluginTestRange extends CorePlugin {
           break;
         case "RESIZE":
         case "MOVE":
-        case "CHANGE":
+        case "RENAME":
           this.ranges[i] = change.range;
           break;
       }

--- a/tests/side_panels/building_blocks/__snapshots__/data_series.test.ts.snap
+++ b/tests/side_panels/building_blocks/__snapshots__/data_series.test.ts.snap
@@ -53,6 +53,7 @@ exports[`Data Series Can render a data series component 1`] = `
         
         
       </div>
+      
     </div>
     
   </div>

--- a/tests/side_panels/building_blocks/__snapshots__/label_range.test.ts.snap
+++ b/tests/side_panels/building_blocks/__snapshots__/label_range.test.ts.snap
@@ -43,6 +43,7 @@ exports[`Label range Can add options to the label range component 1`] = `
         
         
       </div>
+      
     </div>
     <label
       class="o-checkbox d-flex align-items-center mt-2"
@@ -109,6 +110,7 @@ exports[`Label range Can render a label range component 1`] = `
         
         
       </div>
+      
     </div>
     
     


### PR DESCRIPTION
## Description:

Enforce that the ranges on CF & DV belong to the same sheet they do.

Task: [4072640](https://www.odoo.com/odoo/2328/tasks/4072640)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo