### PR TITLE
[FIX] css: fix topbar dropdown css

### DIFF
--- a/src/components/top_bar/dropdown_action/dropdown_action.scss
+++ b/src/components/top_bar/dropdown_action/dropdown_action.scss
@@ -3,16 +3,16 @@
     position: relative;
     display: flex;
     align-items: center;
+  }
 
-    .o-dropdown-content {
-      background-color: white;
+  .o-dropdown-content {
+    background-color: white;
 
-      .o-dropdown-line {
-        display: flex;
+    .o-dropdown-line {
+      display: flex;
 
-        > span {
-          padding: 4px;
-        }
+      > span {
+        padding: 4px;
       }
     }
   }


### PR DESCRIPTION
## Description

The css of the dropdown is broken, `.o-dropdown-content` is not a child of `.o-dropdown`.

Task: [4655143](https://www.odoo.com/odoo/2328/tasks/4655143)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo