### PR TITLE
[IMP] clipboard: copy whole pivot as dynamic pivot

### DIFF
--- a/src/clipboard_handlers/cell_clipboard.ts
+++ b/src/clipboard_handlers/cell_clipboard.ts
@@ -1,4 +1,4 @@
-import { deepEquals, formatValue } from "../helpers";
+import { deepEquals, formatValue, isZoneInside } from "../helpers";
 import { getPasteZones } from "../helpers/clipboard/clipboard_helpers";
 import { canonicalizeNumberValue } from "../helpers/locale";
 import { createPivotFormula } from "../helpers/pivot/pivot_helpers";
@@ -46,8 +46,13 @@ export class CellClipboardHandler extends AbstractCellClipboardHandler<
         const evaluatedCell = this.getters.getEvaluatedCell(position);
         const pivotId = this.getters.getPivotIdFromPosition(position);
         const spreader = this.getters.getArrayFormulaSpreadingOn(position);
-        if (pivotId) {
-          if (spreader && (!deepEquals(spreader, position) || !isCopyingOneCell)) {
+        if (pivotId && spreader) {
+          const pivotZone = this.getters.getSpreadZone(spreader);
+          if (
+            (!deepEquals(spreader, position) || !isCopyingOneCell) &&
+            pivotZone &&
+            !data.zones.some((z) => isZoneInside(pivotZone, z))
+          ) {
             const pivotCell = this.getters.getPivotCellFromPosition(position);
             const formulaPivotId = this.getters.getPivotFormulaId(pivotId);
             const pivotFormula = createPivotFormula(formulaPivotId, pivotCell);

--- a/tests/clipboard/clipboard_plugin.test.ts
+++ b/tests/clipboard/clipboard_plugin.test.ts
@@ -2039,18 +2039,42 @@ describe("clipboard", () => {
     expect(getEvaluatedCell(model, "G4").value).toBe("Total");
     expect(getCell(model, "G4")!.content).toBe("=PIVOT.HEADER(1)");
 
-    // copy entire pivot
-    copy(model, "C1:D5");
+    // copy part of pivot
+    copy(model, "C1:D4");
     paste(model, "G4");
     model.dispatch("SET_FORMULA_VISIBILITY", { show: true });
     // prettier-ignore
-    expect(getEvaluatedGrid(model, "G4:H8")).toEqual([
+    expect(getEvaluatedGrid(model, "G4:H7")).toEqual([
       ["",                                      "=PIVOT.HEADER(1)"],
       ["",                                      '=PIVOT.HEADER(1,"measure","Price")'],
       ['=PIVOT.HEADER(1,"Customer","Alice")',   '=PIVOT.VALUE(1,"Price","Customer","Alice")'],
       ['=PIVOT.HEADER(1,"Customer","Bob")',     '=PIVOT.VALUE(1,"Price","Customer","Bob")'],
-      ["=PIVOT.HEADER(1)",                      '=PIVOT.VALUE(1,"Price")'],
     ]);
+  });
+
+  test("Copying (or cutting) entire pivot does not results in fixed pivot formula", () => {
+    // prettier-ignore
+    const grid = {
+        A1: "Customer", B1: "Price", C1: "=PIVOT(1)",
+        A2: "Alice",    B2: "10",
+        A3: "Bob",      B3: "30"
+    };
+    const model = createModelFromGrid(grid);
+    addPivot(model, "A1:B3", {
+      columns: [],
+      rows: [{ name: "Customer" }],
+      measures: [{ name: "Price", aggregator: "sum" }],
+    });
+
+    copy(model, "C1:D5");
+    paste(model, "G4");
+    expect(getCell(model, "G4")!.content).toBe("=PIVOT(1)");
+    expect(getCell(model, "G5")).toBeUndefined();
+
+    cut(model, "C1:D5");
+    paste(model, "G20");
+    expect(getCell(model, "G20")!.content).toBe("=PIVOT(1)");
+    expect(getCell(model, "G21")).toBeUndefined();
   });
 
   test("copying a spread pivot cell with (Undefined)", () => {
@@ -2067,17 +2091,15 @@ describe("clipboard", () => {
       measures: [{ name: "Price", aggregator: "sum" }],
     });
 
-    // copy entire pivot
-    copy(model, "C1:D5");
+    copy(model, "C1:D4");
     paste(model, "G4");
     model.dispatch("SET_FORMULA_VISIBILITY", { show: true });
     // prettier-ignore
-    expect(getEvaluatedGrid(model, "G4:H8")).toEqual([
+    expect(getEvaluatedGrid(model, "G4:H7")).toEqual([
       ["",                                      "=PIVOT.HEADER(1)"],
       ["",                                      '=PIVOT.HEADER(1,"measure","Price")'],
       ['=PIVOT.HEADER(1,"Customer","Alice")',   '=PIVOT.VALUE(1,"Price","Customer","Alice")'],
       ['=PIVOT.HEADER(1,"Customer","null")',    '=PIVOT.VALUE(1,"Price","Customer","null")'],
-      ["=PIVOT.HEADER(1)",                      '=PIVOT.VALUE(1,"Price")'],
     ]);
   });
 


### PR DESCRIPTION
## Description

Backport of a747d46

When we copy part of a dynamic pivot, we don't copy the values but pivot formulas instead.

But when copying (or cutting) the whole pivot, we should copy the dynamic pivot and not the pivot formulas. The intent of the user in this case is most likely to copy the pivot as a whole and not to replace it with pivot formulas (particularly when cutting).

Task: [4771494](https://www.odoo.com/odoo/2328/tasks/4771494)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo