### PR TITLE
[FIX] pivot: support SUM and AVG aggregators for duration fields

### DIFF
--- a/src/helpers/pivot/pivot_helpers.ts
+++ b/src/helpers/pivot/pivot_helpers.ts
@@ -44,13 +44,13 @@ const AGGREGATOR_NAMES = {
   sum: _t("Sum"),
 };
 
-const NUMBER_CHAR_AGGREGATORS = ["max", "min", "avg", "sum", "count_distinct", "count"];
+const DEFAULT_AGGREGATORS = ["max", "min", "avg", "sum", "count_distinct", "count"];
 
 const AGGREGATORS_BY_FIELD_TYPE = {
-  integer: NUMBER_CHAR_AGGREGATORS,
-  char: NUMBER_CHAR_AGGREGATORS,
+  integer: DEFAULT_AGGREGATORS,
+  char: DEFAULT_AGGREGATORS,
+  datetime: DEFAULT_AGGREGATORS,
   boolean: ["count_distinct", "count", "bool_and", "bool_or"],
-  datetime: ["max", "min", "count_distinct", "count"],
 };
 
 export const AGGREGATORS = {};

--- a/tests/pivots/spreadsheet_pivot/spreadsheet_pivot.test.ts
+++ b/tests/pivots/spreadsheet_pivot/spreadsheet_pivot.test.ts
@@ -1808,6 +1808,30 @@ describe("Spreadsheet Pivot", () => {
     expect(getEvaluatedCell(model, "B27").formattedValue).toBe("2022/04/14 01:02:03");
   });
 
+  test("Pivot aggregates duration fields with correct SUM and AVG values", () => {
+    const model = createModelFromGrid({
+      A1: "Duration",
+      A2: "01:30:00",
+      A3: "02:00:00",
+      A4: "00:45:00",
+    });
+    addPivot(model, "A1:A4", {
+      columns: [],
+      rows: [],
+      measures: [
+        { id: "Duration:avg", fieldName: "Duration", aggregator: "avg" },
+        { id: "Duration:sum", fieldName: "Duration", aggregator: "sum" },
+      ],
+    });
+    setCellContent(model, "A6", '=PIVOT.VALUE(1,"Duration:avg")');
+    setCellContent(model, "B6", '=PIVOT.VALUE(1,"Duration:sum")');
+
+    const pivot = model.getters.getPivot("1");
+    expect(pivot.getFields().Duration?.type).toBe("datetime");
+    expect(getEvaluatedCell(model, "A6").formattedValue).toBe("01:25:00");
+    expect(getEvaluatedCell(model, "B6").formattedValue).toBe("04:15:00");
+  });
+
   test("Pivot with measure AVG on text values does not crash", () => {
     const model = createModelFromGrid({ A1: "Customer", A2: "Jean", A3: "Marc" });
     addPivot(model, "A1:A3", {

--- a/tests/pivots/spreadsheet_pivot/spreadsheet_pivot_side_panel.test.ts
+++ b/tests/pivots/spreadsheet_pivot/spreadsheet_pivot_side_panel.test.ts
@@ -440,6 +440,33 @@ describe("Spreadsheet pivot side panel", () => {
     ]);
   });
 
+  test("Supports SUM and AVG aggregators for duration fields", async () => {
+    setCellContent(model, "A1", "name");
+    setCellContent(model, "A2", "Alice");
+    setCellContent(model, "B1", "duration");
+    setCellContent(model, "B2", "01:30:00");
+    addPivot(model, "A1:B2", {}, "3");
+    env.openSidePanel("PivotSidePanel", { pivotId: "3" });
+    await nextTick();
+    await click(fixture.querySelector(".o-pivot-measure .add-dimension")!);
+    await click(fixture.querySelectorAll(".o-autocomplete-value")[1]);
+
+    // Default aggregator for duration fields is "count"
+    expect(model.getters.getPivotCoreDefinition("3").measures).toEqual([
+      { id: "duration:count", fieldName: "duration", aggregator: "count" },
+    ]);
+
+    await setInputValueAndTrigger(".pivot-measure select", "sum");
+    expect(model.getters.getPivotCoreDefinition("3").measures).toEqual([
+      { id: "duration:sum", fieldName: "duration", aggregator: "sum" },
+    ]);
+
+    await setInputValueAndTrigger(".pivot-measure select", "avg");
+    expect(model.getters.getPivotCoreDefinition("3").measures).toEqual([
+      { id: "duration:avg", fieldName: "duration", aggregator: "avg" },
+    ]);
+  });
+
   test("can add a datetime measure", async () => {
     setCellContent(model, "A1", "name");
     setCellContent(model, "A2", "Alice");


### PR DESCRIPTION
## Description:
Steps to reproduce:
- Create a pivot with a duration-formatted column.
- Go to the side panel and add the duration field to the Measures section.

Current behavior before PR:
- Datetime-formatted fields (such as durations) could not
be aggregated using SUM or AVG in pivot measures.
- This blocked users from summing or averaging durations

Desired behavior after PR is merged:
- SUM and AVG aggregators are supported for datetime fields,
- Allowing meaningful aggregation of duration values in pivot tables.

Task: [4945217](https://www.odoo.com/odoo/2328/tasks/4945217)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo