### PR TITLE
[IMP] pivots: prevent huge pivot tables

### DIFF
--- a/src/components/side_panel/pivot/pivot_layout_configurator/pivot_layout_configurator.ts
+++ b/src/components/side_panel/pivot/pivot_layout_configurator/pivot_layout_configurator.ts
@@ -7,6 +7,7 @@ import {
 } from "../../../../helpers/pivot/pivot_helpers";
 import { PivotRuntimeDefinition } from "../../../../helpers/pivot/pivot_runtime_definition";
 import { Store, useStore } from "../../../../store_engine";
+import { _t } from "../../../../translation";
 import { SortDirection, SpreadsheetChildEnv, UID } from "../../../../types";
 import {
   Aggregator,
@@ -338,5 +339,16 @@ export class PivotLayoutConfigurator extends Component<Props, SpreadsheetChildEn
     const fieldName = field ? getFieldDisplayName(field) : "";
 
     return measureDisplayTerms.descriptions[measureDisplay.type](fieldName);
+  }
+
+  getHugeDimensionErrorMessage(dimension: PivotDimensionType) {
+    const pivot = this.env.model.getters.getPivot(this.props.pivotId);
+    const possibleValues = pivot.getPossibleFieldValues(dimension);
+    return possibleValues.length > 100
+      ? _t(
+          "This dimension contains a lot of values (%s), and might slow down the pivot table.",
+          possibleValues.length
+        )
+      : undefined;
   }
 }

--- a/src/components/side_panel/pivot/pivot_layout_configurator/pivot_layout_configurator.xml
+++ b/src/components/side_panel/pivot/pivot_layout_configurator/pivot_layout_configurator.xml
@@ -15,6 +15,15 @@
           t-att-style="dragAndDrop.itemsStyle[col.nameWithGranularity]"
           class="pt-1">
           <PivotDimension dimension="col" onRemoved.bind="removeDimension">
+            <t t-set-slot="upper-right-icons">
+              <t t-set="errorMessage" t-value="getHugeDimensionErrorMessage(col)"/>
+              <i
+                t-if="errorMessage"
+                class="text-warning fa fa-exclamation-triangle"
+                t-att-title="errorMessage"
+              />
+            </t>
+
             <PivotDimensionGranularity
               t-if="isDateOrDatetimeField(col)"
               dimension="col"
@@ -47,6 +56,15 @@
           t-att-style="dragAndDrop.itemsStyle[row.nameWithGranularity]"
           class="pt-1">
           <PivotDimension dimension="row" onRemoved.bind="removeDimension">
+            <t t-set-slot="upper-right-icons">
+              <t t-set="errorMessage" t-value="getHugeDimensionErrorMessage(row)"/>
+              <i
+                t-if="errorMessage"
+                class="text-warning fa fa-exclamation-triangle"
+                t-att-title="errorMessage"
+              />
+            </t>
+
             <PivotDimensionGranularity
               t-if="isDateOrDatetimeField(row)"
               dimension="row"

--- a/src/components/translations_terms.ts
+++ b/src/components/translations_terms.ts
@@ -1,6 +1,7 @@
+import { formatValue } from "../helpers";
 import { _t } from "../translation";
 import { GeoChartColorScale } from "../types/chart/geo_chart";
-import { CommandResult } from "../types/index";
+import { CommandResult, Locale } from "../types/index";
 
 export const CfTerms = {
   Errors: {
@@ -262,3 +263,14 @@ export const measureDisplayTerms = {
     ),
   },
 };
+
+export function getPivotTooBigErrorMessage(numberOfCells: number, locale: Locale): string {
+  const formattedNumber = formatValue(numberOfCells, {
+    format: "0,00",
+    locale: locale,
+  });
+  return _t(
+    "Oops—this pivot table is quite large (%s cells). Try simplifying it using the side panel.",
+    formattedNumber
+  );
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -316,6 +316,7 @@ export const PIVOT_TABLE_CONFIG = {
 };
 export const PIVOT_INDENT = 15;
 export const PIVOT_COLLAPSE_ICON_SIZE = 12;
+export const PIVOT_MAX_NUMBER_OF_CELLS = 1e5;
 
 export const DEFAULT_CURRENCY: Currency = {
   symbol: "$",

--- a/src/functions/module_lookup.ts
+++ b/src/functions/module_lookup.ts
@@ -1,3 +1,5 @@
+import { getPivotTooBigErrorMessage } from "../components/translations_terms";
+import { PIVOT_MAX_NUMBER_OF_CELLS } from "../constants";
 import { getFullReference, range, splitReference, toXC, toZone } from "../helpers/index";
 import { addAlignFormatToPivotHeader } from "../helpers/pivot/pivot_helpers";
 import { _t } from "../translation";
@@ -916,6 +918,9 @@ export const PIVOT = {
       return error;
     }
     const table = pivot.getCollapsedTableStructure();
+    if (table.numberOfCells > PIVOT_MAX_NUMBER_OF_CELLS) {
+      return new EvaluationError(getPivotTooBigErrorMessage(table.numberOfCells, this.locale));
+    }
     const cells = table.getPivotCells(visibilityOptions);
 
     let headerRows = 0;

--- a/src/helpers/pivot/table_spreadsheet_pivot.ts
+++ b/src/helpers/pivot/table_spreadsheet_pivot.ts
@@ -406,6 +406,10 @@ export class SpreadsheetPivotTable {
       return [row, ...this.rowTreeToRows(node.children, row)];
     });
   }
+
+  get numberOfCells() {
+    return this.rows.length * this.getNumberOfDataColumns();
+  }
 }
 
 export const EMPTY_PIVOT_CELL = { type: "EMPTY" } as const;


### PR DESCRIPTION
## Description

With this commit, we prevent huge pivot tables from spreading, which helps mitigate performance issues. It is still quite slow, because to know if a pivot is huge, we first need to compute its rows/columns, which is slow (looping on many cells in spreadsheet, or huge RPCs in odoo). But this commit should help a bit.

- An error message is raised when updating a pivot that is too big.
- Problematic dimensions are highlighted in side panel.
- re-insert static pivot is prevented for huge pivots.

Task: [4164183](https://www.odoo.com/odoo/2328/tasks/4164183)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo