### PR TITLE
[FIX] spreadsheet_pivot: empty row when number added to char field

### DIFF
--- a/src/helpers/pivot/spreadsheet_pivot/spreadsheet_pivot.ts
+++ b/src/helpers/pivot/spreadsheet_pivot/spreadsheet_pivot.ts
@@ -371,9 +371,15 @@ export class SpreadsheetPivot implements Pivot<SpreadsheetPivotRuntimeDefinition
   }
 
   private filterDataEntriesFromDomainNode(dataEntries: DataEntries, domain: PivotNode) {
-    const { field, value } = domain;
+    const { field, value, type } = domain;
     const { nameWithGranularity } = this.getDimension(field);
-    return dataEntries.filter((entry) => entry[nameWithGranularity]?.value === value);
+    return dataEntries.filter((entry) => {
+      const cellValue = entry[nameWithGranularity]?.value;
+      if (type === "char") {
+        return String(cellValue) === String(value);
+      }
+      return cellValue === value;
+    });
   }
 
   private getDimension(nameWithGranularity: string): PivotDimension {

--- a/tests/pivots/spreadsheet_pivot/spreadsheet_pivot.test.ts
+++ b/tests/pivots/spreadsheet_pivot/spreadsheet_pivot.test.ts
@@ -142,6 +142,21 @@ describe("Spreadsheet Pivot", () => {
     ]);
   });
 
+  test("Pivot does not create empty row when number is added in char field", () => {
+    // prettier-ignore
+    const grid = {
+      A1: "Text",     B1: "Value",    C1: "=PIVOT(1)",
+      A2: "Hello",    B2: "10",
+      A3: "45",       B3: "20",
+    };
+    const model = createModelFromGrid(grid);
+    addPivot(model, "A1:B3", {
+      rows: [{ fieldName: "Text", order: "asc" }],
+      measures: [{ id: "Value:sum", fieldName: "Value", aggregator: "sum" }],
+    });
+    expect(getEvaluatedGrid(model, "C3:C4")).toEqual([["45"], ["Hello"]]);
+  });
+
   test("Values aren't detected as date if they have a date format but a non-numeric value", () => {
     const model = new Model();
     setCellContent(model, "A1", "Col1");


### PR DESCRIPTION
## Description:

When a pivot field is of type 'char' and contains both string and numeric values, numeric values were not matched correctly due to strict type comparison.

This resulted in unexpected empty rows in the pivot.

This PR ensures that values in 'char' fields are compared as strings, fixing the grouping issue.

Task: [4878778](https://www.odoo.com/odoo/2328/tasks/4878778)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo