### PR TITLE
[FIX] pivot: make pivot update notification sticky

### DIFF
--- a/src/components/side_panel/pivot/pivot_side_panel/pivot_side_panel_store.ts
+++ b/src/components/side_panel/pivot/pivot_side_panel/pivot_side_panel_store.ts
@@ -151,7 +151,7 @@ export class PivotSidePanelStore extends SpreadsheetStore {
             "Pivot updates only work with dynamic pivot tables. Use %s or re-insert the static pivot from the Data menu.",
             pivotExample
           ),
-          sticky: false,
+          sticky: true,
         });
       }
     }

--- a/tests/pivots/spreadsheet_pivot/spreadsheet_pivot_side_panel.test.ts
+++ b/tests/pivots/spreadsheet_pivot/spreadsheet_pivot_side_panel.test.ts
@@ -488,7 +488,7 @@ describe("Spreadsheet pivot side panel", () => {
     await click(fixture.querySelectorAll(".o-autocomplete-value")[1]);
     expect(mockNotify).toHaveBeenCalledWith({
       text: "Pivot updates only work with dynamic pivot tables. Use =PIVOT(1) or re-insert the static pivot from the Data menu.",
-      sticky: false,
+      sticky: true,
       type: "info",
     });
 


### PR DESCRIPTION
When there is a static pivot formula, and the user tries to update something, the notification disappears too quickly. It's almost impossible to fully read before it disappear. And users probably needs to read it multiple times to understand.

Task: 4680152

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo