### PR TITLE
[FIX] menu_items: fix sequence calculation for pivot data sources

### DIFF
--- a/src/actions/data_actions.ts
+++ b/src/actions/data_actions.ts
@@ -72,7 +72,7 @@ export const splitToColumns: ActionSpec = {
 export const reinsertDynamicPivotMenu: ActionSpec = {
   id: "reinsert_dynamic_pivot",
   name: _t("Re-insert dynamic pivot"),
-  sequence: 1020,
+  sequence: 60,
   icon: "o-spreadsheet-Icon.INSERT_PIVOT",
   children: [ACTIONS.REINSERT_DYNAMIC_PIVOT_CHILDREN],
   isVisible: (env) =>
@@ -82,7 +82,7 @@ export const reinsertDynamicPivotMenu: ActionSpec = {
 export const reinsertStaticPivotMenu: ActionSpec = {
   id: "reinsert_static_pivot",
   name: _t("Re-insert static pivot"),
-  sequence: 1020,
+  sequence: 70,
   icon: "o-spreadsheet-Icon.INSERT_PIVOT",
   children: [ACTIONS.REINSERT_STATIC_PIVOT_CHILDREN],
   isVisible: (env) =>

--- a/src/registries/menus/topbar_menu_registry.ts
+++ b/src/registries/menus/topbar_menu_registry.ts
@@ -461,8 +461,9 @@ topbarMenuRegistry
     sequence: 40,
     separator: true,
   })
-  .addChild("data_sources_data", ["data"], (env) => {
+  .addChild("pivot_data_sources", ["data"], (env) => {
     const sequence = 50;
+    const numberOfPivots = env.model.getters.getPivotIds().length;
     return env.model.getters.getPivotIds().map((pivotId, index) => {
       const highlightProvider = {
         get highlights() {
@@ -472,7 +473,7 @@ topbarMenuRegistry
       return {
         id: `item_pivot_${env.model.getters.getPivotFormulaId(pivotId)}`,
         name: env.model.getters.getPivotDisplayName(pivotId),
-        sequence: sequence + index,
+        sequence: sequence + index / numberOfPivots,
         execute: (env) => env.openSidePanel("PivotSidePanel", { pivotId }),
         onStartHover: (env) => env.getStore(HighlightStore).register(highlightProvider),
         onStopHover: (env) => env.getStore(HighlightStore).unRegister(highlightProvider),


### PR DESCRIPTION
Depending on the number of pivot tables, the pivot items could be displayed after other items (e.g. Re-insert dynamic pivot) in the topbar menu.

Practically, the number of pivots to observe the issue is not realistic, as it requires more than 970 pivots.
But the issue can be observed easily with 25 lists in Odoo.

To fix the issue, we need to compute the sequence with decimal numbers, to ensure that the pivot items are always between the first sequence (50) and sequence + 1 (51).

Task: 5025230

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo