### PR TITLE
[FIX] chart: fix treemap colors with single range

### DIFF
--- a/src/helpers/figures/charts/runtime/chartjs_dataset.ts
+++ b/src/helpers/figures/charts/runtime/chartjs_dataset.ts
@@ -717,7 +717,7 @@ function getTreeMapElementColor(
   }
 
   const rootNode = tree.find((node) => node.label === rootCategory);
-  if (!rootNode) {
+  if (!rootNode || !rootNode.children.length) {
     return baseColor;
   }
   const treeNodesByLevel = pyramidizeTree(rootNode.children);

--- a/tests/figures/chart/treemap/treemap_chart_plugin.test.ts
+++ b/tests/figures/chart/treemap/treemap_chart_plugin.test.ts
@@ -430,5 +430,32 @@ describe("TreeMap chart", () => {
         "#778899"
       );
     });
+
+    test("TreeMap category colors with single level", () => {
+      // prettier-ignore
+      const grid = {
+            A1: "Year", C1: "Sales",
+            A2: "2023", C2: "20",
+            A3: "2024", C3: "100",
+      };
+      setGrid(model, grid);
+      const chartId = createTreeMapChart(model, {
+        dataSets: [{ dataRange: "A1:A3" }],
+        labelRange: "C1:C3",
+        coloringOptions: {
+          type: "categoryColor",
+          useValueBasedGradient: true,
+          colors: ["#778899", "#112233"],
+        },
+      });
+      const getColor = getBackgroundColorCallback(chartId);
+
+      expect(getColor(getTreeMapElement({ depth: 0, path: "2023", isLeaf: true }))).toEqual(
+        "#112233"
+      );
+      expect(getColor(getTreeMapElement({ depth: 0, path: "2024", isLeaf: true }))).toEqual(
+        "#778899"
+      );
+    });
   });
 });


### PR DESCRIPTION
## Description

The treemap would crash if trying to create a treemap with a hierarchy on a single range.

Task: [4752235](https://www.odoo.com/odoo/2328/tasks/4752235)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo