### PR TITLE
[FIX] xlsx: make import verbose

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -190,7 +190,7 @@ export class Model extends EventBus<any> implements CommandDispatcher {
     config: Partial<ModelConfig> = {},
     stateUpdateMessages: StateUpdateMessage[] = [],
     uuidGenerator: UuidGenerator = new UuidGenerator(),
-    verboseImport = false
+    verboseImport = true
   ) {
     const start = performance.now();
     console.debug("##### Model creation #####");

--- a/tests/model/model.test.ts
+++ b/tests/model/model.test.ts
@@ -374,10 +374,16 @@ describe("Model", () => {
     const transport = new MockTransportService();
     const spy = jest.spyOn(transport, "sendMessage");
     const xlsxData = await getTextXlsxFiles();
-    new Model(xlsxData, {
-      transportService: transport,
-      client: { id: "test", name: "Test" },
-    });
+    new Model(
+      xlsxData,
+      {
+        transportService: transport,
+        client: { id: "test", name: "Test" },
+      },
+      undefined,
+      undefined,
+      false
+    );
     expect(spy).toHaveBeenCalledWith({
       type: "SNAPSHOT",
       version: MESSAGE_VERSION,
@@ -391,11 +397,17 @@ describe("Model", () => {
     const transport = new MockTransportService();
     const spy = jest.spyOn(transport, "sendMessage");
     const xlsxData = await getTextXlsxFiles();
-    new Model(xlsxData, {
-      transportService: transport,
-      client: { id: "test", name: "Test" },
-      mode: "readonly",
-    });
+    new Model(
+      xlsxData,
+      {
+        transportService: transport,
+        client: { id: "test", name: "Test" },
+        mode: "readonly",
+      },
+      undefined,
+      undefined,
+      false
+    );
     expect(spy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Description

e6ebca3 (probably) mistakenly changed the default `verboseImport` model argument from `true` to `false`. This meant that we no longer got any information in the console about what happened during the import of an XLSX file.


## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo