### PR TITLE
[FIX] data_validation,conditional_format: fix rule range deletion

### DIFF
--- a/src/components/selection_input/selection_input.ts
+++ b/src/components/selection_input/selection_input.ts
@@ -220,10 +220,14 @@ export class SelectionInput extends Component<Props, SpreadsheetChildEnv> {
 
   addEmptyInput() {
     this.store.addEmptyRange();
+    const rangeId = this.ranges[this.ranges.length - 1].id;
+    this.store.changeRange(rangeId, "");
+    this.triggerChange();
   }
 
   removeInput(rangeId: number) {
     const index = this.store.selectionInputs.findIndex((range) => range.id === rangeId);
+    this.store.removeRange(rangeId);
     this.props.onSelectionRemoved?.(index);
     this.props.onSelectionConfirmed?.();
   }

--- a/src/components/selection_input/selection_input.xml
+++ b/src/components/selection_input/selection_input.xml
@@ -52,13 +52,13 @@
         <button class="o-button o-add-selection" t-if="canAddRange" t-on-click="addEmptyInput">
           Add range
         </button>
-        <div class="ms-auto" t-if="store.hasFocus">
+        <div class="ms-auto" t-if="store.hasMainFocus">
           <button class="o-button o-selection-ko" t-if="isResettable" t-on-click="reset">
             Reset
           </button>
           <button
             class="o-button primary ms-2 o-selection-ok"
-            t-if="store.hasFocus"
+            t-if="store.hasMainFocus"
             t-att-disabled="!isConfirmable"
             t-on-click="confirm">
             Confirm

--- a/src/components/selection_input/selection_input_store.ts
+++ b/src/components/selection_input/selection_input_store.ts
@@ -233,10 +233,6 @@ export class SelectionInputStore extends SpreadsheetStore {
     return this.selectionInputs.every((range) => range.isValidRange);
   }
 
-  get hasFocus(): boolean {
-    return this.selectionInputs.some((i) => i.isFocused);
-  }
-
   private get hasMainFocus() {
     const focusedElement = this.focusStore.focusedElement;
     return !!focusedElement && focusedElement === this;

--- a/tests/conditional_formatting/conditional_formatting_panel_component.test.ts
+++ b/tests/conditional_formatting/conditional_formatting_panel_component.test.ts
@@ -440,6 +440,54 @@ describe("UI of conditional formats", () => {
       );
     });
 
+    test("Can remove a valid, invalid or empty range", async () => {
+      await click(fixture, selectors.buttonAdd);
+      await nextTick();
+
+      await setInputValueAndTrigger(selectors.ruleEditor.editor.operatorInput, "BeginsWith");
+      setInputValueAndTrigger(".o-selection-input input", "A1:A4");
+      expect(document.querySelectorAll(".o-selection-input input")).toHaveLength(1);
+
+      // Add & remove a valid range
+      await simulateClick(".o-add-selection");
+      const range1 = document.querySelectorAll(".o-selection-input input")[1];
+      await setInputValueAndTrigger(range1, "B1:B4");
+      const remove1 = document.querySelectorAll(".o-remove-selection")[1];
+      await simulateClick(remove1);
+      expect(document.querySelectorAll(".o-selection-input input")).toHaveLength(1);
+
+      // Add & remove an invalid range
+      await simulateClick(".o-add-selection");
+      const range2 = document.querySelectorAll(".o-selection-input input")[1];
+      await setInputValueAndTrigger(range2, "B1:MERA");
+      const remove2 = document.querySelectorAll(".o-remove-selection")[1];
+      await simulateClick(remove2);
+      expect(document.querySelectorAll(".o-selection-input input")).toHaveLength(1);
+
+      // Add & remove an empty range
+      await simulateClick(".o-add-selection");
+      const remove3 = document.querySelectorAll(".o-remove-selection")[1];
+      await simulateClick(remove3);
+      expect(document.querySelectorAll(".o-selection-input input")).toHaveLength(1);
+
+      // Add & remove a valid range positioned before an empty range
+      await simulateClick(".o-add-selection");
+      const range4 = document.querySelectorAll(".o-selection-input input")[1];
+      await setInputValueAndTrigger(range4, "B1:B4");
+      await simulateClick(".o-add-selection");
+      const remove4 = document.querySelectorAll(".o-remove-selection")[1];
+      await simulateClick(remove4);
+      expect(document.querySelectorAll(".o-selection-input input")).toHaveLength(2);
+
+      editStandaloneComposer(selectors.ruleEditor.editor.valueInput, "ABC");
+
+      // The CF rule should be saved with the one range only
+      await click(fixture, selectors.buttonSave);
+      expect(model.getters.getConditionalFormats(sheetId)[2]).toMatchObject({
+        ranges: ["A1:A4"],
+      });
+    });
+
     test("can delete Rule", async () => {
       const dispatch = spyModelDispatch(model);
       const previews = document.querySelectorAll(selectors.listPreview);

--- a/tests/data_validation/data_validation_generics_side_panel_component.test.ts
+++ b/tests/data_validation/data_validation_generics_side_panel_component.test.ts
@@ -155,6 +155,56 @@ describe("data validation sidePanel component", () => {
     expect(errorMessageEl?.textContent).toContain("The range is invalid.");
   });
 
+  test("Can remove a valid, invalid or empty range", async () => {
+    await simulateClick(".o-dv-add");
+    await nextTick();
+    await changeCriterionType("dateIs");
+
+    setInputValueAndTrigger(".o-selection-input input", "A1:A4");
+    expect(document.querySelectorAll(".o-selection-input input")).toHaveLength(1);
+
+    // Add & remove a valid range
+    await simulateClick(".o-add-selection");
+    const range1 = document.querySelectorAll(".o-selection-input input")[1];
+    await setInputValueAndTrigger(range1, "B1:B4");
+    const remove1 = document.querySelectorAll(".o-remove-selection")[1];
+    await simulateClick(remove1);
+    expect(document.querySelectorAll(".o-selection-input input")).toHaveLength(1);
+
+    // Add & remove an invalid range
+    await simulateClick(".o-add-selection");
+    const range2 = document.querySelectorAll(".o-selection-input input")[1];
+    await setInputValueAndTrigger(range2, "B1:HOLA");
+    const remove2 = document.querySelectorAll(".o-remove-selection")[1];
+    await simulateClick(remove2);
+    expect(document.querySelectorAll(".o-selection-input input")).toHaveLength(1);
+
+    // Add & remove an empty range
+    await simulateClick(".o-add-selection");
+    const remove3 = document.querySelectorAll(".o-remove-selection")[1];
+    await simulateClick(remove3);
+    expect(document.querySelectorAll(".o-selection-input input")).toHaveLength(1);
+
+    // Add & remove a valid range positioned before an empty range
+    await simulateClick(".o-add-selection");
+    const range4 = document.querySelectorAll(".o-selection-input input")[1];
+    await setInputValueAndTrigger(range4, "B1:B4");
+    await simulateClick(".o-add-selection");
+    const remove4 = document.querySelectorAll(".o-remove-selection")[1];
+    await simulateClick(remove4);
+    expect(document.querySelectorAll(".o-selection-input input")).toHaveLength(2);
+
+    await editStandaloneComposer(".o-dv-settings .o-composer", "=DATE(2025,1,1)");
+
+    // The DV rule should be saved with the one range only
+    await simulateClick(".o-dv-save");
+    expect(getDataValidationRules(model, sheetId)).toMatchObject([
+      {
+        ranges: ["A1:A4"],
+      },
+    ]);
+  });
+
   test("Invalid input values with single input", async () => {
     await simulateClick(".o-dv-add");
     await nextTick();


### PR DESCRIPTION
Prior to this commit, clicking the trash icon next to a range in DV/CF did not remove the range due to a missing event handler. This bug was introduced by this commit: https://github.com/odoo/o-spreadsheet/pull/5027/commits/f64e482ec0935b1243dd6a67fabbc21f886beb9e

This commit ensures that the deletion action is correctly triggered, allowing a proper management of CF/DV rules

Steps to reproduce:
- Create a DV/CF rule
- Add a new range (valid or invalid)
- Click on the trash icon next to the range
- Nothing happens

Task: [4589387](https://www.odoo.com/odoo/2328/tasks/4589387)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo