### PR TITLE
[FIX] sheet: autoresize doesn't work on evaluated multiline cell

### DIFF
--- a/src/helpers/text_helper.ts
+++ b/src/helpers/text_helper.ts
@@ -25,14 +25,19 @@ export function getDefaultCellHeight(
   if (!cell || (!cell.isFormula && !cell.content)) {
     return DEFAULT_CELL_HEIGHT;
   }
-  const maxWidth = cell.style?.wrapping === "wrap" ? colSize - 2 * MIN_CELL_TEXT_MARGIN : undefined;
+  const content = cell.isFormula ? "" : cell.content;
+  return getCellContentHeight(ctx, content, cell.style, colSize);
+}
 
-  const numberOfLines = cell.isFormula
-    ? 1
-    : splitTextToWidth(ctx, cell.content, cell.style, maxWidth).length;
-
-  const fontSize = computeTextFontSizeInPixels(cell.style);
-
+export function getCellContentHeight(
+  ctx: CanvasRenderingContext2D,
+  content: string,
+  style: Style | undefined,
+  colSize: number
+) {
+  const maxWidth = style?.wrapping === "wrap" ? colSize - 2 * MIN_CELL_TEXT_MARGIN : undefined;
+  const numberOfLines = splitTextToWidth(ctx, content, style, maxWidth).length;
+  const fontSize = computeTextFontSizeInPixels(style);
   return computeTextLinesHeight(fontSize, numberOfLines) + 2 * PADDING_AUTORESIZE_VERTICAL;
 }
 

--- a/src/plugins/ui_feature/ui_sheet.ts
+++ b/src/plugins/ui_feature/ui_sheet.ts
@@ -1,7 +1,13 @@
-import { GRID_ICON_MARGIN, ICON_EDGE_LENGTH, PADDING_AUTORESIZE_HORIZONTAL } from "../../constants";
+import {
+  DEFAULT_CELL_HEIGHT,
+  GRID_ICON_MARGIN,
+  ICON_EDGE_LENGTH,
+  PADDING_AUTORESIZE_HORIZONTAL,
+} from "../../constants";
 import {
   computeIconWidth,
   computeTextWidth,
+  getCellContentHeight,
   largeMax,
   positions,
   splitTextToWidth,
@@ -46,13 +52,7 @@ export class SheetUIPlugin extends UIPlugin {
         }
         break;
       case "AUTORESIZE_ROWS":
-        this.dispatch("RESIZE_COLUMNS_ROWS", {
-          elements: cmd.rows,
-          dimension: "ROW",
-          size: null,
-          sheetId: cmd.sheetId,
-        });
-
+        this.autoResizeRows(cmd.sheetId, cmd.rows);
         break;
     }
   }
@@ -169,5 +169,49 @@ export class SheetUIPlugin extends UIPlugin {
       return this.getters.checkZonesExistInSheet(sheetId, zones);
     }
     return CommandResult.Success;
+  }
+
+  private autoResizeRows(sheetId: UID, rows: HeaderIndex[]) {
+    const rowSizes: (number | null)[] = [];
+    for (const row of rows) {
+      let evaluatedRowSize = 0;
+      for (const cellId of this.getters.getRowCells(sheetId, row)) {
+        const cell = this.getters.getCellById(cellId);
+        if (!cell) {
+          continue;
+        }
+        const position = this.getters.getCellPosition(cell.id);
+        const colSize = this.getters.getColSize(sheetId, position.col);
+
+        if (cell.isFormula) {
+          const content = this.getters.getEvaluatedCell(position).formattedValue;
+          const evaluatedSize = getCellContentHeight(this.ctx, content, cell?.style, colSize);
+          if (evaluatedSize > evaluatedRowSize && evaluatedSize > DEFAULT_CELL_HEIGHT) {
+            evaluatedRowSize = evaluatedSize;
+          }
+        } else {
+          const content = cell.content;
+          const dynamicRowSize = getCellContentHeight(this.ctx, content, cell?.style, colSize);
+          // Only keep the size of evaluated cells if it's bigger than the dynamic row size
+          if (dynamicRowSize >= evaluatedRowSize && dynamicRowSize > DEFAULT_CELL_HEIGHT) {
+            evaluatedRowSize = 0;
+          }
+        }
+      }
+      rowSizes.push(evaluatedRowSize || null);
+    }
+
+    const groupedSizes = new Map<number | null, HeaderIndex[]>(rowSizes.map((size) => [size, []]));
+    for (let i = 0; i < rowSizes.length; i++) {
+      groupedSizes.get(rowSizes[i])?.push(rows[i]);
+    }
+    for (const [size, rows] of groupedSizes) {
+      this.dispatch("RESIZE_COLUMNS_ROWS", {
+        elements: rows,
+        dimension: "ROW",
+        size,
+        sheetId,
+      });
+    }
   }
 }

--- a/tests/formats/formatting_plugin.test.ts
+++ b/tests/formats/formatting_plugin.test.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_FONT_SIZE,
   GRID_ICON_MARGIN,
   ICON_EDGE_LENGTH,
+  MIN_CELL_TEXT_MARGIN,
   NEWLINE,
   PADDING_AUTORESIZE_HORIZONTAL,
   PADDING_AUTORESIZE_VERTICAL,
@@ -560,6 +561,35 @@ describe("Autoresize", () => {
       size: null,
       sheetId,
     });
+  });
+
+  test("Can autoresize a row with evaluated multi-line content", () => {
+    setCellContent(model, "A1", '="Hello\nThere"');
+    expect(model.getters.getRowSize(sheetId, 0)).toBe(DEFAULT_CELL_HEIGHT);
+    model.dispatch("AUTORESIZE_ROWS", { sheetId, rows: [0] });
+    const numberOfLines = 2;
+    const lineHeight = 13; // default font size in px
+    const expectedHeight =
+      numberOfLines * (lineHeight + MIN_CELL_TEXT_MARGIN) -
+      MIN_CELL_TEXT_MARGIN +
+      2 * PADDING_AUTORESIZE_VERTICAL;
+    expect(model.getters.getRowSize(sheetId, 0)).toBe(expectedHeight);
+  });
+
+  test("Evaluated multi-line content have no impact on autoresize if it's not taller than non-evaluated content", () => {
+    setCellContent(model, "A1", '="Hello\nThere"');
+
+    setCellContent(model, "B1", "Hello\nThere\nGeneral");
+    model.dispatch("AUTORESIZE_ROWS", { sheetId, rows: [0] });
+    expect(model.getters.getUserRowSize(sheetId, 0)).toBe(undefined);
+
+    setCellContent(model, "B1", "Hello\nThere");
+    model.dispatch("AUTORESIZE_ROWS", { sheetId, rows: [0] });
+    expect(model.getters.getUserRowSize(sheetId, 0)).toBe(undefined);
+
+    setCellContent(model, "B1", "Hello");
+    model.dispatch("AUTORESIZE_ROWS", { sheetId, rows: [0] });
+    expect(model.getters.getUserRowSize(sheetId, 0)).toBe(36);
   });
 
   test("Can autoresize a column in another sheet", () => {


### PR DESCRIPTION
## Description

If a cell is a formula returning a multi-line content, the autoresize do nothing.

Task: [4609545](https://www.odoo.com/odoo/2328/tasks/4609545)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo