### PR TITLE
[REF] range: Range is a POJO

### DIFF
--- a/src/clipboard_handlers/tables_clipboard.ts
+++ b/src/clipboard_handlers/tables_clipboard.ts
@@ -70,7 +70,7 @@ export class TableClipboardHandler extends AbstractCellClipboardHandler<
         ) {
           copiedTablesIds.add(table.id);
           copiedTable = {
-            range: coreTable.range.rangeData,
+            range: this.getters.getRangeData(coreTable.range),
             config: coreTable.config,
             type: coreTable.type,
           };

--- a/src/components/composer/composer/abstract_composer_store.ts
+++ b/src/components/composer/composer/abstract_composer_store.ts
@@ -489,7 +489,7 @@ export abstract class AbstractComposerStore extends SpreadsheetStore {
 
   private getRangeReference(range: Range, fixedParts: Readonly<RangePart[]>) {
     let _fixedParts = [...fixedParts];
-    const newRange = range.clone({ parts: _fixedParts });
+    const newRange = { ...range, parts: _fixedParts };
     return this.getters.getSelectionRangeString(newRange, this.sheetId);
   }
 

--- a/src/components/selection_input/selection_input_store.ts
+++ b/src/components/selection_input/selection_input_store.ts
@@ -85,7 +85,7 @@ export class SelectionInputStore extends SpreadsheetStore {
       if (previousXc) {
         parts = this.getters.getRangeFromSheetXC(inputSheetId, previousXc).parts;
       }
-      const newRange = range.clone({ parts });
+      const newRange = { ...range, parts };
       const xc = this.getters.getSelectionRangeString(newRange, inputSheetId);
       this.setRange(this.focusedRangeIndex, [xc]);
     }

--- a/src/components/side_panel/table_panel/table_panel.ts
+++ b/src/components/side_panel/table_panel/table_panel.ts
@@ -94,7 +94,7 @@ export class TablePanel extends Component<Props, SpreadsheetChildEnv> {
     const result = this.env.model.dispatch("UPDATE_TABLE", {
       sheetId,
       zone: this.props.table.range.zone,
-      newTableRange: uiTable.range.rangeData,
+      newTableRange: this.env.model.getters.getRangeData(uiTable.range),
       tableType: newTableType,
     });
     const updatedTable = this.env.model.getters.getCoreTable(getTableTopLeft(this.props.table));
@@ -154,7 +154,7 @@ export class TablePanel extends Component<Props, SpreadsheetChildEnv> {
     const result = this.env.model.dispatch(cmdToCall, {
       sheetId,
       zone: this.props.table.range.zone,
-      newTableRange: newRange.rangeData,
+      newTableRange: this.env.model.getters.getRangeData(newRange),
       tableType: this.getNewTableType(newRange.zone),
     });
 

--- a/src/helpers/figures/charts/chart_common.ts
+++ b/src/helpers/figures/charts/chart_common.ts
@@ -31,7 +31,7 @@ import { CellErrorType } from "../../../types/errors";
 import { ColorGenerator, relativeLuminance } from "../../color";
 import { formatValue } from "../../format/format";
 import { isDefined, largeMax } from "../../misc";
-import { duplicateRangeInDuplicatedSheet } from "../../range";
+import { createRange, duplicateRangeInDuplicatedSheet } from "../../range";
 import { rangeReference } from "../../references";
 import { getZoneArea, isFullRow, toUnboundedZone, zoneToDimension, zoneToXc } from "../../zones";
 
@@ -260,7 +260,7 @@ export function toExcelDataset(getters: CoreGetters, ds: DataSet): ExcelChartDat
     }
   }
 
-  const dataRange = ds.dataRange.clone({ zone: dataZone });
+  const dataRange = createRange({ ...ds.dataRange, zone: dataZone }, getters.getSheetSize);
   let label = {};
   if (ds.customLabel) {
     label = {
@@ -294,7 +294,7 @@ export function toExcelLabelRange(
   if (shouldRemoveFirstLabel && labelRange.zone.bottom > labelRange.zone.top) {
     zone.top = zone.top + 1;
   }
-  const range = labelRange.clone({ zone });
+  const range = createRange({ ...labelRange, zone: zone }, getters.getSheetSize);
   return getters.getRangeString(range, "forceSheetReference", { useBoundedReference: true });
 }
 

--- a/src/helpers/formulas.ts
+++ b/src/helpers/formulas.ts
@@ -2,9 +2,8 @@ import { rangeTokenize } from "../formulas";
 import { Range, RangeAdapter, UID } from "../types";
 import { CellErrorType } from "../types/errors";
 import { concat } from "./misc";
-import { createInvalidRange, createRange, getRangeParts, getRangeString } from "./range";
+import { createInvalidRange, createRangeFromXc, getRangeString } from "./range";
 import { rangeReference, splitReference } from "./references";
-import { toUnboundedZone } from "./zones";
 
 export function adaptFormulaStringRanges(
   defaultSheetId: string,
@@ -82,10 +81,7 @@ function getRange(sheetXC: string, sheetId: UID): Range {
     }
   }
 
-  const unboundedZone = toUnboundedZone(xc);
-  const parts = getRangeParts(xc, unboundedZone);
+  const rangeInterface = { prefixSheet, xc, sheetId, invalidSheetName: "" };
 
-  const rangeInterface = { prefixSheet, zone: unboundedZone, sheetId, invalidSheetName: "", parts };
-
-  return createRange(rangeInterface, defaultGetSheetSize);
+  return createRangeFromXc(rangeInterface, defaultGetSheetSize);
 }

--- a/src/helpers/formulas.ts
+++ b/src/helpers/formulas.ts
@@ -1,8 +1,8 @@
 import { rangeTokenize } from "../formulas";
-import { Range, RangeAdapter, UID, ZoneDimension } from "../types";
+import { Range, RangeAdapter, UID } from "../types";
 import { CellErrorType } from "../types/errors";
 import { concat } from "./misc";
-import { createRange, getRangeParts, getRangeString } from "./range";
+import { createInvalidRange, createRange, getRangeParts, getRangeString } from "./range";
 import { rangeReference, splitReference } from "./references";
 import { toUnboundedZone } from "./zones";
 
@@ -69,7 +69,7 @@ function defaultGetSheetSize(sheetId: UID) {
 
 function getRange(sheetXC: string, sheetId: UID): Range {
   if (!rangeReference.test(sheetXC)) {
-    return invalidRange(sheetXC, defaultGetSheetSize);
+    return createInvalidRange(sheetXC);
   }
 
   let sheetName: string | undefined;
@@ -88,17 +88,4 @@ function getRange(sheetXC: string, sheetId: UID): Range {
   const rangeInterface = { prefixSheet, zone: unboundedZone, sheetId, invalidSheetName: "", parts };
 
   return createRange(rangeInterface, defaultGetSheetSize);
-}
-
-function invalidRange(sheetXC: string, getSheetSize: (sheetId: UID) => ZoneDimension): Range {
-  return createRange(
-    {
-      sheetId: "",
-      zone: { left: -1, top: -1, right: -1, bottom: -1 },
-      parts: [],
-      invalidXc: sheetXC,
-      prefixSheet: false,
-    },
-    getSheetSize
-  );
 }

--- a/src/helpers/formulas.ts
+++ b/src/helpers/formulas.ts
@@ -4,7 +4,7 @@ import { CellErrorType } from "../types/errors";
 import { concat } from "./misc";
 import { getRangeString, RangeImpl } from "./range";
 import { rangeReference, splitReference } from "./references";
-import { toUnboundedZone } from "./zones";
+import { boundUnboundedZone, toUnboundedZone } from "./zones";
 
 export function adaptFormulaStringRanges(
   defaultSheetId: string,
@@ -83,9 +83,10 @@ function getRange(sheetXC: string, sheetId: UID): Range {
   }
 
   const unboundedZone = toUnboundedZone(xc);
+  const zone = boundUnboundedZone(unboundedZone, defaultGetSheetSize(sheetId));
   const parts = RangeImpl.getRangeParts(xc, unboundedZone);
 
-  const rangeInterface = { prefixSheet, unboundedZone, sheetId, invalidSheetName: "", parts };
+  const rangeInterface = { prefixSheet, unboundedZone, zone, sheetId, invalidSheetName: "", parts };
 
   return new RangeImpl(rangeInterface, defaultGetSheetSize).orderZone();
 }
@@ -95,6 +96,7 @@ function invalidRange(sheetXC: string, getSheetSize: (sheetId: UID) => ZoneDimen
     {
       sheetId: "",
       unboundedZone: { left: -1, top: -1, right: -1, bottom: -1 },
+      zone: { left: -1, top: -1, right: -1, bottom: -1 },
       parts: [],
       invalidXc: sheetXC,
       prefixSheet: false,

--- a/src/helpers/formulas.ts
+++ b/src/helpers/formulas.ts
@@ -2,7 +2,7 @@ import { rangeTokenize } from "../formulas";
 import { Range, RangeAdapter, UID, ZoneDimension } from "../types";
 import { CellErrorType } from "../types/errors";
 import { concat } from "./misc";
-import { RangeImpl } from "./range";
+import { getRangeString, RangeImpl } from "./range";
 import { rangeReference, splitReference } from "./references";
 import { toUnboundedZone } from "./zones";
 
@@ -53,7 +53,7 @@ export function adaptStringRange(
     return sheetXC;
   }
 
-  const newSheetXC = change.range.getRangeString(defaultSheetId, getSheetNameGetter(applyChange));
+  const newSheetXC = getRangeString(change.range, defaultSheetId, getSheetNameGetter(applyChange));
   return newSheetXC === CellErrorType.InvalidReference ? sheetXC : newSheetXC;
 }
 

--- a/src/helpers/formulas.ts
+++ b/src/helpers/formulas.ts
@@ -2,7 +2,7 @@ import { rangeTokenize } from "../formulas";
 import { Range, RangeAdapter, UID, ZoneDimension } from "../types";
 import { CellErrorType } from "../types/errors";
 import { concat } from "./misc";
-import { createRange, getRangeString, RangeImpl } from "./range";
+import { createRange, getRangeParts, getRangeString } from "./range";
 import { rangeReference, splitReference } from "./references";
 import { toUnboundedZone } from "./zones";
 
@@ -83,7 +83,7 @@ function getRange(sheetXC: string, sheetId: UID): Range {
   }
 
   const unboundedZone = toUnboundedZone(xc);
-  const parts = RangeImpl.getRangeParts(xc, unboundedZone);
+  const parts = getRangeParts(xc, unboundedZone);
 
   const rangeInterface = { prefixSheet, zone: unboundedZone, sheetId, invalidSheetName: "", parts };
 

--- a/src/helpers/formulas.ts
+++ b/src/helpers/formulas.ts
@@ -2,9 +2,9 @@ import { rangeTokenize } from "../formulas";
 import { Range, RangeAdapter, UID, ZoneDimension } from "../types";
 import { CellErrorType } from "../types/errors";
 import { concat } from "./misc";
-import { getRangeString, RangeImpl } from "./range";
+import { createRange, getRangeString, RangeImpl } from "./range";
 import { rangeReference, splitReference } from "./references";
-import { boundUnboundedZone, toUnboundedZone } from "./zones";
+import { toUnboundedZone } from "./zones";
 
 export function adaptFormulaStringRanges(
   defaultSheetId: string,
@@ -83,19 +83,17 @@ function getRange(sheetXC: string, sheetId: UID): Range {
   }
 
   const unboundedZone = toUnboundedZone(xc);
-  const zone = boundUnboundedZone(unboundedZone, defaultGetSheetSize(sheetId));
   const parts = RangeImpl.getRangeParts(xc, unboundedZone);
 
-  const rangeInterface = { prefixSheet, unboundedZone, zone, sheetId, invalidSheetName: "", parts };
+  const rangeInterface = { prefixSheet, zone: unboundedZone, sheetId, invalidSheetName: "", parts };
 
-  return new RangeImpl(rangeInterface, defaultGetSheetSize).orderZone();
+  return createRange(rangeInterface, defaultGetSheetSize);
 }
 
 function invalidRange(sheetXC: string, getSheetSize: (sheetId: UID) => ZoneDimension): Range {
-  return new RangeImpl(
+  return createRange(
     {
       sheetId: "",
-      unboundedZone: { left: -1, top: -1, right: -1, bottom: -1 },
       zone: { left: -1, top: -1, right: -1, bottom: -1 },
       parts: [],
       invalidXc: sheetXC,

--- a/src/helpers/formulas.ts
+++ b/src/helpers/formulas.ts
@@ -70,18 +70,5 @@ function getRange(sheetXC: string, sheetId: UID): Range {
   if (!rangeReference.test(sheetXC)) {
     return createInvalidRange(sheetXC);
   }
-
-  let sheetName: string | undefined;
-  let xc = sheetXC;
-  let prefixSheet = false;
-  if (sheetXC.includes("!")) {
-    ({ xc, sheetName } = splitReference(sheetXC));
-    if (sheetName) {
-      prefixSheet = true;
-    }
-  }
-
-  const rangeInterface = { prefixSheet, xc, sheetId, invalidSheetName: "" };
-
-  return createRangeFromXc(rangeInterface, defaultGetSheetSize);
+  return createRangeFromXc({ xc: sheetXC, sheetId }, defaultGetSheetSize);
 }

--- a/src/helpers/range.ts
+++ b/src/helpers/range.ts
@@ -39,7 +39,6 @@ import {
 interface RangeArgs {
   zone: Readonly<UnboundedZone>;
   parts: readonly RangePart[];
-  invalidXc?: string;
   /** true if the user provided the range with the sheet name */
   prefixSheet: boolean;
   /** the name of any sheet that is invalid */
@@ -50,7 +49,6 @@ interface RangeArgs {
 
 interface RangeXcArgs {
   xc: string;
-  invalidXc?: string;
   /** true if the user provided the range with the sheet name */
   prefixSheet: boolean;
   /** the name of any sheet that is invalid */
@@ -72,7 +70,6 @@ export function createRange(args: RangeArgs, getSheetSize: (sheetId: UID) => Zon
     unboundedZone,
     zone,
     parts,
-    invalidXc: args.invalidXc,
     prefixSheet: args.prefixSheet,
     invalidSheetName: args.invalidSheetName,
     sheetId: args.sheetId,
@@ -89,7 +86,6 @@ export function createRangeFromXc(
     {
       zone: unboundedZone,
       parts,
-      invalidXc: args.invalidXc,
       sheetId: args.sheetId,
       prefixSheet: args.prefixSheet,
       invalidSheetName: args.invalidSheetName,

--- a/src/helpers/range.ts
+++ b/src/helpers/range.ts
@@ -94,29 +94,6 @@ export class RangeImpl implements Range {
     return this._zone;
   }
 
-  static getRangeParts(xc: string, zone: UnboundedZone): RangePart[] {
-    const parts = xc.split(":").map((p) => {
-      const isFullRow = isRowReference(p);
-      return {
-        colFixed: isFullRow ? false : p.startsWith("$"),
-        rowFixed: isFullRow ? p.startsWith("$") : p.includes("$", 1),
-      };
-    });
-
-    const isFullCol = zone.bottom === undefined;
-    const isFullRow = zone.right === undefined;
-    if (isFullCol) {
-      parts[0].rowFixed = parts[0].rowFixed || parts[1].rowFixed;
-      parts[1].rowFixed = parts[0].rowFixed || parts[1].rowFixed;
-    }
-    if (isFullRow) {
-      parts[0].colFixed = parts[0].colFixed || parts[1].colFixed;
-      parts[1].colFixed = parts[0].colFixed || parts[1].colFixed;
-    }
-
-    return parts;
-  }
-
   /**
    *
    * @param rangeParams optional, values to put in the cloned range instead of the current values of the range
@@ -327,6 +304,29 @@ export function getCellPositionsInRanges(ranges: Range[]): CellPosition[] {
     }
   }
   return cellPositions;
+}
+
+export function getRangeParts(xc: string, zone: UnboundedZone): RangePart[] {
+  const parts = xc.split(":").map((p) => {
+    const isFullRow = isRowReference(p);
+    return {
+      colFixed: isFullRow ? false : p.startsWith("$"),
+      rowFixed: isFullRow ? p.startsWith("$") : p.includes("$", 1),
+    };
+  });
+
+  const isFullCol = zone.bottom === undefined;
+  const isFullRow = zone.right === undefined;
+  if (isFullCol) {
+    parts[0].rowFixed = parts[0].rowFixed || parts[1].rowFixed;
+    parts[1].rowFixed = parts[0].rowFixed || parts[1].rowFixed;
+  }
+  if (isFullRow) {
+    parts[0].colFixed = parts[0].colFixed || parts[1].colFixed;
+    parts[1].colFixed = parts[0].colFixed || parts[1].colFixed;
+  }
+
+  return parts;
 }
 
 /**

--- a/src/helpers/range.ts
+++ b/src/helpers/range.ts
@@ -62,7 +62,7 @@ interface RangeArgs {
   sheetId: UID;
 }
 
-export class RangeImpl implements Range {
+class RangeImpl implements Range {
   private readonly _zone: Readonly<Zone | UnboundedZone>;
   readonly zone: Readonly<Zone>;
   readonly parts: Range["parts"];

--- a/src/helpers/range.ts
+++ b/src/helpers/range.ts
@@ -254,14 +254,17 @@ export function getRangeParts(xc: string, zone: UnboundedZone): RangePart[] {
  * Left should be smaller than right, top should be smaller than bottom.
  * If it's not the case, simply invert them, and invert the linked parts
  */
-export function orderRange(range: Range, getSheetSize: (sheetId: UID) => ZoneDimension): Range {
+export function orderRange(range: Range): Range {
   if (isZoneOrdered(range.zone)) {
     return range;
   }
-  const zone = { ...range.unboundedZone };
+  const unboundedZone = { ...range.unboundedZone };
+  const zone = { ...range.zone };
   let parts = range.parts;
-  if (zone.right !== undefined && zone.right < zone.left) {
-    let right = zone.right;
+  if (unboundedZone.right !== undefined && unboundedZone.right < unboundedZone.left) {
+    let right = unboundedZone.right;
+    unboundedZone.right = unboundedZone.left;
+    unboundedZone.left = right;
     zone.right = zone.left;
     zone.left = right;
     parts = [
@@ -276,8 +279,10 @@ export function orderRange(range: Range, getSheetSize: (sheetId: UID) => ZoneDim
     ];
   }
 
-  if (zone.bottom !== undefined && zone.bottom < zone.top) {
-    let bottom = zone.bottom;
+  if (unboundedZone.bottom !== undefined && unboundedZone.bottom < unboundedZone.top) {
+    let bottom = unboundedZone.bottom;
+    unboundedZone.bottom = unboundedZone.top;
+    unboundedZone.top = bottom;
     zone.bottom = zone.top;
     zone.top = bottom;
     parts = [
@@ -291,17 +296,15 @@ export function orderRange(range: Range, getSheetSize: (sheetId: UID) => ZoneDim
       },
     ];
   }
-  return createRange(
-    {
-      zone,
-      parts,
-      invalidXc: range.invalidXc,
-      prefixSheet: range.prefixSheet,
-      invalidSheetName: range.invalidSheetName,
-      sheetId: range.sheetId,
-    },
-    getSheetSize
-  );
+  return {
+    unboundedZone,
+    zone,
+    parts,
+    invalidXc: range.invalidXc,
+    prefixSheet: range.prefixSheet,
+    invalidSheetName: range.invalidSheetName,
+    sheetId: range.sheetId,
+  };
 }
 
 export function getRangeAdapter(cmd: Command): RangeAdapter | undefined {

--- a/src/helpers/range.ts
+++ b/src/helpers/range.ts
@@ -48,6 +48,17 @@ interface RangeArgs {
   sheetId: UID;
 }
 
+interface RangeXcArgs {
+  xc: string;
+  invalidXc?: string;
+  /** true if the user provided the range with the sheet name */
+  prefixSheet: boolean;
+  /** the name of any sheet that is invalid */
+  invalidSheetName?: string;
+  /** the sheet on which the range is defined */
+  sheetId: UID;
+}
+
 export function createRange(args: RangeArgs, getSheetSize: (sheetId: UID) => ZoneDimension): Range {
   const unboundedZone = args.zone;
   const zone = boundUnboundedZone(unboundedZone, getSheetSize(args.sheetId));
@@ -66,6 +77,25 @@ export function createRange(args: RangeArgs, getSheetSize: (sheetId: UID) => Zon
     invalidSheetName: args.invalidSheetName,
     sheetId: args.sheetId,
   };
+}
+
+export function createRangeFromXc(
+  args: RangeXcArgs,
+  getSheetSize: (sheetId: UID) => ZoneDimension
+): Range {
+  const unboundedZone = toUnboundedZone(args.xc);
+  const parts = getRangeParts(args.xc, unboundedZone);
+  return createRange(
+    {
+      zone: unboundedZone,
+      parts,
+      invalidXc: args.invalidXc,
+      sheetId: args.sheetId,
+      prefixSheet: args.prefixSheet,
+      invalidSheetName: args.invalidSheetName,
+    },
+    getSheetSize
+  );
 }
 
 export function createInvalidRange(sheetXC: string): Range {
@@ -226,7 +256,7 @@ export function getCellPositionsInRanges(ranges: Range[]): CellPosition[] {
   return cellPositions;
 }
 
-export function getRangeParts(xc: string, zone: UnboundedZone): RangePart[] {
+function getRangeParts(xc: string, zone: UnboundedZone): RangePart[] {
   const parts = xc.split(":").map((p) => {
     const isFullRow = isRowReference(p);
     return {

--- a/src/helpers/range.ts
+++ b/src/helpers/range.ts
@@ -124,14 +124,6 @@ export class RangeImpl implements Range {
     return parts;
   }
 
-  get isFullCol(): boolean {
-    return this._zone.bottom === undefined;
-  }
-
-  get isFullRow(): boolean {
-    return this._zone.right === undefined;
-  }
-
   /**
    * Check that a zone is valid regarding the order of top-bottom and left-right.
    * Left should be smaller than right, top should be smaller than bottom.
@@ -241,6 +233,14 @@ export function createInvalidRange(
     getSheetSize
   );
   return range;
+}
+
+export function isFullColRange(range: Range): boolean {
+  return isFullCol(range.unboundedZone);
+}
+
+export function isFullRowRange(range: Range): boolean {
+  return isFullRow(range.unboundedZone);
 }
 
 export function getRangeString(

--- a/src/helpers/range.ts
+++ b/src/helpers/range.ts
@@ -90,13 +90,6 @@ export class RangeImpl implements Range {
     this.parts = _fixedParts;
   }
 
-  static fromRange(range: Range, getSheetSize: (sheetId: UID) => ZoneDimension): RangeImpl {
-    if (range instanceof RangeImpl) {
-      return range;
-    }
-    return new RangeImpl(range, getSheetSize);
-  }
-
   get unboundedZone(): UnboundedZone {
     return this._zone;
   }
@@ -380,8 +373,7 @@ export function orderRange(range: Range, getSheetSize: (sheetId: UID) => ZoneDim
   }
   return createRange(
     {
-      unboundedZone: zone,
-      zone: boundUnboundedZone(zone, getSheetSize(range.sheetId)),
+      zone,
       parts,
       invalidXc: range.invalidXc,
       prefixSheet: range.prefixSheet,

--- a/src/helpers/range.ts
+++ b/src/helpers/range.ts
@@ -51,11 +51,11 @@ interface RangeArgs {
 export function createRange(args: RangeArgs, getSheetSize: (sheetId: UID) => ZoneDimension): Range {
   const unboundedZone = args.zone;
   const zone = boundUnboundedZone(unboundedZone, getSheetSize(args.sheetId));
-  let parts = [...args.parts];
+  let parts = args.parts;
   if (args.parts.length === 1 && getZoneArea(zone) > 1) {
-    parts.push({ ...args.parts[0] });
+    parts = [args.parts[0], args.parts[0]];
   } else if (args.parts.length === 2 && getZoneArea(zone) === 1) {
-    parts.pop();
+    parts = [args.parts[0]];
   }
   return {
     unboundedZone,

--- a/src/helpers/range.ts
+++ b/src/helpers/range.ts
@@ -49,8 +49,6 @@ interface RangeArgs {
 
 interface RangeXcArgs {
   xc: string;
-  /** true if the user provided the range with the sheet name */
-  prefixSheet: boolean;
   /** the name of any sheet that is invalid */
   invalidSheetName?: string;
   /** the sheet on which the range is defined */
@@ -76,18 +74,24 @@ export function createRange(args: RangeArgs, getSheetSize: (sheetId: UID) => Zon
   };
 }
 
+/**
+ * Create a range from a string XC: A1, Sheet1!A1
+ * The XC is expected to be valid.
+ */
 export function createRangeFromXc(
   args: RangeXcArgs,
   getSheetSize: (sheetId: UID) => ZoneDimension
 ): Range {
-  const unboundedZone = toUnboundedZone(args.xc);
-  const parts = getRangeParts(args.xc, unboundedZone);
+  const fullXc = args.xc;
+  const { xc, sheetName } = splitReference(fullXc);
+  const unboundedZone = toUnboundedZone(xc);
+  const parts = getRangeParts(xc, unboundedZone);
   return createRange(
     {
       zone: unboundedZone,
       parts,
       sheetId: args.sheetId,
-      prefixSheet: args.prefixSheet,
+      prefixSheet: Boolean(sheetName),
       invalidSheetName: args.invalidSheetName,
     },
     getSheetSize

--- a/src/helpers/range.ts
+++ b/src/helpers/range.ts
@@ -11,7 +11,6 @@ import {
   MoveRangeCommand,
   Range,
   RangeAdapter,
-  RangeData,
   RangePart,
   RangeStringOptions,
   RemoveColumnsRowsCommand,
@@ -125,13 +124,6 @@ export class RangeImpl implements Range {
 
   get isFullRow(): boolean {
     return this._zone.right === undefined;
-  }
-
-  get rangeData(): RangeData {
-    return {
-      _zone: this._zone,
-      _sheetId: this.sheetId,
-    };
   }
 
   /**

--- a/src/helpers/zones.ts
+++ b/src/helpers/zones.ts
@@ -592,6 +592,21 @@ export function getZoneArea(zone: Zone): number {
   return (zone.bottom - zone.top + 1) * (zone.right - zone.left + 1);
 }
 
+export function boundUnboundedZone(
+  unboundedZone: Readonly<UnboundedZone>,
+  sheetSize: ZoneDimension
+): Readonly<Zone> {
+  const { left, top, bottom, right } = unboundedZone;
+  if (right !== undefined && bottom !== undefined) {
+    return unboundedZone as Readonly<Zone>;
+  } else if (bottom === undefined && right !== undefined) {
+    return { right, top, left, bottom: sheetSize.numberOfRows - 1 };
+  } else if (right === undefined && bottom !== undefined) {
+    return { bottom, left, top, right: sheetSize.numberOfCols - 1 };
+  }
+  throw new Error("Bad zone format");
+}
+
 /**
  * Check if the zones are continuous, ie. if they can be merged into a single zone without
  * including cells outside the zones

--- a/src/helpers/zones.ts
+++ b/src/helpers/zones.ts
@@ -583,7 +583,7 @@ export function isFullRow(zone: UnboundedZone): boolean {
   return zone.right === undefined;
 }
 
-function isFullCol(zone: UnboundedZone): boolean {
+export function isFullCol(zone: UnboundedZone): boolean {
   return zone.bottom === undefined;
 }
 

--- a/src/model.ts
+++ b/src/model.ts
@@ -220,6 +220,7 @@ export class Model extends EventBus<any> implements CommandDispatcher {
     this.coreGetters.getRangeString = this.range.getRangeString.bind(this.range);
     this.coreGetters.getRangeFromSheetXC = this.range.getRangeFromSheetXC.bind(this.range);
     this.coreGetters.createAdaptedRanges = this.range.createAdaptedRanges.bind(this.range);
+    this.coreGetters.getRangeData = this.range.getRangeData.bind(this.range);
     this.coreGetters.getRangeDataFromXc = this.range.getRangeDataFromXc.bind(this.range);
     this.coreGetters.getRangeDataFromZone = this.range.getRangeDataFromZone.bind(this.range);
     this.coreGetters.getRangeFromRangeData = this.range.getRangeFromRangeData.bind(this.range);

--- a/src/plugins/core/merge.ts
+++ b/src/plugins/core/merge.ts
@@ -1,5 +1,4 @@
 import {
-  RangeImpl,
   clip,
   deepEquals,
   getFullReference,
@@ -168,17 +167,16 @@ export class MergePlugin extends CorePlugin<MergeState> implements MergeState {
    * Same as `getRangeString` but add all necessary merge to the range to make it a valid selection
    */
   getSelectionRangeString(range: Range, forSheetId: UID): string {
-    const rangeImpl = RangeImpl.fromRange(range, this.getters.getSheetSize);
-    const expandedZone = this.getters.expandZone(rangeImpl.sheetId, rangeImpl.zone);
-    const expandedRange = rangeImpl.clone({
+    const expandedZone = this.getters.expandZone(range.sheetId, range.zone);
+    const expandedRange = range.clone({
       unboundedZone: {
         ...expandedZone,
-        bottom: isFullColRange(rangeImpl) ? undefined : expandedZone.bottom,
-        right: isFullRowRange(rangeImpl) ? undefined : expandedZone.right,
+        bottom: isFullColRange(range) ? undefined : expandedZone.bottom,
+        right: isFullRowRange(range) ? undefined : expandedZone.right,
       },
     });
     const rangeString = this.getters.getRangeString(expandedRange, forSheetId);
-    if (this.isSingleCellOrMerge(rangeImpl.sheetId, rangeImpl.zone)) {
+    if (this.isSingleCellOrMerge(range.sheetId, range.zone)) {
       const { sheetName, xc } = splitReference(rangeString);
       return getFullReference(sheetName, xc.split(":")[0]);
     }

--- a/src/plugins/core/merge.ts
+++ b/src/plugins/core/merge.ts
@@ -5,6 +5,8 @@ import {
   getFullReference,
   isDefined,
   isEqual,
+  isFullColRange,
+  isFullRowRange,
   overlap,
   positions,
   splitReference,
@@ -171,8 +173,8 @@ export class MergePlugin extends CorePlugin<MergeState> implements MergeState {
     const expandedRange = rangeImpl.clone({
       unboundedZone: {
         ...expandedZone,
-        bottom: rangeImpl.isFullCol ? undefined : expandedZone.bottom,
-        right: rangeImpl.isFullRow ? undefined : expandedZone.right,
+        bottom: isFullColRange(rangeImpl) ? undefined : expandedZone.bottom,
+        right: isFullRowRange(rangeImpl) ? undefined : expandedZone.right,
       },
     });
     const rangeString = this.getters.getRangeString(expandedRange, forSheetId);

--- a/src/plugins/core/merge.ts
+++ b/src/plugins/core/merge.ts
@@ -1,5 +1,6 @@
 import {
   clip,
+  createRange,
   deepEquals,
   getFullReference,
   isDefined,
@@ -168,13 +169,17 @@ export class MergePlugin extends CorePlugin<MergeState> implements MergeState {
    */
   getSelectionRangeString(range: Range, forSheetId: UID): string {
     const expandedZone = this.getters.expandZone(range.sheetId, range.zone);
-    const expandedRange = range.clone({
-      unboundedZone: {
-        ...expandedZone,
-        bottom: isFullColRange(range) ? undefined : expandedZone.bottom,
-        right: isFullRowRange(range) ? undefined : expandedZone.right,
+    const expandedRange = createRange(
+      {
+        ...range,
+        zone: {
+          ...expandedZone,
+          bottom: isFullColRange(range) ? undefined : expandedZone.bottom,
+          right: isFullRowRange(range) ? undefined : expandedZone.right,
+        },
       },
-    });
+      this.getters.getSheetSize
+    );
     const rangeString = this.getters.getRangeString(expandedRange, forSheetId);
     if (this.isSingleCellOrMerge(range.sheetId, range.zone)) {
       const { sheetName, xc } = splitReference(rangeString);

--- a/src/plugins/core/range.ts
+++ b/src/plugins/core/range.ts
@@ -5,6 +5,8 @@ import {
   duplicateRangeInDuplicatedSheet,
   getRangeAdapter,
   getRangeString,
+  isFullColRange,
+  isFullRowRange,
   isZoneValid,
   RangeImpl,
   rangeReference,
@@ -127,25 +129,27 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
         return range;
       }
       const copySheetId = range.prefixSheet ? range.sheetId : sheetId;
+      const isFullRow = isFullRowRange(range);
+      const isFullCol = isFullColRange(range);
       const unboundZone = {
         ...range.unboundedZone,
         // Don't shift left if the range is a full row without header
         left:
-          range.isFullRow && !range.unboundedZone.hasHeader
+          isFullRow && !range.unboundedZone.hasHeader
             ? range.unboundedZone.left
             : range.unboundedZone.left + (range.parts[0].colFixed ? 0 : offsetX),
         // Don't shift right if the range is a full row
-        right: range.isFullRow
+        right: isFullRow
           ? range.unboundedZone.right
           : range.unboundedZone.right! +
             ((range.parts[1] || range.parts[0]).colFixed ? 0 : offsetX),
         // Don't shift up if the range is a column row without header
         top:
-          range.isFullCol && !range.unboundedZone.hasHeader
+          isFullCol && !range.unboundedZone.hasHeader
             ? range.unboundedZone.top
             : range.unboundedZone.top + (range.parts[0].rowFixed ? 0 : offsetY),
         // Don't shift down if the range is a full column
-        bottom: range.isFullCol
+        bottom: isFullCol
           ? range.unboundedZone.bottom
           : range.unboundedZone.bottom! +
             ((range.parts[1] || range.parts[0]).rowFixed ? 0 : offsetY),
@@ -174,8 +178,8 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
     const unboundedZone = {
       left: rangeImpl.zone.left,
       top: rangeImpl.zone.top,
-      right: rangeImpl.isFullRow ? undefined : right,
-      bottom: rangeImpl.isFullCol ? undefined : bottom,
+      right: isFullRowRange(rangeImpl) ? undefined : right,
+      bottom: isFullColRange(rangeImpl) ? undefined : bottom,
     };
     return createRange({ ...rangeImpl, zone: unboundedZone }, this.getters.getSheetSize);
   }

--- a/src/plugins/core/range.ts
+++ b/src/plugins/core/range.ts
@@ -158,8 +158,7 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
         createRange(
           { ...range, sheetId: copySheetId, zone: unboundZone },
           this.getters.getSheetSize
-        ),
-        this.getters.getSheetSize
+        )
       );
     });
   }

--- a/src/plugins/core/range.ts
+++ b/src/plugins/core/range.ts
@@ -10,7 +10,6 @@ import {
   isFullRowRange,
   isZoneValid,
   orderRange,
-  RangeImpl,
   rangeReference,
   recomputeZones,
   splitReference,
@@ -92,7 +91,7 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
    * direction can be incorrect. This function ensure that an incorrect range gets removed.
    */
   private verifyRangeRemoved(adaptRange: ApplyRangeChange): ApplyRangeChange {
-    return (range: RangeImpl) => {
+    return (range: Range) => {
       const result: ApplyRangeChangeResult = adaptRange(range);
       if (result.changeType !== "NONE" && !isZoneValid(result.range.zone)) {
         return { range: result.range, changeType: "REMOVE" };

--- a/src/plugins/core/range.ts
+++ b/src/plugins/core/range.ts
@@ -8,6 +8,7 @@ import {
   isFullColRange,
   isFullRowRange,
   isZoneValid,
+  orderRange,
   RangeImpl,
   rangeReference,
   recomputeZones,
@@ -154,7 +155,10 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
           : range.unboundedZone.bottom! +
             ((range.parts[1] || range.parts[0]).rowFixed ? 0 : offsetY),
       };
-      return range.clone({ sheetId: copySheetId, unboundedZone: unboundZone }).orderZone();
+      return orderRange(
+        range.clone({ sheetId: copySheetId, unboundedZone: unboundZone }),
+        this.getters.getSheetSize
+      );
     });
   }
 

--- a/src/plugins/core/range.ts
+++ b/src/plugins/core/range.ts
@@ -124,8 +124,7 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
   // ---------------------------------------------------------------------------
 
   createAdaptedRanges(ranges: Range[], offsetX: number, offsetY: number, sheetId: UID): Range[] {
-    const rangesImpl = ranges.map((range) => RangeImpl.fromRange(range, this.getters.getSheetSize));
-    return rangesImpl.map((range) => {
+    return ranges.map((range) => {
       if (!isZoneValid(range.zone)) {
         return range;
       }
@@ -167,25 +166,23 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
    */
   removeRangesSheetPrefix(sheetId: UID, ranges: Range[]): Range[] {
     return ranges.map((range) => {
-      const rangeImpl = RangeImpl.fromRange(range, this.getters.getSheetSize);
-      if (rangeImpl.prefixSheet && rangeImpl.sheetId === sheetId) {
-        return rangeImpl.clone({ prefixSheet: false });
+      if (range.prefixSheet && range.sheetId === sheetId) {
+        return range.clone({ prefixSheet: false });
       }
-      return rangeImpl;
+      return range;
     });
   }
 
   extendRange(range: Range, dimension: Dimension, quantity: number): Range {
-    const rangeImpl = RangeImpl.fromRange(range, this.getters.getSheetSize);
-    const right = dimension === "COL" ? rangeImpl.zone.right + quantity : rangeImpl.zone.right;
-    const bottom = dimension === "ROW" ? rangeImpl.zone.bottom + quantity : rangeImpl.zone.bottom;
+    const right = dimension === "COL" ? range.zone.right + quantity : range.zone.right;
+    const bottom = dimension === "ROW" ? range.zone.bottom + quantity : range.zone.bottom;
     const unboundedZone = {
-      left: rangeImpl.zone.left,
-      top: rangeImpl.zone.top,
-      right: isFullRowRange(rangeImpl) ? undefined : right,
-      bottom: isFullColRange(rangeImpl) ? undefined : bottom,
+      left: range.zone.left,
+      top: range.zone.top,
+      right: isFullRowRange(range) ? undefined : right,
+      bottom: isFullColRange(range) ? undefined : bottom,
     };
-    return createRange({ ...rangeImpl, zone: unboundedZone }, this.getters.getSheetSize);
+    return createRange({ ...range, zone: unboundedZone }, this.getters.getSheetSize);
   }
 
   /**
@@ -279,12 +276,8 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
    * Allows you to recompute ranges from the same sheet
    */
   recomputeRanges(ranges: Range[], rangesToRemove: Range[]): Range[] {
-    const zones = ranges.map(
-      (range) => RangeImpl.fromRange(range, this.getters.getSheetSize).unboundedZone
-    );
-    const zonesToRemove = rangesToRemove.map(
-      (range) => RangeImpl.fromRange(range, this.getters.getSheetSize).unboundedZone
-    );
+    const zones = ranges.map((range) => range.unboundedZone);
+    const zonesToRemove = rangesToRemove.map((range) => range.unboundedZone);
     return recomputeZones(zones, zonesToRemove).map((zone) =>
       this.getRangeFromZone(ranges[0].sheetId, zone)
     );
@@ -319,9 +312,7 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
   }
 
   getRangesUnion(ranges: Range[]): Range {
-    const zones = ranges.map(
-      (range) => RangeImpl.fromRange(range, this.getters.getSheetSize).unboundedZone
-    );
+    const zones = ranges.map((range) => range.unboundedZone);
     const unionOfZones = unionUnboundedZones(...zones);
     return this.getRangeFromZone(ranges[0].sheetId, unionOfZones);
   }

--- a/src/plugins/core/range.ts
+++ b/src/plugins/core/range.ts
@@ -2,6 +2,7 @@ import { compile } from "../../formulas";
 import {
   duplicateRangeInDuplicatedSheet,
   getRangeAdapter,
+  getRangeString,
   isZoneValid,
   RangeImpl,
   rangeReference,
@@ -241,7 +242,7 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
     if (!this.getters.tryGetSheet(range.sheetId)) {
       return CellErrorType.InvalidReference;
     }
-    return range.getRangeString(forSheetId, this.getters.getSheetName, options);
+    return getRangeString(range, forSheetId, this.getters.getSheetName, options);
   }
 
   getRangeDataFromXc(sheetId: UID, xc: string): RangeData {

--- a/src/plugins/core/range.ts
+++ b/src/plugins/core/range.ts
@@ -4,6 +4,7 @@ import {
   createRange,
   duplicateRangeInDuplicatedSheet,
   getRangeAdapter,
+  getRangeParts,
   getRangeString,
   isFullColRange,
   isFullRowRange,
@@ -206,7 +207,7 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
     }
     const sheetId = this.getters.getSheetIdByName(sheetName) || defaultSheetId;
     const unboundedZone = toUnboundedZone(xc);
-    const parts = RangeImpl.getRangeParts(xc, unboundedZone);
+    const parts = getRangeParts(xc, unboundedZone);
     const invalidSheetName =
       sheetName && !this.getters.getSheetIdByName(sheetName) ? sheetName : undefined;
 

--- a/src/plugins/core/range.ts
+++ b/src/plugins/core/range.ts
@@ -2,9 +2,9 @@ import { compile } from "../../formulas";
 import {
   createInvalidRange,
   createRange,
+  createRangeFromXc,
   duplicateRangeInDuplicatedSheet,
   getRangeAdapter,
-  getRangeParts,
   getRangeString,
   isFullColRange,
   isFullRowRange,
@@ -13,7 +13,6 @@ import {
   rangeReference,
   recomputeZones,
   splitReference,
-  toUnboundedZone,
   unionUnboundedZones,
 } from "../../helpers/index";
 import { CellErrorType } from "../../types/errors";
@@ -207,14 +206,12 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
       }
     }
     const sheetId = this.getters.getSheetIdByName(sheetName) || defaultSheetId;
-    const unboundedZone = toUnboundedZone(xc);
-    const parts = getRangeParts(xc, unboundedZone);
     const invalidSheetName =
       sheetName && !this.getters.getSheetIdByName(sheetName) ? sheetName : undefined;
 
-    const rangeInterface = { prefixSheet, zone: unboundedZone, sheetId, invalidSheetName, parts };
+    const rangeInterface = { prefixSheet, xc, sheetId, invalidSheetName };
 
-    return createRange(rangeInterface, this.getters.getSheetSize);
+    return createRangeFromXc(rangeInterface, this.getters.getSheetSize);
   }
 
   /**

--- a/src/plugins/core/range.ts
+++ b/src/plugins/core/range.ts
@@ -155,7 +155,10 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
             ((range.parts[1] || range.parts[0]).rowFixed ? 0 : offsetY),
       };
       return orderRange(
-        range.clone({ sheetId: copySheetId, unboundedZone: unboundZone }),
+        createRange(
+          { ...range, sheetId: copySheetId, zone: unboundZone },
+          this.getters.getSheetSize
+        ),
         this.getters.getSheetSize
       );
     });
@@ -167,7 +170,7 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
   removeRangesSheetPrefix(sheetId: UID, ranges: Range[]): Range[] {
     return ranges.map((range) => {
       if (range.prefixSheet && range.sheetId === sheetId) {
-        return range.clone({ prefixSheet: false });
+        return { ...range, prefixSheet: false };
       }
       return range;
     });
@@ -192,7 +195,7 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
    */
   getRangeFromSheetXC(defaultSheetId: UID, sheetXC: string): Range {
     if (!rangeReference.test(sheetXC) || !this.getters.tryGetSheet(defaultSheetId)) {
-      return createInvalidRange(sheetXC, this.getters.getSheetSize);
+      return createInvalidRange(sheetXC);
     }
 
     let sheetName: string | undefined;
@@ -285,7 +288,7 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
 
   getRangeFromRangeData(data: RangeData): Range {
     if (!this.getters.tryGetSheet(data._sheetId)) {
-      return createInvalidRange(CellErrorType.InvalidReference, this.getters.getSheetSize);
+      return createInvalidRange(CellErrorType.InvalidReference);
     }
     const rangeInterface = {
       prefixSheet: false,

--- a/src/plugins/core/range.ts
+++ b/src/plugins/core/range.ts
@@ -196,22 +196,12 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
       return createInvalidRange(sheetXC);
     }
 
-    let sheetName: string | undefined;
-    let xc = sheetXC;
-    let prefixSheet = false;
-    if (sheetXC.includes("!")) {
-      ({ xc, sheetName } = splitReference(sheetXC));
-      if (sheetName) {
-        prefixSheet = true;
-      }
-    }
+    const { sheetName } = splitReference(sheetXC);
     const sheetId = this.getters.getSheetIdByName(sheetName) || defaultSheetId;
     const invalidSheetName =
       sheetName && !this.getters.getSheetIdByName(sheetName) ? sheetName : undefined;
 
-    const rangeInterface = { prefixSheet, xc, sheetId, invalidSheetName };
-
-    return createRangeFromXc(rangeInterface, this.getters.getSheetSize);
+    return createRangeFromXc({ xc: sheetXC, sheetId, invalidSheetName }, this.getters.getSheetSize);
   }
 
   /**

--- a/src/plugins/core/range.ts
+++ b/src/plugins/core/range.ts
@@ -43,6 +43,7 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
     "getRangeString",
     "getRangeFromSheetXC",
     "createAdaptedRanges",
+    "getRangeData",
     "getRangeDataFromXc",
     "getRangeDataFromZone",
     "getRangeFromRangeData",
@@ -244,12 +245,17 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
   }
 
   getRangeDataFromXc(sheetId: UID, xc: string): RangeData {
-    return this.getters.getRangeFromSheetXC(sheetId, xc).rangeData;
+    const range = this.getters.getRangeFromSheetXC(sheetId, xc);
+    return this.getRangeDataFromZone(range.sheetId, range.unboundedZone);
   }
 
   getRangeDataFromZone(sheetId: UID, zone: Zone | UnboundedZone): RangeData {
     zone = this.getters.getUnboundedZone(sheetId, zone);
     return { _sheetId: sheetId, _zone: zone };
+  }
+
+  getRangeData(range: Range): RangeData {
+    return this.getRangeDataFromZone(range.sheetId, range.unboundedZone);
   }
 
   getRangeFromZone(sheetId: UID, zone: Zone | UnboundedZone): Range {

--- a/src/stores/formula_fingerprints_store.ts
+++ b/src/stores/formula_fingerprints_store.ts
@@ -2,7 +2,6 @@ import {
   AlternatingColorGenerator,
   isFullColRange,
   isFullRowRange,
-  RangeImpl,
   reorderZone,
   setColorAlpha,
 } from "../helpers";
@@ -179,7 +178,7 @@ export class FormulaFingerprintStore extends SpreadsheetStore {
       dy: 0,
       dSheet: 0,
     };
-    for (const range of dependencies as RangeImpl[]) {
+    for (const range of dependencies) {
       const zone = range.zone;
       const [left, right] = range.parts;
       const rangeSheetIndex = this.getters.getSheetIds().indexOf(range.sheetId);

--- a/src/stores/formula_fingerprints_store.ts
+++ b/src/stores/formula_fingerprints_store.ts
@@ -1,4 +1,11 @@
-import { AlternatingColorGenerator, RangeImpl, reorderZone, setColorAlpha } from "../helpers";
+import {
+  AlternatingColorGenerator,
+  isFullColRange,
+  isFullRowRange,
+  RangeImpl,
+  reorderZone,
+  setColorAlpha,
+} from "../helpers";
 import { PositionMap } from "../plugins/ui_core_views/cell_evaluation/position_map";
 import {
   Cell,
@@ -180,8 +187,8 @@ export class FormulaFingerprintStore extends SpreadsheetStore {
 
       // in relative mode, we offset the col and row by the cell's position
       // in absolute mode, we offset the col and row relative to the sheet
-      const isLeftUnbounded = range.isFullRow && !range.unboundedZone.hasHeader;
-      const isTopUnbounded = range.isFullCol && !range.unboundedZone.hasHeader;
+      const isLeftUnbounded = isFullRowRange(range) && !range.unboundedZone.hasHeader;
+      const isTopUnbounded = isFullColRange(range) && !range.unboundedZone.hasHeader;
       const leftOffset = isLeftUnbounded || left?.colFixed ? 0 : colCellOffset;
       const topOffset = isTopUnbounded || left?.rowFixed ? 0 : rowCellOffset;
 

--- a/src/types/range.ts
+++ b/src/types/range.ts
@@ -16,7 +16,6 @@ export interface Range extends Cloneable<Range> {
   readonly invalidSheetName?: string;
   /** the sheet on which the range is defined */
   readonly sheetId: UID;
-  readonly rangeData: RangeData;
 
   getRangeString: (
     forSheetId: UID,

--- a/src/types/range.ts
+++ b/src/types/range.ts
@@ -1,11 +1,11 @@
-import { Cloneable, UID, UnboundedZone, Zone } from "./misc";
+import { UID, UnboundedZone, Zone } from "./misc";
 
 export interface RangePart {
   readonly colFixed: boolean;
   readonly rowFixed: boolean;
 }
 
-export interface Range extends Cloneable<Range> {
+export interface Range {
   readonly zone: Readonly<Zone>;
   readonly unboundedZone: Readonly<UnboundedZone>;
   readonly parts: readonly RangePart[];

--- a/src/types/range.ts
+++ b/src/types/range.ts
@@ -16,12 +16,6 @@ export interface Range extends Cloneable<Range> {
   readonly invalidSheetName?: string;
   /** the sheet on which the range is defined */
   readonly sheetId: UID;
-
-  getRangeString: (
-    forSheetId: UID,
-    getSheetName: (sheetId: UID) => string,
-    options?: RangeStringOptions
-  ) => string;
 }
 
 export interface RangeStringOptions {

--- a/tests/range_plugin.test.ts
+++ b/tests/range_plugin.test.ts
@@ -538,7 +538,7 @@ describe("range plugin", () => {
 
     test("requesting a range without parts", () => {
       const r = m.getters.getRangeFromSheetXC("s1", "A1");
-      const rNoParts = r.clone({ parts: [] });
+      const rNoParts = { ...r, parts: [] };
       expect(m.getters.getRangeString(rNoParts, "forceSheetName")).toBe("s1!A1");
     });
 

--- a/tests/table/table_panel_component.test.ts
+++ b/tests/table/table_panel_component.test.ts
@@ -1,4 +1,4 @@
-import { RangeImpl, toUnboundedZone, toZone, zoneToXc } from "../../src/helpers";
+import { toUnboundedZone, toZone, zoneToXc } from "../../src/helpers";
 import { SpreadsheetChildEnv, Table, UID } from "../../src/types";
 import {
   createTable,
@@ -125,7 +125,7 @@ describe("Table side panel", () => {
     await setInputValueAndTrigger(".o-selection input", "D2:E");
     await click(fixture, ".o-selection .o-selection-ok");
     expect(fixture.querySelector<HTMLInputElement>(".o-selection input")?.value).toEqual("D2:E");
-    const tableRange = getTable(model, sheetId).range as RangeImpl;
+    const tableRange = getTable(model, sheetId).range;
     expect(tableRange.unboundedZone).toEqual(toUnboundedZone("D2:E"));
     expect(model.getters.getSelectedZone()).toEqual(toZone("D2"));
   });

--- a/tests/table/tables_plugin.test.ts
+++ b/tests/table/tables_plugin.test.ts
@@ -744,7 +744,7 @@ describe("Table plugin", () => {
       paste(model, "A5");
       expect(model.getters.getTables(sheet1Id)).toHaveLength(0);
       const copiedTable = getTable(model, "A5", "sheet2Id");
-      expect(copiedTable).toMatchObject({ range: { _zone: toZone("A5:B8") } });
+      expect(copiedTable).toMatchObject({ range: { zone: toZone("A5:B8") } });
     });
 
     test("Can cut and paste multiple tables", () => {


### PR DESCRIPTION
These commits are part of a broader refactoring effort to simplify Range by
removing the `RangeImpl` class, making `Range` a plain old javascipt object
(POJO).

There are currently 2 concepts: `Range` and `RangeImp`. The original intent
was to abstract away the details of unbounded ranges from business logic.
However, in practice, various parts of the code increasingly require access
to these details as new features are introduced. And both have converged
more and more over time. While the abstraction was well-intentioned, it has
proven to be an abstraction that do not really fit all needs.


We now use a pojo because:

- (almost) all our other data structures are POJOs except `RangeImpl`
- POJOs are simpler and easy to work with
- keeping data separate from business logic is what we do everywhere else
- business logic is currently spread across 3 different locations:
  Range plugin, helper functions, Range class

Task: 4676075