### PR TITLE
[FIX] spreadsheet: unwrap 1x1 matrix results across rules (CF, DV, filters, charts)

### DIFF
--- a/src/components/composer/composer/cell_composer_store.ts
+++ b/src/components/composer/composer/cell_composer_store.ts
@@ -1,3 +1,4 @@
+import { isMultipleElementMatrix, toScalar } from "../../../functions/helper_matrices";
 import { parseLiteral } from "../../../helpers/cells";
 import {
   formatValue,
@@ -285,11 +286,14 @@ export class CellComposerStore extends AbstractComposerStore {
       ? this.getters.evaluateFormula(this.sheetId, content)
       : parseLiteral(content, this.getters.getLocale());
 
-    if (isMatrix(cellValue)) {
+    if (isMultipleElementMatrix(cellValue)) {
       return true;
     }
 
-    const validationResult = this.getters.getValidationResultForCellValue(cellValue, cellPosition);
+    const validationResult = this.getters.getValidationResultForCellValue(
+      toScalar(cellValue),
+      cellPosition
+    );
     if (!validationResult.isValid && validationResult.rule.isBlocking) {
       return false;
     }

--- a/src/components/side_panel/chart/gauge_chart_panel/gauge_chart_design_panel.ts
+++ b/src/components/side_panel/chart/gauge_chart_panel/gauge_chart_design_panel.ts
@@ -1,4 +1,5 @@
 import { Component, useState } from "@odoo/owl";
+import { isMultipleElementMatrix, toScalar } from "../../../../functions/helper_matrices";
 import { tryToNumber } from "../../../../functions/helpers";
 import { deepCopy } from "../../../../helpers/index";
 import { _t } from "../../../../translation";
@@ -9,7 +10,6 @@ import {
   DispatchResult,
   SpreadsheetChildEnv,
   UID,
-  isMatrix,
 } from "../../../../types/index";
 import { StandaloneComposer } from "../../../composer/standalone_composer/standalone_composer";
 import { css } from "../../../helpers/css";
@@ -213,10 +213,10 @@ export class GaugeChartDesignPanel extends Component<Props, SpreadsheetChildEnv>
       return tryToNumber(value, locale) !== undefined;
     }
     const evaluatedValue = this.env.model.getters.evaluateFormula(this.sheetId, value);
-    if (isMatrix(evaluatedValue)) {
+    if (isMultipleElementMatrix(evaluatedValue)) {
       return false;
     }
-    return tryToNumber(evaluatedValue, locale) !== undefined;
+    return tryToNumber(toScalar(evaluatedValue), locale) !== undefined;
   }
 
   get sheetId() {

--- a/src/helpers/figures/charts/gauge_chart.ts
+++ b/src/helpers/figures/charts/gauge_chart.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_GAUGE_MIDDLE_COLOR,
   DEFAULT_GAUGE_UPPER_COLOR,
 } from "../../../constants";
+import { isMultipleElementMatrix, toScalar } from "../../../functions/helper_matrices";
 import { tryToNumber } from "../../../functions/helpers";
 import { BasePlugin } from "../../../plugins/base_plugin";
 import { _t } from "../../../translation";
@@ -18,7 +19,6 @@ import {
   RangeAdapter,
   UID,
   Validation,
-  isMatrix,
 } from "../../../types";
 import { ChartCreationContext } from "../../../types/chart/chart";
 import {
@@ -396,7 +396,9 @@ function getSectionThresholdValue(
 
 function getFormulaNumberValue(sheetId: UID, formula: string, getters: Getters) {
   const value = getters.evaluateFormula(sheetId, formula);
-  return isMatrix(value) ? undefined : tryToNumber(value, getters.getLocale());
+  return isMultipleElementMatrix(value)
+    ? undefined
+    : tryToNumber(toScalar(value), getters.getLocale());
 }
 
 function getInvalidGaugeRuntime(chart: GaugeChart, getters: Getters): GaugeChartRuntime {

--- a/src/plugins/ui_core_views/evaluation_conditional_format.ts
+++ b/src/plugins/ui_core_views/evaluation_conditional_format.ts
@@ -1,4 +1,5 @@
 import { compile } from "../../formulas";
+import { isMultipleElementMatrix, toScalar } from "../../functions/helper_matrices";
 import { parseLiteral } from "../../helpers/cells";
 import { colorNumberString, getColorScale, isInside, percentile } from "../../helpers/index";
 import { clip, largeMax, largeMin, lazy } from "../../helpers/misc";
@@ -6,7 +7,6 @@ import { criterionEvaluatorRegistry } from "../../registries/criterion_registry"
 import {
   CellIsRule,
   CellPosition,
-  CellValue,
   CellValueType,
   ColorScaleMidPointThreshold,
   ColorScaleRule,
@@ -24,7 +24,6 @@ import {
   UID,
   Zone,
   invalidateCFEvaluationCommands,
-  isMatrix,
 } from "../../types/index";
 import { CoreViewPlugin } from "../core_view_plugin";
 import { CoreViewCommand, invalidateEvaluationCommands } from "./../../types/commands";
@@ -372,13 +371,14 @@ export class EvaluationConditionalFormatPlugin extends CoreViewPlugin {
       }
       return this.getters.evaluateFormula(sheetId, value) ?? "";
     });
-    if (evaluatedCriterionValues.some(isMatrix)) {
+
+    if (evaluatedCriterionValues.some(isMultipleElementMatrix)) {
       return false;
     }
 
     const evaluatedCriterion = {
       type: rule.operator,
-      values: evaluatedCriterionValues as CellValue[],
+      values: evaluatedCriterionValues.map(toScalar),
     };
     return evaluator.isValueValid(cell.value ?? "", evaluatedCriterion, this.getters, sheetId);
   }

--- a/src/plugins/ui_core_views/evaluation_data_validation.ts
+++ b/src/plugins/ui_core_views/evaluation_data_validation.ts
@@ -1,6 +1,7 @@
 import { DVTerms } from "../../components/translations_terms";
 import { GRAY_200 } from "../../constants";
 import { compile } from "../../formulas";
+import { isMultipleElementMatrix, toScalar } from "../../functions/helper_matrices";
 import { chipTextColor, getCellPositionsInRanges, isDefined, isInside, lazy } from "../../helpers";
 import { parseLiteral } from "../../helpers/cells";
 import { criterionEvaluatorRegistry } from "../../registries/criterion_registry";
@@ -19,7 +20,6 @@ import {
   Offset,
   Style,
   UID,
-  isMatrix,
 } from "../../types";
 import { CoreViewCommand, invalidateEvaluationCommands } from "../../types/commands";
 import { CoreViewPlugin } from "../core_view_plugin";
@@ -232,10 +232,10 @@ export class EvaluationDataValidationPlugin extends CoreViewPlugin {
 
     const offset = this.getCellOffsetInRule(cellPosition, rule);
     const evaluatedCriterionValues = this.getEvaluatedCriterionValues(sheetId, offset, criterion);
-    if (evaluatedCriterionValues.some(isMatrix)) {
+    if (evaluatedCriterionValues.some(isMultipleElementMatrix)) {
       return undefined;
     }
-    const evaluatedCriterion = { ...criterion, values: evaluatedCriterionValues as CellValue[] };
+    const evaluatedCriterion = { ...criterion, values: evaluatedCriterionValues.map(toScalar) };
 
     if (evaluator.isValueValid(cellValue, evaluatedCriterion, this.getters, sheetId)) {
       return undefined;

--- a/src/plugins/ui_stateful/filter_evaluation.ts
+++ b/src/plugins/ui_stateful/filter_evaluation.ts
@@ -1,3 +1,4 @@
+import { isMultipleElementMatrix, toScalar } from "../../functions/helper_matrices";
 import {
   deepCopy,
   getUniqueText,
@@ -12,7 +13,6 @@ import { parseLiteral } from "../../helpers/cells";
 import { criterionEvaluatorRegistry } from "../../registries/criterion_registry";
 import {
   CellPosition,
-  CellValue,
   Command,
   CommandResult,
   CriterionFilter,
@@ -23,7 +23,6 @@ import {
   FilterId,
   Table,
   UID,
-  isMatrix,
 } from "../../types";
 import { LocalCommand, UpdateFilterCommand } from "../../types/commands";
 import { UIPlugin } from "../ui_plugin";
@@ -198,13 +197,13 @@ export class FilterEvaluationPlugin extends UIPlugin {
           }
           return this.getters.evaluateFormula(sheetId, value) ?? "";
         });
-        if (evaluatedCriterionValues.some(isMatrix)) {
+        if (evaluatedCriterionValues.some(isMultipleElementMatrix)) {
           continue;
         }
 
         const evaluatedCriterion = {
           type: filterValue.type,
-          values: evaluatedCriterionValues as CellValue[],
+          values: evaluatedCriterionValues.map(toScalar),
           dateValue: filterValue.dateValue,
         };
         for (let row = filteredZone.top; row <= filteredZone.bottom; row++) {

--- a/tests/conditional_formatting/conditional_formatting_plugin.test.ts
+++ b/tests/conditional_formatting/conditional_formatting_plugin.test.ts
@@ -1218,6 +1218,26 @@ describe("conditional formats types", () => {
         const computedStyle = shouldMatch ? { fillColor: "#ff0f0f" } : {};
         expect(getStyle(model, "A1")).toEqual(computedStyle);
       });
+
+      test("applies conditional formatting correctly when formula returns a 1x1 matrix", () => {
+        setCellContent(model, "A1", "test");
+        model.dispatch("ADD_CONDITIONAL_FORMAT", {
+          cf: {
+            rule: {
+              type: "CellIsRule",
+              operator: "containsText",
+              values: ['=IF(TRUE, $A$1, "something else")'],
+              style: { fillColor: "#ff0f0f" },
+            },
+            id: "11",
+          },
+          ranges: toRangesData(sheetId, "A1:A2"),
+          sheetId,
+        });
+
+        expect(getStyle(model, "A1")).toEqual({ fillColor: "#ff0f0f" });
+        expect(getStyle(model, "A2")).toEqual({});
+      });
     });
 
     describe("Operator EndsWith", () => {

--- a/tests/data_validation/data_validation_blocking_component.test.ts
+++ b/tests/data_validation/data_validation_blocking_component.test.ts
@@ -118,4 +118,12 @@ describe("Data validation with blocking rule", () => {
 
     expect(getCellContent(model, "A1")).toBe("1");
   });
+
+  test("User cannot input formula returning 1x1 matrix that fails blocking DV rule", async () => {
+    addDataValidation(model, "A1", "id", { type: "containsText", values: ["hi"] }, "blocking");
+    composerStore.startEdition('=IF(TRUE, A2, "something else")');
+    composerStore.stopEdition();
+
+    expect(getCellContent(model, "A1")).toBe("");
+  });
 });

--- a/tests/data_validation/evaluation_data_validation_plugin.test.ts
+++ b/tests/data_validation/evaluation_data_validation_plugin.test.ts
@@ -140,6 +140,18 @@ describe("Data validation evaluation", () => {
       expect(model.getters.isDataValidationInvalid(A1)).toEqual(false);
     });
 
+    test("applies data validation correctly when formula returns a 1x1 matrix", () => {
+      addDataValidation(model, "A1:A2", "id", {
+        type: "containsText",
+        values: ['=IF(1=1, $A$1, "something else")'],
+      });
+
+      setCellContent(model, "A1", "random text");
+      setCellContent(model, "A2", "text");
+      expect(model.getters.isDataValidationInvalid(A1)).toBe(false);
+      expect(model.getters.isDataValidationInvalid({ sheetId, col: 0, row: 1 })).toBe(true);
+    });
+
     test("Criterion with spreading formula values is ignored ", () => {
       addDataValidation(model, "A1", "id", {
         type: "isGreaterThan",

--- a/tests/figures/chart/gauge/gauge_chart_plugin.test.ts
+++ b/tests/figures/chart/gauge/gauge_chart_plugin.test.ts
@@ -354,6 +354,22 @@ describe("datasource tests", function () {
       const runtime = model.getters.getChartRuntime("1") as GaugeChartRuntime;
       expect(runtime.inflectionValues).toHaveLength(1); // only the lower inflection point is valid and kept
     });
+
+    test("accepts sectionRule formulas returning a 1x1 matrix", () => {
+      setCellContent(model, "A1", "10");
+
+      sectionRule = {
+        ...sectionRule,
+        rangeMin: '=IF(TRUE, A1, "something else")',
+        rangeMax: '=IF(TRUE, A1, "something else")',
+      };
+      const result = createGaugeChart(model, { dataRange: "A1", sectionRule }, "1");
+      expect(result).toBeSuccessfullyDispatched();
+
+      const runtime = model.getters.getChartRuntime("1") as GaugeChartRuntime;
+      expect(runtime.minValue).toMatchObject({ value: 10 });
+      expect(runtime.maxValue).toMatchObject({ value: 10 });
+    });
   });
 
   test("Gauge Chart is deleted on sheet deletion", () => {

--- a/tests/table/filter_evaluation_plugin.test.ts
+++ b/tests/table/filter_evaluation_plugin.test.ts
@@ -432,4 +432,20 @@ describe("Filter criterion test", () => {
       expect(getFilteredRows()).toEqual(expectedFilteredRows);
     }
   );
+
+  test("applies filter correctly when formula returns a 1x1 matrix", () => {
+    const grid = {
+      A2: "text",
+      A3: "random",
+    };
+    setGrid(model, grid);
+    createTableWithFilter(model, "A1:A3");
+
+    updateFilterCriterion(model, "A1", {
+      type: "containsText",
+      values: ['=IF(TRUE, $A$2, "something else")'],
+    });
+
+    expect(getFilteredRows()).toEqual([2]);
+  });
 });


### PR DESCRIPTION
## Description:

Previously, formulas returning a 1x1 matrix (e.g. `=IF(TRUE, A1, "else")`) were not properly handled across multiple features like **Conditional Formatting**, **Data Validation**, **Filters**, and **Gauge Chart configuration**.

These formulas were ignored because the evaluated result was a matrix, and we did not unwrap it to a scalar value. As a result:

* Conditional formatting styles were not applied
* Data validation rules silently failed
* Filter conditions were skipped
* Gauge chart configuration failed validation
* Users could enter invalid 1x1 formulas that violated blocking rules

### This PR fixes all of the above:

* Unwraps 1x1 matrices into scalar values before evaluating rules
* Applies this logic consistently across CF, DV, filters, and gauge charts
* Prevents 1x1 formulas from being accepted when they violate blocking DV rules
* Adds tests to cover these behaviors

Task: [4876691](https://www.odoo.com/odoo/2328/tasks/4876691)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo