### PR TITLE
[FIX] Stores: skip unnecessary renderings

### DIFF
--- a/src/components/bottom_bar/bottom_bar_sheet/bottom_bar_sheet.ts
+++ b/src/components/bottom_bar/bottom_bar_sheet/bottom_bar_sheet.ts
@@ -157,11 +157,11 @@ export class BottomBarSheet extends Component<Props, SpreadsheetChildEnv> {
     if (ev.key === "Enter") {
       ev.preventDefault();
       this.stopEdition();
-      this.DOMFocusableElementStore.focusableElement?.focus();
+      this.DOMFocusableElementStore.focus();
     }
     if (ev.key === "Escape") {
       this.cancelEdition();
-      this.DOMFocusableElementStore.focusableElement?.focus();
+      this.DOMFocusableElementStore.focus();
     }
   }
 

--- a/src/components/composer/composer_focus_store.ts
+++ b/src/components/composer/composer_focus_store.ts
@@ -20,29 +20,32 @@ export class ComposerFocusStore extends SpreadsheetStore {
 
   focusTopBarComposer(selection: ComposerSelection) {
     if (this.getters.isReadonly()) {
-      return;
+      return "noStateChange";
     }
     this.topBarFocus = "contentFocus";
     this.gridFocusMode = "inactive";
-    this.setComposerContent({ selection } || {});
+    this.setComposerContent({ selection });
+    return;
   }
 
   focusGridComposerContent() {
     if (this.getters.isReadonly()) {
-      return;
+      return "noStateChange";
     }
     this.topBarFocus = "inactive";
     this.gridFocusMode = "contentFocus";
     this.setComposerContent({});
+    return;
   }
 
   focusGridComposerCell(content?: string, selection?: ComposerSelection) {
     if (this.getters.isReadonly()) {
-      return;
+      return "noStateChange";
     }
     this.topBarFocus = "inactive";
     this.gridFocusMode = "cellFocus";
-    this.setComposerContent({ content, selection } || {});
+    this.setComposerContent({ content, selection });
+    return;
   }
 
   /**

--- a/src/components/composer/grid_composer/grid_composer.ts
+++ b/src/components/composer/grid_composer/grid_composer.ts
@@ -179,7 +179,7 @@ export class GridComposer extends Component<Props, SpreadsheetChildEnv> {
       this.isEditing = isEditing;
       if (!isEditing) {
         this.rect = this.defaultRect;
-        this.DOMFocusableElementStore.focusableElement?.focus();
+        this.DOMFocusableElementStore.focus();
         return;
       }
       const position = this.env.model.getters.getActivePosition();

--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -181,7 +181,7 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
     useEffect(
       () => {
         if (!this.sidePanel.isOpen) {
-          this.DOMFocusableElementStore.focusableElement?.focus();
+          this.DOMFocusableElementStore.focus();
         }
       },
       () => [this.sidePanel.isOpen]
@@ -405,7 +405,7 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
       !this.env.model.getters.getSelectedFigureId() &&
       this.composerStore.editionMode === "inactive"
     ) {
-      this.DOMFocusableElementStore.focusableElement?.focus();
+      this.DOMFocusableElementStore.focus();
     }
   }
 

--- a/src/components/grid/hovered_cell_store.ts
+++ b/src/components/grid/hovered_cell_store.ts
@@ -14,12 +14,20 @@ export class HoveredCellStore extends SpreadsheetStore {
   }
 
   hover(position: Position) {
+    if (position.col === this.col && position.row === this.row) {
+      return "noStateChange";
+    }
     this.col = position.col;
     this.row = position.row;
+    return;
   }
 
   clear() {
+    if (this.col === undefined && this.row === undefined) {
+      return "noStateChange";
+    }
     this.col = undefined;
     this.row = undefined;
+    return;
   }
 }

--- a/src/components/helpers/draw_grid_hook.ts
+++ b/src/components/helpers/draw_grid_hook.ts
@@ -42,10 +42,6 @@ export function useGridDrawing(refName: string, model: Model, canvasSize: () => 
 
     for (const layer of OrderedLayers()) {
       model.drawLayer(renderingContext, layer);
-      // @ts-ignore 'drawLayer' is not declated as a mutator because:
-      // it does not mutate anything. Most importantly it's used
-      // during rendering. Invoking a mutator during rendering would
-      // trigger another rendering, ultimately resulting in an infinite loop.
       rendererStore.drawLayer(renderingContext, layer);
     }
   }

--- a/src/components/popover/cell_popover_store.ts
+++ b/src/components/popover/cell_popover_store.ts
@@ -33,7 +33,11 @@ export class CellPopoverStore extends SpreadsheetStore {
   }
 
   close() {
+    if (!this.persistentPopover) {
+      return "noStateChange";
+    }
     this.persistentPopover = undefined;
+    return;
   }
 
   get persistentCellPopover(): OpenCellPopover | ClosedCellPopover {

--- a/src/store_engine/store_hooks.ts
+++ b/src/store_engine/store_hooks.ts
@@ -82,7 +82,10 @@ export function proxifyStoreMutation<S extends { mutators: readonly (keyof S)[] 
         const functionProxy = new Proxy(value, {
           // trap the function call
           apply(target, thisArg, argArray) {
-            Reflect.apply(target, thisStore, argArray);
+            const res = Reflect.apply(target, thisStore, argArray);
+            if (res === "noStateChange") {
+              return;
+            }
             callback();
           },
         });

--- a/src/stores/DOM_focus_store.ts
+++ b/src/stores/DOM_focus_store.ts
@@ -1,8 +1,17 @@
 export class DOMFocusableElementStore {
-  mutators = ["setFocusableElement"] as const;
-  focusableElement: HTMLElement | undefined = undefined;
+  mutators = ["setFocusableElement", "focus"] as const;
+  private focusableElement: HTMLElement | undefined = undefined;
 
   setFocusableElement(element: HTMLElement) {
     this.focusableElement = element;
+    return "noStateChange";
+  }
+
+  focus() {
+    if (this.focusableElement === document.activeElement) {
+      return "noStateChange";
+    }
+    this.focusableElement?.focus();
+    return;
   }
 }

--- a/src/stores/renderer_store.ts
+++ b/src/stores/renderer_store.ts
@@ -6,7 +6,7 @@ export interface Renderer {
 }
 
 export class RendererStore {
-  mutators = ["register", "unRegister"] as const;
+  mutators = ["register", "unRegister", "drawLayer"] as const;
   private renderers: Partial<Record<LayerName, Renderer[]>> = {};
 
   register(renderer: Renderer) {
@@ -29,13 +29,13 @@ export class RendererStore {
 
   drawLayer(context: GridRenderingContext, layer: LayerName) {
     const renderers = this.renderers[layer];
-    if (!renderers) {
-      return;
+    if (renderers) {
+      for (const renderer of renderers) {
+        context.ctx.save();
+        renderer.drawLayer(context, layer);
+        context.ctx.restore();
+      }
     }
-    for (const renderer of renderers) {
-      context.ctx.save();
-      renderer.drawLayer(context, layer);
-      context.ctx.restore();
-    }
+    return "noStateChange";
   }
 }

--- a/tests/bottom_bar/bottom_bar_component.test.ts
+++ b/tests/bottom_bar/bottom_bar_component.test.ts
@@ -348,20 +348,17 @@ describe("BottomBar component", () => {
     test.each(["Enter", "Escape"])(
       "Pressing %s ends the edition and yields back the DOM focus",
       async (key) => {
-        const focusElement = jest.fn();
-        const focusableElementStore = env.getStore(DOMFocusableElementStore);
-        const defaultFocusElement = document.createElement("div");
-        defaultFocusElement.focus = focusElement;
-        focusableElementStore.setFocusableElement(defaultFocusElement);
-
         const sheetName = fixture.querySelector<HTMLElement>(".o-sheet-name")!;
+        const triggerRender = jest.fn();
+        env["__spreadsheet_stores__"].on("store-updated", null, triggerRender);
         // will give focus back to the component main node
         triggerMouseEvent(sheetName, "dblclick");
         await nextTick();
         sheetName.textContent = "New name";
-        expect(focusElement).not.toHaveBeenCalled();
+        expect(triggerRender).not.toHaveBeenCalled();
         await keyDown({ key });
-        expect(focusElement).toHaveBeenCalled();
+        const focusableElementStore = env.getStore(DOMFocusableElementStore);
+        expect(focusableElementStore.focus).toHaveBeenCalled();
       }
     );
   });

--- a/tests/test_helpers/helpers.ts
+++ b/tests/test_helpers/helpers.ts
@@ -153,7 +153,9 @@ export function makeTestFixture() {
 
 class FakeRendererStore extends RendererStore {
   // we don't want to actually draw anything on the canvas as it cannot be tested
-  drawLayer(renderingContext: GridRenderingContext, layer: LayerName) {}
+  drawLayer(renderingContext: GridRenderingContext, layer: LayerName) {
+    return "noStateChange";
+  }
 }
 
 interface SpreadsheetChildEnvWithStores extends SpreadsheetChildEnv {


### PR DESCRIPTION
Currently, calling the mutator of a Store (through `useStore`) will automatically trigger a full-on rendering of the spreadsheet. The rationale being that the sotre state **might** have been updated but this also mean that we will trigger a full render even if the call to the mutatore had 0 effect.

This revision adds the possibility for a store to specifcally notify that its state was not altered and that the render can therefore be skipped.

This leaves more room for granularity than a reactivity observer would and we avoid its overhead as well.

Task: 4781429

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo