### PR TITLE
[REF] perfs: draw conditional formats icons with `Path2D`

### DIFF
--- a/src/components/icons/icons.ts
+++ b/src/components/icons/icons.ts
@@ -1,6 +1,6 @@
 import { ICON_EDGE_LENGTH } from "../../constants";
 import { iconsOnCellRegistry } from "../../registries/icons_on_cell_registry";
-import { ImageSrc } from "../../types/image";
+import { ImageSVG } from "../../types/image";
 import { css } from "../helpers";
 
 css/* scss */ `
@@ -32,69 +32,106 @@ export type IconSetType = keyof typeof ICON_SETS;
 // -----------------------------------------------------------------------------
 // We need here the svg of the icons that we need to convert to images for the renderer
 // -----------------------------------------------------------------------------
-const ARROW_DOWN =
-  '<svg class="o-icon arrow-down" width="10" height="10" focusable="false" viewBox="0 0 448 512"><path fill="#E06666" d="M413.1 222.5l22.2 22.2c9.4 9.4 9.4 24.6 0 33.9L241 473c-9.4 9.4-24.6 9.4-33.9 0L12.7 278.6c-9.4-9.4-9.4-24.6 0-33.9l22.2-22.2c9.5-9.5 25-9.3 34.3.4L184 343.4V56c0-13.3 10.7-24 24-24h32c13.3 0 24 10.7 24 24v287.4l114.8-120.5c9.3-9.8 24.8-10 34.3-.4z"></path></svg>';
-const ARROW_UP =
-  '<svg class="o-icon arrow-up" width="10" height="10" focusable="false" viewBox="0 0 448 512"><path fill="#6AA84F" d="M34.9 289.5l-22.2-22.2c-9.4-9.4-9.4-24.6 0-33.9L207 39c9.4-9.4 24.6-9.4 33.9 0l194.3 194.3c9.4 9.4 9.4 24.6 0 33.9L413 289.4c-9.5 9.5-25 9.3-34.3-.4L264 168.6V456c0 13.3-10.7 24-24 24h-32c-13.3 0-24-10.7-24-24V168.6L69.2 289.1c-9.3 9.8-24.8 10-34.3.4z"></path></svg>';
-const ARROW_RIGHT =
-  '<svg class="o-icon arrow-right" width="10" height="10" focusable="false" viewBox="0 0 448 512"><path fill="#F0AD4E" d="M190.5 66.9l22.2-22.2c9.4-9.4 24.6-9.4 33.9 0L441 239c9.4 9.4 9.4 24.6 0 33.9L246.6 467.3c-9.4 9.4-24.6 9.4-33.9 0l-22.2-22.2c-9.5-9.5-9.3-25 .4-34.3L311.4 296H24c-13.3 0-24-10.7-24-24v-32c0-13.3 10.7-24 24-24h287.4L190.9 101.2c-9.8-9.3-10-24.8-.4-34.3z"></path></svg>';
+const ARROW_DOWN: ImageSVG = {
+  width: 448,
+  height: 512,
+  fillColor: "#E06666",
+  path: "M413.1 222.5l22.2 22.2c9.4 9.4 9.4 24.6 0 33.9L241 473c-9.4 9.4-24.6 9.4-33.9 0L12.7 278.6c-9.4-9.4-9.4-24.6 0-33.9l22.2-22.2c9.5-9.5 25-9.3 34.3.4L184 343.4V56c0-13.3 10.7-24 24-24h32c13.3 0 24 10.7 24 24v287.4l114.8-120.5c9.3-9.8 24.8-10 34.3-.4z",
+};
+const ARROW_UP: ImageSVG = {
+  width: 448,
+  height: 512,
+  fillColor: "#6AA84F",
+  path: "M34.9 289.5l-22.2-22.2c-9.4-9.4-9.4-24.6 0-33.9L207 39c9.4-9.4 24.6-9.4 33.9 0l194.3 194.3c9.4 9.4 9.4 24.6 0 33.9L413 289.4c-9.5 9.5-25 9.3-34.3-.4L264 168.6V456c0 13.3-10.7 24-24 24h-32c-13.3 0-24-10.7-24-24V168.6L69.2 289.1c-9.3 9.8-24.8 10-34.3.4z",
+};
+const ARROW_RIGHT: ImageSVG = {
+  width: 448,
+  height: 512,
+  fillColor: "#F0AD4E",
+  path: "M190.5 66.9l22.2-22.2c9.4-9.4 24.6-9.4 33.9 0L441 239c9.4 9.4 9.4 24.6 0 33.9L246.6 467.3c-9.4 9.4-24.6 9.4-33.9 0l-22.2-22.2c-9.5-9.5-9.3-25 .4-34.3L311.4 296H24c-13.3 0-24-10.7-24-24v-32c0-13.3 10.7-24 24-24h287.4L190.9 101.2c-9.8-9.3-10-24.8-.4-34.3z",
+};
 
-const SMILE =
-  '<svg class="o-icon smile" width="10" height="10" focusable="false" viewBox="0 0 496 512"><path fill="#6AA84F" d="M248 8C111 8 0 119 0 256s111 248 248 248 248-111 248-248S385 8 248 8zm0 448c-110.3 0-200-89.7-200-200S137.7 56 248 56s200 89.7 200 200-89.7 200-200 200zm-80-216c17.7 0 32-14.3 32-32s-14.3-32-32-32-32 14.3-32 32 14.3 32 32 32zm160 0c17.7 0 32-14.3 32-32s-14.3-32-32-32-32 14.3-32 32 14.3 32 32 32zm4 72.6c-20.8 25-51.5 39.4-84 39.4s-63.2-14.3-84-39.4c-8.5-10.2-23.7-11.5-33.8-3.1-10.2 8.5-11.5 23.6-3.1 33.8 30 36 74.1 56.6 120.9 56.6s90.9-20.6 120.9-56.6c8.5-10.2 7.1-25.3-3.1-33.8-10.1-8.4-25.3-7.1-33.8 3.1z"></path></svg>';
-const MEH =
-  '<svg class="o-icon meh" width="10" height="10" focusable="false" viewBox="0 0 496 512"><path fill="#F0AD4E" d="M248 8C111 8 0 119 0 256s111 248 248 248 248-111 248-248S385 8 248 8zm0 448c-110.3 0-200-89.7-200-200S137.7 56 248 56s200 89.7 200 200-89.7 200-200 200zm-80-216c17.7 0 32-14.3 32-32s-14.3-32-32-32-32 14.3-32 32 14.3 32 32 32zm160-64c-17.7 0-32 14.3-32 32s14.3 32 32 32 32-14.3 32-32-14.3-32-32-32zm8 144H160c-13.2 0-24 10.8-24 24s10.8 24 24 24h176c13.2 0 24-10.8 24-24s-10.8-24-24-24z"></path></svg>';
-const FROWN =
-  '<svg class="o-icon frown" width="10" height="10" focusable="false" viewBox="0 0 496 512"><path fill="#E06666" d="M248 8C111 8 0 119 0 256s111 248 248 248 248-111 248-248S385 8 248 8zm0 448c-110.3 0-200-89.7-200-200S137.7 56 248 56s200 89.7 200 200-89.7 200-200 200zm-80-216c17.7 0 32-14.3 32-32s-14.3-32-32-32-32 14.3-32 32 14.3 32 32 32zm160-64c-17.7 0-32 14.3-32 32s14.3 32 32 32 32-14.3 32-32-14.3-32-32-32zm-80 128c-40.2 0-78 17.7-103.8 48.6-8.5 10.2-7.1 25.3 3.1 33.8 10.2 8.4 25.3 7.1 33.8-3.1 16.6-19.9 41-31.4 66.9-31.4s50.3 11.4 66.9 31.4c8.1 9.7 23.1 11.9 33.8 3.1 10.2-8.5 11.5-23.6 3.1-33.8C326 321.7 288.2 304 248 304z"></path></svg>';
+const SMILE: ImageSVG = {
+  width: 496,
+  height: 512,
+  fillColor: "#6AA84F",
+  path: "M248 8C111 8 0 119 0 256s111 248 248 248 248-111 248-248S385 8 248 8zm0 448c-110.3 0-200-89.7-200-200S137.7 56 248 56s200 89.7 200 200-89.7 200-200 200zm-80-216c17.7 0 32-14.3 32-32s-14.3-32-32-32-32 14.3-32 32 14.3 32 32 32zm160 0c17.7 0 32-14.3 32-32s-14.3-32-32-32-32 14.3-32 32 14.3 32 32 32zm4 72.6c-20.8 25-51.5 39.4-84 39.4s-63.2-14.3-84-39.4c-8.5-10.2-23.7-11.5-33.8-3.1-10.2 8.5-11.5 23.6-3.1 33.8 30 36 74.1 56.6 120.9 56.6s90.9-20.6 120.9-56.6c8.5-10.2 7.1-25.3-3.1-33.8-10.1-8.4-25.3-7.1-33.8 3.1z",
+};
+const MEH: ImageSVG = {
+  width: 496,
+  height: 512,
+  fillColor: "#F0AD4E",
+  path: "M248 8C111 8 0 119 0 256s111 248 248 248 248-111 248-248S385 8 248 8zm0 448c-110.3 0-200-89.7-200-200S137.7 56 248 56s200 89.7 200 200-89.7 200-200 200zm-80-216c17.7 0 32-14.3 32-32s-14.3-32-32-32-32 14.3-32 32 14.3 32 32 32zm160-64c-17.7 0-32 14.3-32 32s14.3 32 32 32 32-14.3 32-32-14.3-32-32-32zm8 144H160c-13.2 0-24 10.8-24 24s10.8 24 24 24h176c13.2 0 24-10.8 24-24s-10.8-24-24-24z",
+};
+const FROWN: ImageSVG = {
+  width: 496,
+  height: 512,
+  fillColor: "#E06666",
+  path: "M248 8C111 8 0 119 0 256s111 248 248 248 248-111 248-248S385 8 248 8zm0 448c-110.3 0-200-89.7-200-200S137.7 56 248 56s200 89.7 200 200-89.7 200-200 200zm-80-216c17.7 0 32-14.3 32-32s-14.3-32-32-32-32 14.3-32 32 14.3 32 32 32zm160-64c-17.7 0-32 14.3-32 32s14.3 32 32 32 32-14.3 32-32-14.3-32-32-32zm-80 128c-40.2 0-78 17.7-103.8 48.6-8.5 10.2-7.1 25.3 3.1 33.8 10.2 8.4 25.3 7.1 33.8-3.1 16.6-19.9 41-31.4 66.9-31.4s50.3 11.4 66.9 31.4c8.1 9.7 23.1 11.9 33.8 3.1 10.2-8.5 11.5-23.6 3.1-33.8C326 321.7 288.2 304 248 304z",
+};
 
-const GREEN_DOT =
-  '<svg class="o-icon green-dot" width="10" height="10" focusable="false" viewBox="0 0 512 512"><path fill="#6AA84F" d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8z"></path></svg>';
-const YELLOW_DOT =
-  '<svg class="o-icon yellow-dot" width="10" height="10" focusable="false" viewBox="0 0 512 512"><path fill="#F0AD4E" d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8z"></path></svg>';
-const RED_DOT =
-  '<svg class="o-icon red-dot" width="10" height="10" focusable="false" viewBox="0 0 512 512"><path fill="#E06666" d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8z"></path></svg>';
+const DOT_PATH = "M256 9 a247 247 0 1 0.1 0 0";
+const GREEN_DOT: ImageSVG = {
+  width: 512,
+  height: 512,
+  fillColor: "#6AA84F",
+  path: DOT_PATH,
+};
+const YELLOW_DOT: ImageSVG = {
+  width: 512,
+  height: 512,
+  fillColor: "#F0AD4E",
+  path: DOT_PATH,
+};
+const RED_DOT: ImageSVG = {
+  width: 512,
+  height: 512,
+  fillColor: "#E06666",
+  path: DOT_PATH,
+};
 
-function getIconSrc(svg: string): ImageSrc {
-  /** We have to add xmlns, as it's not added by owl in the canvas */
-  svg = `<svg xmlns="http://www.w3.org/2000/svg" ${svg.slice(4)}`;
-  return "data:image/svg+xml; charset=utf8, " + encodeURIComponent(svg);
-}
-
-export const ICONS = {
+export const ICONS: Record<
+  string,
+  {
+    template: string;
+    svg: ImageSVG;
+  }
+> = {
   arrowGood: {
     template: "ARROW_UP",
-    img: getIconSrc(ARROW_UP),
+    svg: ARROW_UP,
   },
   arrowNeutral: {
     template: "ARROW_RIGHT",
-    img: getIconSrc(ARROW_RIGHT),
+    svg: ARROW_RIGHT,
   },
   arrowBad: {
     template: "ARROW_DOWN",
-    img: getIconSrc(ARROW_DOWN),
+    svg: ARROW_DOWN,
   },
   smileyGood: {
     template: "SMILE",
-    img: getIconSrc(SMILE),
+    svg: SMILE,
   },
   smileyNeutral: {
     template: "MEH",
-    img: getIconSrc(MEH),
+    svg: MEH,
   },
   smileyBad: {
     template: "FROWN",
-    img: getIconSrc(FROWN),
+    svg: FROWN,
   },
   dotGood: {
     template: "GREEN_DOT",
-    img: getIconSrc(GREEN_DOT),
+    svg: GREEN_DOT,
   },
   dotNeutral: {
     template: "YELLOW_DOT",
-    img: getIconSrc(YELLOW_DOT),
+    svg: YELLOW_DOT,
   },
   dotBad: {
     template: "RED_DOT",
-    img: getIconSrc(RED_DOT),
+    svg: RED_DOT,
   },
 };
 
@@ -119,6 +156,7 @@ export const ICON_SETS = {
 iconsOnCellRegistry.add("conditional_formatting", (getters, position) => {
   const icon = getters.getConditionalIcon(position);
   if (icon) {
-    return ICONS[icon].img;
+    return ICONS[icon].svg;
   }
+  return undefined;
 });

--- a/src/plugins/ui_feature/ui_sheet.ts
+++ b/src/plugins/ui_feature/ui_sheet.ts
@@ -19,7 +19,7 @@ import {
 import { localizeFormula } from "../../helpers/locale";
 import { iconsOnCellRegistry } from "../../registries/icons_on_cell_registry";
 import { CellValueType, Command, CommandResult, LocalCommand, UID } from "../../types";
-import { ImageSrc } from "../../types/image";
+import { ImageSVG } from "../../types/image";
 import { CellPosition, HeaderIndex, Pixel, Style, Zone } from "../../types/misc";
 import { UIPlugin } from "../ui_plugin";
 
@@ -27,7 +27,7 @@ export class SheetUIPlugin extends UIPlugin {
   static getters = [
     "doesCellHaveGridIcon",
     "getCellWidth",
-    "getCellIconSrc",
+    "getCellIconSvg",
     "getTextWidth",
     "getCellText",
     "getCellMultiLineText",
@@ -95,7 +95,7 @@ export class SheetUIPlugin extends UIPlugin {
       );
     }
 
-    const icon = this.getters.getCellIconSrc(position);
+    const icon = this.getters.getCellIconSvg(position);
     if (icon) {
       contentWidth += computeIconWidth(style);
     }
@@ -117,7 +117,7 @@ export class SheetUIPlugin extends UIPlugin {
     return contentWidth;
   }
 
-  getCellIconSrc(position: CellPosition): ImageSrc | undefined {
+  getCellIconSvg(position: CellPosition): ImageSVG | undefined {
     const callbacks = iconsOnCellRegistry.getAll();
     for (const callback of callbacks) {
       const imageSrc = callback(this.getters, position);

--- a/src/registries/icons_on_cell_registry.ts
+++ b/src/registries/icons_on_cell_registry.ts
@@ -1,10 +1,10 @@
 import { CellPosition, Getters } from "../types";
-import { ImageSrc } from "../types/image";
+import { ImageSVG } from "../types/image";
 import { Registry } from "./registry";
 
-type ImageSrcCallback = (getters: Getters, position: CellPosition) => ImageSrc | undefined;
+type ImageSvgCallback = (getters: Getters, position: CellPosition) => ImageSVG | undefined;
 
 /**
  * Registry to draw icons on cells
  */
-export const iconsOnCellRegistry = new Registry<ImageSrcCallback>();
+export const iconsOnCellRegistry = new Registry<ImageSvgCallback>();

--- a/src/types/image.ts
+++ b/src/types/image.ts
@@ -1,11 +1,12 @@
-import { Alias } from "..";
 import { FigureSize } from "./figure";
 import { XLSXFigureSize } from "./xlsx";
 
-/**
- * Image source given to <img src="..."/>
- */
-export type ImageSrc = string & Alias;
+export type ImageSVG = {
+  path: string;
+  width: number;
+  height: number;
+  fillColor: string;
+};
 
 export interface Image {
   path: string;

--- a/src/types/rendering.ts
+++ b/src/types/rendering.ts
@@ -1,4 +1,5 @@
 import { memoize } from "../helpers/misc";
+import { ImageSVG } from "./image";
 import { Alias, Align, Border, DataBarFill, Pixel, Style, VerticalAlign, Zone } from "./misc";
 
 /**
@@ -39,7 +40,7 @@ export interface Image {
   clipIcon: Rect | null;
   size: Pixel;
   type: "icon"; //| "Picture"
-  image: HTMLImageElement;
+  svg: ImageSVG;
 }
 
 /**


### PR DESCRIPTION
## Description

This commit replaces de use of `drawImage` with `Path2D` to draw conditional formats icons.

Scrolling around in a sheet full of CF icons, `drawIcon` went from taking ~35% of the total rendering time to ~10%.

Task: [4655049](https://www.odoo.com/odoo/2328/tasks/4655049)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo