### PR TITLE
[FIX] pivot: pivot panel with multiple of same dimensions

### DIFF
--- a/src/components/side_panel/pivot/pivot_layout_configurator/pivot_layout_configurator.xml
+++ b/src/components/side_panel/pivot/pivot_layout_configurator/pivot_layout_configurator.xml
@@ -9,7 +9,7 @@
           fields="props.unusedGroupableFields"
         />
       </div>
-      <t t-foreach="props.definition.columns" t-as="col" t-key="col.nameWithGranularity">
+      <t t-foreach="props.definition.columns" t-as="col" t-key="col_index">
         <div
           t-on-pointerdown="(ev) => this.startDragAndDrop(col, ev)"
           t-att-style="dragAndDrop.itemsStyle[col.nameWithGranularity]"
@@ -35,7 +35,7 @@
           fields="props.unusedGroupableFields"
         />
       </div>
-      <t t-foreach="props.definition.rows" t-as="row" t-key="row.nameWithGranularity">
+      <t t-foreach="props.definition.rows" t-as="row" t-key="row_index">
         <div
           t-on-pointerdown="(ev) => this.startDragAndDrop(row, ev)"
           t-att-style="dragAndDrop.itemsStyle[row.nameWithGranularity]"

--- a/tests/pivots/spreadsheet_pivot/spreadsheet_pivot_side_panel.test.ts
+++ b/tests/pivots/spreadsheet_pivot/spreadsheet_pivot_side_panel.test.ts
@@ -292,4 +292,15 @@ describe("Spreadsheet pivot side panel", () => {
     expect(invalidDimensionEl.classList).toContain("pivot-dimension-invalid");
     expect(invalidDimensionEl.querySelector(".fa-exclamation-triangle")).not.toBe(null);
   });
+
+  test("Pivot with multiple time the same dimension does not crash the side panel", async () => {
+    setCellContent(model, "A1", "ValidDimension");
+    setCellContent(model, "A2", "10");
+    addPivot(model, "A1:A2", {
+      columns: [{ name: "ValidDimension" }, { name: "ValidDimension" }],
+    });
+    env.openSidePanel("PivotSidePanel", { pivotId: "1" });
+    await nextTick();
+    expect(1).toBe(1);
+  });
 });


### PR DESCRIPTION
## Description

It's possible to end up in a situation where multiple dimensions of the pivot are the same. This happens if we have multiple date dimensions with different granularities, and that the field change type to become a char/number field. This made the pivot panel crash.

Note: it's a really niche case. The fix only ensure the panel does not crash, however there is some weirdness in the pivot panel (drag & drop drags both dimensions, delete remove both dimensions, etc.). That's not ideal, but since the use case is very niche and the user can manually remove the duplicates, it's probably ok to leave it like that.

Task: [4775660](https://www.odoo.com/odoo/2328/tasks/4775660)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo