### PR TITLE
[FIX] uuid: remove black magic to generate uuid

### DIFF
--- a/src/helpers/uuid.ts
+++ b/src/helpers/uuid.ts
@@ -24,12 +24,11 @@ export class UuidGenerator {
     if (this.isFastIdStrategy) {
       this.fastIdStart++;
       return String(this.fastIdStart);
-      //@ts-ignore
-    } else if (window.crypto && window.crypto.getRandomValues) {
-      //@ts-ignore
-      return ([1e7] + -1e3).replace(/[018]/g, (c) =>
-        (c ^ (crypto.getRandomValues(new Uint8Array(1))[0] & (15 >> (c / 4)))).toString(16)
-      );
+    } else if (window.crypto) {
+      return "10000000-1000".replace(/[01]/g, (c) => {
+        const n = Number(c);
+        return (n ^ (crypto.getRandomValues(new Uint8Array(1))[0] & (15 >> (n / 4)))).toString(16);
+      });
     } else {
       // mainly for jest and other browsers that do not have the crypto functionality
       return "xxxxxxxx-xxxx".replace(/[xy]/g, function (c) {
@@ -48,12 +47,11 @@ export class UuidGenerator {
     if (this.isFastIdStrategy) {
       this.fastIdStart++;
       return String(this.fastIdStart);
-      //@ts-ignore
-    } else if (window.crypto && window.crypto.getRandomValues) {
-      //@ts-ignore
-      return ([1e7] + -1e3 + -4e3 + -8e3 + -1e11).replace(/[018]/g, (c) =>
-        (c ^ (crypto.getRandomValues(new Uint8Array(1))[0] & (15 >> (c / 4)))).toString(16)
-      );
+    } else if (window.crypto) {
+      return "10000000-1000-4000-8000-100000000000".replace(/[018]/g, (c) => {
+        const n = Number(c);
+        return (n ^ (crypto.getRandomValues(new Uint8Array(1))[0] & (15 >> (n / 4)))).toString(16);
+      });
     } else {
       // mainly for jest and other browsers that do not have the crypto functionality
       return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, function (c) {


### PR DESCRIPTION
## Description

The code to generate UUIDs was copied straight from the internet and contained some nonsensical nonsense.

`([1e7] + -1e3 + -4e3 + -8e3 + -1e11)` looks like some cryptographic magic, but all it does is generate a STATIC STRING. This is gibberish. The @ts-ignore are also not needed with proper typing and conversion.

This commit also adds some tests for the generation of UUIDs, ensuring we don't burn everything, which can happens as proven by ec362e2bff.

Task: [4574102](https://www.odoo.com/odoo/2328/tasks/4574102)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo