### PR TITLE
 [IMP] figure: allow do copy/download chart/image in dashboard

### DIFF
--- a/src/components/figures/chart/chart_type_switcher/chart_type_switcher.scss
+++ b/src/components/figures/chart/chart_type_switcher/chart_type_switcher.scss
@@ -1,0 +1,18 @@
+.o-spreadsheet .o-figure {
+  &:not(:hover) .o-dashboard-chart-select {
+    display: none !important;
+  }
+
+  .o-dashboard-chart-select {
+    cursor: default;
+
+    .o-chart-type-item {
+      opacity: 0.3;
+
+      &.active,
+      &:hover {
+        background: $os-button-active-bg;
+      }
+    }
+  }
+}

--- a/src/components/figures/chart/chart_type_switcher/chart_type_switcher.ts
+++ b/src/components/figures/chart/chart_type_switcher/chart_type_switcher.ts
@@ -1,0 +1,100 @@
+import { Component } from "@odoo/owl";
+import { BACKGROUND_CHART_COLOR } from "../../../../constants";
+import { chartRegistry, chartSubtypeRegistry } from "../../../../registries";
+import { ChartDefinition, ChartType, FigureUI, Rect, SpreadsheetChildEnv } from "../../../../types";
+import { getBoundingRectAsPOJO } from "../../../helpers/dom_helpers";
+
+const lineBarPieRegex = /line|bar|pie/;
+
+interface Props {
+  figureUI: FigureUI;
+  openContextMenu: (rect: Rect) => void;
+}
+
+export class ChartTypeSwitcherMenu extends Component<Props, SpreadsheetChildEnv> {
+  static template = "spreadsheet.ChartTypeSwitcherMenu";
+  static components = {};
+  static props = { figureUI: Object, openContextMenu: Function };
+
+  private originalChartDefinition!: ChartDefinition;
+
+  setup() {
+    super.setup();
+    this.originalChartDefinition = this.env.model.getters.getChartDefinition(
+      this.props.figureUI.id
+    );
+  }
+
+  get shouldBeDisplayed() {
+    const definition = this.env.model.getters.getChartDefinition(this.props.figureUI.id);
+    if (!lineBarPieRegex.test(definition.type)) {
+      return false;
+    }
+    return true;
+  }
+
+  get availableTypes() {
+    const types = ["column", "line", "pie"];
+    return types.map((type) => {
+      const item = chartSubtypeRegistry.get(type);
+      return {
+        ...item,
+        icon: this.getIconClasses(item.chartType),
+      };
+    });
+  }
+
+  getIconClasses(type: ChartType) {
+    if (type.includes("bar")) {
+      return "fa fa-bar-chart";
+    }
+    if (type.includes("line")) {
+      return "fa fa-line-chart";
+    }
+    if (type.includes("pie")) {
+      return "fa fa-pie-chart";
+    }
+    return "";
+  }
+
+  onTypeChange(type: ChartType) {
+    const figureId = this.props.figureUI.id;
+    const currentDefinition = this.env.model.getters.getChartDefinition(figureId);
+    if (currentDefinition.type === type) {
+      return;
+    }
+
+    let definition: ChartDefinition;
+    if (this.originalChartDefinition.type === type) {
+      definition = this.originalChartDefinition;
+    } else {
+      const newChartInfo = chartSubtypeRegistry.get(type);
+      const ChartClass = chartRegistry.get(newChartInfo.chartType);
+      const chartCreationContext = this.env.model.getters.getContextCreationChart(figureId);
+      if (!chartCreationContext) return;
+      definition = {
+        ...ChartClass.getChartDefinitionFromContextCreation(chartCreationContext),
+        ...newChartInfo.subtypeDefinition,
+      } as ChartDefinition;
+    }
+
+    this.env.model.dispatch("UPDATE_CHART", {
+      definition,
+      figureId,
+      sheetId: this.env.model.getters.getActiveSheetId(),
+    });
+  }
+
+  get selectedChartType() {
+    return this.env.model.getters.getChartDefinition(this.props.figureUI.id).type;
+  }
+
+  get backgroundColor() {
+    const color = this.env.model.getters.getChartDefinition(this.props.figureUI.id).background;
+    return "background-color: " + (color || BACKGROUND_CHART_COLOR);
+  }
+
+  openContextMenu(ev: MouseEvent) {
+    this.props.openContextMenu(getBoundingRectAsPOJO(ev.target as HTMLElement));
+  }
+}

--- a/src/components/figures/chart/chart_type_switcher/chart_type_switcher.xml
+++ b/src/components/figures/chart/chart_type_switcher/chart_type_switcher.xml
@@ -1,0 +1,24 @@
+<templates>
+  <t t-name="spreadsheet.ChartTypeSwitcherMenu">
+    <div
+      class="o-dashboard-chart-select position-absolute top-0 end-0"
+      t-on-click.stop=""
+      t-if="shouldBeDisplayed">
+      <div class="d-flex flex-row px-1" t-att-style="backgroundColor">
+        <t t-foreach="availableTypes" t-as="type" t-key="type.chartSubtype">
+          <button
+            t-attf-class=" {{type.icon}} {{type.chartType === selectedChartType ? 'active' : ''}}"
+            class="o-chart-type-item btn mt-1 me-1 p-1 "
+            t-att-title="type.displayName"
+            t-on-click="() => this.onTypeChange(type.chartSubtype)"
+            t-att-data-id="type.chartSubtype"
+          />
+        </t>
+        <button
+          class="o-chart-type-item btn mt-1 p-1 fa fa-ellipsis-v"
+          t-on-click="openContextMenu"
+        />
+      </div>
+    </div>
+  </t>
+</templates>

--- a/src/components/figures/figure/figure.ts
+++ b/src/components/figures/figure/figure.ts
@@ -318,7 +318,6 @@ export class FigureComponent extends Component<Props, SpreadsheetChildEnv> {
   }
 
   onContextMenu(ev: MouseEvent) {
-    if (this.env.isDashboard()) return;
     this.openContextMenu({ x: ev.clientX, y: ev.clientY, width: 0, height: 0 });
   }
 

--- a/src/components/figures/figure/figure.ts
+++ b/src/components/figures/figure/figure.ts
@@ -318,6 +318,7 @@ export class FigureComponent extends Component<Props, SpreadsheetChildEnv> {
   }
 
   onContextMenu(ev: MouseEvent) {
+    if (this.env.isDashboard()) return;
     this.openContextMenu({ x: ev.clientX, y: ev.clientY, width: 0, height: 0 });
   }
 

--- a/src/components/figures/figure/figure.xml
+++ b/src/components/figures/figure/figure.xml
@@ -16,6 +16,7 @@
           t-key="props.figureUI.id"
           onFigureDeleted="props.onFigureDeleted"
           figureUI="props.figureUI"
+          openContextMenu.bind="openContextMenu"
         />
         <div class="o-figure-menu position-absolute m-2" t-if="!env.isDashboard()">
           <div

--- a/src/components/figures/figure/figure.xml
+++ b/src/components/figures/figure/figure.xml
@@ -4,7 +4,7 @@
       <div
         class="o-figure w-100 h-100"
         t-on-pointerdown.stop="(ev) => this.onMouseDown(ev)"
-        t-on-contextmenu.prevent.stop="(ev) => !env.model.getters.isReadonly() and this.onContextMenu(ev)"
+        t-on-contextmenu.prevent.stop="(ev) => this.onContextMenu(ev)"
         t-ref="figure"
         t-att-style="props.style"
         t-att-data-id="props.figureUI.id"
@@ -27,13 +27,13 @@
             t-on-contextmenu.prevent.stop="showMenu">
             <t t-call="o-spreadsheet-Icon.LIST"/>
           </div>
-          <Menu
-            t-if="menuState.isOpen"
-            anchorRect="menuState.anchorRect"
-            menuItems="menuState.menuItems"
-            onClose="() => this.menuState.isOpen=false"
-          />
         </div>
+        <Menu
+          t-if="menuState.isOpen"
+          anchorRect="menuState.anchorRect"
+          menuItems="menuState.menuItems"
+          onClose="() => this.menuState.isOpen=false"
+        />
       </div>
       <div class="o-figure-border w-100 h-100 position-absolute pe-none" t-att-style="borderStyle"/>
       <t t-if="isSelected">

--- a/src/components/figures/figure/figure.xml
+++ b/src/components/figures/figure/figure.xml
@@ -4,7 +4,7 @@
       <div
         class="o-figure w-100 h-100"
         t-on-pointerdown.stop="(ev) => this.onMouseDown(ev)"
-        t-on-contextmenu.prevent.stop="(ev) => this.onContextMenu(ev)"
+        t-on-contextmenu.prevent.stop="(ev) => !env.model.getters.isReadonly() and this.onContextMenu(ev)"
         t-ref="figure"
         t-att-style="props.style"
         t-att-data-id="props.figureUI.id"

--- a/src/components/figures/figure_chart/figure_chart.ts
+++ b/src/components/figures/figure_chart/figure_chart.ts
@@ -1,7 +1,8 @@
 import { Component } from "@odoo/owl";
 import { chartComponentRegistry } from "../../../registries/chart_types";
-import { ChartType, FigureUI, SpreadsheetChildEnv } from "../../../types";
+import { ChartType, FigureUI, Rect, SpreadsheetChildEnv } from "../../../types";
 import { css } from "../../helpers/css";
+import { ChartTypeSwitcherMenu } from "../chart/chart_type_switcher/chart_type_switcher";
 
 // -----------------------------------------------------------------------------
 // STYLE
@@ -19,6 +20,7 @@ interface Props {
   // style by hand in the useEffect()
   figureUI: FigureUI;
   onFigureDeleted: () => void;
+  openContextMenu: (rect: Rect) => void;
 }
 
 export class ChartFigure extends Component<Props, SpreadsheetChildEnv> {
@@ -26,8 +28,9 @@ export class ChartFigure extends Component<Props, SpreadsheetChildEnv> {
   static props = {
     figureUI: Object,
     onFigureDeleted: Function,
+    openContextMenu: Function,
   };
-  static components = {};
+  static components = { ChartTypeSwitcherMenu };
 
   onDoubleClick() {
     this.env.model.dispatch("SELECT_FIGURE", { figureId: this.props.figureUI.id });

--- a/src/components/figures/figure_chart/figure_chart.xml
+++ b/src/components/figures/figure_chart/figure_chart.xml
@@ -7,5 +7,12 @@
         t-key="this.props.figureUI.id"
       />
     </div>
+    <div t-if="env.isDashboard()" class="position-absolute top-0 end-0">
+      <ChartTypeSwitcherMenu
+        t-if="env.isDashboard()"
+        figureUI="props.figureUI"
+        openContextMenu="props.openContextMenu"
+      />
+    </div>
   </t>
 </templates>

--- a/src/components/figures/figure_image/figure_image.ts
+++ b/src/components/figures/figure_image/figure_image.ts
@@ -1,9 +1,10 @@
 import { Component } from "@odoo/owl";
-import { FigureUI, SpreadsheetChildEnv, UID } from "../../../types";
+import { FigureUI, Rect, SpreadsheetChildEnv, UID } from "../../../types";
 
 interface Props {
   figureUI: FigureUI;
   onFigureDeleted: () => void;
+  openContextMenu: (rect: Rect) => void;
 }
 
 export class ImageFigure extends Component<Props, SpreadsheetChildEnv> {
@@ -11,6 +12,7 @@ export class ImageFigure extends Component<Props, SpreadsheetChildEnv> {
   static props = {
     figureUI: Object,
     onFigureDeleted: Function,
+    openContextMenu: Function,
   };
   static components = {};
 

--- a/src/helpers/figures/charts/bar_chart.ts
+++ b/src/helpers/figures/charts/bar_chart.ts
@@ -238,7 +238,7 @@ export function createBarChartRuntime(chart: BarChart, getters: Getters): BarCha
     options: {
       ...CHART_COMMON_OPTIONS,
       indexAxis: chart.horizontal ? "y" : "x",
-      layout: getChartLayout(definition),
+      layout: getChartLayout(definition, chartData),
       scales: getBarChartScales(definition, chartData),
       plugins: {
         title: getChartTitle(definition),

--- a/src/helpers/figures/charts/combo_chart.ts
+++ b/src/helpers/figures/charts/combo_chart.ts
@@ -240,7 +240,7 @@ export function createComboChartRuntime(chart: ComboChart, getters: Getters): Co
     },
     options: {
       ...CHART_COMMON_OPTIONS,
-      layout: getChartLayout(definition),
+      layout: getChartLayout(definition, chartData),
       scales: getBarChartScales(definition, chartData),
       plugins: {
         title: getChartTitle(definition),

--- a/src/helpers/figures/charts/funnel_chart.ts
+++ b/src/helpers/figures/charts/funnel_chart.ts
@@ -220,7 +220,7 @@ export function createFunnelChartRuntime(chart: FunnelChart, getters: Getters): 
     options: {
       ...CHART_COMMON_OPTIONS,
       indexAxis: "y",
-      layout: getChartLayout(definition),
+      layout: getChartLayout(definition, chartData),
       scales: getFunnelChartScales(definition, chartData),
       plugins: {
         title: getChartTitle(definition),

--- a/src/helpers/figures/charts/geo_chart.ts
+++ b/src/helpers/figures/charts/geo_chart.ts
@@ -201,7 +201,7 @@ export function createGeoChartRuntime(chart: GeoChart, getters: Getters): GeoCha
     },
     options: {
       ...CHART_COMMON_OPTIONS,
-      layout: getChartLayout(definition),
+      layout: getChartLayout(definition, chartData),
       scales: getGeoChartScales(definition, chartData),
       plugins: {
         title: getChartTitle(definition),

--- a/src/helpers/figures/charts/line_chart.ts
+++ b/src/helpers/figures/charts/line_chart.ts
@@ -247,7 +247,7 @@ export function createLineChartRuntime(chart: LineChart, getters: Getters): Char
     },
     options: {
       ...CHART_COMMON_OPTIONS,
-      layout: getChartLayout(definition),
+      layout: getChartLayout(definition, chartData),
       scales: getLineChartScales(definition, chartData),
       plugins: {
         title: getChartTitle(definition),

--- a/src/helpers/figures/charts/pie_chart.ts
+++ b/src/helpers/figures/charts/pie_chart.ts
@@ -211,7 +211,7 @@ export function createPieChartRuntime(chart: PieChart, getters: Getters): PieCha
     },
     options: {
       ...CHART_COMMON_OPTIONS,
-      layout: getChartLayout(definition),
+      layout: getChartLayout(definition, chartData),
       plugins: {
         title: getChartTitle(definition),
         legend: getPieChartLegend(definition, chartData),

--- a/src/helpers/figures/charts/pyramid_chart.ts
+++ b/src/helpers/figures/charts/pyramid_chart.ts
@@ -214,7 +214,7 @@ export function createPyramidChartRuntime(
     options: {
       ...CHART_COMMON_OPTIONS,
       indexAxis: "y",
-      layout: getChartLayout(definition),
+      layout: getChartLayout(definition, chartData),
       scales: getPyramidChartScales(definition, chartData),
       plugins: {
         title: getChartTitle(definition),

--- a/src/helpers/figures/charts/radar_chart.ts
+++ b/src/helpers/figures/charts/radar_chart.ts
@@ -232,7 +232,7 @@ export function createRadarChartRuntime(chart: RadarChart, getters: Getters): Ra
     },
     options: {
       ...CHART_COMMON_OPTIONS,
-      layout: getChartLayout(definition),
+      layout: getChartLayout(definition, chartData),
       scales: getRadarChartScales(definition, chartData),
       plugins: {
         title: getChartTitle(definition),

--- a/src/helpers/figures/charts/runtime/chart_data_extractor.ts
+++ b/src/helpers/figures/charts/runtime/chart_data_extractor.ts
@@ -90,6 +90,7 @@ export function getBarChartData(
     axisFormats,
     labels,
     locale: getters.getLocale(),
+    topPadding: getExtraTopPaddingForDashboard(definition, getters),
   };
 }
 
@@ -174,6 +175,7 @@ export function getLineChartData(
     locale: getters.getLocale(),
     trendDataSetsValues,
     axisType,
+    topPadding: getExtraTopPaddingForDashboard(definition, getters),
   };
 }
 
@@ -205,6 +207,7 @@ export function getPieChartData(
     axisFormats: { y: dataSetFormat },
     labels,
     locale: getters.getLocale(),
+    topPadding: getExtraTopPaddingForDashboard(definition, getters),
   };
 }
 
@@ -974,4 +977,13 @@ function makeDatasetsCumulative(datasets: DatasetValues[], order: "asc" | "desc"
     }
     return { ...dataset, data };
   });
+}
+
+export function getExtraTopPaddingForDashboard(
+  definition: GenericDefinition<PieChartDefinition | LineChartDefinition | BarChartDefinition>,
+  getters: Getters
+) {
+  const { title, legendPosition } = definition;
+  const hasTitleOrLegendTop = (title && title.text) || legendPosition === "top";
+  return getters.isDashboard() && !hasTitleOrLegendTop ? 30 : 0;
 }

--- a/src/helpers/figures/charts/runtime/chartjs_layout.ts
+++ b/src/helpers/figures/charts/runtime/chartjs_layout.ts
@@ -1,17 +1,22 @@
 import { ChartOptions } from "chart.js";
 import { CHART_PADDING, CHART_PADDING_BOTTOM, CHART_PADDING_TOP } from "../../../../constants";
-import { ChartWithDataSetDefinition, GenericDefinition } from "../../../../types/chart";
+import {
+  ChartRuntimeGenerationArgs,
+  ChartWithDataSetDefinition,
+  GenericDefinition,
+} from "../../../../types/chart";
 
 type ChartLayout = ChartOptions["layout"];
 
 export function getChartLayout(
-  definition: GenericDefinition<ChartWithDataSetDefinition>
+  definition: GenericDefinition<ChartWithDataSetDefinition>,
+  args: ChartRuntimeGenerationArgs
 ): ChartLayout {
   return {
     padding: {
       left: CHART_PADDING,
       right: CHART_PADDING,
-      top: CHART_PADDING_TOP,
+      top: Math.max(CHART_PADDING_TOP, args.topPadding || 0),
       bottom: CHART_PADDING_BOTTOM,
     },
   };

--- a/src/helpers/figures/charts/scatter_chart.ts
+++ b/src/helpers/figures/charts/scatter_chart.ts
@@ -240,7 +240,7 @@ export function createScatterChartRuntime(
     },
     options: {
       ...CHART_COMMON_OPTIONS,
-      layout: getChartLayout(definition),
+      layout: getChartLayout(definition, chartData),
       scales: getScatterChartScales(definition, chartData),
       plugins: {
         title: getChartTitle(definition),

--- a/src/helpers/figures/charts/sunburst_chart.ts
+++ b/src/helpers/figures/charts/sunburst_chart.ts
@@ -197,7 +197,7 @@ export function createSunburstChartRuntime(
     options: {
       cutout: "25%",
       ...(CHART_COMMON_OPTIONS as ChartOptions<"doughnut">),
-      layout: getChartLayout(definition),
+      layout: getChartLayout(definition, chartData),
       plugins: {
         title: getChartTitle(definition),
         legend: getSunburstChartLegend(definition, chartData),

--- a/src/helpers/figures/charts/waterfall_chart.ts
+++ b/src/helpers/figures/charts/waterfall_chart.ts
@@ -236,7 +236,7 @@ export function createWaterfallChartRuntime(
     },
     options: {
       ...CHART_COMMON_OPTIONS,
-      layout: getChartLayout(definition),
+      layout: getChartLayout(definition, chartData),
       scales: getWaterfallChartScales(definition, chartData),
       plugins: {
         title: getChartTitle(definition),

--- a/src/registries/figure_registry.ts
+++ b/src/registries/figure_registry.ts
@@ -95,6 +95,9 @@ function getCopyMenuItem(
       }
       const osClipboardContent = await env.model.getters.getClipboardTextAndImageContent();
       await env.clipboard.write(osClipboardContent);
+      if (type === "image") {
+        env.notifyUser({ sticky: false, type: "success", text: _t("Image copied to clipboard") });
+      }
     },
     icon: "o-spreadsheet-Icon.CLIPBOARD",
     isReadonlyAllowed: type === "image",
@@ -168,6 +171,7 @@ function getCopyChartAsImageMenuItem(figureId: UID, env: SpreadsheetChildEnv): A
         "text/html": innerHTML,
         "image/png": blob,
       });
+      env.notifyUser({ sticky: false, type: "success", text: _t("Chart copied to clipboard") });
     },
     isReadonlyAllowed: true,
   };

--- a/src/types/chart/chart.ts
+++ b/src/types/chart/chart.ts
@@ -195,6 +195,7 @@ export interface ChartRuntimeGenerationArgs {
   locale: Locale;
   trendDataSetsValues?: (Point[] | undefined)[];
   axisType?: AxisType;
+  topPadding?: number;
 }
 
 /** Generic definition of chart to create a runtime: omit the chart type and the dataRange of the dataSets*/

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -197,6 +197,7 @@ export const readonlyAllowedCommands = new Set<CommandTypes>([
   "SET_FORMULA_VISIBILITY",
 
   "UPDATE_FILTER",
+  "UPDATE_CHART",
 ]);
 
 export const coreTypes = new Set<CoreCommandTypes>([

--- a/src/variables.scss
+++ b/src/variables.scss
@@ -1,1 +1,2 @@
 $os-text-body: #374151;
+$os-button-active-bg: #e6f2f3;

--- a/tests/figures/__snapshots__/figure_component.test.ts.snap
+++ b/tests/figures/__snapshots__/figure_component.test.ts.snap
@@ -51,9 +51,8 @@ exports[`figures selected figure snapshot 1`] = `
           />
         </svg>
       </div>
-      
-      
     </div>
+    
     
   </div>
   <div

--- a/tests/figures/chart/chart_dashboard_component.test.ts
+++ b/tests/figures/chart/chart_dashboard_component.test.ts
@@ -2,8 +2,8 @@ import { Model } from "../../../src";
 import { CHART_PADDING_TOP } from "../../../src/constants";
 import { LineChartDefinition } from "../../../src/types/chart";
 import { createChart, updateChart } from "../../test_helpers/commands_helpers";
-import { click } from "../../test_helpers/dom_helper";
-import { mockChart, mountSpreadsheet } from "../../test_helpers/helpers";
+import { click, triggerMouseEvent } from "../../test_helpers/dom_helper";
+import { mockChart, mountSpreadsheet, nextTick } from "../../test_helpers/helpers";
 
 mockChart();
 
@@ -61,5 +61,27 @@ describe("combo charts", () => {
     expect(chartDefinition.type).toBe("line");
     expect(chartDefinition.stacked).toBe(true);
     expect(chartDefinition.fillArea).toBe(true);
+  });
+
+  test("Can open menu to copy/download figures in dashboard mode", async () => {
+    createChart(model, { type: "bar" }, chartId);
+    model.updateMode("dashboard");
+    const { fixture } = await mountSpreadsheet({ model });
+
+    triggerMouseEvent(".o-figure", "contextmenu");
+    await nextTick();
+    expect(".o-menu-item").toHaveCount(0);
+
+    await click(fixture, ".o-figure .fa-ellipsis-v");
+    const menuItems = [...document.querySelectorAll<HTMLElement>(".o-menu-item")].map(
+      (item) => item.dataset.name
+    );
+
+    // ADRM TODO
+    // if (type === "image") {
+    //   expect(menuItems).toEqual(["copy", "download"]);
+    // } else {
+    expect(menuItems).toEqual(["copy_as_image", "download"]);
+    // }
   });
 });

--- a/tests/figures/chart/chart_dashboard_component.test.ts
+++ b/tests/figures/chart/chart_dashboard_component.test.ts
@@ -1,0 +1,65 @@
+import { Model } from "../../../src";
+import { CHART_PADDING_TOP } from "../../../src/constants";
+import { LineChartDefinition } from "../../../src/types/chart";
+import { createChart, updateChart } from "../../test_helpers/commands_helpers";
+import { click } from "../../test_helpers/dom_helper";
+import { mockChart, mountSpreadsheet } from "../../test_helpers/helpers";
+
+mockChart();
+
+let model: Model;
+const chartId = "someuuid";
+
+describe("combo charts", () => {
+  beforeEach(async () => {
+    model = new Model();
+  });
+
+  test.each(["bar", "line", "pie"] as const)(
+    "%s charts have more top padding in dashboard mode if there is no title/legend",
+    (chartType) => {
+      createChart(model, { type: chartType, legendPosition: "none", title: { text: "" } }, chartId);
+      model.updateMode("dashboard");
+
+      let runtime = model.getters.getChartRuntime(chartId) as any;
+      expect(runtime.chartJsConfig.options?.layout?.padding?.top).toBe(30);
+
+      updateChart(model, chartId, { title: { text: "some title" } });
+      runtime = model.getters.getChartRuntime(chartId) as any;
+      expect(runtime.chartJsConfig.options?.layout?.padding?.top).toBe(CHART_PADDING_TOP);
+
+      updateChart(model, chartId, { legendPosition: "top", title: { text: "" } });
+      runtime = model.getters.getChartRuntime(chartId) as any;
+      expect(runtime.chartJsConfig.options?.layout?.padding?.top).toBe(CHART_PADDING_TOP);
+    }
+  );
+
+  test("Can change chart type in dashboard", async () => {
+    createChart(model, { type: "bar" }, chartId);
+    model.updateMode("dashboard");
+    const { fixture } = await mountSpreadsheet({ model });
+
+    await click(fixture, ".o-figure [data-id='line']");
+    expect(model.getters.getChart(chartId)?.type).toBe("line");
+  });
+
+  test("Can only change type of line/pie/bar charts", async () => {
+    createChart(model, { type: "radar" }, chartId);
+    model.updateMode("dashboard");
+    await mountSpreadsheet({ model });
+    expect(".o-figure-menu-item").toHaveCount(0);
+  });
+
+  test("Original chart configuration is kept when switching back and forth", async () => {
+    createChart(model, { type: "line", stacked: true, fillArea: true }, chartId);
+    model.updateMode("dashboard");
+    const { fixture } = await mountSpreadsheet({ model });
+
+    await click(fixture, ".o-figure [data-id='pie']");
+    await click(fixture, ".o-figure [data-id='line']");
+    const chartDefinition = model.getters.getChartDefinition(chartId) as LineChartDefinition;
+    expect(chartDefinition.type).toBe("line");
+    expect(chartDefinition.stacked).toBe(true);
+    expect(chartDefinition.fillArea).toBe(true);
+  });
+});

--- a/tests/figures/chart/charts_component.test.ts
+++ b/tests/figures/chart/charts_component.test.ts
@@ -197,30 +197,6 @@ describe("charts", () => {
     expect(fixture.querySelector(".o-figure-menu-item")).not.toBeNull();
   });
 
-  test.each(TEST_CHART_TYPES)(
-    "charts don't have a menu button in dashboard mode",
-    async (chartType) => {
-      await mountSpreadsheet();
-      createTestChart(chartType);
-      model.updateMode("dashboard");
-      await nextTick();
-      expect(fixture.querySelector(".o-figure")).not.toBeNull();
-      expect(fixture.querySelector(".o-figure-menu-item")).toBeNull();
-    }
-  );
-
-  test.each(TEST_CHART_TYPES)(
-    "charts don't have a menu button in readonly mode",
-    async (chartType) => {
-      await mountSpreadsheet();
-      createTestChart(chartType);
-      model.updateMode("readonly");
-      await nextTick();
-      expect(fixture.querySelector(".o-figure")).not.toBeNull();
-      expect(fixture.querySelector(".o-chart-menu-item")).toBeNull();
-    }
-  );
-
   test.each(TEST_CHART_TYPES)("Click on Edit button will prefill sidepanel", async (chartType) => {
     createTestChart(chartType);
     await mountChartSidePanel();

--- a/tests/figures/chart/charts_component.test.ts
+++ b/tests/figures/chart/charts_component.test.ts
@@ -5,7 +5,6 @@ import { BACKGROUND_CHART_COLOR } from "../../../src/constants";
 import { toHex, toZone } from "../../../src/helpers";
 import { ScorecardChart } from "../../../src/helpers/figures/charts";
 import { getChartColorsGenerator } from "../../../src/helpers/figures/charts/runtime";
-import { ClipboardPlugin } from "../../../src/plugins/ui_stateful";
 import {
   CHART_TYPES,
   ChartDefinition,
@@ -53,7 +52,6 @@ import {
 } from "../../test_helpers/dom_helper";
 import { getCellContent } from "../../test_helpers/getters_helpers";
 import {
-  getPlugin,
   mockChart,
   mockGeoJsonService,
   mountComponentWithPortalTarget,
@@ -114,8 +112,8 @@ async function mountChartSidePanel(figureId = chartId) {
   ({ fixture, env } = await mountComponentWithPortalTarget(ChartPanel, { props, model }));
 }
 
-async function mountSpreadsheet() {
-  ({ env, model, fixture } = await mountSpreadsheetHelper({ model }));
+async function mountSpreadsheet(partialEnv?: Partial<SpreadsheetChildEnv>) {
+  ({ env, model, fixture } = await mountSpreadsheetHelper({ model }, partialEnv));
 }
 
 let fixture: HTMLElement;
@@ -329,7 +327,8 @@ describe("charts", () => {
   test.each([TEST_CHART_TYPES])(
     "Copy a chart as a figure pushes it in the clipboard as a File",
     async (chartType) => {
-      await mountSpreadsheet();
+      const notifyUser = jest.fn();
+      await mountSpreadsheet({ notifyUser });
       createTestChart(chartType);
       await nextTick();
       await simulateClick(".o-figure");
@@ -342,14 +341,16 @@ describe("charts", () => {
       }
       const clipboardContent = clipboard.content;
 
-      const cbPlugin = getPlugin(model, ClipboardPlugin);
-      //@ts-ignore
-      const clipboardHtmlData = JSON.stringify(cbPlugin.getSheetData());
       const imgData = new window.Chart("test", mockChartData).toBase64Image();
 
       expect(clipboardContent).toMatchObject({
         "text/html": `<img src="${xmlEscape(imgData)}" />`,
         "image/png": expect.any(Blob),
+      });
+      expect(notifyUser).toHaveBeenCalledWith({
+        sticky: false,
+        type: "success",
+        text: "Chart copied to clipboard",
       });
     }
   );

--- a/tests/figures/figure_component.test.ts
+++ b/tests/figures/figure_component.test.ts
@@ -787,24 +787,6 @@ describe("figures", () => {
         expect(menuPopover.style.left).toBe(`${MENU_WIDTH - 50 - 25 + 32}px`);
       });
 
-      test("Can only copy/download figures in dashboard mode", async () => {
-        model.updateMode("dashboard");
-        await nextTick();
-
-        triggerMouseEvent(".o-figure", "contextmenu");
-        await nextTick();
-
-        const menuItems = [...document.querySelectorAll<HTMLElement>(".o-menu-item")].map(
-          (item) => item.dataset.name
-        );
-
-        if (type === "image") {
-          expect(menuItems).toEqual(["copy", "download"]);
-        } else {
-          expect(menuItems).toEqual(["copy_as_image", "download"]);
-        }
-      });
-
       test("Click on Menu button open context menu", async () => {
         expect(fixture.querySelector(".o-figure")).not.toBeNull();
         await simulateClick(".o-figure");

--- a/tests/figures/figure_component.test.ts
+++ b/tests/figures/figure_component.test.ts
@@ -12,6 +12,7 @@ import { figureRegistry } from "../../src/registries";
 import { Figure, Pixel, Position, SpreadsheetChildEnv, UID } from "../../src/types";
 
 import { FigureComponent } from "../../src/components/figures/figure/figure";
+import { ChartFigure } from "../../src/components/figures/figure_chart/figure_chart";
 import { downloadFile } from "../../src/components/helpers/dom_helpers";
 import { ClipboardMIMEType } from "../../src/types/clipboard";
 import {
@@ -117,7 +118,7 @@ const TEMPLATE = xml/* xml */ `
 
 class TextFigure extends Component<FigureComponent["props"], SpreadsheetChildEnv> {
   static template = TEMPLATE;
-  static props = FigureComponent.props;
+  static props = ChartFigure.props;
 }
 
 mockChart();

--- a/tests/figures/figure_component.test.ts
+++ b/tests/figures/figure_component.test.ts
@@ -66,6 +66,7 @@ let model: Model;
 let parent: Spreadsheet;
 let sheetId: UID;
 let env: SpreadsheetChildEnv;
+let notifyUser: jest.Mock;
 
 function createFigure(
   model: Model,
@@ -140,7 +141,8 @@ beforeEach(() => {
 
 describe("figures", () => {
   beforeEach(async () => {
-    ({ model, parent, fixture, env } = await mountSpreadsheet());
+    notifyUser = jest.fn();
+    ({ model, parent, fixture, env } = await mountSpreadsheet(undefined, { notifyUser }));
     mockSpreadsheetRect = { top: 100, left: 200, height: 1000, width: 1000 };
     mockFigureMenuItemRect = { top: 500, left: 500 };
     sheetId = model.getters.getActiveSheetId();
@@ -698,6 +700,15 @@ describe("figures", () => {
         const figureIds = getFigureIds(model, sheetId);
         expect(getFigureDefinition(model, figureIds[0], type)).toEqual(figureDef);
         expect(getFigureDefinition(model, figureIds[1], type)).toEqual(figureDef);
+        if (type === "image") {
+          expect(notifyUser).toHaveBeenCalledWith({
+            text: "Image copied to clipboard",
+            type: "success",
+            sticky: false,
+          });
+        } else {
+          expect(notifyUser).not.toHaveBeenCalled();
+        }
       });
 
       test(`Can cut/paste a figure ${type} with its context menu`, async () => {

--- a/tests/figures/figure_component.test.ts
+++ b/tests/figures/figure_component.test.ts
@@ -776,17 +776,22 @@ describe("figures", () => {
         expect(menuPopover.style.left).toBe(`${MENU_WIDTH - 50 - 25 + 32}px`);
       });
 
-      test("Cannot open context menu on right click in dashboard mode", async () => {
+      test("Can only copy/download figures in dashboard mode", async () => {
         model.updateMode("dashboard");
+        await nextTick();
+
         triggerMouseEvent(".o-figure", "contextmenu");
         await nextTick();
-        expect(document.querySelector(".o-menu")).toBeFalsy();
-      });
 
-      test("Cannot open context menu on right click in readonly mode", async () => {
-        model.updateMode("readonly");
-        triggerMouseEvent(".o-figure", "contextmenu");
-        expect(document.querySelector(".o-menu")).toBeFalsy();
+        const menuItems = [...document.querySelectorAll<HTMLElement>(".o-menu-item")].map(
+          (item) => item.dataset.name
+        );
+
+        if (type === "image") {
+          expect(menuItems).toEqual(["copy", "download"]);
+        } else {
+          expect(menuItems).toEqual(["copy_as_image", "download"]);
+        }
       });
 
       test("Click on Menu button open context menu", async () => {


### PR DESCRIPTION
### [IMP] figure: add notification when copying figure to clipboard

This commit adds a notification when the user put a chart/figure
to the clipboard, so he knows that the button did something.


### [IMP] figure: allow do copy/download chart/image in dashboard

This commits enables the context menu when right-clicking on a chart
in dashboard mode, with for only available options to copy or download
the chart/image.


Task: [4648362](https://www.odoo.com/odoo/2328/tasks/4648362)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo