### PR TITLE
[IMP] pivots: table type synced with pivot structure

### DIFF
--- a/src/helpers/pivot/pivot_menu_items.ts
+++ b/src/helpers/pivot/pivot_menu_items.ts
@@ -31,7 +31,7 @@ export const FIX_FORMULAS: ActionSpec = {
     if (!pivot.isValid()) {
       return;
     }
-    env.model.dispatch("INSERT_PIVOT", {
+    env.model.dispatch("SPLIT_PIVOT_FORMULA", {
       sheetId,
       col,
       row,

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -977,14 +977,17 @@ export interface DuplicatePivotInNewSheetCommand {
   newSheetId: UID;
 }
 
-export interface InsertPivotWithTableCommand {
+export interface InsertPivotWithTableCommand extends PositionDependentCommand {
   type: "INSERT_PIVOT_WITH_TABLE";
-  sheetId: UID;
-  col: HeaderIndex;
-  row: HeaderIndex;
   pivotId: UID;
   table: PivotTableData;
   pivotMode: "static" | "dynamic";
+}
+
+export interface SplitPivotFormulaCommand extends PositionDependentCommand {
+  type: "SPLIT_PIVOT_FORMULA";
+  pivotId: UID;
+  table: PivotTableData;
 }
 
 export type CoreCommand =
@@ -1134,7 +1137,8 @@ export type LocalCommand =
   | RefreshPivotCommand
   | InsertNewPivotCommand
   | DuplicatePivotInNewSheetCommand
-  | InsertPivotWithTableCommand;
+  | InsertPivotWithTableCommand
+  | SplitPivotFormulaCommand;
 
 export type Command = CoreCommand | LocalCommand;
 


### PR DESCRIPTION
## Description

Backport of 0f46e97

If a user had linked a dynamic table to a pivot formula (`=PIVOT(1)`) the table would not be adapted accordingly when the user converted their pivot into "splitted" individual formulas. This revision detects if a dynamic table is attached the anchor of the dynamic pivot formula and converts it along the pivot such that it matches the the pivot range.

Task: [4771509](https://www.odoo.com/odoo/2328/tasks/4771509)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo