### PR TITLE
[FIX] ComposerStore: placeholder should be localized

### DIFF
--- a/src/components/composer/composer/cell_composer_store.ts
+++ b/src/components/composer/composer/cell_composer_store.ts
@@ -121,8 +121,7 @@ export class CellComposerStore extends AbstractComposerStore {
     if (!spreader) {
       return undefined;
     }
-    const cell = this.getters.getCell(spreader);
-    return cell?.content;
+    return this.getters.getCellText(spreader, { showFormula: true });
   }
 
   get currentEditedCell(): CellPosition {

--- a/tests/composer/composer_integration_component.test.ts
+++ b/tests/composer/composer_integration_component.test.ts
@@ -24,7 +24,9 @@ import {
   setCellContent,
   setSelection,
   setStyle,
+  updateLocale,
 } from "../test_helpers/commands_helpers";
+import { FR_LOCALE } from "../test_helpers/constants";
 import {
   click,
   clickCell,
@@ -845,6 +847,25 @@ describe("TopBar composer", () => {
     await keyDown({ key: "Enter" });
     expect(topBarComposer!.textContent).toBe("");
     expect(topBarComposer.attributes.getNamedItem("placeholder")?.value).toEqual("=MUNIT(3)");
+  });
+
+  test("Spreaded cell placeholder follows the current locale", async () => {
+    ({ model, fixture } = await mountSpreadsheet());
+    setCellContent(model, "A1", "=SEQUENCE(3,3)");
+    selectCell(model, "A2");
+    updateLocale(model, FR_LOCALE);
+    await nextTick();
+
+    const topBarComposer = document.querySelector(".o-spreadsheet-topbar .o-composer")!;
+    expect(topBarComposer.textContent).toBe("");
+    expect(topBarComposer.attributes.getNamedItem("placeholder")?.value).toEqual("=SEQUENCE(3;3)");
+
+    await simulateClick(topBarComposer);
+    expect(topBarComposer!.textContent).toBe("");
+
+    await keyDown({ key: "Enter" });
+    expect(topBarComposer!.textContent).toBe("");
+    expect(topBarComposer.attributes.getNamedItem("placeholder")?.value).toEqual("=SEQUENCE(3;3)");
   });
 
   test("opening and closing the assistant preserves the focus on the top bar composer", async () => {


### PR DESCRIPTION
How to reproduce:
- Write a spill formula in A1 ( `=SEQUENCE(3,3)` )
- change locale to FR
- select A2
- The placeholder in the topbar composer is not properly localized, the separators are commas and not semicolons

Task: 4817738

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [4817738](https://www.odoo.com/odoo/2328/tasks/4817738)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo