### PR TITLE
[PERF] table: faster table extend check

### DIFF
--- a/src/plugins/core/tables.ts
+++ b/src/plugins/core/tables.ts
@@ -6,7 +6,6 @@ import {
   isInside,
   isZoneInside,
   overlap,
-  positions,
   positionToZone,
   range,
   zoneToDimension,
@@ -268,17 +267,19 @@ export class TablePlugin extends CorePlugin<TableState> implements TableState {
         ? { ...zone, bottom: zone.bottom + 1, top: zone.bottom + 1 }
         : { ...zone, right: zone.right + 1, left: zone.right + 1 };
 
-    for (const position of positions(zoneToCheckIfEmpty)) {
-      const cellPosition = { sheetId, ...position };
-      // Since this plugin is loaded before CellPlugin, the getters still give us the old cell content
-      const cellContent = this.getters.getCell(cellPosition)?.content;
+    for (let row = zoneToCheckIfEmpty.top; row <= zoneToCheckIfEmpty.bottom; row++) {
+      for (let col = zoneToCheckIfEmpty.left; col <= zoneToCheckIfEmpty.right; col++) {
+        const cellPosition = { sheetId, col, row };
+        // Since this plugin is loaded before CellPlugin, the getters still give us the old cell content
+        const cellContent = this.getters.getCell(cellPosition)?.content;
 
-      if (
-        cellContent ||
-        this.getters.isInMerge(cellPosition) ||
-        this.getTablesOverlappingZones(sheetId, [positionToZone(position)]).length
-      ) {
-        return "none";
+        if (
+          cellContent ||
+          this.getters.isInMerge(cellPosition) ||
+          this.getTablesOverlappingZones(sheetId, [positionToZone(cellPosition)]).length
+        ) {
+          return "none";
+        }
       }
     }
     return direction;


### PR DESCRIPTION
Steps to reproduce:
- Add a lot of rows (10k)
- Write something on A2
- Add a table on A1:A10000
- On another column, fill the column with values
- Copy-paste all those values on B2

=> it's slow

before:	1.2s (~50% total time)
after:	5ms (0.4%)

We are building the entire list of positions even though the code early-returns at the first position.

Task:

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo