### PR TITLE
[FIX] edition: escape closes the composer

### DIFF
--- a/src/plugins/ui/edition.ts
+++ b/src/plugins/ui/edition.ts
@@ -125,8 +125,8 @@ export class EditionPlugin extends UIPlugin {
         break;
       case "STOP_EDITION":
         if (cmd.cancel) {
-          this.cancelEditionAndActivateSheet();
           this.resetContent();
+          this.cancelEditionAndActivateSheet();
         } else {
           this.stopEdition();
         }
@@ -140,8 +140,8 @@ export class EditionPlugin extends UIPlugin {
         this.replaceSelection(cmd.text);
         break;
       case "SELECT_FIGURE":
-        this.cancelEditionAndActivateSheet();
         this.resetContent();
+        this.cancelEditionAndActivateSheet();
         break;
       case "ADD_COLUMNS_ROWS":
         this.onAddElements(cmd);
@@ -202,8 +202,8 @@ export class EditionPlugin extends UIPlugin {
         const sheetIdExists = !!this.getters.tryGetSheet(this.sheetId);
         if (!sheetIdExists && this.mode !== "inactive") {
           this.sheetId = this.getters.getActiveSheetId();
-          this.cancelEditionAndActivateSheet();
           this.resetContent();
+          this.cancelEditionAndActivateSheet();
           this.ui.notifyUI({
             type: "ERROR",
             text: CELL_DELETED_MESSAGE,

--- a/tests/collaborative/collaborative.test.ts
+++ b/tests/collaborative/collaborative.test.ts
@@ -636,6 +636,18 @@ describe("Multi users synchronisation", () => {
     expect(alice.getters.getEditionMode()).toBe("inactive");
   });
 
+  test("Delete sheet & Don't notify cell is deleted when composer is in selecting mode", () => {
+    const activeSheetId = alice.getters.getActiveSheetId();
+    createSheet(alice, { sheetId: "42" });
+    selectCell(alice, "A4");
+    setCellContent(alice, "A4", "=A1+");
+    alice.dispatch("START_EDITION");
+    const spy = jest.spyOn(alice["config"], "notifyUI");
+    alice.dispatch("DELETE_SHEET", { sheetId: activeSheetId });
+    expect(spy).toHaveBeenCalled();
+    expect(alice.getters.getEditionMode()).toBe("inactive");
+  });
+
   test("Delete row & Don't notify cell is deleted when composer is not active", () => {
     selectCell(alice, "A4");
     alice.dispatch("START_EDITION", { text: "hello" });

--- a/tests/plugins/edition.test.ts
+++ b/tests/plugins/edition.test.ts
@@ -331,6 +331,17 @@ describe("edition", () => {
     });
     model.dispatch("STOP_EDITION", { cancel: true });
     expect(model.getters.getCurrentContent()).toBe("");
+    expect(model.getters.getEditionMode()).toBe("inactive");
+  });
+
+  test("cancel edition with initial content in a selecting position", () => {
+    const model = new Model();
+    setCellContent(model, "A1", "=A12+");
+    model.dispatch("START_EDITION");
+    expect(model.getters.getEditionMode()).toBe("selecting");
+    model.dispatch("STOP_EDITION", { cancel: true });
+    expect(model.getters.getCurrentContent()).toBe("=A12+");
+    expect(model.getters.getEditionMode()).toBe("inactive");
   });
 
   test("ranges are not highlighted when inactive", () => {

--- a/tests/plugins/figures.test.ts
+++ b/tests/plugins/figures.test.ts
@@ -7,6 +7,7 @@ import {
   freezeColumns,
   freezeRows,
   selectCell,
+  setCellContent,
   setViewportOffset,
   undo,
 } from "../test_helpers/commands_helpers";
@@ -352,7 +353,7 @@ describe("figure plugin", () => {
     expect(model.getters.getSelectedFigureId()).toBeNull();
   });
 
-  test("Selecting a cell cancel the edition of a cell", () => {
+  test("Selecting a figure cancels the edition of a cell", () => {
     const model = new Model();
     model.dispatch("CREATE_FIGURE", {
       sheetId: model.getters.getActiveSheetId(),
@@ -371,6 +372,26 @@ describe("figure plugin", () => {
     model.dispatch("SELECT_FIGURE", { id: "someuuid" });
     expect(model.getters.getEditionMode()).toBe("inactive");
     expect(model.getters.getActiveCell()?.evaluated.value).toBeUndefined();
+  });
+
+  test("Selecting a figure cancels the edition of a cell in selecting mode", () => {
+    const model = new Model();
+    setCellContent(model, "A1", "=A1+");
+    model.dispatch("CREATE_FIGURE", {
+      sheetId: model.getters.getActiveSheetId(),
+      figure: {
+        id: "someuuid",
+        x: 10,
+        y: 10,
+        tag: "hey",
+        width: 10,
+        height: 10,
+      },
+    });
+    model.dispatch("START_EDITION");
+    expect(model.getters.getEditionMode()).toBe("selecting");
+    model.dispatch("SELECT_FIGURE", { id: "someuuid" });
+    expect(model.getters.getEditionMode()).toBe("inactive");
   });
 
   test("cannot duplicate figure ids", () => {


### PR DESCRIPTION
## Description:

Steps to reproduce:
- in A1: type =A2+
- press Enter to validate the formula
- double click on A1 to re-open the composer
- Press Escape

=> the composer doesn't close and there's a weird black hightlight

Task: [4646699](https://www.odoo.com/odoo/2328/tasks/4646699)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo