### PR TITLE
[FIX] funnel chart: tooltip stays after mouse leaves the element

### DIFF
--- a/src/components/figures/chart/chartJs/chartjs_funnel_chart.ts
+++ b/src/components/figures/chart/chartJs/chartjs_funnel_chart.ts
@@ -77,11 +77,11 @@ export function getFunnelChartElement() {
     }
 
     /** Check if the mouse is inside the trapezoid */
-    inRange(mouseX: number, mouseY: number, useFinalPosition: boolean) {
-      const { x, y, width, height, nextElementWidth, base } = this.getProps(
-        ["x", "y", "width", "height", "nextElementWidth", "base"],
-        useFinalPosition
-      ) as any;
+    inRange(mouseX: number, mouseY: number) {
+      const props = ["x", "y", "width", "height", "nextElement", "base", "options"];
+      let { x, y, height, nextElement, base } = this.getProps(props) as any;
+      const width = getElementWidth(this);
+      const nextElementWidth = nextElement ? getElementWidth(nextElement) : 0;
 
       const startX = Math.min(x, base);
       const startY = y - height / 2;


### PR DESCRIPTION
## Description

After hovering a funnel chart trapezoïd, the tooltip stays even after the mouse leaves the element, until the mouse leaves the chart.

This was because changes were made to `FunnelChartElement` in e34ee5b921, but we forgot to modify the `inRange` method to adapt to those changes.

Task: [4724993](https://www.odoo.com/odoo/2328/tasks/4724993)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo