### PR TITLE
[FIX] OT: Fix chart commands OT

### DIFF
--- a/src/collaborative/ot/ot_specific.ts
+++ b/src/collaborative/ot/ot_specific.ts
@@ -33,6 +33,7 @@ otRegistry.addTransformation(
   ["CREATE_CHART", "UPDATE_CHART"],
   updateChartRangesTransformation
 );
+
 otRegistry.addTransformation("DELETE_SHEET", ["MOVE_RANGES"], transformTargetSheetId);
 otRegistry.addTransformation("DELETE_FIGURE", ["UPDATE_FIGURE", "UPDATE_CHART"], updateChartFigure);
 otRegistry.addTransformation("CREATE_SHEET", ["CREATE_SHEET"], createSheetTransformation);
@@ -84,7 +85,12 @@ function updateChartRangesTransformation(
 ): UpdateChartCommand | CreateChartCommand {
   return {
     ...toTransform,
-    definition: transformDefinition(toTransform.definition, executed),
+    definition: transformDefinition(
+      toTransform.definition,
+      toTransform.sheetId,
+      toTransform.sheetMap,
+      executed
+    ),
   };
 }
 

--- a/src/components/side_panel/chart/main_chart_panel/main_chart_panel.ts
+++ b/src/components/side_panel/chart/main_chart_panel/main_chart_panel.ts
@@ -1,7 +1,11 @@
 import { Component, onWillUpdateProps, useState } from "@odoo/owl";
 import { ChartSidePanel, chartSidePanelComponentRegistry } from "..";
 import { BACKGROUND_HEADER_COLOR } from "../../../../constants";
-import { getChartDefinitionFromContextCreation, getChartTypes } from "../../../../helpers/charts";
+import {
+  getChartDefinitionFromContextCreation,
+  getChartSheetMap,
+  getChartTypes,
+} from "../../../../helpers/charts";
 import { _lt } from "../../../../translation";
 import { ChartDefinition, ChartType, SpreadsheetChildEnv, UID } from "../../../../types/index";
 import { css } from "../../../helpers/css";
@@ -90,6 +94,7 @@ export class ChartPanel extends Component<Props, SpreadsheetChildEnv> {
       definition,
       id: figureId,
       sheetId: this.env.model.getters.getFigureSheetId(figureId)!,
+      sheetMap: getChartSheetMap(this.env.model.getters, definition),
     });
   }
 
@@ -99,10 +104,12 @@ export class ChartPanel extends Component<Props, SpreadsheetChildEnv> {
       throw new Error("Chart not defined.");
     }
     const definition = getChartDefinitionFromContextCreation(context, type);
+    const sheetId = this.env.model.getters.getFigureSheetId(this.figureId)!;
     this.env.model.dispatch("UPDATE_CHART", {
       definition,
       id: this.figureId,
-      sheetId: this.env.model.getters.getFigureSheetId(this.figureId)!,
+      sheetId,
+      sheetMap: getChartSheetMap(this.env.model.getters, definition),
     });
   }
 

--- a/src/components/spreadsheet/spreadsheet.ts
+++ b/src/components/spreadsheet/spreadsheet.ts
@@ -327,7 +327,7 @@ export class Spreadsheet extends Component<SpreadsheetProps, SpreadsheetChildEnv
     this.model.dispatch("UNFOCUS_SELECTION_INPUT");
     this.composer.topBarFocus = "inactive";
     this.composer.gridFocusMode = "cellFocus";
-    this.setComposerContent({ content, selection } || {});
+    this.setComposerContent({ content, selection });
   }
 
   /**

--- a/src/helpers/charts/abstract_chart.ts
+++ b/src/helpers/charts/abstract_chart.ts
@@ -47,6 +47,8 @@ export abstract class AbstractChart {
    */
   static transformDefinition(
     definition: ChartDefinition,
+    sheetId: UID,
+    sheetMap: Record<string, UID>,
     executed: AddColumnsRowsCommand | RemoveColumnsRowsCommand
   ): ChartDefinition {
     throw new Error("This method should be implemented by sub class");

--- a/src/helpers/charts/bar_chart.ts
+++ b/src/helpers/charts/bar_chart.ts
@@ -33,6 +33,7 @@ import {
   copyDataSetsWithNewSheetId,
   copyLabelRangeWithNewSheetId,
   createDataSets,
+  getSheetMapFromChartDefinitionWithDatasetsWithZone,
   toExcelDataset,
   transformChartDefinitionWithDataSetsWithZone,
   updateChartRangesWithDataSets,
@@ -53,10 +54,14 @@ chartRegistry.add("bar", {
     BarChart.validateChartDefinition(validator, definition),
   transformDefinition: (
     definition: BarChartDefinition,
+    sheetId: UID,
+    sheetMap: Record<string, UID>,
     executed: AddColumnsRowsCommand | RemoveColumnsRowsCommand
-  ) => BarChart.transformDefinition(definition, executed),
+  ) => BarChart.transformDefinition(definition, sheetId, sheetMap, executed),
   getChartDefinitionFromContextCreation: (context: ChartCreationContext) =>
     BarChart.getDefinitionFromContextCreation(context),
+  getDataSheetMapFromDefinition: (getters: CoreGetters, def: BarChartDefinition) =>
+    BarChart.getDataSheetMap(getters, def),
   name: _lt("Bar"),
 });
 
@@ -86,9 +91,11 @@ export class BarChart extends AbstractChart {
 
   static transformDefinition(
     definition: BarChartDefinition,
+    sheetId: UID,
+    sheetMap: Record<string, UID>,
     executed: AddColumnsRowsCommand | RemoveColumnsRowsCommand
   ): BarChartDefinition {
-    return transformChartDefinitionWithDataSetsWithZone(definition, executed);
+    return transformChartDefinitionWithDataSetsWithZone(definition, sheetId, sheetMap, executed);
   }
 
   static validateChartDefinition(
@@ -110,6 +117,13 @@ export class BarChart extends AbstractChart {
       verticalAxisPosition: "left",
       labelRange: context.auxiliaryRange || undefined,
     };
+  }
+
+  static getDataSheetMap(
+    getters: CoreGetters,
+    definition: BarChartDefinition
+  ): Record<string, UID> {
+    return getSheetMapFromChartDefinitionWithDatasetsWithZone(getters, definition);
   }
 
   getContextCreation(): ChartCreationContext {

--- a/src/helpers/charts/chart_factory.ts
+++ b/src/helpers/charts/chart_factory.ts
@@ -62,13 +62,15 @@ export function validateChartDefinition(
  */
 export function transformDefinition(
   definition: ChartDefinition,
+  sheetId: UID,
+  sheetMap: Record<string, UID>,
   executed: AddColumnsRowsCommand | RemoveColumnsRowsCommand
 ): ChartDefinition {
   const transformation = chartRegistry.getAll().find((factory) => factory.match(definition.type));
   if (!transformation) {
     throw new Error("Unknown chart type.");
   }
-  return transformation.transformDefinition(definition, executed);
+  return transformation.transformDefinition(definition, sheetId, sheetMap, executed);
 }
 
 /**
@@ -80,6 +82,14 @@ export function getChartDefinitionFromContextCreation(
 ) {
   const chartClass = chartRegistry.get(type);
   return chartClass.getChartDefinitionFromContextCreation(context);
+}
+
+/**
+ * Get an empty definition based on the given context and the given type
+ */
+export function getChartSheetMap(getters: CoreGetters, definition: ChartDefinition) {
+  const chartClass = chartRegistry.get(definition.type);
+  return chartClass.getDataSheetMapFromDefinition(getters, definition);
 }
 
 export function getChartTypes(): Record<string, string> {

--- a/src/helpers/charts/line_chart.ts
+++ b/src/helpers/charts/line_chart.ts
@@ -39,6 +39,7 @@ import {
   copyDataSetsWithNewSheetId,
   copyLabelRangeWithNewSheetId,
   createDataSets,
+  getSheetMapFromChartDefinitionWithDatasetsWithZone,
   toExcelDataset,
   transformChartDefinitionWithDataSetsWithZone,
   updateChartRangesWithDataSets,
@@ -61,10 +62,14 @@ chartRegistry.add("line", {
     LineChart.validateChartDefinition(validator, definition as LineChartDefinition),
   transformDefinition: (
     definition: LineChartDefinition,
+    sheetId: UID,
+    sheetMap: Record<string, UID>,
     executed: AddColumnsRowsCommand | RemoveColumnsRowsCommand
-  ) => LineChart.transformDefinition(definition, executed),
+  ) => LineChart.transformDefinition(definition, sheetId, sheetMap, executed),
   getChartDefinitionFromContextCreation: (context: ChartCreationContext) =>
     LineChart.getDefinitionFromContextCreation(context),
+  getDataSheetMapFromDefinition: (getters: CoreGetters, def: LineChartDefinition) =>
+    LineChart.getDataSheetMap(getters, def),
   name: _lt("Line"),
 });
 
@@ -105,9 +110,11 @@ export class LineChart extends AbstractChart {
 
   static transformDefinition(
     definition: LineChartDefinition,
+    sheetId: UID,
+    sheetMap: Record<string, UID>,
     executed: AddColumnsRowsCommand | RemoveColumnsRowsCommand
   ): LineChartDefinition {
-    return transformChartDefinitionWithDataSetsWithZone(definition, executed);
+    return transformChartDefinitionWithDataSetsWithZone(definition, sheetId, sheetMap, executed);
   }
 
   static getDefinitionFromContextCreation(context: ChartCreationContext): LineChartDefinition {
@@ -152,6 +159,12 @@ export class LineChart extends AbstractChart {
       stacked: this.stacked,
       cumulative: this.cumulative,
     };
+  }
+  static getDataSheetMap(
+    getters: CoreGetters,
+    definition: LineChartDefinition
+  ): Record<string, UID> {
+    return getSheetMapFromChartDefinitionWithDatasetsWithZone(getters, definition);
   }
 
   getContextCreation(): ChartCreationContext {

--- a/src/helpers/charts/pie_chart.ts
+++ b/src/helpers/charts/pie_chart.ts
@@ -41,6 +41,7 @@ import {
   copyDataSetsWithNewSheetId,
   copyLabelRangeWithNewSheetId,
   createDataSets,
+  getSheetMapFromChartDefinitionWithDatasetsWithZone,
   toExcelDataset,
   transformChartDefinitionWithDataSetsWithZone,
   updateChartRangesWithDataSets,
@@ -61,10 +62,14 @@ chartRegistry.add("pie", {
     PieChart.validateChartDefinition(validator, definition),
   transformDefinition: (
     definition: PieChartDefinition,
+    sheetId: UID,
+    sheetMap: Record<string, UID>,
     executed: AddColumnsRowsCommand | RemoveColumnsRowsCommand
-  ) => PieChart.transformDefinition(definition, executed),
+  ) => PieChart.transformDefinition(definition, sheetId, sheetMap, executed),
   getChartDefinitionFromContextCreation: (context: ChartCreationContext) =>
     PieChart.getDefinitionFromContextCreation(context),
+  getDataSheetMapFromDefinition: (getters: CoreGetters, def: PieChartDefinition) =>
+    PieChart.getDataSheetMap(getters, def),
   name: _lt("Pie"),
 });
 
@@ -90,9 +95,11 @@ export class PieChart extends AbstractChart {
 
   static transformDefinition(
     definition: PieChartDefinition,
+    sheetId: UID,
+    sheetMap: Record<string, UID>,
     executed: AddColumnsRowsCommand | RemoveColumnsRowsCommand
   ): PieChartDefinition {
-    return transformChartDefinitionWithDataSetsWithZone(definition, executed);
+    return transformChartDefinitionWithDataSetsWithZone(definition, sheetId, sheetMap, executed);
   }
 
   static validateChartDefinition(
@@ -112,6 +119,13 @@ export class PieChart extends AbstractChart {
       type: "pie",
       labelRange: context.auxiliaryRange || undefined,
     };
+  }
+
+  static getDataSheetMap(
+    getters: CoreGetters,
+    definition: PieChartDefinition
+  ): Record<string, UID> {
+    return getSheetMapFromChartDefinitionWithDatasetsWithZone(getters, definition);
   }
 
   getDefinition(): PieChartDefinition {

--- a/src/helpers/clipboard/clipboard_figure_state.ts
+++ b/src/helpers/clipboard/clipboard_figure_state.ts
@@ -9,7 +9,7 @@ import {
   UID,
   Zone,
 } from "../../types";
-import { AbstractChart } from "../charts";
+import { AbstractChart, getChartSheetMap } from "../charts";
 import { UuidGenerator } from "../uuid";
 import { ClipboardOperation, ClipboardOptions, ClipboardState } from "./../../types/clipboard";
 
@@ -72,12 +72,14 @@ export class ClipboardFigureState implements ClipboardState {
     const newChart = this.copiedChart.copyInSheetId(sheetId);
     const newId = new UuidGenerator().smallUuid();
 
+    const definition = newChart.getDefinition();
     this.dispatch("CREATE_CHART", {
       id: newId,
       sheetId,
       position,
       size: { height: this.copiedFigure.height, width: this.copiedFigure.width },
-      definition: newChart.getDefinition(),
+      definition,
+      sheetMap: getChartSheetMap(this.getters, definition),
     });
 
     if (this.operation === "CUT") {

--- a/src/helpers/references.ts
+++ b/src/helpers/references.ts
@@ -1,4 +1,4 @@
-import { getUnquotedSheetName } from "./misc";
+import { getComposerSheetName, getUnquotedSheetName } from "./misc";
 
 /** Reference of a cell (eg. A1, $B$5) */
 export const cellReference = new RegExp(/\$?([A-Z]{1,3})\$?([0-9]{1,7})/, "i");
@@ -69,4 +69,8 @@ export function splitReference(ref: string): { sheetName?: string; xc: string } 
   const xc = parts.pop()!;
   const sheetName = getUnquotedSheetName(parts.join("!")) || undefined;
   return { sheetName, xc };
+}
+
+export function mergeReference(xc: string, sheetName: string | undefined) {
+  return sheetName ? `${getComposerSheetName(sheetName)}!${xc}` : xc;
 }

--- a/src/plugins/core/chart.ts
+++ b/src/plugins/core/chart.ts
@@ -1,6 +1,10 @@
 import { DEFAULT_FIGURE_HEIGHT, DEFAULT_FIGURE_WIDTH, FIGURE_ID_SPLITTER } from "../../constants";
 import { AbstractChart } from "../../helpers/charts/abstract_chart";
-import { chartFactory, validateChartDefinition } from "../../helpers/charts/chart_factory";
+import {
+  chartFactory,
+  getChartSheetMap,
+  validateChartDefinition,
+} from "../../helpers/charts/chart_factory";
 import {
   ChartCreationContext,
   ChartDefinition,
@@ -94,12 +98,14 @@ export class ChartPlugin extends CorePlugin<ChartState> implements ChartState {
             const duplicatedFigureId = `${cmd.sheetIdTo}${FIGURE_ID_SPLITTER}${figureIdBase}`;
             const chart = this.charts[fig.id]?.copyForSheetId(cmd.sheetIdTo);
             if (chart) {
+              const definition = chart.getDefinition();
               this.dispatch("CREATE_CHART", {
                 id: duplicatedFigureId,
                 position: { x: fig.x, y: fig.y },
                 size: { width: fig.width, height: fig.height },
-                definition: chart.getDefinition(),
+                definition: definition,
                 sheetId: cmd.sheetIdTo,
+                sheetMap: getChartSheetMap(this.getters, definition),
               });
             }
           }

--- a/src/plugins/core/sheet.ts
+++ b/src/plugins/core/sheet.ts
@@ -78,7 +78,7 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
     "checkElementsIncludeAllNonFrozenHeaders",
   ] as const;
 
-  readonly sheetIdsMapName: Record<string, UID | undefined> = {};
+  readonly sheetIdsMapName: Record<string, UID> = {};
   readonly orderedSheetIds: UID[] = [];
   readonly sheets: Record<UID, Sheet | undefined> = {};
   readonly cellPosition: Record<UID, CellPosition | undefined> = {};

--- a/src/registries/chart_types.ts
+++ b/src/registries/chart_types.ts
@@ -37,9 +37,15 @@ export interface ChartBuilder {
   ): CommandResult | CommandResult[];
   transformDefinition(
     definition: ChartDefinition,
+    sheetId: UID,
+    sheetMap: Record<string, UID>,
     executed: AddColumnsRowsCommand | RemoveColumnsRowsCommand
   ): ChartDefinition;
   getChartDefinitionFromContextCreation(context: ChartCreationContext): ChartDefinition;
+  getDataSheetMapFromDefinition(
+    getters: CoreGetters,
+    definition: ChartDefinition
+  ): Record<string, UID>;
   name: string;
 }
 

--- a/src/registries/menus/menu_items_actions.ts
+++ b/src/registries/menus/menu_items_actions.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_FIGURE_HEIGHT, DEFAULT_FIGURE_WIDTH } from "../../constants";
+import { getChartSheetMap } from "../../helpers/charts";
 import {
   areZonesContinuous,
   largeMax,
@@ -15,6 +16,7 @@ import {
   interactivePasteFromOS,
 } from "../../helpers/ui/paste_interactive";
 import { _lt } from "../../translation";
+import { BarChartDefinition } from "../../types/chart";
 import { CellValueType, Dimension, Format, SpreadsheetChildEnv, Style } from "../../types/index";
 
 //------------------------------------------------------------------------------
@@ -636,21 +638,24 @@ export const CREATE_CHART = (env: SpreadsheetChildEnv) => {
   }
   const newLegendPos = dataSetZone.right === dataSetZone.left ? "none" : "top"; //Using the same variable as above to identify number of columns involved.
 
+  const definition: BarChartDefinition = {
+    title,
+    dataSets,
+    labelRange,
+    type: "bar",
+    stacked: false,
+    dataSetsHaveTitle,
+    verticalAxisPosition: "left",
+    legendPosition: newLegendPos,
+  };
+
   env.model.dispatch("CREATE_CHART", {
     sheetId,
     id,
     position,
     size,
-    definition: {
-      title,
-      dataSets,
-      labelRange,
-      type: "bar",
-      stacked: false,
-      dataSetsHaveTitle,
-      verticalAxisPosition: "left",
-      legendPosition: newLegendPos,
-    },
+    definition: definition,
+    sheetMap: getChartSheetMap(env.model.getters, definition),
   });
   env.model.dispatch("SELECT_FIGURE", { id });
   env.openSidePanel("ChartPanel");

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -430,12 +430,14 @@ export interface CreateChartCommand extends SheetDependentCommand {
   position?: { x: Pixel; y: Pixel };
   size?: { width: Pixel; height: Pixel };
   definition: ChartDefinition;
+  sheetMap: Record<string, UID>;
 }
 
 export interface UpdateChartCommand extends SheetDependentCommand {
   type: "UPDATE_CHART";
   id: UID;
   definition: ChartDefinition;
+  sheetMap: Record<string, UID>;
 }
 
 //------------------------------------------------------------------------------

--- a/tests/collaborative/collaborative_history.test.ts
+++ b/tests/collaborative/collaborative_history.test.ts
@@ -449,6 +449,7 @@ describe("Collaborative local history", () => {
               verticalAxisPosition: "left",
               legendPosition: "none",
             },
+            sheetMap: { Sheet1: "Sheet1" },
           },
           {
             type: "UPDATE_CHART",

--- a/tests/collaborative/collaborative_sheet_manipulations.test.ts
+++ b/tests/collaborative/collaborative_sheet_manipulations.test.ts
@@ -927,4 +927,16 @@ describe("Collaborative Sheet manipulation", () => {
       }
     );
   });
+
+  test("Concurrently create a chart and add a row in another sheet", () => {
+    createSheet(bob, { sheetId: "sheet2", name: "Sheet2" });
+    network.concurrent(() => {
+      addRows(alice, "after", 1, 1);
+      createChart(charlie, { dataSets: ["Sheet1!A1:A5", "Sheet2!A1:A5"] }, "chartId", "sheet2");
+    });
+    expect([alice, bob, charlie]).toHaveSynchronizedValue(
+      (user) => (user.getters.getChartDefinition("chartId") as BarChartDefinition).dataSets,
+      ["Sheet1!A1:A6", "A1:A5"]
+    );
+  });
 });

--- a/tests/collaborative/inverses.test.ts
+++ b/tests/collaborative/inverses.test.ts
@@ -296,6 +296,7 @@ describe("Inverses commands", () => {
       sheetId: "42",
       definition: {} as LineChartDefinition,
       id: "1",
+      sheetMap: {},
     };
     test.each([
       updateCell,

--- a/tests/collaborative/ot/ot.test.ts
+++ b/tests/collaborative/ot/ot.test.ts
@@ -19,6 +19,7 @@ describe("OT with DELETE_FIGURE", () => {
     type: "UPDATE_CHART",
     sheetId: "42",
     definition: {} as LineChartDefinition,
+    sheetMap: { Sheet1: "Sheet1" },
   };
   const updateFigure: Omit<UpdateFigureCommand, "id"> = {
     type: "UPDATE_FIGURE",

--- a/tests/collaborative/ot/ot_columns_added.test.ts
+++ b/tests/collaborative/ot/ot_columns_added.test.ts
@@ -6,6 +6,7 @@ import {
   AddMergeCommand,
   ClearCellCommand,
   ClearFormattingCommand,
+  CreateChartCommand,
   CreateFilterTableCommand,
   DeleteContentCommand,
   FreezeColumnsCommand,
@@ -18,7 +19,9 @@ import {
   SetFormattingCommand,
   UpdateCellCommand,
   UpdateCellPositionCommand,
+  UpdateChartCommand,
 } from "../../../src/types";
+import { BarChartDefinition } from "../../../src/types/chart";
 import { createEqualCF, target, toRangesData } from "../../test_helpers/helpers";
 
 describe("OT with ADD_COLUMNS_ROWS with dimension COL", () => {
@@ -460,6 +463,51 @@ describe("OT with ADD_COLUMNS_ROWS with dimension COL", () => {
       const command = { ...toTransform, quantity: 2 };
       const result = transform(command, addColumnsBefore);
       expect(result).toEqual({ ...command });
+    });
+  });
+
+  describe("OT with AddColumns and UPDATE_CHART/CREATE_CHART", () => {
+    const definition: BarChartDefinition = {
+      type: "bar",
+      dataSets: ["sheet1!M1:M10", "sheet2!M1:M10"],
+      dataSetsHaveTitle: false,
+      labelRange: "sheet1!M1:M10",
+      verticalAxisPosition: "left",
+      legendPosition: "top",
+      stacked: false,
+      title: "test",
+    };
+
+    test("CREATE_CHART ranges are updated on the same sheet as addColumns", () => {
+      const toTransform: CreateChartCommand = {
+        type: "CREATE_CHART",
+        sheetId,
+        id: "chart1",
+        definition,
+        sheetMap: { sheet1: sheetId, sheet2: sheetId + "_" },
+      };
+      const result = transform(toTransform, addColumnsBefore) as CreateChartCommand;
+      expect(result.definition).toEqual({
+        ...definition,
+        dataSets: ["sheet1!O1:O10", "sheet2!M1:M10"],
+        labelRange: "sheet1!O1:O10",
+      });
+    });
+
+    test("UPDATE_CHART ranges are updated on the same sheet as addColumns", () => {
+      const toTransform: UpdateChartCommand = {
+        type: "UPDATE_CHART",
+        sheetId,
+        id: "chart1",
+        definition,
+        sheetMap: { sheet1: sheetId, sheet2: sheetId + "_" },
+      };
+      const result = transform(toTransform, addColumnsBefore) as UpdateChartCommand;
+      expect(result.definition).toEqual({
+        ...definition,
+        dataSets: ["sheet1!O1:O10", "sheet2!M1:M10"],
+        labelRange: "sheet1!O1:O10",
+      });
     });
   });
 });

--- a/tests/collaborative/ot/ot_columns_removed.test.ts
+++ b/tests/collaborative/ot/ot_columns_removed.test.ts
@@ -6,6 +6,7 @@ import {
   AddMergeCommand,
   ClearCellCommand,
   ClearFormattingCommand,
+  CreateChartCommand,
   CreateFilterTableCommand,
   DeleteContentCommand,
   FreezeColumnsCommand,
@@ -18,7 +19,9 @@ import {
   SetFormattingCommand,
   UpdateCellCommand,
   UpdateCellPositionCommand,
+  UpdateChartCommand,
 } from "../../../src/types";
+import { BarChartDefinition } from "../../../src/types/chart";
 import { createEqualCF, target, toRangesData } from "../../test_helpers/helpers";
 
 describe("OT with REMOVE_COLUMN", () => {
@@ -466,6 +469,51 @@ describe("OT with REMOVE_COLUMN", () => {
       const command = { ...toTransform, quantity: 3 };
       const result = transform(command, removeColumns);
       expect(result).toEqual({ ...command });
+    });
+  });
+
+  describe("OT with AddColumns and UPDATE_CHART/CREATE_CHART", () => {
+    const definition: BarChartDefinition = {
+      type: "bar",
+      dataSets: ["sheet1!M1:M10", "sheet2!M1:M10"],
+      dataSetsHaveTitle: false,
+      labelRange: "sheet1!M1:M10",
+      verticalAxisPosition: "left",
+      legendPosition: "top",
+      stacked: false,
+      title: "test",
+    };
+
+    test("CREATE_CHART ranges are updated on the same sheet as addColumns", () => {
+      const toTransform: CreateChartCommand = {
+        type: "CREATE_CHART",
+        sheetId,
+        id: "chart1",
+        definition,
+        sheetMap: { sheet1: sheetId, sheet2: sheetId + "_" },
+      };
+      const result = transform(toTransform, removeColumns) as CreateChartCommand;
+      expect(result.definition).toEqual({
+        ...definition,
+        dataSets: ["sheet1!J1:J10", "sheet2!M1:M10"],
+        labelRange: "sheet1!J1:J10",
+      });
+    });
+
+    test("UPDATE_CHART ranges are updated on the same sheet as addColumns", () => {
+      const toTransform: UpdateChartCommand = {
+        type: "UPDATE_CHART",
+        sheetId,
+        id: "chart1",
+        definition,
+        sheetMap: { sheet1: sheetId, sheet2: sheetId + "_" },
+      };
+      const result = transform(toTransform, removeColumns) as UpdateChartCommand;
+      expect(result.definition).toEqual({
+        ...definition,
+        dataSets: ["sheet1!J1:J10", "sheet2!M1:M10"],
+        labelRange: "sheet1!J1:J10",
+      });
     });
   });
 });

--- a/tests/collaborative/ot/ot_rows_added.test.ts
+++ b/tests/collaborative/ot/ot_rows_added.test.ts
@@ -6,6 +6,7 @@ import {
   AddMergeCommand,
   ClearCellCommand,
   ClearFormattingCommand,
+  CreateChartCommand,
   CreateFilterTableCommand,
   DeleteContentCommand,
   FreezeColumnsCommand,
@@ -18,7 +19,9 @@ import {
   SetFormattingCommand,
   UpdateCellCommand,
   UpdateCellPositionCommand,
+  UpdateChartCommand,
 } from "../../../src/types";
+import { BarChartDefinition } from "../../../src/types/chart";
 import { createEqualCF, target, toRangesData } from "../../test_helpers/helpers";
 
 describe("OT with ADD_COLUMNS_ROWS with dimension ROW", () => {
@@ -455,6 +458,52 @@ describe("OT with ADD_COLUMNS_ROWS with dimension ROW", () => {
       const command = { ...toTransform, quantity: 2 };
       const result = transform(command, addRowsBefore);
       expect(result).toEqual({ ...command });
+    });
+  });
+
+  describe("OT with addRows and UPDATE_CHART/CREATE_CHART", () => {
+    const definition: BarChartDefinition = {
+      type: "bar",
+      dataSets: ["sheet1!A5:A15", "sheet2!A5:A15"],
+      dataSetsHaveTitle: false,
+      labelRange: "sheet1!A5:A15",
+      verticalAxisPosition: "left",
+      legendPosition: "top",
+      stacked: false,
+      title: "test",
+    };
+
+    test("CREATE_CHART ranges are updated on the same sheet as addRows", () => {
+      const toTransform: CreateChartCommand = {
+        type: "CREATE_CHART",
+        sheetId,
+        id: "chart1",
+        definition,
+        sheetMap: { sheet1: sheetId, sheet2: sheetId + "_" },
+      };
+      const result = transform(toTransform, addRowsBefore) as CreateChartCommand;
+      expect(result.definition).toEqual({
+        ...definition,
+        dataSets: ["sheet1!A5:A17", "sheet2!A5:A15"],
+        labelRange: "sheet1!A5:A17",
+      });
+    });
+
+    test("UPDATE_CHART ranges are updated on the same sheet as addRow", () => {
+      const toTransform: UpdateChartCommand = {
+        type: "UPDATE_CHART",
+        sheetId,
+        id: "chart1",
+        definition,
+        sheetMap: { sheet1: sheetId, sheet2: sheetId + "_" },
+      };
+      const command = { ...toTransform, quantity: 2 };
+      const result = transform(command, addRowsBefore) as UpdateChartCommand;
+      expect(result.definition).toEqual({
+        ...definition,
+        dataSets: ["sheet1!A5:A17", "sheet2!A5:A15"],
+        labelRange: "sheet1!A5:A17",
+      });
     });
   });
 });

--- a/tests/collaborative/ot/ot_rows_removed.test.ts
+++ b/tests/collaborative/ot/ot_rows_removed.test.ts
@@ -6,6 +6,7 @@ import {
   AddMergeCommand,
   ClearCellCommand,
   ClearFormattingCommand,
+  CreateChartCommand,
   CreateFilterTableCommand,
   DeleteContentCommand,
   FreezeColumnsCommand,
@@ -18,7 +19,9 @@ import {
   SetFormattingCommand,
   UpdateCellCommand,
   UpdateCellPositionCommand,
+  UpdateChartCommand,
 } from "../../../src/types";
+import { BarChartDefinition } from "../../../src/types/chart";
 import { createEqualCF, target, toRangesData } from "../../test_helpers/helpers";
 
 describe("OT with REMOVE_COLUMNS_ROWS with dimension ROW", () => {
@@ -466,6 +469,51 @@ describe("OT with REMOVE_COLUMNS_ROWS with dimension ROW", () => {
       const command = { ...toTransform, quantity: 3 };
       const result = transform(command, removeRows);
       expect(result).toEqual({ ...command });
+    });
+  });
+
+  describe("OT with removeRows and UPDATE_CHART/CREATE_CHART", () => {
+    const definition: BarChartDefinition = {
+      type: "bar",
+      dataSets: ["sheet1!A1:A10", "sheet2!A1:A10"],
+      dataSetsHaveTitle: false,
+      labelRange: "sheet1!A1:A10",
+      verticalAxisPosition: "left",
+      legendPosition: "top",
+      stacked: false,
+      title: "test",
+    };
+
+    test("CREATE_CHART ranges are updated on the same sheet as removeRows", () => {
+      const toTransform: CreateChartCommand = {
+        type: "CREATE_CHART",
+        sheetId,
+        id: "chart1",
+        definition,
+        sheetMap: { sheet1: sheetId, sheet2: sheetId + "_" },
+      };
+      const result = transform(toTransform, removeRows) as CreateChartCommand;
+      expect(result.definition).toEqual({
+        ...definition,
+        dataSets: ["sheet1!A1:A7", "sheet2!A1:A10"],
+        labelRange: "sheet1!A1:A7",
+      });
+    });
+
+    test("UPDATE_CHART ranges are updated on the same sheet as removeRows", () => {
+      const toTransform: UpdateChartCommand = {
+        type: "UPDATE_CHART",
+        sheetId,
+        id: "chart1",
+        definition,
+        sheetMap: { sheet1: sheetId, sheet2: sheetId + "_" },
+      };
+      const result = transform(toTransform, removeRows) as UpdateChartCommand;
+      expect(result.definition).toEqual({
+        ...definition,
+        dataSets: ["sheet1!A1:A7", "sheet2!A1:A10"],
+        labelRange: "sheet1!A1:A7",
+      });
     });
   });
 });

--- a/tests/collaborative/ot/ot_sheet_deleted.test.ts
+++ b/tests/collaborative/ot/ot_sheet_deleted.test.ts
@@ -107,6 +107,7 @@ describe("OT with DELETE_SHEET", () => {
     type: "CREATE_CHART",
     id: "1",
     definition: {} as any,
+    sheetMap: { Sheet1: "Sheet1" },
   };
   const resizeColumns: Omit<ResizeColumnsRowsCommand, "sheetId"> = {
     type: "RESIZE_COLUMNS_ROWS",

--- a/tests/components/charts.test.ts
+++ b/tests/components/charts.test.ts
@@ -2,6 +2,7 @@ import { CommandResult, Model, Spreadsheet } from "../../src";
 import { ChartTerms } from "../../src/components/translations_terms";
 import { BACKGROUND_CHART_COLOR, MENU_WIDTH } from "../../src/constants";
 import { toHex, toZone } from "../../src/helpers";
+import { getChartSheetMap } from "../../src/helpers/charts";
 import { ChartDefinition } from "../../src/types";
 import { PieChartRuntime } from "../../src/types/chart";
 import { BarChartDefinition } from "../../src/types/chart/bar_chart";
@@ -385,13 +386,15 @@ describe("figures", () => {
         case "basicChart":
           const hasTitle = dataSeries.querySelector("input[type=checkbox]") as HTMLInputElement;
           triggerMouseEvent(hasTitle, "click");
+          const definition = model.getters.getChartDefinition(chartId);
           expect(dispatch).toHaveBeenLastCalledWith("UPDATE_CHART", {
             id: chartId,
             sheetId,
             definition: {
-              ...model.getters.getChartDefinition(chartId),
+              ...definition,
               dataSetsHaveTitle: false,
             },
+            sheetMap: getChartSheetMap(model.getters, definition),
           });
           break;
         case "scorecard":
@@ -405,13 +408,15 @@ describe("figures", () => {
       }
       await simulateClick(".o-panel .inactive");
       setInputValueAndTrigger(".o-chart-title input", "hello", "change");
+      const definition = model.getters.getChartDefinition(chartId);
       expect(dispatch).toHaveBeenLastCalledWith("UPDATE_CHART", {
         id: chartId,
         sheetId,
         definition: {
-          ...model.getters.getChartDefinition(chartId),
+          ...definition,
           title: "hello",
         },
+        sheetMap: getChartSheetMap(model.getters, definition),
       });
     }
   );
@@ -519,13 +524,15 @@ describe("figures", () => {
           break;
         }
       }
+      const definition = model.getters.getChartDefinition(chartId);
       expect(dispatch).toHaveBeenLastCalledWith("UPDATE_CHART", {
         id: chartId,
         sheetId,
         definition: {
-          ...model.getters.getChartDefinition(chartId),
+          ...definition,
           background: "#000000",
         },
+        sheetMap: getChartSheetMap(model.getters, definition),
       });
       if (chartType === "basicChart") {
         const figureCanvas = fixture.querySelector(".o-figure-canvas");
@@ -1134,13 +1141,15 @@ describe("figures", () => {
           break;
         }
       }
+      let definition = model.getters.getChartDefinition(chartId);
       expect(dispatch).toHaveBeenLastCalledWith("UPDATE_CHART", {
         id: chartId,
         sheetId,
         definition: {
-          ...model.getters.getChartDefinition(chartId),
+          ...definition,
           baselineColorUp: "#0000FF",
         },
+        sheetMap: getChartSheetMap(model.getters, definition),
       });
 
       // Change color of "down" value of baseline
@@ -1156,13 +1165,15 @@ describe("figures", () => {
           break;
         }
       }
+      definition = model.getters.getChartDefinition(chartId);
       expect(dispatch).toHaveBeenLastCalledWith("UPDATE_CHART", {
         id: chartId,
         sheetId,
         definition: {
-          ...model.getters.getChartDefinition(chartId),
+          ...definition,
           baselineColorDown: "#FF0000",
         },
+        sheetMap: getChartSheetMap(model.getters, definition),
       });
     });
   });

--- a/tests/menu_items_registry.test.ts
+++ b/tests/menu_items_registry.test.ts
@@ -1,6 +1,7 @@
 import { Model, Spreadsheet } from "../src";
 import { fontSizes } from "../src/fonts";
 import { zoneToXc } from "../src/helpers";
+import { getChartSheetMap } from "../src/helpers/charts";
 import { interactivePaste } from "../src/helpers/ui/paste_interactive";
 import {
   colMenuRegistry,
@@ -1149,6 +1150,7 @@ describe("Menu Item actions", () => {
         x: (width - DEFAULT_FIGURE_WIDTH) / 2,
         y: (height - DEFAULT_FIGURE_HEIGHT) / 2,
       }; // Position at the center of the viewport
+      payload.sheetMap = getChartSheetMap(model.getters, payload.definition);
       expect(dispatchSpy).toHaveBeenCalledWith("CREATE_CHART", payload);
     });
 
@@ -1174,6 +1176,7 @@ describe("Menu Item actions", () => {
         x: (width - DEFAULT_FIGURE_WIDTH) / 2,
         y: (height - DEFAULT_FIGURE_HEIGHT + offsetCorrectionY) / 2,
       }; // Position at the center of the viewport
+      payload.sheetMap = getChartSheetMap(model.getters, payload.definition);
       expect(dispatchSpy).toHaveBeenCalledWith("CREATE_CHART", payload);
     });
 
@@ -1190,6 +1193,7 @@ describe("Menu Item actions", () => {
         x: (width - DEFAULT_FIGURE_WIDTH + offsetCorrectionX) / 2,
         y: (height - DEFAULT_FIGURE_HEIGHT) / 2,
       }; // Position at the center of the viewport
+      payload.sheetMap = getChartSheetMap(model.getters, payload.definition);
       expect(dispatchSpy).toHaveBeenCalledWith("CREATE_CHART", payload);
     });
 
@@ -1208,6 +1212,7 @@ describe("Menu Item actions", () => {
         x: (width - DEFAULT_FIGURE_WIDTH + offsetCorrectionX) / 2,
         y: (height - DEFAULT_FIGURE_HEIGHT + offsetCorrectionY) / 2,
       }; // Position at the center of the viewport
+      payload.sheetMap = getChartSheetMap(model.getters, payload.definition);
       expect(dispatchSpy).toHaveBeenCalledWith("CREATE_CHART", payload);
     });
 
@@ -1226,6 +1231,7 @@ describe("Menu Item actions", () => {
         x: 0,
         y: 0,
       }; // Position at the center of the viewport
+      payload.sheetMap = getChartSheetMap(model.getters, payload.definition);
       expect(dispatchSpy).toHaveBeenCalledWith("CREATE_CHART", payload);
     });
 
@@ -1251,6 +1257,7 @@ describe("Menu Item actions", () => {
         x: offsetCorrectionX,
         y: offsetCorrectionY,
       }; // Position at the top of the bottom pane of the viewport
+      payload.sheetMap = getChartSheetMap(model.getters, payload.definition);
       expect(dispatchSpy).toHaveBeenCalledWith("CREATE_CHART", payload);
     });
 
@@ -1270,6 +1277,7 @@ describe("Menu Item actions", () => {
         x: 2 * DEFAULT_CELL_WIDTH + (width - DEFAULT_FIGURE_WIDTH) / 2,
         y: 4 * DEFAULT_CELL_HEIGHT + (height - DEFAULT_FIGURE_HEIGHT) / 2,
       }; // Position at the center of the viewport
+      payload.sheetMap = getChartSheetMap(model.getters, payload.definition);
       expect(dispatchSpy).toHaveBeenCalledWith("CREATE_CHART", payload);
     });
 
@@ -1292,6 +1300,7 @@ describe("Menu Item actions", () => {
         x: 2 * DEFAULT_CELL_WIDTH + (width - DEFAULT_FIGURE_WIDTH) / 2,
         y: 4 * DEFAULT_CELL_HEIGHT + (height - DEFAULT_FIGURE_HEIGHT + offsetCorrectionY) / 2,
       }; // Position at the center of the viewport
+      payload.sheetMap = getChartSheetMap(model.getters, payload.definition);
       expect(dispatchSpy).toHaveBeenCalledWith("CREATE_CHART", payload);
     });
 
@@ -1314,6 +1323,7 @@ describe("Menu Item actions", () => {
         x: 2 * DEFAULT_CELL_WIDTH + (width - DEFAULT_FIGURE_WIDTH + offsetCorrectionX) / 2,
         y: 4 * DEFAULT_CELL_HEIGHT + (height - DEFAULT_FIGURE_HEIGHT) / 2,
       }; // Position at the center of the viewport
+      payload.sheetMap = getChartSheetMap(model.getters, payload.definition);
       expect(dispatchSpy).toHaveBeenCalledWith("CREATE_CHART", payload);
     });
 
@@ -1338,6 +1348,7 @@ describe("Menu Item actions", () => {
         x: 2 * DEFAULT_CELL_WIDTH + (width - DEFAULT_FIGURE_WIDTH + offsetCorrectionX) / 2,
         y: 4 * DEFAULT_CELL_HEIGHT + (height - DEFAULT_FIGURE_HEIGHT + offsetCorrectionY) / 2,
       }; // Position at the center of the viewport
+      payload.sheetMap = getChartSheetMap(model.getters, payload.definition);
       expect(dispatchSpy).toHaveBeenCalledWith("CREATE_CHART", payload);
     });
 
@@ -1347,6 +1358,7 @@ describe("Menu Item actions", () => {
       const payload = { ...defaultPayload };
       payload.definition.dataSets = ["B2:B5"];
       payload.definition.labelRange = undefined;
+      payload.sheetMap = getChartSheetMap(model.getters, payload.definition);
       expect(dispatchSpy).toHaveBeenCalledWith("CREATE_CHART", payload);
     });
 
@@ -1357,6 +1369,7 @@ describe("Menu Item actions", () => {
       payload.definition.dataSets = ["B1:B5"];
       payload.definition.labelRange = undefined;
       payload.definition.dataSetsHaveTitle = true;
+      payload.sheetMap = getChartSheetMap(model.getters, payload.definition);
       expect(dispatchSpy).toHaveBeenCalledWith("CREATE_CHART", payload);
     });
 
@@ -1366,6 +1379,7 @@ describe("Menu Item actions", () => {
       const payload = { ...defaultPayload };
       payload.definition.dataSets = ["B2:B5"];
       payload.definition.labelRange = "A2:A5";
+      payload.sheetMap = getChartSheetMap(model.getters, payload.definition);
       expect(dispatchSpy).toHaveBeenCalledWith("CREATE_CHART", payload);
     });
 
@@ -1376,6 +1390,7 @@ describe("Menu Item actions", () => {
       payload.definition.dataSets = ["B1:B5"];
       payload.definition.labelRange = "A2:A5";
       payload.definition.dataSetsHaveTitle = true;
+      payload.sheetMap = getChartSheetMap(model.getters, payload.definition);
       expect(dispatchSpy).toHaveBeenCalledWith("CREATE_CHART", payload);
     });
 
@@ -1388,6 +1403,7 @@ describe("Menu Item actions", () => {
       payload.definition.title = "";
       payload.definition.dataSetsHaveTitle = false;
       payload.definition.labelRange = "B1:B4";
+      payload.sheetMap = getChartSheetMap(model.getters, payload.definition);
       expect(dispatchSpy).toHaveBeenCalledWith("CREATE_CHART", payload);
     });
     test("Chart title should only generate string and numerical values", async () => {
@@ -1399,6 +1415,7 @@ describe("Menu Item actions", () => {
       payload.definition.title = "Title1 and 3";
       payload.definition.dataSetsHaveTitle = true;
       payload.definition.labelRange = "C2:C4";
+      payload.sheetMap = getChartSheetMap(model.getters, payload.definition);
       await nextTick();
       expect(dispatchSpy).toHaveBeenCalledWith("CREATE_CHART", payload);
     });
@@ -1411,6 +1428,7 @@ describe("Menu Item actions", () => {
       payload.definition.title = "Title1, 3 and Title2";
       payload.definition.dataSetsHaveTitle = true;
       payload.definition.labelRange = "C2:C4";
+      payload.sheetMap = getChartSheetMap(model.getters, payload.definition);
       expect(dispatchSpy).toHaveBeenCalledWith("CREATE_CHART", payload);
     });
     test("[Case 1] Chart is inserted with proper legend position", () => {
@@ -1421,6 +1439,7 @@ describe("Menu Item actions", () => {
       payload.definition.labelRange = "A2:A5";
       payload.definition.dataSetsHaveTitle = true;
       payload.definition.legendPosition = "none";
+      payload.sheetMap = getChartSheetMap(model.getters, payload.definition);
       expect(dispatchSpy).toHaveBeenCalledWith("CREATE_CHART", payload);
     });
     test("[Case 2] Chart is inserted with proper legend position", () => {
@@ -1431,6 +1450,7 @@ describe("Menu Item actions", () => {
       payload.definition.dataSetsHaveTitle = true;
       payload.definition.labelRange = "F2:F5";
       payload.definition.legendPosition = "top";
+      payload.sheetMap = getChartSheetMap(model.getters, payload.definition);
       expect(dispatchSpy).toHaveBeenCalledWith("CREATE_CHART", payload);
     });
   });

--- a/tests/plugins/chart/basic_chart.test.ts
+++ b/tests/plugins/chart/basic_chart.test.ts
@@ -1,7 +1,7 @@
 import { Model } from "../../../src";
 import { ChartTerms } from "../../../src/components/translations_terms";
 import { FIGURE_ID_SPLITTER, MAX_CHAR_LABEL } from "../../../src/constants";
-import { BarChart } from "../../../src/helpers/charts";
+import { BarChart, getChartSheetMap } from "../../../src/helpers/charts";
 import { toZone, zoneToXc } from "../../../src/helpers/zones";
 import { ChartPlugin } from "../../../src/plugins/core/chart";
 import { BorderCommand, CommandResult } from "../../../src/types";
@@ -626,10 +626,13 @@ describe("datasource tests", function () {
       "1"
     );
     createSheet(model, { sheetId: "42" });
+    const def = model.getters.getChartDefinition("1");
+
     const result = model.dispatch("UPDATE_CHART", {
-      definition: model.getters.getChartDefinition("1"),
+      definition: def,
       sheetId: model.getters.getActiveSheetId(),
       id: "2",
+      sheetMap: getChartSheetMap(model.getters, def),
     });
 
     updateChart(model, "1", { legendPosition: "left" });

--- a/tests/plugins/custom_colors.test.ts
+++ b/tests/plugins/custom_colors.test.ts
@@ -1,5 +1,6 @@
 import { Model } from "../../src";
-import { UID } from "../../src/types";
+import { getChartSheetMap } from "../../src/helpers/charts";
+import { ChartDefinition, UID } from "../../src/types";
 import { createChart, createScorecardChart, setStyle } from "../test_helpers/commands_helpers";
 import { createColorScale, createEqualCF, target, toRangesData } from "../test_helpers/helpers";
 
@@ -87,19 +88,21 @@ describe("custom colors are correctly handled when editing charts", () => {
       sheetId
     );
     expect(model.getters.getCustomColors()).toEqual(["#123456"]);
+    const definition: ChartDefinition = {
+      title: "a title",
+      dataSets: [],
+      type: "bar",
+      stacked: false,
+      dataSetsHaveTitle: false,
+      verticalAxisPosition: "left",
+      legendPosition: "none",
+      background: "#112233",
+    };
     model.dispatch("UPDATE_CHART", {
       sheetId,
       id: "1",
-      definition: {
-        title: "a title",
-        dataSets: [],
-        type: "bar",
-        stacked: false,
-        dataSetsHaveTitle: false,
-        verticalAxisPosition: "left",
-        legendPosition: "none",
-        background: "#112233",
-      },
+      definition: definition,
+      sheetMap: getChartSheetMap(model.getters, definition),
     });
     expect(model.getters.getCustomColors()).toEqual(["#112233", "#123456"]);
     model.dispatch("DELETE_FIGURE", {
@@ -111,31 +114,33 @@ describe("custom colors are correctly handled when editing charts", () => {
 
   test("Gauge colors are taken into account", () => {
     expect(model.getters.getCustomColors()).toEqual([]);
+    const definition: ChartDefinition = {
+      title: "a title",
+      type: "gauge",
+      dataRange: "B1:B4",
+      sectionRule: {
+        rangeMin: "0",
+        rangeMax: "100",
+        colors: {
+          lowerColor: "#112233",
+          middleColor: "#123456",
+          upperColor: "#2468BD",
+        },
+        lowerInflectionPoint: {
+          type: "number" as const,
+          value: "33",
+        },
+        upperInflectionPoint: {
+          type: "number" as const,
+          value: "66",
+        },
+      },
+    };
     model.dispatch("CREATE_CHART", {
       sheetId,
       id: "1",
-      definition: {
-        title: "a title",
-        type: "gauge",
-        dataRange: "B1:B4",
-        sectionRule: {
-          rangeMin: "0",
-          rangeMax: "100",
-          colors: {
-            lowerColor: "#112233",
-            middleColor: "#123456",
-            upperColor: "#2468BD",
-          },
-          lowerInflectionPoint: {
-            type: "number" as const,
-            value: "33",
-          },
-          upperInflectionPoint: {
-            type: "number" as const,
-            value: "66",
-          },
-        },
-      },
+      definition: definition,
+      sheetMap: getChartSheetMap(model.getters, definition),
     });
     expect(model.getters.getCustomColors()).toEqual(["#2468BD", "#112233", "#123456"]);
   });

--- a/tests/test_helpers/commands_helpers.ts
+++ b/tests/test_helpers/commands_helpers.ts
@@ -1,4 +1,5 @@
 import { HEADER_HEIGHT, HEADER_WIDTH } from "../../src/constants";
+import { getChartSheetMap } from "../../src/helpers/charts";
 import { isInside, lettersToNumber, toCartesian, toZone } from "../../src/helpers/index";
 import { Model } from "../../src/model";
 import {
@@ -101,23 +102,24 @@ export function createChart(
 ) {
   const id = chartId || model.uuidGenerator.uuidv4();
   sheetId = sheetId || model.getters.getActiveSheetId();
-
+  const def: ChartDefinition = {
+    title: data.title || "test",
+    dataSets: data.dataSets || [],
+    dataSetsHaveTitle: data.dataSetsHaveTitle !== undefined ? data.dataSetsHaveTitle : true,
+    labelRange: data.labelRange,
+    type: data.type || "bar",
+    background: data.background,
+    verticalAxisPosition: ("verticalAxisPosition" in data && data.verticalAxisPosition) || "left",
+    legendPosition: data.legendPosition || "top",
+    stacked: ("stacked" in data && data.stacked) || false,
+    labelsAsText: ("labelsAsText" in data && data.labelsAsText) || false,
+    cumulative: ("cumulative" in data && data.cumulative) || false,
+  };
   return model.dispatch("CREATE_CHART", {
     id,
     sheetId,
-    definition: {
-      title: data.title || "test",
-      dataSets: data.dataSets || [],
-      dataSetsHaveTitle: data.dataSetsHaveTitle !== undefined ? data.dataSetsHaveTitle : true,
-      labelRange: data.labelRange,
-      type: data.type || "bar",
-      background: data.background,
-      verticalAxisPosition: ("verticalAxisPosition" in data && data.verticalAxisPosition) || "left",
-      legendPosition: data.legendPosition || "top",
-      stacked: ("stacked" in data && data.stacked) || false,
-      labelsAsText: ("labelsAsText" in data && data.labelsAsText) || false,
-      cumulative: ("cumulative" in data && data.cumulative) || false,
-    },
+    definition: def,
+    sheetMap: getChartSheetMap(model.getters, def),
   });
 }
 
@@ -130,20 +132,23 @@ export function createScorecardChart(
   const id = chartId || model.uuidGenerator.uuidv4();
   sheetId = sheetId || model.getters.getActiveSheetId();
 
+  const def: ScorecardChartDefinition = {
+    type: "scorecard",
+    title: data.title || "",
+    baseline: data.baseline || "",
+    keyValue: data.keyValue || "",
+    baselineDescr: data.baselineDescr || "",
+    baselineMode: data.baselineMode || "difference",
+    baselineColorDown: data.baselineColorDown || "#DC6965",
+    baselineColorUp: data.baselineColorUp || "#00A04A",
+    background: data.background,
+  };
+
   return model.dispatch("CREATE_CHART", {
     id,
     sheetId,
-    definition: {
-      type: "scorecard",
-      title: data.title || "",
-      baseline: data.baseline || "",
-      keyValue: data.keyValue || "",
-      baselineDescr: data.baselineDescr || "",
-      baselineMode: data.baselineMode || "difference",
-      baselineColorDown: data.baselineColorDown || "#DC6965",
-      baselineColorUp: data.baselineColorUp || "#00A04A",
-      background: data.background,
-    },
+    definition: def,
+    sheetMap: getChartSheetMap(model.getters, def),
   });
 }
 
@@ -156,32 +161,35 @@ export function createGaugeChart(
   const id = chartId || model.uuidGenerator.uuidv4();
   sheetId = sheetId || model.getters.getActiveSheetId();
 
+  const def: GaugeChartDefinition = {
+    type: "gauge",
+    background: data.background,
+    title: data.title || "",
+    dataRange: data.dataRange || "",
+    sectionRule: data.sectionRule || {
+      rangeMin: "0",
+      rangeMax: "100",
+      colors: {
+        lowerColor: "#6aa84f",
+        middleColor: "#f1c232",
+        upperColor: "#cc0000",
+      },
+      lowerInflectionPoint: {
+        type: "number",
+        value: "33",
+      },
+      upperInflectionPoint: {
+        type: "number",
+        value: "66",
+      },
+    },
+  };
+
   return model.dispatch("CREATE_CHART", {
     id,
     sheetId,
-    definition: {
-      type: "gauge",
-      background: data.background,
-      title: data.title || "",
-      dataRange: data.dataRange || "",
-      sectionRule: data.sectionRule || {
-        rangeMin: "0",
-        rangeMax: "100",
-        colors: {
-          lowerColor: "#6aa84f",
-          middleColor: "#f1c232",
-          upperColor: "#cc0000",
-        },
-        lowerInflectionPoint: {
-          type: "number",
-          value: "33",
-        },
-        upperInflectionPoint: {
-          type: "number",
-          value: "66",
-        },
-      },
-    },
+    definition: def,
+    sheetMap: getChartSheetMap(model.getters, def),
   });
 }
 
@@ -202,6 +210,7 @@ export function updateChart(
     id: chartId,
     sheetId,
     definition: def,
+    sheetMap: getChartSheetMap(model.getters, def),
   });
 }
 

--- a/tests/test_helpers/constants.ts
+++ b/tests/test_helpers/constants.ts
@@ -6,7 +6,7 @@ type CommandMapping = {
   [key in CoreCommandTypes]: Extract<CoreCommand, { type: key }>;
 };
 
-const TEST_CHART_DATA = {
+export const TEST_CHART_DATA = {
   basicChart: {
     type: "bar" as const,
     dataSets: ["B1:B4"],
@@ -171,12 +171,14 @@ export const TEST_COMMANDS: CommandMapping = {
     size: { width: 200, height: 200 },
     id: "figureId",
     sheetId: "Sheet1",
+    sheetMap: { Sheet1: "Sheet1" },
   },
   UPDATE_CHART: {
     type: "UPDATE_CHART",
     definition: TEST_CHART_DATA.basicChart,
     id: "figureId",
     sheetId: "Sheet1",
+    sheetMap: { Sheet1: "Sheet1" },
   },
   RESIZE_COLUMNS_ROWS: {
     type: "RESIZE_COLUMNS_ROWS",


### PR DESCRIPTION
Task: 4717724

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [4717724](https://www.odoo.com/odoo/2328/tasks/4717724)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo