### PR TITLE
[IMP] cells: do not remove filtered rows when deleting content

### DIFF
--- a/src/actions/edit_actions.ts
+++ b/src/actions/edit_actions.ts
@@ -83,7 +83,7 @@ export const findAndReplace: ActionSpec = {
 export const deleteValues: ActionSpec = {
   name: _t("Delete values"),
   execute: (env) =>
-    env.model.dispatch("DELETE_CONTENT", {
+    env.model.dispatch("DELETE_UNFILTERED_CONTENT", {
       sheetId: env.model.getters.getActiveSheetId(),
       target: env.model.getters.getSelectedZones(),
     }),

--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -231,13 +231,13 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
         : this.onComposerContentFocused();
     },
     Delete: () => {
-      this.env.model.dispatch("DELETE_CONTENT", {
+      this.env.model.dispatch("DELETE_UNFILTERED_CONTENT", {
         sheetId: this.env.model.getters.getActiveSheetId(),
         target: this.env.model.getters.getSelectedZones(),
       });
     },
     Backspace: () => {
-      this.env.model.dispatch("DELETE_CONTENT", {
+      this.env.model.dispatch("DELETE_UNFILTERED_CONTENT", {
         sheetId: this.env.model.getters.getActiveSheetId(),
         target: this.env.model.getters.getSelectedZones(),
       });

--- a/src/plugins/ui_feature/ui_sheet.ts
+++ b/src/plugins/ui_feature/ui_sheet.ts
@@ -3,6 +3,7 @@ import {
   computeIconWidth,
   computeTextWidth,
   formatValue,
+  groupConsecutive,
   isEqual,
   largeMax,
   positions,
@@ -59,7 +60,20 @@ export class SheetUIPlugin extends UIPlugin {
           size: null,
           sheetId: cmd.sheetId,
         });
+        break;
 
+      case "DELETE_UNFILTERED_CONTENT":
+        const newTarget: Zone[] = [];
+        for (const target of cmd.target) {
+          const nonFilteredRows = range(target.top, target.bottom + 1).filter(
+            (row) => !this.getters.isRowFiltered(cmd.sheetId, row)
+          );
+          const consecutiveRows = groupConsecutive(nonFilteredRows);
+          for (const group of consecutiveRows) {
+            newTarget.push({ ...target, top: group[0], bottom: group[group.length - 1] });
+          }
+        }
+        this.dispatch("DELETE_CONTENT", { sheetId: cmd.sheetId, target: newTarget });
         break;
     }
   }

--- a/src/registries/repeat_commands_registry.ts
+++ b/src/registries/repeat_commands_registry.ts
@@ -80,6 +80,7 @@ repeatLocalCommandTransformRegistry.add("AUTORESIZE_ROWS", repeatAutoResizeComma
 repeatLocalCommandTransformRegistry.add("SORT_CELLS", repeatSortCellsCommand);
 repeatLocalCommandTransformRegistry.add("SUM_SELECTION", genericRepeat);
 repeatLocalCommandTransformRegistry.add("SET_DECIMAL", genericRepeat);
+repeatLocalCommandTransformRegistry.add("DELETE_UNFILTERED_CONTENT", genericRepeat);
 
 export function genericRepeat<T extends Command>(getters: Getters, command: T): T {
   let transformedCommand = deepCopy(command);

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -1013,6 +1013,10 @@ export interface PaintFormat extends TargetDependentCommand {
   type: "PAINT_FORMAT";
 }
 
+export interface DeleteUnfilteredContentCommand extends TargetDependentCommand {
+  type: "DELETE_UNFILTERED_CONTENT";
+}
+
 export type CoreCommand =
   // /** History */
   // | SelectiveUndoCommand
@@ -1162,7 +1166,8 @@ export type LocalCommand =
   | DuplicatePivotInNewSheetCommand
   | InsertPivotWithTableCommand
   | SplitPivotFormulaCommand
-  | PaintFormat;
+  | PaintFormat
+  | DeleteUnfilteredContentCommand;
 
 export type Command = CoreCommand | LocalCommand;
 

--- a/tests/grid/grid_component.test.ts
+++ b/tests/grid/grid_component.test.ts
@@ -84,6 +84,8 @@ import {
   mockChart,
   mountSpreadsheet,
   nextTick,
+  spyModelDispatch,
+  target,
   toRangesData,
   typeInComposerGrid,
 } from "../test_helpers/helpers";
@@ -285,13 +287,17 @@ describe("Grid component", () => {
       expect(getCellContent(model, "A1")).toBe("a");
     });
 
-    test("pressing BACKSPACE remove the content of a cell", async () => {
+    test.each(["Backspace", "Delete"])("pressing %s remove the content of a cell", async (key) => {
       setCellContent(model, "A1", "test");
-      await nextTick();
-      keyDown({ key: "Backspace" });
+      const dispatch = spyModelDispatch(model);
+      keyDown({ key });
       expect(getSelectionAnchorCellXc(model)).toBe("A1");
       expect(composerStore.editionMode).toBe("inactive");
       expect(getCellContent(model, "A1")).toBe("");
+      expect(dispatch).toHaveBeenCalledWith("DELETE_UNFILTERED_CONTENT", {
+        sheetId: model.getters.getActiveSheetId(),
+        target: target("A1"),
+      });
     });
 
     test("pressing shift+ENTER in edit mode stop editing and move one cell up", async () => {

--- a/tests/menus/menu_items_registry.test.ts
+++ b/tests/menus/menu_items_registry.test.ts
@@ -298,7 +298,7 @@ describe("Menu Item actions", () => {
 
   test("Edit -> edit_delete_cell_values", () => {
     doAction(["edit", "delete", "edit_delete_cell_values"], env);
-    expect(dispatch).toHaveBeenCalledWith("DELETE_CONTENT", {
+    expect(dispatch).toHaveBeenCalledWith("DELETE_UNFILTERED_CONTENT", {
       sheetId: env.model.getters.getActiveSheetId(),
       target: env.model.getters.getSelectedZones(),
     });

--- a/tests/repeat_commands_plugin.test.ts
+++ b/tests/repeat_commands_plugin.test.ts
@@ -96,6 +96,7 @@ describe("Repeat commands basics", () => {
       "SORT_CELLS",
       "SUM_SELECTION",
       "SET_DECIMAL",
+      "DELETE_UNFILTERED_CONTENT",
     ].sort();
     const registryKeys = repeatLocalCommandTransformRegistry.getKeys().sort();
     expect(repeatableCommands).toEqual(registryKeys);
@@ -556,5 +557,18 @@ describe("Repeat local commands", () => {
     setSelection(model, ["A1:A2"]);
     redo(model);
     expect(getCell(model, "A3")?.content).toEqual("=SUM(A1:A2)");
+  });
+
+  test("Repeat delete unfiltered content", () => {
+    setCellContent(model, "A1", "1");
+    setCellContent(model, "A2", "2");
+
+    model.dispatch("DELETE_UNFILTERED_CONTENT", { sheetId, target: target("A1") });
+    expect(getCellContent(model, "A1")).toEqual("");
+    expect(getCellContent(model, "A2")).toEqual("2");
+
+    setSelection(model, ["A2"]);
+    redo(model);
+    expect(getCellContent(model, "A2")).toEqual("");
   });
 });


### PR DESCRIPTION
## Description

When deleting cell content, the content of cells in filtered rows should not be removed.

Task: [4594840](https://www.odoo.com/odoo/2328/tasks/4594840)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo