### PR TITLE
[FIX] composer: multiline composer breaks the topbar layout

### DIFF
--- a/src/components/composer/top_bar_composer/top_bar_composer.ts
+++ b/src/components/composer/top_bar_composer/top_bar_composer.ts
@@ -24,6 +24,10 @@ const FX_SVG = /*xml*/ `
 `;
 
 css/* scss */ `
+  .o-topbar-composer-container {
+    height: ${TOPBAR_TOOLBAR_HEIGHT}px;
+  }
+
   .o-topbar-composer {
     height: fit-content;
     margin-top: -1px;

--- a/src/components/composer/top_bar_composer/top_bar_composer.xml
+++ b/src/components/composer/top_bar_composer/top_bar_composer.xml
@@ -1,16 +1,18 @@
 <templates>
   <t t-name="o-spreadsheet-TopBarComposer">
-    <div
-      class="o-topbar-composer bg-white user-select-text"
-      t-on-click.stop=""
-      t-att-style="containerStyle">
-      <Composer
-        focus="focus"
-        inputStyle="composerStyle"
-        onComposerContentFocused.bind="onFocus"
-        composerStore="composerStore"
-        placeholder="composerStore.placeholder"
-      />
+    <div class="o-topbar-composer-container w-100">
+      <div
+        class="o-topbar-composer position-relative bg-white user-select-text"
+        t-on-click.stop=""
+        t-att-style="containerStyle">
+        <Composer
+          focus="focus"
+          inputStyle="composerStyle"
+          onComposerContentFocused.bind="onFocus"
+          composerStore="composerStore"
+          placeholder="composerStore.placeholder"
+        />
+      </div>
     </div>
   </t>
 </templates>

--- a/tests/__snapshots__/top_bar_component.test.ts.snap
+++ b/tests/__snapshots__/top_bar_component.test.ts.snap
@@ -589,25 +589,29 @@ exports[`TopBar component can set cell format 1`] = `
           
         </div>
         <div
-          class="o-topbar-composer bg-white user-select-text"
-          style="border-color:#E0E2E4; border-right:none; "
+          class="o-topbar-composer-container w-100"
         >
           <div
-            class="o-composer-container w-100 h-100"
+            class="o-topbar-composer position-relative bg-white user-select-text"
+            style="border-color:#E0E2E4; border-right:none; "
           >
             <div
-              class="d-flex flex-row position-relative"
+              class="o-composer-container w-100 h-100"
             >
-              
               <div
-                class="o-composer w-100 text-start"
-                contenteditable="true"
-                spellcheck="false"
-                style="padding:5px 0px 5px 8px; max-height:100px; line-height:24px; height:34px; "
-                tabindex="1"
-              />
+                class="d-flex flex-row position-relative"
+              >
+                
+                <div
+                  class="o-composer w-100 text-start"
+                  contenteditable="true"
+                  spellcheck="false"
+                  style="padding:5px 0px 5px 8px; max-height:100px; line-height:24px; height:34px; "
+                  tabindex="1"
+                />
+              </div>
+              
             </div>
-            
           </div>
         </div>
         
@@ -1613,25 +1617,29 @@ exports[`TopBar component simple rendering 1`] = `
       
     </div>
     <div
-      class="o-topbar-composer bg-white user-select-text"
-      style="border-color:#E0E2E4; border-right:none; "
+      class="o-topbar-composer-container w-100"
     >
       <div
-        class="o-composer-container w-100 h-100"
+        class="o-topbar-composer position-relative bg-white user-select-text"
+        style="border-color:#E0E2E4; border-right:none; "
       >
         <div
-          class="d-flex flex-row position-relative"
+          class="o-composer-container w-100 h-100"
         >
-          
           <div
-            class="o-composer w-100 text-start"
-            contenteditable="true"
-            spellcheck="false"
-            style="padding:5px 0px 5px 8px; max-height:100px; line-height:24px; height:34px; "
-            tabindex="1"
-          />
+            class="d-flex flex-row position-relative"
+          >
+            
+            <div
+              class="o-composer w-100 text-start"
+              contenteditable="true"
+              spellcheck="false"
+              style="padding:5px 0px 5px 8px; max-height:100px; line-height:24px; height:34px; "
+              tabindex="1"
+            />
+          </div>
+          
         </div>
-        
       </div>
     </div>
     

--- a/tests/spreadsheet/__snapshots__/spreadsheet_component.test.ts.snap
+++ b/tests/spreadsheet/__snapshots__/spreadsheet_component.test.ts.snap
@@ -590,25 +590,29 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
         
       </div>
       <div
-        class="o-topbar-composer bg-white user-select-text"
-        style="border-color:#E0E2E4; border-right:none; "
+        class="o-topbar-composer-container w-100"
       >
         <div
-          class="o-composer-container w-100 h-100"
+          class="o-topbar-composer position-relative bg-white user-select-text"
+          style="border-color:#E0E2E4; border-right:none; "
         >
           <div
-            class="d-flex flex-row position-relative"
+            class="o-composer-container w-100 h-100"
           >
-            
             <div
-              class="o-composer w-100 text-start"
-              contenteditable="true"
-              spellcheck="false"
-              style="padding:5px 0px 5px 8px; max-height:100px; line-height:24px; height:34px; "
-              tabindex="1"
-            />
+              class="d-flex flex-row position-relative"
+            >
+              
+              <div
+                class="o-composer w-100 text-start"
+                contenteditable="true"
+                spellcheck="false"
+                style="padding:5px 0px 5px 8px; max-height:100px; line-height:24px; height:34px; "
+                tabindex="1"
+              />
+            </div>
+            
           </div>
-          
         </div>
       </div>
       


### PR DESCRIPTION
## Description

Opening a multi-line composer in the topbar would break the layout of the topbar since the topbar does not have a fixed height anymore with 6bfcd98.

This commit fixes that by adding a container around the composer with a fixed height.

Task: [4521789](https://www.odoo.com/odoo/2328/tasks/4521789)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo