### PR TITLE
[PERF] borders: avoid call to getCellBorder in setBorder

### DIFF
--- a/src/plugins/core/borders.ts
+++ b/src/plugins/core/borders.ts
@@ -412,7 +412,7 @@ export class BordersPlugin extends CorePlugin<BordersPluginState> implements Bor
       if (
         border?.left &&
         col > 0 &&
-        !deepEquals(this.getCellBorder({ sheetId, col: col - 1, row })?.right, border?.left)
+        !deepEquals(this.borders[sheetId]?.[col - 1]?.[row]?.right, border?.left)
       ) {
         this.history.update("borders", sheetId, col - 1, row, "right", undefined);
       }
@@ -422,7 +422,7 @@ export class BordersPlugin extends CorePlugin<BordersPluginState> implements Bor
       if (
         border?.top &&
         row > 0 &&
-        !deepEquals(this.getCellBorder({ sheetId, col, row: row - 1 })?.bottom, border?.top)
+        !deepEquals(this.borders[sheetId]?.[col]?.[row - 1]?.bottom, border?.top)
       ) {
         this.history.update("borders", sheetId, col, row - 1, "bottom", undefined);
       }
@@ -432,7 +432,7 @@ export class BordersPlugin extends CorePlugin<BordersPluginState> implements Bor
       if (
         border?.right &&
         col < maxCol &&
-        !deepEquals(this.getCellBorder({ sheetId, col: col + 1, row })?.left, border?.right)
+        !deepEquals(this.borders[sheetId]?.[col + 1]?.[row]?.left, border?.right)
       ) {
         this.history.update("borders", sheetId, col + 1, row, "left", undefined);
       }
@@ -442,7 +442,7 @@ export class BordersPlugin extends CorePlugin<BordersPluginState> implements Bor
       if (
         border?.bottom &&
         row < maxRow &&
-        !deepEquals(this.getCellBorder({ sheetId, col, row: row + 1 })?.top, border?.bottom)
+        !deepEquals(this.borders[sheetId]?.[col]?.[row + 1]?.top, border?.bottom)
       ) {
         this.history.update("borders", sheetId, col, row + 1, "top", undefined);
       }


### PR DESCRIPTION
getCellBorder performs a deepCopy to avoid changing the reference to the border. But applied to a lot of data, deepCopy is heavy.

As in setBorder we are not reusing the result of
getCellBorder, we can afford to use a version without deepCopy of getCellBorder.

For the application of the borders of a sheet of 1000 rows and 1000 columns, measurements show a total time saving of 50%

Task: [4591697](https://www.odoo.com/odoo/2328/tasks/4591697)
