### PR TITLE
[IMP] side panel: allow to open multiple side panels

### DIFF
--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -184,12 +184,12 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
     this.cellPopovers = useStore(CellPopoverStore);
 
     useEffect(
-      () => {
-        if (!this.sidePanel.isOpen) {
+      (isMainPanelOpen, isSecondaryPanelOpen) => {
+        if (!isMainPanelOpen && !isSecondaryPanelOpen) {
           this.DOMFocusableElementStore.focus();
         }
       },
-      () => [this.sidePanel.isOpen]
+      () => [this.sidePanel.isMainPanelOpen, this.sidePanel.isSecondaryPanelOpen]
     );
 
     useTouchScroll(this.gridRef, this.moveCanvas.bind(this), () => {

--- a/src/components/side_panel/side_panel/side_panel.xml
+++ b/src/components/side_panel/side_panel/side_panel.xml
@@ -1,34 +1,77 @@
 <templates>
   <t t-name="o-spreadsheet-SidePanel">
-    <div class="o-sidePanel" t-if="sidePanelStore.isOpen">
-      <div class="o-sidePanelHeader">
-        <div class="o-sidePanelTitle o-fw-bold" t-esc="getTitle()"/>
-        <div class="o-sidePanelClose" t-on-click="close">✕</div>
+    <t t-if="props.isCollapsed" t-call="o-spreadsheet-SidePanelCollapsed"/>
+    <t t-else="" t-call="o-spreadsheet-SidePanelExtended"/>
+  </t>
+
+  <t t-name="o-spreadsheet-SidePanelExtended">
+    <div class="o-sidePanel h-100">
+      <div class="o-sidePanelHeader d-flex align-items-center justify-content-between">
+        <div
+          t-if="props.isPinned and props.onToggleCollapsePanel"
+          class="o-collapse-panel o-sidePanelAction rounded"
+          t-on-click="props.onToggleCollapsePanel">
+          <i class="fa fa-angle-double-right"/>
+        </div>
+        <div class="o-sidePanelTitle o-fw-bold ms-2" t-esc="getTitle()"/>
+        <div
+          t-if="props.onTogglePinPanel"
+          class="o-pin-panel o-sidePanelAction ms-auto rounded"
+          t-att-class="{'active': props.isPinned}"
+          t-on-click="props.onTogglePinPanel"
+          t-att-title="pinInfoMessage">
+          <i class="fa fa-thumb-tack"/>
+        </div>
+        <div class="o-sidePanelClose o-sidePanelAction rounded" t-on-click="props.onCloseSidePanel">
+          ✕
+        </div>
       </div>
       <div class="o-sidePanelBody-container d-flex flex-grow-1 ">
         <div class="o-sidePanel-handle-container">
           <div
             class="o-sidePanel-handle"
-            t-on-pointerdown="startHandleDrag"
-            t-on-dblclick="sidePanelStore.resetPanelSize">
+            t-on-pointerdown="props.onStartHandleDrag"
+            t-on-dblclick="props.onResetPanelSize">
             <t t-call="o-spreadsheet-Icon.THIN_DRAG_HANDLE"/>
           </div>
         </div>
         <div class="o-sidePanelBody">
           <t
-            t-component="panel.Body"
-            t-props="sidePanelStore.panelProps"
-            onCloseSidePanel.bind="close"
-            t-key="'Body_' + sidePanelStore.componentTag + sidePanelStore.panelKey"
+            t-component="props.panelContent.Body"
+            t-props="props.panelProps"
+            onCloseSidePanel="props.onCloseSidePanel"
           />
         </div>
-        <div class="o-sidePanelFooter" t-if="panel?.Footer">
-          <t
-            t-component="panel.Footer"
-            t-props="sidePanelStore.panelProps"
-            t-key="'Footer_' + sidePanelStore.componentTag"
-          />
+        <div class="o-sidePanelFooter" t-if="props.panelContent?.Footer">
+          <t t-component="props.panelContent.Footer" t-props="props.panelProps"/>
         </div>
+      </div>
+    </div>
+  </t>
+
+  <t t-name="o-spreadsheet-SidePanelCollapsed">
+    <div class="o-sidePanel collapsed w-100 h-100" t-on-click="props.onToggleCollapsePanel">
+      <div class="d-flex flex-column align-items-center">
+        <div
+          t-if="props.onToggleCollapsePanel"
+          class="o-collapse-panel o-sidePanelAction rounded mb-1">
+          <i class="fa fa-angle-double-left"/>
+        </div>
+        <div
+          t-if="props.onTogglePinPanel"
+          class="o-pin-panel o-sidePanelAction rounded mb-1"
+          t-att-class="{'active': props.isPinned}"
+          t-on-click.stop="props.onTogglePinPanel"
+          t-att-title="pinInfoMessage">
+          <i class="fa fa-thumb-tack"/>
+        </div>
+        <div
+          class="o-sidePanelClose o-sidePanelAction rounded mb-1"
+          t-on-click.stop="props.onCloseSidePanel">
+          ✕
+        </div>
+
+        <div class="o-sidePanelTitle o-fw-bold" t-esc="getTitle()"/>
       </div>
     </div>
   </t>

--- a/src/components/side_panel/side_panel/side_panel_store.ts
+++ b/src/components/side_panel/side_panel/side_panel_store.ts
@@ -1,7 +1,9 @@
 import { sidePanelRegistry } from "../../../registries/side_panel_registry";
 import { SpreadsheetStore } from "../../../stores";
+import { NotificationStore } from "../../../stores/notification_store";
+import { _t } from "../../../translation";
 
-interface SidePanelProps {
+export interface SidePanelProps {
   onCloseSidePanel?: () => void;
   [key: string]: any;
 }
@@ -19,51 +21,133 @@ interface ClosedSidePanel {
 export type SidePanelState = OpenSidePanel | ClosedSidePanel;
 
 export const DEFAULT_SIDE_PANEL_SIZE = 350;
+export const COLLAPSED_SIDE_PANEL_SIZE = 45;
 export const MIN_SHEET_VIEW_WIDTH = 150;
 
-export class SidePanelStore extends SpreadsheetStore {
-  mutators = ["open", "toggle", "close", "changePanelSize", "resetPanelSize"] as const;
-  initialPanelProps: SidePanelProps = {};
-  componentTag: string = "";
-  panelSize = DEFAULT_SIDE_PANEL_SIZE;
+interface PanelInfo {
+  initialPanelProps: SidePanelProps;
+  componentTag: string;
+  size: number;
+}
 
-  get isOpen() {
-    if (!this.componentTag) {
-      return false;
-    }
-    return this.computeState(this.componentTag, this.initialPanelProps).isOpen;
+export class SidePanelStore extends SpreadsheetStore {
+  mutators = [
+    "open",
+    "toggle",
+    "close",
+    "changePanelSize",
+    "resetPanelSize",
+    "togglePinPanel",
+    "closeMainPanel",
+    "changeSpreadsheetWidth",
+    "toggleCollapseMainPanel",
+  ] as const;
+
+  mainPanel: (PanelInfo & { isCollapsed?: boolean; isPined?: boolean }) | undefined = undefined;
+  secondaryPanel: PanelInfo | undefined;
+  availableWidth: number = 0;
+
+  get isMainPanelOpen() {
+    return this.mainPanel && this.mainPanel.componentTag
+      ? this.computeState(this.mainPanel).isOpen
+      : false;
   }
 
-  get panelProps(): SidePanelProps {
-    const state = this.computeState(this.componentTag, this.initialPanelProps);
+  get isSecondaryPanelOpen() {
+    return this.secondaryPanel && this.secondaryPanel.componentTag
+      ? this.computeState(this.secondaryPanel).isOpen
+      : false;
+  }
+
+  get mainPanelProps(): SidePanelProps | undefined {
+    return this.mainPanel ? this.getPanelProps(this.mainPanel) : undefined;
+  }
+
+  get mainPanelKey(): string | undefined {
+    return this.mainPanel ? this.getPanelKey(this.mainPanel) : undefined;
+  }
+
+  get secondaryPanelProps(): SidePanelProps | undefined {
+    return this.secondaryPanel ? this.getPanelProps(this.secondaryPanel) : undefined;
+  }
+
+  get secondaryPanelKey(): string | undefined {
+    return this.secondaryPanel ? this.getPanelKey(this.secondaryPanel) : undefined;
+  }
+
+  get totalPanelSize() {
+    return (this.mainPanel?.size || 0) + (this.secondaryPanel?.size ?? 0);
+  }
+
+  private getPanelProps(panelInfo: PanelInfo): SidePanelProps {
+    const state = this.computeState(panelInfo);
     if (state.isOpen) {
       return state.props ?? {};
     }
     return {};
   }
 
-  get panelKey(): string | undefined {
-    const state = this.computeState(this.componentTag, this.initialPanelProps);
+  private getPanelKey(panelInfo: PanelInfo): string | undefined {
+    const state = this.computeState(panelInfo);
     if (state.isOpen) {
       return state.key;
     }
     return undefined;
   }
 
-  open(componentTag: string, panelProps: SidePanelProps = {}) {
-    const state = this.computeState(componentTag, panelProps);
+  open(componentTag: string, initialPanelProps: SidePanelProps = {}) {
+    const newPanelInfo = { initialPanelProps, componentTag, size: DEFAULT_SIDE_PANEL_SIZE };
+    const state = this.computeState(newPanelInfo);
     if (!state.isOpen) {
       return;
     }
-    if (this.isOpen && componentTag !== this.componentTag) {
-      this.initialPanelProps?.onCloseSidePanel?.();
+
+    if (!this.mainPanel || !this.mainPanel.isPined) {
+      if (this.mainPanel && componentTag !== this.mainPanel.componentTag) {
+        this.mainPanel.initialPanelProps?.onCloseSidePanel?.();
+      }
+      this.mainPanel = {
+        initialPanelProps: state.props ?? {},
+        componentTag,
+        size: this.mainPanel?.size || DEFAULT_SIDE_PANEL_SIZE,
+        isCollapsed: false,
+      };
+      return;
     }
-    this.componentTag = componentTag;
-    this.initialPanelProps = state.props ?? {};
+
+    if (this.getPanelKey(this.mainPanel) === state.key) {
+      if (this.mainPanel.isCollapsed) {
+        this.toggleCollapseMainPanel();
+      }
+      return;
+    }
+
+    // Try to open secondary panel if main panel is pinned
+    if (
+      !this.secondaryPanel &&
+      this.totalPanelSize + DEFAULT_SIDE_PANEL_SIZE > this.availableWidth
+    ) {
+      this.get(NotificationStore).notifyUser({
+        sticky: false,
+        type: "warning",
+        text: _t("The window is too small to display multiple side panels."),
+      });
+      return;
+    }
+
+    if (this.secondaryPanel && componentTag !== this.secondaryPanel.componentTag) {
+      this.secondaryPanel.initialPanelProps?.onCloseSidePanel?.();
+    }
+    this.secondaryPanel = {
+      initialPanelProps: state.props ?? {},
+      componentTag: componentTag,
+      size: this.secondaryPanel?.size || DEFAULT_SIDE_PANEL_SIZE,
+    };
   }
 
   toggle(componentTag: string, panelProps: SidePanelProps) {
-    if (this.isOpen && componentTag === this.componentTag) {
+    const panel = this.mainPanel?.isPined ? this.secondaryPanel : this.mainPanel;
+    if (panel && componentTag === panel.componentTag) {
       this.close();
     } else {
       this.open(componentTag, panelProps);
@@ -71,34 +155,97 @@ export class SidePanelStore extends SpreadsheetStore {
   }
 
   close() {
-    this.initialPanelProps.onCloseSidePanel?.();
-    this.initialPanelProps = {};
-    this.componentTag = "";
+    if (this.mainPanel?.isPined) {
+      if (this.secondaryPanel) {
+        this.secondaryPanel.initialPanelProps.onCloseSidePanel?.();
+        this.secondaryPanel = undefined;
+      }
+      return;
+    }
+    this.mainPanel?.initialPanelProps.onCloseSidePanel?.();
+    this.mainPanel = undefined;
   }
 
-  changePanelSize(size: number, spreadsheetElWidth: number) {
-    if (size < DEFAULT_SIDE_PANEL_SIZE) {
-      this.panelSize = DEFAULT_SIDE_PANEL_SIZE;
-    } else if (size > spreadsheetElWidth - MIN_SHEET_VIEW_WIDTH) {
-      this.panelSize = Math.max(spreadsheetElWidth - MIN_SHEET_VIEW_WIDTH, DEFAULT_SIDE_PANEL_SIZE);
-    } else {
-      this.panelSize = size;
+  closeMainPanel() {
+    this.mainPanel?.initialPanelProps.onCloseSidePanel?.();
+    this.mainPanel = this.secondaryPanel || undefined;
+    this.secondaryPanel = undefined;
+  }
+
+  changePanelSize(panel: "mainPanel" | "secondaryPanel", size: number) {
+    const panelInfo = this[panel];
+    if (!panelInfo || ("isCollapsed" in panelInfo && panelInfo.isCollapsed)) {
+      return;
+    }
+
+    size = Math.max(size, DEFAULT_SIDE_PANEL_SIZE);
+    let otherPanelSize =
+      panel === "mainPanel" ? this.secondaryPanel?.size || 0 : this.mainPanel?.size || 0;
+
+    if (size > this.availableWidth - otherPanelSize) {
+      if (panel === "mainPanel" && this.secondaryPanel) {
+        // reduce the secondary panel size to fit the main panel
+        this.secondaryPanel.size = Math.max(this.availableWidth - size, DEFAULT_SIDE_PANEL_SIZE);
+        otherPanelSize = this.secondaryPanel.size;
+      }
+      size = Math.max(this.availableWidth - otherPanelSize, DEFAULT_SIDE_PANEL_SIZE);
+    }
+    panelInfo.size = size;
+  }
+
+  resetPanelSize(panel: "mainPanel" | "secondaryPanel") {
+    const panelInfo = this[panel];
+    if (!panelInfo) {
+      return;
+    }
+    panelInfo.size = DEFAULT_SIDE_PANEL_SIZE;
+  }
+
+  togglePinPanel() {
+    if (!this.mainPanel) {
+      return;
+    }
+    this.mainPanel.isPined = !this.mainPanel.isPined;
+    if (!this.mainPanel.isPined && this.secondaryPanel) {
+      this.secondaryPanel?.initialPanelProps.onCloseSidePanel?.();
+      this.mainPanel = this.secondaryPanel;
+      this.secondaryPanel = undefined;
+    }
+    if (!this.mainPanel.isPined && this.mainPanel?.isCollapsed) {
+      this.mainPanel.isCollapsed = false;
+      this.changePanelSize("mainPanel", DEFAULT_SIDE_PANEL_SIZE);
     }
   }
 
-  resetPanelSize() {
-    this.panelSize = DEFAULT_SIDE_PANEL_SIZE;
+  toggleCollapseMainPanel() {
+    if (!this.mainPanel || !this.mainPanel.isPined) {
+      return;
+    }
+    if (this.mainPanel.isCollapsed) {
+      this.mainPanel.isCollapsed = false;
+      this.changePanelSize("mainPanel", DEFAULT_SIDE_PANEL_SIZE);
+    } else {
+      this.mainPanel.isCollapsed = true;
+      this.mainPanel.size = COLLAPSED_SIDE_PANEL_SIZE;
+    }
   }
 
-  private computeState(componentTag: string, panelProps: SidePanelProps): SidePanelState {
+  private computeState({ componentTag, initialPanelProps }: PanelInfo): SidePanelState {
     const customComputeState = sidePanelRegistry.get(componentTag).computeState;
-    if (!customComputeState) {
-      return {
-        isOpen: true,
-        props: panelProps,
-      };
-    } else {
-      return customComputeState(this.getters, panelProps);
+    const state: SidePanelState = customComputeState
+      ? customComputeState(this.getters, initialPanelProps)
+      : { isOpen: true, props: initialPanelProps };
+    return state.isOpen ? { ...state, key: state.key || componentTag } : state;
+  }
+
+  changeSpreadsheetWidth(width: number) {
+    this.availableWidth = width - MIN_SHEET_VIEW_WIDTH;
+    if (this.secondaryPanel && width - this.totalPanelSize < MIN_SHEET_VIEW_WIDTH) {
+      this.secondaryPanel?.initialPanelProps.onCloseSidePanel?.();
+      this.secondaryPanel = undefined;
+    }
+    if (this.mainPanel && width - this.totalPanelSize < MIN_SHEET_VIEW_WIDTH) {
+      this.mainPanel.size = Math.max(width - MIN_SHEET_VIEW_WIDTH, DEFAULT_SIDE_PANEL_SIZE);
     }
   }
 }

--- a/src/components/side_panel/side_panels/side_panels.ts
+++ b/src/components/side_panel/side_panels/side_panels.ts
@@ -1,0 +1,103 @@
+import { Component, useEffect } from "@odoo/owl";
+import { sidePanelRegistry } from "../../../registries/side_panel_registry";
+import { Store, useStore } from "../../../store_engine";
+import { SpreadsheetChildEnv } from "../../../types";
+import { cssPropertiesToCss } from "../../helpers";
+import { startDnd } from "../../helpers/drag_and_drop";
+import { useSpreadsheetRect } from "../../helpers/position_hook";
+import { SidePanel } from "../side_panel/side_panel";
+import { SidePanelStore } from "../side_panel/side_panel_store";
+
+export class SidePanels extends Component<{}, SpreadsheetChildEnv> {
+  static template = "o-spreadsheet-SidePanels";
+  static props = {};
+  static components = { SidePanel };
+  sidePanelStore!: Store<SidePanelStore>;
+  spreadsheetRect = useSpreadsheetRect();
+
+  setup() {
+    this.sidePanelStore = useStore(SidePanelStore);
+    useEffect(
+      () => {
+        if (this.sidePanelStore.mainPanel && !this.sidePanelStore.isMainPanelOpen) {
+          this.sidePanelStore.closeMainPanel();
+        }
+        if (this.sidePanelStore.secondaryPanel && !this.sidePanelStore.isSecondaryPanelOpen) {
+          this.sidePanelStore.close();
+        }
+      },
+      () => [this.sidePanelStore.isMainPanelOpen, this.sidePanelStore.isSecondaryPanelOpen]
+    );
+  }
+
+  startHandleDrag(panel: "mainPanel" | "secondaryPanel", ev: MouseEvent) {
+    const startingCursor = document.body.style.cursor;
+    const panelInfo =
+      panel === "mainPanel" ? this.sidePanelStore.mainPanel : this.sidePanelStore.secondaryPanel;
+    if (!panelInfo) {
+      return;
+    }
+    const startSize = panelInfo.size;
+    const startPosition = ev.clientX;
+    const onMouseMove = (ev: MouseEvent) => {
+      document.body.style.cursor = "col-resize";
+      const newSize = startSize + startPosition - ev.clientX;
+      this.sidePanelStore.changePanelSize(panel, newSize);
+    };
+    const cleanUp = () => {
+      document.body.style.cursor = startingCursor;
+    };
+    startDnd(onMouseMove, cleanUp);
+  }
+
+  get mainPanelProps(): SidePanel["props"] | undefined {
+    const panelProps = this.sidePanelStore.mainPanelProps;
+    if (!this.sidePanelStore.mainPanel || !panelProps) {
+      return undefined;
+    }
+    return {
+      panelContent: sidePanelRegistry.get(this.sidePanelStore.mainPanel.componentTag),
+      panelProps,
+      onCloseSidePanel: () => this.sidePanelStore.closeMainPanel(),
+      onTogglePinPanel: () => this.sidePanelStore.togglePinPanel(),
+      onStartHandleDrag: (ev: MouseEvent) => this.startHandleDrag("mainPanel", ev),
+      onResetPanelSize: () => this.sidePanelStore.resetPanelSize("mainPanel"),
+      isPinned: this.sidePanelStore.mainPanel?.isPined,
+      onToggleCollapsePanel: () => this.sidePanelStore.toggleCollapseMainPanel(),
+      isCollapsed: this.sidePanelStore.mainPanel?.isCollapsed,
+    };
+  }
+
+  get secondaryPanelProps(): SidePanel["props"] | undefined {
+    const panelProps = this.sidePanelStore.secondaryPanelProps;
+    if (!this.sidePanelStore.secondaryPanel || !panelProps) {
+      return undefined;
+    }
+    return {
+      panelContent: sidePanelRegistry.get(this.sidePanelStore.secondaryPanel.componentTag),
+      panelProps,
+      onCloseSidePanel: () => this.sidePanelStore.close(),
+      onStartHandleDrag: (ev: MouseEvent) => this.startHandleDrag("secondaryPanel", ev),
+      onResetPanelSize: () => this.sidePanelStore.resetPanelSize("secondaryPanel"),
+    };
+  }
+
+  get panelList() {
+    return [
+      {
+        key: this.sidePanelStore.secondaryPanelKey,
+        props: this.secondaryPanelProps,
+        style: this.sidePanelStore.secondaryPanel
+          ? cssPropertiesToCss({ width: `${this.sidePanelStore.secondaryPanel.size}px` })
+          : "",
+      },
+      {
+        key: this.sidePanelStore.mainPanelKey,
+        props: this.mainPanelProps,
+        style: this.sidePanelStore.mainPanel
+          ? cssPropertiesToCss({ width: `${this.sidePanelStore.mainPanel.size}px` })
+          : "",
+      },
+    ].filter((panel) => panel.key && panel.props);
+  }
+}

--- a/src/components/side_panel/side_panels/side_panels.xml
+++ b/src/components/side_panel/side_panels/side_panels.xml
@@ -1,0 +1,11 @@
+<templates>
+  <t t-name="o-spreadsheet-SidePanels" t-if="sidePanelStore.isMainPanelOpen">
+    <div class="o-sidePanels d-flex">
+      <t t-foreach="panelList" t-as="panel" t-key="panel.key">
+        <div t-att-style="panel.style">
+          <SidePanel t-key="panel.key" t-props="panel.props"/>
+        </div>
+      </t>
+    </div>
+  </t>
+</templates>

--- a/src/components/spreadsheet/spreadsheet.ts
+++ b/src/components/spreadsheet/spreadsheet.ts
@@ -63,8 +63,8 @@ import { HeaderGroupContainer } from "../header_group/header_group_container";
 import { css, cssPropertiesToCss } from "../helpers/css";
 import { useSpreadsheetRect } from "../helpers/position_hook";
 import { useScreenWidth } from "../helpers/screen_width_hook";
-import { SidePanel } from "../side_panel/side_panel/side_panel";
-import { SidePanelStore } from "../side_panel/side_panel/side_panel_store";
+import { DEFAULT_SIDE_PANEL_SIZE, SidePanelStore } from "../side_panel/side_panel/side_panel_store";
+import { SidePanels } from "../side_panel/side_panels/side_panels";
 import { TopBar } from "../top_bar/top_bar";
 import { instantiateClipboard } from "./../../helpers/clipboard/navigator_clipboard_wrapper";
 
@@ -330,7 +330,7 @@ export class Spreadsheet extends Component<SpreadsheetProps, SpreadsheetChildEnv
     TopBar,
     Grid,
     BottomBar,
-    SidePanel,
+    SidePanels,
     SpreadsheetDashboard,
     HeaderGroupContainer,
     FullScreenChart,
@@ -357,7 +357,9 @@ export class Spreadsheet extends Component<SpreadsheetProps, SpreadsheetChildEnv
     } else {
       properties["grid-template-rows"] = `min-content auto min-content`;
     }
-    properties["grid-template-columns"] = `auto ${this.sidePanel.panelSize}px`;
+    properties["grid-template-columns"] = `auto ${Math.min(
+      this.sidePanel.totalPanelSize || DEFAULT_SIDE_PANEL_SIZE
+    )}px`;
 
     return cssPropertiesToCss(properties);
   }
@@ -455,7 +457,7 @@ export class Spreadsheet extends Component<SpreadsheetProps, SpreadsheetChildEnv
       this.checkViewportSize();
     });
     const resizeObserver = new ResizeObserver(() => {
-      this.sidePanel.changePanelSize(this.sidePanel.panelSize, this.spreadsheetRect.width);
+      this.sidePanel.changeSpreadsheetWidth(this.spreadsheetRect.width);
     });
   }
 

--- a/src/components/spreadsheet/spreadsheet.xml
+++ b/src/components/spreadsheet/spreadsheet.xml
@@ -9,7 +9,7 @@
         <TopBar onClick="() => this.focusGrid()" dropdownMaxHeight="gridHeight"/>
         <div
           class="o-grid-container"
-          t-att-class="{'o-two-columns': !sidePanel.isOpen}"
+          t-att-class="{'o-two-columns': !sidePanel.isMainPanelOpen}"
           t-att-style="gridContainerStyle"
           t-on-click="this.focusGrid">
           <div class="o-top-left"/>
@@ -23,7 +23,7 @@
             <Grid exposeFocus="(focus) => this._focusGrid = focus"/>
           </div>
         </div>
-        <SidePanel/>
+        <SidePanels/>
         <BottomBar onClick="() => this.focusGrid()"/>
       </t>
     </div>

--- a/tests/figures/chart/funnel/funnel_panel_component.test.ts
+++ b/tests/figures/chart/funnel/funnel_panel_component.test.ts
@@ -1,5 +1,5 @@
 import { Model, SpreadsheetChildEnv } from "../../../../src";
-import { SidePanel } from "../../../../src/components/side_panel/side_panel/side_panel";
+import { SidePanels } from "../../../../src/components/side_panel/side_panels/side_panels";
 import {
   click,
   createFunnelChart,
@@ -22,7 +22,7 @@ let env: SpreadsheetChildEnv;
 describe("Funnel chart side panel", () => {
   beforeEach(async () => {
     model = new Model();
-    ({ fixture, env } = await mountComponentWithPortalTarget(SidePanel, { model }));
+    ({ fixture, env } = await mountComponentWithPortalTarget(SidePanels, { model }));
   });
 
   describe("Config panel", () => {

--- a/tests/figures/chart/gauge/gauge_panel_component.test.ts
+++ b/tests/figures/chart/gauge/gauge_panel_component.test.ts
@@ -1,5 +1,5 @@
 import { CommandResult, Model, SpreadsheetChildEnv } from "../../../../src";
-import { SidePanel } from "../../../../src/components/side_panel/side_panel/side_panel";
+import { SidePanels } from "../../../../src/components/side_panel/side_panels/side_panels";
 import { ChartTerms } from "../../../../src/components/translations_terms";
 import { createGaugeChart, setInputValueAndTrigger, simulateClick } from "../../../test_helpers";
 import {
@@ -21,7 +21,7 @@ const chartId = "chartId";
 beforeEach(async () => {
   model = new Model();
   createGaugeChart(model, TEST_CHART_DATA.gauge, chartId);
-  ({ fixture, env } = await mountComponentWithPortalTarget(SidePanel, { model }));
+  ({ fixture, env } = await mountComponentWithPortalTarget(SidePanels, { model }));
   await openChartConfigSidePanel(model, env, chartId);
 });
 

--- a/tests/figures/chart/geochart/geo_chart_panel_component.test.ts
+++ b/tests/figures/chart/geochart/geo_chart_panel_component.test.ts
@@ -1,5 +1,5 @@
 import { Model, SpreadsheetChildEnv, UID } from "../../../../src";
-import { SidePanel } from "../../../../src/components/side_panel/side_panel/side_panel";
+import { SidePanels } from "../../../../src/components/side_panel/side_panels/side_panels";
 import { GeoChartDefinition } from "../../../../src/types/chart/geo_chart";
 import {
   changeRoundColorPickerColor,
@@ -34,7 +34,7 @@ function getGeoChartDefinition(chartId: UID): GeoChartDefinition {
 describe("Geo chart side panel", () => {
   beforeEach(async () => {
     model = new Model({}, { external: { geoJsonService: mockGeoJsonService } });
-    ({ fixture, env } = await mountComponentWithPortalTarget(SidePanel, { model }));
+    ({ fixture, env } = await mountComponentWithPortalTarget(SidePanels, { model }));
   });
 
   describe("Config panel", () => {

--- a/tests/figures/chart/pyramid_chart/pyramid_chart_component.test.ts
+++ b/tests/figures/chart/pyramid_chart/pyramid_chart_component.test.ts
@@ -1,5 +1,5 @@
 import { Model, SpreadsheetChildEnv } from "../../../../src";
-import { SidePanel } from "../../../../src/components/side_panel/side_panel/side_panel";
+import { SidePanels } from "../../../../src/components/side_panel/side_panels/side_panels";
 import { createChart } from "../../../test_helpers";
 import { openChartConfigSidePanel } from "../../../test_helpers/chart_helpers";
 import { setInputValueAndTrigger, simulateClick } from "../../../test_helpers/dom_helper";
@@ -12,7 +12,7 @@ let env: SpreadsheetChildEnv;
 describe("Pyramid chart side panel", () => {
   beforeEach(async () => {
     model = new Model();
-    ({ fixture, env } = await mountComponentWithPortalTarget(SidePanel, { model }));
+    ({ fixture, env } = await mountComponentWithPortalTarget(SidePanels, { model }));
   });
 
   test("Only first 2 ranges are enabled when changing the selection input", async () => {

--- a/tests/figures/chart/scorecard/scorecard_chart_component.test.ts
+++ b/tests/figures/chart/scorecard/scorecard_chart_component.test.ts
@@ -1,5 +1,5 @@
 import { Model } from "../../../../src";
-import { SidePanel } from "../../../../src/components/side_panel/side_panel/side_panel";
+import { SidePanels } from "../../../../src/components/side_panel/side_panels/side_panels";
 import {
   DEFAULT_SCORECARD_BASELINE_COLOR_DOWN,
   DEFAULT_SCORECARD_BASELINE_COLOR_UP,
@@ -481,7 +481,7 @@ describe("Scorecard charts rendering", () => {
       baseline: {},
       baselineDescr: {},
     };
-    ({ fixture, env } = await mountComponentWithPortalTarget(SidePanel, { model }));
+    ({ fixture, env } = await mountComponentWithPortalTarget(SidePanels, { model }));
 
     /*
      * We mock the fillText method of the canvas context to get the font size and color used

--- a/tests/figures/chart/sunburst/sunburst_panel_component.test.ts
+++ b/tests/figures/chart/sunburst/sunburst_panel_component.test.ts
@@ -1,5 +1,5 @@
 import { Model, SpreadsheetChildEnv, UID } from "../../../../src";
-import { SidePanel } from "../../../../src/components/side_panel/side_panel/side_panel";
+import { SidePanels } from "../../../../src/components/side_panel/side_panels/side_panels";
 import { ColorGenerator } from "../../../../src/helpers";
 import { SunburstChartDefinition } from "../../../../src/types/chart";
 import {
@@ -30,7 +30,7 @@ function getSunburstDefinition(chartId: UID): SunburstChartDefinition {
 describe("Sunburst chart side panel", () => {
   beforeEach(async () => {
     model = new Model();
-    ({ fixture, env } = await mountComponentWithPortalTarget(SidePanel, { model }));
+    ({ fixture, env } = await mountComponentWithPortalTarget(SidePanels, { model }));
   });
 
   describe("Config panel", () => {

--- a/tests/figures/chart/treemap/treemap_panel_component.test.ts
+++ b/tests/figures/chart/treemap/treemap_panel_component.test.ts
@@ -1,5 +1,5 @@
 import { Model, SpreadsheetChildEnv, UID } from "../../../../src";
-import { SidePanel } from "../../../../src/components/side_panel/side_panel/side_panel";
+import { SidePanels } from "../../../../src/components/side_panel/side_panels/side_panels";
 import { ColorGenerator } from "../../../../src/helpers";
 import { TreeMapChartDefinition } from "../../../../src/types/chart/tree_map_chart";
 import {
@@ -31,7 +31,7 @@ function getTreeMapChartDefinition(chartId: UID): TreeMapChartDefinition {
 describe("TreeMap chart side panel", () => {
   beforeEach(async () => {
     model = new Model();
-    ({ fixture, env } = await mountComponentWithPortalTarget(SidePanel, { model }));
+    ({ fixture, env } = await mountComponentWithPortalTarget(SidePanels, { model }));
   });
 
   describe("Config panel", () => {

--- a/tests/figures/chart/waterfall/waterfall_panel_component.test.ts
+++ b/tests/figures/chart/waterfall/waterfall_panel_component.test.ts
@@ -1,5 +1,5 @@
 import { Model, SpreadsheetChildEnv, UID } from "../../../../src";
-import { SidePanel } from "../../../../src/components/side_panel/side_panel/side_panel";
+import { SidePanels } from "../../../../src/components/side_panel/side_panels/side_panels";
 import { WaterfallChartDefinition } from "../../../../src/types/chart/waterfall_chart";
 import {
   changeRoundColorPickerColor,
@@ -26,7 +26,7 @@ function getWaterfallDefinition(chartId: UID): WaterfallChartDefinition {
 describe("Waterfall chart side panel", () => {
   beforeEach(async () => {
     model = new Model();
-    ({ fixture, env } = await mountComponentWithPortalTarget(SidePanel, { model }));
+    ({ fixture, env } = await mountComponentWithPortalTarget(SidePanels, { model }));
   });
 
   describe("Config panel", () => {

--- a/tests/pivots/spreadsheet_pivot/__snapshots__/spreadsheet_pivot_side_panel.test.ts.snap
+++ b/tests/pivots/spreadsheet_pivot/__snapshots__/spreadsheet_pivot_side_panel.test.ts.snap
@@ -2,20 +2,30 @@
 
 exports[`Spreadsheet pivot side panel It should correctly be displayed 1`] = `
 <div
-  class="o-sidePanel"
+  class="o-sidePanel h-100"
 >
   <div
-    class="o-sidePanelHeader"
+    class="o-sidePanelHeader d-flex align-items-center justify-content-between"
   >
+    
     <div
-      class="o-sidePanelTitle o-fw-bold"
+      class="o-sidePanelTitle o-fw-bold ms-2"
     >
       Pivot #1
     </div>
     <div
-      class="o-sidePanelClose"
+      class="o-pin-panel o-sidePanelAction ms-auto rounded"
+      title="Pin this panel to allow to open another side panel beside it."
     >
-      ✕
+      <i
+        class="fa fa-thumb-tack"
+      />
+    </div>
+    
+    <div
+      class="o-sidePanelClose o-sidePanelAction rounded"
+    >
+       ✕ 
     </div>
   </div>
   <div
@@ -222,20 +232,30 @@ exports[`Spreadsheet pivot side panel It should correctly be displayed 1`] = `
 
 exports[`Spreadsheet pivot side panel It should display only the selection input when the dataSet is not valid 1`] = `
 <div
-  class="o-sidePanel"
+  class="o-sidePanel h-100"
 >
   <div
-    class="o-sidePanelHeader"
+    class="o-sidePanelHeader d-flex align-items-center justify-content-between"
   >
+    
     <div
-      class="o-sidePanelTitle o-fw-bold"
+      class="o-sidePanelTitle o-fw-bold ms-2"
     >
       Pivot #1
     </div>
     <div
-      class="o-sidePanelClose"
+      class="o-pin-panel o-sidePanelAction ms-auto rounded"
+      title="Pin this panel to allow to open another side panel beside it."
     >
-      ✕
+      <i
+        class="fa fa-thumb-tack"
+      />
+    </div>
+    
+    <div
+      class="o-sidePanelClose o-sidePanelAction rounded"
+    >
+       ✕ 
     </div>
   </div>
   <div

--- a/tests/spreadsheet/side_panel_component.test.ts
+++ b/tests/spreadsheet/side_panel_component.test.ts
@@ -1,13 +1,15 @@
 import { Component, xml } from "@odoo/owl";
 import { Model, Spreadsheet } from "../../src";
 import {
+  COLLAPSED_SIDE_PANEL_SIZE,
   DEFAULT_SIDE_PANEL_SIZE,
   MIN_SHEET_VIEW_WIDTH,
   SidePanelStore,
 } from "../../src/components/side_panel/side_panel/side_panel_store";
 import { SidePanelContent, sidePanelRegistry } from "../../src/registries/side_panel_registry";
+import { Store } from "../../src/store_engine";
 import { createSheet } from "../test_helpers/commands_helpers";
-import { doubleClick, dragElement, simulateClick } from "../test_helpers/dom_helper";
+import { click, doubleClick, dragElement, simulateClick } from "../test_helpers/dom_helper";
 import { addToRegistry, mountSpreadsheet, nextTick } from "../test_helpers/helpers";
 import { mockGetBoundingClientRect } from "../test_helpers/mock_helpers";
 
@@ -20,6 +22,8 @@ let fixture: HTMLElement;
 let parent: Spreadsheet;
 let sidePanelContent: { [key: string]: SidePanelContent };
 let model: Model;
+let sidePanelStore: Store<SidePanelStore>;
+let notifyUser = jest.fn();
 
 class Body extends Component<any, any> {
   static template = xml`
@@ -53,8 +57,12 @@ class BodyWithoutProps extends Component<any, any> {
 }
 
 beforeEach(async () => {
-  ({ parent, fixture, model } = await mountSpreadsheet());
+  spreadsheetWidth = 1000;
+  notifyUser = jest.fn();
+  ({ parent, fixture, model } = await mountSpreadsheet(undefined, { notifyUser }));
   sidePanelContent = Object.assign({}, sidePanelRegistry.content);
+  sidePanelStore = parent.env.getStore(SidePanelStore);
+  sidePanelStore.changeSpreadsheetWidth(spreadsheetWidth);
 });
 
 afterEach(() => {
@@ -308,12 +316,11 @@ describe("Side Panel", () => {
       await dragElement(fixture.querySelector(".o-sidePanel-handle")!, { y: 0, x: -100 });
       await nextTick();
       expect(spreadsheetEl.style["grid-template-columns"]).toBe("auto 450px");
-      expect(parent.env.getStore(SidePanelStore).panelSize).toBe(450);
+      expect(sidePanelStore.mainPanel?.size).toBe(450);
     });
 
     test("Can resize the side panel with the sidePanelStore", async () => {
-      const store = parent.env.getStore(SidePanelStore);
-      store.changePanelSize(400, spreadsheetWidth);
+      sidePanelStore.changePanelSize("mainPanel", 400);
       await nextTick();
 
       const spreadsheetEl = fixture.querySelector<HTMLElement>(".o-spreadsheet")!;
@@ -321,38 +328,195 @@ describe("Side Panel", () => {
     });
 
     test("Cannot make the side panel smaller than its default size", () => {
-      const store = parent.env.getStore(SidePanelStore);
-      store.changePanelSize(100, spreadsheetWidth);
-      expect(store.panelSize).toBe(DEFAULT_SIDE_PANEL_SIZE);
+      sidePanelStore.changePanelSize("mainPanel", 100);
+      expect(sidePanelStore.mainPanel?.size).toBe(DEFAULT_SIDE_PANEL_SIZE);
     });
 
     test("Cannot make the sheetView too small", () => {
-      const store = parent.env.getStore(SidePanelStore);
-      store.changePanelSize(900, spreadsheetWidth);
-      expect(store.panelSize).toBe(spreadsheetWidth - MIN_SHEET_VIEW_WIDTH);
+      sidePanelStore.changePanelSize("mainPanel", 900);
+      expect(sidePanelStore.mainPanel?.size).toBe(spreadsheetWidth - MIN_SHEET_VIEW_WIDTH);
 
-      store.changePanelSize(2000, spreadsheetWidth);
-      expect(store.panelSize).toBe(spreadsheetWidth - MIN_SHEET_VIEW_WIDTH);
+      sidePanelStore.changePanelSize("mainPanel", 2000);
+      expect(sidePanelStore.mainPanel?.size).toBe(spreadsheetWidth - MIN_SHEET_VIEW_WIDTH);
     });
 
     test("Side panel is resized when spreadsheet is resized", async () => {
-      const store = parent.env.getStore(SidePanelStore);
-      store.changePanelSize(850, spreadsheetWidth);
+      sidePanelStore.changePanelSize("mainPanel", 2000);
 
       spreadsheetWidth = 600;
       await nextTick();
       window.resizers.resize();
-      expect(store.panelSize).toBe(600 - MIN_SHEET_VIEW_WIDTH);
+      expect(sidePanelStore.mainPanel?.size).toBe(600 - MIN_SHEET_VIEW_WIDTH);
     });
 
     test("Can double click to reset the panel size", async () => {
-      const store = parent.env.getStore(SidePanelStore);
-      store.changePanelSize(400, spreadsheetWidth);
+      sidePanelStore.changePanelSize("mainPanel", 400);
       await nextTick();
 
       await doubleClick(fixture.querySelector(".o-sidePanel-handle")!);
       await nextTick();
-      expect(store.panelSize).toBe(DEFAULT_SIDE_PANEL_SIZE);
+      expect(sidePanelStore.mainPanel?.size).toBe(DEFAULT_SIDE_PANEL_SIZE);
+    });
+  });
+
+  describe("Pin & collapse side panel", () => {
+    beforeEach(async () => {
+      addToRegistry(sidePanelRegistry, "CUSTOM_PANEL", { title: "Custom Panel", Body: Body });
+      addToRegistry(sidePanelRegistry, "CUSTOM_PANEL_2", { title: "Custom Panel 2", Body: Body });
+      parent.env.openSidePanel("CUSTOM_PANEL");
+      await nextTick();
+    });
+
+    test("Can pin a side panel", async () => {
+      expect(sidePanelStore.mainPanel?.isPined).toBeFalsy();
+      expect(".o-pin-panel").not.toHaveClass("active");
+
+      await click(fixture, ".o-pin-panel");
+      expect(sidePanelStore.mainPanel?.isPined).toBe(true);
+      expect(".o-pin-panel").toHaveClass("active");
+
+      parent.env.openSidePanel("CUSTOM_PANEL_2");
+      await nextTick();
+
+      const panels = fixture.querySelectorAll(".o-sidePanel");
+      expect(panels).toHaveLength(2);
+      expect(panels[1].querySelector(".o-sidePanelTitle")).toHaveText("Custom Panel");
+      expect(panels[0].querySelector(".o-sidePanelTitle")).toHaveText("Custom Panel 2");
+      expect(panels[0].querySelector(".o-pin-panel")).toBeNull();
+    });
+
+    test("Unpinning a panel close it if another panel is open", async () => {
+      sidePanelStore.togglePinPanel();
+      parent.env.openSidePanel("CUSTOM_PANEL_2");
+      await nextTick();
+
+      expect(".o-sidePanel").toHaveCount(2);
+
+      await click(fixture, ".o-pin-panel");
+      expect(".o-sidePanel").toHaveCount(1);
+      expect(".o-sidePanelTitle").toHaveText("Custom Panel 2");
+    });
+
+    test("Can collapse pined panel", async () => {
+      expect(".o-collapse-panel").toHaveCount(0);
+      await click(fixture, ".o-pin-panel");
+      expect(".o-collapse-panel").toHaveCount(1);
+
+      await click(fixture, ".o-collapse-panel");
+      expect(".o-sidePanel").toHaveClass("collapsed");
+      expect(sidePanelStore.mainPanel?.isCollapsed).toBe(true);
+      expect(sidePanelStore.mainPanel?.size).toBe(COLLAPSED_SIDE_PANEL_SIZE);
+
+      await click(fixture, ".o-collapse-panel");
+      expect(".o-sidePanel").not.toHaveClass("collapsed");
+      expect(sidePanelStore.mainPanel?.isCollapsed).toBe(false);
+      expect(sidePanelStore.mainPanel?.size).toBe(DEFAULT_SIDE_PANEL_SIZE);
+    });
+
+    test("Unpinning a panel un-collapses it", async () => {
+      await click(fixture, ".o-pin-panel");
+      await click(fixture, ".o-collapse-panel");
+
+      expect(".o-sidePanel").toHaveClass("collapsed");
+      expect(sidePanelStore.mainPanel?.size).toBe(COLLAPSED_SIDE_PANEL_SIZE);
+
+      await click(fixture, ".o-pin-panel");
+      expect(".o-sidePanel").not.toHaveClass("collapsed");
+      expect(sidePanelStore.mainPanel?.size).toBe(DEFAULT_SIDE_PANEL_SIZE);
+    });
+
+    test("Cannot open two panels with the same key", async () => {
+      const panelKey = "myKey";
+      addToRegistry(sidePanelRegistry, "OTHER_PANEL", {
+        title: "Custom Panel",
+        Body: Body,
+        computeState: () => ({
+          isOpen: true,
+          key: "CUSTOM_PANEL", // This is the key of the first panel opened
+        }),
+      });
+
+      await click(fixture, ".o-pin-panel");
+      parent.env.openSidePanel("OTHER_PANEL", { key: panelKey });
+      await nextTick();
+      expect(".o-sidePanel").toHaveCount(1);
+      expect(".o-sidePanelTitle").toHaveText("Custom Panel");
+    });
+
+    test("Re-opening the same panel un-collapses it", async () => {
+      await click(fixture, ".o-pin-panel");
+      await click(fixture, ".o-collapse-panel");
+
+      expect(".o-sidePanel").toHaveClass("collapsed");
+      expect(sidePanelStore.mainPanel?.size).toBe(COLLAPSED_SIDE_PANEL_SIZE);
+
+      parent.env.openSidePanel("CUSTOM_PANEL");
+      await nextTick();
+      expect(".o-sidePanel").not.toHaveClass("collapsed");
+      expect(sidePanelStore.mainPanel?.size).toBe(DEFAULT_SIDE_PANEL_SIZE);
+    });
+
+    test("Can resize panels when two panels are open", async () => {
+      sidePanelStore.togglePinPanel();
+      parent.env.openSidePanel("CUSTOM_PANEL_2");
+      await nextTick();
+
+      const handles = fixture.querySelectorAll(".o-sidePanel-handle");
+      expect(handles).toHaveLength(2);
+
+      await dragElement(handles[0], { y: 0, x: -50 }, undefined, true);
+      expect(sidePanelStore.mainPanel?.size).toBe(DEFAULT_SIDE_PANEL_SIZE);
+      expect(sidePanelStore.secondaryPanel?.size).toBe(DEFAULT_SIDE_PANEL_SIZE + 50);
+
+      await dragElement(handles[1], { y: 0, x: -25 }, undefined, true);
+      expect(sidePanelStore.mainPanel?.size).toBe(DEFAULT_SIDE_PANEL_SIZE + 25);
+      expect(sidePanelStore.secondaryPanel?.size).toBe(DEFAULT_SIDE_PANEL_SIZE + 50);
+    });
+
+    test("Resizing the man panel reduces the size of the secondary panel if there is not enough space", async () => {
+      sidePanelStore.togglePinPanel();
+      parent.env.openSidePanel("CUSTOM_PANEL_2");
+      await nextTick();
+
+      const handles = fixture.querySelectorAll(".o-sidePanel-handle");
+      expect(handles).toHaveLength(2);
+
+      await dragElement(handles[0], { y: 0, x: -150 }, undefined, true);
+      expect(sidePanelStore.mainPanel?.size).toBe(DEFAULT_SIDE_PANEL_SIZE);
+      expect(sidePanelStore.secondaryPanel?.size).toBe(DEFAULT_SIDE_PANEL_SIZE + 150);
+
+      await dragElement(handles[1], { y: 0, x: -1000 }, undefined, true);
+      expect(sidePanelStore.mainPanel?.size).toBe(
+        1000 - MIN_SHEET_VIEW_WIDTH - DEFAULT_SIDE_PANEL_SIZE
+      );
+      expect(sidePanelStore.secondaryPanel?.size).toBe(DEFAULT_SIDE_PANEL_SIZE);
+    });
+
+    test("Secondary side panel closes if the sheet is too small", async () => {
+      sidePanelStore.togglePinPanel();
+      parent.env.openSidePanel("CUSTOM_PANEL_2");
+      await nextTick();
+      expect(".o-sidePanel").toHaveCount(2);
+
+      sidePanelStore.changeSpreadsheetWidth(600);
+      await nextTick();
+
+      expect(".o-sidePanel").toHaveCount(1);
+      expect(".o-sidePanelTitle").toHaveText("Custom Panel");
+    });
+
+    test("Cannot open second size panel if the spreadsheet is too small", async () => {
+      sidePanelStore.changeSpreadsheetWidth(600);
+      sidePanelStore.togglePinPanel();
+      parent.env.openSidePanel("CUSTOM_PANEL_2");
+      await nextTick();
+
+      expect(".o-sidePanel").toHaveCount(1);
+      expect(notifyUser).toHaveBeenCalledWith({
+        sticky: false,
+        type: "warning",
+        text: "The window is too small to display multiple side panels.",
+      });
     });
   });
 });

--- a/tests/table/table_dropdown_button_component.test.ts
+++ b/tests/table/table_dropdown_button_component.test.ts
@@ -1,6 +1,6 @@
 import { Component, xml } from "@odoo/owl";
 import { Model } from "../../src";
-import { SidePanel } from "../../src/components/side_panel/side_panel/side_panel";
+import { SidePanels } from "../../src/components/side_panel/side_panels/side_panels";
 import { TableDropdownButton } from "../../src/components/tables/table_dropdown_button/table_dropdown_button";
 import { toZone, zoneToXc } from "../../src/helpers";
 import { SpreadsheetChildEnv, UID } from "../../src/types";
@@ -13,11 +13,11 @@ let sheetId: UID;
 let fixture: HTMLElement;
 
 class Parent extends Component<{}, SpreadsheetChildEnv> {
-  static components = { TableDropdownButton, SidePanel };
+  static components = { TableDropdownButton, SidePanels };
   static template = xml/*xml*/ `
   <div class="o-spreadsheet">
     <TableDropdownButton />
-    <SidePanel />
+    <SidePanels />
   </div>
   `;
   static props = {};

--- a/tests/table/table_panel_component.test.ts
+++ b/tests/table/table_panel_component.test.ts
@@ -13,7 +13,7 @@ import { getCell } from "../test_helpers/getters_helpers";
 import { mountComponentWithPortalTarget, nextTick } from "../test_helpers/helpers";
 
 import { Model } from "../../src";
-import { SidePanel } from "../../src/components/side_panel/side_panel/side_panel";
+import { SidePanels } from "../../src/components/side_panel/side_panels/side_panels";
 import { TableTerms } from "../../src/components/translations_terms";
 import { TABLE_PRESETS } from "../../src/helpers/table_presets";
 
@@ -35,7 +35,7 @@ describe("Table side panel", () => {
     model = new Model();
     sheetId = model.getters.getActiveSheetId();
     createTable(model, "A1:C3");
-    ({ fixture, env } = await mountComponentWithPortalTarget(SidePanel, { model }));
+    ({ fixture, env } = await mountComponentWithPortalTarget(SidePanels, { model }));
     env.openSidePanel("TableSidePanel", {});
     await nextTick();
   });

--- a/tests/table/table_style_editor_panel_component.test.ts
+++ b/tests/table/table_style_editor_panel_component.test.ts
@@ -1,5 +1,5 @@
 import { Model } from "../../src";
-import { SidePanel } from "../../src/components/side_panel/side_panel/side_panel";
+import { SidePanels } from "../../src/components/side_panel/side_panels/side_panels";
 import { TableStyleEditorPanelProps } from "../../src/components/side_panel/table_style_editor_panel/table_style_editor_panel";
 import { buildTableStyle } from "../../src/helpers/table_presets";
 import { SpreadsheetChildEnv, TableStyle } from "../../src/types";
@@ -12,7 +12,7 @@ let fixture: HTMLElement;
 let env: SpreadsheetChildEnv;
 
 async function mountPanel(partialProps: Partial<TableStyleEditorPanelProps> = {}) {
-  ({ fixture, env } = await mountComponentWithPortalTarget(SidePanel, { model }));
+  ({ fixture, env } = await mountComponentWithPortalTarget(SidePanels, { model }));
   const props = { onCloseSidePanel: () => {}, ...partialProps };
   env.openSidePanel("TableStyleEditorPanel", { ...props });
   await nextTick();


### PR DESCRIPTION
## Description

With this commit, it's now possible to pin a side panel and to open another side panel next to it. The pinned side panel can also be collapsed.

Task: [4823848](https://www.odoo.com/odoo/2328/tasks/4823848)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo