### PR TITLE
[IMP] xlsx: prevent exporting the SPLIT function

### DIFF
--- a/src/functions/module_text.ts
+++ b/src/functions/module_text.ts
@@ -430,7 +430,7 @@ export const SPLIT = {
 
     return transposeMatrix([result]);
   },
-  isExported: true,
+  isExported: false,
 } satisfies AddFunctionDescription;
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
The `SPLIT` function does not exist in Excel yet. This function
causes an error when exporting and importing an .xlsx file in excel.
The `TEXTSPLIT` function will be therefore introduced here: https://github.com/odoo/o-spreadsheet/pull/6417

Task: [4766568](https://www.odoo.com/odoo/2328/tasks/4766568)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo