### PR TITLE
[FIX] pivot: treat empty strings the same as blank cells

### DIFF
--- a/src/helpers/pivot/spreadsheet_pivot/spreadsheet_pivot.ts
+++ b/src/helpers/pivot/spreadsheet_pivot/spreadsheet_pivot.ts
@@ -385,7 +385,9 @@ export class SpreadsheetPivot implements Pivot<SpreadsheetPivotRuntimeDefinition
 
   private getTypeFromZone(sheetId: UID, zone: Zone) {
     const cells = this.getters.getEvaluatedCellsInZone(sheetId, zone);
-    const nonEmptyCells = cells.filter((cell) => cell.type !== CellValueType.empty);
+    const nonEmptyCells = cells.filter(
+      (cell) => !(cell.type === CellValueType.empty || cell.value === "")
+    );
     if (nonEmptyCells.length === 0) {
       return "integer";
     }

--- a/tests/pivots/spreadsheet_pivot/spreadsheet_pivot.test.ts
+++ b/tests/pivots/spreadsheet_pivot/spreadsheet_pivot.test.ts
@@ -333,12 +333,16 @@ describe("Spreadsheet Pivot", () => {
     const model = createModelWithPivot("A1:I5");
     setCellContent(model, "C3", '=""');
     setCellContent(model, "C5", "");
+    setCellContent(model, "A2", '=""');
+    setCellContent(model, "A3", "");
     setCellContent(model, "A26", "=pivot(1)");
 
     updatePivot(model, "1", {
       columns: [{ fieldName: "Contact Name", order: "asc" }],
     });
 
+    const pivot = model.getters.getPivot("1");
+    expect(pivot.getFields()).toMatchObject({ "Created on": { type: "datetime" } });
     expect(getEvaluatedGrid(model, "B26:F26")).toEqual([
       ["Alice", "Michel", "(Undefined)", "Total", ""],
     ]);


### PR DESCRIPTION
## Description

This commit make it so that empty strings are treated the same as blank cells in pivot fields. Before this, an empty string in a column would make the pivot field into a `char` field.

Task: [4889073](https://www.odoo.com/odoo/2328/tasks/4889073)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo