### PR TITLE
[FIX] chart: only spread relevant options in datasets

### DIFF
--- a/src/helpers/range.ts
+++ b/src/helpers/range.ts
@@ -228,8 +228,9 @@ export function spreadRange(getters: Getters, dataSets: CustomizedDataSet[]): Cu
     if (zone.bottom !== zone.top && zone.left != zone.right) {
       if (zone.right) {
         for (let j = zone.left; j <= zone.right; ++j) {
+          const datasetOptions = j === zone.left ? dataSet : { yAxisId: dataSet.yAxisId };
           postProcessedRanges.push({
-            ...dataSet,
+            ...datasetOptions,
             dataRange: `${sheetPrefix}${zoneToXc({
               left: j,
               right: j,
@@ -240,8 +241,9 @@ export function spreadRange(getters: Getters, dataSets: CustomizedDataSet[]): Cu
         }
       } else {
         for (let j = zone.top; j <= zone.bottom!; ++j) {
+          const datasetOptions = j === zone.top ? dataSet : { yAxisId: dataSet.yAxisId };
           postProcessedRanges.push({
-            ...dataSet,
+            ...datasetOptions,
             dataRange: `${sheetPrefix}${zoneToXc({
               left: zone.left,
               right: zone.right,

--- a/tests/figures/chart/charts_component.test.ts
+++ b/tests/figures/chart/charts_component.test.ts
@@ -1298,6 +1298,28 @@ describe("charts", () => {
     }
   );
 
+  test("Only yAxisId option is copied when spreading a range of a selection input", async () => {
+    createChart(
+      model,
+      {
+        type: "bar",
+        dataSets: [
+          { dataRange: "B1:B4", backgroundColor: "#FF0000", label: "MyLabel", yAxisId: "y1" },
+        ],
+      },
+      chartId
+    );
+    await mountSpreadsheet();
+    await openChartConfigSidePanel(chartId);
+    await setInputValueAndTrigger(".o-data-series input", "B2:C4");
+    await simulateClick(".o-data-series .o-selection-ok");
+    const definition = model.getters.getChartDefinition(chartId) as BarChartDefinition;
+    expect(definition.dataSets).toEqual([
+      { dataRange: "B2:B4", backgroundColor: "#FF0000", label: "MyLabel", yAxisId: "y1" },
+      { dataRange: "C2:C4", yAxisId: "y1" },
+    ]);
+  });
+
   describe("Scorecard specific tests", () => {
     test("can edit chart baseline colors", async () => {
       createTestChart("scorecard");


### PR DESCRIPTION
## Description

In the chart side panel, if we enter a range like `A1:B3` it will be spread into multiple datasets (`A1:A3` and `B1:B3`). The problem is that the dataset settings were also copied for each dataset. So They had the same color, same label, ... which obviously does not make sense.

Now only the `yAxisId` option is copied to the new dataset.

Task: [4577783](https://www.odoo.com/odoo/2328/tasks/4577783)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo