### PR TITLE
[FIX] Chart: fix data series reordering

### DIFF
--- a/src/components/selection_input/selection_input.ts
+++ b/src/components/selection_input/selection_input.ts
@@ -1,5 +1,6 @@
 import { Component, onWillUpdateProps, useEffect, useRef, useState } from "@odoo/owl";
 import { ALERT_DANGER_BG } from "../../constants";
+import { range } from "../../helpers";
 import { Store, useLocalStore } from "../../store_engine";
 import { Color, SpreadsheetChildEnv } from "../../types";
 import { css, cssPropertiesToCss } from "../helpers/css";
@@ -163,12 +164,10 @@ export class SelectionInput extends Component<Props, SpreadsheetChildEnv> {
         if (originalIndex === finalIndex) {
           return;
         }
-        const draggedItems = [...draggableIds];
-        draggedItems.splice(originalIndex, 1);
-        draggedItems.splice(finalIndex, 0, rangeId);
-        this.props.onSelectionReordered?.(
-          this.store.selectionInputs.map((range) => draggedItems.indexOf(range.id))
-        );
+        const indexes = range(0, draggableIds.length);
+        indexes.splice(originalIndex, 1);
+        indexes.splice(finalIndex, 0, originalIndex);
+        this.props.onSelectionReordered?.(indexes);
         this.props.onSelectionConfirmed?.();
         this.store.confirm();
       },

--- a/tests/figures/chart/charts_component.test.ts
+++ b/tests/figures/chart/charts_component.test.ts
@@ -840,19 +840,20 @@ describe("charts", () => {
         }),
         "o-selection": (el: HTMLElement) => ({
           y: 0,
-          height: 200,
+          height: 300,
         }),
       });
       await mountSpreadsheet();
     });
 
-    test("can reorder ranges in chart panel", async () => {
+    test("can reorder ranges in chart panel (last to first)", async () => {
       createChart(
         model,
         {
           dataSets: [
             { dataRange: "B1:B4", label: "serie_1", backgroundColor: "#FF0000" },
             { dataRange: "C1:C4", label: "serie_2", backgroundColor: "#00FF00" },
+            { dataRange: "D1:D4", label: "serie_3", backgroundColor: "#0000FF" },
           ],
           labelRange: "A2:A4",
           type: "line",
@@ -862,14 +863,44 @@ describe("charts", () => {
       await openChartConfigSidePanel(model, env, chartId);
       await dragElement(
         fixture.querySelectorAll(".o-drag-handle")[0],
-        { x: 0, y: 150 },
+        { x: 0, y: 250 },
         undefined,
         true
       );
       const definition = model.getters.getChartDefinition(chartId) as LineChartDefinition;
       expect(definition.dataSets).toMatchObject([
         { dataRange: "C1:C4", label: "serie_2", backgroundColor: "#00FF00" },
+        { dataRange: "D1:D4", label: "serie_3", backgroundColor: "#0000FF" },
         { dataRange: "B1:B4", label: "serie_1", backgroundColor: "#FF0000" },
+      ]);
+    });
+
+    test("can reorder ranges in chart panel (first to last)", async () => {
+      createChart(
+        model,
+        {
+          dataSets: [
+            { dataRange: "B1:B4", label: "serie_1", backgroundColor: "#FF0000" },
+            { dataRange: "C1:C4", label: "serie_2", backgroundColor: "#00FF00" },
+            { dataRange: "D1:D4", label: "serie_3", backgroundColor: "#0000FF" },
+          ],
+          labelRange: "A2:A4",
+          type: "line",
+        },
+        chartId
+      );
+      await openChartConfigSidePanel(model, env, chartId);
+      await dragElement(
+        fixture.querySelectorAll(".o-drag-handle")[2],
+        { x: 0, y: 50 },
+        undefined,
+        true
+      );
+      const definition = model.getters.getChartDefinition(chartId) as LineChartDefinition;
+      expect(definition.dataSets).toMatchObject([
+        { dataRange: "D1:D4", label: "serie_3", backgroundColor: "#0000FF" },
+        { dataRange: "B1:B4", label: "serie_1", backgroundColor: "#FF0000" },
+        { dataRange: "C1:C4", label: "serie_2", backgroundColor: "#00FF00" },
       ]);
     });
 


### PR DESCRIPTION
## Task Description

When trying to move data series for more than one position (above or below), we face a bug where the final order is not right. For example, with 3 dataseries (lets call them d1, d2 and d3), if the user tries to put d3 at the first position, he will end with [d2, d3, d1] instead of [d3, d1, d2].

## Related Task

- Task: [4600194](https://www.odoo.com/odoo/2328/tasks/4600194)
