### PR TITLE
[IMP/FIX] autocomplete_dropdown: Improve dropdown readability

### DIFF
--- a/src/components/composer/autocomplete_dropdown/autocomplete_dropdown.xml
+++ b/src/components/composer/autocomplete_dropdown/autocomplete_dropdown.xml
@@ -17,7 +17,7 @@
               t-as="content"
               t-key="content_index"
               t-att-class="content.class"
-              t-attf-style="color: {{content.color || 'inherit'}};"
+              t-attf-style="color: {{content.color || '#000000'}};"
               t-esc="content.value"
             />
           </div>

--- a/tests/composer/__snapshots__/autocomplete_dropdown_component.test.ts.snap
+++ b/tests/composer/__snapshots__/autocomplete_dropdown_component.test.ts.snap
@@ -17,7 +17,7 @@ exports[`Functions autocomplete autocomplete simple snapshot with =S 1`] = `
         S
       </span>
       <span
-        style="color: inherit;"
+        style="color: #000000;"
       >
         UM
       </span>
@@ -43,7 +43,7 @@ exports[`Functions autocomplete autocomplete simple snapshot with =S 1`] = `
         S
       </span>
       <span
-        style="color: inherit;"
+        style="color: #000000;"
       >
         ZZ
       </span>
@@ -78,7 +78,7 @@ exports[`composer Assistant render above the cell when not enough place below 1`
           S
         </span>
         <span
-          style="color: inherit;"
+          style="color: #000000;"
         >
           UM
         </span>
@@ -104,7 +104,7 @@ exports[`composer Assistant render above the cell when not enough place below 1`
           S
         </span>
         <span
-          style="color: inherit;"
+          style="color: #000000;"
         >
           ZZ
         </span>
@@ -141,7 +141,7 @@ exports[`composer Assistant render below the cell by default 1`] = `
           S
         </span>
         <span
-          style="color: inherit;"
+          style="color: #000000;"
         >
           UM
         </span>
@@ -167,7 +167,7 @@ exports[`composer Assistant render below the cell by default 1`] = `
           S
         </span>
         <span
-          style="color: inherit;"
+          style="color: #000000;"
         >
           ZZ
         </span>

--- a/tests/data_validation/data_validation_list_component.test.ts
+++ b/tests/data_validation/data_validation_list_component.test.ts
@@ -12,6 +12,7 @@ import {
   createTable,
   setCellContent,
   setSelection,
+  setStyle,
 } from "../test_helpers/commands_helpers";
 import { click, keyDown, setInputValueAndTrigger } from "../test_helpers/dom_helper";
 import { getCellContent } from "../test_helpers/getters_helpers";
@@ -304,6 +305,24 @@ describe("autocomplete in composer", () => {
     expect(values).toHaveLength(2);
     expect(values[0].textContent).toBe("ok");
     expect(values[1].textContent).toBe("hello");
+  });
+
+  test("Autocomplete dropdown text should be black by default", async () => {
+    addDataValidation(model, "A1", "id", {
+      type: "isValueInList",
+      values: ["hello"],
+      displayStyle: "arrow",
+    });
+    setStyle(model, "A1", {
+      textColor: "#FFFF00",
+      fillColor: "#000000",
+    });
+    ({ fixture, parent } = await mountComposerWrapper(model));
+    await typeInComposer("");
+    const values = fixture.querySelectorAll<HTMLElement>(".o-autocomplete-value span");
+    expect(values).toHaveLength(1);
+    expect(values[0].textContent).toBe("hello");
+    expect(values[0].style.color).toBe("rgb(0, 0, 0)");
   });
 });
 


### PR DESCRIPTION
## Description:

Previously, the auto-complete dropdown in the composer was difficult to read when the cell background was dark and the text color was light. This commit fixes the issue by setting the auto-complete dropdown text color to black by default.

Task: [4813433](https://www.odoo.com/odoo/2328/tasks/4813433)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo