### PR TITLE
[FIX] clipboard: insert cells bugged with array formulas

### DIFF
--- a/src/helpers/clipboard/clipboard_cells_state.ts
+++ b/src/helpers/clipboard/clipboard_cells_state.ts
@@ -16,7 +16,12 @@ import {
   UID,
   Zone,
 } from "../../types";
-import { ClipboardMIMEType, ClipboardOperation, ClipboardOptions } from "../../types/clipboard";
+import {
+  ClipboardCopyOptions,
+  ClipboardMIMEType,
+  ClipboardOperation,
+  ClipboardOptions,
+} from "../../types/clipboard";
 import { xmlEscape } from "../../xlsx/helpers/xml_helpers";
 import { formatValue } from "../format";
 import { deepCopy, deepEquals, range } from "../misc";
@@ -59,7 +64,8 @@ export class ClipboardCellsState extends ClipboardCellsAbstractState {
     operation: ClipboardOperation,
     getters: Getters,
     dispatch: CommandDispatcher["dispatch"],
-    selection: SelectionStreamProcessor
+    selection: SelectionStreamProcessor,
+    mode: ClipboardCopyOptions = "copyPaste"
   ) {
     super(operation, getters, dispatch, selection);
     if (!zones.length) {
@@ -96,7 +102,7 @@ export class ClipboardCellsState extends ClipboardCellsAbstractState {
         const spreader = getters.getArrayFormulaSpreadingOn(position);
         let cell = getters.getCell(position);
         const evaluatedCell = getters.getEvaluatedCell(position);
-        if (spreader) {
+        if (mode !== "shiftCells" && spreader) {
           const isSpreaderCopied =
             rowsIndex.includes(spreader.row) && columnsIndex.includes(spreader.col);
           const content = isSpreaderCopied

--- a/src/plugins/ui_stateful/clipboard.ts
+++ b/src/plugins/ui_stateful/clipboard.ts
@@ -4,6 +4,7 @@ import { ClipboardOsState } from "../../helpers/clipboard/clipboard_os_state";
 import { isZoneValid } from "../../helpers/index";
 import {
   ClipboardContent,
+  ClipboardCopyOptions,
   ClipboardMIMEType,
   ClipboardOperation,
   ClipboardState,
@@ -84,12 +85,12 @@ export class ClipboardPlugin extends UIPlugin {
       }
       case "INSERT_CELL": {
         const { cut, paste } = this.getInsertCellsTargets(cmd.zone, cmd.shiftDimension);
-        const state = this.getClipboardStateForCopyCells(cut, "CUT");
+        const state = this.getClipboardStateForCopyCells(cut, "CUT", "shiftCells");
         return state.isPasteAllowed(paste);
       }
       case "DELETE_CELL": {
         const { cut, paste } = this.getDeleteCellsTargets(cmd.zone, cmd.shiftDimension);
-        const state = this.getClipboardStateForCopyCells(cut, "CUT");
+        const state = this.getClipboardStateForCopyCells(cut, "CUT", "shiftCells");
         return state.isPasteAllowed(paste);
       }
       case "ACTIVATE_PAINT_FORMAT": {
@@ -172,13 +173,13 @@ export class ClipboardPlugin extends UIPlugin {
           });
           break;
         }
-        const state = this.getClipboardStateForCopyCells(cut, "CUT");
+        const state = this.getClipboardStateForCopyCells(cut, "CUT", "shiftCells");
         state.paste(paste);
         break;
       }
       case "INSERT_CELL": {
         const { cut, paste } = this.getInsertCellsTargets(cmd.zone, cmd.shiftDimension);
-        const state = this.getClipboardStateForCopyCells(cut, "CUT");
+        const state = this.getClipboardStateForCopyCells(cut, "CUT", "shiftCells");
         state.paste(paste);
         break;
       }
@@ -339,8 +340,19 @@ export class ClipboardPlugin extends UIPlugin {
     return { cut: [cut], paste: [paste] };
   }
 
-  private getClipboardStateForCopyCells(zones: Zone[], operation: ClipboardOperation) {
-    return new ClipboardCellsState(zones, operation, this.getters, this.dispatch, this.selection);
+  private getClipboardStateForCopyCells(
+    zones: Zone[],
+    operation: ClipboardOperation,
+    mode: ClipboardCopyOptions = "copyPaste"
+  ) {
+    return new ClipboardCellsState(
+      zones,
+      operation,
+      this.getters,
+      this.dispatch,
+      this.selection,
+      mode
+    );
   }
 
   /**

--- a/src/plugins/ui_stateful/selection.ts
+++ b/src/plugins/ui_stateful/selection.ts
@@ -673,7 +673,8 @@ export class GridSelectionPlugin extends UIPlugin {
       "CUT",
       this.getters,
       this.dispatch,
-      this.selection
+      this.selection,
+      "shiftCells"
     );
     const base = isBasedBefore ? cmd.base : cmd.base + 1;
     const pasteTarget = [

--- a/src/types/clipboard.ts
+++ b/src/types/clipboard.ts
@@ -15,6 +15,7 @@ export interface ClipboardOptions {
   selectTarget?: boolean;
 }
 export type ClipboardPasteOptions = "onlyFormat" | "onlyValue";
+export type ClipboardCopyOptions = "copyPaste" | "shiftCells";
 export type ClipboardOperation = "CUT" | "COPY";
 
 export interface ClipboardState {

--- a/tests/clipboard/clipboard_plugin.test.ts
+++ b/tests/clipboard/clipboard_plugin.test.ts
@@ -26,9 +26,11 @@ import {
   createSheet,
   createSheetWithName,
   cut,
+  deleteCells,
   deleteColumns,
   deleteRows,
   deleteSheet,
+  insertCells,
   merge,
   paste,
   pasteFromOSClipboard,
@@ -56,6 +58,7 @@ import {
 import {
   addTestPlugin,
   createEqualCF,
+  createModelFromGrid,
   getGrid,
   target,
   toRangesData,
@@ -2034,6 +2037,20 @@ describe("clipboard: pasting outside of sheet", () => {
     expect(getStyle(model, "B3")).toEqual({ bold: true, fillColor: "red" });
     expect(getCellContent(model, "C2")).toBe("c2");
     expect(getCellContent(model, "C3")).toBe("c2");
+  });
+
+  test("Can insert and delete cells inside an array formula", () => {
+    const model = createModelFromGrid({ A1: "=MUNIT(2)" });
+
+    insertCells(model, "B1", "down");
+    expect(getCell(model, "A1")?.content).toBe("=MUNIT(2)");
+    expect(getCellContent(model, "A1")).toBe("1");
+    expect(getCell(model, "B2")).toBe(undefined);
+
+    deleteCells(model, "A2", "left");
+    expect(getCell(model, "A1")?.content).toBe("=MUNIT(2)");
+    expect(getCellContent(model, "A1")).toBe("1");
+    expect(getCell(model, "A2")).toBe(undefined);
   });
 
   test("fill right selection with multiple columns -> copies first column and pastes in each subsequent column, ", async () => {

--- a/tests/sheet/selection_plugin.test.ts
+++ b/tests/sheet/selection_plugin.test.ts
@@ -40,6 +40,7 @@ import {
 } from "../test_helpers/commands_helpers";
 import {
   getActivePosition,
+  getCell,
   getCellContent,
   getSelectionAnchorCellXc,
 } from "../test_helpers/getters_helpers";
@@ -1062,6 +1063,23 @@ describe("move elements(s)", () => {
     expect(result).toBeCancelledBecause(CommandResult.InvalidHeaderIndex);
     result = moveRows(model, -1, [0]);
     expect(result).toBeCancelledBecause(CommandResult.InvalidHeaderIndex);
+  });
+
+  test("Can move a row with an array formula", () => {
+    const model = new Model();
+    setCellContent(model, "A4", "=MUNIT(2)");
+    moveRows(model, 0, [3], "before");
+    expect(getCell(model, "A1")?.content).toEqual("=MUNIT(2)");
+    expect(getCellContent(model, "A1")).toEqual("1");
+    expect(getCell(model, "B1")).toEqual(undefined);
+  });
+
+  test("Moving a column with spreaded results do not copy them", () => {
+    const model = new Model();
+    setCellContent(model, "C1", "=MUNIT(2)");
+    moveColumns(model, "A", ["D"], "before");
+    expect(getCell(model, "A1")).toEqual(undefined);
+    expect(getCell(model, "D1")?.content).toEqual("=MUNIT(2)");
   });
 });
 


### PR DESCRIPTION
## Description

The insert/delete cell features, as well as the drag & drop of rows/columns is implemented with the clipboards. Under the hood, they do cut/paste operations.

But some behaviour is specific to copy/paste and should not be applied to those features: here we should not copy part of array formulas. We don't want an "insert cell" inside an array formula to copy a part of the values of the array formula.

Task: [4938311](https://www.odoo.com/odoo/2328/tasks/4938311)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo