### PR TITLE
[FIX] side_panel: replace side panel instead of stacking it

### DIFF
--- a/src/actions/insert_actions.ts
+++ b/src/actions/insert_actions.ts
@@ -319,7 +319,7 @@ export const insertDropdown: ActionSpec = {
     env.openSidePanel("DataValidationEditor", {
       rule: localizeDataValidationRule(rule, env.model.getters.getLocale()),
       onExit: () => {
-        env.openSidePanel("DataValidation");
+        env.replaceSidePanel("DataValidation", "DataValidationEditor");
       },
     });
   },

--- a/src/components/side_panel/pivot/pivot_layout_configurator/pivot_measure/pivot_measure.ts
+++ b/src/components/side_panel/pivot/pivot_layout_configurator/pivot_measure/pivot_measure.ts
@@ -79,7 +79,7 @@ export class PivotMeasureEditor extends Component<Props> {
   }
 
   openShowValuesAs() {
-    this.env.openSidePanel("PivotMeasureDisplayPanel", {
+    this.env.replaceSidePanel("PivotMeasureDisplayPanel", `pivot_key_${this.props.pivotId}`, {
       pivotId: this.props.pivotId,
       measure: this.props.measure,
     });

--- a/src/components/side_panel/pivot/pivot_measure_display_panel/pivot_measure_display_panel.ts
+++ b/src/components/side_panel/pivot/pivot_measure_display_panel/pivot_measure_display_panel.ts
@@ -54,12 +54,24 @@ export class PivotMeasureDisplayPanel extends Component<Props, SpreadsheetChildE
   }
 
   onSave() {
-    this.env.openSidePanel("PivotSidePanel", { pivotId: this.props.pivotId });
+    this.env.replaceSidePanel(
+      "PivotSidePanel",
+      `pivot_measure_display_${this.props.pivotId}_${this.props.measure.id}`,
+      {
+        pivotId: this.props.pivotId,
+      }
+    );
   }
 
   onCancel() {
     this.store.cancelMeasureDisplayEdition();
-    this.env.openSidePanel("PivotSidePanel", { pivotId: this.props.pivotId });
+    this.env.replaceSidePanel(
+      "PivotSidePanel",
+      `pivot_measure_display_${this.props.pivotId}_${this.props.measure.id}`,
+      {
+        pivotId: this.props.pivotId,
+      }
+    );
   }
 
   get fieldChoices() {

--- a/src/components/spreadsheet/spreadsheet.ts
+++ b/src/components/spreadsheet/spreadsheet.ts
@@ -406,6 +406,7 @@ export class Spreadsheet extends Component<SpreadsheetProps, SpreadsheetChildEnv
       loadLocales: this.model.config.external.loadLocales,
       isDashboard: () => this.model.getters.isDashboard(),
       openSidePanel: this.sidePanel.open.bind(this.sidePanel),
+      replaceSidePanel: this.sidePanel.replace.bind(this.sidePanel),
       toggleSidePanel: this.sidePanel.toggle.bind(this.sidePanel),
       clipboard: this.env.clipboard || instantiateClipboard(),
       startCellEdition: (content?: string) =>

--- a/src/registries/side_panel_registry.ts
+++ b/src/registries/side_panel_registry.ts
@@ -145,7 +145,11 @@ sidePanelRegistry.add("PivotMeasureDisplayPanel", {
     try {
       // This will throw if the pivot or measure does not exist
       getters.getPivot(props.pivotId).getMeasure(props.measure.id);
-      return { isOpen: true, props, key: "pivot_measure_display" };
+      return {
+        isOpen: true,
+        props,
+        key: `pivot_measure_display_${props.pivotId}_${props.measure.id}`,
+      };
     } catch (e) {
       return { isOpen: false };
     }

--- a/src/types/env.ts
+++ b/src/types/env.ts
@@ -24,6 +24,7 @@ export interface SpreadsheetChildEnv extends NotificationStoreMethods {
   imageProvider?: ImageProviderInterface;
   isDashboard: () => boolean;
   openSidePanel: (panel: string, panelProps?: any) => void;
+  replaceSidePanel: (panel: string, currentPanel: string, panelProps?: any) => void;
   toggleSidePanel: (panel: string, panelProps?: any) => void;
   clipboard: ClipboardInterface;
   startCellEdition: (content?: string) => void;

--- a/tests/pivots/pivot_measure/pivot_measure_display_panel.test.ts
+++ b/tests/pivots/pivot_measure/pivot_measure_display_panel.test.ts
@@ -9,9 +9,10 @@ import { addPivot, removePivot, updatePivot } from "../../test_helpers/pivot_hel
 
 let model: Model;
 const pivotId: UID = "pivotId";
+const measureId: UID = "m1";
 let sheetId: UID;
 let fixture: HTMLElement;
-let openSidePanelSpy: jest.Mock;
+let replaceSidePanelSpy: jest.Mock;
 let env: SpreadsheetChildEnv;
 
 function getPivotMeasures() {
@@ -19,15 +20,15 @@ function getPivotMeasures() {
 }
 
 describe("Standalone side panel tests", () => {
-  openSidePanelSpy = jest.fn();
+  replaceSidePanelSpy = jest.fn();
   async function mountPanel(measure?: PivotCoreMeasure) {
     ({ fixture } = await mountComponent(PivotMeasureDisplayPanel, {
       model,
-      env: { openSidePanel: openSidePanelSpy },
+      env: { replaceSidePanel: replaceSidePanelSpy },
       props: {
         onCloseSidePanel: () => {},
         pivotId: pivotId,
-        measure: measure || { fieldName: "TestMeasure", aggregator: "count", id: "m1" },
+        measure: measure || { fieldName: "TestMeasure", aggregator: "count", id: measureId },
       },
     }));
   }
@@ -39,7 +40,7 @@ describe("Standalone side panel tests", () => {
     addPivot(
       model,
       "A1:A2",
-      { measures: [{ fieldName: "TestMeasure", aggregator: "count", id: "m1" }] },
+      { measures: [{ fieldName: "TestMeasure", aggregator: "count", id: measureId }] },
       pivotId
     );
   });
@@ -219,11 +220,15 @@ describe("Standalone side panel tests", () => {
     });
   });
 
-  test("Saving the display opens back the pivot side panel", async () => {
+  test("Saving the display replace the pivot side panel", async () => {
     await mountPanel();
     await click(fixture, ".o-pivot-measure-save");
 
-    expect(openSidePanelSpy).toHaveBeenCalledWith("PivotSidePanel", { pivotId });
+    expect(replaceSidePanelSpy).toHaveBeenCalledWith(
+      "PivotSidePanel",
+      `pivot_measure_display_${pivotId}_${measureId}`,
+      { pivotId }
+    );
   });
 
   test("Can cancel the edition of the measure display", async () => {
@@ -234,7 +239,11 @@ describe("Standalone side panel tests", () => {
     expect(getPivotMeasures()[0].display).toEqual({ type: "%_of_grand_total" });
 
     await click(fixture, ".o-pivot-measure-cancel");
-    expect(openSidePanelSpy).toHaveBeenCalledWith("PivotSidePanel", { pivotId });
+    expect(replaceSidePanelSpy).toHaveBeenCalledWith(
+      "PivotSidePanel",
+      `pivot_measure_display_${pivotId}_${measureId}`,
+      { pivotId }
+    );
     expect(getPivotMeasures()[0].display).toEqual(undefined);
   });
 });

--- a/tests/spreadsheet/side_panel_component.test.ts
+++ b/tests/spreadsheet/side_panel_component.test.ts
@@ -459,6 +459,31 @@ describe("Side Panel", () => {
       expect(".o-sidePanelTitle").toHaveText("Custom Panel");
     });
 
+    test("Reopening main panel from secondary panel closes secondary panel", async () => {
+      await click(fixture, ".o-pin-panel");
+
+      parent.env.openSidePanel("CUSTOM_PANEL_2");
+      await nextTick();
+      expect(".o-sidePanel").toHaveCount(2);
+
+      parent.env.replaceSidePanel("CUSTOM_PANEL", "CUSTOM_PANEL_2");
+      await nextTick();
+      expect(".o-sidePanel").toHaveCount(1);
+      expect(".o-sidePanelTitle").toHaveText("Custom Panel");
+    });
+
+    test("Reopening main panel directly does not close secondary panel", async () => {
+      await click(fixture, ".o-pin-panel");
+
+      parent.env.openSidePanel("CUSTOM_PANEL_2");
+      await nextTick();
+      expect(".o-sidePanel").toHaveCount(2);
+
+      parent.env.openSidePanel("CUSTOM_PANEL");
+      await nextTick();
+      expect(".o-sidePanel").toHaveCount(2);
+    });
+
     test("Re-opening the same panel un-collapses it", async () => {
       await click(fixture, ".o-pin-panel");
       await click(fixture, ".o-collapse-panel");
@@ -467,6 +492,20 @@ describe("Side Panel", () => {
       expect(sidePanelStore.mainPanel?.size).toBe(COLLAPSED_SIDE_PANEL_SIZE);
 
       parent.env.openSidePanel("CUSTOM_PANEL");
+      await nextTick();
+      expect(".o-sidePanel").not.toHaveClass("collapsed");
+      expect(sidePanelStore.mainPanel?.size).toBe(DEFAULT_SIDE_PANEL_SIZE);
+    });
+
+    test("Reopening main panel from secondary panel should expand it if collapsed", async () => {
+      await click(fixture, ".o-pin-panel");
+      await click(fixture, ".o-collapse-panel");
+
+      expect(".o-sidePanel").toHaveClass("collapsed");
+      expect(sidePanelStore.mainPanel?.size).toBe(COLLAPSED_SIDE_PANEL_SIZE);
+
+      parent.env.openSidePanel("CUSTOM_PANEL_2");
+      parent.env.replaceSidePanel("CUSTOM_PANEL", "CUSTOM_PANEL_2");
       await nextTick();
       expect(".o-sidePanel").not.toHaveClass("collapsed");
       expect(sidePanelStore.mainPanel?.size).toBe(DEFAULT_SIDE_PANEL_SIZE);

--- a/tests/test_helpers/helpers.ts
+++ b/tests/test_helpers/helpers.ts
@@ -223,6 +223,7 @@ export function makeTestEnv(
     model,
     isDashboard: mockEnv.isDashboard || (() => false),
     openSidePanel: mockEnv.openSidePanel || sidePanelStore.open.bind(sidePanelStore),
+    replaceSidePanel: mockEnv.replaceSidePanel || sidePanelStore.replace.bind(sidePanelStore),
     toggleSidePanel: mockEnv.toggleSidePanel || sidePanelStore.toggle.bind(sidePanelStore),
     clipboard: mockEnv.clipboard || new MockClipboard(),
     //FIXME : image provider is not built on top of the file store of the model if provided


### PR DESCRIPTION
## Description:

Steps to reproduce:
- Open the global filter side panel (list of all filters)
- Pin the panel
- Click on a specific filter to view/edit it

Current behavior before PR:
- A second side panel was opened instead of replacing the current one
- Clicking 'Cancel' on the new panel had no effect
- Clicking 'Remove' caused a traceback

Desired behavior after PR is merged:
- The new side panel replaces the current one (main or secondary)
- The previous panel is restored correctly on 'Cancel' or 'Remove'
- If the new panel is already open, we simply close the current one

Task: [4911603](https://www.odoo.com/odoo/2328/tasks/4911603)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo