### PR TITLE
[FIX] pie_chart: use chart background for border color

### DIFF
--- a/src/helpers/charts/pie_chart.ts
+++ b/src/helpers/charts/pie_chart.ts
@@ -246,7 +246,7 @@ function createPieChartRuntime(chart: PieChart, getters: Getters): PieChartRunti
     const dataset: ChartDataSets = {
       label,
       data,
-      borderColor: "#FFFFFF",
+      borderColor: chart.background || "#FFFFFF",
       backgroundColor,
     };
     config.data!.datasets!.push(dataset);

--- a/tests/components/charts.test.ts
+++ b/tests/components/charts.test.ts
@@ -3,6 +3,7 @@ import { ChartTerms } from "../../src/components/translations_terms";
 import { BACKGROUND_CHART_COLOR, MENU_WIDTH } from "../../src/constants";
 import { toHex, toZone } from "../../src/helpers";
 import { ChartDefinition } from "../../src/types";
+import { PieChartRuntime } from "../../src/types/chart";
 import { BarChartDefinition } from "../../src/types/chart/bar_chart";
 import { LineChartDefinition } from "../../src/types/chart/line_chart";
 import { getCellContent } from "../test_helpers";
@@ -1363,6 +1364,13 @@ describe("figures", () => {
 
     await keyDown("z", { ctrlKey: true });
     expect(getCellContent(model, "D6")).toEqual("");
+  });
+
+  test("Pie chart border color matches the background color", async () => {
+    createTestChart("basicChart");
+    updateChart(model, chartId, { type: "pie", background: "#FF0000" });
+    const runtime = model.getters.getChartRuntime(chartId) as PieChartRuntime;
+    expect(runtime.chartJsConfig.data?.datasets?.[0].borderColor).toBe("#FF0000");
   });
 });
 


### PR DESCRIPTION
## Description:

Previously, the border color was always white(or `BACKGROUND_CHART_COLOR` in newer versions).

Now, it defaults to the chart background if available; otherwise, it falls back to white.

Task: [4570603](https://www.odoo.com/odoo/2328/tasks/4570603)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo