### PR TITLE
[IMP] collaborative: test auto-fill overwrite

### DIFF
--- a/tests/collaborative/collaborative.test.ts
+++ b/tests/collaborative/collaborative.test.ts
@@ -28,6 +28,7 @@ import {
   paste,
   redo,
   setCellContent,
+  setFormat,
   setStyle,
   undo,
   ungroupHeaders,
@@ -591,6 +592,24 @@ describe("Multi users synchronisation", () => {
     expect([alice, bob, charlie, david]).toHaveSynchronizedValue(
       (user) => getCellContent(user, "A1"),
       "hello"
+    );
+  });
+
+  test("autofill overwrite style and format", () => {
+    setCellContent(alice, "A1", "hello");
+    network.concurrent(() => {
+      setStyle(alice, "A2", { bold: true });
+      setFormat(alice, "A2", "0.0%");
+      bob.dispatch("AUTOFILL_SELECT", { col: 0, row: 1 });
+      bob.dispatch("AUTOFILL");
+    });
+    expect([alice, bob, charlie]).toHaveSynchronizedValue(
+      (user) => getCell(user, "A2")?.style,
+      undefined
+    );
+    expect([alice, bob, charlie]).toHaveSynchronizedValue(
+      (user) => getCell(user, "A2")?.format,
+      undefined
     );
   });
 


### PR DESCRIPTION
## Description:

This commit adds a test where the auto-fill
overwrites a concurrent style/format update.

Task: [0](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo