### PR TITLE
[FIX] demo: fix `clear` action again

### DIFF
--- a/demo/main.js
+++ b/demo/main.js
@@ -79,7 +79,8 @@ class Demo extends Component {
     topbarMenuRegistry.addChild("clear", ["file"], {
       name: "Clear",
       sequence: 10.5,
-      execute: async (env) => {
+      execute: async () => {
+        stores.resetStores();
         this.leaveCollaborativeSession();
         await fetch(`http://${window.location.hostname}:9090/clear`);
         await this.initiateConnection({});


### PR DESCRIPTION
in 18.0, resetting a spreadsheet implies also clearing the store container. Again no tests in demo and the forwardport went sour.

Task: 0

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo