### PR TITLE
[REF] borders: refactor border for infinite spreadsheet

### DIFF
--- a/src/clipboard_handlers/borders_clipboard.ts
+++ b/src/clipboard_handlers/borders_clipboard.ts
@@ -1,43 +1,61 @@
-import { positionToZone, recomputeZones } from "../helpers";
+import { splitZoneForPaste } from "../helpers/clipboard/clipboard_helpers";
+import { deepEquals, groupConsecutive } from "../helpers/misc";
+import { ZoneBorder, ZoneBorderData } from "../plugins/core";
 import {
-  Border,
-  CellPosition,
+  BorderDescr,
+  BorderPosition,
   ClipboardCellData,
   ClipboardOptions,
   ClipboardPasteTarget,
   HeaderIndex,
   UID,
-  Zone,
 } from "../types";
 import { AbstractCellClipboardHandler } from "./abstract_cell_clipboard_handler";
 
 type ClipboardContent = {
-  borders: (Border | null)[][];
+  borders: ZoneBorder[];
+  width: number;
+  height: number;
 };
 
 export class BorderClipboardHandler extends AbstractCellClipboardHandler<
   ClipboardContent,
-  Border | null
+  ZoneBorder
 > {
-  private queuedBordersToAdd: Record<string, Zone[]> = {};
-
   copy(data: ClipboardCellData): ClipboardContent | undefined {
     const sheetId = data.sheetId;
     if (data.zones.length === 0) {
       return;
     }
-    const { rowsIndexes, columnsIndexes } = data;
-    const borders: (Border | null)[][] = [];
-
-    for (const row of rowsIndexes) {
-      const bordersInRow: (Border | null)[] = [];
-      for (const col of columnsIndexes) {
-        const position = { col, row, sheetId };
-        bordersInRow.push(this.getters.getCellBorder(position));
+    const borders: ZoneBorder[] = [];
+    let colsBefore = 0;
+    for (const cols of groupConsecutive(data.columnsIndexes)) {
+      let rowsBefore = 0;
+      for (const rows of groupConsecutive(data.rowsIndexes)) {
+        const zone = {
+          left: cols[0],
+          right: cols[cols.length - 1],
+          top: rows[0],
+          bottom: rows[rows.length - 1],
+        };
+        borders.push(
+          ...this.getters.getBorders(sheetId, zone).map(({ zone: borderZone, style }) => {
+            return {
+              zone: {
+                left: borderZone.left - zone.left + colsBefore,
+                right: borderZone.right && borderZone.right - zone.left + colsBefore,
+                top: borderZone.top - zone.top + rowsBefore,
+                bottom: borderZone.bottom && borderZone.bottom - zone.top + rowsBefore,
+              },
+              style,
+            };
+          })
+        );
+        rowsBefore += rows.length;
       }
-      borders.push(bordersInRow);
+      colsBefore += cols.length;
     }
-    return { borders };
+    return { borders, width: data.columnsIndexes.length, height: data.rowsIndexes.length };
   }
 
   paste(target: ClipboardPasteTarget, content: ClipboardContent, options: ClipboardOptions) {
@@ -47,47 +65,69 @@ export class BorderClipboardHandler extends AbstractCellClipboardHandler<
     }
     const zones = target.zones;
     if (!options.isCutOperation) {
-      this.pasteFromCopy(sheetId, zones, content.borders);
+      for (const zone of zones) {
+        for (const pasteZone of splitZoneForPaste(zone, content.width, content.height)) {
+          this.pasteBorderZone(sheetId, pasteZone.left, pasteZone.top, content.borders);
+        }
+      }
     } else {
       const { left, top } = zones[0];
-      this.pasteZone(sheetId, left, top, content.borders);
+      this.pasteBorderZone(sheetId, left, top, content.borders);
     }
-
-    this.executeQueuedChanges(sheetId);
   }
 
-  pasteZone(sheetId: UID, col: HeaderIndex, row: HeaderIndex, borders: (Border | null)[][]) {
-    for (const [r, rowBorders] of borders.entries()) {
-      for (const [c, originBorders] of rowBorders.entries()) {
-        const position = { col: col + c, row: row + r, sheetId };
-        this.pasteBorder(originBorders, position);
+  pasteBorderZone(sheetId: UID, col: HeaderIndex, row: HeaderIndex, borders: ZoneBorder[]) {
+    for (const border of borders) {
+      const zone = {
+        left: border.zone.left + col,
+        right: (border.zone.right && border.zone.right + col) || border.zone.left + col,
+        top: border.zone.top + row,
+        bottom: (border.zone.bottom && border.zone.bottom + row) || border.zone.top + row,
+      };
+      for (const [position, style] of this.getOptimalBorderCommands(border.style)) {
+        if (style)
+          this.dispatch("SET_ZONE_BORDERS", {
+            sheetId,
+            target: [zone],
+            border: { position, ...style },
+          });
       }
     }
   }
 
-  /**
-   * Paste the border at the given position to the target position
-   */
-  private pasteBorder(originBorders: Border | null, target: CellPosition) {
-    const targetBorders = this.getters.getCellBorder(target);
-    const border = {
-      ...targetBorders,
-      ...originBorders,
-    };
-    const borderKey = JSON.stringify(border);
-    if (!this.queuedBordersToAdd[borderKey]) {
-      this.queuedBordersToAdd[borderKey] = [];
+  getOptimalBorderCommands(border: ZoneBorderData): [BorderPosition, BorderDescr | undefined][] {
+    const hv = deepEquals(border.horizontal, border.vertical);
+    const external = deepEquals(border.left, border.right, border.top, border.bottom);
+    if (hv && external && deepEquals(border.horizontal, border.left)) {
+      return [["all", border.top]];
+    } else if (hv && external) {
+      return [
+        ["hv", border.horizontal],
+        ["external", border.top],
+      ];
+    } else if (external) {
+      return [
+        ["h", border.horizontal],
+        ["v", border.vertical],
+        ["external", border.top],
+      ];
+    } else if (hv) {
+      return [
+        ["hv", border.horizontal],
+        ["top", border.top],
+        ["bottom", border.bottom],
+        ["left", border.left],
+        ["right", border.right],
+      ];
+    } else {
+      return [
+        ["h", border.horizontal],
+        ["v", border.vertical],
+        ["top", border.top],
+        ["bottom", border.bottom],
+        ["left", border.left],
+        ["right", border.right],
+      ];
     }
-    this.queuedBordersToAdd[borderKey].push(positionToZone(target));
-  }
-
-  private executeQueuedChanges(pasteSheetTarget: UID) {
-    for (const borderKey in this.queuedBordersToAdd) {
-      const zones = this.queuedBordersToAdd[borderKey];
-      const border = JSON.parse(borderKey) as Border;
-      const target = recomputeZones(zones, []);
-      this.dispatch("SET_BORDERS_ON_TARGET", { sheetId: pasteSheetTarget, target, border });
-    }
-    this.queuedBordersToAdd = {};
   }
 }

--- a/src/clipboard_handlers/index.ts
+++ b/src/clipboard_handlers/index.ts
@@ -28,7 +28,7 @@ clipboardHandlersRegistries.cellHandlers
   .add("cell", CellClipboardHandler)
   .add("sheet", SheetClipboardHandler)
   .add("merge", MergeClipboardHandler)
-  .add("border", BorderClipboardHandler)
   .add("table", TableClipboardHandler)
   .add("conditionalFormat", ConditionalFormatClipboardHandler)
-  .add("references", ReferenceClipboardHandler);
+  .add("references", ReferenceClipboardHandler)
+  .add("border", BorderClipboardHandler);

--- a/src/components/tables/hovered_table_store.ts
+++ b/src/components/tables/hovered_table_store.ts
@@ -1,6 +1,6 @@
 import { TABLE_HOVER_BACKGROUND_COLOR } from "../../constants";
 import { range } from "../../helpers";
-import { PositionMap } from "../../plugins/ui_core_views/cell_evaluation/position_map";
+import { PositionMap } from "../../helpers/cells/position_map";
 import { SpreadsheetStore } from "../../stores";
 import { Color, Command, Position } from "../../types";
 

--- a/src/helpers/cells/position_map.ts
+++ b/src/helpers/cells/position_map.ts
@@ -34,6 +34,10 @@ export class PositionMap<T> {
     return this.map[sheetId];
   }
 
+  clearSheet(sheetId: UID) {
+    delete this.map[sheetId];
+  }
+
   has({ sheetId, col, row }: CellPosition): boolean {
     return this.map[sheetId]?.[col]?.[row] !== undefined;
   }

--- a/src/helpers/cells/position_map.ts
+++ b/src/helpers/cells/position_map.ts
@@ -1,4 +1,4 @@
-import { CellPosition, UID } from "../../../types";
+import { CellPosition, UID } from "../..";
 
 export class PositionMap<T> {
   private map: Record<UID, Record<number, Record<number, T>>> = {};
@@ -18,6 +18,12 @@ export class PositionMap<T> {
       map[sheetId][col] = {};
     }
     map[sheetId][col][row] = value;
+  }
+
+  setMany(values: Iterable<[CellPosition, T]>) {
+    for (const [position, value] of values) {
+      this.set(position, value);
+    }
   }
 
   get({ sheetId, col, row }: CellPosition): T | undefined {

--- a/src/helpers/clipboard/clipboard_helpers.ts
+++ b/src/helpers/clipboard/clipboard_helpers.ts
@@ -40,7 +40,11 @@ export function getClipboardDataPositions(sheetId: UID, zones: Zone[]): Clipboar
  * The clipped zone is copied as many times as it fits in the target.
  * This returns the list of zones where the clipped zone is copy-pasted.
  */
-function splitZoneForPaste(selection: Zone, splitWidth: number, splitHeight: number): Zone[] {
+export function splitZoneForPaste(
+  selection: Zone,
+  splitWidth: number,
+  splitHeight: number
+): Zone[] {
   const right = Math.max(selection.right - splitWidth + 1, selection.left);
   const bottom = Math.max(selection.bottom - splitHeight + 1, selection.top);
   const zones: Zone[] = [];

--- a/src/helpers/misc.ts
+++ b/src/helpers/misc.ts
@@ -387,9 +387,18 @@ export function getAddHeaderStartIndex(position: "before" | "after", base: numbe
 }
 
 /**
- * Compares two objects.
+ * Compares n objects.
  */
-export function deepEquals(o1: any, o2: any): boolean {
+
+export function deepEquals(...o: any[]): boolean {
+  if (o.length <= 1) return true;
+  for (let index = 1; index < o.length; index++) {
+    if (!_deepEquals(o[0], o[index])) return false;
+  }
+  return true;
+}
+
+function _deepEquals(o1: any, o2: any): boolean {
   if (o1 === o2) return true;
   if ((o1 && !o2) || (o2 && !o1)) return false;
   if (typeof o1 !== typeof o2) return false;
@@ -405,7 +414,7 @@ export function deepEquals(o1: any, o2: any): boolean {
   for (const key in o1) {
     if (typeof o1[key] !== typeof o2[key]) return false;
     if (typeof o1[key] === "object") {
-      if (!deepEquals(o1[key], o2[key])) return false;
+      if (!_deepEquals(o1[key], o2[key])) return false;
     } else {
       if (o1[key] !== o2[key]) return false;
     }

--- a/src/helpers/zones.ts
+++ b/src/helpers/zones.ts
@@ -1,4 +1,12 @@
-import { CellPosition, Position, UID, UnboundedZone, Zone, ZoneDimension } from "../types";
+import {
+  AdjacentEdge,
+  CellPosition,
+  Position,
+  UID,
+  UnboundedZone,
+  Zone,
+  ZoneDimension,
+} from "../types";
 import {
   MAX_COL,
   MAX_ROW,
@@ -347,15 +355,15 @@ export function unionUnboundedZones(...zones: UnboundedZone[]): UnboundedZone {
 /**
  * Compute the intersection of two zones. Returns nothing if the two zones don't overlap
  */
-export function intersection(z1: Zone, z2: Zone): Zone | undefined {
+export function intersection(z1: UnboundedZone, z2: Zone): Zone | undefined {
   if (!overlap(z1, z2)) {
     return undefined;
   }
   return {
     top: Math.max(z1.top, z2.top),
     left: Math.max(z1.left, z2.left),
-    bottom: Math.min(z1.bottom, z2.bottom),
-    right: Math.min(z1.right, z2.right),
+    bottom: z1.bottom !== undefined ? Math.min(z1.bottom, z2.bottom) : z1.bottom ?? z2.bottom,
+    right: z1.right !== undefined ? Math.min(z1.right, z2.right) : z1.right ?? z2.right,
   };
 }
 
@@ -363,20 +371,68 @@ export function intersection(z1: Zone, z2: Zone): Zone | undefined {
  * Two zones are equal if they represent the same area, so we clearly cannot use
  * reference equality.
  */
-export function isEqual(z1: Zone, z2: Zone): boolean {
+export function isEqual(z1: UnboundedZone, z2: UnboundedZone): boolean {
   return (
-    z1.left === z2.left && z1.right === z2.right && z1.top === z2.top && z1.bottom === z2.bottom
+    z1.left === z2.left &&
+    z1.right === z2.right &&
+    z1.top === z2.top &&
+    z1.bottom === z2.bottom &&
+    z1.hasHeader === z2.hasHeader
   );
+}
+
+/**
+ * Two zones are adjacent if they -partially- share an edge.
+ * Returns the adjacent size of z1 as well as the indexes of the header by which they are adjacent.
+ */
+export function adjacent(z1: UnboundedZone, z2: Zone): AdjacentEdge | undefined {
+  if (intersection(z1, z2)) return undefined;
+  let adjacentEdge: AdjacentEdge | undefined = undefined;
+  if (z1.left === z2.right + 1) {
+    adjacentEdge = {
+      position: "left",
+      start: Math.max(z1.top, z2.top),
+      stop: z1.bottom !== undefined ? Math.min(z1.bottom, z2.bottom) : z2.bottom,
+    };
+  }
+  if (z1.right !== undefined && z1.right + 1 === z2.left) {
+    adjacentEdge = {
+      position: "right",
+      start: Math.max(z1.top, z2.top),
+      stop: z1.bottom !== undefined ? Math.min(z1.bottom, z2.bottom) : z2.bottom,
+    };
+  }
+  if (z1.top === z2.bottom + 1) {
+    adjacentEdge = {
+      position: "top",
+      start: Math.max(z1.left, z2.left),
+      stop: z1.right !== undefined ? Math.min(z1.right, z2.right) : z2.right,
+    };
+  }
+  if (z1.bottom !== undefined && z1.bottom + 1 === z2.top) {
+    adjacentEdge = {
+      position: "bottom",
+      start: Math.max(z1.left, z2.left),
+      stop: z1.right !== undefined ? Math.min(z1.right, z2.right) : z2.right,
+    };
+  }
+  return adjacentEdge && adjacentEdge.start <= adjacentEdge.stop ? adjacentEdge : undefined;
 }
 
 /**
  * Return true if two zones overlap, false otherwise.
  */
-export function overlap(z1: Zone, z2: Zone): boolean {
-  if (z1.bottom < z2.top || z2.bottom < z1.top) {
+export function overlap(z1: UnboundedZone, z2: UnboundedZone): boolean {
+  if (
+    (z1.bottom !== undefined && z1.bottom < z2.top) ||
+    (z2.bottom !== undefined && z2.bottom < z1.top)
+  ) {
     return false;
   }
-  if (z1.right < z2.left || z2.right < z1.left) {
+  if (
+    (z1.right !== undefined && z1.right < z2.left) ||
+    (z2.right !== undefined && z2.right < z1.left)
+  ) {
     return false;
   }
   return true;
@@ -385,7 +441,7 @@ export function overlap(z1: Zone, z2: Zone): boolean {
 /**
  * Returns true if any two zones in the given list overlap.
  */
-export function hasOverlappingZones(zones: Zone[]): boolean {
+export function hasOverlappingZones(zones: UnboundedZone[]): boolean {
   for (let i = 0; i < zones.length - 1; i++) {
     for (let j = i + 1; j < zones.length; j++) {
       if (overlap(zones[i], zones[j])) {
@@ -776,4 +832,62 @@ export function mergeContiguousZones(zones: Zone[]) {
     }
   }
   return mergedZones;
+}
+
+export function splitIfAdjacent(zone: UnboundedZone, zoneToRemove: Zone): UnboundedZone[] {
+  const adjacentEdge = adjacent(zone, zoneToRemove);
+  if (!adjacentEdge) return [zone];
+  const newZones: UnboundedZone[] = [];
+  switch (adjacentEdge.position) {
+    case "bottom":
+    case "top":
+      newZones.push({
+        top: zone.top,
+        bottom: zone.bottom,
+        left: adjacentEdge.start,
+        right: adjacentEdge.stop,
+      });
+      if (adjacentEdge.start > zone.left) {
+        newZones.push({
+          top: zone.top,
+          bottom: zone.bottom,
+          left: zone.left,
+          right: adjacentEdge.start - 1,
+        });
+      }
+      if (zone.right === undefined || adjacentEdge.stop < zone.right) {
+        newZones.push({
+          top: zone.top,
+          bottom: zone.bottom,
+          left: adjacentEdge.stop + 1,
+          right: zone.right,
+        });
+      }
+      return newZones;
+    case "left":
+    case "right":
+      newZones.push({
+        top: adjacentEdge.start,
+        bottom: adjacentEdge.stop,
+        left: zone.left,
+        right: zone.right,
+      });
+      if (adjacentEdge.start > zone.top) {
+        newZones.push({
+          top: zone.top,
+          bottom: adjacentEdge.start - 1,
+          left: zone.left,
+          right: zone.right,
+        });
+      }
+      if (zone.bottom === undefined || adjacentEdge.stop < zone.bottom) {
+        newZones.push({
+          top: adjacentEdge.stop + 1,
+          bottom: zone.bottom,
+          left: zone.left,
+          right: zone.right,
+        });
+      }
+      return newZones;
+  }
 }

--- a/src/plugins/core/borders.ts
+++ b/src/plugins/core/borders.ts
@@ -1,21 +1,20 @@
-import { DEFAULT_BORDER_DESC } from "../../constants";
+import { PositionMap } from "../../helpers/cells/position_map";
 import {
   deepCopy,
   deepEquals,
   getItemId,
-  groupConsecutive,
-  groupItemIdsByZones,
-  isDefined,
-  iterateItemIdsPositions,
-  range,
+  intersection,
+  positionToZone,
   recomputeZones,
+  removeFalsyAttributes,
   toZone,
 } from "../../helpers/index";
+import { adjacent, overlap, splitIfAdjacent, zoneToXc } from "../../helpers/zones";
 import {
-  AddColumnsRowsCommand,
+  ApplyRangeChange,
   Border,
+  BorderData,
   BorderDescr,
-  BorderPosition,
   CellPosition,
   Color,
   CommandResult,
@@ -23,23 +22,39 @@ import {
   ExcelWorkbookData,
   HeaderIndex,
   SetBorderCommand,
+  SetZoneBordersCommand,
   UID,
+  UnboundedZone,
   WorkbookData,
   Zone,
 } from "../../types/index";
 import { CorePlugin } from "../core_plugin";
 
+export type ZoneBorderData = {
+  top?: BorderDescr;
+  bottom?: BorderDescr;
+  left?: BorderDescr;
+  right?: BorderDescr;
+  vertical?: BorderDescr;
+  horizontal?: BorderDescr;
+};
+
+export type ZoneBorder = {
+  zone: UnboundedZone;
+  style: ZoneBorderData;
+};
+
 interface BordersPluginState {
-  readonly borders: Record<UID, ((Border | undefined)[] | undefined)[] | undefined>;
+  readonly borders: Record<UID, ZoneBorder[] | undefined>;
 }
-/**
- * Formatting plugin.
- *
- * This plugin manages all things related to a cell look:
- * - borders
- */
+
 export class BordersPlugin extends CorePlugin<BordersPluginState> implements BordersPluginState {
-  static getters = ["getCellBorder", "getBordersColors"] as const;
+  static getters = [
+    "getCellBorder",
+    "getBorders",
+    "getBordersColors",
+    "getCellBordersInZone",
+  ] as const;
 
   public readonly borders: BordersPluginState["borders"] = {};
 
@@ -50,7 +65,7 @@ export class BordersPlugin extends CorePlugin<BordersPluginState> implements Bor
   allowDispatch(cmd: CoreCommand) {
     switch (cmd.type) {
       case "SET_BORDER":
-        return this.checkBordersUnchanged(cmd);
+        return this.checkValidations(cmd, this.checkBordersUnchanged, this.ensureHasBorder);
       default:
         return CommandResult.Success;
     }
@@ -64,15 +79,7 @@ export class BordersPlugin extends CorePlugin<BordersPluginState> implements Bor
         }
         break;
       case "DUPLICATE_SHEET":
-        const borders = this.borders[cmd.sheetId];
-        if (borders) {
-          // borders is a sparse 2D array.
-          // map and slice preserve empty values and do not set `undefined` instead
-          const bordersCopy = borders
-            .slice()
-            .map((col) => col?.slice().map((border) => deepCopy(border)));
-          this.history.update("borders", cmd.sheetIdTo, bordersCopy);
-        }
+        this.history.update("borders", cmd.sheetIdTo, deepCopy(this.borders[cmd.sheetId]));
         break;
       case "DELETE_SHEET":
         const allBorders = { ...this.borders };
@@ -80,535 +87,346 @@ export class BordersPlugin extends CorePlugin<BordersPluginState> implements Bor
         this.history.update("borders", allBorders);
         break;
       case "SET_BORDER":
-        this.setBorder(cmd.sheetId, cmd.col, cmd.row, cmd.border);
+        if (cmd.border) this.addBorders(cmd.sheetId, [positionToZone(cmd)], cmd.border);
         break;
       case "SET_BORDERS_ON_TARGET":
         for (const zone of cmd.target) {
-          for (let row = zone.top; row <= zone.bottom; row++) {
-            for (let col = zone.left; col <= zone.right; col++) {
-              this.setBorder(cmd.sheetId, col, row, cmd.border);
+          for (let col = zone.left; col <= zone.right; col++) {
+            for (let row = zone.top; row <= zone.bottom; row++) {
+              this.addBorder(
+                cmd.sheetId,
+                { left: col, right: col, top: row, bottom: row },
+                cmd.border && Object.keys(cmd.border).length ? cmd.border : undefined
+              );
             }
           }
         }
         break;
       case "SET_ZONE_BORDERS":
-        if (cmd.border) {
-          const target = cmd.target.map((zone) => this.getters.expandZone(cmd.sheetId, zone));
-          this.setBorders(
-            cmd.sheetId,
-            target,
-            cmd.border.position,
-            cmd.border.color === ""
-              ? undefined
-              : {
-                  style: cmd.border.style || DEFAULT_BORDER_DESC.style,
-                  color: cmd.border.color || DEFAULT_BORDER_DESC.color,
-                }
-          );
+        const target = cmd.target.map((zone) => this.getters.expandZone(cmd.sheetId, zone));
+        if (cmd.border.position === "clear") {
+          this.clearBorders(cmd.sheetId, target);
+        } else {
+          this.addBorders(cmd.sheetId, target, this.borderDataToNewBorderData(cmd.border));
         }
         break;
       case "CLEAR_FORMATTING":
         this.clearBorders(cmd.sheetId, cmd.target);
         break;
-      case "REMOVE_COLUMNS_ROWS":
-        const elements = [...cmd.elements].sort((a, b) => b - a);
-        for (const group of groupConsecutive(elements)) {
-          if (cmd.dimension === "COL") {
-            const zone = this.getters.getColsZone(cmd.sheetId, group[group.length - 1], group[0]);
-            this.clearInsideBorders(cmd.sheetId, [zone]);
-            this.shiftBordersHorizontally(cmd.sheetId, group[0] + 1, -group.length);
-          } else {
-            const zone = this.getters.getRowsZone(cmd.sheetId, group[group.length - 1], group[0]);
-            this.clearInsideBorders(cmd.sheetId, [zone]);
-            this.shiftBordersVertically(cmd.sheetId, group[0] + 1, -group.length);
-          }
-        }
-        break;
-      case "ADD_COLUMNS_ROWS":
-        if (cmd.dimension === "COL") {
-          this.handleAddColumns(cmd);
-        } else {
-          this.handleAddRows(cmd);
-        }
-        break;
     }
   }
 
-  /**
-   * Move borders according to the inserted columns.
-   * Ensure borders continuity.
-   */
-  private handleAddColumns(cmd: AddColumnsRowsCommand) {
-    // The new columns have already been inserted in the sheet at this point.
-    let colLeftOfInsertion: HeaderIndex;
-    let colRightOfInsertion: HeaderIndex;
-    if (cmd.position === "before") {
-      this.shiftBordersHorizontally(cmd.sheetId, cmd.base, cmd.quantity);
-      colLeftOfInsertion = cmd.base - 1;
-      colRightOfInsertion = cmd.base + cmd.quantity;
-    } else {
-      this.shiftBordersHorizontally(cmd.sheetId, cmd.base + 1, cmd.quantity);
-      colLeftOfInsertion = cmd.base;
-      colRightOfInsertion = cmd.base + cmd.quantity + 1;
+  beforeHandle(cmd: CoreCommand): void {
+    if (cmd.type === "REMOVE_COLUMNS_ROWS") {
+      if (cmd.dimension === "ROW") {
+        this.onRowRemove(cmd.sheetId, cmd.elements);
+      } else {
+        this.onColRemove(cmd.sheetId, cmd.elements);
+      }
     }
-    this.ensureColumnBorderContinuity(cmd.sheetId, colLeftOfInsertion, colRightOfInsertion);
   }
 
-  /**
-   * Move borders according to the inserted rows.
-   * Ensure borders continuity.
-   */
-  private handleAddRows(cmd: AddColumnsRowsCommand) {
-    // The new rows have already been inserted at this point.
-    let rowAboveInsertion: HeaderIndex;
-    let rowBelowInsertion: HeaderIndex;
-    if (cmd.position === "before") {
-      this.shiftBordersVertically(cmd.sheetId, cmd.base, cmd.quantity);
-      rowAboveInsertion = cmd.base - 1;
-      rowBelowInsertion = cmd.base + cmd.quantity;
-    } else {
-      this.shiftBordersVertically(cmd.sheetId, cmd.base + 1, cmd.quantity);
-      rowAboveInsertion = cmd.base;
-      rowBelowInsertion = cmd.base + cmd.quantity + 1;
+  adaptRanges(applyChange: ApplyRangeChange, sheetId: UID) {
+    const newBorders: ZoneBorder[] = [];
+    for (const border of this.borders[sheetId] ?? []) {
+      const change = applyChange(this.getters.getRangeFromZone(sheetId, border.zone));
+      switch (change.changeType) {
+        case "RESIZE":
+        case "CHANGE":
+        case "MOVE":
+          newBorders.push({ ...border, zone: change.range.unboundedZone });
+          break;
+        case "NONE":
+          newBorders.push(border);
+          break;
+      }
     }
-    this.ensureRowBorderContinuity(cmd.sheetId, rowAboveInsertion, rowBelowInsertion);
+    this.history.update(
+      "borders",
+      sheetId,
+      newBorders.filter((border) => !this.borderIsClear(border))
+    );
+  }
+
+  private onRowRemove(sheetId: UID, rowsIndex: HeaderIndex[]) {
+    const rows = new Set(rowsIndex);
+    const newBorders: ZoneBorder[] = [];
+    for (const border of this.borders[sheetId] ?? []) {
+      let newBorder = border;
+      if (rows.has(border.zone.top)) {
+        newBorder = deepCopy(border);
+        newBorder.style.top = border.style.horizontal;
+      }
+      if (border.zone.bottom !== undefined && rows.has(border.zone.bottom)) {
+        newBorder = newBorder === border ? deepCopy(border) : newBorder;
+        newBorder.style.bottom = border.style.horizontal;
+      }
+      newBorders.push(newBorder);
+    }
+    this.history.update("borders", sheetId, newBorders);
+  }
+
+  private onColRemove(sheetId: UID, colsIndex: HeaderIndex[]) {
+    const cols = new Set(colsIndex);
+    const newBorders: ZoneBorder[] = [];
+    for (const border of this.borders[sheetId] ?? []) {
+      let newBorder = border;
+      if (cols.has(border.zone.left)) {
+        newBorder = deepCopy(border);
+        newBorder.style.left = border.style.vertical;
+      }
+      if (border.zone.right !== undefined && cols.has(border.zone.right)) {
+        newBorder = newBorder === border ? deepCopy(border) : newBorder;
+        newBorder.style.right = border.style.vertical;
+      }
+      newBorders.push(newBorder);
+    }
+    this.history.update(
+      "borders",
+      sheetId,
+      newBorders.filter((border) => !this.borderIsClear(border))
+    );
   }
 
   // ---------------------------------------------------------------------------
   // Getters
   // ---------------------------------------------------------------------------
 
-  getCellBorder({ sheetId, col, row }: CellPosition): Border | null {
-    const border = this.borders[sheetId]?.[col]?.[row];
-    return border?.top || border?.bottom || border?.left || border?.right ? deepCopy(border) : null;
+  getCellBorder(position: CellPosition): Border {
+    return this.getZoneExternalBorders(position.sheetId, positionToZone(position));
   }
 
-  getBordersColors(sheetId: UID): Color[] {
-    const colors: Color[] = [];
-    const sheetBorders = this.borders[sheetId];
-    if (sheetBorders) {
-      for (const borders of sheetBorders.filter(isDefined)) {
-        for (const cellBorder of borders) {
-          if (cellBorder) {
-            for (const direction of ["top", "bottom", "left", "right"] as Array<keyof Border>) {
-              const color = cellBorder[direction]?.color;
-              if (color) {
-                colors.push(color);
-              }
-            }
-          }
+  private getZoneExternalBorders(sheetId: UID, zone: Zone): ZoneBorderData {
+    const externalBorders: ZoneBorderData = {};
+    for (const border of this.borders[sheetId] ?? []) {
+      if (overlap(border.zone, zone)) {
+        externalBorders.right =
+          (zone.right === border.zone.right ? border.style.right : border.style.vertical) ??
+          externalBorders.right;
+        externalBorders.left =
+          (zone.left === border.zone.left ? border.style.left : border.style.vertical) ??
+          externalBorders.left;
+        externalBorders.bottom =
+          (zone.bottom === border.zone.bottom ? border.style.bottom : border.style.horizontal) ??
+          externalBorders.bottom;
+        externalBorders.top =
+          (zone.top === border.zone.top ? border.style.top : border.style.horizontal) ??
+          externalBorders.top;
+      }
+    }
+    return externalBorders;
+  }
+
+  getCellBordersInZone(sheetId: UID, zone: Zone): PositionMap<Border> {
+    const borders = new PositionMap<Border>();
+    for (const border of this.borders[sheetId] ?? []) {
+      const { zone: bzone, style: bstyle } = border;
+      const inter = intersection(bzone, zone);
+      if (!inter) continue;
+      for (let col = inter.left; col <= inter.right; col++) {
+        for (let row = inter.top; row <= inter.bottom; row++) {
+          const cell = borders.get({ sheetId, col, row }) ?? {};
+          cell.right = (col === bzone.right ? bstyle.right : bstyle.vertical) ?? cell.right;
+          cell.left = (col === bzone.left ? bstyle.left : bstyle.vertical) ?? cell.left;
+          cell.bottom = (row === bzone.bottom ? bstyle.bottom : bstyle.horizontal) ?? cell.bottom;
+          cell.top = (row === bzone.top ? bstyle.top : bstyle.horizontal) ?? cell.top;
+          borders.set({ sheetId, col, row }, cell);
         }
       }
     }
-    return colors;
+    return borders;
+  }
+
+  getBordersColors(sheetId: UID): Color[] {
+    const colors: Set<Color> = new Set<Color>();
+    for (const border of this.borders[sheetId] ?? []) {
+      for (const style of Object.values(border.style)) {
+        if (style?.color) colors.add(style.color);
+      }
+    }
+    return [...colors];
+  }
+
+  getBorders(sheetId: UID, zone: Zone): ZoneBorder[] {
+    const borders: ZoneBorder[] = [];
+    for (const existingBorder of this.borders[sheetId] ?? []) {
+      const inter = intersection(existingBorder.zone, zone);
+      if (!inter) {
+        continue;
+      }
+      borders.push(this.computeBorderFromZone(inter, existingBorder));
+    }
+    return borders;
   }
 
   // ---------------------------------------------------------------------------
   // Private
   // ---------------------------------------------------------------------------
 
-  /**
-   * Ensure border continuity between two columns.
-   * If the two columns have the same borders (at each row respectively),
-   * the same borders are applied to each cell in between.
-   */
-  private ensureColumnBorderContinuity(
-    sheetId: UID,
-    leftColumn: HeaderIndex,
-    rightColumn: HeaderIndex
-  ) {
-    const targetCols = range(leftColumn + 1, rightColumn);
-    for (let row: HeaderIndex = 0; row < this.getters.getNumberRows(sheetId); row++) {
-      const leftBorder = this.getCellBorder({ sheetId, col: leftColumn, row });
-      const rightBorder = this.getCellBorder({ sheetId, col: rightColumn, row });
-      if (leftBorder && rightBorder) {
-        const commonSides = this.getCommonSides(leftBorder, rightBorder);
-        for (const col of targetCols) {
-          this.addBorder(sheetId, col, row, commonSides);
-        }
-      }
-    }
+  private computeBorderFromZone(newZone: UnboundedZone, border: ZoneBorder): ZoneBorder {
+    const oldPosition = border.style;
+    const oldZone = border.zone;
+    const equalSide = {
+      top: newZone.top === oldZone.top,
+      bottom: newZone.bottom === oldZone.bottom,
+      left: newZone.left === oldZone.left,
+      right: newZone.right === oldZone.right,
+    };
+    return {
+      zone: newZone,
+      style: {
+        top: equalSide.top ? oldPosition.top : oldPosition.horizontal,
+        bottom: equalSide.bottom ? oldPosition.bottom : oldPosition.horizontal,
+        left: equalSide.left ? oldPosition.left : oldPosition.vertical,
+        right: equalSide.right ? oldPosition.right : oldPosition.vertical,
+        vertical: oldPosition.vertical,
+        horizontal: oldPosition.horizontal,
+      },
+    };
   }
 
-  /**
-   * Ensure border continuity between two rows.
-   * If the two rows have the same borders (at each column respectively),
-   * the same borders are applied to each cell in between.
-   */
-  private ensureRowBorderContinuity(sheetId: UID, topRow: HeaderIndex, bottomRow: HeaderIndex) {
-    const targetRows = range(topRow + 1, bottomRow);
-    for (let col: HeaderIndex = 0; col < this.getters.getNumberCols(sheetId); col++) {
-      const aboveBorder = this.getCellBorder({ sheetId, col, row: topRow });
-      const belowBorder = this.getCellBorder({ sheetId, col, row: bottomRow });
-      if (aboveBorder && belowBorder) {
-        const commonSides = this.getCommonSides(aboveBorder, belowBorder);
-        for (const row of targetRows) {
-          this.addBorder(sheetId, col, row, commonSides);
-        }
-      }
-    }
+  private borderIsClear(border: ZoneBorder) {
+    const style = border.style;
+    if (style.left || style.right || style.bottom || style.top) return false;
+    const zone = border.zone;
+    if ((zone.bottom === undefined || zone.top < zone.bottom) && style.horizontal) return false;
+    if ((zone.right === undefined || zone.left < zone.right) && style.vertical) return false;
+    return true;
   }
 
-  /**
-   * From two borders, return a new border with sides defined in both borders.
-   * i.e. the intersection of two borders.
-   */
-  private getCommonSides(border1: Border, border2: Border): Border {
-    const commonBorder = {};
-    for (const side of ["top", "bottom", "left", "right"]) {
-      if (border1[side] && deepEquals(border1[side], border2[side])) {
-        commonBorder[side] = border1[side];
-      }
-    }
-    return commonBorder;
-  }
-
-  /**
-   * Get all the columns which contains at least a border
-   */
-  private getColumnsWithBorders(sheetId: UID): HeaderIndex[] {
-    const sheetBorders = this.borders[sheetId];
-    if (!sheetBorders) return [];
-    return Object.keys(sheetBorders).map((index) => parseInt(index, 10));
-  }
-
-  /**
-   * Get all the rows which contains at least a border
-   */
-  private getRowsWithBorders(sheetId: UID): number[] {
-    const sheetBorders = this.borders[sheetId]?.filter(isDefined);
-    if (!sheetBorders) return [];
-    const rowsWithBorders = new Set<number>();
-    for (const rowBorders of sheetBorders) {
-      for (const rowBorder in rowBorders) {
-        rowsWithBorders.add(parseInt(rowBorder, 10));
-      }
-    }
-    return Array.from(rowsWithBorders);
-  }
-
-  /**
-   * Get the range of all the rows in the sheet
-   */
-  private getRowsRange(sheetId: UID): HeaderIndex[] {
-    const sheetBorders = this.borders[sheetId];
-    if (!sheetBorders) return [];
-    return range(0, this.getters.getNumberRows(sheetId) + 1);
-  }
-
-  /**
-   * Move borders of a sheet horizontally.
-   * @param sheetId
-   * @param start starting column (included)
-   * @param delta how much borders will be moved (negative if moved to the left)
-   */
-  private shiftBordersHorizontally(sheetId: UID, start: HeaderIndex, delta: number) {
-    const borders = this.borders[sheetId];
-    if (!borders) return;
-    this.getColumnsWithBorders(sheetId)
-      .filter((col) => col >= start)
-      .sort((a, b) => (delta < 0 ? a - b : b - a)) // start by the end when moving up
-      .forEach((col) => {
-        this.moveBordersOfColumn(sheetId, col, delta);
-      });
-  }
-
-  /**
-   * Move borders of a sheet vertically.
-   * @param sheetId
-   * @param start starting row (included)
-   * @param delta how much borders will be moved (negative if moved to the above)
-   */
-  private shiftBordersVertically(sheetId: UID, start: HeaderIndex, delta: number) {
-    const borders = this.borders[sheetId];
-    if (!borders) return;
-    if (delta < 0) {
-      this.moveBordersOfRow(sheetId, start, delta, {
-        destructive: false,
-      });
-    }
-    this.getRowsWithBorders(sheetId)
-      .filter((row) => row >= start)
-      .sort((a, b) => (delta < 0 ? a - b : b - a)) // start by the end when moving up
-      .forEach((row) => {
-        this.moveBordersOfRow(sheetId, row, delta);
-      });
-  }
-
-  /**
-   * Moves the borders (left if `vertical` or top if `horizontal` depending on
-   * `borderDirection`) of all cells in an entire row `delta` rows to the right
-   * (`delta` > 0) or to the left (`delta` < 0).
-   * Note that as the left of a cell is the right of the cell-1, if the left is
-   * moved the right is also moved. However, if `horizontal`, the bottom border
-   * is not moved.
-   * It does it by replacing the target border by the moved border. If the
-   * argument `destructive` is given false, the target border is preserved if
-   * the moved border is empty
-   */
-  private moveBordersOfRow(
-    sheetId: UID,
-    row: HeaderIndex,
-    delta: number,
-    { destructive }: { destructive: boolean } = { destructive: true }
-  ) {
-    const borders = this.borders[sheetId];
-    if (!borders) return;
-    this.getColumnsWithBorders(sheetId).forEach((col) => {
-      const targetBorder = borders[col]?.[row + delta];
-      const movedBorder = borders[col]?.[row];
-      this.history.update(
-        "borders",
-        sheetId,
-        col,
-        row + delta,
-        destructive ? movedBorder : movedBorder || targetBorder
-      );
-      this.history.update("borders", sheetId, col, row, undefined);
-    });
-  }
-
-  /**
-   * Moves the borders (left if `vertical` or top if `horizontal` depending on
-   * `borderDirection`) of all cells in an entire column `delta` columns below
-   * (`delta` > 0) or above (`delta` < 0).
-   * Note that as the top of a cell is the bottom of the cell-1, if the top is
-   * moved the bottom is also moved. However, if `vertical`, the right border
-   * is not moved.
-   * It does it by replacing the target border by the moved border. If the
-   * argument `destructive` is given false, the target border is preserved if
-   * the moved border is empty
-   */
-  private moveBordersOfColumn(
-    sheetId: UID,
-    col: HeaderIndex,
-    delta: number,
-    { destructive }: { destructive: boolean } = { destructive: true }
-  ) {
-    const borders = this.borders[sheetId];
-    if (!borders) return;
-    this.getRowsRange(sheetId).forEach((row) => {
-      const targetBorder = borders[col + delta]?.[row];
-      const movedBorder = borders[col]?.[row];
-      this.history.update(
-        "borders",
-        sheetId,
-        col + delta,
-        row,
-        destructive ? movedBorder : movedBorder || targetBorder
-      );
-      if (destructive) {
-        this.history.update("borders", sheetId, col, row, undefined);
-      }
-    });
-  }
-
-  /**
-   * Set the borders of a cell.
-   * It overrides the current border if override === true.
-   */
-  private setBorder(
-    sheetId: UID,
-    col: HeaderIndex,
-    row: HeaderIndex,
-    border?: Border,
-    override = true
-  ) {
-    const maxCol = this.getters.getNumberCols(sheetId) - 1;
-    const maxRow = this.getters.getNumberRows(sheetId) - 1;
-    if (override || !this.borders[sheetId]?.[col]?.[row]?.left) {
-      this.history.update("borders", sheetId, col, row, "left", border?.left);
-      if (
-        border?.left &&
-        col > 0 &&
-        !deepEquals(this.borders[sheetId]?.[col - 1]?.[row]?.right, border?.left)
-      ) {
-        this.history.update("borders", sheetId, col - 1, row, "right", undefined);
-      }
-    }
-    if (override || !this.borders[sheetId]?.[col]?.[row]?.top) {
-      this.history.update("borders", sheetId, col, row, "top", border?.top);
-      if (
-        border?.top &&
-        row > 0 &&
-        !deepEquals(this.borders[sheetId]?.[col]?.[row - 1]?.bottom, border?.top)
-      ) {
-        this.history.update("borders", sheetId, col, row - 1, "bottom", undefined);
-      }
-    }
-    if (override || !this.borders[sheetId]?.[col]?.[row]?.right) {
-      this.history.update("borders", sheetId, col, row, "right", border?.right);
-      if (
-        border?.right &&
-        col < maxCol &&
-        !deepEquals(this.borders[sheetId]?.[col + 1]?.[row]?.left, border?.right)
-      ) {
-        this.history.update("borders", sheetId, col + 1, row, "left", undefined);
-      }
-    }
-    if (override || !this.borders[sheetId]?.[col]?.[row]?.bottom) {
-      this.history.update("borders", sheetId, col, row, "bottom", border?.bottom);
-      if (
-        border?.bottom &&
-        row < maxRow &&
-        !deepEquals(this.borders[sheetId]?.[col]?.[row + 1]?.top, border?.bottom)
-      ) {
-        this.history.update("borders", sheetId, col, row + 1, "top", undefined);
-      }
-    }
-  }
-
-  /**
-   * Remove the borders of a zone
-   */
-  private clearBorders(sheetId: UID, zones: Zone[], eraseBoundaries = false) {
-    const maxCol = this.getters.getNumberCols(sheetId) - 1;
-    const maxRow = this.getters.getNumberRows(sheetId) - 1;
-    for (const zone of recomputeZones(zones)) {
-      for (let row = zone.top; row <= zone.bottom; row++) {
-        if (eraseBoundaries) {
-          if (zone.left > 0) {
-            this.history.update("borders", sheetId, zone.left - 1, row, "right", undefined);
-          }
-          if (zone.right < maxCol) {
-            this.history.update("borders", sheetId, zone.right + 1, row, "left", undefined);
-          }
-        }
-        for (let col = zone.left; col <= zone.right; col++) {
-          this.history.update("borders", sheetId, col, row, undefined);
-          if (eraseBoundaries) {
-            if (zone.top > 0) {
-              this.history.update("borders", sheetId, col, zone.top - 1, "bottom", undefined);
-            }
-            if (zone.bottom < maxRow) {
-              this.history.update("borders", sheetId, col, zone.bottom + 1, "top", undefined);
-            }
-          }
-        }
-      }
-    }
-  }
-
-  /**
-   * Remove the borders inside of a zone
-   */
-  private clearInsideBorders(sheetId: UID, zones: Zone[]) {
+  private clearBorders(sheetId: UID, zones: Zone[]) {
     for (const zone of zones) {
-      for (let row = zone.top; row <= zone.bottom; row++) {
-        for (let col = zone.left; col <= zone.right; col++) {
-          this.history.update("borders", sheetId, col, row, undefined);
-        }
-      }
+      this.removeAndClearAdjacent(sheetId, zone);
     }
   }
 
-  /**
-   * Add a border to the existing one to a cell
-   */
-  private addBorder(sheetId: UID, col: HeaderIndex, row: HeaderIndex, border: Border) {
-    this.setBorder(sheetId, col, row, {
-      ...this.getCellBorder({ sheetId, col, row }),
-      ...border,
-    });
+  private removeAndClearAdjacent(sheetId: UID, zone: Zone) {
+    const borders: ZoneBorder[] = [];
+    for (const existingBorder of this.borders[sheetId] ?? []) {
+      for (const updatedBorderZone of recomputeZones([existingBorder.zone], [zone])) {
+        for (const newZone of splitIfAdjacent(updatedBorderZone, zone)) {
+          const border = this.computeBorderFromZone(newZone, existingBorder);
+          const adjacentEdge = adjacent(newZone, zone);
+          switch (adjacentEdge?.position) {
+            case "left":
+              border.style.left = undefined;
+              break;
+            case "right":
+              border.style.right = undefined;
+              break;
+            case "top":
+              border.style.top = undefined;
+              break;
+            case "bottom":
+              border.style.bottom = undefined;
+              break;
+          }
+          borders.push(border);
+        }
+      }
+    }
+    this.history.update("borders", sheetId, borders);
   }
 
-  /**
-   * Set the borders of a zone by computing the borders to add from the given
-   * command
-   */
-  private setBorders(
+  private addBorders(sheetId: UID, zones: Zone[], border: ZoneBorderData) {
+    for (const zone of zones) {
+      this.addBorder(sheetId, zone, border);
+    }
+  }
+
+  private addBorder(
     sheetId: UID,
-    zones: Zone[],
-    position: BorderPosition,
-    border: BorderDescr | undefined
+    zone: Zone,
+    newBorder: ZoneBorderData | undefined,
+    force = false
   ) {
-    if (position === "clear") {
-      return this.clearBorders(sheetId, zones, true);
-    }
-    for (const zone of recomputeZones(zones)) {
-      if (position === "all") {
-        for (let row = zone.top; row <= zone.bottom; row++) {
-          for (let col = zone.left; col <= zone.right; col++) {
-            this.addBorder(sheetId, col, row, {
-              top: border,
-              right: border,
-              bottom: border,
-              left: border,
-            });
+    const borders: ZoneBorder[] = [];
+    const plannedBorder = newBorder ? { zone, style: newBorder } : undefined;
+    const sideToClear = {
+      left: force || !!newBorder?.left,
+      right: force || !!newBorder?.right,
+      top: force || !!newBorder?.top,
+      bottom: force || !!newBorder?.bottom,
+    };
+    let editingZone: Zone[] = [zone];
+    for (const existingBorder of this.borders[sheetId] ?? []) {
+      const inter = intersection(existingBorder.zone, zone);
+      if (!inter) {
+        // Clear adjacent borders on which you write
+        const adjacentEdge = adjacent(existingBorder.zone, zone);
+        if (adjacentEdge && sideToClear[adjacentEdge.position]) {
+          for (const newZone of splitIfAdjacent(existingBorder.zone, zone)) {
+            const border = this.computeBorderFromZone(newZone, existingBorder);
+            const adjacentEdge = adjacent(newZone, zone);
+            switch (adjacentEdge?.position) {
+              case "left":
+                border.style.left = undefined;
+                break;
+              case "right":
+                border.style.right = undefined;
+                break;
+              case "top":
+                border.style.top = undefined;
+                break;
+              case "bottom":
+                border.style.bottom = undefined;
+                break;
+            }
+            borders.push(border);
           }
+        } else {
+          borders.push(existingBorder);
         }
+        continue;
       }
-      if (position === "h" || position === "hv") {
-        if (zone.top === zone.bottom) {
-          continue;
+
+      if (plannedBorder) {
+        let border = this.computeBorderFromZone(inter, plannedBorder).style;
+        if (!force) {
+          border = {
+            ...this.computeBorderFromZone(inter, existingBorder).style,
+            ...removeFalsyAttributes(border),
+          };
         }
-        for (let col = zone.left; col <= zone.right; col++) {
-          this.addBorder(sheetId, col, zone.top, { bottom: border });
-          for (let row = zone.top + 1; row < zone.bottom; row++) {
-            this.addBorder(sheetId, col, row, { top: border, bottom: border });
-          }
-          this.addBorder(sheetId, col, zone.bottom, { top: border });
-        }
+        borders.push({ zone: inter, style: border });
       }
-      if (position === "v" || position === "hv") {
-        if (zone.left === zone.right) {
-          continue;
-        }
-        for (let row = zone.top; row <= zone.bottom; row++) {
-          this.addBorder(sheetId, zone.left, row, { right: border });
-          for (let col = zone.left + 1; col < zone.right; col++) {
-            this.addBorder(sheetId, col, row, { left: border, right: border });
-          }
-          this.addBorder(sheetId, zone.right, row, { left: border });
-        }
-      }
-      if (position === "left" || position === "external") {
-        for (let row = zone.top; row <= zone.bottom; row++) {
-          this.addBorder(sheetId, zone.left, row, { left: border });
-        }
-      }
-      if (position === "right" || position === "external") {
-        for (let row = zone.top; row <= zone.bottom; row++) {
-          this.addBorder(sheetId, zone.right, row, { right: border });
-        }
-      }
-      if (position === "top" || position === "external") {
-        for (let col = zone.left; col <= zone.right; col++) {
-          this.addBorder(sheetId, col, zone.top, { top: border });
-        }
-      }
-      if (position === "bottom" || position === "external") {
-        for (let col = zone.left; col <= zone.right; col++) {
-          this.addBorder(sheetId, col, zone.bottom, { bottom: border });
-        }
+      editingZone = recomputeZones(editingZone, [inter]);
+      for (const updatedBorderZone of recomputeZones([existingBorder.zone], [inter])) {
+        borders.push(this.computeBorderFromZone(updatedBorderZone, existingBorder));
       }
     }
+    if (plannedBorder) {
+      borders.push(...editingZone.map((zone) => this.computeBorderFromZone(zone, plannedBorder)));
+    }
+    this.history.update(
+      "borders",
+      sheetId,
+      borders.filter((border) => !this.borderIsClear(border))
+    );
   }
 
-  /**
-   * Compute the borders to add to the given zone merged.
-   */
-  private addBordersToMerge(sheetId: UID, zone: Zone) {
-    const { left, right, top, bottom } = zone;
-    const bordersTopLeft = this.getCellBorder({ sheetId, col: left, row: top });
-    const bordersBottomRight = this.getCellBorder({ sheetId, col: right, row: bottom });
-    this.clearBorders(sheetId, [zone]);
-    if (bordersTopLeft?.top) {
-      this.setBorders(sheetId, [{ ...zone, bottom: top }], "top", bordersTopLeft.top);
+  private borderDataToNewBorderData(border: BorderData): ZoneBorderData {
+    const borderPosition: ZoneBorderData = {};
+    const borderStyle = { color: border.color ?? "#000000", style: border.style ?? "thin" };
+    if (["all", "external", "top"].includes(border.position)) {
+      borderPosition.top = { ...borderStyle };
     }
-    if (bordersTopLeft?.left) {
-      this.setBorders(sheetId, [{ ...zone, right: left }], "left", bordersTopLeft.left);
+    if (["all", "external", "bottom"].includes(border.position)) {
+      borderPosition.bottom = { ...borderStyle };
     }
-    if (bordersBottomRight?.bottom) {
-      this.setBorders(sheetId, [{ ...zone, top: bottom }], "bottom", bordersBottomRight.bottom);
-    } else if (bordersTopLeft?.bottom) {
-      this.setBorders(sheetId, [{ ...zone, top: bottom }], "bottom", bordersTopLeft.bottom);
+    if (["all", "external", "left"].includes(border.position)) {
+      borderPosition.left = { ...borderStyle };
     }
-    if (bordersBottomRight?.right) {
-      this.setBorders(sheetId, [{ ...zone, left: right }], "right", bordersBottomRight.right);
-    } else if (bordersTopLeft?.right) {
-      this.setBorders(sheetId, [{ ...zone, left: right }], "right", bordersTopLeft.right);
+    if (["all", "external", "right"].includes(border.position)) {
+      borderPosition.right = { ...borderStyle };
     }
+    if (["all", "hv", "v"].includes(border.position)) {
+      borderPosition.vertical = { ...borderStyle };
+    }
+    if (["all", "hv", "h"].includes(border.position)) {
+      borderPosition.horizontal = { ...borderStyle };
+    }
+    return borderPosition;
   }
 
   private checkBordersUnchanged(cmd: SetBorderCommand) {
@@ -621,18 +439,32 @@ export class BordersPlugin extends CorePlugin<BordersPluginState> implements Bor
     return CommandResult.Success;
   }
 
+  private ensureHasBorder(cmd: SetBorderCommand | SetZoneBordersCommand) {
+    if (!cmd.border) return CommandResult.NoChanges;
+    return CommandResult.Success;
+  }
+
+  /**
+   * Compute the borders to add to the given zone merged.
+   */
+  private addBordersToMerge(sheetId: UID, zone: Zone) {
+    const border = {
+      ...this.getZoneExternalBorders(sheetId, zone),
+      ...removeFalsyAttributes(this.getCellBorder({ sheetId, col: zone.left, row: zone.top })),
+    };
+    this.addBorder(sheetId, zone, border, true);
+  }
+
   // ---------------------------------------------------------------------------
   // Import/Export
   // ---------------------------------------------------------------------------
 
   import(data: WorkbookData) {
-    // Borders
     if (Object.keys(data.borders || {}).length) {
       for (const sheet of data.sheets) {
-        for (const [position, borderId] of iterateItemIdsPositions(sheet.id, sheet.borders)) {
-          const { sheetId, col, row } = position;
-          const border = data.borders[borderId];
-          this.setBorder(sheetId, col, row, border, false);
+        for (const zoneXc in sheet.borders) {
+          const borderId = sheet.borders[zoneXc];
+          this.addBorder(sheet.id, toZone(zoneXc), data.borders[borderId]);
         }
       }
     }
@@ -647,21 +479,12 @@ export class BordersPlugin extends CorePlugin<BordersPluginState> implements Bor
   }
 
   export(data: WorkbookData) {
-    const borders: { [borderId: number]: Border } = {};
+    const borders: { [borderId: number]: ZoneBorderData } = {};
     for (const sheet of data.sheets) {
-      const positionsByBorder: Record<number, CellPosition[]> = {};
-      for (let col: HeaderIndex = 0; col < sheet.colNumber; col++) {
-        for (let row: HeaderIndex = 0; row < sheet.rowNumber; row++) {
-          const border = this.getCellBorder({ sheetId: sheet.id, col, row });
-          if (border) {
-            const borderId = getItemId(border, borders);
-            const position = { sheetId: sheet.id, col, row };
-            positionsByBorder[borderId] ??= [];
-            positionsByBorder[borderId].push(position);
-          }
-        }
+      sheet.borders = {};
+      for (const border of this.borders[sheet.id] ?? []) {
+        sheet.borders[zoneToXc(border.zone)] = getItemId(border.style, borders);
       }
-      sheet.borders = groupItemIdsByZones(positionsByBorder);
     }
     data.borders = borders;
   }

--- a/src/plugins/core/cell.ts
+++ b/src/plugins/core/cell.ts
@@ -4,6 +4,7 @@ import { compileTokens } from "../../formulas/compiler";
 import { isEvaluationError, toString } from "../../functions/helpers";
 import { deepEquals, isExcelCompatible, isTextFormat, recomputeZones } from "../../helpers";
 import { parseLiteral } from "../../helpers/cells";
+import { PositionMap } from "../../helpers/cells/position_map";
 import {
   getItemId,
   groupItemIdsByZones,
@@ -46,7 +47,6 @@ import {
   Zone,
 } from "../../types/index";
 import { CorePlugin } from "../core_plugin";
-import { PositionMap } from "../ui_core_views/cell_evaluation/position_map";
 
 interface CoreState {
   // this.cells[sheetId][cellId] --> cell|undefined

--- a/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
@@ -10,6 +10,7 @@ import {
   union,
 } from "../../../helpers";
 import { createEvaluatedCell, evaluateLiteral } from "../../../helpers/cells";
+import { PositionMap } from "../../../helpers/cells/position_map";
 import { ModelConfig } from "../../../model";
 import { onIterationEndEvaluationRegistry } from "../../../registries/evaluation_registry";
 import { _t } from "../../../translation";
@@ -36,7 +37,6 @@ import {
 } from "../../../types/errors";
 import { CompilationParameters, buildCompilationParameters } from "./compilation_parameters";
 import { FormulaDependencyGraph } from "./formula_dependency_graph";
-import { PositionMap } from "./position_map";
 import { PositionSet, SheetSizes } from "./position_set";
 import { RTreeBoundingBox } from "./r_tree";
 import { SpreadingRelation } from "./spreading_relation";

--- a/src/plugins/ui_core_views/cell_evaluation/formula_dependency_graph.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/formula_dependency_graph.ts
@@ -1,7 +1,7 @@
 import { positionToZone } from "../../../helpers";
+import { PositionMap } from "../../../helpers/cells/position_map";
 import { recomputeZones } from "../../../helpers/recompute_zones";
 import { CellPosition, UID, Zone } from "../../../types";
-import { PositionMap } from "./position_map";
 import { PositionSet } from "./position_set";
 import { RTreeBoundingBox, RTreeItem, SpreadsheetRTree } from "./r_tree";
 

--- a/src/plugins/ui_core_views/cell_evaluation/spreading_relation.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/spreading_relation.ts
@@ -1,6 +1,6 @@
 import { positionToZone } from "../../../helpers";
+import { PositionMap } from "../../../helpers/cells/position_map";
 import { CellPosition, UID, Zone } from "../../../types";
-import { PositionMap } from "./position_map";
 import { SpreadsheetRTree } from "./r_tree";
 
 /**

--- a/src/plugins/ui_feature/cell_computed_style.ts
+++ b/src/plugins/ui_feature/cell_computed_style.ts
@@ -1,13 +1,13 @@
 import { LINK_COLOR } from "../../constants";
 import { PositionMap } from "../../helpers/cells/position_map";
-import { isObjectEmptyRecursive, removeFalsyAttributes } from "../../helpers/index";
+import { isObjectEmptyRecursive, positionToZone, removeFalsyAttributes } from "../../helpers/index";
 import {
   Command,
   invalidateBordersCommands,
   invalidateCFEvaluationCommands,
   invalidateEvaluationCommands,
 } from "../../types";
-import { Border, CellPosition, Style } from "../../types/misc";
+import { Border, CellPosition, Style, UID, Zone } from "../../types/misc";
 import { UIPlugin } from "../ui_plugin";
 import { doesCommandInvalidatesTableStyle } from "./table_computed_style";
 
@@ -52,13 +52,35 @@ export class CellComputedStylePlugin extends UIPlugin {
     }
   }
 
-  getCellComputedBorder(position: CellPosition): Border | null {
+  getCellComputedBorder(position: CellPosition, precomputeZone?: Zone): Border | null {
     let border = this.borders.get(position);
     if (border === undefined) {
-      border = this.computeCellBorder(position);
-      this.borders.set(position, border);
+      this.precomputeCellBorders(position.sheetId, precomputeZone ?? positionToZone(position));
+      border = this.borders.get(position);
     }
-    return border;
+    return border ?? null;
+  }
+
+  private precomputeCellBorders(sheetId: UID, zone: Zone) {
+    const borders = this.getters.getCellBordersInZone(sheetId, zone);
+    const tableBorders = this.getters.getCellTableBorderZone(sheetId, zone);
+    for (let col = zone.left; col <= zone.right; col++) {
+      for (let row = zone.top; row <= zone.bottom; row++) {
+        const position = { sheetId, col, row };
+        if (this.borders.get(position) !== undefined) continue;
+        const cellBorder = borders.get(position);
+        const cellTableBorder = tableBorders.get(position);
+        const border = {
+          ...removeFalsyAttributes(cellTableBorder),
+          ...removeFalsyAttributes(cellBorder),
+        };
+        if (isObjectEmptyRecursive(border)) {
+          this.borders.set(position, null);
+        } else {
+          this.borders.set(position, border);
+        }
+      }
+    }
   }
 
   getCellComputedStyle(position: CellPosition): Style {
@@ -68,19 +90,6 @@ export class CellComputedStylePlugin extends UIPlugin {
       this.styles.set(position, style);
     }
     return style;
-  }
-
-  private computeCellBorder(position: CellPosition): Border | null {
-    const cellBorder = this.getters.getCellBorder(position) || {};
-    const cellTableBorder = this.getters.getCellTableBorder(position) || {};
-
-    // Use removeFalsyAttributes to avoid overwriting borders with undefined values
-    const border = {
-      ...removeFalsyAttributes(cellTableBorder),
-      ...removeFalsyAttributes(cellBorder),
-    };
-
-    return isObjectEmptyRecursive(border) ? null : border;
   }
 
   private computeCellStyle(position: CellPosition): Style {

--- a/src/stores/formula_fingerprints_store.ts
+++ b/src/stores/formula_fingerprints_store.ts
@@ -5,7 +5,7 @@ import {
   reorderZone,
   setColorAlpha,
 } from "../helpers";
-import { PositionMap } from "../plugins/ui_core_views/cell_evaluation/position_map";
+import { PositionMap } from "../helpers/cells/position_map";
 import {
   Cell,
   CellPosition,

--- a/src/types/misc.ts
+++ b/src/types/misc.ts
@@ -77,6 +77,12 @@ export interface Selection {
   zones: Zone[];
 }
 
+export type AdjacentEdge = {
+  position: "left" | "top" | "bottom" | "right";
+  start: HeaderIndex;
+  stop: HeaderIndex;
+};
+
 export interface UnboundedZone {
   top: HeaderIndex;
   bottom: HeaderIndex | undefined;

--- a/src/types/workbook_data.ts
+++ b/src/types/workbook_data.ts
@@ -1,9 +1,9 @@
 import { CellValue, DataValidationRule, Format, Locale } from ".";
+import { ZoneBorderData } from "../plugins/core";
 import { ExcelChartDefinition } from "./chart/chart";
 import { ConditionalFormat } from "./conditional_formatting";
 import { Image } from "./image";
 import {
-  Border,
   Color,
   Dimension,
   HeaderGroup,
@@ -74,7 +74,7 @@ export interface WorkbookData {
   sheets: SheetData[];
   styles: { [key: number]: Style };
   formats: { [key: number]: Format };
-  borders: { [key: number]: Border };
+  borders: { [key: number]: ZoneBorderData };
   pivots: { [key: string]: PivotData };
   pivotNextId: number;
   revisionId: UID;

--- a/src/xlsx/functions/worksheet.ts
+++ b/src/xlsx/functions/worksheet.ts
@@ -10,8 +10,8 @@ import {
   toXC,
   toZone,
 } from "../../helpers";
+import { PositionMap } from "../../helpers/cells/position_map";
 import { withHttps } from "../../helpers/links";
-import { PositionMap } from "../../plugins/ui_core_views/cell_evaluation/position_map";
 import { ExcelHeaderData, ExcelSheetData, ExcelWorkbookData } from "../../types";
 import { CellErrorType } from "../../types/errors";
 import { XLSXStructure, XMLAttributes, XMLString } from "../../types/xlsx";

--- a/tests/borders/border_plugin.test.ts
+++ b/tests/borders/border_plugin.test.ts
@@ -11,6 +11,8 @@ import {
   deleteCells,
   deleteColumns,
   deleteRows,
+  moveColumns,
+  moveRows,
   paste,
   selectCell,
   setAnchorCorner,
@@ -795,6 +797,102 @@ describe("Grid manipulation", () => {
     expect(getBorder(model, "C3")).toBeNull();
     // untouched as the border are the same
     expect(getBorder(model, "D2")).toEqual({ top: DEFAULT_BORDER_DESC });
+  });
+
+  test("Moving top row", () => {
+    setZoneBorders(model, { position: "external" }, ["B2:D4"]);
+    moveRows(model, 9, [1], "after");
+    const newBorders = model.getters.getBorders(model.getters.getActiveSheetId(), toZone("A1:Z25"));
+
+    expect(newBorders[0]).toMatchObject({
+      style: {
+        left: DEFAULT_BORDER_DESC,
+        right: DEFAULT_BORDER_DESC,
+        bottom: DEFAULT_BORDER_DESC,
+      },
+      zone: toZone("B2:D3"),
+    });
+
+    expect(newBorders[1]).toMatchObject({
+      style: {
+        left: DEFAULT_BORDER_DESC,
+        right: DEFAULT_BORDER_DESC,
+        top: DEFAULT_BORDER_DESC,
+      },
+      zone: toZone("B10:D10"),
+    });
+  });
+
+  test("Moving bottom row", () => {
+    setZoneBorders(model, { position: "external" }, ["B2:D4"]);
+    moveRows(model, 9, [3], "after");
+    const newBorders = model.getters.getBorders(model.getters.getActiveSheetId(), toZone("A1:Z25"));
+
+    expect(newBorders[0]).toMatchObject({
+      style: {
+        left: DEFAULT_BORDER_DESC,
+        right: DEFAULT_BORDER_DESC,
+        top: DEFAULT_BORDER_DESC,
+      },
+      zone: toZone("B2:D3"),
+    });
+
+    expect(newBorders[1]).toMatchObject({
+      style: {
+        left: DEFAULT_BORDER_DESC,
+        right: DEFAULT_BORDER_DESC,
+        bottom: DEFAULT_BORDER_DESC,
+      },
+      zone: toZone("B10:D10"),
+    });
+  });
+
+  test("Moving left col", () => {
+    setZoneBorders(model, { position: "external" }, ["B2:D4"]);
+    moveColumns(model, "F", ["B"], "after");
+    const newBorders = model.getters.getBorders(model.getters.getActiveSheetId(), toZone("A1:Z25"));
+
+    expect(newBorders[0]).toMatchObject({
+      style: {
+        right: DEFAULT_BORDER_DESC,
+        top: DEFAULT_BORDER_DESC,
+        bottom: DEFAULT_BORDER_DESC,
+      },
+      zone: toZone("B2:C4"),
+    });
+
+    expect(newBorders[1]).toMatchObject({
+      style: {
+        left: DEFAULT_BORDER_DESC,
+        top: DEFAULT_BORDER_DESC,
+        bottom: DEFAULT_BORDER_DESC,
+      },
+      zone: toZone("F2:F4"),
+    });
+  });
+
+  test("Moving right col", () => {
+    setZoneBorders(model, { position: "external" }, ["B2:D4"]);
+    moveColumns(model, "F", ["D"], "after");
+    const newBorders = model.getters.getBorders(model.getters.getActiveSheetId(), toZone("A1:Z25"));
+
+    expect(newBorders[0]).toMatchObject({
+      style: {
+        left: DEFAULT_BORDER_DESC,
+        top: DEFAULT_BORDER_DESC,
+        bottom: DEFAULT_BORDER_DESC,
+      },
+      zone: toZone("B2:C4"),
+    });
+
+    expect(newBorders[1]).toMatchObject({
+      style: {
+        right: DEFAULT_BORDER_DESC,
+        top: DEFAULT_BORDER_DESC,
+        bottom: DEFAULT_BORDER_DESC,
+      },
+      zone: toZone("F2:F4"),
+    });
   });
 
   test("Setting a *clear* border on a cell removes the adjacent border cell", () => {

--- a/tests/borders/border_plugin.test.ts
+++ b/tests/borders/border_plugin.test.ts
@@ -1,5 +1,8 @@
 import { DEFAULT_BORDER_DESC } from "../../src/constants";
+import { toZone } from "../../src/helpers";
+import { removeFalsyAttributes } from "../../src/helpers/misc";
 import { Model } from "../../src/model";
+import { BordersPlugin } from "../../src/plugins/core";
 import { BorderDescr, CommandResult } from "../../src/types/index";
 import {
   addColumns,
@@ -24,6 +27,7 @@ import {
   getComputedBorder,
 } from "../test_helpers/getters_helpers";
 import "../test_helpers/helpers"; // to have getcontext mocks
+import { getPlugin } from "../test_helpers/helpers";
 
 describe("borders", () => {
   test("can add and remove a border, on empty cell", () => {
@@ -440,6 +444,27 @@ describe("borders", () => {
     });
     expect(getBorder(model, "B2")).toBeNull();
   });
+
+  test("Add single internal borders", () => {
+    const model = new Model();
+    setZoneBorders(model, { position: "hv" }, ["C3:D4"]);
+    expect(getBorder(model, "C3")).toEqual({
+      right: DEFAULT_BORDER_DESC,
+      bottom: DEFAULT_BORDER_DESC,
+    });
+    expect(getBorder(model, "D3")).toEqual({
+      bottom: DEFAULT_BORDER_DESC,
+      left: DEFAULT_BORDER_DESC,
+    });
+    expect(getBorder(model, "C4")).toEqual({
+      right: DEFAULT_BORDER_DESC,
+      top: DEFAULT_BORDER_DESC,
+    });
+    expect(getBorder(model, "D4")).toEqual({
+      top: DEFAULT_BORDER_DESC,
+      left: DEFAULT_BORDER_DESC,
+    });
+  });
 });
 
 describe("Grid manipulation", () => {
@@ -775,17 +800,131 @@ describe("Grid manipulation", () => {
   test("Setting a *clear* border on a cell removes the adjacent border cell", () => {
     const model = new Model();
     const b = DEFAULT_BORDER_DESC;
+    const allSides = { left: b, right: b, top: b, bottom: b };
     setZoneBorders(model, { position: "all" }, ["A1:C3"]);
     setZoneBorders(model, { position: "clear" }, ["B2"]);
-    expect(getBorder(model, "A1")).toEqual({ top: b, bottom: b, left: b, right: b });
+
+    /**
+     * ----------------     ----------------
+     * | A1 | B1 | C1 |     | A1 | B1 | C1 |
+     * ----------------     ------    ------
+     * | A2 | B2 | C2 |  => | A2   B2   C2 |
+     * ----------------     ------    ------
+     * | A3 | B3 | C3 |     | A3 | B3 | C3 |
+     * ----------------     ----------------
+     */
+
+    expect(getBorder(model, "A1")).toEqual(allSides);
     expect(getBorder(model, "A2")).toEqual({ top: b, bottom: b, left: b });
-    expect(getBorder(model, "A3")).toEqual({ top: b, bottom: b, left: b, right: b });
+    expect(getBorder(model, "A3")).toEqual(allSides);
     expect(getBorder(model, "B1")).toEqual({ top: b, left: b, right: b });
     expect(getBorder(model, "B2")).toBeNull();
     expect(getBorder(model, "B3")).toEqual({ bottom: b, left: b, right: b });
-    expect(getBorder(model, "C1")).toEqual({ top: b, bottom: b, left: b, right: b });
+    expect(getBorder(model, "C1")).toEqual(allSides);
     expect(getBorder(model, "C2")).toEqual({ top: b, bottom: b, right: b });
-    expect(getBorder(model, "C3")).toEqual({ top: b, bottom: b, left: b, right: b });
+    expect(getBorder(model, "C3")).toEqual(allSides);
+  });
+
+  test("Setting a *clear* border on multiple cells removes the adjacent border cell ", () => {
+    const model = new Model();
+    const b = DEFAULT_BORDER_DESC;
+    const allSides = { left: b, right: b, top: b, bottom: b };
+    const sheetId = model.getters.getActiveSheetId();
+    setZoneBorders(model, { position: "all" }, ["A1:F6"]);
+    const borders = getPlugin(model, BordersPlugin);
+    const getZoneBorder = (zone: string) => {
+      return removeFalsyAttributes(borders["getZoneExternalBorders"](sheetId, toZone(zone)));
+    };
+
+    expect(getZoneBorder("A1:B2")).toEqual(allSides);
+    expect(getZoneBorder("C1:D2")).toEqual(allSides);
+    expect(getZoneBorder("E1:F2")).toEqual(allSides);
+    expect(getZoneBorder("A3:B4")).toEqual(allSides);
+    expect(getZoneBorder("C3:D4")).toEqual(allSides);
+    expect(getZoneBorder("E3:F4")).toEqual(allSides);
+    expect(getZoneBorder("A5:B6")).toEqual(allSides);
+    expect(getZoneBorder("A5:D6")).toEqual(allSides);
+    expect(getZoneBorder("A5:E6")).toEqual(allSides);
+
+    /**
+     * ----------------     ----------------
+     * | A1 | C1 | E1 |     | A1 | C1 | E1 |
+     * | B2 | D2 | F2 |     | B2 | D2 | F2 |
+     * ----------------     ------    ------
+     * | A3 | C3 | E3 |  => | A3   C3   E3 |
+     * | B4 | D4 | F4 |  => | B4   D4   F4 |
+     * ----------------     ------    ------
+     * | A5 | C5 | E5 |     | A5 | C5 | E5 |
+     * | B6 | D6 | F6 |     | B6 | D6 | F6 |
+     * ----------------     ----------------
+     */
+    setZoneBorders(model, { position: "clear" }, ["C3:D4"]);
+
+    expect(getZoneBorder("A1:B2")).toEqual(allSides);
+    expect(getZoneBorder("C1:D2")).toEqual({ top: b, right: b, left: b });
+    expect(getZoneBorder("E1:F2")).toEqual(allSides);
+    expect(getZoneBorder("A3:B4")).toEqual({ top: b, bottom: b, left: b });
+    expect(getZoneBorder("C3:D4")).toEqual({});
+    expect(getZoneBorder("E3:F4")).toEqual({ top: b, bottom: b, right: b });
+    expect(getZoneBorder("A5:B6")).toEqual(allSides);
+    expect(getZoneBorder("C5:D6")).toEqual({ bottom: b, left: b, right: b });
+    expect(getZoneBorder("E5:F6")).toEqual(allSides);
+  });
+
+  test("deleting row at the edge of the border", () => {
+    const sheetId = model.getters.getActiveSheetId();
+    const borders = getPlugin(model, BordersPlugin);
+    const getZoneBorder = (zone: string) => {
+      return removeFalsyAttributes(borders["getZoneExternalBorders"](sheetId, toZone(zone)));
+    };
+    const blackBorder: BorderDescr = { style: "thin", color: "#000000" };
+    const whiteBorder: BorderDescr = { style: "thin", color: "#ffffff" };
+
+    setZoneBorders(model, { position: "external", ...blackBorder }, ["C3:E5"]);
+    setZoneBorders(model, { position: "hv", ...whiteBorder }, ["C3:E5"]);
+    deleteRows(model, [4]);
+    expect(getZoneBorder("C3:E4")).toEqual({
+      top: blackBorder,
+      right: blackBorder,
+      left: blackBorder,
+      bottom: whiteBorder,
+    });
+
+    deleteRows(model, [2]);
+    expect(getZoneBorder("C3:E3")).toEqual({
+      top: whiteBorder,
+      right: blackBorder,
+      left: blackBorder,
+      bottom: whiteBorder,
+    });
+  });
+
+  test("deleting col at the edge of the border", () => {
+    const sheetId = model.getters.getActiveSheetId();
+    const borders = getPlugin(model, BordersPlugin);
+    const getZoneBorder = (zone: string) => {
+      return removeFalsyAttributes(borders["getZoneExternalBorders"](sheetId, toZone(zone)));
+    };
+    const blackBorder: BorderDescr = { style: "thin", color: "#000000" };
+    const whiteBorder: BorderDescr = { style: "thin", color: "#ffffff" };
+
+    setZoneBorders(model, { position: "external", ...blackBorder }, ["C3:E5"]);
+    setZoneBorders(model, { position: "hv", ...whiteBorder }, ["C3:E5"]);
+    deleteColumns(model, ["E"]);
+    expect(getZoneBorder("C3:D5")).toEqual({
+      top: blackBorder,
+      right: whiteBorder,
+      left: blackBorder,
+      bottom: blackBorder,
+    });
+
+    deleteColumns(model, ["C"]);
+    expect(getZoneBorder("C3:C5")).toEqual({
+      top: blackBorder,
+      right: whiteBorder,
+      left: whiteBorder,
+      bottom: blackBorder,
+    });
   });
 
   describe("manipulate borders on boundaries of the sheet", () => {
@@ -862,8 +1001,7 @@ describe("Border continuity", () => {
   };
   test("border continuity is preserved when adding a row before", () => {
     const model = new Model();
-    setZoneBorders(model, { position: "external" }, ["A1"]);
-    setZoneBorders(model, { position: "external" }, ["A2"]);
+    setZoneBorders(model, { position: "all" }, ["A1: A2"]);
     expect(getBorder(model, "A1")).toEqual(border);
     expect(getBorder(model, "A2")).toEqual(border);
     expect(getBorder(model, "A3")).toBeNull();
@@ -875,8 +1013,7 @@ describe("Border continuity", () => {
 
   test("border continuity is preserved when adding a row after", () => {
     const model = new Model();
-    setZoneBorders(model, { position: "external" }, ["A1"]);
-    setZoneBorders(model, { position: "external" }, ["A2"]);
+    setZoneBorders(model, { position: "all" }, ["A1: A2"]);
     expect(getBorder(model, "A1")).toEqual(border);
     expect(getBorder(model, "A2")).toEqual(border);
     expect(getBorder(model, "A3")).toBeNull();
@@ -888,8 +1025,7 @@ describe("Border continuity", () => {
 
   test("border continuity is preserved when adding a column before", () => {
     const model = new Model();
-    setZoneBorders(model, { position: "external" }, ["A1"]);
-    setZoneBorders(model, { position: "external" }, ["B1"]);
+    setZoneBorders(model, { position: "all" }, ["A1: B1"]);
     expect(getBorder(model, "A1")).toEqual(border);
     expect(getBorder(model, "B1")).toEqual(border);
     expect(getBorder(model, "C1")).toBeNull();
@@ -901,8 +1037,7 @@ describe("Border continuity", () => {
 
   test("border continuity is preserved when adding a column after", () => {
     const model = new Model();
-    setZoneBorders(model, { position: "external" }, ["A1"]);
-    setZoneBorders(model, { position: "external" }, ["B1"]);
+    setZoneBorders(model, { position: "all" }, ["A1: B1"]);
     expect(getBorder(model, "A1")).toEqual(border);
     expect(getBorder(model, "B1")).toEqual(border);
     expect(getBorder(model, "C1")).toBeNull();
@@ -910,6 +1045,67 @@ describe("Border continuity", () => {
     expect(getBorder(model, "A1")).toEqual(border);
     expect(getBorder(model, "B1")).toEqual(border);
     expect(getBorder(model, "C1")).toEqual(border);
+  });
+
+  test("insert column after cell with external border", () => {
+    const model = new Model();
+    setZoneBorders(model, { position: "external" }, ["B2"]);
+    addColumns(model, "after", "B", 1);
+    expect(getBorder(model, "B2")).toEqual({
+      top: DEFAULT_BORDER_DESC,
+      bottom: DEFAULT_BORDER_DESC,
+      left: DEFAULT_BORDER_DESC,
+      right: DEFAULT_BORDER_DESC,
+    });
+  });
+
+  test("insert column before cell with external border", () => {
+    const model = new Model();
+    setZoneBorders(model, { position: "external" }, ["B2"]);
+    addColumns(model, "before", "B", 1);
+    expect(getBorder(model, "C2")).toEqual({
+      top: DEFAULT_BORDER_DESC,
+      bottom: DEFAULT_BORDER_DESC,
+      left: DEFAULT_BORDER_DESC,
+      right: DEFAULT_BORDER_DESC,
+    });
+  });
+
+  test("delete column after cell with external border", () => {
+    const model = new Model();
+    setZoneBorders(model, { position: "external" }, ["B2"]);
+    deleteColumns(model, ["C"]);
+    expect(getBorder(model, "B2")).toEqual({
+      top: DEFAULT_BORDER_DESC,
+      bottom: DEFAULT_BORDER_DESC,
+      left: DEFAULT_BORDER_DESC,
+      right: DEFAULT_BORDER_DESC,
+    });
+  });
+
+  test("insert row after cell with external border", () => {
+    const model = new Model();
+    const s = DEFAULT_BORDER_DESC;
+    setZoneBorders(model, { position: "external" }, ["B2"]);
+    addRows(model, "after", 1, 1);
+    expect(getBorder(model, "B2")).toEqual({ top: s, bottom: s, left: s, right: s });
+  });
+
+  test("insert row before cell with external border", () => {
+    const model = new Model();
+    const s = DEFAULT_BORDER_DESC;
+    setZoneBorders(model, { position: "external" }, ["B2"]);
+    addRows(model, "before", 1, 1);
+    expect(getBorder(model, "B2")).toBeNull();
+    expect(getBorder(model, "B3")).toEqual({ top: s, bottom: s, left: s, right: s });
+  });
+
+  test("delete row  after cell with external border", () => {
+    const model = new Model();
+    const s = DEFAULT_BORDER_DESC;
+    setZoneBorders(model, { position: "external" }, ["B2"]);
+    deleteRows(model, [2]);
+    expect(getBorder(model, "B2")).toEqual({ top: s, bottom: s, left: s, right: s });
   });
 });
 

--- a/tests/cells/merges_plugin.test.ts
+++ b/tests/cells/merges_plugin.test.ts
@@ -394,9 +394,7 @@ describe("merges", () => {
 
   test("setting border => merging => unmerging", () => {
     const model = new Model();
-    setAnchorCorner(model, "B1");
-
-    setZoneBorders(model, { position: "external" });
+    setZoneBorders(model, { position: "external" }, ["A1:B1"]);
     expect(getBorder(model, "A1")).toEqual({
       left: DEFAULT_BORDER_DESC,
       bottom: DEFAULT_BORDER_DESC,
@@ -408,7 +406,7 @@ describe("merges", () => {
       top: DEFAULT_BORDER_DESC,
     });
     merge(model, "A1:B1");
-    merge(model, "A1:B1");
+    unMerge(model, "A1:B1");
     expect(getBorder(model, "A1")).toEqual({
       left: DEFAULT_BORDER_DESC,
       bottom: DEFAULT_BORDER_DESC,
@@ -424,6 +422,12 @@ describe("merges", () => {
   test("setting border to topleft => merging => unmerging", () => {
     const model = new Model();
     setZoneBorders(model, { position: "external" }, ["A1"]);
+    expect(getBorder(model, "A1")).toEqual({
+      left: DEFAULT_BORDER_DESC,
+      bottom: DEFAULT_BORDER_DESC,
+      top: DEFAULT_BORDER_DESC,
+      right: DEFAULT_BORDER_DESC,
+    });
     merge(model, "A1:B1");
     expect(getBorder(model, "A1")).toEqual({
       left: DEFAULT_BORDER_DESC,
@@ -448,7 +452,7 @@ describe("merges", () => {
     });
   });
 
-  test("setting border to  => setting style => merging => unmerging", () => {
+  test("setting border => setting style => merging => unmerging", () => {
     const model = new Model();
     setZoneBorders(model, { position: "external" }, ["A1"]);
     setStyle(model, "A1", { fillColor: "red" });

--- a/tests/helpers/positions_map.test.ts
+++ b/tests/helpers/positions_map.test.ts
@@ -1,4 +1,4 @@
-import { PositionMap } from "../../src/plugins/ui_core_views/cell_evaluation/position_map";
+import { PositionMap } from "../../src/helpers/cells/position_map";
 
 describe("PositionMap", () => {
   test("set an element", () => {

--- a/tests/helpers/zones_helpers.test.ts
+++ b/tests/helpers/zones_helpers.test.ts
@@ -1,10 +1,12 @@
 import {
+  adjacent,
   createAdaptedZone,
   excludeTopLeft,
   isZoneValid,
   mergeContiguousZones,
   overlap,
   positions,
+  splitIfAdjacent,
   toCartesian,
   toUnboundedZone,
   toZone,
@@ -16,10 +18,276 @@ import { target } from "../test_helpers/helpers";
 
 describe("overlap", () => {
   test("one zone above the other", () => {
-    const z1 = { top: 0, right: 0, bottom: 0, left: 0 };
-    const z2 = { top: 3, right: 0, bottom: 5, left: 0 };
+    const z1 = toZone("A1");
+    const z2 = toZone("A3:A5");
     expect(overlap(z1, z2)).toBe(false);
     expect(overlap(z2, z1)).toBe(false);
+  });
+
+  test("1 vertically unbounded zone", () => {
+    const z1 = toUnboundedZone("A:A");
+    const z2 = toZone("A3:A5");
+    expect(overlap(z1, z2)).toBe(true);
+    expect(overlap(z2, z1)).toBe(true);
+  });
+
+  test("2 vertically unbounded zone", () => {
+    const z1 = toUnboundedZone("A:A");
+    const z2 = toUnboundedZone("A3:A");
+    expect(overlap(z1, z2)).toBe(true);
+    expect(overlap(z2, z1)).toBe(true);
+  });
+
+  test("1 horizontally unbounded zone", () => {
+    const z1 = toUnboundedZone("A4:4");
+    const z2 = toZone("A3:A5");
+    expect(overlap(z1, z2)).toBe(true);
+    expect(overlap(z2, z1)).toBe(true);
+  });
+
+  test("2 horizontally unbounded zone", () => {
+    const z1 = toUnboundedZone("A4:4");
+    const z2 = toUnboundedZone("A3:5");
+    expect(overlap(z1, z2)).toBe(true);
+    expect(overlap(z2, z1)).toBe(true);
+  });
+
+  test("full zone", () => {
+    const z1 = { top: 0, right: undefined, bottom: undefined, left: 0 };
+    const z2 = { top: 0, right: undefined, bottom: undefined, left: 0 };
+    expect(overlap(z1, z2)).toBe(true);
+    expect(overlap(z2, z1)).toBe(true);
+  });
+
+  test("vertical and horizontal", () => {
+    const z1 = toUnboundedZone("A4:4");
+    const z2 = toUnboundedZone("C3:C");
+    expect(overlap(z1, z2)).toBe(true);
+    expect(overlap(z2, z1)).toBe(true);
+  });
+});
+
+describe("adjacent", () => {
+  test("adjacent left", () => {
+    expect(adjacent(toZone("C3:E5"), toZone("B2:B4"))).toEqual({
+      position: "left",
+      start: 2,
+      stop: 3,
+    });
+    expect(adjacent(toZone("C3:E5"), toZone("B2:B3"))).toEqual({
+      position: "left",
+      start: 2,
+      stop: 2,
+    });
+    expect(adjacent(toZone("C3:E5"), toZone("B4"))).toEqual({
+      position: "left",
+      start: 3,
+      stop: 3,
+    });
+    expect(adjacent(toZone("C3:E5"), toZone("B5:B10"))).toEqual({
+      position: "left",
+      start: 4,
+      stop: 4,
+    });
+  });
+
+  test("not adjacent left", () => {
+    expect(adjacent(toZone("C3:E5"), toZone("B6:B10"))).toBeUndefined();
+    expect(adjacent(toZone("C3:E5"), toZone("A3:A5"))).toBeUndefined();
+    expect(adjacent(toZone("C3:E5"), toZone("C3:C5"))).toBeUndefined();
+  });
+
+  test("adjacent right", () => {
+    expect(adjacent(toZone("C3:E5"), toZone("F2:F4"))).toEqual({
+      position: "right",
+      start: 2,
+      stop: 3,
+    });
+    expect(adjacent(toZone("C3:E5"), toZone("F2:F3"))).toEqual({
+      position: "right",
+      start: 2,
+      stop: 2,
+    });
+    expect(adjacent(toZone("C3:E5"), toZone("F4"))).toEqual({
+      position: "right",
+      start: 3,
+      stop: 3,
+    });
+    expect(adjacent(toZone("C3:E5"), toZone("F5:F10"))).toEqual({
+      position: "right",
+      start: 4,
+      stop: 4,
+    });
+  });
+
+  test("not adjacent right", () => {
+    expect(adjacent(toZone("C3:E5"), toZone("F6:F10"))).toBeUndefined();
+    expect(adjacent(toZone("C3:E5"), toZone("G3:G5"))).toBeUndefined();
+    expect(adjacent(toZone("C3:E5"), toZone("E3:E5"))).toBeUndefined();
+  });
+
+  test("adjacent top", () => {
+    expect(adjacent(toZone("C3:E5"), toZone("B2:D2"))).toEqual({
+      position: "top",
+      start: 2,
+      stop: 3,
+    });
+    expect(adjacent(toZone("C3:E5"), toZone("B2:C2"))).toEqual({
+      position: "top",
+      start: 2,
+      stop: 2,
+    });
+    expect(adjacent(toZone("C3:E5"), toZone("D2"))).toEqual({
+      position: "top",
+      start: 3,
+      stop: 3,
+    });
+    expect(adjacent(toZone("C3:E5"), toZone("E2:H2"))).toEqual({
+      position: "top",
+      start: 4,
+      stop: 4,
+    });
+  });
+
+  test("not adjacent top", () => {
+    expect(adjacent(toZone("C3:E5"), toZone("F2:H2"))).toBeUndefined();
+    expect(adjacent(toZone("C3:E5"), toZone("B1:D1"))).toBeUndefined();
+    expect(adjacent(toZone("C3:E5"), toZone("B3:D3"))).toBeUndefined();
+  });
+
+  test("adjacent bottom", () => {
+    expect(adjacent(toZone("C3:E5"), toZone("B6:D6"))).toEqual({
+      position: "bottom",
+      start: 2,
+      stop: 3,
+    });
+    expect(adjacent(toZone("C3:E5"), toZone("B6:C6"))).toEqual({
+      position: "bottom",
+      start: 2,
+      stop: 2,
+    });
+    expect(adjacent(toZone("C3:E5"), toZone("D6"))).toEqual({
+      position: "bottom",
+      start: 3,
+      stop: 3,
+    });
+    expect(adjacent(toZone("C3:E5"), toZone("E6:G10"))).toEqual({
+      position: "bottom",
+      start: 4,
+      stop: 4,
+    });
+  });
+
+  test("not adjacent bottom", () => {
+    expect(adjacent(toZone("C3:E5"), toZone("F6:H6"))).toBeUndefined();
+    expect(adjacent(toZone("C3:E5"), toZone("C7:H7"))).toBeUndefined();
+    expect(adjacent(toZone("C3:E5"), toZone("C5:H5"))).toBeUndefined();
+  });
+});
+
+describe("splitIfAdjacent", () => {
+  test("adjacent left", () => {
+    expect(splitIfAdjacent(toZone("C3:E5"), toZone("B2:B4"))).toEqual([
+      toZone("C3:E4"),
+      toZone("C5:E5"),
+    ]);
+    expect(splitIfAdjacent(toZone("C3:E5"), toZone("B2:B3"))).toEqual([
+      toZone("C3:E3"),
+      toZone("C4:E5"),
+    ]);
+    expect(splitIfAdjacent(toZone("C3:E5"), toZone("B4"))).toEqual([
+      toZone("C4:E4"),
+      toZone("C3:E3"),
+      toZone("C5:E5"),
+    ]);
+    expect(splitIfAdjacent(toZone("C3:E5"), toZone("B5:B10"))).toEqual([
+      toZone("C5:E5"),
+      toZone("C3:E4"),
+    ]);
+  });
+
+  test("not adjacent left", () => {
+    expect(splitIfAdjacent(toZone("C3:E5"), toZone("B6:B10"))).toEqual([toZone("C3:E5")]);
+    expect(splitIfAdjacent(toZone("C3:E5"), toZone("A3:A5"))).toEqual([toZone("C3:E5")]);
+    expect(splitIfAdjacent(toZone("C3:E5"), toZone("C3:C5"))).toEqual([toZone("C3:E5")]);
+  });
+
+  test("adjacent right", () => {
+    expect(splitIfAdjacent(toZone("C3:E5"), toZone("F2:F4"))).toEqual([
+      toZone("C3:E4"),
+      toZone("C5:E5"),
+    ]);
+    expect(splitIfAdjacent(toZone("C3:E5"), toZone("F2:F3"))).toEqual([
+      toZone("C3:E3"),
+      toZone("C4:E5"),
+    ]);
+    expect(splitIfAdjacent(toZone("C3:E5"), toZone("F4"))).toEqual([
+      toZone("C4:E4"),
+      toZone("C3:E3"),
+      toZone("C5:E5"),
+    ]);
+    expect(splitIfAdjacent(toZone("C3:E5"), toZone("F5:F10"))).toEqual([
+      toZone("C5:E5"),
+      toZone("C3:E4"),
+    ]);
+  });
+
+  test("not adjacent right", () => {
+    expect(splitIfAdjacent(toZone("C3:E5"), toZone("F6:F10"))).toEqual([toZone("C3:E5")]);
+    expect(splitIfAdjacent(toZone("C3:E5"), toZone("G3:G5"))).toEqual([toZone("C3:E5")]);
+    expect(splitIfAdjacent(toZone("C3:E5"), toZone("E3:E5"))).toEqual([toZone("C3:E5")]);
+  });
+
+  test("adjacent top", () => {
+    expect(splitIfAdjacent(toZone("C3:E5"), toZone("B2:D2"))).toEqual([
+      toZone("C3:D5"),
+      toZone("E3:E5"),
+    ]);
+    expect(splitIfAdjacent(toZone("C3:E5"), toZone("B2:C2"))).toEqual([
+      toZone("C3:C5"),
+      toZone("D3:E5"),
+    ]);
+    expect(splitIfAdjacent(toZone("C3:E5"), toZone("D2"))).toEqual([
+      toZone("D3:D5"),
+      toZone("C3:C5"),
+      toZone("E3:E5"),
+    ]);
+    expect(splitIfAdjacent(toZone("C3:E5"), toZone("E2:H2"))).toEqual([
+      toZone("E3:E5"),
+      toZone("C3:D5"),
+    ]);
+  });
+
+  test("not adjacent top", () => {
+    expect(splitIfAdjacent(toZone("C3:E5"), toZone("F2:H2"))).toEqual([toZone("C3:E5")]);
+    expect(splitIfAdjacent(toZone("C3:E5"), toZone("B1:D1"))).toEqual([toZone("C3:E5")]);
+    expect(splitIfAdjacent(toZone("C3:E5"), toZone("B3:D3"))).toEqual([toZone("C3:E5")]);
+  });
+
+  test("adjacent bottom", () => {
+    expect(splitIfAdjacent(toZone("C3:E5"), toZone("B6:D6"))).toEqual([
+      toZone("C3:D5"),
+      toZone("E3:E5"),
+    ]);
+    expect(splitIfAdjacent(toZone("C3:E5"), toZone("B6:C6"))).toEqual([
+      toZone("C3:C5"),
+      toZone("D3:E5"),
+    ]);
+    expect(splitIfAdjacent(toZone("C3:E5"), toZone("D6"))).toEqual([
+      toZone("D3:D5"),
+      toZone("C3:C5"),
+      toZone("E3:E5"),
+    ]);
+    expect(splitIfAdjacent(toZone("C3:E5"), toZone("E6:H6"))).toEqual([
+      toZone("E3:E5"),
+      toZone("C3:D5"),
+    ]);
+  });
+
+  test("not adjacent bottom", () => {
+    expect(splitIfAdjacent(toZone("C3:E5"), toZone("F6:H6"))).toEqual([toZone("C3:E5")]);
+    expect(splitIfAdjacent(toZone("C3:E5"), toZone("B7:D7"))).toEqual([toZone("C3:E5")]);
+    expect(splitIfAdjacent(toZone("C3:E5"), toZone("B5:D5"))).toEqual([toZone("C3:E5")]);
   });
 });
 

--- a/tests/renderer/cell_animations.test.ts
+++ b/tests/renderer/cell_animations.test.ts
@@ -18,7 +18,6 @@ import {
   addIconCF,
   addRows,
   copy,
-  createDynamicTable,
   createSheet,
   deleteColumns,
   paste,
@@ -29,8 +28,8 @@ import {
   setFormat,
   setStyle,
   setViewportOffset,
+  setZoneBorders,
   undo,
-  updateTableConfig,
 } from "../test_helpers/commands_helpers";
 import { setGrid, toRangesData } from "../test_helpers/helpers";
 import { MockGridRenderingContext } from "../test_helpers/renderer_helpers";
@@ -505,63 +504,51 @@ describe("Individual animation tests", () => {
   });
 
   test("Can animate a border fading in", () => {
-    setGrid(model, { A1: "1", A2: "=MUNIT(A1)" });
-    createDynamicTable(model, "A2", { styleId: "TableStyleLight1" });
     drawGrid();
     expect(getBoxFromXc("A3").border).toEqual(undefined);
-
-    setCellContent(model, "A1", "2");
+    setZoneBorders(model, { ...DEFAULT_BORDER_DESC, position: "top" }, ["A3"]);
     drawGrid();
     expect(getBoxFromXc("A3").border).toEqual({
       top: { ...DEFAULT_BORDER_DESC, opacity: 0 },
-      bottom: { ...DEFAULT_BORDER_DESC, opacity: 0 },
     });
 
     animationFrameCallback(0);
     expect(getBoxFromXc("A3").border).toEqual({
       top: { ...DEFAULT_BORDER_DESC, opacity: 0 },
-      bottom: { ...DEFAULT_BORDER_DESC, opacity: 0 },
     });
 
     animationFrameCallback(CELL_ANIMATION_DURATION / 2);
     expect(getBoxFromXc("A3").border).toEqual({
       top: { ...DEFAULT_BORDER_DESC, opacity: 0.5 },
-      bottom: { ...DEFAULT_BORDER_DESC, opacity: 0.5 },
     });
 
     animationFrameCallback(CELL_ANIMATION_DURATION);
     expect(getBoxFromXc("A3").border).toEqual({
       top: { ...DEFAULT_BORDER_DESC, opacity: undefined },
-      bottom: { ...DEFAULT_BORDER_DESC, opacity: undefined },
     });
   });
 
   test("Can animate a border fading out", () => {
-    setGrid(model, { A1: "2", A2: "=MUNIT(A1)" });
-    createDynamicTable(model, "A2", { styleId: "TableStyleLight1" });
+    setZoneBorders(model, { ...DEFAULT_BORDER_DESC, position: "top" }, ["A3"]);
     drawGrid();
     expect(getBoxFromXc("A3").border).toEqual({
       top: DEFAULT_BORDER_DESC,
-      bottom: DEFAULT_BORDER_DESC,
     });
 
-    setCellContent(model, "A1", "1");
+    setZoneBorders(model, { position: "clear" }, ["A3"]);
     drawGrid();
     expect(getBoxFromXc("A3").border).toEqual({
       top: { ...DEFAULT_BORDER_DESC, opacity: 1 },
-      bottom: { ...DEFAULT_BORDER_DESC, opacity: 1 },
     });
 
     animationFrameCallback(0);
     expect(getBoxFromXc("A3").border).toEqual({
       top: { ...DEFAULT_BORDER_DESC, opacity: 1 },
-      bottom: { ...DEFAULT_BORDER_DESC, opacity: 1 },
     });
 
     animationFrameCallback(CELL_ANIMATION_DURATION / 2);
     expect(getBoxFromXc("A3").border).toEqual({
       top: { ...DEFAULT_BORDER_DESC, opacity: 0.5 },
-      bottom: { ...DEFAULT_BORDER_DESC, opacity: 0.5 },
     });
 
     animationFrameCallback(CELL_ANIMATION_DURATION);
@@ -569,37 +556,31 @@ describe("Individual animation tests", () => {
   });
 
   test("Can animate a border changing color", () => {
-    setGrid(model, { A2: "=MUNIT(2)" });
-    createDynamicTable(model, "A2", { styleId: "TableStyleLight1" });
+    setZoneBorders(model, { ...DEFAULT_BORDER_DESC, position: "top" }, ["B2"]);
     drawGrid();
     expect(getBoxFromXc("B2").border).toEqual({
       top: { ...DEFAULT_BORDER_DESC, color: "#000000" },
-      bottom: { ...DEFAULT_BORDER_DESC, color: "#000000" },
     });
 
-    updateTableConfig(model, "A2", { styleId: "TableStyleLight2" });
+    setZoneBorders(model, { color: "#346B90", position: "top" }, ["B2"]);
     drawGrid();
     expect(getBoxFromXc("B2").border).toEqual({
       top: { ...DEFAULT_BORDER_DESC, color: "#000000" },
-      bottom: { ...DEFAULT_BORDER_DESC, color: "#000000" },
     });
 
     animationFrameCallback(0);
     expect(getBoxFromXc("B2").border).toEqual({
       top: { ...DEFAULT_BORDER_DESC, color: "#000000" },
-      bottom: { ...DEFAULT_BORDER_DESC, color: "#000000" },
     });
 
     animationFrameCallback(CELL_ANIMATION_DURATION / 2);
     expect(getBoxFromXc("B2").border).toEqual({
       top: { ...DEFAULT_BORDER_DESC, color: "#1A3648" },
-      bottom: { ...DEFAULT_BORDER_DESC, color: "#1A3648" },
     });
 
     animationFrameCallback(CELL_ANIMATION_DURATION);
     expect(getBoxFromXc("B2").border).toEqual({
       top: { ...DEFAULT_BORDER_DESC, color: "#346B90" },
-      bottom: { ...DEFAULT_BORDER_DESC, color: "#346B90" },
     });
   });
 

--- a/tests/sheet/sheet_manipulation_plugin.test.ts
+++ b/tests/sheet/sheet_manipulation_plugin.test.ts
@@ -1,7 +1,7 @@
-import { DEFAULT_BORDER_DESC, DEFAULT_CELL_HEIGHT, DEFAULT_CELL_WIDTH } from "../../src/constants";
+import { DEFAULT_CELL_HEIGHT, DEFAULT_CELL_WIDTH } from "../../src/constants";
 import { lettersToNumber, toXC, toZone } from "../../src/helpers";
 import { Model } from "../../src/model";
-import { Border, CommandResult } from "../../src/types";
+import { CommandResult } from "../../src/types";
 import { CellErrorType } from "../../src/types/errors";
 import {
   activateSheet,
@@ -20,7 +20,6 @@ import {
   setCellContent,
   setSelection,
   setStyle,
-  setZoneBorders,
   undo,
   unfreezeColumns,
   unfreezeRows,
@@ -315,133 +314,14 @@ describe("Columns", () => {
     });
   });
 
-  describe("Correctly update borders", () => {
-    test("Add columns with simple border", () => {
-      const s = { style: "thin", color: "#000" };
-      model = new Model({
-        sheets: [
-          {
-            borders: {
-              A2: 1,
-            },
-          },
-        ],
-        borders: { 1: { top: s } },
-      });
-      expect(getBorder(model, "A1")).toBeNull();
-      expect(getBorder(model, "A2")).toEqual({ top: s });
-      addColumns(model, "before", "A", 1);
-      expect(getBorder(model, "A1")).toBeNull();
-      expect(getBorder(model, "A2")).toBeNull();
-      expect(getBorder(model, "B1")).toBeNull();
-      expect(getBorder(model, "B2")).toEqual({ top: s });
-      expect(getBorder(model, "C1")).toBeNull();
-      expect(getBorder(model, "C2")).toBeNull();
-      addColumns(model, "after", "B", 1);
-      expect(getBorder(model, "A1")).toBeNull();
-      expect(getBorder(model, "A2")).toBeNull();
-      expect(getBorder(model, "B1")).toBeNull();
-      expect(getBorder(model, "B2")).toEqual({ top: s });
-      expect(getBorder(model, "C1")).toBeNull();
-      expect(getBorder(model, "C2")).toBeNull();
-    });
-    test("Add columns with two consecutive borders", () => {
-      const s = { style: "thin", color: "#000" };
-      model = new Model({
-        sheets: [
-          {
-            borders: {
-              A2: 1,
-              B2: 1,
-              A4: 2,
-              B4: 2,
-              C4: 2,
-            },
-          },
-        ],
-        borders: { 1: { top: s }, 2: { left: s } },
-      });
-      expect(getBorder(model, "A1")).toBeNull();
-      expect(getBorder(model, "A2")).toEqual({ top: s });
-      expect(getBorder(model, "B1")).toBeNull();
-      expect(getBorder(model, "B2")).toEqual({ top: s });
-      expect(getBorder(model, "A4")).toEqual({ left: s });
-      expect(getBorder(model, "B4")).toEqual({ left: s });
-      expect(getBorder(model, "C4")).toEqual({ left: s });
-      addColumns(model, "before", "A", 1);
-      expect(getBorder(model, "A1")).toBeNull();
-      expect(getBorder(model, "A2")).toBeNull();
-      expect(getBorder(model, "B1")).toBeNull();
-      expect(getBorder(model, "B2")).toEqual({ top: s });
-      expect(getBorder(model, "C1")).toBeNull();
-      expect(getBorder(model, "C2")).toEqual({ top: s });
-      expect(getBorder(model, "A4")).toBeNull();
-      expect(getBorder(model, "B4")).toEqual({ left: s });
-      expect(getBorder(model, "C4")).toEqual({ left: s });
-      expect(getBorder(model, "D4")).toEqual({ left: s });
-      addColumns(model, "after", "B", 1);
-      expect(getBorder(model, "A1")).toBeNull();
-      expect(getBorder(model, "A2")).toBeNull();
-      expect(getBorder(model, "B1")).toBeNull();
-      expect(getBorder(model, "B2")).toEqual({ top: s });
-      expect(getBorder(model, "C1")).toBeNull();
-      expect(getBorder(model, "C2")).toEqual({ top: s });
-      expect(getBorder(model, "D1")).toBeNull();
-      expect(getBorder(model, "D2")).toEqual({ top: s });
-    });
-
-    test("insert column after cell with external border", () => {
-      const model = new Model();
-      setZoneBorders(model, { position: "external" }, ["B2"]);
-      addColumns(model, "after", "B", 1);
-      expect(getBorder(model, "B2")).toEqual({
-        top: DEFAULT_BORDER_DESC,
-        bottom: DEFAULT_BORDER_DESC,
-        left: DEFAULT_BORDER_DESC,
-        right: DEFAULT_BORDER_DESC,
-      });
-    });
-
-    test("insert column before cell with external border", () => {
-      const model = new Model();
-      setZoneBorders(model, { position: "external" }, ["B2"]);
-      addColumns(model, "before", "B", 1);
-      expect(getBorder(model, "C2")).toEqual({
-        top: DEFAULT_BORDER_DESC,
-        bottom: DEFAULT_BORDER_DESC,
-        left: DEFAULT_BORDER_DESC,
-        right: DEFAULT_BORDER_DESC,
-      });
-    });
-
-    test("delete column after cell with external border", () => {
-      const model = new Model();
-      setZoneBorders(model, { position: "external" }, ["B2"]);
-      deleteColumns(model, ["C"]);
-      expect(getBorder(model, "B2")).toEqual({
-        top: DEFAULT_BORDER_DESC,
-        bottom: DEFAULT_BORDER_DESC,
-        left: DEFAULT_BORDER_DESC,
-        right: DEFAULT_BORDER_DESC,
-      });
-    });
-  });
-
-  describe("Correctly update border and style", () => {
-    let border: Border;
+  describe("Correctly update style", () => {
     beforeEach(() => {
-      border = { top: { style: "thin", color: "#000000" } };
       model = new Model({
         sheets: [
           {
             id: "sheet1",
             colNumber: 4,
             rowNumber: 4,
-            borders: {
-              "A2:A3": 1,
-              "B2:B4": 1,
-              "D2:D3": 1,
-            },
             styles: {
               A1: 1,
               A3: 1,
@@ -458,13 +338,11 @@ describe("Columns", () => {
         ],
         styles: { 1: { textColor: "#fe0000" } },
         formats: { 1: "0.00%" },
-        borders: { 1: border },
       });
     });
     test("On deletion", () => {
       deleteColumns(model, ["B"]);
       const style = { textColor: "#fe0000" };
-      const s = { style: "thin", color: "#000000" };
       expect(getCell(model, "B1")).toBeUndefined();
       expect(getCell(model, "B2")).toBeUndefined();
       expect(getCell(model, "B3")).toBeUndefined();
@@ -475,25 +353,10 @@ describe("Columns", () => {
         C1: { style },
         C3: { style },
       });
-      expect(getBorder(model, "A2")).toEqual({ top: s });
-      expect(getBorder(model, "A3")).toEqual({ top: s });
-      expect(getBorder(model, "B4")).toEqual({ top: s });
-      expect(getBorder(model, "C2")).toEqual({ top: s });
-      expect(getBorder(model, "C3")).toEqual({ top: s });
     });
+
     test("On addition", () => {
-      const s = { style: "thin", color: "#000000" };
       const style = { textColor: "#fe0000" };
-      expect(getBorder(model, "A1")).toBeNull();
-      expect(getBorder(model, "A2")).toEqual({ top: s });
-      expect(getBorder(model, "A3")).toEqual({ top: s });
-      expect(getBorder(model, "B1")).toBeNull();
-      expect(getBorder(model, "B2")).toEqual({ top: s });
-      expect(getBorder(model, "B3")).toEqual({ top: s });
-      expect(getBorder(model, "B4")).toEqual({ top: s });
-      expect(getBorder(model, "D1")).toBeNull();
-      expect(getBorder(model, "D2")).toEqual({ top: s });
-      expect(getBorder(model, "D3")).toEqual({ top: s });
       addColumns(model, "before", "B", 1);
       addColumns(model, "after", "C", 2);
       expect(getCellsObject(model, "sheet1")).toMatchObject({
@@ -507,28 +370,6 @@ describe("Columns", () => {
         C4: { style },
         E1: { style },
       });
-      expect(getBorder(model, "A2")).toEqual({ top: s });
-      expect(getBorder(model, "A3")).toEqual({ top: s });
-      expect(getBorder(model, "B2")).toEqual({ top: s });
-      expect(getBorder(model, "B3")).toEqual({ top: s });
-      expect(getBorder(model, "B4")).toBeNull();
-      expect(getBorder(model, "C2")).toEqual({ top: s });
-      expect(getBorder(model, "C3")).toEqual({ top: s });
-      expect(getBorder(model, "C4")).toEqual({ top: s });
-      expect(getBorder(model, "D1")).toBeNull();
-      expect(getBorder(model, "D2")).toBeNull();
-      expect(getBorder(model, "D3")).toBeNull();
-      expect(getBorder(model, "D4")).toEqual({ top: s });
-      expect(getBorder(model, "E1")).toBeNull();
-      expect(getBorder(model, "E2")).toBeNull();
-      expect(getBorder(model, "E3")).toBeNull();
-      expect(getBorder(model, "E4")).toEqual({ top: s });
-      expect(getBorder(model, "F2")).toBeNull();
-      expect(getBorder(model, "F3")).toBeNull();
-      expect(getBorder(model, "F4")).toEqual({ top: s });
-      expect(getBorder(model, "G1")).toBeNull();
-      expect(getBorder(model, "G2")).toEqual({ top: s });
-      expect(getBorder(model, "G3")).toEqual({ top: s });
       expect(Object.values(getMerges(model))[0]).toMatchObject({
         left: 2,
         right: 5,
@@ -1046,13 +887,6 @@ describe("Rows", () => {
             id: "sheet1",
             colNumber: 4,
             rowNumber: 4,
-            borders: {
-              "B1:B2": 1,
-              B4: 1,
-              "C1:C2": 1,
-              C4: 1,
-              D2: 1,
-            },
             styles: {
               "A1:A2": 1,
               A4: 1,
@@ -1068,11 +902,9 @@ describe("Rows", () => {
         ],
         styles: { 1: { textColor: "#fe0000" } },
         formats: { 1: "0.00%" },
-        borders: { 1: { top: { style: "thin", color: "#000000" } } },
       });
     });
     test("On deletion", () => {
-      const s = { style: "thin", color: "#000000" };
       const style = { textColor: "#fe0000" };
       const sheetId = model.getters.getActiveSheetId();
       expect(Object.keys(model.getters.getCells(sheetId))).toHaveLength(8); // 7 NumberCells + 1 emptyCell in merge with style
@@ -1083,32 +915,14 @@ describe("Rows", () => {
       expect(Object.values(model.getters.getCells(sheetId))).toHaveLength(5); // 4 NumberCells +1 emptyCell with no merge, but with style
       expect(getCell(model, "A1")).toMatchObject({ style });
       expect(getCell(model, "A3")).toMatchObject({ style });
-      expect(getBorder(model, "B1")).toEqual({ top: s });
-      expect(getBorder(model, "B2")).toBeNull();
-      expect(getBorder(model, "B3")).toEqual({ top: s });
       expect(getCell(model, "C1")).toMatchObject({ style });
       expect(getCell(model, "C3")).toMatchObject({ style });
       expect(getCell(model, "D2")).toMatchObject({ style });
-      expect(getBorder(model, "C1")).toEqual({ top: s });
-      expect(getBorder(model, "C2")).toBeNull();
-      expect(getBorder(model, "C3")).toEqual({ top: s });
-      expect(getBorder(model, "D2")).toBeNull();
     });
 
     test("On addition", () => {
-      const s = { style: "thin", color: "#000000" };
       addRows(model, "before", 1, 1);
       const style = { textColor: "#fe0000" };
-      expect(getBorder(model, "B1")).toEqual({ top: s });
-      expect(getBorder(model, "B2")).toEqual({ top: s });
-      expect(getBorder(model, "B3")).toEqual({ top: s });
-      expect(getBorder(model, "B4")).toBeNull();
-      expect(getBorder(model, "B5")).toEqual({ top: s });
-      expect(getBorder(model, "C1")).toEqual({ top: s });
-      expect(getBorder(model, "C2")).toEqual({ top: s });
-      expect(getBorder(model, "C3")).toEqual({ top: s });
-      expect(getBorder(model, "C4")).toBeNull();
-      expect(getBorder(model, "C5")).toEqual({ top: s });
       addRows(model, "after", 2, 2);
       expect(getCellsObject(model, "sheet1")).toMatchObject({
         A1: { style },
@@ -1121,49 +935,10 @@ describe("Rows", () => {
         D3: { style },
         A5: { style },
       });
-      expect(getBorder(model, "B1")).toEqual({ top: s });
-      expect(getBorder(model, "B2")).toEqual({ top: s });
-      expect(getBorder(model, "B3")).toEqual({ top: s });
-      expect(getBorder(model, "B4")).toBeNull();
-      expect(getBorder(model, "B5")).toBeNull();
-      expect(getBorder(model, "B6")).toBeNull();
-      expect(getBorder(model, "B7")).toEqual({ top: s });
-      expect(getBorder(model, "C1")).toEqual({ top: s });
-      expect(getBorder(model, "C2")).toEqual({ top: s });
-      expect(getBorder(model, "C3")).toEqual({ top: s });
-      expect(getBorder(model, "C4")).toBeNull();
-      expect(getBorder(model, "C5")).toBeNull();
-      expect(getBorder(model, "C6")).toBeNull();
-      expect(getBorder(model, "C7")).toEqual({ top: s });
       expect(Object.values(getMerges(model))[0]).toMatchObject({
         top: 2,
         bottom: 5,
       });
-    });
-
-    test("insert row after cell with external border", () => {
-      const model = new Model();
-      const s = DEFAULT_BORDER_DESC;
-      setZoneBorders(model, { position: "external" }, ["B2"]);
-      addRows(model, "after", 1, 1);
-      expect(getBorder(model, "B2")).toEqual({ top: s, bottom: s, left: s, right: s });
-    });
-
-    test("insert row before cell with external border", () => {
-      const model = new Model();
-      const s = DEFAULT_BORDER_DESC;
-      setZoneBorders(model, { position: "external" }, ["B2"]);
-      addRows(model, "before", 1, 1);
-      expect(getBorder(model, "B2")).toBeNull();
-      expect(getBorder(model, "B3")).toEqual({ top: s, bottom: s, left: s, right: s });
-    });
-
-    test("delete row  after cell with external border", () => {
-      const model = new Model();
-      const s = DEFAULT_BORDER_DESC;
-      setZoneBorders(model, { position: "external" }, ["B2"]);
-      deleteRows(model, [2]);
-      expect(getBorder(model, "B2")).toEqual({ top: s, bottom: s, left: s, right: s });
     });
   });
 

--- a/tests/table/table_computed_style_plugin.test.ts
+++ b/tests/table/table_computed_style_plugin.test.ts
@@ -1,6 +1,7 @@
 import { Model } from "../../src";
 import { toXC, toZone } from "../../src/helpers";
 import { TABLE_PRESETS } from "../../src/helpers/table_presets";
+import { GridRenderer } from "../../src/stores/grid_renderer_store";
 import { Style, UID } from "../../src/types";
 import {
   createTable,
@@ -29,6 +30,7 @@ import {
 } from "../test_helpers/commands_helpers";
 import { getTable } from "../test_helpers/getters_helpers";
 import { toCellPosition } from "../test_helpers/helpers";
+import { makeStoreWithModel } from "../test_helpers/stores";
 
 let model: Model;
 let sheetId: UID;
@@ -186,6 +188,20 @@ describe("Table style", () => {
       deleteContent(model, ["A1:B4"]);
       expect(getTable(model, "A1")).toBeUndefined();
       expect(getCellStyle("A1")).toEqual({});
+    });
+
+    test("Table style is rendered", () => {
+      createTable(model, "A7:A9");
+      updateTableConfig(model, "A7:A9", outerBordersTableStyle);
+      const styleBorderDescr = { style: "thin", color: "#000000" };
+
+      const { store: gridRendererStore } = makeStoreWithModel(model, GridRenderer);
+      const boxes = gridRendererStore["getGridBoxes"](toZone("A9"));
+      expect(boxes.find((box) => box.id === "A9")?.border).toEqual({
+        bottom: styleBorderDescr,
+        left: styleBorderDescr,
+        right: styleBorderDescr,
+      });
     });
   });
 

--- a/tests/test_helpers/commands_helpers.ts
+++ b/tests/test_helpers/commands_helpers.ts
@@ -766,8 +766,8 @@ export function setZoneBorders(model: Model, border: BorderData, xcs?: string[])
     target,
     border: {
       position: border.position,
-      color: border.color,
-      style: border.style,
+      color: border.color ?? "#000000",
+      style: border.style ?? "thin",
     },
   });
 }

--- a/tests/test_helpers/getters_helpers.ts
+++ b/tests/test_helpers/getters_helpers.ts
@@ -168,7 +168,13 @@ export function getBorder(
   sheetId: UID = model.getters.getActiveSheetId()
 ): Border | null {
   const { col, row } = toCartesian(xc);
-  return model.getters.getCellBorder({ sheetId, col, row });
+  const cellBorder = model.getters.getCellBorder({ sheetId, col, row });
+  Object.keys(cellBorder).forEach(
+    (key) =>
+      (!cellBorder[key] || (cellBorder[key].color ?? cellBorder[key].style) === undefined) &&
+      delete cellBorder[key]
+  );
+  return Object.entries(cellBorder).length ? cellBorder : null;
 }
 
 /**


### PR DESCRIPTION
This commit refactor the border plugin to save border style
based on zones with similar borders style instead of saving cell-wise borders.

The goal of this commit was to allow the writing and editing of style on large
zones without the current performance dip.

Groundwork for the infinite viewport task

Task: 4852413

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo