### PR TITLE
[FIX] selection_input: fix range deletion

### DIFF
--- a/src/components/selection_input/selection_input.ts
+++ b/src/components/selection_input/selection_input.ts
@@ -224,8 +224,11 @@ export class SelectionInput extends Component<Props, SpreadsheetChildEnv> {
 
   removeInput(rangeId: number) {
     const index = this.store.selectionInputs.findIndex((range) => range.id === rangeId);
-    this.props.onSelectionRemoved?.(index);
-    this.props.onSelectionConfirmed?.();
+    if (this.ranges.find((range) => range.id === rangeId)?.xc) {
+      this.props.onSelectionRemoved?.(index);
+      this.props.onSelectionConfirmed?.();
+    }
+    this.store.removeRange(rangeId);
   }
 
   onInputChanged(rangeId: number, ev: InputEvent) {

--- a/tests/conditional_formatting/conditional_formatting_panel_component.test.ts
+++ b/tests/conditional_formatting/conditional_formatting_panel_component.test.ts
@@ -440,6 +440,54 @@ describe("UI of conditional formats", () => {
       );
     });
 
+    test("Can remove a valid, invalid or empty range", async () => {
+      await click(fixture, selectors.buttonAdd);
+      await nextTick();
+
+      await setInputValueAndTrigger(selectors.ruleEditor.editor.operatorInput, "BeginsWith");
+      setInputValueAndTrigger(".o-selection-input input", "A1:A4");
+      expect(document.querySelectorAll(".o-selection-input input")).toHaveLength(1);
+
+      // Add & remove a valid range
+      await simulateClick(".o-add-selection");
+      const range1 = document.querySelectorAll(".o-selection-input input")[1];
+      await setInputValueAndTrigger(range1, "B1:B4");
+      const remove1 = document.querySelectorAll(".o-remove-selection")[1];
+      await simulateClick(remove1);
+      expect(document.querySelectorAll(".o-selection-input input")).toHaveLength(1);
+
+      // Add & remove an invalid range
+      await simulateClick(".o-add-selection");
+      const range2 = document.querySelectorAll(".o-selection-input input")[1];
+      await setInputValueAndTrigger(range2, "MERA");
+      const remove2 = document.querySelectorAll(".o-remove-selection")[1];
+      await simulateClick(remove2);
+      expect(document.querySelectorAll(".o-selection-input input")).toHaveLength(1);
+
+      // Add & remove an empty range
+      await simulateClick(".o-add-selection");
+      const remove3 = document.querySelectorAll(".o-remove-selection")[1];
+      await simulateClick(remove3);
+      expect(document.querySelectorAll(".o-selection-input input")).toHaveLength(1);
+
+      // Add & remove a valid range positioned before an empty range
+      await simulateClick(".o-add-selection");
+      const range4 = document.querySelectorAll(".o-selection-input input")[1];
+      await setInputValueAndTrigger(range4, "B1:B4");
+      await simulateClick(".o-add-selection");
+      const remove4 = document.querySelectorAll(".o-remove-selection")[1];
+      await simulateClick(remove4);
+      expect(document.querySelectorAll(".o-selection-input input")).toHaveLength(2);
+
+      editStandaloneComposer(selectors.ruleEditor.editor.valueInput, "ABC");
+
+      // The CF rule should be saved with the one range only
+      await click(fixture, selectors.buttonSave);
+      expect(model.getters.getConditionalFormats(sheetId)[2]).toMatchObject({
+        ranges: ["A1:A4"],
+      });
+    });
+
     test("can delete Rule", async () => {
       const dispatch = spyModelDispatch(model);
       const previews = document.querySelectorAll(selectors.listPreview);

--- a/tests/data_validation/data_validation_generics_side_panel_component.test.ts
+++ b/tests/data_validation/data_validation_generics_side_panel_component.test.ts
@@ -155,6 +155,56 @@ describe("data validation sidePanel component", () => {
     expect(errorMessageEl?.textContent).toContain("The range is invalid.");
   });
 
+  test("Can remove a valid, invalid or empty range", async () => {
+    await simulateClick(".o-dv-add");
+    await nextTick();
+    await changeCriterionType("dateIs");
+
+    setInputValueAndTrigger(".o-selection-input input", "A1:A4");
+    expect(document.querySelectorAll(".o-selection-input input")).toHaveLength(1);
+
+    // Add & remove a valid range
+    await simulateClick(".o-add-selection");
+    const range1 = document.querySelectorAll(".o-selection-input input")[1];
+    await setInputValueAndTrigger(range1, "B1:B4");
+    const remove1 = document.querySelectorAll(".o-remove-selection")[1];
+    await simulateClick(remove1);
+    expect(document.querySelectorAll(".o-selection-input input")).toHaveLength(1);
+
+    // Add & remove an invalid range
+    await simulateClick(".o-add-selection");
+    const range2 = document.querySelectorAll(".o-selection-input input")[1];
+    await setInputValueAndTrigger(range2, "B1:HOLA");
+    const remove2 = document.querySelectorAll(".o-remove-selection")[1];
+    await simulateClick(remove2);
+    expect(document.querySelectorAll(".o-selection-input input")).toHaveLength(1);
+
+    // Add & remove an empty range
+    await simulateClick(".o-add-selection");
+    const remove3 = document.querySelectorAll(".o-remove-selection")[1];
+    await simulateClick(remove3);
+    expect(document.querySelectorAll(".o-selection-input input")).toHaveLength(1);
+
+    // Add & remove a valid range positioned before an empty range
+    await simulateClick(".o-add-selection");
+    const range4 = document.querySelectorAll(".o-selection-input input")[1];
+    await setInputValueAndTrigger(range4, "B1:B4");
+    await simulateClick(".o-add-selection");
+    const remove4 = document.querySelectorAll(".o-remove-selection")[1];
+    await simulateClick(remove4);
+    expect(document.querySelectorAll(".o-selection-input input")).toHaveLength(2);
+
+    await editStandaloneComposer(".o-dv-settings .o-composer", "=DATE(2025,1,1)");
+
+    // The DV rule should be saved with the one range only
+    await simulateClick(".o-dv-save");
+    expect(getDataValidationRules(model, sheetId)).toMatchObject([
+      {
+        ranges: ["A1:A4"],
+      },
+    ]);
+  });
+
   test("Invalid input values with single input", async () => {
     await simulateClick(".o-dv-add");
     await nextTick();

--- a/tests/figures/chart/charts_component.test.ts
+++ b/tests/figures/chart/charts_component.test.ts
@@ -1094,6 +1094,19 @@ describe("charts", () => {
     ]);
   });
 
+  test("Can remove an empty data series range", async () => {
+    createTestChart("basicChart");
+    await mountChartSidePanel();
+    await simulateClick(".o-data-series .o-add-selection");
+    await simulateClick(".o-data-series .o-add-selection");
+    expect(document.querySelectorAll(".o-selection-input input")).toHaveLength(4);
+    const element = document.querySelectorAll(".o-data-series input")[2];
+    await setInputValueAndTrigger(element, "C1:C4");
+    const remove = document.querySelectorAll(".o-data-series .o-remove-selection")[1];
+    await simulateClick(remove);
+    expect(document.querySelectorAll(".o-selection-input input")).toHaveLength(3);
+  });
+
   test("Custom design is kept when removing a data series", async () => {
     createTestChart("basicChart");
     updateChart(model, chartId, {

--- a/tests/selection_input/selection_input_component.test.ts
+++ b/tests/selection_input/selection_input_component.test.ts
@@ -158,6 +158,38 @@ describe("Selection Input", () => {
     expect(fixture.querySelectorAll(".o-remove-selection").length).toBe(2);
   });
 
+  test("can remove an empty selection input", async () => {
+    await createSelectionInput();
+    await simulateClick(".o-add-selection");
+    await simulateClick(".o-add-selection");
+    expect(document.querySelectorAll(".o-selection-input input")).toHaveLength(3);
+    const range1 = document.querySelectorAll(".o-selection-input input")[0];
+    await setInputValueAndTrigger(range1, "A1:A4");
+    const range2 = document.querySelectorAll(".o-selection-input input")[2];
+    await setInputValueAndTrigger(range2, "C1:C4");
+    // We have 3 selection inputs, the second one is empty
+    const removeEmptyRangeQuery = document.querySelectorAll(".o-remove-selection")[1];
+    await simulateClick(removeEmptyRangeQuery);
+    expect(document.querySelectorAll(".o-selection-input input")).toHaveLength(2);
+  });
+
+  test("can remove a non-empty selection input", async () => {
+    await createSelectionInput();
+    await simulateClick(".o-add-selection");
+    await simulateClick(".o-add-selection");
+    expect(document.querySelectorAll(".o-selection-input input")).toHaveLength(3);
+    const range1 = document.querySelectorAll(".o-selection-input input")[0];
+    await setInputValueAndTrigger(range1, "A1:A4");
+    const range2 = document.querySelectorAll(".o-selection-input input")[1];
+    await setInputValueAndTrigger(range2, "B1:B4");
+    const range3 = document.querySelectorAll(".o-selection-input input")[2];
+    await setInputValueAndTrigger(range3, "C1:C4");
+
+    const removeEmptyRangeQuery = document.querySelectorAll(".o-remove-selection")[1];
+    await simulateClick(removeEmptyRangeQuery);
+    expect(document.querySelectorAll(".o-selection-input input")).toHaveLength(2);
+  });
+
   test("update with invalid input hide confirm button", async () => {
     await createSelectionInput();
     await simulateClick(fixture.querySelector("input")!);


### PR DESCRIPTION
Prior to this commit, clicking the trash icon next to a range in DV/CF did not remove the range due to a missing event handler. This bug was introduced by this commit: 011e2237a56f0fa082d066a2aaea717b32d4c0e5

This commit ensures that the deletion action is correctly triggered, allowing a proper management of CF/DV rules

Steps to reproduce:
- Create a DV/CF rule
- Add a new range (valid or invalid)
- Click on the trash icon next to the range
- Nothing happens

Task: [4589387](https://www.odoo.com/odoo/2328/tasks/4589387)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo