### PR TITLE
[FIX] composer: prevent unintended composer scroll on token hover

### DIFF
--- a/src/components/composer/composer/composer.ts
+++ b/src/components/composer/composer/composer.ts
@@ -321,6 +321,16 @@ export class Composer extends Component<CellComposerProps, SpreadsheetChildEnv> 
       },
       () => [this.props.composerStore.editionMode !== "inactive"]
     );
+
+    useEffect(
+      () => {
+        this.contentHelper.scrollSelectionIntoView();
+      },
+      () => [
+        this.props.composerStore.composerSelection.start,
+        this.props.composerStore.composerSelection.end,
+      ]
+    );
   }
 
   // ---------------------------------------------------------------------------
@@ -578,6 +588,7 @@ export class Composer extends Component<CellComposerProps, SpreadsheetChildEnv> 
       // not main button, probably a context menu
       return;
     }
+    this.debouncedHover.stopDebounce();
     this.contentHelper.removeSelection();
   }
 
@@ -677,7 +688,6 @@ export class Composer extends Component<CellComposerProps, SpreadsheetChildEnv> 
         const { start, end } = this.props.composerStore.composerSelection;
         this.contentHelper.selectRange(start, end);
       }
-      this.contentHelper.scrollSelectionIntoView();
     }
 
     this.shouldProcessInputEvents = true;

--- a/tests/composer/composer_hover.test.ts
+++ b/tests/composer/composer_hover.test.ts
@@ -259,6 +259,15 @@ describe("Composer hover", () => {
     expect(".o-speech-bubble").toHaveCount(0);
   });
 
+  test("Hovering a composer token does not scroll composer to cursor", async () => {
+    const mockScrollIntoView = jest.fn();
+    await typeInComposer("=SUM(1,\n2,\n3,\n4,\n5,\n6,\n7,\n8,\n9,\n10)");
+    HTMLElement.prototype.scrollIntoView = mockScrollIntoView;
+
+    await hoverComposerContent("SUM");
+    expect(mockScrollIntoView).not.toHaveBeenCalled();
+  });
+
   test("Bubble disappear when selecting a text with the mouse", async () => {
     await typeInComposer("=12");
     await hoverComposerContent("=");


### PR DESCRIPTION
## Description:

Before this commit:
- The composer unexpectedly scrolled when a user hovered over a token.
- A race condition between hover and click causes a user's click to be ignored.

After this commit:
- Composer scroll is stable and only moves intentionally with the cursor.
- The debounced hover is now cancelled on mousedown for more reliable clicks.

Task: [4822973](https://www.odoo.com/odoo/2328/tasks/4822973)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo