### PR TITLE
[FIX] header_size: resize row based on link label instead of full link

### DIFF
--- a/src/helpers/text_helper.ts
+++ b/src/helpers/text_helper.ts
@@ -9,6 +9,7 @@ import {
   PADDING_AUTORESIZE_VERTICAL,
 } from "../constants";
 import { Cell, Pixel, PixelPosition, Style } from "../types";
+import { isMarkdownLink, parseMarkdownLink } from "./misc";
 
 export function computeTextLinesHeight(textLineHeight: number, numberOfLines: number = 1) {
   return numberOfLines * (textLineHeight + MIN_CELL_TEXT_MARGIN) - MIN_CELL_TEXT_MARGIN;
@@ -111,6 +112,7 @@ export function splitTextToWidth(
   width: number | undefined
 ): string[] {
   if (!style) style = {};
+  if (isMarkdownLink(text)) text = parseMarkdownLink(text).label;
   const brokenText: string[] = [];
 
   // Checking if text contains NEWLINE before split makes it very slightly slower if text contains it,

--- a/tests/headers/resizing_plugin.test.ts
+++ b/tests/headers/resizing_plugin.test.ts
@@ -655,4 +655,16 @@ describe("Model resizer", () => {
     expect(model.getters.getColSize(sheetId, 0)).toBe(26);
     expect(model.getters.getRowSize(sheetId, 0)).toBe(27);
   });
+
+  test("Should use markdown label instead of full link for auto row height", () => {
+    const model = new Model();
+    const sheetId = model.getters.getActiveSheetId();
+
+    setStyle(model, "A1", { wrapping: "wrap" });
+    const initialCellHeight = getDefaultCellHeight(getCell(model, "A1"));
+    expect(model.getters.getRowSize(sheetId, 0)).toBe(initialCellHeight);
+
+    setCellContent(model, "A1", "[link](https://example.com)");
+    expect(model.getters.getRowSize(sheetId, 0)).toBe(initialCellHeight);
+  });
 });


### PR DESCRIPTION
## Description:

Before this commit:
- Row height was calculated using the full Markdown link (label + URL), 
which could lead to incorrect row resizing when word wrap was enabled.

After this commit:
- Only the link label is used to compute row height,
resulting in accurate sizing.

Task: [4886598](https://www.odoo.com/odoo/2328/tasks/4886598)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo