### PR TITLE
[FIX] UUID: `uuidGenerator.smallUuid()` crashes on browsers

### DIFF
--- a/src/helpers/uuid.ts
+++ b/src/helpers/uuid.ts
@@ -27,7 +27,7 @@ export class UuidGenerator {
       //@ts-ignore
     } else if (window.crypto && window.crypto.getRandomValues) {
       //@ts-ignore
-      return [1e7 + -1e3].replace(/[018]/g, (c) =>
+      return ([1e7] + -1e3).replace(/[018]/g, (c) =>
         (c ^ (crypto.getRandomValues(new Uint8Array(1))[0] & (15 >> (c / 4)))).toString(16)
       );
     } else {


### PR DESCRIPTION
Calling `uuidGenerator.smallUuid()` raises a traceback. The tests were running fine because the error only appear if `window.crypto` is defined, which is not the case in the test environment.

Task: 0

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo