### PR TITLE
[FIX] selection, header_sizes_ui: fix row resize on insert above and move selection

### DIFF
--- a/src/plugins/ui_stateful/selection.ts
+++ b/src/plugins/ui_stateful/selection.ts
@@ -1,4 +1,4 @@
-import { SELECTION_BORDER_COLOR } from "../../constants";
+import { DEFAULT_CELL_WIDTH, SELECTION_BORDER_COLOR } from "../../constants";
 import { SUM } from "../../functions/module_math";
 import { AVERAGE, COUNT, COUNTA, MAX, MIN } from "../../functions/module_statistical";
 import { ClipboardCellsState } from "../../helpers/clipboard/clipboard_cells_state";
@@ -31,6 +31,7 @@ import {
   LocalCommand,
   Locale,
   MoveColumnsRowsCommand,
+  Pixel,
   RemoveColumnsRowsCommand,
   Selection,
   Sheet,
@@ -649,7 +650,16 @@ export class GridSelectionPlugin extends UIPlugin {
     const isBasedBefore = cmd.base < start;
     const deltaCol = isBasedBefore && isCol ? thickness : 0;
     const deltaRow = isBasedBefore && !isCol ? thickness : 0;
-
+    const toRemove = isBasedBefore ? cmd.elements.map((el) => el + thickness) : cmd.elements;
+    const originalSize = Object.fromEntries(
+      toRemove.map((element): [HeaderIndex, Pixel | null] => {
+        const size = isCol
+          ? this.getters.getColSize(cmd.sheetId, element)
+          : this.getters.getUserRowSize(cmd.sheetId, element);
+        const isDefaultCol = isCol && size === DEFAULT_CELL_WIDTH;
+        return [element, isDefaultCol || size === undefined ? null : size];
+      })
+    );
     const target = [
       {
         left: isCol ? start + deltaCol : 0,
@@ -676,14 +686,12 @@ export class GridSelectionPlugin extends UIPlugin {
     ];
     state.paste(pasteTarget, { selectTarget: true });
 
-    const toRemove = isBasedBefore ? cmd.elements.map((el) => el + thickness) : cmd.elements;
     let currentIndex = isBasedBefore ? cmd.base : cmd.base + 1;
     for (const element of toRemove) {
-      const size = this.getters.getHeaderSize(cmd.sheetId, cmd.dimension, element);
       this.dispatch("RESIZE_COLUMNS_ROWS", {
         dimension: cmd.dimension,
         sheetId: cmd.sheetId,
-        size,
+        size: originalSize[element],
         elements: [currentIndex],
       });
       currentIndex += 1;

--- a/tests/sheet/selection_plugin.test.ts
+++ b/tests/sheet/selection_plugin.test.ts
@@ -34,6 +34,7 @@ import {
   setAnchorCorner,
   setCellContent,
   setSelection,
+  setStyle,
   setViewportOffset,
   undo,
 } from "../test_helpers/commands_helpers";
@@ -993,6 +994,26 @@ describe("move elements(s)", () => {
     expect(model.getters.getRowSize(sheetId, 0)).toEqual(10);
     expect(model.getters.getRowSize(sheetId, 1)).toEqual(DEFAULT_CELL_HEIGHT);
     expect(model.getters.getRowSize(sheetId, 2)).toEqual(20);
+  });
+
+  test("Move multiline row preserves its size", () => {
+    const model = new Model();
+    const sheetId = model.getters.getActiveSheetId();
+    setCellContent(model, "A3", "Hello\nWorld");
+    expect(model.getters.getRowSize(sheetId, 2)).toEqual(36);
+    moveRows(model, 1, [2], "before");
+    expect(model.getters.getRowSize(sheetId, 1)).toEqual(36);
+    moveRows(model, 2, [1], "before");
+    expect(model.getters.getRowSize(sheetId, 2)).toEqual(36);
+  });
+
+  test("Moving a row with wrapped text should not convert its height to fixed row size", () => {
+    const model = new Model();
+    const sheetId = model.getters.getActiveSheetId();
+    setCellContent(model, "A3", "Hello\nWorld");
+    setStyle(model, "A3", { wrapping: "wrap" });
+    moveRows(model, 1, [2], "before");
+    expect(model.getters.getUserRowSize(sheetId, 1)).toEqual(undefined);
   });
 
   test("Can move a column to the end of the sheet", () => {

--- a/tests/sheet/selection_plugin.test.ts
+++ b/tests/sheet/selection_plugin.test.ts
@@ -1016,6 +1016,15 @@ describe("move elements(s)", () => {
     expect(model.getters.getUserRowSize(sheetId, 1)).toEqual(undefined);
   });
 
+  test("Preserves wrapped row height when a row is moved above it", () => {
+    const model = new Model();
+    const sheetId = model.getters.getActiveSheetId();
+    setCellContent(model, "A2", "Hello\nWorld");
+    setStyle(model, "A2", { wrapping: "wrap" });
+    moveRows(model, 1, [2], "before");
+    expect(model.getters.getRowSize(sheetId, 2)).toEqual(36);
+  });
+
   test("Can move a column to the end of the sheet", () => {
     const model = new Model();
     setCellContent(model, "A1", "5");
@@ -1054,6 +1063,15 @@ describe("move elements(s)", () => {
     result = moveRows(model, -1, [0]);
     expect(result).toBeCancelledBecause(CommandResult.InvalidHeaderIndex);
   });
+});
+
+test("Preserves wrapped row height when inserting a row above", () => {
+  const model = new Model();
+  const sheetId = model.getters.getActiveSheetId();
+  setCellContent(model, "A2", "Hello\nWorld");
+  setStyle(model, "A2", { wrapping: "wrap" });
+  addRows(model, "before", 1, 1);
+  expect(model.getters.getRowSize(sheetId, 2)).toEqual(36);
 });
 
 describe("Selection loop (ctrl + a)", () => {


### PR DESCRIPTION
## Description:

Before this PR:
- Resized rows reverted to default height when moved up/down.
- Dragging a default-height row above a resized row resets its size.
- Inserting a row above a resized row resets its size.

After this PR:
- Resized height is preserved when moving rows.
- Dragging rows above resized ones keeps the size intact.
- Inserting the above resized rows retains their size.

Task: [4885579](https://www.odoo.com/odoo/2328/tasks/4885579)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo