### PR TITLE
[FIX] composer: fix stacking context issue in composer

### DIFF
--- a/src/components/composer/composer/composer.xml
+++ b/src/components/composer/composer/composer.xml
@@ -42,7 +42,7 @@
         />
       </div>
       <div
-        class="o-composer-assistant-container shadow position-absolute"
+        class="o-composer-assistant-container shadow position-absolute z-1"
         t-att-style="assistantContainerStyle"
         t-if="props.focus !== 'inactive' and !assistant.forcedClosed and assistantIsAvailable">
         <span


### PR DESCRIPTION
The composer assistant did not have a `z-index`. This caused a problem in the standalone composer, which also does not have a `z-index`. That meant that the composer assistant was renderer below elements with opacity < 1, because those elements create a new stacking context (https://www.w3.org/TR/css-color-3/#transparency).

This commit fixes the issue by adding a `z-index: 1` to the composer assistant, so it is above elements with the same stacking context as the composer.

Task: [4623945](https://www.odoo.com/odoo/2328/tasks/4623945)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo