### PR TITLE
[IMP] carousel: re-organize menu items

### DIFF
--- a/tests/figures/carousel/carousel_figure_component.test.ts
+++ b/tests/figures/carousel/carousel_figure_component.test.ts
@@ -175,6 +175,17 @@ describe("Carousel figure component", () => {
       expect(onFigureDeleted).toHaveBeenCalled();
     });
 
+    test("Can delete a carousel item", () => {
+      createCarousel(model, { items: [{ type: "carouselDataView" }] }, "carouselId");
+
+      const action = getCarouselMenuItem("carouselId", "delete_carousel_item");
+      expect(action?.isVisible(env)).toBe(true);
+      action?.execute?.(env);
+
+      expect(model.getters.getCarousel("carouselId").items).toHaveLength(0);
+      expect(action?.isVisible(env)).toBe(false);
+    });
+
     test("Can copy the carousel", () => {
       createCarousel(model, { items: [] }, "carouselId");
       const action = getCarouselMenuItem("carouselId", "copy");


### PR DESCRIPTION
## Description

Carousels have a lot of menu items, some that are about the carousel itself, some that are about the selected chart in the carousel.

This commit organizes the menu items with a separator between the carousel and chart menu items.

Task: [5059617](https://www.odoo.com/odoo/2328/tasks/5059617)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo