### PR TITLE
[FIX] ClickableCells: cache empty positions as well

### DIFF
--- a/src/components/dashboard/clickable_cell_store.ts
+++ b/src/components/dashboard/clickable_cell_store.ts
@@ -19,7 +19,7 @@ export interface ClickableCell {
 }
 
 export class ClickableCellsStore extends SpreadsheetStore {
-  private _clickableCells: Record<UID, Record<string, CellClickableItem>> = markRaw({});
+  private _clickableCells: Record<UID, Record<string, CellClickableItem | undefined>> = markRaw({});
   private _registryItems: CellClickableItem[] = markRaw(
     clickableCellRegistry.getAll().sort((a, b) => a.sequence - b.sequence)
   );
@@ -46,9 +46,7 @@ export class ClickableCellsStore extends SpreadsheetStore {
     }
     if (!(xc in clickableCells[sheetId]!)) {
       const clickableCell = this.findClickableItem(position);
-      if (clickableCell) {
-        clickableCells[sheetId][xc] = clickableCell;
-      }
+      clickableCells[sheetId][xc] = clickableCell;
     }
     return clickableCells[sheetId][xc];
   }

--- a/tests/grid/dashboard_grid_component.test.ts
+++ b/tests/grid/dashboard_grid_component.test.ts
@@ -149,6 +149,27 @@ describe("Grid component in dashboard mode", () => {
     clickableCellRegistry.remove("fake");
   });
 
+  test("Clickable cell actions are computed only once per cell", async () => {
+    const fn = jest.fn();
+    clickableCellRegistry.add("fake", {
+      condition: (position, getters) => {
+        if (position.col === 0 && position.row === 0) {
+          fn();
+        }
+        return false;
+      },
+      execute: (position) => {},
+      sequence: 5,
+    });
+    setCellContent(model, "A1", "coucou");
+    model.updateMode("dashboard");
+    await nextTick();
+    expect(fn).toHaveBeenCalledTimes(1);
+    await nextTick();
+    expect(fn).toHaveBeenCalledTimes(1);
+    clickableCellRegistry.remove("fake");
+  });
+
   test("Clickable cells actions can have a tooltip", async () => {
     clickableCellRegistry.add("fake", {
       condition: () => true,


### PR DESCRIPTION
Currently, we do not cache the positions which don't have a match of clickable item. This means that everytime we try to access the corresponding CellClickableItem, we will go through all the matchers, even though we know for sure it will not match anything.

Task: 5007745

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo