### PR TITLE
Master carouse figure imp behaviour adrm

### DIFF
--- a/src/actions/menu_items_actions.ts
+++ b/src/actions/menu_items_actions.ts
@@ -409,7 +409,7 @@ export const CREATE_CHART = (env: SpreadsheetChildEnv) => {
   const result = env.model.dispatch("CREATE_CHART", {
     sheetId,
     figureId,
-    chartId: figureId,
+    chartId: env.model.uuidGenerator.smallUuid(),
     col,
     row,
     offset,

--- a/src/clipboard_handlers/index.ts
+++ b/src/clipboard_handlers/index.ts
@@ -2,6 +2,7 @@ import { Registry } from "../registries/registry";
 import { AbstractCellClipboardHandler } from "./abstract_cell_clipboard_handler";
 import { AbstractFigureClipboardHandler } from "./abstract_figure_clipboard_handler";
 import { BorderClipboardHandler } from "./borders_clipboard";
+import { CarouselClipboardHandler } from "./carousel_clipboard";
 import { CellClipboardHandler } from "./cell_clipboard";
 import { ChartClipboardHandler } from "./chart_clipboard";
 import { ConditionalFormatClipboardHandler } from "./conditional_format_clipboard";
@@ -19,7 +20,8 @@ export const clipboardHandlersRegistries = {
 
 clipboardHandlersRegistries.figureHandlers
   .add("chart", ChartClipboardHandler)
-  .add("image", ImageClipboardHandler);
+  .add("image", ImageClipboardHandler)
+  .add("carousel", CarouselClipboardHandler);
 
 clipboardHandlersRegistries.cellHandlers
   .add("dataValidation", DataValidationClipboardHandler)

--- a/src/components/figures/chart/chartJs/chartjs.ts
+++ b/src/components/figures/chart/chartJs/chartjs.ts
@@ -135,9 +135,9 @@ export class ChartJsComponent extends Component<Props, SpreadsheetChildEnv> {
     let chartData = chartRuntime.chartJsConfig as ChartConfiguration<any>;
     if (this.shouldAnimate && this.animationStore) {
       const chartType = this.env.model.getters.getChart(this.props.chartId)?.type;
-      if (chartType && this.animationStore.animationPlayed[this.animationFigureId] !== chartType) {
+      if (chartType && this.animationStore.animationPlayed[this.animationChartId] !== chartType) {
         chartData = this.enableAnimationInChartData(chartData);
-        this.animationStore.disableAnimationForChart(this.animationFigureId, chartType);
+        this.animationStore.disableAnimationForChart(this.animationChartId, chartType);
       }
     }
 
@@ -152,7 +152,7 @@ export class ChartJsComponent extends Component<Props, SpreadsheetChildEnv> {
       const chartType = this.env.model.getters.getChart(this.props.chartId)?.type;
       if (chartType && this.hasChartDataChanged() && this.animationStore) {
         chartData = this.enableAnimationInChartData(chartData);
-        this.animationStore.disableAnimationForChart(this.animationFigureId, chartType);
+        this.animationStore.disableAnimationForChart(this.animationChartId, chartType);
       }
     }
 
@@ -182,7 +182,7 @@ export class ChartJsComponent extends Component<Props, SpreadsheetChildEnv> {
     };
   }
 
-  get animationFigureId() {
+  get animationChartId() {
     return this.props.isFullScreen ? this.props.chartId + "-fullscreen" : this.props.chartId;
   }
 }

--- a/src/components/figures/chart/gauge/gauge_chart_component.ts
+++ b/src/components/figures/chart/gauge/gauge_chart_component.ts
@@ -41,17 +41,17 @@ export class GaugeChartComponent extends Component<Props, SpreadsheetChildEnv> {
         if (
           this.env.isDashboard() &&
           lastRuntime === undefined && // first render
-          this.animationStore?.animationPlayed[this.animationFigureId] !== "gauge"
+          this.animationStore?.animationPlayed[this.animationChartId] !== "gauge"
         ) {
           animation = this.drawGaugeWithAnimation();
-          this.animationStore?.disableAnimationForChart(this.animationFigureId, "gauge");
+          this.animationStore?.disableAnimationForChart(this.animationChartId, "gauge");
         } else if (
           this.env.isDashboard() &&
           lastRuntime !== undefined && // not first render
           !deepEquals(this.runtime, lastRuntime)
         ) {
           animation = this.drawGaugeWithAnimation();
-          this.animationStore?.disableAnimationForChart(this.animationFigureId, "gauge");
+          this.animationStore?.disableAnimationForChart(this.animationChartId, "gauge");
         } else {
           drawGaugeChart(this.canvasEl, this.runtime);
         }
@@ -88,7 +88,7 @@ export class GaugeChartComponent extends Component<Props, SpreadsheetChildEnv> {
     return this.canvas.el as HTMLCanvasElement;
   }
 
-  get animationFigureId() {
+  get animationChartId() {
     return this.props.isFullScreen ? this.props.chartId + "-fullscreen" : this.props.chartId;
   }
 }

--- a/src/components/figures/figure/figure.ts
+++ b/src/components/figures/figure/figure.ts
@@ -157,10 +157,10 @@ export class FigureComponent extends Component<Props, SpreadsheetChildEnv> {
     return this.isSelected ? ACTIVE_BORDER_WIDTH : this.borderWidth;
   }
 
-  get borderStyle() {
+  getBorderStyle(position: "top" | "right" | "bottom" | "left"): string {
     const borderWidth = this.getBorderWidth();
     const borderColor = this.isSelected ? SELECTION_BORDER_COLOR : FIGURE_BORDER_COLOR;
-    return `border: ${borderWidth}px solid ${borderColor};`;
+    return `border-${position}: ${borderWidth}px solid ${borderColor};`;
   }
 
   get wrapperStyle() {

--- a/src/components/figures/figure/figure.xml
+++ b/src/components/figures/figure/figure.xml
@@ -36,46 +36,63 @@
             onClose="() => this.menuState.isOpen=false"
           />
         </div>
+        <div t-if="!env.isDashboard()" class="position-absolute top-0 start-0 pe-none w-100 h-100">
+          <div
+            class="o-figure-border pe-auto w-100 h-0 position-absolute pb-2"
+            t-att-style="getBorderStyle('top')"
+          />
+          <div
+            class="o-figure-border pe-auto h-100 position-absolute start-0 ps-2"
+            t-att-style="getBorderStyle('left')"
+          />
+          <div
+            class="o-figure-border pe-auto w-100 position-absolute bottom-0 pt-2"
+            t-att-style="getBorderStyle('bottom')"
+          />
+          <div
+            class="o-figure-border pe-auto h-100 position-absolute end-0 pe-2"
+            t-att-style="getBorderStyle('right')"
+          />
+        </div>
       </div>
-      <div class="o-figure-border w-100 h-100 position-absolute pe-none" t-att-style="borderStyle"/>
       <t t-if="isSelected and !env.isMobile()">
         <div
-          class="o-fig-anchor o-top"
+          class="o-fig-anchor o-top pe-auto"
           t-att-style="this.getResizerPosition('top')"
           t-on-pointerdown="(ev) => this.clickAnchor(0,-1, ev)"
         />
         <div
-          class="o-fig-anchor o-topRight"
+          class="o-fig-anchor o-topRight pe-auto"
           t-att-style="this.getResizerPosition('top right')"
           t-on-pointerdown="(ev) => this.clickAnchor(1,-1, ev)"
         />
         <div
-          class="o-fig-anchor o-right"
+          class="o-fig-anchor o-right pe-auto"
           t-att-style="this.getResizerPosition('right')"
           t-on-pointerdown="(ev) => this.clickAnchor(1,0, ev)"
         />
         <div
-          class="o-fig-anchor o-bottomRight"
+          class="o-fig-anchor o-bottomRight pe-auto"
           t-att-style="this.getResizerPosition('bottom right')"
           t-on-pointerdown="(ev) => this.clickAnchor(1,1, ev)"
         />
         <div
-          class="o-fig-anchor o-bottom"
+          class="o-fig-anchor o-bottom pe-auto"
           t-att-style="this.getResizerPosition('bottom')"
           t-on-pointerdown="(ev) => this.clickAnchor(0,1, ev)"
         />
         <div
-          class="o-fig-anchor o-bottomLeft"
+          class="o-fig-anchor o-bottomLeft pe-auto"
           t-att-style="this.getResizerPosition('bottom left')"
           t-on-pointerdown="(ev) => this.clickAnchor(-1,1, ev)"
         />
         <div
-          class="o-fig-anchor o-left"
+          class="o-fig-anchor o-left pe-auto"
           t-att-style="this.getResizerPosition('left')"
           t-on-pointerdown="(ev) => this.clickAnchor(-1,0, ev)"
         />
         <div
-          class="o-fig-anchor o-topLeft"
+          class="o-fig-anchor o-topLeft pe-auto"
           t-att-style="this.getResizerPosition('top left')"
           t-on-pointerdown="(ev) => this.clickAnchor(-1,-1, ev)"
         />

--- a/src/components/figures/figure_carousel/figure_carousel.ts
+++ b/src/components/figures/figure_carousel/figure_carousel.ts
@@ -78,12 +78,6 @@ export class CarouselFigure extends Component<Props, SpreadsheetChildEnv> {
       sheetId: this.env.model.getters.getActiveSheetId(),
       item,
     });
-    if (
-      item.type === "carouselDataView" &&
-      this.env.model.getters.getSelectedFigureId() === this.props.figureUI.id
-    ) {
-      this.env.model.dispatch("SELECT_FIGURE", { figureId: null });
-    }
   }
 
   get headerStyle(): string {

--- a/src/plugins/core/carousel.ts
+++ b/src/plugins/core/carousel.ts
@@ -68,11 +68,11 @@ export class CarouselPlugin extends CorePlugin<CarouselState> implements Carouse
                 definition: {
                   items: carousel.items.map((item): CarouselItem => {
                     if (item.type === "carouselDataView") {
-                      return { type: "carouselDataView" };
+                      return { ...item };
                     }
                     const chartIdBase = item.chartId.split(FIGURE_ID_SPLITTER).pop();
                     const newChartId = `${cmd.sheetIdTo}${FIGURE_ID_SPLITTER}${chartIdBase}`;
-                    return { type: "chart", chartId: newChartId };
+                    return { ...item, chartId: newChartId };
                   }),
                 },
               });
@@ -96,7 +96,7 @@ export class CarouselPlugin extends CorePlugin<CarouselState> implements Carouse
         return true;
       }
     }
-    throw false;
+    return false;
   }
 
   getCarousel(figureId: UID): Carousel {

--- a/src/plugins/core/chart.ts
+++ b/src/plugins/core/chart.ts
@@ -332,7 +332,7 @@ export class ChartPlugin extends CorePlugin<ChartState> implements ChartState {
       : CommandResult.Success;
   }
 
-  /** If the command would create a new figure, there need to be a position & offset defined in the command */
+  /** If the command is meant to create a new figure, the position & offset argument need to be defined in the command */
   private checkFigureArguments(cmd: CreateChartCommand): CommandResult {
     if (this.getters.getFigure(cmd.sheetId, cmd.figureId)) {
       return CommandResult.Success;

--- a/src/plugins/ui_stateful/carousel_ui.ts
+++ b/src/plugins/ui_stateful/carousel_ui.ts
@@ -121,10 +121,10 @@ export class CarouselUIPlugin extends UIPlugin {
     }
 
     const carousel = this.getters.getCarousel(figureId);
-    if (!this.carouselStates[figureId]) {
-      this.carouselStates[figureId] = this.getCarouselItemId(carousel.items[0]);
-    } else if (carousel.items.length === 0) {
+    if (carousel.items.length === 0) {
       delete this.carouselStates[figureId];
+    } else if (!this.carouselStates[figureId]) {
+      this.carouselStates[figureId] = this.getCarouselItemId(carousel.items[0]);
     } else if (
       !carousel.items.some((item) => this.getCarouselItemId(item) === this.carouselStates[figureId])
     ) {

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -1442,6 +1442,7 @@ export const enum CommandResult {
   InvalidPivotDataSet = "InvalidPivotDataSet",
   InvalidPivotCustomField = "InvalidPivotCustomField",
   MissingFigureArguments = "MissingFigureArguments",
+  InvalidCarouselItem = "InvalidCarouselItem",
 }
 
 export interface CommandHandler<T> {

--- a/tests/figures/__snapshots__/figure_component.test.ts.snap
+++ b/tests/figures/__snapshots__/figure_component.test.ts.snap
@@ -55,41 +55,58 @@ exports[`figures selected figure snapshot 1`] = `
       
     </div>
     
+    <div
+      class="position-absolute top-0 start-0 pe-none w-100 h-100"
+    >
+      <div
+        class="o-figure-border pe-auto w-100 h-0 position-absolute pb-2"
+        style="border-top: 2px solid #3266ca;"
+      />
+      <div
+        class="o-figure-border pe-auto h-100 position-absolute start-0 ps-2"
+        style="border-left: 2px solid #3266ca;"
+      />
+      <div
+        class="o-figure-border pe-auto w-100 position-absolute bottom-0 pt-2"
+        style="border-bottom: 2px solid #3266ca;"
+      />
+      <div
+        class="o-figure-border pe-auto h-100 position-absolute end-0 pe-2"
+        style="border-right: 2px solid #3266ca;"
+      />
+    </div>
+    
   </div>
   <div
-    class="o-figure-border w-100 h-100 position-absolute pe-none"
-    style="border: 2px solid #3266ca;"
-  />
-  <div
-    class="o-fig-anchor o-top"
+    class="o-fig-anchor o-top pe-auto"
     style="top:-3px; right:calc(50% - 3px); "
   />
   <div
-    class="o-fig-anchor o-topRight"
+    class="o-fig-anchor o-topRight pe-auto"
     style="top:-3px; right:-3px; "
   />
   <div
-    class="o-fig-anchor o-right"
+    class="o-fig-anchor o-right pe-auto"
     style="bottom:calc(50% - 3px); right:-3px; "
   />
   <div
-    class="o-fig-anchor o-bottomRight"
+    class="o-fig-anchor o-bottomRight pe-auto"
     style="bottom:-3px; right:-3px; "
   />
   <div
-    class="o-fig-anchor o-bottom"
+    class="o-fig-anchor o-bottom pe-auto"
     style="bottom:-3px; right:calc(50% - 3px); "
   />
   <div
-    class="o-fig-anchor o-bottomLeft"
+    class="o-fig-anchor o-bottomLeft pe-auto"
     style="bottom:-3px; left:-3px; "
   />
   <div
-    class="o-fig-anchor o-left"
+    class="o-fig-anchor o-left pe-auto"
     style="bottom:calc(50% - 3px); left:-3px; "
   />
   <div
-    class="o-fig-anchor o-topLeft"
+    class="o-fig-anchor o-topLeft pe-auto"
     style="top:-3px; left:-3px; "
   />
   

--- a/tests/figures/carousel/carousel_panel_component.test.ts
+++ b/tests/figures/carousel/carousel_panel_component.test.ts
@@ -73,6 +73,7 @@ describe("Carousel panel component", () => {
   test("Can remove a carousel item", async () => {
     createCarousel(model, { items: [] }, "carouselId");
     addNewChartToCarousel(model, "carouselId", { type: "radar" });
+    model = new Model(model.exportData());
     await mountCarouselPanel(model, "carouselId");
     expect(model.getters.getCarousel("carouselId").items).toHaveLength(1);
 

--- a/tests/figures/figure_component.test.ts
+++ b/tests/figures/figure_component.test.ts
@@ -683,14 +683,16 @@ describe("figures", () => {
     test("Border for figure", async () => {
       createFigure(model);
       await nextTick();
-      expect(getElStyle(".o-figure-border", "border")).toEqual(`1px solid ${FIGURE_BORDER_COLOR}`);
+      expect(getElStyle(".o-figure-border", "border-top")).toEqual(
+        `1px solid ${FIGURE_BORDER_COLOR}`
+      );
     });
 
     test("Border for selected figure", async () => {
       createFigure(model, { id: "figureId" });
       model.dispatch("SELECT_FIGURE", { figureId: "figureId" });
       await nextTick();
-      expect(getElStyle(".o-figure-border", "border")).toEqual(
+      expect(getElStyle(".o-figure-border", "border-top")).toEqual(
         `2px solid ${SELECTION_BORDER_COLOR}`
       );
     });
@@ -698,14 +700,16 @@ describe("figures", () => {
     test("Border for image figure", async () => {
       createImage(model, { figureId: "figureId" });
       await nextTick();
-      expect(getElStyle(".o-figure-border", "border")).toEqual(`0px solid ${FIGURE_BORDER_COLOR}`);
+      expect(getElStyle(".o-figure-border", "border-top")).toEqual(
+        `0px solid ${FIGURE_BORDER_COLOR}`
+      );
     });
 
     test("Border for selected image figure", async () => {
       createImage(model, { figureId: "figureId" });
       model.dispatch("SELECT_FIGURE", { figureId: "figureId" });
       await nextTick();
-      expect(getElStyle(".o-figure-border", "border")).toEqual(
+      expect(getElStyle(".o-figure-border", "border-top")).toEqual(
         `2px solid ${SELECTION_BORDER_COLOR}`
       );
     });
@@ -713,10 +717,10 @@ describe("figures", () => {
     test("No border in dashboard mode", async () => {
       createFigure(model, { id: "figureId" });
       await nextTick();
-      expect(getElStyle(".o-figure-border", "border-width")).toEqual("1px");
+      expect(getElStyle(".o-figure-border", "border-top-width")).toEqual("1px");
       model.updateMode("dashboard");
       await nextTick();
-      expect(getElStyle(".o-figure-border", "border-width")).toEqual("0px");
+      expect(".o-figure-border").toHaveCount(0);
     });
   });
 


### PR DESCRIPTION
### [IMP] carousel: add missing menu items

This commit adds the menu items that were missing from the carousel:
- copy
- cut
- copy as image
- download


### [IMP] carousel: allow to copy/paste carousel figures

This commit adds a new clipboard handler to copy/paste carousel figures.


### [IMP] carousel: make figure clickable in data view

When the carousel was showing the data behind the figure, the figure
was not clickable. this commit make the borders clickable, so the user
can resize/drag & drop the figure.


### [FIX] carousel: various fixes

Fixes comments of PR #6907 that we didn't address due to
deadlines constraints.

Task: [5017194](https://www.odoo.com/odoo/2328/tasks/5017194)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo