### PR TITLE
[FIX] Charts: Hide datasets instead of filtering them

### DIFF
--- a/src/helpers/figures/charts/bar_chart.ts
+++ b/src/helpers/figures/charts/bar_chart.ts
@@ -53,6 +53,7 @@ import {
   filterEmptyDataPoints,
   getChartDatasetFormat,
   getChartDatasetValues,
+  getChartJsLegend,
   getChartLabelValues,
   getDefaultChartJsRuntime,
 } from "./chart_ui_common";
@@ -246,9 +247,7 @@ export function createBarChartRuntime(chart: BarChart, getters: Getters): BarCha
     ...localeFormat,
     horizontalChart: chart.horizontal,
   });
-  const legend: DeepPartial<LegendOptions<"bar">> = {
-    labels: { color: fontColor },
-  };
+  const legend: DeepPartial<LegendOptions<"bar">> = getChartJsLegend(fontColor);
   if (chart.legendPosition === "none") {
     legend.display = false;
   } else {
@@ -316,11 +315,12 @@ export function createBarChartRuntime(chart: BarChart, getters: Getters): BarCha
   const colors = getChartColorsGenerator(definition, dataSetsValues.length);
   const trendDatasets: any[] = [];
   for (const index in dataSetsValues) {
-    const { label, data } = dataSetsValues[index];
+    const { label, data, hidden } = dataSetsValues[index];
     const color = colors.next();
     const dataset: ChartDataset<"bar", number[]> = {
       label,
       data,
+      hidden,
       borderColor: definition.background || BACKGROUND_CHART_COLOR,
       borderWidth: definition.stacked ? 1 : 0,
       backgroundColor: color,

--- a/src/helpers/figures/charts/chart_common.ts
+++ b/src/helpers/figures/charts/chart_common.ts
@@ -477,6 +477,9 @@ export function getTrendDatasetForBarChart(
   const filteredValues: number[] = [];
   const filteredLabels: number[] = [];
   const labels: number[] = [];
+  if (dataset.hidden) {
+    return;
+  }
   for (let i = 0; i < dataset.data.length; i++) {
     if (typeof dataset.data[i] === "number") {
       filteredValues.push(dataset.data[i]);

--- a/src/helpers/figures/charts/chart_common_line_scatter.ts
+++ b/src/helpers/figures/charts/chart_common_line_scatter.ts
@@ -26,6 +26,7 @@ import {
   filterEmptyDataPoints,
   getChartDatasetFormat,
   getChartDatasetValues,
+  getChartJsLegend,
   getChartLabelFormat,
   getChartLabelValues,
   getDefaultChartJsRuntime,
@@ -136,7 +137,9 @@ export function getTrendDatasetForLineChart(
   const filteredLabels: number[] = [];
   const labels: number[] = [];
   const datasetLength = dataset.data.length;
-
+  if (dataset.hidden) {
+    return;
+  }
   if (datasetLength < 2) {
     return;
   }
@@ -226,9 +229,8 @@ export function createLineOrScatterChartRuntime(
   const fontColor = chartFontColor(chart.background);
   const config = getDefaultChartJsRuntime(chart, labels, fontColor, options);
 
-  const legend: DeepPartial<LegendOptions<"line">> = {
+  const legend: DeepPartial<LegendOptions<"line">> = getChartJsLegend(fontColor, {
     labels: {
-      color: fontColor,
       generateLabels(chart) {
         // color the legend labels with the dataset color, without any transparency
         const { data } = chart;
@@ -239,7 +241,8 @@ export function createLineOrScatterChartRuntime(
         return labels;
       },
     },
-  };
+  });
+
   if (chart.legendPosition === "none") {
     legend.display = false;
   } else {
@@ -343,7 +346,7 @@ export function createLineOrScatterChartRuntime(
 
   const definition = chart.getDefinition();
   const colors = getChartColorsGenerator(definition, dataSetsValues.length);
-  for (let [index, { label, data }] of dataSetsValues.entries()) {
+  for (let [index, { label, data, hidden }] of dataSetsValues.entries()) {
     const color = colors.next();
     let backgroundRGBA = colorToRGBA(color);
     if (areaChart) {
@@ -369,6 +372,7 @@ export function createLineOrScatterChartRuntime(
     const dataset: ChartDataset = {
       label,
       data,
+      hidden,
       tension: 0, // 0 -> render straight lines, which is much faster
       borderColor: color,
       backgroundColor,

--- a/src/helpers/figures/charts/combo_chart.ts
+++ b/src/helpers/figures/charts/combo_chart.ts
@@ -56,6 +56,7 @@ import {
   filterEmptyDataPoints,
   getChartDatasetFormat,
   getChartDatasetValues,
+  getChartJsLegend,
   getChartLabelValues,
   getDefaultChartJsRuntime,
 } from "./chart_ui_common";
@@ -251,9 +252,8 @@ export function createComboChartRuntime(chart: ComboChart, getters: Getters): Co
 
   const fontColor = chartFontColor(chart.background);
   const config = getDefaultChartJsRuntime(chart, labels, fontColor, localeFormat);
-  const legend: DeepPartial<LegendOptions<"bar">> = {
-    labels: { color: fontColor },
-  };
+  const legend: DeepPartial<LegendOptions<"bar">> = getChartJsLegend(fontColor);
+
   if (chart.legendPosition === "none") {
     legend.display = false;
   } else {
@@ -320,13 +320,14 @@ export function createComboChartRuntime(chart: ComboChart, getters: Getters): Co
   let maxLength = 0;
   const trendDatasets: any[] = [];
 
-  for (let [index, { label, data }] of dataSetsValues.entries()) {
+  for (let [index, { label, data, hidden }] of dataSetsValues.entries()) {
     const design = definition.dataSets[index];
     const color = colors.next();
     const type = design?.type ?? "line";
     const dataset: ChartDataset<"bar" | "line", number[]> = {
       label: design?.label ?? label,
       data,
+      hidden,
       borderColor: color,
       backgroundColor: color,
       yAxisID: design?.yAxisId ?? "y",
@@ -334,7 +335,6 @@ export function createComboChartRuntime(chart: ComboChart, getters: Getters): Co
       order: type === "bar" ? dataSetsValues.length + index : index,
     };
     config.data.datasets.push(dataset);
-
     const trend = definition.dataSets?.[index].trend;
     if (!trend?.display) {
       continue;

--- a/src/helpers/figures/charts/pie_chart.ts
+++ b/src/helpers/figures/charts/pie_chart.ts
@@ -306,7 +306,9 @@ function filterNegativeValues(
 export function createPieChartRuntime(chart: PieChart, getters: Getters): PieChartRuntime {
   const labelValues = getChartLabelValues(getters, chart.dataSets, chart.labelRange);
   let labels = labelValues.formattedValues;
-  let dataSetsValues = getChartDatasetValues(getters, chart.dataSets);
+  let dataSetsValues = getChartDatasetValues(getters, chart.dataSets).filter(
+    (dataSet) => !dataSet.hidden
+  );
   if (shouldRemoveFirstLabel(chart.labelRange, chart.dataSets[0], chart.dataSetsHaveTitle)) {
     labels.shift();
   }

--- a/src/helpers/figures/charts/pyramid_chart.ts
+++ b/src/helpers/figures/charts/pyramid_chart.ts
@@ -191,8 +191,9 @@ export function createPyramidChartRuntime(
   const barDef: BarChartDefinition = { ...chart.getDefinition(), type: "bar" };
   const barChart = new BarChart(barDef, chart.sheetId, getters);
   const barRuntime = createBarChartRuntime(barChart, getters);
+  // align design with filtered datasets
   const config = barRuntime.chartJsConfig;
-  let datasets = config.data?.datasets;
+  let datasets = config.data?.datasets.filter((dataSet) => !dataSet.hidden);
   if (datasets && datasets[0]) {
     datasets[0].data = datasets[0].data.map((value: number) => (value > 0 ? value : 0));
   }

--- a/src/helpers/figures/charts/waterfall_chart.ts
+++ b/src/helpers/figures/charts/waterfall_chart.ts
@@ -342,7 +342,7 @@ export function createWaterfallChartRuntime(
 ): WaterfallChartRuntime {
   const labelValues = getChartLabelValues(getters, chart.dataSets, chart.labelRange);
   let labels = labelValues.formattedValues;
-  let dataSetsValues = getChartDatasetValues(getters, chart.dataSets);
+  let dataSetsValues = getChartDatasetValues(getters, chart.dataSets).filter((ds) => !ds.hidden);
   if (shouldRemoveFirstLabel(chart.labelRange, chart.dataSets[0], chart.dataSetsHaveTitle)) {
     labels.shift();
   }

--- a/src/types/chart/chart.ts
+++ b/src/types/chart/chart.ts
@@ -59,6 +59,7 @@ export interface LabelValues {
 export interface DatasetValues {
   readonly label?: string;
   readonly data: any[];
+  readonly hidden?: boolean;
 }
 
 export interface DatasetDesign {

--- a/tests/figures/chart/__snapshots__/chart_plugin.test.ts.snap
+++ b/tests/figures/chart/__snapshots__/chart_plugin.test.ts.snap
@@ -24,6 +24,7 @@ exports[`Linear/Time charts font color is white with a dark background color 1`]
             },
           ],
           "fill": false,
+          "hidden": false,
           "label": "10",
           "pointBackgroundColor": "#4EA7F2",
           "tension": 0,
@@ -63,6 +64,7 @@ exports[`Linear/Time charts font color is white with a dark background color 1`]
         "legend": {
           "labels": {
             "color": "#FFFFFF",
+            "filter": [Function],
             "generateLabels": [Function],
           },
           "onClick": [Function],
@@ -143,6 +145,7 @@ exports[`Linear/Time charts snapshot test of chartJS configuration for date char
             },
           ],
           "fill": false,
+          "hidden": false,
           "label": "Series 1",
           "pointBackgroundColor": "#4EA7F2",
           "tension": 0,
@@ -183,6 +186,7 @@ exports[`Linear/Time charts snapshot test of chartJS configuration for date char
         "legend": {
           "labels": {
             "color": "#000000",
+            "filter": [Function],
             "generateLabels": [Function],
           },
           "onClick": [Function],
@@ -270,6 +274,7 @@ exports[`Linear/Time charts snapshot test of chartJS configuration for linear ch
             },
           ],
           "fill": false,
+          "hidden": false,
           "label": "Series 1",
           "pointBackgroundColor": "#4EA7F2",
           "tension": 0,
@@ -310,6 +315,7 @@ exports[`Linear/Time charts snapshot test of chartJS configuration for linear ch
         "legend": {
           "labels": {
             "color": "#000000",
+            "filter": [Function],
             "generateLabels": [Function],
           },
           "onClick": [Function],
@@ -375,6 +381,7 @@ exports[`datasource tests create a chart with stacked bar 1`] = `
           "data": [
             30,
           ],
+          "hidden": false,
           "label": "P4",
         },
       ],
@@ -412,6 +419,7 @@ exports[`datasource tests create a chart with stacked bar 1`] = `
         "legend": {
           "labels": {
             "color": "#000000",
+            "filter": [Function],
           },
           "onClick": [Function],
           "position": "top",
@@ -475,6 +483,7 @@ exports[`datasource tests create chart with a dataset of one cell (no title) 1`]
             30,
           ],
           "fill": false,
+          "hidden": false,
           "label": "Series 1",
           "pointBackgroundColor": "#4EA7F2",
           "tension": 0,
@@ -512,6 +521,7 @@ exports[`datasource tests create chart with a dataset of one cell (no title) 1`]
         "legend": {
           "labels": {
             "color": "#000000",
+            "filter": [Function],
             "generateLabels": [Function],
           },
           "onClick": [Function],
@@ -577,6 +587,7 @@ exports[`datasource tests create chart with column datasets 1`] = `
             12,
           ],
           "fill": false,
+          "hidden": false,
           "label": "first column dataset",
           "pointBackgroundColor": "#4EA7F2",
           "tension": 0,
@@ -590,6 +601,7 @@ exports[`datasource tests create chart with column datasets 1`] = `
             18,
           ],
           "fill": false,
+          "hidden": false,
           "label": "second column datase…",
           "pointBackgroundColor": "#EA6175",
           "tension": 0,
@@ -629,6 +641,7 @@ exports[`datasource tests create chart with column datasets 1`] = `
         "legend": {
           "labels": {
             "color": "#000000",
+            "filter": [Function],
             "generateLabels": [Function],
           },
           "onClick": [Function],
@@ -694,6 +707,7 @@ exports[`datasource tests create chart with column datasets with category title 
             12,
           ],
           "fill": false,
+          "hidden": false,
           "label": "first column dataset",
           "pointBackgroundColor": "#4EA7F2",
           "tension": 0,
@@ -707,6 +721,7 @@ exports[`datasource tests create chart with column datasets with category title 
             18,
           ],
           "fill": false,
+          "hidden": false,
           "label": "second column datase…",
           "pointBackgroundColor": "#EA6175",
           "tension": 0,
@@ -746,6 +761,7 @@ exports[`datasource tests create chart with column datasets with category title 
         "legend": {
           "labels": {
             "color": "#000000",
+            "filter": [Function],
             "generateLabels": [Function],
           },
           "onClick": [Function],
@@ -811,6 +827,7 @@ exports[`datasource tests create chart with column datasets without series title
             12,
           ],
           "fill": false,
+          "hidden": false,
           "label": "Series 1",
           "pointBackgroundColor": "#4EA7F2",
           "tension": 0,
@@ -824,6 +841,7 @@ exports[`datasource tests create chart with column datasets without series title
             18,
           ],
           "fill": false,
+          "hidden": false,
           "label": "Series 2",
           "pointBackgroundColor": "#EA6175",
           "tension": 0,
@@ -863,6 +881,7 @@ exports[`datasource tests create chart with column datasets without series title
         "legend": {
           "labels": {
             "color": "#000000",
+            "filter": [Function],
             "generateLabels": [Function],
           },
           "onClick": [Function],
@@ -918,7 +937,21 @@ exports[`datasource tests create chart with only the dataset title (no data) 1`]
   "background": "#FFFFFF",
   "chartJsConfig": {
     "data": {
-      "datasets": [],
+      "datasets": [
+        {
+          "backgroundColor": "#4EA7F2",
+          "borderColor": "#4EA7F2",
+          "data": [
+            undefined,
+            undefined,
+          ],
+          "fill": false,
+          "hidden": true,
+          "label": "30",
+          "pointBackgroundColor": "#4EA7F2",
+          "tension": 0,
+        },
+      ],
       "labels": [
         "P5",
         "P6",
@@ -952,6 +985,7 @@ exports[`datasource tests create chart with only the dataset title (no data) 1`]
         "legend": {
           "labels": {
             "color": "#000000",
+            "filter": [Function],
             "generateLabels": [Function],
           },
           "onClick": [Function],
@@ -1017,6 +1051,7 @@ exports[`datasource tests create chart with rectangle dataset 1`] = `
             12,
           ],
           "fill": false,
+          "hidden": false,
           "label": "first column dataset",
           "pointBackgroundColor": "#4EA7F2",
           "tension": 0,
@@ -1030,6 +1065,7 @@ exports[`datasource tests create chart with rectangle dataset 1`] = `
             18,
           ],
           "fill": false,
+          "hidden": false,
           "label": "second column datase…",
           "pointBackgroundColor": "#EA6175",
           "tension": 0,
@@ -1069,6 +1105,7 @@ exports[`datasource tests create chart with rectangle dataset 1`] = `
         "legend": {
           "labels": {
             "color": "#000000",
+            "filter": [Function],
             "generateLabels": [Function],
           },
           "onClick": [Function],
@@ -1134,6 +1171,7 @@ exports[`datasource tests create chart with row datasets 1`] = `
             32,
           ],
           "fill": false,
+          "hidden": false,
           "label": "first row dataset",
           "pointBackgroundColor": "#4EA7F2",
           "tension": 0,
@@ -1147,6 +1185,7 @@ exports[`datasource tests create chart with row datasets 1`] = `
             42,
           ],
           "fill": false,
+          "hidden": false,
           "label": "second row dataset",
           "pointBackgroundColor": "#EA6175",
           "tension": 0,
@@ -1186,6 +1225,7 @@ exports[`datasource tests create chart with row datasets 1`] = `
         "legend": {
           "labels": {
             "color": "#000000",
+            "filter": [Function],
             "generateLabels": [Function],
           },
           "onClick": [Function],
@@ -1251,6 +1291,7 @@ exports[`datasource tests create chart with row datasets with category title 1`]
             32,
           ],
           "fill": false,
+          "hidden": false,
           "label": "first row dataset",
           "pointBackgroundColor": "#4EA7F2",
           "tension": 0,
@@ -1264,6 +1305,7 @@ exports[`datasource tests create chart with row datasets with category title 1`]
             42,
           ],
           "fill": false,
+          "hidden": false,
           "label": "second row dataset",
           "pointBackgroundColor": "#EA6175",
           "tension": 0,
@@ -1303,6 +1345,7 @@ exports[`datasource tests create chart with row datasets with category title 1`]
         "legend": {
           "labels": {
             "color": "#000000",
+            "filter": [Function],
             "generateLabels": [Function],
           },
           "onClick": [Function],
@@ -1368,6 +1411,7 @@ exports[`datasource tests create chart with row datasets without series title 1`
             32,
           ],
           "fill": false,
+          "hidden": false,
           "label": "Series 1",
           "pointBackgroundColor": "#4EA7F2",
           "tension": 0,
@@ -1381,6 +1425,7 @@ exports[`datasource tests create chart with row datasets without series title 1`
             42,
           ],
           "fill": false,
+          "hidden": false,
           "label": "Series 2",
           "pointBackgroundColor": "#EA6175",
           "tension": 0,
@@ -1420,6 +1465,7 @@ exports[`datasource tests create chart with row datasets without series title 1`
         "legend": {
           "labels": {
             "color": "#000000",
+            "filter": [Function],
             "generateLabels": [Function],
           },
           "onClick": [Function],

--- a/tests/figures/chart/chart_plugin.test.ts
+++ b/tests/figures/chart/chart_plugin.test.ts
@@ -263,7 +263,8 @@ describe("datasource tests", function () {
       title: { text: "test" },
       type: "line",
     });
-    expect(data.datasets).toEqual([]);
+    expect(data.datasets.length).toEqual(1);
+    expect(data.datasets[0].hidden).toBeTruthy();
     expect(model.getters.getChartRuntime("1")).toMatchSnapshot();
   });
 
@@ -343,7 +344,9 @@ describe("datasource tests", function () {
       "1"
     );
     const chart = model.getters.getChartRuntime("1")! as LineChartRuntime;
-    expect(chart.chartJsConfig.data!.datasets?.length).toEqual(1);
+    expect(chart.chartJsConfig.data!.datasets?.length).toEqual(2);
+    expect(chart.chartJsConfig.data!.datasets?.[0].hidden).toBeFalsy();
+    expect(chart.chartJsConfig.data!.datasets?.[1].hidden).toBeTruthy();
   });
 
   test("empty datasets are filtered in different locales", () => {
@@ -380,7 +383,9 @@ describe("datasource tests", function () {
       "1"
     );
     const chart = model.getters.getChartRuntime("1")! as LineChartRuntime;
-    expect(chart.chartJsConfig.data!.datasets?.length).toEqual(1);
+    expect(chart.chartJsConfig.data!.datasets?.length).toEqual(2);
+    expect(chart.chartJsConfig.data!.datasets?.[0].hidden).toBeFalsy();
+    expect(chart.chartJsConfig.data!.datasets?.[1].hidden).toBeTruthy();
   });
 
   test("create a chart with stacked bar", () => {
@@ -685,7 +690,9 @@ describe("datasource tests", function () {
     );
     deleteRows(model, [1, 2, 3, 4]);
     const data = getChartConfiguration(model, "1").data;
-    expect(data.datasets).toHaveLength(0);
+    expect(data.datasets).toHaveLength(2);
+    expect(data.datasets[0].hidden).toBeTruthy();
+    expect(data.datasets[1].hidden).toBeTruthy();
     expect(data.labels).toEqual([]);
   });
 
@@ -1806,7 +1813,8 @@ describe("Chart design configuration", () => {
     );
     const data = getChartConfiguration(model, "1").data;
     expect(data.labels).toEqual(["P1"]);
-    expect(data.datasets).toEqual([]);
+    expect(data.datasets).toHaveLength(1);
+    expect(data.datasets[0].hidden).toBeTruthy();
   });
 
   test("no data points at all", () => {
@@ -1818,7 +1826,8 @@ describe("Chart design configuration", () => {
     );
     const data = getChartConfiguration(model, "1").data;
     expect(data.labels).toEqual([]);
-    expect(data.datasets).toEqual([]);
+    expect(data.datasets).toHaveLength(1);
+    expect(data.datasets[0].hidden).toBeTruthy();
   });
 
   test.each([{ format: "0.00%" }, { style: { textColor: "#FFF" } }])(
@@ -1837,7 +1846,8 @@ describe("Chart design configuration", () => {
       );
       const data = getChartConfiguration(model, "1").data;
       expect(data.labels).toEqual([]);
-      expect(data.datasets).toEqual([]);
+      expect(data.datasets).toHaveLength(1);
+      expect(data.datasets[0].hidden).toBeTruthy();
     }
   );
 
@@ -1857,7 +1867,8 @@ describe("Chart design configuration", () => {
       );
       const data = getChartConfiguration(model, "1").data;
       expect(data.labels).toEqual([]);
-      expect(data.datasets).toEqual([]);
+      expect(data.datasets).toHaveLength(1);
+      expect(data.datasets[0].hidden).toBeTruthy();
     }
   );
 
@@ -1884,7 +1895,8 @@ describe("Chart design configuration", () => {
     );
     const data = getChartConfiguration(model, "1").data;
     expect(data.labels).toEqual(["0"]);
-    expect(data.datasets).toEqual([]);
+    expect(data.datasets).toHaveLength(1);
+    expect(data.datasets[0].hidden).toBeTruthy();
   });
 
   test("Changing the format of a cell reevaluates a chart runtime", () => {
@@ -2807,7 +2819,8 @@ describe("Chart evaluation", () => {
     setCellContent(model, "C3", "1");
     expect(getChartConfiguration(model, "1").data!.datasets![0]!.data![0]).toBe(1);
     deleteColumns(model, ["C"]);
-    expect(getChartConfiguration(model, "1").data!.datasets.length).toBe(0);
+    expect(getChartConfiguration(model, "1").data!.datasets.length).toBe(1);
+    expect(getChartConfiguration(model, "1").data!.datasets[0].hidden).toBeTruthy();
   });
 
   test("undo/redo invalidates the chart runtime", () => {
@@ -2866,27 +2879,33 @@ describe("Chart evaluation", () => {
 
     test("hidden columns are filtered", () => {
       let chart = model.getters.getChartRuntime("1")! as LineChartRuntime;
-      expect(chart.chartJsConfig.data.datasets?.length).toEqual(2);
+      expect(chart.chartJsConfig.data.datasets).toHaveLength(2);
+      expect(chart.chartJsConfig.data.datasets[1].hidden).toBeFalsy();
       hideColumns(model, ["C"]);
       chart = model.getters.getChartRuntime("1")! as LineChartRuntime;
-      expect(chart.chartJsConfig.data.datasets?.length).toEqual(1);
+      expect(chart.chartJsConfig.data.datasets).toHaveLength(2);
+      expect(chart.chartJsConfig.data.datasets[1].hidden).toBeTruthy();
       expect(chart.chartJsConfig.data.datasets![0].label).toBe("first column dataset");
       unhideColumns(model, ["C"]);
       chart = model.getters.getChartRuntime("1")! as LineChartRuntime;
-      expect(chart.chartJsConfig.data.datasets?.length).toEqual(2);
+      expect(chart.chartJsConfig.data.datasets).toHaveLength(2);
+      expect(chart.chartJsConfig.data.datasets[1].hidden).toBeFalsy();
     });
 
     test("folded group of columns are filtered", () => {
       let chart = model.getters.getChartRuntime("1")! as LineChartRuntime;
-      expect(chart.chartJsConfig.data.datasets?.length).toEqual(2);
+      expect(chart.chartJsConfig.data.datasets).toHaveLength(2);
+      expect(chart.chartJsConfig.data.datasets[1].hidden).toBeFalsy();
       groupHeaders(model, "COL", 2, 2);
       foldHeaderGroup(model, "COL", 2, 2);
       chart = model.getters.getChartRuntime("1")! as LineChartRuntime;
-      expect(chart.chartJsConfig.data.datasets?.length).toEqual(1);
+      expect(chart.chartJsConfig.data.datasets).toHaveLength(2);
+      expect(chart.chartJsConfig.data.datasets[1].hidden).toBeTruthy();
       expect(chart.chartJsConfig.data.datasets![0].label).toBe("first column dataset");
       unfoldHeaderGroup(model, "COL", 2, 2);
       chart = model.getters.getChartRuntime("1")! as LineChartRuntime;
-      expect(chart.chartJsConfig.data.datasets?.length).toEqual(2);
+      expect(chart.chartJsConfig.data.datasets).toHaveLength(2);
+      expect(chart.chartJsConfig.data.datasets[1].hidden).toBeFalsy();
     });
 
     test("hidden rows are filtered", () => {
@@ -2931,6 +2950,29 @@ describe("Chart evaluation", () => {
       chart = model.getters.getChartRuntime("1")! as LineChartRuntime;
       expect(chart.chartJsConfig.data.datasets![0].data?.length).toEqual(4);
       expect(chart.chartJsConfig.data.labels).toEqual(["P1", "P2", "P3", "P4"]);
+    });
+
+    test("configuration is synchronized between the definition the runtime", () => {
+      updateChart(model, "1", {
+        dataSets: [
+          { dataRange: "B2:B5", label: "first", backgroundColor: "#123456" },
+          { dataRange: "C2:C5", label: "second", backgroundColor: "#222222" },
+        ],
+      });
+      const definition = model.getters.getChartDefinition("1") as LineChartDefinition;
+      let runtime = model.getters.getChartRuntime("1")! as LineChartRuntime;
+      expect(runtime.chartJsConfig.data.datasets).toHaveLength(2);
+      hideColumns(model, ["B"]);
+      runtime = model.getters.getChartRuntime("1")! as LineChartRuntime;
+      expect(runtime.chartJsConfig.data.datasets).toHaveLength(2);
+      expect(runtime.chartJsConfig.data.datasets![0].label).toEqual(definition.dataSets![0].label);
+      expect(runtime.chartJsConfig.data.datasets![1].label).toEqual(definition.dataSets![1].label);
+      expect(runtime.chartJsConfig.data.datasets![0].backgroundColor).toEqual(
+        definition.dataSets![0].backgroundColor
+      );
+      expect(runtime.chartJsConfig.data.datasets![1].backgroundColor).toEqual(
+        definition.dataSets![1].backgroundColor
+      );
     });
   });
 


### PR DESCRIPTION
Currently, we filter out datasets that do not contain visible data in
the chart runtime data (see https://github.com/odoo/o-spreadsheet/pull/4838). Unfortunately, we inadvertently
created desynchronization between the datasets in the runtime and the
ones in the chart definition, which can lead to some errors while
generating the rest of the runtime (e.g. each dataset has some design
attributes and by filtering the runtime dataset uphill, we no longer
know which design belongs to which dataset).

This revision suggest another approach: Keeping the datasets intact
and mark them as 'hidden' to maintain the '1 to 1' relation between the
core definition and runtime arbitrarily filter out the "hidden" datasets
during the rendering of the chart. We align ourselves with the
data structure[^1] of chartJs to make it easier.

[^1]: https://www.chartjs.org/docs/latest/general/data-structures.html#dataset-configuration

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [4577744](https://www.odoo.com/odoo/2328/tasks/4577744)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo