### PR TITLE
[FIX] Formats: text format should not mark the cell as non-empty

### DIFF
--- a/src/helpers/cells/cell_evaluation.ts
+++ b/src/helpers/cells/cell_evaluation.ts
@@ -30,7 +30,10 @@ export function evaluateLiteral(
   literalCell: LiteralCell,
   localeFormat: LocaleFormat
 ): EvaluatedCell {
-  const value = isTextFormat(localeFormat.format) ? literalCell.content : literalCell.parsedValue;
+  const value =
+    isTextFormat(localeFormat.format) && literalCell.parsedValue !== null
+      ? literalCell.content
+      : literalCell.parsedValue;
   const functionResult = { value, format: localeFormat.format };
   return createEvaluatedCell(functionResult, localeFormat.locale);
 }
@@ -92,6 +95,9 @@ function _createEvaluatedCell(
   if (isEvaluationError(value)) {
     return errorCell(value, message);
   }
+  if (value === null) {
+    return emptyCell(format);
+  }
   if (isTextFormat(format)) {
     // TO DO:
     // with the next line, the value of the cell is transformed depending on the format.
@@ -99,9 +105,7 @@ function _createEvaluatedCell(
     // to interpret the value as a number.
     return textCell(toString(value), format, formattedValue);
   }
-  if (value === null) {
-    return emptyCell(format);
-  }
+
   if (typeof value === "number") {
     if (isDateTimeFormat(format || "")) {
       return dateTimeCell(value, format, formattedValue);

--- a/tests/formats/plain_text_format.test.ts
+++ b/tests/formats/plain_text_format.test.ts
@@ -92,4 +92,11 @@ describe("Plain text format", () => {
     expect(getCell(importedModel, "A1")?.format).toBe("@");
     expect(getCellContent(importedModel, "A1")).toBe("00009");
   });
+
+  test("Cells with no content stay empty with a text format", () => {
+    setFormat(model, "A1", "@");
+    expect(getCell(model, "A1")?.content).toBe("");
+    expect(getEvaluatedCell(model, "A1").value).toBe(null);
+    expect(getEvaluatedCell(model, "A1").type).toBe(CellValueType.empty);
+  });
 });


### PR DESCRIPTION
Currently, a cell without content but with a text format is interpreted as a non-empty cell which is incorrect. Regardless of the format applied, if the cells has no content, it should be marked as an empty evaluated cell.

Task: 4856923

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo