### PR TITLE
[IMP] xlsx: prevent exporting `FILTER` function

### DIFF
--- a/src/functions/module_filter.ts
+++ b/src/functions/module_filter.ts
@@ -160,7 +160,7 @@ export const FILTER = {
 
     return mode === "row" ? transposeMatrix(result) : result;
   },
-  isExported: true,
+  isExported: false,
 } satisfies AddFunctionDescription;
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
The current implementation of the FILTER `function` is different from the one adopted by Excel, therefore this commit marks it as not exportable.

Task: [4766579](https://www.odoo.com/odoo/2328/tasks/4766579)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo