### PR TITLE
[FIX] popover: rename props to kebab-case

### DIFF
--- a/src/components/border_editor/border_editor.ts
+++ b/src/components/border_editor/border_editor.ts
@@ -179,7 +179,7 @@ export class BorderEditor extends Component<BorderEditorProps, SpreadsheetChildE
   get lineStylePickerPopoverProps(): PopoverProps {
     return {
       anchorRect: this.lineStylePickerAnchorRect,
-      positioning: "BottomLeft",
+      positioning: "bottom-left",
       verticalOffset: 0,
     };
   }
@@ -188,7 +188,7 @@ export class BorderEditor extends Component<BorderEditorProps, SpreadsheetChildE
     return {
       anchorRect: this.props.anchorRect,
       maxHeight: this.props.maxHeight,
-      positioning: "BottomLeft",
+      positioning: "bottom-left",
       verticalOffset: 0,
     };
   }

--- a/src/components/color_picker/color_picker.ts
+++ b/src/components/color_picker/color_picker.ts
@@ -250,7 +250,7 @@ export class ColorPicker extends Component<ColorPickerProps, SpreadsheetChildEnv
     return {
       anchorRect: this.props.anchorRect,
       maxHeight: this.props.maxHeight,
-      positioning: "BottomLeft",
+      positioning: "bottom-left",
       verticalOffset: 0,
     };
   }

--- a/src/components/error_tooltip/error_tooltip.ts
+++ b/src/components/error_tooltip/error_tooltip.ts
@@ -89,7 +89,7 @@ export const ErrorToolTipPopoverBuilder: PopoverBuilders = {
           cellPosition: position,
         },
         Component: ErrorToolTip,
-        cellCorner: "TopRight",
+        cellCorner: "top-right",
       };
     }
     return { isOpen: false };

--- a/src/components/filters/filter_menu/filter_menu.ts
+++ b/src/components/filters/filter_menu/filter_menu.ts
@@ -282,7 +282,7 @@ export const FilterMenuPopoverBuilder: PopoverBuilders = {
       isOpen: true,
       props: { filterPosition: position },
       Component: FilterMenu,
-      cellCorner: "BottomLeft",
+      cellCorner: "bottom-left",
     };
   },
 };

--- a/src/components/font_size_editor/font_size_editor.ts
+++ b/src/components/font_size_editor/font_size_editor.ts
@@ -68,7 +68,7 @@ export class FontSizeEditor extends Component<Props, SpreadsheetChildEnv> {
     const { x, y, width, height } = this.rootEditorRef.el!.getBoundingClientRect();
     return {
       anchorRect: { x, y, width, height },
-      positioning: "BottomLeft",
+      positioning: "bottom-left",
       verticalOffset: 0,
     };
   }

--- a/src/components/link/link_display/link_display.ts
+++ b/src/components/link/link_display/link_display.ts
@@ -132,7 +132,7 @@ export const LinkCellPopoverBuilder: PopoverBuilders = {
       isOpen: true,
       Component: LinkDisplay,
       props: { cellPosition: position },
-      cellCorner: "BottomLeft",
+      cellCorner: "bottom-left",
     };
   },
 };

--- a/src/components/link/link_editor/link_editor.ts
+++ b/src/components/link/link_editor/link_editor.ts
@@ -174,7 +174,7 @@ export const LinkEditorPopoverBuilder: PopoverBuilders = {
       isOpen: true,
       props: { cellPosition: position },
       Component: LinkEditor,
-      cellCorner: "BottomLeft",
+      cellCorner: "bottom-left",
     };
   },
 };

--- a/src/components/menu/menu.ts
+++ b/src/components/menu/menu.ts
@@ -121,7 +121,7 @@ export class Menu extends Component<Props, SpreadsheetChildEnv> {
   static components = { Menu, Popover };
   static defaultProps = {
     depth: 1,
-    popoverPositioning: "TopRight",
+    popoverPositioning: "top-right",
   };
   private subMenu: MenuState = useState({
     isOpen: false,

--- a/src/components/popover/popover.ts
+++ b/src/components/popover/popover.ts
@@ -7,7 +7,7 @@ import { css, cssPropertiesToCss } from "../helpers/css";
 import { usePopoverContainer, useSpreadsheetRect } from "../helpers/position_hook";
 import { CSSProperties } from "./../../types/misc";
 
-type PopoverPosition = "TopLeft" | "TopRight" | "BottomLeft" | "BottomRight";
+type PopoverPosition = "top-left" | "top-right" | "bottom-left" | "bottom-right";
 type DisplayValue = "none" | "block";
 
 export interface PopoverProps {
@@ -64,7 +64,7 @@ export class Popover extends Component<PopoverProps, SpreadsheetChildEnv> {
     slots: Object,
   };
   static defaultProps = {
-    positioning: "BottomLeft",
+    positioning: "bottom-left",
     verticalOffset: 0,
     onMouseWheel: () => {},
     onPopoverMoved: () => {},
@@ -107,7 +107,7 @@ export class Popover extends Component<PopoverProps, SpreadsheetChildEnv> {
       const spreadsheetRect = this.spreadsheetRect;
 
       const popoverPositionHelper =
-        this.props.positioning === "BottomLeft"
+        this.props.positioning === "bottom-left"
           ? new BottomLeftPopoverContext(anchor, this.containerRect, propsMaxSize, spreadsheetRect)
           : new TopRightPopoverContext(anchor, this.containerRect, propsMaxSize, spreadsheetRect);
 
@@ -217,10 +217,10 @@ abstract class PopoverPositionContext {
     const shouldRenderAtBottom = this.shouldRenderAtBottom(elDims.height);
     const shouldRenderAtRight = this.shouldRenderAtRight(elDims.width);
 
-    if (shouldRenderAtBottom && shouldRenderAtRight) return "BottomRight";
-    if (shouldRenderAtBottom && !shouldRenderAtRight) return "BottomLeft";
-    if (!shouldRenderAtBottom && shouldRenderAtRight) return "TopRight";
-    return "TopLeft";
+    if (shouldRenderAtBottom && shouldRenderAtRight) return "bottom-right";
+    if (shouldRenderAtBottom && !shouldRenderAtRight) return "bottom-left";
+    if (!shouldRenderAtBottom && shouldRenderAtRight) return "top-right";
+    return "top-left";
   }
 }
 

--- a/src/components/side_panel/chart/chart_type_picker/chart_type_picker.ts
+++ b/src/components/side_panel/chart/chart_type_picker/chart_type_picker.ts
@@ -118,7 +118,7 @@ export class ChartTypePicker extends Component<Props, SpreadsheetChildEnv> {
     const { bottom, right, width } = target.getBoundingClientRect();
     this.state.popoverProps = {
       anchorRect: { x: right, y: bottom, width: 0, height: 0 },
-      positioning: "TopRight",
+      positioning: "top-right",
       verticalOffset: 0,
     };
 

--- a/src/components/side_panel/pivot/pivot_layout_configurator/add_dimension_button/add_dimension_button.ts
+++ b/src/components/side_panel/pivot/pivot_layout_configurator/add_dimension_button/add_dimension_button.ts
@@ -102,7 +102,7 @@ export class AddDimensionButton extends Component<Props, SpreadsheetChildEnv> {
     const { x, y, width, height } = this.buttonRef.el!.getBoundingClientRect();
     return {
       anchorRect: { x, y, width, height },
-      positioning: "BottomLeft",
+      positioning: "bottom-left",
     };
   }
 

--- a/src/components/side_panel/select_menu/select_menu.xml
+++ b/src/components/side_panel/select_menu/select_menu.xml
@@ -13,7 +13,7 @@
       anchorRect="menuAnchorRect"
       onClose.bind="onMenuClosed"
       menuId="menuId"
-      popoverPositioning="'BottomLeft'"
+      popoverPositioning="'bottom-left'"
     />
   </t>
 </templates>

--- a/src/components/tables/table_dropdown_button/table_dropdown_button.ts
+++ b/src/components/tables/table_dropdown_button/table_dropdown_button.ts
@@ -61,7 +61,7 @@ export class TableDropdownButton extends Component<Props, SpreadsheetChildEnv> {
     this.topBarToolStore.openDropdown();
     this.state.popoverProps = {
       anchorRect: { x: left, y: bottom, width: 0, height: 0 },
-      positioning: "BottomLeft",
+      positioning: "bottom-left",
       verticalOffset: 0,
     };
   }

--- a/src/components/tables/table_style_picker/table_style_picker.ts
+++ b/src/components/tables/table_style_picker/table_style_picker.ts
@@ -85,7 +85,7 @@ export class TableStylePicker extends Component<TableStylePickerProps, Spreadshe
     const { bottom, right } = target.getBoundingClientRect();
     this.state.popoverProps = {
       anchorRect: { x: right, y: bottom, width: 0, height: 0 },
-      positioning: "TopRight",
+      positioning: "top-right",
       verticalOffset: 0,
     };
   }

--- a/src/components/top_bar/dropdown_action/dropdown_action.ts
+++ b/src/components/top_bar/dropdown_action/dropdown_action.ts
@@ -47,7 +47,7 @@ export class DropdownAction extends Component<Props, SpreadsheetChildEnv> {
       : { x: 0, y: 0, width: 0, height: 0 };
     return {
       anchorRect: rect,
-      positioning: "BottomLeft",
+      positioning: "bottom-left",
       verticalOffset: 0,
       class: "rounded",
     };

--- a/src/components/top_bar/number_formats_tool/number_formats_tool.xml
+++ b/src/components/top_bar/number_formats_tool/number_formats_tool.xml
@@ -11,7 +11,7 @@
       anchorRect="state.anchorRect"
       menuItems="state.menuItems"
       onClose="() => {}"
-      popoverPositioning="'BottomLeft'"
+      popoverPositioning="'bottom-left'"
     />
   </div>
 </templates>

--- a/src/components/top_bar/top_bar.ts
+++ b/src/components/top_bar/top_bar.ts
@@ -300,7 +300,7 @@ export class TopBar extends Component<Props, SpreadsheetChildEnv> {
       : { x: 0, y: 0, width: 0, height: 0 };
     return {
       anchorRect: rect,
-      positioning: "BottomLeft",
+      positioning: "bottom-left",
       verticalOffset: 0,
       class: "rounded",
       maxWidth: 300,

--- a/src/components/top_bar/top_bar.xml
+++ b/src/components/top_bar/top_bar.xml
@@ -96,7 +96,7 @@
       menuItems="state.menuState.menuItems"
       onClose="() => this.closeMenus()"
       onMenuClicked="() => this.props.onClick()"
-      popoverPositioning="'BottomLeft'"
+      popoverPositioning="'bottom-left'"
     />
     <Popover t-if="state.toolsPopoverState.isOpen" t-props="toolsPopoverProps">
       <div class="d-flex px-2 py-1 flex-wrap" style="background-color:white;">

--- a/src/types/cell_popovers.ts
+++ b/src/types/cell_popovers.ts
@@ -4,7 +4,7 @@ import { CellPosition, PropsOf } from "./misc";
 import { Rect } from "./rendering";
 
 export type CellPopoverType = "ErrorToolTip" | "LinkDisplay" | "FilterMenu" | "LinkEditor";
-export type PopoverPropsPosition = "TopRight" | "BottomLeft";
+export type PopoverPropsPosition = "top-right" | "bottom-left";
 
 type MaxSizedComponentConstructor = ComponentConstructor & {
   maxSize?: { maxWidth?: number; maxHeight?: number };

--- a/tests/menus/context_menu_component.test.ts
+++ b/tests/menus/context_menu_component.test.ts
@@ -847,7 +847,7 @@ describe("Context Menu position on large screen 1000px/1000px", () => {
   test("Can position menu on the bottom left of the anchor", async () => {
     await renderContextMenu(200, 200, {
       anchorRect: { x: 200, y: 200, width: 100, height: 100 },
-      popoverPositioning: "BottomLeft",
+      popoverPositioning: "bottom-left",
     });
     expect(getMenuPosition()).toEqual({ left: 200, top: 300 });
   });
@@ -855,7 +855,7 @@ describe("Context Menu position on large screen 1000px/1000px", () => {
   test("Can position menu on the top right of the anchor", async () => {
     await renderContextMenu(200, 200, {
       anchorRect: { x: 200, y: 200, width: 100, height: 100 },
-      popoverPositioning: "TopRight",
+      popoverPositioning: "top-right",
     });
     expect(getMenuPosition()).toEqual({ left: 300, top: 200 });
   });

--- a/tests/popover/popover_component.test.ts
+++ b/tests/popover/popover_component.test.ts
@@ -76,7 +76,7 @@ describe("Popover sizing", () => {
   test("Prop maxHeight and maxWidth make popover use CSS maxwidth/height", async () => {
     await mountTestPopover({
       anchorRect: { x: 0, y: 0, width: 0, height: 0 },
-      positioning: "TopRight",
+      positioning: "top-right",
       maxWidth: POPOVER_WIDTH,
       maxHeight: POPOVER_HEIGHT,
       childHeight: 100,
@@ -91,7 +91,7 @@ describe("Popover sizing", () => {
   test("Popover use the spreadsheet size to compute its max size", async () => {
     await mountTestPopover({
       anchorRect: { x: 0, y: 0, width: 0, height: 0 },
-      positioning: "TopRight",
+      positioning: "top-right",
       childHeight: 100,
       childWidth: 100,
     });
@@ -107,7 +107,7 @@ describe("Popover positioning", () => {
     test("Popover right of point", async () => {
       await mountTestPopover({
         anchorRect: { x: 0, y: 0, width: 0, height: 0 },
-        positioning: "TopRight",
+        positioning: "top-right",
         childHeight: 100,
         childWidth: 100,
       });
@@ -121,7 +121,7 @@ describe("Popover positioning", () => {
       const box = { x: 0, y: 0, width: 100, height: 100 };
       await mountTestPopover({
         anchorRect: box,
-        positioning: "TopRight",
+        positioning: "top-right",
         childWidth: 50,
         childHeight: 50,
       });
@@ -136,7 +136,7 @@ describe("Popover positioning", () => {
       const box = { x: viewPortDims.width - 50, y: 0, width: 50, height: 50 };
       await mountTestPopover({
         anchorRect: box,
-        positioning: "TopRight",
+        positioning: "top-right",
         childWidth: 100,
         childHeight: 100,
       });
@@ -151,7 +151,7 @@ describe("Popover positioning", () => {
       const box = { x: 0, y: viewPortDims.height - 50, width: 50, height: 50 };
       await mountTestPopover({
         anchorRect: box,
-        positioning: "TopRight",
+        positioning: "top-right",
         childHeight: 100,
         childWidth: 100,
       });
@@ -171,7 +171,7 @@ describe("Popover positioning", () => {
       };
       await mountTestPopover({
         anchorRect: box,
-        positioning: "TopRight",
+        positioning: "top-right",
         childHeight: 100,
         childWidth: 100,
       });
@@ -182,11 +182,11 @@ describe("Popover positioning", () => {
     });
   });
 
-  describe("Popover positioned BottomLeft", () => {
+  describe("Popover positioned bottom-left", () => {
     test("Popover bottom of point", async () => {
       await mountTestPopover({
         anchorRect: { x: 0, y: 0, width: 0, height: 0 },
-        positioning: "BottomLeft",
+        positioning: "bottom-left",
         childHeight: 100,
         childWidth: 100,
       });
@@ -200,7 +200,7 @@ describe("Popover positioning", () => {
       const box = { x: 0, y: 0, width: 100, height: 100 };
       await mountTestPopover({
         anchorRect: box,
-        positioning: "BottomLeft",
+        positioning: "bottom-left",
         childHeight: 100,
         childWidth: 100,
       });
@@ -215,7 +215,7 @@ describe("Popover positioning", () => {
       const box = { x: viewPortDims.width - 50, y: 0, width: 50, height: 50 };
       await mountTestPopover({
         anchorRect: box,
-        positioning: "BottomLeft",
+        positioning: "bottom-left",
         childWidth: 100,
         childHeight: 100,
       });
@@ -230,7 +230,7 @@ describe("Popover positioning", () => {
       const box = { x: 0, y: viewPortDims.height - 50, width: 50, height: 50 };
       await mountTestPopover({
         anchorRect: box,
-        positioning: "BottomLeft",
+        positioning: "bottom-left",
         childHeight: 100,
         childWidth: 100,
       });
@@ -251,7 +251,7 @@ describe("Popover positioning", () => {
       await mountTestPopover({
         anchorRect: box,
         containerRect: { x: 0, y: 0, ...viewPortDims },
-        positioning: "BottomLeft",
+        positioning: "bottom-left",
         childHeight: 100,
         childWidth: 100,
       });
@@ -272,7 +272,7 @@ describe("Popover positioning", () => {
     };
     await mountTestPopover({
       anchorRect,
-      positioning: "BottomLeft",
+      positioning: "bottom-left",
       childHeight: 100,
       childWidth: 100,
     });
@@ -292,7 +292,7 @@ describe("Popover positioning", () => {
     };
     await mountTestPopover({
       anchorRect,
-      positioning: "BottomLeft",
+      positioning: "bottom-left",
       childHeight: 100,
       childWidth: 100,
     });
@@ -307,7 +307,7 @@ describe("Popover positioning", () => {
     });
     await mountTestPopover({
       anchorRect: { x: 0, y: 0, width: 0, height: 0 },
-      positioning: "BottomLeft",
+      positioning: "bottom-left",
       childHeight: 100,
       childWidth: 100,
     });
@@ -317,7 +317,7 @@ describe("Popover positioning", () => {
     app.destroy();
     await mountTestPopover({
       anchorRect: { x: 300, y: 300, width: 0, height: 0 },
-      positioning: "BottomLeft",
+      positioning: "bottom-left",
       childHeight: 100,
       childWidth: 100,
     });
@@ -327,7 +327,7 @@ describe("Popover positioning", () => {
     app.destroy();
     await mountTestPopover({
       anchorRect: { x: 1400, y: 1400, width: 0, height: 0 },
-      positioning: "BottomLeft",
+      positioning: "bottom-left",
       childHeight: 100,
       childWidth: 100,
     });

--- a/tests/table/table_styles_popover_component.test.ts
+++ b/tests/table/table_styles_popover_component.test.ts
@@ -19,7 +19,7 @@ async function mountPopover(partialProps: Partial<TableStylesPopoverProps> = {})
     onStylePicked: () => {},
     popoverProps: {
       anchorRect: { x: 0, y: 0, width: 0, height: 0 },
-      positioning: "TopRight",
+      positioning: "top-right",
       verticalOffset: 0,
     },
     ...partialProps,


### PR DESCRIPTION
There's a linting test in odoo flagging string props that should probably be translated:

`<Greeting a="'Hello'"/>`

In this case the props should be modified with `.translate`.

`<Greeting a.translate="Hello"/>`

But of course, not all string props are user-facing strings that should be translated. Some are just technical parameters.

The current heuristic implemeted in the linting test is:

if the string starts with an uppercase letter (and it's not all uppercase), then it's probably a user-facing string.

It means the props `"BottomLeft"` etc. are flagged as such even though they are technical parameter.

This commit renames those props to avoid being wrongly flagged.

Task: 0

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo