### PR TITLE
[FIX] data_validation: preserve rule order when updating a rule

### DIFF
--- a/src/plugins/core/data_validation.ts
+++ b/src/plugins/core/data_validation.ts
@@ -172,7 +172,7 @@ export class DataValidationPlugin
       newRule.criterion.values = Array.from(new Set(newRule.criterion.values));
     }
 
-    const adaptedRules = this.removeRangesFromRules(sheetId, newRule.ranges, rules);
+    const adaptedRules = this.removeRangesFromRules(sheetId, newRule.ranges, rules, newRule.id);
     const ruleIndex = adaptedRules.findIndex((rule) => rule.id === newRule.id);
 
     if (ruleIndex !== -1) {
@@ -183,10 +183,18 @@ export class DataValidationPlugin
     }
   }
 
-  private removeRangesFromRules(sheetId: UID, ranges: Range[], rules: DataValidationRule[]) {
+  private removeRangesFromRules(
+    sheetId: UID,
+    ranges: Range[],
+    rules: DataValidationRule[],
+    editingRuleId?: UID
+  ) {
     rules = deepCopy(rules);
     const rangesXcs = ranges.map((range) => this.getters.getRangeString(range, sheetId));
     for (const rule of rules) {
+      if (rule.id === editingRuleId) {
+        continue; // Skip the rule being edited to preserve its place in the list
+      }
       const ruleRanges = rule.ranges.map((range) => this.getters.getRangeString(range, sheetId));
       rule.ranges = recomputeZones(ruleRanges, rangesXcs).map((xc) =>
         this.getters.getRangeFromSheetXC(sheetId, xc)

--- a/tests/data_validation/data_validation_generics_side_panel_component.test.ts
+++ b/tests/data_validation/data_validation_generics_side_panel_component.test.ts
@@ -188,6 +188,20 @@ describe("data validation sidePanel component", () => {
     expect(model.getters.getDataValidationRules(sheetId)).toMatchObject([{ isBlocking: true }]);
   });
 
+  test("Preserves rule order when editing and saving via data validation preview panel", async () => {
+    addDataValidation(model, "A1", "id1", { type: "isEqual", values: ["5"] });
+    addDataValidation(model, "A2", "id2", { type: "isEqual", values: ["10"] });
+
+    await nextTick();
+    expect(getDataValidationRules(model, sheetId)).toMatchObject([{ id: "id1" }, { id: "id2" }]);
+
+    await click(fixture.querySelector(".o-dv-preview")!);
+    await nextTick();
+    await simulateClick(fixture.querySelector(".o-dv-save")!);
+
+    expect(getDataValidationRules(model, sheetId)).toMatchObject([{ id: "id1" }, { id: "id2" }]);
+  });
+
   describe("Locale", () => {
     test("Number preview is localized", async () => {
       updateLocale(model, FR_LOCALE);


### PR DESCRIPTION
## Description:

Previously, when multiple data validation rules existed, updating a rule caused it to move to the end of the list, disrupting the original order.

This PR ensures that the rule order is preserved when a rule is edited and saved.

Task: [4863726](https://www.odoo.com/odoo/2328/tasks/4863726)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo