### PR TITLE
[PERF] autofill: improve command dispatching

### DIFF
--- a/src/plugins/core/borders.ts
+++ b/src/plugins/core/borders.ts
@@ -81,6 +81,15 @@ export class BordersPlugin extends CorePlugin<BordersPluginState> implements Bor
       case "SET_BORDER":
         this.setBorder(cmd.sheetId, cmd.col, cmd.row, cmd.border);
         break;
+      case "SET_BORDERS_ON_TARGET":
+        for (const zone of cmd.target) {
+          for (let row = zone.top; row <= zone.bottom; row++) {
+            for (let col = zone.left; col <= zone.right; col++) {
+              this.setBorder(cmd.sheetId, col, row, cmd.border);
+            }
+          }
+        }
+        break;
       case "SET_ZONE_BORDERS":
         if (cmd.border) {
           const target = cmd.target.map((zone) => this.getters.expandZone(cmd.sheetId, zone));

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -222,6 +222,7 @@ export const coreTypes = new Set<CoreCommandTypes>([
   "CLEAR_FORMATTING",
   "SET_BORDER",
   "SET_ZONE_BORDERS",
+  "SET_BORDERS_ON_TARGET",
 
   /** CHART */
   "CREATE_CHART",
@@ -526,6 +527,11 @@ export interface SetZoneBordersCommand extends TargetDependentCommand {
 
 export interface SetBorderCommand extends PositionDependentCommand {
   type: "SET_BORDER";
+  border: Border | undefined;
+}
+
+export interface SetBorderTargetCommand extends TargetDependentCommand {
+  type: "SET_BORDERS_ON_TARGET";
   border: Border | undefined;
 }
 
@@ -1080,6 +1086,7 @@ export type CoreCommand =
   | ClearFormattingCommand
   | SetZoneBordersCommand
   | SetBorderCommand
+  | SetBorderTargetCommand
 
   /** CHART */
   | CreateChartCommand

--- a/tests/borders/border_plugin.test.ts
+++ b/tests/borders/border_plugin.test.ts
@@ -12,6 +12,7 @@ import {
   selectCell,
   setAnchorCorner,
   setBorders,
+  setBordersOnTarget,
   setCellContent,
   setZoneBorders,
   undo,
@@ -115,6 +116,26 @@ describe("borders", () => {
     expect(setBorders(model, "A1", { top: undefined })).toBeCancelledBecause(
       CommandResult.NoChanges
     );
+  });
+
+  test("Can set border on a target", () => {
+    const model = new Model();
+    const border = { top: DEFAULT_BORDER_DESC };
+    setBordersOnTarget(model, ["A1:A2", "B2:B3"], border);
+    expect(getBorder(model, "A1")).toEqual({
+      top: DEFAULT_BORDER_DESC,
+      bottom: DEFAULT_BORDER_DESC,
+    });
+    expect(getBorder(model, "A2")).toEqual({
+      top: DEFAULT_BORDER_DESC,
+    });
+    expect(getBorder(model, "B2")).toEqual({
+      top: DEFAULT_BORDER_DESC,
+      bottom: DEFAULT_BORDER_DESC,
+    });
+    expect(getBorder(model, "B3")).toEqual({
+      top: DEFAULT_BORDER_DESC,
+    });
   });
 
   test("can set all borders in a zone", () => {

--- a/tests/test_helpers/commands_helpers.ts
+++ b/tests/test_helpers/commands_helpers.ts
@@ -546,6 +546,19 @@ export function setBorders(
   });
 }
 
+export function setBordersOnTarget(
+  model: Model,
+  xcs: string[],
+  border?: Border,
+  sheetId: UID = model.getters.getActiveSheetId()
+) {
+  return model.dispatch("SET_BORDERS_ON_TARGET", {
+    sheetId,
+    target: xcs.map(toZone),
+    border,
+  });
+}
+
 /**
  * Clear a cell
  */

--- a/tests/test_helpers/constants.ts
+++ b/tests/test_helpers/constants.ts
@@ -109,6 +109,12 @@ export const TEST_COMMANDS: CommandMapping = {
     border: { top: DEFAULT_BORDER_DESC },
     sheetId: "Sheet1",
   },
+  SET_BORDERS_ON_TARGET: {
+    type: "SET_BORDERS_ON_TARGET",
+    target: target("A1"),
+    border: { top: DEFAULT_BORDER_DESC },
+    sheetId: "Sheet1",
+  },
   CREATE_FILTER_TABLE: {
     type: "CREATE_FILTER_TABLE",
     target: target("A1"),
@@ -382,6 +388,7 @@ export const OT_TESTS_TARGET_DEPENDANT_COMMANDS = [
   TEST_COMMANDS.CREATE_FILTER_TABLE,
   TEST_COMMANDS.REMOVE_FILTER_TABLE,
   TEST_COMMANDS.CLEAR_CELLS,
+  TEST_COMMANDS.SET_BORDERS_ON_TARGET,
 ];
 
 export const OT_TESTS_ZONE_DEPENDANT_COMMANDS = [


### PR DESCRIPTION
Before this commit, the command dispatching for autofill was inefficient, leading to large command sizes and performance issues. This commit optimizes the command dispatching process, reducing the size of the commands and improving performance.

The main changes are about borders, conditional formats and data validation rules. These three commands were previously dispatched separately, with a change of one cell in the range/zone. Now, the new range/zone is computed and dispatched in one command (one command by CF, by border, by DV rule).

This commit introduces a new command for the border (`SET_BORDER_TARGET`) as we cannot use the `SET_ZONE_BORDER` in this case as it does not take the same parameters. In master, we could change `SET_BORDER` command to take a target instead of a position and then remove the `SET_BORDER_TARGET` command.

Command size for autofilling a row (26 cells) with two CFs and a border to the bottom of the sheet (99 rows) was reduced from 2.9MB to 244KB:

Task: 4718202

