### PR TITLE
[FIX] collapsible: remove `overflow: hidden`

### DIFF
--- a/src/components/side_panel/components/collapse/collapse.scss
+++ b/src/components/side_panel/components/collapse/collapse.scss
@@ -1,5 +1,0 @@
-.o-spreadsheet {
-  .os-collapse {
-    overflow: hidden;
-  }
-}

--- a/src/components/side_panel/components/collapse/collapse.ts
+++ b/src/components/side_panel/components/collapse/collapse.ts
@@ -34,6 +34,7 @@ export class Collapse extends Component<Props, SpreadsheetChildEnv> {
       return;
     }
     el.classList.remove("d-none");
+    el.classList.add("overflow-hidden");
     const startHeight = isCollapsed ? el.scrollHeight : 0;
     const endHeight = isCollapsed ? 0 : el.scrollHeight;
 
@@ -42,6 +43,7 @@ export class Collapse extends Component<Props, SpreadsheetChildEnv> {
       { duration: 350, easing: "ease" }
     );
     animation.onfinish = () => {
+      el.classList.remove("overflow-hidden");
       if (this.props.isCollapsed) {
         el.classList.add("d-none");
       }


### PR DESCRIPTION
## Description

The collapsible sections have an `overflow: hidden` property. This breaks the drop-downs menus inside of them. The `overflow: hidden` is only needed during the collapse animation, we can remove it after.

Task: [4684080](https://www.odoo.com/odoo/2328/tasks/4684080)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo