### PR TITLE
[FIX] selection: prevent partial move of table rows with headers

### DIFF
--- a/src/components/headers_overlay/headers_overlay.ts
+++ b/src/components/headers_overlay/headers_overlay.ts
@@ -23,7 +23,7 @@ import { ContextMenuType } from "../grid/grid";
 import { css, cssPropertiesToCss } from "../helpers/css";
 import { isCtrlKey } from "../helpers/dom_helpers";
 import { dragAndDropBeyondTheViewport, startDnd } from "../helpers/drag_and_drop";
-import { MergeErrorMessage } from "../translations_terms";
+import { MergeErrorMessage, TableHeaderMoveErrorMessage } from "../translations_terms";
 import { ComposerFocusStore } from "./../composer/composer_focus_store";
 
 // -----------------------------------------------------------------------------
@@ -641,8 +641,13 @@ export class RowResizer extends AbstractResizer {
       elements,
       position: this.state.position,
     });
-    if (!result.isSuccessful && result.reasons.includes(CommandResult.WillRemoveExistingMerge)) {
-      this.env.raiseError(MergeErrorMessage);
+
+    if (!result.isSuccessful) {
+      if (result.reasons.includes(CommandResult.WillRemoveExistingMerge)) {
+        this.env.raiseError(MergeErrorMessage);
+      } else if (result.reasons.includes(CommandResult.CannotMoveTableHeader)) {
+        this.env.raiseError(TableHeaderMoveErrorMessage);
+      }
     }
   }
 

--- a/src/components/translations_terms.ts
+++ b/src/components/translations_terms.ts
@@ -95,6 +95,8 @@ export const MergeErrorMessage = _t(
   "Merged cells are preventing this operation. Unmerge those cells and try again."
 );
 
+export const TableHeaderMoveErrorMessage = _t("The header row of a table can't be moved.");
+
 export const SplitToColumnsTerms = {
   Errors: {
     Unexpected: _t("Cannot split the selection for an unknown reason"),

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -1225,6 +1225,7 @@ export const enum CommandResult {
   Success = "Success",
   CancelledForUnknownReason = "CancelledForUnknownReason",
   WillRemoveExistingMerge = "WillRemoveExistingMerge",
+  CannotMoveTableHeader = "CannotMoveTableHeader",
   MergeIsDestructive = "MergeIsDestructive",
   CellIsMerged = "CellIsMerged",
   InvalidTarget = "InvalidTarget",

--- a/tests/sheet/selection_plugin.test.ts
+++ b/tests/sheet/selection_plugin.test.ts
@@ -15,6 +15,7 @@ import {
   addColumns,
   addRows,
   createSheet,
+  createTable,
   deleteColumns,
   deleteRows,
   hideColumns,
@@ -43,6 +44,7 @@ import {
   getCellContent,
   getCellText,
   getSelectionAnchorCellXc,
+  getTable,
 } from "../test_helpers/getters_helpers";
 import { createModelFromGrid } from "../test_helpers/helpers";
 
@@ -969,6 +971,19 @@ describe("move elements(s)", () => {
   test("can't move rows between rows containing common merged ", () => {
     const result = moveRows(model, 7, [1, 2]);
     expect(result).toBeCancelledBecause(CommandResult.WillRemoveExistingMerge);
+  });
+
+  test("rejects moving part of a table with headers", () => {
+    createTable(model, "A1:A4", { numberOfHeaders: 2 });
+    const result = moveRows(model, 5, [1]);
+    expect(result).toBeCancelledBecause(CommandResult.CannotMoveTableHeader);
+  });
+
+  test("allows moving the whole table with headers", () => {
+    createTable(model, "A1:A2");
+    expect(getTable(model, "A1")!.range.zone).toEqual(toZone("A1:A2"));
+    moveRows(model, 9, [0, 1], "after");
+    expect(getTable(model, "A9")!.range.zone).toEqual(toZone("A9:A10"));
   });
 
   test("Move a resized column preserves its size", () => {


### PR DESCRIPTION
## Description:

#### Steps to reproduce

* Create a table with headers
* Select some rows including the header row, but not the whole table
* Try to move the selected rows

#### Current behavior

The move is allowed even when only part of the table (including headers) is selected.
This results in broken table structure or orphaned headers.

#### Desired behavior after PR is merged

Row moves are allowed only if:

* The headers are not included in the selection, **or**
* The entire table (including headers) is selected.


Task: [4862731](https://www.odoo.com/odoo/2328/tasks/4862731)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo