### PR TITLE
[FIX] pivot: `month` granularity sorting

### DIFF
--- a/src/helpers/pivot/spreadsheet_pivot/data_entry_spreadsheet_pivot.ts
+++ b/src/helpers/pivot/spreadsheet_pivot/data_entry_spreadsheet_pivot.ts
@@ -1,4 +1,5 @@
-import { CellValue, EvaluatedCell } from "../../../types";
+import { toNumber } from "../../../functions/helpers";
+import { CellValue, DEFAULT_LOCALE, EvaluatedCell } from "../../../types";
 import { PivotDimension, PivotTableColumn, PivotTableRow } from "../../../types/pivot";
 import { SpreadsheetPivotTable } from "../table_spreadsheet_pivot";
 import { SpreadsheetPivotRuntimeDefinition } from "./runtime_definition_spreadsheet_pivot";
@@ -254,7 +255,9 @@ function compareDimensionValues(dimension: PivotDimension, a: string, b: string)
     return dimension.order === "asc" ? -1 : 1;
   }
   if (dimension.type === "integer" || dimension.type === "date") {
-    return dimension.order === "asc" ? Number(a) - Number(b) : Number(b) - Number(a);
+    return dimension.order === "asc"
+      ? toNumber(a, DEFAULT_LOCALE) - toNumber(b, DEFAULT_LOCALE)
+      : toNumber(b, DEFAULT_LOCALE) - toNumber(a, DEFAULT_LOCALE);
   }
   return dimension.order === "asc" ? a.localeCompare(b) : b.localeCompare(a);
 }

--- a/tests/pivots/spreadsheet_pivot/spreadsheet_pivot.test.ts
+++ b/tests/pivots/spreadsheet_pivot/spreadsheet_pivot.test.ts
@@ -550,7 +550,7 @@ describe("Spreadsheet Pivot", () => {
     expect(getEvaluatedGrid(model, "B26:F26")).toEqual([["5", "9", "14", "Total", ""]]);
   });
 
-  test("month should be supported", () => {
+  test("month should be supported and correctly ordered", () => {
     const model = createModelWithPivot("A1:I5");
     updatePivot(model, "1", {
       columns: [{ name: "Created on", granularity: "month", order: "asc" }],
@@ -558,6 +558,15 @@ describe("Spreadsheet Pivot", () => {
       measures: [{ name: "Expected Revenue", aggregator: "sum" }],
     });
     setCellContent(model, "A26", `=pivot(1)`);
+    expect(getEvaluatedGrid(model, "B26:F26")).toEqual([
+      ["February 2024", "March 2024", "April 2024", "Total", ""],
+    ]);
+
+    updatePivot(model, "1", {
+      columns: [{ name: "Created on", granularity: "month", order: "desc" }],
+      rows: [],
+      measures: [{ name: "Expected Revenue", aggregator: "sum" }],
+    });
     expect(getEvaluatedGrid(model, "B26:F26")).toEqual([
       ["April 2024", "March 2024", "February 2024", "Total", ""],
     ]);


### PR DESCRIPTION
## Description

The `month` granularity sorting wasn't working. The issue was that we were using `Number(value)` instead of `toNumber(value)` to convert the field value to a number.

Task: [4781810](https://www.odoo.com/odoo/2328/tasks/4781810)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo