### PR TITLE
[FIX] collaborative: check all overlapping zones

### DIFF
--- a/src/collaborative/ot/ot_helpers.ts
+++ b/src/collaborative/ot/ot_helpers.ts
@@ -21,5 +21,5 @@ export function transformZone<Z extends Zone | UnboundedZone>(
       executed.quantity
     );
   }
-  return { ...zone };
+  return zone;
 }

--- a/src/collaborative/ot/ot_specific.ts
+++ b/src/collaborative/ot/ot_specific.ts
@@ -116,10 +116,8 @@ function mergeTransformation(
   }
   const target: Zone[] = [];
   for (const zone1 of cmd.target) {
-    for (const zone2 of executed.target) {
-      if (!overlap(zone1, zone2)) {
-        target.push({ ...zone1 });
-      }
+    if (executed.target.every((zone2) => !overlap(zone1, zone2))) {
+      target.push(zone1);
     }
   }
   if (target.length) {

--- a/tests/collaborative/ot/ot_merged.test.ts
+++ b/tests/collaborative/ot/ot_merged.test.ts
@@ -109,6 +109,11 @@ describe("OT with ADD_MERGE", () => {
       const result = transform(command, addMerge);
       expect(result).toBeUndefined();
     });
+    test("some overlapping merges and some distinct merges", () => {
+      const command = { ...cmd, target: target("A1:A3,E1:F2") };
+      const result = transform(command, { ...addMerge, target: target("A2:A4,G1:G2") });
+      expect(result).toEqual({ ...cmd, target: target("E1:F2") });
+    });
     test("two overlapping merges in different sheets", () => {
       const command = { ...cmd, target: target("C3:D5"), sheetId: "another sheet" };
       const result = transform(command, addMerge);


### PR DESCRIPTION
## Description:

Steps to reproduce:
- merge A2:A3 and F1:F2

Then, concurrently:
- Alice merges A1:A3 (increase the current merge) and C1:C2
- Bob removes merges in A2:A3 and F1:F2

Assuming Alice's revision arrives first to the server (`executed` in the code).
When Bob's revision is transformed against Alice's, both zones in Bob's
command are kept, which makes the command invalid since A2:A3 is no longer
a merge (it is now A1:A3). Because it's invalid, the entire command is
rejected, even though F1:F2 should still be un-merged to preserve Bob's
intention.

The merge transformation is wrong.
The current code keeps a zone if at least one of the zones in the executed
command doesn't overlap.

But it should check all zones and should be kept if none are overlapping.
Said differently: the zone should be dropped if it overlaps any of the
`executed.target` zone.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo