### PR TITLE
[FIX] spreadsheet: add name to DUPLICATE_SHEET

### DIFF
--- a/src/migrations/data.ts
+++ b/src/migrations/data.ts
@@ -13,6 +13,7 @@ import {
   UuidGenerator,
   zoneToXc,
 } from "../helpers/index";
+import { _lt } from "../translation";
 import { StateUpdateMessage } from "../types/collaborative/transport_service";
 import {
   CoreCommand,
@@ -406,6 +407,7 @@ export function repairInitialMessages(
   initialMessages = dropCommands(initialMessages, "SORT_CELLS");
   initialMessages = dropCommands(initialMessages, "SET_DECIMAL");
   initialMessages = fixChartDefinitions(data, initialMessages);
+  initialMessages = fixTranslatedDuplicateSheetName(data, initialMessages);
   return initialMessages;
 }
 
@@ -508,6 +510,44 @@ function fixChartDefinitions(data: Partial<WorkbookData>, initialMessages: State
   return messages;
 }
 
+function fixTranslatedDuplicateSheetName(
+  data: Partial<WorkbookData>,
+  initialMessages: StateUpdateMessage[]
+): StateUpdateMessage[] {
+  const sheetNames = {};
+  for (const sheet of data.sheets || []) {
+    sheetNames[sheet.id] = sheet.name;
+  }
+  const messages: StateUpdateMessage[] = [];
+  for (const message of initialMessages) {
+    if (message.type === "REMOTE_REVISION") {
+      const commands: CoreCommand[] = [];
+      for (const cmd of message.commands) {
+        switch (cmd.type) {
+          case "DUPLICATE_SHEET":
+            cmd.sheetNameTo = getDuplicateSheetName(
+              sheetNames[cmd.sheetId],
+              Object.values(sheetNames)
+            );
+            break;
+          case "CREATE_SHEET":
+          case "RENAME_SHEET":
+            sheetNames[cmd.sheetId] = cmd.name || getNextSheetName(Object.values(sheetNames));
+            break;
+        }
+        commands.push(cmd);
+      }
+      messages.push({
+        ...message,
+        commands,
+      });
+    } else {
+      messages.push(message);
+    }
+  }
+  return initialMessages;
+}
+
 // -----------------------------------------------------------------------------
 // Helpers
 // -----------------------------------------------------------------------------
@@ -554,4 +594,26 @@ export function createEmptyExcelWorkbookData(): ExcelWorkbookData {
     ...createEmptyWorkbookData(),
     sheets: [createEmptyExcelSheet(INITIAL_SHEET_ID, "Sheet1")],
   };
+}
+
+function getDuplicateSheetName(nameToDuplicate: string, names: string[]): string {
+  let i = 1;
+  const baseName = _lt("Copy of %s", nameToDuplicate);
+  let name = baseName.toString();
+  while (names.includes(name)) {
+    name = `${baseName} (${i})`;
+    i++;
+  }
+  return name;
+}
+
+function getNextSheetName(names: string[]): string {
+  const baseName = "Sheet";
+  let i = 1;
+  let name = `${baseName}${i}`;
+  while (names.includes(name)) {
+    name = `${baseName}${i}`;
+    i++;
+  }
+  return name;
 }

--- a/src/plugins/core/sheet.ts
+++ b/src/plugins/core/sheet.ts
@@ -76,6 +76,7 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
     "getSheetZone",
     "getPaneDivisions",
     "checkElementsIncludeAllNonFrozenHeaders",
+    "getDuplicateSheetName",
   ] as const;
 
   readonly sheetIdsMapName: Record<string, UID | undefined> = {};
@@ -204,7 +205,7 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
         this.showSheet(cmd.sheetId);
         break;
       case "DUPLICATE_SHEET":
-        this.duplicateSheet(cmd.sheetId, cmd.sheetIdTo);
+        this.duplicateSheet(cmd.sheetId, cmd.sheetIdTo, cmd.sheetNameTo);
         break;
       case "DELETE_SHEET":
         this.deleteSheet(this.sheets[cmd.sheetId]!);
@@ -730,9 +731,8 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
     this.history.update("sheets", sheetId, "isVisible", true);
   }
 
-  private duplicateSheet(fromId: UID, toId: UID) {
+  private duplicateSheet(fromId: UID, toId: UID, toName: string) {
     const sheet = this.getSheet(fromId);
-    const toName = this.getDuplicateSheetName(sheet.name);
     const newSheet: Sheet = deepCopy(sheet);
     newSheet.id = toId;
     newSheet.name = toName;
@@ -766,7 +766,7 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
     this.history.update("sheetIdsMapName", sheetIdsMapName);
   }
 
-  private getDuplicateSheetName(sheetName: string) {
+  getDuplicateSheetName(sheetName: string) {
     let i = 1;
     const names = this.orderedSheetIds.map(this.getSheetName.bind(this));
     const baseName = _lt("Copy of %s", sheetName);

--- a/src/registries/menus/sheet_menu_registry.ts
+++ b/src/registries/menus/sheet_menu_registry.ts
@@ -21,10 +21,13 @@ sheetMenuRegistry
     sequence: 20,
     action: (env) => {
       const sheetIdFrom = env.model.getters.getActiveSheetId();
+      const sheetNameFrom = env.model.getters.getSheetName(sheetIdFrom);
       const sheetIdTo = env.model.uuidGenerator.smallUuid();
+      const sheetNameTo = env.model.getters.getDuplicateSheetName(sheetNameFrom);
       env.model.dispatch("DUPLICATE_SHEET", {
         sheetId: sheetIdFrom,
         sheetIdTo,
+        sheetNameTo,
       });
       env.model.dispatch("ACTIVATE_SHEET", { sheetIdFrom, sheetIdTo });
     },

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -343,6 +343,7 @@ export interface DeleteSheetCommand extends SheetDependentCommand {
 export interface DuplicateSheetCommand extends SheetDependentCommand {
   type: "DUPLICATE_SHEET";
   sheetIdTo: UID;
+  sheetNameTo: string;
 }
 
 export interface MoveSheetCommand extends SheetDependentCommand {

--- a/tests/collaborative/collaborative.test.ts
+++ b/tests/collaborative/collaborative.test.ts
@@ -434,6 +434,7 @@ describe("Multi users synchronisation", () => {
     alice.dispatch("DUPLICATE_SHEET", {
       sheetId: firstSheetId,
       sheetIdTo: "42",
+      sheetNameTo: "Copy of Sheet1",
     });
     expect([alice, bob, charlie]).toHaveSynchronizedValue(
       (user) => user.getters.getActiveSheetId(),
@@ -528,6 +529,7 @@ describe("Multi users synchronisation", () => {
     alice.dispatch("DUPLICATE_SHEET", {
       sheetId: alice.getters.getActiveSheetId(),
       sheetIdTo: "Sheet2",
+      sheetNameTo: "Copy of Sheet1",
     });
     expect([alice, bob, charlie]).toHaveSynchronizedExportedData();
   });
@@ -995,6 +997,7 @@ describe("Multi users synchronisation", () => {
       alice.dispatch("DUPLICATE_SHEET", {
         sheetId: "Sheet1",
         sheetIdTo: "sheet2",
+        sheetNameTo: "Copy of Sheet1",
       });
       createFilter(charlie, "A1:B4", firstSheetId);
     });
@@ -1015,6 +1018,7 @@ describe("Multi users synchronisation", () => {
       charlie.dispatch("DUPLICATE_SHEET", {
         sheetId: firstSheetId,
         sheetIdTo: "sheet2",
+        sheetNameTo: "Copy of Sheet1",
       });
       charlie.dispatch("DELETE_SHEET", { sheetId: firstSheetId });
     });

--- a/tests/collaborative/collaborative_history.test.ts
+++ b/tests/collaborative/collaborative_history.test.ts
@@ -969,7 +969,11 @@ describe("Collaborative local history", () => {
   test("do not transformed revisions with concurrently rejected commands", () => {
     const { network, alice, bob, charlie } = setupCollaborativeEnv();
     const initialCols = alice.getters.getNumberCols("Sheet1");
-    charlie.dispatch("DUPLICATE_SHEET", { sheetId: "Sheet1", sheetIdTo: "duplicateSheetId" });
+    charlie.dispatch("DUPLICATE_SHEET", {
+      sheetId: "Sheet1",
+      sheetIdTo: "duplicateSheetId",
+      sheetNameTo: "Copy of Sheet1",
+    });
     network.concurrent(() => {
       undo(charlie);
 

--- a/tests/collaborative/inverses.test.ts
+++ b/tests/collaborative/inverses.test.ts
@@ -116,6 +116,7 @@ describe("Inverses commands", () => {
       type: "DUPLICATE_SHEET",
       sheetId: "1",
       sheetIdTo: "2",
+      sheetNameTo: "Copy of Sheet1",
     };
     expect(inverseCommand(duplicateSheet)).toEqual([{ type: "DELETE_SHEET", sheetId: "2" }]);
   });

--- a/tests/collaborative/ot/ot_sheet_deleted.test.ts
+++ b/tests/collaborative/ot/ot_sheet_deleted.test.ts
@@ -191,6 +191,7 @@ describe("OT with DELETE_SHEET", () => {
     const cmd: Omit<DuplicateSheetCommand, "sheetId"> = {
       type: "DUPLICATE_SHEET",
       sheetIdTo: "sheetIdTo",
+      sheetNameTo: "Copy of Sheet1",
     };
 
     test("Delete the sheet on which the command is triggered", () => {

--- a/tests/components/bottom_bar.test.ts
+++ b/tests/components/bottom_bar.test.ts
@@ -268,6 +268,7 @@ describe("BottomBar component", () => {
     expect(dispatch).toHaveBeenCalledWith("DUPLICATE_SHEET", {
       sheetId: sheet,
       sheetIdTo: expect.any(String),
+      sheetNameTo: expect.any(String),
     });
   });
 

--- a/tests/plugins/borders.test.ts
+++ b/tests/plugins/borders.test.ts
@@ -356,6 +356,7 @@ describe("Grid manipulation", () => {
     model.dispatch("DUPLICATE_SHEET", {
       sheetId: firstSheetId,
       sheetIdTo: secondSheetId,
+      sheetNameTo: "Copy of Sheet1",
     });
     addColumns(model, "before", "A", 1, secondSheetId);
     expect(getBorder(model, "B2", firstSheetId)).toEqual({ top: b, left: b, right: b, bottom: b });
@@ -371,6 +372,7 @@ describe("Grid manipulation", () => {
     model.dispatch("DUPLICATE_SHEET", {
       sheetId: firstSheetId,
       sheetIdTo: secondSheetId,
+      sheetNameTo: "Copy of Sheet1",
     });
     addRows(model, "before", 0, 1, secondSheetId);
     expect(getBorder(model, "B2", firstSheetId)).toEqual({ top: b, left: b, right: b, bottom: b });
@@ -463,7 +465,7 @@ describe("Grid manipulation", () => {
     setBorder(model, "external", "B2");
     const sheetId = model.getters.getActiveSheetId();
     const sheetIdTo = "42";
-    model.dispatch("DUPLICATE_SHEET", { sheetId, sheetIdTo });
+    model.dispatch("DUPLICATE_SHEET", { sheetId, sheetIdTo, sheetNameTo: "Copy of Sheet1" });
     model.dispatch("ACTIVATE_SHEET", { sheetIdFrom: sheetId, sheetIdTo });
     expect(getBorder(model, "B2")).toEqual({ top: b, left: b, right: b, bottom: b });
   });

--- a/tests/plugins/chart/basic_chart.test.ts
+++ b/tests/plugins/chart/basic_chart.test.ts
@@ -765,12 +765,14 @@ describe("datasource tests", function () {
     model.dispatch("DUPLICATE_SHEET", {
       sheetId: "1",
       sheetIdTo: "SheetNoFigure",
+      sheetNameTo: "Copy of Sheet1",
     });
     activateSheet(model, "SheetNoFigure");
     expect(model.getters.getVisibleFigures()).toEqual([]);
     model.dispatch("DUPLICATE_SHEET", {
       sheetId: "2",
       sheetIdTo: "SheetWithFigure",
+      sheetNameTo: "Copy of Sheet1",
     });
     activateSheet(model, "2");
     const { x, y, height, width, tag } = model.getters.getVisibleFigures()[0];
@@ -848,6 +850,7 @@ describe("datasource tests", function () {
     model.dispatch("DUPLICATE_SHEET", {
       sheetIdTo: secondSheetId,
       sheetId: firstSheetId,
+      sheetNameTo: "Copy of Sheet1",
     });
 
     expect(model.getters.getFigures(secondSheetId)).toHaveLength(1);
@@ -887,12 +890,14 @@ describe("datasource tests", function () {
     model.dispatch("DUPLICATE_SHEET", {
       sheetId: firstSheetId,
       sheetIdTo: secondSheetId,
+      sheetNameTo: "Copy of Sheet1",
     });
 
     const newModel = new Model(model.exportData());
     newModel.dispatch("DUPLICATE_SHEET", {
       sheetId: secondSheetId,
       sheetIdTo: thirdSheetId,
+      sheetNameTo: "Copy of Sheet1",
     });
 
     const figuresSh1 = newModel.getters.getFigures(firstSheetId);
@@ -941,6 +946,7 @@ describe("datasource tests", function () {
     model.dispatch("DUPLICATE_SHEET", {
       sheetIdTo: thirdSheetId,
       sheetId: firstSheetId,
+      sheetNameTo: "Copy of Sheet1",
     });
     const duplicatedFigure = model.getters.getFigures(thirdSheetId)[0];
     const duplicatedChartDefinition = model.getters.getChartDefinition(duplicatedFigure.id);
@@ -1846,7 +1852,11 @@ test("Duplicating a sheet dispatches `CREATE_CHART` for each chart", () => {
   // @ts-ignore
   const spyDispatch = jest.spyOn(chartPlugin, "dispatch");
   const sheetId = model.getters.getActiveSheetId();
-  model.dispatch("DUPLICATE_SHEET", { sheetId, sheetIdTo: "copyOf" + sheetId });
+  model.dispatch("DUPLICATE_SHEET", {
+    sheetId,
+    sheetIdTo: "copyOf" + sheetId,
+    sheetNameTo: "Copy of Sheet1",
+  });
   // first chart duplicated
   expect(spyDispatch).toHaveBeenNthCalledWith(1, "CREATE_CHART", expect.any(Object));
   expect(spyDispatch).toHaveBeenNthCalledWith(2, "CREATE_FIGURE", expect.any(Object));

--- a/tests/plugins/chart/common_chart.test.ts
+++ b/tests/plugins/chart/common_chart.test.ts
@@ -102,6 +102,7 @@ describe("Single cell chart background color", () => {
     model.dispatch("DUPLICATE_SHEET", {
       sheetIdTo: secondSheetId,
       sheetId: firstSheetId,
+      sheetNameTo: "Copy of Sheet1",
     });
     const secondSheetFigures = model.getters.getFigures(secondSheetId);
     expect(secondSheetFigures.length).toBe(1);

--- a/tests/plugins/chart/gauge_chart.test.ts
+++ b/tests/plugins/chart/gauge_chart.test.ts
@@ -341,6 +341,7 @@ describe("datasource tests", function () {
     model.dispatch("DUPLICATE_SHEET", {
       sheetIdTo: secondSheetId,
       sheetId: firstSheetId,
+      sheetNameTo: "Copy of Sheet1",
     });
 
     expect(model.getters.getFigures(secondSheetId)).toHaveLength(1);

--- a/tests/plugins/chart/scorecard_chart.test.ts
+++ b/tests/plugins/chart/scorecard_chart.test.ts
@@ -184,6 +184,7 @@ describe("datasource tests", function () {
     model.dispatch("DUPLICATE_SHEET", {
       sheetIdTo: secondSheetId,
       sheetId: firstSheetId,
+      sheetNameTo: "Copy of Sheet1",
     });
 
     expect(model.getters.getFigures(secondSheetId)).toHaveLength(1);

--- a/tests/plugins/conditional_formatting.test.ts
+++ b/tests/plugins/conditional_formatting.test.ts
@@ -175,7 +175,11 @@ describe("conditional format", () => {
       ranges: toRangesData(sheetId, "A1:A4"),
       sheetId,
     });
-    model.dispatch("DUPLICATE_SHEET", { sheetId, sheetIdTo: "Sheet2" });
+    model.dispatch("DUPLICATE_SHEET", {
+      sheetId,
+      sheetIdTo: "Sheet2",
+      sheetNameTo: "Copy of Sheet1",
+    });
     expect(model.getters.getConditionalFormats("Sheet2")).toEqual([
       {
         id: expect.any(String),

--- a/tests/plugins/filter_evaluation.test.ts
+++ b/tests/plugins/filter_evaluation.test.ts
@@ -163,6 +163,7 @@ describe("Filter Evaluation Plugin", () => {
     model.dispatch("DUPLICATE_SHEET", {
       sheetId: "sh1",
       sheetIdTo: "sh2",
+      sheetNameTo: "Copy of Sheet1",
     });
     expect(model.getters.getFilter("sh2", 0, 0)).toBeTruthy();
   });

--- a/tests/plugins/filters.test.ts
+++ b/tests/plugins/filters.test.ts
@@ -142,6 +142,7 @@ describe("Filters plugin", () => {
       model.dispatch("DUPLICATE_SHEET", {
         sheetId: sheetId,
         sheetIdTo: sheet2Id,
+        sheetNameTo: "Copy of Sheet1",
       });
       expect(getFilterValues(model, sheet2Id)).toMatchObject([{ zone: "A1:A3", value: ["C"] }]);
       updateFilter(model, "A1", ["D"], sheet2Id);
@@ -158,6 +159,7 @@ describe("Filters plugin", () => {
       model.dispatch("DUPLICATE_SHEET", {
         sheetId: sheetId,
         sheetIdTo: sheet2Id,
+        sheetNameTo: "Copy of Sheet1",
       });
       expect(getFilterValues(model, sheet2Id)).toMatchObject([{ zone: "B1:B3", value: ["C"] }]);
       deleteColumns(model, ["A"], sheet2Id);

--- a/tests/plugins/header_visibility.test.ts
+++ b/tests/plugins/header_visibility.test.ts
@@ -346,7 +346,11 @@ describe("Hide Rows", () => {
     addRows(model, "after", 99, 1);
     const plugin = getPlugin(model, HeaderSizePlugin);
     expect(plugin.sizes[sheetId].ROW.length).toEqual(101);
-    model.dispatch("DUPLICATE_SHEET", { sheetId, sheetIdTo: "sheet2" });
+    model.dispatch("DUPLICATE_SHEET", {
+      sheetId,
+      sheetIdTo: "sheet2",
+      sheetNameTo: "Copy of Sheet1",
+    });
     expect(plugin.sizes["sheet2"].ROW.length).toEqual(101);
   });
 });

--- a/tests/plugins/import_export.test.ts
+++ b/tests/plugins/import_export.test.ts
@@ -700,7 +700,7 @@ test("Data of a duplicate sheet are correctly duplicated", () => {
   const model = new Model();
   setCellContent(model, "A1", "hello");
   const sheetId = model.getters.getActiveSheetId();
-  model.dispatch("DUPLICATE_SHEET", { sheetId, sheetIdTo: "42" });
+  model.dispatch("DUPLICATE_SHEET", { sheetId, sheetIdTo: "42", sheetNameTo: "Copy of Sheet1" });
   expect(getCellContent(model, "A1", sheetId)).toBe("hello");
   expect(getCellContent(model, "A1", "42")).toBe("hello");
   const data = model.exportData();

--- a/tests/plugins/merges.test.ts
+++ b/tests/plugins/merges.test.ts
@@ -82,6 +82,7 @@ describe("merges", () => {
     model.dispatch("DUPLICATE_SHEET", {
       sheetId: firstSheetId,
       sheetIdTo: secondSheetId,
+      sheetNameTo: "Copy of Sheet1",
     });
     merge(model, "B2:B3", secondSheetId);
     expect(model.getters.getMerges(secondSheetId)).toEqual([
@@ -100,6 +101,7 @@ describe("merges", () => {
     model.dispatch("DUPLICATE_SHEET", {
       sheetId: firstSheetId,
       sheetIdTo: secondSheetId,
+      sheetNameTo: "Copy of Sheet1",
     });
     deleteSheet(model, secondSheetId);
     expect(model.getters.getMerges(secondSheetId)).toEqual([]);
@@ -635,6 +637,7 @@ describe("merges", () => {
     model.dispatch("DUPLICATE_SHEET", {
       sheetId: firstSheetId,
       sheetIdTo: secondSheetId,
+      sheetNameTo: "Copy of Sheet1",
     });
     addColumns(model, "before", "A", 1, "42");
     expect(model.getters.getMerges(firstSheetId)).toEqual([

--- a/tests/plugins/sheets.test.ts
+++ b/tests/plugins/sheets.test.ts
@@ -606,7 +606,11 @@ describe("sheets", () => {
     const model = new Model();
     const sheet = model.getters.getActiveSheetId();
     const name = `Copy of ${model.getters.getSheetIds().map(model.getters.getSheetName)}`;
-    model.dispatch("DUPLICATE_SHEET", { sheetId: sheet, sheetIdTo: model.uuidGenerator.uuidv4() });
+    model.dispatch("DUPLICATE_SHEET", {
+      sheetId: sheet,
+      sheetIdTo: model.uuidGenerator.uuidv4(),
+      sheetNameTo: "Copy of Sheet1",
+    });
     const sheetIds = model.getters.getSheetIds();
     expect(sheetIds).toHaveLength(2);
     expect(model.getters.getSheetName(sheetIds[sheetIds.length - 1])).toBe(name);
@@ -619,7 +623,11 @@ describe("sheets", () => {
   test("Duplicate a sheet does not make the newly created active", () => {
     const model = new Model();
     const sheetId = model.getters.getActiveSheetId();
-    model.dispatch("DUPLICATE_SHEET", { sheetId: sheetId, sheetIdTo: "42" });
+    model.dispatch("DUPLICATE_SHEET", {
+      sheetId: sheetId,
+      sheetIdTo: "42",
+      sheetNameTo: "Copy of Sheet1",
+    });
     expect(model.getters.getActiveSheetId()).toBe(sheetId);
   });
 
@@ -647,7 +655,11 @@ describe("sheets", () => {
     });
     const sheet = model.getters.getActiveSheetId();
     setCellContent(model, "A1", "42");
-    model.dispatch("DUPLICATE_SHEET", { sheetId: sheet, sheetIdTo: model.uuidGenerator.uuidv4() });
+    model.dispatch("DUPLICATE_SHEET", {
+      sheetId: sheet,
+      sheetIdTo: model.uuidGenerator.uuidv4(),
+      sheetNameTo: "Copy of Sheet1",
+    });
     expect(model.getters.getSheetIds()).toHaveLength(2);
     const newSheet = model.getters.getSheetIds()[1];
     activateSheet(model, newSheet);
@@ -683,7 +695,11 @@ describe("sheets", () => {
     });
     const sheet = model.getters.getActiveSheetId();
     setCellContent(model, "A1", "42");
-    model.dispatch("DUPLICATE_SHEET", { sheetId: sheet, sheetIdTo: model.uuidGenerator.uuidv4() });
+    model.dispatch("DUPLICATE_SHEET", {
+      sheetId: sheet,
+      sheetIdTo: model.uuidGenerator.uuidv4(),
+      sheetNameTo: "Copy of Sheet1",
+    });
     expect(model.getters.getSheetIds()).toHaveLength(2);
     const newSheetId = model.getters.getSheetIds()[1];
     activateSheet(model, newSheetId);
@@ -721,7 +737,11 @@ describe("sheets", () => {
       ],
     });
     const sheet = model.getters.getActiveSheetId();
-    model.dispatch("DUPLICATE_SHEET", { sheetId: sheet, sheetIdTo: model.uuidGenerator.uuidv4() });
+    model.dispatch("DUPLICATE_SHEET", {
+      sheetId: sheet,
+      sheetIdTo: model.uuidGenerator.uuidv4(),
+      sheetNameTo: "Copy of Sheet1",
+    });
     expect(model.getters.getSheetIds()).toHaveLength(2);
     const newSheet = model.getters.getSheetIds()[1];
     activateSheet(model, newSheet);
@@ -737,7 +757,7 @@ describe("sheets", () => {
     const sheetId = model.getters.getActiveSheetId();
     const chartId = "uuid";
     createChart(model, { dataSets: ["Sheet1!B1:B4"], labelRange: "Sheet1!A2:A4" }, chartId);
-    model.dispatch("DUPLICATE_SHEET", { sheetId, sheetIdTo: "42" });
+    model.dispatch("DUPLICATE_SHEET", { sheetId, sheetIdTo: "42", sheetNameTo: "Copy of Sheet1" });
     model.dispatch("UPDATE_FIGURE", {
       sheetId: sheetId,
       id: chartId,
@@ -753,7 +773,11 @@ describe("sheets", () => {
   test("Cols and Rows are correctly duplicated", () => {
     const model = new Model();
     const sheet = model.getters.getActiveSheetId();
-    model.dispatch("DUPLICATE_SHEET", { sheetId: sheet, sheetIdTo: model.uuidGenerator.uuidv4() });
+    model.dispatch("DUPLICATE_SHEET", {
+      sheetId: sheet,
+      sheetIdTo: model.uuidGenerator.uuidv4(),
+      sheetNameTo: "Copy of Sheet1",
+    });
     expect(model.getters.getSheetIds()).toHaveLength(2);
     resizeColumns(model, ["A"], 1);
     resizeRows(model, [0], 1);
@@ -774,7 +798,11 @@ describe("sheets", () => {
       ],
     });
     const sheet = model.getters.getActiveSheetId();
-    model.dispatch("DUPLICATE_SHEET", { sheetId: sheet, sheetIdTo: model.uuidGenerator.uuidv4() });
+    model.dispatch("DUPLICATE_SHEET", {
+      sheetId: sheet,
+      sheetIdTo: model.uuidGenerator.uuidv4(),
+      sheetNameTo: "Copy of Sheet1",
+    });
     expect(model.getters.getSheetIds()).toHaveLength(2);
     unMerge(model, "A1:A2");
     const newSheet = model.getters.getSheetIds()[1];
@@ -787,10 +815,15 @@ describe("sheets", () => {
     const model = new Model();
     const firstSheetId = model.getters.getActiveSheetId();
     const duplicatedSheetId = "new-sheet-id";
-    model.dispatch("DUPLICATE_SHEET", { sheetId: firstSheetId, sheetIdTo: duplicatedSheetId });
+    model.dispatch("DUPLICATE_SHEET", {
+      sheetId: firstSheetId,
+      sheetIdTo: duplicatedSheetId,
+      sheetNameTo: "Copy of Sheet1",
+    });
     const result = model.dispatch("DUPLICATE_SHEET", {
       sheetId: firstSheetId,
       sheetIdTo: duplicatedSheetId,
+      sheetNameTo: "Copy of Sheet1",
     });
     expect(result).toBeCancelledBecause(CommandResult.DuplicatedSheetId);
   });
@@ -869,6 +902,7 @@ describe("sheets", () => {
     testUndoRedo(model, expect, "DUPLICATE_SHEET", {
       sheetIdTo: "42",
       sheetId: model.getters.getActiveSheetId(),
+      sheetNameTo: "Copy of Sheet1",
     });
   });
 

--- a/tests/test_helpers/constants.ts
+++ b/tests/test_helpers/constants.ts
@@ -98,6 +98,7 @@ export const TEST_COMMANDS: CommandMapping = {
     type: "DUPLICATE_SHEET",
     sheetId: "Sheet1",
     sheetIdTo: "duplicateSheetId",
+    sheetNameTo: "Copy of Sheet1",
   },
   MOVE_SHEET: {
     type: "MOVE_SHEET",


### PR DESCRIPTION
When duplicating sheet, the name was based on the
translation of "Copy of", which would lead to divergent sheet name if multiple users had different locale.

Task: 4640070

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [4640070](https://www.odoo.com/odoo/2328/tasks/4640070)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo