### PR TITLE
[FIX] error_tooltip: Do not show cause position in dashboard

### DIFF
--- a/src/components/error_tooltip/error_tooltip.ts
+++ b/src/components/error_tooltip/error_tooltip.ts
@@ -48,6 +48,9 @@ export class ErrorToolTip extends Component<ErrorToolTipProps, SpreadsheetChildE
   }
 
   get errorOriginPositionString() {
+    if (this.env.model.getters.isDashboard()) {
+      return "";
+    }
     const evaluationError = this.evaluationError;
     const position = evaluationError?.errorOriginPosition;
     if (!position || deepEquals(position, this.props.cellPosition)) {

--- a/tests/popover/error_tooltip_component.test.ts
+++ b/tests/popover/error_tooltip_component.test.ts
@@ -75,6 +75,15 @@ describe("Error tooltip component", () => {
     expect(".fst-italic").toHaveText(" Caused by A1");
   });
 
+  test("Do not display error origin position in dashboard", async () => {
+    const model = new Model();
+    setCellContent(model, "A1", "=1/0");
+    setCellContent(model, "A2", "=A1");
+    model.updateMode("dashboard");
+    await mountErrorTooltip(model, "A2");
+    expect(".fst-italic").toHaveCount(0);
+  });
+
   test("can display error position from another sheet", async () => {
     const model = new Model();
     createSheet(model, { sheetId: "sheet2" });


### PR DESCRIPTION
Task: 4926129

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo