### PR TITLE
[IMP] highlight: change color

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,7 +3,7 @@ import { BorderDescr, Color, Currency, Style } from "./types";
 export const CANVAS_SHIFT = 0.5;
 
 // Colors
-export const HIGHLIGHT_COLOR = "#37A850";
+export const HIGHLIGHT_COLOR = "#017E84";
 export const BACKGROUND_GRAY_COLOR = "#f5f5f5";
 export const BACKGROUND_HEADER_COLOR = "#F8F9FA";
 export const BACKGROUND_HEADER_SELECTED_COLOR = "#E8EAED";
@@ -16,7 +16,7 @@ export const CELL_BORDER_COLOR = "#E2E3E3";
 export const BACKGROUND_CHART_COLOR = "#FFFFFF";
 export const DISABLED_TEXT_COLOR = "#CACACA";
 export const DEFAULT_COLOR_SCALE_MIDPOINT_COLOR = 0xb6d7a8;
-export const LINK_COLOR = "#017E84";
+export const LINK_COLOR = HIGHLIGHT_COLOR;
 export const FILTERS_COLOR = "#188038";
 export const BACKGROUND_HEADER_FILTER_COLOR = "#E6F4EA";
 export const SEPARATOR_COLOR = "#E0E2E4";
@@ -48,7 +48,7 @@ export const BUTTON_HOVER_BG = GRAY_300;
 export const BUTTON_HOVER_TEXT_COLOR = "#111827";
 export const BUTTON_ACTIVE_BG = "#e6f2f3";
 export const BUTTON_ACTIVE_TEXT_COLOR = "#111827";
-export const ACTION_COLOR = "#017E84";
+export const ACTION_COLOR = HIGHLIGHT_COLOR;
 export const ACTION_COLOR_HOVER = "#01585c";
 export const ALERT_WARNING_BG = "#FBEBCC";
 export const ALERT_WARNING_BORDER = "#F8E2B3";


### PR DESCRIPTION
Open a pivot side panel.
-> the pivot cells are hightlighted but

- the green is ugly (it doesn't fit well with other colors)
- this green is never used in odoo's color palette

With this commit, the current color is replaced with a color already used. The color is already used to indicate a focus (underline border on focused input)

Task: 4862780

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo