### PR TITLE
[FIX] pivot: copy from referenced id

### DIFF
--- a/src/formulas/parser.ts
+++ b/src/formulas/parser.ts
@@ -323,7 +323,11 @@ export function parse(str: string): AST {
 }
 
 export function parseTokens(tokens: Token[]): AST {
-  const richTokens = tokens.map((token, index) => ({ ...token, tokenIndex: index }));
+  const richTokens = tokens.map((token, index) => ({
+    type: token.type,
+    value: token.value,
+    tokenIndex: index,
+  }));
   const tokensToParse = richTokens.filter((x) => x.type !== "SPACE");
   const tokenList = new TokenList(tokensToParse);
   if (tokenList.current?.value === "=") {

--- a/tests/clipboard/clipboard_plugin.test.ts
+++ b/tests/clipboard/clipboard_plugin.test.ts
@@ -2228,6 +2228,25 @@ describe("clipboard", () => {
     expect(getEvaluatedCell(model, "G5").format).toBe("#,##0.0");
   });
 
+  test("copy spread pivot from a referenced id", () => {
+    // prettier-ignore
+    const grid = {
+      A1: "Customer", B1: "Price", C1: "1",
+      A2: "Alice",    B2: "10",    C2: "=PIVOT(C1)",
+      A3: "Bob",      B3: "30"
+    };
+    const model = createModelFromGrid(grid);
+    addPivot(model, "A1:B3", {
+      columns: [],
+      rows: [{ fieldName: "Customer" }],
+      measures: [{ id: "Price:sum", fieldName: "Price", aggregator: "sum" }],
+    });
+
+    copy(model, "D4");
+    paste(model, "G4");
+    expect(getCell(model, "G4")?.content).toBe('=PIVOT.VALUE(1,"Price:sum","Customer","Alice")');
+  });
+
   test("copying a spread pivot cell with (Undefined)", () => {
     // prettier-ignore
     const grid = {


### PR DESCRIPTION
Steps to reproduce

- insert a pivot into a spreadsheet
- type the formula =PIVOT(A1) where A1 contains the pivot id
- copy any value from the pivot
- paste it somewhere else => the "fixed" formula should be pasted, but only the value is pasted

The bug was introduced by 816977d7b8a5

`...token` doesn't work as expected. For reference tokens coming stored on the cells, the objects are not POJO, but instances of `RangeReferenceToken`. The `value` property is a getter `get value()` which is ignored when spreading the object (=> `.value` is undefined)

Task: 4756878

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo