### PR TITLE
[FIX] Cells: newline is not a valid date separator

### DIFF
--- a/src/helpers/dates.ts
+++ b/src/helpers/dates.ts
@@ -3,7 +3,7 @@
 // -----------------------------------------------------------------------------
 
 import { CellValue, Format, Locale } from "../types";
-import { isDefined } from "./misc";
+import { isDefined, whiteSpaceCharacters } from "./misc";
 
 /**
  * All Spreadsheet dates are internally stored as an object with two values:
@@ -157,8 +157,12 @@ const DATE_JS_1900_OFFSET = INITIAL_JS_DAY.getTime() - INITIAL_1900_DAY.getTime(
 export const mdyDateRegexp = /^\d{1,2}(\/|-|\s)\d{1,2}((\/|-|\s)\d{1,4})?$/;
 export const ymdDateRegexp = /^\d{3,4}(\/|-|\s)\d{1,2}(\/|-|\s)\d{1,2}$/;
 
-const dateSeparatorsRegex = /\/|-|\s/;
-const dateRegexp = /^(\d{1,4})[\/-\s](\d{1,4})([\/-\s](\d{1,4}))?$/;
+const whiteSpaceChars = whiteSpaceCharacters.join("");
+
+const dateSeparatorsRegex = new RegExp(`\/|-|${whiteSpaceCharacters.join("|")}`);
+const dateRegexp = new RegExp(
+  `^(\\d{1,4})[\/${whiteSpaceChars}\-](\\d{1,4})([\/${whiteSpaceChars}\-](\\d{1,4}))?$`
+);
 
 export const timeRegexp = /((\d+(:\d+)?(:\d+)?\s*(AM|PM))|(\d+:\d+(:\d+)?))$/;
 

--- a/src/helpers/misc.ts
+++ b/src/helpers/misc.ts
@@ -480,6 +480,8 @@ export const specialWhiteSpaceRegexp = new RegExp(
 );
 const newLineRegexp = /(\r\n|\r)/g;
 
+export const whiteSpaceCharacters = specialWhiteSpaceSpecialCharacters.concat([" "]);
+
 /**
  * Replace all different newlines characters by \n
  */

--- a/tests/cells/cell_plugin.test.ts
+++ b/tests/cells/cell_plugin.test.ts
@@ -562,6 +562,16 @@ test.each([
 );
 
 test.each([
+  ["5 5", CellValueType.number],
+  ["5\n5", CellValueType.text],
+])("Date detection", (str, type) => {
+  const model = new Model();
+  setCellContent(model, "A1", str);
+  expect(getCellContent(model, "A1")).toEqual(str);
+  expect(getEvaluatedCell(model, "A1")?.type).toBe(type);
+});
+
+test.each([
   ["12/31/1999", "36525", "m/d/yyyy"],
   ["30€", "30", "#,##0[$€]"],
   ["50.69%", "0.5069", "0.00%"],


### PR DESCRIPTION
How to reproduce:
- Write "5\n5" in a cell

-> the cell is in error

It is detected as a date but the format parser crashes as it does not expect a newline character and rightfully so. If the user purposely adds a newline character, it is clear they are not trying to write something that looks like a number.

Task: 4910327

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo