### PR TITLE
[IMP] clipboard: ignore hidden cells when copying ranges

### DIFF
--- a/src/clipboard_handlers/abstract_clipboard_handler.ts
+++ b/src/clipboard_handlers/abstract_clipboard_handler.ts
@@ -12,7 +12,7 @@ import {
 export class ClipboardHandler<T> {
   constructor(protected getters: Getters, protected dispatch: CommandDispatcher["dispatch"]) {}
 
-  copy(data: ClipboardData): T | undefined {
+  copy(data: ClipboardData, isCutOperation: boolean): T | undefined {
     return;
   }
 

--- a/src/clipboard_handlers/tables_clipboard.ts
+++ b/src/clipboard_handlers/tables_clipboard.ts
@@ -41,7 +41,7 @@ export class TableClipboardHandler extends AbstractCellClipboardHandler<
   ClipboardContent,
   TableCell
 > {
-  copy(data: ClipboardCellData): ClipboardContent {
+  copy(data: ClipboardCellData, isCutOperation?: boolean): ClipboardContent {
     const sheetId = data.sheetId;
 
     const { rowsIndexes, columnsIndexes, zones } = data;
@@ -69,8 +69,20 @@ export class TableClipboardHandler extends AbstractCellClipboardHandler<
           zones.some((z) => isZoneInside(tableZone, z))
         ) {
           copiedTablesIds.add(table.id);
+          let { numberOfRows } = zoneToDimension(tableZone);
+          for (let rowIndex = tableZone.top; rowIndex <= tableZone.bottom; rowIndex++) {
+            if (!isCutOperation && !rowsIndexes.includes(rowIndex)) {
+              numberOfRows--;
+            }
+          }
+          const range = coreTable.range;
+          const newRange = this.getters.extendRange(
+            coreTable.range,
+            "ROW",
+            range.zone.top + numberOfRows - 1 - range.zone.bottom
+          );
           copiedTable = {
-            range: this.getters.getRangeData(coreTable.range),
+            range: this.getters.getRangeData(newRange),
             config: coreTable.config,
             type: coreTable.type,
           };

--- a/src/components/paint_format_button/paint_format_store.ts
+++ b/src/components/paint_format_button/paint_format_store.ts
@@ -70,7 +70,7 @@ export class PaintFormatStore extends SpreadsheetStore {
 
     const copiedData = {};
     for (const handler of this.clipboardHandlers) {
-      Object.assign(copiedData, handler.copy(getClipboardDataPositions(sheetId, zones)));
+      Object.assign(copiedData, handler.copy(getClipboardDataPositions(sheetId, zones), false));
     }
 
     return copiedData as ClipboardContent;

--- a/src/plugins/ui_stateful/clipboard.ts
+++ b/src/plugins/ui_stateful/clipboard.ts
@@ -138,8 +138,8 @@ export class ClipboardPlugin extends UIPlugin {
         const zones = this.getters.getSelectedZones();
         this.status = "visible";
         this.originSheetId = this.getters.getActiveSheetId();
-        this.copiedData = this.copy(zones);
         this._isCutOperation = cmd.type === "CUT";
+        this.copiedData = this.copy(zones);
         break;
       case "PASTE_FROM_OS_CLIPBOARD": {
         this._isCutOperation = false;
@@ -381,7 +381,7 @@ export class ClipboardPlugin extends UIPlugin {
     let copiedData = {};
     const clipboardData = this.getClipboardData(zones);
     for (const { handlerName, handler } of this.selectClipboardHandlers(clipboardData)) {
-      const data = handler.copy(clipboardData);
+      const data = handler.copy(clipboardData, this._isCutOperation);
       copiedData[handlerName] = data;
       const minimalKeys = ["sheetId", "cells", "zones", "figureId"];
       for (const key of minimalKeys) {
@@ -722,7 +722,11 @@ export class ClipboardPlugin extends UIPlugin {
     if (selectedFigureId) {
       return { figureId: selectedFigureId, sheetId };
     }
-    return getClipboardDataPositions(sheetId, zones);
+    const data = getClipboardDataPositions(sheetId, zones);
+    if (!this._isCutOperation) {
+      data.rowsIndexes = data.rowsIndexes.filter((r) => !this.getters.isRowFiltered(sheetId, r));
+    }
+    return data;
   }
 
   // ---------------------------------------------------------------------------

--- a/tests/clipboard/clipboard_plugin.test.ts
+++ b/tests/clipboard/clipboard_plugin.test.ts
@@ -32,11 +32,14 @@ import {
   createSheet,
   createSheetWithName,
   createTable,
+  createTableWithFilter,
   cut,
   deleteCells,
   deleteColumns,
   deleteRows,
   deleteSheet,
+  hideColumns,
+  hideRows,
   insertCells,
   merge,
   paste,
@@ -52,6 +55,7 @@ import {
   setZoneBorders,
   unMerge,
   undo,
+  updateFilter,
   updateLocale,
 } from "../test_helpers/commands_helpers";
 import {
@@ -2026,6 +2030,86 @@ describe("clipboard", () => {
     cut(model, "B1");
     paste(model, "C3");
     expect(getCell(model, "C3")!.content).toBe(expectedInvalidFormula);
+  });
+
+  test("filtered rows are ignored when copying range", () => {
+    //prettier-ignore
+    const model = createModelFromGrid({
+      B2: "b2", C2: "c2", D2: "d2",
+      B3: "b3", C3: "c3", D3: "d3",
+      B4: "b4", C4: "c4", D4: "d4",
+    });
+
+    createTableWithFilter(model, "B2:D4");
+    updateFilter(model, "C3", ["c3"]);
+    copy(model, "B2:D4");
+    paste(model, "B5");
+
+    expect(getEvaluatedGrid(model, "B5:D7")).toEqual([
+      ["b2", "c2", "d2"],
+      ["b4", "c4", "d4"],
+      ["", "", ""],
+    ]);
+  });
+
+  test("filtered rows are ignored when cutting range", () => {
+    //prettier-ignore
+    const model = createModelFromGrid({
+      B2: "b2", C2: "c2", D2: "d2",
+      B3: "b3", C3: "c3", D3: "d3",
+      B4: "b4", C4: "c4", D4: "d4",
+    });
+
+    createTableWithFilter(model, "B2:D4");
+    updateFilter(model, "C3", ["c3"]);
+    cut(model, "B2:D4");
+    paste(model, "B5");
+
+    expect(getEvaluatedGrid(model, "B5:D7")).toEqual([
+      ["b2", "c2", "d2"],
+      ["b3", "c3", "d3"],
+      ["b4", "c4", "d4"],
+    ]);
+  });
+
+  test("hidden rows/columns are taken into account when copypasting range", () => {
+    //prettier-ignore
+    const model = createModelFromGrid({
+      B2: "b2", C2: "c2", D2: "d2",
+      B3: "b3", C3: "c3", D3: "d3",
+      B4: "b4", C4: "c4", D4: "d4",
+    });
+
+    hideRows(model, [2]);
+    hideColumns(model, ["C"]);
+    copy(model, "B2:D4");
+    paste(model, "E1");
+
+    expect(getEvaluatedGrid(model, "E1:G3")).toEqual([
+      ["b2", "c2", "d2"],
+      ["b3", "c3", "d3"],
+      ["b4", "c4", "d4"],
+    ]);
+  });
+
+  test("hidden rows/columns are taken into account when cutpasting range", () => {
+    //prettier-ignore
+    const model = createModelFromGrid({
+      B2: "b2", C2: "c2", D2: "d2",
+      B3: "b3", C3: "c3", D3: "d3",
+      B4: "b4", C4: "c4", D4: "d4",
+    });
+
+    hideRows(model, [2]);
+    hideColumns(model, ["C"]);
+    cut(model, "B2:D4");
+    paste(model, "E1");
+
+    expect(getEvaluatedGrid(model, "E1:G3")).toEqual([
+      ["b2", "c2", "d2"],
+      ["b3", "c3", "d3"],
+      ["b4", "c4", "d4"],
+    ]);
   });
 
   test("copying a spread pivot cell results in the fixed pivot formula", () => {

--- a/tests/figures/chart/charts_component.test.ts
+++ b/tests/figures/chart/charts_component.test.ts
@@ -1725,16 +1725,12 @@ describe("charts", () => {
 
   describe("trend line", () => {
     beforeEach(() => {
-      //@prettier-ignore
+      //prettier-ignore
       setGrid(model, {
-        A1: "1",
-        B1: "1",
-        A2: "2",
-        B2: "4",
-        A3: "3",
-        B3: "27",
-        A4: "4",
-        B4: "64",
+        A1: "1", B1: "1",
+        A2: "2", B2: "4",
+        A3: "3", B3: "27",
+        A4: "4", B4: "64",
       });
     });
     test.each(["bar", "line", "scatter", "combo"] as const)(

--- a/tests/table/tables_plugin.test.ts
+++ b/tests/table/tables_plugin.test.ts
@@ -773,8 +773,6 @@ describe("Table plugin", () => {
 
     test("Copy tables that are in a bigger selection", () => {
       createTable(model, "A1:B4");
-      updateFilter(model, "A1", ["thisIsAValue"]);
-
       cut(model, "A1:C5");
       paste(model, "A5");
       expect(getTable(model, "A1")).toBeFalsy();
@@ -905,7 +903,7 @@ describe("Table plugin", () => {
 
   describe("Import/Export", () => {
     test("Import/Export tables", () => {
-      createTable(model, "A1:B5");
+      createTableWithFilter(model, "A1:B5");
       updateTableConfig(model, "A1", { bandedColumns: true, styleId: "TableStyleDark2" });
       createTable(model, "C5:C9");
       setCellContent(model, "A2", "5");
@@ -918,7 +916,12 @@ describe("Table plugin", () => {
       expect(exported.sheets[0].tables).toMatchObject([
         {
           range: "A1:B5",
-          config: { ...DEFAULT_TABLE_CONFIG, bandedColumns: true, styleId: "TableStyleDark2" },
+          config: {
+            ...DEFAULT_TABLE_CONFIG,
+            hasFilters: true,
+            bandedColumns: true,
+            styleId: "TableStyleDark2",
+          },
         },
         { range: "C5:C9" }, // default config is not exported
       ]);
@@ -927,7 +930,12 @@ describe("Table plugin", () => {
       expect(imported.getters.getTables(sheetId)).toMatchObject([
         {
           range: { zone: toZone("A1:B5") },
-          config: { ...DEFAULT_TABLE_CONFIG, bandedColumns: true, styleId: "TableStyleDark2" },
+          config: {
+            ...DEFAULT_TABLE_CONFIG,
+            hasFilters: true,
+            bandedColumns: true,
+            styleId: "TableStyleDark2",
+          },
         },
         { range: { zone: toZone("C5:C9") }, config: DEFAULT_TABLE_CONFIG },
       ]);

--- a/tests/table/tables_plugin.test.ts
+++ b/tests/table/tables_plugin.test.ts
@@ -877,6 +877,30 @@ describe("Table plugin", () => {
         bold: true,
       });
     });
+
+    test("Copy table and adjacent cells", () => {
+      const sheet1Id = model.getters.getActiveSheetId();
+      createTableWithFilter(model, "B2:C4");
+      setCellContent(model, "B3", "4");
+      updateFilter(model, "B2", ["4"]);
+      copy(model, "A1:D5");
+      paste(model, "E6");
+      expect(model.getters.getTables(sheet1Id)).toHaveLength(2);
+      const copiedTable = getTable(model, "F7");
+      expect(copiedTable).toMatchObject({ range: { zone: toZone("F7:G8") } });
+    });
+
+    test("Cut table and adjacent cells", () => {
+      const sheet1Id = model.getters.getActiveSheetId();
+      createTableWithFilter(model, "B2:C4");
+      setCellContent(model, "B3", "4");
+      updateFilter(model, "B2", ["4"]);
+      cut(model, "A1:D5");
+      paste(model, "E6");
+      expect(model.getters.getTables(sheet1Id)).toHaveLength(1);
+      const copiedTable = getTable(model, "F7");
+      expect(copiedTable).toMatchObject({ range: { zone: toZone("F7:G9") } });
+    });
   });
 
   describe("Import/Export", () => {


### PR DESCRIPTION
## Task Description

When copying a range, we should ignore the hidden rows/columns and not paste their contents. This should be done only for the copy operation, not the cut.

## Related Task
- Task: [3872420](https://www.odoo.com/odoo/2328/tasks/3872420)
