### PR TITLE
[FIX] auto_complete: remove toggle button for data validation

### DIFF
--- a/src/components/composer/composer/abstract_composer_store.ts
+++ b/src/components/composer/composer/abstract_composer_store.ts
@@ -569,6 +569,7 @@ export abstract class AbstractComposerStore extends SpreadsheetStore {
           proposals,
           selectProposal: provider.selectProposal,
           autoSelectFirstProposal: provider.autoSelectFirstProposal ?? false,
+          canBeToggled: provider.canBeToggled,
         };
       }
       if (exactMatch && this._currentContent !== this.initialContent) {
@@ -597,6 +598,7 @@ export abstract class AbstractComposerStore extends SpreadsheetStore {
           proposals,
           selectProposal: provider.selectProposal,
           autoSelectFirstProposal: provider.autoSelectFirstProposal ?? false,
+          canBeToggled: provider.canBeToggled,
         };
       }
     }

--- a/src/components/composer/composer/composer.ts
+++ b/src/components/composer/composer/composer.ts
@@ -608,10 +608,12 @@ export class Composer extends Component<CellComposerProps, SpreadsheetChildEnv> 
   }
 
   closeAssistant() {
+    if (!this.canBeToggled) return;
     this.assistant.forcedClosed = true;
   }
 
   openAssistant() {
+    if (!this.canBeToggled) return;
     this.assistant.forcedClosed = false;
   }
 
@@ -623,6 +625,10 @@ export class Composer extends Component<CellComposerProps, SpreadsheetChildEnv> 
     ) {
       event.stopPropagation();
     }
+  }
+
+  get canBeToggled() {
+    return this.autoCompleteState.provider?.canBeToggled ?? true;
   }
 
   // ---------------------------------------------------------------------------
@@ -822,7 +828,7 @@ export class Composer extends Component<CellComposerProps, SpreadsheetChildEnv> 
   }
 
   private autoComplete(value: string) {
-    if (!value || this.assistant.forcedClosed) {
+    if (!value || (this.assistant.forcedClosed && this.canBeToggled)) {
       return;
     }
     this.autoCompleteState.provider?.selectProposal(value);

--- a/src/components/composer/composer/composer.xml
+++ b/src/components/composer/composer/composer.xml
@@ -7,7 +7,7 @@
       />
       <div class="d-flex flex-row position-relative">
         <span
-          t-if="props.focus !== 'inactive' and assistantIsAvailable and assistant.forcedClosed"
+          t-if="props.focus !== 'inactive' and assistantIsAvailable and canBeToggled and assistant.forcedClosed"
           role="button"
           title="Show formula help"
           t-on-click="openAssistant"
@@ -45,12 +45,13 @@
       <div
         class="o-composer-assistant-container shadow position-absolute z-1"
         t-att-style="assistantContainerStyle"
-        t-if="props.focus !== 'inactive' and !assistant.forcedClosed and assistantIsAvailable"
+        t-if="props.focus !== 'inactive' and assistantIsAvailable and !(canBeToggled and assistant.forcedClosed)"
         t-on-wheel.stop=""
         t-on-pointerdown.prevent.stop=""
         t-on-pointerup.prevent.stop=""
         t-on-click.prevent.stop="">
         <span
+          t-if="canBeToggled and !assistant.forcedClosed"
           role="button"
           t-on-click="closeAssistant"
           class="fa-stack position-absolute top-0 start-100 translate-middle fs-4">

--- a/src/registries/auto_completes/auto_complete_registry.ts
+++ b/src/registries/auto_completes/auto_complete_registry.ts
@@ -23,6 +23,7 @@ export interface AutoCompleteProvider {
   proposals: AutoCompleteProposal[];
   selectProposal(text: string): void;
   autoSelectFirstProposal: boolean;
+  canBeToggled?: boolean;
 }
 
 interface ComposerStoreInterface {
@@ -44,6 +45,7 @@ interface ComposerStoreInterface {
 export interface AutoCompleteProviderDefinition {
   sequence?: number;
   autoSelectFirstProposal?: boolean;
+  canBeToggled?: boolean;
   displayAllOnInitialContent?: boolean;
   maxDisplayedProposals?: number;
   getProposals(

--- a/src/registries/auto_completes/data_validation_auto_complete.ts
+++ b/src/registries/auto_completes/data_validation_auto_complete.ts
@@ -3,6 +3,7 @@ import { autoCompleteProviders } from "./auto_complete_registry";
 
 autoCompleteProviders.add("dataValidation", {
   displayAllOnInitialContent: true,
+  canBeToggled: false,
   getProposals(tokenAtCursor, content) {
     if (content.startsWith("=")) {
       return [];

--- a/tests/composer/autocomplete_dropdown_component.test.ts
+++ b/tests/composer/autocomplete_dropdown_component.test.ts
@@ -7,7 +7,7 @@ import { autoCompleteProviders } from "../../src/registries";
 import { Store } from "../../src/store_engine";
 import { ContentEditableHelper } from "../__mocks__/content_editable_helper";
 import { registerCleanup } from "../setup/jest.setup";
-import { selectCell } from "../test_helpers/commands_helpers";
+import { addDataValidation, selectCell } from "../test_helpers/commands_helpers";
 import {
   click,
   getElStyle,
@@ -379,6 +379,46 @@ describe("Functions autocomplete", () => {
       expect(document.activeElement).toBe(composerEl);
       expect(fixture.querySelectorAll(".o-autocomplete-value")).toHaveLength(2);
     });
+  });
+});
+
+describe("Data validation autocomplete", () => {
+  beforeEach(async () => {
+    ({ model, fixture, parent } = await mountComposerWrapper());
+  });
+
+  test("should not display close button in autocomplete for data validation", async () => {
+    addDataValidation(model, "A1", "id", {
+      type: "isValueInList",
+      values: ["1", "2", "3"],
+      displayStyle: "arrow",
+    });
+    await typeInComposer("");
+    expect(fixture.querySelectorAll(".o-autocomplete-value")).toHaveLength(3);
+    expect(fixture.querySelector(".fa-times-circle")).toBeFalsy();
+  });
+
+  test("closing formula assistant should not affect data validation autocomplete visibility", async () => {
+    addDataValidation(model, "A1", "id", {
+      type: "isValueInList",
+      values: [" 1", "2", "3"],
+      displayStyle: "arrow",
+    });
+
+    await typeInComposer("=SU");
+    expect(fixture.querySelectorAll(".o-autocomplete-value")).toHaveLength(1);
+    expect(fixture.querySelector(".fa-times-circle")).toBeTruthy();
+
+    await click(fixture, ".fa-times-circle");
+    expect(fixture.querySelectorAll(".o-autocomplete-value")).toHaveLength(0);
+    expect(fixture.querySelector(".fa-times-circle")).toBeFalsy();
+
+    await keyDown({ key: "Escape" });
+    await typeInComposer("");
+
+    expect(fixture.querySelectorAll(".o-autocomplete-value")).toHaveLength(3);
+    expect(fixture.querySelector(".fa-times-circle")).toBeFalsy();
+    expect(fixture.querySelector(".fa-question-circle")).toBeFalsy();
   });
 });
 


### PR DESCRIPTION
## Description:

Before this pr:
- The autocomplete assistant in data validation
included an open/close toggle button.

After this pr:
- The toggle button is removed in the data validation context to simplify the UI
and prevent accidental closure.

Task: [4854464](https://www.odoo.com/odoo/2328/tasks/4854464)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo