### PR TITLE
[FIX] Collaborative: Send client position on activeSheet change

### DIFF
--- a/src/plugins/ui/selection.ts
+++ b/src/plugins/ui/selection.ts
@@ -235,6 +235,8 @@ export class GridSelectionPlugin extends UIPlugin {
           const { col, row } = this.getters.getNextVisibleCellPosition(cmd.sheetIdTo, 0, 0);
           this.selectCell(col, row);
         }
+        const { col, row } = this.gridSelection.anchor.cell;
+        this.moveClient({ sheetId: this.activeSheet.id, col, row });
         break;
       }
       case "REMOVE_COLUMNS_ROWS": {

--- a/tests/collaborative/collaborative_selection.test.ts
+++ b/tests/collaborative/collaborative_selection.test.ts
@@ -268,6 +268,32 @@ describe("Collaborative selection", () => {
     );
   });
 
+  test("Client positions are updated when changing their active sheet", () => {
+    const sheetId = alice.getters.getActiveSheetId();
+    createSheet(alice, { sheetId: "42", activate: true });
+    jest.advanceTimersByTime(DEBOUNCE_TIME + 100);
+    expect([alice, bob, charlie]).toHaveSynchronizedValue(
+      (user) => user.getters.getConnectedClients(),
+      new Set([
+        {
+          id: "alice",
+          name: "Alice",
+          position: { col: 0, row: 0, sheetId: "42" },
+        },
+        {
+          id: "bob",
+          name: "Bob",
+          position: { col: 0, row: 0, sheetId },
+        },
+        {
+          id: "charlie",
+          name: "Charlie",
+          position: { col: 0, row: 0, sheetId },
+        },
+      ])
+    );
+  });
+
   test("Can send custom data in client", () => {
     const sheetId = alice.getters.getActiveSheetId();
     new Model(alice.exportData(), {


### PR DESCRIPTION
How to reproduce:
- Bob and Alice are on the same sheet, Bob sees Alice's position
- Alice creates a second sheet and activates it -> Bob still sees Alice as present in the same sheet as him
- Bob moves to the second sheet -> Bob does not see Alice and Alice does not see Bob

When activating a new sheet, the updated client position is not sent to the session.

Task: 4736980

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo