### PR TITLE
[WIP] base_extractor: handle integer '0' correctly 

### DIFF
--- a/src/xlsx/extraction/base_extractor.ts
+++ b/src/xlsx/extraction/base_extractor.ts
@@ -285,7 +285,7 @@ export class XlsxBaseExtractor {
     optionalArgs?: ExtractArg
   ) {
     if (optionalArgs?.required) {
-      if (optionalArgs?.default) {
+      if (optionalArgs?.default != null) {
         this.warningManager.addParsingWarning(
           `Missing required ${missingElementName} in element <${parentElement.tagName}> of ${this.currentFile}, replacing it by the default value ${optionalArgs.default}`
         );


### PR DESCRIPTION
## Description:

Task: [4730308](https://www.odoo.com/odoo/my-tasks/4730308)
[Freeze Planning Numbers (1).xlsx](https://github.com/user-attachments/files/20633188/Freeze.Planning.Numbers.1.xlsx)

Tested Versions:
16.0 and later (unable to test earlier versions).

Steps to Reproduce:
1. Open the Documents app.
2. Import the attached Excel file created/exported from Numbers.
3. Attempt to open the file.
4. The operation will fail.

Background:
macOS Numbers omits the border_id attribute for a cell when applyBorder is 0. (same for fillId and other missing attributes)
Microsoft Excel, by contrast, always writes a border_id attribute, no matter what applyBorder is set to.

Now, odoo reads the cell

https://github.com/odoo/o-spreadsheet/blob/2ff9f1ab0ea3380c3897c24fb15e66d560b5bf57/src/xlsx/extraction/style_extractor.ts#L198-L213

`getStyles()` call `extractAttr()` with `optionalArgs.default = 0` 

https://github.com/odoo/o-spreadsheet/blob/2ff9f1ab0ea3380c3897c24fb15e66d560b5bf57/src/xlsx/extraction/base_extractor.ts#L167-L178

`attribute` is falsy, calling `handleMissingValue()`  

https://github.com/odoo/o-spreadsheet/blob/2ff9f1ab0ea3380c3897c24fb15e66d560b5bf57/src/xlsx/extraction/base_extractor.ts#L282-L298

Since `optionalArgs.default = 0`, `optionalArgs?.default` is falsy.
This lead to the system to throw error, instead of `addParsingWarning()` and assign the default value zero to the cell. 

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo