### PR TITLE
[FIX] sheet: autoresize didn't work for array formula

### DIFF
--- a/src/plugins/ui_feature/ui_sheet.ts
+++ b/src/plugins/ui_feature/ui_sheet.ts
@@ -183,7 +183,7 @@ export class SheetUIPlugin extends UIPlugin {
         const position = this.getters.getCellPosition(cell.id);
         const colSize = this.getters.getColSize(sheetId, position.col);
 
-        if (cell.isFormula) {
+        if (cell.isFormula || this.getters.getArrayFormulaSpreadingOn(position)) {
           const content = this.getters.getEvaluatedCell(position).formattedValue;
           const evaluatedSize = getCellContentHeight(this.ctx, content, cell?.style, colSize);
           if (evaluatedSize > evaluatedRowSize && evaluatedSize > DEFAULT_CELL_HEIGHT) {


### PR DESCRIPTION
## Description:

Rows populated by array formulas (e.g., RANDARRAY) were not autoresized correctly when their content overflowed due to large font sizes.

This PR ensures that autoresize takes into account the evaluated content and style of spreaded cells.

Task: [4822877](https://www.odoo.com/odoo/2328/tasks/4822877)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo