### PR TITLE
[REV] pivot: re-introduce pivot missing cell insertion

### DIFF
--- a/src/components/pivot_html_renderer/pivot_html_renderer.ts
+++ b/src/components/pivot_html_renderer/pivot_html_renderer.ts
@@ -1,0 +1,375 @@
+import { Component, useState } from "@odoo/owl";
+import {
+  FunctionResultObject,
+  Maybe,
+  SpreadsheetChildEnv,
+  SpreadsheetPivotTable,
+  UID,
+} from "../..";
+import { toString } from "../../functions/helpers";
+import { formatValue } from "../../helpers";
+import { generatePivotArgs } from "../../helpers/pivot/pivot_helpers";
+import { css } from "../helpers";
+import { Checkbox } from "../side_panel/components/checkbox/checkbox";
+
+interface PivotDialogColumn {
+  formula: string;
+  value: string;
+  isMissing: boolean;
+  style?: string;
+  span: number;
+}
+
+interface PivotDialogRow {
+  formula: string;
+  value: string;
+  isMissing: boolean;
+  style?: string;
+}
+
+interface PivotDialogValue {
+  formula: string;
+  value: string;
+  isMissing: boolean;
+}
+
+interface Props {
+  pivotId: UID;
+  onCellClicked: (formula: string) => void;
+}
+
+interface State {
+  showMissingValuesOnly: boolean;
+}
+
+css/* scss */ `
+  .o_pivot_html_renderer {
+    width: 100%;
+    border-collapse: collapse;
+
+    &:hover {
+      cursor: pointer;
+    }
+
+    td,
+    th {
+      border: 1px solid #dee2e6;
+      background-color: #fff;
+      padding: 0.3rem;
+      white-space: nowrap;
+
+      &:hover {
+        filter: brightness(0.9);
+      }
+    }
+
+    td {
+      text-align: right;
+    }
+
+    th {
+      background-color: #f5f5f5;
+      font-weight: bold;
+      color: black;
+    }
+
+    .o_missing_value {
+      color: #46646d;
+      background: #e7f2f6;
+    }
+  }
+`;
+
+interface TableData {
+  columns: PivotDialogColumn[][];
+  rows: PivotDialogRow[];
+  values: PivotDialogValue[][];
+}
+
+export class PivotHTMLRenderer extends Component<Props, SpreadsheetChildEnv> {
+  static template = "o_spreadsheet.PivotHTMLRenderer";
+  static components = { Checkbox };
+  static props = {
+    pivotId: String,
+    onCellClicked: Function,
+  };
+
+  private pivot = this.env.model.getters.getPivot(this.props.pivotId);
+  data: TableData = {
+    columns: [],
+    rows: [],
+    values: [],
+  };
+  private state: State = useState({
+    showMissingValuesOnly: false,
+  });
+
+  setup() {
+    const table = this.pivot.getTableStructure();
+    const formulaId = this.env.model.getters.getPivotFormulaId(this.props.pivotId);
+    this.data = {
+      columns: this._buildColHeaders(formulaId, table),
+      rows: this._buildRowHeaders(formulaId, table),
+      values: this._buildValues(formulaId, table),
+    };
+  }
+
+  get tracker() {
+    return this.env.model.getters.getPivotPresenceTracker(this.props.pivotId);
+  }
+
+  // ---------------------------------------------------------------------
+  // Missing values building
+  // ---------------------------------------------------------------------
+
+  /**
+   * Retrieve the data to display in the Pivot Table
+   * In the case when showMissingValuesOnly is false, the returned value
+   * is the complete data
+   * In the case when showMissingValuesOnly is true, the returned value is
+   * the data which contains only missing values in the rows and cols. In
+   * the rows, we also return the parent rows of rows which contains missing
+   * values, to give context to the user.
+   *
+   */
+  getTableData(): TableData {
+    if (!this.state.showMissingValuesOnly) {
+      return this.data;
+    }
+    const colIndexes = this.getColumnsIndexes();
+    const rowIndexes = this.getRowsIndexes();
+    const columns = this.buildColumnsMissing(colIndexes);
+    const rows = this.buildRowsMissing(rowIndexes);
+    const values = this.buildValuesMissing(colIndexes, rowIndexes);
+    return { columns, rows, values };
+  }
+
+  /**
+   * Retrieve the parents of the given row
+   * ex:
+   *  Australia
+   *    January
+   *    February
+   * The parent of "January" is "Australia"
+   */
+  private addRecursiveRow(index: number): number[] {
+    const rows = this.pivot.getTableStructure().rows;
+    const row = [...rows[index].values];
+    if (row.length <= 1) {
+      return [index];
+    }
+    row.pop();
+    const parentRowIndex = rows.findIndex((r) => JSON.stringify(r.values) === JSON.stringify(row));
+    return [index].concat(this.addRecursiveRow(parentRowIndex));
+  }
+  /**
+   * Create the columns to be used, based on the indexes of the columns in
+   * which a missing value is present
+   *
+   */
+  private buildColumnsMissing(indexes: number[]): PivotDialogColumn[][] {
+    // columnsMap explode the columns in an array of array of the same
+    // size with the index of each column, repeated 'span' times.
+    // ex:
+    //  | A     | B |
+    //  | 1 | 2 | 3 |
+    // => [
+    //      [0, 0, 1]
+    //      [0, 1, 2]
+    //    ]
+    const columnsMap: number[][] = [];
+    for (const column of this.data.columns) {
+      const columnMap: number[] = [];
+      for (const index in column) {
+        for (let i = 0; i < column[index].span; i++) {
+          columnMap.push(parseInt(index, 10));
+        }
+      }
+      columnsMap.push(columnMap);
+    }
+    // Remove the columns that are not present in indexes
+    for (let i = columnsMap[columnsMap.length - 1].length; i >= 0; i--) {
+      if (!indexes.includes(i)) {
+        for (const columnMap of columnsMap) {
+          columnMap.splice(i, 1);
+        }
+      }
+    }
+    // Build the columns
+    const columns: PivotDialogColumn[][] = [];
+    for (const mapIndex in columnsMap) {
+      const column: PivotDialogColumn[] = [];
+      let index: number | undefined = undefined;
+      let span = 1;
+      for (let i = 0; i < columnsMap[mapIndex].length; i++) {
+        if (index !== columnsMap[mapIndex][i]) {
+          if (index !== undefined) {
+            column.push(Object.assign({}, this.data.columns[mapIndex][index], { span }));
+          }
+          index = columnsMap[mapIndex][i];
+          span = 1;
+        } else {
+          span++;
+        }
+      }
+      if (index !== undefined) {
+        column.push(Object.assign({}, this.data.columns[mapIndex][index], { span }));
+      }
+      columns.push(column);
+    }
+    return columns;
+  }
+  /**
+   * Create the rows to be used, based on the indexes of the rows in
+   * which a missing value is present.
+   */
+  private buildRowsMissing(indexes: number[]): PivotDialogRow[] {
+    return indexes.map((index) => this.data.rows[index]);
+  }
+  /**
+   * Create the value to be used, based on the indexes of the columns and
+   * rows in which a missing value is present.
+   */
+  private buildValuesMissing(colIndexes: number[], rowIndexes: number[]): PivotDialogValue[][] {
+    const values: PivotDialogValue[][] = colIndexes.map(() => []);
+    for (const row of rowIndexes) {
+      for (const col in colIndexes) {
+        values[col].push(this.data.values[colIndexes[col]][row]);
+      }
+    }
+    return values;
+  }
+  private getColumnsIndexes(): number[] {
+    const indexes: Set<number> = new Set();
+    for (let i = 0; i < this.data.columns.length; i++) {
+      const exploded: PivotDialogColumn[] = [];
+      for (let y = 0; y < this.data.columns[i].length; y++) {
+        for (let x = 0; x < this.data.columns[i][y].span; x++) {
+          exploded.push(this.data.columns[i][y]);
+        }
+      }
+      for (let y = 0; y < exploded.length; y++) {
+        if (exploded[y].isMissing) {
+          indexes.add(y);
+        }
+      }
+    }
+    for (let i = 0; i < this.data.columns[this.data.columns.length - 1].length; i++) {
+      const values = this.data.values[i];
+      if (values.find((x) => x.isMissing)) {
+        indexes.add(i);
+      }
+    }
+    return Array.from(indexes).sort((a, b) => a - b);
+  }
+  private getRowsIndexes(): number[] {
+    const rowIndexes: Set<number> = new Set();
+    for (let i = 0; i < this.data.rows.length; i++) {
+      if (this.data.rows[i].isMissing) {
+        rowIndexes.add(i);
+      }
+      for (const col of this.data.values) {
+        if (col[i].isMissing) {
+          this.addRecursiveRow(i).forEach((x) => rowIndexes.add(x));
+        }
+      }
+    }
+    return Array.from(rowIndexes).sort((a, b) => a - b);
+  }
+
+  // ---------------------------------------------------------------------
+  // Data table creation
+  // ---------------------------------------------------------------------
+
+  _buildColHeaders(id: UID, table: SpreadsheetPivotTable): PivotDialogColumn[][] {
+    const headers: PivotDialogColumn[][] = [];
+    for (const row of table.columns) {
+      const current: PivotDialogColumn[] = [];
+      for (const cell of row) {
+        const args: Maybe<FunctionResultObject>[] = [];
+        for (let i = 0; i < cell.fields.length; i++) {
+          args.push({ value: cell.fields[i] }, { value: cell.values[i] });
+        }
+        const domain = this.pivot.parseArgsToPivotDomain(args);
+        const locale = this.env.model.getters.getLocale();
+        if (domain.at(-1)?.field === "measure") {
+          const { value, format } = this.pivot.getPivotMeasureValue(
+            toString(domain.at(-1)!.value),
+            domain
+          );
+          current.push({
+            formula: `=PIVOT.HEADER(${generatePivotArgs(id, domain).join(",")})`,
+            value: formatValue(value, { format, locale }),
+            span: cell.width,
+            isMissing: !this.tracker?.isHeaderPresent(domain),
+          });
+        } else {
+          const { value, format } = this.pivot.getPivotHeaderValueAndFormat(domain);
+          current.push({
+            formula: `=PIVOT.HEADER(${generatePivotArgs(id, domain).join(",")})`,
+            value: formatValue(value, { format, locale }),
+            span: cell.width,
+            isMissing: !this.tracker?.isHeaderPresent(domain),
+          });
+        }
+      }
+      headers.push(current);
+    }
+    const last = headers[headers.length - 1];
+    headers[headers.length - 1] = last.map((cell) => {
+      if (!cell.isMissing) {
+        cell.style = "color: #756f6f;";
+      }
+      return cell;
+    });
+    return headers;
+  }
+  _buildRowHeaders(id: UID, table: SpreadsheetPivotTable): PivotDialogRow[] {
+    const headers: PivotDialogRow[] = [];
+    for (const row of table.rows) {
+      const args: Maybe<FunctionResultObject>[] = [];
+      for (let i = 0; i < row.fields.length; i++) {
+        args.push({ value: row.fields[i] }, { value: row.values[i] });
+      }
+      const domain = this.pivot.parseArgsToPivotDomain(args);
+      const { value, format } = this.pivot.getPivotHeaderValueAndFormat(domain);
+      const locale = this.env.model.getters.getLocale();
+      const cell: PivotDialogRow = {
+        formula: `=PIVOT.HEADER(${generatePivotArgs(id, domain).join(",")})`,
+        value: formatValue(value, { format, locale }),
+        isMissing: !this.tracker?.isHeaderPresent(domain),
+      };
+      if (row.indent > 1) {
+        cell.style = `padding-left: ${row.indent - 1 * 10}px`;
+      }
+      headers.push(cell);
+    }
+    return headers;
+  }
+  _buildValues(id: UID, table: SpreadsheetPivotTable): PivotDialogValue[][] {
+    const values: PivotDialogValue[][] = [];
+    for (const col of table.columns.at(-1) || []) {
+      const current: PivotDialogValue[] = [];
+      const measure = toString(col.values[col.values.length - 1]);
+      for (const row of table.rows) {
+        const args: Maybe<FunctionResultObject>[] = [];
+        for (let i = 0; i < row.fields.length; i++) {
+          args.push({ value: row.fields[i] }, { value: row.values[i] });
+        }
+        for (let i = 0; i < col.fields.length - 1; i++) {
+          args.push({ value: col.fields[i] }, { value: col.values[i] });
+        }
+        const domain = this.pivot.parseArgsToPivotDomain(args);
+        const { value, format } = this.pivot.getPivotCellValueAndFormat(measure, domain);
+        const locale = this.env.model.getters.getLocale();
+        current.push({
+          formula: `=PIVOT.VALUE(${generatePivotArgs(id, domain, measure).join(",")})`,
+          value: formatValue(value, { format, locale }),
+          isMissing: !this.tracker?.isValuePresent(measure, domain),
+        });
+      }
+      values.push(current);
+    }
+    return values;
+  }
+}

--- a/src/components/pivot_html_renderer/pivot_html_renderer.xml
+++ b/src/components/pivot_html_renderer/pivot_html_renderer.xml
@@ -1,0 +1,50 @@
+<templates>
+  <t t-name="o_spreadsheet.PivotHTMLRenderer">
+    <div class="o_pivot_html_renderer">
+      <Checkbox
+        name="'missing_values'"
+        label.translate="Display missing cells only"
+        value="state.showMissingValuesOnly"
+        onChange.bind="(value) => this.state.showMissingValuesOnly = value"
+        className="'m-2'"
+      />
+      <t t-set="tableData" t-value="getTableData()"/>
+      <table
+        class="o_pivot_html_renderer"
+        t-if="tableData.values.length > 0 or tableData.rows.length > 0">
+        <tr t-foreach="tableData.columns" t-as="row" t-key="row_index">
+          <t t-if="row_index === 0">
+            <th t-att-rowspan="tableData.columns.length"/>
+          </t>
+          <t t-foreach="row" t-as="cell" t-key="cell_index">
+            <th
+              t-att-colspan="cell.span"
+              t-att-style="cell.style"
+              t-att-class="{ o_missing_value: cell.isMissing }"
+              t-on-click="() => props.onCellClicked(cell.formula)">
+              <t t-esc="cell.value"/>
+            </th>
+          </t>
+        </tr>
+        <t t-foreach="tableData.rows" t-as="row" t-key="row_index">
+          <tr>
+            <th
+              t-att-style="row.style"
+              t-att-class="{ o_missing_value: row.isMissing }"
+              t-on-click="() => props.onCellClicked(row.formula)">
+              <t t-esc="row.value"/>
+            </th>
+            <t t-foreach="tableData.values" t-as="col" t-key="col_index">
+              <td
+                t-att-class="{ o_missing_value: col[row_index].isMissing }"
+                t-on-click="() => props.onCellClicked(col[row_index].formula)">
+                <t t-esc="col[row_index].value"/>
+              </td>
+            </t>
+          </tr>
+        </t>
+      </table>
+      <div class="alert alert-info" t-else="1">This pivot has no cell missing on this sheet</div>
+    </div>
+  </t>
+</templates>

--- a/src/functions/module_lookup.ts
+++ b/src/functions/module_lookup.ts
@@ -778,6 +778,9 @@ export const PIVOT_VALUE = {
       };
     }
     const domain = pivot.parseArgsToPivotDomain(domainArgs);
+    if (this.getters.getActiveSheetId() === this.__originSheetId) {
+      this.getters.getPivotPresenceTracker(pivotId)?.trackValue(_measure, domain);
+    }
     return pivot.getPivotCellValueAndFormat(_measure, domain);
   },
 } satisfies AddFunctionDescription;
@@ -817,6 +820,9 @@ export const PIVOT_HEADER = {
       };
     }
     const domain = pivot.parseArgsToPivotDomain(domainArgs);
+    if (this.getters.getActiveSheetId() === this.__originSheetId) {
+      this.getters.getPivotPresenceTracker(_pivotId)?.trackHeader(domain);
+    }
     const lastNode = domain.at(-1);
     if (lastNode?.field === "measure") {
       return pivot.getPivotMeasureValue(toString(lastNode.value), domain);

--- a/src/helpers/pivot/pivot_helpers.ts
+++ b/src/helpers/pivot/pivot_helpers.ts
@@ -132,7 +132,11 @@ export function isDateOrDatetimeField(field: PivotField) {
   return DATE_FIELDS.includes(field.type);
 }
 
-function generatePivotArgs(formulaId: string, domain: PivotDomain, measure?: string): string[] {
+export function generatePivotArgs(
+  formulaId: string,
+  domain: PivotDomain,
+  measure?: string
+): string[] {
   const args: string[] = [formulaId];
   if (measure) {
     args.push(`"${measure}"`);

--- a/src/helpers/pivot/pivot_presence_tracker.ts
+++ b/src/helpers/pivot/pivot_presence_tracker.ts
@@ -1,0 +1,31 @@
+import { CellValue } from "../..";
+import { toString } from "../../functions/helpers";
+import { PivotDomain } from "../../types";
+
+export class PivotPresenceTracker {
+  private trackedValues: Set<String> = new Set();
+
+  private domainToArray(domain: PivotDomain): (string | CellValue)[] {
+    return domain.flatMap((node) => [node.field, toString(node.value)]);
+  }
+
+  isValuePresent(measure: string, domain: PivotDomain) {
+    const key = JSON.stringify({ measure, domain: this.domainToArray(domain) });
+    return this.trackedValues.has(key);
+  }
+
+  isHeaderPresent(domain: PivotDomain) {
+    const key = JSON.stringify({ domain: this.domainToArray(domain) });
+    return this.trackedValues.has(key);
+  }
+
+  trackValue(measure: string, domain: PivotDomain) {
+    const key = JSON.stringify({ measure, domain: this.domainToArray(domain) });
+    this.trackedValues.add(key);
+  }
+
+  trackHeader(domain: PivotDomain) {
+    const key = JSON.stringify({ domain: this.domainToArray(domain) });
+    this.trackedValues.add(key);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -121,6 +121,7 @@ import {
 import { supportedPivotPositionalFormulaRegistry } from "./helpers/pivot/pivot_positional_formula_registry";
 
 import { CellComposerStore } from "./components/composer/composer/cell_composer_store";
+import { PivotHTMLRenderer } from "./components/pivot_html_renderer/pivot_html_renderer";
 import { SidePanelCollapsible } from "./components/side_panel/components/collapsible/side_panel_collapsible";
 import { PivotMeasureDisplayPanelStore } from "./components/side_panel/pivot/pivot_measure_display_panel/pivot_measure_display_panel_store";
 import { TextInput } from "./components/text_input/text_input";
@@ -407,6 +408,7 @@ export const components = {
   PivotDimensionOrder,
   PivotDimension,
   PivotLayoutConfigurator,
+  PivotHTMLRenderer,
   EditableName,
   PivotDeferUpdate,
   PivotTitleSection,

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -44,6 +44,7 @@ import {
 import { CellComputedStylePlugin } from "./ui_feature/cell_computed_style";
 import { DataValidationInsertionPlugin } from "./ui_feature/datavalidation_insertion";
 import { HistoryPlugin } from "./ui_feature/local_history";
+import { PivotPresencePlugin } from "./ui_feature/pivot_presence_plugin";
 import { SplitToColumnsPlugin } from "./ui_feature/split_to_columns";
 import { TableAutofillPlugin } from "./ui_feature/table_autofill";
 import { TableComputedStylePlugin } from "./ui_feature/table_computed_style";
@@ -85,6 +86,7 @@ export const featurePluginRegistry = new Registry<UIPluginConstructor>()
   .add("automatic_sum", AutomaticSumPlugin)
   .add("format", FormatPlugin)
   .add("insert_pivot", InsertPivotPlugin)
+  .add("pivot_presence", PivotPresencePlugin)
   .add("split_to_columns", SplitToColumnsPlugin)
   .add("collaborative", CollaborativePlugin)
   .add("history", HistoryPlugin)

--- a/src/plugins/ui_feature/pivot_presence_plugin.ts
+++ b/src/plugins/ui_feature/pivot_presence_plugin.ts
@@ -1,0 +1,32 @@
+import { PivotPresenceTracker } from "../../helpers/pivot/pivot_presence_tracker";
+import { Command, UID } from "../../types";
+import { UIPlugin } from "../ui_plugin";
+
+export class PivotPresencePlugin extends UIPlugin {
+  static getters = ["getPivotPresenceTracker"] as const;
+
+  private trackPresencePivotId?: UID;
+  private tracker?: PivotPresenceTracker;
+
+  handle(cmd: Command) {
+    switch (cmd.type) {
+      case "PIVOT_START_PRESENCE_TRACKING":
+        this.tracker = new PivotPresenceTracker();
+        this.trackPresencePivotId = cmd.pivotId;
+        break;
+      case "PIVOT_STOP_PRESENCE_TRACKING":
+        this.trackPresencePivotId = undefined;
+        break;
+    }
+  }
+
+  getPivotPresenceTracker(pivotId: UID) {
+    if (this.trackPresencePivotId !== pivotId) {
+      return undefined;
+    }
+    if (!this.tracker) {
+      throw new Error("Tracker not initialized");
+    }
+    return this.tracker;
+  }
+}

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -1014,6 +1014,15 @@ export interface PaintFormat extends TargetDependentCommand {
   type: "PAINT_FORMAT";
 }
 
+export interface PivotStartPresenceTracking {
+  type: "PIVOT_START_PRESENCE_TRACKING";
+  pivotId: UID;
+}
+
+export interface PivotStopPresenceTracking {
+  type: "PIVOT_STOP_PRESENCE_TRACKING";
+}
+
 export type CoreCommand =
   // /** History */
   // | SelectiveUndoCommand
@@ -1163,7 +1172,9 @@ export type LocalCommand =
   | DuplicatePivotInNewSheetCommand
   | InsertPivotWithTableCommand
   | SplitPivotFormulaCommand
-  | PaintFormat;
+  | PaintFormat
+  | PivotStartPresenceTracking
+  | PivotStopPresenceTracking;
 
 export type Command = CoreCommand | LocalCommand;
 

--- a/src/types/getters.ts
+++ b/src/types/getters.ts
@@ -29,6 +29,7 @@ import { CellComputedStylePlugin } from "../plugins/ui_feature/cell_computed_sty
 import { CollaborativePlugin } from "../plugins/ui_feature/collaborative";
 import { HeaderVisibilityUIPlugin } from "../plugins/ui_feature/header_visibility_ui";
 import { HistoryPlugin } from "../plugins/ui_feature/local_history";
+import { PivotPresencePlugin } from "../plugins/ui_feature/pivot_presence_plugin";
 import { SortPlugin } from "../plugins/ui_feature/sort";
 import { SplitToColumnsPlugin } from "../plugins/ui_feature/split_to_columns";
 import { TableComputedStylePlugin } from "../plugins/ui_feature/table_computed_style";
@@ -142,4 +143,5 @@ export type Getters = {
   PluginGetters<typeof CellComputedStylePlugin> &
   PluginGetters<typeof DynamicTablesPlugin> &
   PluginGetters<typeof PivotUIPlugin> &
+  PluginGetters<typeof PivotPresencePlugin> &
   PluginGetters<typeof TableComputedStylePlugin>;

--- a/tests/components/__snapshots__/pivot_html_renderer.test.ts.snap
+++ b/tests/components/__snapshots__/pivot_html_renderer.test.ts.snap
@@ -1,0 +1,99 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Pivot HTML Renderer Rendering a simple pivot table 1`] = `
+<div>
+  <div
+    class="o_pivot_html_renderer"
+  >
+    <label
+      class="o-checkbox d-flex align-items-center m-2"
+    >
+      <input
+        class="me-2"
+        name="missing_values"
+        type="checkbox"
+      />
+      Display missing cells only
+      
+    </label>
+    
+    <table
+      class="o_pivot_html_renderer"
+    >
+      <tr>
+        <th
+          rowspan="2"
+        />
+        
+        <th
+          class="o_missing_value"
+          colspan="1"
+        >
+          Total
+        </th>
+        
+        
+      </tr>
+      <tr>
+        
+        <th
+          class="o_missing_value"
+          colspan="1"
+        >
+          Score
+        </th>
+        
+        
+      </tr>
+      
+      
+      <tr>
+        <th
+          class="o_missing_value"
+        >
+          Alice
+        </th>
+        <td
+          class="o_missing_value"
+        >
+          1
+        </td>
+        
+        
+      </tr>
+      <tr>
+        <th
+          class="o_missing_value"
+        >
+          Bob
+        </th>
+        <td
+          class="o_missing_value"
+        >
+          1
+        </td>
+        
+        
+      </tr>
+      <tr>
+        <th
+          class="o_missing_value"
+        >
+          Total
+        </th>
+        <td
+          class="o_missing_value"
+        >
+          2
+        </td>
+        
+        
+      </tr>
+      
+      
+    </table>
+    
+    
+  </div>
+</div>
+`;

--- a/tests/components/pivot_html_renderer.test.ts
+++ b/tests/components/pivot_html_renderer.test.ts
@@ -1,0 +1,91 @@
+import { Model, UID } from "../../src";
+import { PivotHTMLRenderer } from "../../src/components/pivot_html_renderer/pivot_html_renderer";
+import { createSheet } from "../test_helpers/commands_helpers";
+import { click } from "../test_helpers/dom_helper";
+import { createModelFromGrid, mountComponent } from "../test_helpers/helpers";
+import { addPivot } from "../test_helpers/pivot_helpers";
+
+let fixture: HTMLElement;
+
+async function mountPivotHtmlRenderer(
+  model: Model,
+  pivotId: UID,
+  onCellClicked: PivotHTMLRenderer["props"]["onCellClicked"] = () => {}
+) {
+  const props = {
+    pivotId,
+    onCellClicked,
+  };
+  model.dispatch("PIVOT_START_PRESENCE_TRACKING", { pivotId });
+  model.dispatch("EVALUATE_CELLS");
+  ({ fixture } = await mountComponent(PivotHTMLRenderer, { env: { model }, props }));
+}
+
+describe("Pivot HTML Renderer", () => {
+  test("Rendering a simple pivot table", async () => {
+    // prettier-ignore
+    const grid = {
+      A1: "Name",  B1: "Age", C1: "Score",
+      A2: "Alice", B2: "25",  C2: "90",
+      A3: "Bob",   B3: "30",  C3: "85",
+    };
+    const model = createModelFromGrid(grid);
+    addPivot(model, "A1:C3", {
+      rows: [{ fieldName: "Name" }],
+      measures: [{ id: "Score", fieldName: "Score", aggregator: "count" }],
+    });
+
+    await mountPivotHtmlRenderer(model, model.getters.getPivotIds()[0]);
+    expect(fixture).toMatchSnapshot();
+  });
+
+  test("Pivot with all formula on sheet", async () => {
+    // prettier-ignore
+    const grid = {
+      A1: "Name",                            B1: "Age",                                    C1: "Score",
+      A2: "Alice",                           B2: "25",                                     C2: "90",
+      A3: "Bob",                             B3: "30",                                     C3: "85",
+
+      A5: "",                                B5: "=PIVOT.HEADER(1)",
+      A6: "",                                B6: `=PIVOT.HEADER(1,"measure","Score")`,
+      A7: `=PIVOT.HEADER(1,"Name","Alice")`, B7: `=PIVOT.VALUE(1,"Score","Name","Alice")`,
+      A8: `=PIVOT.HEADER(1,"Name","Bob")`,   B8: `=PIVOT.VALUE(1,"Score","Name","Bob")`,
+      A9: "=PIVOT.HEADER(1)",                B9: `=PIVOT.VALUE(1,"Score")`,
+    };
+    const model = createModelFromGrid(grid);
+    addPivot(model, "A1:C3", {
+      rows: [{ fieldName: "Name" }],
+      measures: [{ id: "Score", fieldName: "Score", aggregator: "count" }],
+    });
+    await mountPivotHtmlRenderer(model, model.getters.getPivotIds()[0]);
+    expect(fixture.querySelectorAll(".o_missing_value")).toHaveLength(0);
+    await click(fixture, "input[type=checkbox]");
+    expect(fixture.querySelector("table")).toBeNull();
+    expect(fixture.querySelector(".alert-info")?.innerHTML).toEqual(
+      "This pivot has no cell missing on this sheet"
+    );
+  });
+
+  test("Pivot with all formula on another sheet", async () => {
+    // prettier-ignore
+    const grid = {
+      A1: "Name",                            B1: "Age",                                    C1: "Score",
+      A2: "Alice",                           B2: "25",                                     C2: "90",
+      A3: "Bob",                             B3: "30",                                     C3: "85",
+
+      A5: "",                                B5: "=PIVOT.HEADER(1)",
+      A6: "",                                B6: `=PIVOT.HEADER(1,"measure","Score")`,
+      A7: `=PIVOT.HEADER(1,"Name","Alice")`, B7: `=PIVOT.VALUE(1,"Score","Name","Alice")`,
+      A8: `=PIVOT.HEADER(1,"Name","Bob")`,   B8: `=PIVOT.VALUE(1,"Score","Name","Bob")`,
+      A9: "=PIVOT.HEADER(1)",                B9: `=PIVOT.VALUE(1,"Score")`,
+    };
+    const model = createModelFromGrid(grid);
+    addPivot(model, "A1:C3", {
+      rows: [{ fieldName: "Name" }],
+      measures: [{ id: "Score", fieldName: "Score", aggregator: "count" }],
+    });
+    createSheet(model, { activate: true });
+    await mountPivotHtmlRenderer(model, model.getters.getPivotIds()[0]);
+    expect(fixture.querySelectorAll(".o_missing_value")).toHaveLength(8);
+  });
+});


### PR DESCRIPTION
This commit reverts the commit https://github.com/odoo/enterprise/commit/c4a481aa5fd4c4168e2ec0252bca46ac95cf1a67

While we revert this commit, we took the opportunity to move a part of the code in the o-spreadsheet codebase.

For now, the feature is not usable in o-spreadsheet as we do not a Dialog, but it's something that will happen in master.

Task: 4707732

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo