### PR TITLE
[FIX] color: `toHex` don't work with alpha = 0

### DIFF
--- a/src/helpers/color.ts
+++ b/src/helpers/color.ts
@@ -130,7 +130,10 @@ function rgbaStringToHex(color: Color): Color {
     throw new Error("invalid color");
   } else if (stringVals.length === 4) {
     const alpha = parseFloat(stringVals.pop() || "1");
-    alphaHex = Math.round((alpha || 1) * 255);
+    if (isNaN(alpha)) {
+      throw new Error("invalid alpha value");
+    }
+    alphaHex = Math.round(alpha * 255);
   }
   const vals = stringVals.map((val) => parseInt(val, 10));
   if (alphaHex !== 255) {

--- a/tests/colors/color_helpers.test.ts
+++ b/tests/colors/color_helpers.test.ts
@@ -64,6 +64,12 @@ const testColors: { input: Color; hex: Color; rgba: RGBA; hsla: HSLA }[] = [
     rgba: { a: 0.502, r: 30, g: 80, b: 16 },
     hsla: { a: 0.502, h: 107, s: 66.67, l: 18.8 },
   },
+  {
+    input: "rgba(0, 0, 0, 0)",
+    hex: "#00000000",
+    rgba: { a: 0, r: 0, g: 0, b: 0 },
+    hsla: { a: 0, h: 0, s: 0, l: 0 },
+  },
 ];
 
 describe("toHex", () => {
@@ -107,6 +113,7 @@ describe("hslaToRGBA", () => {
 describe("isColorValid", () => {
   test("valid colors", () => {
     expect(isColorValid("rgb(255, 255, 255)")).toBe(true);
+    expect(isColorValid("rgba(255, 255, 255, 1)")).toBe(true);
     expect(isColorValid("#000")).toBe(true);
     expect(isColorValid("#000000")).toBe(true);
   });
@@ -115,6 +122,10 @@ describe("isColorValid", () => {
     expect(isColorValid("")).toBe(false);
     expect(isColorValid("#")).toBe(false);
     expect(isColorValid("rgb(256, 255, 255)")).toBe(false);
+    expect(isColorValid("rgb(255, 280, 255)")).toBe(false);
+    expect(isColorValid("rgb(256, 255, -1)")).toBe(false);
+    expect(isColorValid("rgba(256, 255, 255, 6)")).toBe(false);
+    expect(isColorValid("rgba(256, 255, 255, -0.1)")).toBe(false);
     expect(isColorValid("#azazaz")).toBe(false);
   });
 });


### PR DESCRIPTION
## Description

When converting `rgba(0, 0, 0, 0)` to hex, the result should be `#00000000` but it was `#000000FF`. The code contained `alpha || 1`, which is wrong if the alpha is 0.

Task: [4660317](https://www.odoo.com/odoo/2328/tasks/4660317)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo