### PR TITLE
[FIX] grid_overlay: stop interval on error

### DIFF
--- a/src/components/helpers/time_hooks.ts
+++ b/src/components/helpers/time_hooks.ts
@@ -11,21 +11,30 @@ interface IntervalTimer {
 export function useInterval(callback: () => void, delay: number): IntervalTimer {
   let intervalId: number | undefined;
   const { setInterval, clearInterval } = window;
+  const pause = () => {
+    clearInterval(intervalId);
+    intervalId = undefined;
+  };
+  const safeCallback = () => {
+    try {
+      callback();
+    } catch (e) {
+      pause();
+      throw e;
+    }
+  };
   useEffect(
     () => {
-      intervalId = setInterval(callback, delay);
+      intervalId = setInterval(safeCallback, delay);
       return () => clearInterval(intervalId);
     },
     () => [delay]
   );
   return {
-    pause: () => {
-      clearInterval(intervalId);
-      intervalId = undefined;
-    },
+    pause,
     resume: () => {
       if (intervalId === undefined) {
-        intervalId = setInterval(callback, delay);
+        intervalId = setInterval(safeCallback, delay);
       }
     },
   };


### PR DESCRIPTION
## Description

If there is a bug somewhere and that an error is raised in the model, every subsequent call to a model getter might raise an error since the model is not in a valid state.

This is a bit of a problem in the grid_overlay where we have an interval running every 200ms. If the model is in error and the interval is running, we will raise a new error every 200ms. This is less than ideal.

This commit stops the interval when an error is raised in its callback.

Task: [4746478](https://www.odoo.com/odoo/2328/tasks/4746478)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo