### PR TITLE
[FIX] tables, bottom_bar_statistic: react to change in cell format

### DIFF
--- a/src/components/bottom_bar/bottom_bar_statistic/aggregate_statistics_store.ts
+++ b/src/components/bottom_bar/bottom_bar_statistic/aggregate_statistics_store.ts
@@ -70,7 +70,7 @@ export class AggregateStatisticsStore extends SpreadsheetStore {
   handle(cmd: Command) {
     if (
       invalidateEvaluationCommands.has(cmd.type) ||
-      (cmd.type === "UPDATE_CELL" && "content" in cmd)
+      (cmd.type === "UPDATE_CELL" && ("content" in cmd || "format" in cmd))
     ) {
       this.isDirty = true;
     }

--- a/src/plugins/ui_core_views/dynamic_tables.ts
+++ b/src/plugins/ui_core_views/dynamic_tables.ts
@@ -45,7 +45,7 @@ export class DynamicTablesPlugin extends UIPlugin {
   handle(cmd: Command) {
     if (
       invalidateEvaluationCommands.has(cmd.type) ||
-      (cmd.type === "UPDATE_CELL" && "content" in cmd) ||
+      (cmd.type === "UPDATE_CELL" && ("content" in cmd || "format" in cmd)) ||
       cmd.type === "EVALUATE_CELLS"
     ) {
       this.tables = {};

--- a/src/plugins/ui_feature/table_computed_style.ts
+++ b/src/plugins/ui_feature/table_computed_style.ts
@@ -34,7 +34,7 @@ export class TableComputedStylePlugin extends UIPlugin {
   handle(cmd: Command) {
     if (
       invalidateEvaluationCommands.has(cmd.type) ||
-      (cmd.type === "UPDATE_CELL" && "content" in cmd) ||
+      (cmd.type === "UPDATE_CELL" && ("content" in cmd || "format" in cmd)) ||
       cmd.type === "EVALUATE_CELLS"
     ) {
       this.tableStyles = {};

--- a/tests/bottom_bar/aggregate_statistics_store.test.ts
+++ b/tests/bottom_bar/aggregate_statistics_store.test.ts
@@ -10,6 +10,7 @@ import {
   selectCell,
   setAnchorCorner,
   setCellContent,
+  setFormat,
   setSelection,
 } from "../test_helpers/commands_helpers";
 import { getCellError, getEvaluatedCell } from "../test_helpers/getters_helpers";
@@ -192,5 +193,16 @@ describe("Aggregate statistic functions", () => {
     activateSheet(model, sId1);
     selectAll(model);
     expect(store.statisticFnResults["Count"]?.()).toBe(3);
+  });
+
+  test("statistic is updated when a cell format changes", () => {
+    const { store, model } = makeStore(AggregateStatisticsStore);
+    setCellContent(model, "A1", '=IF(CELL("format",B1)="0.00%",3,0)');
+    setSelection(model, ["A1"]);
+
+    expect(store.statisticFnResults["Sum"]?.()).toBe(0);
+
+    setFormat(model, "B1", "0.00%");
+    expect(store.statisticFnResults["Sum"]?.()).toBe(3);
   });
 });

--- a/tests/table/dynamic_table_plugin.test.ts
+++ b/tests/table/dynamic_table_plugin.test.ts
@@ -10,6 +10,7 @@ import {
   duplicateSheet,
   paste,
   setCellContent,
+  setFormat,
   updateFilter,
   updateTableConfig,
   updateTableZone,
@@ -164,6 +165,15 @@ describe("Dynamic tables", () => {
 
     setCellContent(model, "C10", "=0/0");
     expect(getTables(model, sheetId)[0]).toMatchObject({ zone: "A1" });
+  });
+
+  test("Dynamic tables are updated when format changes", () => {
+    setCellContent(model, "A2", '=MUNIT(IF(CELL("format",A1)="0.00%",3,2))');
+    createDynamicTable(model, "A2");
+    expect(getTables(model, sheetId)[0]).toMatchObject({ zone: "A2:B3" });
+
+    setFormat(model, "A1", "0.00%");
+    expect(getTables(model, sheetId)[0]).toMatchObject({ zone: "A2:C4" });
   });
 
   test("Can copy/paste a dynamic table", () => {


### PR DESCRIPTION
### [FIX] bottom_bar_statistic: react to change in cell format

The bottom bar statistic tool was not reacting to a change in format,
which it should because changing a format can change the evaluation.


### [FIX] tables: react to change in cell format

The dynamic tables were not reacting to a change in format, which
they should because changing a format can change the evaluation.

Task: 4747031

Task: [4747031](https://www.odoo.com/odoo/2328/tasks/4747031)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo