### PR TITLE
[FIX] pivot: remove spaces from date function

### DIFF
--- a/src/helpers/pivot/pivot_time_adapter.ts
+++ b/src/helpers/pivot/pivot_time_adapter.ts
@@ -49,7 +49,7 @@ const dayAdapter: PivotTimeAdapterNotNull<number> = {
   },
   toFunctionValue(normalizedValue) {
     const jsDate = toJsDate(normalizedValue, DEFAULT_LOCALE);
-    return `DATE(${jsDate.getFullYear()}, ${jsDate.getMonth() + 1}, ${jsDate.getDate()})`;
+    return `DATE(${jsDate.getFullYear()},${jsDate.getMonth() + 1},${jsDate.getDate()})`;
   },
 };
 

--- a/tests/pivots/pivot_helpers.test.ts
+++ b/tests/pivots/pivot_helpers.test.ts
@@ -195,7 +195,7 @@ describe("ToFunctionValue", () => {
   test.each(["date", "datetime"])("Format values of %s fields", (type: string) => {
     const dimension = { type, granularity: "day" };
     // day
-    expect(toFunctionPivotValue("1/11/2020", dimension)).toBe("DATE(2020, 1, 11)");
+    expect(toFunctionPivotValue("1/11/2020", dimension)).toBe("DATE(2020,1,11)");
     // year
     dimension.granularity = "year";
     expect(toFunctionPivotValue("2020", dimension)).toBe("2020");


### PR DESCRIPTION
## Description:

Removed extra spaces in front of the day and month in DATE function.

Task: [4725023](https://www.odoo.com/odoo/2328/tasks/4725023)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo