### PR TITLE
[FIX] GridComposer: limit the composer size

### DIFF
--- a/src/components/composer/composer/composer.ts
+++ b/src/components/composer/composer/composer.ts
@@ -531,6 +531,16 @@ export class Composer extends Component<ComposerProps, SpreadsheetChildEnv> {
     }
   }
 
+  onWheel(event: WheelEvent) {
+    // detect if scrollbar is available
+    if (
+      this.composerRef.el &&
+      this.composerRef.el.scrollHeight > this.composerRef.el.clientHeight
+    ) {
+      event.stopPropagation();
+    }
+  }
+
   // ---------------------------------------------------------------------------
   // Private
   // ---------------------------------------------------------------------------

--- a/src/components/composer/composer/composer.xml
+++ b/src/components/composer/composer/composer.xml
@@ -20,6 +20,7 @@
         t-on-compositionend="onCompositionEnd"
         t-on-dblclick="onDblClick"
         t-on-contextmenu="onContextMenu"
+        t-on-wheel="onWheel"
       />
 
       <Popover

--- a/src/components/composer/grid_composer/grid_composer.ts
+++ b/src/components/composer/grid_composer/grid_composer.ts
@@ -94,12 +94,15 @@ export class GridComposer extends Component<Props, SpreadsheetChildEnv> {
   }
 
   get composerProps(): ComposerProps {
+    // Remove the wrapper border width
+    const maxHeight = this.props.gridDims.height - this.rect.y - 2 * COMPOSER_BORDER_WIDTH;
     return {
       focus: this.props.focus,
       isDefaultFocus: true,
       onComposerContentFocused: this.props.onComposerContentFocused,
       onComposerCellFocused: this.props.onComposerCellFocused,
       onInputContextMenu: this.props.onInputContextMenu,
+      inputStyle: `max-height: ${maxHeight}px;`,
     };
   }
 

--- a/tests/composer/__snapshots__/composer_integration_component.test.ts.snap
+++ b/tests/composer/__snapshots__/composer_integration_component.test.ts.snap
@@ -12,7 +12,7 @@ exports[`Grid composer grid composer basic style Grid composer snapshot 1`] = `
       class="o-composer w-100 text-start active"
       contenteditable="true"
       spellcheck="false"
-      style=""
+      style="max-height: 982.6px;"
       tabindex="1"
     >
       A

--- a/tests/composer/composer_integration_component.test.ts
+++ b/tests/composer/composer_integration_component.test.ts
@@ -544,6 +544,28 @@ describe("Grid composer", () => {
     expect(getCellContent(model, "B2")).toBe("");
   });
 
+  test("Wheel event on the composer should not scroll the viewport if the composer has a scrollbar", async () => {
+    const viewport = model.getters.getActiveMainViewport();
+    // Describes a div that has a scrollbar - the scrollHeight is greater than the clientHeight
+    jest.spyOn(HTMLDivElement.prototype, "clientHeight", "get").mockImplementation(() => 50);
+    jest.spyOn(HTMLDivElement.prototype, "scrollHeight", "get").mockImplementation(() => 150);
+    await startComposition("5");
+    triggerWheelEvent(document.activeElement!, { deltaY: 4 * DEFAULT_CELL_HEIGHT });
+    await nextTick();
+    expect(model.getters.getActiveMainViewport()).toMatchObject(viewport);
+
+    // Describes a div without a scrollbar, the scrollHeight matches the clientheight
+    jest.spyOn(HTMLDivElement.prototype, "clientHeight", "get").mockImplementation(() => 50);
+    jest.spyOn(HTMLDivElement.prototype, "scrollHeight", "get").mockImplementation(() => 50);
+    await nextTick();
+    triggerWheelEvent(document.activeElement!, { deltaY: 4 * DEFAULT_CELL_HEIGHT });
+    expect(model.getters.getActiveMainViewport()).toMatchObject({
+      ...viewport,
+      top: viewport.top + 4,
+      bottom: viewport.bottom + 4,
+    });
+  });
+
   describe("grid composer basic style", () => {
     const composerContainerSelector = ".o-grid .o-grid-composer";
 

--- a/tests/grid/__snapshots__/grid_component.test.ts.snap
+++ b/tests/grid/__snapshots__/grid_component.test.ts.snap
@@ -83,7 +83,7 @@ exports[`Grid component simple rendering snapshot 1`] = `
         class="o-composer w-100 text-start"
         contenteditable="true"
         spellcheck="false"
-        style=""
+        style="max-height: 1008.6px;"
         tabindex="1"
       />
       

--- a/tests/spreadsheet/__snapshots__/spreadsheet_component.test.ts.snap
+++ b/tests/spreadsheet/__snapshots__/spreadsheet_component.test.ts.snap
@@ -698,7 +698,7 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
               class="o-composer w-100 text-start"
               contenteditable="true"
               spellcheck="false"
-              style=""
+              style="max-height: 1008.6px;"
               tabindex="1"
             />
             


### PR DESCRIPTION
Currently, opening the gridcomposer with a content with too many lines will completely break the layout as the composer is not bounded.

This revision forces a limit size to it, similarly to the strategy done in the TopbarComposer. It also allows users to scroll inside the said composer when possible.

Task: 4686816

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo