### PR TITLE
[FIX] xlsx: correctly export aggregated charts

### DIFF
--- a/src/helpers/figures/charts/radar_chart.ts
+++ b/src/helpers/figures/charts/radar_chart.ts
@@ -180,9 +180,6 @@ export class RadarChart extends AbstractChart {
   }
 
   getDefinitionForExcel(): ExcelChartDefinition | undefined {
-    if (this.aggregated) {
-      return undefined;
-    }
     const dataSets: ExcelChartDataset[] = this.dataSets
       .map((ds: DataSet) => toExcelDataset(this.getters, ds))
       .filter((ds) => ds.range !== "" && ds.range !== CellErrorType.InvalidReference);

--- a/tests/xlsx/xlsx_export.test.ts
+++ b/tests/xlsx/xlsx_export.test.ts
@@ -1274,9 +1274,9 @@ describe("Test XLSX export", () => {
       expect(await exportPrettifiedXlsx(model)).toMatchSnapshot();
     });
 
-    test.each(["bar", "line", "pie"] as const)(
+    test.each(["bar", "line", "pie", "radar"] as const)(
       "%s chart that aggregate labels is exported as normal chart, ignoring the aggregation",
-      async (type: "bar" | "line" | "pie") => {
+      async (type) => {
         const model = new Model();
         createChart(model, { aggregated: true, type }, "1");
         const exportedData = getExportedExcelData(model);


### PR DESCRIPTION
## Description

Follow up of #6075, for charts radar charts.

The feature to aggregate the chart data based on the labels does not exist in xlsx files. But rather than exporting the chart as normal, ignoring the aggregation, we exported the chart as an image.

Task: [4954426](https://www.odoo.com/odoo/2328/tasks/4954426)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo