### PR TITLE
[FIX] Table: avoid triggering an unecessary evaluation

### DIFF
--- a/src/plugins/core/tables.ts
+++ b/src/plugins/core/tables.ts
@@ -138,7 +138,9 @@ export class TablePlugin extends CorePlugin<TableState> implements TableState {
         const ranges = cmd.ranges.map((rangeData) => this.getters.getRangeFromRangeData(rangeData));
         const union = this.getters.getRangesUnion(ranges);
         const mergesInTarget = this.getters.getMergesInZone(cmd.sheetId, union.zone);
-        this.dispatch("REMOVE_MERGE", { sheetId: cmd.sheetId, target: mergesInTarget });
+        if (mergesInTarget.length) {
+          this.dispatch("REMOVE_MERGE", { sheetId: cmd.sheetId, target: mergesInTarget });
+        }
 
         const id = this.uuidGenerator.smallUuid();
         const config = cmd.config || DEFAULT_TABLE_CONFIG;

--- a/tests/table/tables_plugin.test.ts
+++ b/tests/table/tables_plugin.test.ts
@@ -31,10 +31,16 @@ import {
   getFilter,
   getTable,
 } from "../test_helpers/getters_helpers";
-import { getFilterHiddenValues, toRangeData, toRangesData } from "../test_helpers/helpers";
+import {
+  getFilterHiddenValues,
+  getPlugin,
+  toRangeData,
+  toRangesData,
+} from "../test_helpers/helpers";
 
 import { DEFAULT_BORDER_DESC } from "../../src/constants";
 import { TABLE_PRESETS } from "../../src/helpers/table_presets";
+import { EvaluationPlugin } from "../../src/plugins/ui_core_views";
 import { TABLE_STYLE_ALL_RED } from "../test_helpers/constants";
 import { DEFAULT_TABLE_CONFIG } from "./../../src/helpers/table_presets";
 
@@ -115,6 +121,19 @@ describe("Table plugin", () => {
       test("Add Merge is correctly rejected when creating a merge inside a table", () => {
         createTable(model, "A1:A5");
         expect(merge(model, "A1:A2")).toBeCancelledBecause(CommandResult.MergeInTable);
+      });
+
+      test("Inserting a table only invalidates the evaluation if it overlaps a merge", () => {
+        merge(model, "A1:B1");
+
+        const evaluator = getPlugin(model, EvaluationPlugin)["evaluator"];
+        const evaluateSpy = jest.spyOn(evaluator, "evaluateAllCells");
+
+        createTable(model, "D1:E5");
+        expect(evaluateSpy).not.toHaveBeenCalled();
+
+        createTable(model, "A1:B4");
+        expect(evaluateSpy).toHaveBeenCalled();
       });
     });
 


### PR DESCRIPTION
When inserting a table, we first clear the merges taht could overlap. However, the command is dispatched regardless of the presence of an overlapping merge and the simple action of dispatching it will trigger a full reevaluation of the spreadsheet because `REMOVE_MERGE` is flagged as a command that invalidates the full evaluation.

Task: 4862862

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo