### PR TITLE
[IMP] Charts: keep and disable useless dataseries for pyramid chart

### DIFF
--- a/src/components/selection_input/selection_input.xml
+++ b/src/components/selection_input/selection_input.xml
@@ -27,6 +27,7 @@
             t-att-style="getColor(range)"
             class="o-input mb-2"
             t-att-class="{
+              'o-disabled-ranges' : range.disabled and !range.isFocused,
               'o-focused' : range.isFocused,
               'o-invalid border-danger position-relative': isInvalid || !range.isValidRange,
               'text-decoration-underline': range.xc and range.isFocused and state.mode === 'select-range'
@@ -35,9 +36,15 @@
           />
           <span
             t-if="isInvalid || !range.isValidRange"
-            class="error-icon text-danger position-absolute d-flex align-items-center"
+            class="input-icon text-danger position-absolute d-flex align-items-center"
             title="This range is invalid">
             <t t-call="o-spreadsheet-Icon.ERROR"/>
+          </span>
+          <span
+            class="input-icon o-disabled-ranges position-absolute d-flex align-items-center"
+            t-if="!range.isFocused and range.disabled"
+            t-att-title="props.disabledRangeTitle">
+            <t t-call="o-spreadsheet-Icon.CIRCLE_INFO"/>
           </span>
         </div>
         <button
@@ -47,7 +54,6 @@
           <t t-call="o-spreadsheet-Icon.TRASH_FILLED"/>
         </button>
       </div>
-
       <div class="d-flex flex-row w-100 o-selection-input">
         <button class="o-button o-add-selection" t-if="canAddRange" t-on-click="addEmptyInput">
           Add range

--- a/src/components/selection_input/selection_input_store.ts
+++ b/src/components/selection_input/selection_input_store.ts
@@ -30,6 +30,7 @@ export class SelectionInputStore extends SpreadsheetStore {
     "reset",
     "confirm",
     "updateColors",
+    "updateDisabledRanges",
   ] as const;
   private ranges: RangeInputValue[] = [];
   focusedRangeIndex: number | null = null;
@@ -41,7 +42,8 @@ export class SelectionInputStore extends SpreadsheetStore {
     get: Get,
     private initialRanges: string[] = [],
     private readonly inputHasSingleRange: boolean = false,
-    public colors: Color[] = []
+    public colors: Color[] = [],
+    public disabledRanges: boolean[] = []
   ) {
     super(get);
     if (inputHasSingleRange && initialRanges.length > 1) {
@@ -173,6 +175,10 @@ export class SelectionInputStore extends SpreadsheetStore {
     }));
   }
 
+  updateDisabledRanges(disabledRanges: boolean[]) {
+    this.disabledRanges = disabledRanges;
+  }
+
   confirm() {
     for (const range of this.selectionInputs) {
       if (range.xc === "") {
@@ -210,7 +216,11 @@ export class SelectionInputStore extends SpreadsheetStore {
    * Return a list of all valid XCs.
    * e.g. ["A1", "Sheet2!B3", "E12"]
    */
-  get selectionInputs(): (RangeInputValue & { isFocused: boolean; isValidRange: boolean })[] {
+  get selectionInputs(): (RangeInputValue & {
+    isFocused: boolean;
+    isValidRange: boolean;
+    disabled?: boolean;
+  })[] {
     return this.ranges.map((input, index) =>
       Object.assign({}, input, {
         color:
@@ -221,6 +231,7 @@ export class SelectionInputStore extends SpreadsheetStore {
             : null,
         isFocused: this.hasMainFocus && this.focusedRangeIndex === index,
         isValidRange: input.xc === "" || this.getters.isRangeValid(input.xc),
+        disabled: this.disabledRanges?.[index],
       })
     );
   }

--- a/src/components/side_panel/chart/building_blocks/data_series/data_series.ts
+++ b/src/components/side_panel/chart/building_blocks/data_series/data_series.ts
@@ -11,6 +11,7 @@ interface Props {
   onSelectionReordered?: (indexes: number[]) => void;
   onSelectionRemoved?: (index: number) => void;
   onSelectionConfirmed: () => void;
+  maxNumberOfUsedRanges?: number;
   title?: string;
 }
 
@@ -25,10 +26,17 @@ export class ChartDataSeries extends Component<Props, SpreadsheetChildEnv> {
     onSelectionRemoved: { type: Function, optional: true },
     onSelectionConfirmed: Function,
     title: { type: String, optional: true },
+    maxNumberOfUsedRanges: { type: Number, optional: true },
   };
 
   get ranges(): string[] {
     return this.props.ranges.map((r) => r.dataRange);
+  }
+
+  get disabledRanges(): boolean[] {
+    return this.props.ranges.map((r, i) =>
+      this.props.maxNumberOfUsedRanges ? i >= this.props.maxNumberOfUsedRanges : false
+    );
   }
 
   get colors(): (Color | undefined)[] {

--- a/src/components/side_panel/chart/building_blocks/data_series/data_series.xml
+++ b/src/components/side_panel/chart/building_blocks/data_series/data_series.xml
@@ -10,6 +10,8 @@
         onSelectionReordered="props.onSelectionReordered"
         onSelectionRemoved="props.onSelectionRemoved"
         colors="colors"
+        disabledRanges="disabledRanges"
+        disabledRangeTitle.translate="Excluded due to chart limits. Drag to swap with another range."
       />
     </Section>
   </t>

--- a/src/components/side_panel/chart/building_blocks/generic_side_panel/config_panel.ts
+++ b/src/components/side_panel/chart/building_blocks/generic_side_panel/config_panel.ts
@@ -2,6 +2,7 @@ import { Component, useState } from "@odoo/owl";
 import { createValidRange, spreadRange } from "../../../../../helpers";
 import { createDataSets } from "../../../../../helpers/figures/charts";
 import { getChartColorsGenerator } from "../../../../../helpers/figures/charts/runtime";
+import { chartRegistry } from "../../../../../registries/chart_types";
 import { _t } from "../../../../../translation";
 import {
   ChartWithDataSetDefinition,
@@ -218,5 +219,9 @@ export class GenericChartConfigPanel extends Component<Props, SpreadsheetChildEn
       return labelRange.zone.top + 1;
     }
     return undefined;
+  }
+
+  get maxNumberOfUsedRanges(): number | undefined {
+    return chartRegistry.get(this.props.definition.type).dataSeriesLimit;
   }
 }

--- a/src/components/side_panel/chart/building_blocks/generic_side_panel/config_panel.xml
+++ b/src/components/side_panel/chart/building_blocks/generic_side_panel/config_panel.xml
@@ -7,6 +7,7 @@
         onSelectionConfirmed.bind="onDataSeriesConfirmed"
         onSelectionReordered.bind="onDataSeriesReordered"
         onSelectionRemoved.bind="onDataSeriesRemoved"
+        maxNumberOfUsedRanges="maxNumberOfUsedRanges"
       />
       <ChartLabelRange
         range="this.getLabelRange()"

--- a/src/components/side_panel/chart/geo_chart_panel/geo_chart_config_panel.ts
+++ b/src/components/side_panel/chart/geo_chart_panel/geo_chart_config_panel.ts
@@ -1,4 +1,3 @@
-import { spreadRange } from "../../../../helpers";
 import { GenericChartConfigPanel } from "../building_blocks/generic_side_panel/config_panel";
 import { GeoChartRegionSelectSection } from "./geo_chart_region_select_section";
 
@@ -7,14 +6,11 @@ export class GeoChartConfigPanel extends GenericChartConfigPanel {
   static components = { ...GenericChartConfigPanel.components, GeoChartRegionSelectSection };
 
   get dataRanges() {
-    return this.getDataSeriesRanges().slice(0, 1);
+    return this.getDataSeriesRanges();
   }
 
-  onDataSeriesConfirmed() {
-    this.dataSets = spreadRange(this.env.model.getters, this.dataSets).slice(0, 1);
-    this.state.datasetDispatchResult = this.props.updateChart(this.props.figureId, {
-      dataSets: this.dataSets,
-    });
+  get disabledRanges() {
+    return this.props.definition.dataSets.map((ds, i) => i > 0);
   }
 
   getLabelRangeOptions() {

--- a/src/components/side_panel/chart/geo_chart_panel/geo_chart_config_panel.xml
+++ b/src/components/side_panel/chart/geo_chart_panel/geo_chart_config_panel.xml
@@ -9,9 +9,11 @@
 
       <ChartDataSeries
         ranges="dataRanges"
-        onSelectionChanged="(ranges) => this.onDataSeriesRangesChanged(ranges)"
-        onSelectionConfirmed="() => this.onDataSeriesConfirmed()"
-        hasSingleRange="true"
+        onSelectionChanged.bind="onDataSeriesRangesChanged"
+        onSelectionConfirmed.bind="onDataSeriesConfirmed"
+        onSelectionReordered.bind="onDataSeriesReordered"
+        onSelectionRemoved.bind="onDataSeriesRemoved"
+        maxNumberOfUsedRanges="maxNumberOfUsedRanges"
       />
       <ChartLabelRange
         range="this.getLabelRange()"

--- a/src/helpers/figures/charts/pyramid_chart.ts
+++ b/src/helpers/figures/charts/pyramid_chart.ts
@@ -66,7 +66,7 @@ export class PyramidChart extends AbstractChart {
       definition.dataSets,
       sheetId,
       definition.dataSetsHaveTitle
-    ).slice(0, 2);
+    );
     this.labelRange = createValidRange(getters, sheetId, definition.labelRange);
     this.background = definition.background;
     this.legendPosition = definition.legendPosition;

--- a/src/helpers/figures/charts/runtime/chart_data_extractor.ts
+++ b/src/helpers/figures/charts/runtime/chart_data_extractor.ts
@@ -100,7 +100,7 @@ export function getPyramidChartData(
   labelRange: Range | undefined,
   getters: Getters
 ): ChartRuntimeGenerationArgs {
-  const barChartData = getBarChartData(definition, dataSets, labelRange, getters);
+  const barChartData = getBarChartData(definition, dataSets.slice(0, 2), labelRange, getters);
   const barDataset = barChartData.dataSetsValues.filter((ds) => !ds.hidden);
 
   const pyramidDatasetValues: DatasetValues[] = [];
@@ -242,10 +242,11 @@ export function getRadarChartData(
 
 export function getGeoChartData(
   definition: GeoChartDefinition,
-  dataSets: DataSet[],
+  fullDataSets: DataSet[],
   labelRange: Range | undefined,
   getters: Getters
 ): GeoChartRuntimeGenerationArgs {
+  const dataSets = fullDataSets.slice(0, 1);
   const labelValues = getChartLabelValues(getters, dataSets, labelRange);
   let labels = labelValues.formattedValues;
   if (shouldRemoveFirstLabel(labelRange, dataSets[0], definition.dataSetsHaveTitle || false)) {

--- a/src/registries/chart_types.ts
+++ b/src/registries/chart_types.ts
@@ -84,6 +84,7 @@ export interface ChartBuilder {
   ): ChartDefinition;
   getChartDefinitionFromContextCreation(context: ChartCreationContext): ChartDefinition;
   sequence: number;
+  dataSeriesLimit?: number;
 }
 
 /**
@@ -180,6 +181,7 @@ chartRegistry.add("pyramid", {
   transformDefinition: PyramidChart.transformDefinition,
   getChartDefinitionFromContextCreation: PyramidChart.getDefinitionFromContextCreation,
   sequence: 80,
+  dataSeriesLimit: 2,
 });
 chartRegistry.add("radar", {
   match: (type) => type === "radar",
@@ -200,6 +202,7 @@ chartRegistry.add("geo", {
   transformDefinition: GeoChart.transformDefinition,
   getChartDefinitionFromContextCreation: GeoChart.getDefinitionFromContextCreation,
   sequence: 90,
+  dataSeriesLimit: 1,
 });
 chartRegistry.add("funnel", {
   match: (type) => type === "funnel",
@@ -210,6 +213,7 @@ chartRegistry.add("funnel", {
   transformDefinition: FunnelChart.transformDefinition,
   getChartDefinitionFromContextCreation: FunnelChart.getDefinitionFromContextCreation,
   sequence: 100,
+  dataSeriesLimit: 1,
 });
 chartRegistry.add("sunburst", {
   match: (type) => type === "sunburst",

--- a/tests/data_validation/data_validation_generics_side_panel_component.test.ts
+++ b/tests/data_validation/data_validation_generics_side_panel_component.test.ts
@@ -148,7 +148,7 @@ describe("data validation sidePanel component", () => {
     await editStandaloneComposer(composer, "=SUM(1,2)");
 
     await simulateClick(".o-dv-save");
-    expect(fixture.querySelector(".o-selection-input .error-icon")).toBeTruthy();
+    expect(fixture.querySelector(".o-selection-input .input-icon.text-danger")).toBeTruthy();
     expect(fixture.querySelector(".o-selection-input .o-invalid")).toBeTruthy();
     const errorMessageEl = fixture.querySelector(".o-validation-error");
     expect(errorMessageEl).toBeTruthy();

--- a/tests/figures/chart/geochart/geo_chart_panel_component.test.ts
+++ b/tests/figures/chart/geochart/geo_chart_panel_component.test.ts
@@ -53,19 +53,18 @@ describe("Geo chart side panel", () => {
       expect(".o-geo-region select").toHaveValue("usa");
     });
 
-    test("Can only select a single data range", async () => {
+    test("Only one data range is enabled", async () => {
       createGeoChart(model, {
-        dataSets: [{ dataRange: "A1:A3" }, { dataRange: "B1:B3" }],
+        dataSets: [{ dataRange: "A1:A3" }],
       });
       await openChartConfigSidePanel(model, env, chartId);
       expect(".o-data-series input").toHaveCount(1);
-      expect(".o-data-series input").toHaveValue("A1:A3");
 
       await setInputValueAndTrigger(".o-data-series input", "A1:D3");
       await simulateClick(".o-data-series .o-selection-ok");
 
-      expect(".o-data-series input").toHaveValue("A1:A3");
-      expect(getGeoChartDefinition(chartId)?.dataSets).toMatchObject([{ dataRange: "A1:A3" }]);
+      expect(".o-data-series input").toHaveCount(4);
+      expect(".o-data-series input.o-disabled-ranges").toHaveCount(3);
     });
 
     test("Can change the displayed region", async () => {

--- a/tests/figures/chart/pyramid_chart/pyramid_chart_component.test.ts
+++ b/tests/figures/chart/pyramid_chart/pyramid_chart_component.test.ts
@@ -1,6 +1,5 @@
-import { Model, SpreadsheetChildEnv, UID } from "../../../../src";
+import { Model, SpreadsheetChildEnv } from "../../../../src";
 import { SidePanel } from "../../../../src/components/side_panel/side_panel/side_panel";
-import { PyramidChartDefinition } from "../../../../src/types/chart/pyramid_chart";
 import { createChart } from "../../../test_helpers";
 import { openChartConfigSidePanel } from "../../../test_helpers/chart_helpers";
 import { setInputValueAndTrigger, simulateClick } from "../../../test_helpers/dom_helper";
@@ -10,17 +9,13 @@ let model: Model;
 let fixture: HTMLElement;
 let env: SpreadsheetChildEnv;
 
-function getPyramidDefinition(chartId: UID): PyramidChartDefinition {
-  return model.getters.getChartDefinition(chartId) as PyramidChartDefinition;
-}
-
 describe("Pyramid chart side panel", () => {
   beforeEach(async () => {
     model = new Model();
     ({ fixture, env } = await mountComponentWithPortalTarget(SidePanel, { model }));
   });
 
-  test("Only first 2 ranges are kept when changing the selection input", async () => {
+  test("Only first 2 ranges are enabled when changing the selection input", async () => {
     createChart(model, { type: "pyramid", dataSets: [] }, "id");
     await openChartConfigSidePanel(model, env, "id");
 
@@ -29,14 +24,7 @@ describe("Pyramid chart side panel", () => {
     await nextTick();
     await simulateClick(".o-data-series .o-selection-ok");
 
-    expect(getPyramidDefinition("id").dataSets).toEqual([
-      { dataRange: "A1:A5" },
-      { dataRange: "B1:B5" },
-    ]);
-
-    const inputs = fixture.querySelectorAll<HTMLInputElement>(".o-chart .o-data-series input");
-    expect(inputs).toHaveLength(2);
-    expect(inputs[0].value).toBe("A1:A5");
-    expect(inputs[1].value).toBe("B1:B5");
+    expect(".o-data-series input").toHaveCount(4);
+    expect(".o-data-series input.o-disabled-ranges").toHaveCount(2);
   });
 });

--- a/tests/figures/chart/pyramid_chart/pyramid_chart_plugin.test.ts
+++ b/tests/figures/chart/pyramid_chart/pyramid_chart_plugin.test.ts
@@ -1,6 +1,5 @@
 import { ChartCreationContext, ChartJSRuntime, Model } from "../../../../src";
 import { PyramidChart } from "../../../../src/helpers/figures/charts/pyramid_chart";
-import { PyramidChartDefinition } from "../../../../src/types/chart/pyramid_chart";
 import {
   GENERAL_CHART_CREATION_CONTEXT,
   getChartTooltipValues,
@@ -34,13 +33,6 @@ describe("population pyramid chart", () => {
   describe("Pyramid chart definition and runtime", () => {
     beforeEach(() => {
       model = new Model();
-    });
-
-    test("We only keep the first two datasets", () => {
-      const dataSets = [{ dataRange: "A1" }, { dataRange: "A2" }, { dataRange: "A3" }];
-      createChart(model, { type: "pyramid", dataSets }, "id");
-      const definition = model.getters.getChartDefinition("id") as PyramidChartDefinition;
-      expect(definition.dataSets).toEqual([{ dataRange: "A1" }, { dataRange: "A2" }]);
     });
 
     test("Runtime is a stacked bar chart, with the second dataset converted to negative values", () => {

--- a/tests/pivots/spreadsheet_pivot/__snapshots__/spreadsheet_pivot_side_panel.test.ts.snap
+++ b/tests/pivots/spreadsheet_pivot/__snapshots__/spreadsheet_pivot_side_panel.test.ts.snap
@@ -126,6 +126,7 @@ exports[`Spreadsheet pivot side panel It should correctly be displayed 1`] = `
                       type="text"
                     />
                     
+                    
                   </div>
                   
                 </div>
@@ -345,7 +346,7 @@ exports[`Spreadsheet pivot side panel It should display only the selection input
                       type="text"
                     />
                     <span
-                      class="error-icon text-danger position-absolute d-flex align-items-center"
+                      class="input-icon text-danger position-absolute d-flex align-items-center"
                       title="This range is invalid"
                     >
                       <div
@@ -356,6 +357,7 @@ exports[`Spreadsheet pivot side panel It should display only the selection input
                         />
                       </div>
                     </span>
+                    
                     
                   </div>
                   

--- a/tests/side_panels/building_blocks/__snapshots__/data_series.test.ts.snap
+++ b/tests/side_panels/building_blocks/__snapshots__/data_series.test.ts.snap
@@ -31,6 +31,7 @@ exports[`Data Series Can render a data series component 1`] = `
             type="text"
           />
           
+          
         </div>
         
       </div>

--- a/tests/side_panels/building_blocks/__snapshots__/label_range.test.ts.snap
+++ b/tests/side_panels/building_blocks/__snapshots__/label_range.test.ts.snap
@@ -31,6 +31,7 @@ exports[`Label range Can add options to the label range component 1`] = `
             type="text"
           />
           
+          
         </div>
         
       </div>
@@ -91,6 +92,7 @@ exports[`Label range Can render a label range component 1`] = `
             style=""
             type="text"
           />
+          
           
         </div>
         


### PR DESCRIPTION
## Task Description

Currently, when creating a pyramid chart with more than two data series, we are removing the unused ones, which lead to a loss of data series when switching back to another chart type.

This PR aims to change this behavior, by keeping all the data series but keeping only the first two in the runtime, and showing the redondant series as disabled in the config panel.

## Related Task

- Task: [4570622](https://www.odoo.com/odoo/2328/tasks/4570622)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo