### PR TITLE
[IMP] composer: one-liner formula in top bar composer

### DIFF
--- a/src/components/composer/composer/abstract_composer_store.ts
+++ b/src/components/composer/composer/abstract_composer_store.ts
@@ -462,8 +462,8 @@ export abstract class AbstractComposerStore extends SpreadsheetStore {
     this.col = col;
     this.sheetId = sheetId;
     this.row = row;
-    this.initialContent = this.getComposerContent({ sheetId, col, row });
     this.editionMode = "editing";
+    this.initialContent = this.getComposerContent({ sheetId, col, row });
     this.setContent(str || this.initialContent, selection);
     this.colorIndexByRange = {};
     const zone = positionToZone({ col: this.col, row: this.row });

--- a/src/components/composer/composer/cell_composer_store.ts
+++ b/src/components/composer/composer/cell_composer_store.ts
@@ -24,6 +24,7 @@ import {
   Command,
   Direction,
   Format,
+  FormulaCell,
   Locale,
   RemoveColumnsRowsCommand,
   isMatrix,
@@ -204,9 +205,7 @@ export class CellComposerStore extends AbstractComposerStore {
     const locale = this.getters.getLocale();
     const cell = this.getters.getCell(position);
     if (cell?.isFormula) {
-      const prettifiedContent = cell.compiledFormula.isBadExpression
-        ? cell.content
-        : prettify(parseTokens(cell.compiledFormula.tokens), 80);
+      const prettifiedContent = this.getPrettifiedFormula(cell);
       return localizeFormula(prettifiedContent, locale);
     }
     const spreader = this.model.getters.getArrayFormulaSpreadingOn(position);
@@ -236,6 +235,17 @@ export class CellComposerStore extends AbstractComposerStore {
         }
         return this.numberComposerContent(value, format, locale);
     }
+  }
+
+  private getPrettifiedFormula(cell: FormulaCell): string {
+    if (cell.compiledFormula.isBadExpression) {
+      return cell.content;
+    }
+    const width =
+      this.editionMode === "inactive"
+        ? Infinity // one liner
+        : 80;
+    return prettify(parseTokens(cell.compiledFormula.tokens), width);
   }
 
   private numberComposerContent(value: number, format: Format | undefined, locale: Locale): string {

--- a/tests/composer/composer_store.test.ts
+++ b/tests/composer/composer_store.test.ts
@@ -1216,4 +1216,28 @@ describe("edition", () => {
       ")"
     );
   });
+
+  test("display as one-liner when inactive", () => {
+    const content = // prettier-ignore
+      "=SUM(\n" +
+      "\t11111111, \n" +
+      "\t22222222, \n" +
+      "\t33333333, \n" +
+      "\t44444444, \n" +
+      "\t55555555, \n" +
+      "\t66666666, \n" +
+      "\t77777777, \n" +
+      "\t88888888\n" +
+      ")";
+    setCellContent(model, "A1", content);
+    expect(composerStore.currentContent).toBe(
+      "=SUM(11111111, 22222222, 33333333, 44444444, 55555555, 66666666, 77777777, 88888888)"
+    );
+    composerStore.startEdition();
+    expect(composerStore.currentContent).toBe(content);
+    composerStore.stopEdition();
+    expect(composerStore.currentContent).toBe(
+      "=SUM(11111111, 22222222, 33333333, 44444444, 55555555, 66666666, 77777777, 88888888)"
+    );
+  });
 });


### PR DESCRIPTION
## Description:

Let's imagine a long formula `SUMIFS(...a...lot...of...args...)` which is prettified such that the first line only has `=SUMIFS(`, and arguments are nested on new lines.

When selecting this cell, you can only see `=SUMIFS(` in the top bar composer and it doesn't help figuring out what's in this cell. Particularly if several cells have similar SUMIFS formulas (but with different arguments).

With this commit, the formula is displayed in one line when the top bar composer is inactive.
Task: [5045737](https://www.odoo.com/odoo/2328/tasks/5045737)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo