### PR TITLE
[FIX] helpers: preserve sparse(empty) elements in removeIndexesFromArray

### DIFF
--- a/src/helpers/misc.ts
+++ b/src/helpers/misc.ts
@@ -506,8 +506,17 @@ export function memoize<T extends any[], U>(func: (...args: T) => U): (...args: 
   }[funcName];
 }
 
+/**
+ * removeIndexesFromArray removes only the specified indexes from the array.
+ * Sparse (empty) elements are preserved unless their index is explicitly removed.
+ */
 export function removeIndexesFromArray<T>(array: readonly T[], indexes: number[]): T[] {
-  return array.filter((_, index) => !indexes.includes(index));
+  const toRemove = new Set(indexes);
+  const newArray: T[] = [];
+  for (let i = 0; i < array.length; i++) {
+    if (!toRemove.has(i)) newArray.push(array[i]);
+  }
+  return newArray;
 }
 
 export function insertItemsAtIndex<T>(array: readonly T[], items: T[], index: number): T[] {

--- a/tests/sheet/selection_plugin.test.ts
+++ b/tests/sheet/selection_plugin.test.ts
@@ -1016,6 +1016,28 @@ describe("move elements(s)", () => {
     expect(model.getters.getUserRowSize(sheetId, 1)).toEqual(undefined);
   });
 
+  test("Moving a resized row above does not change next row's size", () => {
+    const model = new Model();
+    const sheetId = model.getters.getActiveSheetId();
+    setCellContent(model, "A2", "Hello\nRow1");
+    resizeRows(model, [1], 50);
+    setCellContent(model, "A3", "Hello\nRow2");
+    moveRows(model, 0, [1], "before");
+    expect(model.getters.getRowSize(sheetId, 0)).toEqual(50);
+    expect(model.getters.getRowSize(sheetId, 2)).toEqual(36);
+  });
+
+  test("Moving a row above a resized row should not inherit its size", () => {
+    const model = new Model();
+    const sheetId = model.getters.getActiveSheetId();
+    setCellContent(model, "A1", "Hello\nWorld");
+    resizeRows(model, [0], 50);
+    setCellContent(model, "A2", "Hello");
+    moveRows(model, 0, [1], "before");
+    expect(model.getters.getRowSize(sheetId, 0)).toEqual(23);
+    expect(model.getters.getRowSize(sheetId, 1)).toEqual(50);
+  });
+
   test("Preserves wrapped row height when a row is moved above it", () => {
     const model = new Model();
     const sheetId = model.getters.getActiveSheetId();


### PR DESCRIPTION
## Description:
Steps to reproduce:
- Enter multiline text in row 1, 2, and (optionally) row 3.
- Resize one of the rows (e.g. row 1 or 2).
- Move the other row above the resized one.
- One of the rows either resets to the default height or wrongly keeps a user-defined height.

Current behavior before PR:
- removeIndexesFromArray() used filter(), which skips sparse (empty) elements.
- This caused user-defined row sizes (stored sparsely) to be lost or misapplied during row moves.

Desired behavior after PR is merged:
- Rewrote the function to use a for loop with Set to track removed indexes.
- This preserves all array elements, including sparse (empty) ones.

Task: [4977932](https://www.odoo.com/odoo/2328/tasks/4977932)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo