### PR TITLE
[FIX] pivot: get column sub-total of calculated measure

### DIFF
--- a/src/helpers/pivot/pivot_presentation.ts
+++ b/src/helpers/pivot/pivot_presentation.ts
@@ -177,6 +177,17 @@ export default function (PivotClass: PivotUIConstructor) {
           values.push(this._getPivotCellValueAndFormat(measure.id, rowDomain.concat(domain)));
         }
         return values;
+      } else if (
+        rowDomain.length === this.definition.rows.length &&
+        colDomain.length &&
+        colDomain.length < this.definition.columns.length
+      ) {
+        const colSubTree = this.getSubTreeMatchingDomain(table.getColTree(), colDomain);
+        const domains = this.treeToLeafDomains(colSubTree, colDomain);
+        for (const domain of domains) {
+          values.push(this._getPivotCellValueAndFormat(measure.id, rowDomain.concat(domain)));
+        }
+        return values;
       } else {
         const tree = table.getRowTree();
         const subTree = this.getSubTreeMatchingDomain(tree, rowDomain);


### PR DESCRIPTION
## Description

On a pivot with columns grouped by, for example, `year` and `customer`, the formula `=PIVOT(1, "calculated measure", "year", 2024)` would always return 0. It worked if there were either no or a full column domain in the formula, but a partial column domain returned 0 instead of returning the sub-total of the calculated measure for the partial column domain.

Task: [4728690](https://www.odoo.com/odoo/2328/tasks/4728690)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo