### PR TITLE
[IMP] data_validation: toggle checkbox with space key

### DIFF
--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -463,6 +463,19 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
     });
   }
 
+  private processSpaceKey(ev: KeyboardEvent) {
+    if (
+      this.env.model.getters.hasBooleanValidationInZones(this.env.model.getters.getSelectedZones())
+    ) {
+      ev.preventDefault();
+      ev.stopPropagation();
+      this.env.model.dispatch("TOGGLE_CHECKBOX", {
+        sheetId: this.env.model.getters.getActiveSheetId(),
+        target: this.env.model.getters.getSelectedZones(),
+      });
+    }
+  }
+
   getClientPositionKey(client: Client) {
     return `${client.id}-${client.position?.sheetId}-${client.position?.col}-${client.position?.row}`;
   }
@@ -554,6 +567,12 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
       ev.preventDefault();
       ev.stopPropagation();
       handler();
+      return;
+    }
+    // Space key is handled separately because the default and the propagation
+    // of the event should be stopped conditionally (presence of a validation rule)
+    if (keyDownString === " ") {
+      this.processSpaceKey(ev);
       return;
     }
 

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -44,6 +44,7 @@ import {
   UIOptionsPlugin,
 } from "./ui_feature";
 import { CellComputedStylePlugin } from "./ui_feature/cell_computed_style";
+import { CheckboxTogglePlugin } from "./ui_feature/checkbox_toggle";
 import { DataValidationInsertionPlugin } from "./ui_feature/datavalidation_insertion";
 import { HistoryPlugin } from "./ui_feature/local_history";
 import { PivotPresencePlugin } from "./ui_feature/pivot_presence_plugin";
@@ -96,6 +97,7 @@ export const featurePluginRegistry = new Registry<UIPluginConstructor>()
   .add("table_autofill", TableAutofillPlugin)
   .add("table_ui_resize", TableResizeUI)
   .add("datavalidation_insert", DataValidationInsertionPlugin)
+  .add("checkbox_toggle", CheckboxTogglePlugin)
   .add("geo_features", GeoFeaturePlugin);
 
 // Plugins which have a state, but which should not be shared in collaborative

--- a/src/plugins/ui_feature/checkbox_toggle.ts
+++ b/src/plugins/ui_feature/checkbox_toggle.ts
@@ -1,0 +1,45 @@
+import { Command, UID, Zone } from "../../types/index";
+import { UIPlugin } from "../ui_plugin";
+
+export class CheckboxTogglePlugin extends UIPlugin {
+  static getters = ["hasBooleanValidationInZones"] as const;
+
+  handle(cmd: Command) {
+    switch (cmd.type) {
+      case "TOGGLE_CHECKBOX":
+        this.toggleCheckbox(cmd.sheetId, cmd.target);
+        break;
+    }
+  }
+
+  hasBooleanValidationInZones(zones: Zone[]) {
+    const sheetId = this.getters.getActiveSheetId();
+    for (const zone of zones) {
+      for (let col = zone.left; col <= zone.right; col++) {
+        for (let row = zone.top; row <= zone.bottom; row++) {
+          if (this.getters.isCellValidCheckbox({ col, row, sheetId })) {
+            return true;
+          }
+        }
+      }
+    }
+    return false;
+  }
+
+  private toggleCheckbox(sheetId: UID, target: Zone[]) {
+    for (const zone of target) {
+      for (let col = zone.left; col <= zone.right; col++) {
+        for (let row = zone.top; row <= zone.bottom; row++) {
+          const position = { col, row, sheetId };
+          if (this.getters.isCellValidCheckbox(position)) {
+            const content = this.getters.getEvaluatedCell(position).value ? "FALSE" : "TRUE";
+            this.dispatch("UPDATE_CELL", {
+              ...position,
+              content,
+            });
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -1045,6 +1045,10 @@ export interface PivotStopPresenceTracking {
   type: "PIVOT_STOP_PRESENCE_TRACKING";
 }
 
+export interface ToggleCheckboxCommand extends TargetDependentCommand {
+  type: "TOGGLE_CHECKBOX";
+}
+
 export type CoreCommand =
   // /** History */
   // | SelectiveUndoCommand
@@ -1198,7 +1202,8 @@ export type LocalCommand =
   | PaintFormat
   | DeleteUnfilteredContentCommand
   | PivotStartPresenceTracking
-  | PivotStopPresenceTracking;
+  | PivotStopPresenceTracking
+  | ToggleCheckboxCommand;
 
 export type Command = CoreCommand | LocalCommand;
 

--- a/src/types/getters.ts
+++ b/src/types/getters.ts
@@ -27,6 +27,7 @@ import { GeoFeaturePlugin } from "../plugins/ui_feature";
 import { AutofillPlugin } from "../plugins/ui_feature/autofill";
 import { AutomaticSumPlugin } from "../plugins/ui_feature/automatic_sum";
 import { CellComputedStylePlugin } from "../plugins/ui_feature/cell_computed_style";
+import { CheckboxTogglePlugin } from "../plugins/ui_feature/checkbox_toggle";
 import { CollaborativePlugin } from "../plugins/ui_feature/collaborative";
 import { HeaderVisibilityUIPlugin } from "../plugins/ui_feature/header_visibility_ui";
 import { HistoryPlugin } from "../plugins/ui_feature/local_history";
@@ -147,4 +148,5 @@ export type Getters = {
   PluginGetters<typeof TableComputedStylePlugin> &
   PluginGetters<typeof GeoFeaturePlugin> &
   PluginGetters<typeof PivotPresencePlugin> &
-  PluginGetters<typeof TableComputedStylePlugin>;
+  PluginGetters<typeof TableComputedStylePlugin> &
+  PluginGetters<typeof CheckboxTogglePlugin>;

--- a/tests/data_validation/data_validation_checkbox_component.test.ts
+++ b/tests/data_validation/data_validation_checkbox_component.test.ts
@@ -3,9 +3,10 @@ import {
   addDataValidation,
   createTableWithFilter,
   setCellContent,
+  setSelection,
   setStyle,
 } from "../test_helpers/commands_helpers";
-import { click } from "../test_helpers/dom_helper";
+import { click, keyDown } from "../test_helpers/dom_helper";
 import { getCellContent, getStyle } from "../test_helpers/getters_helpers";
 import { mountSpreadsheet, nextTick } from "../test_helpers/helpers";
 
@@ -49,6 +50,53 @@ describe("Checkbox component", () => {
     await click(checkbox);
     expect(getCellContent(model, "A1")).toBe("FALSE");
     expect(checkbox?.checked).toBe(false);
+  });
+
+  test("can check and uncheck with space key", async () => {
+    const model = new Model();
+    addDataValidation(model, "A1", "id", { type: "isBoolean", values: [] });
+    const { fixture } = await mountSpreadsheet({ model });
+    await nextTick();
+    const checkbox = fixture.querySelector(".o-dv-checkbox input") as HTMLInputElement;
+    expect(checkbox?.checked).toBe(false);
+    await keyDown({ key: " " });
+    expect(getCellContent(model, "A1")).toBe("TRUE");
+    expect(checkbox?.checked).toBe(true);
+    await keyDown({ key: " " });
+    expect(getCellContent(model, "A1")).toBe("FALSE");
+    expect(checkbox?.checked).toBe(false);
+  });
+
+  test("Can toggle checkbox in selection with space key", async () => {
+    const model = new Model();
+    addDataValidation(model, "B2:B3", "id", { type: "isBoolean", values: [] });
+    const { fixture } = await mountSpreadsheet({ model });
+    await nextTick();
+    const checkboxB2 = fixture.querySelectorAll(".o-dv-checkbox input")[0] as HTMLInputElement;
+    const checkboxB3 = fixture.querySelectorAll(".o-dv-checkbox input")[1] as HTMLInputElement;
+    setSelection(model, ["A1:B2"]);
+    expect(checkboxB2?.checked).toBe(false);
+    expect(checkboxB3?.checked).toBe(false);
+
+    await keyDown({ key: " " });
+    expect(getCellContent(model, "B2")).toBe("TRUE");
+    expect(getCellContent(model, "B3")).toBe("FALSE");
+    expect(checkboxB2?.checked).toBe(true);
+    expect(checkboxB3?.checked).toBe(false);
+    setSelection(model, ["A1:B3"]);
+
+    await keyDown({ key: " " });
+    expect(getCellContent(model, "B2")).toBe("FALSE");
+    expect(getCellContent(model, "B3")).toBe("TRUE");
+    expect(checkboxB2?.checked).toBe(false);
+    expect(checkboxB3?.checked).toBe(true);
+    setSelection(model, ["A1"]);
+
+    await keyDown({ key: " " });
+    expect(getCellContent(model, "B2")).toBe("FALSE");
+    expect(getCellContent(model, "B3")).toBe("TRUE");
+    expect(checkboxB2?.checked).toBe(false);
+    expect(checkboxB3?.checked).toBe(true);
   });
 
   test("Data validation checkbox on formula is disabled", async () => {


### PR DESCRIPTION
With this commit, the checkbox component can be toggled with the space key.

Task: 4659429

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo