### PR TITLE
[FIX] sheet: make sheetName comparison case incensitive

### DIFF
--- a/src/helpers/sheet.ts
+++ b/src/helpers/sheet.ts
@@ -1,4 +1,5 @@
 import { Row } from "../types";
+import { getUnquotedSheetName } from "./misc";
 
 export function createDefaultRows(rowNumber: number): Row[] {
   const rows: Row[] = [];
@@ -9,4 +10,14 @@ export function createDefaultRows(rowNumber: number): Row[] {
     rows.push(row);
   }
   return rows;
+}
+
+export function isSheetNameEqual(name1: string | undefined, name2: string | undefined): boolean {
+  if (name1 === undefined || name2 === undefined) {
+    return false;
+  }
+  return (
+    getUnquotedSheetName(name1.trim().toUpperCase()) ===
+    getUnquotedSheetName(name2.trim().toUpperCase())
+  );
 }

--- a/src/plugins/core/range.ts
+++ b/src/plugins/core/range.ts
@@ -13,6 +13,7 @@ import {
   splitReference,
   toUnboundedZone,
 } from "../../helpers/index";
+import { isSheetNameEqual } from "../../helpers/sheet";
 import {
   ApplyRangeChange,
   ApplyRangeChangeResult,
@@ -167,7 +168,7 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
           if (range.sheetId === cmd.sheetId) {
             return { changeType: "CHANGE", range };
           }
-          if (cmd.name && range.invalidSheetName === cmd.name) {
+          if (isSheetNameEqual(range.invalidSheetName, cmd.name)) {
             const invalidSheetName = undefined;
             const sheetId = cmd.sheetId;
             const newRange = range.clone({ sheetId, invalidSheetName });

--- a/src/plugins/core/sheet.ts
+++ b/src/plugins/core/sheet.ts
@@ -14,6 +14,7 @@ import {
   range,
   toCartesian,
 } from "../../helpers/index";
+import { isSheetNameEqual } from "../../helpers/sheet";
 import { _lt, _t } from "../../translation";
 import {
   Cell,
@@ -358,7 +359,7 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
     if (name) {
       const unquotedName = getUnquotedSheetName(name);
       for (const key in this.sheetIdsMapName) {
-        if (key.toUpperCase() === unquotedName.toUpperCase()) {
+        if (isSheetNameEqual(key, unquotedName)) {
           return this.sheetIdsMapName[key];
         }
       }
@@ -656,7 +657,7 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
     const { orderedSheetIds, sheets } = this;
     const name = cmd.name && cmd.name.trim().toLowerCase();
 
-    if (orderedSheetIds.find((id) => sheets[id]?.name.toLowerCase() === name)) {
+    if (orderedSheetIds.find((id) => isSheetNameEqual(sheets[id]?.name, name))) {
       return CommandResult.DuplicatedSheetName;
     }
     if (FORBIDDEN_IN_EXCEL_REGEX.test(name!)) {

--- a/src/plugins/ui/edition.ts
+++ b/src/plugins/ui/edition.ts
@@ -14,6 +14,7 @@ import {
   updateSelectionOnInsertion,
 } from "../../helpers/index";
 import { loopThroughReferenceType } from "../../helpers/reference_type";
+import { isSheetNameEqual } from "../../helpers/sheet";
 import { _lt } from "../../translation";
 import { Highlight, Range, RangePart, UID, Zone } from "../../types";
 import { SelectionEvent } from "../../types/event_stream";
@@ -162,7 +163,7 @@ export class EditionPlugin extends UIPlugin {
             const { xc, sheetName: sheet } = splitReference(token.value);
             const sheetName = sheet || this.getters.getSheetName(this.sheetId);
             const activeSheetId = this.getters.getActiveSheetId();
-            if (this.getters.getSheetName(activeSheetId) !== sheetName) {
+            if (!isSheetNameEqual(this.getters.getSheetName(activeSheetId), sheetName)) {
               return false;
             }
             const refRange = this.getters.getRangeFromSheetXC(activeSheetId, xc);

--- a/src/xlsx/conversion/formula_conversion.ts
+++ b/src/xlsx/conversion/formula_conversion.ts
@@ -1,4 +1,4 @@
-import { cellReference, toCartesian, toXC } from "../../helpers";
+import { cellReference, isSheetNameEqual, toCartesian, toXC } from "../../helpers";
 import { RangePart } from "../../types";
 import { XLSXImportData, XLSXSharedFormula, XLSXWorksheet } from "../../types/xlsx";
 import { SUBTOTAL_FUNCTION_CONVERSION_MAP } from "./conversion_maps";
@@ -66,8 +66,8 @@ function convertFormula(formula: string, data: XLSXImportData): string {
     externalRefId = Number(externalRefId) - 1;
     cellRef = cellRef.replace(/\$/g, "");
 
-    const sheetIndex = data.externalBooks[externalRefId].sheetNames.findIndex(
-      (name) => name === sheetName
+    const sheetIndex = data.externalBooks[externalRefId].sheetNames.findIndex((name) =>
+      isSheetNameEqual(name, sheetName)
     );
     if (sheetIndex === -1) {
       return match;

--- a/src/xlsx/conversion/table_conversion.ts
+++ b/src/xlsx/conversion/table_conversion.ts
@@ -1,5 +1,5 @@
 import { INCORRECT_RANGE_STRING } from "../../constants";
-import { deepEquals, toCartesian, toXC, toZone, zoneToXc } from "../../helpers";
+import { deepEquals, isSheetNameEqual, toCartesian, toXC, toZone, zoneToXc } from "../../helpers";
 import { BorderDescr, CellData, Style, WorkbookData, Zone } from "../../types";
 import { SheetData } from "../../types/workbook_data";
 import { XLSXImportData, XLSXTable, XLSXWorksheet } from "../../types/xlsx";
@@ -163,7 +163,7 @@ function applyStyleToZone(appliedStyle: Style, zone: Zone, cells: CellMap, style
  */
 function convertTableFormulaReferences(convertedSheets: SheetData[], xlsxSheets: XLSXWorksheet[]) {
   for (let tableSheet of convertedSheets) {
-    const tables = xlsxSheets.find((s) => s.sheetName === tableSheet.name)!.tables;
+    const tables = xlsxSheets.find((s) => isSheetNameEqual(s.sheetName, tableSheet.name))!.tables;
 
     for (let table of tables) {
       const tabRef = table.name + "[";

--- a/src/xlsx/helpers/content_helpers.ts
+++ b/src/xlsx/helpers/content_helpers.ts
@@ -1,7 +1,7 @@
 import { DEFAULT_FONT_SIZE } from "../../constants";
 import { tokenize } from "../../formulas";
 import { functionRegistry } from "../../functions";
-import { deepEquals, splitReference, toUnboundedZone } from "../../helpers";
+import { deepEquals, isSheetNameEqual, splitReference, toUnboundedZone } from "../../helpers";
 import {
   ConditionalFormattingOperatorValues,
   ExcelCellData,
@@ -245,7 +245,7 @@ export function getRangeSize(
   ({ xc, sheetName } = splitReference(reference));
   let rangeSheetIndex: number;
   if (sheetName) {
-    const index = data.sheets.findIndex((sheet) => sheet.name === sheetName);
+    const index = data.sheets.findIndex((sheet) => isSheetNameEqual(sheet.name, sheetName));
     if (index < 0) {
       throw new Error("Unable to find a sheet with the name " + sheetName);
     }

--- a/tests/components/spreadsheet.test.ts
+++ b/tests/components/spreadsheet.test.ts
@@ -1,6 +1,6 @@
 import { Model } from "../../src";
 import { Spreadsheet } from "../../src/components";
-import { DEBOUNCE_TIME, DEFAULT_CELL_HEIGHT } from "../../src/constants";
+import { DEBOUNCE_TIME, DEFAULT_CELL_HEIGHT, DEFAULT_CELL_WIDTH } from "../../src/constants";
 import { args, functionRegistry } from "../../src/functions";
 import { toZone } from "../../src/helpers";
 import { OPEN_CF_SIDEPANEL_ACTION } from "../../src/registries";
@@ -15,6 +15,7 @@ import {
 } from "../test_helpers/commands_helpers";
 import {
   clickCell,
+  dragElement,
   getElComputedStyle,
   hoverCell,
   keyDown,
@@ -501,6 +502,28 @@ describe("Composer / selectionInput interactions", () => {
     setCellContent(model, "B2", "=A1");
   });
 
+  test.each(["=A1", "=Sheet1!A1", "=SHEET1!A1", "=sheet1!A1"])(
+    "Moving Highlight update composer",
+    async (xc) => {
+      selectCell(model, "D2");
+      await nextTick();
+      await typeInComposerGrid(xc);
+
+      expect(model.getters.getHighlights().map((h) => h.zone)).toEqual([toZone("A1")]);
+      expect(fixture.querySelectorAll(".o-spreadsheet .o-highlight")).toHaveLength(1);
+
+      await dragElement(
+        ".o-spreadsheet .o-highlight .o-border-n",
+        DEFAULT_CELL_WIDTH,
+        DEFAULT_CELL_HEIGHT * 2
+      );
+      await nextTick();
+
+      expect(model.getters.getHighlights().map((h) => h.zone)).toEqual([toZone("B3")]);
+      expect(fixture.querySelectorAll(".o-spreadsheet .o-highlight")).toHaveLength(1);
+    }
+  );
+
   test("Switching from selection input to composer should update the highlihts", async () => {
     //open cf sidepanel
     selectCell(model, "B2");
@@ -517,6 +540,7 @@ describe("Composer / selectionInput interactions", () => {
     expect(model.getters.getHighlights().map((h) => h.zone)).toEqual([toZone("A1")]);
     expect(fixture.querySelectorAll(".o-spreadsheet .o-highlight")).toHaveLength(1);
   });
+
   test.each(["A", "="])(
     "Switching from grid composer to selection input should update the highlights and hide the highlight components",
     async (composerContent) => {

--- a/tests/helpers/sheet.test.ts
+++ b/tests/helpers/sheet.test.ts
@@ -1,0 +1,22 @@
+import { isSheetNameEqual } from "../../src/helpers";
+
+test("sheet equality", () => {
+  expect(isSheetNameEqual("Sheet1", "Sheet1")).toBeTruthy();
+  expect(isSheetNameEqual("Sheet1", "SHEET1")).toBeTruthy();
+  expect(isSheetNameEqual("Sheet1", "sheet1")).toBeTruthy();
+  expect(isSheetNameEqual("Sheet1", "'sheet1'")).toBeTruthy();
+  expect(isSheetNameEqual("Sheet1", "'SHEET1'")).toBeTruthy();
+  expect(isSheetNameEqual("Sheet1", "ShEeT1")).toBeTruthy();
+  expect(isSheetNameEqual("Sheet1", "Sheet1 ")).toBeTruthy();
+  expect(isSheetNameEqual("Sheet1", " Sheet1")).toBeTruthy();
+});
+
+test("sheet inequality", () => {
+  expect(isSheetNameEqual("Sheet1", "Sheet")).toBeFalsy();
+  expect(isSheetNameEqual("Sheet1", '"Sheet1"')).toBeFalsy();
+  expect(isSheetNameEqual("Sheet1", "Sheet 1")).toBeFalsy();
+  expect(isSheetNameEqual("Sheet1", "Sheet1!")).toBeFalsy();
+  expect(isSheetNameEqual("Sheet1", "Sheet2")).toBeFalsy();
+  expect(isSheetNameEqual("Sheet1", "")).toBeFalsy();
+  expect(isSheetNameEqual("Sheet1", undefined)).toBeFalsy();
+});

--- a/tests/test_helpers/xlsx.ts
+++ b/tests/test_helpers/xlsx.ts
@@ -1,10 +1,10 @@
-import { toCartesian, toXC, toZone } from "../../src/helpers";
+import { isSheetNameEqual, toCartesian, toXC, toZone } from "../../src/helpers";
 import { Border, Color, ConditionalFormat, Style } from "../../src/types";
 import { DEFAULT_CELL_HEIGHT, DEFAULT_CELL_WIDTH } from "./../../src/constants";
 import { CellData, SheetData, WorkbookData } from "./../../src/types/workbook_data";
 
 export function getWorkbookSheet(sheetName: string, data: WorkbookData): SheetData | undefined {
-  return data.sheets.find((sheet) => sheet.name === sheetName);
+  return data.sheets.find((sheet) => isSheetNameEqual(sheet.name, sheetName));
 }
 
 export function getWorkbookCell(col: number, row: number, sheet: SheetData): CellData | undefined {


### PR DESCRIPTION
As sheetName are case incensitive, the comparaison should too.

Task: 4707398

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [4707398](https://www.odoo.com/odoo/2328/tasks/4707398)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo