### PR TITLE
[FIX] xlsx: correctly import labels from scatter charts

### DIFF
--- a/src/xlsx/extraction/chart_extractor.ts
+++ b/src/xlsx/extraction/chart_extractor.ts
@@ -36,10 +36,7 @@ export class XlsxChartExtractor extends XlsxBaseExtractor {
             this.querySelectorAll(rootChartElement, `c:${chartType}`)!,
             chartType
           ),
-          labelRange: this.extractChildTextContent(
-            rootChartElement,
-            `c:ser ${chartType === "scatterChart" ? "c:numRef" : "c:cat"} c:f`
-          ),
+          labelRange: this.extractLabelRange(chartType, rootChartElement),
           backgroundColor: this.extractChildAttr(
             rootChartElement,
             "c:chartSpace > c:spPr a:srgbClr",
@@ -59,6 +56,16 @@ export class XlsxChartExtractor extends XlsxBaseExtractor {
         };
       }
     )[0];
+  }
+
+  private extractLabelRange(chartType: XLSXChartType, rootChartElement: Element) {
+    if (chartType === "scatterChart") {
+      return (
+        this.extractChildTextContent(rootChartElement, `c:ser c:strRef c:f`) ||
+        this.extractChildTextContent(rootChartElement, `c:ser c:numRef c:f`)
+      );
+    }
+    return this.extractChildTextContent(rootChartElement, `c:ser c:cat c:f`);
   }
 
   private extractComboChart(chartElement: Element): ExcelChartDefinition {


### PR DESCRIPTION
When importing an XLSX file containing a scatter chart into o-spreadsheet, the labels were not imported correctly. Instead, the actual range was used as labels by default, leading to incorrect visualization.

Steps to reproduce:
    1. Create an Excel file with a chart.
    2. Export the file as XLSX.
    3. Import the file into o-spreadsheet.
    4. The labels are not imported; instead, the data range is incorrectly used as labels.

Task: [4626572](https://www.odoo.com/odoo/2328/tasks/4626572)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo