### PR TITLE
[FIX] chart: improve chartjs extension robustness

### DIFF
--- a/src/components/figures/chart/chartJs/chartjs.ts
+++ b/src/components/figures/chart/chartJs/chartjs.ts
@@ -1,17 +1,13 @@
 import { Component, onMounted, onWillUnmount, useEffect, useRef } from "@odoo/owl";
 import { Chart, ChartConfiguration } from "chart.js/auto";
 import { deepCopy } from "../../../../helpers";
+import { getChartJSConstructor } from "../../../../helpers/figures/charts/chart_ui_common";
 import { Figure, SpreadsheetChildEnv } from "../../../../types";
 import { ChartJSRuntime } from "../../../../types/chart/chart";
-import { chartShowValuesPlugin } from "./chartjs_show_values_plugin";
-import { waterfallLinesPlugin } from "./chartjs_waterfall_plugin";
 
 interface Props {
   figure: Figure;
 }
-
-window.Chart?.register(waterfallLinesPlugin);
-window.Chart?.register(chartShowValuesPlugin);
 
 export class ChartJsComponent extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ChartJsComponent";
@@ -64,7 +60,8 @@ export class ChartJsComponent extends Component<Props, SpreadsheetChildEnv> {
   private createChart(chartData: ChartConfiguration) {
     const canvas = this.canvas.el as HTMLCanvasElement;
     const ctx = canvas.getContext("2d")!;
-    this.chart = new window.Chart(ctx, chartData as ChartConfiguration);
+    const Chart = getChartJSConstructor();
+    this.chart = new Chart(ctx, chartData as ChartConfiguration);
   }
 
   private updateChartJs(chartRuntime: ChartJSRuntime) {

--- a/src/helpers/figures/charts/chart_common_line_scatter.ts
+++ b/src/helpers/figures/charts/chart_common_line_scatter.ts
@@ -19,6 +19,7 @@ import {
   filterEmptyDataPoints,
   getChartDatasetFormat,
   getChartDatasetValues,
+  getChartJSConstructor,
   getChartLabelFormat,
   getChartLabelValues,
   getDefaultChartJsRuntime,
@@ -104,11 +105,12 @@ function canBeLinearChart(chart: LineChart | ScatterChart, getters: Getters): bo
 let missingTimeAdapterAlreadyWarned = false;
 
 function isLuxonTimeAdapterInstalled() {
-  if (!window.Chart) {
+  const Chart = getChartJSConstructor();
+  if (!Chart) {
     return false;
   }
   // @ts-ignore
-  const adapter = new window.Chart._adapters._date({});
+  const adapter = new Chart._adapters._date({});
   const isInstalled = adapter._id === "luxon";
   if (!isInstalled && !missingTimeAdapterAlreadyWarned) {
     missingTimeAdapterAlreadyWarned = true;
@@ -133,7 +135,8 @@ function getLineOrScatterConfiguration(
       generateLabels(chart) {
         // color the legend labels with the dataset color, without any transparency
         const { data } = chart;
-        const labels = window.Chart.defaults.plugins.legend.labels.generateLabels!(chart);
+        const Chart = getChartJSConstructor();
+        const labels = Chart.defaults.plugins.legend.labels.generateLabels!(chart);
         for (const [index, label] of labels.entries()) {
           label.fillStyle = data.datasets![index].borderColor as string;
         }

--- a/src/helpers/figures/charts/chart_ui_common.ts
+++ b/src/helpers/figures/charts/chart_ui_common.ts
@@ -1,4 +1,6 @@
 import type { BasePlatform, ChartConfiguration, ChartOptions, ChartType } from "chart.js";
+import { chartShowValuesPlugin } from "../../../components/figures/chart/chartJs/chartjs_show_values_plugin";
+import { waterfallLinesPlugin } from "../../../components/figures/chart/chartJs/chartjs_waterfall_plugin";
 import { ChartTerms } from "../../../components/translations_terms";
 import { DEFAULT_CHART_FONT_SIZE, DEFAULT_CHART_PADDING, MAX_CHAR_LABEL } from "../../../constants";
 import { isEvaluationError } from "../../../functions/helpers";
@@ -306,7 +308,8 @@ export function chartToImage(
   if ("chartJsConfig" in runtime) {
     const config = deepCopy(runtime.chartJsConfig);
     config.plugins = [backgroundColorChartJSPlugin];
-    const chart = new window.Chart(canvas, config);
+    const Chart = getChartJSConstructor();
+    const chart = new Chart(canvas, config);
     const imgContent = chart.toBase64Image() as string;
     chart.destroy();
     div.remove();
@@ -341,3 +344,12 @@ const backgroundColorChartJSPlugin = {
     ctx.restore();
   },
 };
+
+/** Return window.Chart, making sure all our extensions are loaded in ChartJS */
+export function getChartJSConstructor() {
+  if (window.Chart && !window.Chart?.registry.plugins.get("chartShowValuesPlugin")) {
+    window.Chart.register(chartShowValuesPlugin);
+    window.Chart.register(waterfallLinesPlugin);
+  }
+  return window.Chart;
+}

--- a/tests/figures/chart/charts_component.test.ts
+++ b/tests/figures/chart/charts_component.test.ts
@@ -1802,6 +1802,23 @@ test("ChartJS charts are correctly destroyed and re-created when runtime change 
   expect(spyConstructor).toHaveBeenCalled();
 });
 
+test("ChartJS charts extensions are loaded when mounting a chart, and are only loaded once", async () => {
+  window.Chart.registry.plugins["items"] = [];
+  model = new Model();
+  const spyRegister = jest.spyOn(window.Chart, "register");
+  createChart(model, { type: "bar" }, chartId);
+  await mountSpreadsheet();
+  expect(spyRegister).toHaveBeenCalledTimes(2);
+  expect(window.Chart.registry.plugins["items"]).toMatchObject([
+    { id: "chartShowValuesPlugin" },
+    { id: "waterfallLinesPlugin" },
+  ]);
+
+  createChart(model, { type: "line" }, "chart2");
+  await nextTick();
+  expect(spyRegister).toHaveBeenCalledTimes(2);
+});
+
 describe("Change chart type", () => {
   beforeEach(() => {
     model = new Model();

--- a/tests/test_helpers/helpers.ts
+++ b/tests/test_helpers/helpers.ts
@@ -721,8 +721,16 @@ export const mockChart = () => {
     _id = "luxon";
   }
   class ChartMock {
-    static register = () => {};
+    static register = (item: any) => ChartMock.registry.plugins.items.push(item);
     static _adapters = { _date: MockLuxonTimeAdapter };
+    static registry = {
+      plugins: {
+        items: [] as any[],
+        get(key: string) {
+          return ChartMock.registry.plugins.items.find((item) => item.id === key);
+        },
+      },
+    };
     constructor(ctx: unknown, chartData: ChartConfiguration) {
       Object.assign(mockChartData, chartData);
       this.constructorMock();


### PR DESCRIPTION
## Description

This commit makes it so our ChartJS extensions work even if the chartJS library was reloaded between the moment where we loaded the `o_spreadsheet` library and the moment where we actually use the extensions.

Task: [4627232](https://www.odoo.com/odoo/2328/tasks/4627232)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo