### PR TITLE
[IMP] model: improve figure export data

### DIFF
--- a/src/migrations/data.ts
+++ b/src/migrations/data.ts
@@ -275,13 +275,13 @@ function fixChartDefinitions(data: Partial<WorkbookData>, initialMessages: State
       if (
         figure.tag === "chart" &&
         data.version &&
-        compareVersions(String(data.version), "18.5.2") < 0
+        compareVersions(String(data.version), "18.5.11") < 0
       ) {
         map[figure.id] = (figure as any).data;
       }
     });
     for (const chartId in sheet.charts || {}) {
-      if (data.version && compareVersions(String(data.version), "18.5.2") >= 0) {
+      if (data.version && compareVersions(String(data.version), "18.5.11") >= 0) {
         map[chartId] = sheet.charts[chartId].chart;
       }
     }

--- a/src/migrations/data.ts
+++ b/src/migrations/data.ts
@@ -272,15 +272,19 @@ function fixChartDefinitions(data: Partial<WorkbookData>, initialMessages: State
   const map = {};
   for (const sheet of data.sheets || []) {
     sheet.figures?.forEach((figure) => {
-      if (figure.tag === "chart") {
-        // chart definition
-        if (data.version && compareVersions(String(data.version), "18.5.1") <= 0) {
-          map[figure.data.chartId] = figure.data;
-        } else {
-          map[figure.id] = figure.data;
-        }
+      if (
+        figure.tag === "chart" &&
+        data.version &&
+        compareVersions(String(data.version), "18.5.2") < 0
+      ) {
+        map[figure.id] = (figure as any).data;
       }
     });
+    for (const chartId in sheet.charts || {}) {
+      if (data.version && compareVersions(String(data.version), "18.5.2") >= 0) {
+        map[chartId] = sheet.charts[chartId].chart;
+      }
+    }
   }
   for (const message of initialMessages) {
     if (message.type === "REMOTE_REVISION") {
@@ -415,6 +419,9 @@ export function createEmptySheet(sheetId: UID, name: string): SheetData {
     conditionalFormats: [],
     dataValidationRules: [],
     figures: [],
+    charts: {},
+    carousels: {},
+    images: {},
     tables: [],
     isVisible: true,
   };
@@ -438,10 +445,10 @@ export function createEmptyWorkbookData(sheetName = "Sheet1"): WorkbookData {
 
 export function createEmptyExcelSheet(sheetId: UID, name: string): ExcelSheetData {
   return {
-    ...(createEmptySheet(sheetId, name) as Omit<ExcelSheetData, "charts">),
-    charts: [],
-    images: [],
+    ...createEmptySheet(sheetId, name),
+    tables: [],
     cellValues: {},
+    formulaSpillRanges: {},
   };
 }
 

--- a/src/migrations/migration_steps.ts
+++ b/src/migrations/migration_steps.ts
@@ -549,15 +549,12 @@ migrationStepRegistry
       return data;
     },
   })
-  .add("18.5.2", {
+  .add("18.5.11", {
     migrate(data: any): WorkbookData {
       for (const sheet of data.sheets || []) {
-        if (!sheet.charts) {
-          sheet.charts = {};
-        }
-        if (!sheet.images) {
-          sheet.images = {};
-        }
+        sheet.charts = {};
+        sheet.images = {};
+        sheet.carousels = {};
 
         for (const figure of sheet.figures || []) {
           if (figure.tag === "chart") {
@@ -568,6 +565,18 @@ migrationStepRegistry
             const image = figure.data;
             delete figure.data;
             sheet.images[figure.id] = { figureId: figure.id, image };
+          } else if (figure.tag === "carousel") {
+            const carousel = figure.data;
+            delete figure.data;
+            // TODO figure.data.chartDefintion.fieldMatching ????
+            sheet.carousels[figure.id] = {
+              figureId: figure.id,
+              carousel: { items: carousel.items, title: carousel.title },
+            };
+            for (const chartId in carousel.chartDefinitions || {}) {
+              const chart = carousel.chartDefinitions[chartId];
+              sheet.charts[chartId] = { figureId: figure.id, chart };
+            }
           }
         }
       }

--- a/src/migrations/migration_steps.ts
+++ b/src/migrations/migration_steps.ts
@@ -372,7 +372,7 @@ migrationStepRegistry
   })
   .add("18.0.4", {
     // "Add operator in gauge inflection points",
-    migrate(data: WorkbookData): any {
+    migrate(data: any): any {
       for (const sheet of data.sheets || []) {
         for (const figure of sheet.figures || []) {
           if (figure.tag !== "chart" || figure.data.type !== "gauge") {
@@ -503,7 +503,7 @@ migrationStepRegistry
     },
   })
   .add("18.4.2", {
-    migrate(data: WorkbookData): any {
+    migrate(data: any): any {
       for (const sheet of data.sheets || []) {
         for (const figure of sheet.figures || []) {
           if (figure.tag !== "chart" || figure.data.type !== "scorecard") {
@@ -538,11 +538,36 @@ migrationStepRegistry
     },
   })
   .add("18.5.1", {
-    migrate(data: WorkbookData): any {
+    migrate(data: any): any {
       for (const sheet of data.sheets || []) {
         for (const figure of sheet.figures || []) {
           if (figure.tag === "chart") {
             figure.data.chartId = figure.id;
+          }
+        }
+      }
+      return data;
+    },
+  })
+  .add("18.5.2", {
+    migrate(data: any): WorkbookData {
+      for (const sheet of data.sheets || []) {
+        if (!sheet.charts) {
+          sheet.charts = {};
+        }
+        if (!sheet.images) {
+          sheet.images = {};
+        }
+
+        for (const figure of sheet.figures || []) {
+          if (figure.tag === "chart") {
+            const chart = figure.data;
+            delete figure.data;
+            sheet.charts[figure.id] = { figureId: figure.id, chart };
+          } else if (figure.tag === "image") {
+            const image = figure.data;
+            delete figure.data;
+            sheet.images[figure.id] = { figureId: figure.id, image };
           }
         }
       }

--- a/src/plugins/core/carousel.ts
+++ b/src/plugins/core/carousel.ts
@@ -122,22 +122,19 @@ export class CarouselPlugin extends CorePlugin<CarouselState> implements Carouse
 
   import(data: WorkbookData) {
     for (const sheet of data.sheets) {
-      const carousels = (sheet.figures || []).filter((figure) => figure.tag === "carousel");
-      for (const carousel of carousels) {
-        this.history.update("carousels", sheet.id, carousel.id, {
-          items: carousel.data.items,
-          title: carousel.data.title,
-        });
+      for (const carouselId in sheet.carousels || {}) {
+        const { carousel } = sheet.carousels[carouselId];
+        this.history.update("carousels", sheet.id, carouselId, carousel);
       }
     }
   }
 
   export(data: WorkbookData) {
     for (const sheet of data.sheets) {
-      const carousels = sheet.figures.filter((figure) => figure.tag === "carousel");
-      for (const carousel of carousels) {
-        if (this.carousels[sheet.id]?.[carousel.id]) {
-          carousel.data = { ...carousel.data, ...this.carousels[sheet.id]?.[carousel.id] };
+      for (const carouselId in this.carousels[sheet.id] || {}) {
+        const carousel = this.carousels[sheet.id]?.[carouselId];
+        if (carousel) {
+          sheet.carousels[carouselId] = { figureId: carouselId, carousel };
         }
       }
     }

--- a/src/plugins/core/chart.ts
+++ b/src/plugins/core/chart.ts
@@ -12,7 +12,6 @@ import {
   CreateChartCommand,
   DeleteChartCommand,
   DOMDimension,
-  FigureData,
   HeaderIndex,
   PixelPosition,
   UID,
@@ -212,23 +211,10 @@ export class ChartPlugin extends CorePlugin<ChartState> implements ChartState {
 
   import(data: WorkbookData) {
     for (const sheet of data.sheets) {
-      if (sheet.figures) {
-        for (const figure of sheet.figures) {
-          // TODO:
-          // figure data should be external IMO => chart should be in sheet.chart
-          // instead of in figure.data
-          if (figure.tag === "chart") {
-            const chartId = figure.data.chartId;
-            const chart = this.createChart(figure.id, figure.data, sheet.id);
-            this.charts[chartId] = { chart, figureId: figure.id };
-          } else if (figure.tag === "carousel") {
-            for (const chartId in figure.data.chartDefinitions || {}) {
-              const chartDefinition = figure.data.chartDefinitions[chartId];
-              const chart = this.createChart(figure.id, chartDefinition, sheet.id);
-              this.charts[chartId] = { chart, figureId: figure.id };
-            }
-          }
-        }
+      for (const chartId in sheet.charts) {
+        const { figureId, chart: chartData } = sheet.charts[chartId];
+        const chart = this.createChart(figureId, chartData, sheet.id);
+        this.charts[chartId] = { chart, figureId };
       }
     }
   }
@@ -236,35 +222,15 @@ export class ChartPlugin extends CorePlugin<ChartState> implements ChartState {
   export(data: WorkbookData) {
     if (data.sheets) {
       for (const sheet of data.sheets) {
-        // TODO This code is false, if two plugins want to insert figures on the sheet, it will crash !
-        const sheetFigures = this.getters.getFigures(sheet.id);
-        const figures: FigureData<any>[] = [];
-        for (const sheetFigure of sheetFigures) {
-          const figure = sheetFigure as FigureData<any>;
-          const chartId = Object.keys(this.charts).find(
-            (chartId) => this.charts[chartId]?.figureId === sheetFigure.id
-          );
-          if (figure && figure.tag === "chart" && chartId) {
-            const data = this.charts[chartId]?.chart.getDefinition();
-            if (data) {
-              figure.data = { ...data, chartId };
-              figures.push(figure);
-            }
-          } else if (figure && figure.tag === "carousel") {
-            const chartIds = Object.keys(this.charts).filter(
-              (chartId) => this.charts[chartId]?.figureId === sheetFigure.id
-            );
-            const data = {};
-            for (const chartId of chartIds) {
-              data[chartId] = this.charts[chartId]?.chart.getDefinition();
-            }
-            figure.data = { chartDefinitions: data };
-            figures.push(figure);
-          } else {
-            figures.push(figure);
+        for (const chartId of this.getChartIds(sheet.id)) {
+          const figureChart = this.charts[chartId];
+          if (figureChart) {
+            sheet.charts[chartId] = {
+              figureId: figureChart.figureId,
+              chart: figureChart.chart.getDefinition(),
+            };
           }
         }
-        sheet.figures = figures;
       }
     }
   }
@@ -304,10 +270,11 @@ export class ChartPlugin extends CorePlugin<ChartState> implements ChartState {
    */
   private addChart(figureId: UID, chartId: UID, definition: ChartDefinition) {
     const sheetId = this.getters.getFigureSheetId(figureId);
-    if (sheetId) {
-      const chart = this.createChart(figureId, definition, sheetId);
-      this.history.update("charts", chartId, { figureId, chart });
+    if (!sheetId) {
+      throw new Error(`Figure with id ${figureId} does not exist.`);
     }
+    const chart = this.createChart(figureId, definition, sheetId);
+    this.history.update("charts", chartId, { figureId, chart });
   }
 
   private checkChartDuplicate(cmd: CreateChartCommand): CommandResult {

--- a/src/plugins/core/figures.ts
+++ b/src/plugins/core/figures.ts
@@ -364,8 +364,7 @@ export class FigurePlugin extends CorePlugin<FigureState> implements FigureState
   export(data: WorkbookData) {
     for (const sheet of data.sheets) {
       for (const figure of this.getFigures(sheet.id)) {
-        const data = undefined;
-        sheet.figures.push({ ...figure, data });
+        sheet.figures.push({ ...figure });
       }
     }
   }

--- a/src/plugins/core/sheet.ts
+++ b/src/plugins/core/sheet.ts
@@ -17,6 +17,7 @@ import {
   toCartesian,
 } from "../../helpers/index";
 import { isSheetNameEqual } from "../../helpers/sheet";
+import { createEmptySheet } from "../../migrations/data";
 import {
   Cell,
   CellPosition,
@@ -283,21 +284,11 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
     data.sheets = this.orderedSheetIds.filter(isDefined).map((id) => {
       const sheet = this.sheets[id]!;
       const sheetData: SheetData = {
+        ...createEmptySheet(sheet.id, sheet.name),
         id: sheet.id,
         name: sheet.name,
         colNumber: sheet.numberOfCols,
         rowNumber: this.getters.getNumberRows(sheet.id),
-        rows: {},
-        cols: {},
-        merges: [],
-        cells: {},
-        styles: {},
-        formats: {},
-        borders: {},
-        conditionalFormats: [],
-        dataValidationRules: [],
-        figures: [],
-        tables: [],
         areGridLinesVisible:
           sheet.areGridLinesVisible === undefined ? true : sheet.areGridLinesVisible,
         isVisible: sheet.isVisible,

--- a/src/plugins/ui_core_views/evaluation_chart.ts
+++ b/src/plugins/ui_core_views/evaluation_chart.ts
@@ -1,13 +1,14 @@
 import { BACKGROUND_CHART_COLOR } from "../../constants";
 import { chartFontColor, chartRuntimeFactory, chartToImageUrl } from "../../helpers/figures/charts";
-import { Color, ExcelWorkbookData, FigureData, Range, UID } from "../../types";
-import { ChartRuntime, ExcelChartDefinition } from "../../types/chart/chart";
+import { Color, ExcelWorkbookData, Range, UID } from "../../types";
+import { ChartRuntime } from "../../types/chart/chart";
 import {
   CoreViewCommand,
   invalidateCFEvaluationCommands,
   invalidateChartEvaluationCommands,
   invalidateEvaluationCommands,
 } from "../../types/commands";
+import { Image } from "../../types/image";
 import { CoreViewPlugin } from "../core_view_plugin";
 
 interface EvaluationChartStyle {
@@ -94,49 +95,34 @@ export class EvaluationChartPlugin extends CoreViewPlugin<EvaluationChartState> 
 
   exportForExcel(data: ExcelWorkbookData) {
     for (const sheet of data.sheets) {
-      if (!sheet.images) {
-        sheet.images = [];
-      }
-      const sheetFigures = this.getters.getFigures(sheet.id);
-      const figures: FigureData<ExcelChartDefinition>[] = [];
-      for (const figure of sheetFigures) {
-        if (!figure || figure.tag !== "chart") {
-          continue;
-        }
-        const chartId = this.getters
-          .getChartIds(sheet.id)
-          .find((chartId) => this.getters.getFigureIdFromChartId(chartId) === figure.id);
-        if (!chartId) {
-          continue;
-        }
+      for (const chartId of this.getters.getChartIds(sheet.id)) {
         const chart = this.getters.getChart(chartId);
-        const figureData = chart?.getDefinitionForExcel(this.getters);
-        if (figureData) {
-          figures.push({
-            ...figure,
-            data: figureData,
-          });
+        const excelDefinition = chart?.getDefinitionForExcel(this.getters);
+        const figureId = this.getters.getFigureIdFromChartId(chartId);
+
+        if (excelDefinition) {
+          sheet.charts[chartId] = { figureId, chart: excelDefinition };
         } else {
-          if (!chart) {
-            continue;
-          }
           const type = this.getters.getChartType(chartId);
           const runtime = this.getters.getChartRuntime(chartId);
-          const img = chartToImageUrl(runtime, figure, type);
-          if (img) {
-            sheet.images.push({
-              ...figure,
-              tag: "image",
-              data: {
+          const figure = this.getters.getFigure(sheet.id, figureId);
+          const figureData = sheet.figures.find((f) => f.id === figureId);
+
+          if (figure && figureData) {
+            const imgSrc = chartToImageUrl(runtime, figure, type);
+            if (imgSrc) {
+              const image: Image = {
                 mimetype: "image/png",
-                path: img,
+                path: imgSrc,
                 size: { width: figure.width, height: figure.height },
-              },
-            });
+              };
+              sheet.images[figureId] = { figureId, image };
+              figureData.tag = "image";
+              delete sheet.charts[chartId];
+            }
           }
         }
       }
-      sheet.charts = figures;
     }
   }
 }

--- a/src/types/workbook_data.ts
+++ b/src/types/workbook_data.ts
@@ -1,19 +1,16 @@
-import { CellValue, DataValidationRule, Format, Locale } from ".";
+import {
+  Carousel,
+  CellValue,
+  ChartDefinition,
+  DataValidationRule,
+  Figure,
+  Format,
+  Locale,
+} from ".";
 import { ZoneBorderData } from "../plugins/core";
-import { ExcelChartDefinition } from "./chart/chart";
 import { ConditionalFormat } from "./conditional_formatting";
 import { Image } from "./image";
-import {
-  Color,
-  Dimension,
-  HeaderGroup,
-  HeaderIndex,
-  PaneDivision,
-  Pixel,
-  PixelPosition,
-  Style,
-  UID,
-} from "./misc";
+import { Color, Dimension, HeaderGroup, PaneDivision, Style, UID } from "./misc";
 import { PivotCoreDefinition } from "./pivot";
 import { CoreTableType, TableConfig, TableStyleTemplateName } from "./table";
 
@@ -28,17 +25,6 @@ export interface HeaderData {
   isHidden?: boolean;
 }
 
-export interface FigureData<T> {
-  id: UID;
-  col: HeaderIndex;
-  row: HeaderIndex;
-  offset: PixelPosition;
-  width: Pixel;
-  height: Pixel;
-  tag: string;
-  data: T;
-}
-
 export interface SheetData {
   id: string;
   name: string;
@@ -49,7 +35,10 @@ export interface SheetData {
   formats: { [zone: string]: number };
   borders: { [zone: string]: number };
   merges: string[];
-  figures: FigureData<any>[];
+  figures: Figure[];
+  charts: { [chartId: string]: { figureId: UID; chart: ChartDefinition } };
+  carousels: { [carouselId: string]: { figureId: UID; carousel: Carousel } };
+  images: { [imageId: string]: { figureId: UID; image: Image } };
   cols: { [key: number]: HeaderData };
   rows: { [key: number]: HeaderData };
   conditionalFormats: ConditionalFormat[];
@@ -87,11 +76,11 @@ export interface ExcelWorkbookData extends WorkbookData {
   sheets: ExcelSheetData[];
 }
 
-export interface ExcelSheetData extends Omit<SheetData, "figureTables" | "cols" | "rows"> {
+export interface ExcelSheetData
+  extends Omit<SheetData, "figureTables" | "cols" | "rows" | "charts"> {
   cellValues: { [xc: string]: CellValue | undefined };
   formulaSpillRanges: { [xc: string]: string };
-  charts: FigureData<ExcelChartDefinition>[];
-  images: FigureData<Image>[];
+  charts: { [chartId: string]: { figureId: UID; chart: any } };
   tables: ExcelTableData[];
   cols: { [key: number]: ExcelHeaderData };
   rows: { [key: number]: ExcelHeaderData };

--- a/src/xlsx/conversion/sheet_conversion.ts
+++ b/src/xlsx/conversion/sheet_conversion.ts
@@ -55,7 +55,8 @@ export function convertSheets(
       rows: convertRows(sheet, sheetDims[1], rowHeaderGroups),
       conditionalFormats: convertConditionalFormats(sheet.cfs, data.dxfs, warningManager),
       dataValidationRules: convertDataValidationRules(sheet.dataValidations, warningManager),
-      figures: convertFigures(sheet),
+      ...convertFigures(sheet),
+      carousels: {},
       isVisible: sheet.isVisible,
       panes: sheetOptions
         ? { xSplit: sheetOptions.pane.xSplit, ySplit: sheetOptions.pane.ySplit }

--- a/src/xlsx/functions/charts.ts
+++ b/src/xlsx/functions/charts.ts
@@ -1,7 +1,7 @@
 import { CHART_AXIS_TITLE_FONT_SIZE, CHART_TITLE_FONT_SIZE } from "../../constants";
 import { ColorGenerator, largeMax, lightenColor, range } from "../../helpers";
 import { chartMutedFontColor } from "../../helpers/figures/charts";
-import { Color, ExcelWorkbookData, FigureData } from "../../types";
+import { Color, ExcelWorkbookData } from "../../types";
 import { ExcelChartDataset, ExcelChartDefinition, TitleDesign } from "../../types/chart/chart";
 import { XMLAttributes, XMLString, XlsxHexColor } from "../../types/xlsx";
 import {
@@ -45,7 +45,7 @@ const valAxId = 88853993;
 const secondaryValAxId = 88853994;
 
 export function createChart(
-  chart: FigureData<ExcelChartDefinition>,
+  chart: ExcelChartDefinition,
   chartSheetIndex: string,
   data: ExcelWorkbookData
 ): XMLDocument {
@@ -56,17 +56,17 @@ export function createChart(
   ];
 
   const chartShapeProperty = shapeProperty({
-    backgroundColor: chart.data.backgroundColor,
+    backgroundColor: chart.backgroundColor,
     line: { color: "000000" },
   });
   // <manualLayout/> to manually position the chart in the figure container
   let title = escapeXml``;
-  if (chart.data.title?.text) {
-    const titleColor = toXlsxHexColor(chartMutedFontColor(chart.data.backgroundColor));
-    const fontSize = chart.data.title.fontSize ?? CHART_TITLE_FONT_SIZE;
+  if (chart.title?.text) {
+    const titleColor = toXlsxHexColor(chartMutedFontColor(chart.backgroundColor));
+    const fontSize = chart.title.fontSize ?? CHART_TITLE_FONT_SIZE;
     title = escapeXml/*xml*/ `
       <c:title>
-        ${insertText(chart.data.title.text, titleColor, fontSize, chart.data.title)}
+        ${insertText(chart.title.text, titleColor, fontSize, chart.title)}
         <c:overlay val="0" />
       </c:title>
     `;
@@ -74,30 +74,30 @@ export function createChart(
 
   // switch on chart type
   let plot = escapeXml``;
-  switch (chart.data.type) {
+  switch (chart.type) {
     case "bar":
-      plot = addBarChart(chart.data);
+      plot = addBarChart(chart);
       break;
     case "combo":
-      plot = addComboChart(chart.data);
+      plot = addComboChart(chart);
       break;
     case "pyramid":
-      plot = addPyramidChart(chart.data);
+      plot = addPyramidChart(chart);
       break;
     case "line":
-      plot = addLineChart(chart.data);
+      plot = addLineChart(chart);
       break;
     case "scatter":
-      plot = addScatterChart(chart.data);
+      plot = addScatterChart(chart);
       break;
     case "pie":
-      plot = addDoughnutChart(chart.data, chartSheetIndex, data);
+      plot = addDoughnutChart(chart, chartSheetIndex, data);
       break;
     case "radar":
-      plot = addRadarChart(chart.data);
+      plot = addRadarChart(chart);
   }
   let position: ElementPosition = "none";
-  switch (chart.data.legendPosition) {
+  switch (chart.legendPosition) {
     case "bottom":
       position = "b";
       break;
@@ -111,7 +111,7 @@ export function createChart(
       position = "t";
       break;
   }
-  const fontColor = chart.data.fontColor;
+  const fontColor = chart.fontColor;
   const xml = escapeXml/*xml*/ `
     <c:chartSpace ${formatAttributes(namespaces)}>
       <c:roundedCorners val="0" />
@@ -124,7 +124,7 @@ export function createChart(
           <!-- how the chart element is placed on the chart -->
           <c:layout />
           ${plot}
-          ${shapeProperty({ backgroundColor: chart.data.backgroundColor })}
+          ${shapeProperty({ backgroundColor: chart.backgroundColor })}
         </c:plotArea>
         ${position !== "none" ? addLegend(position, fontColor) : ""}
       </c:chart>

--- a/src/xlsx/xlsx_reader.ts
+++ b/src/xlsx/xlsx_reader.ts
@@ -26,7 +26,7 @@ import { getXLSXFilesOfType } from "./helpers/xlsx_helper";
 import { XLSXImportWarningManager } from "./helpers/xlsx_parser_error_manager";
 import { escapeTagNamespaces, parseXML } from "./helpers/xml_helpers";
 
-const EXCEL_IMPORT_VERSION = "18.4.2";
+const EXCEL_IMPORT_VERSION = "18.5.2";
 
 export class XlsxReader {
   warningManager: XLSXImportWarningManager;

--- a/src/xlsx/xlsx_reader.ts
+++ b/src/xlsx/xlsx_reader.ts
@@ -26,7 +26,7 @@ import { getXLSXFilesOfType } from "./helpers/xlsx_helper";
 import { XLSXImportWarningManager } from "./helpers/xlsx_parser_error_manager";
 import { escapeTagNamespaces, parseXML } from "./helpers/xml_helpers";
 
-const EXCEL_IMPORT_VERSION = "18.5.2";
+const EXCEL_IMPORT_VERSION = "18.5.11";
 
 export class XlsxReader {
   warningManager: XLSXImportWarningManager;

--- a/src/xlsx/xlsx_writer.ts
+++ b/src/xlsx/xlsx_writer.ts
@@ -132,8 +132,9 @@ function createWorksheets(data: ExcelWorkbookData, construct: XLSXStructure): XL
     // Figures and Charts
     let drawingNode = escapeXml``;
     const drawingRelIds: string[] = [];
-    for (const chart of sheet.charts) {
-      const xlsxChartId = convertChartId(chart.id, construct);
+    for (const chartId in sheet.charts) {
+      const { chart } = sheet.charts[chartId];
+      const xlsxChartId = convertChartId(chartId, construct);
       const chartRelId = addRelsToFile(
         construct.relsFiles,
         `xl/drawings/_rels/drawing${sheetIndex}.xml.rels`,
@@ -152,13 +153,14 @@ function createWorksheets(data: ExcelWorkbookData, construct: XLSXStructure): XL
       );
     }
 
-    for (const image of sheet.images) {
-      const mimeType = image.data.mimetype;
+    for (const imageId in sheet.images) {
+      const { image } = sheet.images[imageId];
+      const mimeType = image.mimetype;
       if (mimeType === undefined) continue;
       const extension = IMAGE_MIMETYPE_TO_EXTENSION_MAPPING[mimeType];
       // only support exporting images with mimetypes specified in the mapping
       if (extension === undefined) continue;
-      const xlsxImageId = convertImageId(image.id);
+      const xlsxImageId = convertImageId(imageId);
       const imageFileName = `image${xlsxImageId}.${extension}`;
 
       const imageRelId = addRelsToFile(
@@ -172,11 +174,11 @@ function createWorksheets(data: ExcelWorkbookData, construct: XLSXStructure): XL
       drawingRelIds.push(imageRelId);
       files.push({
         path: `xl/media/${imageFileName}`,
-        imageSrc: image.data.path,
+        imageSrc: image.path,
       });
     }
 
-    const drawings = [...sheet.charts, ...sheet.images];
+    const drawings = sheet.figures;
     if (drawings.length) {
       const drawingRelId = addRelsToFile(
         construct.relsFiles,

--- a/tests/collaborative/collaborative_history.test.ts
+++ b/tests/collaborative/collaborative_history.test.ts
@@ -477,7 +477,7 @@ describe("Collaborative local history", () => {
       },
     ];
 
-    test("spreadsheet data before 18.5.2", () => {
+    test("spreadsheet data before 18.5.11", () => {
       const data = {
         revisionId: "initial_revision",
         version: "18.4.2",
@@ -513,10 +513,10 @@ describe("Collaborative local history", () => {
       expect(definition2.dataSets).toEqual([{ dataRange: "B1:B3" }]);
     });
 
-    test("spreadsheet data after 18.5.2", () => {
+    test("spreadsheet data after 18.5.11", () => {
       const data = {
         revisionId: "initial_revision",
-        version: "18.5.2",
+        version: "18.5.11",
         sheets: [
           {
             id: "sheet1",

--- a/tests/collaborative/collaborative_history.test.ts
+++ b/tests/collaborative/collaborative_history.test.ts
@@ -426,7 +426,7 @@ describe("Collaborative local history", () => {
     expect(getCell(model, "A1")?.format).toBeUndefined();
   });
 
-  test("Update chart revisions contain the full definition", () => {
+  describe("Update chart revisions contain the full definition", () => {
     const initialMessages: StateUpdateMessage[] = [
       {
         type: "REMOTE_REVISION",
@@ -436,7 +436,7 @@ describe("Collaborative local history", () => {
         commands: [
           {
             type: "UPDATE_CHART",
-            figureId: "fig1",
+            figureId: "chart1",
             chartId: "chart1",
             //@ts-ignore the old command would handle a partial definition
             definition: { dataSets: [{ dataRange: "A1:A3" }] },
@@ -444,7 +444,7 @@ describe("Collaborative local history", () => {
           {
             type: "CREATE_CHART",
             sheetId: "sheet1",
-            figureId: "fig2",
+            figureId: "chart2",
             chartId: "chart2",
             col: 0,
             row: 0,
@@ -467,7 +467,7 @@ describe("Collaborative local history", () => {
           },
           {
             type: "UPDATE_CHART",
-            figureId: "fig2",
+            figureId: "chart2",
             chartId: "chart2",
             //@ts-ignore the old command would handle a partial definition
             definition: { dataSets: [{ dataRange: "B1:B3" }] },
@@ -476,40 +476,83 @@ describe("Collaborative local history", () => {
         serverRevisionId: "initial_revision",
       },
     ];
-    const data = {
-      revisionId: "initial_revision",
-      version: "18.5.1",
-      sheets: [
-        {
-          id: "sheet1",
-          figures: [
-            {
-              id: "fig1",
-              tag: "chart",
-              width: 400,
-              height: 300,
-              x: 100,
-              y: 100,
-              data: {
-                chartId: "chart1",
-                type: "line",
-                dataSetsHaveTitle: false,
-                dataSets: [{ dataRange: "Sheet1!B26:B35" }, { dataRange: "Sheet1!C26:C35" }],
-                legendPosition: "top",
-                title: "Line",
-                stacked: false,
-                cumulative: false,
+
+    test("spreadsheet data before 18.5.2", () => {
+      const data = {
+        revisionId: "initial_revision",
+        version: "18.4.2",
+        sheets: [
+          {
+            id: "sheet1",
+            figures: [
+              {
+                id: "chart1",
+                tag: "chart",
+                width: 400,
+                height: 300,
+                x: 100,
+                y: 100,
+                data: {
+                  type: "line",
+                  dataSetsHaveTitle: false,
+                  dataSets: [{ dataRange: "Sheet1!B26:B35" }, { dataRange: "Sheet1!C26:C35" }],
+                  legendPosition: "top",
+                  title: "Line",
+                  stacked: false,
+                  cumulative: false,
+                },
+              },
+            ],
+          },
+        ],
+      };
+      const model = new Model(data, {}, initialMessages);
+      const definition1 = model.getters.getChartDefinition("chart1") as LineChartDefinition;
+      expect(definition1.dataSets).toEqual([{ dataRange: "A1:A3" }]);
+      const definition2 = model.getters.getChartDefinition("chart2") as LineChartDefinition;
+      expect(definition2.dataSets).toEqual([{ dataRange: "B1:B3" }]);
+    });
+
+    test("spreadsheet data after 18.5.2", () => {
+      const data = {
+        revisionId: "initial_revision",
+        version: "18.5.2",
+        sheets: [
+          {
+            id: "sheet1",
+            figures: [
+              {
+                id: "chart1",
+                tag: "chart",
+                width: 400,
+                height: 300,
+                x: 100,
+                y: 100,
+              },
+            ],
+            charts: {
+              chart1: {
+                figureId: "chart1",
+                chart: {
+                  type: "line",
+                  dataSetsHaveTitle: false,
+                  dataSets: [{ dataRange: "Sheet1!B26:B35" }, { dataRange: "Sheet1!C26:C35" }],
+                  legendPosition: "top",
+                  title: "Line",
+                  stacked: false,
+                  cumulative: false,
+                },
               },
             },
-          ],
-        },
-      ],
-    };
-    const model = new Model(data, {}, initialMessages);
-    const definition1 = model.getters.getChartDefinition("chart1") as LineChartDefinition;
-    expect(definition1.dataSets).toEqual([{ dataRange: "A1:A3" }]);
-    const definition2 = model.getters.getChartDefinition("chart2") as LineChartDefinition;
-    expect(definition2.dataSets).toEqual([{ dataRange: "B1:B3" }]);
+          },
+        ],
+      };
+      const model = new Model(data, {}, initialMessages);
+      const definition1 = model.getters.getChartDefinition("chart1") as LineChartDefinition;
+      expect(definition1.dataSets).toEqual([{ dataRange: "A1:A3" }]);
+      const definition2 = model.getters.getChartDefinition("chart2") as LineChartDefinition;
+      expect(definition2.dataSets).toEqual([{ dataRange: "B1:B3" }]);
+    });
   });
 
   test("Undo/redo your own change only", () => {

--- a/tests/figures/chart/charts_component.test.ts
+++ b/tests/figures/chart/charts_component.test.ts
@@ -93,7 +93,7 @@ function createTestChart(
       createChart(
         model,
         { ...TEST_CHART_DATA.basicChart, type },
-        chartId,
+        newChartId,
         undefined,
         partialFigure
       );
@@ -175,7 +175,7 @@ describe("charts", () => {
   });
 
   test.each(TEST_CHART_TYPES)("can export a chart %s", (chartType) => {
-    createTestChart(chartType, undefined, {
+    createTestChart(chartType, "chartId", {
       size: { height: 335, width: 536 },
       figureId: "figureId",
     });
@@ -184,22 +184,23 @@ describe("charts", () => {
     const sheet = data.sheets.find((s) => s.id === activeSheetId)!;
     expect(sheet.figures).toMatchObject([
       {
-        data: {
-          chartId,
-          ...TEST_CHART_DATA[chartType],
-        },
         id: "figureId",
         height: 335,
         tag: "chart",
         width: 536,
         col: 0,
         row: 0,
-        offset: {
-          x: 0,
-          y: 0,
-        },
+        offset: { x: 0, y: 0 },
       },
     ]);
+    expect(sheet.charts).toMatchObject({
+      chartId: {
+        figureId: "figureId",
+        chart: {
+          ...TEST_CHART_DATA[chartType],
+        },
+      },
+    });
   });
 
   test.each(TEST_CHART_TYPES)("charts have a menu button", async (chartType) => {
@@ -2272,6 +2273,7 @@ describe("charts with multiple sheets", () => {
   beforeEach(async () => {
     mockChartData = mockChart();
     const data = {
+      version: "18.4.1",
       sheets: [
         {
           name: "Sheet1",

--- a/tests/figures/image/image_file_store.test.ts
+++ b/tests/figures/image/image_file_store.test.ts
@@ -318,13 +318,18 @@ describe("image file store", () => {
         col: 0,
         row: 0,
         offset: { x: 0, y: 0 },
-        data: {
+      },
+    ];
+    data.sheets[0].images = {
+      imageId: {
+        figureId: "imageId",
+        image: {
           path: "/image/1",
           size: { width: 100, height: 100 },
           mimetype: "image/jpeg",
         },
       },
-    ];
+    };
     new Model(
       data,
       {

--- a/tests/figures/image/image_plugin.test.ts
+++ b/tests/figures/image/image_plugin.test.ts
@@ -161,15 +161,15 @@ describe("test image import & export", function () {
         tag: "image",
         height: 300,
         width: 400,
-        offset: {
-          x: 0,
-          y: 0,
-        },
+        offset: { x: 0, y: 0 },
         col: 0,
         row: 0,
-        data: model.getters.getImage(imageId),
       },
     ]);
+    expect(sheet.images[imageId]).toEqual({
+      figureId: imageId,
+      image: model.getters.getImage(imageId),
+    });
   });
   test("can import an image", () => {
     const model = new Model();

--- a/tests/model/data.test.ts
+++ b/tests/model/data.test.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_REVISION_ID } from "../../src/constants";
-import { getCurrentVersion, load } from "../../src/migrations/data";
+import { createEmptySheet, getCurrentVersion, load } from "../../src/migrations/data";
 import { DEFAULT_LOCALE } from "../../src/types";
 
 describe("load data", () => {
@@ -108,42 +108,8 @@ describe("load data", () => {
         ],
       }).sheets
     ).toEqual([
-      {
-        id: "1",
-        name: "Sheet1",
-        cells: {},
-        styles: {},
-        borders: {},
-        formats: {},
-        colNumber: 26,
-        rowNumber: 100,
-        cols: {},
-        rows: {},
-        merges: ["A1:B2"],
-        conditionalFormats: [],
-        dataValidationRules: [],
-        figures: [],
-        tables: [],
-        isVisible: true,
-      },
-      {
-        id: "asdf",
-        name: "Sheet2",
-        cells: {},
-        styles: {},
-        borders: {},
-        formats: {},
-        colNumber: 26,
-        rowNumber: 100,
-        cols: {},
-        rows: {},
-        merges: ["C3:D4"],
-        conditionalFormats: [],
-        dataValidationRules: [],
-        figures: [],
-        tables: [],
-        isVisible: true,
-      },
+      { ...createEmptySheet("1", "Sheet1"), merges: ["A1:B2"] },
+      { ...createEmptySheet("asdf", "Sheet2"), merges: ["C3:D4"] },
     ]);
   });
 

--- a/tests/model/model_import_export.test.ts
+++ b/tests/model/model_import_export.test.ts
@@ -8,7 +8,7 @@ import {
 } from "../../src/constants";
 import { toCartesian, toZone } from "../../src/helpers";
 import { DEFAULT_TABLE_CONFIG } from "../../src/helpers/table_presets";
-import { getCurrentVersion } from "../../src/migrations/data";
+import { createEmptySheet, getCurrentVersion } from "../../src/migrations/data";
 import {
   BorderDescr,
   ColorScaleRule,
@@ -16,6 +16,7 @@ import {
   DEFAULT_LOCALES,
   IconSetRule,
 } from "../../src/types";
+import { BarChartDefinition } from "../../src/types/chart";
 import {
   activateSheet,
   resizeColumns,
@@ -171,8 +172,7 @@ describe("Migrations", () => {
     });
 
     const data = model.exportData();
-    expect(data.sheets[0].figures[0].data).toEqual({
-      chartId: "1",
+    expect(data.sheets[0].charts["1"].chart).toEqual({
       type: "line",
       title: { text: "demo chart" },
       labelRange: "'My sheet'!A27:A35",
@@ -183,8 +183,7 @@ describe("Migrations", () => {
       stacked: false,
       humanize: true,
     });
-    expect(data.sheets[0].figures[1].data).toEqual({
-      chartId: "2",
+    expect(data.sheets[0].charts["2"].chart).toEqual({
       type: "bar",
       title: { text: "demo chart 2" },
       labelRange: "'My sheet'!A27:A35",
@@ -195,8 +194,7 @@ describe("Migrations", () => {
       stacked: false,
       humanize: true,
     });
-    expect(data.sheets[0].figures[2].data).toEqual({
-      chartId: "3",
+    expect(data.sheets[0].charts["3"].chart).toEqual({
       type: "bar",
       title: { text: "demo chart 3" },
       labelRange: "'My sheet'!A27",
@@ -207,8 +205,7 @@ describe("Migrations", () => {
       stacked: false,
       humanize: true,
     });
-    expect(data.sheets[0].figures[3].data).toEqual({
-      chartId: "4",
+    expect(data.sheets[0].charts["4"].chart).toEqual({
       type: "bar",
       title: { text: "demo chart 4" },
       labelRange: "'My sheet'!A27",
@@ -220,6 +217,7 @@ describe("Migrations", () => {
       humanize: true,
     });
   });
+
   test.each(FORBIDDEN_SHEETNAME_CHARS)("migrate version 7: sheet Names", (char) => {
     const model = new Model({
       version: 7,
@@ -294,12 +292,9 @@ describe("Migrations", () => {
     const cells = data.sheets[1].cells;
     expect(cells.A1!).toBe("=sheetName_!A2");
 
-    const figures = data.sheets[1].figures;
-    expect(figures[0].data?.dataSets).toEqual([
-      { dataRange: "A1:A2" },
-      { dataRange: "'My sheet'!A1:A2" },
-    ]);
-    expect(figures[0].data?.labelRange).toBe("sheetName_!B1:B2");
+    const chart = data.sheets[1].charts["1"].chart as BarChartDefinition;
+    expect(chart?.dataSets).toEqual([{ dataRange: "A1:A2" }, { dataRange: "'My sheet'!A1:A2" }]);
+    expect(chart?.labelRange).toBe("sheetName_!B1:B2");
 
     const cfs = data.sheets[1].conditionalFormats;
     const rule1 = cfs[0].rule as ColorScaleRule;
@@ -777,7 +772,58 @@ test("migrate version 18.5.1: chartId is added to figure data", () => {
     ],
   };
   const model = new Model(data);
-  expect(model.exportData().sheets[0].figures[0].data.chartId).toBe("someuuid");
+  expect(model.exportData().sheets[0].charts["someuuid"]).toBeDefined();
+});
+
+test("migrate version 18.5.2: figure data is split between image and chart", () => {
+  const data = {
+    version: "18.4.2",
+    sheets: [
+      {
+        id: "sh1",
+        figures: [
+          {
+            id: "chartId",
+            tag: "chart",
+            height: 380,
+            width: 380,
+            col: 0,
+            row: 0,
+            offset: { x: 0, y: 0 },
+            data: { type: "line", title: "demo chart", labelRange: "", dataSets: [] },
+          },
+          {
+            id: "imageId",
+            tag: "image",
+            height: 380,
+            width: 380,
+            col: 0,
+            row: 0,
+            offset: { x: 0, y: 0 },
+            data: { path: "/image/1", size: { width: 100, height: 100 }, mimetype: "image/jpeg" },
+          },
+        ],
+      },
+    ],
+  };
+  const model = new Model(data);
+  const exportedData = model.exportData();
+  expect(exportedData.sheets[0].figures).toMatchObject([
+    { id: "chartId", tag: "chart" },
+    { id: "imageId", tag: "image" },
+  ]);
+  expect(exportedData.sheets[0].charts).toMatchObject({
+    chartId: {
+      chart: { type: "line", title: "demo chart" },
+      figureId: "chartId",
+    },
+  });
+  expect(exportedData.sheets[0].images).toMatchObject({
+    imageId: {
+      image: { path: "/image/1", size: { width: 100, height: 100 }, mimetype: "image/jpeg" },
+      figureId: "imageId",
+    },
+  });
 });
 
 describe("Import", () => {
@@ -910,9 +956,7 @@ test("complete import, then export", () => {
     revisionId: DEFAULT_REVISION_ID,
     sheets: [
       {
-        id: "someuuid",
-        colNumber: 10,
-        rowNumber: 10,
+        ...createEmptySheet("someuuid", "My sheet"),
         merges: ["A1:A2"],
         cols: {
           0: { size: 42 },
@@ -939,35 +983,16 @@ test("complete import, then export", () => {
           B1: 2,
         },
         name: "My sheet",
-        conditionalFormats: [],
-        dataValidationRules: [],
-        figures: [],
-        tables: [],
         areGridLinesVisible: true,
-        isVisible: true,
         panes: { ySplit: 1, xSplit: 5 },
         headerGroups: { COL: [], ROW: [] },
       },
       {
-        id: "someuuid_2",
-        colNumber: 10,
-        rowNumber: 10,
-        merges: [],
-        cols: {},
-        rows: {},
+        ...createEmptySheet("someuuid_2", "My sheet 2"),
         cells: {
           A1: "hello",
         },
-        styles: {},
-        formats: {},
-        borders: {},
-        name: "My sheet 2",
-        conditionalFormats: [],
-        dataValidationRules: [],
-        figures: [],
-        tables: [],
         areGridLinesVisible: false,
-        isVisible: true,
         headerGroups: { COL: [], ROW: [] },
       },
     ],
@@ -1041,19 +1066,7 @@ test("import then export (figures)", () => {
     revisionId: DEFAULT_REVISION_ID,
     sheets: [
       {
-        id: "someuuid",
-        colNumber: 10,
-        rowNumber: 10,
-        merges: [],
-        cols: {},
-        rows: {},
-        cells: {},
-        styles: {},
-        formats: {},
-        borders: {},
-        name: "My sheet",
-        conditionalFormats: [],
-        dataValidationRules: [],
+        ...createEmptySheet("someuuid", "My sheet"),
         figures: [
           {
             id: "otheruuid",
@@ -1064,9 +1077,7 @@ test("import then export (figures)", () => {
             height: 100,
           },
         ],
-        tables: [],
         areGridLinesVisible: true,
-        isVisible: true,
         headerGroups: { COL: [], ROW: [] },
       },
     ],

--- a/tests/model/model_import_export.test.ts
+++ b/tests/model/model_import_export.test.ts
@@ -775,7 +775,7 @@ test("migrate version 18.5.1: chartId is added to figure data", () => {
   expect(model.exportData().sheets[0].charts["someuuid"]).toBeDefined();
 });
 
-test("migrate version 18.5.2: figure data is split between image and chart", () => {
+test("migrate version 18.5.11: figure data is split between image and chart", () => {
   const data = {
     version: "18.4.2",
     sheets: [

--- a/tests/test_helpers/xlsx.ts
+++ b/tests/test_helpers/xlsx.ts
@@ -1,5 +1,13 @@
 import { isSheetNameEqual, toCartesian, toXC, toZone } from "../../src/helpers";
-import { Border, Color, ConditionalFormat, Style } from "../../src/types";
+import {
+  Border,
+  ChartDefinition,
+  Color,
+  ConditionalFormat,
+  Figure,
+  Style,
+  UID,
+} from "../../src/types";
 import { DEFAULT_CELL_HEIGHT, DEFAULT_CELL_WIDTH } from "./../../src/constants";
 import { DataValidationRuleData, SheetData, WorkbookData } from "./../../src/types/workbook_data";
 
@@ -98,4 +106,21 @@ export function getRowPosition(row: number, sheetData: SheetData) {
     position += sheetData.rows[i]?.size || DEFAULT_CELL_HEIGHT;
   }
   return position;
+}
+
+export function getWorkbookChartWithTitle(
+  sheet: SheetData,
+  chartTitle: string
+): { chartId: UID; figureId: UID; chart: ChartDefinition; figure: Figure } {
+  const chartId = Object.keys(sheet.charts).find(
+    (id) => sheet.charts[id].chart.title.text === chartTitle
+  )!;
+  const figureId = sheet.charts[chartId].figureId;
+  const figure = sheet.figures.find((figure) => figure.id === figureId)!;
+  return {
+    chartId,
+    figureId,
+    chart: sheet.charts[chartId].chart,
+    figure,
+  };
 }

--- a/tests/xlsx/xlsx_export.test.ts
+++ b/tests/xlsx/xlsx_export.test.ts
@@ -1263,7 +1263,7 @@ describe("Test XLSX export", () => {
         "2"
       );
       const exported = getExportedExcelData(model);
-      expect(exported.sheets[0].charts[0].data).toEqual(exported.sheets[0].charts[1].data);
+      expect(exported.sheets[0].charts["1"].chart).toEqual(exported.sheets[0].charts["2"].chart);
     });
 
     test("multiple charts in the same sheet", async () => {
@@ -1340,8 +1340,8 @@ describe("Test XLSX export", () => {
         const model = new Model();
         createChart(model, { aggregated: true, type }, "1");
         const exportedData = getExportedExcelData(model);
-        expect(exportedData.sheets[0].charts.length).toBe(1);
-        expect(exportedData.sheets[0].images.length).toBe(0);
+        expect(Object.keys(exportedData.sheets[0].charts).length).toBe(1);
+        expect(Object.keys(exportedData.sheets[0].images).length).toBe(0);
       }
     );
 
@@ -1350,8 +1350,9 @@ describe("Test XLSX export", () => {
         sheets: chartData.sheets,
       });
       createScorecardChart(model, TEST_CHART_DATA.scorecard);
-      expect(getExportedExcelData(model).sheets[0].charts.length).toBe(0);
-      expect(getExportedExcelData(model).sheets[0].images.length).toBe(1);
+      const exportedData = getExportedExcelData(model);
+      expect(Object.keys(exportedData.sheets[0].charts).length).toBe(0);
+      expect(Object.keys(exportedData.sheets[0].images).length).toBe(1);
     });
 
     test("Gauge Chart is exported as an image", () => {
@@ -1359,8 +1360,9 @@ describe("Test XLSX export", () => {
         sheets: chartData.sheets,
       });
       createGaugeChart(model, TEST_CHART_DATA.gauge);
-      expect(getExportedExcelData(model).sheets[0].charts.length).toBe(0);
-      expect(getExportedExcelData(model).sheets[0].images.length).toBe(1);
+      const exportedData = getExportedExcelData(model);
+      expect(Object.keys(exportedData.sheets[0].charts).length).toBe(0);
+      expect(Object.keys(exportedData.sheets[0].images).length).toBe(1);
     });
 
     test("stacked bar chart", async () => {
@@ -1904,11 +1906,15 @@ describe("Test XLSX export", () => {
     createSheet(model, { name: longSheetNameWithSpaces });
     createSheet(model, { name: longSheetName });
     setCellContent(model, "A1", `='${longSheetNameWithSpaces}'!A1`);
-    createChart(model, {
-      type: "bar",
-      dataSets: [{ dataRange: `${longSheetName}!A1:A4` }],
-      labelRange: `${longSheetName}!A1:A4`,
-    });
+    createChart(
+      model,
+      {
+        type: "bar",
+        dataSets: [{ dataRange: `${longSheetName}!A1:A4` }],
+        labelRange: `${longSheetName}!A1:A4`,
+      },
+      "chartId"
+    );
 
     const fixedSheetName = "a".repeat(31);
     const fixedSheetNameWithSpaces = "Hey " + "a".repeat(27);
@@ -1916,8 +1922,10 @@ describe("Test XLSX export", () => {
     expect(exportedData.sheets[1].name).toBe(fixedSheetName);
     expect(exportedData.sheets[0].cells["A1"]).toBe(`='${fixedSheetNameWithSpaces}'!A1`);
     expect(exportedData.sheets[0].cells["A1"]).toBe(`='${fixedSheetNameWithSpaces}'!A1`);
-    expect(exportedData.sheets[0].charts[0].data.labelRange).toBe(`${fixedSheetName}!A2:A4`);
-    expect(exportedData.sheets[0].charts[0].data.dataSets[0]).toEqual({
+    expect(exportedData.sheets[0].charts["chartId"].chart.labelRange).toBe(
+      `${fixedSheetName}!A2:A4`
+    );
+    expect(exportedData.sheets[0].charts["chartId"].chart.dataSets[0]).toEqual({
       label: {
         reference: `${fixedSheetName}!A1`,
       },

--- a/tests/xlsx/xlsx_import.test.ts
+++ b/tests/xlsx/xlsx_import.test.ts
@@ -13,7 +13,6 @@ import { ComboChartDefinition } from "../../src/types/chart/combo_chart";
 import { LineChartDefinition } from "../../src/types/chart/line_chart";
 import { PieChartDefinition } from "../../src/types/chart/pie_chart";
 import { ScatterChartDefinition } from "../../src/types/chart/scatter_chart";
-import { Image } from "../../src/types/image";
 import { SheetData, WorkbookData } from "../../src/types/workbook_data";
 import { XLSXSharedFormula } from "../../src/types/xlsx";
 import { hexaToInt } from "../../src/xlsx/conversion/color_conversion";
@@ -41,6 +40,7 @@ import {
   getWorkbookCellBorder,
   getWorkbookCellFormat,
   getWorkbookCellStyle,
+  getWorkbookChartWithTitle,
   getWorkbookSheet,
   standardizeColor,
 } from "../test_helpers/xlsx";
@@ -743,7 +743,7 @@ describe("Import xlsx data", () => {
     const testSheet = getWorkbookSheet("jestCharts", convertedData)!;
     // Cells in the 1st column of the sheet contains jsons with expected figure data
     const figZone = toZone(figureZone);
-    const figure = testSheet.figures.find((figure) => figure.data.title.text === chartTitle)!;
+    const { figure } = getWorkbookChartWithTitle(testSheet, chartTitle);
 
     // Don't test exact positions, because excel does some esoteric magic for units and sizes (+our conversion is wonky, hello hardcoded DPI)
     // We'll only test that the figure corners are located in the correct cells
@@ -764,23 +764,23 @@ describe("Import xlsx data", () => {
 
   test.each([
     [
-      "line",
+      "line chart",
       [
         { dataRange: "Sheet1!B26:B35", backgroundColor: "#7030A0" },
         { dataRange: "Sheet1!C26:C35", backgroundColor: "#C65911" },
       ],
     ],
     [
-      "bar",
+      "bar chart",
       [
         { dataRange: "Sheet1!B27:B35", backgroundColor: "#7030A0" },
         { dataRange: "Sheet1!C27:C35", backgroundColor: "#C65911" },
       ],
     ],
-  ])("Can import charts %s with dataset colors", (chartType, chartDatasets) => {
+  ])("Can import charts %s with dataset colors", (chartTitle, chartDatasets) => {
     const testSheet = getWorkbookSheet("jestCharts", convertedData)!;
-    const figure = testSheet.figures.find((figure) => figure.data.type === chartType);
-    const chartData = figure!.data as LineChartDefinition | BarChartDefinition;
+    const { chart } = getWorkbookChartWithTitle(testSheet, chartTitle);
+    const chartData = chart as LineChartDefinition | BarChartDefinition;
     expect(chartData.dataSets).toMatchObject(chartDatasets);
   });
 
@@ -804,8 +804,8 @@ describe("Import xlsx data", () => {
     ],
   ])("Can import %s charts with dataset trendlines", (chartTitle, chartDatasets) => {
     const testSheet = getWorkbookSheet("jestCharts", convertedData)!;
-    const figure = testSheet.figures.find((figure) => figure.data.title.text === chartTitle);
-    const chartData = figure!.data as LineChartDefinition | BarChartDefinition;
+    const { chart } = getWorkbookChartWithTitle(testSheet, chartTitle);
+    const chartData = chart as LineChartDefinition | BarChartDefinition;
     expect(chartData.dataSets).toMatchObject(chartDatasets);
   });
 
@@ -841,8 +841,8 @@ describe("Import xlsx data", () => {
     "Can import charts %s without dataset titles",
     (chartTitle, chartType, chartColor, chartDatasets) => {
       const testSheet = getWorkbookSheet("jestCharts", convertedData)!;
-      const figure = testSheet.figures.find((figure) => figure.data.title.text === chartTitle)!;
-      const chartData = figure.data as BarChartDefinition | ComboChartDefinition;
+      const { chart } = getWorkbookChartWithTitle(testSheet, chartTitle);
+      const chartData = chart as LineChartDefinition | BarChartDefinition;
       expect(chartData.title.text).toEqual(chartTitle);
       expect(chartData.type).toEqual(chartType);
       expect(standardizeColor(chartData.background!)).toEqual(standardizeColor(chartColor));
@@ -855,10 +855,9 @@ describe("Import xlsx data", () => {
 
   test("Can import horizontal bar charts", () => {
     const testSheet = getWorkbookSheet("jestCharts", convertedData)!;
-    const figure = testSheet.figures.find(
-      (figure) => figure.data.title.text === "horizontal bar chart"
-    )!;
-    const chartData = figure.data as BarChartDefinition;
+    const { chart } = getWorkbookChartWithTitle(testSheet, "horizontal bar chart");
+    const chartData = chart as BarChartDefinition;
+
     expect(chartData.title.text).toEqual("horizontal bar chart");
     expect(chartData.type).toEqual("bar");
     expect(chartData.horizontal).toEqual(true);
@@ -866,10 +865,9 @@ describe("Import xlsx data", () => {
 
   test("Can import doughnut charts", () => {
     const testSheet = getWorkbookSheet("jestCharts", convertedData)!;
-    const figure = testSheet.figures.find(
-      (figure) => figure.data.title.text === "doughnut chart with hole"
-    )!;
-    const chartData = figure.data as PieChartDefinition;
+    const { chart } = getWorkbookChartWithTitle(testSheet, "doughnut chart with hole");
+    const chartData = chart as PieChartDefinition;
+
     expect(chartData.title.text).toEqual("doughnut chart with hole");
     expect(chartData.type).toEqual("pie");
     expect(chartData.isDoughnut).toEqual(true);
@@ -882,8 +880,9 @@ describe("Import xlsx data", () => {
     ["combo chart", "none"],
   ])("Can import %s charts with correct legend position", (chartTitle, chartLegendPosition) => {
     const testSheet = getWorkbookSheet("jestCharts", convertedData)!;
-    const figure = testSheet.figures.find((figure) => figure.data.title.text === chartTitle)!;
-    const chartData = figure.data as BarChartDefinition | ComboChartDefinition;
+    const { chart } = getWorkbookChartWithTitle(testSheet, chartTitle);
+    const chartData = chart as BarChartDefinition | ComboChartDefinition;
+
     expect(chartData.title.text).toEqual(chartTitle);
     expect(chartData.legendPosition).toEqual(chartLegendPosition);
   });
@@ -912,8 +911,9 @@ describe("Import xlsx data", () => {
     "Can import charts %s with dataset titles",
     (chartTitle, chartType, chartColor, chartDatasets) => {
       const testSheet = getWorkbookSheet("jestCharts", convertedData)!;
-      const figure = testSheet.figures.find((figure) => figure.data.title.text === chartTitle)!;
-      const chartData = figure.data as LineChartDefinition | PieChartDefinition;
+      const { chart } = getWorkbookChartWithTitle(testSheet, chartTitle);
+      const chartData = chart as LineChartDefinition | PieChartDefinition;
+
       expect(chartData.title.text).toEqual(chartTitle);
       expect(chartData.type).toEqual(chartType);
       expect(standardizeColor(chartData.background!)).toEqual(standardizeColor(chartColor));
@@ -926,8 +926,8 @@ describe("Import xlsx data", () => {
 
   test("Can import scatter plot", () => {
     const testSheet = getWorkbookSheet("jestCharts", convertedData)!;
-    const figure = testSheet.figures.find((figure) => figure.data.title.text === "scatter chart")!;
-    const chartData = figure.data as ScatterChartDefinition;
+    const { chart } = getWorkbookChartWithTitle(testSheet, "scatter chart");
+    const chartData = chart as ScatterChartDefinition;
     expect(chartData.title.text).toEqual("scatter chart");
     expect(chartData.type).toEqual("scatter");
     expect(standardizeColor(chartData.background!)).toEqual(standardizeColor("#fff"));
@@ -938,10 +938,8 @@ describe("Import xlsx data", () => {
 
   test("Can import scatter plot with textual labels", () => {
     const testSheet = getWorkbookSheet("jestCharts", convertedData)!;
-    const figure = testSheet.figures.find(
-      (figure) => figure.data.title.text === "scatter chart with textual labels"
-    )!;
-    const chartData = figure.data as ScatterChartDefinition;
+    const { chart } = getWorkbookChartWithTitle(testSheet, "scatter chart with textual labels");
+    const chartData = chart as ScatterChartDefinition;
     expect(chartData.title.text).toEqual("scatter chart with textual labels");
     expect(chartData.type).toEqual("scatter");
     expect(standardizeColor(chartData.background!)).toEqual(standardizeColor("#fff"));
@@ -974,7 +972,7 @@ describe("Import xlsx data", () => {
   test("Can import images", () => {
     const testSheet = getWorkbookSheet("jestImages", convertedData)!;
     const figure = testSheet.figures.find((figure) => figure.tag === "image")!;
-    const imageData = figure.data as Image;
+    const imageData = testSheet.images["1"].image;
     expect(imageData.path).toEqual("relative path");
     expect(figure.width).toEqual(figure.height);
   });


### PR DESCRIPTION
## Description:

Currently, charts/images/carousels are exported inside `figure.data`
in the JSON. That's not ideal, `figure.data` then needs to be typed as
`any`, and the charts plugin need to be aware of carousels for its
import.

This commit changes the export, now each plugin has its own key in the
data, so it can be typed correctly and they are not interlinked.

Task: 5002886

Task: [5002886](https://www.odoo.com/odoo/2328/tasks/5002886)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo