### PR TITLE
[REV] topbar: remove overflow hidden

### DIFF
--- a/src/components/top_bar/top_bar.ts
+++ b/src/components/top_bar/top_bar.ts
@@ -63,12 +63,10 @@ css/* scss */ `
     font-size: 13px;
     font-weight: 500;
     background-color: #fff;
-    width: inherit;
 
     .o-topbar-top {
       border-bottom: 1px solid ${SEPARATOR_COLOR};
       padding: 2px 10px;
-      overflow: hidden;
 
       /* Menus */
       .o-topbar-topleft {

--- a/src/components/top_bar/top_bar.xml
+++ b/src/components/top_bar/top_bar.xml
@@ -1,7 +1,7 @@
 <templates>
   <t t-name="o-spreadsheet-TopBar">
     <div
-      class="o-spreadsheet-topbar o-two-columns d-flex flex-column user-select-none overflow-hidden"
+      class="o-spreadsheet-topbar o-two-columns d-flex flex-column user-select-none"
       t-on-click="props.onClick">
       <div class="o-topbar-top d-flex justify-content-between">
         <!-- Menus -->

--- a/tests/__snapshots__/top_bar_component.test.ts.snap
+++ b/tests/__snapshots__/top_bar_component.test.ts.snap
@@ -6,7 +6,7 @@ exports[`TopBar component can set cell format 1`] = `
     class="o-spreadsheet"
   >
     <div
-      class="o-spreadsheet-topbar o-two-columns d-flex flex-column user-select-none overflow-hidden"
+      class="o-spreadsheet-topbar o-two-columns d-flex flex-column user-select-none"
     >
       <div
         class="o-topbar-top d-flex justify-content-between"
@@ -1115,7 +1115,7 @@ exports[`TopBar component can set cell format 1`] = `
 
 exports[`TopBar component simple rendering 1`] = `
 <div
-  class="o-spreadsheet-topbar o-two-columns d-flex flex-column user-select-none overflow-hidden"
+  class="o-spreadsheet-topbar o-two-columns d-flex flex-column user-select-none"
 >
   <div
     class="o-topbar-top d-flex justify-content-between"

--- a/tests/spreadsheet/__snapshots__/spreadsheet_component.test.ts.snap
+++ b/tests/spreadsheet/__snapshots__/spreadsheet_component.test.ts.snap
@@ -7,7 +7,7 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
 >
   
   <div
-    class="o-spreadsheet-topbar o-two-columns d-flex flex-column user-select-none overflow-hidden"
+    class="o-spreadsheet-topbar o-two-columns d-flex flex-column user-select-none"
   >
     <div
       class="o-topbar-top d-flex justify-content-between"
@@ -1011,7 +1011,7 @@ exports[`components take the small screen into account 1`] = `
 >
   
   <div
-    class="o-spreadsheet-topbar o-two-columns d-flex flex-column user-select-none overflow-hidden"
+    class="o-spreadsheet-topbar o-two-columns d-flex flex-column user-select-none"
   >
     <div
       class="o-topbar-top d-flex justify-content-between"


### PR DESCRIPTION
Commit 48d7a15dae mistakenly added `overflow: hidden` to the topbar. That breaks the formula assistant. This commit removes it.

Task: 0

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo