### PR TITLE
[IMP] pivot: insert pivot with real date

### DIFF
--- a/src/helpers/pivot/pivot_time_adapter.ts
+++ b/src/helpers/pivot/pivot_time_adapter.ts
@@ -193,7 +193,12 @@ const quarterNumberAdapter: PivotTimeAdapterNotNull<number> = {
 
 const yearAdapter: PivotTimeAdapterNotNull<number> = {
   normalizeFunctionValue(value) {
-    return toNumber(value, DEFAULT_LOCALE);
+    const year = toNumber(value, DEFAULT_LOCALE);
+    if (year > 3000) {
+      // interpret the value as a full date
+      return toJsDate(year, DEFAULT_LOCALE).getFullYear();
+    }
+    return year;
   },
   toValueAndFormat(normalizedValue) {
     return {

--- a/src/helpers/pivot/pivot_time_adapter.ts
+++ b/src/helpers/pivot/pivot_time_adapter.ts
@@ -1,10 +1,10 @@
-import { toNumber } from "../../functions/helpers";
+import { toJsDate, toNumber } from "../../functions/helpers";
 import { Registry } from "../../registries/registry";
 import { _t } from "../../translation";
 import { CellValue, DEFAULT_LOCALE } from "../../types";
 import { EvaluationError } from "../../types/errors";
 import { Granularity, PivotTimeAdapter, PivotTimeAdapterNotNull } from "../../types/pivot";
-import { DAYS, MONTHS, formatValue } from "../format/format";
+import { DAYS, MONTHS } from "../format/format";
 
 export const pivotTimeAdapterRegistry = new Registry<PivotTimeAdapter<CellValue>>();
 
@@ -48,8 +48,8 @@ const dayAdapter: PivotTimeAdapterNotNull<number> = {
     };
   },
   toFunctionValue(normalizedValue) {
-    const date = toNumber(normalizedValue, DEFAULT_LOCALE);
-    return `"${formatValue(date, { locale: DEFAULT_LOCALE, format: "mm/dd/yyyy" })}"`;
+    const jsDate = toJsDate(normalizedValue, DEFAULT_LOCALE);
+    return `DATE(${jsDate.getFullYear()}, ${jsDate.getMonth() + 1}, ${jsDate.getDate()})`;
   },
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -128,6 +128,7 @@ import {
   parseDimension,
   pivotNormalizationValueRegistry,
   pivotToFunctionValueRegistry,
+  toFunctionPivotValue,
   toNormalizedPivotValue,
 } from "./helpers/pivot/pivot_helpers";
 import { getPivotHighlights } from "./helpers/pivot/pivot_highlight";
@@ -296,6 +297,7 @@ export const helpers = {
   toNumber,
   toString,
   toNormalizedPivotValue,
+  toFunctionPivotValue,
   toXC,
   toZone,
   toUnboundedZone,

--- a/tests/pivots/pivot_helpers.test.ts
+++ b/tests/pivots/pivot_helpers.test.ts
@@ -194,7 +194,7 @@ describe("ToFunctionValue", () => {
   test.each(["date", "datetime"])("Format values of %s fields", (type: string) => {
     const dimension = { type, granularity: "day" };
     // day
-    expect(toFunctionPivotValue("1/11/2020", dimension)).toBe(`"01/11/2020"`);
+    expect(toFunctionPivotValue("1/11/2020", dimension)).toBe("DATE(2020, 1, 11)");
     // year
     dimension.granularity = "year";
     expect(toFunctionPivotValue("2020", dimension)).toBe("2020");

--- a/tests/pivots/pivot_helpers.test.ts
+++ b/tests/pivots/pivot_helpers.test.ts
@@ -48,6 +48,7 @@ describe("toNormalizedPivotValue", () => {
       expect(toNormalizedPivotValue(dimension, 2020)).toBe(2020);
       expect(toNormalizedPivotValue(dimension, "false")).toBe(false);
       expect(toNormalizedPivotValue(dimension, false)).toBe(false);
+      expect(toNormalizedPivotValue(dimension, "2020-12-31")).toBe(2020);
 
       dimension.granularity = "day_of_month";
       expect(toNormalizedPivotValue(dimension, "1")).toBe(1);


### PR DESCRIPTION
Purpose
-------
Currently, when you group a pivot by day and insert it in a spreadsheet, the generated pivot functions look like

=PIVOT.VALUE(2,"amount_total","date_order:day","06/01/2023")

"06/01/2023" is ambiguous. Is it the 6th January 2023 or the 1st June 2023 ? It turns out it's always interpreted as a US date (mm/dd/yyyy): 1st June 2023. Even if the spreadsheet locale is FR (dd/mm/yyyy). If the locale is FR, it's inconsistent then: if you type "06/01/2023" in a cell, it's interpreted with the FR locale as 6th January 2023, but specifically in PIVOT functions, it's interpreted as 1st June 2023. The reason is historic: before the introduction of locales, everything was US, always. When we introduced locales, we left the way it was interpreted in PIVOT functions to avoid breaking existing spreadsheet when changing the locale)

Alternatives

- Interpret the string in PIVOT functions with the spreadsheet locale. This is a breaking change though. We could upgrade spreadsheets for simple cases, but not if the date comes from a reference to another cell, with an arbitrary complex construction with functions. Changing the locale would also break all pivots with hard-coded date string.
- Support only "real" dates in PIVOT functions (DATE(2023, 6, 1) instead of the hardcoded strings). It means no more ambiguity and no inconsistencies anymore. But it's a breaking change and we can't upgrade all existing spreadsheets (same issue as above). The benefit compared to the alternative above is that dates that we would not be properly upgraded would now result in errors, allowing the user to spot the issue and fix it.
- Insert functions with string dates with the year first "2023/06/01". Those dates are always interpreted as yyyy/mm/dd which makes them unambiguous, no matter the spreadsheet locale. If the user manually types a PIVOT function with "06/01/2023", we keep the current behavior and interpret it has US. This ensure there's no breaking change.
- Same as above but insert functions with DATE(2023, 6, 1). Preserve the current behavior and interpret hard-coded date strings as US.

The last two options are preferred to avoid any breaking change. We choose the last one to encourage users to use DATE(...) and avoid hard-coded date strings in formulas, which don't work well when changing the spreadsheet locale.

Task: 3973659

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo