### PR TITLE
[FIX] cf: do not override changes on cancel

### DIFF
--- a/src/components/side_panel/conditional_formatting/cf_editor/cf_editor.ts
+++ b/src/components/side_panel/conditional_formatting/cf_editor/cf_editor.ts
@@ -137,8 +137,9 @@ css/* scss */ `
 `;
 interface Props {
   editedCf: ConditionalFormat;
-  onSave: () => void;
+  onExit: () => void;
   onCancel: () => void;
+  isNewCf: boolean;
 }
 
 type CFType = "CellIsRule" | "ColorScaleRule" | "IconSetRule" | "DataBarRule";
@@ -173,7 +174,8 @@ export class ConditionalFormattingEditor extends Component<Props, SpreadsheetChi
   static props = {
     editedCf: Object,
     onCancel: Function,
-    onSave: Function,
+    onExit: Function,
+    isNewCf: Boolean,
   };
   static components = {
     SelectionInput,
@@ -194,6 +196,7 @@ export class ConditionalFormattingEditor extends Component<Props, SpreadsheetChi
   colorNumberString = colorNumberString;
 
   private state!: State;
+  private hasEditedCf = this.props.isNewCf;
 
   setup() {
     this.state = useState<State>({
@@ -259,6 +262,9 @@ export class ConditionalFormattingEditor extends Component<Props, SpreadsheetChi
       ranges: ranges.map((xc) => this.env.model.getters.getRangeDataFromXc(sheetId, xc)),
       sheetId,
     });
+    if (result.isSuccessful) {
+      this.hasEditedCf = true;
+    }
     const reasons = result.reasons.filter((r) => r !== CommandResult.NoChanges);
     if (!newCf.suppressErrors) {
       this.state.errors = reasons;
@@ -282,7 +288,15 @@ export class ConditionalFormattingEditor extends Component<Props, SpreadsheetChi
   onSave() {
     const result = this.updateConditionalFormat({});
     if (result.length === 0) {
-      this.props.onSave();
+      this.props.onExit();
+    }
+  }
+
+  onCancel() {
+    if (this.hasEditedCf) {
+      this.props.onCancel();
+    } else {
+      this.props.onExit();
     }
   }
 

--- a/src/components/side_panel/conditional_formatting/cf_editor/cf_editor.xml
+++ b/src/components/side_panel/conditional_formatting/cf_editor/cf_editor.xml
@@ -40,7 +40,7 @@
       </Section>
       <Section class="'pt-1'">
         <div class="o-sidePanelButtons">
-          <button t-on-click="props.onCancel" class="o-button o-cf-cancel">Cancel</button>
+          <button t-on-click="onCancel" class="o-button o-cf-cancel">Cancel</button>
           <button
             t-on-click="onSave"
             class="o-button primary o-cf-save"

--- a/src/components/side_panel/conditional_formatting/conditional_formatting.xml
+++ b/src/components/side_panel/conditional_formatting/conditional_formatting.xml
@@ -11,8 +11,9 @@
       <t t-if="state.mode === 'edit'">
         <ConditionalFormattingEditor
           editedCf="editedCF"
-          onSave.bind="switchToList"
+          onExit.bind="switchToList"
           onCancel.bind="cancelEdition"
+          isNewCf="originalEditedCf === undefined"
         />
       </t>
     </div>

--- a/tests/conditional_formatting/conditional_formatting_panel_component.test.ts
+++ b/tests/conditional_formatting/conditional_formatting_panel_component.test.ts
@@ -539,6 +539,27 @@ describe("UI of conditional formats", () => {
       });
     });
 
+    test("Pressing cancel after doing nothing in the panel does not override changes from another user", async () => {
+      await click(fixture, selectors.buttonAdd);
+      await click(fixture, selectors.buttonSave);
+      const cfId = model.getters.getConditionalFormats(sheetId)[0].id;
+
+      // Open the panel
+      await click(fixture, selectors.listPreview);
+      // Someone else changes the CF in the meantime
+      model.dispatch("ADD_CONDITIONAL_FORMAT", {
+        cf: createEqualCF("2", { fillColor: "#ff0000" }, cfId),
+        ranges: toRangesData(sheetId, "A1:A2"),
+        sheetId,
+      });
+      // Press cancel
+      await click(fixture, selectors.buttonCancel);
+      expect(model.getters.getConditionalFormats(sheetId)[0].rule).toMatchObject({
+        operator: "Equal",
+        style: { fillColor: "#ff0000" },
+      });
+    });
+
     test("The error messages only appear when clicking save, not when changing the operator type", async () => {
       await click(fixture, selectors.buttonAdd);
 


### PR DESCRIPTION
## Description

- Open the side panel to edit a conditional format.
- Another user changes the CF
- The first user presses cancel
- The changes from the second user will be overriden. They should not, the first user changed nothing and pressed cancel.

This commit fixes that, if the user did not change anything, cancel will do nothing. Note that as soon the user changes anything, pressing cancel will override the changes from another user. We cannot have a side panel that both make the changes in the sheet instantly, and also preserve changes from other users.

Task: [4609695](https://www.odoo.com/odoo/2328/tasks/4609695)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo