### PR TITLE
[FIX] Find&Replace: target correct next match

### DIFF
--- a/src/plugins/ui_feature/find_and_replace.ts
+++ b/src/plugins/ui_feature/find_and_replace.ts
@@ -274,7 +274,6 @@ export class FindAndReplacePlugin extends UIPlugin {
 
     const selectedMatch = this.searchMatches[this.selectedMatchIndex];
     this.replaceMatch(selectedMatch, replaceWith);
-    this.selectNextCell(Direction.next);
   }
   /**
    * Apply the replace function to all the matches one time.

--- a/tests/find_and_replace/find_and_replace_plugin.test.ts
+++ b/tests/find_and_replace/find_and_replace_plugin.test.ts
@@ -737,6 +737,17 @@ describe("replace", () => {
     expect(matchIndex).toStrictEqual(null);
     expect(getActivePosition(model)).toBe("A1");
   });
+
+  test("replacing correctly moves the selection to the next match", () => {
+    model.dispatch("UPDATE_SEARCH", { toSearch: "hell", searchOptions });
+    expect(getActivePosition(model)).toBe("A1");
+    model.dispatch("SELECT_SEARCH_NEXT_MATCH");
+    expect(getActivePosition(model)).toBe("A3");
+    model.dispatch("REPLACE_SEARCH", { replaceWith: "2" });
+    expect(getActivePosition(model)).toBe("A4");
+    model.dispatch("REPLACE_SEARCH", { replaceWith: "2" });
+    expect(getActivePosition(model)).toBe("A1");
+  });
 });
 
 test("replace don't replace value resulting from array formula", () => {


### PR DESCRIPTION
How to reproduce:
- create more than 3 cells with the same content
- open Find&Replace and look for that content
- try to replace it with something else and hit the "Replace" button

Your selection is now on the third result and not the second one as we could expect.

Task: 4817971

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo