### PR TITLE
[PERF] worksheet: Move PositionMap constant declarations outside of f…

### DIFF
--- a/src/xlsx/functions/worksheet.ts
+++ b/src/xlsx/functions/worksheet.ts
@@ -65,6 +65,9 @@ export function addRows(
   sheet: ExcelSheetData
 ): XMLString {
   const rowNodes: XMLString[] = [];
+  const styles = new PositionMap(iterateItemIdsPositions(sheet.id, sheet.styles));
+  const borders = new PositionMap(iterateItemIdsPositions(sheet.id, sheet.borders));
+  const formats = new PositionMap(iterateItemIdsPositions(sheet.id, sheet.formats));
   for (let r = 0; r < sheet.rowNumber; r++) {
     const rowAttrs: XMLAttributes = [["r", r + 1]];
     const row = sheet.rows[r] || {};
@@ -80,10 +83,6 @@ export function addRows(
     if (row.collapsed) {
       rowAttrs.push(["collapsed", 1]);
     }
-
-    const styles = new PositionMap(iterateItemIdsPositions(sheet.id, sheet.styles));
-    const borders = new PositionMap(iterateItemIdsPositions(sheet.id, sheet.borders));
-    const formats = new PositionMap(iterateItemIdsPositions(sheet.id, sheet.formats));
     const cellNodes: XMLString[] = [];
     for (let c = 0; c < sheet.colNumber; c++) {
       const xc = toXC(c, r);


### PR DESCRIPTION
…or loop in addRows

Previously, heavy PositionMap constants were declared within the for loop, leading to unnecessary overhead on each iteration. This change moves their declaration outside the loop to optimize performance.

Task: [4563258](https://www.odoo.com/odoo/2328/tasks/4563258)
