### PR TITLE
[FIX] selection: allow to de-select a zone

### DIFF
--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -508,6 +508,7 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
       if (this.paintFormatStore.isActive) {
         this.paintFormatStore.pasteFormat(this.env.model.getters.getSelectedZones());
       }
+      this.env.model.selection.updateSelection();
     };
     this.dragNDropGrid.start(ev, onMouseMove, onMouseUp);
   }

--- a/src/components/headers_overlay/headers_overlay.ts
+++ b/src/components/headers_overlay/headers_overlay.ts
@@ -292,6 +292,7 @@ abstract class AbstractResizer extends Component<ResizerProps, SpreadsheetChildE
       this.state.isSelecting = false;
       this.lastSelectedElementIndex = null;
       this._computeGrabDisplay(ev);
+      this.env.model.selection.updateSelection();
     };
     this.dragNDropGrid.start(ev, mouseMoveSelect, mouseUpSelect);
   }

--- a/src/helpers/zones.ts
+++ b/src/helpers/zones.ts
@@ -373,6 +373,13 @@ export function isZoneInside(smallZone: Zone, biggerZone: Zone): boolean {
   return isEqual(union(biggerZone, smallZone), biggerZone);
 }
 
+/**
+ * Check if a zone is already in the list of zones.
+ */
+export function isZoneAlreadyInZones(zone: Zone, zones: Zone[]): boolean {
+  return zones.some((z) => isEqual(z, zone));
+}
+
 export function zoneToDimension(zone: Zone): ZoneDimension {
   return {
     numberOfRows: zone.bottom - zone.top + 1,
@@ -690,4 +697,39 @@ export function mergeContiguousZones(zones: Zone[]) {
     }
   }
   return mergedZones;
+}
+
+/**
+ * Splits zone z2 by removing the overlapping zone z1 (fully inside z2).
+ * Returns the remaining parts of z2 that don't overlap with z1.
+ *
+ * Diagram:
+ * ┌──────────── z2 ─────────────┐
+ * │              1              │
+ * │--------─────────────--------│
+ * │  2    |     z1      |    3  │
+ * │--------─────────────--------│
+ * │              4              │
+ * └─────────────────────────────┘
+ *
+ * Input:
+ *   z1 = { top: 2, bottom: 3, left: 2, right: 3 }
+ *   z2 = { top: 1, bottom: 4, left: 1, right: 4 }
+ *
+ * Output:
+ * [
+ *   { top: 4, bottom: 4, left: 1, right: 4 },  // bottom
+ *   { top: 2, bottom: 3, left: 4, right: 4 },  // right
+ *   { top: 2, bottom: 3, left: 1, right: 1 },  // left
+ *   { top: 1, bottom: 1, left: 1, right: 4 }   // top
+ * ]
+ */
+export function splitZone(z1: Zone, z2: Zone): Zone[] {
+  const zones: Zone[] = [];
+  if (z1.bottom < z2.bottom) zones.push({ ...z2, top: z1.bottom + 1 });
+  if (z1.right < z2.right)
+    zones.push({ ...z2, left: z1.right + 1, top: z1.top, bottom: z1.bottom });
+  if (z1.left > z2.left) zones.push({ ...z2, right: z1.left - 1, top: z1.top, bottom: z1.bottom });
+  if (z1.top > z2.top) zones.push({ ...z2, bottom: z1.top - 1 });
+  return zones;
 }

--- a/src/plugins/ui_stateful/selection.ts
+++ b/src/plugins/ui_stateful/selection.ts
@@ -5,7 +5,10 @@ import {
   clip,
   deepCopy,
   isEqual,
+  isZoneAlreadyInZones,
+  isZoneInside,
   positionToZone,
+  splitZone,
   uniqueZones,
   updateSelectionOnDeletion,
   updateSelectionOnInsertion,
@@ -74,6 +77,7 @@ export class GridSelectionPlugin extends UIPlugin {
     },
     zones: [{ top: 0, left: 0, bottom: 0, right: 0 }],
   };
+  private isCurrentZoneInsideZones: boolean = false;
   private selectedFigureId: UID | null = null;
   private sheetsData: { [sheet: string]: SheetInfo } = {};
   private moveClient: (position: ClientPosition) => void;
@@ -111,24 +115,55 @@ export class GridSelectionPlugin extends UIPlugin {
   }
 
   private handleEvent(event: SelectionEvent) {
-    const anchor = event.anchor;
-    let zones: Zone[] = [];
+    let anchor = event.anchor;
+    let zones: Zone[] = [...this.gridSelection.zones];
     switch (event.mode) {
       case "overrideSelection":
         zones = [anchor.zone];
         break;
       case "updateAnchor":
-        zones = [...this.gridSelection.zones];
-        const index = zones.findIndex((z: Zone) => isEqual(z, event.previousAnchor.zone));
-        if (index >= 0) {
-          zones[index] = anchor.zone;
+        const prevZone = event.previousAnchor.zone;
+        if (!isEqual(prevZone, anchor.zone)) {
+          this.isCurrentZoneInsideZones =
+            isZoneAlreadyInZones(anchor.zone, zones) && zones.length > 2;
+          const index = zones.findIndex((z: Zone) => isEqual(z, prevZone));
+          if (index >= 0) {
+            zones[index] = anchor.zone;
+          }
         }
         break;
       case "newAnchor":
-        zones = [...this.gridSelection.zones, anchor.zone];
+        this.isCurrentZoneInsideZones =
+          isZoneAlreadyInZones(anchor.zone, zones) && zones.length > 1;
+        zones.push(anchor.zone);
+        break;
+      case "updateSelection":
+        const currentZone = this.gridSelection.anchor.zone;
+        let newAnchorZone: Zone | undefined;
+        if (this.isCurrentZoneInsideZones) {
+          zones = zones.filter((zone) => !isEqual(zone, currentZone));
+          newAnchorZone = zones.at(-1);
+        } else {
+          const zoneToSplit = zones.find(
+            (zone) => isZoneInside(currentZone, zone) && !isEqual(currentZone, zone)
+          );
+          if (zoneToSplit) {
+            const splittedZones = splitZone(currentZone, zoneToSplit);
+            zones = zones
+              .filter((z) => !isEqual(z, currentZone) && !isEqual(z, zoneToSplit))
+              .concat(splittedZones);
+            newAnchorZone = splittedZones.at(-1);
+          }
+        }
+        if (newAnchorZone) {
+          anchor = {
+            cell: { col: newAnchorZone.left, row: newAnchorZone.top },
+            zone: newAnchorZone,
+          };
+        }
         break;
     }
-    this.setSelectionMixin(event.anchor, zones);
+    this.setSelectionMixin(anchor, zones);
     /** Any change to the selection has to be reflected in the selection processor. */
     this.selection.resetDefaultAnchor(this, deepCopy(this.gridSelection.anchor));
     const { col, row } = this.gridSelection.anchor.cell;

--- a/src/selection_stream/selection_stream_processor.ts
+++ b/src/selection_stream/selection_stream_processor.ts
@@ -44,6 +44,7 @@ interface SelectionProcessor {
   moveAnchorCell(direction: Direction, step: SelectionStep): DispatchResult;
   setAnchorCorner(col: number, row: number): DispatchResult;
   addCellToSelection(col: number, row: number): DispatchResult;
+  updateSelection(): DispatchResult;
   resizeAnchorZone(direction: Direction, step: SelectionStep): DispatchResult;
   selectColumn(index: number, mode: SelectionEvent["mode"]): DispatchResult;
   selectRow(index: number, mode: SelectionEvent["mode"]): DispatchResult;
@@ -211,6 +212,20 @@ export class SelectionStreamProcessorImpl implements SelectionStreamProcessor {
   }
 
   /**
+   * update the current selection.
+   */
+  updateSelection(): DispatchResult {
+    return this.processEvent({
+      options: {
+        scrollIntoView: false,
+        unbounded: true,
+      },
+      anchor: this.anchor,
+      mode: "updateSelection",
+    });
+  }
+
+  /**
    * Increase or decrease the size of the current anchor zone.
    * The anchor cell remains where it is. It's the opposite side
    * of the anchor zone which moves.
@@ -291,7 +306,10 @@ export class SelectionStreamProcessorImpl implements SelectionStreamProcessor {
     });
   }
 
-  selectColumn(index: HeaderIndex, mode: SelectionEvent["mode"]): DispatchResult {
+  selectColumn(
+    index: HeaderIndex,
+    mode: Exclude<SelectionEvent["mode"], "updateSelection">
+  ): DispatchResult {
     const sheetId = this.getters.getActiveSheetId();
     const bottom = this.getters.getNumberRows(sheetId) - 1;
     let zone = { left: index, right: index, top: 0, bottom };
@@ -318,7 +336,10 @@ export class SelectionStreamProcessorImpl implements SelectionStreamProcessor {
     });
   }
 
-  selectRow(index: HeaderIndex, mode: SelectionEvent["mode"]): DispatchResult {
+  selectRow(
+    index: HeaderIndex,
+    mode: Exclude<SelectionEvent["mode"], "updateSelection">
+  ): DispatchResult {
     const sheetId = this.getters.getActiveSheetId();
     const right = this.getters.getNumberCols(sheetId) - 1;
     let zone = { top: index, bottom: index, left: 0, right };

--- a/src/types/event_stream/selection_events.ts
+++ b/src/types/event_stream/selection_events.ts
@@ -8,6 +8,6 @@ export type SelectionEventOptions = {
 export interface SelectionEvent {
   anchor: AnchorZone;
   previousAnchor: AnchorZone;
-  mode: "newAnchor" | "overrideSelection" | "updateAnchor";
+  mode: "newAnchor" | "overrideSelection" | "updateAnchor" | "updateSelection";
   options: SelectionEventOptions;
 }

--- a/tests/sheet/selection_plugin.test.ts
+++ b/tests/sheet/selection_plugin.test.ts
@@ -40,6 +40,7 @@ import {
   setSelection,
   setViewportOffset,
   undo,
+  updateSelection,
 } from "../test_helpers/commands_helpers";
 import {
   getActivePosition,
@@ -1416,5 +1417,143 @@ describe("Multiple selection updates after insertion and deletion", () => {
       { left: 0, right: 9, top: 4, bottom: 4 },
       { left: 0, right: 9, top: 9, bottom: 9 },
     ]);
+  });
+});
+
+describe("Grid selection updates zones correctly when deselecting zone", () => {
+  let model: Model;
+
+  beforeEach(() => {
+    model = new Model({ sheets: [{ colNumber: 5, rowNumber: 5 }] });
+  });
+
+  test("can deselect a single cell", () => {
+    selectCell(model, "A1");
+    let selection = model.getters.getSelection();
+    expect(selection.zones.length).toBe(1);
+    expect(selection.anchor.cell).toEqual(toCartesian("A1"));
+
+    addCellToSelection(model, "B2");
+    updateSelection(model);
+    selection = model.getters.getSelection();
+    expect(selection.zones.length).toBe(2);
+    expect(selection.anchor.cell).toEqual(toCartesian("B2"));
+
+    addCellToSelection(model, "B2");
+    updateSelection(model);
+    selection = model.getters.getSelection();
+    expect(selection.zones.length).toBe(1);
+    expect(selection.anchor.cell).toEqual(toCartesian("A1"));
+  });
+
+  test("can deselect a cell from a zone", () => {
+    setSelection(model, ["A1:C3"]);
+    let selection = model.getters.getSelection();
+    expect(selection.zones.length).toBe(1);
+    expect(selection.anchor.cell).toEqual(toCartesian("A1"));
+
+    addCellToSelection(model, "B2");
+    updateSelection(model);
+    selection = model.getters.getSelection();
+    expect(selection.anchor.cell).toEqual(toCartesian("A1"));
+    expect(selection.zones).toEqual([
+      { left: 0, right: 2, top: 2, bottom: 2 },
+      { left: 2, right: 2, top: 1, bottom: 1 },
+      { left: 0, right: 0, top: 1, bottom: 1 },
+      { left: 0, right: 2, top: 0, bottom: 0 },
+    ]);
+  });
+
+  test("can deselect sub-zone from a larger zone", () => {
+    setSelection(model, ["A1:C4"]);
+    let selection = model.getters.getSelection();
+    expect(selection.zones.length).toBe(1);
+
+    addCellToSelection(model, "B2");
+    setAnchorCorner(model, "B3");
+    updateSelection(model);
+    selection = model.getters.getSelection();
+    expect(selection.anchor.cell).toEqual(toCartesian("A1"));
+    expect(selection.zones).toEqual([
+      { left: 0, right: 2, top: 3, bottom: 3 }, // bottom
+      { left: 2, right: 2, top: 1, bottom: 2 }, // right
+      { left: 0, right: 0, top: 1, bottom: 2 }, // left
+      { left: 0, right: 2, top: 0, bottom: 0 }, // top
+    ]);
+  });
+
+  test("can deselect merged cell from selection", () => {
+    merge(model, "A1:A2");
+
+    setSelection(model, ["A1:B3"]);
+    let selection = model.getters.getSelection();
+    expect(selection.zones.length).toBe(1);
+
+    addCellToSelection(model, "A1");
+    updateSelection(model);
+    selection = model.getters.getSelection();
+    expect(selection.anchor.cell).toEqual(toCartesian("B1"));
+    expect(selection.zones).toEqual([
+      { left: 0, right: 1, top: 2, bottom: 2 }, // right
+      { left: 1, right: 1, top: 0, bottom: 1 }, // bottom
+    ]);
+  });
+
+  test("re-selecting a zone remove it from selection", () => {
+    setSelection(model, ["A1"]);
+    let selection = model.getters.getSelection();
+    expect(selection.zones.length).toBe(1);
+
+    addCellToSelection(model, "B2");
+    setAnchorCorner(model, "B3");
+    updateSelection(model);
+    selection = model.getters.getSelection();
+    expect(selection.anchor.cell).toEqual(toCartesian("B2"));
+    expect(selection.zones).toEqual([
+      { left: 0, right: 0, top: 0, bottom: 0 }, // right
+      { left: 1, right: 1, top: 1, bottom: 2 }, // bottom
+    ]);
+
+    addCellToSelection(model, "B2");
+    setAnchorCorner(model, "B3");
+    updateSelection(model); // [B2, B3] zone remove from zones
+    selection = model.getters.getSelection();
+    expect(selection.anchor.cell).toEqual(toCartesian("A1"));
+    expect(selection.zones.length).toBe(1);
+  });
+
+  test("re-selecting a row removes it from selection", () => {
+    selectRow(model, 0, "overrideSelection");
+    let selection = model.getters.getSelection();
+    expect(selection.zones[0]).toEqual(toZone("A1:E1"));
+
+    selectRow(model, 1, "newAnchor");
+    updateSelection(model);
+    selection = model.getters.getSelection();
+    expect(selection.zones.length).toEqual(2);
+
+    selectRow(model, 0, "newAnchor");
+    updateSelection(model);
+    selection = model.getters.getSelection();
+    expect(selection.zones.length).toEqual(1);
+    expect(selection.zones[0]).toEqual(toZone("A2:E2"));
+  });
+
+  test("re-selecting a column removes it from selection", () => {
+    selectColumn(model, 0, "overrideSelection");
+    let selection = model.getters.getSelection();
+    expect(selection.zones.length).toBe(1);
+    expect(selection.zones[0]).toEqual(toZone("A1:A5"));
+
+    selectColumn(model, 1, "newAnchor");
+    updateSelection(model);
+    selection = model.getters.getSelection();
+    expect(selection.zones.length).toEqual(2);
+
+    selectColumn(model, 0, "newAnchor");
+    updateSelection(model);
+    selection = model.getters.getSelection();
+    expect(selection.zones.length).toEqual(1);
+    expect(selection.zones[0]).toEqual(toZone("B1:B5"));
   });
 });

--- a/tests/test_helpers/commands_helpers.ts
+++ b/tests/test_helpers/commands_helpers.ts
@@ -856,6 +856,10 @@ export function addCellToSelection(model: Model, xc: string): DispatchResult {
   return model.selection.addCellToSelection(col, row);
 }
 
+export function updateSelection(model: Model): DispatchResult {
+  return model.selection.updateSelection();
+}
+
 /**
  * Move a conditianal formatting rule
  */


### PR DESCRIPTION
## Description:

Before this pr:
- Ctrl+Click on a selected cell had no effect.
- Users could add to the selection, but couldn't remove cells or zones.

Issue Example:
1. Select range A1:C3.
2. Ctrl+Click on B2.
3. Expected: Selection splits into A1:C1, A2, C2, A3:C3.
4. Previously, Ctrl+Click did not deselect B2.

After this pr:
- Ctrl+Click on a selected cell now removes it.
- The selection splits into separate zones as needed.

Technical Changes:
- UpdateSelection is now triggered on mouseup, allowing precise detection of Ctrl+Click behavior.
- The selection logic removes the zone from any existing selection zones.
- Splits overlapping zones into non-overlapping parts.

Task: [4647187](https://www.odoo.com/odoo/2328/tasks/4647187)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo