### PR TITLE
[FIX] animations: fix pivot collapse animation

### DIFF
--- a/src/registries/cell_animation_registry.ts
+++ b/src/registries/cell_animation_registry.ts
@@ -107,6 +107,57 @@ cellAnimationRegistry.add("textFadeOut", {
   },
 });
 
+cellAnimationRegistry.add("iconFadeIn", {
+  id: "iconFadeIn",
+  easingFn: "easeInCubic",
+  hasAnimation: (oldBox, newBox) => {
+    return Boolean(
+      (!oldBox?.icons?.left && newBox?.icons?.left) ||
+        (!oldBox?.icons?.right && newBox?.icons?.right) ||
+        (!oldBox?.icons?.center && newBox?.icons?.center)
+    );
+  },
+  updateAnimation: function (progress, animatedBox, oldBox, newBox) {
+    const iconOpacity = EASING_FN[this.easingFn](progress);
+    if (animatedBox.icons.left && newBox.icons.left && !oldBox.icons.left) {
+      animatedBox.icons.left.opacity = iconOpacity;
+    }
+    if (animatedBox.icons.right && newBox.icons.right && !oldBox.icons.right) {
+      animatedBox.icons.right.opacity = iconOpacity;
+    }
+    if (animatedBox.icons.center && newBox.icons.center && !oldBox.icons.center) {
+      animatedBox.icons.center.opacity = iconOpacity;
+    }
+  },
+});
+
+cellAnimationRegistry.add("iconFadeOut", {
+  id: "iconFadeOut",
+  easingFn: "easeOutCubic",
+  hasAnimation: (oldBox, newBox) => {
+    return Boolean(
+      (oldBox?.icons?.left && !newBox?.icons?.left) ||
+        (oldBox?.icons?.right && !newBox?.icons?.right) ||
+        (oldBox?.icons?.center && !newBox?.icons?.center)
+    );
+  },
+  updateAnimation: function (progress, animatedBox, oldBox, newBox) {
+    const iconOpacity = 1 - EASING_FN[this.easingFn](progress);
+    if (!animatedBox.icons) {
+      animatedBox.icons = {};
+    }
+    if (oldBox.icons.left && !newBox.icons.left) {
+      animatedBox.icons.left = { ...oldBox.icons.left, opacity: iconOpacity };
+    }
+    if (oldBox.icons.right && !newBox.icons.right) {
+      animatedBox.icons.right = { ...oldBox.icons.right, opacity: iconOpacity };
+    }
+    if (oldBox.icons.center && !newBox.icons.center) {
+      animatedBox.icons.center = { ...oldBox.icons.center, opacity: iconOpacity };
+    }
+  },
+});
+
 cellAnimationRegistry.add("textChange", {
   id: "textChange",
   easingFn: "easeOutCubic",
@@ -115,8 +166,8 @@ cellAnimationRegistry.add("textChange", {
     const newText = newBox?.content?.textLines?.join("\n");
     // Note: here, we also animate changes to icons layout (margins/size change, or icon appearing/disappearing)
     // because a change to the icon layout will impact where the text is positioned.
-    return (
-      Boolean(oldText && newText && oldText !== newText) || hasIconLayoutChange(newBox, oldBox)
+    return Boolean(
+      oldText && newText && (oldText !== newText || hasIconLayoutChange(newBox, oldBox))
     );
   },
   updateAnimation: function (progress, animatedBox, oldBox, newBox) {
@@ -134,7 +185,7 @@ cellAnimationRegistry.add("textChange", {
       height: newBox.height,
       style: { ...newBox.style },
       skipCellGridLines: true,
-      content: newBox.content,
+      content: newBox.content ? { ...newBox.content } : undefined,
       clipRect: newBox.clipRect || {
         ...newBox,
         // large width to avoid clipping the text it it didn't have a clipRect before,
@@ -154,7 +205,7 @@ cellAnimationRegistry.add("textChange", {
       height: newBox.height,
       style: { ...oldBox.style },
       skipCellGridLines: true,
-      content: oldBox.content,
+      content: oldBox.content ? { ...oldBox.content } : undefined,
       clipRect: oldBox.clipRect || {
         ...newBox,
         x: Math.max(0, newBox.x - (oldBox.content?.width || 0)),

--- a/src/stores/grid_renderer_store.ts
+++ b/src/stores/grid_renderer_store.ts
@@ -420,6 +420,7 @@ export class GridRenderer extends SpreadsheetStore {
           continue;
         }
         ctx.save();
+        ctx.globalAlpha = icon.opacity ?? 1;
         ctx.beginPath();
         const clipRect = icon.clipRect || box;
         ctx.rect(clipRect.x, clipRect.y, clipRect.width, clipRect.height);

--- a/src/types/rendering.ts
+++ b/src/types/rendering.ts
@@ -36,7 +36,7 @@ export type RenderingBorder = {
   left?: BorderDescrWithOpacity;
 };
 
-export type RenderingGridIcon = GridIcon & { clipRect?: Rect };
+export type RenderingGridIcon = GridIcon & { clipRect?: Rect; opacity?: number };
 
 export interface RenderingBox {
   id: string;

--- a/tests/renderer/cell_animations.test.ts
+++ b/tests/renderer/cell_animations.test.ts
@@ -639,13 +639,14 @@ describe("Individual animation tests", () => {
     expect(getBoxFromXc("B3-icon-left-slide-out")).toBe(undefined);
   });
 
-  test("Icon appearing trigger a text sliding animation containing the icon", () => {
-    setGrid(model, { A1: '=""', B3: "=A1" });
+  test("Icon appearing without text change trigger a text sliding animation containing the icon", () => {
+    setGrid(model, { B3: "8" });
     addIconCF(model, "B3", ["3", "7"], "arrows");
+    undo(model);
     drawGrid();
     expect(getBoxFromXc("B3").icons.left?.svg).toEqual(undefined);
 
-    setCellContent(model, "A1", "8");
+    redo(model);
     drawGrid();
 
     animationFrameCallback(0);
@@ -659,20 +660,39 @@ describe("Individual animation tests", () => {
     });
     expect(getBoxFromXc("B3-text-slide-out")).toMatchObject({
       icons: { left: undefined },
-      content: { textLines: [""] },
+      content: { textLines: ["8"] },
       y: b3Box.y + DEFAULT_CELL_HEIGHT / 2,
     });
     expect(getBoxFromXc("B3-icon-left-slide-in")).toBe(undefined);
     expect(getBoxFromXc("B3-icon-left-slide-out")).toBe(undefined);
   });
 
-  test("Icon disappearing trigger a text sliding animation containing the icon", () => {
+  test("Both icon and text appearing at once triggers a fade in animation", () => {
+    setGrid(model, { A1: '=""', B3: "=A1" });
+    addIconCF(model, "B3", ["3", "7"], "arrows");
+    drawGrid();
+    expect(getBoxFromXc("B3").icons.left?.svg).toEqual(undefined);
+
+    setCellContent(model, "A1", "8");
+    drawGrid();
+
+    animationFrameCallback(0);
+    animationFrameCallback(CELL_ANIMATION_DURATION / 2);
+    expect(getBoxFromXc("B3")).toMatchObject({
+      icons: { left: { opacity: 0.5 } },
+      textOpacity: 0.5,
+    });
+    expect(getBoxFromXc("B3-text-slide-in")).toBe(undefined);
+    expect(getBoxFromXc("B3-text-slide-out")).toBe(undefined);
+  });
+
+  test("Icon disappearing with text staying triggers a text sliding animation containing the icon", () => {
     setGrid(model, { A1: "9", B3: "=A1" });
     addIconCF(model, "B3", ["3", "7"], "arrows");
     drawGrid();
     expect(getBoxFromXc("B3").icons.left?.svg).toEqual(ICONS.arrowGood.svg);
 
-    setCellContent(model, "A1", '=""');
+    undo(model);
     drawGrid();
 
     animationFrameCallback(0);
@@ -681,7 +701,7 @@ describe("Individual animation tests", () => {
     expect(b3Box.icons.left?.svg).toEqual(undefined);
     expect(getBoxFromXc("B3-text-slide-in")).toMatchObject({
       icons: { left: undefined },
-      content: { textLines: [""] },
+      content: { textLines: ["9"] },
       y: b3Box.y - DEFAULT_CELL_HEIGHT / 2,
     });
     expect(getBoxFromXc("B3-text-slide-out")).toMatchObject({
@@ -693,35 +713,23 @@ describe("Individual animation tests", () => {
     expect(getBoxFromXc("B3-icon-left-slide-out")).toBe(undefined);
   });
 
-  test("Icon disappearing trigger a text sliding animation containing the icon", () => {
-    setGrid(model, { A1: '=""', B3: "=A1" });
+  test("Icon and text both disappearing at once triggers a fade out animation", () => {
+    setGrid(model, { A1: "9", B3: "=A1" });
     addIconCF(model, "B3", ["3", "7"], "arrows");
     drawGrid();
-    expect(getBoxFromXc("B3").icons.left?.svg).toEqual(undefined);
+    expect(getBoxFromXc("B3").icons.left?.svg).toEqual(ICONS.arrowGood.svg);
 
-    setCellContent(model, "A1", "8");
+    setCellContent(model, "A1", '=""');
     drawGrid();
 
     animationFrameCallback(0);
     animationFrameCallback(CELL_ANIMATION_DURATION / 2);
-    const b3Box = getBoxFromXc("B3");
-    expect(b3Box.icons.left?.svg).toEqual(undefined);
-    expect(getBoxFromXc("B3-text-slide-in")).toMatchObject({
-      icons: { left: { svg: ICONS.arrowGood.svg, clipRect: model.getters.getRect(toZone("B3")) } },
-      content: { textLines: ["8"] },
-      x: b3Box.x,
-      y: b3Box.y - DEFAULT_CELL_HEIGHT / 2,
-      width: b3Box.width,
-      height: b3Box.height,
+    expect(getBoxFromXc("B3")).toMatchObject({
+      icons: { left: { opacity: 0.5 } },
+      textOpacity: 0.5,
     });
-    expect(getBoxFromXc("B3-text-slide-out")).toMatchObject({
-      icons: { left: undefined },
-      content: { textLines: [""] },
-      x: b3Box.x,
-      y: b3Box.y + DEFAULT_CELL_HEIGHT / 2,
-      width: b3Box.width,
-      height: b3Box.height,
-    });
+    expect(getBoxFromXc("B3-text-slide-in")).toBe(undefined);
+    expect(getBoxFromXc("B3-text-slide-out")).toBe(undefined);
   });
 
   test("Can animate a data bar change", () => {


### PR DESCRIPTION
## Description

The cells animations on pivot collapse were not working correctly. The headers of the pivots would appear suddenly without any animation.

This is because the `textChange` animation isn't working when text is appearing or disappearing. This animation should not even be used in that case, we should use `fadeIn` and `fadeOut` animations instead.

Task: [4894210](https://www.odoo.com/odoo/2328/tasks/4894210)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo