### PR TITLE
[FIX] pie chart: prevent overlapping shown values

### DIFF
--- a/src/components/figures/chart/chartJs/chartjs_show_values_plugin.ts
+++ b/src/components/figures/chart/chartJs/chartjs_show_values_plugin.ts
@@ -156,12 +156,26 @@ function drawPieChartValues(
       const midAngle = (startAngle + endAngle) / 2;
       const midRadius = (innerRadius + outerRadius) / 2;
       const x = bar.x + midRadius * Math.cos(midAngle);
-      const y = bar.y + midRadius * Math.sin(midAngle) + 7;
+      const y = bar.y + midRadius * Math.sin(midAngle);
+      const displayValue = options.callback(value);
+
+      const textHeight = 12; // ChartJS default
+      const textWidth = computeTextWidth(ctx, displayValue, { fontSize: textHeight }, "px");
+
+      const radius = outerRadius - innerRadius;
+      // Check if the text fits in the slice. Not perfect, but good enough heuristic.
+      if (textWidth >= radius || radius < textHeight) {
+        continue;
+      }
+      const sliceAngle = endAngle - startAngle;
+      const midWidth = 2 * midRadius * Math.tan(sliceAngle / 2);
+      if (sliceAngle < Math.PI / 2 && (textWidth >= midWidth || midWidth < textHeight)) {
+        continue;
+      }
 
       ctx.fillStyle = chartFontColor(options.background);
       ctx.strokeStyle = options.background || "#ffffff";
 
-      const displayValue = options.callback(value);
       drawTextWithBackground(displayValue, x, y, ctx);
     }
   }


### PR DESCRIPTION
## Description

The `show value` option for pie chart was displaying values no matter the size of the chart or the size of the pie slice of the value. This commit adds a check to prevent the value from being shown if the slice is too small, and that the value will be displayed outside of it.

Task: [4639810](https://www.odoo.com/odoo/2328/tasks/4639810)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo