### PR TITLE
[FIX] UUID: make `smallUuid` stronger

### DIFF
--- a/src/helpers/uuid.ts
+++ b/src/helpers/uuid.ts
@@ -26,13 +26,13 @@ export class UuidGenerator {
       return String(this.fastIdStart);
       //@ts-ignore
     } else if (window.crypto && window.crypto.getRandomValues) {
-      return (1e7).toString().replace(/[018]/g, (c) =>
-        //@ts-ignore
+      //@ts-ignore
+      return [1e7 + -1e3].replace(/[018]/g, (c) =>
         (c ^ (crypto.getRandomValues(new Uint8Array(1))[0] & (15 >> (c / 4)))).toString(16)
       );
     } else {
       // mainly for jest and other browsers that do not have the crypto functionality
-      return "xxxxxxxx".replace(/[xy]/g, function (c) {
+      return "xxxxxxxx-xxxx".replace(/[xy]/g, function (c) {
         var r = (Math.random() * 16) | 0,
           v = c == "x" ? r : (r & 0x3) | 0x8;
         return v.toString(16);


### PR DESCRIPTION
The recent introduction of `smallUuid` highlighted an unexpected use of the uuid's. In the internal mapping of plugins, we create objects which keys are uuids and we expect the Object to respect the order of insertion.

Unfortunately, the order of insertion in an Object is not guaranteed all the time. Specifically, the keys that are `number`or that can be coerced as a number have a priority over `string`.

Since `uuidv4` contains a dash (`-`), it cannot be coerced as a number but `smallUuid` surely can. It turns out its use can yield to unexpected behaviours and indeterministic tests.

Task: 0

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo