### PR TITLE
[FIX] pivot: allow to group by error

### DIFF
--- a/src/helpers/pivot/pivot_helpers.ts
+++ b/src/helpers/pivot/pivot_helpers.ts
@@ -1,7 +1,13 @@
 import { boolAnd, boolOr } from "../../functions/helper_logical";
 import { countUnique, sum } from "../../functions/helper_math";
 import { average, countAny, max, min } from "../../functions/helper_statistical";
-import { inferFormat, toBoolean, toNumber, toString } from "../../functions/helpers";
+import {
+  inferFormat,
+  isEvaluationError,
+  toBoolean,
+  toNumber,
+  toString,
+} from "../../functions/helpers";
 import { Registry } from "../../registries/registry";
 import { _t } from "../../translation";
 import {
@@ -10,6 +16,7 @@ import {
   FunctionResultObject,
   Locale,
   Matrix,
+  Maybe,
   Pivot,
 } from "../../types";
 import { EvaluationError } from "../../types/errors";
@@ -197,10 +204,14 @@ export function createPivotFormula(formulaId: string, cell: PivotTableCell) {
  */
 export function toNormalizedPivotValue(
   dimension: Pick<PivotDimension, "type" | "displayName" | "granularity">,
-  groupValue
-) {
+  groupValue: Maybe<CellValue | FunctionResultObject>
+): CellValue {
   if (groupValue === null || groupValue === "null") {
     return null;
+  }
+  const extractedGroupValue = typeof groupValue === "object" ? groupValue.value : groupValue;
+  if (isEvaluationError(extractedGroupValue)) {
+    return extractedGroupValue;
   }
   const groupValueString =
     typeof groupValue === "boolean"

--- a/src/helpers/pivot/spreadsheet_pivot/spreadsheet_pivot.ts
+++ b/src/helpers/pivot/spreadsheet_pivot/spreadsheet_pivot.ts
@@ -262,10 +262,7 @@ export class SpreadsheetPivot implements Pivot<SpreadsheetPivotRuntimeDefinition
     if (finalCell.value === null) {
       return { value: _t("(Undefined)") };
     }
-    return {
-      value: finalCell.value,
-      format: finalCell.format,
-    };
+    return finalCell;
   }
 
   getPivotCellValueAndFormat(measureId: string, domain: PivotDomain): FunctionResultObject {

--- a/tests/pivots/spreadsheet_pivot/spreadsheet_pivot.test.ts
+++ b/tests/pivots/spreadsheet_pivot/spreadsheet_pivot.test.ts
@@ -1749,6 +1749,29 @@ describe("Spreadsheet Pivot", () => {
     });
   });
 
+  test("can group by value in error", () => {
+    // prettier-ignore
+    const grid = {
+      A1: "Customer", B1: "Price", C1: "=PIVOT(1)",
+      A2: "Alice",    B2: "10",
+      A3: "=0/0",     B3: "20",
+    };
+    const model = createModelFromGrid(grid);
+    addPivot(model, "A1:B3", {
+      columns: [],
+      rows: [{ fieldName: "Customer" }],
+      measures: [{ fieldName: "Price", aggregator: "sum", id: "Price:sum" }],
+    });
+    expect(getEvaluatedCell(model, "C4").message).toBe("The divisor must be different from zero.");
+    expect(getEvaluatedGrid(model, "C1:D5")).toEqual([
+      ["(#1) Pivot", "Total"],
+      ["", "Price"],
+      ["Alice", "10"],
+      ["#DIV/0!", "20"],
+      ["Total", "30"],
+    ]);
+  });
+
   test("Cannot use PIVOT function inside its range", () => {
     const model = createModelWithPivot("A1:I5");
     setCellContent(model, "B3", `=PIVOT("1")`);


### PR DESCRIPTION
Steps to reproduce:

Given the following grid:

    A		B
1   Person	Price
2   =0/0	15

- Creates a pivot from the range A1:B2
- group by "Person"
- use =PIVOT(1) somewhere

=> the result is a single cell in error with #DIV/0!

There's no message or help to find the error.
Now, the error is considered as a valid groupable value and it appears in the pivot.

Task: 4886041

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo