### PR TITLE
[FIX] topbar: empty composer is focusable in readonly mode

### DIFF
--- a/src/components/composer/top_bar_composer/top_bar_composer.ts
+++ b/src/components/composer/top_bar_composer/top_bar_composer.ts
@@ -26,7 +26,9 @@ css/* scss */ `
     margin-top: -1px;
     border: 1px solid;
 
-    .o-composer:empty:not(:focus):not(.active)::before {
+    /* In readonly we always show the fx icon if the composer is empty, not matter the focus */
+    .o-composer:empty:not(:focus):not(.active)::before,
+    &.o-topbar-composer-readonly .o-composer:empty::before {
       content: url("data:image/svg+xml,${encodeURIComponent(FX_SVG)}");
       position: relative;
       top: 20%;

--- a/src/components/composer/top_bar_composer/top_bar_composer.xml
+++ b/src/components/composer/top_bar_composer/top_bar_composer.xml
@@ -2,6 +2,9 @@
   <t t-name="o-spreadsheet-TopBarComposer">
     <div
       class="o-topbar-composer bg-white user-select-text"
+      t-att-class="{
+        'o-topbar-composer-readonly': env.model.getters.isReadonly(),
+      }"
       t-on-click.stop=""
       t-att-style="containerStyle">
       <Composer

--- a/tests/top_bar_component.test.ts
+++ b/tests/top_bar_component.test.ts
@@ -600,7 +600,9 @@ describe("TopBar component", () => {
   test("Keep focus on the composer when clicked in readonly mode", async () => {
     ({ fixture } = await mountParent(new Model({}, { mode: "readonly" })));
 
-    let composerEl = fixture.querySelector(".o-spreadsheet-topbar div.o-composer")! as HTMLElement;
+    const topBarComposerEl = fixture.querySelector<HTMLElement>(".o-topbar-composer")!;
+    expect(topBarComposerEl.classList).toContain("o-topbar-composer-readonly");
+    const composerEl = fixture.querySelector<HTMLElement>(".o-spreadsheet-topbar div.o-composer")!;
     expect(document.activeElement).not.toBe(composerEl);
     await simulateClick(composerEl);
     expect(document.activeElement).toBe(composerEl);


### PR DESCRIPTION
## Description

In readonly mode, the composer is still focusable (because we might want to copy its content). But that also meant that the "Fx" symbol was removed when clicking on an empty composer, when there's no text to select.

Task: [4653139](https://www.odoo.com/odoo/2328/tasks/4653139)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo