### PR TITLE
[FIX] ChartRuntime: take devicePixelRatio in account to draw

### DIFF
--- a/src/components/figures/chart/chartJs/chartjs.ts
+++ b/src/components/figures/chart/chartJs/chartjs.ts
@@ -39,7 +39,7 @@ export class ChartJsComponent extends Component<Props, SpreadsheetChildEnv> {
     });
     useEffect(
       () => this.updateChartJs(deepCopy(this.chartRuntime)),
-      () => [this.chartRuntime]
+      () => [this.chartRuntime, window.devicePixelRatio]
     );
   }
 

--- a/src/components/figures/chart/scorecard/chart_scorecard.ts
+++ b/src/components/figures/chart/scorecard/chart_scorecard.ts
@@ -20,7 +20,7 @@ export class ScorecardChart extends Component<Props, SpreadsheetChildEnv> {
     useEffect(this.createChart.bind(this), () => {
       const canvas = this.canvas.el as HTMLCanvasElement;
       const rect = canvas.getBoundingClientRect();
-      return [rect.width, rect.height, this.runtime, this.canvas.el];
+      return [rect.width, rect.height, this.runtime, this.canvas.el, window.devicePixelRatio];
     });
   }
 

--- a/src/helpers/figures/charts/scorecard_chart.ts
+++ b/src/helpers/figures/charts/scorecard_chart.ts
@@ -187,8 +187,10 @@ export class ScorecardChart extends AbstractChart {
 
 export function drawScoreChart(structure: ScorecardChartConfig, canvas: HTMLCanvasElement) {
   const ctx = canvas.getContext("2d")!;
-  canvas.width = structure.canvas.width;
-  canvas.height = structure.canvas.height;
+  const dpr = window.devicePixelRatio || 1;
+  canvas.width = structure.canvas.width * dpr;
+  canvas.height = structure.canvas.height * dpr;
+  ctx.scale(dpr, dpr);
 
   ctx.fillStyle = structure.canvas.backgroundColor;
   ctx.fillRect(0, 0, structure.canvas.width, structure.canvas.height);


### PR DESCRIPTION
The charts were not redrawn when the devicePixelRatio was altered
and the homebrew chart (scorecard) was not scaled, which led to blurry
charts on Mac screens for instance.

Task: 4661712

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo