### PR TITLE
[IMP] color-picker: remove additional #

### DIFF
--- a/src/components/color_picker/color_picker.ts
+++ b/src/components/color_picker/color_picker.ts
@@ -366,7 +366,7 @@ export class ColorPicker extends Component<ColorPickerProps, SpreadsheetChildEnv
 
   setHexColor(ev: InputEvent) {
     // only support HEX code input
-    const val = (ev.target as HTMLInputElement).value.slice(0, 7);
+    const val = (ev.target as HTMLInputElement).value.replace("##", "#").slice(0, 7);
     this.state.customHexColor = val;
     if (!isColorValid(val)) {
     } else {

--- a/src/components/color_picker/color_picker.xml
+++ b/src/components/color_picker/color_picker.xml
@@ -71,7 +71,6 @@
               t-on-click.stop=""
               t-att-value="state.customHexColor"
               t-on-input="setHexColor"
-              maxlength="7"
             />
             <div class="o-color-preview" t-att-style="colorPreviewStyle"/>
           </div>

--- a/tests/colors/__snapshots__/color_picker_component.test.ts.snap
+++ b/tests/colors/__snapshots__/color_picker_component.test.ts.snap
@@ -500,7 +500,6 @@ exports[`Color Picker buttons Full component rendering 1`] = `
       class="o-custom-input-preview"
     >
       <input
-        maxlength="7"
         type="text"
       />
       <div

--- a/tests/colors/color_picker_component.test.ts
+++ b/tests/colors/color_picker_component.test.ts
@@ -176,7 +176,11 @@ describe("Color Picker buttons", () => {
 
   test.each([
     "#fff",
+    "##fff",
     "fff",
+    "#ffffff",
+    "##ffffff",
+    "ffffff",
     "#FFFFFF00", // Hex + alpha
   ])("Can input a custom HEX code, alpha is ignored", async (hexCode) => {
     await mountColorPicker();
@@ -184,12 +188,15 @@ describe("Color Picker buttons", () => {
 
     const inputTarget = fixture.querySelector(".o-custom-input-preview input")!;
     await setInputValueAndTrigger(inputTarget, hexCode as Color);
-    expect((inputTarget as HTMLInputElement).value).toBeSameColorAs(hexCode.slice(0, 7));
+    expect((inputTarget as HTMLInputElement).value).toBeSameColorAs(
+      hexCode.replace("##", "#").slice(0, 7)
+    );
     const addButton = fixture.querySelector(".o-add-button")!;
     expect(addButton.classList).not.toContain("o-disabled");
   });
 
   test.each([
+    "#fff#000",
     "rgb(1,1,1)", // rgb
     "rgb(1,1,1,0.5)", // rgba
   ])("refuse non strictly HEX codes", async (hexCode) => {


### PR DESCRIPTION
How to reproduce
    Copy a color code (i.e. #E6F2F3)
    Create a custom table
    Edit its color using the color picker
    Double-click the current code and replace it by #E6F2F3
    As the double-click doesn't grab the #, you get ##E6F2F

Task: 4687930

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [4687930](https://www.odoo.com/odoo/2328/tasks/4687930)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo