### PR TITLE
FIX] Cells: content with new lines is always a string

### DIFF
--- a/src/helpers/misc.ts
+++ b/src/helpers/misc.ts
@@ -420,11 +420,11 @@ export function removeFalsyAttributes(obj: Object): Object {
 }
 
 /**
- * Equivalent to "\s" in regexp, minus the new lines characters
+ * Equivalent to "\s" in regexp, minus the new lines characters and the standard space character.
  *
  * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Character_Classes
  */
-const specialWhiteSpaceSpecialCharacters = [
+export const specialWhiteSpaceSpecialCharacters = [
   "\t",
   "\f",
   "\v",
@@ -444,6 +444,8 @@ export const specialWhiteSpaceRegexp = new RegExp(
   "g"
 );
 const newLineRegexp = /(\r\n|\r)/g;
+
+export const whiteSpaceCharacters = specialWhiteSpaceSpecialCharacters.concat([" "]);
 
 /**
  * Replace all different newlines characters by \n

--- a/tests/cells/cell_plugin.test.ts
+++ b/tests/cells/cell_plugin.test.ts
@@ -561,6 +561,13 @@ test.each([
   }
 );
 
+test.each(["5\n\n", "\n5\n", "\n\n5"])("Content with new lines is detected as text", (str) => {
+  const model = new Model();
+  setCellContent(model, "A1", str);
+  expect(getCellContent(model, "A1")).toEqual(str);
+  expect(getEvaluatedCell(model, "A1")?.type).toBe(CellValueType.text);
+});
+
 test.each([
   ["12/31/1999", "36525", "m/d/yyyy"],
   ["30€", "30", "#,##0[$€]"],

--- a/tests/helpers/numbers_helpers.test.ts
+++ b/tests/helpers/numbers_helpers.test.ts
@@ -74,6 +74,10 @@ describe("isNumber", () => {
     expect(isNumber("$123$", locale)).toBe(false);
     expect(isNumber("$123€", locale)).toBe(false);
     expect(isNumber("12$3", locale)).toBe(false);
+    expect(isNumber("5\n5", locale)).toBe(false);
+    expect(isNumber("5 5", locale)).toBe(false);
+    expect(isNumber("5\n", locale)).toBe(false);
+    expect(isNumber("\n5", locale)).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Description:
How to reproduce:

- in a cell, write 5 and then a bunch of new lines (Alt+Enter)
- validate the input

=> we only keep the value 5 and trim the rest

Task: [4907670](https://www.odoo.com/odoo/2328/tasks/4907670)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo