### PR TITLE
[FIX] Composer: keep focus with interacting with formula assistant

### DIFF
--- a/src/components/composer/composer/composer.xml
+++ b/src/components/composer/composer/composer.xml
@@ -44,7 +44,11 @@
       <div
         class="o-composer-assistant-container shadow position-absolute z-1"
         t-att-style="assistantContainerStyle"
-        t-if="props.focus !== 'inactive' and !assistant.forcedClosed and assistantIsAvailable">
+        t-if="props.focus !== 'inactive' and !assistant.forcedClosed and assistantIsAvailable"
+        t-on-wheel.stop=""
+        t-on-pointerdown.prevent.stop=""
+        t-on-pointerup.prevent.stop=""
+        t-on-click.prevent.stop="">
         <span
           role="button"
           t-on-click="closeAssistant"
@@ -52,13 +56,7 @@
           <i class="fa fa-circle fa-stack-1x fa-inverse"/>
           <i class="fa fa-times-circle fa-stack-1x text-muted"/>
         </span>
-        <div
-          class="o-composer-assistant overflow-auto"
-          t-att-style="assistantStyle"
-          t-on-wheel.stop=""
-          t-on-pointerdown.prevent.stop=""
-          t-on-click.prevent.stop=""
-          t-on-pointerup.prevent.stop="">
+        <div class="o-composer-assistant overflow-auto" t-att-style="assistantStyle">
           <FunctionDescriptionProvider
             t-if="functionDescriptionState.showDescription"
             functionName="functionDescriptionState.functionName"

--- a/tests/composer/composer_integration_component.test.ts
+++ b/tests/composer/composer_integration_component.test.ts
@@ -824,4 +824,24 @@ describe("TopBar composer", () => {
     expect(topBarComposer!.textContent).toBe("");
     expect(topBarComposer.attributes.getNamedItem("placeholder")?.value).toEqual("=MUNIT(3)");
   });
+
+  test("opening and closing the assistant preserves the focus on the top bar composer", async () => {
+    ({ model, fixture } = await mountSpreadsheet());
+    await click(fixture, ".o-spreadsheet-topbar .o-composer");
+    let composerEl = document.querySelector(".o-spreadsheet-topbar .o-composer");
+    expect(document.activeElement).toBe(composerEl);
+
+    await typeInComposerTopBar("=SUM(", false);
+    composerEl = document.querySelector(".o-spreadsheet-topbar .o-composer");
+    expect(document.activeElement).toBe(composerEl);
+    expect(fixture.querySelector(".o-formula-assistant")).toBeDefined();
+    expect(fixture.querySelector(".o-spreadsheet-topbar .fa-question-circle")).toBe(null);
+    expect(fixture.querySelector(".o-spreadsheet-topbar .fa-times-circle")).not.toBe(null);
+    await simulateClick(".o-spreadsheet-topbar .fa-times-circle");
+    expect(document.activeElement).toBe(composerEl);
+    expect(fixture.querySelector(".o-formula-assistant")).toBe(null);
+    await simulateClick(".o-spreadsheet-topbar .fa-question-circle");
+    expect(fixture.querySelector(".o-formula-assistant")).toBeDefined();
+    expect(document.activeElement).toBe(composerEl);
+  });
 });


### PR DESCRIPTION
How to reproduce:
- start editing a cell content in the *topbar* composer with "=sum"
- click on the "x" icon of the formula assistant to close it

==> the composer was closed and the cell contains only "=sum" which is evaluated as a #BAD_EXPR formula

This seemed to work on the grid composer because the 'onBlur' handler would find a related target that has the `composerFocusableElement` attribute where it would not find an equivalent in the top bar composer.

Task: 4771772

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo