### PR TITLE
[FIX] xlsx: `=undefined` when importing array formula

### DIFF
--- a/src/xlsx/extraction/sheet_extractor.ts
+++ b/src/xlsx/extraction/sheet_extractor.ts
@@ -1,3 +1,4 @@
+import { positions, toXC, toZone } from "../../helpers";
 import {
   XLSXCell,
   XLSXColumn,
@@ -245,12 +246,13 @@ export class XlsxSheetExtractor extends XlsxBaseExtractor {
   }
 
   private extractRows(worksheet: Element): XLSXRow[] {
+    const spilledCells = new Set<string>();
     return this.mapOnElements(
       { parent: worksheet, query: "sheetData row" },
       (rowElement): XLSXRow => {
         return {
           index: this.extractAttr(rowElement, "r", { required: true })?.asNum()!,
-          cells: this.extractCells(rowElement),
+          cells: this.extractCells(rowElement, spilledCells),
           height: this.extractAttr(rowElement, "ht")?.asNum(),
           customHeight: this.extractAttr(rowElement, "customHeight")?.asBool(),
           hidden: this.extractAttr(rowElement, "hidden")?.asBool(),
@@ -260,16 +262,30 @@ export class XlsxSheetExtractor extends XlsxBaseExtractor {
     );
   }
 
-  private extractCells(row: Element): XLSXCell[] {
+  private extractCells(row: Element, spilledCells: Set<string>): XLSXCell[] {
     return this.mapOnElements({ parent: row, query: "c" }, (cellElement): XLSXCell => {
+      const xc = this.extractAttr(cellElement, "r", { required: true })?.asString()!;
+      const formula = this.extractCellFormula(cellElement);
+
+      if (formula?.ref && formula.sharedIndex === undefined) {
+        const zone = toZone(formula.ref);
+        for (const { col, row } of positions(zone)) {
+          const followerXc = toXC(col, row);
+          if (followerXc !== xc) {
+            spilledCells.add(followerXc);
+          }
+        }
+      }
+
+      const isSpilled = spilledCells.has(xc);
       return {
-        xc: this.extractAttr(cellElement, "r", { required: true })?.asString()!,
+        xc,
         styleIndex: this.extractAttr(cellElement, "s")?.asNum(),
         type: CELL_TYPE_CONVERSION_MAP[
           this.extractAttr(cellElement, "t", { default: "n" })?.asString()!
         ],
-        value: this.extractChildTextContent(cellElement, "v"),
-        formula: this.extractCellFormula(cellElement),
+        value: isSpilled ? undefined : this.extractChildTextContent(cellElement, "v") ?? undefined,
+        formula: isSpilled ? undefined : formula,
       };
     });
   }
@@ -277,11 +293,15 @@ export class XlsxSheetExtractor extends XlsxBaseExtractor {
   private extractCellFormula(cellElement: Element): XLSXFormula | undefined {
     const formulaElement = this.querySelector(cellElement, "f");
     if (!formulaElement) return undefined;
-    return {
-      content: this.extractTextContent(formulaElement),
-      sharedIndex: this.extractAttr(formulaElement, "si")?.asNum(),
-      ref: this.extractAttr(formulaElement, "ref")?.asString(),
-    };
+    const content = this.extractTextContent(formulaElement);
+    const sharedIndex = this.extractAttr(formulaElement, "si")?.asNum();
+    const ref = this.extractAttr(formulaElement, "ref")?.asString();
+
+    // This is the case of spilled cells of array formulas where <f> is empty
+    if ((content === undefined || content.trim() === "") && sharedIndex === undefined) {
+      return undefined;
+    }
+    return { content, sharedIndex, ref };
   }
 
   private extractHyperLinks(worksheet: Element): XLSXHyperLink[] {

--- a/tests/__xlsx__/xlsx_demo_data/xl/worksheets/sheet3.xml
+++ b/tests/__xlsx__/xlsx_demo_data/xl/worksheets/sheet3.xml
@@ -54,10 +54,23 @@
       <c r="A4" t="s">
         <v>356</v>
       </c>
+      <c r="G4">
+        <f t="array" ref="G4:H5">RANDARRAY(2,2)</f>
+        <v>0.123456</v>
+      </c>
+      <c r="H4">
+        <v>0.234567</v>
+      </c>
     </row>
     <row r="5" spans="1:8" ht="75" customHeight="1" x14ac:dyDescent="0.2">
       <c r="A5" t="s">
         <v>360</v>
+      </c>
+      <c r="G5">
+        <v>0.345678</v>
+      </c>
+      <c r="H5">
+        <v>0.456789</v>
       </c>
     </row>
   </sheetData>

--- a/tests/xlsx/xlsx_import.test.ts
+++ b/tests/xlsx/xlsx_import.test.ts
@@ -66,6 +66,15 @@ describe("Import xlsx data", () => {
     expect(cell?.content).toEqual("=SUM(A1)");
   });
 
+  test("Can import array formula correctly and spill ranges values skipped", () => {
+    const sheet = getWorkbookSheet("jestSheet", convertedData)!;
+
+    expect(sheet.cells["G4"]?.content).toEqual("=RANDARRAY(2,2)");
+    expect(sheet.cells["H4"]?.content).toBeUndefined();
+    expect(sheet.cells["G5"]?.content).toBeUndefined();
+    expect(sheet.cells["H5"]?.content).toBeUndefined();
+  });
+
   test("Can import merge", () => {
     const testSheet = getWorkbookSheet("jestSheet", convertedData)!;
     expect(testSheet.merges).toEqual(["D1:E2"]);


### PR DESCRIPTION
## Description:

Steps to reproduce:

* Write an array formula =RANDARRAY(20) in Excel.
* Import the file into `o-spreadsheet`.

Current behavior:

* The anchor cell shows #SPILL!.
* Spill cells are populated with =undefined, causing #BAD_EXPR and spill errors.

Desired behavior:

* Only the anchor retains the formula.
* Spill cells are empty (no phantom content), so the array spills correctly without #SPILL!.

Task: [4812508](https://www.odoo.com/odoo/2328/tasks/4812508)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo