### PR TITLE
[FIX] Config: check stylesheets scope

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -25,10 +25,7 @@ if [ "$HUSKY_PRE_COMMIT" != 0 ]; then
             exec git diff --cached --color | grep -nE $consoleregexp -A 2 -B 2
             read -p "There are some occurrences of forbidden patterns at your modification. Are you sure want to continue? (y/n)" yn
             echo $yn | grep ^[Yy]$
-            if [ $? -eq 0 ]
-            then
-                exit 0; #THE USER WANTS TO CONTINUE
-            else
+            if [ $? -ne 0 ]; then
                 exit 1; # THE USER DONT WANT TO CONTINUE SO ROLLBACK
             fi
         else
@@ -36,4 +33,7 @@ if [ "$HUSKY_PRE_COMMIT" != 0 ]; then
             exec git diff --cached --color | grep -nE $consoleregexp -A 2 -B 2
         fi
     fi
+
+    # Css wrap check
+    node .husky/scss_check.js
 fi

--- a/.husky/scss_check.js
+++ b/.husky/scss_check.js
@@ -1,0 +1,48 @@
+import { execSync } from "child_process";
+import { existsSync, readFileSync } from "fs";
+import process from "process";
+
+const commentPattern = /\/\/.*|\/\*[\s\S]*?\*\//g;
+const firstLevelSelectorPattern = /^(?!(\s|\$|\})).+/gm;
+
+// Get scss files in diff
+const files = execSync("git diff --name-only --cached")
+  .toString()
+  .split("\n")
+  .filter((file) => file.endsWith(".scss"));
+
+const faultyFiles = [];
+
+for (const file of files) {
+  if (!existsSync(file)) continue;
+  let content = readFileSync(file, "utf8");
+
+  // Remove content of comments
+  content = content.replace(commentPattern, "");
+  // look for first level selectors
+  const firstLevelSelectors = content.match(firstLevelSelectorPattern) || [];
+  if (!firstLevelSelectors.every((line) => line.startsWith(".o-spreadsheet "))) {
+    faultyFiles.push(file);
+  }
+}
+
+if (faultyFiles.length > 0) {
+  const fileList = " - " + faultyFiles.join("\n - ");
+  console.log(`\x1b[31m
+Some scss files are not scoped to .o-spreadsheet. Please fix them before committing.
+Faulty files:
+
+${fileList}
+
+Every css selector should be encompassed within .o-spreadsheet. For example:
+.o-spreadsheet {
+    ...
+}
+or 
+.o-spreadsheet .foo {
+    ...
+}
+\x1b[0m
+`);
+  process.exit(1);
+}


### PR DESCRIPTION
The style that we define in our component can sometimes interfere within Odoo. This revision adds a step to force the style to be scoped to 'o-spreadsheet'.

Task: 4629441

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo