### PR TITLE
[FIX] data validation: handle cell format in auto-complete

### DIFF
--- a/src/components/side_panel/criterion_form/value_in_range_criterion/value_in_range_criterion.xml
+++ b/src/components/side_panel/criterion_form/value_in_range_criterion/value_in_range_criterion.xml
@@ -10,11 +10,11 @@
       <div class="o-dv-list-values p-1 d-flex align-items-center">
         <div class="me-2">
           <RoundColorPicker
-            currentColor="props.criterion.colors?.[value] || '#E7E9ED'"
-            onColorPicked="(c) => this.onColorChanged(c, value)"
+            currentColor="props.criterion.colors?.[value.value] || '#E7E9ED'"
+            onColorPicked="(c) => this.onColorChanged(c, value.value)"
           />
         </div>
-        <input type="text" class="o-input" t-att-value="value" disabled="1"/>
+        <input type="text" class="o-input" t-att-value="value.label" disabled="1"/>
       </div>
     </t>
 

--- a/src/registries/auto_completes/data_validation_auto_complete.ts
+++ b/src/registries/auto_completes/data_validation_auto_complete.ts
@@ -22,26 +22,31 @@ autoCompleteProviders.add("dataValidation", {
     const sheetId = this.composer.currentEditedCell.sheetId;
     const values =
       rule.criterion.type === "isValueInRange"
-        ? Array.from(new Set(this.getters.getDataValidationRangeValues(sheetId, rule.criterion)))
-        : rule.criterion.values;
+        ? this.getters.getDataValidationRangeValues(sheetId, rule.criterion)
+        : rule.criterion.values.map((value) => ({ label: value, value }));
 
     const isChip = rule.criterion.displayStyle === "chip";
     if (!isChip) {
-      return values.map((value) => ({ text: value }));
+      return values.map((value) => ({
+        text: value.value,
+        fuzzySearchKey: value.label,
+        htmlContent: [{ value: value.label }],
+      }));
     }
     const colors = rule.criterion.colors;
     return values.map((value) => {
-      const color = colors?.[value];
+      const color = colors?.[value.value];
       return {
-        text: value,
+        text: value.value,
         htmlContent: [
           {
-            value,
+            value: value.label,
             color: color ? chipTextColor(color) : undefined,
             backgroundColor: color || GRAY_200,
             classes: ["badge rounded-pill fs-6 fw-normal w-100 mt-1 text-start"],
           },
         ],
+        fuzzySearchKey: value.label,
       };
     });
   },

--- a/src/registries/criterion_registry.ts
+++ b/src/registries/criterion_registry.ts
@@ -626,7 +626,7 @@ criterionEvaluatorRegistry.add("isValueInRange", {
     }
     const criterionValues = getters.getDataValidationRangeValues(sheetId, criterion);
     return criterionValues
-      .map((value) => value.toLowerCase())
+      .map((value) => value.value.toLowerCase())
       .includes(value.toString().toLowerCase());
   },
   getErrorString: (criterion: EvaluatedCriterion) =>

--- a/tests/data_validation/data_validation_list_component.test.ts
+++ b/tests/data_validation/data_validation_list_component.test.ts
@@ -13,10 +13,12 @@ import {
   addDataValidation,
   createTableWithFilter,
   setCellContent,
+  setFormat,
   setSelection,
   setStyle,
 } from "../test_helpers/commands_helpers";
 import {
+  changeRoundColorPickerColor,
   click,
   clickGridIcon,
   getElComputedStyle,
@@ -264,6 +266,20 @@ describe("Edit criterion in side panel", () => {
       expect((getDataValidationRules(model)[0].criterion as IsValueInListCriterion).colors).toEqual(
         {}
       );
+    });
+
+    test("formatted value is displayed instead of raw value", async () => {
+      setCellContent(model, "B1", "5");
+      setFormat(model, "B1", "0.00$");
+      await nextTick();
+
+      const inputs = fixture.querySelectorAll<HTMLInputElement>(".o-dv-list-values .o-input");
+      expect(inputs).toHaveLength(1);
+      expect(inputs[0]).toHaveValue("5.00$");
+      await changeRoundColorPickerColor(".o-dv-list-values", "#CFE2F3");
+      await click(fixture, ".o-dv-save");
+      const criterion = getDataValidationRules(model)[0].criterion as IsValueInListCriterion;
+      expect(criterion.colors).toEqual({ "5": "#CFE2F3" });
     });
   });
 });


### PR DESCRIPTION
## Description

The auto complete of data validation showed the raw cell value instead of the formatted value. We should display the formatted value in the auto-complete, but still use the raw value when selecting a proposal.

The same issue was also present in the side panel.

Task: [4865661](https://www.odoo.com/odoo/2328/tasks/4865661)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo