### PR TITLE
[FIX] filter: fix horrible performances with huge data filters

### DIFF
--- a/src/components/filters/filter_menu/filter_menu.ts
+++ b/src/components/filters/filter_menu/filter_menu.ts
@@ -174,26 +174,30 @@ export class FilterMenu extends Component<Props, SpreadsheetChildEnv> {
       position.col,
       position.row
     );
+    const normalizedFilteredValues = new Set(filterValues.map(toLowerCase));
 
-    const strValues = [...cellValues, ...filterValues];
-    const normalizedFilteredValues = filterValues.map(toLowerCase);
+    const set = new Set<string>();
+    const values: (Value & { normalizedValue: string })[] = [];
+    const addValue = (value: string) => {
+      const normalizedValue = toLowerCase(value);
+      if (!set.has(normalizedValue)) {
+        values.push({
+          string: value || "",
+          checked: !normalizedFilteredValues.has(normalizedValue),
+          normalizedValue,
+        });
+        set.add(normalizedValue);
+      }
+    };
+    cellValues.forEach(addValue);
+    filterValues.forEach(addValue);
 
-    // Set with lowercase values to avoid duplicates
-    const normalizedValues = [...new Set(strValues.map(toLowerCase))];
-
-    const sortedValues = normalizedValues.sort((val1, val2) =>
-      val1.localeCompare(val2, undefined, { numeric: true, sensitivity: "base" })
+    return values.sort((val1, val2) =>
+      val1.normalizedValue.localeCompare(val2.normalizedValue, undefined, {
+        numeric: true,
+        sensitivity: "base",
+      })
     );
-
-    return sortedValues.map((normalizedValue) => {
-      const checked =
-        normalizedFilteredValues.findIndex((filteredValue) => filteredValue === normalizedValue) ===
-        -1;
-      return {
-        checked,
-        string: strValues.find((val) => toLowerCase(val) === normalizedValue) || "",
-      };
-    });
   }
 
   checkValue(value: Value) {

--- a/src/plugins/ui/filter_evaluation.ts
+++ b/src/plugins/ui/filter_evaluation.ts
@@ -197,9 +197,10 @@ export class FilterEvaluationPlugin extends UIPlugin {
       if (hiddenRows.has(filter.zoneWithHeaders.top)) continue;
       const filteredValues = this.filterValues[sheetId]?.[filter.id]?.map(toLowerCase);
       if (!filteredValues || !filter.filteredZone) continue;
+      const filteredValuesSet = new Set(filteredValues);
       for (let row = filter.filteredZone.top; row <= filter.filteredZone.bottom; row++) {
         const value = this.getCellValueAsString(sheetId, filter.col, row);
-        if (filteredValues.includes(value)) {
+        if (filteredValuesSet.has(value)) {
           hiddenRows.add(row);
         }
       }


### PR DESCRIPTION
## Description

On a spreadsheet with 10,000 rows, opening the filter menu and filtering all the values is really slow. This commit improves the performance a bit.

On a data filter with 10,000 rows:
- `getFilterValues` (when opening filter menu): ~1000ms => ~70ms
- `updateHiddenRows` (when filtering all values): ~543ms => ~8ms

Note that the filter menu still takes a while to open and is laggy. It's because we create a HTML list with 10,000 elements, which is very slow. Fixing this would require big changes in the filter menu component, so it won't be done in stable.

Task: [4658998](https://www.odoo.com/odoo/2328/tasks/4658998)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo