### PR TITLE
[IMP] dashboard: make menu to change chart type

### DIFF
--- a/src/actions/figure_menu_actions.ts
+++ b/src/actions/figure_menu_actions.ts
@@ -43,6 +43,7 @@ export function getChartMenuActions(
           "text/html": innerHTML,
           "image/png": blob,
         });
+        env.notifyUser({ sticky: false, type: "success", text: _t("Chart copied to clipboard") });
       },
     },
     {
@@ -70,7 +71,7 @@ export function getImageMenuActions(
   env: SpreadsheetChildEnv
 ): Action[] {
   const menuItemSpecs: ActionSpec[] = [
-    getCopyMenuItem(figureId, env),
+    getCopyMenuItem(figureId, env, _t("Image copied to clipboard")),
     getCutMenuItem(figureId, env),
     {
       id: "reset_size",
@@ -119,7 +120,11 @@ export function getImageMenuActions(
   return createActions(menuItemSpecs);
 }
 
-function getCopyMenuItem(figureId: UID, env: SpreadsheetChildEnv): ActionSpec {
+function getCopyMenuItem(
+  figureId: UID,
+  env: SpreadsheetChildEnv,
+  copiedNotificationMessage?: string
+): ActionSpec {
   return {
     id: "copy",
     name: _t("Copy"),
@@ -130,6 +135,9 @@ function getCopyMenuItem(figureId: UID, env: SpreadsheetChildEnv): ActionSpec {
       env.model.dispatch("COPY");
       const osClipboardContent = await env.model.getters.getClipboardTextAndImageContent();
       await env.clipboard.write(osClipboardContent);
+      if (copiedNotificationMessage) {
+        env.notifyUser({ sticky: false, type: "success", text: copiedNotificationMessage });
+      }
     },
     icon: "o-spreadsheet-Icon.CLIPBOARD",
   };

--- a/src/actions/figure_menu_actions.ts
+++ b/src/actions/figure_menu_actions.ts
@@ -1,49 +1,13 @@
-import { Action, ActionSpec, createActions } from "../actions/action";
-import { ChartFigure } from "../components/figures/figure_chart/figure_chart";
-import { ImageFigure } from "../components/figures/figure_image/figure_image";
+import { UID } from "..";
 import { downloadFile } from "../components/helpers/dom_helpers";
 import { chartToImageFile, chartToImageUrl } from "../helpers/figures/charts";
 import { getMaxFigureSize } from "../helpers/figures/figure/figure";
 import { _t } from "../translation";
-import { SpreadsheetChildEnv, UID } from "../types";
+import { SpreadsheetChildEnv } from "../types";
 import { xmlEscape } from "../xlsx/helpers/xml_helpers";
-import { Registry } from "./registry";
+import { Action, ActionSpec, createActions } from "./action";
 
-//------------------------------------------------------------------------------
-// Figure Registry
-//------------------------------------------------------------------------------
-
-/**
- * This registry is intended to map a type of figure (tag) to a class of
- * component, that will be used in the UI to represent the figure.
- *
- * The most important type of figure will be the Chart
- */
-
-export interface FigureContent {
-  Component: any;
-  menuBuilder: (figureId: UID, onFigureDeleted: () => void, env: SpreadsheetChildEnv) => Action[];
-  SidePanelComponent?: string;
-  keepRatio?: boolean;
-  minFigSize?: number;
-  borderWidth?: number;
-}
-
-export const figureRegistry = new Registry<FigureContent>();
-figureRegistry.add("chart", {
-  Component: ChartFigure,
-  SidePanelComponent: "ChartPanel",
-  menuBuilder: getChartMenu,
-});
-figureRegistry.add("image", {
-  Component: ImageFigure,
-  keepRatio: true,
-  minFigSize: 20,
-  borderWidth: 0,
-  menuBuilder: getImageMenuRegistry,
-});
-
-function getChartMenu(
+export function getChartMenuActions(
   figureId: UID,
   onFigureDeleted: () => void,
   env: SpreadsheetChildEnv
@@ -100,7 +64,7 @@ function getChartMenu(
   return createActions(menuItemSpecs);
 }
 
-function getImageMenuRegistry(
+export function getImageMenuActions(
   figureId: UID,
   onFigureDeleted: () => void,
   env: SpreadsheetChildEnv

--- a/src/actions/figure_menu_actions.ts
+++ b/src/actions/figure_menu_actions.ts
@@ -45,6 +45,7 @@ export function getChartMenuActions(
         });
         env.notifyUser({ sticky: false, type: "success", text: _t("Chart copied to clipboard") });
       },
+      isReadonlyAllowed: true,
     },
     {
       id: "download",
@@ -59,10 +60,13 @@ export function getChartMenuActions(
         const url = chartToImageUrl(runtime, figure, chartType)!;
         downloadFile(url, "chart");
       },
+      isReadonlyAllowed: true,
     },
     getDeleteMenuItem(figureId, onFigureDeleted, env),
   ];
-  return createActions(menuItemSpecs);
+  return createActions(menuItemSpecs).filter((action) =>
+    env.model.getters.isReadonly() ? action.isReadonlyAllowed : true
+  );
 }
 
 export function getImageMenuActions(

--- a/src/components/figures/chart/chart_dashboard_menu/chart_dashboard_menu.scss
+++ b/src/components/figures/chart/chart_dashboard_menu/chart_dashboard_menu.scss
@@ -1,0 +1,18 @@
+.o-spreadsheet .o-figure {
+  &:not(:hover) .o-dashboard-chart-select {
+    display: none !important;
+  }
+
+  .o-dashboard-chart-select {
+    cursor: default;
+
+    .o-chart-dashboard-item {
+      opacity: 0.3;
+
+      &.active,
+      &:hover {
+        background: $os-button-active-bg;
+      }
+    }
+  }
+}

--- a/src/components/figures/chart/chart_dashboard_menu/chart_dashboard_menu.ts
+++ b/src/components/figures/chart/chart_dashboard_menu/chart_dashboard_menu.ts
@@ -1,0 +1,103 @@
+import { Component, onWillUpdateProps, useState } from "@odoo/owl";
+import { getChartMenuActions } from "../../../../actions/figure_menu_actions";
+import { BACKGROUND_CHART_COLOR } from "../../../../constants";
+import { chartRegistry, chartSubtypeRegistry } from "../../../../registries/chart_types";
+import { ChartDefinition, ChartType, FigureUI, SpreadsheetChildEnv } from "../../../../types";
+import { Menu, MenuState } from "../../../menu/menu";
+
+interface Props {
+  figureUI: FigureUI;
+}
+
+export class ChartDashboardMenu extends Component<Props, SpreadsheetChildEnv> {
+  static template = "spreadsheet.ChartDashboardMenu";
+  static components = { Menu };
+  static props = { figureUI: Object };
+
+  private originalChartDefinition!: ChartDefinition;
+
+  private menuState: MenuState = useState({ isOpen: false, anchorRect: null, menuItems: [] });
+
+  setup() {
+    super.setup();
+    this.originalChartDefinition = this.env.model.getters.getChartDefinition(
+      this.props.figureUI.id
+    );
+    onWillUpdateProps(({ figureUI }: Props) => {
+      if (figureUI.id !== this.props.figureUI.id) {
+        this.originalChartDefinition = this.env.model.getters.getChartDefinition(figureUI.id);
+      }
+    });
+  }
+
+  getAvailableTypes() {
+    const definition = this.env.model.getters.getChartDefinition(this.props.figureUI.id);
+    if (!["line", "bar", "pie"].includes(definition.type)) {
+      return [];
+    }
+
+    return ["column", "line", "pie"].map((type) => {
+      const item = chartSubtypeRegistry.get(type);
+      return {
+        ...item,
+        icon: this.getIconClasses(item.chartType),
+      };
+    });
+  }
+
+  getIconClasses(type: ChartType) {
+    if (type.includes("bar")) {
+      return "fa fa-bar-chart";
+    }
+    if (type.includes("line")) {
+      return "fa fa-line-chart";
+    }
+    if (type.includes("pie")) {
+      return "fa fa-pie-chart";
+    }
+    return "";
+  }
+
+  onTypeChange(type: ChartType) {
+    const figureId = this.props.figureUI.id;
+    const currentDefinition = this.env.model.getters.getChartDefinition(figureId);
+    if (currentDefinition.type === type) {
+      return;
+    }
+
+    let definition: ChartDefinition;
+    if (this.originalChartDefinition.type === type) {
+      definition = this.originalChartDefinition;
+    } else {
+      const newChartInfo = chartSubtypeRegistry.get(type);
+      const ChartClass = chartRegistry.get(newChartInfo.chartType);
+      const chartCreationContext = this.env.model.getters.getContextCreationChart(figureId);
+      if (!chartCreationContext) return;
+      definition = {
+        ...ChartClass.getChartDefinitionFromContextCreation(chartCreationContext),
+        ...newChartInfo.subtypeDefinition,
+      } as ChartDefinition;
+    }
+
+    this.env.model.dispatch("UPDATE_CHART", {
+      definition,
+      figureId,
+      sheetId: this.env.model.getters.getActiveSheetId(),
+    });
+  }
+
+  get selectedChartType() {
+    return this.env.model.getters.getChartDefinition(this.props.figureUI.id).type;
+  }
+
+  get backgroundColor() {
+    const color = this.env.model.getters.getChartDefinition(this.props.figureUI.id).background;
+    return "background-color: " + (color || BACKGROUND_CHART_COLOR);
+  }
+
+  openContextMenu(ev: MouseEvent) {
+    this.menuState.isOpen = true;
+    this.menuState.anchorRect = { x: ev.clientX, y: ev.clientY, width: 0, height: 0 };
+    this.menuState.menuItems = getChartMenuActions(this.props.figureUI.id, () => {}, this.env);
+  }
+}

--- a/src/components/figures/chart/chart_dashboard_menu/chart_dashboard_menu.xml
+++ b/src/components/figures/chart/chart_dashboard_menu/chart_dashboard_menu.xml
@@ -1,0 +1,27 @@
+<templates>
+  <t t-name="spreadsheet.ChartDashboardMenu">
+    <div class="o-dashboard-chart-select position-absolute top-0 end-0" t-on-click.stop="">
+      <div class="d-flex flex-row px-1" t-att-style="backgroundColor">
+        <t t-foreach="getAvailableTypes()" t-as="type" t-key="type.chartSubtype">
+          <button
+            t-attf-class=" {{type.icon}} {{type.chartType === selectedChartType ? 'active' : ''}}"
+            class="o-chart-dashboard-item btn mt-1 me-1 p-1 "
+            t-att-title="type.displayName"
+            t-on-click="() => this.onTypeChange(type.chartSubtype)"
+            t-att-data-id="type.chartSubtype"
+          />
+        </t>
+        <button
+          class="o-chart-dashboard-item btn mt-1 p-1 fa fa-ellipsis-v"
+          t-on-click="openContextMenu"
+        />
+      </div>
+      <Menu
+        t-if="menuState.isOpen"
+        anchorRect="menuState.anchorRect"
+        menuItems="menuState.menuItems"
+        onClose="() => this.menuState.isOpen=false"
+      />
+    </div>
+  </t>
+</templates>

--- a/src/components/figures/figure/figure.ts
+++ b/src/components/figures/figure/figure.ts
@@ -4,7 +4,7 @@ import {
   FIGURE_BORDER_COLOR,
   SELECTION_BORDER_COLOR,
 } from "../../../constants";
-import { figureRegistry } from "../../../registries/figure_registry";
+import { figureRegistry } from "../../../registries/figures_registry";
 import {
   AnchorOffset,
   CSSProperties,

--- a/src/components/figures/figure_chart/figure_chart.ts
+++ b/src/components/figures/figure_chart/figure_chart.ts
@@ -2,6 +2,7 @@ import { Component } from "@odoo/owl";
 import { chartComponentRegistry } from "../../../registries/chart_types";
 import { ChartType, FigureUI, SpreadsheetChildEnv } from "../../../types";
 import { css } from "../../helpers/css";
+import { ChartDashboardMenu } from "../chart/chart_dashboard_menu/chart_dashboard_menu";
 
 // -----------------------------------------------------------------------------
 // STYLE
@@ -27,7 +28,7 @@ export class ChartFigure extends Component<Props, SpreadsheetChildEnv> {
     figureUI: Object,
     onFigureDeleted: Function,
   };
-  static components = {};
+  static components = { ChartDashboardMenu };
 
   onDoubleClick() {
     this.env.model.dispatch("SELECT_FIGURE", { figureId: this.props.figureUI.id });

--- a/src/components/figures/figure_chart/figure_chart.xml
+++ b/src/components/figures/figure_chart/figure_chart.xml
@@ -7,5 +7,8 @@
         t-key="this.props.figureUI.id"
       />
     </div>
+    <div t-if="env.isDashboard()" class="position-absolute top-0 end-0">
+      <ChartDashboardMenu figureUI="props.figureUI"/>
+    </div>
   </t>
 </templates>

--- a/src/components/figures/figure_container/figure_container.ts
+++ b/src/components/figures/figure_container/figure_container.ts
@@ -2,7 +2,7 @@ import { Component, onMounted, onWillUpdateProps, useState } from "@odoo/owl";
 import { ComponentsImportance, MIN_FIG_SIZE } from "../../../constants";
 import { isDefined } from "../../../helpers";
 import { rectUnion } from "../../../helpers/rectangle";
-import { figureRegistry } from "../../../registries/figure_registry";
+import { figureRegistry } from "../../../registries/figures_registry";
 import {
   AnchorOffset,
   Figure,

--- a/src/helpers/figures/charts/bar_chart.ts
+++ b/src/helpers/figures/charts/bar_chart.ts
@@ -236,7 +236,7 @@ export function createBarChartRuntime(chart: BarChart, getters: Getters): BarCha
     options: {
       ...CHART_COMMON_OPTIONS,
       indexAxis: chart.horizontal ? "y" : "x",
-      layout: getChartLayout(definition),
+      layout: getChartLayout(definition, chartData),
       scales: getBarChartScales(definition, chartData),
       plugins: {
         title: getChartTitle(definition),

--- a/src/helpers/figures/charts/combo_chart.ts
+++ b/src/helpers/figures/charts/combo_chart.ts
@@ -240,7 +240,7 @@ export function createComboChartRuntime(chart: ComboChart, getters: Getters): Co
     },
     options: {
       ...CHART_COMMON_OPTIONS,
-      layout: getChartLayout(definition),
+      layout: getChartLayout(definition, chartData),
       scales: getBarChartScales(definition, chartData),
       plugins: {
         title: getChartTitle(definition),

--- a/src/helpers/figures/charts/funnel_chart.ts
+++ b/src/helpers/figures/charts/funnel_chart.ts
@@ -220,7 +220,7 @@ export function createFunnelChartRuntime(chart: FunnelChart, getters: Getters): 
     options: {
       ...CHART_COMMON_OPTIONS,
       indexAxis: "y",
-      layout: getChartLayout(definition),
+      layout: getChartLayout(definition, chartData),
       scales: getFunnelChartScales(definition, chartData),
       plugins: {
         title: getChartTitle(definition),

--- a/src/helpers/figures/charts/geo_chart.ts
+++ b/src/helpers/figures/charts/geo_chart.ts
@@ -201,7 +201,7 @@ export function createGeoChartRuntime(chart: GeoChart, getters: Getters): GeoCha
     },
     options: {
       ...CHART_COMMON_OPTIONS,
-      layout: getChartLayout(definition),
+      layout: getChartLayout(definition, chartData),
       scales: getGeoChartScales(definition, chartData),
       plugins: {
         title: getChartTitle(definition),

--- a/src/helpers/figures/charts/line_chart.ts
+++ b/src/helpers/figures/charts/line_chart.ts
@@ -245,7 +245,7 @@ export function createLineChartRuntime(chart: LineChart, getters: Getters): Char
     },
     options: {
       ...CHART_COMMON_OPTIONS,
-      layout: getChartLayout(definition),
+      layout: getChartLayout(definition, chartData),
       scales: getLineChartScales(definition, chartData),
       plugins: {
         title: getChartTitle(definition),

--- a/src/helpers/figures/charts/pie_chart.ts
+++ b/src/helpers/figures/charts/pie_chart.ts
@@ -216,7 +216,7 @@ export function createPieChartRuntime(chart: PieChart, getters: Getters): PieCha
         chart.isDoughnut && definition.pieHolePercentage !== undefined
           ? definition.pieHolePercentage + "%"
           : undefined,
-      layout: getChartLayout(definition),
+      layout: getChartLayout(definition, chartData),
       plugins: {
         title: getChartTitle(definition),
         legend: getPieChartLegend(definition, chartData),

--- a/src/helpers/figures/charts/pyramid_chart.ts
+++ b/src/helpers/figures/charts/pyramid_chart.ts
@@ -214,7 +214,7 @@ export function createPyramidChartRuntime(
     options: {
       ...CHART_COMMON_OPTIONS,
       indexAxis: "y",
-      layout: getChartLayout(definition),
+      layout: getChartLayout(definition, chartData),
       scales: getPyramidChartScales(definition, chartData),
       plugins: {
         title: getChartTitle(definition),

--- a/src/helpers/figures/charts/radar_chart.ts
+++ b/src/helpers/figures/charts/radar_chart.ts
@@ -232,7 +232,7 @@ export function createRadarChartRuntime(chart: RadarChart, getters: Getters): Ra
     },
     options: {
       ...CHART_COMMON_OPTIONS,
-      layout: getChartLayout(definition),
+      layout: getChartLayout(definition, chartData),
       scales: getRadarChartScales(definition, chartData),
       plugins: {
         title: getChartTitle(definition),

--- a/src/helpers/figures/charts/runtime/chart_data_extractor.ts
+++ b/src/helpers/figures/charts/runtime/chart_data_extractor.ts
@@ -91,6 +91,7 @@ export function getBarChartData(
     axisFormats,
     labels,
     locale: getters.getLocale(),
+    topPadding: getTopPaddingForDashboard(definition, getters),
   };
 }
 
@@ -175,6 +176,7 @@ export function getLineChartData(
     locale: getters.getLocale(),
     trendDataSetsValues,
     axisType,
+    topPadding: getTopPaddingForDashboard(definition, getters),
   };
 }
 
@@ -206,6 +208,7 @@ export function getPieChartData(
     axisFormats: { y: dataSetFormat },
     labels,
     locale: getters.getLocale(),
+    topPadding: getTopPaddingForDashboard(definition, getters),
   };
 }
 
@@ -978,4 +981,13 @@ export function makeDatasetsCumulative(
     }
     return { ...dataset, data };
   });
+}
+
+export function getTopPaddingForDashboard(
+  definition: GenericDefinition<PieChartDefinition | LineChartDefinition | BarChartDefinition>,
+  getters: Getters
+) {
+  const { title, legendPosition } = definition;
+  const hasTitleOrLegendTop = (title && title.text) || legendPosition === "top";
+  return getters.isDashboard() && !hasTitleOrLegendTop ? 30 : 0;
 }

--- a/src/helpers/figures/charts/runtime/chartjs_layout.ts
+++ b/src/helpers/figures/charts/runtime/chartjs_layout.ts
@@ -1,17 +1,22 @@
 import { ChartOptions } from "chart.js";
 import { CHART_PADDING, CHART_PADDING_BOTTOM, CHART_PADDING_TOP } from "../../../../constants";
-import { ChartWithDataSetDefinition, GenericDefinition } from "../../../../types/chart";
+import {
+  ChartRuntimeGenerationArgs,
+  ChartWithDataSetDefinition,
+  GenericDefinition,
+} from "../../../../types/chart";
 
 type ChartLayout = ChartOptions["layout"];
 
 export function getChartLayout(
-  definition: GenericDefinition<ChartWithDataSetDefinition>
+  definition: GenericDefinition<ChartWithDataSetDefinition>,
+  args: ChartRuntimeGenerationArgs
 ): ChartLayout {
   return {
     padding: {
       left: CHART_PADDING,
       right: CHART_PADDING,
-      top: CHART_PADDING_TOP,
+      top: Math.max(CHART_PADDING_TOP, args.topPadding || 0),
       bottom: CHART_PADDING_BOTTOM,
     },
   };

--- a/src/helpers/figures/charts/scatter_chart.ts
+++ b/src/helpers/figures/charts/scatter_chart.ts
@@ -240,7 +240,7 @@ export function createScatterChartRuntime(
     },
     options: {
       ...CHART_COMMON_OPTIONS,
-      layout: getChartLayout(definition),
+      layout: getChartLayout(definition, chartData),
       scales: getScatterChartScales(definition, chartData),
       plugins: {
         title: getChartTitle(definition),

--- a/src/helpers/figures/charts/sunburst_chart.ts
+++ b/src/helpers/figures/charts/sunburst_chart.ts
@@ -208,7 +208,7 @@ export function createSunburstChartRuntime(
     options: {
       cutout: chart.pieHolePercentage === undefined ? "25%" : `${chart.pieHolePercentage}%`,
       ...(CHART_COMMON_OPTIONS as ChartOptions<"doughnut">),
-      layout: getChartLayout(definition),
+      layout: getChartLayout(definition, chartData),
       plugins: {
         title: getChartTitle(definition),
         legend: getSunburstChartLegend(definition, chartData),

--- a/src/helpers/figures/charts/tree_map_chart.ts
+++ b/src/helpers/figures/charts/tree_map_chart.ts
@@ -222,7 +222,7 @@ export function createTreeMapChartRuntime(
     },
     options: {
       ...CHART_COMMON_OPTIONS,
-      layout: getChartLayout(definition),
+      layout: getChartLayout(definition, chartData),
       plugins: {
         title: getChartTitle(definition),
         legend: { display: false },

--- a/src/helpers/figures/charts/waterfall_chart.ts
+++ b/src/helpers/figures/charts/waterfall_chart.ts
@@ -236,7 +236,7 @@ export function createWaterfallChartRuntime(
     },
     options: {
       ...CHART_COMMON_OPTIONS,
-      layout: getChartLayout(definition),
+      layout: getChartLayout(definition, chartData),
       scales: getWaterfallChartScales(definition, chartData),
       plugins: {
         title: getChartTitle(definition),

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,6 +110,7 @@ import {
 import { supportedPivotPositionalFormulaRegistry } from "./helpers/pivot/pivot_positional_formula_registry";
 
 import { CellComposerStore } from "./components/composer/composer/cell_composer_store";
+import { ChartDashboardMenu } from "./components/figures/chart/chart_dashboard_menu/chart_dashboard_menu";
 import { chartJsExtensionRegistry } from "./components/figures/chart/chartJs/chart_js_extension";
 import { ComboChartDesignPanel } from "./components/side_panel/chart/combo_chart/combo_chart_design_panel";
 import { FunnelChartDesignPanel } from "./components/side_panel/chart/funnel_chart_panel/funnel_chart_design_panel";
@@ -414,6 +415,7 @@ export const components = {
   SidePanelCollapsible,
   RadioSelection,
   GeoChartRegionSelectSection,
+  ChartDashboardMenu,
 };
 
 export const hooks = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -163,7 +163,7 @@ import {
   chartRegistry,
   chartSubtypeRegistry,
 } from "./registries/chart_types";
-import { figureRegistry } from "./registries/figure_registry";
+import { figureRegistry } from "./registries/figures_registry";
 import { iconsOnCellRegistry } from "./registries/icons_on_cell_registry";
 import { inverseCommandRegistry } from "./registries/inverse_command_registry";
 import {

--- a/src/registries/figures_registry.ts
+++ b/src/registries/figures_registry.ts
@@ -1,0 +1,40 @@
+import { Action } from "../actions/action";
+import { getChartMenuActions, getImageMenuActions } from "../actions/figure_menu_actions";
+import { ChartFigure } from "../components/figures/figure_chart/figure_chart";
+import { ImageFigure } from "../components/figures/figure_image/figure_image";
+import { SpreadsheetChildEnv, UID } from "../types";
+import { Registry } from "./registry";
+
+//------------------------------------------------------------------------------
+// Figure Registry
+//------------------------------------------------------------------------------
+
+/**
+ * This registry is intended to map a type of figure (tag) to a class of
+ * component, that will be used in the UI to represent the figure.
+ *
+ * The most important type of figure will be the Chart
+ */
+
+export interface FigureContent {
+  Component: any;
+  menuBuilder: (figureId: UID, onFigureDeleted: () => void, env: SpreadsheetChildEnv) => Action[];
+  SidePanelComponent?: string;
+  keepRatio?: boolean;
+  minFigSize?: number;
+  borderWidth?: number;
+}
+
+export const figureRegistry = new Registry<FigureContent>();
+figureRegistry.add("chart", {
+  Component: ChartFigure,
+  SidePanelComponent: "ChartPanel",
+  menuBuilder: getChartMenuActions,
+});
+figureRegistry.add("image", {
+  Component: ImageFigure,
+  keepRatio: true,
+  minFigSize: 20,
+  borderWidth: 0,
+  menuBuilder: getImageMenuActions,
+});

--- a/src/types/chart/chart.ts
+++ b/src/types/chart/chart.ts
@@ -218,6 +218,7 @@ export interface ChartRuntimeGenerationArgs {
   locale: Locale;
   trendDataSetsValues?: (Point[] | undefined)[];
   axisType?: AxisType;
+  topPadding?: number;
 }
 
 /** Generic definition of chart to create a runtime: omit the chart type and the dataRange of the dataSets*/

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -197,6 +197,7 @@ export const readonlyAllowedCommands = new Set<CommandTypes>([
   "SET_FORMULA_VISIBILITY",
 
   "UPDATE_FILTER",
+  "UPDATE_CHART",
 ]);
 
 export const coreTypes = new Set<CoreCommandTypes>([

--- a/src/variables.scss
+++ b/src/variables.scss
@@ -1,1 +1,2 @@
 $os-text-body: #374151;
+$os-button-active-bg: #e6f2f3;

--- a/tests/figures/chart/chart_menu_dashboard_component.test.ts
+++ b/tests/figures/chart/chart_menu_dashboard_component.test.ts
@@ -1,0 +1,83 @@
+import { Model } from "../../../src";
+import { CHART_PADDING_TOP } from "../../../src/constants";
+import { LineChartDefinition } from "../../../src/types/chart";
+import { createChart, updateChart } from "../../test_helpers/commands_helpers";
+import { click, triggerMouseEvent } from "../../test_helpers/dom_helper";
+import { mockChart, mountSpreadsheet, nextTick } from "../../test_helpers/helpers";
+
+mockChart();
+
+let model: Model;
+const chartId = "someuuid";
+
+describe("chart menu for dashboard", () => {
+  beforeEach(async () => {
+    model = new Model();
+  });
+
+  test.each(["bar", "line", "pie"] as const)(
+    "%s charts have more top padding in dashboard mode if there is no title/legend",
+    (chartType) => {
+      createChart(model, { type: chartType, legendPosition: "none", title: { text: "" } }, chartId);
+      model.updateMode("dashboard");
+
+      let runtime = model.getters.getChartRuntime(chartId) as any;
+      expect(runtime.chartJsConfig.options?.layout?.padding?.top).toBe(30);
+
+      updateChart(model, chartId, { title: { text: "some title" } });
+      runtime = model.getters.getChartRuntime(chartId) as any;
+      expect(runtime.chartJsConfig.options?.layout?.padding?.top).toBe(CHART_PADDING_TOP);
+
+      updateChart(model, chartId, { legendPosition: "top", title: { text: "" } });
+      runtime = model.getters.getChartRuntime(chartId) as any;
+      expect(runtime.chartJsConfig.options?.layout?.padding?.top).toBe(CHART_PADDING_TOP);
+    }
+  );
+
+  test("Can change chart type in dashboard", async () => {
+    createChart(model, { type: "bar" }, chartId);
+    model.updateMode("dashboard");
+    const { fixture } = await mountSpreadsheet({ model });
+
+    await click(fixture, ".o-figure [data-id='line']");
+    expect(model.getters.getChart(chartId)?.type).toBe("line");
+  });
+
+  test("Can only change type of line/pie/bar charts", async () => {
+    createChart(model, { type: "radar" }, chartId);
+    model.updateMode("dashboard");
+    await mountSpreadsheet({ model });
+    expect(".o-chart-dashboard-item").toHaveCount(1);
+    expect(".o-chart-dashboard-item.fa-ellipsis-v").toHaveCount(1);
+  });
+
+  test("Original chart configuration is kept when switching back and forth", async () => {
+    createChart(model, { type: "line", stacked: true, fillArea: true }, chartId);
+    model.updateMode("dashboard");
+    const { fixture } = await mountSpreadsheet({ model });
+
+    await click(fixture, ".o-figure [data-id='pie']");
+    await click(fixture, ".o-figure [data-id='line']");
+    const chartDefinition = model.getters.getChartDefinition(chartId) as LineChartDefinition;
+    expect(chartDefinition.type).toBe("line");
+    expect(chartDefinition.stacked).toBe(true);
+    expect(chartDefinition.fillArea).toBe(true);
+  });
+
+  test("Can open menu to copy/download chart in dashboard mode", async () => {
+    createChart(model, { type: "bar" }, chartId);
+    model.updateMode("dashboard");
+    const { fixture } = await mountSpreadsheet({ model });
+
+    triggerMouseEvent(".o-figure", "contextmenu");
+    await nextTick();
+    expect(".o-menu-item").toHaveCount(0);
+
+    await click(fixture, ".o-figure .fa-ellipsis-v");
+    const menuItems = [...document.querySelectorAll<HTMLElement>(".o-menu-item")].map(
+      (item) => item.dataset.name
+    );
+
+    expect(menuItems).toEqual(["copy_as_image", "download"]);
+  });
+});

--- a/tests/figures/figure_component.test.ts
+++ b/tests/figures/figure_component.test.ts
@@ -65,6 +65,7 @@ let model: Model;
 let parent: Spreadsheet;
 let sheetId: UID;
 let env: SpreadsheetChildEnv;
+let notifyUser: jest.Mock;
 
 function createFigure(
   model: Model,
@@ -139,7 +140,8 @@ beforeEach(() => {
 
 describe("figures", () => {
   beforeEach(async () => {
-    ({ model, parent, fixture, env } = await mountSpreadsheet());
+    notifyUser = jest.fn();
+    ({ model, parent, fixture, env } = await mountSpreadsheet(undefined, { notifyUser }));
     mockSpreadsheetRect = { top: 100, left: 200, height: 1000, width: 1000 };
     mockFigureMenuItemRect = { top: 500, left: 500 };
     sheetId = model.getters.getActiveSheetId();
@@ -697,6 +699,15 @@ describe("figures", () => {
         const figureIds = getFigureIds(model, sheetId);
         expect(getFigureDefinition(model, figureIds[0], type)).toEqual(figureDef);
         expect(getFigureDefinition(model, figureIds[1], type)).toEqual(figureDef);
+        if (type === "image") {
+          expect(notifyUser).toHaveBeenCalledWith({
+            text: "Image copied to clipboard",
+            type: "success",
+            sticky: false,
+          });
+        } else {
+          expect(notifyUser).not.toHaveBeenCalled();
+        }
       });
 
       test(`Can cut/paste a figure ${type} with its context menu`, async () => {

--- a/tests/figures/figure_component.test.ts
+++ b/tests/figures/figure_component.test.ts
@@ -12,7 +12,7 @@ import { Figure, Pixel, Position, SpreadsheetChildEnv, UID } from "../../src/typ
 
 import { FigureComponent } from "../../src/components/figures/figure/figure";
 import { downloadFile } from "../../src/components/helpers/dom_helpers";
-import { figureRegistry } from "../../src/registries/figure_registry";
+import { figureRegistry } from "../../src/registries/figures_registry";
 import { ClipboardMIMEType } from "../../src/types/clipboard";
 import {
   activateSheet,


### PR DESCRIPTION
### [IMP] dashboard: make menu to change chart type

This commit adds items that appear on hover of a chart in dashboard
to change the chart type.

It also allows to download the chart as an image in dashboard.


### [IMP] figure: add notification when copying figure to clipboard

This commit adds a notification when the user put a chart/figure
to the clipboard, so he knows that the button did something.


### [MOV] figure: move figure menu items in another file

This commit moves the figure menu items to a new file to avoid
circular dependencies in the next commit.

Task: [4497382](https://www.odoo.com/odoo/2328/tasks/4497382)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo