### PR TITLE
[FIX] Xlsx: do not nest literal strings

### DIFF
--- a/src/xlsx/functions/styles.ts
+++ b/src/xlsx/functions/styles.ts
@@ -158,9 +158,9 @@ export function addStyles(styles: XLSXStyle[]): XMLString {
     if (alignAttrs.length > 0) {
       attributes.push(["applyAlignment", "1"]); // for Libre Office
       styleNodes.push(
-        escapeXml/*xml*/ `<xf ${formatAttributes(
-          attributes
-        )}>${escapeXml/*xml*/ `<alignment ${formatAttributes(alignAttrs)} />`}</xf> `
+        escapeXml/*xml*/ `<xf ${formatAttributes(attributes)}><alignment ${formatAttributes(
+          alignAttrs
+        )} /></xf> `
       );
     } else {
       styleNodes.push(escapeXml/*xml*/ `<xf ${formatAttributes(attributes)} />`);


### PR DESCRIPTION
There was a nesting of calls to literal strings. Not only was it useless but it was messing with the minification library that we use inside odoo ( [rjsmin](https://github.com/ndparker/rjsmin/) ).

This commit should address the problem originally spotted in https://github.com/odoo/o-spreadsheet/pull/2439

Task: 0

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo