### PR TITLE
[FIX] collaborative: monkey party tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "rollup": "^2.38.5",
         "rollup-plugin-dts": "^4.2.0",
         "rollup-plugin-typescript2": "^0.34.1",
+        "seedrandom": "^3.0.5",
         "ts-jest": "^27.0.5",
         "typedoc": "0.24.8",
         "typedoc-plugin-markdown": "3.11.1",
@@ -9286,6 +9287,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/seedrandom": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
+      "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==",
+      "dev": true
+    },
     "node_modules/semver": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -18287,6 +18294,12 @@
       "requires": {
         "xmlchars": "^2.2.0"
       }
+    },
+    "seedrandom": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
+      "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==",
+      "dev": true
     },
     "semver": {
       "version": "6.3.0",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "rollup": "^2.38.5",
     "rollup-plugin-dts": "^4.2.0",
     "rollup-plugin-typescript2": "^0.34.1",
+    "seedrandom": "^3.0.5",
     "ts-jest": "^27.0.5",
     "typedoc": "0.24.8",
     "typedoc-plugin-markdown": "3.11.1",

--- a/src/collaborative/ot/ot_specific.ts
+++ b/src/collaborative/ot/ot_specific.ts
@@ -92,6 +92,9 @@ function createSheetTransformation(
   cmd: CreateSheetCommand,
   executed: CreateSheetCommand
 ): CreateSheetCommand {
+  if (cmd.sheetId === executed.sheetId) {
+    cmd = { ...cmd, sheetId: `${cmd.sheetId}~` };
+  }
   if (cmd.name === executed.name) {
     return {
       ...cmd,

--- a/src/helpers/zones.ts
+++ b/src/helpers/zones.ts
@@ -102,19 +102,22 @@ export function toZoneWithoutBoundaryChanges(xc: string): UnboundedZone {
  */
 export function toUnboundedZone(xc: string): UnboundedZone {
   const zone = toZoneWithoutBoundaryChanges(xc);
-  if (zone.right !== undefined && zone.right < zone.left) {
-    const tmp = zone.left;
-    zone.left = zone.right;
-    zone.right = tmp;
-  }
-  if (zone.bottom !== undefined && zone.bottom < zone.top) {
-    const tmp = zone.top;
-    zone.top = zone.bottom;
-    zone.bottom = tmp;
-  }
+  reorderZone(zone);
   return zone;
 }
 
+export function reorderZone<Z extends UnboundedZone | Zone>(zone: Z) {
+  if (zone.right !== undefined && zone.right < zone.left) {
+    const right = zone.left;
+    zone.left = zone.right;
+    zone.right = right;
+  }
+  if (zone.bottom !== undefined && zone.bottom < zone.top) {
+    const bottom = zone.top;
+    zone.top = zone.bottom;
+    zone.bottom = bottom;
+  }
+}
 /**
  * Convert from a cartesian reference to a Zone.
  * Will return throw an error if given a unbounded zone (eg : A:A).

--- a/src/history/local_history.ts
+++ b/src/history/local_history.ts
@@ -33,7 +33,6 @@ export class LocalHistory extends EventBus implements CommandHandler<Command> {
     this.session.on("new-local-state-update", this, this.onNewLocalStateUpdate);
     this.session.on("revision-undone", this, ({ commands }) => this.selectiveUndo(commands));
     this.session.on("revision-redone", this, ({ commands }) => this.selectiveRedo(commands));
-    this.session.on("pending-revisions-dropped", this, ({ revisionIds }) => this.drop(revisionIds));
     this.session.on("snapshot", this, () => {
       this.undoStack = [];
       this.redoStack = [];
@@ -91,11 +90,6 @@ export class LocalHistory extends EventBus implements CommandHandler<Command> {
 
   canRedo(): boolean {
     return this.redoStack.length > 0;
-  }
-
-  private drop(revisionIds: UID[]) {
-    this.undoStack = this.undoStack.filter((id) => !revisionIds.includes(id));
-    this.redoStack = [];
   }
 
   private onNewLocalStateUpdate({ id }: { id: UID }) {

--- a/src/history/selective_history.ts
+++ b/src/history/selective_history.ts
@@ -98,9 +98,16 @@ export class SelectiveHistory<T = unknown> {
     this.insert(redoId, this.buildEmpty(redoId), insertAfter);
   }
 
-  drop(operationId: UID) {
+  rebase(operationId: UID) {
+    const operation = this.get(operationId);
+    const execution = [...this.tree.execution(this.HEAD_BRANCH).startAfter(operationId)];
     this.revertBefore(operationId);
+    const baseId = this.HEAD_OPERATION.id;
     this.tree.drop(operationId);
+    this.insert(operationId, operation, baseId);
+    for (const { operation } of execution) {
+      this.insert(operation.id, operation.data, this.HEAD_OPERATION.id);
+    }
   }
 
   /**

--- a/src/plugins/core/cell.ts
+++ b/src/plugins/core/cell.ts
@@ -96,6 +96,10 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
         return this.checkValidations(cmd, this.checkCellOutOfSheet, this.checkUselessUpdateCell);
       case "CLEAR_CELL":
         return this.checkValidations(cmd, this.checkCellOutOfSheet, this.checkUselessClearCell);
+      case "UPDATE_CELL_POSITION":
+        return !cmd.cellId || this.cells[cmd.sheetId]?.[cmd.cellId]
+          ? CommandResult.Success
+          : CommandResult.InvalidCellId;
       default:
         return CommandResult.Success;
     }

--- a/src/plugins/core/cell.ts
+++ b/src/plugins/core/cell.ts
@@ -38,7 +38,7 @@ const LINK_STYLE = { textColor: LINK_COLOR };
 
 interface CoreState {
   // this.cells[sheetId][cellId] --> cell|undefined
-  cells: Record<UID, Record<UID, Cell | undefined>>;
+  cells: Record<UID, Record<UID, Cell | undefined> | undefined>;
   nextId: number;
 }
 
@@ -139,6 +139,9 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
           format: "",
         });
         break;
+      case "DELETE_SHEET": {
+        this.history.update("cells", cmd.sheetId, undefined);
+      }
     }
   }
 

--- a/src/plugins/core/sheet.ts
+++ b/src/plugins/core/sheet.ts
@@ -102,6 +102,9 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
       case "CREATE_SHEET": {
         return this.checkValidations(cmd, this.checkSheetName, this.checkSheetPosition);
       }
+      case "DUPLICATE_SHEET": {
+        return this.sheets[cmd.sheetIdTo] ? CommandResult.DuplicatedSheetId : CommandResult.Success;
+      }
       case "MOVE_SHEET":
         const currentIndex = this.orderedSheetIds.indexOf(cmd.sheetId);
         if (cmd.direction === "left") {

--- a/src/plugins/core/sheet.ts
+++ b/src/plugins/core/sheet.ts
@@ -1052,6 +1052,9 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
       zones.push(...cmd.target);
     }
     if ("ranges" in cmd && Array.isArray(cmd.ranges)) {
+      if (cmd.ranges.some((rangeData) => !this.getters.tryGetSheet(rangeData._sheetId))) {
+        return CommandResult.InvalidSheetId;
+      }
       zones.push(
         ...cmd.ranges.map((rangeData) => this.getters.getRangeFromRangeData(rangeData).zone)
       );

--- a/src/types/collaborative/session.ts
+++ b/src/types/collaborative/session.ts
@@ -50,11 +50,6 @@ export interface NewLocalStateUpdateEvent {
   id: UID;
 }
 
-export interface RevisionsDroppedEvent {
-  type: "pending-revisions-dropped";
-  revisionIds: UID[];
-}
-
 export interface SnapshotEvent {
   type: "snapshot";
 }
@@ -66,7 +61,6 @@ export type CollaborativeEvent =
   | RevisionAcknowledgedEvent
   | RevisionUndone
   | RevisionRedone
-  | RevisionsDroppedEvent
   | SnapshotEvent
   | CollaborativeEventReceived;
 

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -47,7 +47,9 @@ export interface SheetDependentCommand {
   sheetId: UID;
 }
 
-export function isSheetDependent(cmd: CoreCommand): boolean {
+export function isSheetDependent(
+  cmd: CoreCommand
+): cmd is Extract<CoreCommand, SheetDependentCommand> {
   return "sheetId" in cmd;
 }
 
@@ -56,7 +58,9 @@ export interface GridDependentCommand {
   dimension: Dimension;
 }
 
-export function isGridDependent(cmd: CoreCommand): boolean {
+export function isGridDependent(
+  cmd: CoreCommand
+): cmd is Extract<CoreCommand, GridDependentCommand> {
   return "dimension" in cmd && "sheetId" in cmd;
 }
 
@@ -65,7 +69,9 @@ export interface TargetDependentCommand {
   target: Zone[];
 }
 
-export function isTargetDependent(cmd: CoreCommand): boolean {
+export function isTargetDependent(
+  cmd: CoreCommand
+): cmd is Extract<CoreCommand, TargetDependentCommand> {
   return "target" in cmd && "sheetId" in cmd;
 }
 
@@ -73,7 +79,9 @@ export interface RangesDependentCommand {
   ranges: RangeData[];
 }
 
-export function isRangeDependant(cmd: CoreCommand): boolean {
+export function isRangeDependant(
+  cmd: CoreCommand
+): cmd is Extract<CoreCommand, RangesDependentCommand> {
   return "ranges" in cmd;
 }
 
@@ -83,7 +91,9 @@ export interface PositionDependentCommand {
   row: number;
 }
 
-export function isPositionDependent(cmd: CoreCommand): boolean {
+export function isPositionDependent(
+  cmd: CoreCommand
+): cmd is Extract<CoreCommand, PositionDependentCommand> {
   return "col" in cmd && "row" in cmd && "sheetId" in cmd;
 }
 
@@ -1056,6 +1066,7 @@ export const enum CommandResult {
   InvalidRange,
   InvalidZones,
   InvalidSheetId,
+  InvalidCellId,
   InputAlreadyFocused,
   MaximumRangesReached,
   InvalidInputId,

--- a/tests/collaborative/collaborative.test.ts
+++ b/tests/collaborative/collaborative.test.ts
@@ -278,6 +278,12 @@ describe("Multi users synchronisation", () => {
     ]);
     undo(bob);
     expect([alice, bob, charlie]).toHaveSynchronizedValue((user) => getCell(user, "B3"), undefined);
+    expect([alice, bob, charlie]).toHaveSynchronizedValue(
+      (user) => getCellContent(user, "C1"),
+      "hello"
+    );
+    undo(bob);
+    expect([alice, bob, charlie]).toHaveSynchronizedValue((user) => getCell(user, "B3"), undefined);
     expect([alice, bob, charlie]).toHaveSynchronizedValue((user) => getCell(user, "C1"), undefined);
     expect(undo(bob)).toBeCancelledBecause(CommandResult.EmptyUndoStack);
   });

--- a/tests/collaborative/collaborative_monkey_party.test.ts
+++ b/tests/collaborative/collaborative_monkey_party.test.ts
@@ -1,0 +1,297 @@
+import seedrandom from "seedrandom";
+import { Model } from "../../src";
+import { deepCopy, deepEquals, range, reorderZone, zoneToXc } from "../../src/helpers";
+import {
+  Command,
+  CoreCommand,
+  isPositionDependent,
+  isRangeDependant,
+  isSheetDependent,
+  isTargetDependent,
+  UnboundedZone,
+} from "../../src/types";
+import { getRangeValues } from "../test_helpers";
+import { TEST_COMMANDS } from "../test_helpers/constants";
+import { MockTransportService } from "../__mocks__/transport_service";
+import { setupCollaborativeEnv } from "./collaborative_helpers";
+
+/**
+ * The monkey party test simulates random user actions in a collaborative environment
+ * to ensure all users remain synchronized.
+ *
+ * If a randomly generated test fails, it minimizes the failing commands and
+ * generates a minimal test case that you can copy-paste from the console.
+ *
+ * By default, this test runs once with a deterministic seed to prevent
+ * non-deterministic behavior in the CI pipeline.
+ *
+ * It is intended to be run locally from time to time by increasing `PARTY_COUNT`.
+ */
+
+const PARTY_COUNT: number = 1; // increase this number to run more tests and enjoy the parties 🐵🎉
+
+describe("monkey party", () => {
+  const now = Date.now();
+  const seeds = range(0, PARTY_COUNT).map((i) => (now + i).toString());
+
+  test.each(PARTY_COUNT === 1 ? ["deterministic-seed"] : seeds)(
+    "monkey party with seed %s",
+    (seed) => {
+      seedrandom(seed, { global: true });
+      const { network, alice, bob, charlie } = setupCollaborativeEnv();
+
+      // duplicate commands to test the same command interacting with itself
+      const commands = deepCopy(Object.values(TEST_COMMANDS).concat(Object.values(TEST_COMMANDS)));
+      addUndoRedo(commands);
+      randomizeCommandsPayload(commands);
+
+      const actions = assignUser(shuffle(commands), [alice, bob, charlie]);
+      const concurrentActions = randomizeConcurrentActions(actions);
+      const { fail, executedActions } = run(network, [alice, bob, charlie], concurrentActions);
+      if (fail) {
+        const generatedTestCode = actionsToTestCode(
+          `failed with seed ${seed}`,
+          minimizeFailingCommands(executedActions)
+        );
+        console.log(generatedTestCode);
+        expect([alice, bob, charlie]).toHaveSynchronizedExportedData();
+        throw new Error(`Failed with seed ${seed}!`);
+      }
+      expect([alice, bob, charlie]).toHaveSynchronizedExportedData();
+    }
+  );
+});
+
+function addUndoRedo(commands: CoreCommand[]) {
+  const undoRedoRatio = 0.2;
+  const undoRedoCount = Math.floor(commands.length * undoRedoRatio);
+  commands.push(
+    ...new Array(undoRedoCount).fill({ type: "REQUEST_UNDO" }),
+    ...new Array(undoRedoCount).fill({ type: "REQUEST_REDO" })
+  );
+}
+
+type UserAction = { command: Command; user: Model };
+
+function randomChoice<T>(arr: T[]): T {
+  return arr[Math.floor(Math.random() * arr.length)];
+}
+
+function shuffle<T>(arr: T[]): T[] {
+  return arr
+    .map((value) => ({ value, sort: Math.random() }))
+    .sort((a, b) => a.sort - b.sort)
+    .map(({ value }) => value);
+}
+
+/**
+ * Returns a random integer between min (inclusive) and max (inclusive).
+ */
+function randomIntFromInterval(min: number, max: number) {
+  return Math.floor(Math.random() * (max - min + 1) + min);
+}
+
+function randomizeConcurrentActions(commands: UserAction[]): UserAction[][] {
+  const result: UserAction[][] = [];
+  while (commands.length) {
+    const groupSize = randomIntFromInterval(1, 6);
+    result.push(commands.splice(0, groupSize));
+  }
+  return result;
+}
+
+function assignUser(commands: CoreCommand[], users: Model[]): UserAction[] {
+  return commands.map((cmd) => ({ command: cmd, user: randomChoice(users) }));
+}
+
+function actionsToTestCode(testTitle: string, actions: UserAction[][]) {
+  const code: string[] = [];
+  code.push(`test("${testTitle}", () => {`);
+  code.push("const { network, alice, bob, charlie } = setupCollaborativeEnv();");
+  for (const commandGroup of actions) {
+    if (commandGroup.length === 1) {
+      appendCommand(code, commandGroup[0]);
+    } else {
+      code.push("network.concurrent(() => {");
+      for (const action of commandGroup) {
+        appendCommand(code, action);
+      }
+      code.push("});");
+    }
+  }
+  code.push("expect([alice, bob, charlie]).toHaveSynchronizedExportedData();", "});");
+  return code.join("\n");
+}
+
+function appendCommand(code: string[], { user, command }: UserAction) {
+  const userName = user.getters.getClient().name.toLowerCase();
+  if (command.type === "REQUEST_UNDO") {
+    code.push(`undo(${userName});`);
+  } else if (command.type === "REQUEST_REDO") {
+    code.push(`redo(${userName});`);
+  } else {
+    const cmdPayload = JSON.stringify({ ...command, type: undefined });
+    code.push(`${userName}.dispatch("${command.type}", ${cmdPayload});`);
+  }
+}
+
+function rerunTest(actions: UserAction[][]) {
+  const { network, alice, bob, charlie } = setupCollaborativeEnv();
+  const newUsers = { alice, bob, charlie };
+  for (const concurrentChunk of actions) {
+    for (const action of concurrentChunk) {
+      action.user = newUsers[action.user.getters.getClient().name.toLowerCase()];
+    }
+  }
+  return run(network, [alice, bob, charlie], actions);
+}
+
+function minimizeFailingCommands(actions: UserAction[][]) {
+  // try removing concurrent actions chunk by chunk
+  let reduced = true;
+  while (reduced) {
+    reduced = false;
+    for (let chunkIndex = 0; chunkIndex < actions.length; chunkIndex++) {
+      const testCase = actions.slice(0, chunkIndex).concat(actions.slice(chunkIndex + 1));
+
+      const { fail } = rerunTest(testCase);
+      if (fail) {
+        actions = testCase;
+        reduced = true;
+      } else {
+        // reduce the chunk command-by-command
+        let chunkReduced = true;
+        while (chunkReduced) {
+          chunkReduced = false;
+          const chunk = actions[chunkIndex];
+          for (let cmdIndex = 0; cmdIndex < chunk.length; cmdIndex++) {
+            const testChunkCase = [...actions];
+            testChunkCase[chunkIndex] = chunk.slice(0, cmdIndex).concat(chunk.slice(cmdIndex + 1));
+            const { fail } = rerunTest(testChunkCase);
+            if (fail) {
+              actions = testChunkCase;
+              chunkReduced = true;
+            }
+          }
+        }
+      }
+    }
+  }
+  return actions;
+}
+
+function areSynced(users: Model[]): boolean {
+  for (let i = 0; i < users.length - 1; i++) {
+    if (!deepEquals(users[i].exportData(), users[i + 1].exportData())) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function evaluationsAreSynced(users: Model[]): boolean {
+  for (let i = 0; i < users.length - 1; i++) {
+    for (const sheetId of users[i].getters.getSheetIds()) {
+      const sheetZoneXc = zoneToXc(users[i].getters.getSheetZone(sheetId));
+      const valuesUserA = getRangeValues(users[i], sheetZoneXc, sheetId);
+      const valuesUserB = getRangeValues(users[i + 1], sheetZoneXc, sheetId);
+      if (!deepEquals(valuesUserA, valuesUserB)) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+function run(network: MockTransportService, users: Model[], actions: UserAction[][]) {
+  const executed: UserAction[][] = [];
+  for (const commandGroup of actions) {
+    const concurrentlyExecuted: UserAction[] = [];
+    executed.push(concurrentlyExecuted);
+    try {
+      network.concurrent(() => {
+        for (const { command, user } of commandGroup) {
+          const result = user.dispatch(command.type, command);
+          if (result.isSuccessful) {
+            concurrentlyExecuted.push({ command, user });
+          }
+        }
+      });
+      expect(evaluationsAreSynced(users)).toBe(true);
+    } catch (e) {
+      console.error(e);
+      concurrentlyExecuted.length = 0;
+      concurrentlyExecuted.push(...commandGroup);
+      return {
+        fail: true,
+        executedActions: executed,
+      };
+    }
+  }
+  return {
+    fail: !areSynced(users),
+    executedActions: executed,
+  };
+}
+
+function randomizeCommandsPayload(commands: CoreCommand[]) {
+  const allSheetIds = commands.map((cmd) => cmd.sheetId).filter(Boolean);
+  for (const command of commands) {
+    if (isSheetDependent(command)) {
+      command.sheetId = randomChoice(allSheetIds);
+    }
+    if (isTargetDependent(command)) {
+      command.target = Array.from(range(1, randomIntFromInterval(2, 3)), generateRandomZone);
+    } else if (isPositionDependent(command)) {
+      command.col = randomIntFromInterval(0, 10);
+      command.row = randomIntFromInterval(0, 10);
+    } else if (isRangeDependant(command)) {
+      command.ranges = command.ranges.map((range) => ({
+        _sheetId: randomChoice(allSheetIds),
+        _zone: generateUnboundedRandomZone(),
+      }));
+    }
+  }
+}
+
+function generateUnboundedRandomZone(): UnboundedZone {
+  switch (randomChoice(["bounded", "full-row", "full-col"])) {
+    case "full-row": {
+      const hasHeader = Math.random() > 0.5;
+      const zone = {
+        hasHeader,
+        left: !hasHeader ? 0 : randomIntFromInterval(0, 10),
+        right: undefined,
+        top: randomIntFromInterval(0, 10),
+        bottom: randomIntFromInterval(0, 10),
+      };
+      reorderZone(zone);
+      return zone;
+    }
+    case "full-col": {
+      const hasHeader = Math.random() > 0.5;
+      const zone = {
+        hasHeader,
+        left: randomIntFromInterval(0, 10),
+        right: randomIntFromInterval(0, 10),
+        top: !hasHeader ? 0 : randomIntFromInterval(0, 10),
+        bottom: undefined,
+      };
+      reorderZone(zone);
+      return zone;
+    }
+    default:
+      return generateRandomZone();
+  }
+}
+
+function generateRandomZone() {
+  const zone = {
+    left: randomIntFromInterval(0, 10),
+    right: randomIntFromInterval(0, 10),
+    top: randomIntFromInterval(0, 10),
+    bottom: randomIntFromInterval(0, 10),
+  };
+  reorderZone(zone);
+  return zone;
+}

--- a/tests/plugins/conditional_formatting.test.ts
+++ b/tests/plugins/conditional_formatting.test.ts
@@ -306,6 +306,15 @@ describe("conditional format", () => {
     });
   });
 
+  test("Conditional formatting with an unbounded range on an invalid sheet", () => {
+    const result = model.dispatch("ADD_CONDITIONAL_FORMAT", {
+      cf: createEqualCF("4", { fillColor: "#0000FF" }, "2"),
+      ranges: toRangesData("not-a-valid-sheet-id", "B1,A1:A"),
+      sheetId,
+    });
+    expect(result).toBeCancelledBecause(CommandResult.InvalidSheetId);
+  });
+
   test("Conditional formatting with empty target", () => {
     const result = model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: createEqualCF("4", { fillColor: "#0000FF" }, "2"),

--- a/tests/plugins/sheets.test.ts
+++ b/tests/plugins/sheets.test.ts
@@ -785,6 +785,18 @@ describe("sheets", () => {
     expect(model.exportData().sheets[1].merges).toHaveLength(1);
   });
 
+  test("cannot duplicate a sheet twice with the same new id", () => {
+    const model = new Model();
+    const firstSheetId = model.getters.getActiveSheetId();
+    const duplicatedSheetId = "new-sheet-id";
+    model.dispatch("DUPLICATE_SHEET", { sheetId: firstSheetId, sheetIdTo: duplicatedSheetId });
+    const result = model.dispatch("DUPLICATE_SHEET", {
+      sheetId: firstSheetId,
+      sheetIdTo: duplicatedSheetId,
+    });
+    expect(result).toBeCancelledBecause(CommandResult.DuplicatedSheetId);
+  });
+
   test("Can delete the active sheet", () => {
     const model = new Model();
     const sheet1 = model.getters.getActiveSheetId();

--- a/tests/plugins/sheets.test.ts
+++ b/tests/plugins/sheets.test.ts
@@ -11,6 +11,7 @@ import {
   createSheetWithName,
   deleteColumns,
   deleteRows,
+  deleteSheet,
   freezeColumns,
   freezeRows,
   hideColumns,
@@ -238,6 +239,17 @@ describe("sheets", () => {
     const model = new Model();
     setCellContent(model, "A1", "hello");
     expect(getCell(model, "A1", "invalidSheetId")!).toBe(undefined);
+  });
+
+  test("delete then create a sheet with the same id", () => {
+    const model = new Model();
+    const newSheetId = "42";
+    createSheet(model, { sheetId: newSheetId });
+    setCellContent(model, "A1", "hello", newSheetId);
+    deleteSheet(model, newSheetId);
+    createSheet(model, { sheetId: newSheetId });
+    expect(getCell(model, "A1", newSheetId)).toBeUndefined();
+    expect(model.exportData().sheets[1].cells).toEqual({});
   });
 
   test("cannot activate an invalid sheet", () => {

--- a/tests/test_helpers/constants.ts
+++ b/tests/test_helpers/constants.ts
@@ -1,0 +1,249 @@
+import { BACKGROUND_CHART_COLOR, DEFAULT_BORDER_DESC } from "../../src/constants";
+import { CoreCommand, CoreCommandTypes } from "../../src/types";
+import { target, toRangesData } from "./helpers";
+
+type CommandMapping = {
+  [key in CoreCommandTypes]: Extract<CoreCommand, { type: key }>;
+};
+
+const TEST_CHART_DATA = {
+  basicChart: {
+    type: "bar" as const,
+    dataSets: ["B1:B4"],
+    labelRange: "A2:A4",
+    dataSetsHaveTitle: true,
+    title: "hello",
+    background: BACKGROUND_CHART_COLOR,
+    stacked: false,
+    legendPosition: "top" as const,
+    verticalAxisPosition: "left" as const,
+  },
+};
+
+export const TEST_COMMANDS: CommandMapping = {
+  UPDATE_CELL: {
+    type: "UPDATE_CELL",
+    col: 0,
+    row: 0,
+    content: "hello",
+    sheetId: "Sheet1",
+  },
+  UPDATE_CELL_POSITION: {
+    type: "UPDATE_CELL_POSITION",
+    cellId: "Id",
+    sheetId: "Sheet1",
+    row: 0,
+    col: 0,
+  },
+  CLEAR_CELL: {
+    type: "CLEAR_CELL",
+    col: 0,
+    row: 0,
+    sheetId: "Sheet1",
+  },
+  DELETE_CONTENT: {
+    type: "DELETE_CONTENT",
+    target: target("A1"),
+    sheetId: "Sheet1",
+  },
+  ADD_MERGE: {
+    type: "ADD_MERGE",
+    target: target("A1:A2"),
+    sheetId: "Sheet1",
+  },
+  REMOVE_MERGE: {
+    type: "REMOVE_MERGE",
+    target: target("A1:A2"),
+    sheetId: "Sheet1",
+  },
+  SET_FORMATTING: {
+    type: "SET_FORMATTING",
+    target: target("A1"),
+    style: { bold: true },
+    sheetId: "Sheet1",
+  },
+  CLEAR_FORMATTING: {
+    type: "CLEAR_FORMATTING",
+    target: target("A1"),
+    sheetId: "Sheet1",
+  },
+  SET_BORDER: {
+    type: "SET_BORDER",
+    col: 0,
+    row: 0,
+    border: { top: DEFAULT_BORDER_DESC },
+    sheetId: "Sheet1",
+  },
+  CREATE_FILTER_TABLE: {
+    type: "CREATE_FILTER_TABLE",
+    target: target("A1"),
+    sheetId: "Sheet1",
+  },
+  REMOVE_FILTER_TABLE: {
+    type: "REMOVE_FILTER_TABLE",
+    target: target("A1"),
+    sheetId: "Sheet1",
+  },
+  HIDE_SHEET: {
+    type: "HIDE_SHEET",
+    sheetId: "Sheet1",
+  },
+  CREATE_SHEET: {
+    type: "CREATE_SHEET",
+    sheetId: "newSheetId",
+    name: "newSheetName",
+    position: 0,
+  },
+  DUPLICATE_SHEET: {
+    type: "DUPLICATE_SHEET",
+    sheetId: "Sheet1",
+    sheetIdTo: "duplicateSheetId",
+  },
+  MOVE_SHEET: {
+    type: "MOVE_SHEET",
+    sheetId: "Sheet1",
+    direction: "left",
+  },
+  DELETE_SHEET: {
+    type: "DELETE_SHEET",
+    sheetId: "Sheet1",
+  },
+  RENAME_SHEET: {
+    type: "RENAME_SHEET",
+    sheetId: "Sheet1",
+    name: "newName",
+  },
+  SHOW_SHEET: {
+    type: "SHOW_SHEET",
+    sheetId: "Sheet1",
+  },
+  ADD_CONDITIONAL_FORMAT: {
+    type: "ADD_CONDITIONAL_FORMAT",
+    ranges: toRangesData("sheetId", "A1"),
+    cf: {
+      id: "cfId",
+      rule: {
+        values: ["1"],
+        operator: "Equal",
+        type: "CellIsRule",
+        style: { fillColor: "#FF0000" },
+      },
+    },
+    sheetId: "Sheet1",
+  },
+  REMOVE_CONDITIONAL_FORMAT: {
+    type: "REMOVE_CONDITIONAL_FORMAT",
+    id: "cfId",
+    sheetId: "Sheet1",
+  },
+  MOVE_CONDITIONAL_FORMAT: {
+    type: "MOVE_CONDITIONAL_FORMAT",
+    sheetId: "Sheet1",
+    cfId: "cfId",
+    direction: "up",
+  },
+  CREATE_FIGURE: {
+    type: "CREATE_FIGURE",
+    figure: {
+      id: "figureId",
+      tag: "tag",
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 100,
+    },
+    sheetId: "Sheet1",
+  },
+  DELETE_FIGURE: {
+    type: "DELETE_FIGURE",
+    id: "figureId",
+    sheetId: "Sheet1",
+  },
+  UPDATE_FIGURE: {
+    type: "UPDATE_FIGURE",
+    id: "figureId",
+    sheetId: "Sheet1",
+  },
+  CREATE_CHART: {
+    type: "CREATE_CHART",
+    definition: TEST_CHART_DATA.basicChart,
+    position: { x: 0, y: 0 },
+    size: { width: 200, height: 200 },
+    id: "figureId",
+    sheetId: "Sheet1",
+  },
+  UPDATE_CHART: {
+    type: "UPDATE_CHART",
+    definition: TEST_CHART_DATA.basicChart,
+    id: "figureId",
+    sheetId: "Sheet1",
+  },
+  RESIZE_COLUMNS_ROWS: {
+    type: "RESIZE_COLUMNS_ROWS",
+    dimension: "ROW",
+    elements: [0],
+    size: 100,
+    sheetId: "Sheet1",
+  },
+  ADD_COLUMNS_ROWS: {
+    type: "ADD_COLUMNS_ROWS",
+    position: "after",
+    dimension: "ROW",
+    base: 0,
+    quantity: 1,
+    sheetId: "Sheet1",
+  },
+  REMOVE_COLUMNS_ROWS: {
+    type: "REMOVE_COLUMNS_ROWS",
+    dimension: "ROW",
+    elements: [0],
+    sheetId: "Sheet1",
+  },
+  FREEZE_COLUMNS: {
+    type: "FREEZE_COLUMNS",
+    sheetId: "Sheet1",
+    quantity: 1,
+  },
+  FREEZE_ROWS: {
+    type: "FREEZE_ROWS",
+    sheetId: "Sheet1",
+    quantity: 1,
+  },
+  UNFREEZE_COLUMNS: {
+    type: "UNFREEZE_COLUMNS",
+    sheetId: "Sheet1",
+  },
+  UNFREEZE_ROWS: {
+    type: "UNFREEZE_ROWS",
+    sheetId: "Sheet1",
+  },
+  UNFREEZE_COLUMNS_ROWS: {
+    type: "UNFREEZE_COLUMNS_ROWS",
+    sheetId: "Sheet1",
+  },
+  HIDE_COLUMNS_ROWS: {
+    type: "HIDE_COLUMNS_ROWS",
+    dimension: "ROW",
+    elements: [0],
+    sheetId: "Sheet1",
+  },
+  UNHIDE_COLUMNS_ROWS: {
+    type: "UNHIDE_COLUMNS_ROWS",
+    dimension: "ROW",
+    elements: [0],
+    sheetId: "Sheet1",
+  },
+  SET_GRID_LINES_VISIBILITY: {
+    type: "SET_GRID_LINES_VISIBILITY",
+    sheetId: "Sheet1",
+    areGridLinesVisible: true,
+  },
+  MOVE_RANGES: {
+    type: "MOVE_RANGES",
+    target: target("A1"),
+    sheetId: "Sheet1",
+    targetSheetId: "Sheet1",
+    col: 0,
+    row: 0,
+  },
+};


### PR DESCRIPTION
## Description:

This commit introduces a test that simulates random user actions in a
collaborative environment to ensure that all users remains synchronized.

This already revealed many, *many* issues. And some of them would have
been impossible to spot without this.

If a randomly generated test fails, it minimizes the failing commands and
generates a minimal test case that you can copy-paste from the console.

By default, this test runs only once, with a deterministic seed to avoid
non-deterministic tests on the CI pipeline.

This is meant to be run locally, from time to time, by increasing
`PARTY_COUNT`.

Task: [4567308](https://www.odoo.com/odoo/2328/tasks/4567308)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo