### PR TITLE
[FIX] spreadsheet: parasitic render at every click

### DIFF
--- a/src/components/top_bar/top_bar.ts
+++ b/src/components/top_bar/top_bar.ts
@@ -250,7 +250,9 @@ export class TopBar extends Component<Props, SpreadsheetChildEnv> {
   }
 
   private openMenu(menu: Action, ev: MouseEvent) {
-    this.topBarToolStore.closeDropdowns();
+    if (this.topBarToolStore.currentDropdown) {
+      this.topBarToolStore.closeDropdowns();
+    }
     this.state.toolsPopoverState.isOpen = false;
     this.state.menuState.isOpen = true;
     this.state.menuState.anchorRect = getBoundingRectAsPOJO(ev.currentTarget as HTMLElement);
@@ -264,7 +266,9 @@ export class TopBar extends Component<Props, SpreadsheetChildEnv> {
   }
 
   closeMenus() {
-    this.topBarToolStore.closeDropdowns();
+    if (this.topBarToolStore.currentDropdown) {
+      this.topBarToolStore.closeDropdowns();
+    }
     this.state.toolsPopoverState.isOpen = false;
     this.state.menuState.isOpen = false;
     this.state.menuState.parentMenu = undefined;
@@ -290,7 +294,9 @@ export class TopBar extends Component<Props, SpreadsheetChildEnv> {
   }
 
   toggleMoreTools() {
-    this.topBarToolStore.closeDropdowns();
+    if (this.topBarToolStore.currentDropdown) {
+      this.topBarToolStore.closeDropdowns();
+    }
     this.state.toolsPopoverState.isOpen = !this.state.toolsPopoverState.isOpen;
   }
 

--- a/tests/top_bar_component.test.ts
+++ b/tests/top_bar_component.test.ts
@@ -959,7 +959,7 @@ describe("Topbar svg icon", () => {
   });
 });
 
-test("Clicking on a topbar button triggers three renders", async () => {
+test("Clicking on a topbar button triggers two renders", async () => {
   jest.useFakeTimers();
   const transportService = new MockTransportService();
 
@@ -975,10 +975,9 @@ test("Clicking on a topbar button triggers three renders", async () => {
 
   await click(fixture, ".o-spreadsheet-topbar [title='Bold (Ctrl+B)']");
 
-  // two renders from the collaboration session
-  // one from the top bar interaction
+  // two renders from the model (one from the command handling and one from the collaborative session)
   expect(modelRender).toHaveBeenCalledTimes(2);
-  expect(storeRender).toHaveBeenCalledTimes(1);
+  expect(storeRender).toHaveBeenCalledTimes(0);
 });
 
 describe("Responsive Top bar behaviour", () => {


### PR DESCRIPTION
## Description

Since the topbar refactor, a new render is triggered at every single click event, no matter where we click. This breaks every input with `t-att-value`, their content is reset at each click.

Task: [4737827](https://www.odoo.com/odoo/2328/tasks/4737827)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo