### PR TITLE
[FIX] HeaderOverlay: Fix unhide button position

### DIFF
--- a/src/components/headers_overlay/headers_overlay.ts
+++ b/src/components/headers_overlay/headers_overlay.ts
@@ -6,6 +6,7 @@ import {
   ICON_EDGE_LENGTH,
   MIN_COL_WIDTH,
   MIN_ROW_HEIGHT,
+  SCROLLBAR_WIDTH,
   SELECTION_BORDER_COLOR,
   UNHIDE_ICON_EDGE_LENGTH,
 } from "../../constants";
@@ -374,6 +375,10 @@ export class ColResizer extends AbstractResizer {
     this.MIN_ELEMENT_SIZE = MIN_COL_WIDTH;
   }
 
+  get sheetId() {
+    return this.env.model.getters.getActiveSheetId();
+  }
+
   _getEvOffset(ev: MouseEvent): Pixel {
     return ev.offsetX;
   }
@@ -403,14 +408,11 @@ export class ColResizer extends AbstractResizer {
   }
 
   _getDimensionsInViewport(index: HeaderIndex): HeaderDimensions {
-    return this.env.model.getters.getColDimensionsInViewport(
-      this.env.model.getters.getActiveSheetId(),
-      index
-    );
+    return this.env.model.getters.getColDimensionsInViewport(this.sheetId, index);
   }
 
   _getElementSize(index: HeaderIndex): Pixel {
-    return this.env.model.getters.getColSize(this.env.model.getters.getActiveSheetId(), index);
+    return this.env.model.getters.getColSize(this.sheetId, index);
   }
 
   _getMaxSize(): Pixel {
@@ -423,7 +425,7 @@ export class ColResizer extends AbstractResizer {
     const cols = this.env.model.getters.getActiveCols();
     this.env.model.dispatch("RESIZE_COLUMNS_ROWS", {
       dimension: "COL",
-      sheetId: this.env.model.getters.getActiveSheetId(),
+      sheetId: this.sheetId,
       elements: cols.has(index) ? [...cols] : [index],
       size,
     });
@@ -437,7 +439,7 @@ export class ColResizer extends AbstractResizer {
       elements.push(colIndex);
     }
     const result = this.env.model.dispatch("MOVE_COLUMNS_ROWS", {
-      sheetId: this.env.model.getters.getActiveSheetId(),
+      sheetId: this.sheetId,
       dimension: "COL",
       base: this.state.base,
       elements,
@@ -462,7 +464,7 @@ export class ColResizer extends AbstractResizer {
   _fitElementSize(index: HeaderIndex): void {
     const cols = this.env.model.getters.getActiveCols();
     this.env.model.dispatch("AUTORESIZE_COLUMNS", {
-      sheetId: this.env.model.getters.getActiveSheetId(),
+      sheetId: this.sheetId,
       cols: cols.has(index) ? [...cols] : [index],
     });
   }
@@ -476,7 +478,7 @@ export class ColResizer extends AbstractResizer {
   }
 
   _getPreviousVisibleElement(index: HeaderIndex): HeaderIndex {
-    const sheetId = this.env.model.getters.getActiveSheetId();
+    const sheetId = this.sheetId;
     let row: HeaderIndex;
     for (row = index - 1; row >= 0; row--) {
       if (!this.env.model.getters.isColHidden(sheetId, row)) {
@@ -488,7 +490,7 @@ export class ColResizer extends AbstractResizer {
 
   unhide(hiddenElements: HeaderIndex[]) {
     this.env.model.dispatch("UNHIDE_COLUMNS_ROWS", {
-      sheetId: this.env.model.getters.getActiveSheetId(),
+      sheetId: this.sheetId,
       elements: hiddenElements,
       dimension: "COL",
     });
@@ -506,7 +508,7 @@ css/* scss */ `
     left: 0;
     right: 0;
     width: ${HEADER_WIDTH}px;
-    height: 100%;
+    height: calc(100% - ${HEADER_HEIGHT + SCROLLBAR_WIDTH}px);
     &.o-dragging {
       cursor: grabbing;
     }
@@ -575,6 +577,10 @@ export class RowResizer extends AbstractResizer {
 
   private rowResizerRef!: Ref<HTMLElement>;
 
+  get sheetId() {
+    return this.env.model.getters.getActiveSheetId();
+  }
+
   _getEvOffset(ev: MouseEvent): Pixel {
     return ev.offsetY;
   }
@@ -604,14 +610,11 @@ export class RowResizer extends AbstractResizer {
   }
 
   _getDimensionsInViewport(index: HeaderIndex): HeaderDimensions {
-    return this.env.model.getters.getRowDimensionsInViewport(
-      this.env.model.getters.getActiveSheetId(),
-      index
-    );
+    return this.env.model.getters.getRowDimensionsInViewport(this.sheetId, index);
   }
 
   _getElementSize(index: HeaderIndex): Pixel {
-    return this.env.model.getters.getRowSize(this.env.model.getters.getActiveSheetId(), index);
+    return this.env.model.getters.getRowSize(this.sheetId, index);
   }
 
   _getMaxSize(): Pixel {
@@ -624,7 +627,7 @@ export class RowResizer extends AbstractResizer {
     const rows = this.env.model.getters.getActiveRows();
     this.env.model.dispatch("RESIZE_COLUMNS_ROWS", {
       dimension: "ROW",
-      sheetId: this.env.model.getters.getActiveSheetId(),
+      sheetId: this.sheetId,
       elements: rows.has(index) ? [...rows] : [index],
       size,
     });
@@ -638,7 +641,7 @@ export class RowResizer extends AbstractResizer {
       elements.push(rowIndex);
     }
     const result = this.env.model.dispatch("MOVE_COLUMNS_ROWS", {
-      sheetId: this.env.model.getters.getActiveSheetId(),
+      sheetId: this.sheetId,
       dimension: "ROW",
       base: this.state.base,
       elements,
@@ -663,7 +666,7 @@ export class RowResizer extends AbstractResizer {
   _fitElementSize(index: HeaderIndex): void {
     const rows = this.env.model.getters.getActiveRows();
     this.env.model.dispatch("AUTORESIZE_ROWS", {
-      sheetId: this.env.model.getters.getActiveSheetId(),
+      sheetId: this.sheetId,
       rows: rows.has(index) ? [...rows] : [index],
     });
   }
@@ -677,7 +680,7 @@ export class RowResizer extends AbstractResizer {
   }
 
   _getPreviousVisibleElement(index: HeaderIndex): HeaderIndex {
-    const sheetId = this.env.model.getters.getActiveSheetId();
+    const sheetId = this.sheetId;
     let row: HeaderIndex;
     for (row = index - 1; row >= 0; row--) {
       if (!this.env.model.getters.isRowHidden(sheetId, row)) {
@@ -689,7 +692,7 @@ export class RowResizer extends AbstractResizer {
 
   unhide(hiddenElements: HeaderIndex[]) {
     this.env.model.dispatch("UNHIDE_COLUMNS_ROWS", {
-      sheetId: this.env.model.getters.getActiveSheetId(),
+      sheetId: this.sheetId,
       dimension: "ROW",
       elements: hiddenElements,
     });

--- a/src/components/headers_overlay/headers_overlay.xml
+++ b/src/components/headers_overlay/headers_overlay.xml
@@ -9,7 +9,7 @@
 
   <t t-name="o-spreadsheet-RowResizer" owl="1">
     <div
-      class="o-row-resizer"
+      class="o-row-resizer overflow-hidden"
       t-on-mousemove.self="onMouseMove"
       t-on-mouseleave="onMouseLeave"
       t-on-mousedown.self.prevent="select"
@@ -37,24 +37,28 @@
           <div class="dragging-resizer" t-if="state.isResizing"/>
         </div>
       </t>
+      <t t-set="viewportZone" t-value="env.model.getters.getActiveMainViewport()"/>
       <t
-        t-foreach="env.model.getters.getHiddenRowsGroups(env.model.getters.getActiveSheetId())"
+        t-foreach="env.model.getters.getHiddenRowsGroups(sheetId)"
         t-as="hiddenItem"
         t-key="hiddenItem_index">
-        <t t-if="!hiddenItem.includes(0)">
+        <t
+          t-if="env.model.getters.isVisibleInViewport(sheetId, viewportZone.left, hiddenItem[0]-1)">
           <div
             class="o-unhide"
             t-att-data-index="hiddenItem_index"
+            t-att-data-direction="'up'"
             t-attf-style="top:{{unhideStyleValue(hiddenItem[0]) - 17}}px;"
             t-on-click="() => this.unhide(hiddenItem)">
             <t t-call="o-spreadsheet-Icon.TRIANGLE_UP"/>
           </div>
         </t>
         <t
-          t-if="!hiddenItem.includes(env.model.getters.getNumberRows(env.model.getters.getActiveSheetId())-1)">
+          t-if="env.model.getters.isVisibleInViewport(sheetId,viewportZone.left, hiddenItem[hiddenItem.length-1]+1)">
           <div
             class="o-unhide"
             t-att-data-index="hiddenItem_index"
+            t-att-data-direction="'down'"
             t-attf-style="top:{{unhideStyleValue(hiddenItem[0]) + 3}}px;"
             t-on-click="() => this.unhide(hiddenItem)">
             <t t-call="o-spreadsheet-Icon.TRIANGLE_DOWN"/>
@@ -66,7 +70,7 @@
 
   <t t-name="o-spreadsheet-ColResizer" owl="1">
     <div
-      class="o-col-resizer"
+      class="o-col-resizer overflow-hidden"
       t-on-mousemove.self="onMouseMove"
       t-on-mouseleave="onMouseLeave"
       t-on-mousedown.self.prevent="select"
@@ -94,24 +98,27 @@
           <div class="dragging-resizer" t-if="state.isResizing"/>
         </div>
       </t>
+      <t t-set="viewportZone" t-value="env.model.getters.getActiveMainViewport()"/>
       <t
-        t-foreach="env.model.getters.getHiddenColsGroups(env.model.getters.getActiveSheetId())"
+        t-foreach="env.model.getters.getHiddenColsGroups(sheetId)"
         t-as="hiddenItem"
         t-key="hiddenItem_index">
-        <t t-if="!hiddenItem.includes(0)">
+        <t t-if="env.model.getters.isVisibleInViewport(sheetId, hiddenItem[0]-1, viewportZone.top)">
           <div
             class="o-unhide"
             t-att-data-index="hiddenItem_index"
+            t-att-data-direction="'left'"
             t-attf-style="left:{{unhideStyleValue(hiddenItem[0]) - 17}}px; margin-right:6px;"
             t-on-click="() => this.unhide(hiddenItem)">
             <t t-call="o-spreadsheet-Icon.TRIANGLE_LEFT"/>
           </div>
         </t>
         <t
-          t-if="!hiddenItem.includes(env.model.getters.getNumberCols(env.model.getters.getActiveSheetId())-1)">
+          t-if="env.model.getters.isVisibleInViewport(sheetId, hiddenItem[hiddenItem.length-1]+1, viewportZone.top)">
           <div
             class="o-unhide"
             t-att-data-index="hiddenItem_index"
+            t-att-data-direction="'right'"
             t-attf-style="left:{{unhideStyleValue(hiddenItem[0]) + 3}}px;"
             t-on-click="() => this.unhide(hiddenItem)">
             <t t-call="o-spreadsheet-Icon.TRIANGLE_RIGHT"/>

--- a/src/plugins/ui/sheetview.ts
+++ b/src/plugins/ui/sheetview.ts
@@ -364,7 +364,8 @@ export class SheetViewPlugin extends UIPlugin {
         ? this.getters.getSheetViewVisibleCols()
         : this.getters.getSheetViewVisibleRows();
     const startIndex = visibleHeaders.findIndex((header) => referenceHeaderIndex >= header);
-    const endIndex = visibleHeaders.findIndex((header) => targetHeaderIndex <= header);
+    let endIndex = visibleHeaders.findIndex((header) => targetHeaderIndex <= header);
+    endIndex = endIndex === -1 ? visibleHeaders.length : endIndex;
     const relevantIndexes = visibleHeaders.slice(startIndex, endIndex);
     let offset = 0;
     for (const i of relevantIndexes) {

--- a/tests/components/__snapshots__/grid.test.ts.snap
+++ b/tests/components/__snapshots__/grid.test.ts.snap
@@ -27,7 +27,7 @@ exports[`Grid component simple rendering snapshot 1`] = `
     class="o-overlay"
   >
     <div
-      class="o-col-resizer"
+      class="o-col-resizer overflow-hidden"
     >
       
       
@@ -37,7 +37,7 @@ exports[`Grid component simple rendering snapshot 1`] = `
     </div>
     
     <div
-      class="o-row-resizer"
+      class="o-row-resizer overflow-hidden"
     >
       
       

--- a/tests/components/__snapshots__/spreadsheet.test.ts.snap
+++ b/tests/components/__snapshots__/spreadsheet.test.ts.snap
@@ -432,7 +432,7 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
       class="o-overlay"
     >
       <div
-        class="o-col-resizer"
+        class="o-col-resizer overflow-hidden"
       >
         
         
@@ -442,7 +442,7 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
       </div>
       
       <div
-        class="o-row-resizer"
+        class="o-row-resizer overflow-hidden"
       >
         
         

--- a/tests/test_helpers/commands_helpers.ts
+++ b/tests/test_helpers/commands_helpers.ts
@@ -1,3 +1,4 @@
+import { HEADER_HEIGHT, HEADER_WIDTH } from "../../src/constants";
 import { isInside, lettersToNumber, toCartesian, toZone } from "../../src/helpers/index";
 import { Model } from "../../src/model";
 import {
@@ -8,6 +9,7 @@ import {
   ClipboardPasteOptions,
   CreateSheetCommand,
   DispatchResult,
+  Pixel,
   SortDirection,
   SortOptions,
   Style,
@@ -815,5 +817,14 @@ export function setFormat(
     sheetId,
     target,
     format,
+  });
+}
+
+export function setSheetviewSize(model: Model, height: Pixel, width: Pixel, hasHeaders = true) {
+  return model.dispatch("RESIZE_SHEETVIEW", {
+    height,
+    width,
+    gridOffsetX: hasHeaders ? HEADER_WIDTH : 0,
+    gridOffsetY: hasHeaders ? HEADER_HEIGHT : 0,
   });
 }


### PR DESCRIPTION
The visibility of the button to unhide headers never properly accounted for the presence of the frozen pane. Furthermore, recent fixes in the viewport made the situation worse because the offset of the last header was badly computed when it was hidden.

Task: 4548264

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [4548264](https://www.odoo.com/odoo/2328/tasks/4548264)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo