### PR TITLE
[FIX] function: IF should not mutate its input

### DIFF
--- a/src/functions/module_logical.ts
+++ b/src/functions/module_logical.ts
@@ -70,7 +70,7 @@ export const IF = {
       return { value: "" };
     }
     if (result.value === null) {
-      result.value = "";
+      return { ...result, value: "" };
     }
     return result;
   },
@@ -98,7 +98,7 @@ export const IFERROR = {
       return { value: "" };
     }
     if (result.value === null) {
-      result.value = "";
+      return { ...result, value: "" };
     }
     return result;
   },
@@ -126,7 +126,7 @@ export const IFNA = {
       return { value: "" };
     }
     if (result.value === null) {
-      result.value = "";
+      return { ...result, value: "" };
     }
     return result;
   },
@@ -167,7 +167,7 @@ export const IFS = {
           return { value: "" };
         }
         if (result.value === null) {
-          result.value = "";
+          return { ...result, value: "" };
         }
         return result;
       }

--- a/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
@@ -35,8 +35,8 @@ import { RTreeBoundingBox } from "./r_tree";
 import { SpreadingRelation } from "./spreading_relation";
 
 const MAX_ITERATION = 30;
-const ERROR_CYCLE_CELL = createEvaluatedCell(new CircularDependencyError());
-const EMPTY_CELL = createEvaluatedCell({ value: null });
+const ERROR_CYCLE_CELL = Object.freeze(createEvaluatedCell(new CircularDependencyError()));
+const EMPTY_CELL = Object.freeze(createEvaluatedCell({ value: null }));
 
 export class Evaluator {
   private readonly getters: Getters;

--- a/tests/evaluation/evaluation.test.ts
+++ b/tests/evaluation/evaluation.test.ts
@@ -383,6 +383,16 @@ describe("evaluateCells", () => {
     expect(evaluateCell("A1", { A1: "=IF(A2<>0,1+1,sum(A2,A3))", A2: "0", A3: "10" })).toBe(10);
   });
 
+  test("IF does not mutate the empty cell value", () => {
+    const grid = evaluateGrid({
+      A1: "=ISBLANK(C1)",
+      A2: "=IF(TRUE,B1,B1)",
+      A3: "=ISBLANK(C1)",
+    });
+    expect(grid.A1).toBe(true);
+    expect(grid.A3).toBe(true);
+  });
+
   test("evaluate formula returns the cell error value when we pass an invalid formula", () => {
     let model = new Model();
     const sheetId = model.getters.getActiveSheetId();


### PR DESCRIPTION

## Description:

Steps to reproduce:

- add a formula =IF(TRUE,B1,B2) where B1 is empty
- add a formula below =ISBLANK(C1) where C1 is empty => the result of ISBLANK is false but it should be true.

The first IF changed the value of the shared EMPTY_CELL object from `null` to `""`.

A future step to prevent other similar issues would be to leverage Typescript readonly properties to mark all evaluated cells and intermediary results as readonly. But it's for an another task, probably in master.

Task: [4783504](https://www.odoo.com/odoo/2328/tasks/4783504)
opw: [4778681](https://www.odoo.com/odoo/2328/tasks/4778681)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo