### PR TITLE
[FIX] evaluation: fix issue when writing formula on spilled data

### DIFF
--- a/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
@@ -93,11 +93,9 @@ export class Evaluator {
   }
 
   getArrayFormulaSpreadingOn(position: CellPosition): CellPosition | undefined {
-    const hasArrayFormulaResult =
-      this.getEvaluatedCell(position).type !== CellValueType.empty &&
-      !this.getters.getCell(position)?.isFormula;
-    if (!hasArrayFormulaResult) {
-      return this.spreadingRelations.isArrayFormula(position) ? position : undefined;
+    const isEmpty = this.getEvaluatedCell(position).type === CellValueType.empty;
+    if (isEmpty) {
+      return undefined;
     }
     const arrayFormulas = this.spreadingRelations.searchFormulaPositionsSpreadingOn(
       position.sheetId,

--- a/tests/evaluation/evaluation_formula_array.test.ts
+++ b/tests/evaluation/evaluation_formula_array.test.ts
@@ -744,6 +744,16 @@ describe("evaluate formulas that return an array", () => {
       expect(getEvaluatedCell(model, "A3").value).toBe("#SPILL!");
     });
 
+    test("recompute when spread if filled by a formula", () => {
+      setCellContent(model, "A1", "=MFILL(1,2,42)");
+      expect(getEvaluatedCell(model, "A1").value).toBe(42);
+      expect(getEvaluatedCell(model, "A2").value).toBe(42);
+      setCellContent(model, "A2", "=MFILL(1,2,421)");
+      expect(getEvaluatedCell(model, "A1").value).toBe("#SPILL!");
+      expect(getEvaluatedCell(model, "A2").value).toBe(421);
+      expect(getEvaluatedCell(model, "A3").value).toBe(421);
+    });
+
     test("recompute cell depending on spread values computed in between", () => {
       const model = new Model({
         sheets: [


### PR DESCRIPTION
Writing a formula on the spilled data of another formula doesn't trigger the evaluation of the 2nd formula.

Task: 4757650

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo