### PR TITLE
[FIX] pie chart: legend going dark

### DIFF
--- a/src/helpers/figures/charts/runtime/chartjs_legend.ts
+++ b/src/helpers/figures/charts/runtime/chartjs_legend.ts
@@ -69,22 +69,20 @@ export function getPieChartLegend(
   const { dataSetsValues } = args;
   const dataSetsLength = Math.max(0, ...dataSetsValues.map((ds) => ds?.data?.length ?? 0));
   const colors = getPieColors(new ColorGenerator(dataSetsLength), dataSetsValues);
+  const fontColor = chartFontColor(definition.background);
   return {
     ...getLegendDisplayOptions(definition, args),
     labels: {
-      color: chartFontColor(definition.background),
       usePointStyle: true,
-      //@ts-ignore
       generateLabels: (c) =>
-        //@ts-ignore
-        c.data.labels.map((label, index) => ({
-          text: label,
+        c.data.labels?.map((label, index) => ({
+          text: String(label),
           strokeStyle: colors[index],
           fillStyle: colors[index],
           pointStyle: "rect",
-          hidden: false,
           lineWidth: 2,
-        })),
+          fontColor,
+        })) || [],
       filter: (legendItem, data) => {
         return "datasetIndex" in legendItem
           ? !data.datasets[legendItem.datasetIndex!].hidden

--- a/tests/figures/chart/pie_chart_plugin.test.ts
+++ b/tests/figures/chart/pie_chart_plugin.test.ts
@@ -52,6 +52,7 @@ describe("pie chart", () => {
         labelRange: "Sheet1!A1:A2",
         dataSetsHaveTitle: false,
         type: "pie",
+        background: "#000000",
       },
       "1"
     );
@@ -59,18 +60,18 @@ describe("pie chart", () => {
       {
         text: "P1",
         fillStyle: "#4EA7F2",
-        hidden: false,
         lineWidth: 2,
         pointStyle: "rect",
         strokeStyle: "#4EA7F2",
+        fontColor: "#FFFFFF",
       },
       {
         text: "P2",
         fillStyle: "#EA6175",
-        hidden: false,
         lineWidth: 2,
         pointStyle: "rect",
         strokeStyle: "#EA6175",
+        fontColor: "#FFFFFF",
       },
     ]);
   });


### PR DESCRIPTION
## Description

The legend font color of pie charts does not change color based on the chart's background color. If the chart background is black, the legend becomes invisible.

This commit also removes some ts-ignore.

Task: [4663996](https://www.odoo.com/odoo/2328/tasks/4663996)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo