### PR TITLE
[FIX] Topbar: Fix Z-index

### DIFF
--- a/src/components/spreadsheet/spreadsheet.ts
+++ b/src/components/spreadsheet/spreadsheet.ts
@@ -318,7 +318,6 @@ css/* scss */ `
     }
   }
 
-  .o-spreadsheet-topbar-wrapper,
   .o-spreadsheet-bottombar-wrapper {
     z-index: ${ComponentsImportance.ScrollBar + 1};
   }


### PR DESCRIPTION
There was a faulty css rule added with the mobile mode which overrode the z-index of the topbar to a lower value. This caused the gridComposer to be always on top of the topbar composer.

Task: 4981390

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [4981390](https://www.odoo.com/odoo/2328/tasks/4981390)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo