### PR TITLE
[FIX] demo: missing waiting on image upload

### DIFF
--- a/tools/server/main.cjs
+++ b/tools/server/main.cjs
@@ -112,8 +112,10 @@ app.post("/upload-image", function (req, res) {
         // This opens up the writeable stream to `output`
         const writeStream = fs.createWriteStream(output);
         // This pipes the POST data to the file
+        writeStream.on("finish", () => {
+          res.send("../" + output);
+        });
         readStream.pipe(writeStream);
-        res.send("../" + output);
       }
     });
   } catch (err) {


### PR DESCRIPTION
The route `upload-image` in the demo server wasn't waiting for the stream to write the whole image to a file before sending the response.

This led to corrupted images when trying to create a figure with a large image.

Task: 0

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo