### PR TITLE
[FIX] auto_complete: showing all proposal on single match

### DIFF
--- a/src/components/composer/composer/abstract_composer_store.ts
+++ b/src/components/composer/composer/abstract_composer_store.ts
@@ -585,7 +585,7 @@ export abstract class AbstractComposerStore extends SpreadsheetStore {
           proposals,
           (p) => p.fuzzySearchKey || p.text
         );
-        if (!exactMatch || filteredProposals.length > 1) {
+        if (!exactMatch || filteredProposals.length) {
           proposals = filteredProposals;
         }
       }

--- a/tests/composer/auto_complete/function_auto_complete_store.test.ts
+++ b/tests/composer/auto_complete/function_auto_complete_store.test.ts
@@ -1,5 +1,5 @@
 import { CellComposerStore } from "../../../src/components/composer/composer/cell_composer_store";
-import { setCellContent } from "../../test_helpers/commands_helpers";
+import { selectCell, setCellContent } from "../../test_helpers/commands_helpers";
 import { makeStore } from "../../test_helpers/stores";
 
 describe("Function auto complete", () => {
@@ -14,5 +14,30 @@ describe("Function auto complete", () => {
     expect(proposals?.[1].text).toEqual("SUMIF");
     autoComplete?.selectProposal(proposals![0].text);
     expect(composer.currentContent).toEqual("=SUM(");
+  });
+
+  test("function auto complete uses fuzzy search", () => {
+    const { store: composer, model } = makeStore(CellComposerStore);
+    setCellContent(model, "A1", "=VOK");
+    composer.startEdition();
+    const autoComplete = composer.autocompleteProvider;
+    const proposals = autoComplete?.proposals;
+    expect(proposals).toHaveLength(1);
+    expect(proposals?.[0].text).toBe("VLOOKUP");
+    autoComplete?.selectProposal(proposals![0].text);
+    expect(composer.currentContent).toEqual("=VLOOKUP(");
+  });
+
+  test("reselect cell with existing content shows correct autocomplete proposals", () => {
+    const { store: composer, model } = makeStore(CellComposerStore);
+    setCellContent(model, "A1", "=VLOOKUP");
+    selectCell(model, "A1");
+    composer.startEdition();
+    const autoComplete = composer.autocompleteProvider;
+    const proposals = autoComplete?.proposals;
+    expect(proposals).toHaveLength(1);
+    expect(proposals?.[0].text).toBe("VLOOKUP");
+    autoComplete?.selectProposal(proposals![0].text);
+    expect(composer.currentContent).toEqual("=VLOOKUP(");
   });
 });


### PR DESCRIPTION
## Description:

Before this commit:
- Typing '=VLOOKUP' showed all proposals instead of just 'VLOOKUP'.

After this commit:
- Now only the correct match is shown.

Task: [4735015](https://www.odoo.com/odoo/2328/tasks/4735015)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo