### PR TITLE
[FIX] Spreadsheet: Fix touch scroll

### DIFF
--- a/src/components/helpers/touch_scroll_hook.ts
+++ b/src/components/helpers/touch_scroll_hook.ts
@@ -70,6 +70,11 @@ export function useTouchScroll(
   function onTouchEnd(ev: MouseEvent) {
     isMouseDown = false;
     lastX = lastY = 0;
+    if (resetTimeout) {
+      clearTimeout(resetTimeout);
+    }
+    velocityX *= 1.2;
+    velocityY *= 1.2;
     requestAnimationFrame(scroll);
   }
 

--- a/tests/grid/grid_component.test.ts
+++ b/tests/grid/grid_component.test.ts
@@ -218,8 +218,17 @@ describe("Grid component", () => {
     expect(model.getters.getActiveSheetDOMScrollInfo().scrollY).toBe(30);
     triggerTouchEvent(grid, "touchend", { clientX: 0, clientY: 120 });
     expect(model.getters.getActiveSheetDOMScrollInfo().scrollY).toBe(30);
-    jest.runOnlyPendingTimers();
+    jest.advanceTimersByTime(timeDelta);
     expect(model.getters.getActiveSheetDOMScrollInfo().scrollY).toBeGreaterThan(30);
+    let previousScrollY = model.getters.getActiveSheetDOMScrollInfo().scrollY;
+    jest.advanceTimersByTime(timeDelta);
+    expect(model.getters.getActiveSheetDOMScrollInfo().scrollY).toBeGreaterThan(previousScrollY);
+    previousScrollY = model.getters.getActiveSheetDOMScrollInfo().scrollY;
+    jest.advanceTimersByTime(timeDelta);
+    expect(model.getters.getActiveSheetDOMScrollInfo().scrollY).toBeGreaterThan(previousScrollY);
+    previousScrollY = model.getters.getActiveSheetDOMScrollInfo().scrollY;
+    jest.advanceTimersByTime(timeDelta);
+    expect(model.getters.getActiveSheetDOMScrollInfo().scrollY).toBeGreaterThan(previousScrollY);
   });
 
   test("scroll inertia is reset after some time", async () => {


### PR DESCRIPTION
This commit addresses two issues:
- When fixing the scroll inertia reset, we missed the mark and killed it altogether. The tests were not extensive enough
- the inertia scroll speed can feel a bit sluggish. A simple multiplication factor is added to improve the experience.

Task: 4829283

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo