### PR TITLE
[FIX] menu: do not execute click callback on disabled menus

### DIFF
--- a/demo/main.js
+++ b/demo/main.js
@@ -314,9 +314,9 @@ class Demo extends Component {
 }
 
 Demo.template = xml/* xml */ `
-  <div t-if="state.displayHeader" class="d-flex flex flex-column justify-content vh-100">
+  <div t-if="state.displayHeader" class="d-flex flex flex-column justify-content">
     <div class="p-3 border-bottom">A header</div>
-    <div class="flex-fill">
+    <div class="flex-fill" style="height: 100dvh !important;width: 100dvw !important;">
       <Spreadsheet model="model" notifyUser="notifyUser" t-key="state.key"/>
     </div>
   </div>

--- a/src/actions/action.ts
+++ b/src/actions/action.ts
@@ -101,13 +101,21 @@ export function createAction(item: ActionSpec): Action {
   const icon = item.icon;
   const secondaryIcon = item.secondaryIcon;
   const itemId = item.id || nextItemId++;
+  const isEnabled = item.isEnabled ? item.isEnabled : () => true;
   return {
     id: itemId.toString(),
     name: typeof name === "function" ? name : () => name,
     isVisible: item.isVisible ? item.isVisible : () => true,
-    isEnabled: item.isEnabled ? item.isEnabled : () => true,
+    isEnabled: isEnabled,
     isActive: item.isActive,
-    execute: item.execute,
+    execute: item.execute
+      ? (env, isMiddleClick) => {
+          if (isEnabled(env)) {
+            return item.execute!(env, isMiddleClick);
+          }
+          return undefined;
+        }
+      : undefined,
     children: children
       ? (env) => {
           return children

--- a/src/components/menu/menu.ts
+++ b/src/components/menu/menu.ts
@@ -192,4 +192,11 @@ export class Menu extends Component<MenuProps, SpreadsheetChildEnv> {
     menu.onStopHover?.(this.env);
     this.props.onMouseLeave?.(menu, ev);
   }
+
+  onClickMenu(menu: Action, ev: CustomEvent) {
+    if (!this.isEnabled(menu)) {
+      return;
+    }
+    this.props.onClickMenu?.(menu, ev);
+  }
 }

--- a/src/components/menu/menu.xml
+++ b/src/components/menu/menu.xml
@@ -17,8 +17,8 @@
           <div
             t-att-title="getName(menuItem)"
             t-att-data-name="menuItem.id"
-            t-on-click="(ev) => this.props.onClickMenu?.(menuItem, ev)"
-            t-on-auxclick="(ev) => this.props.onClickMenu?.(menuItem, ev)"
+            t-on-click="(ev) => this.onClickMenu(menuItem, ev)"
+            t-on-auxclick="(ev) => this.onClickMenu(menuItem, ev)"
             t-on-mouseover="(ev) => this.props.onMouseOver?.(menuItem, ev)"
             t-on-mouseenter="(ev) => this.onMouseEnter?.(menuItem, ev)"
             t-on-mouseleave="(ev) => this.onMouseLeave?.(menuItem)"

--- a/src/components/menu_popover/menu_popover.ts
+++ b/src/components/menu_popover/menu_popover.ts
@@ -239,10 +239,6 @@ export class MenuPopover extends Component<Props, SpreadsheetChildEnv> {
   }
 
   onClickMenu(menu: Action, ev: MouseEvent) {
-    if (!this.isEnabled(menu)) {
-      return;
-    }
-
     if (this.isRoot(menu)) {
       this.openSubMenu(menu, ev.currentTarget as HTMLElement);
     } else {

--- a/tests/menus/menu_component.test.ts
+++ b/tests/menus/menu_component.test.ts
@@ -1,0 +1,26 @@
+import { createActions } from "../../src/actions/action";
+import { Menu } from "../../src/components/menu/menu";
+import { simulateClick } from "../test_helpers/dom_helper";
+import { mountComponent } from "../test_helpers/helpers";
+
+describe("Menu component", () => {
+  test("Execute is not called when menu item is disabled", async () => {
+    const callback = jest.fn();
+    const menuItems = createActions([
+      {
+        id: "test_menu",
+        name: "Test Menu",
+        isEnabled: () => false,
+      },
+    ]);
+
+    const selector = ".o-menu div[data-name='test_menu']";
+    const { fixture } = await mountComponent(Menu, {
+      props: { menuItems, onClose: () => {}, onClickMenu: () => callback() },
+    });
+
+    expect(fixture.querySelector(selector)!.classList).toContain("disabled");
+    await simulateClick(selector);
+    expect(callback).not.toHaveBeenCalled();
+  });
+});

--- a/tests/menus/menu_items_registry.test.ts
+++ b/tests/menus/menu_items_registry.test.ts
@@ -45,6 +45,7 @@ import {
 
 import { Currency, Model } from "../../src";
 
+import { ActionSpec, createAction } from "../../src/actions/action";
 import { CellComposerStore } from "../../src/components/composer/composer/cell_composer_store";
 import { FONT_SIZES } from "../../src/constants";
 import { functionRegistry } from "../../src/functions";
@@ -168,11 +169,13 @@ describe("Menu Item actions", () => {
   });
 
   test("Edit -> undo", () => {
+    setCellContent(model, "A1", "coucou");
     doAction(["edit", "undo"], env);
     expect(dispatch).toHaveBeenCalledWith("REQUEST_UNDO");
   });
 
   test("Edit -> redo", () => {
+    setCellContent(model, "A1", "coucou");
     doAction(["edit", "redo"], env);
     expect(dispatch).toHaveBeenCalledWith("REQUEST_REDO");
   });
@@ -1990,5 +1993,18 @@ describe("Menu Item actions", () => {
       expect(unfreezeRowAction.isVisible(env)).toBe(true);
       expect(unfreezeAllAction.isVisible(env)).toBe(true);
     });
+  });
+
+  test("calling execute on a disabled action should have no effect", () => {
+    const executeMock = jest.fn();
+    const ActionSpec: ActionSpec = {
+      isEnabled: () => false,
+      execute: () => executeMock(),
+      name: () => "TestAction",
+    };
+
+    const action = createAction(ActionSpec);
+    action.execute?.(env);
+    expect(executeMock).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Following the split of the menu component in two parts, the logic that prevent an `Action` callback to be called when the menu is disabled was not correctly split and just existed in the `MenuPopover` component.

Task: 4859723

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [4859723](https://www.odoo.com/odoo/2328/tasks/4859723)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo