### PR TITLE
[FIX] OT: Fix chart transformations

### DIFF
--- a/src/collaborative/ot/ot_specific.ts
+++ b/src/collaborative/ot/ot_specific.ts
@@ -5,14 +5,12 @@ import {
   overlap,
   range,
 } from "../../helpers";
-import { transformDefinition } from "../../helpers/figures/charts";
 import { DEFAULT_TABLE_CONFIG } from "../../helpers/table_presets";
 import { otRegistry } from "../../registries";
 import {
   AddColumnsRowsCommand,
   AddMergeCommand,
   AddPivotCommand,
-  CreateChartCommand,
   CreateSheetCommand,
   CreateTableCommand,
   DeleteFigureCommand,
@@ -47,16 +45,6 @@ import { transformRangeData, transformZone } from "./ot_helpers";
 otRegistry.addTransformation("ADD_COLUMNS_ROWS", ["ADD_COLUMNS_ROWS"], addHeadersTransformation);
 otRegistry.addTransformation("REMOVE_COLUMNS_ROWS", ["ADD_COLUMNS_ROWS"], addHeadersTransformation);
 
-otRegistry.addTransformation(
-  "ADD_COLUMNS_ROWS",
-  ["CREATE_CHART", "UPDATE_CHART"],
-  updateChartRangesTransformation
-);
-otRegistry.addTransformation(
-  "REMOVE_COLUMNS_ROWS",
-  ["CREATE_CHART", "UPDATE_CHART"],
-  updateChartRangesTransformation
-);
 otRegistry.addTransformation("DELETE_SHEET", ["MOVE_RANGES"], transformTargetSheetId);
 otRegistry.addTransformation("DELETE_FIGURE", ["UPDATE_FIGURE", "UPDATE_CHART"], updateChartFigure);
 otRegistry.addTransformation("CREATE_SHEET", ["CREATE_SHEET"], createSheetTransformation);
@@ -169,16 +157,6 @@ function updateChartFigure(
     return undefined;
   }
   return toTransform;
-}
-
-function updateChartRangesTransformation(
-  toTransform: UpdateChartCommand | CreateChartCommand,
-  executed: AddColumnsRowsCommand | RemoveColumnsRowsCommand
-): UpdateChartCommand | CreateChartCommand {
-  return {
-    ...toTransform,
-    definition: transformDefinition(toTransform.definition, executed),
-  };
 }
 
 function createSheetTransformation(

--- a/src/collaborative/ot/srt_specific.ts
+++ b/src/collaborative/ot/srt_specific.ts
@@ -1,11 +1,14 @@
 import { deepCopy } from "../../helpers";
+import { transformDefinition } from "../../helpers/figures/charts";
 import { adaptFormulaStringRanges, adaptStringRange } from "../../helpers/formulas";
 import { specificRangeTransformRegistry } from "../../registries/srt_registry";
 import {
   AddConditionalFormatCommand,
   AddDataValidationCommand,
   AddPivotCommand,
+  CreateChartCommand,
   UpdateCellCommand,
+  UpdateChartCommand,
   UpdatePivotCommand,
 } from "../../types/commands";
 import { RangeAdapter } from "../../types/misc";
@@ -101,3 +104,16 @@ function addPivotCommandAdaptRange<Cmd extends AddPivotCommand | UpdatePivotComm
 }
 specificRangeTransformRegistry.add("ADD_PIVOT", addPivotCommandAdaptRange);
 specificRangeTransformRegistry.add("UPDATE_PIVOT", addPivotCommandAdaptRange);
+
+specificRangeTransformRegistry.add("CREATE_CHART", updateChartRangesTransformation);
+specificRangeTransformRegistry.add("UPDATE_CHART", updateChartRangesTransformation);
+
+function updateChartRangesTransformation<Cmd extends UpdateChartCommand | CreateChartCommand>(
+  cmd: Cmd,
+  applyChange: RangeAdapter
+): Cmd {
+  return {
+    ...cmd,
+    definition: transformDefinition(cmd.sheetId, cmd.definition, applyChange),
+  };
+}

--- a/src/helpers/figures/charts/abstract_chart.ts
+++ b/src/helpers/figures/charts/abstract_chart.ts
@@ -1,11 +1,4 @@
-import {
-  AddColumnsRowsCommand,
-  ApplyRangeChange,
-  CommandResult,
-  CoreGetters,
-  RemoveColumnsRowsCommand,
-  UID,
-} from "../../../types";
+import { ApplyRangeChange, CommandResult, CoreGetters, RangeAdapter, UID } from "../../../types";
 import {
   ChartCreationContext,
   ChartDefinition,
@@ -47,8 +40,9 @@ export abstract class AbstractChart {
    * functions will be called during operational transform process
    */
   static transformDefinition(
+    chartSheetId: UID,
     definition: ChartDefinition,
-    executed: AddColumnsRowsCommand | RemoveColumnsRowsCommand
+    applyChange: RangeAdapter
   ): ChartDefinition {
     throw new Error("This method should be implemented by sub class");
   }

--- a/src/helpers/figures/charts/bar_chart.ts
+++ b/src/helpers/figures/charts/bar_chart.ts
@@ -1,14 +1,13 @@
 import type { ChartConfiguration } from "chart.js";
 import { BACKGROUND_CHART_COLOR } from "../../../constants";
 import {
-  AddColumnsRowsCommand,
   ApplyRangeChange,
   Color,
   CommandResult,
   CoreGetters,
   Getters,
   Range,
-  RemoveColumnsRowsCommand,
+  RangeAdapter,
   UID,
 } from "../../../types";
 import { BarChartDefinition, BarChartRuntime } from "../../../types/chart/bar_chart";
@@ -88,10 +87,11 @@ export class BarChart extends AbstractChart {
   }
 
   static transformDefinition(
+    chartSheetId: UID,
     definition: BarChartDefinition,
-    executed: AddColumnsRowsCommand | RemoveColumnsRowsCommand
+    applyChange: RangeAdapter
   ): BarChartDefinition {
-    return transformChartDefinitionWithDataSetsWithZone(definition, executed);
+    return transformChartDefinitionWithDataSetsWithZone(chartSheetId, definition, applyChange);
   }
 
   static validateChartDefinition(

--- a/src/helpers/figures/charts/chart_factory.ts
+++ b/src/helpers/figures/charts/chart_factory.ts
@@ -5,14 +5,7 @@ import {
 } from "../../../constants";
 import { isEvaluationError } from "../../../functions/helpers";
 import { chartRegistry } from "../../../registries/chart_types";
-import {
-  AddColumnsRowsCommand,
-  CellValueType,
-  CommandResult,
-  RemoveColumnsRowsCommand,
-  UID,
-  Zone,
-} from "../../../types";
+import { CellValueType, CommandResult, RangeAdapter, UID, Zone } from "../../../types";
 import { LineChartDefinition, SunburstChartDefinition } from "../../../types/chart";
 import { ChartDefinition, ChartRuntime } from "../../../types/chart/chart";
 import { CoreGetters, Getters } from "../../../types/getters";
@@ -74,14 +67,15 @@ export function validateChartDefinition(
  * functions will be called during operational transform process
  */
 export function transformDefinition(
+  chartSheetId: UID,
   definition: ChartDefinition,
-  executed: AddColumnsRowsCommand | RemoveColumnsRowsCommand
+  applyrange: RangeAdapter
 ): ChartDefinition {
   const transformation = chartRegistry.getAll().find((factory) => factory.match(definition.type));
   if (!transformation) {
     throw new Error("Unknown chart type.");
   }
-  return transformation.transformDefinition(definition, executed);
+  return transformation.transformDefinition(chartSheetId, definition, applyrange);
 }
 
 /**

--- a/src/helpers/figures/charts/combo_chart.ts
+++ b/src/helpers/figures/charts/combo_chart.ts
@@ -1,7 +1,6 @@
 import { ChartConfiguration } from "chart.js";
 import { BACKGROUND_CHART_COLOR } from "../../../constants";
 import {
-  AddColumnsRowsCommand,
   ApplyRangeChange,
   ChartCreationContext,
   Color,
@@ -11,7 +10,7 @@ import {
   ExcelChartDefinition,
   Getters,
   Range,
-  RemoveColumnsRowsCommand,
+  RangeAdapter,
   UID,
 } from "../../../types";
 import {
@@ -87,10 +86,11 @@ export class ComboChart extends AbstractChart {
   }
 
   static transformDefinition(
+    chartSheetId: UID,
     definition: ComboChartDefinition,
-    executed: AddColumnsRowsCommand | RemoveColumnsRowsCommand
+    applyChange: RangeAdapter
   ): ComboChartDefinition {
-    return transformChartDefinitionWithDataSetsWithZone(definition, executed);
+    return transformChartDefinitionWithDataSetsWithZone(chartSheetId, definition, applyChange);
   }
 
   static validateChartDefinition(

--- a/src/helpers/figures/charts/funnel_chart.ts
+++ b/src/helpers/figures/charts/funnel_chart.ts
@@ -1,14 +1,13 @@
 import { ChartConfiguration } from "chart.js";
 import { BACKGROUND_CHART_COLOR } from "../../../constants";
 import {
-  AddColumnsRowsCommand,
   ApplyRangeChange,
   Color,
   CommandResult,
   CoreGetters,
   Getters,
   Range,
-  RemoveColumnsRowsCommand,
+  RangeAdapter,
   UID,
 } from "../../../types";
 import {
@@ -85,10 +84,11 @@ export class FunnelChart extends AbstractChart {
   }
 
   static transformDefinition(
+    chartSheetId: UID,
     definition: FunnelChartDefinition,
-    executed: AddColumnsRowsCommand | RemoveColumnsRowsCommand
+    applyChange: RangeAdapter
   ): FunnelChartDefinition {
-    return transformChartDefinitionWithDataSetsWithZone(definition, executed);
+    return transformChartDefinitionWithDataSetsWithZone(chartSheetId, definition, applyChange);
   }
 
   static validateChartDefinition(

--- a/src/helpers/figures/charts/geo_chart.ts
+++ b/src/helpers/figures/charts/geo_chart.ts
@@ -1,14 +1,13 @@
 import { ChartConfiguration } from "chart.js";
 import { BACKGROUND_CHART_COLOR } from "../../../constants";
 import {
-  AddColumnsRowsCommand,
   ApplyRangeChange,
   Color,
   CommandResult,
   CoreGetters,
   Getters,
   Range,
-  RemoveColumnsRowsCommand,
+  RangeAdapter,
   UID,
 } from "../../../types";
 import { LegendPosition } from "../../../types/chart";
@@ -77,10 +76,11 @@ export class GeoChart extends AbstractChart {
   }
 
   static transformDefinition(
+    chartSheetId: UID,
     definition: GeoChartDefinition,
-    executed: AddColumnsRowsCommand | RemoveColumnsRowsCommand
+    applyChange: RangeAdapter
   ): GeoChartDefinition {
-    return transformChartDefinitionWithDataSetsWithZone(definition, executed);
+    return transformChartDefinitionWithDataSetsWithZone(chartSheetId, definition, applyChange);
   }
 
   static validateChartDefinition(

--- a/src/helpers/figures/charts/line_chart.ts
+++ b/src/helpers/figures/charts/line_chart.ts
@@ -1,14 +1,13 @@
 import { ChartConfiguration } from "chart.js";
 import { BACKGROUND_CHART_COLOR } from "../../../constants";
 import {
-  AddColumnsRowsCommand,
   ApplyRangeChange,
   Color,
   CommandResult,
   CoreGetters,
   Getters,
   Range,
-  RemoveColumnsRowsCommand,
+  RangeAdapter,
   UID,
 } from "../../../types";
 import {
@@ -100,10 +99,11 @@ export class LineChart extends AbstractChart {
   }
 
   static transformDefinition(
+    chartSheetId: UID,
     definition: LineChartDefinition,
-    executed: AddColumnsRowsCommand | RemoveColumnsRowsCommand
+    applyChange: RangeAdapter
   ): LineChartDefinition {
-    return transformChartDefinitionWithDataSetsWithZone(definition, executed);
+    return transformChartDefinitionWithDataSetsWithZone(chartSheetId, definition, applyChange);
   }
 
   static getDefinitionFromContextCreation(context: ChartCreationContext): LineChartDefinition {

--- a/src/helpers/figures/charts/pie_chart.ts
+++ b/src/helpers/figures/charts/pie_chart.ts
@@ -1,14 +1,13 @@
 import type { ChartConfiguration } from "chart.js";
 import { BACKGROUND_CHART_COLOR } from "../../../constants";
 import {
-  AddColumnsRowsCommand,
   ApplyRangeChange,
   Color,
   CommandResult,
   CoreGetters,
   Getters,
   Range,
-  RemoveColumnsRowsCommand,
+  RangeAdapter,
   UID,
 } from "../../../types";
 import {
@@ -77,10 +76,11 @@ export class PieChart extends AbstractChart {
   }
 
   static transformDefinition(
+    chartSheetId: UID,
     definition: PieChartDefinition,
-    executed: AddColumnsRowsCommand | RemoveColumnsRowsCommand
+    applyChange: RangeAdapter
   ): PieChartDefinition {
-    return transformChartDefinitionWithDataSetsWithZone(definition, executed);
+    return transformChartDefinitionWithDataSetsWithZone(chartSheetId, definition, applyChange);
   }
 
   static validateChartDefinition(

--- a/src/helpers/figures/charts/pyramid_chart.ts
+++ b/src/helpers/figures/charts/pyramid_chart.ts
@@ -1,14 +1,13 @@
 import { ChartConfiguration } from "chart.js";
 import { BACKGROUND_CHART_COLOR } from "../../../constants";
 import {
-  AddColumnsRowsCommand,
   ApplyRangeChange,
   Color,
   CommandResult,
   CoreGetters,
   Getters,
   Range,
-  RemoveColumnsRowsCommand,
+  RangeAdapter,
   UID,
 } from "../../../types";
 import {
@@ -78,10 +77,11 @@ export class PyramidChart extends AbstractChart {
   }
 
   static transformDefinition(
+    chartSheetId: UID,
     definition: PyramidChartDefinition,
-    executed: AddColumnsRowsCommand | RemoveColumnsRowsCommand
+    applyChange: RangeAdapter
   ): PyramidChartDefinition {
-    return transformChartDefinitionWithDataSetsWithZone(definition, executed);
+    return transformChartDefinitionWithDataSetsWithZone(chartSheetId, definition, applyChange);
   }
 
   static validateChartDefinition(

--- a/src/helpers/figures/charts/radar_chart.ts
+++ b/src/helpers/figures/charts/radar_chart.ts
@@ -1,7 +1,6 @@
 import { ChartConfiguration } from "chart.js";
 import { BACKGROUND_CHART_COLOR } from "../../../constants";
 import {
-  AddColumnsRowsCommand,
   ApplyRangeChange,
   Color,
   CommandResult,
@@ -9,7 +8,7 @@ import {
   DatasetDesign,
   Getters,
   Range,
-  RemoveColumnsRowsCommand,
+  RangeAdapter,
   UID,
 } from "../../../types";
 import {
@@ -84,10 +83,11 @@ export class RadarChart extends AbstractChart {
   }
 
   static transformDefinition(
+    chartSheetId: UID,
     definition: RadarChartDefinition,
-    executed: AddColumnsRowsCommand | RemoveColumnsRowsCommand
+    applyChange: RangeAdapter
   ): RadarChartDefinition {
-    return transformChartDefinitionWithDataSetsWithZone(definition, executed);
+    return transformChartDefinitionWithDataSetsWithZone(chartSheetId, definition, applyChange);
   }
 
   static validateChartDefinition(

--- a/src/helpers/figures/charts/scatter_chart.ts
+++ b/src/helpers/figures/charts/scatter_chart.ts
@@ -1,14 +1,13 @@
 import { ChartConfiguration } from "chart.js";
 import { BACKGROUND_CHART_COLOR } from "../../../constants";
 import {
-  AddColumnsRowsCommand,
   ApplyRangeChange,
   Color,
   CommandResult,
   CoreGetters,
   Getters,
   Range,
-  RemoveColumnsRowsCommand,
+  RangeAdapter,
   UID,
 } from "../../../types";
 import {
@@ -92,10 +91,11 @@ export class ScatterChart extends AbstractChart {
   }
 
   static transformDefinition(
+    chartSheetId: UID,
     definition: ScatterChartDefinition,
-    executed: AddColumnsRowsCommand | RemoveColumnsRowsCommand
+    applyChange: RangeAdapter
   ): ScatterChartDefinition {
-    return transformChartDefinitionWithDataSetsWithZone(definition, executed);
+    return transformChartDefinitionWithDataSetsWithZone(chartSheetId, definition, applyChange);
   }
 
   static getDefinitionFromContextCreation(context: ChartCreationContext): ScatterChartDefinition {

--- a/src/helpers/figures/charts/scorecard_chart.ts
+++ b/src/helpers/figures/charts/scorecard_chart.ts
@@ -1,4 +1,3 @@
-import { transformZone } from "../../../collaborative/ot/ot_helpers";
 import {
   CHART_PADDING,
   DEFAULT_SCORECARD_BASELINE_COLOR_DOWN,
@@ -8,7 +7,6 @@ import {
 import { toNumber } from "../../../functions/helpers";
 import { _t } from "../../../translation";
 import {
-  AddColumnsRowsCommand,
   ApplyRangeChange,
   CellValueType,
   Color,
@@ -18,9 +16,8 @@ import {
   Getters,
   Locale,
   Range,
-  RemoveColumnsRowsCommand,
+  RangeAdapter,
   UID,
-  UnboundedZone,
 } from "../../../types";
 import { ChartCreationContext } from "../../../types/chart/chart";
 import {
@@ -29,13 +26,14 @@ import {
   ScorecardChartDefinition,
   ScorecardChartRuntime,
 } from "../../../types/chart/scorecard_chart";
+import { CellErrorType } from "../../../types/errors";
 import { Validator } from "../../../types/validator";
 import { formatValue, humanizeNumber } from "../../format/format";
+import { adaptStringRange } from "../../formulas";
 import { isNumber } from "../../numbers";
 import { createValidRange } from "../../range";
 import { rangeReference } from "../../references";
 import { clipTextWithEllipsis, drawDecoratedText } from "../../text_helper";
-import { toUnboundedZone, zoneToXc } from "../../zones";
 import { AbstractChart } from "./abstract_chart";
 import { adaptChartRange, duplicateLabelRangeInDuplicatedSheet } from "./chart_common";
 import { ScorecardChartConfig } from "./scorecard_chart_config_builder";
@@ -206,22 +204,28 @@ export class ScorecardChart extends AbstractChart {
   }
 
   static transformDefinition(
+    chartSheetId: UID,
     definition: ScorecardChartDefinition,
-    executed: AddColumnsRowsCommand | RemoveColumnsRowsCommand
+    applyChange: RangeAdapter
   ): ScorecardChartDefinition {
-    let baselineZone: UnboundedZone | undefined;
-    let keyValueZone: UnboundedZone | undefined;
-
+    let baseline: string | undefined;
+    let keyValue: string | undefined;
     if (definition.baseline) {
-      baselineZone = transformZone(toUnboundedZone(definition.baseline), executed);
+      const adaptedRange = adaptStringRange(chartSheetId, definition.baseline, applyChange);
+      if (adaptedRange !== CellErrorType.InvalidReference) {
+        baseline = adaptedRange;
+      }
     }
     if (definition.keyValue) {
-      keyValueZone = transformZone(toUnboundedZone(definition.keyValue), executed);
+      const adaptedRange = adaptStringRange(chartSheetId, definition.keyValue, applyChange);
+      if (adaptedRange !== CellErrorType.InvalidReference) {
+        keyValue = adaptedRange;
+      }
     }
     return {
       ...definition,
-      baseline: baselineZone ? zoneToXc(baselineZone) : undefined,
-      keyValue: keyValueZone ? zoneToXc(keyValueZone) : undefined,
+      baseline,
+      keyValue,
     };
   }
 

--- a/src/helpers/figures/charts/sunburst_chart.ts
+++ b/src/helpers/figures/charts/sunburst_chart.ts
@@ -1,14 +1,13 @@
 import type { ChartConfiguration, ChartOptions } from "chart.js";
 import { BACKGROUND_CHART_COLOR } from "../../../constants";
 import {
-  AddColumnsRowsCommand,
   ApplyRangeChange,
   Color,
   CommandResult,
   CoreGetters,
   Getters,
   Range,
-  RemoveColumnsRowsCommand,
+  RangeAdapter,
   UID,
 } from "../../../types";
 import { SunburstChartDefinition, SunburstChartRuntime } from "../../../types/chart";
@@ -74,10 +73,11 @@ export class SunburstChart extends AbstractChart {
   }
 
   static transformDefinition(
+    chartSheetId: UID,
     definition: SunburstChartDefinition,
-    executed: AddColumnsRowsCommand | RemoveColumnsRowsCommand
+    applyChange: RangeAdapter
   ): SunburstChartDefinition {
-    return transformChartDefinitionWithDataSetsWithZone(definition, executed);
+    return transformChartDefinitionWithDataSetsWithZone(chartSheetId, definition, applyChange);
   }
 
   static validateChartDefinition(

--- a/src/helpers/figures/charts/tree_map_chart.ts
+++ b/src/helpers/figures/charts/tree_map_chart.ts
@@ -1,14 +1,13 @@
 import { ChartConfiguration } from "chart.js";
 import { BACKGROUND_CHART_COLOR } from "../../../constants";
 import {
-  AddColumnsRowsCommand,
   ApplyRangeChange,
   Color,
   CommandResult,
   CoreGetters,
   Getters,
   Range,
-  RemoveColumnsRowsCommand,
+  RangeAdapter,
   UID,
 } from "../../../types";
 import {
@@ -87,10 +86,11 @@ export class TreeMapChart extends AbstractChart {
   }
 
   static transformDefinition(
+    chartSheetId: UID,
     definition: TreeMapChartDefinition,
-    executed: AddColumnsRowsCommand | RemoveColumnsRowsCommand
+    applyChange: RangeAdapter
   ): TreeMapChartDefinition {
-    return transformChartDefinitionWithDataSetsWithZone(definition, executed);
+    return transformChartDefinitionWithDataSetsWithZone(chartSheetId, definition, applyChange);
   }
 
   static validateChartDefinition(

--- a/src/helpers/figures/charts/waterfall_chart.ts
+++ b/src/helpers/figures/charts/waterfall_chart.ts
@@ -1,14 +1,13 @@
 import type { ChartConfiguration } from "chart.js";
 import { BACKGROUND_CHART_COLOR } from "../../../constants";
 import {
-  AddColumnsRowsCommand,
   ApplyRangeChange,
   Color,
   CommandResult,
   CoreGetters,
   Getters,
   Range,
-  RemoveColumnsRowsCommand,
+  RangeAdapter,
   UID,
 } from "../../../types";
 import {
@@ -92,10 +91,11 @@ export class WaterfallChart extends AbstractChart {
   }
 
   static transformDefinition(
+    chartSheetId: UID,
     definition: WaterfallChartDefinition,
-    executed: AddColumnsRowsCommand | RemoveColumnsRowsCommand
+    applyChange: RangeAdapter
   ): WaterfallChartDefinition {
-    return transformChartDefinitionWithDataSetsWithZone(definition, executed);
+    return transformChartDefinitionWithDataSetsWithZone(chartSheetId, definition, applyChange);
   }
 
   static validateChartDefinition(

--- a/src/helpers/formulas.ts
+++ b/src/helpers/formulas.ts
@@ -1,6 +1,5 @@
 import { rangeTokenize } from "../formulas";
 import { Range, RangeAdapter, UID } from "../types";
-import { CellErrorType } from "../types/errors";
 import { concat } from "./misc";
 import { createInvalidRange, createRangeFromXc, getRangeString } from "./range";
 import { rangeReference, splitReference } from "./references";
@@ -52,8 +51,7 @@ export function adaptStringRange(
     return sheetXC;
   }
 
-  const newSheetXC = getRangeString(change.range, defaultSheetId, getSheetNameGetter(applyChange));
-  return newSheetXC === CellErrorType.InvalidReference ? sheetXC : newSheetXC;
+  return getRangeString(change.range, defaultSheetId, getSheetNameGetter(applyChange));
 }
 
 function getSheetNameGetter(applyChange: RangeAdapter) {

--- a/src/helpers/formulas.ts
+++ b/src/helpers/formulas.ts
@@ -3,6 +3,7 @@ import { Range, RangeAdapter, UID } from "../types";
 import { concat } from "./misc";
 import { createInvalidRange, createRangeFromXc, getRangeString } from "./range";
 import { rangeReference, splitReference } from "./references";
+import { isSheetNameEqual } from "./sheet";
 
 export function adaptFormulaStringRanges(
   defaultSheetId: string,
@@ -31,12 +32,16 @@ export function adaptFormulaStringRanges(
 }
 
 export function adaptStringRange(
-  defaultSheetId: string,
+  defaultSheetId: UID,
   sheetXC: string,
   applyChange: RangeAdapter
 ): string {
   const sheetName = splitReference(sheetXC).sheetName;
-  if (sheetName ? sheetName !== applyChange.sheetName : defaultSheetId !== applyChange.sheetId) {
+  if (
+    sheetName
+      ? !isSheetNameEqual(sheetName, applyChange.sheetName)
+      : defaultSheetId !== applyChange.sheetId
+  ) {
     return sheetXC;
   }
   const sheetId = sheetName ? applyChange.sheetId : defaultSheetId;

--- a/src/registries/chart_types.ts
+++ b/src/registries/chart_types.ts
@@ -27,14 +27,7 @@ import {
   createWaterfallChartRuntime,
 } from "../helpers/figures/charts/waterfall_chart";
 import { _t } from "../translation";
-import {
-  AddColumnsRowsCommand,
-  CommandResult,
-  CoreGetters,
-  Getters,
-  RemoveColumnsRowsCommand,
-  UID,
-} from "../types";
+import { CommandResult, CoreGetters, Getters, RangeAdapter, UID } from "../types";
 import {
   BarChartDefinition,
   GaugeChartDefinition,
@@ -79,8 +72,9 @@ export interface ChartBuilder {
     definition: ChartDefinition
   ): CommandResult | CommandResult[];
   transformDefinition(
+    chartSheetId: UID,
     definition: ChartDefinition,
-    executed: AddColumnsRowsCommand | RemoveColumnsRowsCommand
+    applyRange: RangeAdapter
   ): ChartDefinition;
   getChartDefinitionFromContextCreation(context: ChartCreationContext): ChartDefinition;
   sequence: number;

--- a/tests/collaborative/collaborative_sheet_manipulations.test.ts
+++ b/tests/collaborative/collaborative_sheet_manipulations.test.ts
@@ -640,7 +640,7 @@ describe("Collaborative Sheet manipulation", () => {
         (user) => user.getters.getChartDefinition(chartId),
         {
           ...chartDef,
-          dataSets: [{ dataRange: "A1:A3" }, { dataRange: "H1:H3" }],
+          dataSets: [{ dataRange: "A1:A3", yAxisId: "y" }, { dataRange: "H1:H3" }],
           labelRange: "H3",
         }
       );

--- a/tests/collaborative/ot/ot.test.ts
+++ b/tests/collaborative/ot/ot.test.ts
@@ -1,5 +1,11 @@
 import { transform } from "../../../src/collaborative/ot/ot";
-import { DeleteFigureCommand, UpdateChartCommand, UpdateFigureCommand } from "../../../src/types";
+import {
+  AddColumnsRowsCommand,
+  DeleteFigureCommand,
+  UpdateCellCommand,
+  UpdateChartCommand,
+  UpdateFigureCommand,
+} from "../../../src/types";
 import { LineChartDefinition } from "../../../src/types/chart/line_chart";
 
 describe("OT with DELETE_FIGURE", () => {
@@ -31,5 +37,29 @@ describe("OT with DELETE_FIGURE", () => {
         figureId: "otherId",
       });
     });
+  });
+});
+
+test("OT supports case-insensitive sheetname", () => {
+  const UpdateCellCommand: UpdateCellCommand = {
+    type: "UPDATE_CELL",
+    sheetId: "sh1",
+    col: 0,
+    row: 0,
+    // purposefully using lowercase "sheet1" to test case insensitivity
+    content: "=sheet1!C5",
+  };
+  const AddColumnCommand: AddColumnsRowsCommand = {
+    type: "ADD_COLUMNS_ROWS",
+    sheetId: "sh1",
+    base: 1,
+    dimension: "COL",
+    quantity: 1,
+    position: "after",
+    sheetName: "Sheet1",
+  };
+  expect(transform(UpdateCellCommand, AddColumnCommand)).toEqual({
+    ...UpdateCellCommand,
+    content: "=Sheet1!D5",
   });
 });

--- a/tests/collaborative/ot/ot_columns_added.test.ts
+++ b/tests/collaborative/ot/ot_columns_added.test.ts
@@ -602,6 +602,12 @@ describe("OT with AddColumns and UPDATE_CHART/CREATE_CHART", () => {
     sheetName,
   };
 
+  const addColOnSheet2: AddColumnsRowsCommand = {
+    ...addColumnsBefore,
+    sheetId: "sh2",
+    sheetName: "Sheet2",
+  };
+
   test("CREATE_CHART ranges are updated on the same sheet as addColumns", () => {
     const toTransform: CreateChartCommand = {
       type: "CREATE_CHART",
@@ -613,11 +619,18 @@ describe("OT with AddColumns and UPDATE_CHART/CREATE_CHART", () => {
       col: 0,
       row: 0,
     };
-    const result = transform(toTransform, addColumnsBefore) as CreateChartCommand;
+    let result = transform(toTransform, addColumnsBefore) as CreateChartCommand;
     expect(result.definition).toEqual({
       ...definition,
       dataSets: [{ dataRange: "Sheet1!O1:O10" }, { dataRange: "Sheet2!M1:M10" }],
       labelRange: "Sheet1!O1:O10",
+    });
+
+    result = transform(toTransform, addColOnSheet2) as CreateChartCommand;
+    expect(result.definition).toEqual({
+      ...definition,
+      dataSets: [{ dataRange: "Sheet1!M1:M10" }, { dataRange: "Sheet2!O1:O10" }],
+      labelRange: "Sheet1!M1:M10",
     });
   });
 
@@ -629,11 +642,18 @@ describe("OT with AddColumns and UPDATE_CHART/CREATE_CHART", () => {
       definition,
     };
 
-    const result = transform(toTransform, addColumnsBefore) as UpdateChartCommand;
+    let result = transform(toTransform, addColumnsBefore) as UpdateChartCommand;
     expect(result.definition).toEqual({
       ...definition,
       dataSets: [{ dataRange: "Sheet1!O1:O10" }, { dataRange: "Sheet2!M1:M10" }],
       labelRange: "Sheet1!O1:O10",
+    });
+
+    result = transform(toTransform, addColOnSheet2) as UpdateChartCommand;
+    expect(result.definition).toEqual({
+      ...definition,
+      dataSets: [{ dataRange: "Sheet1!M1:M10" }, { dataRange: "Sheet2!O1:O10" }],
+      labelRange: "Sheet1!M1:M10",
     });
   });
 });

--- a/tests/collaborative/ot/ot_columns_removed.test.ts
+++ b/tests/collaborative/ot/ot_columns_removed.test.ts
@@ -591,7 +591,7 @@ describe("Transform adapt string formulas on row deletion", () => {
   );
 });
 
-describe("OT with AddColumns and UPDATE_CHART/CREATE_CHART", () => {
+describe("OT with RemoveColumns and UPDATE_CHART/CREATE_CHART", () => {
   const sheetId = "sheet1";
   const sheetName = "Sheet1";
   const definition: BarChartDefinition = {
@@ -612,7 +612,13 @@ describe("OT with AddColumns and UPDATE_CHART/CREATE_CHART", () => {
     sheetName,
   };
 
-  test("CREATE_CHART ranges are updated on the same sheet as addColumns", () => {
+  const removeColumnsOnSheet2: RemoveColumnsRowsCommand = {
+    ...removeColumns,
+    sheetId: "sh2",
+    sheetName: "Sheet2",
+  };
+
+  test("CREATE_CHART ranges are updated on the same sheet as RemoveColumns", () => {
     const toTransform: CreateChartCommand = {
       type: "CREATE_CHART",
       sheetId,
@@ -623,26 +629,40 @@ describe("OT with AddColumns and UPDATE_CHART/CREATE_CHART", () => {
       offset: { x: 0, y: 0 },
       size: { width: 0, height: 0 },
     };
-    const result = transform(toTransform, removeColumns) as CreateChartCommand;
+    let result = transform(toTransform, removeColumns) as CreateChartCommand;
     expect(result.definition).toEqual({
       ...definition,
       dataSets: [{ dataRange: "Sheet1!J1:J10" }, { dataRange: "Sheet2!M1:M10" }],
       labelRange: "Sheet1!J1:J10",
     });
+
+    result = transform(toTransform, removeColumnsOnSheet2) as CreateChartCommand;
+    expect(result.definition).toEqual({
+      ...definition,
+      dataSets: [{ dataRange: "Sheet1!M1:M10" }, { dataRange: "Sheet2!J1:J10" }],
+      labelRange: "Sheet1!M1:M10",
+    });
   });
 
-  test("UPDATE_CHART ranges are updated on the same sheet as addColumns", () => {
+  test("UPDATE_CHART ranges are updated on the same sheet as RemoveColumns", () => {
     const toTransform: UpdateChartCommand = {
       type: "UPDATE_CHART",
       sheetId,
       figureId: "chart1",
       definition,
     };
-    const result = transform(toTransform, removeColumns) as UpdateChartCommand;
+    let result = transform(toTransform, removeColumns) as UpdateChartCommand;
     expect(result.definition).toEqual({
       ...definition,
       dataSets: [{ dataRange: "Sheet1!J1:J10" }, { dataRange: "Sheet2!M1:M10" }],
       labelRange: "Sheet1!J1:J10",
+    });
+
+    result = transform(toTransform, removeColumnsOnSheet2) as UpdateChartCommand;
+    expect(result.definition).toEqual({
+      ...definition,
+      dataSets: [{ dataRange: "Sheet1!M1:M10" }, { dataRange: "Sheet2!J1:J10" }],
+      labelRange: "Sheet1!M1:M10",
     });
   });
 });

--- a/tests/collaborative/ot/ot_rows_added.test.ts
+++ b/tests/collaborative/ot/ot_rows_added.test.ts
@@ -596,6 +596,12 @@ describe("OT with addRows and UPDATE_CHART/CREATE_CHART", () => {
     sheetName,
   };
 
+  const addRowsOnSheet2: AddColumnsRowsCommand = {
+    ...addRowsBefore,
+    sheetId: "sh2",
+    sheetName: "Sheet2",
+  };
+
   test("CREATE_CHART ranges are updated on the same sheet as addRows", () => {
     const toTransform: CreateChartCommand = {
       type: "CREATE_CHART",
@@ -607,11 +613,18 @@ describe("OT with addRows and UPDATE_CHART/CREATE_CHART", () => {
       offset: { x: 0, y: 0 },
       size: { width: 0, height: 0 },
     };
-    const result = transform(toTransform, addRowsBefore) as CreateChartCommand;
+    let result = transform(toTransform, addRowsBefore) as CreateChartCommand;
     expect(result.definition).toEqual({
       ...definition,
       dataSets: [{ dataRange: "Sheet1!A5:A17" }, { dataRange: "Sheet2!A5:A15" }],
       labelRange: "Sheet1!A5:A17",
+    });
+
+    result = transform(toTransform, addRowsOnSheet2) as CreateChartCommand;
+    expect(result.definition).toEqual({
+      ...definition,
+      dataSets: [{ dataRange: "Sheet1!A5:A15" }, { dataRange: "Sheet2!A5:A17" }],
+      labelRange: "Sheet1!A5:A15",
     });
   });
 
@@ -623,11 +636,18 @@ describe("OT with addRows and UPDATE_CHART/CREATE_CHART", () => {
       definition,
     };
 
-    const result = transform(toTransform, addRowsBefore) as UpdateChartCommand;
+    let result = transform(toTransform, addRowsBefore) as UpdateChartCommand;
     expect(result.definition).toEqual({
       ...definition,
       dataSets: [{ dataRange: "Sheet1!A5:A17" }, { dataRange: "Sheet2!A5:A15" }],
       labelRange: "Sheet1!A5:A17",
+    });
+
+    result = transform(toTransform, addRowsOnSheet2) as UpdateChartCommand;
+    expect(result.definition).toEqual({
+      ...definition,
+      dataSets: [{ dataRange: "Sheet1!A5:A15" }, { dataRange: "Sheet2!A5:A17" }],
+      labelRange: "Sheet1!A5:A15",
     });
   });
 });

--- a/tests/collaborative/ot/ot_rows_removed.test.ts
+++ b/tests/collaborative/ot/ot_rows_removed.test.ts
@@ -614,6 +614,12 @@ describe("OT with removeRows and UPDATE_CHART/CREATE_CHART", () => {
     sheetName,
   };
 
+  const removeRowsOnSheet2: RemoveColumnsRowsCommand = {
+    ...removeRows,
+    sheetId: "sh2",
+    sheetName: "Sheet2",
+  };
+
   test("CREATE_CHART ranges are updated on the same sheet as removeRows", () => {
     const toTransform: CreateChartCommand = {
       type: "CREATE_CHART",
@@ -625,11 +631,18 @@ describe("OT with removeRows and UPDATE_CHART/CREATE_CHART", () => {
       offset: { x: 0, y: 0 },
       size: { width: 0, height: 0 },
     };
-    const result = transform(toTransform, removeRows) as CreateChartCommand;
+    let result = transform(toTransform, removeRows) as CreateChartCommand;
     expect(result.definition).toEqual({
       ...definition,
       dataSets: [{ dataRange: "Sheet1!A1:A7" }, { dataRange: "Sheet2!A1:A10" }],
       labelRange: "Sheet1!A1:A7",
+    });
+
+    result = transform(toTransform, removeRowsOnSheet2) as CreateChartCommand;
+    expect(result.definition).toEqual({
+      ...definition,
+      dataSets: [{ dataRange: "Sheet1!A1:A10" }, { dataRange: "Sheet2!A1:A7" }],
+      labelRange: "Sheet1!A1:A10",
     });
   });
 
@@ -640,11 +653,18 @@ describe("OT with removeRows and UPDATE_CHART/CREATE_CHART", () => {
       figureId: "chart1",
       definition,
     };
-    const result = transform(toTransform, removeRows) as UpdateChartCommand;
+    let result = transform(toTransform, removeRows) as UpdateChartCommand;
     expect(result.definition).toEqual({
       ...definition,
       dataSets: [{ dataRange: "Sheet1!A1:A7" }, { dataRange: "Sheet2!A1:A10" }],
       labelRange: "Sheet1!A1:A7",
+    });
+
+    result = transform(toTransform, removeRowsOnSheet2) as UpdateChartCommand;
+    expect(result.definition).toEqual({
+      ...definition,
+      dataSets: [{ dataRange: "Sheet1!A1:A10" }, { dataRange: "Sheet2!A1:A7" }],
+      labelRange: "Sheet1!A1:A10",
     });
   });
 });


### PR DESCRIPTION
Currently, we transform chart ranges upon the addition/deletion of
headers in a sheet regardless if the range belongs to the said sheet.

e.g.
- given a chart with a range  A1:A3 on sheet1 and a second A1:A3  on sheet2
- delete a the second row of sheet1

Both ranges are transformed and set to A1:A2. There is a double issue
with the range on sheet2.
1. it's range zone is updated
2. the sheet prefix is removed, meaning that it no longer points towards
   the same sheet!

Task: 4717724

Task: [4717724](https://www.odoo.com/odoo/2328/tasks/4717724)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo