### PR TITLE
[FIX] chart: prevent selecting trend lines in data series selector

### DIFF
--- a/src/components/figures/chart/chartJs/chartjs_show_values_plugin.ts
+++ b/src/components/figures/chart/chartJs/chartjs_show_values_plugin.ts
@@ -1,9 +1,6 @@
 import { ChartType, Plugin } from "chart.js";
 import { computeTextWidth } from "../../../../helpers";
-import {
-  TREND_LINE_XAXIS_ID,
-  chartFontColor,
-} from "../../../../helpers/figures/charts/chart_common";
+import { chartFontColor, isTrendLineAxis } from "../../../../helpers/figures/charts/chart_common";
 import { Color } from "../../../../types";
 
 export interface ChartShowValuesPluginOptions {
@@ -72,7 +69,7 @@ function drawLineOrBarOrRadarChartValues(
   const textsPositions: Record<number, number[]> = {};
 
   for (const dataset of chart._metasets) {
-    if (dataset.xAxisID === TREND_LINE_XAXIS_ID || dataset.hidden) {
+    if (isTrendLineAxis(dataset.axisID) || dataset.hidden) {
       continue;
     }
 
@@ -126,7 +123,7 @@ function drawHorizontalBarChartValues(
   const textsPositions: Record<number, number[]> = {};
 
   for (const dataset of chart._metasets) {
-    if (dataset.xAxisID === TREND_LINE_XAXIS_ID) {
+    if (isTrendLineAxis(dataset.axisID)) {
       return; // ignore trend lines
     }
 

--- a/src/components/side_panel/chart/building_blocks/series_design/series_design_editor.ts
+++ b/src/components/side_panel/chart/building_blocks/series_design/series_design_editor.ts
@@ -48,8 +48,8 @@ export class SeriesDesignEditor extends Component<Props, SpreadsheetChildEnv> {
       .map((d) => d.label);
   }
 
-  updateSerieEditor(ev) {
-    this.state.index = ev.target.selectedIndex;
+  updateEditedSeries(ev: Event) {
+    this.state.index = (ev.target as HTMLSelectElement).selectedIndex;
   }
 
   updateDataSeriesColor(color: string) {
@@ -62,7 +62,7 @@ export class SeriesDesignEditor extends Component<Props, SpreadsheetChildEnv> {
     this.props.updateChart(this.props.figureId, { dataSets });
   }
 
-  getDataSerieColor() {
+  getDataSeriesColor() {
     const dataSets = this.props.definition.dataSets;
     if (!dataSets?.[this.state.index]) return "";
     const color = dataSets[this.state.index].backgroundColor;
@@ -71,8 +71,8 @@ export class SeriesDesignEditor extends Component<Props, SpreadsheetChildEnv> {
       : getNthColor(this.state.index, getColorsPalette(this.props.definition.dataSets.length));
   }
 
-  updateDataSeriesLabel(ev) {
-    const label = ev.target.value;
+  updateDataSeriesLabel(ev: Event) {
+    const label = (ev.target as HTMLInputElement).value;
     const dataSets = this.props.definition.dataSets;
     if (!dataSets?.[this.state.index]) return;
     dataSets[this.state.index] = {
@@ -82,7 +82,7 @@ export class SeriesDesignEditor extends Component<Props, SpreadsheetChildEnv> {
     this.props.updateChart(this.props.figureId, { dataSets });
   }
 
-  getDataSerieLabel() {
+  getDataSeriesLabel() {
     const dataSets = this.props.definition.dataSets;
     return dataSets[this.state.index]?.label || this.getDataSeries()[this.state.index];
   }

--- a/src/components/side_panel/chart/building_blocks/series_design/series_design_editor.ts
+++ b/src/components/side_panel/chart/building_blocks/series_design/series_design_editor.ts
@@ -1,5 +1,6 @@
 import { Component, useState } from "@odoo/owl";
 import { getColorsPalette, getNthColor, toHex } from "../../../../../helpers";
+import { isTrendLineAxis } from "../../../../../helpers/figures/charts";
 import {
   ChartWithDataSetDefinition,
   DispatchResult,
@@ -42,7 +43,9 @@ export class SeriesDesignEditor extends Component<Props, SpreadsheetChildEnv> {
     if (!runtime || !("chartJsConfig" in runtime)) {
       return [];
     }
-    return runtime.chartJsConfig.data.datasets.map((d) => d.label);
+    return runtime.chartJsConfig.data.datasets
+      .filter((d) => !isTrendLineAxis(d["xAxisID"] ?? ""))
+      .map((d) => d.label);
   }
 
   updateSerieEditor(ev) {

--- a/src/components/side_panel/chart/building_blocks/series_design/series_design_editor.xml
+++ b/src/components/side_panel/chart/building_blocks/series_design/series_design_editor.xml
@@ -6,7 +6,7 @@
           <select
             class="o-input data-series-selector"
             t-model="state.label"
-            t-on-change="(ev) => this.updateSerieEditor(ev)">
+            t-on-change="(ev) => this.updateEditedSeries(ev)">
             <t t-foreach="getDataSeries()" t-as="serie" t-key="serie_index">
               <option
                 t-att-value="serie"
@@ -19,7 +19,7 @@
             <div class="d-flex align-items-center">
               <span class="o-section-title mb-0 pe-2">Series color</span>
               <RoundColorPicker
-                currentColor="getDataSerieColor()"
+                currentColor="getDataSeriesColor()"
                 onColorPicked.bind="updateDataSeriesColor"
               />
             </div>
@@ -28,7 +28,7 @@
             <input
               class="o-input o-serie-label-editor"
               type="text"
-              t-att-value="getDataSerieLabel()"
+              t-att-value="getDataSeriesLabel()"
               t-on-change="(ev) => this.updateDataSeriesLabel(ev)"
             />
           </Section>

--- a/src/components/side_panel/chart/building_blocks/series_design/series_with_axis_design_editor.ts
+++ b/src/components/side_panel/chart/building_blocks/series_design/series_with_axis_design_editor.ts
@@ -148,7 +148,7 @@ export class SeriesWithAxisDesignEditor extends Component<Props, SpreadsheetChil
     this.updateTrendLineValue(index, { window });
   }
 
-  getDataSerieColor(index: number) {
+  getDataSeriesColor(index: number) {
     const dataSets = this.props.definition.dataSets;
     if (!dataSets?.[index]) return "";
     const color = dataSets[index].backgroundColor;
@@ -160,7 +160,7 @@ export class SeriesWithAxisDesignEditor extends Component<Props, SpreadsheetChil
   getTrendLineColor(index: number) {
     return (
       this.getTrendLineConfiguration(index)?.color ??
-      setColorAlpha(this.getDataSerieColor(index), 0.5)
+      setColorAlpha(this.getDataSeriesColor(index), 0.5)
     );
   }
 

--- a/src/helpers/figures/charts/chart_common.ts
+++ b/src/helpers/figures/charts/chart_common.ts
@@ -35,6 +35,7 @@ import { rangeReference } from "../../references";
 import { getZoneArea, isFullRow, toUnboundedZone, zoneToDimension, zoneToXc } from "../../zones";
 
 export const TREND_LINE_XAXIS_ID = "x1";
+export const MOVING_AVERAGE_TREND_LINE_XAXIS_ID = "xMovingAverage";
 
 /**
  * This file contains helpers that are common to different charts (mainly
@@ -446,4 +447,8 @@ export function getPieColors(colors: ColorGenerator, dataSetsValues: DatasetValu
   }
 
   return pieColors;
+}
+
+export function isTrendLineAxis(axisID: string) {
+  return axisID === TREND_LINE_XAXIS_ID || axisID === MOVING_AVERAGE_TREND_LINE_XAXIS_ID;
 }

--- a/src/helpers/figures/charts/runtime/chart_data_extractor.ts
+++ b/src/helpers/figures/charts/runtime/chart_data_extractor.ts
@@ -512,7 +512,9 @@ function canBeDateChart(
     definition.dataSetsHaveTitle || false
   );
   const labelFormat = getChartLabelFormat(getters, labelRange, removeFirstLabel);
-  return Boolean(labelFormat && timeFormatLuxonCompatible.test(labelFormat));
+  const test = Boolean(labelFormat && timeFormatLuxonCompatible.test(labelFormat));
+  // return Boolean(labelFormat && timeFormatLuxonCompatible.test(labelFormat));
+  return test;
 }
 
 function canBeLinearChart(

--- a/src/helpers/figures/charts/runtime/chartjs_dataset.ts
+++ b/src/helpers/figures/charts/runtime/chartjs_dataset.ts
@@ -30,7 +30,12 @@ import {
   rgbaToHex,
   setColorAlpha,
 } from "../../../color";
-import { TREND_LINE_XAXIS_ID, getPieColors } from "../chart_common";
+import {
+  MOVING_AVERAGE_TREND_LINE_XAXIS_ID,
+  TREND_LINE_XAXIS_ID,
+  getPieColors,
+  isTrendLineAxis,
+} from "../chart_common";
 import { truncateLabel } from "../chart_ui_common";
 
 export function getBarChartDatasets(
@@ -183,7 +188,7 @@ export function getScatterChartDatasets(
 ): ChartDataset[] {
   const dataSets: ChartDataset<"line">[] = getLineChartDatasets(definition, args);
   for (const dataSet of dataSets) {
-    if (dataSet.xAxisID !== TREND_LINE_XAXIS_ID) {
+    if (!isTrendLineAxis(dataSet.xAxisID as string)) {
       dataSet.showLine = false;
     }
   }
@@ -346,7 +351,10 @@ function getTrendingLineDataSet(
 
   return {
     type: "line",
-    xAxisID: TREND_LINE_XAXIS_ID,
+    xAxisID:
+      config.type === "trailingMovingAverage"
+        ? MOVING_AVERAGE_TREND_LINE_XAXIS_ID
+        : TREND_LINE_XAXIS_ID,
     yAxisID: dataset.yAxisID,
     label: dataset.label ? _t("Trend line for %s", dataset.label) : "",
     data,

--- a/src/helpers/figures/charts/runtime/chartjs_legend.ts
+++ b/src/helpers/figures/charts/runtime/chartjs_legend.ts
@@ -17,7 +17,7 @@ import {
 import { ComboChartDefinition } from "../../../../types/chart/combo_chart";
 import { RadarChartDefinition } from "../../../../types/chart/radar_chart";
 import { ColorGenerator } from "../../../color";
-import { TREND_LINE_XAXIS_ID, chartFontColor, getPieColors } from "../chart_common";
+import { chartFontColor, getPieColors, isTrendLineAxis } from "../chart_common";
 
 type ChartLegend = DeepPartial<LegendOptions<any>>;
 
@@ -246,7 +246,7 @@ function getCustomLegendLabels(
       usePointStyle: true,
       generateLabels: (chart: Chart) =>
         chart.data.datasets.map((dataset, index) => {
-          if (dataset["xAxisID"] === TREND_LINE_XAXIS_ID) {
+          if (isTrendLineAxis(dataset["xAxisID"])) {
             return {
               text: dataset.label ?? "",
               fontColor,

--- a/src/helpers/figures/charts/runtime/chartjs_scales.ts
+++ b/src/helpers/figures/charts/runtime/chartjs_scales.ts
@@ -31,6 +31,7 @@ import { getColorScale } from "../../../color";
 import { formatValue } from "../../../format/format";
 import { isDefined, range, removeFalsyAttributes } from "../../../misc";
 import {
+  MOVING_AVERAGE_TREND_LINE_XAXIS_ID,
   TREND_LINE_XAXIS_ID,
   chartFontColor,
   formatTickValue,
@@ -67,6 +68,11 @@ export function getBarChartScales(
     scales[TREND_LINE_XAXIS_ID] = {
       ...(scales!.x as any),
       labels: Array(maxLength).fill(""),
+      offset: false,
+      display: false,
+    };
+    scales[MOVING_AVERAGE_TREND_LINE_XAXIS_ID] = {
+      ...(scales!.x as any),
       offset: false,
       display: false,
     };
@@ -110,6 +116,10 @@ export function getLineChartScales(
       ...(scales.x as any),
       display: false,
     };
+    scales[MOVING_AVERAGE_TREND_LINE_XAXIS_ID] = {
+      ...(scales.x as any),
+      display: false,
+    };
     if (axisType === "category" || axisType === "time") {
       /* We add a second x axis here to draw the trend lines, with the labels length being
        * set so that the second axis points match the classical x axis
@@ -118,6 +128,8 @@ export function getLineChartScales(
       scales[TREND_LINE_XAXIS_ID]!["type"] = "category";
       scales[TREND_LINE_XAXIS_ID]!["labels"] = range(0, maxLength).map((x) => x.toString());
       scales[TREND_LINE_XAXIS_ID]!["offset"] = false;
+      scales[MOVING_AVERAGE_TREND_LINE_XAXIS_ID]!["type"] = "category";
+      scales[MOVING_AVERAGE_TREND_LINE_XAXIS_ID]!["offset"] = false;
     }
   }
 

--- a/src/helpers/figures/charts/runtime/chartjs_tooltip.ts
+++ b/src/helpers/figures/charts/runtime/chartjs_tooltip.ts
@@ -15,7 +15,7 @@ import { GeoChartDefinition } from "../../../../types/chart/geo_chart";
 import { RadarChartDefinition } from "../../../../types/chart/radar_chart";
 import { formatValue } from "../../../format/format";
 import { isNumber } from "../../../numbers";
-import { TREND_LINE_XAXIS_ID, formatChartDatasetValue } from "../chart_common";
+import { formatChartDatasetValue, isTrendLineAxis } from "../chart_common";
 
 type ChartTooltip = _DeepPartialObject<TooltipOptions<any>>;
 
@@ -26,9 +26,7 @@ export function getBarChartTooltip(
   return {
     callbacks: {
       title: function (tooltipItems) {
-        return tooltipItems.some((item) => item.dataset.xAxisID !== TREND_LINE_XAXIS_ID)
-          ? undefined
-          : "";
+        return tooltipItems.some((item) => !isTrendLineAxis(item.dataset.xAxisID)) ? undefined : "";
       },
       label: function (tooltipItem) {
         const xLabel = tooltipItem.dataset?.label || tooltipItem.label;
@@ -58,10 +56,9 @@ export function getLineChartTooltip(
   if (axisType === "linear") {
     tooltip.callbacks!.label = (tooltipItem) => {
       const dataSetPoint = tooltipItem.parsed.y as CellValue;
-      let label =
-        tooltipItem.dataset.xAxisID === TREND_LINE_XAXIS_ID
-          ? ""
-          : (tooltipItem.parsed.x as CellValue);
+      let label = isTrendLineAxis(tooltipItem.dataset.xAxisID)
+        ? ""
+        : (tooltipItem.parsed.x as CellValue);
 
       if (typeof label === "string" && isNumber(label, locale)) {
         label = toNumber(label, locale);
@@ -87,8 +84,7 @@ export function getLineChartTooltip(
 
   tooltip.callbacks!.title = function (tooltipItems) {
     const displayTooltipTitle =
-      axisType !== "linear" &&
-      tooltipItems.some((item) => item.dataset.xAxisID !== TREND_LINE_XAXIS_ID);
+      axisType !== "linear" && tooltipItems.some((item) => !isTrendLineAxis(item.dataset.xAxisID));
     return displayTooltipTitle ? undefined : "";
   };
 

--- a/tests/figures/chart/chart_plugin.test.ts
+++ b/tests/figures/chart/chart_plugin.test.ts
@@ -3543,7 +3543,7 @@ describe("trending line", () => {
   });
 });
 
-test("moving average trending line", () => {
+test("moving average trend line", () => {
   // prettier-ignore
   setGrid(model, {
       B1: "Label 1", C1: "1",
@@ -3586,6 +3586,97 @@ test("moving average trending line", () => {
     { x: 4, y: 3.5 },
     { x: 5, y: 4.5 },
   ]);
+});
+
+test("Moving average trend line dataset uses the right axis when combined with other datasets", () => {
+  mockChart(); // mock chart.js with luxon time adapter installed
+  // prettier-ignore
+  setGrid(model, {
+    A1: "A", B1: "=DATE(2025,1,1)", C1: "1", D1: "4",
+    A2: "B", B2: "=DATE(2025,1,2)", C2: "4", D2: "12",
+    A3: "C", B3: "=DATE(2025,1,3)", C3: "9", D3: "34",
+    A4: "D", B4: "=DATE(2025,1,4)", C4: "16", D4: "45",
+    A5: "E", B5: "=DATE(2025,1,5)", C5: "36", D5: "51",
+  });
+  setFormat(model, "B1:B5", "m/d/yyyy hh:mm:ss a");
+  // Line chart with date labels
+  createChart(
+    model,
+    {
+      type: "line",
+      dataSets: [
+        { dataRange: "C1:C5", trend: { display: true, type: "polynomial", order: 1 } },
+        { dataRange: "D1:D5", trend: { display: true, type: "trailingMovingAverage", window: 3 } },
+      ],
+      labelRange: "B1:B5",
+      labelsAsText: false,
+      dataSetsHaveTitle: false,
+    },
+    "1"
+  );
+  let runtime = model.getters.getChartRuntime("1") as LineChartRuntime;
+  // @ts-ignore
+  expect(runtime.chartJsConfig.data.datasets[3].xAxisID).toEqual("xMovingAverage");
+  const scales = getChartConfiguration(model, "1").options.scales;
+  expect(scales.xMovingAverage!["display"]).toEqual(false);
+  expect(scales.xMovingAverage!["offset"]).toEqual(false);
+  expect(scales.xMovingAverage!["type"]).toEqual("category");
+
+  // Line chart with numerical labels
+  updateChart(model, "1", {
+    labelRange: "C1:C5",
+  });
+  runtime = model.getters.getChartRuntime("1") as LineChartRuntime;
+  // @ts-ignore
+  expect(runtime.chartJsConfig.data.datasets[3].xAxisID).toEqual("xMovingAverage");
+  expect(scales.xMovingAverage!["display"]).toEqual(false);
+  expect(scales.xMovingAverage!["offset"]).toEqual(false);
+  expect(scales.xMovingAverage!["type"]).toEqual("category");
+
+  // Line chart with categorical labels
+  updateChart(model, "1", {
+    labelRange: "A1:A5",
+  });
+  runtime = model.getters.getChartRuntime("1") as LineChartRuntime;
+  // @ts-ignore
+  expect(runtime.chartJsConfig.data.datasets[3].xAxisID).toEqual("xMovingAverage");
+  expect(scales.xMovingAverage!["display"]).toEqual(false);
+  expect(scales.xMovingAverage!["offset"]).toEqual(false);
+  expect(scales.xMovingAverage!["type"]).toEqual("category");
+
+  // Bar chart with date labels
+  updateChart(model, "1", {
+    type: "bar",
+    labelRange: "B1:B5",
+  });
+  runtime = model.getters.getChartRuntime("1") as LineChartRuntime;
+  // @ts-ignore
+  expect(runtime.chartJsConfig.data.datasets[3].xAxisID).toEqual("xMovingAverage");
+  expect(scales.xMovingAverage!["display"]).toEqual(false);
+  expect(scales.xMovingAverage!["offset"]).toEqual(false);
+  expect(scales.xMovingAverage!["type"]).toEqual("category");
+
+  // Bar chart with numerical labels
+  updateChart(model, "1", {
+    labelRange: "C1:C5",
+  });
+  runtime = model.getters.getChartRuntime("1") as LineChartRuntime;
+  // @ts-ignore
+  expect(runtime.chartJsConfig.data.datasets[3].xAxisID).toEqual("xMovingAverage");
+  expect(scales.xMovingAverage!["display"]).toEqual(false);
+  expect(scales.xMovingAverage!["offset"]).toEqual(false);
+  expect(scales.xMovingAverage!["type"]).toEqual("category");
+
+  // Bar chart with categorical labels
+  updateChart(model, "1", {
+    labelRange: "A1:A5",
+  });
+  runtime = model.getters.getChartRuntime("1") as LineChartRuntime;
+  // @ts-ignore
+  expect(runtime.chartJsConfig.data.datasets[3].xAxisID).toEqual("xMovingAverage");
+  expect(scales.xMovingAverage!["display"]).toEqual(false);
+  expect(scales.xMovingAverage!["offset"]).toEqual(false);
+  expect(scales.xMovingAverage!["type"]).toEqual("category");
 });
 
 test("logarithmic trending line", () => {

--- a/tests/figures/chart/charts_component.test.ts
+++ b/tests/figures/chart/charts_component.test.ts
@@ -11,7 +11,7 @@ import {
   ChartWithDataSetDefinition,
   SpreadsheetChildEnv,
 } from "../../../src/types";
-import { PieChartRuntime } from "../../../src/types/chart";
+import { PieChartRuntime, TrendConfiguration } from "../../../src/types/chart";
 import { BarChartDefinition, BarChartRuntime } from "../../../src/types/chart/bar_chart";
 import { LineChartDefinition } from "../../../src/types/chart/line_chart";
 import {
@@ -1883,6 +1883,21 @@ describe("charts", () => {
         expect(runtime.chartJsConfig.data.datasets[1].borderColor).toBe("#EFEFEF");
       }
     );
+
+    test("Trend line is not in the choice of data series to edit", async () => {
+      const trend: TrendConfiguration = { type: "polynomial", order: 3, display: true };
+      createChart(
+        model,
+        { dataSets: [{ dataRange: "E1:E4", trend }], type: "line", dataSetsHaveTitle: false },
+        chartId
+      );
+      await mountChartSidePanel(chartId);
+      await openChartDesignSidePanel(model, env, fixture, chartId);
+
+      const dataSeries = fixture.querySelectorAll(".data-series-selector option");
+      expect(dataSeries.length).toBe(1);
+      expect(dataSeries[0]).toHaveText("Series 1");
+    });
   });
 
   test("When a figure is selected, pressing Ctrl+A will not propagate to the grid to select all cells", async () => {


### PR DESCRIPTION
### [FIX] chart: fix some typos/typing in the chart panels

`Serie` without `s` is not a word in English, it should be `Series`.


### [FIX] chart: prevent selecting trend lines in data series selector

When we add a trend line to a data series, we can select
`Trend line for dataset 1` in the select of the data series editor.
We should prevent that.

Task: [4632950](https://www.odoo.com/odoo/2328/tasks/4632950)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo