### PR TITLE
[FIX] borders: Recompute borders on `SET_BORDERS_ON_TARGET`

### DIFF
--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -174,6 +174,7 @@ export const invalidateBordersCommands = new Set<CommandTypes>([
   "AUTOFILL_CELL",
   "SET_BORDER",
   "SET_ZONE_BORDERS",
+  "SET_BORDERS_ON_TARGET",
 ]);
 
 export const readonlyAllowedCommands = new Set<CommandTypes>([

--- a/tests/borders/border_plugin.test.ts
+++ b/tests/borders/border_plugin.test.ts
@@ -921,4 +921,12 @@ describe("Computed borders", () => {
     setZoneBorders(model, { position: "all" }, ["A1"]);
     expect(getComputedBorder(model, "A1")).not.toBeNull();
   });
+
+  test("SET_BORDERS_ON_TARGET command recomputes the borders", () => {
+    const model = new Model();
+    const border = { top: DEFAULT_BORDER_DESC };
+    expect(getComputedBorder(model, "A1")).toBeNull();
+    setBordersOnTarget(model, ["A1"], border);
+    expect(getComputedBorder(model, "A1")).not.toBeNull();
+  });
 });


### PR DESCRIPTION
The new command, notably used in the clipboard paste and autofill, was not added to the subset of commands that invalidate the computed border style.

Task: 5024825

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo