### PR TITLE
[FIX] composer: prevent autocomplete on unknown characters in composer

### DIFF
--- a/src/formulas/tokenizer.ts
+++ b/src/formulas/tokenizer.ts
@@ -136,7 +136,13 @@ function tokenizeString(chars: string[]): Token | null {
   return null;
 }
 
-const separatorRegexp = /\w|\.|!|\$/;
+/**
+  - \p{L} is for any letter (from any language)
+  - \p{N} is for any number
+  - the u flag at the end is for unicode, which enables the `\p{...}` syntax
+ */
+const unicodeSymbolCharRegexp = /\p{L}|\p{N}|_|\.|!|\$/u;
+const SYMBOL_CHARS = new Set("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_.!$");
 
 /**
  * A "Symbol" is just basically any word-like element that can appear in a
@@ -177,7 +183,7 @@ function tokenizeSymbol(chars: string[]): Token | null {
       };
     }
   }
-  while (chars[0] && chars[0].match(separatorRegexp)) {
+  while (chars[0] && (SYMBOL_CHARS.has(chars[0]) || chars[0].match(unicodeSymbolCharRegexp))) {
     result += chars.shift();
   }
   if (result.length) {

--- a/tests/components/spreadsheet.test.ts
+++ b/tests/components/spreadsheet.test.ts
@@ -419,6 +419,18 @@ describe("Composer interactions", () => {
     expect(fixture.querySelector(".o-grid .o-autocomplete-dropdown")).toBeNull();
   });
 
+  test("autocomplete disappears when there is no match with an unknown character", async () => {
+    await typeInComposerGrid("=éSUM");
+    await nextTick();
+    expect(fixture.querySelector(".o-grid .o-autocomplete-dropdown")).toBeNull();
+  });
+
+  test("autocomplete disappear when typing an unknown character", async () => {
+    await typeInComposerGrid("=SéSUM");
+    await nextTick();
+    expect(fixture.querySelector(".o-grid .o-autocomplete-dropdown")).toBeNull();
+  });
+
   test("focus top bar composer does not resize grid composer when autocomplete is displayed", async () => {
     document.activeElement!.dispatchEvent(
       new KeyboardEvent("keydown", { key: "Enter", bubbles: true })

--- a/tests/formulas/tokenizer.test.ts
+++ b/tests/formulas/tokenizer.test.ts
@@ -246,10 +246,38 @@ describe("tokenizer", () => {
     ]);
   });
 
-  test("Unknown characters", () => {
+  test("non-ascii characters", () => {
     expect(tokenize("=ù4")).toEqual([
       { type: "OPERATOR", value: "=" },
-      { type: "UNKNOWN", value: "ù" },
+      { type: "SYMBOL", value: "ù4" },
+    ]);
+    expect(tokenize("=jai_nommé_mon_range")).toEqual([
+      { type: "OPERATOR", value: "=" },
+      { type: "SYMBOL", value: "jai_nommé_mon_range" },
+    ]);
+    expect(tokenize("=ßabc123")).toEqual([
+      { type: "OPERATOR", value: "=" },
+      { type: "SYMBOL", value: "ßabc123" },
+    ]);
+    expect(tokenize("=ぁ72")).toEqual([
+      { type: "OPERATOR", value: "=" },
+      { type: "SYMBOL", value: "ぁ72" },
+    ]);
+    expect(tokenize("=ñôtÁFñ(5, wr_öñg) + šymbøl +4")).toEqual([
+      { type: "OPERATOR", value: "=" },
+      { type: "SYMBOL", value: "ñôtÁFñ" },
+      { type: "LEFT_PAREN", value: "(" },
+      { type: "NUMBER", value: "5" },
+      { type: "COMMA", value: "," },
+      { type: "SPACE", value: " " },
+      { type: "SYMBOL", value: "wr_öñg" },
+      { type: "RIGHT_PAREN", value: ")" },
+      { type: "SPACE", value: " " },
+      { type: "OPERATOR", value: "+" },
+      { type: "SPACE", value: " " },
+      { type: "SYMBOL", value: "šymbøl" },
+      { type: "SPACE", value: " " },
+      { type: "OPERATOR", value: "+" },
       { type: "NUMBER", value: "4" },
     ]);
   });


### PR DESCRIPTION
Before this commit, the composer incorrectly triggered autocomplete suggestions even when unknown or special characters (e.g., "é") were typed. This led to irrelevant suggestions and formula errors when selecting an option.

This commit ensures that unknown characters are properly considered, preventing autocomplete from being triggered in such cases, improving the reliability of the function autocomplete.

Task: [4652661](https://www.odoo.com/odoo/2328/tasks/4652661)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo