### PR TITLE
[IMP] menu: more positioning options for `Menu` component

### DIFF
--- a/src/components/bottom_bar/bottom_bar.ts
+++ b/src/components/bottom_bar/bottom_bar.ts
@@ -124,7 +124,7 @@ export class BottomBar extends Component<Props, SpreadsheetChildEnv> {
   menuState: BottomBarMenuState = useState({
     isOpen: false,
     menuId: undefined,
-    position: null,
+    anchorRect: null,
     menuItems: [],
   });
 
@@ -192,7 +192,7 @@ export class BottomBar extends Component<Props, SpreadsheetChildEnv> {
     this.menuState.isOpen = true;
     this.menuState.menuId = menuId;
     this.menuState.menuItems = registry.getMenuItems();
-    this.menuState.position = { x, y };
+    this.menuState.anchorRect = { x, y, width: 0, height: 0 };
   }
 
   onSheetContextMenu(sheetId: UID, registry: MenuItemRegistry, ev: MenuMouseEvent) {
@@ -209,7 +209,7 @@ export class BottomBar extends Component<Props, SpreadsheetChildEnv> {
     this.menuState.isOpen = false;
     this.menuState.menuId = undefined;
     this.menuState.menuItems = [];
-    this.menuState.position = null;
+    this.menuState.anchorRect = null;
   }
 
   closeContextMenuWithId(menuId: UID) {

--- a/src/components/bottom_bar/bottom_bar.xml
+++ b/src/components/bottom_bar/bottom_bar.xml
@@ -88,7 +88,7 @@
 
       <Menu
         t-if="menuState.isOpen"
-        position="menuState.position"
+        anchorRect="menuState.anchorRect"
         menuItems="menuState.menuItems"
         maxHeight="menuMaxHeight"
         onClose="() => this.closeMenu()"

--- a/src/components/figures/figure/figure.ts
+++ b/src/components/figures/figure/figure.ts
@@ -2,15 +2,14 @@ import { Component, onWillUnmount, useEffect, useRef, useState } from "@odoo/owl
 import {
   ComponentsImportance,
   FIGURE_BORDER_COLOR,
-  MENU_WIDTH,
   SELECTION_BORDER_COLOR,
 } from "../../../constants";
 import { figureRegistry } from "../../../registries/index";
 import {
   CSSProperties,
-  DOMCoordinates,
   Figure,
   Pixel,
+  Rect,
   ResizeDirection,
   SpreadsheetChildEnv,
   UID,
@@ -134,7 +133,7 @@ export class FigureComponent extends Component<Props, SpreadsheetChildEnv> {
     onClickAnchor: () => {},
   };
 
-  private menuState: MenuState = useState({ isOpen: false, position: null, menuItems: [] });
+  private menuState: MenuState = useState({ isOpen: false, anchorRect: null, menuItems: [] });
 
   private figureRef = useRef("figure");
   private menuButtonRef = useRef("menuButton");
@@ -281,25 +280,16 @@ export class FigureComponent extends Component<Props, SpreadsheetChildEnv> {
 
   onContextMenu(ev: MouseEvent) {
     if (this.env.isDashboard()) return;
-    const position = {
-      x: ev.clientX,
-      y: ev.clientY,
-    };
-    this.openContextMenu(position);
+    this.openContextMenu({ x: ev.clientX, y: ev.clientY, width: 0, height: 0 });
   }
 
   showMenu() {
-    const { x, y, width } = this.menuButtonRect;
-    const menuPosition = {
-      x: x >= MENU_WIDTH ? x - MENU_WIDTH : x + width,
-      y: y,
-    };
-    this.openContextMenu(menuPosition);
+    this.openContextMenu(this.menuButtonRect);
   }
 
-  private openContextMenu(position: DOMCoordinates) {
+  private openContextMenu(anchorRect: Rect) {
     this.menuState.isOpen = true;
-    this.menuState.position = position;
+    this.menuState.anchorRect = anchorRect;
     this.menuState.menuItems = figureRegistry
       .get(this.props.figure.tag)
       .menuBuilder(this.props.figure.id, this.props.onFigureDeleted, this.env);

--- a/src/components/figures/figure/figure.xml
+++ b/src/components/figures/figure/figure.xml
@@ -28,7 +28,7 @@
           </div>
           <Menu
             t-if="menuState.isOpen"
-            position="menuState.position"
+            anchorRect="menuState.anchorRect"
             menuItems="menuState.menuItems"
             onClose="() => this.menuState.isOpen=false"
           />

--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -153,7 +153,7 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
     this.highlightStore = useStore(HighlightStore);
     this.menuState = useState({
       isOpen: false,
-      position: null,
+      anchorRect: null,
       menuItems: [],
     });
     this.gridRef = useRef("grid");
@@ -593,7 +593,7 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
       this.cellPopovers.close();
     }
     this.menuState.isOpen = true;
-    this.menuState.position = { x, y };
+    this.menuState.anchorRect = { x, y, width: 0, height: 0 };
     this.menuState.menuItems = registries[type].getMenuItems();
   }
 

--- a/src/components/grid/grid.xml
+++ b/src/components/grid/grid.xml
@@ -54,7 +54,7 @@
       <Menu
         t-if="menuState.isOpen"
         menuItems="menuState.menuItems"
-        position="menuState.position"
+        anchorRect="menuState.anchorRect"
         onClose="() => this.closeMenu()"
       />
       <t t-foreach="staticTables" t-as="table" t-key="table.id">

--- a/src/components/header_group/header_group_container.ts
+++ b/src/components/header_group/header_group_container.ts
@@ -44,7 +44,7 @@ export class HeaderGroupContainer extends Component<Props, SpreadsheetChildEnv> 
   };
   static components = { RowGroup, ColGroup, Menu };
 
-  menu: MenuState = useState({ isOpen: false, position: null, menuItems: [] });
+  menu: MenuState = useState({ isOpen: false, anchorRect: null, menuItems: [] });
 
   getLayerOffset(layerIndex: number): number {
     return layerIndex * GROUP_LAYER_WIDTH;
@@ -59,13 +59,13 @@ export class HeaderGroupContainer extends Component<Props, SpreadsheetChildEnv> 
 
   openContextMenu(position: DOMCoordinates, menuItems: Action[]) {
     this.menu.isOpen = true;
-    this.menu.position = position;
+    this.menu.anchorRect = { ...position, width: 0, height: 0 };
     this.menu.menuItems = menuItems;
   }
 
   closeMenu() {
     this.menu.isOpen = false;
-    this.menu.position = null;
+    this.menu.anchorRect = null;
     this.menu.menuItems = [];
   }
 

--- a/src/components/header_group/header_group_container.xml
+++ b/src/components/header_group/header_group_container.xml
@@ -61,7 +61,7 @@
       <Menu
         t-if="menu.isOpen"
         menuItems="menu.menuItems"
-        position="menu.position"
+        anchorRect="menu.anchorRect"
         onClose.bind="this.closeMenu"
       />
     </div>

--- a/src/components/link/link_editor/link_editor.ts
+++ b/src/components/link/link_editor/link_editor.ts
@@ -3,14 +3,12 @@ import { markdownLink } from "../../../helpers";
 import { detectLink, urlRepresentation } from "../../../helpers/links";
 import { canonicalizeNumberContent } from "../../../helpers/locale";
 import { linkMenuRegistry } from "../../../registries/menus/link_menu_registry";
-import { DOMCoordinates, Link, Position, SpreadsheetChildEnv } from "../../../types";
+import { Link, Position, SpreadsheetChildEnv } from "../../../types";
 import { CellPopoverComponent, PopoverBuilders } from "../../../types/cell_popovers";
 import { css } from "../../helpers/css";
 import { useAbsoluteBoundingRect } from "../../helpers/position_hook";
 import { Menu } from "../../menu/menu";
 
-const MENU_OFFSET_X = 320;
-const MENU_OFFSET_Y = 100;
 const PADDING = 12;
 const LINK_EDITOR_WIDTH = 340 + 2 * PADDING;
 
@@ -84,8 +82,8 @@ export class LinkEditor extends Component<LinkEditorProps, SpreadsheetChildEnv> 
   private menu = useState({
     isOpen: false,
   });
-  private linkEditorRef = useRef("linkEditor");
-  private position: DOMCoordinates = useAbsoluteBoundingRect(this.linkEditorRef);
+  private linkEditorMenuButtonRef = useRef("linkEditorMenuButton");
+  menuButtonRect = useAbsoluteBoundingRect(this.linkEditorMenuButtonRef);
   urlInput = useRef("urlInput");
 
   setup() {
@@ -107,13 +105,6 @@ export class LinkEditor extends Component<LinkEditorProps, SpreadsheetChildEnv> 
       label: cell.formattedValue,
       url: "",
       isUrlEditable: true,
-    };
-  }
-
-  get menuPosition(): DOMCoordinates {
-    return {
-      x: this.position.x + MENU_OFFSET_X - PADDING - 2,
-      y: this.position.y + MENU_OFFSET_Y,
     };
   }
 

--- a/src/components/link/link_editor/link_editor.xml
+++ b/src/components/link/link_editor/link_editor.xml
@@ -3,8 +3,7 @@
     <div
       class="o-link-editor"
       t-on-click.stop="() => this.menu.isOpen=false"
-      t-on-keydown="onKeyDown"
-      t-ref="linkEditor">
+      t-on-keydown="onKeyDown">
       <div class="o-section">
         <div class="o-section-title">Text</div>
         <div class="d-flex">
@@ -41,14 +40,18 @@
           <button t-if="link.url" t-on-click="removeLink" class="o-remove-url o-button-icon">
             ✖
           </button>
-          <button t-if="!link.url" t-on-click.stop="openMenu" class="o-special-link o-button-icon">
+          <button
+            t-if="!link.url"
+            t-on-click.stop="openMenu"
+            class="o-special-link o-button-icon"
+            t-ref="linkEditorMenuButton">
             <t t-call="o-spreadsheet-Icon.LIST"/>
           </button>
         </div>
       </div>
       <Menu
         t-if="menu.isOpen"
-        position="menuPosition"
+        anchorRect="menuButtonRect"
         menuItems="menuItems"
         onMenuClicked="(ev) => this.onSpecialLink(ev)"
         onClose="() => this.menu.isOpen=false"

--- a/src/components/menu/menu.xml
+++ b/src/components/menu/menu.xml
@@ -60,7 +60,7 @@
       <Menu
         t-if="subMenu.isOpen"
         t-key="subMenu.parentMenu.id"
-        position="subMenuPosition"
+        anchorRect="subMenuAnchorRect"
         menuItems="subMenu.menuItems"
         depth="props.depth + 1"
         maxHeight="props.maxHeight"

--- a/src/components/side_panel/components/cog_wheel_menu/cog_wheel_menu.ts
+++ b/src/components/side_panel/components/cog_wheel_menu/cog_wheel_menu.ts
@@ -2,6 +2,7 @@ import { Component, useRef, useState } from "@odoo/owl";
 import { ActionSpec, createActions } from "../../../../actions/action";
 import { MenuMouseEvent } from "../../../../types";
 import { SpreadsheetChildEnv } from "../../../../types/env";
+import { getBoundingRectAsPOJO } from "../../../helpers/dom_helpers";
 import { Menu, MenuState } from "../../../menu/menu";
 
 interface Props {
@@ -16,7 +17,7 @@ export class CogWheelMenu extends Component<Props, SpreadsheetChildEnv> {
   };
 
   private buttonRef = useRef("button");
-  private menuState: MenuState = useState({ isOpen: false, position: null, menuItems: [] });
+  private menuState: MenuState = useState({ isOpen: false, anchorRect: null, menuItems: [] });
 
   private menuId = this.env.model.uuidGenerator.uuidv4();
 
@@ -25,9 +26,8 @@ export class CogWheelMenu extends Component<Props, SpreadsheetChildEnv> {
       return;
     }
 
-    const { x, y } = this.buttonRef.el!.getBoundingClientRect();
     this.menuState.isOpen = !this.menuState.isOpen;
-    this.menuState.position = { x, y };
+    this.menuState.anchorRect = getBoundingRectAsPOJO(this.buttonRef.el!);
     this.menuState.menuItems = createActions(this.props.items);
   }
 }

--- a/src/components/side_panel/components/cog_wheel_menu/cog_wheel_menu.xml
+++ b/src/components/side_panel/components/cog_wheel_menu/cog_wheel_menu.xml
@@ -8,7 +8,7 @@
     <Menu
       t-if="menuState.isOpen"
       menuId="menuId"
-      position="menuState.position"
+      anchorRect="menuState.anchorRect"
       menuItems="menuState.menuItems"
       onClose="() => this.menuState.isOpen=false"
       width="160"

--- a/src/components/side_panel/select_menu/select_menu.ts
+++ b/src/components/side_panel/select_menu/select_menu.ts
@@ -1,7 +1,7 @@
 import { Component, useRef, useState } from "@odoo/owl";
 import { Action } from "../../../actions/action";
 import { UuidGenerator } from "../../../helpers";
-import { DOMCoordinates, MenuMouseEvent, SpreadsheetChildEnv } from "../../../types";
+import { MenuMouseEvent, Rect, SpreadsheetChildEnv } from "../../../types";
 import { useAbsoluteBoundingRect } from "../../helpers/position_hook";
 import { Menu } from "../../menu/menu";
 
@@ -45,10 +45,7 @@ export class SelectMenu extends Component<SelectMenuProps, SpreadsheetChildEnv> 
     this.state.isMenuOpen = false;
   }
 
-  get menuPosition(): DOMCoordinates {
-    return {
-      x: this.selectRect.x,
-      y: this.selectRect.y + this.selectRect.height,
-    };
+  get menuAnchorRect(): Rect {
+    return this.selectRect;
   }
 }

--- a/src/components/side_panel/select_menu/select_menu.xml
+++ b/src/components/side_panel/select_menu/select_menu.xml
@@ -10,9 +10,10 @@
     <Menu
       t-if="state.isMenuOpen"
       menuItems="props.menuItems"
-      position="menuPosition"
+      anchorRect="menuAnchorRect"
       onClose.bind="onMenuClosed"
       menuId="menuId"
+      popoverPositioning="'BottomLeft'"
     />
   </t>
 </templates>

--- a/src/components/tables/table_style_preview/table_style_preview.ts
+++ b/src/components/tables/table_style_preview/table_style_preview.ts
@@ -60,7 +60,7 @@ export class TableStylePreview extends Component<Props, SpreadsheetChildEnv> {
   };
 
   private canvasRef = useRef<HTMLCanvasElement>("canvas");
-  menu: MenuState = useState({ isOpen: false, position: null, menuItems: [] });
+  menu: MenuState = useState({ isOpen: false, anchorRect: null, menuItems: [] });
 
   setup() {
     onWillUpdateProps((nextProps) => {
@@ -89,12 +89,12 @@ export class TableStylePreview extends Component<Props, SpreadsheetChildEnv> {
     }
     this.menu.menuItems = createTableStyleContextMenuActions(this.env, this.props.styleId);
     this.menu.isOpen = true;
-    this.menu.position = { x: event.clientX, y: event.clientY };
+    this.menu.anchorRect = { x: event.clientX, y: event.clientY, width: 0, height: 0 };
   }
 
   closeMenu() {
     this.menu.isOpen = false;
-    this.menu.position = null;
+    this.menu.anchorRect = null;
     this.menu.menuItems = [];
   }
 

--- a/src/components/tables/table_style_preview/table_style_preview.xml
+++ b/src/components/tables/table_style_preview/table_style_preview.xml
@@ -21,7 +21,7 @@
     <Menu
       t-if="menu.isOpen"
       menuItems="menu.menuItems"
-      position="menu.position"
+      anchorRect="menu.anchorRect"
       onClose.bind="this.closeMenu"
     />
   </t>

--- a/src/components/tables/table_styles_popover/table_styles_popover.ts
+++ b/src/components/tables/table_styles_popover/table_styles_popover.ts
@@ -5,7 +5,6 @@ import { SpreadsheetChildEnv } from "../../../types";
 import { TableConfig } from "../../../types/table";
 import { css } from "../../helpers";
 import { isChildEvent } from "../../helpers/dom_helpers";
-import { MenuState } from "../../menu/menu";
 import { Popover, PopoverProps } from "../../popover/popover";
 import { TableStylePreview } from "../table_style_preview/table_style_preview";
 
@@ -85,7 +84,6 @@ export class TableStylesPopover extends Component<TableStylesPopoverProps, Sprea
 
   private tableStyleListRef = useRef("tableStyleList");
   state = useState<State>({ selectedCategory: this.initialSelectedCategory });
-  menu: MenuState = useState({ isOpen: false, position: null, menuItems: [] });
 
   setup(): void {
     useExternalListener(window, "click", this.onExternalClick, { capture: true });

--- a/src/components/top_bar/number_formats_tool/number_formats_tool.ts
+++ b/src/components/top_bar/number_formats_tool/number_formats_tool.ts
@@ -1,8 +1,9 @@
 import { Component, useRef, useState } from "@odoo/owl";
 import { Action, createAction } from "../../../actions/action";
 import { formatNumberMenuItemSpec } from "../../../registries";
-import { DOMCoordinates, SpreadsheetChildEnv } from "../../../types";
+import { Rect, SpreadsheetChildEnv } from "../../../types";
 import { ActionButton } from "../../action_button/action_button";
+import { getBoundingRectAsPOJO } from "../../helpers/dom_helpers";
 import { ToolBarDropdownStore, useToolBarDropdownStore } from "../../helpers/top_bar_tool_hook";
 import { Menu } from "../../menu/menu";
 
@@ -12,7 +13,7 @@ interface Props {
 
 interface State {
   menuItems: Action[];
-  position: DOMCoordinates;
+  anchorRect: Rect;
 }
 
 export class NumberFormatsTool extends Component<Props, SpreadsheetChildEnv> {
@@ -24,7 +25,7 @@ export class NumberFormatsTool extends Component<Props, SpreadsheetChildEnv> {
 
   buttonRef = useRef("buttonRef");
   state: State = useState({
-    position: { x: 0, y: 0 },
+    anchorRect: { x: 0, y: 0, width: 0, height: 0 },
     menuItems: [],
   });
 
@@ -38,8 +39,7 @@ export class NumberFormatsTool extends Component<Props, SpreadsheetChildEnv> {
     } else {
       const menu = createAction(this.formatNumberMenuItemSpec);
       this.state.menuItems = menu.children(this.env).sort((a, b) => a.sequence - b.sequence);
-      const { x, y, height } = this.buttonRef.el!.getBoundingClientRect();
-      this.state.position = { x, y: y + height };
+      this.state.anchorRect = getBoundingRectAsPOJO(this.buttonRef.el!);
       this.topBarToolStore.openDropdown();
     }
   }

--- a/src/components/top_bar/number_formats_tool/number_formats_tool.xml
+++ b/src/components/top_bar/number_formats_tool/number_formats_tool.xml
@@ -6,6 +6,12 @@
       onClick.bind="toggleMenu"
       class="props.class"
     />
-    <Menu t-if="isActive" position="state.position" menuItems="state.menuItems" onClose="() => {}"/>
+    <Menu
+      t-if="isActive"
+      anchorRect="state.anchorRect"
+      menuItems="state.menuItems"
+      onClose="() => {}"
+      popoverPositioning="'BottomLeft'"
+    />
   </div>
 </templates>

--- a/src/components/top_bar/top_bar.ts
+++ b/src/components/top_bar/top_bar.ts
@@ -128,7 +128,7 @@ export class TopBar extends Component<Props, SpreadsheetChildEnv> {
   toolsCategories = topBarToolBarRegistry.getCategories();
 
   state: State = useState({
-    menuState: { isOpen: false, position: null, menuItems: [] },
+    menuState: { isOpen: false, anchorRect: null, menuItems: [] },
     invisibleToolsCategories: [],
     toolsPopoverState: { isOpen: false },
   });
@@ -252,9 +252,8 @@ export class TopBar extends Component<Props, SpreadsheetChildEnv> {
   private openMenu(menu: Action, ev: MouseEvent) {
     this.topBarToolStore.closeDropdowns();
     this.state.toolsPopoverState.isOpen = false;
-    const { left, top, height } = (ev.currentTarget as HTMLElement).getBoundingClientRect();
     this.state.menuState.isOpen = true;
-    this.state.menuState.position = { x: left, y: top + height };
+    this.state.menuState.anchorRect = getBoundingRectAsPOJO(ev.currentTarget as HTMLElement);
     this.state.menuState.menuItems = menu
       .children(this.env)
       .sort((a, b) => a.sequence - b.sequence);

--- a/src/components/top_bar/top_bar.xml
+++ b/src/components/top_bar/top_bar.xml
@@ -92,10 +92,11 @@
     </div>
     <Menu
       t-if="state.menuState.isOpen"
-      position="state.menuState.position"
+      anchorRect="state.menuState.anchorRect"
       menuItems="state.menuState.menuItems"
       onClose="() => this.closeMenus()"
       onMenuClicked="() => this.props.onClick()"
+      popoverPositioning="'BottomLeft'"
     />
     <Popover t-if="state.toolsPopoverState.isOpen" t-props="toolsPopoverProps">
       <div class="d-flex px-2 py-1 flex-wrap" style="background-color:white;">

--- a/tests/figures/figure_component.test.ts
+++ b/tests/figures/figure_component.test.ts
@@ -613,7 +613,7 @@ describe("figures", () => {
         await simulateClick(".o-figure-menu-item");
         const menuPopover = fixture.querySelector<HTMLElement>(".o-popover")!;
         expect(menuPopover.style.top).toBe(`${500 - 25}px`); // 25 : spreadsheet offset of the mockGetBoundingClientRect
-        expect(menuPopover.style.left).toBe(`${500 - 25 - MENU_WIDTH}px`);
+        expect(menuPopover.style.left).toBe(`${500 - 25}px`);
       });
 
       test(`figure menu position is correct when menu button position < MENU_WIDTH for ${type}`, async () => {
@@ -654,7 +654,7 @@ describe("figures", () => {
         await simulateClick(".o-figure-menu-item");
         const menuPopover = fixture.querySelector(".o-menu")?.parentElement;
         expect(menuPopover?.style.top).toBe(`${500 - 100}px`);
-        expect(menuPopover?.style.left).toBe(`${500 - 200 - MENU_WIDTH}px`);
+        expect(menuPopover?.style.left).toBe(`${500 - 200}px`);
       });
 
       test("Selecting a figure and hitting Ctrl does not unselect it", async () => {

--- a/tests/link/link_editor_component.test.ts
+++ b/tests/link/link_editor_component.test.ts
@@ -22,6 +22,7 @@ import { mockGetBoundingClientRect } from "../test_helpers/mock_helpers";
 
 mockGetBoundingClientRect({
   "o-spreadsheet": () => ({ top: 0, left: 0, height: 1000, width: 1000 }),
+  "o-special-link": () => ({ top: 100, left: 100, height: 50, width: 50 }),
 });
 
 describe("link editor component", () => {
@@ -156,6 +157,16 @@ describe("link editor component", () => {
     expect(labelInput().value).toBe("Sheet2");
     expect(urlInput().value).toBe("Sheet2");
     expect(urlInput().disabled).toBe(true);
+  });
+
+  test("special link menu position", async () => {
+    const sheetId = "42";
+    createSheet(model, { sheetId });
+    await openLinkEditor(model, "A1");
+    await simulateClick("button.o-special-link");
+    const popover = fixture.querySelector(".o-menu")!.closest<HTMLElement>(".o-popover")!;
+    expect(popover.style.top).toBe("100px");
+    expect(popover.style.left).toBe("150px");
   });
 
   test("label is changed to canonical form in model", async () => {


### PR DESCRIPTION
The `Menu` component was taking a `{x,y}` props for its positioning.
This is not enough to cover that cases when we want the menu to be
positioned around a rectangle when there is not enough space for the
menu to be displayed at the bottom left.

With this commit:
- the menu of `SelectMenu` no longer overlap with the select
   when the menu is displayed upwards
- the menu of `Figure` is positioned to the right of the figure and only flip
    to the left if there is not enough space
- the menu of `LinkEditor` is positioned to the right of the menu button instead of a random position

Task: [4655815](https://www.odoo.com/odoo/2328/tasks/4655815)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo