### PR TITLE
[IMP] carousel: improve  drag & drop of chart over carousel

### DIFF
--- a/src/components/figures/figure_container/figure_container.ts
+++ b/src/components/figures/figure_container/figure_container.ts
@@ -559,21 +559,34 @@ export class FiguresContainer extends Component<Props, SpreadsheetChildEnv> {
     if (figureUI.tag !== "chart") {
       return undefined;
     }
-    const minimumOverlap = 20; // Minimum overlap in pixels to consider a carousel overlapping
-    const carousels = otherFigures.filter((f) => f.tag === "carousel");
 
-    return carousels.find((carousel) => {
-      const xOverlap = Math.max(
-        0,
-        Math.min(figureUI.x + figureUI.width, carousel.x + carousel.width) -
-          Math.max(figureUI.x, carousel.x)
-      );
-      const yOverlap = Math.max(
-        0,
-        Math.min(figureUI.y + figureUI.height, carousel.y + carousel.height) -
-          Math.max(figureUI.y, carousel.y)
-      );
-      return xOverlap >= minimumOverlap && yOverlap >= minimumOverlap;
-    });
+    const figureCenterX = figureUI.x + figureUI.width / 2;
+    const figureCenterY = figureUI.y + figureUI.height / 2;
+
+    let bestMatch: FigureUI | undefined;
+    let smallestDistance = Infinity;
+
+    for (const figure of otherFigures) {
+      if (figure.tag !== "carousel") {
+        continue;
+      }
+      const carouselCenterX = figure.x + figure.width / 2;
+      const carouselCenterY = figure.y + figure.height / 2;
+
+      const distanceX = Math.abs(figureCenterX - carouselCenterX);
+      const distanceY = Math.abs(figureCenterY - carouselCenterY);
+      const squaredDistance = distanceX ** 2 + distanceY ** 2;
+
+      if (
+        distanceX <= figureUI.width / 2 &&
+        distanceY <= figureUI.height / 2 &&
+        squaredDistance < smallestDistance
+      ) {
+        smallestDistance = squaredDistance;
+        bestMatch = figure;
+      }
+    }
+
+    return bestMatch;
   }
 }

--- a/tests/figures/carousel/carousel_figure_component.test.ts
+++ b/tests/figures/carousel/carousel_figure_component.test.ts
@@ -111,6 +111,35 @@ describe("Carousel figure component", () => {
     expect(model.getters.getFigures(sheetId)).toHaveLength(1);
   });
 
+  test("When drag & dropping a chart, the chart merges with the closest carousel rather than the first one", async () => {
+    createCarousel(model, { items: [] }, "carouselId1", undefined, {
+      col: 0,
+      row: 0,
+      size: { width: 200, height: 200 },
+      figureId: "carouselId1",
+    });
+    createCarousel(model, { items: [] }, "carouselId2", undefined, {
+      col: 0,
+      row: 0,
+      offset: { x: 0, y: 200 },
+      size: { width: 200, height: 200 },
+      figureId: "carouselId2",
+    });
+    createChart(model, { type: "bar" }, "chartId", undefined, {
+      col: 0,
+      row: 0,
+      offset: { x: 0, y: 0 },
+      size: { width: 300, height: 300 },
+      figureId: "chartFigureId",
+    });
+    await mountSpreadsheet({ model });
+
+    // Move the chart down a bit, so it still overlaps the first carousel but is closer to the second one.
+    await clickAndDrag(".o-figure[data-id=chartFigureId]", { x: 0, y: 80 }, { x: 0, y: 0 }, true);
+    expect(model.getters.getCarousel("carouselId1").items).toHaveLength(0);
+    expect(model.getters.getCarousel("carouselId2").items).toHaveLength(1);
+  });
+
   test("Can define a carousel title", async () => {
     createCarousel(
       model,


### PR DESCRIPTION
## Description

We can drag & drop a chart over a carousel to add it to the carousel.

The current behaviour is not the best:
- even if the chart barely overlaps the carousel, it will still be added to it
- we merge the chart with the first overlapping carousel we find, not the one with the most overlap

This commit fixes the issues by using the distance between the centers of the two figures to check if they should be merged, and which carousel to choose.

Task: [5059979](https://www.odoo.com/odoo/2328/tasks/5059979)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo