### PR TITLE
[FIX] header_overlay: restore row/col move preview

### DIFF
--- a/src/components/headers_overlay/headers_overlay.ts
+++ b/src/components/headers_overlay/headers_overlay.ts
@@ -306,7 +306,7 @@ css/* scss */ `
     position: absolute;
     top: 0;
     left: ${HEADER_WIDTH}px;
-    right: 0;
+    right: ${SCROLLBAR_WIDTH}px;
     height: ${HEADER_HEIGHT}px;
     &.o-dragging {
       cursor: grabbing;
@@ -506,9 +506,8 @@ css/* scss */ `
     position: absolute;
     top: ${HEADER_HEIGHT}px;
     left: 0;
-    right: 0;
+    bottom: ${SCROLLBAR_WIDTH}px;
     width: ${HEADER_WIDTH}px;
-    height: calc(100% - ${HEADER_HEIGHT + SCROLLBAR_WIDTH}px);
     &.o-dragging {
       cursor: grabbing;
     }

--- a/src/components/headers_overlay/headers_overlay.xml
+++ b/src/components/headers_overlay/headers_overlay.xml
@@ -9,7 +9,7 @@
 
   <t t-name="o-spreadsheet-RowResizer" owl="1">
     <div
-      class="o-row-resizer overflow-hidden"
+      class="o-row-resizer"
       t-on-mousemove.self="onMouseMove"
       t-on-mouseleave="onMouseLeave"
       t-on-mousedown.self.prevent="select"
@@ -37,40 +37,44 @@
           <div class="dragging-resizer" t-if="state.isResizing"/>
         </div>
       </t>
-      <t t-set="viewportZone" t-value="env.model.getters.getActiveMainViewport()"/>
-      <t
-        t-foreach="env.model.getters.getHiddenRowsGroups(sheetId)"
-        t-as="hiddenItem"
-        t-key="hiddenItem_index">
+      <div
+        t-if="env.model.getters.getHiddenRowsGroups(sheetId).length"
+        class="pe-none overflow-hidden flex-shrink-0 position-relative h-100">
+        <t t-set="viewportZone" t-value="env.model.getters.getActiveMainViewport()"/>
         <t
-          t-if="env.model.getters.isVisibleInViewport(sheetId, viewportZone.left, hiddenItem[0]-1)">
-          <div
-            class="o-unhide"
-            t-att-data-index="hiddenItem_index"
-            t-att-data-direction="'up'"
-            t-attf-style="top:{{unhideStyleValue(hiddenItem[0]) - 17}}px;"
-            t-on-click="() => this.unhide(hiddenItem)">
-            <t t-call="o-spreadsheet-Icon.TRIANGLE_UP"/>
-          </div>
+          t-foreach="env.model.getters.getHiddenRowsGroups(sheetId)"
+          t-as="hiddenItem"
+          t-key="hiddenItem_index">
+          <t
+            t-if="env.model.getters.isVisibleInViewport(sheetId, viewportZone.left, hiddenItem[0]-1)">
+            <div
+              class="o-unhide pe-auto"
+              t-att-data-index="hiddenItem_index"
+              t-att-data-direction="'up'"
+              t-attf-style="top:{{unhideStyleValue(hiddenItem[0]) - 17}}px;"
+              t-on-click="() => this.unhide(hiddenItem)">
+              <t t-call="o-spreadsheet-Icon.TRIANGLE_UP"/>
+            </div>
+          </t>
+          <t
+            t-if="env.model.getters.isVisibleInViewport(sheetId,viewportZone.left, hiddenItem[hiddenItem.length-1]+1)">
+            <div
+              class="o-unhide pe-auto"
+              t-att-data-index="hiddenItem_index"
+              t-att-data-direction="'down'"
+              t-attf-style="top:{{unhideStyleValue(hiddenItem[0]) + 3}}px;"
+              t-on-click="() => this.unhide(hiddenItem)">
+              <t t-call="o-spreadsheet-Icon.TRIANGLE_DOWN"/>
+            </div>
+          </t>
         </t>
-        <t
-          t-if="env.model.getters.isVisibleInViewport(sheetId,viewportZone.left, hiddenItem[hiddenItem.length-1]+1)">
-          <div
-            class="o-unhide"
-            t-att-data-index="hiddenItem_index"
-            t-att-data-direction="'down'"
-            t-attf-style="top:{{unhideStyleValue(hiddenItem[0]) + 3}}px;"
-            t-on-click="() => this.unhide(hiddenItem)">
-            <t t-call="o-spreadsheet-Icon.TRIANGLE_DOWN"/>
-          </div>
-        </t>
-      </t>
+      </div>
     </div>
   </t>
 
   <t t-name="o-spreadsheet-ColResizer" owl="1">
     <div
-      class="o-col-resizer overflow-hidden"
+      class="o-col-resizer d-flex"
       t-on-mousemove.self="onMouseMove"
       t-on-mouseleave="onMouseLeave"
       t-on-mousedown.self.prevent="select"
@@ -98,33 +102,38 @@
           <div class="dragging-resizer" t-if="state.isResizing"/>
         </div>
       </t>
-      <t t-set="viewportZone" t-value="env.model.getters.getActiveMainViewport()"/>
-      <t
-        t-foreach="env.model.getters.getHiddenColsGroups(sheetId)"
-        t-as="hiddenItem"
-        t-key="hiddenItem_index">
-        <t t-if="env.model.getters.isVisibleInViewport(sheetId, hiddenItem[0]-1, viewportZone.top)">
-          <div
-            class="o-unhide"
-            t-att-data-index="hiddenItem_index"
-            t-att-data-direction="'left'"
-            t-attf-style="left:{{unhideStyleValue(hiddenItem[0]) - 17}}px; margin-right:6px;"
-            t-on-click="() => this.unhide(hiddenItem)">
-            <t t-call="o-spreadsheet-Icon.TRIANGLE_LEFT"/>
-          </div>
-        </t>
+      <div
+        t-if="env.model.getters.getHiddenColsGroups(sheetId).length"
+        class="pe-none overflow-hidden flex-shrink-0 position-relative w-100">
+        <t t-set="viewportZone" t-value="env.model.getters.getActiveMainViewport()"/>
         <t
-          t-if="env.model.getters.isVisibleInViewport(sheetId, hiddenItem[hiddenItem.length-1]+1, viewportZone.top)">
-          <div
-            class="o-unhide"
-            t-att-data-index="hiddenItem_index"
-            t-att-data-direction="'right'"
-            t-attf-style="left:{{unhideStyleValue(hiddenItem[0]) + 3}}px;"
-            t-on-click="() => this.unhide(hiddenItem)">
-            <t t-call="o-spreadsheet-Icon.TRIANGLE_RIGHT"/>
-          </div>
+          t-foreach="env.model.getters.getHiddenColsGroups(sheetId)"
+          t-as="hiddenItem"
+          t-key="hiddenItem_index">
+          <t
+            t-if="env.model.getters.isVisibleInViewport(sheetId, hiddenItem[0]-1, viewportZone.top)">
+            <div
+              class="o-unhide pe-auto"
+              t-att-data-index="hiddenItem_index"
+              t-att-data-direction="'left'"
+              t-attf-style="left:{{unhideStyleValue(hiddenItem[0]) - 17}}px; margin-right:6px;"
+              t-on-click="() => this.unhide(hiddenItem)">
+              <t t-call="o-spreadsheet-Icon.TRIANGLE_LEFT"/>
+            </div>
+          </t>
+          <t
+            t-if="env.model.getters.isVisibleInViewport(sheetId, hiddenItem[hiddenItem.length-1]+1, viewportZone.top)">
+            <div
+              class="o-unhide pe-auto"
+              t-att-data-index="hiddenItem_index"
+              t-att-data-direction="'right'"
+              t-attf-style="left:{{unhideStyleValue(hiddenItem[0]) + 3}}px;"
+              t-on-click="() => this.unhide(hiddenItem)">
+              <t t-call="o-spreadsheet-Icon.TRIANGLE_RIGHT"/>
+            </div>
+          </t>
         </t>
-      </t>
+      </div>
     </div>
   </t>
 </templates>

--- a/tests/components/__snapshots__/grid.test.ts.snap
+++ b/tests/components/__snapshots__/grid.test.ts.snap
@@ -27,9 +27,8 @@ exports[`Grid component simple rendering snapshot 1`] = `
     class="o-overlay"
   >
     <div
-      class="o-col-resizer overflow-hidden"
+      class="o-col-resizer d-flex"
     >
-      
       
       
       
@@ -37,9 +36,8 @@ exports[`Grid component simple rendering snapshot 1`] = `
     </div>
     
     <div
-      class="o-row-resizer overflow-hidden"
+      class="o-row-resizer"
     >
-      
       
       
       

--- a/tests/components/__snapshots__/spreadsheet.test.ts.snap
+++ b/tests/components/__snapshots__/spreadsheet.test.ts.snap
@@ -432,9 +432,8 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
       class="o-overlay"
     >
       <div
-        class="o-col-resizer overflow-hidden"
+        class="o-col-resizer d-flex"
       >
-        
         
         
         
@@ -442,9 +441,8 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
       </div>
       
       <div
-        class="o-row-resizer overflow-hidden"
+        class="o-row-resizer"
       >
-        
         
         
         


### PR DESCRIPTION
## Description:

Before this pr:
- Column drag preview (grey column with black border) was missing, 
Due to overflow-hidden from task [4548264](https://www.odoo.com/odoo/2328/tasks/4548264).
- The unhide button could overflow visually because it was not properly wrapped.

After this pr:
- Drag preview is visible again when the overflow-hidden change is reverted.
- Wrap unhide button inside a container and adjust its style to prevent overflow.

Task: [4747268](https://www.odoo.com/odoo/2328/tasks/4747268)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo