### PR TITLE
[IMP] chart: detect hierarchical chart at chart creation

### DIFF
--- a/tests/figures/chart/menu_item_insert_chart.test.ts
+++ b/tests/figures/chart/menu_item_insert_chart.test.ts
@@ -24,6 +24,7 @@ import {
   mockChart,
   mountSpreadsheet,
   nextTick,
+  setGrid,
   spyModelDispatch,
 } from "../../test_helpers/helpers";
 
@@ -492,6 +493,44 @@ describe("Insert chart menu item", () => {
       },
     };
     expect(dispatchSpy).toHaveBeenCalledWith("CREATE_CHART", payload);
+  });
+
+  test("Chart with multiple string columns is a sunburst chart (without headers)", () => {
+    // prettier-ignore
+    const grid = {
+      K1: "Group1",    L1: "SubGroup1",    M1: "40",
+      K2: "Group1",    L2: "SubGroup2",    M2: "20",
+      K3: "Group2",    L3: "SubGroup1",    M3: "10",
+    };
+    setGrid(model, grid);
+    setSelection(model, ["K1"]);
+    insertChart();
+    const chartId = model.getters.getFigures(model.getters.getActiveSheetId()).at(-1)!.id;
+    expect(model.getters.getChartDefinition(chartId)).toMatchObject({
+      type: "sunburst",
+      dataSets: [{ dataRange: "K1:K3" }, { dataRange: "L1:L3" }],
+      dataSetsHaveTitle: false,
+      labelRange: "M1:M3",
+    });
+  });
+
+  test("Chart with multiple string columns is a sunburst chart (with headers)", () => {
+    // prettier-ignore
+    const grid = {
+      K1: "Header1",   L1: "Header2",      M1: "Header3",
+      K2: "Group1",    L2: "SubGroup1",    M2: "20",
+                       L3: "SubGroup2",    M3: "10",
+    };
+    setGrid(model, grid);
+    setSelection(model, ["K1"]);
+    insertChart();
+    const chartId = model.getters.getFigures(model.getters.getActiveSheetId()).at(-1)!.id;
+    expect(model.getters.getChartDefinition(chartId)).toMatchObject({
+      type: "sunburst",
+      dataSets: [{ dataRange: "K1:K3" }, { dataRange: "L1:L3" }],
+      dataSetsHaveTitle: true,
+      labelRange: "M1:M3",
+    });
   });
 
   test("Chart can be inserted with unbounded ranges", () => {


### PR DESCRIPTION
## Description

With this commit, at the chart creation we will check if the data in the selected zone looks like a hierarchical dataset (multiple columns with string values, and one column with numeric values). If so, we will create a sunburst chart instead of a car chart.

Task: [4724420](https://www.odoo.com/odoo/2328/tasks/4724420)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo