### PR TITLE
[FIX] CFSidePanel: do not crash when deleting the edited CF

### DIFF
--- a/src/components/side_panel/conditional_formatting/conditional_formatting.ts
+++ b/src/components/side_panel/conditional_formatting/conditional_formatting.ts
@@ -61,6 +61,8 @@ export class ConditionalFormattingPanel extends Component<Props, SpreadsheetChil
         } else {
           this.switchToList();
         }
+      } else if (!this.editedCF) {
+        this.switchToList();
       }
     });
   }

--- a/tests/conditional_formatting/conditional_formatting_panel_component.test.ts
+++ b/tests/conditional_formatting/conditional_formatting_panel_component.test.ts
@@ -10,6 +10,7 @@ import {
   createSheet,
   paste,
   setSelection,
+  undo,
   updateLocale,
 } from "../test_helpers/commands_helpers";
 import {
@@ -1096,6 +1097,13 @@ describe("UI of conditional formats", () => {
     expect(
       fixture.querySelector(selectors.colorScaleEditor.midColor)?.parentElement?.classList
     ).toContain("invisible");
+  });
+
+  test("Undo the creation of a new CF will switch the panel to the list mode", async () => {
+    await click(fixture, selectors.buttonAdd);
+    undo(model);
+    await nextTick();
+    expect(selectors.listPreviewPanel).toHaveCount(1);
   });
 
   describe("Icon set CF", () => {


### PR DESCRIPTION
How to reproduce:
- Open CF sidepanel
- click "Add another rule"
- Undo by either Clicking the grid and Ctrl+z or hit the undo button of the toolbar

-> traceback

Task: 4880418

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo