### PR TITLE
[FIX] menus: hide invalid 'delete' option from edit menu

### DIFF
--- a/src/registries/menus/menu_items_actions.ts
+++ b/src/registries/menus/menu_items_actions.ts
@@ -246,6 +246,12 @@ export const CAN_REMOVE_COLUMNS_ROWS = (
   dimension: Dimension,
   env: SpreadsheetChildEnv
 ): boolean => {
+  if (
+    (dimension === "COL" && env.model.getters.getActiveRows().size > 0) ||
+    (dimension === "ROW" && env.model.getters.getActiveCols().size > 0)
+  ) {
+    return false;
+  }
   const sheetId = env.model.getters.getActiveSheetId();
   const selectedElements = env.model.getters.getElementsFromSelection(dimension);
 

--- a/tests/menu_items_registry.test.ts
+++ b/tests/menu_items_registry.test.ts
@@ -310,6 +310,11 @@ describe("Menu Item actions", () => {
 
       expect(getNode(path).isVisible(env)).toBeFalsy();
     });
+
+    test("Selecting column should hide the option for row deletion", async () => {
+      selectColumn(model, 4, "overrideSelection");
+      expect(getNode(path).isVisible(env)).toBeFalsy();
+    });
   });
 
   describe("Edit -> edit_delete_column", () => {
@@ -381,6 +386,11 @@ describe("Menu Item actions", () => {
       selectColumn(model, 3, "newAnchor");
       selectColumn(model, lastColumn, "updateAnchor");
 
+      expect(getNode(path).isVisible(env)).toBeFalsy();
+    });
+
+    test("Selecting row should hide the option for column deletion", async () => {
+      selectRow(model, 4, "overrideSelection");
       expect(getNode(path).isVisible(env)).toBeFalsy();
     });
   });


### PR DESCRIPTION
## Description:

Before this commit:
- The menu incorrectly showed a 'Delete' option for full column/row selections, which is an invalid action.

After this commit:
- Hides the particular 'Delete' menu item when selecting an entire row or column.
- The menu now correctly reflects permissible actions.

Task: [4854659](https://www.odoo.com/odoo/2328/tasks/4854659)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo