### PR TITLE
[FIX] Composer: Remove formatting when pasting external content

### DIFF
--- a/src/components/bottom_bar_sheet/bottom_bar_sheet.ts
+++ b/src/components/bottom_bar_sheet/bottom_bar_sheet.ts
@@ -164,15 +164,13 @@ export class BottomBarSheet extends Component<Props, SpreadsheetChildEnv> {
   }
 
   private stopEdition() {
-    const input = this.sheetNameRef.el;
-    if (!this.state.isEditing || !input) return;
+    if (!this.state.isEditing || !this.sheetNameRef.el) return;
 
     this.state.isEditing = false;
     this.editionState = "initializing";
-    input.blur();
+    this.sheetNameRef.el.blur();
 
     const inputValue = this.getInputContent() || "";
-    input.innerText = inputValue;
 
     interactiveRenameSheet(this.env, this.props.sheetId, inputValue, () => this.startEdition());
   }

--- a/src/components/bottom_bar_sheet/bottom_bar_sheet.xml
+++ b/src/components/bottom_bar_sheet/bottom_bar_sheet.xml
@@ -20,7 +20,7 @@
           t-on-dblclick="() => this.onDblClick()"
           t-on-focusout="() => this.onFocusOut()"
           t-on-keydown="(ev) => this.onKeyDown(ev)"
-          t-att-contenteditable="state.isEditing ? 'true': 'false'"
+          t-att-contenteditable="state.isEditing ? 'plaintext-only': 'false'"
         />
         <span class="o-sheet-icon ms-1" t-on-click.stop="(ev) => this.onIconClick(ev)">
           <t t-call="o-spreadsheet-Icon.TRIANGLE_DOWN"/>

--- a/src/components/composer/composer/composer.xml
+++ b/src/components/composer/composer/composer.xml
@@ -7,7 +7,7 @@
         t-att-style="props.inputStyle"
         t-ref="o_composer"
         tabindex="1"
-        t-att-contenteditable="env.model.getters.isReadonly() ? 'false' : 'true'"
+        t-att-contenteditable="env.model.getters.isReadonly() ? 'false' : 'plaintext-only'"
         spellcheck="false"
         t-on-keydown="onKeydown"
         t-on-mousewheel.stop=""

--- a/tests/__snapshots__/top_bar_component.test.ts.snap
+++ b/tests/__snapshots__/top_bar_component.test.ts.snap
@@ -583,7 +583,7 @@ exports[`TopBar component can set cell format 1`] = `
           >
             <div
               class="o-composer w-100 text-start"
-              contenteditable="true"
+              contenteditable="plaintext-only"
               spellcheck="false"
               style="padding:5px 0px 5px 8px; max-height:100px; line-height:24px; height:34px; "
               tabindex="1"
@@ -1498,7 +1498,7 @@ exports[`TopBar component simple rendering 1`] = `
       >
         <div
           class="o-composer w-100 text-start"
-          contenteditable="true"
+          contenteditable="plaintext-only"
           spellcheck="false"
           style="padding:5px 0px 5px 8px; max-height:100px; line-height:24px; height:34px; "
           tabindex="1"

--- a/tests/bottom_bar/bottom_bar_component.test.ts
+++ b/tests/bottom_bar/bottom_bar_component.test.ts
@@ -258,7 +258,7 @@ describe("BottomBar component", () => {
       expect(sheetName.getAttribute("contenteditable")).toEqual("false");
       await doubleClick(sheetName);
       await nextTick();
-      expect(sheetName.getAttribute("contenteditable")).toEqual("true");
+      expect(sheetName.getAttribute("contenteditable")).toEqual("plaintext-only");
       expect(document.activeElement).toEqual(sheetName);
     });
 
@@ -277,7 +277,7 @@ describe("BottomBar component", () => {
       await nextTick();
       await click(fixture, ".o-menu-item[data-name='rename'");
       const sheetName = fixture.querySelector<HTMLElement>(".o-sheet-name")!;
-      expect(sheetName.getAttribute("contenteditable")).toEqual("true");
+      expect(sheetName.getAttribute("contenteditable")).toEqual("plaintext-only");
       expect(document.activeElement).toEqual(sheetName);
     });
 

--- a/tests/composer/__snapshots__/composer_integration_component.test.ts.snap
+++ b/tests/composer/__snapshots__/composer_integration_component.test.ts.snap
@@ -10,7 +10,7 @@ exports[`Grid composer grid composer basic style Grid composer snapshot 1`] = `
   >
     <div
       class="o-composer w-100 text-start active"
-      contenteditable="true"
+      contenteditable="plaintext-only"
       spellcheck="false"
       style="max-height: 982.6px;"
       tabindex="1"

--- a/tests/grid/__snapshots__/grid_component.test.ts.snap
+++ b/tests/grid/__snapshots__/grid_component.test.ts.snap
@@ -79,7 +79,7 @@ exports[`Grid component simple rendering snapshot 1`] = `
     >
       <div
         class="o-composer w-100 text-start"
-        contenteditable="true"
+        contenteditable="plaintext-only"
         spellcheck="false"
         style="max-height: 1008.6px;"
         tabindex="1"

--- a/tests/spreadsheet/__snapshots__/spreadsheet_component.test.ts.snap
+++ b/tests/spreadsheet/__snapshots__/spreadsheet_component.test.ts.snap
@@ -584,7 +584,7 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
         >
           <div
             class="o-composer w-100 text-start"
-            contenteditable="true"
+            contenteditable="plaintext-only"
             spellcheck="false"
             style="padding:5px 0px 5px 8px; max-height:100px; line-height:24px; height:34px; "
             tabindex="1"
@@ -694,7 +694,7 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
           >
             <div
               class="o-composer w-100 text-start"
-              contenteditable="true"
+              contenteditable="plaintext-only"
               spellcheck="false"
               style="max-height: 1008.6px;"
               tabindex="1"


### PR DESCRIPTION
Currently, if we copy html content from outside and paste it in the composer, we let the full formatting take place and then override the content with our own. However, we did not consider this possibility when we introduced a "diff" strategy to override the composer content and in some cases, if the html has a color style attribute that is not a color (inherit, initial, ...) the code crashes.

That being said, Good news everyone, the attribute removed in #3922 is finally available on all browsers!! `plaintext-only` will automatically clear the formatting of a content pasted inside a contentEditable div.

Task: 4910559

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo