### PR TITLE
[FIX] composer: empty composer assistant shadow

### DIFF
--- a/src/components/composer/composer/composer.ts
+++ b/src/components/composer/composer/composer.ts
@@ -434,7 +434,6 @@ export class Composer extends Component<ComposerProps, SpreadsheetChildEnv> {
     ) {
       return;
     }
-    this.autoCompleteState.showProvider = true;
     this.autoCompleteState.type = "function";
     let values = Object.entries(functionRegistry.content)
       .filter(([_, { hidden }]) => !hidden)
@@ -450,6 +449,9 @@ export class Composer extends Component<ComposerProps, SpreadsheetChildEnv> {
 
     if (searchTerm) {
       values = fuzzyLookup(searchTerm, values, (t) => t.text).slice(0, AUTOCOMPLETE_ENTRIES);
+    }
+    if (values.length) {
+      this.autoCompleteState.showProvider = true;
     }
     this.autoCompleteState.values = values.slice(0, AUTOCOMPLETE_ENTRIES);
     this.autoCompleteState.getHtmlContent = (value) =>

--- a/tests/composer/formula_assistant_component.test.ts
+++ b/tests/composer/formula_assistant_component.test.ts
@@ -96,12 +96,21 @@ describe("formula assistant", () => {
     test("empty not show autocomplete", async () => {
       await typeInComposer("");
       expect(document.activeElement).toBe(composerEl);
+      expect(fixture.querySelectorAll(".o-composer-assistant")).toHaveLength(0);
       expect(fixture.querySelectorAll(".o-formula-assistant")).toHaveLength(0);
     });
 
     test("= do not show formula assistant", async () => {
       await typeInComposer("=");
       expect(document.activeElement).toBe(composerEl);
+      expect(fixture.querySelectorAll(".o-composer-assistant")).toHaveLength(0);
+      expect(fixture.querySelectorAll(".o-formula-assistant")).toHaveLength(0);
+    });
+
+    test("no search match does not show formula assistant", async () => {
+      await typeInComposer("=ZZZZ");
+      expect(document.activeElement).toBe(composerEl);
+      expect(fixture.querySelectorAll(".o-composer-assistant")).toHaveLength(0);
       expect(fixture.querySelectorAll(".o-formula-assistant")).toHaveLength(0);
     });
 


### PR DESCRIPTION
## Description

If searching form a function in the composer, but no matches are found, we still showed the assistant, leading to an empty shadow.

Task: [4774936](https://www.odoo.com/odoo/2328/tasks/4774936)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo