### PR TITLE
[FIX] Spreadsheet: reset scroll inertia after some time

### DIFF
--- a/src/components/helpers/touch_scroll_hook.ts
+++ b/src/components/helpers/touch_scroll_hook.ts
@@ -4,8 +4,9 @@ import { useRefListener } from "./listener_hook";
 const friction = 0.95;
 
 const verticalScrollFactor = 1;
-
 const horizontalScrollFactor = 1;
+
+export const resetTimeoutDuration = 100;
 
 export function useTouchScroll(
   ref: Ref<HTMLElement>,
@@ -20,6 +21,7 @@ export function useTouchScroll(
   let velocityY = 0;
   let isMouseDown = false;
   let lastTime = 0;
+  let resetTimeout: NodeJS.Timeout | null = null;
 
   useRefListener(ref, "touchstart", onTouchStart, { capture: false });
   useRefListener(ref, "touchmove", onTouchMove, { capture: false });
@@ -34,6 +36,11 @@ export function useTouchScroll(
 
   function onTouchMove(event: TouchEvent) {
     if (!isMouseDown) return;
+
+    if (resetTimeout) {
+      clearTimeout(resetTimeout);
+      resetTimeout = null;
+    }
 
     const currentTime = Date.now();
     const { clientX, clientY } = event.touches[0];
@@ -53,7 +60,10 @@ export function useTouchScroll(
       }
       event.stopPropagation();
     }
-
+    resetTimeout = setTimeout(() => {
+      velocityX = 0;
+      velocityY = 0;
+    }, resetTimeoutDuration);
     updateScroll(deltaX * horizontalScrollFactor, deltaY * verticalScrollFactor);
   }
 

--- a/tests/grid/grid_component.test.ts
+++ b/tests/grid/grid_component.test.ts
@@ -1,6 +1,7 @@
 import { Spreadsheet, TransportService } from "../../src";
 import { CellComposerStore } from "../../src/components/composer/composer/cell_composer_store";
 import { ComposerFocusStore } from "../../src/components/composer/composer_focus_store";
+import { resetTimeoutDuration } from "../../src/components/helpers/touch_scroll_hook";
 import { PaintFormatStore } from "../../src/components/paint_format_button/paint_format_store";
 import { CellPopoverStore } from "../../src/components/popover";
 import {
@@ -185,6 +186,7 @@ describe("Grid component", () => {
     expect(getHorizontalScroll()).toBe(70);
     expect(getVerticalScroll()).toBe(50);
   });
+
   test("Event is stopped if not at the top", async () => {
     const grid = fixture.querySelector(".o-grid-overlay")!;
     expect(getHorizontalScroll()).toBe(0);
@@ -203,6 +205,37 @@ describe("Grid component", () => {
     // move up again but we are at the stop: ev not prevented
     triggerTouchEvent(grid, "touchmove", { clientX: 0, clientY: 150, identifier: 4 });
     expect(mockCallback).toBeCalledTimes(2);
+  });
+
+  test("Touch has an inertial scroll", async () => {
+    const timeDelta = 100;
+    const grid = fixture.querySelector(".o-grid-overlay")!;
+    triggerTouchEvent(grid, "touchstart", { clientX: 0, clientY: 150 });
+    triggerTouchEvent(grid, "touchmove", { clientX: 0, clientY: 150 });
+    expect(model.getters.getActiveSheetDOMScrollInfo().scrollY).toBe(0);
+    jest.advanceTimersByTime(timeDelta);
+    triggerTouchEvent(grid, "touchmove", { clientX: 0, clientY: 120 });
+    expect(model.getters.getActiveSheetDOMScrollInfo().scrollY).toBe(30);
+    triggerTouchEvent(grid, "touchend", { clientX: 0, clientY: 120 });
+    expect(model.getters.getActiveSheetDOMScrollInfo().scrollY).toBe(30);
+    jest.runOnlyPendingTimers();
+    expect(model.getters.getActiveSheetDOMScrollInfo().scrollY).toBeGreaterThan(30);
+  });
+
+  test("scroll inertia is reset after some time", async () => {
+    const timeDelta = 100;
+    const grid = fixture.querySelector(".o-grid-overlay")!;
+    triggerTouchEvent(grid, "touchstart", { clientX: 0, clientY: 150 });
+    triggerTouchEvent(grid, "touchmove", { clientX: 0, clientY: 150 });
+    expect(model.getters.getActiveSheetDOMScrollInfo().scrollY).toBe(0);
+    jest.advanceTimersByTime(timeDelta);
+    triggerTouchEvent(grid, "touchmove", { clientX: 0, clientY: 120 });
+    expect(model.getters.getActiveSheetDOMScrollInfo().scrollY).toBe(30);
+    jest.advanceTimersByTime(resetTimeoutDuration + 1);
+    triggerTouchEvent(grid, "touchend", { clientX: 0, clientY: 120 });
+    expect(model.getters.getActiveSheetDOMScrollInfo().scrollY).toBe(30);
+    jest.runOnlyPendingTimers();
+    expect(model.getters.getActiveSheetDOMScrollInfo().scrollY).toBe(30);
   });
 
   describe("keybindings", () => {


### PR DESCRIPTION
How to reproduce:

- easier to reproduce on a browser
- Move the pointer from bottom to top (scroll downwards) and stop your movement abruptly without releasing the pointer
- wait for a bit
- release the pointer
- the viewport "jumps"

If we stop moving for some time, the inertia should be reset.

Task: 4813296

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [4813296](https://www.odoo.com/odoo/2328/tasks/4813296)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo