### PR TITLE
[FIX] pivot_side_panel: allow scrolling in readonly mode

### DIFF
--- a/src/components/side_panel/pivot/pivot_side_panel/pivot_spreadsheet_side_panel/pivot_spreadsheet_side_panel.xml
+++ b/src/components/side_panel/pivot/pivot_side_panel/pivot_spreadsheet_side_panel/pivot_spreadsheet_side_panel.xml
@@ -1,42 +1,44 @@
 <templates>
   <t t-name="o-spreadsheet-PivotSpreadsheetSidePanel">
     <t t-set="isReadonly" t-value="env.model.getters.isReadonly()"/>
-    <div
-      class="d-flex flex-column h-100 justify-content-between overflow-hidden"
-      t-att="isReadonly ? ['inert', 1] : []"
-      t-att-class="{ 'pe-none': isReadonly, 'opacity-50': isReadonly }">
+    <div class="d-flex flex-column h-100 justify-content-between overflow-hidden">
       <div class="h-100 position-relative overflow-x-hidden overflow-y-auto" t-ref="pivotSidePanel">
-        <PivotTitleSection pivotId="props.pivotId" flipAxis.bind="flipAxis"/>
-        <Section title.translate="Range">
-          <SelectionInput
-            ranges="ranges"
-            required="true"
-            isInvalid="shouldDisplayInvalidRangeError"
-            hasSingleRange="true"
-            onSelectionChanged="(ranges) => this.onSelectionChanged(ranges)"
-            onSelectionConfirmed="() => this.onSelectionConfirmed()"
-          />
-          <span
-            class="text-danger sp_range_error_message"
-            t-if="shouldDisplayInvalidRangeError"
-            t-esc="pivot.invalidRangeMessage"
-          />
-        </Section>
+        <div
+          t-att="isReadonly ? ['inert', 1] : []"
+          t-att-class="{ 'pe-none opacity-50': isReadonly }">
+          <PivotTitleSection pivotId="props.pivotId" flipAxis.bind="flipAxis"/>
+          <Section title.translate="Range">
+            <SelectionInput
+              ranges="ranges"
+              required="true"
+              isInvalid="shouldDisplayInvalidRangeError"
+              hasSingleRange="true"
+              onSelectionChanged="(ranges) => this.onSelectionChanged(ranges)"
+              onSelectionConfirmed="() => this.onSelectionConfirmed()"
+            />
+            <span
+              class="text-danger sp_range_error_message"
+              t-if="shouldDisplayInvalidRangeError"
+              t-esc="pivot.invalidRangeMessage"
+            />
+          </Section>
 
-        <PivotLayoutConfigurator
-          t-if="!pivot.isInvalidRange"
-          unusedGroupableFields="store.unusedGroupableFields"
-          measureFields="store.measureFields"
-          unusedGranularities="store.unusedGranularities"
-          dateGranularities="store.dateGranularities"
-          datetimeGranularities="store.datetimeGranularities"
-          definition="definition"
-          onDimensionsUpdated.bind="onDimensionsUpdated"
-          getScrollableContainerEl.bind="getScrollableContainerEl"
-          pivotId="props.pivotId"
-        />
+          <PivotLayoutConfigurator
+            t-if="!pivot.isInvalidRange"
+            unusedGroupableFields="store.unusedGroupableFields"
+            measureFields="store.measureFields"
+            unusedGranularities="store.unusedGranularities"
+            dateGranularities="store.dateGranularities"
+            datetimeGranularities="store.datetimeGranularities"
+            definition="definition"
+            onDimensionsUpdated.bind="onDimensionsUpdated"
+            getScrollableContainerEl.bind="getScrollableContainerEl"
+            pivotId="props.pivotId"
+          />
+        </div>
       </div>
       <PivotDeferUpdate
+        t-if="!isReadonly"
         deferUpdate="store.updatesAreDeferred"
         toggleDeferUpdate="(value) => store.deferUpdates(value)"
         isDirty="store.isDirty"

--- a/tests/pivots/pivot_side_panel.test.ts
+++ b/tests/pivots/pivot_side_panel.test.ts
@@ -25,17 +25,29 @@ describe("Pivot side panel", () => {
     addPivot(model, "A1:B2", {}, "2");
   });
 
-  test("readonly panel is not clickable and greyed", async () => {
-    env.openSidePanel("PivotSidePanel", { pivotId: "2" });
+  test("readonly panel is not clickable and greyed but remains scrollable", async () => {
+    env.openSidePanel("PivotSidePanel", { pivotId: "1" });
     await nextTick();
-    const panel = fixture.querySelector(".o-sidePanelBody > div");
-    expect(panel?.classList).not.toContain("pe-none");
-    expect(panel?.classList).not.toContain("opacity-50");
+
+    const sidePanel = fixture.querySelector(".o-sidePanel")!;
+    let interactiveWrapper = sidePanel.querySelector(".o-sidePanelBody div[inert]");
+    expect(interactiveWrapper).toBeNull();
+
     model.updateMode("readonly");
     await nextTick();
-    expect(panel?.classList).toContain("pe-none");
-    expect(panel?.classList).toContain("opacity-50");
-    expect(panel?.getAttribute("inert")).toBe("1");
+
+    const scrollableContainer = sidePanel.querySelector(".overflow-y-auto")!;
+    expect(scrollableContainer).toBeTruthy();
+
+    // The [inert] wrapper with `pe-none` and `opacity-50` is placed inside the scrollable container,
+    // ensuring that user interactions are blocked while still allowing vertical scrolling.
+    interactiveWrapper = scrollableContainer.querySelector("[inert]")!;
+    expect(interactiveWrapper).toBeTruthy();
+    expect(interactiveWrapper.classList).toContain("pe-none");
+    expect(interactiveWrapper.classList).toContain("opacity-50");
+    expect(interactiveWrapper.getAttribute("inert")).toBe("1");
+
+    expect(fixture.querySelector(".pivot-defer-update")).toBeNull();
   });
 
   test("It should open the pivot editor when pivotId is provided", async () => {

--- a/tests/pivots/spreadsheet_pivot/__snapshots__/spreadsheet_pivot_side_panel.test.ts.snap
+++ b/tests/pivots/spreadsheet_pivot/__snapshots__/spreadsheet_pivot_side_panel.test.ts.snap
@@ -65,129 +65,131 @@ exports[`Spreadsheet pivot side panel It should correctly be displayed 1`] = `
         <div
           class="h-100 position-relative overflow-x-hidden overflow-y-auto"
         >
-          <div
-            class="o-section"
-          >
+          <div>
             <div
-              class="o-section-title"
-            >
-              
-              <div
-                class="d-flex flex-row justify-content-between align-items-center"
-              >
-                 Name 
-                <span
-                  class="fa fa-cog os-cog-wheel-menu-icon o-button-icon"
-                />
-                
-                
-              </div>
-              
-            </div>
-            
-            <div
-              class="w-100"
-            >
-              <input
-                class="os-input w-100 os-pivot-title"
-                type="text"
-              />
-            </div>
-            
-          </div>
-          
-          <div
-            class="o-section"
-          >
-            <div
-              class="o-section-title"
-            >
-              Range
-              
-              
-            </div>
-            
-            <div
-              class="o-selection"
+              class="o-section"
             >
               <div
-                class="o-selection-input d-flex flex-row"
+                class="o-section-title"
               >
+                
                 <div
-                  class="position-relative w-100"
+                  class="d-flex flex-row justify-content-between align-items-center"
                 >
-                  <input
-                    class="o-input mb-2"
-                    placeholder="e.g. A1:A2"
-                    spellcheck="false"
-                    style=""
-                    type="text"
+                   Name 
+                  <span
+                    class="fa fa-cog os-cog-wheel-menu-icon o-button-icon"
                   />
+                  
                   
                 </div>
                 
               </div>
               
-              
               <div
-                class="d-flex flex-row w-100 o-selection-input"
+                class="w-100"
               >
+                <input
+                  class="os-input w-100 os-pivot-title"
+                  type="text"
+                />
+              </div>
+              
+            </div>
+            
+            <div
+              class="o-section"
+            >
+              <div
+                class="o-section-title"
+              >
+                Range
                 
                 
               </div>
+              
+              <div
+                class="o-selection"
+              >
+                <div
+                  class="o-selection-input d-flex flex-row"
+                >
+                  <div
+                    class="position-relative w-100"
+                  >
+                    <input
+                      class="o-input mb-2"
+                      placeholder="e.g. A1:A2"
+                      spellcheck="false"
+                      style=""
+                      type="text"
+                    />
+                    
+                  </div>
+                  
+                </div>
+                
+                
+                <div
+                  class="d-flex flex-row w-100 o-selection-input"
+                >
+                  
+                  
+                </div>
+              </div>
+              
+              
+            </div>
+            
+            <div
+              class="pivot-dimensions o-section"
+            >
+              <div
+                class="o-fw-bold py-1 d-flex flex-row justify-content-between align-items-center o-section-title"
+              >
+                 Columns 
+                <button
+                  class="add-dimension o-button"
+                >
+                  Add
+                </button>
+                
+                
+              </div>
+              
+              
+              <div
+                class="o-fw-bold pt-4 pb-1 d-flex flex-row justify-content-between align-items-center o-section-title"
+              >
+                 Rows 
+                <button
+                  class="add-dimension o-button"
+                >
+                  Add
+                </button>
+                
+                
+              </div>
+              
+              
+              <div
+                class="o-fw-bold pt-4 pb-1 d-flex flex-row justify-content-between align-items-center o-section-title o-pivot-measure"
+              >
+                 Measures 
+                <button
+                  class="add-dimension o-button"
+                >
+                  Add
+                </button>
+                
+                
+              </div>
+              
+              
             </div>
             
             
           </div>
-          
-          <div
-            class="pivot-dimensions o-section"
-          >
-            <div
-              class="o-fw-bold py-1 d-flex flex-row justify-content-between align-items-center o-section-title"
-            >
-               Columns 
-              <button
-                class="add-dimension o-button"
-              >
-                Add
-              </button>
-              
-              
-            </div>
-            
-            
-            <div
-              class="o-fw-bold pt-4 pb-1 d-flex flex-row justify-content-between align-items-center o-section-title"
-            >
-               Rows 
-              <button
-                class="add-dimension o-button"
-              >
-                Add
-              </button>
-              
-              
-            </div>
-            
-            
-            <div
-              class="o-fw-bold pt-4 pb-1 d-flex flex-row justify-content-between align-items-center o-section-title o-pivot-measure"
-            >
-               Measures 
-              <button
-                class="add-dimension o-button"
-              >
-                Add
-              </button>
-              
-              
-            </div>
-            
-            
-          </div>
-          
-          
         </div>
         <div
           class="o-section align-items-center border-top d-flex flex-row justify-content-between py-1 pivot-defer-update"
@@ -281,114 +283,116 @@ exports[`Spreadsheet pivot side panel It should display only the selection input
         <div
           class="h-100 position-relative overflow-x-hidden overflow-y-auto"
         >
-          <div
-            class="o-section"
-          >
+          <div>
             <div
-              class="o-section-title"
-            >
-              
-              <div
-                class="d-flex flex-row justify-content-between align-items-center"
-              >
-                 Name 
-                <span
-                  class="fa fa-cog os-cog-wheel-menu-icon o-button-icon"
-                />
-                
-                
-              </div>
-              
-            </div>
-            
-            <div
-              class="w-100"
-            >
-              <input
-                class="os-input w-100 os-pivot-title"
-                type="text"
-              />
-            </div>
-            
-          </div>
-          
-          <div
-            class="o-section"
-          >
-            <div
-              class="o-section-title"
-            >
-              Range
-              
-              
-            </div>
-            
-            <div
-              class="o-selection"
+              class="o-section"
             >
               <div
-                class="o-selection-input d-flex flex-row"
+                class="o-section-title"
               >
+                
                 <div
-                  class="position-relative w-100"
+                  class="d-flex flex-row justify-content-between align-items-center"
                 >
-                  <input
-                    class="o-input mb-2 o-focused o-invalid border-danger position-relative"
-                    placeholder="e.g. A1:A2"
-                    spellcheck="false"
-                    style=""
-                    type="text"
-                  />
+                   Name 
                   <span
-                    class="error-icon text-danger position-absolute d-flex align-items-center"
-                    title="This range is invalid"
-                  >
-                    <div
-                      class="o-icon"
-                    >
-                      <i
-                        class="fa fa-exclamation-circle"
-                      />
-                    </div>
-                  </span>
+                    class="fa fa-cog os-cog-wheel-menu-icon o-button-icon"
+                  />
+                  
                   
                 </div>
                 
               </div>
-              
               
               <div
-                class="d-flex flex-row w-100 o-selection-input"
+                class="w-100"
               >
+                <input
+                  class="os-input w-100 os-pivot-title"
+                  type="text"
+                />
+              </div>
+              
+            </div>
+            
+            <div
+              class="o-section"
+            >
+              <div
+                class="o-section-title"
+              >
+                Range
                 
+                
+              </div>
+              
+              <div
+                class="o-selection"
+              >
                 <div
-                  class="ms-auto"
+                  class="o-selection-input d-flex flex-row"
                 >
-                  <button
-                    class="o-button o-selection-ko"
+                  <div
+                    class="position-relative w-100"
                   >
-                     Reset 
-                  </button>
-                  
-                  <button
-                    class="o-button primary ms-2 o-selection-ok"
-                  >
-                     Confirm 
-                  </button>
+                    <input
+                      class="o-input mb-2 o-focused o-invalid border-danger position-relative"
+                      placeholder="e.g. A1:A2"
+                      spellcheck="false"
+                      style=""
+                      type="text"
+                    />
+                    <span
+                      class="error-icon text-danger position-absolute d-flex align-items-center"
+                      title="This range is invalid"
+                    >
+                      <div
+                        class="o-icon"
+                      >
+                        <i
+                          class="fa fa-exclamation-circle"
+                        />
+                      </div>
+                    </span>
+                    
+                  </div>
                   
                 </div>
                 
+                
+                <div
+                  class="d-flex flex-row w-100 o-selection-input"
+                >
+                  
+                  <div
+                    class="ms-auto"
+                  >
+                    <button
+                      class="o-button o-selection-ko"
+                    >
+                       Reset 
+                    </button>
+                    
+                    <button
+                      class="o-button primary ms-2 o-selection-ok"
+                    >
+                       Confirm 
+                    </button>
+                    
+                  </div>
+                  
+                </div>
               </div>
+              <span
+                class="text-danger sp_range_error_message"
+              >
+                The pivot cannot be created because the dataset is missing.
+              </span>
+              
             </div>
-            <span
-              class="text-danger sp_range_error_message"
-            >
-              The pivot cannot be created because the dataset is missing.
-            </span>
+            
             
           </div>
-          
-          
         </div>
         <div
           class="o-section align-items-center border-top d-flex flex-row justify-content-between py-1 pivot-defer-update"


### PR DESCRIPTION
## Description:

The `pointer-events: none;` property prevents elements (and their children) from receiving any pointer events, including scroll gestures. As a result, scrolling the pivot dimensions in readonly mode was not possible.

To fix this, we removed `pointer-events: none;` from the main container and applied it only to the child elements of the pivot dimensions.

Task: [4655830](https://www.odoo.com/odoo/2328/tasks/4655830)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo