### PR TITLE
[IMP] filter: fix horrible performances with huge data filters

### DIFF
--- a/src/components/filters/filter_menu_value_list/filter_menu_value_list.xml
+++ b/src/components/filters/filter_menu_value_list/filter_menu_value_list.xml
@@ -9,7 +9,7 @@
         class="w-100 o-input my-2"
         t-ref="filterMenuSearchBar"
         type="text"
-        t-model="state.textFilter"
+        t-on-input="updateSearch"
         placeholder="Search..."
         t-on-keydown="onKeyDown"
       />
@@ -22,7 +22,7 @@
       t-ref="filterValueList"
       t-on-click="this.clearScrolledToValue"
       t-on-scroll="this.clearScrolledToValue">
-      <t t-foreach="displayedValues" t-as="value" t-key="value.string">
+      <t t-foreach="state.displayedValues" t-as="value" t-key="value.string">
         <FilterMenuValueItem
           onClick="() => this.checkValue(value)"
           onMouseMove="() => this.onMouseMove(value)"
@@ -33,7 +33,13 @@
         />
       </t>
       <div
-        t-if="displayedValues.length === 0"
+        t-if="state.hasMoreValues"
+        class="o-filter-load-more o-button-link d-flex justify-content-center py-1"
+        t-on-click="this.loadMoreValues">
+        Load more...
+      </div>
+      <div
+        t-if="state.displayedValues.length === 0"
         class="o-filter-menu-no-values d-flex align-items-center justify-content-center w-100 h-100 ">
         No results
       </div>

--- a/src/plugins/ui_stateful/filter_evaluation.ts
+++ b/src/plugins/ui_stateful/filter_evaluation.ts
@@ -181,9 +181,10 @@ export class FilterEvaluationPlugin extends UIPlugin {
       if (filterValue.filterType === "values") {
         const filteredValues = filterValue.hiddenValues?.map(toLowerCase);
         if (!filteredValues) continue;
+        const filteredValuesSet = new Set(filteredValues);
         for (let row = filteredZone.top; row <= filteredZone.bottom; row++) {
           const value = this.getCellValueAsString(sheetId, filter.col, row);
-          if (filteredValues.includes(value)) {
+          if (filteredValuesSet.has(value)) {
             hiddenRows.add(row);
           }
         }

--- a/tests/table/__snapshots__/filter_menu_component.test.ts.snap
+++ b/tests/table/__snapshots__/filter_menu_component.test.ts.snap
@@ -210,6 +210,7 @@ exports[`Filter menu component Filter Tests Filter menu is correctly rendered 1`
             
             
             
+            
           </div>
         </div>
       </div>

--- a/tests/table/filter_menu_component.test.ts
+++ b/tests/table/filter_menu_component.test.ts
@@ -393,6 +393,46 @@ describe("Filter menu component", () => {
     ).not.toContain("Sort ascending (A ⟶ Z)");
   });
 
+  test("Only the first few values are displayed by default", async () => {
+    for (let i = 1; i < 61; i++) {
+      setCellContent(model, `A${i}`, `${i}`);
+    }
+    createTableWithFilter(model, "A1:A61");
+    await nextTick();
+    await openFilterMenu();
+
+    expect(fixture.querySelectorAll(".o-filter-menu-value")).toHaveLength(50);
+
+    await simulateClick(".o-filter-load-more");
+    expect(fixture.querySelectorAll(".o-filter-menu-value")).toHaveLength(60);
+  });
+
+  test("Search/Clear/Select all all works when some values are not displayed", async () => {
+    for (let i = 1; i < 61; i++) {
+      setCellContent(model, `A${i}`, `${i}`);
+    }
+    createTableWithFilter(model, "A1:A61");
+    await nextTick();
+    await openFilterMenu();
+    expect(fixture.querySelectorAll(".o-filter-menu-value")).toHaveLength(50); // Only 50 values are displayed
+
+    await simulateClick(".o-filter-menu-actions .o-button-link:nth-of-type(2)");
+    expect(getFilterMenuValues().every((val) => !val.isChecked)).toBe(true);
+    await simulateClick(".o-filter-menu-confirm");
+    expect(model.getters.getFilterHiddenValues({ sheetId, col: 0, row: 0 })).toHaveLength(60);
+
+    await openFilterMenu();
+    expect(getFilterMenuValues().every((val) => !val.isChecked)).toBe(true);
+    await simulateClick(".o-filter-menu-actions .o-button-link:nth-of-type(1)");
+    expect(getFilterMenuValues().every((val) => val.isChecked)).toBe(true);
+    await simulateClick(".o-filter-menu-confirm");
+    expect(model.getters.getFilterHiddenValues({ sheetId, col: 0, row: 0 })).toHaveLength(0);
+
+    await openFilterMenu();
+    await setInputValueAndTrigger(".o-filter-menu input", "59");
+    expect(getFilterMenuValues().map((val) => val.value)).toEqual(["59"]);
+  });
+
   describe("Filter criterion tests", () => {
     beforeEach(async () => {
       createTableWithFilter(model, "A1:A5");


### PR DESCRIPTION
On a spreadsheet with 10,000 rows, opening the filter menu and filtering all the values is really slow.

This commit improves the performance of the existing functions, and adds a `load more` button in the filter menu to avoid creating 10000 owl components and DOM elements.

On a data filter with 10,000 rows:
- `getFilterHiddenValues` (when opening filter menu): ~1000ms => ~70ms
- `updateHiddenRows` (when filtering all values): ~543ms => ~8ms

Task: [4658998](https://www.odoo.com/odoo/2328/tasks/4658998)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo