### PR TITLE
[IMP] registry: add key unicity on add

### DIFF
--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -67,6 +67,14 @@ export class FunctionRegistry extends Registry<FunctionDescription> {
 
   add(name: string, addDescr: AddFunctionDescription) {
     name = name.toUpperCase();
+    if (name in this.content) {
+      throw new Error(`${name} is already present in this registry!`);
+    }
+    return this.replace(name, addDescr);
+  }
+
+  replace(name: string, addDescr: AddFunctionDescription) {
+    name = name.toUpperCase();
     if (!functionNameRegex.test(name)) {
       throw new Error(
         _t(
@@ -78,7 +86,7 @@ export class FunctionRegistry extends Registry<FunctionDescription> {
     const descr = addMetaInfoFromArg(name, addDescr);
     validateArguments(descr);
     this.mapping[name] = createComputeFunction(descr);
-    super.add(name, descr);
+    super.replace(name, descr);
     return this;
   }
 }

--- a/src/registries/menu_items_registry.ts
+++ b/src/registries/menu_items_registry.ts
@@ -21,12 +21,20 @@ export class MenuItemRegistry extends Registry<ActionSpec> {
    * @param path Path of items to add this subitem
    * @param value Subitem to add
    */
-  addChild(
+  addChild(key: string, path: string[], value: ActionSpec | ActionBuilder): this {
+    return this._replaceChild(key, path, value, { force: false });
+  }
+
+  replaceChild(key: string, path: string[], value: ActionSpec | ActionBuilder): this {
+    return this._replaceChild(key, path, value, { force: true });
+  }
+
+  private _replaceChild(
     key: string,
     path: string[],
     value: ActionSpec | ActionBuilder,
-    options: { force: boolean } = { force: false }
-  ): MenuItemRegistry {
+    options: { force: boolean } = { force: true }
+  ): this {
     if (typeof value !== "function" && value.id === undefined) {
       value.id = key;
     }

--- a/src/registries/menu_items_registry.ts
+++ b/src/registries/menu_items_registry.ts
@@ -9,7 +9,7 @@ export class MenuItemRegistry extends Registry<ActionSpec> {
   /**
    * @override
    */
-  add(key: string, value: ActionSpec): MenuItemRegistry {
+  replace(key: string, value: ActionSpec): this {
     if (value.id === undefined) {
       value.id = key;
     }

--- a/src/registries/registry.ts
+++ b/src/registries/registry.ts
@@ -15,12 +15,26 @@ export class Registry<T> {
   content: { [key: string]: T } = {};
 
   /**
-   * Add an item to the registry
+   * Add an item to the registry, you can only add if there is no item
+   * already present in the registery with the given key
    *
    * Note that this also returns the registry, so another add method call can
    * be chained
    */
-  add(key: string, value: T): Registry<T> {
+  add(key: string, value: T): this {
+    if (key in this.content) {
+      throw new Error(`${key} is already present in this registry!`);
+    }
+    return this.replace(key, value);
+  }
+
+  /**
+   * Replace (or add) an item to the registry
+   *
+   * Note that this also returns the registry, so another add method call can
+   * be chained
+   */
+  replace(key: string, value: T): this {
     this.content[key] = value;
     return this;
   }

--- a/src/registries/repeat_commands_registry.ts
+++ b/src/registries/repeat_commands_registry.ts
@@ -67,7 +67,6 @@ repeatCommandTransformRegistry.add("CREATE_CHART", repeatCreateChartCommand);
 repeatCommandTransformRegistry.add("CREATE_IMAGE", repeatCreateImageCommand);
 repeatCommandTransformRegistry.add("GROUP_HEADERS", repeatGroupHeadersCommand);
 repeatCommandTransformRegistry.add("UNGROUP_HEADERS", repeatGroupHeadersCommand);
-repeatCommandTransformRegistry.add("UNGROUP_HEADERS", repeatGroupHeadersCommand);
 repeatCommandTransformRegistry.add("UNFOLD_HEADER_GROUPS_IN_ZONE", repeatZoneDependantCommand);
 repeatCommandTransformRegistry.add("FOLD_HEADER_GROUPS_IN_ZONE", repeatZoneDependantCommand);
 

--- a/src/registries/srt_registry.ts
+++ b/src/registries/srt_registry.ts
@@ -24,6 +24,11 @@ export class SpecificRangeTransformRegistry extends Registry<
     return this;
   }
 
+  replace<C extends CoreCommand>(cmdType: C["type"], fn: CommandAdaptRangeFunction<C>): this {
+    super.replace(cmdType, fn);
+    return this;
+  }
+
   get<C extends CoreCommand>(cmdType: C["type"]): CommandAdaptRangeFunction<CoreCommand> {
     return this.content[cmdType];
   }

--- a/src/registries/toolbar_menu_registry.ts
+++ b/src/registries/toolbar_menu_registry.ts
@@ -9,12 +9,15 @@ type ToolBarItem<C extends ComponentConstructor = ComponentConstructor> = {
 
 export class ToolBarRegistry {
   content: { [key: string]: ToolBarItem[] } = {};
-  add(key: string): ToolBarRegistry {
+  add(key: string): this {
+    if (key in this.content) {
+      throw new Error(`${key} is already present in this registry!`);
+    }
     this.content[key] = [];
     return this;
   }
 
-  addChild(key: string, value: ToolBarItem): ToolBarRegistry {
+  addChild(key: string, value: ToolBarItem): this {
     this.content[key].push(value);
     return this;
   }

--- a/src/registries/topbar_component_registry.ts
+++ b/src/registries/topbar_component_registry.ts
@@ -17,9 +17,9 @@ class TopBarComponentRegistry extends Registry<TopbarComponent> {
   mapping: { [key: string]: Function } = {};
   uuidGenerator = new UuidGenerator();
 
-  add(name: string, value: Omit<TopbarComponent, "id">) {
+  replace(name: string, value: Omit<TopbarComponent, "id">) {
     const component: TopbarComponent = { ...value, id: this.uuidGenerator.uuidv4() };
-    return super.add(name, component);
+    return super.replace(name, component);
   }
 
   getAllOrdered(): TopbarComponent[] {

--- a/tests/menus/menu_items_registry.test.ts
+++ b/tests/menus/menu_items_registry.test.ts
@@ -81,7 +81,7 @@ describe("Top Bar Menu Item Registry", () => {
     addToRegistry(registry, "root", { name: "rootNode" });
     registry.addChild("child", ["root"], { id: "unique", name: "child" });
     expect(() =>
-      registry.addChild("child", ["root"], { id: "unique", name: "child" }, { force: true })
+      registry.replaceChild("child", ["root"], { id: "unique", name: "child" })
     ).not.toThrowError();
   });
   test("Menu items can have the same id with different parent nodes", () => {

--- a/tests/test_helpers/helpers.ts
+++ b/tests/test_helpers/helpers.ts
@@ -116,8 +116,14 @@ export function addTestPlugin(
 }
 
 export function addToRegistry<T>(registry: Registry<T>, key: string, value: T) {
-  registry.add(key, value);
-  registerCleanup(() => registry.remove(key));
+  if (registry.contains(key)) {
+    const oldValue = registry.get(key);
+    registry.replace(key, value);
+    registerCleanup(() => registry.replace(key, oldValue));
+  } else {
+    registry.add(key, value);
+    registerCleanup(() => registry.remove(key));
+  }
 }
 
 const realTimeSetTimeout = window.setTimeout.bind(window);


### PR DESCRIPTION
Throw an error if we try to add a key to
the registry that is already present.

`.replace()` allow to add/change an already
present key.

Task: 4712321

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [4712321](https://www.odoo.com/odoo/2328/tasks/4712321)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo