### PR TITLE
[FIX] selection input: highlight color not sync with range color

### DIFF
--- a/src/components/selection_input/selection_input_store.ts
+++ b/src/components/selection_input/selection_input_store.ts
@@ -31,7 +31,7 @@ export class SelectionInputStore extends SpreadsheetStore {
     "confirm",
     "updateColors",
   ] as const;
-  ranges: RangeInputValue[] = [];
+  private ranges: RangeInputValue[] = [];
   focusedRangeIndex: number | null = null;
   private inputSheetId: UID;
   private focusStore = this.get(FocusStore);
@@ -166,6 +166,11 @@ export class SelectionInputStore extends SpreadsheetStore {
 
   updateColors(colors: Color[]) {
     this.colors = colors;
+    const colorGenerator = new ColorGenerator(this.ranges.length, this.colors);
+    this.ranges = this.ranges.map((range) => ({
+      ...range,
+      color: colorGenerator.next(),
+    }));
   }
 
   confirm() {
@@ -206,14 +211,13 @@ export class SelectionInputStore extends SpreadsheetStore {
    * e.g. ["A1", "Sheet2!B3", "E12"]
    */
   get selectionInputs(): (RangeInputValue & { isFocused: boolean; isValidRange: boolean })[] {
-    const generator = new ColorGenerator(this.ranges.length, this.colors);
     return this.ranges.map((input, index) =>
       Object.assign({}, input, {
         color:
           this.hasMainFocus &&
           this.focusedRangeIndex !== null &&
           this.getters.isRangeValid(input.xc)
-            ? generator.next()
+            ? input.color
             : null,
         isFocused: this.hasMainFocus && this.focusedRangeIndex === index,
         isValidRange: input.xc === "" || this.getters.isRangeValid(input.xc),


### PR DESCRIPTION
## Description

After re-ordering the selection inputs of a chart, the highlight colors would not be the same as the range colors.

This was because the store mutator `updateColors` would not update the store range colors. And `store.highlights` is based on `ranges.colors` while `store.selectionInputs` ignores the colors of `store.ranges`.

The test `update of colors are taken into account` was also a bit sketchy. We would modify the `props.colors` array in place, thus the condition `nextProps.colors !== props.colors` would never be satisfied, and `store.updateColors` would never be called.

Task: [4577803](https://www.odoo.com/odoo/2328/tasks/4577803)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo