### PR TITLE
[FIX] pivot: handle vectorized formula

### DIFF
--- a/src/plugins/ui_core_views/pivot_ui.ts
+++ b/src/plugins/ui_core_views/pivot_ui.ts
@@ -22,6 +22,7 @@ import {
   UID,
   UpdatePivotCommand,
   invalidateEvaluationCommands,
+  isMatrix,
 } from "../../types";
 import { Pivot } from "../../types/pivot_runtime";
 import { UIPlugin, UIPluginConfig } from "../ui_plugin";
@@ -198,7 +199,7 @@ export class PivotUIPlugin extends UIPlugin {
     if (!result) {
       return EMPTY_PIVOT_CELL;
     }
-    const { functionName, args } = result;
+    let { functionName, args } = result;
     const formulaId = args[0];
     if (!formulaId) {
       return EMPTY_PIVOT_CELL;
@@ -231,6 +232,9 @@ export class PivotUIPlugin extends UIPlugin {
       return pivotCells[pivotCol][pivotRow];
     }
     try {
+      const offsetRow = position.row - mainPosition.row;
+      const offsetCol = position.col - mainPosition.col;
+      args = args.map((arg) => (isMatrix(arg) ? arg[offsetCol][offsetRow] : arg));
       if (functionName === "PIVOT.HEADER" && args.at(-2) === "measure") {
         const domain = pivot.parseArgsToPivotDomain(
           args.slice(1, -2).map((value) => ({ value } as FunctionResultObject))

--- a/tests/pivots/pivot_plugin.test.ts
+++ b/tests/pivots/pivot_plugin.test.ts
@@ -186,6 +186,33 @@ describe("Pivot plugin", () => {
     );
   });
 
+  test("getPivotCellFromPosition can handle vectorization", () => {
+    // prettier-ignore
+    const grid = {
+      A1: "Stage", B1: "Price", C1: '=PIVOT.VALUE(1,"Price","Stage",SEQUENCE(2))',
+      A2: "1",     B2: "10",
+      A3: "2",     B3: "30",
+    };
+    const model = createModelFromGrid(grid);
+    addPivot(model, "A1:B3", {
+      columns: [],
+      rows: [{ fieldName: "Stage" }],
+      measures: [{ id: "price:sum", fieldName: "Price", aggregator: "sum" }],
+    });
+    selectCell(model, "C1");
+    expect(model.getters.getPivotCellFromPosition(model.getters.getActivePosition())).toMatchObject(
+      {
+        domain: [{ field: "Stage", type: "integer", value: 1 }],
+      }
+    );
+    selectCell(model, "C2");
+    expect(model.getters.getPivotCellFromPosition(model.getters.getActivePosition())).toMatchObject(
+      {
+        domain: [{ field: "Stage", type: "integer", value: 2 }],
+      }
+    );
+  });
+
   test("cannot update a pivot with a wrong id", () => {
     const model = new Model();
     const updateResult = model.dispatch("UPDATE_PIVOT", {


### PR DESCRIPTION
Steps to reproduce:
- Create a pivot.value formula with a SEQUENCE => `getPivotCellFromPosition` returns an incorrect domain.

Task: 5043187

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo