### PR TITLE
[FIX] demo: don't crash server on wrong scss

### DIFF
--- a/tools/bundle_scss/watch_scss_files.cjs
+++ b/tools/bundle_scss/watch_scss_files.cjs
@@ -3,7 +3,11 @@ const { createScssBundle } = require("./scss.cjs");
 
 const watcher = watch("./src", { filter: /\.scss$/, recursive: true }, (ev, name) => {
   console.log(`\n File ${name}: ${ev}`);
-  createScssBundle("build");
+  try {
+    createScssBundle("build");
+  } catch (error) {
+    console.error("Error creating SCSS bundle:", error.message);
+  }
 });
 
 watcher.on("ready", () => console.log("Watching .scss files..."));


### PR DESCRIPTION
## Description

The `createScssBundle` function throws an error if the scss is malformed. The issue is that is crashes the demo server, which is less than ideal when developing with live reload. If you hit save in the middle of writing scss, the server will crash and you have to restart it.

Task: 0

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo