### PR TITLE
[FIX/PERF] Charts: fix loop condition

### DIFF
--- a/src/helpers/charts/chart_ui_common.ts
+++ b/src/helpers/charts/chart_ui_common.ts
@@ -134,7 +134,8 @@ export function getChartLabelValues(
       };
     }
   } else if (dataSets.length === 1) {
-    for (let i = 0; i < getData(getters, dataSets[0]).length; i++) {
+    const dataLength = getData(getters, dataSets[0]).length;
+    for (let i = 0; i < dataLength; i++) {
       labels.formattedValues.push("");
       labels.values.push("");
     }


### PR DESCRIPTION
The "getChartLabelValues" helper would refetch all the chart data at each iteration of a loop for no reason.

Task: 4675166

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo