### PR TITLE
[FIX] Pivot: allowDispatch invalid pivot dataset

### DIFF
--- a/src/plugins/core/spreadsheet_pivot.ts
+++ b/src/plugins/core/spreadsheet_pivot.ts
@@ -1,4 +1,11 @@
-import { ApplyRangeChange, Range } from "../../types";
+import { isZoneValid } from "../../helpers";
+import {
+  ApplyRangeChange,
+  CommandResult,
+  CoreCommand,
+  PivotCoreDefinition,
+  Range,
+} from "../../types";
 import { CorePlugin } from "../core_plugin";
 
 function adaptPivotRange(
@@ -20,6 +27,16 @@ function adaptPivotRange(
 }
 
 export class SpreadsheetPivotCorePlugin extends CorePlugin {
+  allowDispatch(cmd: CoreCommand) {
+    switch (cmd.type) {
+      case "ADD_PIVOT":
+      case "UPDATE_PIVOT":
+        const definition = cmd.pivot;
+        return this.checkDataSetValidity(definition);
+    }
+    return CommandResult.Success;
+  }
+
   adaptRanges(applyChange: ApplyRangeChange) {
     for (const pivotId of this.getters.getPivotIds()) {
       const definition = this.getters.getPivotCoreDefinition(pivotId);
@@ -38,5 +55,16 @@ export class SpreadsheetPivotCorePlugin extends CorePlugin {
         this.dispatch("UPDATE_PIVOT", { pivotId, pivot: { ...definition, dataSet } });
       }
     }
+  }
+
+  private checkDataSetValidity(definition: PivotCoreDefinition) {
+    if (definition.type === "SPREADSHEET" && definition.dataSet) {
+      const { zone, sheetId } = definition.dataSet;
+      if (!sheetId || !this.getters.tryGetSheet(sheetId) || !zone || !isZoneValid(zone)) {
+        return CommandResult.InvalidDataSet;
+      }
+      return this.getters.checkZonesExistInSheet(sheetId, [zone]);
+    }
+    return CommandResult.Success;
   }
 }

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -1300,6 +1300,7 @@ export const enum CommandResult {
   InvalidTableResize = "InvalidTableResize",
   PivotIdNotFound = "PivotIdNotFound",
   EmptyName = "EmptyName",
+  InvalidPivotDataSet = "InvalidPivotDataSet",
 }
 
 export interface CommandHandler<T> {

--- a/tests/pivots/pivot_plugin.test.ts
+++ b/tests/pivots/pivot_plugin.test.ts
@@ -1,9 +1,10 @@
 import { CommandResult, Model } from "../../src";
 import { FORBIDDEN_SHEETNAME_CHARS } from "../../src/constants";
+import { toZone } from "../../src/helpers";
 import { EMPTY_PIVOT_CELL } from "../../src/helpers/pivot/table_spreadsheet_pivot";
 import { renameSheet, selectCell, setCellContent } from "../test_helpers/commands_helpers";
 import { createModelFromGrid, toCellPosition } from "../test_helpers/helpers";
-import { addPivot } from "../test_helpers/pivot_helpers";
+import { addPivot, updatePivot } from "../test_helpers/pivot_helpers";
 
 describe("Pivot plugin", () => {
   test("isSpillPivotFormula", () => {
@@ -101,6 +102,46 @@ describe("Pivot plugin", () => {
       pivotId: "9999",
     });
     expect(updateResult).toBeCancelledBecause(CommandResult.PivotIdNotFound);
+  });
+
+  test("cannot create a pivot with and invalid dataset sheetId or zone", () => {
+    const model = new Model();
+    const createResult1 = addPivot(model, "", {
+      dataSet: { sheetId: "BADSHEETID", zone: toZone("A1:A2") },
+    });
+    expect(createResult1).toBeCancelledBecause(CommandResult.InvalidDataSet);
+    const sheetId = model.getters.getActiveSheetId();
+    const createResult2 = addPivot(model, "", {
+      dataSet: { sheetId, zone: { top: -1, left: 1, bottom: 2, right: 2 } },
+    });
+    expect(createResult2).toBeCancelledBecause(CommandResult.InvalidDataSet);
+
+    // Out of bounds zone
+    const createResult3 = addPivot(model, "", {
+      dataSet: { sheetId, zone: { top: 1, left: 1, bottom: 200, right: 200 } },
+    });
+    expect(createResult3).toBeCancelledBecause(CommandResult.TargetOutOfSheet);
+  });
+
+  test("cannot update a pivot with and invalid dataset sheetId or zone", () => {
+    const model = new Model();
+    addPivot(model, "A1:A2");
+
+    const updateResult1 = updatePivot(model, "1", {
+      dataSet: { sheetId: "BADSHEETID", zone: toZone("A1:A2") },
+    });
+    expect(updateResult1).toBeCancelledBecause(CommandResult.InvalidDataSet);
+    const sheetId = model.getters.getActiveSheetId();
+    const updateResult2 = updatePivot(model, "1", {
+      dataSet: { sheetId, zone: { top: -1, left: 1, bottom: 2, right: 2 } },
+    });
+    expect(updateResult2).toBeCancelledBecause(CommandResult.InvalidDataSet);
+
+    // Out of bounds zone
+    const updateResult3 = updatePivot(model, "1", {
+      dataSet: { sheetId, zone: { top: 1, left: 1, bottom: 200, right: 200 } },
+    });
+    expect(updateResult3).toBeCancelledBecause(CommandResult.TargetOutOfSheet);
   });
 
   test("forbidden characters are removed from new sheet name when duplicating a pivot", () => {

--- a/tests/test_helpers/pivot_helpers.ts
+++ b/tests/test_helpers/pivot_helpers.ts
@@ -36,6 +36,9 @@ export function addPivot(
     pivot.dataSet!.zone = toZone(zone);
   }
   const result = model.dispatch("ADD_PIVOT", { pivot, pivotId });
+  if (!result.isSuccessful) {
+    return result;
+  }
   const instance = model.getters.getPivot(pivotId);
   init && instance?.init();
   return result;


### PR DESCRIPTION
This commit ensures that we do not create or modify spreadsheet pivots with invalid datasets (be it a bad sheetId or an invalid zone).

Task: 4756759

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [4756759](https://www.odoo.com/odoo/2328/tasks/4756759)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo