### PR TITLE
[FIX] tests: Fix migration test

### DIFF
--- a/src/migrations/migration_steps.ts
+++ b/src/migrations/migration_steps.ts
@@ -102,7 +102,6 @@ migrationStepRegistry
           continue;
         }
         const oldName = sheet.name;
-        sanitizeSheetName;
         const escapedName: string = sanitizeSheetName(oldName, "_");
         const newName = getUniqueText(escapedName, namesTaken, {
           compute: (name, i) => `${name}${i}`,
@@ -132,7 +131,7 @@ migrationStepRegistry
         }
         //charts
         for (const figure of sheet.figures || []) {
-          if (figure.type === "chart") {
+          if (figure.tag === "chart") {
             const dataSets = figure.data.dataSets.map(replaceName);
             const labelRange = replaceName(figure.data.labelRange);
             figure.data = { ...figure.data, dataSets, labelRange };

--- a/tests/model/model_import_export.test.ts
+++ b/tests/model/model_import_export.test.ts
@@ -231,11 +231,11 @@ describe("Migrations", () => {
               y: 0,
               width: 100,
               height: 100,
-              type: "chart",
+              tag: "chart",
               data: {
-                dataSets: [`=sheetName${char}!A1:A2`, "My sheet!A1:A2"],
+                dataSets: [`sheetName${char}!A1:A2`, `My sheet!A1:A2`],
                 dataSetsHaveTitle: true,
-                labelRange: `=sheetName${char}!B1:B2`,
+                labelRange: `sheetName${char}!B1:B2`,
                 type: "bar",
               },
             },
@@ -243,7 +243,7 @@ describe("Migrations", () => {
           conditionalFormats: [
             {
               id: 1,
-              ranges: [`=sheetName${char}!A1:A2`],
+              ranges: [`sheetName${char}!A1:A2`],
               rule: {
                 type: "ColorScaleRule",
                 maximum: { type: "formula", value: `=sheetName${char}!B1`, color: 16711680 },
@@ -271,7 +271,7 @@ describe("Migrations", () => {
             },
             {
               id: 3,
-              ranges: [`=sheetName${char}!A1:A2`],
+              ranges: [`sheetName${char}!A1:A2`],
               rule: {
                 type: "ColorScaleRule",
                 minimum: { type: "percentage", value: "33", color: 16711680 },
@@ -292,14 +292,14 @@ describe("Migrations", () => {
 
     const figures = data.sheets[1].figures;
     expect(figures[0].data?.dataSets).toEqual([
-      { dataRange: "=sheetName_!A1:A2" },
-      { dataRange: "My sheet!A1:A2" },
+      { dataRange: "A1:A2" },
+      { dataRange: "'My sheet'!A1:A2" },
     ]);
-    expect(figures[0].data?.labelRange).toBe("=sheetName_!B1:B2");
+    expect(figures[0].data?.labelRange).toBe("sheetName_!B1:B2");
 
     const cfs = data.sheets[1].conditionalFormats;
     const rule1 = cfs[0].rule as ColorScaleRule;
-    expect(cfs[0].ranges).toEqual(["=sheetName_!A1:A2"]);
+    expect(cfs[0].ranges).toEqual(["sheetName_!A1:A2"]);
     expect(rule1.minimum.value).toEqual("=sheetName_!B1");
     expect(rule1.midpoint?.value).toEqual("=sheetName_!B1");
     expect(rule1.maximum.value).toEqual("=sheetName_!B1");
@@ -310,7 +310,7 @@ describe("Migrations", () => {
     expect(rule2.upperInflectionPoint.value).toEqual("=sheetName_!B1");
 
     const rule3 = cfs[2].rule as ColorScaleRule;
-    expect(cfs[2].ranges).toEqual(["=sheetName_!A1:A2"]);
+    expect(cfs[2].ranges).toEqual(["sheetName_!A1:A2"]);
     expect(rule3.minimum.value).toEqual("33");
     expect(rule3.midpoint?.value).toEqual("13");
     expect(rule3.maximum.value).toBeUndefined();


### PR DESCRIPTION
The test written for migration 7 (which removed forbidden characters from the sheet names to keep some compatibility with other spreadsheets) was poorly written. There were two types of mistakes:
- we defined `figure.type` instead of `figure.tag` in both the test and the script
- we defined formulas instead of ranges in both the chart and CF definition

The problem is two-fold: import data are not typed and we never checked the validity of the given data inside a working `Model` instance.

Task: 5008468

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo