### PR TITLE
[FIX] paint_format_store: handle merged cells and selection after paste

### DIFF
--- a/src/components/paint_format_button/paint_format_store.ts
+++ b/src/components/paint_format_button/paint_format_store.ts
@@ -19,7 +19,13 @@ interface ClipboardContent {
   [key: string]: unknown;
 }
 
-const PAINT_FORMAT_HANDLER_KEYS = ["cell", "border", "table", "conditionalFormat"] as const;
+const PAINT_FORMAT_HANDLER_KEYS = [
+  "cell",
+  "border",
+  "table",
+  "conditionalFormat",
+  "merge",
+] as const;
 
 export class PaintFormatStore extends SpreadsheetStore {
   mutators = ["activate", "cancel", "pasteFormat"] as const;

--- a/src/components/paint_format_button/paint_format_store.ts
+++ b/src/components/paint_format_button/paint_format_store.ts
@@ -1,31 +1,30 @@
+import { clipboardHandlersRegistries } from "../../clipboard_handlers";
 import { ClipboardHandler } from "../../clipboard_handlers/abstract_clipboard_handler";
-import { BorderClipboardHandler } from "../../clipboard_handlers/borders_clipboard";
-import { CellClipboardHandler } from "../../clipboard_handlers/cell_clipboard";
-import { ConditionalFormatClipboardHandler } from "../../clipboard_handlers/conditional_format_clipboard";
-import { TableClipboardHandler } from "../../clipboard_handlers/tables_clipboard";
 import { SELECTION_BORDER_COLOR } from "../../constants";
-import { getClipboardDataPositions } from "../../helpers/clipboard/clipboard_helpers";
+import {
+  applyClipboardHandlersPaste,
+  getClipboardDataPositions,
+  getPasteTargetFromHandlers,
+  selectPastedZone,
+} from "../../helpers/clipboard/clipboard_helpers";
 import { Get } from "../../store_engine";
 import { SpreadsheetStore } from "../../stores";
 import { HighlightStore } from "../../stores/highlight_store";
-import { ClipboardCell, Command, Highlight, UID, Zone } from "../../types";
+import { ClipboardCell, ClipboardOptions, Command, Highlight, UID, Zone } from "../../types";
 
 interface ClipboardContent {
   cells: ClipboardCell[][];
   zones: Zone[];
   sheetId: UID;
+  [key: string]: unknown;
 }
+
+const PAINT_FORMAT_HANDLER_KEYS = ["cell", "border", "table", "conditionalFormat"] as const;
 
 export class PaintFormatStore extends SpreadsheetStore {
   mutators = ["activate", "cancel", "pasteFormat"] as const;
 
   protected highlightStore = this.get(HighlightStore);
-  private clipboardHandlers: ClipboardHandler<any>[] = [
-    new CellClipboardHandler(this.getters, this.model.dispatch),
-    new BorderClipboardHandler(this.getters, this.model.dispatch),
-    new TableClipboardHandler(this.getters, this.model.dispatch),
-    new ConditionalFormatClipboardHandler(this.getters, this.model.dispatch),
-  ];
 
   private status: "inactive" | "oneOff" | "persistent" = "inactive";
   private copiedData?: ClipboardContent;
@@ -64,27 +63,52 @@ export class PaintFormatStore extends SpreadsheetStore {
     return this.status !== "inactive";
   }
 
+  private get clipboardHandlers(): {
+    handlerName: string;
+    handler: ClipboardHandler<any>;
+  }[] {
+    return PAINT_FORMAT_HANDLER_KEYS.map((handlerName) => {
+      const HandlerClass = clipboardHandlersRegistries.cellHandlers.get(handlerName);
+      return {
+        handlerName,
+        handler: new HandlerClass(this.getters, this.model.dispatch),
+      };
+    });
+  }
+
   private copyFormats(): ClipboardContent | undefined {
     const sheetId = this.getters.getActiveSheetId();
     const zones = this.getters.getSelectedZones();
 
-    const copiedData = {};
-    for (const handler of this.clipboardHandlers) {
-      Object.assign(copiedData, handler.copy(getClipboardDataPositions(sheetId, zones)));
+    const copiedData: Partial<ClipboardContent> = { zones, sheetId };
+    for (const { handlerName, handler } of this.clipboardHandlers) {
+      const handlerResult = handler.copy(getClipboardDataPositions(sheetId, zones));
+      if (handlerResult !== undefined) {
+        copiedData[handlerName] = handlerResult;
+      }
     }
 
     return copiedData as ClipboardContent;
   }
 
   private paintFormat(sheetId: UID, target: Zone[]) {
-    if (this.copiedData) {
-      for (const handler of this.clipboardHandlers) {
-        handler.paste({ zones: target, sheetId }, this.copiedData, {
-          isCutOperation: false,
-          pasteOption: "onlyFormat",
-        });
-      }
+    if (!this.copiedData) {
+      return;
     }
+    const options: ClipboardOptions = {
+      isCutOperation: false,
+      pasteOption: "onlyFormat",
+    };
+    const { target: pasteTarget, selectedZones } = getPasteTargetFromHandlers(
+      sheetId,
+      target,
+      this.copiedData,
+      this.clipboardHandlers,
+      options
+    );
+    applyClipboardHandlersPaste(this.clipboardHandlers, this.copiedData, pasteTarget, options);
+    selectPastedZone(this.model.selection, target, selectedZones);
+
     if (this.status === "oneOff") {
       this.cancel();
     }

--- a/src/helpers/clipboard/clipboard_helpers.ts
+++ b/src/helpers/clipboard/clipboard_helpers.ts
@@ -1,12 +1,17 @@
+import { ClipboardHandler } from "../../clipboard_handlers/abstract_clipboard_handler";
+import { SelectionStreamProcessor } from "../../selection_stream/selection_stream_processor";
 import {
   ClipboardCellData,
   ClipboardMIMEType,
+  ClipboardOptions,
+  ClipboardPasteTarget,
+  MinimalClipboardData,
   OSClipboardContent,
   ParsedOSClipboardContent,
   UID,
   Zone,
 } from "../../types";
-import { mergeOverlappingZones, positions } from "../zones";
+import { mergeOverlappingZones, positions, union } from "../zones";
 
 export function getClipboardDataPositions(sheetId: UID, zones: Zone[]): ClipboardCellData {
   const lefts = new Set(zones.map((z) => z.left));
@@ -81,3 +86,87 @@ export function parseOSClipboardContent(content: OSClipboardContent): ParsedOSCl
     data: spreadsheetContent,
   };
 }
+
+/**
+ * Applies each clipboard handler to paste its corresponding data into the target.
+ */
+export const applyClipboardHandlersPaste = (
+  handlers: { handlerName: string; handler: ClipboardHandler<any> }[],
+  copiedData: MinimalClipboardData,
+  target: ClipboardPasteTarget,
+  options: ClipboardOptions
+): void => {
+  handlers.forEach(({ handlerName, handler }) => {
+    const data = copiedData[handlerName];
+    if (data) {
+      handler.paste(target, data, options);
+    }
+  });
+};
+
+/**
+ * Returns the paste target based on clipboard handlers.
+ * Also includes the full affected zone and the list of pasted zones for selection.
+ */
+export function getPasteTargetFromHandlers(
+  sheetId: string,
+  zones: Zone[],
+  copiedData: MinimalClipboardData,
+  handlers: { handlerName: string; handler: ClipboardHandler<any> }[],
+  options: ClipboardOptions
+): {
+  target: ClipboardPasteTarget;
+  zone?: Zone;
+  selectedZones: Zone[];
+} {
+  let zone: Zone | undefined = undefined;
+  let selectedZones: Zone[] = [];
+  let target: ClipboardPasteTarget = {
+    sheetId,
+    zones,
+  };
+
+  for (const { handlerName, handler } of handlers) {
+    const handlerData = copiedData[handlerName];
+    if (!handlerData) {
+      continue;
+    }
+    const currentTarget = handler.getPasteTarget(sheetId, zones, handlerData, options);
+    if (currentTarget.figureId) {
+      target.figureId = currentTarget.figureId;
+    }
+    for (const targetZone of currentTarget.zones) {
+      selectedZones.push(targetZone);
+      if (zone === undefined) {
+        zone = targetZone;
+        continue;
+      }
+      zone = union(zone, targetZone);
+    }
+  }
+
+  return {
+    target,
+    zone,
+    selectedZones,
+  };
+}
+
+/**
+ * Updates the selection after a paste operation.
+ */
+export const selectPastedZone = (
+  selection: SelectionStreamProcessor,
+  sourceZones: Zone[],
+  pastedZones: Zone[]
+): void => {
+  const anchorCell = {
+    col: sourceZones[0].left,
+    row: sourceZones[0].top,
+  };
+  selection.getBackToDefault();
+  selection.selectZone(
+    { cell: anchorCell, zone: union(...pastedZones) },
+    { scrollIntoView: false }
+  );
+};

--- a/src/types/clipboard.ts
+++ b/src/types/clipboard.ts
@@ -1,5 +1,5 @@
 import { SpreadsheetClipboardData } from "../plugins/ui_stateful";
-import { HeaderIndex, UID, Zone } from "./misc";
+import { ClipboardCell, HeaderIndex, UID, Zone } from "./misc";
 
 export enum ClipboardMIMEType {
   PlainText = "text/plain",
@@ -40,4 +40,12 @@ export type ClipboardPasteTarget = {
   sheetId: UID;
   zones: Zone[];
   figureId?: UID;
+};
+
+export type MinimalClipboardData = {
+  sheetId?: UID;
+  cells?: ClipboardCell[][];
+  zones?: Zone[];
+  figureId?: UID;
+  [key: string]: unknown;
 };

--- a/tests/grid/grid_component.test.ts
+++ b/tests/grid/grid_component.test.ts
@@ -950,6 +950,23 @@ describe("Grid component", () => {
       expect(model.getters.getConditionalFormats(sheetId)[0].ranges).toEqual(["A1", "C8"]);
     });
 
+    test("Pasting format from merged cells applies merge and updates selection", () => {
+      const sheetId = model.getters.getActiveSheetId();
+      merge(model, "B1:B3");
+      setSelection(model, ["B1:B3"]);
+
+      expect(model.getters.getMerges(sheetId)).toMatchObject([toZone("B1:B3")]);
+      expect(model.getters.getSelectedZones()).toMatchObject([toZone("B1:B3")]);
+
+      paintFormatStore.activate({ persistent: false });
+
+      gridMouseEvent(model, "pointerdown", "A1");
+      gridMouseEvent(model, "pointerup", "A1");
+
+      expect(model.getters.getSelectedZones()).toMatchObject([toZone("A1:A3")]);
+      expect(model.getters.getMerges(sheetId)).toMatchObject([toZone("B1:B3"), toZone("A1:A3")]);
+    });
+
     test("can keep the paint format mode persistently", async () => {
       setCellContent(model, "B2", "b2");
       selectCell(model, "B2");


### PR DESCRIPTION
## Description:

**This PR contains three commits:**

**\[REF] clipboard: extract paste helpers to reduce duplication**
To reuse the same paste logic across `clipboard.ts` and `paint_format_store.ts`, this commit extracts the following helper functions:

* `getPasteTargetFromHandlers`: computes the paste target and collects all affected zones.
* `applyClipboardHandlersPaste`: invokes all registered handlers to apply the pasted data.
* `selectPastedZone`: updates the selection after paste, matching the shape of the copied zones.

This refactor improves readability and reduces duplication.

**\[FIX] paint\_format\_store: update selection after pasting format**
Ensures that after applying a format using the paint format tool, the selection reflects the shape of the originally copied zone — not the full target area.

**\[FIX] paint\_format\_store: copy and apply merges on paste format**
Fixes an issue where merged cells were not carried over when using the paint format tool. The tool now correctly copies merge information from the source and applies it to the target zone.






Task: [4807659](https://www.odoo.com/odoo/project/2328/tasks/4807659)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo