### PR TITLE
[IMP] spreadsheet_edition: move to user

### DIFF
--- a/src/collaborative/session.ts
+++ b/src/collaborative/session.ts
@@ -219,8 +219,12 @@ export class Session extends EventBus<CollaborativeEvent> {
     });
   }
 
-  getClient(): Client {
-    const client = this.clients[this.clientId];
+  getCurrentClient(): Client {
+    return this.getClient(this.clientId);
+  }
+
+  getClient(clientId: ClientId): Client {
+    const client = this.clients[clientId];
     if (!client) {
       throw new ClientDisconnectedError("The client left the session");
     }
@@ -261,7 +265,7 @@ export class Session extends EventBus<CollaborativeEvent> {
       return;
     }
     const type = currentPosition ? "CLIENT_MOVED" : "CLIENT_JOINED";
-    const client = this.getClient();
+    const client = this.getCurrentClient();
     this.clients[this.clientId] = { ...client, position };
     this.transportService.sendMessage({
       type,

--- a/src/components/collaborative_client_tag/collaborative_client_tag.ts
+++ b/src/components/collaborative_client_tag/collaborative_client_tag.ts
@@ -33,6 +33,11 @@ export class ClientTag extends Component<ClientTagProps, SpreadsheetChildEnv> {
   get tagStyle(): string {
     const { col, row, color } = this.props;
     const { height } = this.env.model.getters.getSheetViewDimensionWithHeaders();
+    const visible = this.env.model.getters.isVisibleInViewport({
+      sheetId: this.env.model.getters.getActiveSheetId(),
+      col,
+      row,
+    });
     const { x, y } = this.env.model.getters.getVisibleRect({
       left: col,
       top: row,
@@ -45,6 +50,7 @@ export class ClientTag extends Component<ClientTagProps, SpreadsheetChildEnv> {
       left: `${x - 1}px`,
       border: `1px solid ${color}`,
       "background-color": color,
+      visibility: visible ? "visible" : "hidden",
     });
   }
 }

--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -37,6 +37,7 @@ import { rowMenuRegistry } from "../../registries/menus/row_menu_registry";
 import { Store, useStore } from "../../store_engine";
 import { DOMFocusableElementStore } from "../../stores/DOM_focus_store";
 import { ArrayFormulaHighlight } from "../../stores/array_formula_highlight";
+import { ClientFocusStore } from "../../stores/client_focus_store";
 import { HighlightStore } from "../../stores/highlight_store";
 import { AllowedImageMimeTypes } from "../../types/image";
 import {
@@ -143,6 +144,7 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
   private composerFocusStore!: Store<ComposerFocusStore>;
   private DOMFocusableElementStore!: Store<DOMFocusableElementStore>;
   private paintFormatStore!: Store<PaintFormatStore>;
+  private clientFocusStore!: Store<ClientFocusStore>;
 
   dragNDropGrid = useDragAndDropBeyondTheViewport(this.env);
 
@@ -163,6 +165,7 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
     this.DOMFocusableElementStore = useStore(DOMFocusableElementStore);
     this.sidePanel = useStore(SidePanelStore);
     this.paintFormatStore = useStore(PaintFormatStore);
+    this.clientFocusStore = useStore(ClientFocusStore);
     useStore(ArrayFormulaHighlight);
 
     useChildSubEnv({ getPopoverContainerRect: () => this.getGridRect() });
@@ -479,6 +482,10 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
 
   isCellHovered(col: HeaderIndex, row: HeaderIndex): boolean {
     return this.hoveredCell.col === col && this.hoveredCell.row === row;
+  }
+
+  get focusedClients() {
+    return this.clientFocusStore.focusedClients;
   }
 
   private getGridRect(): Rect {

--- a/src/components/grid/grid.xml
+++ b/src/components/grid/grid.xml
@@ -23,6 +23,7 @@
         onInputContextMenu.bind="onInputContextMenu"
       />
       <canvas t-ref="canvas"/>
+      <t t-set="focused" t-value="focusedClients"/>
       <t
         t-foreach="env.model.getters.getClientsToDisplay()"
         t-as="client"
@@ -32,7 +33,7 @@
           color="client.color"
           col="client.position.col"
           row="client.position.row"
-          active="isCellHovered(client.position.col, client.position.row)"
+          active="isCellHovered(client.position.col, client.position.row) || focused.has(client.id)"
         />
       </t>
       <GridPopover

--- a/src/index.ts
+++ b/src/index.ts
@@ -187,6 +187,7 @@ import { topbarComponentRegistry } from "./registries/topbar_component_registry"
 import { useLocalStore, useStore, useStoreProvider } from "./store_engine";
 import { DependencyContainer } from "./store_engine/dependency_container";
 import { SpreadsheetStore } from "./stores";
+import { ClientFocusStore } from "./stores/client_focus_store";
 import { HighlightStore } from "./stores/highlight_store";
 import { ModelStore } from "./stores/model_store";
 import { NotificationStore } from "./stores/notification_store";
@@ -203,6 +204,7 @@ import { DEFAULT_LOCALE } from "./types/locale";
  */
 
 export const __info__ = {};
+export { LocalTransportService } from "./collaborative/local_transport_service";
 export { Revision } from "./collaborative/revisions";
 export { tokenColors } from "./components/composer/composer/abstract_composer_store";
 export { Spreadsheet } from "./components/index";
@@ -446,6 +448,7 @@ export const stores = {
   SidePanelStore,
   PivotSidePanelStore,
   PivotMeasureDisplayPanelStore,
+  ClientFocusStore,
 };
 
 export type { StoreConstructor, StoreParams } from "./store_engine";

--- a/src/store_engine/dependency_container.ts
+++ b/src/store_engine/dependency_container.ts
@@ -41,6 +41,14 @@ export class DependencyContainer extends EventBus<StoreUpdateEvent> {
   resetStores() {
     this.dependencies.clear();
   }
+
+  dispose() {
+    for (const instance of this.dependencies.values()) {
+      if ("dispose" in instance && typeof instance.dispose === "function") {
+        instance.dispose();
+      }
+    }
+  }
 }
 
 class StoreFactory {

--- a/src/store_engine/store_hooks.ts
+++ b/src/store_engine/store_hooks.ts
@@ -18,6 +18,7 @@ export function useStoreProvider() {
       return proxifyStoreMutation(store, () => container.trigger("store-updated"));
     },
   });
+  onWillUnmount(() => container.dispose());
   return container;
 }
 

--- a/src/stores/client_focus_store.ts
+++ b/src/stores/client_focus_store.ts
@@ -1,0 +1,71 @@
+import { Get } from "../store_engine";
+import { ClientId } from "../types";
+import { SpreadsheetStore } from "./spreadsheet_store";
+
+export class ClientFocusStore extends SpreadsheetStore {
+  mutators = [
+    "focusClient",
+    "unfocusClient",
+    "showClientTag",
+    "hideClientTag",
+    "jumpToClient",
+  ] as const;
+
+  private _showClientTag = false;
+  private clientFocusTimeout = {};
+
+  constructor(get: Get) {
+    super(get);
+    this.onDispose(() => {
+      for (const clientId in this.clientFocusTimeout) {
+        this.unfocusClient(clientId);
+      }
+    });
+  }
+
+  get focusedClients(): Set<ClientId> {
+    const focused = new Set<ClientId>();
+    this.model.getters.getConnectedClients().forEach((client) => {
+      if (this._showClientTag || this.clientFocusTimeout[client.id] !== undefined) {
+        focused.add(client.id);
+      }
+    });
+    return focused;
+  }
+
+  jumpToClient(clientId: ClientId) {
+    const client = this.model.getters.getClient(clientId);
+    this.focusClient(clientId);
+    if (client.position) {
+      this.model.dispatch("ACTIVATE_SHEET", {
+        sheetIdTo: client.position.sheetId,
+        sheetIdFrom: this.getters.getActiveSheetId(),
+      });
+      this.model.dispatch("SCROLL_TO_CELL", { col: client.position.col, row: client.position.row });
+    }
+  }
+
+  showClientTag() {
+    this._showClientTag = true;
+  }
+
+  hideClientTag() {
+    this._showClientTag = false;
+  }
+
+  focusClient(clientId: ClientId) {
+    if (this.clientFocusTimeout[clientId]) {
+      clearTimeout(this.clientFocusTimeout[clientId]);
+    }
+    // This call to unfocus client isn't proxyfied and doesn't trigger a render.
+    // The focus will visually disappear when the next render is triggered
+    this.clientFocusTimeout[clientId] = setTimeout(() => this.unfocusClient(clientId), 3000);
+  }
+
+  unfocusClient(clientId: ClientId) {
+    if (this.clientFocusTimeout[clientId]) {
+      clearTimeout(this.clientFocusTimeout[clientId]);
+    }
+    this.clientFocusTimeout[clientId] = undefined;
+  }
+}

--- a/src/types/collaborative/session.ts
+++ b/src/types/collaborative/session.ts
@@ -1,5 +1,5 @@
 import { CoreCommand } from "../commands";
-import { HeaderIndex, UID } from "../misc";
+import { Color, HeaderIndex, UID } from "../misc";
 
 export type ClientId = string;
 
@@ -7,6 +7,11 @@ export interface Client {
   id: ClientId;
   name: string;
   position?: ClientPosition;
+  color?: Color;
+}
+
+export interface ClientWithPosition extends Client {
+  position: ClientPosition;
 }
 
 export interface ClientPosition {

--- a/src/types/collaborative/transport_service.ts
+++ b/src/types/collaborative/transport_service.ts
@@ -1,7 +1,7 @@
 import { CoreCommand } from "../commands";
 import { UID } from "../misc";
 import { WorkbookData } from "../workbook_data";
-import { Client, ClientId } from "./session";
+import { ClientId, ClientWithPosition } from "./session";
 
 interface AbstractMessage {
   version: number;
@@ -32,7 +32,7 @@ export interface RevisionRedoneMessage extends AbstractMessage {
 
 export interface ClientJoinedMessage extends AbstractMessage {
   type: "CLIENT_JOINED";
-  client: Required<Client>;
+  client: ClientWithPosition;
 }
 
 export interface ClientLeftMessage extends AbstractMessage {
@@ -42,7 +42,7 @@ export interface ClientLeftMessage extends AbstractMessage {
 
 export interface ClientMovedMessage extends AbstractMessage {
   type: "CLIENT_MOVED";
-  client: Required<Client>;
+  client: ClientWithPosition;
 }
 
 /**

--- a/tests/collaborative/collaborative.test.ts
+++ b/tests/collaborative/collaborative.test.ts
@@ -1037,7 +1037,7 @@ test("UI plugins cannot refuse core command and de-synchronize the users", () =>
   class MyUIPlugin extends UIPlugin {
     allowDispatch(cmd: Command) {
       if (cmd.type === "UPDATE_CELL") {
-        return this.getters.getClient().name === "Alice"
+        return this.getters.getCurrentClient().name === "Alice"
           ? CommandResult.Success
           : CommandResult.CancelledForUnknownReason;
       }

--- a/tests/collaborative/collaborative_monkey_party.test.ts
+++ b/tests/collaborative/collaborative_monkey_party.test.ts
@@ -133,7 +133,7 @@ function actionsToTestCode(testTitle: string, actions: UserAction[][]) {
 }
 
 function appendCommand(code: FunctionCodeBuilder, { user, command }: UserAction) {
-  const userName = user.getters.getClient().name.toLowerCase();
+  const userName = user.getters.getCurrentClient().name.toLowerCase();
   if (command.type === "REQUEST_UNDO") {
     code.append(`undo(${userName});`);
   } else if (command.type === "REQUEST_REDO") {
@@ -149,7 +149,7 @@ function rerunTest(actions: UserAction[][]) {
   const newUsers = { alice, bob, charlie };
   for (const concurrentChunk of actions) {
     for (const action of concurrentChunk) {
-      action.user = newUsers[action.user.getters.getClient().name.toLowerCase()];
+      action.user = newUsers[action.user.getters.getCurrentClient().name.toLowerCase()];
     }
   }
   return run(network, [alice, bob, charlie], actions);

--- a/tests/collaborative/collaborative_selection.test.ts
+++ b/tests/collaborative/collaborative_selection.test.ts
@@ -27,22 +27,25 @@ describe("Collaborative selection", () => {
     const sheetId = alice.getters.getActiveSheetId();
     jest.advanceTimersByTime(DEBOUNCE_TIME + 100);
     expect([alice, bob, charlie]).toHaveSynchronizedValue(
-      (user) => user.getters.getConnectedClients(),
+      (user) => new Set(user.getters.getConnectedClients()),
       new Set([
         {
           id: "alice",
           name: "Alice",
           position: { col: 0, row: 0, sheetId },
+          color: undefined,
         },
         {
           id: "bob",
           name: "Bob",
           position: { col: 0, row: 0, sheetId },
+          color: undefined,
         },
         {
           id: "charlie",
           name: "Charlie",
           position: { col: 0, row: 0, sheetId },
+          color: undefined,
         },
       ])
     );
@@ -55,22 +58,25 @@ describe("Collaborative selection", () => {
     jest.advanceTimersByTime(DEBOUNCE_TIME + 100);
     const sheetId = alice.getters.getActiveSheetId();
     expect([alice, bob, charlie]).toHaveSynchronizedValue(
-      (user) => user.getters.getConnectedClients(),
+      (user) => new Set(user.getters.getConnectedClients()),
       new Set([
         {
           id: "alice",
           name: "Alice",
           position: { col: 2, row: 2, sheetId },
+          color: undefined,
         },
         {
           id: "bob",
           name: "Bob",
           position: { col: 1, row: 1, sheetId },
+          color: undefined,
         },
         {
           id: "charlie",
           name: "Charlie",
           position: { col: 0, row: 0, sheetId },
+          color: undefined,
         },
       ])
     );
@@ -91,22 +97,25 @@ describe("Collaborative selection", () => {
     addColumns(bob, "before", "B", 2);
     jest.advanceTimersByTime(DEBOUNCE_TIME + 100);
     expect([alice, bob, charlie]).toHaveSynchronizedValue(
-      (user) => user.getters.getConnectedClients(),
+      (user) => new Set(user.getters.getConnectedClients()),
       new Set([
         {
           id: "alice",
           name: "Alice",
           position: { col: 3, row: 0, sheetId },
+          color: undefined,
         },
         {
           id: "bob",
           name: "Bob",
           position: { col: 0, row: 0, sheetId },
+          color: undefined,
         },
         {
           id: "charlie",
           name: "Charlie",
           position: { col: 0, row: 0, sheetId },
+          color: undefined,
         },
       ])
     );
@@ -119,22 +128,25 @@ describe("Collaborative selection", () => {
     addColumns(alice, "before", "B", 2);
     jest.advanceTimersByTime(DEBOUNCE_TIME + 100);
     expect([alice, bob, charlie]).toHaveSynchronizedValue(
-      (user) => user.getters.getConnectedClients(),
+      (user) => new Set(user.getters.getConnectedClients()),
       new Set([
         {
           id: "alice",
           name: "Alice",
           position: { col: 3, row: 0, sheetId },
+          color: undefined,
         },
         {
           id: "bob",
           name: "Bob",
           position: { col: 3, row: 0, sheetId },
+          color: undefined,
         },
         {
           id: "charlie",
           name: "Charlie",
           position: { col: 0, row: 0, sheetId },
+          color: undefined,
         },
       ])
     );
@@ -145,22 +157,25 @@ describe("Collaborative selection", () => {
     selectColumn(bob, 1, "overrideSelection");
     jest.advanceTimersByTime(DEBOUNCE_TIME + 100);
     expect([alice, bob, charlie]).toHaveSynchronizedValue(
-      (user) => user.getters.getConnectedClients(),
+      (user) => new Set(user.getters.getConnectedClients()),
       new Set([
         {
           id: "alice",
           name: "Alice",
           position: { col: 0, row: 0, sheetId },
+          color: undefined,
         },
         {
           id: "bob",
           name: "Bob",
           position: { col: 1, row: 0, sheetId },
+          color: undefined,
         },
         {
           id: "charlie",
           name: "Charlie",
           position: { col: 0, row: 0, sheetId },
+          color: undefined,
         },
       ])
     );
@@ -170,22 +185,25 @@ describe("Collaborative selection", () => {
     const sheetId = alice.getters.getActiveSheetId();
     jest.advanceTimersByTime(DEBOUNCE_TIME + 100);
     expect([alice, bob, charlie]).toHaveSynchronizedValue(
-      (user) => user.getters.getConnectedClients(),
+      (user) => new Set(user.getters.getConnectedClients()),
       new Set([
         {
           id: "alice",
           name: "Alice",
           position: { col: 0, row: 0, sheetId },
+          color: undefined,
         },
         {
           id: "bob",
           name: "Bob",
           position: { col: 0, row: 0, sheetId },
+          color: undefined,
         },
         {
           id: "charlie",
           name: "Charlie",
           position: { col: 0, row: 0, sheetId },
+          color: undefined,
         },
       ])
     );
@@ -195,48 +213,55 @@ describe("Collaborative selection", () => {
     });
     jest.advanceTimersByTime(DEBOUNCE_TIME + 100);
     expect([alice, bob, charlie, david]).toHaveSynchronizedValue(
-      (user) => user.getters.getConnectedClients(),
+      (user) => new Set(user.getters.getConnectedClients()),
       new Set([
         {
           id: "alice",
           name: "Alice",
           position: { col: 0, row: 0, sheetId },
+          color: undefined,
         },
         {
           id: "bob",
           name: "Bob",
           position: { col: 0, row: 0, sheetId },
+          color: undefined,
         },
         {
           id: "charlie",
           name: "Charlie",
           position: { col: 0, row: 0, sheetId },
+          color: undefined,
         },
         {
           id: "david",
           name: "David",
           position: { col: 0, row: 0, sheetId },
+          color: undefined,
         },
       ])
     );
     david.leaveSession();
     expect([alice, bob, charlie]).toHaveSynchronizedValue(
-      (user) => user.getters.getConnectedClients(),
+      (user) => new Set(user.getters.getConnectedClients()),
       new Set([
         {
           id: "alice",
           name: "Alice",
           position: { col: 0, row: 0, sheetId },
+          color: undefined,
         },
         {
           id: "bob",
           name: "Bob",
           position: { col: 0, row: 0, sheetId },
+          color: undefined,
         },
         {
           id: "charlie",
           name: "Charlie",
           position: { col: 0, row: 0, sheetId },
+          color: undefined,
         },
       ])
     );
@@ -248,22 +273,25 @@ describe("Collaborative selection", () => {
     deleteSheet(alice, sheetId);
     jest.advanceTimersByTime(DEBOUNCE_TIME + 100);
     expect([alice, bob, charlie]).toHaveSynchronizedValue(
-      (user) => user.getters.getConnectedClients(),
+      (user) => new Set(user.getters.getConnectedClients()),
       new Set([
         {
           id: "alice",
           name: "Alice",
           position: { col: 0, row: 0, sheetId: "42" },
+          color: undefined,
         },
         {
           id: "bob",
           name: "Bob",
           position: { col: 0, row: 0, sheetId: "42" },
+          color: undefined,
         },
         {
           id: "charlie",
           name: "Charlie",
           position: { col: 0, row: 0, sheetId: "42" },
+          color: undefined,
         },
       ])
     );
@@ -274,13 +302,13 @@ describe("Collaborative selection", () => {
     createSheet(alice, { sheetId: "42", activate: true });
     jest.advanceTimersByTime(DEBOUNCE_TIME + 100);
     expect([alice, bob, charlie]).toHaveSynchronizedValue(
-      (user) => user.getters.getConnectedClients(),
+      (user) => new Set(user.getters.getConnectedClients()),
       new Set([
         {
           id: "alice",
           name: "Alice",
           position: { col: 0, row: 0, sheetId: "42" },
-        },
+        } as Client,
         {
           id: "bob",
           name: "Bob",
@@ -303,28 +331,32 @@ describe("Collaborative selection", () => {
     });
     jest.advanceTimersByTime(DEBOUNCE_TIME + 100);
     expect([alice, bob, charlie]).toHaveSynchronizedValue(
-      (user) => user.getters.getConnectedClients(),
+      (user) => new Set(user.getters.getConnectedClients()),
       new Set([
         {
           id: "alice",
           name: "Alice",
           position: { col: 0, row: 0, sheetId },
+          color: undefined,
         },
         {
           id: "bob",
           name: "Bob",
           position: { col: 0, row: 0, sheetId },
+          color: undefined,
         },
         {
           id: "charlie",
           name: "Charlie",
           position: { col: 0, row: 0, sheetId },
+          color: undefined,
         },
         {
           id: "david",
           customId: "1",
           name: "David",
           position: { col: 0, row: 0, sheetId },
+          color: undefined,
         },
       ])
     );

--- a/tests/model/model.test.ts
+++ b/tests/model/model.test.ts
@@ -249,7 +249,7 @@ describe("Model", () => {
       handle(cmd: Command) {
         //@ts-ignore
         if (cmd.type === "MY_CMD_2") {
-          if (this.getters.getClient().id === "bob") {
+          if (this.getters.getCurrentClient().id === "bob") {
             numberCall++;
           }
         }

--- a/tests/setup/jest_extend.ts
+++ b/tests/setup/jest_extend.ts
@@ -79,7 +79,7 @@ expect.extend({
     for (const user of users) {
       const result = callback(user);
       if (!this.equals(result, expected, [this.utils.iterableEquality])) {
-        const userId = user.getters.getClient().name;
+        const userId = user.getters.getCurrentClient().name;
         return {
           pass: this.isNot,
           message: () =>
@@ -100,8 +100,8 @@ expect.extend({
         const valuesUserA = a.getters.getEvaluatedCells(sheetId);
         const valuesUserB = b.getters.getEvaluatedCells(sheetId);
         if (!deepEquals(valuesUserA, valuesUserB)) {
-          const clientA = a.getters.getClient().id;
-          const clientB = b.getters.getClient().id;
+          const clientA = a.getters.getCurrentClient().id;
+          const clientB = b.getters.getCurrentClient().id;
           const prettyValuesUserA = getPrettyEvaluatedCells(a, sheetId, sheetZone);
           const prettyValuesUserB = getPrettyEvaluatedCells(b, sheetId, sheetZone);
           return {
@@ -127,8 +127,8 @@ expect.extend({
       const exportA = a.exportData();
       const exportB = b.exportData();
       if (!deepEquals(exportA, exportB)) {
-        const clientA = a.getters.getClient().id;
-        const clientB = b.getters.getClient().id;
+        const clientA = a.getters.getCurrentClient().id;
+        const clientB = b.getters.getCurrentClient().id;
         return {
           pass: this.isNot,
           message: () =>

--- a/tests/spreadsheet/spreadsheet_component.test.ts
+++ b/tests/spreadsheet/spreadsheet_component.test.ts
@@ -257,12 +257,12 @@ test("Can instantiate a spreadsheet with a given client id-name", async () => {
   unPatchSessionMove();
   const client = { id: "alice", name: "Alice" };
   ({ model } = await mountSpreadsheet({ model: new Model({}, { client }) }));
-  expect(model.getters.getClient()).toEqual(client);
+  expect(model.getters.getCurrentClient()).toEqual(client);
 
   // Validate that after the move debounce has run, the client has a position ad
   // additional property
   jest.advanceTimersByTime(DEBOUNCE_TIME + 1);
-  expect(model.getters.getClient()).toEqual({
+  expect(model.getters.getCurrentClient()).toEqual({
     id: "alice",
     name: "Alice",
     position: {

--- a/tests/test_helpers/helpers.ts
+++ b/tests/test_helpers/helpers.ts
@@ -183,6 +183,10 @@ export function makeTestEnv(
     throw new Error("Cannot call makeTestEnv on a partial env that already have a store container");
   }
   const container = new DependencyContainer();
+  registerCleanup(() => {
+    container.dispose();
+  });
+
   container.inject(ModelStore, model);
   container.inject(RendererStore, new FakeRendererStore());
 
@@ -1151,6 +1155,10 @@ export function makeTestComposerStore(
   notificationStore?: NotificationStore
 ): CellComposerStore {
   const container = new DependencyContainer();
+  registerCleanup(() => {
+    container.dispose();
+  });
+
   container.inject(ModelStore, model);
   notificationStore = notificationStore || makeTestNotificationStore();
   container.inject(NotificationStore, notificationStore);

--- a/tests/test_helpers/stores.ts
+++ b/tests/test_helpers/stores.ts
@@ -2,6 +2,7 @@ import { Model } from "../../src";
 import { DependencyContainer, StoreConstructor, StoreParams } from "../../src/store_engine";
 import { ModelStore } from "../../src/stores";
 import { NotificationStore } from "../../src/stores/notification_store";
+import { registerCleanup } from "../setup/jest.setup";
 import { makeTestNotificationStore } from "./helpers";
 
 export function makeStore<T extends StoreConstructor>(Store: T, ...args: StoreParams<T>) {
@@ -14,6 +15,10 @@ export function makeStoreWithModel<T extends StoreConstructor>(
   ...args: StoreParams<T>
 ) {
   const container = new DependencyContainer();
+  registerCleanup(() => {
+    container.dispose();
+  });
+
   container.inject(ModelStore, model);
   container.inject(NotificationStore, makeTestNotificationStore());
   return {


### PR DESCRIPTION
Add a move to user when clicking on an user
on the "connected user" popover.

task-id: 4607572

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo