### PR TITLE
[IMP] formulas: add support for '+' as first character for formulas

### DIFF
--- a/src/components/composer/composer/abstract_composer_store.ts
+++ b/src/components/composer/composer/abstract_composer_store.ts
@@ -7,6 +7,7 @@ import {
   fuzzyLookup,
   getZoneArea,
   isEqual,
+  isFormula,
   isNumber,
   positionToZone,
   splitReference,
@@ -345,7 +346,7 @@ export abstract class AbstractComposerStore extends SpreadsheetStore {
         return;
       }
       if (content) {
-        if (content.startsWith("=")) {
+        if (isFormula(content)) {
           const left = this.currentTokens.filter((t) => t.type === "LEFT_PAREN").length;
           const right = this.currentTokens.filter((t) => t.type === "RIGHT_PAREN").length;
           const missing = left - right;
@@ -404,7 +405,7 @@ export abstract class AbstractComposerStore extends SpreadsheetStore {
     }
     if (isNewCurrentContent || this.editionMode !== "inactive") {
       const locale = this.getters.getLocale();
-      this.currentTokens = text.startsWith("=") ? composerTokenize(text, locale) : [];
+      this.currentTokens = isFormula(text) ? composerTokenize(text, locale) : [];
       if (this.currentTokens.length > 100) {
         if (raise) {
           this.notificationStore.raiseError(
@@ -643,7 +644,7 @@ export abstract class AbstractComposerStore extends SpreadsheetStore {
   }
 
   private updateRangeColor() {
-    if (!this._currentContent.startsWith("=") || this.editionMode === "inactive") {
+    if (!isFormula(this._currentContent) || this.editionMode === "inactive") {
       return;
     }
     const editionSheetId = this.sheetId;
@@ -674,7 +675,7 @@ export abstract class AbstractComposerStore extends SpreadsheetStore {
    * Highlight all ranges that can be found in the composer content.
    */
   get highlights(): Highlight[] {
-    if (!this.currentContent.startsWith("=") || this.editionMode === "inactive") {
+    if (!isFormula(this.currentContent) || this.editionMode === "inactive") {
       return [];
     }
     const editionSheetId = this.sheetId;
@@ -712,7 +713,7 @@ export abstract class AbstractComposerStore extends SpreadsheetStore {
 
   get autocompleteProvider(): AutoCompleteProvider | undefined {
     const content = this.currentContent;
-    const tokenAtCursor = content.startsWith("=")
+    const tokenAtCursor = isFormula(content)
       ? this.tokenAtCursor
       : { type: "STRING", value: content };
     if (
@@ -780,7 +781,7 @@ export abstract class AbstractComposerStore extends SpreadsheetStore {
    * - Previous and next tokens can be separated by spaces
    */
   private canStartComposerRangeSelection(): boolean {
-    if (this._currentContent.startsWith("=")) {
+    if (isFormula(this._currentContent)) {
       const tokenAtCursor = this.tokenAtCursor;
       if (!tokenAtCursor) {
         return false;

--- a/src/components/composer/composer/cell_composer_store.ts
+++ b/src/components/composer/composer/cell_composer_store.ts
@@ -2,6 +2,7 @@ import { parseLiteral } from "../../../helpers/cells";
 import {
   formatValue,
   isDateTimeFormat,
+  isFormula,
   markdownLink,
   numberToString,
   parseDateTime,
@@ -179,7 +180,7 @@ export class CellComposerStore extends AbstractComposerStore {
     if (content) {
       const sheetId = this.getters.getActiveSheetId();
       const cell = this.getters.getEvaluatedCell({ sheetId, col: this.col, row: this.row });
-      if (cell.link && !content.startsWith("=")) {
+      if (cell.link && !isFormula(content)) {
         content = markdownLink(content, cell.link.url);
       }
       this.addHeadersForSpreadingFormula(content);
@@ -241,7 +242,7 @@ export class CellComposerStore extends AbstractComposerStore {
 
   /** Add headers at the end of the sheet so the formula in the composer has enough space to spread */
   private addHeadersForSpreadingFormula(content: string) {
-    if (!content.startsWith("=")) {
+    if (!isFormula(content)) {
       return;
     }
 
@@ -279,7 +280,7 @@ export class CellComposerStore extends AbstractComposerStore {
   private checkDataValidation(): boolean {
     const cellPosition = { sheetId: this.sheetId, col: this.col, row: this.row };
     const content = this.getCurrentCanonicalContent();
-    const cellValue = content.startsWith("=")
+    const cellValue = isFormula(content)
       ? this.getters.evaluateFormula(this.sheetId, content)
       : parseLiteral(content, this.getters.getLocale());
 

--- a/src/components/composer/composer/composer.ts
+++ b/src/components/composer/composer/composer.ts
@@ -1,7 +1,7 @@
 import { Component, onMounted, onWillUnmount, useEffect, useRef, useState } from "@odoo/owl";
 import { NEWLINE, PRIMARY_BUTTON_BG, SCROLLBAR_WIDTH } from "../../../constants";
 import { functionRegistry } from "../../../functions/index";
-import { clip, setColorAlpha } from "../../../helpers/index";
+import { clip, isFormula, setColorAlpha } from "../../../helpers/index";
 
 import { EnrichedToken } from "../../../formulas/composer_tokenizer";
 import { Store, useLocalStore, useStore } from "../../../store_engine";
@@ -306,7 +306,7 @@ export class Composer extends Component<CellComposerProps, SpreadsheetChildEnv> 
     if (
       this.props.focus === "cellFocus" &&
       !this.autoCompleteState.provider &&
-      !content.startsWith("=")
+      !isFormula(content)
     ) {
       this.props.composerStore.stopEdition();
       return;
@@ -555,7 +555,7 @@ export class Composer extends Component<CellComposerProps, SpreadsheetChildEnv> 
       return;
     }
     const composerContent = this.props.composerStore.currentContent;
-    const isValidFormula = composerContent.startsWith("=");
+    const isValidFormula = isFormula(composerContent);
 
     if (isValidFormula) {
       const tokens = this.props.composerStore.currentTokens;
@@ -627,7 +627,7 @@ export class Composer extends Component<CellComposerProps, SpreadsheetChildEnv> 
    */
   private getContentLines(): HtmlContent[][] {
     let value = this.props.composerStore.currentContent;
-    const isValidFormula = value.startsWith("=");
+    const isValidFormula = isFormula(value);
 
     if (value === "") {
       return [];
@@ -726,7 +726,7 @@ export class Composer extends Component<CellComposerProps, SpreadsheetChildEnv> 
     }
     const token = this.props.composerStore.tokenAtCursor;
 
-    if (content.startsWith("=") && token && token.type !== "SYMBOL") {
+    if (isFormula(content) && token && token.type !== "SYMBOL") {
       const tokenContext = token.functionContext;
       const parentFunction = tokenContext?.parent.toUpperCase();
       if (

--- a/src/components/composer/grid_composer/grid_composer.ts
+++ b/src/components/composer/grid_composer/grid_composer.ts
@@ -1,6 +1,7 @@
 import { Component, onWillUpdateProps } from "@odoo/owl";
 import { ComponentsImportance, DEFAULT_FONT, SELECTION_BORDER_COLOR } from "../../../constants";
 import {
+  isFormula as _isFormula,
   deepEquals,
   fontSizeInPixels,
   getFullReference,
@@ -146,7 +147,7 @@ export class GridComposer extends Component<Props, SpreadsheetChildEnv> {
     if (this.composerStore.editionMode === "inactive") {
       return `z-index: -1000;`;
     }
-    const isFormula = this.composerStore.currentContent.startsWith("=");
+    const isFormula = _isFormula(this.composerStore.currentContent);
     const cell = this.env.model.getters.getActiveCell();
     const position = this.env.model.getters.getActivePosition();
     const style = this.env.model.getters.getCellComputedStyle(position);

--- a/src/helpers/misc.ts
+++ b/src/helpers/misc.ts
@@ -680,3 +680,7 @@ export function getUniqueText(
   }
   return newText;
 }
+
+export function isFormula(content: string): boolean {
+  return content.startsWith("=") || content.startsWith("+");
+}

--- a/src/plugins/core/cell.ts
+++ b/src/plugins/core/cell.ts
@@ -2,7 +2,13 @@ import { DEFAULT_STYLE } from "../../constants";
 import { Token, compile } from "../../formulas";
 import { compileTokens } from "../../formulas/compiler";
 import { isEvaluationError, toString } from "../../functions/helpers";
-import { deepEquals, isExcelCompatible, isTextFormat, recomputeZones } from "../../helpers";
+import {
+  deepEquals,
+  isExcelCompatible,
+  isFormula,
+  isTextFormat,
+  recomputeZones,
+} from "../../helpers";
 import { parseLiteral } from "../../helpers/cells";
 import {
   getItemId,
@@ -611,7 +617,7 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
     style: Style | undefined,
     sheetId: UID
   ): Cell {
-    if (!content.startsWith("=")) {
+    if (!isFormula(content)) {
       return this.createLiteralCell(id, content, format, style);
     }
     return this.createFormulaCell(id, content, format, style, sheetId);
@@ -651,13 +657,14 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
     style: Style | undefined,
     sheetId: UID
   ): FormulaCell {
-    const compiledFormula = compile(content);
+    const newContent = content.startsWith("+") ? "=" + content.slice(1) : content;
+    const compiledFormula = compile(newContent);
     if (compiledFormula.dependencies.length) {
       return this.createFormulaCellWithDependencies(id, compiledFormula, format, style, sheetId);
     }
     return {
       id,
-      content,
+      content: newContent,
       style,
       format,
       isFormula: true,

--- a/src/registries/auto_completes/function_auto_complete.ts
+++ b/src/registries/auto_completes/function_auto_complete.ts
@@ -1,6 +1,7 @@
 import { getHtmlContentFromPattern } from "../../components/helpers/html_content_helpers";
 import { COMPOSER_ASSISTANT_COLOR } from "../../constants";
 import { functionRegistry } from "../../functions";
+import { isFormula } from "../../helpers";
 import { autoCompleteProviders } from "./auto_complete_registry";
 
 autoCompleteProviders.add("functions", {
@@ -12,7 +13,7 @@ autoCompleteProviders.add("functions", {
       return [];
     }
     const searchTerm = tokenAtCursor.value;
-    if (!this.composer.currentContent.startsWith("=")) {
+    if (!isFormula(this.composer.currentContent)) {
       return [];
     }
     const values = Object.entries(functionRegistry.content)


### PR DESCRIPTION
This commit adds support for using the plus symbol to add formulas. If you start with a "+" sign, it's automatically interpreted as a "=" and the cell content is saved with "=". This behaviour was inspired by other spreadsheet applications that also support this feature.

Task: [4460183](https://www.odoo.com/odoo/2328/tasks/4460183)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo