### PR TITLE
[IMP] sheet: remove useless translation

### DIFF
--- a/src/helpers/range.ts
+++ b/src/helpers/range.ts
@@ -1,4 +1,3 @@
-import { _t } from "../translation";
 import {
   CellPosition,
   CoreGetters,
@@ -73,7 +72,7 @@ export class RangeImpl implements Range {
     } else if (right === undefined && bottom !== undefined) {
       return { bottom, left, top, right: this.getSheetSize(this.sheetId).numberOfCols - 1 };
     }
-    throw new Error(_t("Bad zone format"));
+    throw new Error("Bad zone format");
   }
 
   static getRangeParts(xc: string, zone: UnboundedZone): RangePart[] {

--- a/src/helpers/zones.ts
+++ b/src/helpers/zones.ts
@@ -1,4 +1,3 @@
-import { _t } from "../translation";
 import { CellPosition, Position, UnboundedZone, Zone, ZoneDimension } from "../types";
 import { lettersToNumber, numberToLetters, toCartesian, toXC } from "./coordinates";
 import { range } from "./misc";
@@ -189,7 +188,7 @@ export function zoneToXc(zone: Zone | UnboundedZone): string {
     return isOneCell ? toXC(left, top) : `${toXC(left, top)}:${toXC(right, bottom)}`;
   }
 
-  throw new Error(_t("Bad zone format"));
+  throw new Error("Bad zone format");
 }
 
 /**

--- a/src/plugins/core/sheet.ts
+++ b/src/plugins/core/sheet.ts
@@ -637,7 +637,7 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
     if (deltaIndex === 0) {
       return currentIndex;
     }
-    throw new Error(_t("There is not enough visible sheets"));
+    throw new Error("There is not enough visible sheets");
   }
 
   private checkSheetName(cmd: RenameSheetCommand | CreateSheetCommand): CommandResult {

--- a/src/selection_stream/selection_stream_processor.ts
+++ b/src/selection_stream/selection_stream_processor.ts
@@ -7,7 +7,6 @@ import {
   reorderZone,
   union,
 } from "../helpers";
-import { _t } from "../translation";
 import {
   AnchorZone,
   CellValueType,
@@ -444,7 +443,7 @@ export class SelectionStreamProcessorImpl implements SelectionStreamProcessor {
   private checkAnchorZoneOrThrow(anchor: AnchorZone) {
     const result = this.checkAnchorZone(anchor);
     if (result === CommandResult.InvalidAnchorZone) {
-      throw new Error(_t("The provided anchor is invalid. The cell must be part of the zone."));
+      throw new Error("The provided anchor is invalid. The cell must be part of the zone.");
     }
   }
 


### PR DESCRIPTION
This error is never supposed to be thrown and even less be shown to the end-user.

Translating the message is useless and adds useless work for translators.

Task: 0

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo