### PR TITLE
[FIX] clipboard: cross-sheet cut/paste is broken for merges

### DIFF
--- a/src/helpers/clipboard/clipboard_cells_state.ts
+++ b/src/helpers/clipboard/clipboard_cells_state.ts
@@ -316,12 +316,7 @@ export class ClipboardCellsState extends ClipboardCellsAbstractState {
       for (let c = 0; c < width; c++) {
         const origin = rowCells[c];
         const position = { col: col + c, row: row + r, sheetId: sheetId };
-        // TODO: refactor this part. the "Paste merge" action is also executed with
-        // MOVE_RANGES in pasteFromCut. Adding a condition on the operation type here
-        // is not appropriate
-        if (this.operation !== "CUT") {
-          this.pasteMergeIfExist(origin.position, position);
-        }
+        this.pasteMergeIfExist(origin.position, position, this.operation);
         this.pasteCell(origin, position, this.operation, clipboardOptions);
         if (shouldPasteCF) {
           this.dispatch("PASTE_CONDITIONAL_FORMAT", {
@@ -414,7 +409,11 @@ export class ClipboardCellsState extends ClipboardCellsAbstractState {
    * If the origin position given is the top left of a merge, merge the target
    * position.
    */
-  private pasteMergeIfExist(origin: CellPosition, target: CellPosition) {
+  private pasteMergeIfExist(
+    origin: CellPosition,
+    target: CellPosition,
+    operation: ClipboardOperation
+  ) {
     let { sheetId, col, row } = origin;
 
     const { col: mainCellColOrigin, row: mainCellRowOrigin } = this.getters.getMainCellPosition(
@@ -426,6 +425,9 @@ export class ClipboardCellsState extends ClipboardCellsAbstractState {
       const merge = this.getters.getMerge(sheetId, col, row);
       if (!merge) {
         return;
+      }
+      if (operation === "CUT") {
+        this.dispatch("REMOVE_MERGE", { sheetId, target: [merge] });
       }
       ({ sheetId, col, row } = target);
       this.dispatch("ADD_MERGE", {

--- a/tests/plugins/clipboard.test.ts
+++ b/tests/plugins/clipboard.test.ts
@@ -311,52 +311,32 @@ describe("clipboard", () => {
 
   test("can copy and paste merged content", () => {
     const model = new Model({
-      sheets: [
-        {
-          id: "s1",
-          colNumber: 5,
-          rowNumber: 5,
-          merges: ["B1:C2"],
-        },
-      ],
+      sheets: [{ id: "s1", colNumber: 5, rowNumber: 5, merges: ["B1:C2"] }],
     });
     copy(model, "B1");
     paste(model, "B4");
-    expect(
-      model.getters.isInMerge(model.getters.getActiveSheetId(), ...toCartesianArray("B4"))
-    ).toBe(true);
-    expect(
-      model.getters.isInMerge(model.getters.getActiveSheetId(), ...toCartesianArray("B5"))
-    ).toBe(true);
-    expect(
-      model.getters.isInMerge(model.getters.getActiveSheetId(), ...toCartesianArray("C4"))
-    ).toBe(true);
-    expect(
-      model.getters.isInMerge(model.getters.getActiveSheetId(), ...toCartesianArray("B5"))
-    ).toBe(true);
+    expect(model.getters.getMerges("s1")).toMatchObject([toZone("B1:C2"), toZone("B4:C5")]);
   });
 
   test("can cut and paste merged content", () => {
     const model = new Model({
-      sheets: [
-        {
-          id: "s2",
-          colNumber: 5,
-          rowNumber: 5,
-          merges: ["B1:C2"],
-        },
-      ],
+      sheets: [{ id: "s2", colNumber: 5, rowNumber: 5, merges: ["B1:C2"] }],
     });
     cut(model, "B1:C2");
     paste(model, "B4");
-    expect(model.getters.isInMerge("s2", ...toCartesianArray("B1"))).toBe(false);
-    expect(model.getters.isInMerge("s2", ...toCartesianArray("B2"))).toBe(false);
-    expect(model.getters.isInMerge("s2", ...toCartesianArray("C1"))).toBe(false);
-    expect(model.getters.isInMerge("s2", ...toCartesianArray("C2"))).toBe(false);
-    expect(model.getters.isInMerge("s2", ...toCartesianArray("B4"))).toBe(true);
-    expect(model.getters.isInMerge("s2", ...toCartesianArray("B5"))).toBe(true);
-    expect(model.getters.isInMerge("s2", ...toCartesianArray("C4"))).toBe(true);
-    expect(model.getters.isInMerge("s2", ...toCartesianArray("C5"))).toBe(true);
+    expect(model.getters.getMerges("s2")).toHaveLength(1);
+    expect(model.getters.getMerges("s2")).toMatchObject([toZone("B4:C5")]);
+  });
+
+  test("can cut and paste merged content in another sheet", () => {
+    const model = new Model({
+      sheets: [{ id: "s1", colNumber: 5, rowNumber: 5, merges: ["B1:C2"] }, { id: "s2" }],
+    });
+    cut(model, "B1:C2");
+    activateSheet(model, "s2");
+    paste(model, "B4");
+    expect(model.getters.getMerges("s1")).toEqual([]);
+    expect(model.getters.getMerges("s2")).toMatchObject([toZone("B4:C5")]);
   });
 
   test("Pasting merge on content will remove the content", () => {


### PR DESCRIPTION
## Description

Preface: the handling of `MOVE_RANGES` is broken in multiple plugins. When calling `adaptRanges`, we don't check that the resulting range is in the same sheet as the original range.

Fixing that in stable is probably not a good idea. This would mean that suddenly cfs/merges could appear where they were previously not, and could break existing sheets.

The handling of copy/paste of merges is done either in `pasteMergeIfExist` (for copy/paste) or by `MOVE_RANGES` (for cut/paste). The latter is broken.

This commit fixes that by handling all the copy/cut cases of the merges in `pasteMergeIfExist` rather than relying on `MOVE_RANGES`. The `MOVE_RANGES` command is still dispatched, but it now do not affect merges since they are already deleted from their original location.

Task: [3905618](https://www.odoo.com/odoo/2328/tasks/3905618)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo