### PR TITLE
[FIX] Formulas: `COLUMN/ROW` spread with range

### DIFF
--- a/src/functions/module_lookup.ts
+++ b/src/functions/module_lookup.ts
@@ -123,15 +123,26 @@ export const COLUMN = {
     if (isEvaluationError(cellReference?.value)) {
       return cellReference;
     }
-    const column =
-      cellReference === undefined
-        ? this.__originCellPosition?.col
-        : toZone(cellReference.value).left;
-    assert(
-      () => column !== undefined,
-      "In this context, the function [[FUNCTION_NAME]] needs to have a cell or range in parameter."
-    );
-    return column! + 1;
+    if (cellReference === undefined) {
+      assert(
+        () => this.__originCellPosition?.col !== undefined,
+        "In this context, the function [[FUNCTION_NAME]] needs to have a cell or range in parameter."
+      );
+      return this.__originCellPosition!.col! + 1;
+    }
+
+    const zone = this.getters.getRangeFromSheetXC(
+      this.getters.getActiveSheetId(),
+      cellReference.value
+    ).zone;
+
+    if (zone.left === zone.right) {
+      return zone.left + 1;
+    }
+
+    return generateMatrix(zone.right - zone.left + 1, 1, (col, row) => ({
+      value: zone.left + col + 1,
+    }));
   },
   isExported: true,
 } satisfies AddFunctionDescription;
@@ -497,15 +508,26 @@ export const ROW = {
     if (isEvaluationError(cellReference?.value)) {
       return cellReference;
     }
-    const row =
-      cellReference === undefined
-        ? this.__originCellPosition?.row
-        : toZone(cellReference.value).top;
-    assert(
-      () => row !== undefined,
-      "In this context, the function [[FUNCTION_NAME]] needs to have a cell or range in parameter."
-    );
-    return row! + 1;
+    if (cellReference === undefined) {
+      assert(
+        () => this.__originCellPosition?.row !== undefined,
+        "In this context, the function [[FUNCTION_NAME]] needs to have a cell or range in parameter."
+      );
+      return this.__originCellPosition!.row! + 1;
+    }
+
+    const zone = this.getters.getRangeFromSheetXC(
+      this.getters.getActiveSheetId(),
+      cellReference.value
+    ).zone;
+
+    if (zone.top === zone.bottom) {
+      return zone.top + 1;
+    }
+
+    return generateMatrix(1, zone.bottom - zone.top + 1, (col, row) => ({
+      value: zone.top + row + 1,
+    }));
   },
   isExported: true,
 } satisfies AddFunctionDescription;

--- a/tests/functions/module_lookup.test.ts
+++ b/tests/functions/module_lookup.test.ts
@@ -1,3 +1,4 @@
+import { range } from "../../src/helpers";
 import { Model } from "../../src/model";
 import { activateSheet, createSheet, setCellContent } from "../test_helpers/commands_helpers";
 import {
@@ -105,11 +106,19 @@ describe("COLUMN formula", () => {
     expect(evaluateCell("A1", { A1: "=COLUMN(Sheet1!$ABC$2)" })).toBe(731);
   });
 
-  test("functional tests on range arguments", () => {
-    expect(evaluateCell("A1", { A1: "=COLUMN(B3:C40)" })).toBe(2);
-    expect(evaluateCell("A1", { A1: "=COLUMN(D3:Z9)" })).toBe(4);
-    expect(evaluateCell("A1", { A1: "=COLUMN($D$3:$Z$9)" })).toBe(4);
-    expect(evaluateCell("A1", { A1: "=COLUMN(Sheet1!$D$3:$Z$9)" })).toBe(4);
+  test.each([
+    ["=COLUMN(B3:C40)", [2, 3]],
+    ["=COLUMN(A3:E9)", [1, 5]],
+    ["=COLUMN($D$3:$Z$9)", [4, 26]],
+    ["=COLUMN(Sheet1!$D$3:$Z$9)", [4, 26]],
+    ["=COLUMN(Sheet1!1:1)", [1, 26]],
+    ["=COLUMN(Sheet2!1:1)", [1, 5]],
+  ])("functional tests on range arguments", (formula, [start, end]) => {
+    const model = new Model();
+    createSheet(model, { sheetId: "Sheet2", name: "Sheet2", cols: 5 });
+    const sheetId = model.getters.getActiveSheetId();
+    const result = model.getters.evaluateFormula(sheetId, formula);
+    expect(result).toEqual(range(start, end + 1).map((col) => [col]));
   });
 
   test("functional tests on range arguments with invalid sheet name", () => {
@@ -537,11 +546,19 @@ describe("ROW formula", () => {
     expect(evaluateCell("A1", { A1: "=ROW(Sheet1!$A$234)" })).toBe(234);
   });
 
-  test("functional tests on range arguments", () => {
-    expect(evaluateCell("A1", { A1: "=ROW(B3:C40)" })).toBe(3);
-    expect(evaluateCell("A1", { A1: "=ROW(D3:Z9)" })).toBe(3);
-    expect(evaluateCell("A1", { A1: "=ROW($D$3:$Z$9)" })).toBe(3);
-    expect(evaluateCell("A1", { A1: "=ROW(Sheet1!$D$3:$Z$9)" })).toBe(3);
+  test.each([
+    ["=ROW(B3:C40)", [3, 40]],
+    ["=ROW(A2:E9)", [2, 9]],
+    ["=ROW($D$3:$Z$9)", [3, 9]],
+    ["=ROW(Sheet1!$D$3:$Z$9)", [3, 9]],
+    ["=ROW(Sheet1!A:A)", [1, 100]],
+    ["=ROW(Sheet2!A:A)", [1, 5]],
+  ])("functional tests on range arguments", (formula, [start, end]) => {
+    const model = new Model();
+    createSheet(model, { sheetId: "Sheet2", name: "Sheet2", rows: 5 });
+    const sheetId = model.getters.getActiveSheetId();
+    const result = model.getters.evaluateFormula(sheetId, formula);
+    expect(result).toEqual([range(start, end + 1)]);
   });
 
   test("functional tests on range arguments with invalid sheet name", () => {


### PR DESCRIPTION
Functions with a `meta` argument are not automatically vectorized.
This revision adds a vectorized-like behaviour for the specific formulas
`COLUMN` and `ROW`.

Task: 4916369

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo