### PR TITLE
[FIX] Functions: OFFSET dependencies are not correctly added

### DIFF
--- a/src/functions/module_lookup.ts
+++ b/src/functions/module_lookup.ts
@@ -1031,7 +1031,7 @@ export const OFFSET = {
       bottom: startingRow + offsetHeight - 1,
     };
 
-    const range = this.getters.getRangeFromZone(this.__originSheetId, dependencyZone);
+    const range = this.getters.getRangeFromZone(sheetId, dependencyZone);
     if (range.invalidXc || range.invalidSheetName) {
       return new InvalidReferenceError();
     }

--- a/tests/functions/module_lookup.test.ts
+++ b/tests/functions/module_lookup.test.ts
@@ -1895,4 +1895,22 @@ describe("OFFSET formula", () => {
     setCellContent(model, "A1", "hola", "Sheet1");
     expect(getEvaluatedCell(model, "D4", "Sheet2").value).toBe("hola");
   });
+
+  test("the formula dependencies are correctly added", () => {
+    const model = new Model({ sheets: [{ id: "sh1" }] });
+    createSheet(model, { sheetId: "sh2" });
+    createSheet(model, { sheetId: "sh3" });
+    setCellContent(model, "A1", "bloub", "sh2");
+    setCellContent(model, "A1", "=OFFSET(Sheet2!A1,0,0)", "sh1");
+    setCellContent(model, "A1", "=OFFSET(Sheet2!A1,0,0)", "sh3");
+
+    expect(getEvaluatedCell(model, "A1", "sh1").value).toBe("bloub");
+    expect(getEvaluatedCell(model, "A1", "sh2").value).toBe("bloub");
+    expect(getEvaluatedCell(model, "A1", "sh3").value).toBe("bloub");
+
+    const model2 = new Model(model.exportData());
+    expect(getEvaluatedCell(model2, "A1", "sh1").value).toBe("bloub");
+    expect(getEvaluatedCell(model2, "A1", "sh2").value).toBe("bloub");
+    expect(getEvaluatedCell(model2, "A1", "sh3").value).toBe("bloub");
+  });
 });


### PR DESCRIPTION
OFFSET is part of the formulas which depednencies need to be dynamically added during its evaluation by interpreting their arguments. Unfortunately, the implementation was wrongly mistakenly assigning the dependency to the sheet of the currently evaluated cell instead of the the sheetId of the actual cell reference.

Task: 5001405

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo