### PR TITLE
[FIX] pivot: allowDispatch wrong sorted column

### DIFF
--- a/src/migrations/migration_steps.ts
+++ b/src/migrations/migration_steps.ts
@@ -426,6 +426,18 @@ migrationStepRegistry
   })
   .add("18.3", {
     migrate(data) {
+      if (!data.pivots) {
+        return data;
+      }
+      for (const pivot of Object.values(data.pivots as WorkbookData["pivots"])) {
+        if (!pivot.sortedColumn) {
+          continue;
+        }
+        const measureIds = pivot.measures.map((measure) => measure.id);
+        if (!measureIds.includes(pivot.sortedColumn.measure)) {
+          delete pivot.sortedColumn;
+        }
+      }
       return data;
     },
   });

--- a/src/plugins/core/pivot.ts
+++ b/src/plugins/core/pivot.ts
@@ -50,7 +50,11 @@ export class PivotCorePlugin extends CorePlugin<CoreState> implements CoreState 
   allowDispatch(cmd: CoreCommand) {
     switch (cmd.type) {
       case "ADD_PIVOT": {
-        return this.checkDuplicatedMeasureIds(cmd.pivot);
+        return this.checkValidations(
+          cmd.pivot,
+          this.checkDuplicatedMeasureIds,
+          this.checkSortedColumnInMeasures
+        );
       }
       case "UPDATE_PIVOT": {
         if (!(cmd.pivotId in this.pivots)) {
@@ -62,7 +66,11 @@ export class PivotCorePlugin extends CorePlugin<CoreState> implements CoreState 
         if (cmd.pivot.name === "") {
           return CommandResult.EmptyName;
         }
-        return this.checkDuplicatedMeasureIds(cmd.pivot);
+        return this.checkValidations(
+          cmd.pivot,
+          this.checkDuplicatedMeasureIds,
+          this.checkSortedColumnInMeasures
+        );
       }
       case "RENAME_PIVOT":
         if (!(cmd.pivotId in this.pivots)) {
@@ -331,6 +339,14 @@ export class PivotCorePlugin extends CorePlugin<CoreState> implements CoreState 
         }
       }
     }
+  }
+
+  private checkSortedColumnInMeasures(definition: PivotCoreDefinition) {
+    const measures = definition.measures.map((measure) => measure.id);
+    if (definition.sortedColumn && !measures.includes(definition.sortedColumn.measure)) {
+      return CommandResult.InvalidDefinition;
+    }
+    return CommandResult.Success;
   }
 
   private checkDuplicatedMeasureIds(definition: PivotCoreDefinition) {

--- a/tests/model/model_import_export.test.ts
+++ b/tests/model/model_import_export.test.ts
@@ -587,6 +587,47 @@ describe("Migrations", () => {
     });
     expect(getCellContent(model, "A1")).toBe("Hello");
   });
+
+  test("migration 18.3: drop sorted column if not part of measure", () => {
+    const data = {
+      version: 24,
+      pivots: {
+        1: {
+          type: "SPREADSHEET",
+          columns: [],
+          domain: [],
+          measures: [{ id: "probability:sum", fieldName: "probability", aggregator: "sum" }],
+          model: "partner",
+          rows: [{ fieldName: "bar" }],
+          sortedColumn: {
+            measure: "foo",
+            order: "asc",
+          },
+          name: "A pivot",
+          formulaId: "1",
+        },
+        2: {
+          type: "SPREADSHEET",
+          columns: [],
+          domain: [],
+          measures: [{ id: "probability:sum", fieldName: "probability", aggregator: "sum" }],
+          model: "partner",
+          rows: [{ fieldName: "bar" }],
+          sortedColumn: {
+            measure: "probability:sum",
+            order: "asc",
+          },
+          name: "A pivot",
+          formulaId: "2",
+        },
+      },
+    };
+    const model = new Model(data);
+    expect(model.getters.getPivot("1").definition.sortedColumn).toBe(undefined);
+    expect(model.getters.getPivot("2").definition.sortedColumn).toEqual(
+      data.pivots["2"].sortedColumn
+    ); // unchanged
+  });
 });
 
 describe("Import", () => {

--- a/tests/pivots/pivot_plugin.test.ts
+++ b/tests/pivots/pivot_plugin.test.ts
@@ -91,6 +91,25 @@ describe("Pivot plugin", () => {
     expect(creationResult.isSuccessful).toBe(false);
   });
 
+  test("sortedColumn must be in the measures", () => {
+    // prettier-ignore
+    const grid = {
+      A1: "Customer", B1: "Price",
+      A2: "Alice",    B2: "10",
+      A3: "Bob",      B3: "30",
+    };
+    const model = createModelFromGrid(grid);
+    const creationResult = addPivot(model, "A1:A2", {
+      measures: [{ id: "Customer:sum", fieldName: "Customer", aggregator: "sum" }],
+      sortedColumn: {
+        domain: [],
+        order: "asc",
+        measure: "Price",
+      },
+    });
+    expect(creationResult).toBeCancelledBecause(CommandResult.InvalidDefinition);
+  });
+
   test("cannot update a pivot with duplicated measure ids", () => {
     const grid = {
       A1: "Customer",


### PR DESCRIPTION
## Description:

With this commit, we ensure the sorted column is
part of the measures

Task: [4613088](https://www.odoo.com/odoo/2328/tasks/4613088)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo