### PR TITLE
[FIX] full_screen_chart: prevent fullscreen chart from closing on drag-out

### DIFF
--- a/src/components/full_screen_chart/full_screen_chart.xml
+++ b/src/components/full_screen_chart/full_screen_chart.xml
@@ -1,9 +1,11 @@
 <templates>
   <t t-name="o-spreadsheet-FullScreenChart">
-    <div
-      class="position-absolute o-fullscreen-chart-overlay w-100 h-100 d-flex"
-      t-if="figureUI"
-      t-on-click="exitFullScreen">
+    <div class="position-absolute o-fullscreen-chart-overlay w-100 h-100 d-flex" t-if="figureUI">
+      <div
+        class="position-absolute top-0 start-0 end-0 bottom-0"
+        t-on-click="exitFullScreen"
+        aria-hidden="true"
+      />
       <button
         class="o-exit top-0 end-0 position-absolute o-button primary m-1"
         t-on-click="exitFullScreen">

--- a/tests/figures/chart/chart_full_screen.test.ts
+++ b/tests/figures/chart/chart_full_screen.test.ts
@@ -1,6 +1,12 @@
 import { Model } from "../../../src";
 import { createScorecardChart, createWaterfallChart } from "../../test_helpers/commands_helpers";
-import { click, keyDown } from "../../test_helpers/dom_helper";
+import {
+  click,
+  keyDown,
+  pointerDown,
+  pointerUp,
+  triggerMouseEvent,
+} from "../../test_helpers/dom_helper";
 import { mockChart, mountSpreadsheet, nextTick } from "../../test_helpers/helpers";
 
 mockChart();
@@ -47,7 +53,7 @@ describe("chart menu for dashboard", () => {
     // Click outside of the chart in the full screen overlay
     await click(fixture, ".o-figure [data-id='fullScreenChart']");
     expect(".o-fullscreen-chart").toHaveCount(1);
-    await click(fixture, ".o-fullscreen-chart-overlay");
+    await click(fixture, ".o-fullscreen-chart-overlay > div:first-child");
     expect(".o-fullscreen-chart").toHaveCount(0);
 
     // Click the exit button in the full screen overlay
@@ -61,5 +67,27 @@ describe("chart menu for dashboard", () => {
     expect(".o-fullscreen-chart").toHaveCount(1);
     await keyDown({ key: "Escape" });
     expect(".o-fullscreen-chart").toHaveCount(0);
+  });
+
+  test("Keeps fullscreen open when pointerdown is inside and pointerup is outside", async () => {
+    createWaterfallChart(model);
+    model.updateMode("dashboard");
+    await nextTick();
+
+    await click(fixture, ".o-figure [data-id='fullScreenChart']");
+    expect(".o-fullscreen-chart").toHaveCount(1);
+
+    const chart = fixture.querySelector(".o-fullscreen-chart")!;
+    const overlay = fixture.querySelector(".o-fullscreen-chart-overlay")!;
+    expect(chart).not.toBeNull();
+    expect(overlay).not.toBeNull();
+
+    await pointerDown(chart);
+    await pointerUp(overlay);
+
+    triggerMouseEvent(overlay, "click");
+    await nextTick();
+
+    expect(".o-fullscreen-chart").toHaveCount(1);
   });
 });

--- a/tests/test_helpers/dom_helper.ts
+++ b/tests/test_helpers/dom_helper.ts
@@ -121,6 +121,11 @@ export async function pointerDown(target: DOMTarget) {
   await nextTick();
 }
 
+export async function pointerUp(target: DOMTarget) {
+  triggerMouseEvent(target, "pointerup");
+  await nextTick();
+}
+
 /**
  * Simulate hovering a cell for a given amount of time.
  * Don't forget to use `jest.useFakeTimers();` when using


### PR DESCRIPTION
## Description:

Steps to reproduce:

1. Open a dashboard and put a chart in fullscreen.
2. mousedown inside the chart.
3. Drag the pointer outside the chart window.
4. Release (mouseup).

Before this PR:
The fullscreen closes unexpectedly. Because mousedown and mouseup occur on different elements, the browser dispatches the click on their nearest common ancestor (the overlay), which had the close handler.

After this PR:

- Introduce a dedicated `.o-fullscreen-chart-backdrop` sibling and move the close handler there.
- Result: drag-out (down in chart, up outside) no longer closes; outside click (down+up on backdrop), Exit button, and `Esc` still close as expected.

Task: [5005933](https://www.odoo.com/odoo/2328/tasks/5005933)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo