### PR TITLE
[IMP] monkey party: add a command to run monkey party test

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "build": "npm-run-all build:js build:bundleJs \"build:bundleXml -- --outDir build\"",
     "doc": "typedoc",
     "precommit": "npm run prettier && npm run doc",
+    "monkey": "SPREADSHEET_MONKEY_COUNT=$npm_config_monkey_count jest 'tests/collaborative/collaborative_monkey_party.test.ts'",
     "test": "jest",
     "test:watch": "jest --watch",
     "prettier": "prettier . --write",

--- a/tests/collaborative/collaborative_monkey_party.test.ts
+++ b/tests/collaborative/collaborative_monkey_party.test.ts
@@ -28,7 +28,12 @@ import { setupCollaborativeEnv } from "./collaborative_helpers";
  * It is intended to be run locally from time to time by increasing `PARTY_COUNT`.
  */
 
-const PARTY_COUNT: number = 1; // increase this number to run more tests and enjoy the parties 🐵🎉
+const PARTY_COUNT = parseInt(process.env.SPREADSHEET_MONKEY_COUNT || "1");
+if (isNaN(PARTY_COUNT)) {
+  throw new Error(
+    "Invalid SPREADSHEET_MONKEY_COUNT. Make sure to use `npm run monkey --monkey_count=10`"
+  );
+}
 
 describe("monkey party", () => {
   const now = Date.now();


### PR DESCRIPTION
This commit introduces a new command called `monkey` to run the test monkey party only. An argument `monkey_count` can be given to run the test multiple times (default to 1).

Note that this new command does not work on Windows. To support it, we have to use the `cross-env` package to set the environment variable and handle "/" and "\" in the path.

Task: 0

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo