### PR TITLE
[FIX] Grid DnD: stop drag-n-drop on sheet change

### DIFF
--- a/src/components/helpers/drag_and_drop_grid_hook.ts
+++ b/src/components/helpers/drag_and_drop_grid_hook.ts
@@ -1,4 +1,4 @@
-import { onWillUnmount } from "@odoo/owl";
+import { onWillUnmount, useEffect } from "@odoo/owl";
 import { MAX_DELAY } from "../../helpers";
 import { SpreadsheetChildEnv } from "../../types/env";
 import { HeaderIndex, Pixel } from "../../types/misc";
@@ -21,7 +21,6 @@ export function useDragAndDropBeyondTheViewport(env: SpreadsheetChildEnv) {
   let startingX: number;
   let startingY: number;
   const getters = env.model.getters;
-  const sheetId = getters.getActiveSheetId();
 
   let cleanUpFns: (() => void)[] = [];
 
@@ -40,9 +39,9 @@ export function useDragAndDropBeyondTheViewport(env: SpreadsheetChildEnv) {
     if (timeOutId) {
       return;
     }
+    const sheetId = getters.getActiveSheetId();
 
     const position = gridOverlayPosition();
-
     const { x: offsetCorrectionX, y: offsetCorrectionY } = getters.getMainViewportCoordinates();
     let { top, left, bottom, right } = getters.getActiveMainViewport();
     let { scrollX, scrollY } = getters.getActiveSheetScrollInfo();
@@ -149,6 +148,13 @@ export function useDragAndDropBeyondTheViewport(env: SpreadsheetChildEnv) {
   onWillUnmount(() => {
     cleanUp();
   });
+
+  useEffect(
+    () => {
+      cleanUp();
+    },
+    () => [getters.getActiveSheetId()]
+  );
 
   return { start: startFn };
 }


### PR DESCRIPTION
Currently, the drag-n-drop grid hook registers the current sheet during its instanciation and computes every move based on that sheet, even if it changes. This means that if the first sheet has a structure that differs from the current sheet, or if it was simply deleted, the hook will misbehave or even crash.

Task: 4737642

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo