### PR TITLE
[FIX] RemoveDuplicate: fix component initialization

### DIFF
--- a/src/components/side_panel/remove_duplicates/remove_duplicates.ts
+++ b/src/components/side_panel/remove_duplicates/remove_duplicates.ts
@@ -30,6 +30,7 @@ export class RemoveDuplicatesPanel extends Component<Props, SpreadsheetChildEnv>
   });
 
   setup() {
+    this.updateColumns();
     onWillUpdateProps(() => this.updateColumns());
   }
 

--- a/tests/remove_duplicates/remove_duplicates_side_panel_component.test.ts
+++ b/tests/remove_duplicates/remove_duplicates_side_panel_component.test.ts
@@ -215,10 +215,13 @@ describe("remove duplicates", () => {
     parent.env.openSidePanel("RemoveDuplicates");
     await nextTick();
 
+    let errors = fixture.querySelectorAll(selectors.sidePanelError);
+    expect(errors.length).toBe(0);
+
     const checkBoxSelectAll = fixture.querySelectorAll(selectors.checkBoxColumnsInput)[0]; // checkBox[0] correspond to " Select all "
     await click(checkBoxSelectAll);
 
-    const errors = fixture.querySelectorAll(selectors.sidePanelError);
+    errors = fixture.querySelectorAll(selectors.sidePanelError);
     expect(errors.length).toBe(1);
     expect(errors[0].textContent).toBe("Please select at latest one column to analyze.");
     expect(fixture.querySelector(selectors.removeDuplicateButton)!.classList).toContain(

--- a/tests/test_helpers/dom_helper.ts
+++ b/tests/test_helpers/dom_helper.ts
@@ -10,15 +10,17 @@ export async function simulateClick(
   selector: DOMTarget,
   x: number = 10,
   y: number = 10,
-  extra: MouseEventInit = { bubbles: true }
+  extra: MouseEventInit = { bubbles: true, cancelable: true }
 ) {
   const target = getTarget(selector);
-  triggerMouseEvent(selector, "mousedown", x, y, extra);
+  const pointerDownEv = triggerMouseEvent(selector, "mousedown", x, y, extra);
   if (target !== document.activeElement) {
     const oldActiveEl = document.activeElement;
-    (document.activeElement as HTMLElement | null)?.dispatchEvent(
-      new FocusEvent("blur", { relatedTarget: target })
-    );
+    if (!pointerDownEv.defaultPrevented) {
+      (document.activeElement as HTMLElement | null)?.dispatchEvent(
+        new FocusEvent("blur", { relatedTarget: target })
+      );
+    }
     /** Dispatching a crafted FocusEvent does not actually focus the target.
      * JSDom pretty much requires us to rely on Element.focus()
      * Because of the problematic behavior addressed in 71a9c8c2,
@@ -161,6 +163,7 @@ export function triggerMouseEvent(
   (ev as any).offsetY = offsetY;
   const target = getTarget(selector);
   target.dispatchEvent(ev);
+  return ev;
 }
 
 export function triggerWheelEvent(


### PR DESCRIPTION
## Description:

The `RemoveDuplicate` component was never correctly initialized but it
was hidden at runtime because opening the sidepanel triggers a full
rendering of `Spreadsheet` which in turn fixed the internal state of
`RemoveDuplicate`.

Also fix/imp the `simulateClick` helper to be closer to the reality

Task: [4646342](https://www.odoo.com/odoo/2328/tasks/4646342)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo