### PR TITLE
[FIX] *: Scope css rules to o-spreadsheet component

### DIFF
--- a/src/components/top_bar/dropdown_action/dropdown_action.scss
+++ b/src/components/top_bar/dropdown_action/dropdown_action.scss
@@ -1,17 +1,19 @@
-.o-dropdown {
-  position: relative;
-  display: flex;
-  align-items: center;
-}
-
-.o-dropdown-content {
-  background-color: white;
-
-  .o-dropdown-line {
+.o-spreadsheet {
+  .o-dropdown {
+    position: relative;
     display: flex;
+    align-items: center;
 
-    > span {
-      padding: 4px;
+    .o-dropdown-content {
+      background-color: white;
+
+      .o-dropdown-line {
+        display: flex;
+
+        > span {
+          padding: 4px;
+        }
+      }
     }
   }
 }

--- a/src/components/top_bar/top_bar.scss
+++ b/src/components/top_bar/top_bar.scss
@@ -1,12 +1,14 @@
-@media (max-width: 900px) {
-  div.o-topbar-responsive {
-    flex-direction: column !important;
+.o-spreadsheet {
+  @media (max-width: 900px) {
+    .o-topbar-responsive {
+      flex-direction: column !important;
+    }
   }
-}
 
-@media (max-width: 768px) {
-  div.irregularity-map span {
-    overflow: auto;
-    align-items: normal !important;
+  @media (max-width: 768px) {
+    .irregularity-map span {
+      overflow: auto;
+      align-items: normal !important;
+    }
   }
 }


### PR DESCRIPTION
Some css rules are not scoped porperly and would override the style of shared classes within the integrator (Odoo). This commit scopes the rules to the root node of this application.

Task: 0

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo