### PR TITLE
[FIX] chart: tooltip issues

### DIFF
--- a/src/helpers/figures/charts/runtime/chart_custom_tooltip.ts
+++ b/src/helpers/figures/charts/runtime/chart_custom_tooltip.ts
@@ -13,7 +13,7 @@ const templates = /* xml */ `
     <div
       class="o-chart-custom-tooltip border rounded px-2 py-1 pe-none mw-100 position-absolute text-nowrap shadow opacity-100">
       <table class="overflow-hidden m-0">
-        <thead>
+        <thead t-if="title">
           <tr>
             <th class="o-tooltip-title align-baseline border-0 text-truncate" t-esc="title" t-attf-style="max-width: {{ labelsMaxWidth }}"/>
           </tr>

--- a/tests/figures/chart/__snapshots__/chart_plugin.test.ts.snap
+++ b/tests/figures/chart/__snapshots__/chart_plugin.test.ts.snap
@@ -92,6 +92,7 @@ exports[`Linear/Time charts font color is white with a dark background color 1`]
         },
         "tooltip": {
           "callbacks": {
+            "beforeLabel": [Function],
             "label": [Function],
             "title": [Function],
           },
@@ -231,6 +232,7 @@ exports[`Linear/Time charts snapshot test of chartJS configuration for date char
         },
         "tooltip": {
           "callbacks": {
+            "beforeLabel": [Function],
             "label": [Function],
             "title": [Function],
           },
@@ -378,6 +380,7 @@ exports[`Linear/Time charts snapshot test of chartJS configuration for linear ch
         },
         "tooltip": {
           "callbacks": {
+            "beforeLabel": [Function],
             "label": [Function],
             "title": [Function],
           },
@@ -499,6 +502,7 @@ exports[`datasource tests create a chart with stacked bar 1`] = `
         },
         "tooltip": {
           "callbacks": {
+            "beforeLabel": [Function],
             "label": [Function],
             "title": [Function],
           },
@@ -619,6 +623,7 @@ exports[`datasource tests create chart with a dataset of one cell (no title) 1`]
         },
         "tooltip": {
           "callbacks": {
+            "beforeLabel": [Function],
             "label": [Function],
             "title": [Function],
           },
@@ -758,6 +763,7 @@ exports[`datasource tests create chart with column datasets 1`] = `
         },
         "tooltip": {
           "callbacks": {
+            "beforeLabel": [Function],
             "label": [Function],
             "title": [Function],
           },
@@ -897,6 +903,7 @@ exports[`datasource tests create chart with column datasets with category title 
         },
         "tooltip": {
           "callbacks": {
+            "beforeLabel": [Function],
             "label": [Function],
             "title": [Function],
           },
@@ -1036,6 +1043,7 @@ exports[`datasource tests create chart with column datasets without series title
         },
         "tooltip": {
           "callbacks": {
+            "beforeLabel": [Function],
             "label": [Function],
             "title": [Function],
           },
@@ -1158,6 +1166,7 @@ exports[`datasource tests create chart with only the dataset title (no data) 1`]
         },
         "tooltip": {
           "callbacks": {
+            "beforeLabel": [Function],
             "label": [Function],
             "title": [Function],
           },
@@ -1297,6 +1306,7 @@ exports[`datasource tests create chart with rectangle dataset 1`] = `
         },
         "tooltip": {
           "callbacks": {
+            "beforeLabel": [Function],
             "label": [Function],
             "title": [Function],
           },
@@ -1436,6 +1446,7 @@ exports[`datasource tests create chart with row datasets 1`] = `
         },
         "tooltip": {
           "callbacks": {
+            "beforeLabel": [Function],
             "label": [Function],
             "title": [Function],
           },
@@ -1575,6 +1586,7 @@ exports[`datasource tests create chart with row datasets with category title 1`]
         },
         "tooltip": {
           "callbacks": {
+            "beforeLabel": [Function],
             "label": [Function],
             "title": [Function],
           },
@@ -1714,6 +1726,7 @@ exports[`datasource tests create chart with row datasets without series title 1`
         },
         "tooltip": {
           "callbacks": {
+            "beforeLabel": [Function],
             "label": [Function],
             "title": [Function],
           },

--- a/tests/figures/chart/bar_chart_plugin.test.ts
+++ b/tests/figures/chart/bar_chart_plugin.test.ts
@@ -2,7 +2,11 @@ import { ChartCreationContext, Model } from "../../../src";
 import { BACKGROUND_CHART_COLOR } from "../../../src/constants";
 import { BarChart } from "../../../src/helpers/figures/charts";
 import { BarChartRuntime } from "../../../src/types/chart";
-import { getChartLegendLabels, isChartAxisStacked } from "../../test_helpers/chart_helpers";
+import {
+  getChartLegendLabels,
+  getChartTooltipValues,
+  isChartAxisStacked,
+} from "../../test_helpers/chart_helpers";
 import {
   createChart,
   setCellContent,
@@ -95,8 +99,8 @@ describe("bar chart", () => {
         label: "dataSetLabel",
         dataset: { xAxisID: "x" },
       };
-      const tooltip = runtime.chartJsConfig.options?.plugins?.tooltip as any;
-      expect(tooltip?.callbacks?.label(tooltipTestItem)).toBe("dataSetLabel: 5€");
+      const tooltipValues = getChartTooltipValues(runtime, tooltipTestItem);
+      expect(tooltipValues).toEqual({ beforeLabel: "dataSetLabel", label: "5€" });
     });
 
     test("Horizontal bar chart cannot have datasets on the right", () => {

--- a/tests/figures/chart/chart_plugin.test.ts
+++ b/tests/figures/chart/chart_plugin.test.ts
@@ -3613,31 +3613,6 @@ test.each(["line", "bar", "pyramid", "pie", "combo", "waterfall", "scatter"] as 
   }
 );
 
-test("Custom chart tooltip is correctly filled", () => {
-  createChart(model, { type: "line" }, "chartId");
-  const runtime = model.getters.getChartRuntime("chartId") as any;
-  const mockChartParent = document.createElement("div");
-  const mockChartCtx: any = {
-    chart: {
-      canvas: { parentNode: mockChartParent },
-      chartArea: { left: 0, top: 0, right: 100, bottom: 100, width: 100, height: 100 },
-    },
-    tooltip: {
-      title: ["Marc Demo"],
-      body: [{ lines: ["dataset title: 1"] }],
-      labelColors: [{ backgroundColor: "#F00" }],
-      dataPoints: [{}],
-    },
-  };
-  runtime.chartJsConfig.options!.plugins!.tooltip!.external?.(mockChartCtx);
-  expect(mockChartParent.querySelector(".o-tooltip-title")).toHaveText("Marc Demo");
-  expect(mockChartParent.querySelector(".o-tooltip-label")).toHaveText("dataset title");
-  expect(mockChartParent.querySelector(".o-tooltip-value")).toHaveText("1");
-  expect(
-    mockChartParent.querySelector<HTMLElement>(".badge")?.style["background-color"]
-  ).toBeSameColorAs("#F00");
-});
-
 test("logarithmic trending line", () => {
   // prettier-ignore
   setGrid(model, {

--- a/tests/figures/chart/chart_tooltip.test.ts
+++ b/tests/figures/chart/chart_tooltip.test.ts
@@ -1,0 +1,103 @@
+import { ChartJSRuntime, Color, Model } from "../../../src";
+import { createChart } from "../../test_helpers/commands_helpers";
+
+interface TooltipArgs {
+  tooltipItem: any;
+  backgroundColor?: Color;
+  title?: string;
+}
+
+function makeTestFixture() {
+  if (document.querySelector("#fixture")) {
+    return {
+      fixture: document.querySelector("#fixture") as HTMLElement,
+      canvas: document.querySelector("canvas") as HTMLCanvasElement,
+    };
+  }
+  const fixture = document.createElement("div");
+  fixture.id = "fixture";
+  document.body.appendChild(fixture);
+
+  const chartContainer = document.createElement("div");
+  chartContainer.id = "chart-container";
+  fixture.appendChild(chartContainer);
+
+  const mockedChartCanvas = document.createElement("canvas");
+  chartContainer.appendChild(mockedChartCanvas);
+
+  return { fixture, canvas: mockedChartCanvas };
+}
+
+function openTooltip(chartConfig: ChartJSRuntime, args: TooltipArgs) {
+  const tooltip = chartConfig.chartJsConfig.options?.plugins?.tooltip as any;
+
+  const { fixture, canvas } = makeTestFixture();
+  const mockChart = {
+    canvas: canvas,
+    config: chartConfig.chartJsConfig,
+    chartArea: { left: 0, top: 0, right: 100, bottom: 100 },
+  };
+  const mockTooltipModel = {
+    opacity: 1,
+    title: [args.title || ""], // We cannot use callback.title because we rely on chartJS default behavior
+    body: [
+      {
+        lines: [tooltip.callbacks.label(args.tooltipItem)],
+      },
+    ],
+    caretX: 50,
+    caretY: 50,
+    dataPoints: [args.tooltipItem],
+    labelColors: [{ backgroundColor: args.backgroundColor || "#FF00FF" }],
+  };
+  tooltip!.external!({ chart: mockChart, tooltip: mockTooltipModel });
+
+  return fixture;
+}
+
+describe("Chart tooltip", () => {
+  test("Basic chart tooltip", () => {
+    const model = new Model();
+    createChart(model, { type: "bar" }, "chartId");
+    const runtime = model.getters.getChartRuntime("chartId") as ChartJSRuntime;
+    const tooltipItem = { parsed: { y: 20 }, dataset: { yAxisID: "y", label: "Ds 1" } };
+
+    const fixture = openTooltip(runtime, {
+      tooltipItem,
+      backgroundColor: "#FFF000",
+      title: "Marc",
+    });
+
+    expect(".o-tooltip-title").toHaveText("Marc");
+    expect(".o-tooltip-label").toHaveText("Ds 1");
+    expect(".o-tooltip-value").toHaveText("20");
+
+    const colorBadge = fixture.querySelector(".badge") as HTMLElement;
+    expect(colorBadge.style.backgroundColor).toBeSameColorAs("#FFF000");
+  });
+
+  test("Opening a new tooltip closes the previous one", () => {
+    const model = new Model();
+    createChart(model, { type: "bar" }, "chartId");
+    const runtime = model.getters.getChartRuntime("chartId") as ChartJSRuntime;
+    const tooltipItem = { parsed: { y: 20 }, dataset: { yAxisID: "y", label: "Ds 1" } };
+
+    openTooltip(runtime, { tooltipItem, title: "Marc" });
+    expect(".o-chart-custom-tooltip").toHaveCount(1);
+    expect(".o-tooltip-title").toHaveText("Marc");
+
+    openTooltip(runtime, { tooltipItem, title: "Jean" });
+    expect(".o-chart-custom-tooltip").toHaveCount(1);
+    expect(".o-tooltip-title").toHaveText("Jean");
+  });
+
+  test("Title div isn't displayed if there is no title", () => {
+    const model = new Model();
+    createChart(model, { type: "bar" }, "chartId");
+    const runtime = model.getters.getChartRuntime("chartId") as ChartJSRuntime;
+    const tooltipItem = { parsed: { y: 20 }, dataset: { yAxisID: "y", label: "Ds 1" } };
+
+    openTooltip(runtime, { tooltipItem, title: "" });
+    expect(".o-tooltip-title").toHaveCount(0);
+  });
+});

--- a/tests/figures/chart/chart_tooltip.test.ts
+++ b/tests/figures/chart/chart_tooltip.test.ts
@@ -42,6 +42,7 @@ function openTooltip(chartConfig: ChartJSRuntime, args: TooltipArgs) {
     title: [args.title || ""], // We cannot use callback.title because we rely on chartJS default behavior
     body: [
       {
+        before: [tooltip.callbacks.beforeLabel(args.tooltipItem)],
         lines: [tooltip.callbacks.label(args.tooltipItem)],
       },
     ],
@@ -99,5 +100,19 @@ describe("Chart tooltip", () => {
 
     openTooltip(runtime, { tooltipItem, title: "" });
     expect(".o-tooltip-title").toHaveCount(0);
+  });
+
+  test("Can handle label with colons", () => {
+    const model = new Model();
+    createChart(model, { type: "bar" }, "chartId");
+    const runtime = model.getters.getChartRuntime("chartId") as ChartJSRuntime;
+    const tooltipItem = {
+      parsed: { y: 20 },
+      dataset: { yAxisID: "y", label: "Avengers: Endgame" },
+    };
+
+    openTooltip(runtime, { tooltipItem });
+    expect(".o-tooltip-label").toHaveText("Avengers: Endgame");
+    expect(".o-tooltip-value").toHaveText("20");
   });
 });

--- a/tests/figures/chart/combo_chart_plugin.test.ts
+++ b/tests/figures/chart/combo_chart_plugin.test.ts
@@ -1,6 +1,6 @@
 import { ChartCreationContext, Model } from "../../../src";
 import { ComboChartRuntime } from "../../../src/types/chart/combo_chart";
-import { getChartLegendLabels } from "../../test_helpers/chart_helpers";
+import { getChartLegendLabels, getChartTooltipValues } from "../../test_helpers/chart_helpers";
 import {
   createChart,
   setCellContent,
@@ -69,12 +69,13 @@ describe("combo chart", () => {
     expect(scales?.y?.ticks?.callback?.apply(null, [1])).toBe("100.00%");
     expect(scales?.y1?.ticks?.callback?.apply(null, [1])).toBe("1.00$");
 
-    const tooltipCallbacks = runtime.chartJsConfig.options?.plugins?.tooltip?.callbacks as any;
     let tooltipItem = { parsed: { y: 20 }, dataIndex: 0, dataset: { yAxisID: "y", label: "Ds 1" } };
-    expect(tooltipCallbacks?.label?.(tooltipItem)).toEqual("Ds 1: 2000.00%");
+    let tooltipValues = getChartTooltipValues(runtime, tooltipItem);
+    expect(tooltipValues).toEqual({ beforeLabel: "Ds 1", label: "2000.00%" });
 
     tooltipItem = { parsed: { y: 20 }, dataIndex: 1, dataset: { yAxisID: "y1", label: "Ds 2" } };
-    expect(tooltipCallbacks?.label?.(tooltipItem)).toEqual("Ds 2: 20.00$");
+    tooltipValues = getChartTooltipValues(runtime, tooltipItem);
+    expect(tooltipValues).toEqual({ beforeLabel: "Ds 2", label: "20.00$" });
   });
 
   test("Can edit the type of the series", () => {

--- a/tests/figures/chart/geochart/geo_chart_plugin.test.ts
+++ b/tests/figures/chart/geochart/geo_chart_plugin.test.ts
@@ -1,6 +1,7 @@
 import { Model } from "../../../../src";
 import { GeoChartRuntime } from "../../../../src/types/chart/geo_chart";
 import { createGeoChart, setCellContent, setFormat, updateChart } from "../../../test_helpers";
+import { getChartTooltipValues } from "../../../test_helpers/chart_helpers";
 import { mockChart, mockGeoJsonService, nextTick } from "../../../test_helpers/helpers";
 
 mockChart();
@@ -112,14 +113,9 @@ describe("Geo charts plugin tests", () => {
 
     createGeoChart(model, { dataSets: [{ dataRange: "B1:B2" }], labelRange: "A1:A2" });
     const runtime = model.getters.getChartRuntime("chartId") as any;
-    expect(
-      runtime.chartJsConfig.options?.plugins?.tooltip?.callbacks?.label?.({
-        raw: {
-          value: 20,
-          feature: { properties: { name: "France" } },
-        },
-      })
-    ).toBe("France: $20");
+    const tooltipItem = { raw: { value: 20, feature: { properties: { name: "France" } } } };
+    const tooltipValues = getChartTooltipValues(runtime, tooltipItem);
+    expect(tooltipValues).toEqual({ beforeLabel: "France", label: "$20" });
   });
 
   test("The projection used depends on the region selected", () => {

--- a/tests/figures/chart/pyramid_chart_plugin.test.ts
+++ b/tests/figures/chart/pyramid_chart_plugin.test.ts
@@ -1,6 +1,7 @@
 import { ChartCreationContext, ChartJSRuntime, Model } from "../../../src";
 import { PyramidChart } from "../../../src/helpers/figures/charts/pyramid_chart";
 import { PyramidChartDefinition } from "../../../src/types/chart/pyramid_chart";
+import { getChartTooltipValues } from "../../test_helpers/chart_helpers";
 import { createChart, setCellContent, setFormat } from "../../test_helpers/commands_helpers";
 
 let model: Model;
@@ -102,8 +103,8 @@ describe("population pyramid chart", () => {
         label: "dataSetLabel",
         dataset: { xAxisID: "x" },
       };
-      const tooltip = runtime.chartJsConfig.options?.plugins?.tooltip as any;
-      expect(tooltip?.callbacks?.label(tooltipTestItem)).toBe("dataSetLabel: 10€");
+      const tooltipValues = getChartTooltipValues(runtime, tooltipTestItem);
+      expect(tooltipValues).toEqual({ beforeLabel: "dataSetLabel", label: "10€" });
     });
 
     test("The negative and positive values have the same max value", () => {

--- a/tests/figures/chart/radar_chart_plugin.test.ts
+++ b/tests/figures/chart/radar_chart_plugin.test.ts
@@ -1,7 +1,7 @@
 import { ChartCreationContext, Model } from "../../../src";
 import { RadarChart } from "../../../src/helpers/figures/charts/radar_chart";
 import { RadarChartRuntime } from "../../../src/types/chart/radar_chart";
-import { getChartLegendLabels } from "../../test_helpers/chart_helpers";
+import { getChartLegendLabels, getChartTooltipValues } from "../../test_helpers/chart_helpers";
 import {
   createChart,
   createRadarChart,
@@ -113,10 +113,9 @@ describe("radar chart", () => {
     const tickCallback = runtime.chartJsConfig.options?.scales?.r?.["ticks"]?.callback as any;
     expect(tickCallback(1)).toBe("1.0 écu d'or");
 
-    const tooltipLabel = runtime.chartJsConfig.options?.plugins?.tooltip?.callbacks?.label as any;
-    expect(tooltipLabel({ parsed: { x: "Louis", r: 14 }, dataset: { label: "Ds1" } })).toBe(
-      "Ds1: 14.0 écu d'or"
-    );
+    const tooltipItem = { parsed: { x: "Louis", r: 14 }, dataset: { label: "Ds1" } };
+    const tooltipValues = getChartTooltipValues(runtime, tooltipItem);
+    expect(tooltipValues).toEqual({ beforeLabel: "Ds1", label: "14.0 écu d'or" });
   });
 
   test("Radar point color depend on the chart background", () => {

--- a/tests/figures/chart/waterfall/waterfall_chart_plugin.test.ts
+++ b/tests/figures/chart/waterfall/waterfall_chart_plugin.test.ts
@@ -12,6 +12,7 @@ import {
   setFormat,
   updateChart,
 } from "../../../test_helpers";
+import { getChartTooltipValues } from "../../../test_helpers/chart_helpers";
 
 let model: Model;
 
@@ -215,11 +216,12 @@ describe("Waterfall chart", () => {
     const runtime = getWaterfallRuntime(chartId);
 
     let tooltipItem = { raw: [0, 30], dataIndex: 0, dataset: { xAxisID: "x" } };
-    const tooltipCallbacks = runtime.chartJsConfig.options?.plugins?.tooltip?.callbacks as any;
-    expect(tooltipCallbacks?.label?.(tooltipItem)).toEqual("Dataset 1: 30€");
+    let tooltipValues = getChartTooltipValues(runtime, tooltipItem);
+    expect(tooltipValues).toEqual({ beforeLabel: "Dataset 1", label: "30€" });
 
     tooltipItem = { raw: [30, -10], dataIndex: 1, dataset: { xAxisID: "x" } };
-    expect(tooltipCallbacks?.label?.(tooltipItem)).toEqual("Dataset 2: -40€");
+    tooltipValues = getChartTooltipValues(runtime, tooltipItem);
+    expect(tooltipValues).toEqual({ beforeLabel: "Dataset 2", label: "-40€" });
   });
 
   test("Waterfall legend", () => {

--- a/tests/test_helpers/chart_helpers.ts
+++ b/tests/test_helpers/chart_helpers.ts
@@ -1,4 +1,5 @@
-import { Model, SpreadsheetChildEnv, UID } from "../../src";
+import { TooltipItem } from "chart.js";
+import { ChartJSRuntime, Model, SpreadsheetChildEnv, UID } from "../../src";
 import { range, toHex } from "../../src/helpers";
 import { click, simulateClick } from "./dom_helper";
 import { nextTick } from "./helpers";
@@ -63,4 +64,34 @@ export function getColorPickerValue(fixture: HTMLElement, selector: string) {
 export async function editColorPicker(fixture: HTMLElement, selector: string, color: string) {
   await click(fixture.querySelector(selector + " .o-round-color-picker-button")!);
   await click(fixture, `.o-color-picker-line-item[data-color='${color}'`);
+}
+
+export function getChartTooltipItemFromDataset(
+  chart: ChartJSRuntime,
+  datasetIndex: number,
+  dataIndex: number
+): Partial<TooltipItem<any>> {
+  const datasetPoint = chart.chartJsConfig!.data!.datasets![datasetIndex].data![dataIndex];
+  const y = typeof datasetPoint === "number" ? datasetPoint : datasetPoint?.["y"];
+  const x = chart.chartJsConfig!.data.labels![dataIndex];
+  const point = chart.chartJsConfig.type === "pie" ? y : { x, y };
+  return {
+    label: "",
+    parsed: point,
+    raw: point,
+    dataset: chart.chartJsConfig.data!.datasets[datasetIndex],
+    datasetIndex,
+    dataIndex,
+  };
+}
+
+export function getChartTooltipValues(
+  chart: ChartJSRuntime,
+  tooltipItem: Partial<TooltipItem<any>>
+) {
+  const callbacks = chart.chartJsConfig!.options!.plugins!.tooltip!.callbacks! as any;
+  return {
+    label: callbacks.label(tooltipItem),
+    beforeLabel: callbacks.beforeLabel(tooltipItem),
+  };
 }


### PR DESCRIPTION
## Description:

### [FIX] chart: handle tooltip with colons in the label

To split the labels and values in the tooltips, we did a simple split
by colon, since our labels had the format `label: value`. But this
obviously breaks when the label itself contains a colon.

With this commit, we now use the `beforeLabel` tooltip callback to
get the label, and the `label` callback to get the value instead of
doing everything in the `label` callback.


### [FIX] chart: remove empty title in tooltip

If there is no title in the tooltip, we still displayed the div
containing the title. That led to a small empty space at the top
of the tooltip.

Task: [4586683](https://www.odoo.com/odoo/2328/tasks/4586683)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo