### PR TITLE
[FIX] clipboard: don't paste both image and text content

### DIFF
--- a/src/helpers/clipboard/clipboard_helpers.ts
+++ b/src/helpers/clipboard/clipboard_helpers.ts
@@ -84,15 +84,19 @@ export function parseOSClipboardContent(
       ?.getAttribute("data-osheet-clipboard");
     spreadsheetContent = oSheetClipboardData && JSON.parse(oSheetClipboardData);
   }
+  const textContent = content[ClipboardMIMEType.PlainText] || "";
+
   let imageBlob: Blob | undefined = undefined;
-  for (const type of AllowedImageMimeTypes) {
-    if (content[type]) {
-      imageBlob = content[type];
-      break;
+  if (!textContent.trim()) {
+    for (const type of AllowedImageMimeTypes) {
+      if (content[type]) {
+        imageBlob = content[type];
+        break;
+      }
     }
   }
   const osClipboardContent: ParsedOSClipboardContent = {
-    text: content[ClipboardMIMEType.PlainText],
+    text: textContent,
     data: spreadsheetContent,
     imageBlob,
   };

--- a/tests/grid/grid_component.test.ts
+++ b/tests/grid/grid_component.test.ts
@@ -2025,6 +2025,18 @@ describe("Copy paste keyboard shortcut", () => {
 
     expect(model.getters.getFigure(sheetId, figures[0].id)).toMatchObject({});
   });
+
+  test("Pasting an OS clipboard with both text and image will only paste the text", async () => {
+    const image = new File(["image"], "image.png", { type: "image/png" });
+    clipboardData.setData("image/png", image);
+    clipboardData.setData(ClipboardMIMEType.PlainText, "Hi !");
+    selectCell(model, "A1");
+    document.body.dispatchEvent(getClipboardEvent("paste", clipboardData));
+    await nextTick();
+
+    expect(getCellContent(model, "A1")).toEqual("Hi !");
+    expect(model.getters.getFigures(sheetId)).toHaveLength(0);
+  });
 });
 
 describe("Header grouping shortcuts", () => {


### PR DESCRIPTION
## Description

If we have a clipboard content that has bot an image and some text data, we would paste both inside the spreadsheet. There's a good chance that this is not what the user expects, as the iamge and the text are likely alternatives for the same content.

That's what happened when pasting from Excel (desktop). The user would end up with both the copied data, and an image of the copied data.

With this commit, we'll ignore the image data if we have text data in the clipboard.

Task: [4876682](https://www.odoo.com/odoo/2328/tasks/4876682)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo