### PR TITLE
[PERF] collaborative: avoid useless transformations

### DIFF
--- a/src/collaborative/ot/ot.ts
+++ b/src/collaborative/ot/ot.ts
@@ -67,10 +67,20 @@ export function transformAll(
   executed: readonly CoreCommand[]
 ): CoreCommand[] {
   let transformedCommands = [...toTransform];
+  const possibleTransformations = new Set(otRegistry.getKeys());
   for (const executedCommand of executed) {
-    transformedCommands = transformedCommands
-      .map((cmd) => transform(cmd, executedCommand))
-      .filter(isDefined);
+    // If the executed command is not in the registry, we skip it
+    // because we know there won't be any transformation impacting the
+    // commands to transform.
+    if (possibleTransformations.has(executedCommand.type)) {
+      transformedCommands = transformedCommands.reduce<CoreCommand[]>((acc, cmd) => {
+        const transformed = transform(cmd, executedCommand);
+        if (transformed) {
+          acc.push(transformed);
+        }
+        return acc;
+      }, []);
+    }
   }
   return transformedCommands;
 }

--- a/src/registries/ot_registry.ts
+++ b/src/registries/ot_registry.ts
@@ -50,14 +50,11 @@ export class OTRegistry extends Registry<
     toTransforms: V[],
     fn: TransformationFunction<CoreCommandTypes, CoreCommandTypes>
   ): this {
-    for (let toTransform of toTransforms) {
-      if (!this.content[toTransform]) {
-        this.content[toTransform] = new Map<
-          CoreCommandTypes,
-          TransformationFunction<CoreCommandTypes, CoreCommandTypes>
-        >();
-      }
-      this.content[toTransform].set(executed, fn);
+    if (!this.content[executed]) {
+      this.content[executed] = new Map();
+    }
+    for (const toTransform of toTransforms) {
+      this.content[executed].set(toTransform, fn);
     }
     return this;
   }
@@ -70,7 +67,7 @@ export class OTRegistry extends Registry<
     toTransform: U,
     executed: V
   ): TransformationFunction<CoreCommandTypes, CoreCommandTypes> | undefined {
-    return this.content[toTransform] && this.content[toTransform].get(executed);
+    return this.content[executed] && this.content[executed].get(toTransform);
   }
 }
 


### PR DESCRIPTION
before: 5+minutes
after:  <2 seconds

dashboard_id 184 on odoo.com is very slow to load: 5+minutes https://www.odoo.com/odoo/dashboards?dashboard_id=184

It's caused by a huge number of transformations performed while replaying revisions upon loading the model.

Specifically, there are 2 revisions with 20k commands each. All commands are UPDATE_CELL or SET_BORDERS. These revisions most probably originates from a huge copy & paste.

Because of history changes (UNDO/REDO) in a collaborative context, those 2 revisions are transformed one against the other. With the current code, it leads to 20k*20k=400M transformations.

One key observation to fix the problem is that an executed UPDATE_CELL or SET_BORDERS won't ever actually transform any command. All transformations performed are actually doing nothing and returns the original command untouched.
Note that all executed commands which are part of the generic transformations are also in the registry.

With this commit, we only call the transformation if the executed command is part of the transformation registry (=it can transform other commands). I had to change the order in `OTRegistry` to be able to use `.getKeys()`

Also, I took the opportunity to replace `.map().filter()` with a single `reduce` to save one array allocation.


Task: [4873461](https://www.odoo.com/odoo/2328/tasks/4873461)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo