### PR TITLE
[FIX] Pivot: sanitize measure id

### DIFF
--- a/src/components/side_panel/pivot/pivot_layout_configurator/pivot_layout_configurator.ts
+++ b/src/components/side_panel/pivot/pivot_layout_configurator/pivot_layout_configurator.ts
@@ -243,7 +243,7 @@ export class PivotLayoutConfigurator extends Component<Props, SpreadsheetChildEn
   }
 
   private getMeasureId(fieldName: string, aggregator?: string) {
-    const baseId = fieldName + (aggregator ? `:${aggregator}` : "");
+    const baseId = fieldName.replaceAll("'", "") + (aggregator ? `:${aggregator}` : "");
     let id = baseId;
     let i = 2;
     while (this.props.definition.measures.some((m) => m.id === id)) {

--- a/tests/pivots/spreadsheet_pivot/spreadsheet_pivot_side_panel.test.ts
+++ b/tests/pivots/spreadsheet_pivot/spreadsheet_pivot_side_panel.test.ts
@@ -90,6 +90,26 @@ describe("Spreadsheet pivot side panel", () => {
     ]);
   });
 
+  test("single quotes are escaped for measure ids", async () => {
+    setCellContent(model, "A1", "Goa'uld");
+    setCellContent(model, "A2", "Anubis");
+    setCellContent(model, "A3", "Teal'c");
+    addPivot(model, "A1:A3", {}, "3");
+    env.openSidePanel("PivotSidePanel", { pivotId: "3" });
+    await nextTick();
+    await click(fixture.querySelectorAll(".add-dimension")[2]);
+    expect(fixture.querySelector(".o-popover")).toBeDefined();
+    await click(fixture.querySelectorAll(".o-autocomplete-value")[1]);
+    expect(fixture.querySelector(".o-popover")).toBeNull();
+    expect(model.getters.getPivotCoreDefinition("3").measures).toMatchObject([
+      {
+        id: "Goauld:count",
+        fieldName: "Goa'uld",
+        aggregator: "count",
+      },
+    ]);
+  });
+
   test("can add a calculated measure", async () => {
     setCellContent(model, "A1", "amount");
     setCellContent(model, "A2", "10");


### PR DESCRIPTION
Currently, the measure id can contain a single quote which poses problem as those are used as a special delimiters inside formulas to delimit specific symbols, like the measure ids. The tokenizer is not able to properly handle that specific case.

This revision forces the sanitization of the measure ids to remove any quote.

Task: 4876828

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo