### PR TITLE
[FIX] css: put `h-100` in o-spreadsheet

### DIFF
--- a/demo/main.css
+++ b/demo/main.css
@@ -12,7 +12,3 @@ body {
     "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
     "Noto Color Emoji" !important;
 }
-.o-spreadsheet {
-  width: 100%;
-  height: 100%;
-}

--- a/src/components/spreadsheet/spreadsheet.xml
+++ b/src/components/spreadsheet/spreadsheet.xml
@@ -1,7 +1,7 @@
 <templates>
   <t t-name="o-spreadsheet-Spreadsheet" owl="1">
     <div
-      class="o-spreadsheet"
+      class="o-spreadsheet h-100 w-100"
       t-on-keydown="(ev) => !env.isDashboard() and this.onKeydown(ev)"
       t-att-style="getStyle()">
       <t t-if="env.isDashboard()">

--- a/tests/components/__snapshots__/spreadsheet.test.ts.snap
+++ b/tests/components/__snapshots__/spreadsheet.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
 <div
-  class="o-spreadsheet"
+  class="o-spreadsheet h-100 w-100"
   style="grid-template-rows: 63px auto 37px"
 >
   


### PR DESCRIPTION
## Description

The library need a `height: 100%` to work properly. It is set manually in both demo and odoo. It should be standard in the lib.

Task: [4652289](https://www.odoo.com/odoo/2328/tasks/4652289)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo