### PR TITLE
[IMP] FontSizeEditor: Enlarge input size

### DIFF
--- a/src/components/font_size_editor/font_size_editor.ts
+++ b/src/components/font_size_editor/font_size_editor.ts
@@ -25,7 +25,8 @@ css/* scss */ `
     input.o-font-size {
       outline: none;
       height: 20px;
-      width: 23px;
+      width: 31px;
+      text-align: center;
     }
   }
   .o-text-options > div {


### PR DESCRIPTION
The input of the fontsize editor has a current arbitrary width of 23 pixels. However, if we input a value with 3 digits (it has a limit entry of 400), the content of the input is cropped.

This revision enlarges the input a bit to make sure that 3 digit values are completely visible.

Task: 4778076

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo