### PR TITLE
[FIX] xlsx: export reversed icon sets

### DIFF
--- a/src/xlsx/constants.ts
+++ b/src/xlsx/constants.ts
@@ -1,12 +1,13 @@
+import { IconSetType } from "../components/icons/icons";
 import { ExcelIconSet } from "../types/xlsx";
 
 /** In XLSX color format (no #)  */
 export const AUTO_COLOR = "000000";
 
-export const XLSX_ICONSET_MAP: Record<string, ExcelIconSet> = {
-  arrow: "3Arrows",
+export const XLSX_ICONSET_MAP: Record<IconSetType, ExcelIconSet> = {
+  arrows: "3Arrows",
   smiley: "3Symbols",
-  dot: "3TrafficLights1",
+  dots: "3TrafficLights1",
 };
 
 export const NAMESPACE = {

--- a/src/xlsx/functions/conditional_formatting.ts
+++ b/src/xlsx/functions/conditional_formatting.ts
@@ -1,3 +1,4 @@
+import { IconSetType, ICON_SETS } from "../../components/icons/icons";
 import { colorNumberString } from "../../helpers";
 import {
   CellIsRule,
@@ -225,10 +226,14 @@ function addIconSetRule(cf: ConditionalFormat, rule: IconSetRule): XMLString {
     const cfValueObjectNodes = cfValueObject.map(
       (attrs) => escapeXml/*xml*/ `<cfvo ${formatAttributes(attrs)} />`
     );
+    const iconSetAttrs: XMLAttributes = [["iconSet", getIconSet(rule.icons)]];
+    if (isIconSetReversed(rule.icons)) {
+      iconSetAttrs.push(["reverse", "1"]);
+    }
     conditionalFormats.push(escapeXml/*xml*/ `
       <conditionalFormatting sqref="${range}">
         <cfRule ${formatAttributes(ruleAttributes)}>
-          <iconSet iconSet="${getIconSet(rule.icons)}">
+          <iconSet ${formatAttributes(iconSetAttrs)}>
             ${joinXmlNodes(cfValueObjectNodes)}
           </iconSet>
         </cfRule>
@@ -250,11 +255,26 @@ function commonCfAttributes(cf: ConditionalFormat): XMLAttributes {
   ];
 }
 
+function isIconSetReversed(iconSet: IconSet): boolean {
+  const defaultIconSet = ICON_SETS[detectIconsType(iconSet)];
+  return iconSet.upper === defaultIconSet.bad && iconSet.lower === defaultIconSet.good;
+}
+
 function getIconSet(iconSet: IconSet): ExcelIconSet {
-  return XLSX_ICONSET_MAP[
-    Object.keys(XLSX_ICONSET_MAP).find((key) => iconSet.upper.toLowerCase().startsWith(key)) ||
-      "dots"
-  ];
+  return XLSX_ICONSET_MAP[detectIconsType(iconSet)];
+}
+
+/**
+ * Partial detection based on "upper" point only.
+ * We support any arbitrary icon in the set, while excel doesn't allow
+ * mixing icons from different types.
+ */
+function detectIconsType(iconSet: IconSet): IconSetType {
+  const type =
+    Object.keys(ICON_SETS).find((type: IconSetType) =>
+      Object.values(ICON_SETS[type]).includes(iconSet.upper)
+    ) || "dots";
+  return type as IconSetType;
 }
 
 function thresholdAttributes(

--- a/tests/__snapshots__/xlsx_export.test.ts.snap
+++ b/tests/__snapshots__/xlsx_export.test.ts.snap
@@ -9781,6 +9781,24 @@ Object {
             </iconSet>
         </cfRule>
     </conditionalFormatting>
+    <conditionalFormatting sqref=\\"B1:B5\\">
+        <cfRule priority=\\"1\\" stopIfTrue=\\"0\\" type=\\"iconSet\\">
+            <iconSet iconSet=\\"3Arrows\\" reverse=\\"1\\">
+                <cfvo type=\\"percent\\" val=\\"0\\"/>
+                <cfvo type=\\"percentile\\" val=\\"33\\" gte=\\"1\\"/>
+                <cfvo type=\\"percentile\\" val=\\"66\\" gte=\\"0\\"/>
+            </iconSet>
+        </cfRule>
+    </conditionalFormatting>
+    <conditionalFormatting sqref=\\"B1:B5\\">
+        <cfRule priority=\\"1\\" stopIfTrue=\\"0\\" type=\\"iconSet\\">
+            <iconSet iconSet=\\"3Arrows\\">
+                <cfvo type=\\"percent\\" val=\\"0\\"/>
+                <cfvo type=\\"percentile\\" val=\\"33\\" gte=\\"1\\"/>
+                <cfvo type=\\"percentile\\" val=\\"66\\" gte=\\"0\\"/>
+            </iconSet>
+        </cfRule>
+    </conditionalFormatting>
     <conditionalFormatting sqref=\\"A1:A5\\">
         <cfRule priority=\\"1\\" stopIfTrue=\\"0\\" type=\\"containsText\\" text=\\"1\\" operator=\\"containsText\\" dxfId=\\"1\\">
             <formula>

--- a/tests/xlsx_export.test.ts
+++ b/tests/xlsx_export.test.ts
@@ -595,6 +595,50 @@ describe("Test XLSX export", () => {
                 },
               },
               {
+                id: "reversed",
+                ranges: ["B1:B5"],
+                rule: {
+                  type: "IconSetRule",
+                  icons: {
+                    upper: "arrowBad",
+                    middle: "arrowNeutral",
+                    lower: "arrowGood",
+                  },
+                  lowerInflectionPoint: {
+                    operator: "ge",
+                    type: "percentile",
+                    value: "33",
+                  },
+                  upperInflectionPoint: {
+                    operator: "gt",
+                    type: "percentile",
+                    value: "66",
+                  },
+                },
+              },
+              {
+                id: "limitation - reversed but different types",
+                ranges: ["B1:B5"],
+                rule: {
+                  type: "IconSetRule",
+                  icons: {
+                    upper: "arrowBad",
+                    middle: "arrowNeutral",
+                    lower: "smileyGood",
+                  },
+                  lowerInflectionPoint: {
+                    operator: "ge",
+                    type: "percentile",
+                    value: "33",
+                  },
+                  upperInflectionPoint: {
+                    operator: "gt",
+                    type: "percentile",
+                    value: "66",
+                  },
+                },
+              },
+              {
                 id: "full style",
                 ranges: ["A1:A5"],
                 rule: {


### PR DESCRIPTION
## Description:

With this commit, we export reversed icon sets to excel file.

Note: if icons from different types are in the set (arrows and smileys), we export the default icon set (based on the upper point) as excel doesn't support mixing icons from different types.

opw: 4237776
opw: 4241567

Task: [4655950](https://www.odoo.com/odoo/2328/tasks/4655950)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo