### PR TITLE
[IMP] Cells: non-formula content with a newline is a string

### DIFF
--- a/src/helpers/cells/cell_evaluation.ts
+++ b/src/helpers/cells/cell_evaluation.ts
@@ -45,6 +45,9 @@ export function parseLiteral(content: string, locale: Locale): CellValue {
   if (content === "") {
     return null;
   }
+  if (content.includes("\n")) {
+    return content;
+  }
   if (isNumber(content, DEFAULT_LOCALE)) {
     return parseNumber(content, DEFAULT_LOCALE);
   }

--- a/tests/cells/cell_plugin.test.ts
+++ b/tests/cells/cell_plugin.test.ts
@@ -584,6 +584,18 @@ test.each([
   }
 );
 
+test.each(["5 \n", " \n 5", "5\n5", "fougere\n", "12:00 \n AM"])(
+  "content with a newline character is automatically a string",
+  (content) => {
+    const model = new Model();
+    setCellContent(model, "A1", content);
+    expect(getCellContent(model, "A1")).toEqual(content);
+    const evaluatedCell = getEvaluatedCell(model, "A1");
+    expect(evaluatedCell.type).toBe(CellValueType.text);
+    expect(evaluatedCell.value).toEqual(content);
+  }
+);
+
 describe("Cell dependencies and tokens are updated", () => {
   let model: Model;
 


### PR DESCRIPTION
There are no really valid and relevant number/boolean representation of numbers which contain newline/carriage return characters.

Right now, we will sometimes allow them (like for dates) but it does not make much sense and is not even properly handled by the format tokenizer.

Task: 4910760

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo