### PR TITLE
[FIX] composer: prevent autocomplete on unknown characters in composer

### DIFF
--- a/src/components/composer/composer/abstract_composer_store.ts
+++ b/src/components/composer/composer/abstract_composer_store.ts
@@ -1,3 +1,4 @@
+import { isSheetAutocomplete } from "../../../formulas";
 import { composerTokenize, EnrichedToken } from "../../../formulas/composer_tokenizer";
 import { POSTFIX_UNARY_OPERATORS } from "../../../formulas/tokenizer";
 import { functionRegistry } from "../../../functions";
@@ -713,9 +714,11 @@ export abstract class AbstractComposerStore extends SpreadsheetStore {
 
   get autocompleteProvider(): AutoCompleteProvider | undefined {
     const content = this.currentContent;
-    const tokenAtCursor = isFormula(content)
-      ? this.tokenAtCursor
-      : { type: "STRING", value: content };
+    const tokenAtCursor =
+      (isFormula(content) && !this.currentTokens.some((token) => token.type === "UNKNOWN")) ||
+      isSheetAutocomplete(this.tokenAtCursor)
+        ? this.tokenAtCursor
+        : { type: "STRING", value: content };
     if (
       this.editionMode === "inactive" ||
       !tokenAtCursor ||

--- a/src/components/composer/composer/composer.ts
+++ b/src/components/composer/composer/composer.ts
@@ -3,6 +3,7 @@ import { NEWLINE, PRIMARY_BUTTON_BG, SCROLLBAR_WIDTH } from "../../../constants"
 import { functionRegistry } from "../../../functions/index";
 import { clip, isFormula, setColorAlpha } from "../../../helpers/index";
 
+import { isSheetAutocomplete } from "../../../formulas";
 import { EnrichedToken } from "../../../formulas/composer_tokenizer";
 import { argTargeting } from "../../../functions/arguments";
 import { Store, useLocalStore, useStore } from "../../../store_engine";
@@ -743,8 +744,14 @@ export class Composer extends Component<CellComposerProps, SpreadsheetChildEnv> 
     }
     const token = this.props.composerStore.tokenAtCursor;
 
-    if (isFormula(composerStore.currentContent) && token && token.type !== "SYMBOL") {
-      const tokenContext = token.functionContext;
+    if (
+      (isFormula(composerStore.currentContent) &&
+        token &&
+        token.type !== "SYMBOL" &&
+        !this.props.composerStore.currentTokens.some((t) => t.type === "UNKNOWN")) ||
+      isSheetAutocomplete(this.props.composerStore.tokenAtCursor)
+    ) {
+      const tokenContext = token?.functionContext;
       const parentFunction = tokenContext?.parent.toUpperCase();
       if (
         tokenContext &&

--- a/src/formulas/helpers.ts
+++ b/src/formulas/helpers.ts
@@ -1,4 +1,5 @@
 import { functionRegistry } from "../functions";
+import { EnrichedToken } from "./composer_tokenizer";
 import { AST, ASTFuncall, iterateAstNodes, parseTokens } from "./parser";
 import { Token } from "./tokenizer";
 
@@ -37,4 +38,11 @@ function getFunctionsFromAST(ast: AST, functionNames: string[]) {
       functionName: node.value.toUpperCase(),
       args: node.args,
     }));
+}
+
+export function isSheetAutocomplete(tokenAtCursor: EnrichedToken | undefined): boolean {
+  return (
+    (tokenAtCursor?.type === "SYMBOL" || tokenAtCursor?.type === "UNKNOWN") &&
+    tokenAtCursor?.value.startsWith("'")
+  );
 }

--- a/tests/composer/auto_complete/function_auto_complete_store.test.ts
+++ b/tests/composer/auto_complete/function_auto_complete_store.test.ts
@@ -15,4 +15,22 @@ describe("Function auto complete", () => {
     autoComplete?.selectProposal(proposals![0].text);
     expect(composer.currentContent).toEqual("=SUM(");
   });
+
+  test("starting with unknown character should stop autocomplete even when adding a valid character", () => {
+    const { store: composer, model } = makeStore(CellComposerStore);
+    setCellContent(model, "A1", "=éSUM");
+    composer.startEdition();
+    const autoComplete = composer.autocompleteProvider;
+    const proposals = autoComplete?.proposals;
+    expect(proposals).toBeUndefined();
+  });
+
+  test("adding an unknown character in the middle of a function should stop autocomplete", () => {
+    const { store: composer, model } = makeStore(CellComposerStore);
+    setCellContent(model, "A1", "=SéSUM");
+    composer.startEdition();
+    const autoComplete = composer.autocompleteProvider;
+    const proposals = autoComplete?.proposals;
+    expect(proposals).toBeUndefined();
+  });
 });


### PR DESCRIPTION
Before this commit, the composer incorrectly triggered autocomplete suggestions even when unknown or special characters (e.g., "é") were typed. This led to irrelevant suggestions and formula errors when selecting an option.

This commit ensures that unknown characters are properly considered, preventing autocomplete from being triggered in such cases, improving the reliability of the function autocomplete.

Task: [4652661](https://www.odoo.com/odoo/2328/tasks/4652661)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo