### PR TITLE
[FIX] Model: change load order of rangeAdapter

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -244,9 +244,6 @@ export class Model extends EventBus<any> implements CommandDispatcher {
     // Initiate stream processor
     this.selection = new SelectionStreamProcessorImpl(this.getters);
 
-    this.coreHandlers.push(this.range);
-    this.handlers.push(this.range);
-
     this.corePluginConfig = this.setupCorePluginConfig();
     this.coreViewPluginConfig = this.setupCoreViewPluginConfig();
     this.uiPluginConfig = this.setupUiPluginConfig();
@@ -365,6 +362,14 @@ export class Model extends EventBus<any> implements CommandDispatcher {
       this.coreGetters[name] = plugin[name].bind(plugin);
     }
     plugin.import(data);
+
+    if (plugin.adaptRanges) {
+      if (!this.coreHandlers.includes(this.range)) {
+        this.coreHandlers.push(this.range);
+        this.handlers.push(this.range);
+      }
+      this.range.addRangeProvider(plugin.adaptRanges.bind(plugin));
+    }
     this.corePlugins.push(plugin);
     this.coreHandlers.push(plugin);
     this.handlers.push(plugin);
@@ -456,7 +461,6 @@ export class Model extends EventBus<any> implements CommandDispatcher {
     return {
       getters: this.coreGetters,
       stateObserver: this.state,
-      range: this.range,
       dispatch: this.dispatchFromCorePlugin,
       canDispatch: this.canDispatch,
       custom: this.config.custom,

--- a/src/plugins/core/range.ts
+++ b/src/plugins/core/range.ts
@@ -17,6 +17,7 @@ import {
 } from "../../helpers/index";
 import { CellErrorType } from "../../types/errors";
 import {
+  AdaptRangeFn,
   ApplyRangeChange,
   ApplyRangeChangeResult,
   Command,
@@ -27,7 +28,6 @@ import {
   Dimension,
   Range,
   RangeData,
-  RangeProvider,
   RangeStringOptions,
   UID,
   UnboundedZone,
@@ -36,7 +36,7 @@ import {
 
 export class RangeAdapter implements CommandHandler<CoreCommand> {
   private getters: CoreGetters;
-  private providers: Array<RangeProvider["adaptRanges"]> = [];
+  private providers: Array<AdaptRangeFn> = [];
   constructor(getters: CoreGetters) {
     this.getters = getters;
   }
@@ -114,7 +114,7 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
    * @param provider a function bound to a plugin that will loop over its internal data structure to find
    * all ranges
    */
-  addRangeProvider(provider: RangeProvider["adaptRanges"]) {
+  addRangeProvider(provider: AdaptRangeFn) {
     this.providers.push(provider);
   }
 

--- a/src/plugins/core/spreadsheet_pivot.ts
+++ b/src/plugins/core/spreadsheet_pivot.ts
@@ -45,6 +45,10 @@ export class SpreadsheetPivotCorePlugin extends CorePlugin {
       }
       if (definition.dataSet) {
         const { sheetId, zone } = definition.dataSet;
+        if (!this.getters.tryGetSheet(sheetId) || !zone || !isZoneValid(zone)) {
+          this.dispatch("UPDATE_PIVOT", { pivotId, pivot: { ...definition, dataSet: undefined } });
+          return;
+        }
         const range = this.getters.getRangeFromZone(sheetId, zone);
         const adaptedRange = adaptPivotRange(range, applyChange);
 

--- a/src/plugins/core_plugin.ts
+++ b/src/plugins/core_plugin.ts
@@ -10,12 +10,10 @@ import {
 } from "../types";
 import { CoreGetters } from "../types/getters";
 import { BasePlugin } from "./base_plugin";
-import { RangeAdapter } from "./core/range";
 
 export interface CorePluginConfig {
   readonly getters: CoreGetters;
   readonly stateObserver: StateObserver;
-  readonly range: RangeAdapter;
   readonly dispatch: CoreCommandDispatcher["dispatch"];
   readonly canDispatch: CoreCommandDispatcher["dispatch"];
   readonly custom: ModelConfig["custom"];
@@ -41,9 +39,10 @@ export class CorePlugin<State = any>
   protected dispatch: CoreCommandDispatcher["dispatch"];
   protected canDispatch: CoreCommandDispatcher["dispatch"];
 
-  constructor({ getters, stateObserver, range, dispatch, canDispatch }: CorePluginConfig) {
+  adaptRanges?(applyChange: ApplyRangeChange, sheetId?: UID, sheetName?: string): void;
+
+  constructor({ getters, stateObserver, dispatch, canDispatch }: CorePluginConfig) {
     super(stateObserver);
-    range.addRangeProvider(this.adaptRanges.bind(this));
     this.getters = getters;
     this.dispatch = dispatch;
     this.canDispatch = canDispatch;
@@ -66,7 +65,7 @@ export class CorePlugin<State = any>
    * @param applyChange a function that, when called, will adapt the range according to the change on the grid
    * @param sheetId an optional sheetId to adapt either range of that sheet specifically, or ranges pointing to that sheet
    */
-  adaptRanges(applyChange: ApplyRangeChange, sheetId?: UID, sheetName?: string): void {}
+  // adaptRanges?(applyChange: ApplyRangeChange, sheetId?: UID, sheetName?: string): void {}
 
   /**
    * Implement this method to clean unused external resources, such as images

--- a/src/types/misc.ts
+++ b/src/types/misc.ts
@@ -304,8 +304,14 @@ export type Dimension = "COL" | "ROW";
 export type ConsecutiveIndexes = HeaderIndex[];
 
 export interface RangeProvider {
-  adaptRanges: (applyChange: ApplyRangeChange, sheetId?: UID, sheetName?: string) => void;
+  adaptRanges?: AdaptRangeFn;
 }
+
+export type AdaptRangeFn = (
+  applyChange: ApplyRangeChange,
+  sheetId?: UID,
+  sheetName?: string
+) => void;
 
 export type Validation<T> = (toValidate: T) => CommandResult | CommandResult[];
 

--- a/tests/figures/chart/gauge/gauge_chart_plugin.test.ts
+++ b/tests/figures/chart/gauge/gauge_chart_plugin.test.ts
@@ -17,6 +17,7 @@ import {
   duplicateSheet,
   paste,
   redo,
+  renameSheet,
   setCellContent,
   setFormat,
   undo,
@@ -117,7 +118,7 @@ describe("datasource tests", function () {
 
   describe("Gauge ranges are adapted", () => {
     beforeEach(() => {
-      createSheet(model, { sheetId: "Sheet2", name: "Sheet2" });
+      createSheet(model, { sheetId: "sh2", name: "Sheet2" });
       createGaugeChart(
         model,
         {
@@ -174,6 +175,24 @@ describe("datasource tests", function () {
         rangeMax: "=C8",
         lowerInflectionPoint: { type: "percentage", value: "=Sheet2!A2" },
         upperInflectionPoint: { type: "number", value: "=SUM('Copy of Sheet1'!B1:C4)" },
+      });
+    });
+
+    test("gauge range are adapted when renaming the sheet", () => {
+      renameSheet(model, "sh2", "Boom");
+      let chart = model.getters.getChartDefinition("chartId") as GaugeChartDefinition;
+      expect(chart.sectionRule).toMatchObject({
+        lowerInflectionPoint: { operator: "<", type: "percentage", value: "=Boom!A2" },
+      });
+      debugger
+      renameSheet(model, "Sheet1", "Magic");
+      expect(chart.dataRange).toStrictEqual("Magic!B1:B4");
+      chart = model.getters.getChartDefinition("chartId") as GaugeChartDefinition;
+      expect(chart.sectionRule).toMatchObject({
+        rangeMin: "=A1+5",
+        rangeMax: "=C8",
+        lowerInflectionPoint: { operator: "<", type: "percentage", value: "=Boom!A2" },
+        upperInflectionPoint: { operator: "<", type: "number", value: "=SUM(Magic!B1:C4)" },
       });
     });
   });


### PR DESCRIPTION
RangeAdapter is an esential component of the core plugin operation as it allows to change the internal ranges of all plugins with a generic transformation.
However, the current situation is not ideal as it will handle all the commands before any other plugin, including the SheetPlugin.

This is an issue because we have a 2-side approach for treating ranges:
1. the Range object which are basically a zone and a sheetId, which seems enough information to work with
2. the xc, which do not hold the sheetId information but rather the sheetName

The RangeAdapter only handles ranges which means it is not designed to react to, let's say, a sheet name change.
the opposite is true as well, XC does not care about change of sheetId.

We could think that the range needs to know the sheet name and react to such a change but the design decisions up until now were not in that favor, we designed several flows, notably commands, that rely on the information of a Range (sheetId + Zone) the migration willbe a nightmare, we'll have to transform lots of stuff but feasible.

This fix is trying to keep the current situation "a range only needs to know the sheetId and zone;, the sheetName can be handled outbound"

With this moto  in mind, the problem we face is that RangeAdapter handles the 'rename_sheet' command which is sooooo specific to sheetPlugin before sheetPlugin handles it, ahd the range transformation (since the range don't know about the sheetname) cannot react properly to that change.

-> solution: move rangeAdapter elsewhere in the stack of plugins, more specifically, it be loaded just before another plugin that needs range adaptation.

## NOTE
the fix suggested here does not work because we implemented some tuff in SpreadsheetPivotCorePlugin that actually relies on the fact that the transformation did not occur yet. 
So on one hand, we want it to occur, for the string transformation, 
on the other hand, we don't want it for the _rangeData transformation.

The real solution should probably be to force every internal structure representation to ranges? which probably means keepng some sort of compiled formula instead of formula strings


## Description:

description of this task, what is implemented and why it is implemented that way.



Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo