### PR TITLE
[FIX] chart: can `UPDATE_CHART` on a non-chart figure

### DIFF
--- a/src/plugins/core/chart.ts
+++ b/src/plugins/core/chart.ts
@@ -264,8 +264,6 @@ export class ChartPlugin extends CorePlugin<ChartState> implements ChartState {
   }
 
   private checkChartExists(cmd: UpdateChartCommand): CommandResult {
-    return this.getters.getFigureSheetId(cmd.id)
-      ? CommandResult.Success
-      : CommandResult.ChartDoesNotExist;
+    return this.isChartDefined(cmd.id) ? CommandResult.Success : CommandResult.ChartDoesNotExist;
   }
 }

--- a/tests/plugins/chart/basic_chart.test.ts
+++ b/tests/plugins/chart/basic_chart.test.ts
@@ -636,6 +636,28 @@ describe("datasource tests", function () {
     expect(result).toBeCancelledBecause(CommandResult.ChartDoesNotExist);
   });
 
+  test("reject updates that target a figure that is not a chart", () => {
+    model.dispatch("CREATE_FIGURE", {
+      sheetId: model.getters.getActiveSheetId(),
+      figure: { id: "2", x: 0, y: 0, width: 100, height: 100, tag: "not a chart" },
+    });
+
+    const result = model.dispatch("UPDATE_CHART", {
+      definition: {
+        dataSets: [],
+        dataSetsHaveTitle: false,
+        verticalAxisPosition: "left",
+        stacked: false,
+        legendPosition: "bottom",
+        title: "test",
+        type: "bar",
+      },
+      sheetId: model.getters.getActiveSheetId(),
+      id: "2",
+    });
+    expect(result).toBeCancelledBecause(CommandResult.ChartDoesNotExist);
+  });
+
   test("chart is not selected after creation and update", () => {
     const chartId = "1234";
     createChart(


### PR DESCRIPTION
## Description

The `checkChartExists` method is wrong, it only checks that a figure with the id exists, not that it is a chart.

Task: [4775605](https://www.odoo.com/odoo/2328/tasks/4775605)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo