### PR TITLE
[FIX] evaluation: fix operation with empty matrices

### DIFF
--- a/src/functions/helper_matrices.ts
+++ b/src/functions/helper_matrices.ts
@@ -2,6 +2,9 @@ import { _t } from "../translation";
 import { Matrix, isMatrix } from "../types";
 
 export function getUnitMatrix(n: number): Matrix<number> {
+  if (n < 1) {
+    throw new Error(_t("Function [[FUNCTION_NAME]] unit matrix error, n should be >= 1"));
+  }
   const matrix: Matrix<number> = Array(n);
   for (let i = 0; i < n; i++) {
     matrix[i] = Array(n).fill(0);
@@ -29,6 +32,10 @@ export function invertMatrix(M: Matrix<number>): {
   // (a) Swap 2 rows. This multiply the determinant by -1.
   // (b) Multiply a row by a scalar. This multiply the determinant by that scalar.
   // (c) Add to a row a multiple of another row. This does not change the determinant.
+
+  if (M.length < 1 || M[0].length < 1) {
+    throw new Error(_t("Function [[FUNCTION_NAME]] invert matrix error, empty matrix"));
+  }
 
   if (M.length !== M[0].length) {
     throw new Error(
@@ -113,8 +120,11 @@ function swapMatrixRows(matrix: number[][], row1: number, row2: number) {
  * Note: we use indexing [col][row] instead of the standard mathematical notation [row][col]
  */
 export function multiplyMatrices(matrix1: Matrix<number>, matrix2: Matrix<number>): Matrix<number> {
+  if (matrix1.length < 1 || matrix2.length < 1) {
+    throw new Error(_t("Cannot multiply matrices: empty matrices cannot be multiplied."));
+  }
   if (matrix1.length !== matrix2[0].length) {
-    throw new Error(_t("Cannot multiply matrices : incompatible matrices size."));
+    throw new Error(_t("Cannot multiply matrices: incompatible matrices size."));
   }
 
   const rowsM1 = matrix1[0].length;

--- a/src/functions/module_array.ts
+++ b/src/functions/module_array.ts
@@ -382,6 +382,11 @@ export const MMULT = {
     const _matrix2 = toMatrix(matrix2);
 
     assert(
+      () => _matrix1.length > 0 && _matrix2.length > 0,
+      _t("In [[FUNCTION_NAME]], the first and second arguments must be non-empty matrices.")
+    );
+
+    assert(
       () => _matrix1.length === _matrix2[0].length,
       _t(
         "In [[FUNCTION_NAME]], the number of columns of the first matrix (%s) must be equal to the \

--- a/tests/functions/module_array.test.ts
+++ b/tests/functions/module_array.test.ts
@@ -1,4 +1,5 @@
 import { Model } from "../../src";
+import { ErrorCell } from "../../src/types";
 import { setCellContent, setFormat } from "../test_helpers/commands_helpers";
 import { getCellContent, getEvaluatedCell, getRangeValues } from "../test_helpers/getters_helpers";
 import {
@@ -749,6 +750,15 @@ describe("MDETERM function", () => {
     };
     expect(evaluateCell("D1", { D1: "=MDETERM(A1:C3)", ...grid })).toBeCloseTo(-4885.9);
   });
+
+  test("Determinant of an empty matrix", () => {
+    const model = createModelFromGrid({});
+    setCellContent(model, "D1", "=MDETERM(A1:C3)");
+    expect(getEvaluatedCell(model, "D1").value).toBe("#ERROR");
+    expect((getEvaluatedCell(model, "D1") as ErrorCell).error.message).toBe(
+      "The argument square_matrix must be a matrix of numbers."
+    );
+  });
 });
 
 describe("MINVERSE function", () => {
@@ -781,6 +791,15 @@ describe("MINVERSE function", () => {
     expect(evaluateCell("D1", { D1: "=MINVERSE(A1)", ...grid })).toEqual(1 / 5);
 
     expect(evaluateCell("D1", { D1: "=MINVERSE(5)", ...grid })).toEqual(1 / 5);
+  });
+
+  test("Inverse of an empty matrix", () => {
+    const model = createModelFromGrid({});
+    setCellContent(model, "D1", "=MINVERSE(A1:C3)");
+    expect(getEvaluatedCell(model, "D1").value).toBe("#ERROR");
+    expect((getEvaluatedCell(model, "D1") as ErrorCell).error.message).toBe(
+      "The argument square_matrix must be a matrix of numbers."
+    );
   });
 
   test("Invert matrices", () => {
@@ -841,7 +860,7 @@ describe("MMULT function", () => {
     expect(evaluateCell("D1", { D1: "=MMULT(5, 5)", ...grid })).toEqual(25);
   });
 
-  test("Invert matrices", () => {
+  test("Multiply matrices", () => {
     //prettier-ignore
     const grid = {
       A1: "1", B1: "2", C1: "3",

--- a/tests/functions/module_statistical.test.ts
+++ b/tests/functions/module_statistical.test.ts
@@ -1,4 +1,6 @@
 import { toXC } from "../../src/helpers";
+import { ErrorCell } from "../../src/types";
+import { setCellContent } from "../test_helpers/commands_helpers";
 import { getEvaluatedCell } from "../test_helpers/getters_helpers";
 import {
   createModelFromGrid,
@@ -2853,6 +2855,23 @@ describe("MATTHEWS formula", () => {
 });
 
 describe("SLOPE formula", () => {
+  test("Slope with an empty matrix for the y values", () => {
+    const model = createModelFromGrid({ B2: "", B3: "", C2: "1", C3: "2" });
+    setCellContent(model, "A1", "=SLOPE(B2:B3, C2:C3)");
+    expect(getEvaluatedCell(model, "A1").value).toBe("#ERROR");
+    expect((getEvaluatedCell(model, "A1") as ErrorCell).error.message).toBe(
+      "Cannot multiply matrices: empty matrices cannot be multiplied."
+    );
+  });
+
+  test("Slope with an empty matrix for the x values", () => {
+    const model = createModelFromGrid({ B2: "", B3: "", C2: "1", C3: "2" });
+    setCellContent(model, "A1", "=SLOPE(C2:C3, B2:B3)");
+    expect(getEvaluatedCell(model, "A1").value).toBe("#ERROR");
+    expect((getEvaluatedCell(model, "A1") as ErrorCell).error.message).toBe(
+      "Cannot multiply matrices: empty matrices cannot be multiplied."
+    );
+  });
   test("Unrelated values", () => {
     //prettier-ignore
     const grid = {
@@ -2914,6 +2933,23 @@ describe("SLOPE formula", () => {
 });
 
 describe("INTERCEPT formula", () => {
+  test("Intercept with an empty matrix for the y values", () => {
+    const model = createModelFromGrid({ B2: "", B3: "", C2: "1", C3: "2" });
+    setCellContent(model, "A1", "=INTERCEPT(B2:B3, C2:C3)");
+    expect(getEvaluatedCell(model, "A1").value).toBe("#ERROR");
+    expect((getEvaluatedCell(model, "A1") as ErrorCell).error.message).toBe(
+      "Cannot multiply matrices: empty matrices cannot be multiplied."
+    );
+  });
+
+  test("Intercept with an empty matrix for the x values", () => {
+    const model = createModelFromGrid({ B2: "", B3: "", C2: "1", C3: "2" });
+    setCellContent(model, "A1", "=INTERCEPT(C2:C3, B2:B3)");
+    expect(getEvaluatedCell(model, "A1").value).toBe("#ERROR");
+    expect((getEvaluatedCell(model, "A1") as ErrorCell).error.message).toBe(
+      "Cannot multiply matrices: empty matrices cannot be multiplied."
+    );
+  });
   test("Unrelated values", () => {
     //prettier-ignore
     const grid = {
@@ -2975,6 +3011,24 @@ describe("INTERCEPT formula", () => {
 });
 
 describe("FORECAST formula", () => {
+  test("Forecast with an empty matrix for the y values", () => {
+    const model = createModelFromGrid({ B2: "", B3: "", C2: "1", C3: "2" });
+    setCellContent(model, "A1", "=FORECAST(1, B2:B3, C2:C3)");
+    expect(getEvaluatedCell(model, "A1").value).toBe("#ERROR");
+    expect((getEvaluatedCell(model, "A1") as ErrorCell).error.message).toBe(
+      "Cannot multiply matrices: empty matrices cannot be multiplied."
+    );
+  });
+
+  test("Forecast with an empty matrix for the x values", () => {
+    const model = createModelFromGrid({ B2: "", B3: "", C2: "1", C3: "2" });
+    setCellContent(model, "A1", "=FORECAST(1, C2:C3, B2:B3)");
+    expect(getEvaluatedCell(model, "A1").value).toBe("#ERROR");
+    expect((getEvaluatedCell(model, "A1") as ErrorCell).error.message).toBe(
+      "Cannot multiply matrices: empty matrices cannot be multiplied."
+    );
+  });
+
   test("Correctly predicts a single value", () => {
     //prettier-ignore
     const grid = {
@@ -3102,6 +3156,23 @@ describe("STEYX formula", () => {
 });
 
 describe("POLYFIT.COEFFS formula", () => {
+  test("Empty matrix for the y values", () => {
+    const model = createModelFromGrid({ B2: "", B3: "", C2: "1", C3: "2" });
+    setCellContent(model, "A1", "=POLYFIT.COEFFS(B2:B3, C2:C3, 2)");
+    expect(getEvaluatedCell(model, "A1").value).toBe("#ERROR");
+    expect((getEvaluatedCell(model, "A1") as ErrorCell).error.message).toBe(
+      "Cannot multiply matrices: empty matrices cannot be multiplied."
+    );
+  });
+
+  test("Empty matrix for the x values", () => {
+    const model = createModelFromGrid({ B2: "", B3: "", C2: "1", C3: "2" });
+    setCellContent(model, "A1", "=POLYFIT.COEFFS(C2:C3, B2:B3, 2)");
+    expect(getEvaluatedCell(model, "A1").value).toBe("#ERROR");
+    expect((getEvaluatedCell(model, "A1") as ErrorCell).error.message).toBe(
+      "Cannot multiply matrices: empty matrices cannot be multiplied."
+    );
+  });
   test("Noisy values", () => {
     //prettier-ignore
     const grid = {
@@ -3176,6 +3247,24 @@ describe("POLYFIT.COEFFS formula", () => {
 });
 
 describe("POLYFIT.FORECAST formula", () => {
+  test("Empty matrix for the y values", () => {
+    const model = createModelFromGrid({ B2: "", B3: "", C2: "1", C3: "2" });
+    setCellContent(model, "A1", "=POLYFIT.FORECAST(1, B2:B3, C2:C3, 2)");
+    expect(getEvaluatedCell(model, "A1").value).toBe("#ERROR");
+    expect((getEvaluatedCell(model, "A1") as ErrorCell).error.message).toBe(
+      "Cannot multiply matrices: empty matrices cannot be multiplied."
+    );
+  });
+
+  test("Empty matrix for the x values", () => {
+    const model = createModelFromGrid({ B2: "", B3: "", C2: "1", C3: "2" });
+    setCellContent(model, "A1", "=POLYFIT.FORECAST(1, C2:C3, B2:B3, 2)");
+    expect(getEvaluatedCell(model, "A1").value).toBe("#ERROR");
+    expect((getEvaluatedCell(model, "A1") as ErrorCell).error.message).toBe(
+      "Cannot multiply matrices: empty matrices cannot be multiplied."
+    );
+  });
+
   test.each(["1", "2", "3", "4"])("degree %s polynomial data", async (degree: string) => {
     const order = parseInt(degree);
     //prettier-ignore


### PR DESCRIPTION
## Task Description

When using empty matrices for math operation (multiplication or inversion), as in the FORECAST formula, we got a traceback and the error message was not clear for the user. This commits aims to fix it by checking that the matrices used in theses operations are not empty and returning an understandable error if it's not the case.

## Related Task

- Task: [5001658](https://www.odoo.com/odoo/2328/tasks/5001658)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo