### PR TITLE
[FIX] renderer: fix text change animation

### DIFF
--- a/src/registries/cell_animation_registry.ts
+++ b/src/registries/cell_animation_registry.ts
@@ -165,6 +165,13 @@ cellAnimationRegistry.add("textChange", {
         : makeIconsEmpty(oldBox.icons),
     };
 
+    if (newBox.content && oldBox.content && slideInBox.content && slideOutBox.content) {
+      const slideInContentY = newBox.content.y + (value - 1) * newBox.height;
+      const slideOutContentY = newBox.content.y + value * newBox.height;
+      slideInBox.content.y = slideInContentY;
+      slideOutBox.content.y = slideOutContentY;
+    }
+
     slideOutBox.style.fillColor = slideInBox.style.fillColor = undefined;
 
     animatedBox.content = undefined;

--- a/tests/renderer/cell_animations.test.ts
+++ b/tests/renderer/cell_animations.test.ts
@@ -334,9 +334,10 @@ describe("Individual animation tests", () => {
     setCellContent(model, "A1", "newText");
     drawGrid();
     const a2Box = getBoxFromXc("A2");
+    const originalContentY = a2Box.y + DEFAULT_CELL_HEIGHT - 13 - MIN_CELL_TEXT_MARGIN + 1; // 13: text height, 1: to avoid borders
     expect(a2Box.content).toEqual(undefined);
     expect(getBoxFromXc("A2-text-slide-in")).toMatchObject({
-      content: { textLines: ["newText"] },
+      content: { textLines: ["newText"], y: originalContentY - DEFAULT_CELL_HEIGHT },
       x: 0,
       y: a2Box.y - DEFAULT_CELL_HEIGHT,
       width: DEFAULT_CELL_WIDTH,
@@ -344,7 +345,7 @@ describe("Individual animation tests", () => {
       skipCellGridLines: true,
     });
     expect(getBoxFromXc("A2-text-slide-out")).toMatchObject({
-      content: { textLines: ["oldText"] },
+      content: { textLines: ["oldText"], y: originalContentY },
       x: 0,
       y: a2Box.y,
       width: DEFAULT_CELL_WIDTH,
@@ -355,10 +356,20 @@ describe("Individual animation tests", () => {
     animationFrameCallback(0);
     expect(getBoxFromXc("A2-text-slide-in").y).toEqual(a2Box.y - DEFAULT_CELL_HEIGHT);
     expect(getBoxFromXc("A2-text-slide-out").y).toEqual(a2Box.y);
+    expect(getBoxFromXc("A2-text-slide-in").content?.y).toEqual(
+      originalContentY - DEFAULT_CELL_HEIGHT
+    );
+    expect(getBoxFromXc("A2-text-slide-out").content?.y).toEqual(originalContentY);
 
     animationFrameCallback(CELL_ANIMATION_DURATION / 2);
     expect(getBoxFromXc("A2-text-slide-in").y).toEqual(a2Box.y - DEFAULT_CELL_HEIGHT / 2);
     expect(getBoxFromXc("A2-text-slide-out").y).toEqual(a2Box.y + DEFAULT_CELL_HEIGHT / 2);
+    expect(getBoxFromXc("A2-text-slide-in").content?.y).toEqual(
+      originalContentY - DEFAULT_CELL_HEIGHT / 2
+    );
+    expect(getBoxFromXc("A2-text-slide-out").content?.y).toEqual(
+      originalContentY + DEFAULT_CELL_HEIGHT / 2
+    );
 
     animationFrameCallback(CELL_ANIMATION_DURATION);
     expect(getBoxFromXc("A2")).toMatchObject({ content: { textLines: ["newText"] } });


### PR DESCRIPTION
Since 5c831be67, the text position is based on `box.content.y` instead of `box.y`. But only the latter was animated.

Task: 0

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo