### PR TITLE
Master full screen chart adrm

### DIFF
--- a/src/components/figures/chart/chartJs/chartjs.ts
+++ b/src/components/figures/chart/chartJs/chartjs.ts
@@ -20,6 +20,7 @@ import { waterfallLinesPlugin } from "./chartjs_waterfall_plugin";
 
 interface Props {
   figureUI: FigureUI;
+  isFullScreen?: boolean;
 }
 
 css/* scss */ `
@@ -67,6 +68,7 @@ export class ChartJsComponent extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ChartJsComponent";
   static props = {
     figureUI: Object,
+    isFullScreen: { type: Boolean, optional: true },
   };
 
   private canvas = useRef("graphContainer");
@@ -123,9 +125,9 @@ export class ChartJsComponent extends Component<Props, SpreadsheetChildEnv> {
   private createChart(chartData: ChartConfiguration<any>) {
     if (this.env.model.getters.isDashboard() && this.animationStore) {
       const chartType = this.env.model.getters.getChart(this.props.figureUI.id)?.type;
-      if (chartType && this.animationStore.animationPlayed[this.props.figureUI.id] !== chartType) {
+      if (chartType && this.animationStore.animationPlayed[this.animationFigureId] !== chartType) {
         chartData = this.enableAnimationInChartData(chartData);
-        this.animationStore.disableAnimationForChart(this.props.figureUI.id, chartType);
+        this.animationStore.disableAnimationForChart(this.animationFigureId, chartType);
       }
     }
 
@@ -139,7 +141,7 @@ export class ChartJsComponent extends Component<Props, SpreadsheetChildEnv> {
       const chartType = this.env.model.getters.getChart(this.props.figureUI.id)?.type;
       if (chartType && this.hasChartDataChanged() && this.animationStore) {
         chartData = this.enableAnimationInChartData(chartData);
-        this.animationStore.disableAnimationForChart(this.props.figureUI.id, chartType);
+        this.animationStore.disableAnimationForChart(this.animationFigureId, chartType);
       }
     }
 
@@ -167,5 +169,11 @@ export class ChartJsComponent extends Component<Props, SpreadsheetChildEnv> {
       ...chartData,
       options: { ...chartData.options, animation: { animateRotate: true } },
     };
+  }
+
+  get animationFigureId() {
+    return this.props.isFullScreen
+      ? this.props.figureUI.id + "-fullscreen"
+      : this.props.figureUI.id;
   }
 }

--- a/src/components/figures/chart/chartJs/chartjs_animation_store.ts
+++ b/src/components/figures/chart/chartJs/chartjs_animation_store.ts
@@ -1,0 +1,13 @@
+import { SpreadsheetStore } from "../../../../stores/spreadsheet_store";
+import { ChartType, UID } from "../../../../types";
+
+export class ChartAnimationStore extends SpreadsheetStore {
+  mutators = ["disableAnimationForChart"] as const;
+
+  animationPlayed = {};
+
+  disableAnimationForChart(chartId: UID, chartType: ChartType) {
+    this.animationPlayed[chartId] = chartType;
+    return "noStateChange";
+  }
+}

--- a/src/components/figures/chart/chartJs/chartjs_animation_store.ts
+++ b/src/components/figures/chart/chartJs/chartjs_animation_store.ts
@@ -2,12 +2,17 @@ import { SpreadsheetStore } from "../../../../stores/spreadsheet_store";
 import { ChartType, UID } from "../../../../types";
 
 export class ChartAnimationStore extends SpreadsheetStore {
-  mutators = ["disableAnimationForChart"] as const;
+  mutators = ["disableAnimationForChart", "enableAnimationForChart"] as const;
 
   animationPlayed = {};
 
   disableAnimationForChart(chartId: UID, chartType: ChartType) {
     this.animationPlayed[chartId] = chartType;
+    return "noStateChange";
+  }
+
+  enableAnimationForChart(chartId: UID) {
+    this.animationPlayed[chartId] = undefined;
     return "noStateChange";
   }
 }

--- a/src/components/figures/chart/chart_dashboard_menu/chart_dashboard_menu.xml
+++ b/src/components/figures/chart/chart_dashboard_menu/chart_dashboard_menu.xml
@@ -2,13 +2,13 @@
   <t t-name="spreadsheet.ChartDashboardMenu">
     <div class="o-dashboard-chart-select position-absolute top-0 end-0" t-on-click.stop="">
       <div class="d-flex flex-row px-1" t-att-style="backgroundColor">
-        <t t-foreach="getAvailableTypes()" t-as="type" t-key="type.chartSubtype">
+        <t t-foreach="getMenuItems()" t-as="item" t-key="item.id">
           <button
-            t-attf-class=" {{type.icon}} {{type.chartType === selectedChartType ? 'active' : ''}}"
+            t-attf-class=" {{item.iconClass}} {{item.isSelected ? 'active' : ''}}"
             class="o-chart-dashboard-item btn mt-1 me-1 p-1 "
-            t-att-title="type.displayName"
-            t-on-click="() => this.onTypeChange(type.chartSubtype)"
-            t-att-data-id="type.chartSubtype"
+            t-att-title="item.label"
+            t-on-click="item.onClick"
+            t-att-data-id="item.id"
           />
         </t>
         <button

--- a/src/components/figures/chart/gauge/gauge_chart_component.ts
+++ b/src/components/figures/chart/gauge/gauge_chart_component.ts
@@ -5,10 +5,16 @@ import { GaugeChartRuntime } from "../../../../types/chart";
 
 interface Props {
   figureUI: FigureUI;
+  isFullScreen?: boolean;
 }
 
 export class GaugeChartComponent extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-GaugeChartComponent";
+  static props = {
+    figureUI: Object,
+    isFullScreen: { type: Boolean, optional: true },
+  };
+
   private canvas = useRef("chartContainer");
 
   get runtime(): GaugeChartRuntime {
@@ -26,7 +32,3 @@ export class GaugeChartComponent extends Component<Props, SpreadsheetChildEnv> {
     );
   }
 }
-
-GaugeChartComponent.props = {
-  figureUI: Object,
-};

--- a/src/components/full_screen_chart/full_screen_chart.scss
+++ b/src/components/full_screen_chart/full_screen_chart.scss
@@ -1,0 +1,11 @@
+.o-spreadsheet {
+  .o-fullscreen-chart-overlay {
+    z-index: 34; /* TODO: use css variables once ComponentsImportance is available in the scss. */
+    background-color: rgba(0, 0, 0, 0.4);
+    padding: 60px;
+
+    .o-figure:not(:hover) .o-dashboard-chart-select {
+      display: block !important;
+    }
+  }
+}

--- a/src/components/full_screen_chart/full_screen_chart.ts
+++ b/src/components/full_screen_chart/full_screen_chart.ts
@@ -1,0 +1,66 @@
+import { Component, onWillUpdateProps, useEffect, useRef } from "@odoo/owl";
+import { chartComponentRegistry } from "../../registries/chart_types";
+import { figureRegistry } from "../../registries/figures_registry";
+import { Store, useStore } from "../../store_engine";
+import { SpreadsheetChildEnv } from "../../types";
+import { ChartDashboardMenu } from "../figures/chart/chart_dashboard_menu/chart_dashboard_menu";
+import { ChartAnimationStore } from "../figures/chart/chartJs/chartjs_animation_store";
+import { useSpreadsheetRect } from "../helpers/position_hook";
+import { FullScreenChartStore } from "./full_screen_chart_store";
+
+export class FullScreenChart extends Component<{}, SpreadsheetChildEnv> {
+  static template = "o-spreadsheet-FullScreenChart";
+  static props = {};
+  static components = { ChartDashboardMenu };
+
+  private fullScreenChartStore!: Store<FullScreenChartStore>;
+  private ref = useRef("fullScreenChart");
+
+  spreadsheetRect = useSpreadsheetRect();
+
+  figureRegistry = figureRegistry;
+
+  setup() {
+    this.fullScreenChartStore = useStore(FullScreenChartStore);
+
+    const animationStore = useStore(ChartAnimationStore);
+    let lastFigureId: string | undefined = undefined;
+    onWillUpdateProps(() => {
+      if (lastFigureId !== this.figureUI?.id) {
+        animationStore.enableAnimationForChart(this.figureUI?.id + "-fullscreen");
+      }
+      lastFigureId = this.figureUI?.id;
+    });
+
+    useEffect(
+      (el) => el?.focus(),
+      () => [this.ref.el]
+    );
+  }
+
+  get figureUI() {
+    return this.fullScreenChartStore.fullScreenFigure;
+  }
+
+  exitFullScreen() {
+    if (this.figureUI) {
+      this.fullScreenChartStore.toggleFullScreenChart(this.figureUI.id);
+    }
+  }
+
+  onKeyDown(ev: KeyboardEvent) {
+    if (ev.key === "Escape") {
+      this.exitFullScreen();
+    }
+  }
+
+  get chartComponent(): (new (...args: any) => Component) | undefined {
+    if (!this.figureUI) return undefined;
+    const type = this.env.model.getters.getChartType(this.figureUI.id);
+    const component = chartComponentRegistry.get(type);
+    if (!component) {
+      throw new Error(`Component is not defined for type ${type}`);
+    }
+    return component;
+  }
+}

--- a/src/components/full_screen_chart/full_screen_chart.xml
+++ b/src/components/full_screen_chart/full_screen_chart.xml
@@ -1,0 +1,32 @@
+<templates>
+  <t t-name="o-spreadsheet-FullScreenChart">
+    <div
+      class="position-absolute o-fullscreen-chart-overlay w-100 h-100 d-flex"
+      t-if="figureUI"
+      t-on-click="exitFullScreen">
+      <button
+        class="o-exit top-0 end-0 position-absolute o-button primary m-1"
+        t-on-click="exitFullScreen">
+        Exit fullscreen
+      </button>
+      <div class="flex-fill">
+        <div
+          class="o-fullscreen-chart o-figure position-relative"
+          tabindex="1"
+          t-ref="fullScreenChart"
+          t-on-click.stop=""
+          t-on-keydown="(ev) => this.onKeyDown(ev)">
+          <t
+            t-component="chartComponent"
+            figureUI="this.figureUI"
+            isFullScreen="true"
+            t-key="this.figureUI.id"
+          />
+          <div class="position-absolute top-0 end-0">
+            <ChartDashboardMenu figureUI="figureUI"/>
+          </div>
+        </div>
+      </div>
+    </div>
+  </t>
+</templates>

--- a/src/components/full_screen_chart/full_screen_chart_store.ts
+++ b/src/components/full_screen_chart/full_screen_chart_store.ts
@@ -1,0 +1,24 @@
+import { SpreadsheetStore } from "../../stores";
+import { FigureUI, UID } from "../../types";
+
+export class FullScreenChartStore extends SpreadsheetStore {
+  mutators = ["toggleFullScreenChart"] as const;
+
+  fullScreenFigure: FigureUI | undefined = undefined;
+
+  toggleFullScreenChart(figureId: string) {
+    if (this.fullScreenFigure?.id === figureId) {
+      this.fullScreenFigure = undefined;
+    } else {
+      this.makeFullScreen(figureId);
+    }
+  }
+
+  private makeFullScreen(figureId: UID) {
+    const sheetId = this.getters.getActiveSheetId();
+    const figure = this.getters.getFigure(sheetId, figureId);
+    if (figure) {
+      this.fullScreenFigure = { ...figure, x: 0, y: 0, width: 0, height: 0 };
+    }
+  }
+}

--- a/src/components/helpers/position_hook.ts
+++ b/src/components/helpers/position_hook.ts
@@ -39,7 +39,9 @@ export function usePopoverContainer(): Rect {
   function updateRect() {
     const env = component.env;
     const newRect =
-      "getPopoverContainerRect" in env ? env.getPopoverContainerRect() : spreadsheetRect;
+      "getPopoverContainerRect" in env && env.getPopoverContainerRect
+        ? env.getPopoverContainerRect()
+        : spreadsheetRect;
     container.x = newRect.x;
     container.y = newRect.y;
     container.width = newRect.width;

--- a/src/components/spreadsheet/spreadsheet.ts
+++ b/src/components/spreadsheet/spreadsheet.ts
@@ -57,6 +57,7 @@ import {
   registerChartJSExtensions,
   unregisterChartJsExtensions,
 } from "../figures/chart/chartJs/chart_js_extension";
+import { FullScreenChart } from "../full_screen_chart/full_screen_chart";
 import { Grid } from "../grid/grid";
 import { HeaderGroupContainer } from "../header_group/header_group_container";
 import { css, cssPropertiesToCss } from "../helpers/css";
@@ -332,6 +333,7 @@ export class Spreadsheet extends Component<SpreadsheetProps, SpreadsheetChildEnv
     SidePanel,
     SpreadsheetDashboard,
     HeaderGroupContainer,
+    FullScreenChart,
   };
 
   sidePanel!: Store<SidePanelStore>;

--- a/src/components/spreadsheet/spreadsheet.xml
+++ b/src/components/spreadsheet/spreadsheet.xml
@@ -3,6 +3,7 @@
     <div class="o-spreadsheet h-100 w-100" t-ref="spreadsheet" t-att-style="getStyle()">
       <t t-if="env.isDashboard()">
         <SpreadsheetDashboard/>
+        <FullScreenChart/>
       </t>
       <t t-else="">
         <TopBar onClick="() => this.focusGrid()" dropdownMaxHeight="gridHeight"/>

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,8 +110,9 @@ import {
 import { supportedPivotPositionalFormulaRegistry } from "./helpers/pivot/pivot_positional_formula_registry";
 
 import { CellComposerStore } from "./components/composer/composer/cell_composer_store";
-import { ChartDashboardMenu } from "./components/figures/chart/chart_dashboard_menu/chart_dashboard_menu";
 import { chartJsExtensionRegistry } from "./components/figures/chart/chartJs/chart_js_extension";
+import { ChartDashboardMenu } from "./components/figures/chart/chart_dashboard_menu/chart_dashboard_menu";
+import { FullScreenChart } from "./components/full_screen_chart/full_screen_chart";
 import { PivotHTMLRenderer } from "./components/pivot_html_renderer/pivot_html_renderer";
 import { ComboChartDesignPanel } from "./components/side_panel/chart/combo_chart/combo_chart_design_panel";
 import { FunnelChartDesignPanel } from "./components/side_panel/chart/funnel_chart_panel/funnel_chart_design_panel";
@@ -418,6 +419,7 @@ export const components = {
   RadioSelection,
   GeoChartRegionSelectSection,
   ChartDashboardMenu,
+  FullScreenChart,
 };
 
 export const hooks = {

--- a/tests/figures/chart/chart_animations.test.ts
+++ b/tests/figures/chart/chart_animations.test.ts
@@ -1,0 +1,75 @@
+import { Chart } from "chart.js";
+import { Model, readonlyAllowedCommands } from "../../../src";
+import { createChart, setCellContent, updateChart } from "../../test_helpers/commands_helpers";
+import { mockChart, mountSpreadsheet, nextTick } from "../../test_helpers/helpers";
+
+mockChart();
+
+let mockedChart: any;
+beforeEach(() => {
+  jest
+    .spyOn((window as any).Chart.prototype, "constructorMock")
+    .mockImplementation(function (this: Chart) {
+      mockedChart = this;
+    });
+});
+
+describe("Chart animations in dashboard", () => {
+  test("Charts are animated only at first render", async () => {
+    const model = new Model();
+    createChart(model, { type: "bar" });
+    model.updateMode("dashboard");
+
+    await mountSpreadsheet({ model });
+    expect(".o-figure").toHaveCount(1);
+    expect(mockedChart.config.options.animation.animateRotate).toBe(true);
+
+    // Scroll the figure out of the viewport and back in
+    model.dispatch("SET_VIEWPORT_OFFSET", { offsetX: 0, offsetY: 500 });
+    await nextTick();
+    expect(".o-figure").toHaveCount(0);
+
+    model.dispatch("SET_VIEWPORT_OFFSET", { offsetX: 0, offsetY: 0 });
+    await nextTick();
+    expect(".o-figure").toHaveCount(1);
+    expect(mockedChart.config.options.animation).toBe(false);
+  });
+
+  test("Animations are replayed only when chart data changes", async () => {
+    readonlyAllowedCommands.add("UPDATE_CELL");
+
+    const model = new Model();
+    createChart(model, { type: "bar", dataSets: [{ dataRange: "A1:A6" }] });
+    model.updateMode("dashboard");
+    await mountSpreadsheet({ model });
+
+    expect(mockedChart.config.options.animation).toEqual({ animateRotate: true });
+
+    // Dispatch a command that doesn't change the chart data
+    setCellContent(model, "A50", "6");
+    await nextTick();
+    expect(mockedChart.config.options.animation).toBe(false);
+
+    // Change the chart data
+    setCellContent(model, "A2", "6");
+    await nextTick();
+    expect(mockedChart.config.options.animation).toEqual({ animateRotate: true });
+
+    readonlyAllowedCommands.delete("UPDATE_CELL");
+  });
+
+  test("Charts are animated when chart type changes", async () => {
+    const model = new Model();
+    createChart(model, { type: "bar", dataSets: [{ dataRange: "A1:A6" }] }, "chartId");
+    model.updateMode("dashboard");
+    await mountSpreadsheet({ model });
+
+    model.dispatch("EVALUATE_CELLS");
+    await nextTick();
+    expect(mockedChart.config.options.animation).toBe(false);
+
+    updateChart(model, "chartId", { type: "pie" });
+    await nextTick();
+    expect(mockedChart.config.options.animation.animateRotate).toBe(true);
+  });
+});

--- a/tests/figures/chart/chart_full_screen.test.ts
+++ b/tests/figures/chart/chart_full_screen.test.ts
@@ -1,0 +1,65 @@
+import { Model } from "../../../src";
+import { createScorecardChart, createWaterfallChart } from "../../test_helpers/commands_helpers";
+import { click, keyDown } from "../../test_helpers/dom_helper";
+import { mockChart, mountSpreadsheet, nextTick } from "../../test_helpers/helpers";
+
+mockChart();
+
+let model: Model;
+let fixture: HTMLElement;
+
+describe("chart menu for dashboard", () => {
+  beforeEach(async () => {
+    model = new Model();
+    ({ fixture } = await mountSpreadsheet({ model }));
+  });
+
+  test("Can make a chart fullscreen in dashboard", async () => {
+    createWaterfallChart(model);
+    model.updateMode("dashboard");
+    await nextTick();
+
+    expect(".o-fullscreen-chart").toHaveCount(0);
+    await click(fixture, ".o-figure [data-id='fullScreenChart']");
+    expect(".o-fullscreen-chart").toHaveCount(1);
+  });
+
+  test("Cannot make scorecard chart fullscreen ", async () => {
+    createScorecardChart(model, {});
+    model.updateMode("dashboard");
+    await nextTick();
+
+    expect(".o-fullscreen-chart").toHaveCount(0);
+    expect(".o-figure [data-id='fullScreenChart']").toHaveCount(0);
+  });
+
+  test("Can exit fullscreen mode", async () => {
+    createWaterfallChart(model);
+    model.updateMode("dashboard");
+    await nextTick();
+
+    // Click fullscreen menu item
+    await click(fixture, ".o-figure [data-id='fullScreenChart']");
+    expect(".o-fullscreen-chart").toHaveCount(1);
+    await click(fixture, ".o-fullscreen-chart [data-id='fullScreenChart']");
+    expect(".o-fullscreen-chart").toHaveCount(0);
+
+    // Click outside of the chart in the full screen overlay
+    await click(fixture, ".o-figure [data-id='fullScreenChart']");
+    expect(".o-fullscreen-chart").toHaveCount(1);
+    await click(fixture, ".o-fullscreen-chart-overlay");
+    expect(".o-fullscreen-chart").toHaveCount(0);
+
+    // Click the exit button in the full screen overlay
+    await click(fixture, ".o-figure [data-id='fullScreenChart']");
+    expect(".o-fullscreen-chart").toHaveCount(1);
+    await click(fixture, ".o-fullscreen-chart-overlay button.o-exit");
+    expect(".o-fullscreen-chart").toHaveCount(0);
+
+    // Press escape key
+    await click(fixture, ".o-figure [data-id='fullScreenChart']");
+    expect(".o-fullscreen-chart").toHaveCount(1);
+    await keyDown({ key: "Escape" });
+    expect(".o-fullscreen-chart").toHaveCount(0);
+  });
+});

--- a/tests/figures/chart/chart_menu_dashboard_component.test.ts
+++ b/tests/figures/chart/chart_menu_dashboard_component.test.ts
@@ -47,7 +47,7 @@ describe("chart menu for dashboard", () => {
     createChart(model, { type: "radar" }, chartId);
     model.updateMode("dashboard");
     await mountSpreadsheet({ model });
-    expect(".o-chart-dashboard-item").toHaveCount(1);
+    expect(".o-chart-dashboard-item").toHaveCount(2); // ellipsis and fullscreen
     expect(".o-chart-dashboard-item.fa-ellipsis-v").toHaveCount(1);
   });
 


### PR DESCRIPTION
## Description:

### [IMP] dashboard: add button to open chart in full screen

This commits adds the possibility to open a chart in full screen mode.
This only exists in dashboard.


### [MOV] charts: extract chart animations from Odoo

Extract the code handling chart animation in dashboard from odoo to
o-spreadsheet.


Task: [4787283](https://www.odoo.com/odoo/2328/tasks/4787283)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo