### PR TITLE
[FIX] pivot: cannot use pivot formula inside its range

### DIFF
--- a/tests/pivots/spreadsheet_pivot/spreadsheet_pivot.test.ts
+++ b/tests/pivots/spreadsheet_pivot/spreadsheet_pivot.test.ts
@@ -1631,6 +1631,16 @@ describe("Spreadsheet Pivot", () => {
     });
   });
 
+  test("Cannot use PIVOT function inside its range", () => {
+    const model = createModelWithPivot("A1:I5");
+    setCellContent(model, "B3", `=PIVOT("1")`);
+    expect(getCellContent(model, "B3")).toBe("#CYCLE");
+    setCellContent(model, "B3", `=PIVOT.VALUE("1", "__count:sum")`);
+    expect(getCellContent(model, "B3")).toBe("#CYCLE");
+    setCellContent(model, "B3", `=PIVOT.HEADER("1")`);
+    expect(getCellContent(model, "B3")).toBe("#CYCLE");
+  });
+
   test("Date dimensions should support empty cells", () => {
     const grid = {
       A1: "Date",


### PR DESCRIPTION
Before this commit, a pivot formula was allowed to be used inside its range. This is now disallowed.

Task: 3986479

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo