### PR TITLE
[FIX] chart: full screen chart icon is wrong

### DIFF
--- a/src/components/figures/chart/chart_dashboard_menu/chart_dashboard_menu.ts
+++ b/src/components/figures/chart/chart_dashboard_menu/chart_dashboard_menu.ts
@@ -64,7 +64,7 @@ export class ChartDashboardMenu extends Component<Props, SpreadsheetChildEnv> {
     if (definition.type === "scorecard") {
       return undefined;
     }
-    const isFullScreen = this.props.chartId === this.fullScreenFigureStore.fullScreenFigure?.id;
+    const isFullScreen = figureId === this.fullScreenFigureStore.fullScreenFigure?.id;
     return {
       id: "fullScreenChart",
       label: isFullScreen ? _t("Exit Full Screen") : _t("Full Screen"),

--- a/tests/figures/chart/chart_full_screen.test.ts
+++ b/tests/figures/chart/chart_full_screen.test.ts
@@ -24,6 +24,19 @@ describe("chart menu for dashboard", () => {
     expect(".o-fullscreen-chart").toHaveCount(1);
   });
 
+  test("Expand icon changes to collapse in full screen", async () => {
+    createWaterfallChart(model);
+    model.updateMode("dashboard");
+    await nextTick();
+
+    expect(".o-figure .fa-expand").toHaveCount(1);
+    expect(".o-fullscreen-chart").toHaveCount(0);
+
+    await click(fixture, ".o-figure .fa-expand");
+    expect(".o-fullscreen-chart").toHaveCount(1);
+    expect(".o-figure .fa-compress").toHaveCount(2); // One in the original chart, one in the full screen overlay
+  });
+
   test("Cannot make scorecard chart fullscreen ", async () => {
     createScorecardChart(model, {});
     model.updateMode("dashboard");


### PR DESCRIPTION
## Description

The icon to make a chart full screen wouldn't be changed to an icon to exit full screen when the chart was already in full screen mode.

Task: [5055958](https://www.odoo.com/odoo/2328/tasks/5055958)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo