### PR TITLE
[FIX] chart: chartJS extensions loaded too late

### DIFF
--- a/src/components/spreadsheet/spreadsheet.ts
+++ b/src/components/spreadsheet/spreadsheet.ts
@@ -2,6 +2,7 @@ import {
   Component,
   onMounted,
   onPatched,
+  onWillStart,
   onWillUnmount,
   onWillUpdateProps,
   useEffect,
@@ -442,11 +443,13 @@ export class Spreadsheet extends Component<SpreadsheetProps, SpreadsheetChildEnv
     });
 
     const render = batched(this.render.bind(this, true));
+    onWillStart(() => {
+      registerChartJSExtensions();
+    });
     onMounted(() => {
       this.checkViewportSize();
       stores.on("store-updated", this, render);
       resizeObserver.observe(this.spreadsheetRef.el!);
-      registerChartJSExtensions();
     });
     onWillUnmount(() => {
       this.unbindModelEvents();


### PR DESCRIPTION
## Description

The `onMounted` hook in child components runs before the one in their parent. So loading the ChartJS extensions in the Spreadsheet's `onMounted` doesn't work, since the `ChartJsComponent` needs them in its own `onMounted`, which runs first.

It actually worked by purr chance before. At the first render of the model, the sheetview size isn't set yet, so `getters.getVisibleFigures()` doesn't return anything. And only at the second render the charts are displayed. However if we tried to load a `Spreadsheet` with a model that has an initialized sheetview size, the charts would not be loaded correctly.

Task: [4954034](https://www.odoo.com/odoo/2328/tasks/4954034)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo