### PR TITLE
[FIX] conditional format: huge revisions on copy/paste cf

### DIFF
--- a/src/clipboard_handlers/conditional_format_clipboard.ts
+++ b/src/clipboard_handlers/conditional_format_clipboard.ts
@@ -26,6 +26,8 @@ export class ConditionalFormatClipboardHandler extends AbstractCellClipboardHand
   Maybe<ClipboardConditionalFormat>
 > {
   private readonly uuidGenerator = new UuidGenerator();
+  private queuedChanges: Record<UID, { toAdd: Zone[]; toRemove: Zone[]; cf: ConditionalFormat }[]> =
+    {};
 
   copy(data: ClipboardCellData): ClipboardContent | undefined {
     if (!data.zones.length) {
@@ -51,6 +53,7 @@ export class ConditionalFormatClipboardHandler extends AbstractCellClipboardHand
   }
 
   paste(target: ClipboardPasteTarget, clippedContent: ClipboardContent, options: ClipboardOptions) {
+    this.queuedChanges = {};
     if (options.pasteOption === "asValue") {
       return;
     }
@@ -62,6 +65,8 @@ export class ConditionalFormatClipboardHandler extends AbstractCellClipboardHand
     } else {
       this.pasteFromCut(sheetId, zones, clippedContent);
     }
+
+    this.executeQueuedChanges();
   }
 
   private pasteFromCut(sheetId: UID, target: Zone[], content: ClipboardContent) {
@@ -92,12 +97,13 @@ export class ConditionalFormatClipboardHandler extends AbstractCellClipboardHand
     isCutOperation?: boolean
   ) {
     if (origin?.rules && origin.rules.length > 0) {
+      const originZone = positionToZone(origin.position);
       const zone = positionToZone(target);
       for (const rule of origin.rules) {
         const toRemoveZones: Zone[] = [];
         if (isCutOperation) {
           //remove from current rule
-          toRemoveZones.push(positionToZone(origin.position));
+          toRemoveZones.push(originZone);
         }
         if (origin.position.sheetId === target.sheetId) {
           this.adaptCFRules(origin.position.sheetId, rule, [zone], toRemoveZones);
@@ -114,32 +120,55 @@ export class ConditionalFormatClipboardHandler extends AbstractCellClipboardHand
    * Add or remove cells to a given conditional formatting rule.
    */
   private adaptCFRules(sheetId: UID, cf: ConditionalFormat, toAdd: Zone[], toRemove: Zone[]) {
-    const newRangesXc = this.getters.getAdaptedCfRanges(sheetId, cf, toAdd, toRemove);
-    if (!newRangesXc) {
-      return;
+    if (!this.queuedChanges[sheetId]) {
+      this.queuedChanges[sheetId] = [];
     }
-    if (newRangesXc.length === 0) {
-      this.dispatch("REMOVE_CONDITIONAL_FORMAT", { id: cf.id, sheetId });
-      return;
+    const queuedChange = this.queuedChanges[sheetId].find((queued) => queued.cf.id === cf.id);
+    if (!queuedChange) {
+      this.queuedChanges[sheetId].push({ toAdd, toRemove, cf });
+    } else {
+      queuedChange.toAdd.push(...toAdd);
+      queuedChange.toRemove.push(...toRemove);
     }
-    this.dispatch("ADD_CONDITIONAL_FORMAT", {
-      cf: {
-        id: cf.id,
-        rule: cf.rule,
-        stopIfTrue: cf.stopIfTrue,
-      },
-      ranges: newRangesXc,
-      sheetId,
-    });
+  }
+
+  private executeQueuedChanges() {
+    for (const sheetId in this.queuedChanges) {
+      for (const { toAdd, toRemove, cf } of this.queuedChanges[sheetId]) {
+        const newRangesXc = this.getters.getAdaptedCfRanges(sheetId, cf, toAdd, toRemove);
+        if (!newRangesXc) {
+          continue;
+        }
+        if (newRangesXc.length === 0) {
+          this.dispatch("REMOVE_CONDITIONAL_FORMAT", { id: cf.id, sheetId });
+          continue;
+        }
+        this.dispatch("ADD_CONDITIONAL_FORMAT", {
+          cf: {
+            id: cf.id,
+            rule: cf.rule,
+            stopIfTrue: cf.stopIfTrue,
+          },
+          ranges: newRangesXc,
+          sheetId,
+        });
+      }
+    }
   }
 
   private getCFToCopyTo(targetSheetId: UID, originCF: ConditionalFormat): ConditionalFormat {
-    const cfInTarget = this.getters
+    let targetCF = this.getters
       .getConditionalFormats(targetSheetId)
       .find((cf) => cf.stopIfTrue === originCF.stopIfTrue && deepEquals(cf.rule, originCF.rule));
 
-    return cfInTarget
-      ? cfInTarget
-      : { ...originCF, id: this.uuidGenerator.smallUuid(), ranges: [] };
+    const queuedCfs = this.queuedChanges[targetSheetId];
+    if (!targetCF && queuedCfs) {
+      targetCF = queuedCfs.find(
+        (queued) =>
+          queued.cf.stopIfTrue === originCF.stopIfTrue && deepEquals(queued.cf.rule, originCF.rule)
+      )?.cf;
+    }
+
+    return targetCF || { ...originCF, id: this.uuidGenerator.uuidv4(), ranges: [] };
   }
 }

--- a/src/plugins/core/conditional_format.ts
+++ b/src/plugins/core/conditional_format.ts
@@ -257,8 +257,9 @@ export class ConditionalFormatPlugin
       currentRanges = rules[replaceIndex].ranges.map(toUnboundedZone);
     }
 
-    currentRanges = currentRanges.concat(toAdd);
-    return recomputeZones(currentRanges, toRemove).map((zone) =>
+    // Remove the zones first in case the same position is in toAdd and toRemove
+    const withRemovedZones = recomputeZones(currentRanges, toRemove);
+    return recomputeZones([...toAdd, ...withRemovedZones], []).map((zone) =>
       this.getters.getRangeDataFromZone(sheetId, zone)
     );
   }

--- a/tests/clipboard/clipboard_plugin.test.ts
+++ b/tests/clipboard/clipboard_plugin.test.ts
@@ -1,11 +1,14 @@
+import { UIPlugin } from "../../src";
 import { clipboardHandlersRegistries } from "../../src/clipboard_handlers";
 import { DEFAULT_BORDER_DESC } from "../../src/constants";
 import { toCartesian, toZone, zoneToXc } from "../../src/helpers";
 import { getClipboardDataPositions } from "../../src/helpers/clipboard/clipboard_helpers";
 import { Model } from "../../src/model";
+import { featurePluginRegistry } from "../../src/plugins";
 import {
   ClipboardMIMEType,
   ClipboardPasteTarget,
+  Command,
   CommandResult,
   DEFAULT_LOCALE,
   DEFAULT_LOCALES,
@@ -59,6 +62,7 @@ import {
   getStyle,
 } from "../test_helpers/getters_helpers";
 import {
+  addTestPlugin,
   createEqualCF,
   createModelFromGrid,
   getGrid,
@@ -1895,6 +1899,28 @@ describe("clipboard", () => {
       { ranges: ["A1"], rule: { style: { fillColor: "#00FF00" } } },
       { ranges: ["B2"], rule: { style: { fillColor: "#FF0000" } } },
     ]);
+  });
+
+  test("copy/paste a CF zone only dispatch a singled ADD_CONDITIONAL_FORMAT", () => {
+    const commands: Command[] = [];
+    class MyUIPlugin extends UIPlugin {
+      handle = (cmd: Command) => commands.push(cmd);
+    }
+    addTestPlugin(featurePluginRegistry, MyUIPlugin);
+
+    const model = new Model({ sheets: [{ colNumber: 5, rowNumber: 5 }] });
+    const sheetId = model.getters.getActiveSheetId();
+    model.dispatch("ADD_CONDITIONAL_FORMAT", {
+      cf: createEqualCF("1", { fillColor: "#FF0000" }, "1"),
+      ranges: toRangesData(sheetId, "A1,A2"),
+      sheetId,
+    });
+
+    copy(model, "A1:A2");
+    paste(model, "B1");
+
+    expect(model.getters.getConditionalFormats(sheetId)).toMatchObject([{ ranges: ["A1:B2"] }]);
+    expect(commands.filter((c) => c.type === "ADD_CONDITIONAL_FORMAT")).toHaveLength(2);
   });
 
   test("can copy and paste a cell which contains a cross-sheet reference", () => {


### PR DESCRIPTION
## Description

When copy/pasting a conditional format, the revision had one ADD_CONDITIONAL_FORMAT command per copied cell. That lead to huge revisions if, for example, a whole column with a CF was copied.

Now the revision only has a single ADD_CONDITIONAL_FORMAT command per modified CF.

The exact same work was done for data validation rules.

Task: [4718522](https://www.odoo.com/odoo/2328/tasks/4718522)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo