### PR TITLE
[FIX] xlsx: cannot import CF with formulas

### DIFF
--- a/src/xlsx/conversion/cf_conversion.ts
+++ b/src/xlsx/conversion/cf_conversion.ts
@@ -1,4 +1,5 @@
 import { ICON_SETS } from "../../components/icons/icons";
+import { tokenize } from "../../formulas";
 import {
   ColorScaleMidPointThreshold,
   ColorScaleThreshold,
@@ -75,9 +76,9 @@ export function convertConditionalFormats(
       case "cellIs":
         if (!rule.operator || !rule.formula || rule.formula.length === 0) continue;
         operator = convertCFCellIsOperator(rule.operator);
-        values.push(rule.formula[0]);
+        values.push(prefixFormula(rule.formula[0]));
         if (rule.formula.length === 2) {
-          values.push(rule.formula[1]);
+          values.push(prefixFormula(rule.formula[1]));
         }
         break;
     }
@@ -241,6 +242,12 @@ function convertIcons(xlsxIconSet: ExcelIconSet, index: number): string {
     : index === 1
     ? ICON_SETS[iconSet].neutral
     : ICON_SETS[iconSet].good;
+}
+
+/** Prefix the string by "=" if the string looks like a formula */
+function prefixFormula(formula: string): string {
+  const tokens = tokenize(formula);
+  return tokens.length === 1 && tokens[0].type !== "REFERENCE" ? formula : "=" + formula;
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/__xlsx__/xlsx_demo_data/xl/sharedStrings.xml
+++ b/tests/__xlsx__/xlsx_demo_data/xl/sharedStrings.xml
@@ -1264,4 +1264,7 @@
   <si>
     <t>Multiple keywords</t>
   </si>
+  <si>
+    <t>CF with formulas</t>
+  </si>
 </sst>

--- a/tests/__xlsx__/xlsx_demo_data/xl/worksheets/sheet5.xml
+++ b/tests/__xlsx__/xlsx_demo_data/xl/worksheets/sheet5.xml
@@ -626,6 +626,15 @@
       </c>
     </row>
     <row r="29" spans="1:12" x14ac:dyDescent="0.2">
+      <c r="A29" s="39" t="s">
+        <v>421</v>
+      </c>
+      <c r="B29">
+        <v>3</v>
+      </c>
+      <c r="C29">
+        <v>10 </v>
+      </c>
       <c r="G29" s="35" t="s">
         <v>297</v>
       </c>
@@ -1144,6 +1153,12 @@
     <cfRule type="cellIs" dxfId="0" priority="1" operator="notBetween">
       <formula>2</formula>
       <formula>4</formula>
+    </cfRule>
+  </conditionalFormatting>
+    <conditionalFormatting sqref="B29:C29">
+    <cfRule type="cellIs" dxfId="22" priority="1" operator="between">
+      <formula>$B$23</formula>
+      <formula>2+2</formula>
     </cfRule>
   </conditionalFormatting>
   <conditionalFormatting sqref="B25:C25">

--- a/tests/xlsx/xlsx_import.test.ts
+++ b/tests/xlsx/xlsx_import.test.ts
@@ -331,6 +331,15 @@ describe("Import xlsx data", () => {
     expect((cf.rule as CellIsRule).values).toEqual(values);
   });
 
+  test("Can import CF with formulas", () => {
+    const testSheet = getWorkbookSheet("jestCfs", convertedData)!;
+    const cf = getCFBeginningAt("B29", testSheet)!;
+
+    expect(cf.rule.type).toEqual("CellIsRule");
+    expect((cf.rule as CellIsRule).operator).toEqual("Between");
+    expect((cf.rule as CellIsRule).values).toEqual(["=$B$23", "=2+2"]);
+  });
+
   test.each([
     ["2 colors max", "H2"],
     ["3 colors max", "H3"],


### PR DESCRIPTION
## Description

Importing a conditional formatting rule with formulas was not working because the formulas are not prefixed by "=" in the xlsx file.

Task: [4945945](https://www.odoo.com/odoo/2328/tasks/4945945)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo