### PR TITLE
[REL] 16.0.65

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@odoo/o-spreadsheet",
-  "version": "16.0.64",
+  "version": "16.0.65",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@odoo/o-spreadsheet",
-      "version": "16.0.64",
+      "version": "16.0.65",
       "license": "LGPL-3.0-or-later",
       "dependencies": {
         "@odoo/owl": "2.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@odoo/o-spreadsheet",
-  "version": "16.0.64",
+  "version": "16.0.65",
   "description": "A spreadsheet component",
   "main": "dist/o-spreadsheet.cjs.js",
   "browser": "dist/o-spreadsheet.iife.js",


### PR DESCRIPTION
### Contains the following commits:

https://github.com/odoo/o-spreadsheet/commit/eed70cb89 [FIX] clipboard: cross-sheet cut/paste is broken for merges [Task: 3905618](https://www.odoo.com/odoo/2328/tasks/3905618)
https://github.com/odoo/o-spreadsheet/commit/db9055ce3 [FIX] css: put `h-100` in o-spreadsheet [Task: 4652289](https://www.odoo.com/odoo/2328/tasks/4652289)
https://github.com/odoo/o-spreadsheet/commit/8ea8decd9 [FIX] edition: escape closes the composer [Task: 4646699](https://www.odoo.com/odoo/2328/tasks/4646699)

Task: 0
