### PR TITLE
[FIX] grid overlay: avoid bazillions of useless renders

### DIFF
--- a/src/components/grid_overlay/grid_overlay.ts
+++ b/src/components/grid_overlay/grid_overlay.ts
@@ -82,7 +82,13 @@ function useCellHovered(env: SpreadsheetChildEnv, gridRef: Ref<HTMLElement>): Pa
     if (isChildEvent(gridRef.el, e)) {
       ({ x, y } = getOffsetRelativeToOverlay(e));
       lastMoved = Date.now();
-      hoveredTable.hover(getPosition());
+      const position = getPosition();
+      if (
+        env.isDashboard() &&
+        (hoveredTable.col !== position.col || hoveredTable.row !== position.row)
+      ) {
+        hoveredTable.hover(getPosition());
+      }
     }
   }
 

--- a/tests/grid/grid_overlay_component.test.ts
+++ b/tests/grid/grid_overlay_component.test.ts
@@ -29,6 +29,7 @@ import {
 import {
   click,
   edgeScrollDelay,
+  gridMouseEvent,
   selectColumnByClicking,
   triggerMouseEvent,
 } from "../test_helpers/dom_helper";
@@ -971,7 +972,7 @@ describe("move selected element(s)", () => {
       ],
     };
     model = new Model(data);
-    ({ fixture } = await mountSpreadsheet({ model }));
+    ({ fixture, env } = await mountSpreadsheet({ model }));
   });
 
   test("select the last selected cols/rows keep all selected zone active", async () => {
@@ -1259,5 +1260,21 @@ describe("move selected element(s)", () => {
     expect(model.getters.getActiveRows()).toEqual(new Set([0, 1]));
     await selectRow(2, { shiftKey: true });
     expect(model.getters.getActiveRows()).toEqual(new Set([0, 1, 2]));
+  });
+
+  test("Moving the mouse around does not trigger useless renders", async () => {
+    const storeRender = jest.fn();
+    env["__spreadsheet_stores__"].on("store-updated", null, storeRender);
+
+    await gridMouseEvent(model, "pointermove", "A1");
+    expect(storeRender).not.toHaveBeenCalled();
+
+    model.updateMode("dashboard");
+    await nextTick();
+    await gridMouseEvent(model, "pointermove", "A2");
+    expect(storeRender).toHaveBeenCalledTimes(1);
+
+    await gridMouseEvent(model, "pointermove", "A2");
+    expect(storeRender).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
The grid overlay would trigger a re-render for each mouse move event. That's a bit much. A render is only useful when:

1) we're in dashboard mode
2) the hovered cell has changed

Task: 0

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo