### PR TITLE
[FIX] SidePanel: Export interface to resolve types

### DIFF
--- a/src/components/side_panel/side_panel/side_panel.ts
+++ b/src/components/side_panel/side_panel/side_panel.ts
@@ -5,7 +5,7 @@ import { _t } from "../../../translation";
 import { SpreadsheetChildEnv } from "../../../types";
 import { css } from "../../helpers/css";
 import { useSpreadsheetRect } from "../../helpers/position_hook";
-import { SidePanelProps } from "./side_panel_store";
+import { SidePanelComponentProps } from "./side_panel_store";
 
 css/* scss */ `
   .o-sidePanel {
@@ -123,9 +123,9 @@ css/* scss */ `
   }
 `;
 
-interface Props {
+export interface SidePanelProps {
   panelContent: SidePanelContent;
-  panelProps: SidePanelProps;
+  panelProps: SidePanelComponentProps;
   onCloseSidePanel: () => void;
   onStartHandleDrag: (ev: MouseEvent) => void;
   onResetPanelSize: () => void;
@@ -135,7 +135,7 @@ interface Props {
   isCollapsed?: boolean;
 }
 
-export class SidePanel extends Component<Props, SpreadsheetChildEnv> {
+export class SidePanel extends Component<SidePanelProps, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-SidePanel";
   static props = {
     panelContent: Object,

--- a/src/components/side_panel/side_panel/side_panel_store.ts
+++ b/src/components/side_panel/side_panel/side_panel_store.ts
@@ -4,14 +4,14 @@ import { NotificationStore } from "../../../stores/notification_store";
 import { ScreenWidthStore } from "../../../stores/screen_width_store";
 import { _t } from "../../../translation";
 
-export interface SidePanelProps {
+export interface SidePanelComponentProps {
   onCloseSidePanel?: () => void;
   [key: string]: any;
 }
 
 interface OpenSidePanel {
   isOpen: true;
-  props?: SidePanelProps;
+  props?: SidePanelComponentProps;
   key?: string;
 }
 
@@ -26,7 +26,7 @@ export const COLLAPSED_SIDE_PANEL_SIZE = 45;
 export const MIN_SHEET_VIEW_WIDTH = 150;
 
 interface PanelInfo {
-  initialPanelProps: SidePanelProps;
+  initialPanelProps: SidePanelComponentProps;
   componentTag: string;
   size: number;
   isCollapsed?: boolean;
@@ -63,7 +63,7 @@ export class SidePanelStore extends SpreadsheetStore {
       : false;
   }
 
-  get mainPanelProps(): SidePanelProps | undefined {
+  get mainPanelProps(): SidePanelComponentProps | undefined {
     return this.mainPanel ? this.getPanelProps(this.mainPanel) : undefined;
   }
 
@@ -71,7 +71,7 @@ export class SidePanelStore extends SpreadsheetStore {
     return this.mainPanel ? this.getPanelKey(this.mainPanel) : undefined;
   }
 
-  get secondaryPanelProps(): SidePanelProps | undefined {
+  get secondaryPanelProps(): SidePanelComponentProps | undefined {
     return this.secondaryPanel ? this.getPanelProps(this.secondaryPanel) : undefined;
   }
 
@@ -83,7 +83,7 @@ export class SidePanelStore extends SpreadsheetStore {
     return (this.mainPanel?.size || 0) + (this.secondaryPanel?.size ?? 0);
   }
 
-  private getPanelProps(panelInfo: PanelInfo): SidePanelProps {
+  private getPanelProps(panelInfo: PanelInfo): SidePanelComponentProps {
     const state = this.computeState(panelInfo);
     if (state.isOpen) {
       return state.props ?? {};
@@ -99,7 +99,7 @@ export class SidePanelStore extends SpreadsheetStore {
     return undefined;
   }
 
-  open(componentTag: string, initialPanelProps: SidePanelProps = {}) {
+  open(componentTag: string, initialPanelProps: SidePanelComponentProps = {}) {
     if (this.screenWidthStore.isSmall) {
       return;
     }
@@ -157,7 +157,7 @@ export class SidePanelStore extends SpreadsheetStore {
     }
   }
 
-  toggle(componentTag: string, panelProps: SidePanelProps) {
+  toggle(componentTag: string, panelProps: SidePanelComponentProps) {
     const panel = this.mainPanel?.isPinned ? this.secondaryPanel : this.mainPanel;
     if (panel && componentTag === panel.componentTag) {
       this.close();

--- a/src/components/side_panel/side_panels/side_panels.ts
+++ b/src/components/side_panel/side_panels/side_panels.ts
@@ -5,7 +5,7 @@ import { SpreadsheetChildEnv } from "../../../types";
 import { cssPropertiesToCss } from "../../helpers";
 import { startDnd } from "../../helpers/drag_and_drop";
 import { useSpreadsheetRect } from "../../helpers/position_hook";
-import { SidePanel } from "../side_panel/side_panel";
+import { SidePanel, SidePanelProps } from "../side_panel/side_panel";
 import { SidePanelStore } from "../side_panel/side_panel_store";
 
 export class SidePanels extends Component<{}, SpreadsheetChildEnv> {
@@ -68,7 +68,7 @@ export class SidePanels extends Component<{}, SpreadsheetChildEnv> {
     };
   }
 
-  get secondaryPanelProps(): SidePanel["props"] | undefined {
+  get secondaryPanelProps(): SidePanelProps | undefined {
     const panelProps = this.sidePanelStore.secondaryPanelProps;
     if (!this.sidePanelStore.secondaryPanel || !panelProps) {
       return undefined;


### PR DESCRIPTION
Following odoo/o-spreadsheet#6536, we can no longer generate the type file.

Task: 0

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo