### PR TITLE
[FIX] pivot: spreadsheet pivot with date fields

### DIFF
--- a/src/components/side_panel/pivot/pivot_layout_configurator/pivot_dimension_granularity/pivot_dimension_granularity.xml
+++ b/src/components/side_panel/pivot/pivot_layout_configurator/pivot_dimension_granularity/pivot_dimension_granularity.xml
@@ -2,7 +2,7 @@
   <t t-name="o-spreadsheet-PivotDimensionGranularity">
     <div class="d-flex flex-row">
       <div class="d-flex flex-row py-1 px-2 w-100 small">
-        <t t-set="granularity" t-value="props.dimension.granularity"/>
+        <t t-set="granularityProps" t-value="props.dimension.granularity || 'month'"/>
         <div class="pivot-dim-operator-label">Granularity</div>
         <select
           class="o_input flex-grow-1"
@@ -11,10 +11,10 @@
             t-foreach="props.allGranularities"
             t-as="granularity"
             t-key="granularity"
-            t-if="props.availableGranularities.has(granularity) || granularity === props.dimension.granularity"
+            t-if="props.availableGranularities.has(granularity) || granularity === granularityProps"
             t-att-value="granularity"
             t-esc="periods[granularity]"
-            t-att-selected="granularity === props.dimension.granularity or (granularity === 'month' and !props.dimension.granularity)"
+            t-att-selected="granularity === granularityProps or (granularity === 'month' and !granularityProps)"
           />
         </select>
       </div>

--- a/src/components/side_panel/pivot/pivot_side_panel/pivot_side_panel_store.ts
+++ b/src/components/side_panel/pivot/pivot_side_panel/pivot_side_panel_store.ts
@@ -243,7 +243,7 @@ export class PivotSidePanelStore extends SpreadsheetStore {
       granularitiesPerFields[field.name] = new Set(granularities);
     }
     for (const field of dateFields) {
-      granularitiesPerFields[field.name].delete(field.granularity);
+      granularitiesPerFields[field.name].delete(field.granularity || "month");
     }
     return granularitiesPerFields;
   }

--- a/src/helpers/pivot/pivot_helpers.ts
+++ b/src/helpers/pivot/pivot_helpers.ts
@@ -229,10 +229,7 @@ export function toNormalizedPivotValue(
 }
 
 function normalizeDateTime(value: CellValue, granularity: Granularity) {
-  if (!granularity) {
-    throw new Error("Missing granularity");
-  }
-  return pivotTimeAdapter(granularity).normalizeFunctionValue(value);
+  return pivotTimeAdapter(granularity ?? "month").normalizeFunctionValue(value);
 }
 
 export function toFunctionPivotValue(
@@ -249,10 +246,7 @@ export function toFunctionPivotValue(
 }
 
 function toFunctionValueDateTime(value: CellValue, granularity: Granularity) {
-  if (!granularity) {
-    throw new Error("Missing granularity");
-  }
-  return pivotTimeAdapter(granularity).toFunctionValue(value);
+  return pivotTimeAdapter(granularity ?? "month").toFunctionValue(value);
 }
 
 export const pivotNormalizationValueRegistry = new Registry<

--- a/src/helpers/pivot/pivot_registry.ts
+++ b/src/helpers/pivot/pivot_registry.ts
@@ -46,6 +46,7 @@ pivotRegistry.add("SPREADSHEET", {
     "year",
     "quarter_number",
     "month_number",
+    "month",
     "iso_week_number",
     "day_of_month",
     "day",

--- a/src/helpers/pivot/pivot_time_adapter.ts
+++ b/src/helpers/pivot/pivot_time_adapter.ts
@@ -126,6 +126,25 @@ const monthNumberAdapter: PivotTimeAdapterNotNull<number> = {
 };
 
 /**
+ * normalizes month number + year
+ */
+const monthAdapter: PivotTimeAdapterNotNull<string> = {
+  normalizeFunctionValue(value) {
+    const date = toNumber(value, DEFAULT_LOCALE);
+    return formatValue(date, { locale: DEFAULT_LOCALE, format: "mm/yyyy" });
+  },
+  toValueAndFormat(normalizedValue) {
+    return {
+      value: toNumber(normalizedValue, DEFAULT_LOCALE),
+      format: "mmmm yyyy",
+    };
+  },
+  toFunctionValue(normalizedValue) {
+    return `"${normalizedValue}"`;
+  },
+};
+
+/**
  * normalizes quarter number
  */
 const quarterNumberAdapter: PivotTimeAdapterNotNull<number> = {
@@ -197,4 +216,5 @@ pivotTimeAdapterRegistry
   .add("day_of_month", nullHandlerDecorator(dayOfMonthAdapter))
   .add("iso_week_number", nullHandlerDecorator(isoWeekNumberAdapter))
   .add("month_number", nullHandlerDecorator(monthNumberAdapter))
+  .add("month", nullHandlerDecorator(monthAdapter))
   .add("quarter_number", nullHandlerDecorator(quarterNumberAdapter));

--- a/src/helpers/pivot/spreadsheet_pivot/date_spreadsheet_pivot.ts
+++ b/src/helpers/pivot/spreadsheet_pivot/date_spreadsheet_pivot.ts
@@ -26,6 +26,9 @@ export function createDate(dimension: PivotDimension, value: CellValue, locale: 
         case "month_number":
           number = date.getMonth() + 1;
           break;
+        case "month":
+          number = Math.floor(toNumber(value, locale));
+          break;
         case "iso_week_number":
           number = date.getIsoWeek();
           break;
@@ -88,6 +91,10 @@ const MAP_VALUE_DIMENSION_DATE: Record<
     values: {},
   },
   month_number: {
+    set: new Set<CellValue>(),
+    values: {},
+  },
+  month: {
     set: new Set<CellValue>(),
     values: {},
   },

--- a/src/helpers/pivot/spreadsheet_pivot/date_spreadsheet_pivot.ts
+++ b/src/helpers/pivot/spreadsheet_pivot/date_spreadsheet_pivot.ts
@@ -6,8 +6,8 @@ import { toNormalizedPivotValue } from "../pivot_helpers";
 const NULL_SYMBOL = Symbol("NULL");
 
 export function createDate(dimension: PivotDimension, value: CellValue, locale: Locale): CellValue {
-  const granularity = dimension.granularity;
-  if (!granularity || !(granularity in MAP_VALUE_DIMENSION_DATE)) {
+  const granularity = dimension.granularity || "month";
+  if (!(granularity in MAP_VALUE_DIMENSION_DATE)) {
     throw new Error(`Unknown date granularity: ${granularity}`);
   }
   const keyInMap = typeof value === "number" || typeof value === "string" ? value : NULL_SYMBOL;

--- a/src/helpers/pivot/spreadsheet_pivot/spreadsheet_pivot.ts
+++ b/src/helpers/pivot/spreadsheet_pivot/spreadsheet_pivot.ts
@@ -229,7 +229,7 @@ export class SpreadsheetPivot implements Pivot<SpreadsheetPivotRuntimeDefinition
     const cells = this.filterDataEntriesFromDomain(this.dataEntries, domain);
     const finalCell = cells[0]?.[dimension.nameWithGranularity];
     if (dimension.type === "date") {
-      const adapter = pivotTimeAdapter(dimension.granularity as Granularity);
+      const adapter = pivotTimeAdapter((dimension.granularity || "month") as Granularity);
       return adapter.toValueAndFormat(lastNode.value, this.getters.getLocale());
     }
     if (!finalCell) {

--- a/src/helpers/pivot/spreadsheet_pivot/spreadsheet_pivot.ts
+++ b/src/helpers/pivot/spreadsheet_pivot/spreadsheet_pivot.ts
@@ -328,7 +328,11 @@ export class SpreadsheetPivot implements Pivot<SpreadsheetPivotRuntimeDefinition
     if (nonEmptyCells.length === 0) {
       return "integer";
     }
-    if (nonEmptyCells.every((cell) => cell.format && isDateTimeFormat(cell.format))) {
+    if (
+      nonEmptyCells.every(
+        (cell) => cell.type === CellValueType.number && cell.format && isDateTimeFormat(cell.format)
+      )
+    ) {
       return "date";
     }
     if (nonEmptyCells.every((cell) => cell.type === CellValueType.boolean)) {

--- a/tests/pivots/spreadsheet_pivot/spreadsheet_pivot.test.ts
+++ b/tests/pivots/spreadsheet_pivot/spreadsheet_pivot.test.ts
@@ -5,6 +5,7 @@ import {
   deleteSheet,
   redo,
   setCellContent,
+  setFormat,
   undo,
 } from "../../test_helpers/commands_helpers";
 import {
@@ -136,6 +137,23 @@ describe("Spreadsheet Pivot", () => {
       { name: "AllDateButOneNumberAndOneString", type: "char" },
       { name: "EmptyData", type: "integer" },
     ]);
+  });
+
+  test("Values aren't detected as date if they have a date format but a non-numeric value", () => {
+    const model = new Model();
+    setCellContent(model, "A1", "Col1");
+    setFormat(model, "A2", "dd/mm/yyyy");
+    addPivot(model, "A1:A2", {});
+    setCellContent(model, "B1", "=PIVOT(1)");
+
+    setCellContent(model, "A2", "notADate");
+    expect(model.getters.getPivot("1").getFields()).toMatchObject({ Col1: { type: "char" } });
+
+    setCellContent(model, "A2", "TRUE");
+    expect(model.getters.getPivot("1").getFields()).toMatchObject({ Col1: { type: "boolean" } });
+
+    setCellContent(model, "A2", "125");
+    expect(model.getters.getPivot("1").getFields()).toMatchObject({ Col1: { type: "date" } });
   });
 
   test("Pivot fields are not loaded if a cell is in error", () => {

--- a/tests/pivots/spreadsheet_pivot/spreadsheet_pivot.test.ts
+++ b/tests/pivots/spreadsheet_pivot/spreadsheet_pivot.test.ts
@@ -308,6 +308,24 @@ describe("Spreadsheet Pivot", () => {
     ]);
   });
 
+  test("Date fields without granularity are defaulted as month", () => {
+    const model = new Model();
+    setCellContent(model, "A1", "Col1");
+    setCellContent(model, "A2", "45323");
+    addPivot(model, "A1:A2", {
+      rows: [{ name: "Col1", order: "asc" }],
+    });
+    setCellContent(model, "B1", "=PIVOT(1)");
+    expect(model.getters.getPivot("1").getFields()).toMatchObject({ Col1: { type: "integer" } });
+
+    // field is now a date, but no granularity is specified since it was a integer when added to the pivot
+    setFormat(model, "A2", "dd/mm/yyyy");
+    expect(model.getters.getPivot("1").getFields()).toMatchObject({ Col1: { type: "date" } });
+
+    setCellContent(model, "E1", "=PIVOT(1)");
+    expect(getCellContent(model, "E3")).toEqual("February 2024");
+  });
+
   test("Empty string values are treated the same as blank cells", () => {
     const model = createModelWithPivot("A1:I5");
     setCellContent(model, "C3", '=""');


### PR DESCRIPTION
### defaultGranularity everywhere ... great

### [FIX] pivot: date dimension detection

A pivot field was detected with type `date` if all of the cells had a
date format, but we didn't check if the cell values were actually
dates.

Task: [4742696](https://www.odoo.com/odoo/2328/tasks/4742696)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo