### PR TITLE
[FIX] clipboard: fix copy-paste from Excel

### DIFF
--- a/src/helpers/clipboard/clipboard_helpers.ts
+++ b/src/helpers/clipboard/clipboard_helpers.ts
@@ -72,12 +72,17 @@ export function parseOSClipboardContent(content: OSClipboardContent): ParsedOSCl
     content[ClipboardMIMEType.Html],
     "text/html"
   );
-  const oSheetClipboardData = htmlDocument
-    .querySelector("div")
-    ?.getAttribute("data-osheet-clipboard");
-  const spreadsheetContent = oSheetClipboardData && JSON.parse(oSheetClipboardData);
   return {
     text: content[ClipboardMIMEType.PlainText],
-    data: spreadsheetContent,
+    data: getOSheetDataFromHTML(htmlDocument),
   };
+}
+
+function getOSheetDataFromHTML(htmlDocument: Document) {
+  if (htmlDocument.body.children.length !== 1) {
+    return undefined;
+  }
+  const oSheetClipboardData =
+    htmlDocument.body.firstElementChild?.getAttribute("data-osheet-clipboard");
+  return oSheetClipboardData && JSON.parse(oSheetClipboardData);
 }

--- a/tests/clipboard/clipboard_plugin.test.ts
+++ b/tests/clipboard/clipboard_plugin.test.ts
@@ -2932,6 +2932,30 @@ describe("cross spreadsheet copy/paste", () => {
     expect(getCell(modelA, "A1")?.content).toBe(escapableString);
     expect(getCell(modelB, "D2")?.content).toBe(escapableString);
   });
+
+  test("wrongly placed o-spreadsheet data in the clipboard is ignored", () => {
+    const modelA = new Model();
+    const modelB = new Model();
+
+    setCellContent(modelA, "A1", "oldContent");
+    copy(modelA, "A1");
+    const clipboardContent = modelA.getters.getClipboardContent();
+    const oldHTML = clipboardContent["text/html"];
+
+    let content = parseOSClipboardContent({
+      "text/html": `<html>${oldHTML}<body><div>randomContent</div></body></html>`,
+      "text/plain": "newContent",
+    });
+    pasteFromOSClipboard(modelB, "D2", content);
+    expect(getCellContent(modelB, "D2")).toBe("newContent");
+
+    content = parseOSClipboardContent({
+      "text/html": `<html><body>${oldHTML}<div>ThatsNotWhatWeGenerate</div></body></html>`,
+      "text/plain": "newContent2",
+    });
+    pasteFromOSClipboard(modelB, "D2", content);
+    expect(getCellContent(modelB, "D2")).toBe("newContent2");
+  });
 });
 
 test("Can use clipboard handlers to paste in a sheet other than the active sheet", () => {


### PR DESCRIPTION
## Description

When copying, we put some `data-osheet` in the clipboard to enable cross-sheet copy-paste. Somehow, somewhy, after we paste it in Excel Desktop, the `data-osheet` is put back in the clipboard by Excel no matter what we copy in the sheet.

This commit adds a bit of sanity check before getting the `data-osheet` from the clipboard content.

Task: [4730469](https://www.odoo.com/odoo/2328/tasks/4730469)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo