### PR TITLE
Saas 18.1 chart legend onclick dashboard v2 adrm

### DIFF
--- a/src/components/figures/chart/chartJs/chart_js_extension.ts
+++ b/src/components/figures/chart/chartJs/chart_js_extension.ts
@@ -1,12 +1,28 @@
-import { Plugin as ChartJSPlugin } from "chart.js";
 import { Registry } from "../../../../registries/registry";
 
-export const chartJsExtensionRegistry = new Registry<ChartJSPlugin>();
+export const chartJsExtensionRegistry = new Registry<{
+  register: (chart: typeof window.Chart) => void;
+  unregister: (chart: typeof window.Chart) => void;
+}>();
 
-/** Return window.Chart, making sure all our extensions are loaded in ChartJS */
-export function getChartJSConstructor() {
-  if (window.Chart && !window.Chart?.registry.plugins.get("chartShowValuesPlugin")) {
-    window.Chart.register(...chartJsExtensionRegistry.getAll());
+export function areChartJSExtensionsLoaded() {
+  return !!window.Chart.registry.plugins.get("chartShowValuesPlugin");
+}
+
+export function registerChartJSExtensions() {
+  if (!window.Chart || areChartJSExtensionsLoaded()) {
+    return;
   }
-  return window.Chart;
+  for (const registryItem of chartJsExtensionRegistry.getAll()) {
+    registryItem.register(window.Chart);
+  }
+}
+
+export function unregisterChartJsExtensions() {
+  if (!window.Chart) {
+    return;
+  }
+  for (const registryItem of chartJsExtensionRegistry.getAll()) {
+    registryItem.unregister(window.Chart);
+  }
 }

--- a/src/components/figures/chart/chartJs/chartjs.ts
+++ b/src/components/figures/chart/chartJs/chartjs.ts
@@ -3,7 +3,7 @@ import { Chart, ChartConfiguration } from "chart.js/auto";
 import { deepCopy } from "../../../../helpers";
 import { Figure, SpreadsheetChildEnv } from "../../../../types";
 import { ChartJSRuntime } from "../../../../types/chart/chart";
-import { chartJsExtensionRegistry, getChartJSConstructor } from "./chart_js_extension";
+import { chartJsExtensionRegistry } from "./chart_js_extension";
 import { chartShowValuesPlugin } from "./chartjs_show_values_plugin";
 import { waterfallLinesPlugin } from "./chartjs_waterfall_plugin";
 
@@ -11,9 +11,14 @@ interface Props {
   figure: Figure;
 }
 
-chartJsExtensionRegistry.add("chartShowValuesPlugin", chartShowValuesPlugin);
-chartJsExtensionRegistry.add("waterfallLinesPlugin", waterfallLinesPlugin);
-
+chartJsExtensionRegistry.add("chartShowValuesPlugin", {
+  register: (Chart) => Chart.register(chartShowValuesPlugin),
+  unregister: (Chart) => Chart.unregister(chartShowValuesPlugin),
+});
+chartJsExtensionRegistry.add("waterfallLinesPlugin", {
+  register: (Chart) => Chart.register(waterfallLinesPlugin),
+  unregister: (Chart) => Chart.unregister(waterfallLinesPlugin),
+});
 export class ChartJsComponent extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ChartJsComponent";
   static props = {
@@ -70,8 +75,7 @@ export class ChartJsComponent extends Component<Props, SpreadsheetChildEnv> {
   private createChart(chartData: ChartConfiguration<any>) {
     const canvas = this.canvas.el as HTMLCanvasElement;
     const ctx = canvas.getContext("2d")!;
-    const Chart = getChartJSConstructor();
-    this.chart = new Chart(ctx, chartData);
+    this.chart = new window.Chart(ctx, chartData);
   }
 
   private updateChartJs(chartData: ChartConfiguration<any>) {

--- a/src/components/spreadsheet/spreadsheet.ts
+++ b/src/components/spreadsheet/spreadsheet.ts
@@ -55,6 +55,10 @@ import {
 import { BottomBar } from "../bottom_bar/bottom_bar";
 import { ComposerFocusStore } from "../composer/composer_focus_store";
 import { SpreadsheetDashboard } from "../dashboard/dashboard";
+import {
+  registerChartJSExtensions,
+  unregisterChartJsExtensions,
+} from "../figures/chart/chartJs/chart_js_extension";
 import { Grid } from "../grid/grid";
 import { HeaderGroupContainer } from "../header_group/header_group_container";
 import { css, cssPropertiesToCss } from "../helpers/css";
@@ -442,11 +446,13 @@ export class Spreadsheet extends Component<SpreadsheetProps, SpreadsheetChildEnv
       this.checkViewportSize();
       stores.on("store-updated", this, render);
       resizeObserver.observe(this.spreadsheetRef.el!);
+      registerChartJSExtensions();
     });
     onWillUnmount(() => {
       this.unbindModelEvents();
       stores.off("store-updated", this);
       resizeObserver.disconnect();
+      unregisterChartJsExtensions();
     });
     onPatched(() => {
       this.checkViewportSize();

--- a/src/helpers/figures/charts/chart_ui_common.ts
+++ b/src/helpers/figures/charts/chart_ui_common.ts
@@ -1,5 +1,4 @@
 import type { ChartConfiguration, ChartOptions } from "chart.js";
-import { getChartJSConstructor } from "../../../components/figures/chart/chartJs/chart_js_extension";
 import { MAX_CHAR_LABEL } from "../../../constants";
 import { Figure } from "../../../types";
 import { GaugeChartRuntime, ScorecardChartRuntime } from "../../../types/chart";
@@ -53,8 +52,7 @@ export function chartToImage(
   if ("chartJsConfig" in runtime) {
     const config = deepCopy(runtime.chartJsConfig);
     config.plugins = [backgroundColorChartJSPlugin];
-    const Chart = getChartJSConstructor();
-    const chart = new Chart(canvas, config as ChartConfiguration);
+    const chart = new window.Chart(canvas, config as ChartConfiguration);
     const imgContent = chart.toBase64Image() as string;
     chart.destroy();
     div.remove();

--- a/src/helpers/figures/charts/chart_ui_common.ts
+++ b/src/helpers/figures/charts/chart_ui_common.ts
@@ -21,6 +21,7 @@ export const CHART_COMMON_OPTIONS: ChartOptions = {
     },
   },
   animation: false,
+  events: ["mousemove", "mouseout", "click", "touchstart", "touchmove", "mouseup"],
 };
 
 export function truncateLabel(label: string | undefined): string {

--- a/src/helpers/figures/charts/runtime/chart_data_extractor.ts
+++ b/src/helpers/figures/charts/runtime/chart_data_extractor.ts
@@ -1,5 +1,4 @@
 import { Point } from "chart.js";
-import { getChartJSConstructor } from "../../../../components/figures/chart/chartJs/chart_js_extension";
 import { ChartTerms } from "../../../../components/translations_terms";
 import {
   evaluatePolynomial,
@@ -544,12 +543,11 @@ function canBeLinearChart(
 let missingTimeAdapterAlreadyWarned = false;
 
 function isLuxonTimeAdapterInstalled() {
-  const Chart = getChartJSConstructor();
-  if (!Chart) {
+  if (!window.Chart) {
     return false;
   }
   // @ts-ignore
-  const adapter = new Chart._adapters._date({});
+  const adapter = new window.Chart._adapters._date({});
   const isInstalled = adapter._id === "luxon";
   if (!isInstalled && !missingTimeAdapterAlreadyWarned) {
     missingTimeAdapterAlreadyWarned = true;

--- a/src/helpers/figures/charts/runtime/chartjs_legend.ts
+++ b/src/helpers/figures/charts/runtime/chartjs_legend.ts
@@ -213,6 +213,9 @@ export const INTERACTIVE_LEGEND_CONFIG = {
     target.style.cursor = "default";
   },
   onClick: (event, legendItem, legend) => {
+    if (event.type !== "click") {
+      return;
+    }
     const index = legendItem.datasetIndex;
     if (!legend.legendItems || index === undefined) {
       return;

--- a/tests/figures/chart/__snapshots__/chart_plugin.test.ts.snap
+++ b/tests/figures/chart/__snapshots__/chart_plugin.test.ts.snap
@@ -47,6 +47,14 @@ exports[`Linear/Time charts font color is white with a dark background color 1`]
           "hitRadius": 15,
         },
       },
+      "events": [
+        "mousemove",
+        "mouseout",
+        "click",
+        "touchstart",
+        "touchmove",
+        "mouseup",
+      ],
       "layout": {
         "padding": {
           "bottom": 10,
@@ -184,6 +192,14 @@ exports[`Linear/Time charts snapshot test of chartJS configuration for date char
           "hitRadius": 15,
         },
       },
+      "events": [
+        "mousemove",
+        "mouseout",
+        "click",
+        "touchstart",
+        "touchmove",
+        "mouseup",
+      ],
       "layout": {
         "padding": {
           "bottom": 10,
@@ -328,6 +344,14 @@ exports[`Linear/Time charts snapshot test of chartJS configuration for linear ch
           "hitRadius": 15,
         },
       },
+      "events": [
+        "mousemove",
+        "mouseout",
+        "click",
+        "touchstart",
+        "touchmove",
+        "mouseup",
+      ],
       "layout": {
         "padding": {
           "bottom": 10,
@@ -446,6 +470,14 @@ exports[`datasource tests create a chart with stacked bar 1`] = `
           "hitRadius": 15,
         },
       },
+      "events": [
+        "mousemove",
+        "mouseout",
+        "click",
+        "touchstart",
+        "touchmove",
+        "mouseup",
+      ],
       "indexAxis": "x",
       "layout": {
         "padding": {
@@ -564,6 +596,14 @@ exports[`datasource tests create chart with a dataset of one cell (no title) 1`]
           "hitRadius": 15,
         },
       },
+      "events": [
+        "mousemove",
+        "mouseout",
+        "click",
+        "touchstart",
+        "touchmove",
+        "mouseup",
+      ],
       "layout": {
         "padding": {
           "bottom": 10,
@@ -700,6 +740,14 @@ exports[`datasource tests create chart with column datasets 1`] = `
           "hitRadius": 15,
         },
       },
+      "events": [
+        "mousemove",
+        "mouseout",
+        "click",
+        "touchstart",
+        "touchmove",
+        "mouseup",
+      ],
       "layout": {
         "padding": {
           "bottom": 10,
@@ -836,6 +884,14 @@ exports[`datasource tests create chart with column datasets with category title 
           "hitRadius": 15,
         },
       },
+      "events": [
+        "mousemove",
+        "mouseout",
+        "click",
+        "touchstart",
+        "touchmove",
+        "mouseup",
+      ],
       "layout": {
         "padding": {
           "bottom": 10,
@@ -972,6 +1028,14 @@ exports[`datasource tests create chart with column datasets without series title
           "hitRadius": 15,
         },
       },
+      "events": [
+        "mousemove",
+        "mouseout",
+        "click",
+        "touchstart",
+        "touchmove",
+        "mouseup",
+      ],
       "layout": {
         "padding": {
           "bottom": 10,
@@ -1091,6 +1155,14 @@ exports[`datasource tests create chart with only the dataset title (no data) 1`]
           "hitRadius": 15,
         },
       },
+      "events": [
+        "mousemove",
+        "mouseout",
+        "click",
+        "touchstart",
+        "touchmove",
+        "mouseup",
+      ],
       "layout": {
         "padding": {
           "bottom": 10,
@@ -1227,6 +1299,14 @@ exports[`datasource tests create chart with rectangle dataset 1`] = `
           "hitRadius": 15,
         },
       },
+      "events": [
+        "mousemove",
+        "mouseout",
+        "click",
+        "touchstart",
+        "touchmove",
+        "mouseup",
+      ],
       "layout": {
         "padding": {
           "bottom": 10,
@@ -1363,6 +1443,14 @@ exports[`datasource tests create chart with row datasets 1`] = `
           "hitRadius": 15,
         },
       },
+      "events": [
+        "mousemove",
+        "mouseout",
+        "click",
+        "touchstart",
+        "touchmove",
+        "mouseup",
+      ],
       "layout": {
         "padding": {
           "bottom": 10,
@@ -1499,6 +1587,14 @@ exports[`datasource tests create chart with row datasets with category title 1`]
           "hitRadius": 15,
         },
       },
+      "events": [
+        "mousemove",
+        "mouseout",
+        "click",
+        "touchstart",
+        "touchmove",
+        "mouseup",
+      ],
       "layout": {
         "padding": {
           "bottom": 10,
@@ -1635,6 +1731,14 @@ exports[`datasource tests create chart with row datasets without series title 1`
           "hitRadius": 15,
         },
       },
+      "events": [
+        "mousemove",
+        "mouseout",
+        "click",
+        "touchstart",
+        "touchmove",
+        "mouseup",
+      ],
       "layout": {
         "padding": {
           "bottom": 10,

--- a/tests/figures/chart/charts_component.test.ts
+++ b/tests/figures/chart/charts_component.test.ts
@@ -1,3 +1,4 @@
+import { App } from "@odoo/owl";
 import { CommandResult, Model, Spreadsheet } from "../../../src";
 import { ChartPanel } from "../../../src/components/side_panel/chart/main_chart_panel/main_chart_panel";
 import { ChartTerms } from "../../../src/components/translations_terms";
@@ -97,12 +98,13 @@ async function mountChartSidePanel(figureId = chartId) {
 }
 
 async function mountSpreadsheet() {
-  ({ env, model, fixture, parent } = await mountSpreadsheetHelper({ model }));
+  ({ env, model, fixture, parent, app } = await mountSpreadsheetHelper({ model }));
 }
 
 let fixture: HTMLElement;
 let model: Model;
 let mockChartData = mockChart();
+let app: App;
 const chartId = "someuuid";
 let sheetId: string;
 let parent: Spreadsheet;
@@ -2110,13 +2112,14 @@ test("ChartJS charts are correctly destroyed and re-created when runtime change 
   expect(spyConstructor).toHaveBeenCalled();
 });
 
-test("ChartJS charts extensions are loaded when mounting a chart, and are only loaded once", async () => {
+test("ChartJS charts extensions are loaded when mounting a spreadsheet, are only loaded once, and removed on unmount", async () => {
   window.Chart.registry.plugins["items"] = [];
   model = new Model();
   const spyRegister = jest.spyOn(window.Chart, "register");
+  const spyUnregister = jest.spyOn(window.Chart, "unregister");
   createChart(model, { type: "bar" }, chartId);
   await mountSpreadsheet();
-  expect(spyRegister).toHaveBeenCalledTimes(1);
+  expect(spyRegister).toHaveBeenCalledTimes(2);
   expect(window.Chart.registry.plugins["items"]).toMatchObject([
     { id: "chartShowValuesPlugin" },
     { id: "waterfallLinesPlugin" },
@@ -2124,7 +2127,11 @@ test("ChartJS charts extensions are loaded when mounting a chart, and are only l
 
   createChart(model, { type: "line" }, "chart2");
   await nextTick();
-  expect(spyRegister).toHaveBeenCalledTimes(1);
+
+  app.destroy();
+  await nextTick();
+  expect(spyUnregister).toHaveBeenCalledTimes(2);
+  expect(window.Chart.registry.plugins["items"]).toEqual([]);
 });
 
 describe("Change chart type", () => {

--- a/tests/test_helpers/helpers.ts
+++ b/tests/test_helpers/helpers.ts
@@ -855,7 +855,14 @@ export const mockChart = () => {
     _id = "luxon";
   }
   class ChartMock {
-    static register = (...items: any[]) => ChartMock.registry.plugins.items.push(...items);
+    static register = (...items: any[]) => {
+      ChartMock.registry.plugins.items.push(...items);
+    };
+    static unregister = (...items: any[]) => {
+      ChartMock.registry.plugins.items = ChartMock.registry.plugins.items.filter((item) =>
+        items.some((i) => i.id === item.id)
+      );
+    };
     static _adapters = { _date: MockLuxonTimeAdapter };
     static registry = {
       plugins: {


### PR DESCRIPTION
### [IMP] chart: add `mouseup` event to listened events

To detect a middle mouse click on a chart, we have to use the
`mouseup` event, the `click` event is not triggered with middle
mouse button.


### [FIX] charts: unregister ChartJS extension on unmount

The ChartJS extension were not unregistered when the leaving the
spreadsheet. Some of them only make sense in the context of the
spreadsheet, so keeping them when leaving could lead to crashes
when using ChartJS elsewhere.

Task: [4636147](https://www.odoo.com/odoo/2328/tasks/4636147)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo