### PR TITLE
[FIX] Clipboard: don't use template literals in _t

### DIFF
--- a/src/plugins/ui_stateful/clipboard.ts
+++ b/src/plugins/ui_stateful/clipboard.ts
@@ -645,7 +645,7 @@ export class ClipboardPlugin extends UIPlugin {
         if (file.size > MAX_FILE_SIZE) {
           this.ui.notifyUI({
             text: _t(
-              `The file you are trying to copy is too large (>%sMB).\nIt will not be added to your OS clipboard.\nYou can download it directly instead.`,
+              "The file you are trying to copy is too large (>%sMB).\nIt will not be added to your OS clipboard.\nYou can download it directly instead.",
               Math.round(MAX_FILE_SIZE / (1024 * 1024))
             ),
             sticky: false,


### PR DESCRIPTION
Using template literals for a translatable string in generally a bad idea as the devleopper could be tempted to interpolate the value directly instead of using a proper placeholder. A check is added inside Odoo to detect such pratices and prevents the modification to be merged. This means that we cannot currently update our library version inside Odoo.

Task: 0

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo