### PR TITLE
[FIX] chart: deleting dataset creates two history steps

### DIFF
--- a/src/components/side_panel/chart/building_blocks/generic_side_panel/config_panel.ts
+++ b/src/components/side_panel/chart/building_blocks/generic_side_panel/config_panel.ts
@@ -68,7 +68,7 @@ export class GenericChartConfigPanel extends Component<Props, SpreadsheetChildEn
     const cancelledReasons = [
       ...(this.state.datasetDispatchResult?.reasons || []),
       ...(this.state.labelsDispatchResult?.reasons || []),
-    ];
+    ].filter((reason) => reason !== CommandResult.NoChanges);
     return cancelledReasons.map(
       (error) => ChartTerms.Errors[error] || ChartTerms.Errors.Unexpected
     );

--- a/src/plugins/core/chart.ts
+++ b/src/plugins/core/chart.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_FIGURE_HEIGHT, DEFAULT_FIGURE_WIDTH, FIGURE_ID_SPLITTER } from "../../constants";
+import { deepEquals } from "../../helpers";
 import { AbstractChart } from "../../helpers/figures/charts/abstract_chart";
 import { chartFactory, validateChartDefinition } from "../../helpers/figures/charts/chart_factory";
 import { ChartCreationContext, ChartDefinition, ChartType } from "../../types/chart/chart";
@@ -64,7 +65,11 @@ export class ChartPlugin extends CorePlugin<ChartState> implements ChartState {
       case "UPDATE_CHART":
         return this.checkValidations(
           cmd,
-          this.chainValidations(this.validateChartDefinition, this.checkChartExists)
+          this.chainValidations(
+            this.validateChartDefinition,
+            this.checkChartExists,
+            this.checkChartChanged
+          )
         );
       default:
         return CommandResult.Success;
@@ -241,5 +246,11 @@ export class ChartPlugin extends CorePlugin<ChartState> implements ChartState {
 
   private checkChartExists(cmd: UpdateChartCommand): CommandResult {
     return this.isChartDefined(cmd.id) ? CommandResult.Success : CommandResult.ChartDoesNotExist;
+  }
+
+  private checkChartChanged(cmd: UpdateChartCommand): CommandResult {
+    return deepEquals(this.getChartDefinition(cmd.id), cmd.definition)
+      ? CommandResult.NoChanges
+      : CommandResult.Success;
   }
 }

--- a/tests/figures/chart/chart_plugin.test.ts
+++ b/tests/figures/chart/chart_plugin.test.ts
@@ -798,7 +798,7 @@ describe("datasource tests", function () {
     expect(cmd3).toBeCancelledBecause(CommandResult.DuplicatedChartId);
   });
 
-  test("reject updates that target a cinexisting chart", () => {
+  test("reject updates that target a inexistent chart", () => {
     createChart(
       model,
       {
@@ -839,6 +839,13 @@ describe("datasource tests", function () {
     });
     expect(result).toBeCancelledBecause(CommandResult.ChartDoesNotExist);
   });
+
+  test("reject update that does not change the chart", () => {
+    createChart(model, { type: "line" }, "1");
+    const result = updateChart(model, "1", {});
+    expect(result).toBeCancelledBecause(CommandResult.NoChanges);
+  });
+
   test("chart is not selected after creation and update", () => {
     const chartId = "1234";
     createChart(

--- a/tests/figures/chart/charts_component.test.ts
+++ b/tests/figures/chart/charts_component.test.ts
@@ -1107,6 +1107,30 @@ describe("charts", () => {
     expect(document.querySelectorAll(".o-selection-input input")).toHaveLength(3);
   });
 
+  test("Removing a data series only create a single history step", async () => {
+    createChart(
+      model,
+      { type: "bar", dataSets: [{ dataRange: "B1" }, { dataRange: "C1" }] },
+      chartId
+    );
+    await mountSpreadsheet();
+    await openChartConfigSidePanel(model, env, chartId);
+    await simulateClick(".o-data-series .o-remove-selection");
+    expect((model.getters.getChartDefinition(chartId) as BarChartDefinition).dataSets).toEqual([
+      { dataRange: "C1", backgroundColor: "#EA6175" },
+    ]);
+    expect(errorMessages()).toEqual([]);
+
+    undo(model);
+    expect((model.getters.getChartDefinition(chartId) as BarChartDefinition).dataSets).toEqual([
+      { dataRange: "B1" },
+      { dataRange: "C1" },
+    ]);
+
+    undo(model);
+    expect(model.getters.getFigures(model.getters.getActiveSheetId())).toHaveLength(0);
+  });
+
   test("Custom design is kept when removing a data series", async () => {
     createTestChart("basicChart");
     updateChart(model, chartId, {


### PR DESCRIPTION
## Description

Before this commit, deleting a dataset in the chart side panel would create two history steps. That was because both `onSelectionConfirmed` and `onSelectionRemoved` were called by the selection input.

This commit fixes the issue by refusing `UPDATE_CHART` commands that do not change the chart definition.

Task: [4775144](https://www.odoo.com/odoo/2328/tasks/4775144)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo