### PR TITLE
[FIX] pivot_time_adapter: use real date for month

### DIFF
--- a/src/helpers/pivot/pivot_time_adapter.ts
+++ b/src/helpers/pivot/pivot_time_adapter.ts
@@ -182,7 +182,8 @@ const monthAdapter: PivotTimeAdapterNotNull<string> = {
     };
   },
   toFunctionValue(normalizedValue) {
-    return `"${normalizedValue}"`;
+    const jsDate = toJsDate(normalizedValue, DEFAULT_LOCALE);
+    return `DATE(${jsDate.getFullYear()},${jsDate.getMonth() + 1},1)`;
   },
 };
 

--- a/tests/pivots/pivot_helpers.test.ts
+++ b/tests/pivots/pivot_helpers.test.ts
@@ -200,6 +200,9 @@ describe("ToFunctionValue", () => {
     dimension.granularity = "year";
     expect(toFunctionPivotValue("2020", dimension)).toBe("2020");
 
+    dimension.granularity = "month";
+    expect(toFunctionPivotValue("4/11/2020", dimension)).toBe("DATE(2020,4,1)");
+
     dimension.granularity = "day_of_month";
     expect(toFunctionPivotValue(1, dimension)).toBe("1");
 


### PR DESCRIPTION
Commit https://github.com/odoo/o-spreadsheet/commit/392cdf83def6e13a8c6d417c364993799c55fa6d did not take into account the changes made in saas-18.3: https://github.com/odoo/odoo/commit/3580b0801ace8b89a6971a0f150c6dca88bf0045

Task: 4787419

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo