### PR TITLE
[FIX] chart: ignore trendline datasets in show values plugin

### DIFF
--- a/src/components/figures/chart/chartJs/chartjs_show_values_plugin.ts
+++ b/src/components/figures/chart/chartJs/chartjs_show_values_plugin.ts
@@ -69,7 +69,7 @@ function drawLineOrBarOrRadarChartValues(
   const textsPositions: Record<number, number[]> = {};
 
   for (const dataset of chart._metasets) {
-    if (isTrendLineAxis(dataset.axisID) || dataset.hidden) {
+    if (isTrendLineAxis(dataset.xAxisID) || dataset.hidden) {
       continue;
     }
 
@@ -123,7 +123,7 @@ function drawHorizontalBarChartValues(
   const textsPositions: Record<number, number[]> = {};
 
   for (const dataset of chart._metasets) {
-    if (isTrendLineAxis(dataset.axisID)) {
+    if (isTrendLineAxis(dataset.xAxisID)) {
       return; // ignore trend lines
     }
 


### PR DESCRIPTION
## Description:

Previously, the show values plugin was displaying values for trend line datasets because it was checking the incorrect key `axisID` to identify them.

This PR correctly passes the `xAxisID` to the `isTrendLineAxis()` function, which checks if the dataset is a trend line.

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo