### PR TITLE
[FIX] spreadsheet: handle inverse increment when autofilling upwards/left

### DIFF
--- a/src/plugins/ui/autofill.ts
+++ b/src/plugins/ui/autofill.ts
@@ -330,7 +330,7 @@ export class AutofillPlugin extends UIPlugin {
   private getRule(cell: Cell, cells: (Cell | undefined)[]): AutofillModifier | undefined {
     const rules = autofillRulesRegistry.getAll().sort((a, b) => a.sequence - b.sequence);
     const rule = rules.find((rule) => rule.condition(cell, cells));
-    return rule && rule.generateRule(cell, cells);
+    return rule && this.direction && rule.generateRule(cell, cells, this.direction);
   }
 
   /**

--- a/src/registries/autofill_rules.ts
+++ b/src/registries/autofill_rules.ts
@@ -1,6 +1,6 @@
 import { DATETIME_FORMAT } from "../constants";
 import { Registry } from "../registry";
-import { AutofillModifier, Cell, CellValueType } from "../types/index";
+import { AutofillModifier, Cell, CellValueType, DIRECTION } from "../types/index";
 
 /**
  * An AutofillRule is used to generate what to do when we need to autofill
@@ -11,7 +11,7 @@ import { AutofillModifier, Cell, CellValueType } from "../types/index";
  */
 export interface AutofillRule {
   condition: (cell: Cell, cells: (Cell | undefined)[]) => boolean;
-  generateRule: (cell: Cell, cells: (Cell | undefined)[]) => AutofillModifier;
+  generateRule: (cell: Cell, cells: (Cell | undefined)[], direction: DIRECTION) => AutofillModifier;
   sequence: number;
 }
 
@@ -80,10 +80,12 @@ autofillRulesRegistry
   })
   .add("increment_number", {
     condition: (cell: Cell) => cell.evaluated.type === CellValueType.number,
-    generateRule: (cell: Cell, cells: (Cell | undefined)[]) => {
+    generateRule: (cell: Cell, cells: (Cell | undefined)[], direction: DIRECTION) => {
       const group = getGroup(cell, cells);
       let increment: number = 1;
-      if (group.length == 2) {
+      if (group.length === 1 && ["up", "left"].includes(direction)) {
+        increment = -1;
+      } else if (group.length == 2) {
         increment = (group[1] - group[0]) * 2;
       } else if (group.length > 2) {
         increment = getAverageIncrement(group) * group.length;

--- a/tests/plugins/autofill.test.ts
+++ b/tests/plugins/autofill.test.ts
@@ -323,6 +323,38 @@ describe("Autofill", () => {
       expect(getCellContent(model, "A9")).toBe("test");
     });
 
+    test("Autofill mixed-mixed values UP", () => {
+      setCellContent(model, "A10", "test");
+      setCellContent(model, "A11", "test1");
+      setCellContent(model, "A12", "4");
+      autofill("A10:A12", "A1");
+      expect(getCellContent(model, "A9")).toBe("3");
+      expect(getCellContent(model, "A8")).toBe("test1");
+      expect(getCellContent(model, "A7")).toBe("test");
+      expect(getCellContent(model, "A6")).toBe("2");
+      expect(getCellContent(model, "A5")).toBe("test1");
+      expect(getCellContent(model, "A4")).toBe("test");
+      expect(getCellContent(model, "A3")).toBe("1");
+      expect(getCellContent(model, "A2")).toBe("test1");
+      expect(getCellContent(model, "A1")).toBe("test");
+    });
+
+    test("Autofill mixed-mixed values LEFT", () => {
+      setCellContent(model, "J1", "test");
+      setCellContent(model, "K1", "test1");
+      setCellContent(model, "L1", "4");
+      autofill("J1:L1", "A1");
+      expect(getCellContent(model, "I1")).toBe("3");
+      expect(getCellContent(model, "H1")).toBe("test1");
+      expect(getCellContent(model, "G1")).toBe("test");
+      expect(getCellContent(model, "F1")).toBe("2");
+      expect(getCellContent(model, "E1")).toBe("test1");
+      expect(getCellContent(model, "D1")).toBe("test");
+      expect(getCellContent(model, "C1")).toBe("1");
+      expect(getCellContent(model, "B1")).toBe("test1");
+      expect(getCellContent(model, "A1")).toBe("test");
+    });
+
     test("Autofill number and text", () => {
       setCellContent(model, "A1", "1");
       setCellContent(model, "A2", "test");


### PR DESCRIPTION
Prior to this commit, autofilling upwards or to the left only correctly inverted the incrementation for numbers, but not when given a group of cells.  This led to incorrect results when autofilling mixed content.

The issue occurred because the rule generator always processed values in the same order, regardless of the autofill direction. When a single numeric value was present in a group of cells, the autofill logic failed to apply a negative increment when filling upwards.

To address this, the rule generator now considers the autofill direction.

Steps to reproduce:
1. Insert the following values in a column:
   - A10: 'test'
   - A11: 'test2'
   - A12: '4'
2. Select A10:A12 and autofill upwards.
3. Expected: A9 should be '3'. Before this fix, it incorrectly showed '5'.

Task: [4199568](https://www.odoo.com/odoo/2328/tasks/4199568)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo