### PR TITLE
Master chart dashboard animation adrm

### DIFF
--- a/src/components/figures/chart/chartJs/chartjs.ts
+++ b/src/components/figures/chart/chartJs/chartjs.ts
@@ -68,7 +68,7 @@ export class ChartJsComponent extends Component<Props, SpreadsheetChildEnv> {
           this.chart?.destroy();
           this.createChart(deepCopy(runtime.chartJsConfig));
         } else {
-          this.updateChartJs(deepCopy(runtime));
+          this.updateChartJs(deepCopy(runtime.chartJsConfig));
         }
         this.currentRuntime = runtime;
       }
@@ -81,8 +81,7 @@ export class ChartJsComponent extends Component<Props, SpreadsheetChildEnv> {
     this.chart = new window.Chart(ctx, chartData);
   }
 
-  private updateChartJs(chartRuntime: ChartJSRuntime) {
-    const chartData = chartRuntime.chartJsConfig as ChartConfiguration;
+  private updateChartJs(chartData: ChartConfiguration<any>) {
     if (chartData.data && chartData.data.datasets) {
       this.chart!.data = chartData.data;
       if (chartData.options?.plugins?.title) {

--- a/src/components/figures/chart/chartJs/chartjs_funnel_chart.ts
+++ b/src/components/figures/chart/chartJs/chartjs_funnel_chart.ts
@@ -8,7 +8,20 @@ import {
 
 export class FunnelChartController extends window.Chart?.BarController {
   static id = "funnel";
-  static defaults = { ...window.Chart?.BarController.defaults, dataElementType: "funnel" };
+  static defaults = {
+    ...window.Chart?.BarController.defaults,
+    dataElementType: "funnel",
+    animation: {
+      duration: (ctx: any) => {
+        if (ctx.type !== "data") {
+          return 1000;
+        }
+        const value = ctx.raw[1];
+        const maxValue = Math.max(...ctx.dataset.data.map((data: [number, number]) => data[1]));
+        return 1000 * (value / maxValue);
+      },
+    },
+  };
 
   /** Called at each chart render to update the elements of the chart (FunnelChartElement) with the updated data */
   updateElements(rects, start, count, mode) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -230,6 +230,7 @@ export {
 export {
   coreTypes,
   invalidateCFEvaluationCommands,
+  invalidateChartEvaluationCommands,
   invalidateDependenciesCommands,
   invalidateEvaluationCommands,
   readonlyAllowedCommands,


### PR DESCRIPTION
## Description:

### [IMP] chart: improve funnel chart default animation

Change the default animation duration of funnel chart elements
from a constant of 1000ms to a scaling value, the smaller the
element the shorter the animation.


### [FIX] chart: fix funnel chart when animation are enabled

The funnel charts didn't work properly when chart animations were
enabled. The `width` property is not accessible during the animation,
we have to compute is manually from `x` and `base`.

Passing `nextElementWidth` at `updateElements` is also not enough,
since it will only be called at the first render, and not at each
animation frame. We can give the reference to the next element instead.


### [IMP] chart: unify `ChartJsComponent` methods arguments

This commit makes the `createChart` and `updateChart` methods of the
`ChartJsComponent` class have the same arguments so they are easier
to override.

Task: [4624050](https://www.odoo.com/odoo/2328/tasks/4624050)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo