### PR TITLE
[FIX] clipboard: avoid huge revisions when copy/paste CFs/DVs

### DIFF
--- a/src/plugins/core/conditional_format.ts
+++ b/src/plugins/core/conditional_format.ts
@@ -1,5 +1,6 @@
 import { compile } from "../../formulas/index";
-import { isInside, recomputeZones } from "../../helpers/index";
+import { isInside, toUnboundedZone } from "../../helpers/index";
+import { futureRecomputeZones } from "../../helpers/recompute_zones";
 import {
   AddConditionalFormatCommand,
   ApplyRangeChange,
@@ -18,6 +19,7 @@ import {
   IconSetRule,
   IconThreshold,
   UID,
+  UnboundedZone,
   Validation,
   WorkbookData,
   Zone,
@@ -239,19 +241,21 @@ export class ConditionalFormatPlugin
   /**
    * Add or remove cells to a given conditional formatting rule and return the adapted CF's XCs.
    */
-  getAdaptedCfRanges(sheetId: UID, cf: ConditionalFormat, toAdd: string[], toRemove: string[]) {
+  getAdaptedCfRanges(sheetId: UID, cf: ConditionalFormat, toAdd: Zone[], toRemove: Zone[]) {
     if (toAdd.length === 0 && toRemove.length === 0) {
       return;
     }
     const rules = this.getters.getConditionalFormats(sheetId);
     const replaceIndex = rules.findIndex((c) => c.id === cf.id);
-    let currentRanges: string[] = [];
+    let currentRanges: UnboundedZone[] = [];
     if (replaceIndex > -1) {
-      currentRanges = rules[replaceIndex].ranges;
+      currentRanges = rules[replaceIndex].ranges.map(toUnboundedZone);
     }
 
     currentRanges = currentRanges.concat(toAdd);
-    return recomputeZones(currentRanges, toRemove);
+    // Remove the zones first in case the same position is in toAdd and toRemove
+    const withRemovedZones = futureRecomputeZones(currentRanges, toRemove);
+    return futureRecomputeZones([...toAdd, ...withRemovedZones], []);
   }
 
   // ---------------------------------------------------------------------------

--- a/src/plugins/ui_feature/autofill.ts
+++ b/src/plugins/ui_feature/autofill.ts
@@ -1,4 +1,4 @@
-import { clip, isInside, positionToZone, toCartesian, toXC } from "../../helpers/index";
+import { clip, isInside, positionToZone, toCartesian, toXC, toZone } from "../../helpers/index";
 import { futureRecomputeZones } from "../../helpers/recompute_zones";
 import { autofillModifiersRegistry, autofillRulesRegistry } from "../../registries/index";
 import {
@@ -313,15 +313,15 @@ export class AutofillPlugin extends UIPlugin {
       if (!cf) {
         continue;
       }
-      const newCfRanges = this.getters.getAdaptedCfRanges(sheetId, cf, changes, []);
-      if (newCfRanges) {
+      const newCfZones = this.getters.getAdaptedCfRanges(sheetId, cf, changes.map(toZone), []);
+      if (newCfZones) {
         this.dispatch("ADD_CONDITIONAL_FORMAT", {
           cf: {
             id: cf.id,
             rule: cf.rule,
             stopIfTrue: cf.stopIfTrue,
           },
-          ranges: newCfRanges.map((xc) => this.getters.getRangeDataFromXc(sheetId, xc)),
+          ranges: newCfZones.map((xc) => this.getters.getRangeDataFromZone(sheetId, xc)),
           sheetId,
         });
       }

--- a/tests/data_validation/data_validation_clipboard_plugin.test.ts
+++ b/tests/data_validation/data_validation_clipboard_plugin.test.ts
@@ -1,5 +1,6 @@
-import { Model } from "../../src";
-import { DataValidationCriterion, UID } from "../../src/types";
+import { Model, UIPlugin } from "../../src";
+import { featurePluginRegistry } from "../../src/plugins";
+import { Command, DataValidationCriterion, UID } from "../../src/types";
 import {
   activateSheet,
   addDataValidation,
@@ -8,7 +9,7 @@ import {
   cut,
   paste,
 } from "../test_helpers/commands_helpers";
-import { getDataValidationRules } from "../test_helpers/helpers";
+import { addTestPlugin, getDataValidationRules } from "../test_helpers/helpers";
 
 describe("Data validation", () => {
   let model: Model;
@@ -135,5 +136,23 @@ describe("Data validation", () => {
       { criterion: { values: ["1"] }, ranges: ["A1"] },
       { criterion: { values: ["5"] }, ranges: ["B2"] },
     ]);
+  });
+
+  test("copy/paste a DV zone only dispatch a singled ADD_DATA_VALIDATION_RULE", () => {
+    const commands: Command[] = [];
+    class MyUIPlugin extends UIPlugin {
+      handle = (cmd: Command) => commands.push(cmd);
+    }
+    addTestPlugin(featurePluginRegistry, MyUIPlugin);
+
+    const model = new Model({ sheets: [{ colNumber: 5, rowNumber: 5 }] });
+    const sheetId = model.getters.getActiveSheetId();
+    addDataValidation(model, "A1:A2", "id", { type: "textContains", values: ["1"] });
+
+    copy(model, "A1:A2");
+    paste(model, "B1");
+
+    expect(getDataValidationRules(model, sheetId)).toMatchObject([{ ranges: ["A1:B2"] }]);
+    expect(commands.filter((c) => c.type === "ADD_DATA_VALIDATION_RULE")).toHaveLength(2);
   });
 });


### PR DESCRIPTION
## Description

When copy/paste a conditional format/data validation, there would be an `ADD_CONDITIONAL_FORMAT` or `ADD_DATA_VALIDATION_RULE` command for each copied cell with a cf/dv. This would create a huge revision.

Task: [4718522](https://www.odoo.com/odoo/2328/tasks/4718522)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo