### PR TITLE
[FIX] pivot: don't aggregate calculated missing value

### DIFF
--- a/src/helpers/pivot/pivot_presentation.ts
+++ b/src/helpers/pivot/pivot_presentation.ts
@@ -217,7 +217,7 @@ export default function (PivotClass: PivotUIConstructor) {
           return this.getSubTreeMatchingDomain(node.children, domain, domainLevel + 1);
         }
       }
-      return tree;
+      return [];
     }
 
     treeToLeafDomains(tree: DimensionTree, parentDomain: PivotDomain = []) {


### PR DESCRIPTION
Steps to reproduce:

- create a pivot with two levels of groups in the rows (Let's say group by Country > Customer)
- add a calculated measure
- add the formula =PIVOT.VALUE(1, "calculated", "Country", "IN") where the value of Country is not found anywhere in the data set

=> `Maximum call stack size exceeded`


Task: [4933818](https://www.odoo.com/odoo/2328/tasks/4933818)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo