### PR TITLE
[REF] tests: add helper to add item to registry

### DIFF
--- a/tests/autofill/autofill_plugin.test.ts
+++ b/tests/autofill/autofill_plugin.test.ts
@@ -24,6 +24,7 @@ import {
 } from "../test_helpers/getters_helpers";
 import {
   XCToMergeCellMap,
+  addToRegistry,
   getDataValidationRules,
   getMergeCellMap,
   getPlugin,
@@ -786,7 +787,7 @@ describe("Autofill", () => {
   });
 
   test("Auto-autofill considers formula spreaded value", () => {
-    functionRegistry.add("SPREAD.EMPTY", {
+    addToRegistry(functionRegistry, "SPREAD.EMPTY", {
       description: "spreads empty values",
       args: [],
       compute: function (): null[][] {

--- a/tests/bottom_bar/aggregate_statistics_store.test.ts
+++ b/tests/bottom_bar/aggregate_statistics_store.test.ts
@@ -13,6 +13,7 @@ import {
   setSelection,
 } from "../test_helpers/commands_helpers";
 import { getCellError, getEvaluatedCell } from "../test_helpers/getters_helpers";
+import { addToRegistry } from "../test_helpers/helpers";
 import { makeStore } from "../test_helpers/stores";
 
 describe("Aggregate statistic functions", () => {
@@ -153,7 +154,7 @@ describe("Aggregate statistic functions", () => {
   });
 
   test("raise error from compilation with specific error message", () => {
-    functionRegistry.add("TWOARGSNEEDED", {
+    addToRegistry(functionRegistry, "TWOARGSNEEDED", {
       description: "any function",
       compute: () => {
         return true;
@@ -171,7 +172,6 @@ describe("Aggregate statistic functions", () => {
     expect(getCellError(model, "A1")).toBe(
       `Invalid number of arguments for the TWOARGSNEEDED function. Expected 2 minimum, but got 1 instead.`
     );
-    functionRegistry.remove("TWOARGSNEEDED");
   });
 
   test("Statistics are recomputed when switching sheets", () => {

--- a/tests/collaborative/collaborative.test.ts
+++ b/tests/collaborative/collaborative.test.ts
@@ -43,6 +43,7 @@ import {
   getStyle,
 } from "../test_helpers/getters_helpers";
 import {
+  addToRegistry,
   createEqualCF,
   getDataValidationRules,
   target,
@@ -621,7 +622,7 @@ describe("Multi users synchronisation", () => {
 
     test("async computation resolving when in other sheet", () => {
       let value: string | number = "LOADING...";
-      functionRegistry.add("GET.ASYNC.VALUE", {
+      addToRegistry(functionRegistry, "GET.ASYNC.VALUE", {
         description: "Get value",
         compute: () => value,
         args: [],
@@ -641,12 +642,11 @@ describe("Multi users synchronisation", () => {
 
       activateSheet(bob, "sheet2");
       expect(getEvaluatedCell(bob, "A1", "sheet2").value).toBe(2);
-      functionRegistry.remove("GET.ASYNC.VALUE");
     });
 
     test("reference to async computation resolving when in other sheet", () => {
       let value: string | number = "LOADING...";
-      functionRegistry.add("GET.ASYNC.VALUE", {
+      addToRegistry(functionRegistry, "GET.ASYNC.VALUE", {
         description: "Get value",
         compute: () => value,
         args: [],
@@ -667,7 +667,6 @@ describe("Multi users synchronisation", () => {
 
       expect(getEvaluatedCell(bob, "A1", firstSheetId).value).toBe(2);
       expect(getEvaluatedCell(bob, "A1", "sheet2").value).toBe(2);
-      functionRegistry.remove("GET.ASYNC.VALUE");
     });
 
     test("evaluation is recomputed after command is rejected because of a concurrent update", () => {
@@ -1000,7 +999,7 @@ test("UI plugins cannot refuse core command and de-synchronize the users", () =>
       return CommandResult.Success;
     }
   }
-  featurePluginRegistry.add("myUIPlugin", MyUIPlugin);
+  addToRegistry(featurePluginRegistry, "myUIPlugin", MyUIPlugin);
   const { alice, bob } = setupCollaborativeEnv();
 
   setCellContent(alice, "A1", "hello");

--- a/tests/composer/autocomplete_dropdown_component.test.ts
+++ b/tests/composer/autocomplete_dropdown_component.test.ts
@@ -5,7 +5,6 @@ import { functionRegistry } from "../../src/functions/index";
 import { Model } from "../../src/model";
 import { autoCompleteProviders } from "../../src/registries";
 import { Store } from "../../src/store_engine";
-import { registerCleanup } from "../setup/jest.setup";
 import { selectCell } from "../test_helpers/commands_helpers";
 import {
   click,
@@ -18,6 +17,7 @@ import {
 import { getCellText } from "../test_helpers/getters_helpers";
 import {
   ComposerWrapper,
+  addToRegistry,
   clearFunctions,
   getInputSelection,
   mountComposerWrapper,
@@ -65,10 +65,6 @@ beforeEach(() => {
       compute: () => 1,
       hidden: true,
     });
-});
-
-afterEach(() => {
-  restoreDefaultFunctions();
 });
 
 describe("Functions autocomplete", () => {
@@ -190,7 +186,7 @@ describe("Functions autocomplete", () => {
 
     test("autocomplete restrict number of proposition to 10", async () => {
       for (let i = 0; i < 20; i++) {
-        functionRegistry.add(`SUM${i + 1}`, {
+        addToRegistry(functionRegistry, `SUM${i + 1}`, {
           description: "do sum",
           args: [],
           compute: () => 1,
@@ -218,7 +214,7 @@ describe("Functions autocomplete", () => {
 
     test("autocomplete fuzzy search", async () => {
       for (const f of ["TEST_FUZZY", "FUZZY_TEST", "TEST_FUZZY_TEST"]) {
-        functionRegistry.add(f, {
+        addToRegistry(functionRegistry, f, {
           description: "",
           args: [],
           compute: () => 1,
@@ -234,7 +230,7 @@ describe("Functions autocomplete", () => {
     });
 
     test("autocomplete not displayed for exact match", async () => {
-      functionRegistry.add("FUZZY", {
+      addToRegistry(functionRegistry, "FUZZY", {
         description: "",
         args: [],
         compute: () => 1,
@@ -276,13 +272,12 @@ describe("Functions autocomplete", () => {
     });
 
     test("key down or up selects auto-complete proposals instead of reference", async () => {
-      registries.autoCompleteProviders.add("test", {
+      addToRegistry(registries.autoCompleteProviders, "test", {
         getProposals() {
           return [{ text: "option 1" }, { text: "option 2" }];
         },
         selectProposal() {},
       });
-      registerCleanup(() => registries.autoCompleteProviders.remove("test"));
       await typeInComposer("=SUM(");
       const proposals = [...fixture.querySelectorAll(".o-autocomplete-value")].map(
         (el) => el.parentElement
@@ -305,13 +300,12 @@ describe("Functions autocomplete", () => {
     });
 
     test("key left or right selects adjacent cell instead of a proposal", async () => {
-      registries.autoCompleteProviders.add("test", {
+      addToRegistry(registries.autoCompleteProviders, "test", {
         getProposals() {
           return [{ text: "option 1" }];
         },
         selectProposal() {},
       });
-      registerCleanup(() => registries.autoCompleteProviders.remove("test"));
       await typeInComposer("=SUM(");
       expect(composerStore.autocompleteProvider?.proposals).toHaveLength(1);
       expect(composerStore.showSelectionIndicator).toBe(true);
@@ -368,7 +362,7 @@ describe("Functions autocomplete", () => {
     });
 
     test("autocomplete proposal can be automatically expanded", async () => {
-      registries.autoCompleteProviders.add("test", {
+      addToRegistry(registries.autoCompleteProviders, "test", {
         getProposals() {
           return [
             { text: "option 1", description: " descr1", alwaysExpanded: true },
@@ -378,7 +372,6 @@ describe("Functions autocomplete", () => {
         },
         selectProposal() {},
       });
-      registerCleanup(() => registries.autoCompleteProviders.remove("test"));
       await typeInComposer("=SUM(");
       const proposals = [...fixture.querySelectorAll(".o-autocomplete-value")].map(
         (el) => el.parentElement?.textContent
@@ -551,12 +544,12 @@ describe("composer Assistant", () => {
 describe("autocomplete boolean functions", () => {
   beforeEach(async () => {
     clearFunctions();
-    functionRegistry.add("TRUE", {
+    addToRegistry(functionRegistry, "TRUE", {
       description: "TRUE",
       args: [],
       compute: () => true,
     });
-    functionRegistry.add("FALSE", {
+    addToRegistry(functionRegistry, "FALSE", {
       description: "FALSE",
       args: [],
       compute: () => false,
@@ -564,10 +557,6 @@ describe("autocomplete boolean functions", () => {
     ({ model, fixture, parent } = await mountComposerWrapper());
     parent.startComposition();
     await nextTick();
-  });
-
-  afterEach(() => {
-    restoreDefaultFunctions();
   });
 
   test("partial TRUE show autocomplete", async () => {
@@ -648,7 +637,7 @@ describe("composer entries", () => {
 });
 
 test("aucomplete supports values with similar names", async () => {
-  autoCompleteProviders.add("test", {
+  addToRegistry(autoCompleteProviders, "test", {
     sequence: 1,
     getProposals() {
       return [
@@ -667,5 +656,4 @@ test("aucomplete supports values with similar names", async () => {
   composerStore = parent.env.getStore(CellComposerStore);
   await typeInComposer("=s");
   expect(fixture.querySelectorAll(".o-autocomplete-value")).toHaveLength(2);
-  autoCompleteProviders.remove("test");
 });

--- a/tests/composer/formula_assistant_component.test.ts
+++ b/tests/composer/formula_assistant_component.test.ts
@@ -9,11 +9,11 @@ import { updateLocale } from "../test_helpers/commands_helpers";
 import { click, getTextNodes, keyDown, keyUp } from "../test_helpers/dom_helper";
 import {
   ComposerWrapper,
+  addToRegistry,
   clearFunctions,
   getInputSelection,
   mountComposerWrapper,
   nextTick,
-  restoreDefaultFunctions,
   typeInComposerHelper,
 } from "../test_helpers/helpers";
 
@@ -39,9 +39,9 @@ beforeEach(async () => {
 });
 
 describe("formula assistant", () => {
-  beforeAll(() => {
+  beforeEach(() => {
     clearFunctions();
-    functionRegistry.add("FUNC0", {
+    addToRegistry(functionRegistry, "FUNC0", {
       description: "func without args",
       args: [],
       compute: () => 1,
@@ -50,13 +50,13 @@ describe("formula assistant", () => {
       (str, ...values) => str,
       () => false
     );
-    functionRegistry.add("FUNC1", {
+    addToRegistry(functionRegistry, "FUNC1", {
       description: "func1 def",
       args: [arg("f1Arg1 (any)", "f1 Arg1 def"), arg("f1Arg2 (any)", _t("f1 Arg2 def"))],
       compute: () => 1,
     });
     setTranslationMethod((str, ...values) => str);
-    functionRegistry.add("FUNC2", {
+    addToRegistry(functionRegistry, "FUNC2", {
       description: "func2 def",
       args: [
         arg("f2Arg1 (any)", "f2 Arg1 def"),
@@ -64,7 +64,7 @@ describe("formula assistant", () => {
       ],
       compute: () => 1,
     });
-    functionRegistry.add("FUNC3", {
+    addToRegistry(functionRegistry, "FUNC3", {
       description: "func3 def",
       args: [
         arg("f3Arg1 (any)", "f3 Arg1 def"),
@@ -72,7 +72,7 @@ describe("formula assistant", () => {
       ],
       compute: () => 1,
     });
-    functionRegistry.add("UPTOWNFUNC", {
+    addToRegistry(functionRegistry, "UPTOWNFUNC", {
       description: "a Bruno Mars song ?",
       args: [
         arg("f4Arg1 (any)", "f4 Arg1 def"),
@@ -81,10 +81,6 @@ describe("formula assistant", () => {
       ],
       compute: () => 1,
     });
-  });
-
-  afterAll(() => {
-    restoreDefaultFunctions();
   });
 
   describe("appearance", () => {
@@ -460,22 +456,18 @@ describe("formula assistant", () => {
 });
 
 describe("formula assistant for boolean functions", () => {
-  beforeAll(() => {
+  beforeEach(() => {
     clearFunctions();
-    functionRegistry.add("TRUE", {
+    addToRegistry(functionRegistry, "TRUE", {
       description: "TRUE",
       args: [],
       compute: () => true,
     });
-    functionRegistry.add("FALSE", {
+    addToRegistry(functionRegistry, "FALSE", {
       description: "FALSE",
       args: [],
       compute: () => false,
     });
-  });
-
-  afterAll(() => {
-    restoreDefaultFunctions();
   });
 
   test.each(["=TRUE(", "=true(", "=FALSE(", "=false("])(

--- a/tests/composer/standalone_composer_component.test.ts
+++ b/tests/composer/standalone_composer_component.test.ts
@@ -7,7 +7,12 @@ import { sidePanelRegistry } from "../../src/registries/side_panel_registry";
 import { Store } from "../../src/store_engine";
 import { createSheet } from "../test_helpers/commands_helpers";
 import { click, getTextNodes, keyDown, simulateClick } from "../test_helpers/dom_helper";
-import { editStandaloneComposer, mountSpreadsheet, nextTick } from "../test_helpers/helpers";
+import {
+  addToRegistry,
+  editStandaloneComposer,
+  mountSpreadsheet,
+  nextTick,
+} from "../test_helpers/helpers";
 
 let env: SpreadsheetChildEnv;
 let onConfirm = jest.fn();
@@ -31,10 +36,6 @@ class SidePanelWithComposer extends Component<any, any> {
   static props = { "*": Object };
   static components = { StandaloneComposer };
 }
-sidePanelRegistry.add("SidePanelWithComposer", {
-  title: "SidePanelWithComposer",
-  Body: SidePanelWithComposer,
-});
 
 async function openSidePanelWithComposer(props?: Partial<StandaloneComposer["props"]>) {
   env.openSidePanel("SidePanelWithComposer", {
@@ -52,6 +53,10 @@ const composerSelector = ".o-sidePanel .o-composer";
 
 describe("Spreadsheet integrations tests", () => {
   beforeEach(async () => {
+    addToRegistry(sidePanelRegistry, "SidePanelWithComposer", {
+      title: "SidePanelWithComposer",
+      Body: SidePanelWithComposer,
+    });
     ({ env, fixture, model } = await mountSpreadsheet());
     composerFocusStore = env.getStore(ComposerFocusStore);
   });

--- a/tests/evaluation/compiler.test.ts
+++ b/tests/evaluation/compiler.test.ts
@@ -4,7 +4,7 @@ import { compile } from "../../src/formulas/index";
 import { functionRegistry } from "../../src/functions";
 import { createValidRange } from "../../src/helpers";
 import { CompiledFormula } from "../../src/types";
-import { evaluateCell, evaluateCellFormat, restoreDefaultFunctions } from "../test_helpers/helpers";
+import { addToRegistry, evaluateCell, evaluateCellFormat } from "../test_helpers/helpers";
 
 function compiledBaseFunction(formula: string): CompiledFormula {
   for (let f in functionCache) {
@@ -77,12 +77,8 @@ describe("expression compiler", () => {
 
 describe("compile functions", () => {
   describe("check number of arguments", () => {
-    afterAll(() => {
-      restoreDefaultFunctions();
-    });
-
     test("with basic arguments", () => {
-      functionRegistry.add("ANYFUNCTION", {
+      addToRegistry(functionRegistry, "ANYFUNCTION", {
         description: "any function",
         compute: () => {
           return true;
@@ -96,11 +92,10 @@ describe("compile functions", () => {
       expect(compiledBaseFunction("=ANYFUNCTION(1)").isBadExpression).toBe(true);
       expect(compiledBaseFunction("=ANYFUNCTION(1,2)").isBadExpression).toBe(false);
       expect(compiledBaseFunction("=ANYFUNCTION(1,2,3)").isBadExpression).toBe(true);
-      restoreDefaultFunctions();
     });
 
     test("with optional argument", () => {
-      functionRegistry.add("OPTIONAL", {
+      addToRegistry(functionRegistry, "OPTIONAL", {
         description: "function with optional argument",
         compute: () => {
           return true;
@@ -113,11 +108,10 @@ describe("compile functions", () => {
       expect(compiledBaseFunction("=OPTIONAL(1)").isBadExpression).toBe(false);
       expect(compiledBaseFunction("=OPTIONAL(1,2)").isBadExpression).toBe(false);
       expect(compiledBaseFunction("=OPTIONAL(1,2,3)").isBadExpression).toBe(true);
-      restoreDefaultFunctions();
     });
 
     test("with default argument", () => {
-      functionRegistry.add("USEDEFAULTARG", {
+      addToRegistry(functionRegistry, "USEDEFAULTARG", {
         description: "function with a default argument",
         compute: () => {
           return true;
@@ -130,11 +124,10 @@ describe("compile functions", () => {
       expect(compiledBaseFunction("=USEDEFAULTARG(1)").isBadExpression).toBe(false);
       expect(compiledBaseFunction("=USEDEFAULTARG(1,2)").isBadExpression).toBe(false);
       expect(compiledBaseFunction("=USEDEFAULTARG(1,2,3)").isBadExpression).toBe(true);
-      restoreDefaultFunctions();
     });
 
     test("with repeatable argument", () => {
-      functionRegistry.add("REPEATABLE", {
+      addToRegistry(functionRegistry, "REPEATABLE", {
         description: "function with repeatable argument",
         compute: (arg) => {
           return true;
@@ -147,11 +140,10 @@ describe("compile functions", () => {
       expect(compiledBaseFunction("=REPEATABLE(1)").isBadExpression).toBe(false);
       expect(compiledBaseFunction("=REPEATABLE(1,2)").isBadExpression).toBe(false);
       expect(compiledBaseFunction("=REPEATABLE(1,2,3,4,5,6)").isBadExpression).toBe(false);
-      restoreDefaultFunctions();
     });
 
     test("with more than one repeatable argument", () => {
-      functionRegistry.add("REPEATABLES", {
+      addToRegistry(functionRegistry, "REPEATABLES", {
         description: "any function",
         compute: (arg) => {
           return true;
@@ -166,13 +158,12 @@ describe("compile functions", () => {
       expect(compiledBaseFunction("=REPEATABLES(1, 2, 3)").isBadExpression).toBe(false);
       expect(compiledBaseFunction("=REPEATABLES(1, 2, 3, 4)").isBadExpression).toBe(true);
       expect(compiledBaseFunction("=REPEATABLES(1, 2, 3, 4, 5)").isBadExpression).toBe(false);
-      restoreDefaultFunctions();
     });
   });
 
   describe("interpret arguments", () => {
-    beforeAll(() => {
-      functionRegistry.add("ISSECONDARGUNDEFINED", {
+    beforeEach(() => {
+      addToRegistry(functionRegistry, "ISSECONDARGUNDEFINED", {
         description: "any function",
         args: [
           { name: "arg1", description: "", type: ["ANY"] },
@@ -186,7 +177,7 @@ describe("compile functions", () => {
         },
       });
 
-      functionRegistry.add("SECONDARGDEFAULTVALUEEQUAL42", {
+      addToRegistry(functionRegistry, "SECONDARGDEFAULTVALUEEQUAL42", {
         description: "function with a default argument",
         args: [
           { name: "arg1", description: "", type: ["ANY"] },
@@ -198,9 +189,6 @@ describe("compile functions", () => {
             : { value: false, format: '"FALSE"' };
         },
       });
-    });
-    afterAll(() => {
-      restoreDefaultFunctions();
     });
     test("empty value interpreted as undefined", () => {
       expect(evaluateCell("A1", { A1: "=ISSECONDARGUNDEFINED(1,)" })).toBe(true);
@@ -219,13 +207,13 @@ describe("compile functions", () => {
   });
 
   describe("with meta arguments", () => {
-    beforeAll(() => {
-      functionRegistry.add("USEMETAARG", {
+    beforeEach(() => {
+      addToRegistry(functionRegistry, "USEMETAARG", {
         description: "function with a meta argument",
         compute: () => true,
         args: [{ name: "arg", description: "", type: ["META"] }],
       });
-      functionRegistry.add("NOTUSEMETAARG", {
+      addToRegistry(functionRegistry, "NOTUSEMETAARG", {
         description: "any function",
         compute: () => true,
         args: [{ name: "arg", description: "", type: ["ANY"] }],

--- a/tests/evaluation/evaluation_formula_array.test.ts
+++ b/tests/evaluation/evaluation_formula_array.test.ts
@@ -18,7 +18,7 @@ import {
   unMerge,
 } from "../test_helpers/commands_helpers";
 import { getCellContent, getCellError, getEvaluatedCell } from "../test_helpers/getters_helpers";
-import { restoreDefaultFunctions } from "../test_helpers/helpers";
+import { addToRegistry } from "../test_helpers/helpers";
 
 let model: Model;
 let sheetId: UID;
@@ -27,7 +27,7 @@ describe("evaluate formulas that return an array", () => {
   beforeEach(() => {
     model = new Model();
     sheetId = model.getters.getActiveSheetId();
-    functionRegistry.add("MFILL", {
+    addToRegistry(functionRegistry, "MFILL", {
       description: "Return an n*n matrix filled with n.",
       args: [
         arg("n (number)", "number of column of the matrix"),
@@ -41,10 +41,6 @@ describe("evaluate formulas that return an array", () => {
         return Array.from({ length: _n }, (_, i) => Array.from({ length: _m }, (_, j) => _v));
       },
     });
-  });
-
-  afterEach(() => {
-    restoreDefaultFunctions();
   });
 
   test("a simple reference to a range cannot return an array", () => {
@@ -107,7 +103,7 @@ describe("evaluate formulas that return an array", () => {
   });
 
   test("can interpolate function name when error is returned", () => {
-    functionRegistry.add("GETERR", {
+    addToRegistry(functionRegistry, "GETERR", {
       description: "Get error",
       compute: () => {
         const error = {
@@ -134,7 +130,7 @@ describe("evaluate formulas that return an array", () => {
 
   describe("spread matrix with format", () => {
     test("can spread matrix of values with matrix of format", () => {
-      functionRegistry.add("MATRIX.2.2", {
+      addToRegistry(functionRegistry, "MATRIX.2.2", {
         description: "Return an 2*2 matrix with some values",
         args: [],
         compute: function () {
@@ -156,7 +152,7 @@ describe("evaluate formulas that return an array", () => {
     });
 
     test("can spread matrix of format depending on matrix of format", () => {
-      functionRegistry.add("MATRIX", {
+      addToRegistry(functionRegistry, "MATRIX", {
         description: "Return the matrix passed as argument",
         args: [arg("matrix (range<number>)", "a matrix")],
         compute: function (matrix) {
@@ -611,7 +607,7 @@ describe("evaluate formulas that return an array", () => {
 
     test("Spreaded formulas with range deps Do not invalidate themselves on evaluation", () => {
       let c = 0;
-      functionRegistry.add("INCREMENTONEVAL", {
+      addToRegistry(functionRegistry, "INCREMENTONEVAL", {
         description: "returns the input, but fancy. Like transpose(transpose(range))",
         args: [arg("range (any, range<any>)", "The matrix to be transposed.")],
         compute: function (values) {
@@ -635,7 +631,7 @@ describe("evaluate formulas that return an array", () => {
     test("array formula depending on array formula result is evaluated once", () => {
       const mockCompute = jest.fn().mockImplementation((values) => values);
 
-      functionRegistry.add("RANGE_IDENTITY", {
+      addToRegistry(functionRegistry, "RANGE_IDENTITY", {
         description: "returns the input. Like transpose(transpose(range))",
         args: [arg("range (range<any>)", "")],
         compute: mockCompute,
@@ -671,7 +667,7 @@ describe("evaluate formulas that return an array", () => {
 
     test("Spreaded formulas with range deps invalidate only once the dependencies of themselves", () => {
       let c = 0;
-      functionRegistry.add("INCREMENTONEVAL", {
+      addToRegistry(functionRegistry, "INCREMENTONEVAL", {
         description: "",
         args: [arg("range (any, range<any>)", "")],
         compute: function () {
@@ -691,7 +687,7 @@ describe("evaluate formulas that return an array", () => {
 
     test("Spreaded formulas with range deps invalidate only once the dependencies of result", () => {
       let c = 0;
-      functionRegistry.add("INCREMENTONEVAL", {
+      addToRegistry(functionRegistry, "INCREMENTONEVAL", {
         description: "",
         args: [arg("range (any, range<any>)", "")],
         compute: function () {

--- a/tests/figures/figure_component.test.ts
+++ b/tests/figures/figure_component.test.ts
@@ -41,6 +41,7 @@ import {
 } from "../test_helpers/dom_helper";
 import { getCellContent, getCellText } from "../test_helpers/getters_helpers";
 import {
+  addToRegistry,
   getFigureDefinition,
   getFigureIds,
   mockChart,
@@ -121,14 +122,11 @@ mockGetBoundingClientRect({
   "o-figure-menu-item": () => ({ ...mockFigureMenuItemRect }),
 });
 
-beforeAll(() => {
-  figureRegistry.add("text", {
+beforeEach(() => {
+  addToRegistry(figureRegistry, "text", {
     Component: TextFigure,
     menuBuilder: () => [],
   });
-});
-afterAll(() => {
-  figureRegistry.remove("text");
 });
 
 describe("figures", () => {

--- a/tests/find_and_replace/find_and_replace_store.test.ts
+++ b/tests/find_and_replace/find_and_replace_store.test.ts
@@ -31,6 +31,7 @@ import {
   getCellError,
   getCellText,
 } from "../test_helpers/getters_helpers";
+import { addToRegistry } from "../test_helpers/helpers";
 import { makeStore } from "../test_helpers/stores";
 
 let model: Model;
@@ -190,7 +191,7 @@ describe("basic search", () => {
 
   test("refresh search when cell is update with EVALUATE_CELLS", async () => {
     let value = "3";
-    functionRegistry.add("GETVALUE", {
+    addToRegistry(functionRegistry, "GETVALUE", {
       description: "Get value",
       compute: () => value,
       args: [],

--- a/tests/formats/formatting_plugin.test.ts
+++ b/tests/formats/formatting_plugin.test.ts
@@ -32,6 +32,7 @@ import {
   getEvaluatedGrid,
 } from "../test_helpers/getters_helpers";
 import {
+  addToRegistry,
   createModelFromGrid,
   getNode,
   makeTestEnv,
@@ -167,7 +168,7 @@ describe("formatting values (with formatters)", () => {
   });
 
   test("SET_DECIMAL considers the evaluated format to infer the decimal position", () => {
-    functionRegistry.add("SET.DYN.FORMAT", {
+    addToRegistry(functionRegistry, "SET.DYN.FORMAT", {
       description: "Returns the value set to the provided format",
       args: [arg("value (any)", "value to format"), arg("format (any)", "format to set.")],
       compute: function (value, format) {
@@ -182,7 +183,6 @@ describe("formatting values (with formatters)", () => {
     selectCell(model, "A1");
     setDecimal(model, "A1", 1);
     expect(getCell(model, "A1")?.format).toBe("0.000");
-    functionRegistry.remove("SET.DYN.FORMAT");
   });
 
   test("SET_DECIMAL on long number that are truncated due to default format don't lose truncated digits", () => {

--- a/tests/functions/functions.test.ts
+++ b/tests/functions/functions.test.ts
@@ -6,16 +6,13 @@ import { Arg, DEFAULT_LOCALE } from "../../src/types";
 import { CellErrorType, EvaluationError } from "../../src/types/errors";
 import { setCellContent, setCellFormat } from "../test_helpers/commands_helpers";
 import { getCellError, getEvaluatedCell } from "../test_helpers/getters_helpers";
-import { evaluateCell, restoreDefaultFunctions } from "../test_helpers/helpers";
+import { addToRegistry, evaluateCell } from "../test_helpers/helpers";
 
 describe("functions", () => {
-  afterAll(() => {
-    restoreDefaultFunctions();
-  });
   test("can add a function", () => {
     const val = evaluateCell("A1", { A1: "=DOUBLEDOUBLE(3)" });
     expect(val).toBe("#NAME?");
-    functionRegistry.add("DOUBLEDOUBLE", {
+    addToRegistry(functionRegistry, "DOUBLEDOUBLE", {
       description: "Double the first argument",
       compute: function (arg) {
         return 2 * toNumber(toScalar(arg), DEFAULT_LOCALE);
@@ -27,7 +24,7 @@ describe("functions", () => {
 
   test("can not add a function with invalid name", () => {
     const createBadFunction = () => {
-      functionRegistry.add("TEST*FUNCTION", {
+      addToRegistry(functionRegistry, "TEST*FUNCTION", {
         description: "Double the first argument",
         compute: () => 0,
         args: [],
@@ -40,7 +37,7 @@ describe("functions", () => {
 
   test("can add a function with underscore", () => {
     const createBadFunction = () => {
-      functionRegistry.add("TEST_FUNCTION", {
+      addToRegistry(functionRegistry, "TEST_FUNCTION", {
         description: "Double the first argument",
         compute: () => 0,
         args: [],
@@ -51,7 +48,7 @@ describe("functions", () => {
 
   test("Function can return value depending on input values", () => {
     const model = new Model();
-    functionRegistry.add("RETURN.VALUE.DEPENDING.ON.INPUT.VALUE", {
+    addToRegistry(functionRegistry, "RETURN.VALUE.DEPENDING.ON.INPUT.VALUE", {
       description: "return value depending on input value",
       compute: function (arg) {
         return toNumber(toScalar(arg), DEFAULT_LOCALE) * 2;
@@ -68,7 +65,7 @@ describe("functions", () => {
 
   test("Function can return value depending on input error", () => {
     const model = new Model();
-    functionRegistry.add("RETURN.VALUE.DEPENDING.ON.INPUT.ERROR", {
+    addToRegistry(functionRegistry, "RETURN.VALUE.DEPENDING.ON.INPUT.ERROR", {
       description: "return value depending on input error",
       compute: function (arg: Arg) {
         return isEvaluationError(toScalar(arg)?.value);
@@ -84,7 +81,7 @@ describe("functions", () => {
 
   test("Function can return error depending on input value", () => {
     const model = new Model();
-    functionRegistry.add("RETURN.ERROR.DEPENDING.ON.INPUT.VALUE", {
+    addToRegistry(functionRegistry, "RETURN.ERROR.DEPENDING.ON.INPUT.VALUE", {
       description: "return value depending on input error",
       compute: function (arg) {
         const error = new EvaluationError("Les calculs sont pas bons KEVIN !");
@@ -101,7 +98,7 @@ describe("functions", () => {
 
   test("Function can return error depending on input error", () => {
     const model = new Model();
-    functionRegistry.add("RETURN.ERROR.DEPENDING.ON.INPUT.ERROR", {
+    addToRegistry(functionRegistry, "RETURN.ERROR.DEPENDING.ON.INPUT.ERROR", {
       description: "return value depending on input error",
       compute: function (arg) {
         return toScalar(arg)?.value === CellErrorType.BadExpression
@@ -119,7 +116,7 @@ describe("functions", () => {
 
   test("Function can return format depending on input format", () => {
     const model = new Model();
-    functionRegistry.add("RETURN.FORMAT.DEPENDING.ON.INPUT.FORMAT", {
+    addToRegistry(functionRegistry, "RETURN.FORMAT.DEPENDING.ON.INPUT.FORMAT", {
       description: "return format depending on input format",
       compute: function (arg) {
         return { value: 42, format: toScalar(arg)?.format };
@@ -138,7 +135,7 @@ describe("functions", () => {
 
   test("Function can return format depending on input value", () => {
     const model = new Model();
-    functionRegistry.add("RETURN.FORMAT.DEPENDING.ON.INPUT.VALUE", {
+    addToRegistry(functionRegistry, "RETURN.FORMAT.DEPENDING.ON.INPUT.VALUE", {
       description: "return format depending on input value",
       compute: function (arg) {
         const value = toNumber(toScalar(arg), DEFAULT_LOCALE);
@@ -166,7 +163,7 @@ describe("functions", () => {
         },
       }
     );
-    functionRegistry.add("GETCOUCOU", {
+    addToRegistry(functionRegistry, "GETCOUCOU", {
       description: "Get coucou's name",
       compute: function () {
         return (this as any).coucou;
@@ -179,7 +176,7 @@ describe("functions", () => {
 
   test("Can use a getter in a function", () => {
     const model = new Model();
-    functionRegistry.add("GETNUMBERCOLS", {
+    addToRegistry(functionRegistry, "GETNUMBERCOLS", {
       description: "Get the number of columns",
       compute: function () {
         const sheetId = (this as any).getters.getActiveSheetId();
@@ -193,7 +190,7 @@ describe("functions", () => {
   });
 
   test("undefined fallback to the zero value in a function", () => {
-    functionRegistry.add("UNDEFINED", {
+    addToRegistry(functionRegistry, "UNDEFINED", {
       description: "undefined",
       // @ts-expect-error can happen in a vanilla javascript code base
       compute: function () {
@@ -205,11 +202,8 @@ describe("functions", () => {
   });
 
   describe("check type of arguments", () => {
-    afterAll(() => {
-      restoreDefaultFunctions();
-    });
     test("reject non-range argument when expecting only range argument", () => {
-      functionRegistry.add("RANGEEXPECTED", {
+      addToRegistry(functionRegistry, "RANGEEXPECTED", {
         description: "function expect number in 1st arg",
         compute: (arg) => {
           return true;
@@ -217,7 +211,7 @@ describe("functions", () => {
         args: [arg("arg1 (range<any>)", "1st argument")],
       });
 
-      functionRegistry.add("FORMULA_RETURNING_RANGE", {
+      addToRegistry(functionRegistry, "FORMULA_RETURNING_RANGE", {
         description: "function returning range",
         compute: () => {
           return [["cucumber"]];
@@ -225,7 +219,7 @@ describe("functions", () => {
         args: [],
       });
 
-      functionRegistry.add("FORMULA_NOT_RETURNING_RANGE", {
+      addToRegistry(functionRegistry, "FORMULA_NOT_RETURNING_RANGE", {
         description: "function returning range",
         compute: () => {
           return "cucumber";
@@ -233,7 +227,7 @@ describe("functions", () => {
         args: [],
       });
 
-      functionRegistry.add("FORMULA_RETURNING_ERROR", {
+      addToRegistry(functionRegistry, "FORMULA_RETURNING_ERROR", {
         description: "function returning ERROR",
         compute: () => {
           return "#ERROR";
@@ -241,7 +235,7 @@ describe("functions", () => {
         args: [],
       });
 
-      functionRegistry.add("FORMULA_TROWING_ERROR", {
+      addToRegistry(functionRegistry, "FORMULA_TROWING_ERROR", {
         description: "function trowing error",
         compute: () => {
           throw new EvaluationError("NOP");
@@ -249,7 +243,7 @@ describe("functions", () => {
         args: [],
       });
 
-      functionRegistry.add("FORMULA_RETURNING_RANGE_WITH_ERROR", {
+      addToRegistry(functionRegistry, "FORMULA_RETURNING_RANGE_WITH_ERROR", {
         description: "function returning range",
         compute: () => {
           return [["#ERROR"]];
@@ -257,7 +251,7 @@ describe("functions", () => {
         args: [],
       });
 
-      functionRegistry.add("FORMULA_RETURNING_RANGE_TROWING_ERROR", {
+      addToRegistry(functionRegistry, "FORMULA_RETURNING_RANGE_TROWING_ERROR", {
         description: "function returning range",
         compute: () => {
           throw new EvaluationError("NOP");
@@ -318,7 +312,7 @@ describe("functions", () => {
     test("simple argument value from a single cell or range reference", () => {
       const m = new Model();
 
-      functionRegistry.add("SIMPLE_VALUE_EXPECTED", {
+      addToRegistry(functionRegistry, "SIMPLE_VALUE_EXPECTED", {
         description: "does not accept a range",
         compute: (arg) => {
           return true;

--- a/tests/functions/vectorization.test.ts
+++ b/tests/functions/vectorization.test.ts
@@ -4,10 +4,10 @@ import { toScalar } from "../../src/functions/helper_matrices";
 import { toString } from "../../src/functions/helpers";
 import { setCellContent } from "../test_helpers/commands_helpers";
 import {
+  addToRegistry,
   checkFunctionDoesntSpreadBeyondRange,
   createModelFromGrid,
   getRangeValuesAsMatrix,
-  restoreDefaultFunctions,
 } from "../test_helpers/helpers";
 
 describe("vectorization", () => {
@@ -18,8 +18,8 @@ describe("vectorization", () => {
     A3: "A3", B3: "B3", C3: "C3",
   };
 
-  beforeAll(() => {
-    functionRegistry.add("FUNCTION.WITHOUT.RANGE.ARGS", {
+  beforeEach(() => {
+    addToRegistry(functionRegistry, "FUNCTION.WITHOUT.RANGE.ARGS", {
       description: "a function with simple args",
       args: [
         { name: "arg1", description: "", type: ["ANY"] },
@@ -30,7 +30,7 @@ describe("vectorization", () => {
       },
     });
 
-    functionRegistry.add("FUNCTION.THAT.SPREADS", {
+    addToRegistry(functionRegistry, "FUNCTION.THAT.SPREADS", {
       description: "a function that spreads a matrix",
       args: [{ name: "arg1", description: "", type: ["ANY"] }],
       compute: function (arg1) {
@@ -43,9 +43,6 @@ describe("vectorization", () => {
     });
   });
 
-  afterAll(() => {
-    restoreDefaultFunctions();
-  });
   test("scalar arg with vertical arg", () => {
     const model = createModelFromGrid(grid);
     setCellContent(model, "D1", "=FUNCTION.WITHOUT.RANGE.ARGS(A1, B1:B2)");

--- a/tests/grid/dashboard_grid_component.test.ts
+++ b/tests/grid/dashboard_grid_component.test.ts
@@ -15,7 +15,7 @@ import {
 } from "../test_helpers/commands_helpers";
 import { keyDown, simulateClick } from "../test_helpers/dom_helper";
 import { getSelectionAnchorCellXc } from "../test_helpers/getters_helpers";
-import { mountSpreadsheet, nextTick, spyDispatch } from "../test_helpers/helpers";
+import { addToRegistry, mountSpreadsheet, nextTick, spyDispatch } from "../test_helpers/helpers";
 
 let fixture: HTMLElement;
 let parent: Spreadsheet;
@@ -123,7 +123,7 @@ describe("Grid component in dashboard mode", () => {
 
   test("Clickable cells actions are properly udpated on viewport scroll", async () => {
     const fn = jest.fn();
-    clickableCellRegistry.add("fake", {
+    addToRegistry(clickableCellRegistry, "fake", {
       condition: (position, getters) => {
         return !!getters.getCell(position)?.content.startsWith("__");
       },
@@ -146,12 +146,11 @@ describe("Grid component in dashboard mode", () => {
     await nextTick();
     await simulateClick("div.o-dashboard-clickable-cell", 10, 10);
     expect(fn).toHaveBeenCalledWith(1, 9);
-    clickableCellRegistry.remove("fake");
   });
 
   test("Triggers clickable cell actions with correct params on left-click and middle-click", async () => {
     const fn = jest.fn();
-    clickableCellRegistry.add("fake", {
+    addToRegistry(clickableCellRegistry, "fake", {
       condition: (position, getters) => {
         return !!getters.getCell(position)?.content.startsWith("__");
       },
@@ -165,11 +164,10 @@ describe("Grid component in dashboard mode", () => {
     expect(fn).toHaveBeenCalledWith(false);
     await simulateClick("div.o-dashboard-clickable-cell", 10, 10, { bubbles: true, button: 1 });
     expect(fn).toHaveBeenCalledWith(true);
-    clickableCellRegistry.remove("fake");
   });
 
   test("Clickable cells actions can have a tooltip", async () => {
-    clickableCellRegistry.add("fake", {
+    addToRegistry(clickableCellRegistry, "fake", {
       condition: () => true,
       execute: () => {},
       title: "hello there",
@@ -180,6 +178,5 @@ describe("Grid component in dashboard mode", () => {
     expect(fixture.querySelector("div.o-dashboard-clickable-cell")?.getAttribute("title")).toBe(
       "hello there"
     );
-    clickableCellRegistry.remove("fake");
   });
 });

--- a/tests/menus/menu_items_registry.test.ts
+++ b/tests/menus/menu_items_registry.test.ts
@@ -38,13 +38,13 @@ import {
   getStyle,
 } from "../test_helpers/getters_helpers";
 import {
+  addToRegistry,
   clearFunctions,
   doAction,
   getDataValidationRules,
   getName,
   getNode,
   makeTestEnv,
-  restoreDefaultFunctions,
   spyModelDispatch,
   target,
 } from "../test_helpers/helpers";
@@ -71,22 +71,22 @@ describe("Top Bar Menu Item Registry", () => {
   beforeEach(() => (registry = new MenuItemRegistry()));
 
   test("Menu registry items have unique ActionSpec path", () => {
-    registry.add("root", { name: "rootNode" });
+    addToRegistry(registry, "root", { name: "rootNode" });
     registry.addChild("child", ["root"], { id: "unique", name: "child" });
     expect(() =>
       registry.addChild("child", ["root"], { id: "unique", name: "child" })
     ).toThrowError('A child with the id "unique" already exists.');
   });
   test("Menu registry entries can be overriden explicitely", () => {
-    registry.add("root", { name: "rootNode" });
+    addToRegistry(registry, "root", { name: "rootNode" });
     registry.addChild("child", ["root"], { id: "unique", name: "child" });
     expect(() =>
       registry.addChild("child", ["root"], { id: "unique", name: "child" }, { force: true })
     ).not.toThrowError();
   });
   test("Menu items can have the same id with different parent nodes", () => {
-    registry.add("root1", { name: "rootNode1" });
-    registry.add("root2", { name: "rootNode2" });
+    addToRegistry(registry, "root1", { name: "rootNode1" });
+    addToRegistry(registry, "root2", { name: "rootNode2" });
     registry.addChild("child", ["root1"], { id: "unique", name: "child" });
     expect(() =>
       registry.addChild("child", ["root2"], { id: "unique", name: "child" })
@@ -104,7 +104,7 @@ describe("Top Bar Menu Item Registry", () => {
     topbarMenuRegistry.content = menuDefinitions;
   });
   test("Can add children to menu Items", () => {
-    topbarMenuRegistry.add("root", { name: "Root", sequence: 1 });
+    addToRegistry(topbarMenuRegistry, "root", { name: "Root", sequence: 1 });
     topbarMenuRegistry.addChild("child1", ["root"], { name: "Child1", sequence: 1 });
     topbarMenuRegistry.addChild("child2", ["root", "child1"], {
       name: "Child2",
@@ -144,7 +144,7 @@ describe("Top Bar Menu Item Registry", () => {
     expect(() =>
       topbarMenuRegistry.addChild("child", ["non-existing"], { name: "child", sequence: 1 })
     ).toThrow();
-    topbarMenuRegistry.add("root", { name: "Root", sequence: 1 });
+    addToRegistry(topbarMenuRegistry, "root", { name: "Root", sequence: 1 });
     expect(() =>
       topbarMenuRegistry.addChild("child1", ["root", "non-existing"], {
         name: "Child1",
@@ -968,7 +968,7 @@ describe("Menu Item actions", () => {
   });
 
   test("Insert -> Function -> All includes new functions", () => {
-    functionRegistry.add("TEST.FUNC", {
+    addToRegistry(functionRegistry, "TEST.FUNC", {
       args: [],
       compute: () => 42,
       description: "Test function",
@@ -979,7 +979,6 @@ describe("Menu Item actions", () => {
       env
     ).children(env);
     expect(allFunctions.map((f) => f.name(env))).toContain("TEST.FUNC");
-    restoreDefaultFunctions();
   });
 
   test("Insert -> Checkbox", () => {
@@ -993,7 +992,7 @@ describe("Menu Item actions", () => {
 
   test("Insert -> Function -> hidden formulas are filtered out", () => {
     clearFunctions();
-    functionRegistry.add("HIDDEN.FUNC", {
+    addToRegistry(functionRegistry, "HIDDEN.FUNC", {
       args: [],
       compute: () => 42,
       description: "Test function",
@@ -1008,7 +1007,6 @@ describe("Menu Item actions", () => {
       env
     ).children(env);
     expect(allFunctions.map((f) => f.name(env))).not.toContain("HIDDEN.FUNC");
-    restoreDefaultFunctions();
   });
 
   describe("Format -> numbers", () => {

--- a/tests/spreadsheet/side_panel_component.test.ts
+++ b/tests/spreadsheet/side_panel_component.test.ts
@@ -8,7 +8,7 @@ import {
 import { SidePanelContent, sidePanelRegistry } from "../../src/registries/side_panel_registry";
 import { createSheet } from "../test_helpers/commands_helpers";
 import { doubleClick, dragElement, simulateClick } from "../test_helpers/dom_helper";
-import { mountSpreadsheet, nextTick } from "../test_helpers/helpers";
+import { addToRegistry, mountSpreadsheet, nextTick } from "../test_helpers/helpers";
 import { mockGetBoundingClientRect } from "../test_helpers/mock_helpers";
 
 let spreadsheetWidth = 1000;
@@ -63,7 +63,7 @@ afterEach(() => {
 
 describe("Side Panel", () => {
   test("Can open a custom side panel", async () => {
-    sidePanelRegistry.add("CUSTOM_PANEL", {
+    addToRegistry(sidePanelRegistry, "CUSTOM_PANEL", {
       title: "Custom Panel",
       Body: Body,
     });
@@ -76,7 +76,7 @@ describe("Side Panel", () => {
   });
 
   test("Can close a side panel", async () => {
-    sidePanelRegistry.add("CUSTOM_PANEL", {
+    addToRegistry(sidePanelRegistry, "CUSTOM_PANEL", {
       title: "Custom Panel",
       Body: Body,
     });
@@ -89,7 +89,7 @@ describe("Side Panel", () => {
   });
 
   test("Can toggle a side panel", async () => {
-    sidePanelRegistry.add("CUSTOM_PANEL", {
+    addToRegistry(sidePanelRegistry, "CUSTOM_PANEL", {
       title: "Custom Panel",
       Body: Body,
     });
@@ -102,11 +102,11 @@ describe("Side Panel", () => {
   });
 
   test("Can toggle a side panel when another is already opened", async () => {
-    sidePanelRegistry.add("CUSTOM_PANEL_1", {
+    addToRegistry(sidePanelRegistry, "CUSTOM_PANEL_1", {
       title: "Custom Panel 1",
       Body: Body,
     });
-    sidePanelRegistry.add("CUSTOM_PANEL_2", {
+    addToRegistry(sidePanelRegistry, "CUSTOM_PANEL_2", {
       title: "Custom Panel 2",
       Body: Body,
     });
@@ -119,7 +119,7 @@ describe("Side Panel", () => {
   });
 
   test("Can open a custom side panel with custom title and panelProps", async () => {
-    sidePanelRegistry.add("CUSTOM_PANEL", {
+    addToRegistry(sidePanelRegistry, "CUSTOM_PANEL", {
       title: () => "Computed Title",
       Body: Body,
     });
@@ -133,7 +133,7 @@ describe("Side Panel", () => {
   });
 
   test("Can open a custom side panel with custom title based on props", async () => {
-    sidePanelRegistry.add("CUSTOM_PANEL", {
+    addToRegistry(sidePanelRegistry, "CUSTOM_PANEL", {
       title: (env, props: any) => `Title: ${props.text}`,
       Body: Body,
     });
@@ -144,7 +144,7 @@ describe("Side Panel", () => {
   });
 
   test("Can open and close a custom side panel without any props", async () => {
-    sidePanelRegistry.add("CUSTOM_PANEL", {
+    addToRegistry(sidePanelRegistry, "CUSTOM_PANEL", {
       title: "Title",
       Body: BodyWithoutProps,
       computeState: () => {
@@ -161,11 +161,11 @@ describe("Side Panel", () => {
   });
 
   test("Can open a side panel when another one is open", async () => {
-    sidePanelRegistry.add("PANEL_1", {
+    addToRegistry(sidePanelRegistry, "PANEL_1", {
       title: "PANEL_1",
       Body: Body,
     });
-    sidePanelRegistry.add("PANEL_2", {
+    addToRegistry(sidePanelRegistry, "PANEL_2", {
       title: "PANEL_2",
       Body: Body2,
     });
@@ -182,7 +182,7 @@ describe("Side Panel", () => {
   });
 
   test("Closing a side panel focuses the grid hidden input", async () => {
-    sidePanelRegistry.add("CUSTOM_PANEL", {
+    addToRegistry(sidePanelRegistry, "CUSTOM_PANEL", {
       title: "Custom Panel",
       Body: Body,
     });
@@ -195,7 +195,7 @@ describe("Side Panel", () => {
 
   test("Closing a side panel executes the onCloseSidePanel callback", async () => {
     const onCloseSidePanel = jest.fn();
-    sidePanelRegistry.add("CUSTOM_PANEL", {
+    addToRegistry(sidePanelRegistry, "CUSTOM_PANEL", {
       title: "Custom Panel",
       Body: Body,
     });
@@ -208,11 +208,11 @@ describe("Side Panel", () => {
 
   test("Switching from one sidepanel to another executes the onCloseSidePanel callback", async () => {
     const onCloseSidePanel = jest.fn();
-    sidePanelRegistry.add("CUSTOM_PANEL_1", {
+    addToRegistry(sidePanelRegistry, "CUSTOM_PANEL_1", {
       title: "Custom Panel 1",
       Body: Body,
     });
-    sidePanelRegistry.add("CUSTOM_PANEL_2", {
+    addToRegistry(sidePanelRegistry, "CUSTOM_PANEL_2", {
       title: "Custom Panel 2",
       Body: Body,
     });
@@ -225,7 +225,7 @@ describe("Side Panel", () => {
 
   test("Side panel does not lose focus upon sheet change", async () => {
     createSheet(model, { activate: true });
-    sidePanelRegistry.add("CUSTOM_PANEL_1", {
+    addToRegistry(sidePanelRegistry, "CUSTOM_PANEL_1", {
       title: "Custom Panel 1",
       Body: Body,
     });
@@ -242,7 +242,7 @@ describe("Side Panel", () => {
   });
 
   test("Can compute side panel props with computeState of the registry", async () => {
-    sidePanelRegistry.add("CUSTOM_PANEL", {
+    addToRegistry(sidePanelRegistry, "CUSTOM_PANEL", {
       title: "Custom Panel",
       Body: Body,
       computeState: () => ({ isOpen: true, props: { text: "test text" } }),
@@ -254,7 +254,7 @@ describe("Side Panel", () => {
 
   test("Can close the side panel with computeState of the registry", async () => {
     let text = "test text";
-    sidePanelRegistry.add("CUSTOM_PANEL", {
+    addToRegistry(sidePanelRegistry, "CUSTOM_PANEL", {
       title: "Custom Panel",
       Body: Body,
       computeState: () => (text ? { isOpen: true, props: { text } } : { isOpen: false }),
@@ -272,7 +272,7 @@ describe("Side Panel", () => {
   test("The onCloseSidePanel callback is called when computeState closes the side panel", async () => {
     const onCloseSidePanel = jest.fn();
     let text = "test text";
-    sidePanelRegistry.add("CUSTOM_PANEL", {
+    addToRegistry(sidePanelRegistry, "CUSTOM_PANEL", {
       title: "Custom Panel",
       Body: Body,
       computeState: () =>
@@ -296,7 +296,7 @@ describe("Side Panel", () => {
 
   describe("Side panel resize", () => {
     beforeEach(async () => {
-      sidePanelRegistry.add("CUSTOM_PANEL_2", { title: "title", Body: Body });
+      addToRegistry(sidePanelRegistry, "CUSTOM_PANEL_2", { title: "title", Body: Body });
       parent.env.openSidePanel("CUSTOM_PANEL_2");
       await nextTick();
     });

--- a/tests/spreadsheet/spreadsheet_component.test.ts
+++ b/tests/spreadsheet/spreadsheet_component.test.ts
@@ -26,12 +26,12 @@ import {
 } from "../test_helpers/dom_helper";
 import { getCellContent } from "../test_helpers/getters_helpers";
 import {
+  addToRegistry,
   doAction,
   mockChart,
   mountComponent,
   mountSpreadsheet,
   nextTick,
-  restoreDefaultFunctions,
   startGridComposition,
   typeInComposerGrid,
   typeInComposerTopBar,
@@ -84,8 +84,8 @@ describe("Simple Spreadsheet Component", () => {
   });
 
   describe("Use of env in a function", () => {
-    beforeAll(() => {
-      functionRegistry.add("GETACTIVESHEET", {
+    beforeEach(() => {
+      addToRegistry(functionRegistry, "GETACTIVESHEET", {
         description: "Get the name of the current sheet",
         compute: function () {
           env = this.env;
@@ -93,10 +93,6 @@ describe("Simple Spreadsheet Component", () => {
         },
         args: [],
       });
-    });
-
-    afterAll(() => {
-      restoreDefaultFunctions();
     });
 
     test("Can use  an external dependency in a function", () => {

--- a/tests/test_helpers/helpers.ts
+++ b/tests/test_helpers/helpers.ts
@@ -112,7 +112,11 @@ export function addTestPlugin(
   Plugin: CorePluginConstructor | UIPluginConstructor
 ) {
   const key = `test-plugin-${Plugin.name}`;
-  registry.add(key, Plugin);
+  addToRegistry(registry, key, Plugin);
+}
+
+export function addToRegistry<T>(registry: Registry<T>, key: string, value: T) {
+  registry.add(key, value);
   registerCleanup(() => registry.remove(key));
 }
 
@@ -570,6 +574,11 @@ export function checkFunctionDoesntSpreadBeyondRange(
  * Remove all functions from the internal function list.
  */
 export function clearFunctions() {
+  _clearFunctions();
+  registerCleanup(restoreDefaultFunctions);
+}
+
+function _clearFunctions() {
   Object.keys(functionMap).forEach((k) => {
     delete functionMap[k];
   });
@@ -583,7 +592,7 @@ export function restoreDefaultFunctions() {
   for (let f in functionCache) {
     delete functionCache[f];
   }
-  clearFunctions();
+  _clearFunctions();
   Object.keys(functionMapRestore).forEach((k) => {
     functionMap[k] = functionMapRestore[k];
   });

--- a/tests/top_bar_component.test.ts
+++ b/tests/top_bar_component.test.ts
@@ -29,6 +29,7 @@ import {
 } from "./test_helpers/dom_helper";
 import { getBorder, getCell, getStyle, getTable } from "./test_helpers/getters_helpers";
 import {
+  addToRegistry,
   getFigureIds,
   getNode,
   mountComponent,
@@ -531,7 +532,7 @@ describe("TopBar component", () => {
   test("Can click on a menuItem do execute action and close menus", async () => {
     const menuDefinitions = Object.assign({}, topbarMenuRegistry.content);
     let number = 0;
-    topbarMenuRegistry.add("test", { name: "Test", sequence: 1 });
+    addToRegistry(topbarMenuRegistry, "test", { name: "Test", sequence: 1 });
     topbarMenuRegistry.addChild("testaction", ["test"], {
       name: "TestAction",
       sequence: 1,
@@ -563,7 +564,7 @@ describe("TopBar component", () => {
 
   test("Can add a custom component to topbar", async () => {
     const compDefinitions = Object.assign({}, topbarComponentRegistry.content);
-    topbarComponentRegistry.add("1", { component: Comp, sequence: 1 });
+    addToRegistry(topbarComponentRegistry, "1", { component: Comp, sequence: 1 });
     await mountParent();
     expect(fixture.querySelectorAll(".o-topbar-test")).toHaveLength(1);
     topbarComponentRegistry.content = compDefinitions;
@@ -572,14 +573,14 @@ describe("TopBar component", () => {
   test("Can add multiple components to topbar with different visibilities", async () => {
     const compDefinitions = Object.assign({}, topbarComponentRegistry.content);
     let comp1Visibility = false;
-    topbarComponentRegistry.add("first", {
+    addToRegistry(topbarComponentRegistry, "first", {
       component: Comp1,
       isVisible: () => {
         return comp1Visibility;
       },
       sequence: 1,
     });
-    topbarComponentRegistry.add("second", { component: Comp2, sequence: 2 });
+    addToRegistry(topbarComponentRegistry, "second", { component: Comp2, sequence: 2 });
     const { parent } = await mountParent();
     expect(fixture.querySelectorAll(".o-topbar-test1")).toHaveLength(0);
     expect(fixture.querySelectorAll(".o-topbar-test2")).toHaveLength(1);
@@ -686,12 +687,12 @@ describe("TopBar component", () => {
 
 test("Can show/hide a TopBarComponent based on condition", async () => {
   const compDefinitions = Object.assign({}, topbarComponentRegistry.content);
-  topbarComponentRegistry.add("1", {
+  addToRegistry(topbarComponentRegistry, "1", {
     component: Comp1,
     isVisible: (env) => true,
     sequence: 1,
   });
-  topbarComponentRegistry.add("2", {
+  addToRegistry(topbarComponentRegistry, "2", {
     component: Comp2,
     isVisible: (env) => false,
     sequence: 2,
@@ -910,7 +911,7 @@ test("The composer helper should be closed on toggle topbar context menu", async
 });
 
 test("The menu items are orderer by their sequence", async () => {
-  topbarMenuRegistry.add("test", {
+  addToRegistry(topbarMenuRegistry, "test", {
     sequence: 1,
     name: "test",
   });

--- a/tests/xlsx/xlsx_export.test.ts
+++ b/tests/xlsx/xlsx_export.test.ts
@@ -28,10 +28,10 @@ import {
 import { TEST_CHART_DATA } from "../test_helpers/constants";
 import { getCellContent } from "../test_helpers/getters_helpers";
 import {
+  addToRegistry,
   exportPrettifiedXlsx,
   getExportedExcelData,
   mockChart,
-  restoreDefaultFunctions,
   toRangesData,
 } from "../test_helpers/helpers";
 
@@ -875,36 +875,32 @@ describe("Test XLSX export", () => {
   });
 
   describe("formulas", () => {
-    beforeAll(() => {
-      functionRegistry.add("NOW", {
+    beforeEach(() => {
+      addToRegistry(functionRegistry, "NOW", {
         ...NOW,
         compute: () => 1,
       });
-      functionRegistry.add("RAND", {
+      addToRegistry(functionRegistry, "RAND", {
         ...RAND,
         compute: () => 1,
       });
-      functionRegistry.add("TODAY", {
+      addToRegistry(functionRegistry, "TODAY", {
         ...TODAY,
         compute: () => 1,
       });
-      functionRegistry.add("RANDARRAY", {
+      addToRegistry(functionRegistry, "RANDARRAY", {
         ...RANDARRAY,
         compute: () => [
           [1, 1],
           [1, 1],
         ],
       });
-      // @ts-ignore
-      functionRegistry.add("RANDBETWEEN", {
+      addToRegistry(functionRegistry, "RANDBETWEEN", {
         ...RANDBETWEEN,
         compute: () => 1,
       });
     });
 
-    afterAll(() => {
-      restoreDefaultFunctions();
-    });
     test("All exportable formulas", async () => {
       const model = new Model(allExportableFormulasData);
       expect(await exportPrettifiedXlsx(model)).toMatchSnapshot();
@@ -925,7 +921,7 @@ describe("Test XLSX export", () => {
     test("can export value and format from non-exportable formulas", async () => {
       const model = new Model();
 
-      functionRegistry.add("NON.EXPORTABLE", {
+      addToRegistry(functionRegistry, "NON.EXPORTABLE", {
         description: "a non exportable formula",
         args: [arg('range (any, range<any>, ,default="a")', "")],
         compute: function () {
@@ -951,7 +947,7 @@ describe("Test XLSX export", () => {
     test("can export value and format from non-exportable formulas that spread", async () => {
       const model = new Model();
 
-      functionRegistry.add("NON.EXPORTABLE.ARRAY.FORMULA", {
+      addToRegistry(functionRegistry, "NON.EXPORTABLE.ARRAY.FORMULA", {
         description: "a non exportable formula that spread",
         args: [],
         compute: function () {


### PR DESCRIPTION

Task: 0

## Description:

This commit adds a helper to temporarily add an item to a registry in a test and properly remove it at the end of the test.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo