### PR TITLE
[IMP] text_input: add autofocus prop

### DIFF
--- a/src/components/text_input/text_input.ts
+++ b/src/components/text_input/text_input.ts
@@ -3,6 +3,7 @@ import { SpreadsheetChildEnv } from "../..";
 import { GRAY_300, TEXT_BODY } from "../../constants";
 import { Ref } from "../../types";
 import { css } from "../helpers";
+import { useAutofocus } from "../helpers/autofocus_hook";
 
 css/* scss */ `
   .o-spreadsheet {
@@ -26,6 +27,7 @@ interface Props {
   class?: string;
   id?: string;
   placeholder?: string;
+  autofocus?: boolean;
 }
 
 export class TextInput extends Component<Props, SpreadsheetChildEnv> {
@@ -45,6 +47,10 @@ export class TextInput extends Component<Props, SpreadsheetChildEnv> {
       type: String,
       optional: true,
     },
+    autofocus: {
+      type: Boolean,
+      optional: true,
+    },
   };
   private inputRef: Ref<HTMLInputElement> = useRef("input");
 
@@ -59,6 +65,9 @@ export class TextInput extends Component<Props, SpreadsheetChildEnv> {
       },
       { capture: true }
     );
+    if (this.props.autofocus) {
+      useAutofocus({ refName: "input" });
+    }
   }
 
   onKeyDown(ev: KeyboardEvent) {

--- a/tests/components/text_input.test.ts
+++ b/tests/components/text_input.test.ts
@@ -94,4 +94,14 @@ describe("TextInput", () => {
     expect(onChange).not.toHaveBeenCalled();
     expect(input.value).toEqual("hello");
   });
+
+  test("Input is not focused by default", async () => {
+    await mountTextInput({ value: "hello", onChange: () => {} });
+    expect(fixture.querySelector("input")).not.toEqual(document.activeElement);
+  });
+
+  test("Can autofocus the input", async () => {
+    await mountTextInput({ value: "hello", onChange: () => {}, autofocus: true });
+    expect(fixture.querySelector("input")).toEqual(document.activeElement);
+  });
 });


### PR DESCRIPTION
This commit adds the autofocus prop to the text_input component. When true, the input will be focused when the component is mounted.

Task: 4591564

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo