### PR TITLE
[FIX] ts: fix compiling of `.d.ts` files

### DIFF
--- a/src/components/figures/chart/chartJs/chartjs_funnel_chart.ts
+++ b/src/components/figures/chart/chartJs/chartjs_funnel_chart.ts
@@ -1,13 +1,20 @@
 import {
+  BarController,
   BarControllerChartOptions,
   BarControllerDatasetOptions,
   BarElement,
   CartesianParsedData,
   CartesianScaleTypeRegistry,
+  Chart,
+  ChartComponent,
   TooltipPositionerFunction,
 } from "chart.js";
+import { AnyObject } from "chart.js/dist/types/basic";
 
-export function getFunnelChartController() {
+export function getFunnelChartController(): ChartComponent & {
+  prototype: BarController;
+  new (chart: Chart, datasetIndex: number): BarController;
+} {
   return class FunnelChartController extends window.Chart?.BarController {
     static id = "funnel";
     static defaults = {
@@ -37,7 +44,10 @@ export function getFunnelChartController() {
   };
 }
 
-export function getFunnelChartElement() {
+export function getFunnelChartElement(): ChartComponent & {
+  prototype: BarElement;
+  new (cfg: AnyObject): BarElement;
+} {
   /**
    * Similar to a bar chart element, but it's a trapezoid rather than a rectangle. The top is of width
    * `width`, and the bottom is of width `nextElementWidth`.


### PR DESCRIPTION
It wasn't possible to compile the lib into `.d.ts` since 8a02a6b, error `... exported class expression may not be private or protected`.[1]

It seems that we cannot have an anonymous class with private/protected methods. We had a similar issue with the `PivotPresentationLayer`.

This commit adds explicit typing to the functions generating the funnel chart classes, so typescript doesn't try to infer types for them.

[1]: see https://github.com/microsoft/TypeScript/issues/30355 or https://github.com/microsoft/TypeScript/issues/36060

Task: 0

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo