### PR TITLE
[FIX] TopBar: Fix readonly mode view

### DIFF
--- a/src/components/composer/composer/composer.ts
+++ b/src/components/composer/composer/composer.ts
@@ -593,6 +593,9 @@ export class Composer extends Component<CellComposerProps, SpreadsheetChildEnv> 
   }
 
   onMouseup() {
+    if (this.env.model.getters.isReadonly()) {
+      return;
+    }
     const selection = this.contentHelper.getCurrentSelection();
     if (selection.start !== selection.end) {
       this.props.composerStore.hoverToken(undefined);

--- a/src/components/top_bar/top_bar.xml
+++ b/src/components/top_bar/top_bar.xml
@@ -25,8 +25,13 @@
         </div>
       </div>
       <!-- Toolbar and Cell Content -->
-      <div class="d-flex o-topbar-responsive" t-ref="toolBarContainer">
-        <div class="o-topbar-toolbar d-flex">
+      <div
+        class="d-flex o-topbar-responsive"
+        t-att-class="{'o-topbar-responsive': !env.model.getters.isReadonly()}"
+        t-ref="toolBarContainer">
+        <div
+          class="o-topbar-toolbar d-flex"
+          t-att-class="{'flex-shrink-0': env.model.getters.isReadonly()}">
           <!-- Toolbar -->
           <div
             t-if="env.model.getters.isReadonly()"

--- a/tests/composer/composer_component.test.ts
+++ b/tests/composer/composer_component.test.ts
@@ -1056,6 +1056,22 @@ describe("composer", () => {
     await keyDown({ key: "F2" });
     expect(composerStore.editionMode).toBe("editing");
   });
+
+  test("Can select text in the composer in readonly mode", async () => {
+    await typeInComposer("=12");
+    model.updateMode("readonly");
+    await nextTick();
+    const spans = fixture.querySelectorAll(".o-composer span");
+    triggerMouseEvent(spans[0], "pointerdown");
+    const selection = document.getSelection()!;
+    const range = document.createRange();
+    range.setStart(spans[0].childNodes[0], 0);
+    range.setEnd(spans[1].childNodes[0], 1);
+    selection.addRange(range);
+    triggerMouseEvent(spans[1], "pointerup");
+    await nextTick();
+    expect(selection.toString()).toBe("=1");
+  });
 });
 
 describe("composer formula color", () => {


### PR DESCRIPTION
### [FIX] TopBar: Fix readonly mode view
Following the introduction of the mobile mode, top bar html/css structure was altered and unfortunately did not account for the readonly mode.

This revision fixes the readonly topbar by reintroducing the text alignement and deactivateing the flex behaviour of the composer as it doesn't answer any functional need in readonly.


### [FIX] Composer: Allow to select text in readonly mode
Task: 5028187

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo