### PR TITLE
[FIX] composer: zone selection with arrow keys

### DIFF
--- a/src/components/composer/composer/abstract_composer_store.ts
+++ b/src/components/composer/composer/abstract_composer_store.ts
@@ -282,7 +282,7 @@ export abstract class AbstractComposerStore extends SpreadsheetStore {
     this.model.selection.capture(
       this,
       {
-        cell: { col: col || zone.left, row: row || zone.right },
+        cell: { col: col ?? zone.left, row: row ?? zone.right },
         zone,
       },
       {

--- a/tests/composer/composer_component.test.ts
+++ b/tests/composer/composer_component.test.ts
@@ -116,6 +116,13 @@ describe("ranges and highlights", () => {
     expect(composerEl.textContent).toBe("=A2");
   });
 
+  test("=Key LEFT in A2, should select and highlight A1", async () => {
+    selectCell(model, "B1");
+    composerEl = await startComposition("=");
+    await keyDown({ key: "ArrowLeft" });
+    expect(composerEl.textContent).toBe("=A1");
+  });
+
   test("reference position is reset at each selection", async () => {
     composerEl = await typeInComposer("=");
     expect(composerEl.querySelector(".selector-flag")).toBeTruthy();


### PR DESCRIPTION
## Description:


The range selection with arrow keys in the composer was previously broken for the first row and column.

This happened because captureSelection used `col || zone.left` and `row || zone.top`, which incorrectly treated 0 as falsy and fell back to the zone boundaries.

This PR replaces `||` with the nullish coalescing operator (??) to correctly preserve 0 values.

Task: [4890605](https://www.odoo.com/odoo/2328/tasks/4890605)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo