### PR TITLE
[FIX] data validation: handle cell format in auto-complete

### DIFF
--- a/src/registries/auto_completes/data_validation_auto_complete.ts
+++ b/src/registries/auto_completes/data_validation_auto_complete.ts
@@ -1,4 +1,5 @@
-import { isNotNull } from "../../helpers";
+import { CellPosition, CellValue, Getters } from "../..";
+import { positions } from "../../helpers";
 import { autoCompleteProviders } from "./auto_complete_registry";
 
 autoCompleteProviders.add("dataValidation", {
@@ -10,34 +11,45 @@ autoCompleteProviders.add("dataValidation", {
     if (!this.composer.currentEditedCell) {
       return [];
     }
-    const position = this.composer.currentEditedCell;
-    const rule = this.getters.getValidationRuleForCell(position);
-    if (
-      !rule ||
-      (rule.criterion.type !== "isValueInList" && rule.criterion.type !== "isValueInRange")
-    ) {
-      return [];
-    }
 
-    let values: string[];
-    if (rule.criterion.type === "isValueInList") {
-      values = rule.criterion.values;
-    } else {
-      const range = this.getters.getRangeFromSheetXC(position.sheetId, rule.criterion.values[0]);
-      values = Array.from(
-        new Set(
-          this.getters
-            .getRangeValues(range)
-            .filter(isNotNull)
-            .map((value) => value.toString())
-            .filter((val) => val !== "")
-        )
-      );
-    }
-    return values.map((value) => ({ text: value }));
+    return getProposedValues(this.getters, this.composer.currentEditedCell).map((value) => ({
+      text: value.value?.toString() || "",
+      htmlContent: [{ value: value.label }],
+      fuzzySearchKey: value.label,
+    }));
   },
   selectProposal(tokenAtCursor, value) {
     this.composer.setCurrentContent(value);
     this.composer.stopEdition();
   },
 });
+
+function getProposedValues(
+  getters: Getters,
+  position: CellPosition
+): { label: string; value: CellValue }[] {
+  const rule = getters.getValidationRuleForCell(position);
+  if (
+    !rule ||
+    (rule.criterion.type !== "isValueInList" && rule.criterion.type !== "isValueInRange")
+  ) {
+    return [];
+  }
+
+  let values: { label: string; value: CellValue }[] = [];
+  if (rule.criterion.type === "isValueInList") {
+    values = rule.criterion.values.map((value) => ({ label: value, value }));
+  } else {
+    const labelsSet = new Set<string>();
+    const range = getters.getRangeFromSheetXC(position.sheetId, rule.criterion.values[0]);
+    for (const p of positions(range.zone)) {
+      const cell = getters.getEvaluatedCell({ ...p, sheetId: range.sheetId });
+      if (cell.formattedValue && !labelsSet.has(cell.formattedValue)) {
+        labelsSet.add(cell.formattedValue);
+        values.push({ label: cell.formattedValue, value: cell.value });
+      }
+    }
+  }
+
+  return values;
+}

--- a/tests/composer/auto_complete/data_validation_auto_complete_store.test.ts
+++ b/tests/composer/auto_complete/data_validation_auto_complete_store.test.ts
@@ -1,5 +1,5 @@
 import { CellComposerStore } from "../../../src/components/composer/composer/cell_composer_store";
-import { addDataValidation, setCellContent } from "../../test_helpers/commands_helpers";
+import { addDataValidation, setCellContent, setFormat } from "../../test_helpers/commands_helpers";
 import { makeStore } from "../../test_helpers/stores";
 
 describe("Data validation auto complete", () => {
@@ -29,5 +29,35 @@ describe("Data validation auto complete", () => {
     const autoComplete = composer.autocompleteProvider;
     const proposals = autoComplete?.proposals;
     expect(proposals).toHaveLength(3);
+  });
+
+  test("Cell formatted value is shown in the proposals", () => {
+    const { store: composer, model } = makeStore(CellComposerStore);
+    addDataValidation(model, "A1", "id", {
+      type: "isValueInRange",
+      values: ["B1:B2"],
+      displayStyle: "arrow",
+    });
+    setCellContent(model, "B1", "5");
+    setFormat(model, "B1", "0.00[$€]");
+    setCellContent(model, "B2", "10");
+    setFormat(model, "B2", "yyyy-mm-dd");
+
+    composer.startEdition();
+    const autoComplete = composer.autocompleteProvider;
+    const proposals = autoComplete?.proposals;
+    expect(proposals).toHaveLength(2);
+    expect(proposals).toMatchObject([
+      {
+        text: "5",
+        htmlContent: [{ value: "5.00€" }],
+        fuzzySearchKey: "5.00€",
+      },
+      {
+        text: "10",
+        htmlContent: [{ value: "1900-01-09" }],
+        fuzzySearchKey: "1900-01-09",
+      },
+    ]);
   });
 });


### PR DESCRIPTION
## Description

The auto complete of data validation showed the raw cell value instead of the formatted value. We should display the formatted value in the auto-complete, but still use the raw value when selecting a proposal.

Task: [4865661](https://www.odoo.com/odoo/2328/tasks/4865661)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo