### PR TITLE
[FIX] xlsx: correctly export aggregated charts

### DIFF
--- a/src/helpers/figures/charts/bar_chart.ts
+++ b/src/helpers/figures/charts/bar_chart.ts
@@ -163,8 +163,6 @@ export class BarChart extends AbstractChart {
   }
 
   getDefinitionForExcel(): ExcelChartDefinition | undefined {
-    // Excel does not support aggregating labels
-    if (this.aggregated) return undefined;
     const dataSets: ExcelChartDataset[] = this.dataSets
       .map((ds: DataSet) => toExcelDataset(this.getters, ds))
       .filter((ds) => ds.range !== "" && ds.range !== INCORRECT_RANGE_STRING);

--- a/src/helpers/figures/charts/line_chart.ts
+++ b/src/helpers/figures/charts/line_chart.ts
@@ -180,8 +180,6 @@ export class LineChart extends AbstractChart {
   }
 
   getDefinitionForExcel(): ExcelChartDefinition | undefined {
-    // Excel does not support aggregating labels
-    if (this.aggregated) return undefined;
     const dataSets: ExcelChartDataset[] = this.dataSets
       .map((ds: DataSet) => toExcelDataset(this.getters, ds))
       .filter((ds) => ds.range !== "" && ds.range !== INCORRECT_RANGE_STRING);

--- a/src/helpers/figures/charts/pie_chart.ts
+++ b/src/helpers/figures/charts/pie_chart.ts
@@ -163,8 +163,6 @@ export class PieChart extends AbstractChart {
   }
 
   getDefinitionForExcel(): ExcelChartDefinition | undefined {
-    // Excel does not support aggregating labels
-    if (this.aggregated) return undefined;
     const dataSets: ExcelChartDataset[] = this.dataSets
       .map((ds: DataSet) => toExcelDataset(this.getters, ds))
       .filter((ds) => ds.range !== "" && ds.range !== INCORRECT_RANGE_STRING);

--- a/tests/xlsx/xlsx_export.test.ts
+++ b/tests/xlsx/xlsx_export.test.ts
@@ -1073,42 +1073,13 @@ describe("Test XLSX export", () => {
     });
 
     test.each(["bar", "line", "pie"] as const)(
-      "%s chart that aggregate labels is exported as image",
+      "%s chart that aggregate labels is exported as normal chart, ignoring the aggregation",
       async (type: "bar" | "line" | "pie") => {
-        const model = new Model({
-          sheets: [
-            {
-              ...chartData.sheets,
-              cells: {
-                ...chartData.sheets[0].cells,
-                A6: { content: "P1" },
-                A7: { content: "P2" },
-                A8: { content: "P3" },
-                A9: { content: "P4" },
-                B6: { content: "17" },
-                B7: { content: "26" },
-                B8: { content: "13" },
-                B9: { content: "31" },
-                C6: { content: "31" },
-                C7: { content: "18" },
-                C8: { content: "9" },
-                C9: { content: "27" },
-              },
-            },
-          ],
-        });
-        createChart(
-          model,
-          {
-            dataSets: ["Sheet1!B1:B9"],
-            labelRange: "Sheet1!A2:A9",
-            aggregated: true,
-            type,
-          },
-          "1"
-        );
-        expect(getExportedExcelData(model).sheets[0].charts.length).toBe(0);
-        expect(getExportedExcelData(model).sheets[0].images.length).toBe(1);
+        const model = new Model();
+        createChart(model, { aggregated: true, type }, "1");
+        const exportedData = getExportedExcelData(model);
+        expect(exportedData.sheets[0].charts.length).toBe(1);
+        expect(exportedData.sheets[0].images.length).toBe(0);
       }
     );
 


### PR DESCRIPTION
## Description

The feature to aggregate the chart data based on the labels does not exist in xlsx files. But rather than exporting the chart as normal, ignoring the aggregation, we exported the chart as an image.

Task: [4714410](https://www.odoo.com/odoo/2328/tasks/4714410)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo