### PR TITLE
[FIX] fingerprints: remove useless replace

### DIFF
--- a/src/stores/formula_fingerprints_store.ts
+++ b/src/stores/formula_fingerprints_store.ts
@@ -205,12 +205,7 @@ export class FormulaFingerprintStore extends SpreadsheetStore {
         }
       }
     }
-    // removes the index placeholders from the normalized formula
-    // =|N0|+|N1|+|N0| -> =|N|+|N|+|N|
-    const normalizedFormula = cell.compiledFormula.normalizedFormula.replace(
-      /(|\w)(\d)(|)/g,
-      "$1$3"
-    );
+    const normalizedFormula = cell.compiledFormula.normalizedFormula;
     return hash(fingerprintVector) + normalizedFormula;
   }
 


### PR DESCRIPTION
Since c99697d8b642, the normalized formula no longer contains the indexes. The regexp removed in this commit is useless.

Task: 0

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo