### PR TITLE
[FIX] Selection: Fix navigation through merges

### DIFF
--- a/src/selection_stream/selection_stream_processor.ts
+++ b/src/selection_stream/selection_stream_processor.ts
@@ -225,26 +225,28 @@ export class SelectionStreamProcessor
       };
     };
 
-    const { col: refCol, row: refRow } = this.getReferencePosition();
+    const { cell: refCell, zone: refZone } = this.getReferenceAnchor();
+    const { col: refCol, row: refRow } = refCell;
     // check if we can shrink selection
     let n = 0;
     while (result !== null) {
       n++;
       if (deltaCol < 0) {
         const newRight = this.getNextAvailableCol(deltaCol, right - (n - 1), refRow);
-        result = refCol <= right - n ? expand({ top, left, bottom, right: newRight }) : null;
+        result = refZone.right <= right - n ? expand({ top, left, bottom, right: newRight }) : null;
       }
       if (deltaCol > 0) {
         const newLeft = this.getNextAvailableCol(deltaCol, left + (n - 1), refRow);
-        result = left + n <= refCol ? expand({ top, left: newLeft, bottom, right }) : null;
+        result = left + n <= refZone.left ? expand({ top, left: newLeft, bottom, right }) : null;
       }
       if (deltaRow < 0) {
         const newBottom = this.getNextAvailableRow(deltaRow, refCol, bottom - (n - 1));
-        result = refRow <= bottom - n ? expand({ top, left, bottom: newBottom, right }) : null;
+        result =
+          refZone.bottom <= bottom - n ? expand({ top, left, bottom: newBottom, right }) : null;
       }
       if (deltaRow > 0) {
         const newTop = this.getNextAvailableRow(deltaRow, refCol, top + (n - 1));
-        result = top + n <= refRow ? expand({ top: newTop, left, bottom, right }) : null;
+        result = top + n <= refZone.top ? expand({ top: newTop, left, bottom, right }) : null;
       }
       result = result ? organizeZone(result) : result;
       if (result && !isEqual(result, anchor.zone)) {
@@ -527,19 +529,29 @@ export class SelectionStreamProcessor
    * If the anchor is hidden, browses from left to right and top to bottom to
    * find a visible cell.
    */
-  private getReferencePosition(): Position {
+  private getReferenceAnchor(): AnchorZone {
     const sheetId = this.getters.getActiveSheetId();
     const anchor = this.anchor;
     const { left, right, top, bottom } = anchor.zone;
     const { col: anchorCol, row: anchorRow } = anchor.cell;
 
+    const col = this.getters.isColHidden(sheetId, anchorCol)
+      ? this.getters.findVisibleHeader(sheetId, "COL", left, right) || anchorCol
+      : anchorCol;
+
+    const row = this.getters.isRowHidden(sheetId, anchorRow)
+      ? this.getters.findVisibleHeader(sheetId, "ROW", top, bottom) || anchorRow
+      : anchorRow;
+
+    const zone = this.getters.expandZone(sheetId, {
+      left: col,
+      right: col,
+      top: row,
+      bottom: row,
+    });
     return {
-      col: this.getters.isColHidden(sheetId, anchorCol)
-        ? this.getters.findVisibleHeader(sheetId, "COL", left, right) || anchorCol
-        : anchorCol,
-      row: this.getters.isRowHidden(sheetId, anchorRow)
-        ? this.getters.findVisibleHeader(sheetId, "ROW", top, bottom) || anchorRow
-        : anchorRow,
+      cell: { col, row },
+      zone,
     };
   }
 

--- a/tests/plugins/selection.test.ts
+++ b/tests/plugins/selection.test.ts
@@ -121,6 +121,60 @@ describe("simple selection", () => {
     expect(model.getters.getSelectedZones()[0]).toEqual({ left: 0, top: 9, right: 0, bottom: 9 });
   });
 
+  test("Can extend selection with Shift-arrow through merges horizontally", () => {
+    const model = new Model();
+    merge(model, "A1:B2");
+    merge(model, "C1:D2");
+    merge(model, "E1:F2");
+
+    selectCell(model, "A1");
+    resizeAnchorZone(model, "right");
+    resizeAnchorZone(model, "right");
+    expect(model.getters.getSelectedZone()).toEqual(toZone("A1:F2"));
+
+    selectCell(model, "B1");
+    resizeAnchorZone(model, "right");
+    resizeAnchorZone(model, "right");
+    expect(model.getters.getSelectedZone()).toEqual(toZone("A1:F2"));
+
+    selectCell(model, "E1");
+    resizeAnchorZone(model, "left");
+    resizeAnchorZone(model, "left");
+    expect(model.getters.getSelectedZone()).toEqual(toZone("A1:F2"));
+
+    selectCell(model, "F1");
+    resizeAnchorZone(model, "left");
+    resizeAnchorZone(model, "left");
+    expect(model.getters.getSelectedZone()).toEqual(toZone("A1:F2"));
+  });
+
+  test("Can extend selection with Shift-arrow through merges horizontally", () => {
+    const model = new Model();
+    merge(model, "A1:B2");
+    merge(model, "A3:B4");
+    merge(model, "A5:B6");
+
+    selectCell(model, "A1");
+    resizeAnchorZone(model, "down");
+    resizeAnchorZone(model, "down");
+    expect(model.getters.getSelectedZone()).toEqual(toZone("A1:B6"));
+
+    selectCell(model, "A2");
+    resizeAnchorZone(model, "down");
+    resizeAnchorZone(model, "down");
+    expect(model.getters.getSelectedZone()).toEqual(toZone("A1:B6"));
+
+    selectCell(model, "A5");
+    resizeAnchorZone(model, "up");
+    resizeAnchorZone(model, "up");
+    expect(model.getters.getSelectedZone()).toEqual(toZone("A1:B6"));
+
+    selectCell(model, "A6");
+    resizeAnchorZone(model, "up");
+    resizeAnchorZone(model, "up");
+    expect(model.getters.getSelectedZone()).toEqual(toZone("A1:B6"));
+  });
+
   test("can expand selection with mouse", () => {
     const model = new Model({
       sheets: [


### PR DESCRIPTION
How to reproduce:
- Create a merge in C3:D4
- click on C5
- Press Arrow-Up (this will select C3:D4)
- press Shift+ArrowDown several times

-> your selection gets stuck to C3:D5

This occurs because the method that extends the selection does not behave correctly when the anchor is set on a Merge, it assumes that the anchor is always a single cell.

Task: 4873718

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo