### PR TITLE
[IMP] pivot: allow grouping of dimension values

### DIFF
--- a/src/components/icons/icons.xml
+++ b/src/components/icons/icons.xml
@@ -809,12 +809,26 @@
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.PLUS_IN_BOX">
-    <svg
-      class="o-icon"
-      width="18"
-      height="18"
-      style="fill:none;stroke-linecap:round;stroke-linejoin:round;stroke-width:1.5">
-      <path stroke="currentColor" d="M1.5,1.5h15v15h-15v-15M9,5v8M5,9h8"/>
+    <svg class="o-icon" width="18" height="18" style="">
+      <path
+        fill="currentColor"
+        d="
+        M.5 2A1.5 1.5 0 0 1 2 .5h14A1.5 1.5 0 0 1 17.5 2v14a1.5 1.5 0 0 1-1.5 1.5H2A1.5 1.5 0 0 1 .5 16V2H2v14h14V2H2
+        M4,9.5 h10 v-1.5 h-10
+        M8.25,3.75 v10 h1.5 v-10
+        "
+      />
+    </svg>
+  </t>
+  <t t-name="o-spreadsheet-Icon.MINUS_IN_BOX">
+    <svg class="o-icon" width="18" height="18" style="">
+      <path
+        fill="currentColor"
+        d="
+        M.5 2A1.5 1.5 0 0 1 2 .5h14A1.5 1.5 0 0 1 17.5 2v14a1.5 1.5 0 0 1-1.5 1.5H2A1.5 1.5 0 0 1 .5 16V2H2v14h14V2H2
+        M4,9.5 h10 v-1.5 h-10
+        "
+      />
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.GROUP_ROWS">

--- a/src/components/side_panel/components/collapsible/side_panel_collapsible.xml
+++ b/src/components/side_panel/components/collapsible/side_panel_collapsible.xml
@@ -1,11 +1,12 @@
 <templates>
   <t t-name="o-spreadsheet-SidePanelCollapsible">
     <div class="" t-att-class="props.class">
-      <div class="o_side_panel_collapsible_title o-fw-bold d-flex align-items-center">
+      <div
+        class="o_side_panel_collapsible_title o-fw-bold d-flex align-items-center"
+        t-on-click="() => this.toggle()">
         <div
           class="collapsor w-100 d-flex align-items-center ps-1"
-          t-att-class="state.isCollapsed ? 'collapsed' : ''"
-          t-on-click="() => this.toggle()">
+          t-att-class="state.isCollapsed ? 'collapsed' : ''">
           <span class="collapsor-arrow">
             <t t-call="o-spreadsheet-Icon.ANGLE_DOWN"/>
           </span>

--- a/src/components/side_panel/pivot/pivot_custom_groups_collapsible/pivot_custom_groups_collapsible.scss
+++ b/src/components/side_panel/pivot/pivot_custom_groups_collapsible/pivot_custom_groups_collapsible.scss
@@ -1,0 +1,22 @@
+.o-spreadsheet .o-pivot-custom-groups {
+  .o_side_panel_collapsible_title {
+    font-size: 13px !important;
+    padding: 4px 0 4px 0 !important;
+
+    .collapsor > div {
+      padding-left: 2px !important;
+    }
+
+    .collapsor-arrow {
+      transform-origin: 5px 7px;
+      .o-icon {
+        width: 10px;
+        height: 14px;
+      }
+    }
+  }
+
+  .os-collapse > div {
+    padding: 0 !important;
+  }
+}

--- a/src/components/side_panel/pivot/pivot_custom_groups_collapsible/pivot_custom_groups_collapsible.ts
+++ b/src/components/side_panel/pivot/pivot_custom_groups_collapsible/pivot_custom_groups_collapsible.ts
@@ -1,0 +1,78 @@
+import { Component } from "@odoo/owl";
+import { deepCopy } from "../../../../helpers";
+import { getUniquePivotGroupName } from "../../../../helpers/pivot/pivot_helpers";
+import { _t } from "../../../../translation";
+import {
+  PivotCoreDefinition,
+  PivotCustomGroup,
+  PivotCustomGroupedField,
+  SpreadsheetChildEnv,
+  UID,
+} from "../../../../types";
+import { TextInput } from "../../../text_input/text_input";
+import { Checkbox } from "../../components/checkbox/checkbox";
+import { SidePanelCollapsible } from "../../components/collapsible/side_panel_collapsible";
+
+export interface Props {
+  pivotId: UID;
+  customField: PivotCustomGroupedField;
+  onCustomFieldUpdated: (definition: Partial<PivotCoreDefinition>) => void;
+}
+
+export class PivotCustomGroupsCollapsible extends Component<Props, SpreadsheetChildEnv> {
+  static template = "o-spreadsheet-PivotCustomGroupsCollapsible";
+  static props = {
+    pivotId: String,
+    customField: Object,
+    onCustomFieldUpdated: Function,
+  };
+  static components = { SidePanelCollapsible, TextInput, Checkbox };
+
+  get groups() {
+    return this.props.customField.groups.sort((a, b) => {
+      if (!a.isOtherGroup && !b.isOtherGroup) {
+        return 0;
+      }
+      return a.isOtherGroup ? 1 : -1;
+    });
+  }
+
+  get hasOthersGroup() {
+    return this.props.customField.groups.some((group) => group.isOtherGroup);
+  }
+
+  addOthersGroup() {
+    if (this.hasOthersGroup) {
+      return;
+    }
+    const newGroup: PivotCustomGroup = {
+      name: getUniquePivotGroupName(_t("Others"), this.props.customField),
+      values: [],
+      isOtherGroup: true,
+    };
+    const groups = [...this.props.customField.groups, newGroup];
+    this.updateCustomField({ ...this.props.customField, groups });
+  }
+
+  onDeleteGroup(groupIndex: number) {
+    const groups = [...this.props.customField.groups];
+    groups.splice(groupIndex, 1);
+    this.updateCustomField({ ...this.props.customField, groups });
+  }
+
+  onRenameGroup(groupIndex: number, newName: string) {
+    const groups = deepCopy(this.props.customField.groups);
+    const group = groups[groupIndex];
+    if (group) {
+      group.name = getUniquePivotGroupName(newName, this.props.customField);
+      this.updateCustomField({ ...this.props.customField, groups });
+    }
+  }
+
+  private updateCustomField(customField: PivotCustomGroupedField) {
+    const definition = this.env.model.getters.getPivotCoreDefinition(this.props.pivotId);
+    this.props.onCustomFieldUpdated({
+      customFields: { ...definition.customFields, [customField.name]: customField },
+    });
+  }
+}

--- a/src/components/side_panel/pivot/pivot_custom_groups_collapsible/pivot_custom_groups_collapsible.xml
+++ b/src/components/side_panel/pivot/pivot_custom_groups_collapsible/pivot_custom_groups_collapsible.xml
@@ -1,0 +1,37 @@
+<templates>
+  <t t-name="o-spreadsheet-PivotCustomGroupsCollapsible">
+    <SidePanelCollapsible
+      class="'o-pivot-custom-groups'"
+      isInitiallyCollapsed="true"
+      title.translate="Groups">
+      <t t-set-slot="content">
+        <div class="ps-4">
+          <div
+            t-foreach="groups"
+            t-as="group"
+            t-key="group_index"
+            class="o-pivot-custom-group pb-1">
+            <div
+              class="d-flex align-items-center justify-content-between small"
+              t-on-pointerdown.stop="">
+              <TextInput
+                value="group.name"
+                onChange="(newName) => this.onRenameGroup(group_index, newName)"
+              />
+              <i
+                class="o-button-icon ps-3 fa fa-trash"
+                t-on-click="() => this.onDeleteGroup(group_index)"
+              />
+            </div>
+          </div>
+          <div
+            t-if="!hasOthersGroup"
+            class="o-button-link o-add-others-group small pb-1"
+            t-on-click="() => this.addOthersGroup()">
+            <span>+ &quot;Others&quot; group</span>
+          </div>
+        </div>
+      </t>
+    </SidePanelCollapsible>
+  </t>
+</templates>

--- a/src/components/side_panel/pivot/pivot_layout_configurator/pivot_layout_configurator.ts
+++ b/src/components/side_panel/pivot/pivot_layout_configurator/pivot_layout_configurator.ts
@@ -22,6 +22,7 @@ import { ComposerFocusStore } from "../../../composer/composer_focus_store";
 import { css } from "../../../helpers";
 import { useDragAndDropListItems } from "../../../helpers/drag_and_drop_dom_items_hook";
 import { measureDisplayTerms } from "../../../translations_terms";
+import { PivotCustomGroupsCollapsible } from "../pivot_custom_groups_collapsible/pivot_custom_groups_collapsible";
 import { AddDimensionButton } from "./add_dimension_button/add_dimension_button";
 import { PivotDimension } from "./pivot_dimension/pivot_dimension";
 import { PivotDimensionGranularity } from "./pivot_dimension_granularity/pivot_dimension_granularity";
@@ -56,6 +57,7 @@ export class PivotLayoutConfigurator extends Component<Props, SpreadsheetChildEn
     PivotDimensionGranularity,
     PivotMeasureEditor,
     PivotSortSection,
+    PivotCustomGroupsCollapsible,
   };
   static props = {
     definition: Object,
@@ -281,6 +283,11 @@ export class PivotLayoutConfigurator extends Component<Props, SpreadsheetChildEn
         },
       ]),
     });
+  }
+
+  getCustomField(dimension: PivotDimensionType) {
+    const definition = this.env.model.getters.getPivotCoreDefinition(this.props.pivotId);
+    return definition.customFields?.[dimension.nameWithGranularity];
   }
 
   updateOrder(updateDimension: PivotDimensionType, order?: SortDirection) {

--- a/src/components/side_panel/pivot/pivot_layout_configurator/pivot_layout_configurator.xml
+++ b/src/components/side_panel/pivot/pivot_layout_configurator/pivot_layout_configurator.xml
@@ -23,6 +23,12 @@
               allGranularities="getGranularitiesFor(col)"
             />
             <PivotDimensionOrder dimension="col" onUpdated.bind="this.updateOrder"/>
+            <PivotCustomGroupsCollapsible
+              t-if="col.isCustomField"
+              pivotId="props.pivotId"
+              customField="getCustomField(col)"
+              onCustomFieldUpdated="props.onDimensionsUpdated"
+            />
           </PivotDimension>
         </div>
       </t>
@@ -49,6 +55,12 @@
               allGranularities="getGranularitiesFor(row)"
             />
             <PivotDimensionOrder dimension="row" onUpdated.bind="this.updateOrder"/>
+            <PivotCustomGroupsCollapsible
+              t-if="row.isCustomField"
+              pivotId="props.pivotId"
+              customField="getCustomField(row)"
+              onCustomFieldUpdated="props.onDimensionsUpdated"
+            />
           </PivotDimension>
         </div>
       </t>

--- a/src/functions/helpers.ts
+++ b/src/functions/helpers.ts
@@ -225,7 +225,7 @@ export function toJsDate(
   return numberToJsDate(toNumber(value, locale));
 }
 
-function toValue(data: FunctionResultObject | CellValue | undefined): CellValue | undefined {
+export function toValue(data: FunctionResultObject | CellValue | undefined): CellValue | undefined {
   if (typeof data === "object" && data !== null && "value" in data) {
     if (isEvaluationError(data.value)) {
       throw data;

--- a/src/helpers/pivot/pivot_menu_items.ts
+++ b/src/helpers/pivot/pivot_menu_items.ts
@@ -1,9 +1,27 @@
-import { SortDirection, SpreadsheetChildEnv } from "../..";
+import {
+  CellValue,
+  PivotCoreDefinition,
+  PivotCustomGroup,
+  PivotCustomGroupedField,
+  PivotField,
+  PivotFields,
+  PivotHeaderCell,
+  SortDirection,
+  SpreadsheetChildEnv,
+} from "../..";
 import { ActionSpec } from "../../actions/action";
 import { _t } from "../../translation";
 import { CellValueType } from "../../types";
-import { deepEquals } from "../misc";
+import { deepCopy, deepEquals } from "../misc";
+import { cellPositions } from "../zones";
 import { domainToColRowDomain } from "./pivot_domain_helpers";
+import {
+  addDimensionToPivotDefinition,
+  getCustomFieldWithParentField,
+  getUniquePivotGroupName,
+  removePivotGroupsContainingValues,
+} from "./pivot_helpers";
+import { pivotRegistry } from "./pivot_registry";
 
 export const pivotProperties: ActionSpec = {
   name: _t("See pivot properties"),
@@ -78,6 +96,114 @@ export const FIX_FORMULAS: ActionSpec = {
   icon: "o-spreadsheet-Icon.PIVOT",
 };
 
+export const groupPivotHeaders: ActionSpec = {
+  name: _t("Group pivot dimensions"),
+  execute: (env) => {
+    const matchingHeaders = getMatchingPivotHeadersInSelection(env);
+    if (!matchingHeaders) {
+      return;
+    }
+    const { pivotId, values, field } = matchingHeaders;
+    const pivot = env.model.getters.getPivot(pivotId);
+    const definition = deepCopy(env.model.getters.getPivotCoreDefinition(pivotId));
+
+    if (!field.isCustomField) {
+      groupValuesInNormalField(definition, values, field, pivot.getFields());
+    } else {
+      const customField = (definition.customFields || {})[field.name];
+      if (!customField) {
+        return;
+      }
+      groupValuesInCustomField(customField, values);
+    }
+
+    env.model.dispatch("UPDATE_PIVOT", { pivotId, pivot: definition });
+  },
+  isVisible: (env) => {
+    const matchingHeaders = getMatchingPivotHeadersInSelection(env);
+    if (!matchingHeaders) {
+      return false;
+    }
+    const { pivotId, values, field } = matchingHeaders;
+    const pivot = env.model.getters.getPivot(pivotId);
+    return (
+      values.length > 1 &&
+      (field.isCustomField || pivotRegistry.get(pivot.type).canHaveCustomGroup(field))
+    );
+  },
+};
+
+export const groupRemainingPivotHeadersAction: ActionSpec = {
+  name: _t("Group all remaining dimensions"),
+  execute: (env) => {
+    const matchingHeaders = getMatchingPivotHeadersInSelection(env);
+    if (!matchingHeaders) {
+      return;
+    }
+    const { pivotId, field } = matchingHeaders;
+    const pivot = env.model.getters.getPivot(pivotId);
+    const definition = deepCopy(env.model.getters.getPivotCoreDefinition(pivotId));
+
+    const customField = field.isCustomField
+      ? (definition.customFields || {})[field.name]
+      : getCustomFieldWithParentField(definition, field, pivot.getFields());
+    if (!customField) {
+      return;
+    }
+    customField.groups.push({
+      name: getUniquePivotGroupName(_t("Others"), customField),
+      values: [],
+      isOtherGroup: true,
+    });
+    addDimensionToPivotDefinition(definition, field.name, customField.name);
+    env.model.dispatch("UPDATE_PIVOT", { pivotId, pivot: definition });
+  },
+  isVisible: (env) => {
+    const matchingHeaders = getMatchingPivotHeadersInSelection(env);
+    if (!matchingHeaders) {
+      return false;
+    }
+    const { pivotId, field, values } = matchingHeaders;
+    return valuesAreAllNonGroupedValues(env, pivotId, values, field);
+  },
+};
+
+export const ungroupPivotHeadersAction: ActionSpec = {
+  name: _t("Ungroup pivot dimensions"),
+  execute: (env) => {
+    const matchingHeaders = getMatchingPivotHeadersInSelection(env);
+    if (!matchingHeaders) {
+      return;
+    }
+    const { pivotId, values, field } = matchingHeaders;
+    const pivot = env.model.getters.getPivot(pivotId);
+    const definition = deepCopy(env.model.getters.getPivotCoreDefinition(pivotId));
+    ungroupPivotHeaders(definition, values, field, pivot.getFields());
+
+    env.model.dispatch("UPDATE_PIVOT", { pivotId, pivot: definition });
+  },
+  isVisible: (env) => {
+    const matchingHeaders = getMatchingPivotHeadersInSelection(env);
+    if (!matchingHeaders) {
+      return false;
+    }
+    const { pivotId, values, field } = matchingHeaders;
+    const pivot = env.model.getters.getPivot(pivotId);
+    const definition = env.model.getters.getPivotCoreDefinition(pivotId);
+
+    if (!field.isCustomField) {
+      // Check if the parent custom grouped field is in the pivot
+      const customField = getCustomFieldWithParentField(definition, field, pivot.getFields());
+      const dimensions = [...definition.rows, ...definition.columns];
+      if (!dimensions.some((d) => d.fieldName === customField.name)) {
+        return false;
+      }
+    }
+
+    return areFieldValuesInGroups(definition, values, field, pivot.getFields());
+  },
+};
+
 export function canSortPivot(env: SpreadsheetChildEnv): boolean {
   const position = env.model.getters.getActivePosition();
   const pivotId = env.model.getters.getPivotIdFromPosition(position);
@@ -148,4 +274,234 @@ function isPivotSortMenuItemActive(
     return false;
   }
   return sortedColumn.measure === pivotCell.measure && deepEquals(sortedColumn.domain, colDomain);
+}
+
+/*
+ * Get the values of the pivot headers in the current selection, if all the pivot headers on the selection belong
+ * to the same pivot, the same field and that the pivot formula is a dynamic pivot. Otherwise return undefined.
+ */
+function getMatchingPivotHeadersInSelection(env: SpreadsheetChildEnv) {
+  let pivotId: string | undefined;
+  let fieldName: string | undefined;
+  const pivotHeaders: PivotHeaderCell[] = [];
+  for (const zone of env.model.getters.getSelectedZones()) {
+    const sheetId = env.model.getters.getActiveSheetId();
+    for (const position of cellPositions(sheetId, zone)) {
+      const cellPivotId = env.model.getters.getPivotIdFromPosition(position);
+      if (!pivotId) {
+        pivotId = cellPivotId;
+      } else if (cellPivotId && pivotId !== cellPivotId) {
+        return undefined;
+      }
+      if (!pivotId) {
+        continue;
+      }
+      const pivotCell = env.model.getters.getPivotCellFromPosition(position);
+      if (pivotCell.type !== "HEADER" || !env.model.getters.isSpillPivotFormula(position)) {
+        continue;
+      }
+      const cellLeafField = pivotCell.domain.at(-1)?.field;
+      if (!fieldName && cellLeafField) {
+        fieldName = cellLeafField;
+      } else if (fieldName && cellLeafField && fieldName !== cellLeafField) {
+        return undefined;
+      }
+      pivotHeaders.push(pivotCell);
+    }
+  }
+  if (!pivotId || !fieldName || pivotHeaders.length === 0) {
+    return undefined;
+  }
+
+  const field = env.model.getters.getPivot(pivotId).getFields()[fieldName];
+  if (!field) {
+    return undefined;
+  }
+  const values = pivotHeaders
+    .map((pivotCell) => pivotCell.domain.at(-1)?.value)
+    .filter((val) => val !== undefined);
+
+  return { pivotId, values, field };
+}
+
+/**
+ *  Remove existing groups containing the selected values, and create a new group
+ */
+function groupValuesInNormalField(
+  definition: PivotCoreDefinition,
+  selectedValues: CellValue[],
+  field: PivotField,
+  fields: PivotFields
+) {
+  const customField = getCustomFieldWithParentField(definition, field, fields);
+
+  removePivotGroupsContainingValues(selectedValues, customField);
+  const newGroup: PivotCustomGroup = {
+    name: getUniquePivotGroupName(_t("Group"), customField),
+    values: selectedValues,
+  };
+  customField.groups.push(newGroup);
+
+  if (!definition.customFields) {
+    definition.customFields = {};
+  }
+  definition.customFields[customField.name] = customField;
+  addDimensionToPivotDefinition(definition, field.name, customField.name);
+}
+
+/**
+ * We either merge the selected values into a single existing group, or create a new group
+ */
+function groupValuesInCustomField(customField: PivotCustomGroupedField, fieldValues: CellValue[]) {
+  const valuesToGroup: Set<CellValue> = new Set();
+  const groupsInSelection: PivotCustomGroup[] = [];
+  for (const value of fieldValues) {
+    const group = customField.groups.find((g) => g.name === value);
+    if (group) {
+      groupsInSelection.push(group);
+      group.values.forEach((v) => valuesToGroup.add(v));
+    } else {
+      valuesToGroup.add(value);
+    }
+  }
+
+  if (groupsInSelection.some((g) => g.isOtherGroup)) {
+    customField.groups = customField.groups.filter(
+      (g) => g.isOtherGroup || !groupsInSelection.includes(g)
+    );
+  } else if (groupsInSelection.length === 0) {
+    const newGroup: PivotCustomGroup = {
+      name: getUniquePivotGroupName(_t("Group"), customField),
+      values: fieldValues,
+    };
+    customField.groups.push(newGroup);
+  } else {
+    const groupsToRemove = groupsInSelection.slice(1);
+    customField.groups = customField.groups.filter((g) => !groupsToRemove.includes(g));
+    groupsInSelection[0].values = Array.from(valuesToGroup);
+  }
+}
+
+function ungroupPivotHeaders(
+  definition: PivotCoreDefinition,
+  fieldValues: CellValue[],
+  field: PivotField,
+  fields: PivotFields
+) {
+  let customField: PivotCustomGroupedField | undefined;
+  // Non-custom field: remove existing groups containing the selected values
+  if (!field.isCustomField) {
+    customField = getCustomFieldWithParentField(definition, field, fields);
+
+    // Check if some values are in the  "Others" group
+    if (
+      customField.groups.some((g) => g.isOtherGroup) &&
+      fieldValues.some((v) => !customField?.groups.some((g) => g.values.includes(v)))
+    ) {
+      customField.groups = customField.groups.filter((g) => !g.isOtherGroup);
+    }
+    removePivotGroupsContainingValues(fieldValues, customField);
+  }
+  // Custom field: remove the selected groups
+  else {
+    customField = (definition.customFields || {})[field.name];
+    if (!customField) {
+      return;
+    }
+    customField.groups = customField.groups.filter((g) => !fieldValues.includes(g.name));
+  }
+
+  if (customField.groups.every((g) => g.values.length === 0 && !g.isOtherGroup)) {
+    removeCustomFieldFromDimensions(definition, customField.name);
+    delete definition.customFields?.[customField.name];
+  }
+}
+
+/**
+ * Checks if the given field values are in any of the groups of the given field.
+ */
+function areFieldValuesInGroups(
+  definition: PivotCoreDefinition,
+  fieldValues: CellValue[],
+  field: PivotField,
+  fields: PivotFields
+): boolean {
+  // If the field is not a custom field, check if there are any custom groups containing the selected values
+  if (!field.isCustomField) {
+    const customField = getCustomFieldWithParentField(definition, field, fields);
+    return customField.groups.some(
+      (group) => group.isOtherGroup || fieldValues.some((value) => group.values.includes(value))
+    );
+  }
+  // If the field is a custom field, check if there are any groups named after the selected values
+  else {
+    const customField = (definition.customFields || {})[field.name];
+    if (!customField) {
+      return false;
+    }
+    return customField.groups.some((group) => fieldValues.includes(group.name));
+  }
+}
+
+/** Checks that the values given are equal to all the values that are not grouped in the pivot dimension. */
+function valuesAreAllNonGroupedValues(
+  env: SpreadsheetChildEnv,
+  pivotId: string,
+  values: CellValue[],
+  field: PivotField
+): boolean {
+  const pivot = env.model.getters.getPivot(pivotId);
+  const definition = env.model.getters.getPivotCoreDefinition(pivotId);
+  const customField = field.isCustomField
+    ? (definition.customFields || {})[field.name]
+    : Object.values(definition.customFields || {}).find((f) => f.parentField === field.name);
+
+  const dimension = pivot.definition.getDimension(field.name);
+  if (
+    !dimension ||
+    !customField ||
+    areFieldValuesInGroups(definition, values, field, pivot.getFields())
+  ) {
+    return false;
+  }
+
+  const possibleValues: Set<CellValue> = new Set(
+    pivot.getPossibleFieldValues(dimension).map((v) => v.value)
+  );
+
+  const groupValues = field.isCustomField
+    ? customField.groups.map((g) => g.name)
+    : customField.groups.flatMap((g) => g.values);
+
+  for (const val of [...values, ...groupValues]) {
+    possibleValues.delete(val);
+  }
+
+  return possibleValues.size === 0;
+}
+
+/**
+ * Remove the given custom field from the rows/columns of the pivot, and replace it by the field it's based on (if the
+ * field isn't already in the pivot). Modifies the definition in place.
+ */
+function removeCustomFieldFromDimensions(definition: PivotCoreDefinition, customFieldName: string) {
+  const customField = definition.customFields?.[customFieldName];
+  if (!customField) {
+    return;
+  }
+
+  const isParentFieldInDimensions = [...definition.rows, ...definition.columns].some(
+    (d) => d.fieldName === customField.parentField
+  );
+
+  for (const dim of [definition.rows, definition.columns]) {
+    const indexInDimension = dim.findIndex((d) => d.fieldName === customFieldName);
+    if (indexInDimension !== -1) {
+      if (!isParentFieldInDimensions) {
+        dim.splice(indexInDimension, 1, { fieldName: customField.parentField });
+      } else {
+        dim.splice(indexInDimension, 1);
+      }
+    }
+  }
 }

--- a/src/helpers/pivot/pivot_registry.ts
+++ b/src/helpers/pivot/pivot_registry.ts
@@ -33,6 +33,7 @@ export interface PivotRegistryItem {
   datetimeGranularities: string[];
   isMeasureCandidate: (field: PivotField) => boolean;
   isGroupable: (field: PivotField) => boolean;
+  canHaveCustomGroup: (field: PivotField) => boolean;
 }
 
 export const pivotRegistry = new Registry<PivotRegistryItem>();
@@ -56,4 +57,5 @@ pivotRegistry.add("SPREADSHEET", {
   datetimeGranularities: [...dateGranularities, "hour_number", "minute_number", "second_number"],
   isMeasureCandidate: (field: PivotField) => field.type !== "boolean",
   isGroupable: () => true,
+  canHaveCustomGroup: (field: PivotField) => field.type === "char" && !field.isCustomField,
 });

--- a/src/helpers/pivot/spreadsheet_pivot/data_entry_spreadsheet_pivot.ts
+++ b/src/helpers/pivot/spreadsheet_pivot/data_entry_spreadsheet_pivot.ts
@@ -235,12 +235,20 @@ export function orderDataEntriesKeys(
   dimension: PivotDimension
 ): string[] {
   const order = dimension.order;
-  if (!order) {
+  const othersGroup = dimension.customGroups?.find((group) => group.isOtherGroup);
+  if (!order && !othersGroup) {
     return Object.keys(groups);
   }
-  return Object.keys(groups).sort((a: string, b: string) =>
-    compareDimensionValues(dimension, a, b)
-  );
+
+  return Object.keys(groups).sort((a: string, b: string) => {
+    if (othersGroup && a === othersGroup.name) {
+      return 1;
+    }
+    if (othersGroup && b === othersGroup.name) {
+      return -1;
+    }
+    return order ? compareDimensionValues(dimension, a, b) : 0;
+  });
 }
 
 /**

--- a/src/helpers/pivot/spreadsheet_pivot/spreadsheet_pivot.ts
+++ b/src/helpers/pivot/spreadsheet_pivot/spreadsheet_pivot.ts
@@ -10,6 +10,7 @@ import {
   Maybe,
   Range,
   UID,
+  ValueAndLabel,
   Zone,
 } from "../../../types";
 import { CellErrorType, EvaluationError } from "../../../types/errors";
@@ -26,10 +27,12 @@ import {
 import { InitPivotParams, Pivot } from "../../../types/pivot_runtime";
 import { toXC } from "../../coordinates";
 import { formatValue, isDateTimeFormat } from "../../format/format";
-import { deepEquals, getUniqueText, isDefined } from "../../misc";
+import { deepEquals, isDefined } from "../../misc";
 import {
   AGGREGATORS_FN,
   areDomainArgsFieldsValid,
+  createCustomFields,
+  getUniquePivotFieldName,
   parseDimension,
   toNormalizedPivotValue,
 } from "../pivot_helpers";
@@ -38,8 +41,8 @@ import { pivotTimeAdapter } from "../pivot_time_adapter";
 import { SpreadsheetPivotTable } from "../table_spreadsheet_pivot";
 import {
   DataEntries,
-  DataEntry,
   dataEntriesToSpreadsheetPivotTable,
+  DataEntry,
   groupPivotDataEntriesBy,
   orderDataEntriesKeys,
 } from "./data_entry_spreadsheet_pivot";
@@ -292,10 +295,8 @@ export class SpreadsheetPivot implements Pivot<SpreadsheetPivotRuntimeDefinition
     }
   }
 
-  getPossibleFieldValues(
-    dimension: PivotDimension
-  ): { value: string | number | boolean; label: string }[] {
-    const values: { value: string | number | boolean; label: string }[] = [];
+  getPossibleFieldValues(dimension: PivotDimension): ValueAndLabel<string | number | boolean>[] {
+    const values: ValueAndLabel<string | number | boolean>[] = [];
     const groups = groupPivotDataEntriesBy(this.dataEntries, dimension);
     const orderedKeys = orderDataEntriesKeys(groups, dimension);
     for (const key of orderedKeys) {
@@ -349,7 +350,12 @@ export class SpreadsheetPivot implements Pivot<SpreadsheetPivotRuntimeDefinition
       const { zone, sheetId } = this.coreDefinition.dataSet;
       const range = this.getters.getRangeFromZone(sheetId, zone);
       try {
-        return this.extractFieldsFromRange(range);
+        const extractedMetaData = this.extractFieldsFromRange(range);
+        const customFields = createCustomFields(this.coreDefinition, extractedMetaData.fields);
+        return {
+          ...extractedMetaData,
+          fields: { ...extractedMetaData.fields, ...customFields },
+        };
       } catch (e) {
         this.invalidRangeError = e;
         return { fields: {}, fieldKeys: [] };
@@ -469,7 +475,7 @@ export class SpreadsheetPivot implements Pivot<SpreadsheetPivotRuntimeDefinition
           bottom: range.zone.bottom,
           right: col,
         });
-        const string = this.findName(field, fields);
+        const string = getUniquePivotFieldName(field, fields);
         fields[string] = {
           name: string,
           type,
@@ -480,16 +486,6 @@ export class SpreadsheetPivot implements Pivot<SpreadsheetPivotRuntimeDefinition
       }
     }
     return { fields, fieldKeys };
-  }
-
-  /**
-   * Take cares of double names
-   */
-  private findName(name: string, fields: PivotFields) {
-    return getUniqueText(name, Object.keys(fields), {
-      compute: (name, i) => `${name}${i}`,
-      start: 2,
-    });
   }
 
   private extractDataEntriesFromRange(range: Range): DataEntries {
@@ -510,6 +506,23 @@ export class SpreadsheetPivot implements Pivot<SpreadsheetPivotRuntimeDefinition
         } else {
           entry[field.name] = cell;
         }
+      }
+      for (const customFieldName in this.definition.customFields || {}) {
+        const customField = this.definition.customFields?.[customFieldName];
+        if (!customField) continue;
+        const baseValue = entry[customField.parentField];
+        const parentField = this.fields[customField.parentField];
+        if (!baseValue || !parentField) {
+          entry[customFieldName] = { value: null, type: CellValueType.empty, formattedValue: "" };
+          continue;
+        }
+        const group =
+          customField.groups.find((g) => g.values.some((v) => v === baseValue?.value)) ||
+          customField.groups.find((g) => g.isOtherGroup);
+        entry[customFieldName] = {
+          ...baseValue,
+          value: group ? group.name : baseValue.value,
+        };
       }
       entry["__count"] = { value: 1, type: CellValueType.number, formattedValue: "1" };
       dataEntries.push(entry);

--- a/src/helpers/zones.ts
+++ b/src/helpers/zones.ts
@@ -1,4 +1,4 @@
-import { CellPosition, Position, UnboundedZone, Zone, ZoneDimension } from "../types";
+import { CellPosition, Position, UID, UnboundedZone, Zone, ZoneDimension } from "../types";
 import {
   MAX_COL,
   MAX_ROW,
@@ -470,6 +470,21 @@ export function positions(zone: Zone): Position[] {
   for (const col of range(left, right + 1)) {
     for (const row of range(top, bottom + 1)) {
       positions.push({ col, row });
+    }
+  }
+  return positions;
+}
+
+/**
+ * Array of all cell positions in the zone.
+ */
+export function cellPositions(sheetId: UID, zone: Zone): CellPosition[] {
+  const positions: CellPosition[] = [];
+
+  const { left, right, top, bottom } = reorderZone(zone);
+  for (const col of range(left, right + 1)) {
+    for (const row of range(top, bottom + 1)) {
+      positions.push({ sheetId, col, row });
     }
   }
   return positions;

--- a/src/index.ts
+++ b/src/index.ts
@@ -134,6 +134,7 @@ import * as CHART_HELPERS from "./helpers/figures/charts";
 import * as CHART_RUNTIME_HELPERS from "./helpers/figures/charts/runtime";
 import {
   areDomainArgsFieldsValid,
+  createCustomFields,
   createPivotFormula,
   getMaxObjectId,
   isDateOrDatetimeField,
@@ -369,6 +370,7 @@ export const helpers = {
   getUniqueText,
   isNumber,
   isDateTime,
+  createCustomFields,
 };
 
 export const links = {

--- a/src/registries/menus/cell_menu_registry.ts
+++ b/src/registries/menus/cell_menu_registry.ts
@@ -107,6 +107,21 @@ cellMenuRegistry
     sequence: 150,
     separator: true,
   })
+  .add("pivot_headers_group", {
+    sequence: 155,
+    icon: "o-spreadsheet-Icon.PLUS_IN_BOX",
+    ...ACTIONS_PIVOT.groupPivotHeaders,
+  })
+  .add("pivot_group_remaining", {
+    sequence: 155,
+    icon: "o-spreadsheet-Icon.PLUS_IN_BOX",
+    ...ACTIONS_PIVOT.groupRemainingPivotHeadersAction,
+  })
+  .add("pivot_headers_ungroup", {
+    sequence: 155,
+    icon: "o-spreadsheet-Icon.MINUS_IN_BOX",
+    ...ACTIONS_PIVOT.ungroupPivotHeadersAction,
+  })
   .add("pivot_sorting", {
     name: _t("Sort pivot"),
     sequence: 155,

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -1373,6 +1373,7 @@ export const enum CommandResult {
   InvalidDefinition = "InvalidDefinition",
   InvalidColor = "InvalidColor",
   InvalidPivotDataSet = "InvalidPivotDataSet",
+  InvalidPivotCustomField = "InvalidPivotCustomField",
 }
 
 export interface CommandHandler<T> {

--- a/src/types/misc.ts
+++ b/src/types/misc.ts
@@ -411,3 +411,8 @@ export type EditionMode =
   | "inactive";
 
 export type SortDirection = "asc" | "desc";
+
+export interface ValueAndLabel<T = string> {
+  value: T;
+  label: string;
+}

--- a/src/types/pivot.ts
+++ b/src/types/pivot.ts
@@ -34,6 +34,9 @@ export interface PivotCoreDimension {
   fieldName: string;
   order?: SortDirection;
   granularity?: Granularity | string;
+  isCustomField?: boolean;
+  parentField?: string;
+  customGroups?: PivotCustomGroup[];
 }
 
 export interface PivotCoreMeasure {
@@ -59,6 +62,7 @@ export interface CommonPivotCoreDefinition {
   deferUpdates?: boolean;
   sortedColumn?: PivotSortedColumn;
   collapsedDomains?: PivotCollapsedDomains;
+  customFields?: Record<string, PivotCustomGroupedField>;
 }
 
 export interface PivotSortedColumn {
@@ -70,6 +74,18 @@ export interface PivotSortedColumn {
 export interface PivotCollapsedDomains {
   COL: PivotDomain[];
   ROW: PivotDomain[];
+}
+
+export interface PivotCustomGroupedField {
+  parentField: string;
+  name: string;
+  groups: PivotCustomGroup[];
+}
+
+export interface PivotCustomGroup {
+  name: string;
+  values: CellValue[];
+  isOtherGroup?: boolean;
 }
 
 export interface SpreadsheetPivotCoreDefinition extends CommonPivotCoreDefinition {
@@ -94,6 +110,9 @@ export interface PivotField {
   string: string;
   aggregator?: string;
   help?: string;
+  isCustomField?: boolean;
+  parentField?: string;
+  customGroups?: PivotCustomGroup[];
 }
 
 export type PivotFields = Record<TechnicalName, PivotField | undefined>;

--- a/tests/pivots/pivot_custom_groups/pivot_custom_groups_component.test.ts
+++ b/tests/pivots/pivot_custom_groups/pivot_custom_groups_component.test.ts
@@ -1,0 +1,102 @@
+import { Model } from "../../../src";
+import { SidePanels } from "../../../src/components/side_panel/side_panels/side_panels";
+import { PivotCustomGroupedField, SpreadsheetChildEnv } from "../../../src/types";
+import { setCellContent } from "../../test_helpers/commands_helpers";
+import { click, setInputValueAndTrigger } from "../../test_helpers/dom_helper";
+import { mountComponentWithPortalTarget, nextTick } from "../../test_helpers/helpers";
+import { createModelWithPivot, updatePivot } from "../../test_helpers/pivot_helpers";
+
+let model: Model;
+let pivotId: string;
+let fixture: HTMLElement;
+let env: SpreadsheetChildEnv;
+
+const TEST_CUSTOM_FIELD: PivotCustomGroupedField = {
+  parentField: "Opportunity",
+  name: "CustomField",
+  groups: [{ name: "MyGroup", values: ["Value1", "Value2"] }],
+};
+
+beforeEach(async () => {
+  model = createModelWithPivot("A1:I5");
+  ({ fixture, env } = await mountComponentWithPortalTarget(SidePanels, { model }));
+  pivotId = model.getters.getPivotIds()[0];
+  setCellContent(model, "A40", "=PIVOT(1)");
+});
+
+async function openPivotSidePanel() {
+  env.openSidePanel("PivotSidePanel", { pivotId });
+  await nextTick();
+}
+
+describe("Pivot custom field panel", () => {
+  test("Can edit group name", async () => {
+    updatePivot(model, pivotId, {
+      rows: [{ fieldName: "CustomField" }],
+      customFields: { CustomField: TEST_CUSTOM_FIELD },
+    });
+    await openPivotSidePanel();
+    await setInputValueAndTrigger(".o-pivot-custom-group  input.os-input", "New group name");
+    expect(model.getters.getPivotCoreDefinition(pivotId).customFields).toMatchObject({
+      CustomField: {
+        groups: [{ name: "New group name", values: ["Value1", "Value2"] }],
+      },
+    });
+  });
+
+  test("Can delete a group", async () => {
+    updatePivot(model, pivotId, {
+      rows: [{ fieldName: "CustomField" }],
+      customFields: { CustomField: TEST_CUSTOM_FIELD },
+    });
+    await openPivotSidePanel();
+    await click(fixture, ".o-pivot-custom-group  .fa-trash");
+    const definition = model.getters.getPivotCoreDefinition(pivotId);
+    expect(definition.customFields?.CustomField.groups).toEqual([]);
+  });
+
+  test("Can add a group with all the non-grouped values", async () => {
+    updatePivot(model, pivotId, {
+      rows: [{ fieldName: "CustomField" }],
+      customFields: { CustomField: TEST_CUSTOM_FIELD },
+    });
+    await openPivotSidePanel();
+    await click(fixture, ".o-add-others-group");
+
+    expect(".o-add-others-group").toHaveCount(0);
+    expect(model.getters.getPivotCoreDefinition(pivotId).customFields).toMatchObject({
+      CustomField: {
+        name: "CustomField",
+        groups: [
+          { name: "MyGroup", values: ["Value1", "Value2"] },
+          { name: "Others", values: [], isOtherGroup: true },
+        ],
+      },
+    });
+  });
+
+  test("Cannot have duplicate group names", async () => {
+    updatePivot(model, pivotId, {
+      rows: [{ fieldName: "CustomField" }],
+      customFields: {
+        CustomField: {
+          parentField: "Opportunity",
+          name: "CustomField",
+          groups: [{ name: "Others", values: ["Value1", "Value2"] }],
+        },
+      },
+    });
+    await openPivotSidePanel();
+    await click(fixture, ".o-add-others-group");
+
+    expect(model.getters.getPivotCoreDefinition(pivotId).customFields).toMatchObject({
+      CustomField: {
+        name: "CustomField",
+        groups: [
+          { name: "Others", values: ["Value1", "Value2"] },
+          { name: "Others2", values: [], isOtherGroup: true },
+        ],
+      },
+    });
+  });
+});

--- a/tests/pivots/pivot_custom_groups/pivot_custom_groups_model.test.ts
+++ b/tests/pivots/pivot_custom_groups/pivot_custom_groups_model.test.ts
@@ -1,0 +1,260 @@
+import { CommandResult, Model, PivotCustomGroupedField, UID } from "../../../src";
+import { setCellContent } from "../../test_helpers/commands_helpers";
+import { getFormattedGrid, target } from "../../test_helpers/helpers";
+import { createModelWithPivot, updatePivot } from "../../test_helpers/pivot_helpers";
+
+let model: Model;
+let pivotId: string;
+let sheetId: UID;
+
+const GROUPED_STAGES_FIELD: PivotCustomGroupedField = {
+  parentField: "Stage",
+  name: "GroupedStages",
+  groups: [
+    { name: "Initial", values: ["New", "Proposition"] },
+    { name: "Final", values: ["Qualified", "Won"] },
+  ],
+};
+
+const GROUPED_OPPORTUNITIES_FIELD: PivotCustomGroupedField = {
+  parentField: "Opportunity",
+  name: "GroupedOpportunities",
+  groups: [
+    { name: "First Group", values: ["my opportunity", "test opportunity"] },
+    { name: "Second Group", values: ["5 VP Chairs", "Access to Online Catalog"] },
+    { name: "Others", isOtherGroup: true, values: [] },
+  ],
+};
+
+beforeEach(() => {
+  model = createModelWithPivot("A1:I22");
+  sheetId = model.getters.getActiveSheetId();
+  model.dispatch("CLEAR_FORMATTING", { sheetId, target: target("F2:F22") });
+  pivotId = model.getters.getPivotIds()[0];
+  setCellContent(model, "A30", "=PIVOT(1)");
+});
+
+describe("Custom field are checked for validity", () => {
+  test("Cannot have duplicated group names", () => {
+    const customField = {
+      ...GROUPED_STAGES_FIELD,
+      groups: [
+        { name: "aa", values: ["New"] },
+        { name: "aa", values: ["Won"] },
+      ],
+    };
+    const result = updatePivot(model, pivotId, { customFields: { GroupedStages: customField } });
+    expect(result).toBeCancelledBecause(CommandResult.InvalidPivotCustomField);
+  });
+
+  test("Cannot have values in multiple groups", () => {
+    const customField = {
+      ...GROUPED_STAGES_FIELD,
+      groups: [
+        { name: "aa", values: ["New"] },
+        { name: "bb", values: ["New"] },
+      ],
+    };
+    const result = updatePivot(model, pivotId, { customFields: { GroupedStages: customField } });
+    expect(result).toBeCancelledBecause(CommandResult.InvalidPivotCustomField);
+  });
+
+  test("Cannot have multiple others groups", () => {
+    const customField = {
+      ...GROUPED_STAGES_FIELD,
+      groups: [
+        { name: "aa", values: [], isOtherGroup: true },
+        { name: "bb", values: [], isOtherGroup: true },
+      ],
+    };
+    const result = updatePivot(model, pivotId, { customFields: { GroupedStages: customField } });
+    expect(result).toBeCancelledBecause(CommandResult.InvalidPivotCustomField);
+  });
+
+  test("Custom field with a wrong parent fields are flagged as invalid", () => {
+    const customField = { ...GROUPED_STAGES_FIELD, parentField: "UnknownField" };
+    const result = updatePivot(model, pivotId, {
+      rows: [{ fieldName: "GroupedStages" }],
+      customFields: { GroupedStages: customField },
+    });
+    expect(result).toBeSuccessfullyDispatched(); // We don't know what fields exist in the core plugin
+
+    const pivot = model.getters.getPivot(pivotId);
+    expect(pivot.definition.rows[0].isValid).toBe(false);
+  });
+});
+
+describe("Custom fields tests", () => {
+  test("Can have a custom field", () => {
+    updatePivot(model, pivotId, {
+      columns: [
+        { fieldName: "GroupedStages", order: "desc" },
+        { fieldName: "Stage", order: "asc" },
+      ],
+      rows: [{ fieldName: "Salesperson", order: "asc" }],
+      measures: [{ fieldName: "Expected Revenue", aggregator: "sum", id: "Expected Revenue:sum" }],
+      customFields: { GroupedStages: GROUPED_STAGES_FIELD },
+    });
+
+    // prettier-ignore
+    expect(getFormattedGrid(model)).toMatchObject({
+        A30:"My pivot",       B30: "Initial",  C30: "",             D30: "Final",      E30: "",       F30: "",
+        A31: "",              B31: "New",      C31: "Proposition",  D31: "Qualified",  E31: "Won",    F31: "Total",
+        A33: "Eden",          B33: "24000",    C33: "15000",        D33: "36000",      E33: "2000",   F33: "77000",
+        A34: "Kevin",         B34: "97500",    C34: "74600",        D34: "51300",      E34: "19800",  F34: "243200",
+        A35: "Total",         B35: "121500",   C35: "89600",        D35: "87300",      E35: "21800",  F35: "320200",
+    });
+  });
+
+  test("Can have an others group will all the non grouped values", () => {
+    updatePivot(model, pivotId, {
+      columns: [{ fieldName: "Stage", order: "asc" }],
+      rows: [{ fieldName: "GroupedOpportunities", order: "asc" }],
+      measures: [{ fieldName: "Expected Revenue", aggregator: "sum", id: "Expected Revenue:sum" }],
+      customFields: { GroupedOpportunities: GROUPED_OPPORTUNITIES_FIELD },
+    });
+
+    // prettier-ignore
+    expect(getFormattedGrid(model)).toMatchObject({
+        A30:"My pivot",       B30: "New",     C30: "Proposition",  D30: "Qualified",  E30: "Won",    F30: "Total",
+        A32: "First Group",   B32: "13000",   C32: "",             D32: "",           E32: "",       F32: "13000",
+        A33: "Second Group",  B33: "",        C33: "5600",         D33: "",           E33: "2000",   F33: "7600",
+        A34: "Others",        B34: "108500",  C34: "84000",        D34: "87300",      E34: "19800",  F34: "299600",
+        A35: "Total",         B35: "121500",  C35: "89600",        D35: "87300",      E35: "21800",  F35: "320200",
+    });
+  });
+
+  test("Can sort custom fields, with others group always being at the end", () => {
+    updatePivot(model, pivotId, {
+      rows: [{ fieldName: "GroupedOpportunities", order: "asc" }],
+      columns: [],
+      measures: [{ fieldName: "Expected Revenue", aggregator: "sum", id: "Expected Revenue:sum" }],
+      customFields: { GroupedOpportunities: GROUPED_OPPORTUNITIES_FIELD },
+    });
+    // prettier-ignore
+    expect(getFormattedGrid(model)).toMatchObject({
+        A32: "First Group",   B32: "13000",
+        A33: "Second Group",  B33: "7600",
+        A34: "Others",        B34: "299600",
+    });
+
+    updatePivot(model, pivotId, {
+      rows: [{ fieldName: "GroupedOpportunities", order: "desc" }],
+    });
+    // prettier-ignore
+    expect(getFormattedGrid(model)).toMatchObject({
+        A32: "Second Group",  B32: "7600",
+        A33: "First Group",   B33: "13000",
+        A34: "Others",        B34: "299600",
+    });
+
+    updatePivot(model, pivotId, {
+      rows: [{ fieldName: "GroupedOpportunities", order: undefined }],
+    });
+    // prettier-ignore
+    expect(getFormattedGrid(model)).toMatchObject({
+        A32: "First Group",   B32: "13000",
+        A33: "Second Group",  B33: "7600",
+        A34: "Others",        B34: "299600",
+    });
+  });
+
+  test("Can have multiple custom fields", () => {
+    updatePivot(model, pivotId, {
+      columns: [{ fieldName: "GroupedStages", order: "desc" }],
+      rows: [{ fieldName: "GroupedOpportunities", order: "asc" }],
+      measures: [{ fieldName: "Expected Revenue", aggregator: "sum", id: "Expected Revenue:sum" }],
+      customFields: {
+        GroupedStages: GROUPED_STAGES_FIELD,
+        GroupedOpportunities: GROUPED_OPPORTUNITIES_FIELD,
+      },
+    });
+
+    // prettier-ignore
+    expect(getFormattedGrid(model)).toMatchObject({
+        A30:"My pivot",       B30: "Initial",  C30: "Final",   D30: "Total",
+        A32: "First Group",   B32: "13000",    C32: "",        D32: "13000",
+        A33: "Second Group",  B33: "5600",     C33: "2000",    D33: "7600",
+        A34: "Others",        B34: "192500",   C34: "107100",  D34: "299600",
+        A35: "Total",         B35: "211100",   C35: "109100",  D35: "320200",
+    });
+  });
+
+  test("Can collapse a custom field", () => {
+    updatePivot(model, pivotId, {
+      columns: [],
+      rows: [
+        { fieldName: "GroupedStages", order: "desc" },
+        { fieldName: "Salesperson", order: "asc" },
+      ],
+      measures: [{ fieldName: "Expected Revenue", aggregator: "sum", id: "Expected Revenue:sum" }],
+      customFields: { GroupedStages: GROUPED_STAGES_FIELD },
+      collapsedDomains: {
+        ROW: [[{ field: "GroupedStages", value: "Initial", type: "custom" }]],
+        COL: [],
+      },
+    });
+
+    // prettier-ignore
+    expect(getFormattedGrid(model)).toMatchObject({
+        A30:"My pivot",       B30: "Total",
+        A32: "Initial",       B32: "211100",
+        A33: "Final",         B33: "109100",
+        A34: "Eden",          B34: "38000",
+        A35: "Kevin",         B35: "71100",
+        A36: "Total",         B36: "320200",
+    });
+  });
+
+  test("Can have the custom group in one dimension, and its parent field in the other", () => {
+    updatePivot(model, pivotId, {
+      columns: [{ fieldName: "GroupedStages", order: "desc" }],
+      rows: [{ fieldName: "Stage", order: "asc" }],
+      measures: [{ fieldName: "Expected Revenue", aggregator: "sum", id: "Expected Revenue:sum" }],
+      customFields: { GroupedStages: GROUPED_STAGES_FIELD },
+    });
+
+    // prettier-ignore
+    expect(getFormattedGrid(model)).toMatchObject({
+        A30:"My pivot",       B30: "Initial",  C30: "Final",   D30: "Total",
+        A32: "New",           B32: "121500",   C32: "",        D32: "121500",
+        A33: "Proposition",   B33: "89600",    C33: "",        D33: "89600",
+        A34: "Qualified",     B34: "",         C34: "87300",   D34: "87300",
+        A35: "Won",           B35: "",         C35: "21800",   D35: "21800",
+        A36: "Total",         B36: "211100",   C36: "109100",  D36: "320200",
+    });
+  });
+
+  test("Can use grouped fields with calculated measures", () => {
+    updatePivot(model, pivotId, {
+      rows: [
+        { fieldName: "GroupedOpportunities", order: "asc" },
+        { fieldName: "Active", order: "asc" },
+      ],
+      columns: [],
+      measures: [
+        {
+          id: "calc",
+          fieldName: "calc",
+          aggregator: "count",
+          computedBy: { formula: "=GroupedOpportunities", sheetId },
+        },
+      ],
+      customFields: { GroupedOpportunities: GROUPED_OPPORTUNITIES_FIELD },
+    });
+
+    // prettier-ignore
+    expect(getFormattedGrid(model)).toMatchObject({
+        A30:"My pivot",       B30: "Total",
+        A32: "First Group",   B32: "2", // Subtotal is count of values in sub-group
+        A33: "FALSE",         B33: "First Group", // Leaf is =GroupedOpportunities
+        A34: "TRUE",          B34: "First Group",
+        A35: "Second Group",  B35: "1",
+        A36: "FALSE",         B36: "Second Group",
+        A37: "Others",        B37: "2",
+        A38: "FALSE",         B38: "Others",
+        A39: "TRUE",          B39: "Others",
+        A40: "Total",         B40: "5",
+    });
+  });
+});

--- a/tests/pivots/pivot_data.ts
+++ b/tests/pivots/pivot_data.ts
@@ -31,7 +31,7 @@ export const pivotModelData = function (xc: string) {
           A19: "01/31/2024",
           A20: "04/02/2024",
           A21: "04/05/2024",
-          A22: "19/05/2024",
+          A22: "05/19/2024",
           B1: "Opportunity",
           B2: "my opportunity",
           B3: "test opportunity",

--- a/tests/pivots/pivot_menu_items.test.ts
+++ b/tests/pivots/pivot_menu_items.test.ts
@@ -1,4 +1,4 @@
-import { Model, SortDirection, SpreadsheetChildEnv } from "../../src";
+import { Model, PivotCustomGroup, SortDirection, SpreadsheetChildEnv } from "../../src";
 import { Action } from "../../src/actions/action";
 import { PIVOT_TABLE_CONFIG } from "../../src/constants";
 import { toCartesian, toZone } from "../../src/helpers";
@@ -26,6 +26,7 @@ import {
   addPivot,
   createModelWithPivot,
   createModelWithTestPivotDataset,
+  updatePivot,
 } from "../test_helpers/pivot_helpers";
 
 const reinsertDynamicPivotPath = ["data", "reinsert_dynamic_pivot", "reinsert_dynamic_pivot_1"];
@@ -744,5 +745,391 @@ describe("Pivot sorting menu item", () => {
 
     selectCell(model, "C21"); // Other column
     expect(getActiveSortOrder()).toEqual([]);
+  });
+});
+
+describe("Pivot (un)grouping menu items", () => {
+  let model: Model;
+  let pivotId: string;
+  let env: SpreadsheetChildEnv;
+  let openSidePanel: jest.Mock;
+
+  beforeEach(() => {
+    model = createModelWithPivot("A1:I22");
+    openSidePanel = jest.fn();
+
+    env = makeTestEnv({ model, openSidePanel });
+    pivotId = model.getters.getPivotIds()[0];
+    updatePivot(model, pivotId, {
+      rows: [],
+      columns: [],
+      measures: [{ id: "measureId", fieldName: "Expected Revenue", aggregator: "sum" }],
+    });
+
+    setCellContent(model, "A25", "=PIVOT(1)");
+  });
+
+  function updatePivotWithGroups(groups: PivotCustomGroup[]) {
+    updatePivot(model, pivotId, {
+      rows: [{ fieldName: "Stage2" }, { fieldName: "Stage" }],
+      customFields: {
+        Stage2: {
+          parentField: "Stage",
+          name: "Stage2",
+          groups: groups,
+        },
+      },
+    });
+  }
+
+  describe("Group pivot headers", () => {
+    test("Menu item is only visible when selecting pivot headers on the same pivot dimension", () => {
+      updatePivot(model, pivotId, {
+        rows: [{ fieldName: "Salesperson" }, { fieldName: "Stage" }],
+      });
+
+      setSelection(model, ["A1"]); // No pivot header selected
+      expect(cellMenuRegistry.get("pivot_headers_group").isVisible!(env)).toBe(false);
+
+      setSelection(model, ["A25"]); // Pivot title
+      expect(cellMenuRegistry.get("pivot_headers_group").isVisible!(env)).toBe(false);
+
+      setSelection(model, ["A27"]); // Single Salesperson header
+      expect(cellMenuRegistry.get("pivot_headers_group").isVisible!(env)).toBe(false);
+
+      setSelection(model, ["A27", "A32"]); // Salesperson headers
+      expect(cellMenuRegistry.get("pivot_headers_group").isVisible!(env)).toBe(true);
+
+      setSelection(model, ["A28:A29"]); // Stage headers
+      expect(cellMenuRegistry.get("pivot_headers_group").isVisible!(env)).toBe(true);
+
+      setSelection(model, ["A27:A29"]); // Salesperson and Stage headers
+      expect(cellMenuRegistry.get("pivot_headers_group").isVisible!(env)).toBe(false);
+    });
+
+    test("Menu item is not visible when selecting non-groupable fields", () => {
+      updatePivot(model, pivotId, {
+        rows: [{ fieldName: "Created on", granularity: "month" }],
+        columns: [{ fieldName: "Expected MRR" }],
+      });
+
+      setSelection(model, ["A27:A28"]); // "Created on" headers
+      expect(cellMenuRegistry.get("pivot_headers_group").isVisible!(env)).toBe(false);
+
+      setSelection(model, ["B25:C25"]); // "Expected MMR" headers
+      expect(cellMenuRegistry.get("pivot_headers_group").isVisible!(env)).toBe(false);
+    });
+
+    test("Menu item is not visible on static pivot formulas", () => {
+      updatePivot(model, pivotId, {
+        rows: [{ fieldName: "Salesperson" }, { fieldName: "Stage" }],
+      });
+      const sheetId = model.getters.getActiveSheetId();
+      model.dispatch("SPLIT_PIVOT_FORMULA", { sheetId, col: 0, row: 24, pivotId });
+
+      setSelection(model, ["A27", "A32"]); // Salesperson headers
+      expect(cellMenuRegistry.get("pivot_headers_group").isVisible!(env)).toBe(false);
+    });
+
+    test("Can group pivot headers", () => {
+      updatePivot(model, pivotId, {
+        rows: [{ fieldName: "Stage" }],
+      });
+
+      setSelection(model, ["A27:A28"]); // Salesperson and Stage headers
+      doAction(["pivot_headers_group"], env, cellMenuRegistry);
+
+      expect(model.getters.getPivotCoreDefinition(pivotId)).toMatchObject({
+        rows: [{ fieldName: "Stage2" }, { fieldName: "Stage" }],
+        customFields: {
+          Stage2: {
+            parentField: "Stage",
+            groups: [{ name: "Group", values: ["New", "Won"] }],
+          },
+        },
+      });
+    });
+
+    test("If some headers are already grouped, remove their group", () => {
+      updatePivotWithGroups([{ name: "CustomGroup", values: ["New", "Won"] }]);
+
+      setSelection(model, ["A28:A29", "A31"]); // "New", "Won" and"Proposition" headers
+      doAction(["pivot_headers_group"], env, cellMenuRegistry);
+
+      expect(model.getters.getPivotCoreDefinition(pivotId)).toMatchObject({
+        rows: [{ fieldName: "Stage2" }, { fieldName: "Stage" }],
+        customFields: {
+          Stage2: {
+            parentField: "Stage",
+            groups: [{ name: "Group", values: ["New", "Won", "Proposition"] }],
+          },
+        },
+      });
+
+      setSelection(model, ["A28:A29"]); // "New" and "Won" headers
+      doAction(["pivot_headers_group"], env, cellMenuRegistry);
+
+      expect(model.getters.getPivotCoreDefinition(pivotId).customFields?.Stage2.groups).toEqual([
+        { name: "Group", values: ["New", "Won"] },
+      ]);
+    });
+
+    test("Can merge value into existing group", () => {
+      updatePivotWithGroups([{ name: "MyGroup", values: ["New", "Won"] }]);
+
+      setSelection(model, ["A27", "A30"]); // "MyGroup" + "Proposition" headers
+      expect(cellMenuRegistry.get("pivot_headers_group").isVisible!(env)).toBe(true);
+      doAction(["pivot_headers_group"], env, cellMenuRegistry);
+
+      expect(model.getters.getPivotCoreDefinition(pivotId)).toMatchObject({
+        rows: [{ fieldName: "Stage2" }, { fieldName: "Stage" }],
+        customFields: {
+          Stage2: {
+            groups: [{ name: "MyGroup", values: ["New", "Won", "Proposition"] }],
+          },
+        },
+      });
+    });
+
+    test("Can merge two existing groups", () => {
+      updatePivotWithGroups([
+        { name: "MyGroup", values: ["New", "Won"] },
+        { name: "Group2", values: ["Proposition", "Qualified"] },
+      ]);
+
+      setSelection(model, ["A27", "A30"]); // "MyGroup" + "Group2" headers
+      expect(cellMenuRegistry.get("pivot_headers_group").isVisible!(env)).toBe(true);
+      doAction(["pivot_headers_group"], env, cellMenuRegistry);
+
+      expect(model.getters.getPivotCoreDefinition(pivotId)).toMatchObject({
+        rows: [{ fieldName: "Stage2" }, { fieldName: "Stage" }],
+        customFields: {
+          Stage2: {
+            groups: [{ name: "MyGroup", values: ["New", "Won", "Proposition", "Qualified"] }],
+          },
+        },
+      });
+    });
+
+    test("Merging a group into others group will remove the group", () => {
+      updatePivotWithGroups([
+        { name: "MyGroup", values: ["New", "Won"] },
+        { name: "Others", values: [], isOtherGroup: true },
+      ]);
+
+      setSelection(model, ["A27", "A30"]); // MyGroup + Others headers
+      doAction(["pivot_headers_group"], env, cellMenuRegistry);
+
+      expect(model.getters.getPivotCoreDefinition(pivotId)).toMatchObject({
+        rows: [{ fieldName: "Stage2" }, { fieldName: "Stage" }],
+        customFields: {
+          Stage2: {
+            groups: [{ name: "Others", values: [], isOtherGroup: true }],
+          },
+        },
+      });
+    });
+  });
+
+  describe("Ungroup pivot headers", () => {
+    test("Menu item is only visible when selecting grouped pivot headers", () => {
+      updatePivotWithGroups([{ name: "MyGroup", values: ["New", "Won"] }]);
+
+      setSelection(model, ["A1"]); // No pivot header selected
+      expect(cellMenuRegistry.get("pivot_headers_ungroup").isVisible!(env)).toBe(false);
+
+      setSelection(model, ["A25"]); // Pivot title
+      expect(cellMenuRegistry.get("pivot_headers_ungroup").isVisible!(env)).toBe(false);
+
+      setSelection(model, ["A27"]); // "MyGroup" header
+      expect(cellMenuRegistry.get("pivot_headers_ungroup").isVisible!(env)).toBe(true);
+
+      setSelection(model, ["A28"]); // "New" header inside MyGroup
+      expect(cellMenuRegistry.get("pivot_headers_ungroup").isVisible!(env)).toBe(true);
+
+      setSelection(model, ["A30"]); // Proposition header in dimension Stage2
+      expect(cellMenuRegistry.get("pivot_headers_ungroup").isVisible!(env)).toBe(false);
+
+      setSelection(model, ["A31"]); // Proposition header in dimension Stage
+      expect(cellMenuRegistry.get("pivot_headers_ungroup").isVisible!(env)).toBe(false);
+    });
+
+    test("Menu item is not visible on grouped values when grouped field is not in the pivot", () => {
+      updatePivot(model, pivotId, {
+        rows: [{ fieldName: "Stage" }],
+        customFields: {
+          Stage2: {
+            parentField: "Stage",
+            name: "Stage2",
+            groups: [{ name: "MyGroup", values: ["New", "Won"] }],
+          },
+        },
+      });
+
+      setSelection(model, ["A27"]); // "New" header inside Stage
+      expect(getEvaluatedCell(model, "A27").value).toEqual("New");
+      expect(cellMenuRegistry.get("pivot_headers_ungroup").isVisible!(env)).toBe(false);
+    });
+
+    test("Un-grouping header deletes the group it belongs to", () => {
+      updatePivotWithGroups([
+        { name: "MyGroup", values: ["New", "Won"] },
+        { name: "SecondGroup", values: ["Proposition", "Qualified"] },
+      ]);
+
+      setSelection(model, ["A28"]); // "New" header inside MyGroup
+      doAction(["pivot_headers_ungroup"], env, cellMenuRegistry);
+
+      expect(model.getters.getPivotCoreDefinition(pivotId).customFields?.Stage2.groups).toEqual([
+        { name: "SecondGroup", values: ["Proposition", "Qualified"] },
+      ]);
+    });
+
+    test("Removing all groups deletes the custom field, and its occurrences in the pivot dimensions", () => {
+      updatePivotWithGroups([
+        { name: "MyGroup", values: ["New", "Won"] },
+        { name: "Others", values: [], isOtherGroup: true },
+      ]);
+
+      setSelection(model, ["A28", "A31"]); // "New" header inside MyGroup and Proposition header in Others group
+      doAction(["pivot_headers_ungroup"], env, cellMenuRegistry);
+
+      expect(model.getters.getPivotCoreDefinition(pivotId).customFields?.Stage2).toBeUndefined();
+      expect(model.getters.getPivotCoreDefinition(pivotId).rows).toEqual([{ fieldName: "Stage" }]);
+    });
+
+    test("The deleted custom field is replaced with its parent field if it wasn't present in the pivot", () => {
+      updatePivot(model, pivotId, {
+        rows: [{ fieldName: "Stage2" }],
+        customFields: {
+          Stage2: {
+            parentField: "Stage",
+            name: "Stage2",
+            groups: [{ name: "MyGroup", values: ["New", "Won"] }],
+          },
+        },
+      });
+
+      setSelection(model, ["A27"]); // "MyGroup" header
+      doAction(["pivot_headers_ungroup"], env, cellMenuRegistry);
+
+      expect(model.getters.getPivotCoreDefinition(pivotId).customFields?.Stage2).toBeUndefined();
+      expect(model.getters.getPivotCoreDefinition(pivotId).rows).toEqual([{ fieldName: "Stage" }]);
+    });
+
+    test("Can remove a group", () => {
+      updatePivotWithGroups([
+        { name: "MyGroup", values: ["New", "Won"] },
+        { name: "Others", values: [], isOtherGroup: true },
+      ]);
+
+      setSelection(model, ["A27"]); // "MyGroup" header
+      doAction(["pivot_headers_ungroup"], env, cellMenuRegistry);
+
+      expect(model.getters.getPivotCoreDefinition(pivotId).customFields?.Stage2.groups).toEqual([
+        { name: "Others", values: [], isOtherGroup: true },
+      ]);
+    });
+
+    test("Can remove the others group", () => {
+      updatePivotWithGroups([
+        { name: "MyGroup", values: ["New", "Won"] },
+        { name: "Others", values: [], isOtherGroup: true },
+      ]);
+
+      setSelection(model, ["A30"]); // "MyGroup" header
+      doAction(["pivot_headers_ungroup"], env, cellMenuRegistry);
+
+      expect(model.getters.getPivotCoreDefinition(pivotId).customFields?.Stage2.groups).toEqual([
+        { name: "MyGroup", values: ["New", "Won"] },
+      ]);
+    });
+  });
+
+  describe("Group remaining pivot headers", () => {
+    test("Menu item is only visible when selecting only non-grouped headers", () => {
+      updatePivotWithGroups([{ name: "MyGroup", values: ["New", "Won"] }]);
+
+      setSelection(model, ["A1"]); // No pivot header selected
+      expect(cellMenuRegistry.get("pivot_group_remaining").isVisible!(env)).toBe(false);
+
+      setSelection(model, ["A25"]); // Pivot title
+      expect(cellMenuRegistry.get("pivot_group_remaining").isVisible!(env)).toBe(false);
+
+      setSelection(model, ["A27"]); // "MyGroup" header
+      expect(cellMenuRegistry.get("pivot_group_remaining").isVisible!(env)).toBe(false);
+
+      setSelection(model, ["A28"]); // "New" header inside MyGroup
+      expect(cellMenuRegistry.get("pivot_group_remaining").isVisible!(env)).toBe(false);
+
+      setSelection(model, ["A30"]); // "Proposition" header in dimension Stage2
+      expect(cellMenuRegistry.get("pivot_group_remaining").isVisible!(env)).toBe(false);
+
+      setSelection(model, ["A30", "A32"]); // "Proposition" and "Qualified" headers in dimension Stage2
+      expect(cellMenuRegistry.get("pivot_group_remaining").isVisible!(env)).toBe(true);
+
+      setSelection(model, ["A31", "A33"]); // "Proposition" and "Qualified" headers in dimension Stage
+      expect(cellMenuRegistry.get("pivot_group_remaining").isVisible!(env)).toBe(true);
+    });
+
+    test("Can group remaining groups", () => {
+      updatePivotWithGroups([{ name: "MyGroup", values: ["New", "Won"] }]);
+
+      setSelection(model, ["A30", "A32"]); // "Proposition", "Qualified" headers inside Stage field
+      doAction(["pivot_group_remaining"], env, cellMenuRegistry);
+
+      expect(model.getters.getPivotCoreDefinition(pivotId).customFields?.Stage2.groups).toEqual([
+        { name: "MyGroup", values: ["New", "Won"] },
+        { name: "Others", values: [], isOtherGroup: true },
+      ]);
+
+      undo(model);
+      setSelection(model, ["A31", "A33"]); // "Proposition", "Qualified" headers inside Stage field
+      doAction(["pivot_group_remaining"], env, cellMenuRegistry);
+      expect(model.getters.getPivotCoreDefinition(pivotId).customFields?.Stage2.groups).toEqual([
+        { name: "MyGroup", values: ["New", "Won"] },
+        { name: "Others", values: [], isOtherGroup: true },
+      ]);
+    });
+
+    test("Removing all groups deletes the custom field", () => {
+      updatePivotWithGroups([
+        { name: "MyGroup", values: ["New", "Won"] },
+        { name: "Others", values: [], isOtherGroup: true },
+      ]);
+
+      setSelection(model, ["A28", "A31"]); // "New" header inside MyGroup and Proposition header in Others group
+      doAction(["pivot_headers_ungroup"], env, cellMenuRegistry);
+
+      expect(model.getters.getPivotCoreDefinition(pivotId).customFields?.Stage2).toBeUndefined();
+    });
+
+    test("Can remove a group", () => {
+      updatePivotWithGroups([
+        { name: "MyGroup", values: ["New", "Won"] },
+        { name: "Others", values: [], isOtherGroup: true },
+      ]);
+
+      setSelection(model, ["A27"]); // "MyGroup" header
+      doAction(["pivot_headers_ungroup"], env, cellMenuRegistry);
+
+      expect(model.getters.getPivotCoreDefinition(pivotId).customFields?.Stage2.groups).toEqual([
+        { name: "Others", values: [], isOtherGroup: true },
+      ]);
+    });
+
+    test("Can remove the others group", () => {
+      updatePivotWithGroups([
+        { name: "MyGroup", values: ["New", "Won"] },
+        { name: "Others", values: [], isOtherGroup: true },
+      ]);
+
+      setSelection(model, ["A30"]); // "MyGroup" header
+      doAction(["pivot_headers_ungroup"], env, cellMenuRegistry);
+
+      expect(model.getters.getPivotCoreDefinition(pivotId).customFields?.Stage2.groups).toEqual([
+        { name: "MyGroup", values: ["New", "Won"] },
+      ]);
+    });
   });
 });


### PR DESCRIPTION
## Description

With this commit, it is now possible to group dimension values of a pivot. The grouping is done using right-click context menu of the pivot cells.

Grouping pivot headers together creates a new field in the pivot, that defines which values are grouped together. Those new `customFields` are defined in the pivot definition.

Task: [4266072](https://www.odoo.com/odoo/2328/tasks/4266072)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo