### PR TITLE
[FIX] chart: avoid useless chart update

### DIFF
--- a/src/components/figures/chart/chartJs/chartjs.ts
+++ b/src/components/figures/chart/chartJs/chartjs.ts
@@ -19,6 +19,8 @@ export class ChartJsComponent extends Component<Props, SpreadsheetChildEnv> {
   private chart?: Chart;
   private currentRuntime!: ChartJSRuntime;
 
+  private currentDevicePixelRatio = window.devicePixelRatio;
+
   get background(): string {
     return this.chartRuntime.background;
   }
@@ -53,15 +55,11 @@ export class ChartJsComponent extends Component<Props, SpreadsheetChildEnv> {
           this.updateChartJs(deepCopy(runtime));
         }
         this.currentRuntime = runtime;
+      } else if (this.currentDevicePixelRatio !== window.devicePixelRatio) {
+        this.currentDevicePixelRatio = window.devicePixelRatio;
+        this.updateChartJs(deepCopy(this.currentRuntime));
       }
     });
-    useEffect(
-      () => {
-        this.currentRuntime = this.chartRuntime;
-        this.updateChartJs(deepCopy(this.currentRuntime));
-      },
-      () => [window.devicePixelRatio]
-    );
   }
 
   private createChart(chartData: ChartConfiguration) {

--- a/tests/figures/chart/charts_component.test.ts
+++ b/tests/figures/chart/charts_component.test.ts
@@ -1,4 +1,4 @@
-import { CommandResult, Model } from "../../../src";
+import { CommandResult, Model, Spreadsheet } from "../../../src";
 import { ChartPanel } from "../../../src/components/side_panel/chart/main_chart_panel/main_chart_panel";
 import { ChartTerms } from "../../../src/components/translations_terms";
 import { BACKGROUND_CHART_COLOR } from "../../../src/constants";
@@ -98,7 +98,7 @@ async function mountChartSidePanel(figureId = chartId) {
 }
 
 async function mountSpreadsheet() {
-  ({ env, model, fixture } = await mountSpreadsheetHelper({ model }));
+  ({ env, model, fixture, parent } = await mountSpreadsheetHelper({ model }));
 }
 
 let fixture: HTMLElement;
@@ -106,6 +106,7 @@ let model: Model;
 let mockChartData = mockChart();
 const chartId = "someuuid";
 let sheetId: string;
+let parent: Spreadsheet;
 
 let env: SpreadsheetChildEnv;
 
@@ -1658,6 +1659,18 @@ describe("charts", () => {
     createTestChart("basicChart");
     await nextTick();
     setCellFormat(model, "B2", "#.##0.00");
+    await nextTick();
+    expect(updateChart).toHaveBeenCalled();
+  });
+
+  test("Chart is re-rendered once if window.devicePixelRatio changes", async () => {
+    await mountSpreadsheet();
+    const updateChart = jest.spyOn((window as any).Chart.prototype, "update");
+    createTestChart("basicChart");
+    await nextTick();
+    expect(updateChart).not.toHaveBeenCalled();
+    window.devicePixelRatio = 2;
+    parent.render(true);
     await nextTick();
     expect(updateChart).toHaveBeenCalled();
   });


### PR DESCRIPTION
Commit f8e4e3f89 made chart render when the devicePixelRatio is changed. But it also caused a chart update at the first `useEfect`, when the component is mounted.

This was a problem because:
1) performance-wise, rendering a chart isn't free
2) it breaks some of our patches in odoo

Task: 0

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo