### PR TITLE
[FIX] xlsx: prevent unwanted legend when importing chart from excel

### DIFF
--- a/src/xlsx/conversion/conversion_maps.ts
+++ b/src/xlsx/conversion/conversion_maps.ts
@@ -151,6 +151,7 @@ export const ICON_SET_CONVERSION_MAP: Record<ExcelIconSet, IconSetType | undefin
 
 /** Map between legend position in XLSX file and human readable position  */
 export const DRAWING_LEGEND_POSITION_CONVERSION_MAP: Record<string, LegendPosition> = {
+  none: "none",
   b: "bottom",
   t: "top",
   l: "left",

--- a/src/xlsx/extraction/chart_extractor.ts
+++ b/src/xlsx/extraction/chart_extractor.ts
@@ -48,7 +48,7 @@ export class XlsxChartExtractor extends XlsxBaseExtractor {
           legendPosition:
             DRAWING_LEGEND_POSITION_CONVERSION_MAP[
               this.extractChildAttr(rootChartElement, "c:legendPos", "val", {
-                default: "b",
+                default: "none",
               }).asString()
             ],
           stacked: barChartGrouping === "stacked",

--- a/tests/__xlsx__/xlsx_demo_data/xl/charts/chart2.xml
+++ b/tests/__xlsx__/xlsx_demo_data/xl/charts/chart2.xml
@@ -386,7 +386,7 @@
       </c:spPr>
     </c:plotArea>
     <c:legend>
-      <c:legendPos val="t"/>
+      <c:legendPos val="r"/>
       <c:overlay val="0"/>
       <c:txPr>
         <a:bodyPr/>

--- a/tests/__xlsx__/xlsx_demo_data/xl/charts/chart3.xml
+++ b/tests/__xlsx__/xlsx_demo_data/xl/charts/chart3.xml
@@ -576,7 +576,7 @@
       </c:spPr>
     </c:plotArea>
     <c:legend>
-      <c:legendPos val="t"/>
+      <c:legendPos val="b"/>
       <c:overlay val="0"/>
       <c:txPr>
         <a:bodyPr/>

--- a/tests/__xlsx__/xlsx_demo_data/xl/charts/chart4.xml
+++ b/tests/__xlsx__/xlsx_demo_data/xl/charts/chart4.xml
@@ -323,25 +323,6 @@
         </a:solidFill>
       </c:spPr>
     </c:plotArea>
-    <c:legend>
-      <c:legendPos val="t"/>
-      <c:overlay val="0"/>
-      <c:txPr>
-        <a:bodyPr/>
-        <a:lstStyle/>
-        <a:p>
-          <a:pPr lvl="0">
-            <a:defRPr sz="1000" b="0" i="0">
-              <a:solidFill>
-                <a:srgbClr val="000000"/>
-              </a:solidFill>
-              <a:latin typeface="+mn-lt"/>
-            </a:defRPr>
-          </a:pPr>
-          <a:endParaRPr lang="en-US"/>
-        </a:p>
-      </c:txPr>
-    </c:legend>
     <c:plotVisOnly val="1"/>
     <c:dispBlanksAs val="zero"/>
     <c:showDLblsOverMax val="1"/>

--- a/tests/xlsx_import.test.ts
+++ b/tests/xlsx_import.test.ts
@@ -756,6 +756,19 @@ describe("Import xlsx data", () => {
     }
   });
 
+  test.each([
+    ["line chart", "top"],
+    ["bar chart", "right"],
+    ["doughnut chart", "bottom"],
+    ["pie chart", "none"],
+  ])("Can import %s charts with correct legend position", (chartTitle, chartLegendPosition) => {
+    const testSheet = getWorkbookSheet("jestCharts", convertedData)!;
+    const figure = testSheet.figures.find((figure) => figure.data.title === chartTitle)!;
+    const chartData = figure.data as BarChartDefinition;
+    expect(chartData.title).toEqual(chartTitle);
+    expect(chartData.legendPosition).toEqual(chartLegendPosition);
+  });
+
   describe("Misc tests", () => {
     test("Newlines characters in strings are removed", () => {
       const testSheet = getWorkbookSheet("jestMiscTest", convertedData)!;


### PR DESCRIPTION
When creating an XLSX file with a chart that has no legend, the legend unexpectedly appears after importing the file. This issue occurs due to the default behavior of the import process, which adds a bottom legend even if it was not initially set.

Task: [4632987](https://www.odoo.com/odoo/2328/tasks/4632987)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo