### PR TITLE
[IMP] side_panel: improve chart side panel UX

### DIFF
--- a/src/components/side_panel/chart/main_chart_panel/main_chart_panel.xml
+++ b/src/components/side_panel/chart/main_chart_panel/main_chart_panel.xml
@@ -1,45 +1,47 @@
 <templates>
   <t t-name="o-spreadsheet-ChartPanel">
-    <div class="o-chart" t-if="figureId">
+    <div class="o-chart d-flex flex-column h-100" t-if="figureId">
       <div class="o-panel">
         <div
           class="o-panel-element o-panel-configuration"
           t-att-class="store.panel !== 'configuration' ? 'inactive' : ''"
-          t-on-click="() => this.store.activatePanel('configuration')">
+          t-on-click="switchPanel.bind(this, 'configuration')">
           <i class="fa fa-sliders"/>
           Configuration
         </div>
         <div
           class="o-panel-element o-panel-design"
           t-att-class="store.panel !== 'design' ? 'inactive' : ''"
-          t-on-click="() => this.store.activatePanel('design')">
+          t-on-click="switchPanel.bind(this, 'design')">
           <i class="fa fa-paint-brush"/>
           Design
         </div>
       </div>
 
       <t t-set="definition" t-value="getChartDefinition(this.figureId)"/>
-      <t t-if="store.panel === 'configuration'">
-        <ChartTypePicker figureId="props.figureId" chartPanelStore="store"/>
-        <t
-          t-component="chartPanel.configuration"
-          definition="definition"
-          figureId="figureId"
-          updateChart.bind="updateChart"
-          canUpdateChart.bind="canUpdateChart"
-          t-key="figureId + definition.type"
-        />
-      </t>
-      <t t-else="">
-        <t
-          t-component="chartPanel.design"
-          definition="definition"
-          figureId="figureId"
-          updateChart.bind="updateChart"
-          canUpdateChart.bind="canUpdateChart"
-          t-key="figureId + definition.type"
-        />
-      </t>
+      <div class="o-panel-content overflow-y-auto" t-ref="panelContent">
+        <div t-att-class="store.panel !== 'configuration' ? 'd-none' : ''">
+          <ChartTypePicker figureId="props.figureId" chartPanelStore="store"/>
+          <t
+            t-component="chartPanel.configuration"
+            definition="definition"
+            figureId="figureId"
+            updateChart.bind="updateChart"
+            canUpdateChart.bind="canUpdateChart"
+            t-key="figureId + definition.type"
+          />
+        </div>
+        <div t-att-class="store.panel !== 'design' ? 'd-none' : ''">
+          <t
+            t-component="chartPanel.design"
+            definition="definition"
+            figureId="figureId"
+            updateChart.bind="updateChart"
+            canUpdateChart.bind="canUpdateChart"
+            t-key="figureId + definition.type"
+          />
+        </div>
+      </div>
     </div>
   </t>
 </templates>

--- a/tests/figures/chart/charts_component.test.ts
+++ b/tests/figures/chart/charts_component.test.ts
@@ -1100,6 +1100,23 @@ describe("charts", () => {
     expect(fixture.querySelector(".o-chart")).toBeFalsy();
   });
 
+  test("restores scroll position when switching tabs in side panel", async () => {
+    createTestChart("basicChart");
+    await mountSpreadsheet();
+    await openChartDesignSidePanel(model, env, fixture, chartId);
+
+    const chartPanel = fixture.querySelector(".o-panel-content")!;
+    chartPanel.scrollTop = 100;
+
+    const configTab = fixture.querySelector(".o-panel-element.inactive")!;
+    await click(configTab);
+    expect(chartPanel.scrollTop).toBe(0);
+
+    const designTab = fixture.querySelector(".o-panel-element.inactive")!;
+    await click(designTab);
+    expect(chartPanel.scrollTop).toBe(100);
+  });
+
   describe.each(TEST_CHART_TYPES)("selecting other chart will adapt sidepanel", (chartType) => {
     test.each(["click", "SELECT_FIGURE command"])("when using %s", async (selectMethod: string) => {
       createTestChart(chartType);


### PR DESCRIPTION
## Description:

- Make tabs sticky while scrolling
- Preserve scroll position when switching tabs
- Retain expanded/collapsed section state

These changes enhance the user experience when navigating and editing charts with long configuration content.

Task: [4752564](https://www.odoo.com/odoo/2328/tasks/4752564)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo