### PR TITLE
[FIX] core: prevent full re-render in dashboards

### DIFF
--- a/src/components/tables/hovered_table_store.ts
+++ b/src/components/tables/hovered_table_store.ts
@@ -19,7 +19,7 @@ export class HoveredTableStore extends SpreadsheetStore {
   }
 
   hover(position: Partial<Position>) {
-    if (position.col === this.col && position.row === this.row) {
+    if (!this.getters.isDashboard() || (position.col === this.col && position.row === this.row)) {
       return "noStateChange";
     }
     this.col = position.col;


### PR DESCRIPTION
Prior to this commit, when we type a value in an input on the side panel and hover back to the grid, the value is lost as we perform a full re-render of the model. This commit mitigates this behaviour by preventing the re-render when we are editing a spreadsheet of type `dashboard`.

Task: [4772026](https://www.odoo.com/odoo/2328/tasks/4772026)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo