### PR TITLE
[FIX] chart: align moving average trendline with bar chart offset

### DIFF
--- a/src/helpers/figures/charts/runtime/chartjs_scales.ts
+++ b/src/helpers/figures/charts/runtime/chartjs_scales.ts
@@ -73,7 +73,7 @@ export function getBarChartScales(
     };
     scales[MOVING_AVERAGE_TREND_LINE_XAXIS_ID] = {
       ...(scales!.x as any),
-      offset: false,
+      offset: true,
       display: false,
     };
   }

--- a/tests/figures/chart/chart_plugin.test.ts
+++ b/tests/figures/chart/chart_plugin.test.ts
@@ -3617,7 +3617,7 @@ test("Moving average trend line dataset uses the right axis when combined with o
   let runtime = model.getters.getChartRuntime("1") as LineChartRuntime;
   // @ts-ignore
   expect(runtime.chartJsConfig.data.datasets[3].xAxisID).toEqual("xMovingAverage");
-  const scales = getChartConfiguration(model, "1").options.scales;
+  let scales = getChartConfiguration(model, "1").options.scales;
   expect(scales.xMovingAverage!["display"]).toEqual(false);
   expect(scales.xMovingAverage!["offset"]).toEqual(false);
   expect(scales.xMovingAverage!["type"]).toEqual("category");
@@ -3652,9 +3652,9 @@ test("Moving average trend line dataset uses the right axis when combined with o
   runtime = model.getters.getChartRuntime("1") as LineChartRuntime;
   // @ts-ignore
   expect(runtime.chartJsConfig.data.datasets[3].xAxisID).toEqual("xMovingAverage");
+  scales = getChartConfiguration(model, "1").options.scales;
   expect(scales.xMovingAverage!["display"]).toEqual(false);
-  expect(scales.xMovingAverage!["offset"]).toEqual(false);
-  expect(scales.xMovingAverage!["type"]).toEqual("category");
+  expect(scales.xMovingAverage!["offset"]).toEqual(true);
 
   // Bar chart with numerical labels
   updateChart(model, "1", {
@@ -3664,8 +3664,7 @@ test("Moving average trend line dataset uses the right axis when combined with o
   // @ts-ignore
   expect(runtime.chartJsConfig.data.datasets[3].xAxisID).toEqual("xMovingAverage");
   expect(scales.xMovingAverage!["display"]).toEqual(false);
-  expect(scales.xMovingAverage!["offset"]).toEqual(false);
-  expect(scales.xMovingAverage!["type"]).toEqual("category");
+  expect(scales.xMovingAverage!["offset"]).toEqual(true);
 
   // Bar chart with categorical labels
   updateChart(model, "1", {
@@ -3675,8 +3674,7 @@ test("Moving average trend line dataset uses the right axis when combined with o
   // @ts-ignore
   expect(runtime.chartJsConfig.data.datasets[3].xAxisID).toEqual("xMovingAverage");
   expect(scales.xMovingAverage!["display"]).toEqual(false);
-  expect(scales.xMovingAverage!["offset"]).toEqual(false);
-  expect(scales.xMovingAverage!["type"]).toEqual("category");
+  expect(scales.xMovingAverage!["offset"]).toEqual(true);
 });
 
 test("logarithmic trending line", () => {


### PR DESCRIPTION
## Description:

Before this pr:
- Trendline started without bar chart offset, causing misalignment.

After this pr:
- Trendline starts with the correct offset, aligned like the data line in the combo chart.

Task: [4653065](https://www.odoo.com/odoo/2328/tasks/4653065)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo