### PR TITLE
[IMP] carousel: enable chart animation at each tab change

### DIFF
--- a/src/components/figures/chart/chartJs/chartjs.ts
+++ b/src/components/figures/chart/chartJs/chartjs.ts
@@ -95,7 +95,7 @@ export class ChartJsComponent extends Component<Props, SpreadsheetChildEnv> {
   }
 
   setup() {
-    if (this.env.model.getters.isDashboard()) {
+    if (this.shouldAnimate) {
       this.animationStore = useStore(ChartAnimationStore);
     }
     onMounted(() => {
@@ -127,7 +127,7 @@ export class ChartJsComponent extends Component<Props, SpreadsheetChildEnv> {
     this.chart?.destroy();
   }
 
-  protected get shouldAnimate() {
+  protected get shouldAnimate(): boolean {
     return this.env.model.getters.isDashboard();
   }
 

--- a/src/components/figures/figure_carousel/figure_carousel.ts
+++ b/src/components/figures/figure_carousel/figure_carousel.ts
@@ -3,6 +3,7 @@ import { DEFAULT_CAROUSEL_TITLE_STYLE } from "../../../constants";
 import { chartStyleToCellStyle, deepEquals } from "../../../helpers";
 import { getCarouselItemTitle } from "../../../helpers/carousel_helpers";
 import { chartComponentRegistry } from "../../../registries/chart_types";
+import { Store, useStore } from "../../../store_engine";
 import {
   Carousel,
   CarouselItem,
@@ -12,6 +13,7 @@ import {
 } from "../../../types";
 import { cellTextStyleToCss, cssPropertiesToCss } from "../../helpers";
 import { ChartDashboardMenu } from "../chart/chart_dashboard_menu/chart_dashboard_menu";
+import { ChartAnimationStore } from "../chart/chartJs/chartjs_animation_store";
 
 interface Props {
   figureUI: FigureUI;
@@ -28,7 +30,11 @@ export class CarouselFigure extends Component<Props, SpreadsheetChildEnv> {
   };
   static components = { ChartDashboardMenu };
 
+  protected animationStore: Store<ChartAnimationStore> | undefined;
+
   setup(): void {
+    this.animationStore = useStore(ChartAnimationStore);
+
     useEffect(() => {
       if (this.selectedCarouselItem?.type === "carouselDataView") {
         this.props.editFigureStyle?.({ "pointer-events": "none" });
@@ -79,6 +85,9 @@ export class CarouselFigure extends Component<Props, SpreadsheetChildEnv> {
       sheetId: this.env.model.getters.getActiveSheetId(),
       item,
     });
+    if (item.type === "chart") {
+      this.animationStore?.enableAnimationForChart(item.chartId);
+    }
   }
 
   get headerStyle(): string {

--- a/tests/figures/carousel/carousel_figure_component.test.ts
+++ b/tests/figures/carousel/carousel_figure_component.test.ts
@@ -1,6 +1,7 @@
 import { ChartConfiguration } from "chart.js";
 import { Model, SpreadsheetChildEnv, UID } from "../../../src";
 import { getCarouselMenuActions } from "../../../src/actions/figure_menu_actions";
+import { ChartAnimationStore } from "../../../src/components/figures/chart/chartJs/chartjs_animation_store";
 import { downloadFile } from "../../../src/components/helpers/dom_helpers";
 import { xmlEscape } from "../../../src/xlsx/helpers/xml_helpers";
 import {
@@ -141,6 +142,24 @@ describe("Carousel figure component", () => {
     expect(".o-chart-dashboard-item").toHaveCount(0); // nothing for the data view
     await click(fixture, ".o-carousel-tab:nth-child(2)");
     expect(".o-chart-dashboard-item").toHaveCount(2); // ellipsis and fullscreen
+  });
+
+  test("Chart animation is played at each carousel tab change", async () => {
+    createCarousel(model, { items: [] }, "carouselId");
+    const radarId = addNewChartToCarousel(model, "carouselId", { type: "radar" });
+    const barId = addNewChartToCarousel(model, "carouselId", { type: "bar" });
+    model.updateMode("dashboard");
+
+    const { fixture, env } = await mountSpreadsheet({ model });
+    const chartAnimationStore = env.getStore(ChartAnimationStore);
+    const enableAnimationSpy = jest.spyOn(chartAnimationStore, "enableAnimationForChart");
+
+    await click(fixture, ".o-carousel-tab:nth-child(2)");
+    expect(enableAnimationSpy).toHaveBeenLastCalledWith(barId);
+    await click(fixture, ".o-carousel-tab:nth-child(1)");
+    expect(enableAnimationSpy).toHaveBeenLastCalledWith(radarId);
+    await click(fixture, ".o-carousel-tab:nth-child(2)");
+    expect(enableAnimationSpy).toHaveBeenLastCalledWith(barId);
   });
 
   describe("Carousel menu items", () => {


### PR DESCRIPTION
## Description

At the moment, the chart animation is only played the first time the carousel tab is displayed. We should animate the charts at each tab change.

Task: [5056084](https://www.odoo.com/odoo/2328/tasks/5056084)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo