### PR TITLE
[FIX] figure: anchor move when resizing with keepSize

### DIFF
--- a/src/components/helpers/figure_drag_helper.ts
+++ b/src/components/helpers/figure_drag_helper.ts
@@ -40,14 +40,14 @@ export function dragFigureForResize(
       height - minFigSize
     );
     const fraction = Math.min(deltaX / width, deltaY / height);
-    width = width * (1 - fraction);
-    height = height * (1 - fraction);
     if (dirX < 0) {
       x = x + width * fraction;
     }
     if (dirY < 0) {
       y = y + height * fraction;
     }
+    width = width * (1 - fraction);
+    height = height * (1 - fraction);
   } else {
     const deltaX = Math.max(
       dirX * (mouseX - mouseInitialX + scrollX - initialScrollX),

--- a/tests/figures/figure_component.test.ts
+++ b/tests/figures/figure_component.test.ts
@@ -321,6 +321,82 @@ describe("figures", () => {
   });
 
   test.each([
+    ["top", { mouseOffsetX: 0, mouseOffsetY: -50 }, { width: 100, height: 150 }],
+    ["topRight", { mouseOffsetX: 50, mouseOffsetY: -50 }, { width: 150, height: 150 }],
+    ["topRight", { mouseOffsetX: 50, mouseOffsetY: 0 }, { width: 150, height: 150 }],
+    ["topRight", { mouseOffsetX: 0, mouseOffsetY: -50 }, { width: 150, height: 150 }],
+    ["right", { mouseOffsetX: 50, mouseOffsetY: 0 }, { width: 150, height: 100 }],
+    ["bottomRight", { mouseOffsetX: 50, mouseOffsetY: 50 }, { width: 150, height: 150 }],
+    ["bottomRight", { mouseOffsetX: 0, mouseOffsetY: 50 }, { width: 150, height: 150 }],
+    ["bottomRight", { mouseOffsetX: 50, mouseOffsetY: 0 }, { width: 150, height: 150 }],
+    ["bottom", { mouseOffsetX: 0, mouseOffsetY: 50 }, { width: 100, height: 150 }],
+    ["bottomLeft", { mouseOffsetX: -50, mouseOffsetY: 50 }, { width: 150, height: 150 }],
+    ["bottomLeft", { mouseOffsetX: 0, mouseOffsetY: 50 }, { width: 150, height: 150 }],
+    ["bottomLeft", { mouseOffsetX: -50, mouseOffsetY: 0 }, { width: 150, height: 150 }],
+    ["left", { mouseOffsetX: -50, mouseOffsetY: 0 }, { width: 150, height: 100 }],
+    ["topLeft", { mouseOffsetX: -50, mouseOffsetY: -50 }, { width: 150, height: 150 }],
+    ["topLeft", { mouseOffsetX: 0, mouseOffsetY: -50 }, { width: 150, height: 150 }],
+    ["topLeft", { mouseOffsetX: -50, mouseOffsetY: 0 }, { width: 150, height: 150 }],
+  ])(
+    "Can resize a figure through its anchors with keepSize",
+    async (anchor: string, mouseMove, expectedSize) => {
+      const figureId = "someuuid";
+      createImage(model, {
+        figureId,
+        col: 5,
+        row: 5,
+        offset: { x: 10, y: 10 },
+        size: {
+          width: 100,
+          height: 100,
+        },
+      });
+      model.dispatch("SELECT_FIGURE", { figureId });
+      await nextTick();
+      await dragAnchor(anchor, mouseMove.mouseOffsetX, mouseMove.mouseOffsetY, true);
+      expect(model.getters.getFigure(sheetId, figureId)).toMatchObject(expectedSize);
+    }
+  );
+
+  test.each([
+    ["top", { mouseOffsetX: 0, mouseOffsetY: -5 }, { offset: { x: 10, y: 5 } }],
+    ["topRight", { mouseOffsetX: 5, mouseOffsetY: -5 }, { offset: { x: 10, y: 5 } }],
+    ["topRight", { mouseOffsetX: 5, mouseOffsetY: 0 }, { offset: { x: 10, y: 5 } }],
+    ["topRight", { mouseOffsetX: 0, mouseOffsetY: -5 }, { offset: { x: 10, y: 5 } }],
+    ["right", { mouseOffsetX: 5, mouseOffsetY: 0 }, { offset: { x: 10, y: 10 } }],
+    ["bottomRight", { mouseOffsetX: 5, mouseOffsetY: 5 }, { offset: { x: 10, y: 10 } }],
+    ["bottomRight", { mouseOffsetX: 0, mouseOffsetY: 5 }, { offset: { x: 10, y: 10 } }],
+    ["bottomRight", { mouseOffsetX: 5, mouseOffsetY: 0 }, { offset: { x: 10, y: 10 } }],
+    ["bottom", { mouseOffsetX: 0, mouseOffsetY: 5 }, { offset: { x: 10, y: 10 } }],
+    ["bottomLeft", { mouseOffsetX: -5, mouseOffsetY: 5 }, { offset: { x: 5, y: 10 } }],
+    ["bottomLeft", { mouseOffsetX: 0, mouseOffsetY: 5 }, { offset: { x: 5, y: 10 } }],
+    ["bottomLeft", { mouseOffsetX: -5, mouseOffsetY: 0 }, { offset: { x: 5, y: 10 } }],
+    ["left", { mouseOffsetX: -5, mouseOffsetY: 0 }, { offset: { x: 5, y: 10 } }],
+    ["topLeft", { mouseOffsetX: -5, mouseOffsetY: -5 }, { offset: { x: 5, y: 5 } }],
+    ["topLeft", { mouseOffsetX: 0, mouseOffsetY: -5 }, { offset: { x: 5, y: 5 } }],
+    ["topLeft", { mouseOffsetX: -5, mouseOffsetY: 0 }, { offset: { x: 5, y: 5 } }],
+  ])(
+    "Resize a figure through its anchors with keepSize correctly adapt anchor",
+    async (anchor: string, mouseMove, expectedSize) => {
+      const figureId = "someuuid";
+      createImage(model, {
+        figureId,
+        col: 5,
+        row: 5,
+        offset: { x: 10, y: 10 },
+        size: {
+          width: 20,
+          height: 20,
+        },
+      });
+      model.dispatch("SELECT_FIGURE", { figureId });
+      await nextTick();
+      await dragAnchor(anchor, mouseMove.mouseOffsetX, mouseMove.mouseOffsetY, true);
+      expect(model.getters.getFigure(sheetId, figureId)).toMatchObject(expectedSize);
+    }
+  );
+
+  test.each([
     ["top", { mouseOffsetX: 0, mouseOffsetY: -100 }],
     ["left", { mouseOffsetX: -100, mouseOffsetY: 0 }],
     ["topLeft", { mouseOffsetX: -100, mouseOffsetY: -100 }],


### PR DESCRIPTION
When resizing image with keepSize active, anchor is moved when it shouldn't.

Task: 4755818

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [4755818](https://www.odoo.com/odoo/2328/tasks/4755818)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo