### PR TITLE
[IMP] carousel: export in xlsx

### DIFF
--- a/src/migrations/data.ts
+++ b/src/migrations/data.ts
@@ -272,15 +272,19 @@ function fixChartDefinitions(data: Partial<WorkbookData>, initialMessages: State
   const map = {};
   for (const sheet of data.sheets || []) {
     sheet.figures?.forEach((figure) => {
-      if (figure.tag === "chart") {
-        // chart definition
-        if (data.version && compareVersions(String(data.version), "18.5.1") <= 0) {
-          map[figure.data.chartId] = figure.data;
-        } else {
-          map[figure.id] = figure.data;
-        }
+      if (
+        figure.tag === "chart" &&
+        data.version &&
+        compareVersions(String(data.version), "18.5.1") > 0
+      ) {
+        map[figure.id] = (figure as any).data;
       }
     });
+    for (const chartId in sheet.charts || {}) {
+      if (data.version && compareVersions(String(data.version), "18.5.1") <= 0) {
+        map[chartId] = sheet.charts[chartId].chart;
+      }
+    }
   }
   for (const message of initialMessages) {
     if (message.type === "REMOTE_REVISION") {
@@ -415,6 +419,9 @@ export function createEmptySheet(sheetId: UID, name: string): SheetData {
     conditionalFormats: [],
     dataValidationRules: [],
     figures: [],
+    charts: {},
+    carousels: {},
+    images: {},
     tables: [],
     isVisible: true,
   };
@@ -438,10 +445,27 @@ export function createEmptyWorkbookData(sheetName = "Sheet1"): WorkbookData {
 
 export function createEmptyExcelSheet(sheetId: UID, name: string): ExcelSheetData {
   return {
-    ...(createEmptySheet(sheetId, name) as Omit<ExcelSheetData, "charts">),
-    charts: [],
-    images: [],
+    id: sheetId,
+    name,
+    colNumber: 26,
+    rowNumber: 100,
+    cells: {},
+    styles: {},
+    formats: {},
+    borders: {},
+    cols: {},
+    rows: {},
+    merges: [],
+    conditionalFormats: [],
+    dataValidationRules: [],
+    figures: [],
+    charts: {},
+    carousels: {},
+    tables: [],
+    isVisible: true,
+    images: {},
     cellValues: {},
+    formulaSpillRanges: {},
   };
 }
 

--- a/src/migrations/migration_steps.ts
+++ b/src/migrations/migration_steps.ts
@@ -372,7 +372,7 @@ migrationStepRegistry
   })
   .add("18.0.4", {
     // "Add operator in gauge inflection points",
-    migrate(data: WorkbookData): any {
+    migrate(data: any): any {
       for (const sheet of data.sheets || []) {
         for (const figure of sheet.figures || []) {
           if (figure.tag !== "chart" || figure.data.type !== "gauge") {
@@ -503,7 +503,7 @@ migrationStepRegistry
     },
   })
   .add("18.4.2", {
-    migrate(data: WorkbookData): any {
+    migrate(data: any): any {
       for (const sheet of data.sheets || []) {
         for (const figure of sheet.figures || []) {
           if (figure.tag !== "chart" || figure.data.type !== "scorecard") {
@@ -538,11 +538,24 @@ migrationStepRegistry
     },
   })
   .add("18.5.1", {
-    migrate(data: WorkbookData): any {
+    migrate(data: any): WorkbookData {
       for (const sheet of data.sheets || []) {
+        if (!sheet.charts) {
+          sheet.charts = {};
+        }
+        if (!sheet.images) {
+          sheet.images = {};
+        }
+
         for (const figure of sheet.figures || []) {
           if (figure.tag === "chart") {
-            figure.data.chartId = figure.id;
+            const chart = figure.data;
+            delete figure.data;
+            sheet.charts[figure.id] = { figureId: figure.id, chart };
+          } else if (figure.tag === "image") {
+            const image = figure.data;
+            delete figure.data;
+            sheet.images[figure.id] = { figureId: figure.id, image };
           }
         }
       }

--- a/src/plugins/core/carousel.ts
+++ b/src/plugins/core/carousel.ts
@@ -4,6 +4,7 @@ import {
   CarouselItem,
   CommandResult,
   CoreCommand,
+  ExcelWorkbookData,
   UID,
   UpdateCarouselCommand,
   WorkbookData,
@@ -138,5 +139,9 @@ export class CarouselPlugin extends CorePlugin<CarouselState> implements Carouse
         }
       }
     }
+  }
+
+  exportForExcel(data: ExcelWorkbookData): void {
+    return this.export(data);
   }
 }

--- a/src/plugins/core/carousel.ts
+++ b/src/plugins/core/carousel.ts
@@ -122,19 +122,19 @@ export class CarouselPlugin extends CorePlugin<CarouselState> implements Carouse
 
   import(data: WorkbookData) {
     for (const sheet of data.sheets) {
-      const carousels = (sheet.figures || []).filter((figure) => figure.tag === "carousel");
-      for (const carousel of carousels) {
-        this.history.update("carousels", sheet.id, carousel.id, { items: carousel.data.items });
+      for (const carouselId in sheet.carousels || {}) {
+        const { carousel } = sheet.carousels[carouselId];
+        this.history.update("carousels", sheet.id, carouselId, carousel);
       }
     }
   }
 
   export(data: WorkbookData) {
     for (const sheet of data.sheets) {
-      const carousels = sheet.figures.filter((figure) => figure.tag === "carousel");
-      for (const carousel of carousels) {
-        if (this.carousels[sheet.id]?.[carousel.id]) {
-          carousel.data = { ...carousel.data, ...this.carousels[sheet.id]?.[carousel.id] };
+      for (const carouselId in this.carousels[sheet.id] || {}) {
+        const carousel = this.carousels[sheet.id]?.[carouselId];
+        if (carousel) {
+          sheet.carousels[carouselId] = { figureId: carouselId, carousel };
         }
       }
     }

--- a/src/plugins/core/figures.ts
+++ b/src/plugins/core/figures.ts
@@ -364,8 +364,7 @@ export class FigurePlugin extends CorePlugin<FigureState> implements FigureState
   export(data: WorkbookData) {
     for (const sheet of data.sheets) {
       for (const figure of this.getFigures(sheet.id)) {
-        const data = undefined;
-        sheet.figures.push({ ...figure, data });
+        sheet.figures.push({ ...figure });
       }
     }
   }

--- a/src/plugins/core/sheet.ts
+++ b/src/plugins/core/sheet.ts
@@ -17,6 +17,7 @@ import {
   toCartesian,
 } from "../../helpers/index";
 import { isSheetNameEqual } from "../../helpers/sheet";
+import { createEmptySheet } from "../../migrations/data";
 import {
   Cell,
   CellPosition,
@@ -283,21 +284,11 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
     data.sheets = this.orderedSheetIds.filter(isDefined).map((id) => {
       const sheet = this.sheets[id]!;
       const sheetData: SheetData = {
+        ...createEmptySheet(sheet.id, sheet.name),
         id: sheet.id,
         name: sheet.name,
         colNumber: sheet.numberOfCols,
         rowNumber: this.getters.getNumberRows(sheet.id),
-        rows: {},
-        cols: {},
-        merges: [],
-        cells: {},
-        styles: {},
-        formats: {},
-        borders: {},
-        conditionalFormats: [],
-        dataValidationRules: [],
-        figures: [],
-        tables: [],
         areGridLinesVisible:
           sheet.areGridLinesVisible === undefined ? true : sheet.areGridLinesVisible,
         isVisible: sheet.isVisible,

--- a/src/plugins/ui_core_views/evaluation_chart.ts
+++ b/src/plugins/ui_core_views/evaluation_chart.ts
@@ -1,13 +1,14 @@
 import { BACKGROUND_CHART_COLOR } from "../../constants";
 import { chartFontColor, chartRuntimeFactory, chartToImageUrl } from "../../helpers/figures/charts";
-import { Color, ExcelWorkbookData, FigureData, Range, UID } from "../../types";
-import { ChartRuntime, ExcelChartDefinition } from "../../types/chart/chart";
+import { Color, ExcelWorkbookData, Range, UID } from "../../types";
+import { ChartRuntime } from "../../types/chart/chart";
 import {
   CoreViewCommand,
   invalidateCFEvaluationCommands,
   invalidateChartEvaluationCommands,
   invalidateEvaluationCommands,
 } from "../../types/commands";
+import { Image } from "../../types/image";
 import { CoreViewPlugin } from "../core_view_plugin";
 
 interface EvaluationChartStyle {
@@ -94,49 +95,34 @@ export class EvaluationChartPlugin extends CoreViewPlugin<EvaluationChartState> 
 
   exportForExcel(data: ExcelWorkbookData) {
     for (const sheet of data.sheets) {
-      if (!sheet.images) {
-        sheet.images = [];
-      }
-      const sheetFigures = this.getters.getFigures(sheet.id);
-      const figures: FigureData<ExcelChartDefinition>[] = [];
-      for (const figure of sheetFigures) {
-        if (!figure || figure.tag !== "chart") {
-          continue;
-        }
-        const chartId = this.getters
-          .getChartIds(sheet.id)
-          .find((chartId) => this.getters.getFigureIdFromChartId(chartId) === figure.id);
-        if (!chartId) {
-          continue;
-        }
+      for (const chartId of this.getters.getChartIds(sheet.id)) {
         const chart = this.getters.getChart(chartId);
-        const figureData = chart?.getDefinitionForExcel(this.getters);
-        if (figureData) {
-          figures.push({
-            ...figure,
-            data: figureData,
-          });
+        const excelDefinition = chart?.getDefinitionForExcel(this.getters);
+        const figureId = this.getters.getFigureIdFromChartId(chartId);
+
+        if (excelDefinition) {
+          sheet.charts[chartId] = { figureId, chart: excelDefinition };
         } else {
-          if (!chart) {
-            continue;
-          }
           const type = this.getters.getChartType(chartId);
           const runtime = this.getters.getChartRuntime(chartId);
-          const img = chartToImageUrl(runtime, figure, type);
-          if (img) {
-            sheet.images.push({
-              ...figure,
-              tag: "image",
-              data: {
+          const figure = this.getters.getFigure(sheet.id, figureId);
+          const figureData = sheet.figures.find((f) => f.id === figureId);
+
+          if (figure && figureData) {
+            const imgSrc = chartToImageUrl(runtime, figure, type);
+            if (imgSrc) {
+              const image: Image = {
                 mimetype: "image/png",
-                path: img,
+                path: imgSrc,
                 size: { width: figure.width, height: figure.height },
-              },
-            });
+              };
+              sheet.images[figureId] = { figureId, image };
+              figureData.tag = "image";
+              delete sheet.charts[chartId];
+            }
           }
         }
       }
-      sheet.charts = figures;
     }
   }
 }

--- a/src/types/workbook_data.ts
+++ b/src/types/workbook_data.ts
@@ -1,19 +1,8 @@
-import { CellValue, DataValidationRule, Format, Locale } from ".";
-import { ExcelChartDefinition } from "./chart/chart";
+import { Carousel, CellValue, DataValidationRule, Figure, Format, Locale } from ".";
+import { ChartDefinition } from "./chart/chart";
 import { ConditionalFormat } from "./conditional_formatting";
 import { Image } from "./image";
-import {
-  Border,
-  Color,
-  Dimension,
-  HeaderGroup,
-  HeaderIndex,
-  PaneDivision,
-  Pixel,
-  PixelPosition,
-  Style,
-  UID,
-} from "./misc";
+import { Border, Color, Dimension, HeaderGroup, PaneDivision, Style, UID } from "./misc";
 import { PivotCoreDefinition } from "./pivot";
 import { CoreTableType, TableConfig, TableStyleTemplateName } from "./table";
 
@@ -28,17 +17,6 @@ export interface HeaderData {
   isHidden?: boolean;
 }
 
-export interface FigureData<T> {
-  id: UID;
-  col: HeaderIndex;
-  row: HeaderIndex;
-  offset: PixelPosition;
-  width: Pixel;
-  height: Pixel;
-  tag: string;
-  data: T;
-}
-
 export interface SheetData {
   id: string;
   name: string;
@@ -49,7 +27,10 @@ export interface SheetData {
   formats: { [zone: string]: number };
   borders: { [zone: string]: number };
   merges: string[];
-  figures: FigureData<any>[];
+  figures: Figure[];
+  charts: { [chartId: string]: { figureId: UID; chart: ChartDefinition } };
+  carousels: { [carouselId: string]: { figureId: UID; carousel: Carousel } };
+  images: { [imageId: string]: { figureId: UID; image: Image } };
   cols: { [key: number]: HeaderData };
   rows: { [key: number]: HeaderData };
   conditionalFormats: ConditionalFormat[];
@@ -87,11 +68,11 @@ export interface ExcelWorkbookData extends WorkbookData {
   sheets: ExcelSheetData[];
 }
 
-export interface ExcelSheetData extends Omit<SheetData, "figureTables" | "cols" | "rows"> {
+export interface ExcelSheetData
+  extends Omit<SheetData, "figureTables" | "cols" | "rows" | "charts"> {
   cellValues: { [xc: string]: CellValue | undefined };
   formulaSpillRanges: { [xc: string]: string };
-  charts: FigureData<ExcelChartDefinition>[];
-  images: FigureData<Image>[];
+  charts: { [chartId: string]: { figureId: UID; chart: any } };
   tables: ExcelTableData[];
   cols: { [key: number]: ExcelHeaderData };
   rows: { [key: number]: ExcelHeaderData };

--- a/src/xlsx/conversion/sheet_conversion.ts
+++ b/src/xlsx/conversion/sheet_conversion.ts
@@ -55,7 +55,8 @@ export function convertSheets(
       rows: convertRows(sheet, sheetDims[1], rowHeaderGroups),
       conditionalFormats: convertConditionalFormats(sheet.cfs, data.dxfs, warningManager),
       dataValidationRules: convertDataValidationRules(sheet.dataValidations, warningManager),
-      figures: convertFigures(sheet),
+      ...convertFigures(sheet),
+      carousels: {},
       isVisible: sheet.isVisible,
       panes: sheetOptions
         ? { xSplit: sheetOptions.pane.xSplit, ySplit: sheetOptions.pane.ySplit }

--- a/src/xlsx/functions/charts.ts
+++ b/src/xlsx/functions/charts.ts
@@ -1,7 +1,7 @@
 import { CHART_AXIS_TITLE_FONT_SIZE, CHART_TITLE_FONT_SIZE } from "../../constants";
 import { ColorGenerator, largeMax, lightenColor, range } from "../../helpers";
 import { chartMutedFontColor } from "../../helpers/figures/charts";
-import { Color, ExcelWorkbookData, FigureData } from "../../types";
+import { Color, ExcelWorkbookData } from "../../types";
 import { ExcelChartDataset, ExcelChartDefinition, TitleDesign } from "../../types/chart/chart";
 import { XMLAttributes, XMLString, XlsxHexColor } from "../../types/xlsx";
 import {
@@ -45,7 +45,7 @@ const valAxId = 88853993;
 const secondaryValAxId = 88853994;
 
 export function createChart(
-  chart: FigureData<ExcelChartDefinition>,
+  chart: ExcelChartDefinition,
   chartSheetIndex: string,
   data: ExcelWorkbookData
 ): XMLDocument {
@@ -56,17 +56,17 @@ export function createChart(
   ];
 
   const chartShapeProperty = shapeProperty({
-    backgroundColor: chart.data.backgroundColor,
+    backgroundColor: chart.backgroundColor,
     line: { color: "000000" },
   });
   // <manualLayout/> to manually position the chart in the figure container
   let title = escapeXml``;
-  if (chart.data.title?.text) {
-    const titleColor = toXlsxHexColor(chartMutedFontColor(chart.data.backgroundColor));
-    const fontSize = chart.data.title.fontSize ?? CHART_TITLE_FONT_SIZE;
+  if (chart.title?.text) {
+    const titleColor = toXlsxHexColor(chartMutedFontColor(chart.backgroundColor));
+    const fontSize = chart.title.fontSize ?? CHART_TITLE_FONT_SIZE;
     title = escapeXml/*xml*/ `
       <c:title>
-        ${insertText(chart.data.title.text, titleColor, fontSize, chart.data.title)}
+        ${insertText(chart.title.text, titleColor, fontSize, chart.title)}
         <c:overlay val="0" />
       </c:title>
     `;
@@ -74,30 +74,30 @@ export function createChart(
 
   // switch on chart type
   let plot = escapeXml``;
-  switch (chart.data.type) {
+  switch (chart.type) {
     case "bar":
-      plot = addBarChart(chart.data);
+      plot = addBarChart(chart);
       break;
     case "combo":
-      plot = addComboChart(chart.data);
+      plot = addComboChart(chart);
       break;
     case "pyramid":
-      plot = addPyramidChart(chart.data);
+      plot = addPyramidChart(chart);
       break;
     case "line":
-      plot = addLineChart(chart.data);
+      plot = addLineChart(chart);
       break;
     case "scatter":
-      plot = addScatterChart(chart.data);
+      plot = addScatterChart(chart);
       break;
     case "pie":
-      plot = addDoughnutChart(chart.data, chartSheetIndex, data);
+      plot = addDoughnutChart(chart, chartSheetIndex, data);
       break;
     case "radar":
-      plot = addRadarChart(chart.data);
+      plot = addRadarChart(chart);
   }
   let position: ElementPosition = "none";
-  switch (chart.data.legendPosition) {
+  switch (chart.legendPosition) {
     case "bottom":
       position = "b";
       break;
@@ -111,7 +111,7 @@ export function createChart(
       position = "t";
       break;
   }
-  const fontColor = chart.data.fontColor;
+  const fontColor = chart.fontColor;
   const xml = escapeXml/*xml*/ `
     <c:chartSpace ${formatAttributes(namespaces)}>
       <c:roundedCorners val="0" />
@@ -124,7 +124,7 @@ export function createChart(
           <!-- how the chart element is placed on the chart -->
           <c:layout />
           ${plot}
-          ${shapeProperty({ backgroundColor: chart.data.backgroundColor })}
+          ${shapeProperty({ backgroundColor: chart.backgroundColor })}
         </c:plotArea>
         ${position !== "none" ? addLegend(position, fontColor) : ""}
       </c:chart>

--- a/src/xlsx/functions/drawings.ts
+++ b/src/xlsx/functions/drawings.ts
@@ -60,7 +60,12 @@ export function createDrawing(
           throw new Error(`Image with figureId ${figure.id} not found in sheet ${sheet.name}`);
         }
         figuresNodes.push(
-          createImageDrawing(figure, convertImageId(imageId), sheet, drawingRelIds[figureIndex])
+          createImageDrawing(
+            figure,
+            convertImageId(imageId, construct),
+            sheet,
+            drawingRelIds[figureIndex]
+          )
         );
         break;
     }

--- a/src/xlsx/helpers/content_helpers.ts
+++ b/src/xlsx/helpers/content_helpers.ts
@@ -248,17 +248,15 @@ export function convertChartId(chartId: UID, construct: XLSXStructure) {
   return xlsxId + 1;
 }
 
-const imageIds: UID[] = [];
-
 /**
  * Convert a image o-spreadsheet id to a xlsx id which
  * are unsigned integers (starting from 1).
  */
-export function convertImageId(imageId: UID) {
-  const xlsxId = imageIds.findIndex((id) => id === imageId);
+export function convertImageId(imageId: UID, construct: XLSXStructure) {
+  const xlsxId = construct.imageIds.findIndex((id) => id === imageId);
   if (xlsxId === -1) {
-    imageIds.push(imageId);
-    return imageIds.length;
+    construct.imageIds.push(imageId);
+    return construct.imageIds.length;
   }
   return xlsxId + 1;
 }

--- a/src/xlsx/xlsx_reader.ts
+++ b/src/xlsx/xlsx_reader.ts
@@ -26,7 +26,7 @@ import { getXLSXFilesOfType } from "./helpers/xlsx_helper";
 import { XLSXImportWarningManager } from "./helpers/xlsx_parser_error_manager";
 import { escapeTagNamespaces, parseXML } from "./helpers/xml_helpers";
 
-const EXCEL_IMPORT_VERSION = "18.4.2";
+const EXCEL_IMPORT_VERSION = "18.5.1";
 
 export class XlsxReader {
   warningManager: XLSXImportWarningManager;

--- a/src/xlsx/xlsx_writer.ts
+++ b/src/xlsx/xlsx_writer.ts
@@ -132,8 +132,9 @@ function createWorksheets(data: ExcelWorkbookData, construct: XLSXStructure): XL
     // Figures and Charts
     let drawingNode = escapeXml``;
     const drawingRelIds: string[] = [];
-    for (const chart of sheet.charts) {
-      const xlsxChartId = convertChartId(chart.id, construct);
+    for (const chartId in sheet.charts) {
+      const { chart } = sheet.charts[chartId];
+      const xlsxChartId = convertChartId(chartId, construct);
       const chartRelId = addRelsToFile(
         construct.relsFiles,
         `xl/drawings/_rels/drawing${sheetIndex}.xml.rels`,
@@ -152,13 +153,14 @@ function createWorksheets(data: ExcelWorkbookData, construct: XLSXStructure): XL
       );
     }
 
-    for (const image of sheet.images) {
-      const mimeType = image.data.mimetype;
+    for (const imageId in sheet.images) {
+      const { image } = sheet.images[imageId];
+      const mimeType = image.mimetype;
       if (mimeType === undefined) continue;
       const extension = IMAGE_MIMETYPE_TO_EXTENSION_MAPPING[mimeType];
       // only support exporting images with mimetypes specified in the mapping
       if (extension === undefined) continue;
-      const xlsxImageId = convertImageId(image.id);
+      const xlsxImageId = convertImageId(imageId);
       const imageFileName = `image${xlsxImageId}.${extension}`;
 
       const imageRelId = addRelsToFile(
@@ -172,11 +174,11 @@ function createWorksheets(data: ExcelWorkbookData, construct: XLSXStructure): XL
       drawingRelIds.push(imageRelId);
       files.push({
         path: `xl/media/${imageFileName}`,
-        imageSrc: image.data.path,
+        imageSrc: image.path,
       });
     }
 
-    const drawings = [...sheet.charts, ...sheet.images];
+    const drawings = sheet.figures;
     if (drawings.length) {
       const drawingRelId = addRelsToFile(
         construct.relsFiles,

--- a/src/xlsx/xlsx_writer.ts
+++ b/src/xlsx/xlsx_writer.ts
@@ -160,7 +160,7 @@ function createWorksheets(data: ExcelWorkbookData, construct: XLSXStructure): XL
       const extension = IMAGE_MIMETYPE_TO_EXTENSION_MAPPING[mimeType];
       // only support exporting images with mimetypes specified in the mapping
       if (extension === undefined) continue;
-      const xlsxImageId = convertImageId(imageId);
+      const xlsxImageId = convertImageId(imageId, construct);
       const imageFileName = `image${xlsxImageId}.${extension}`;
 
       const imageRelId = addRelsToFile(

--- a/src/xlsx/xlsx_writer.ts
+++ b/src/xlsx/xlsx_writer.ts
@@ -21,7 +21,11 @@ import { IMAGE_MIMETYPE_TO_EXTENSION_MAPPING } from "./conversion";
 import { createChart } from "./functions/charts";
 import { addConditionalFormatting } from "./functions/conditional_formatting";
 import { addDataValidationRules } from "./functions/data_validation";
-import { createDrawing } from "./functions/drawings";
+import {
+  convertCarouselsToSeparateFigures,
+  convertImageChartsToImageFigures,
+  createDrawing,
+} from "./functions/drawings";
 import {
   addBorders,
   addCellWiseConditionalFormatting,
@@ -129,11 +133,14 @@ function createWorksheets(data: ExcelWorkbookData, construct: XLSXStructure): XL
     const tablesNode = createTablesForSheet(sheet, sheetIndex, currentTableIndex, construct, files);
     currentTableIndex += sheet.tables.length;
 
+    convertCarouselsToSeparateFigures(data);
+    convertImageChartsToImageFigures(data);
+
     // Figures and Charts
     let drawingNode = escapeXml``;
     const drawingRelIds: string[] = [];
     for (const chartId in sheet.charts) {
-      const { chart } = sheet.charts[chartId];
+      const chart = sheet.charts[chartId].chart.definition;
       const xlsxChartId = convertChartId(chartId, construct);
       const chartRelId = addRelsToFile(
         construct.relsFiles,

--- a/tests/collaborative/collaborative_history.test.ts
+++ b/tests/collaborative/collaborative_history.test.ts
@@ -490,8 +490,12 @@ describe("Collaborative local history", () => {
               height: 300,
               x: 100,
               y: 100,
-              data: {
-                chartId: "chart1",
+            },
+          ],
+          charts: {
+            chart1: {
+              figureId: "fig1",
+              chart: {
                 type: "line",
                 dataSetsHaveTitle: false,
                 dataSets: [{ dataRange: "Sheet1!B26:B35" }, { dataRange: "Sheet1!C26:C35" }],
@@ -501,7 +505,7 @@ describe("Collaborative local history", () => {
                 cumulative: false,
               },
             },
-          ],
+          },
         },
       ],
     };

--- a/tests/figures/chart/charts_component.test.ts
+++ b/tests/figures/chart/charts_component.test.ts
@@ -93,7 +93,7 @@ function createTestChart(
       createChart(
         model,
         { ...TEST_CHART_DATA.basicChart, type },
-        chartId,
+        newChartId,
         undefined,
         partialFigure
       );
@@ -175,7 +175,7 @@ describe("charts", () => {
   });
 
   test.each(TEST_CHART_TYPES)("can export a chart %s", (chartType) => {
-    createTestChart(chartType, undefined, {
+    createTestChart(chartType, "chartId", {
       size: { height: 335, width: 536 },
       figureId: "figureId",
     });
@@ -184,22 +184,23 @@ describe("charts", () => {
     const sheet = data.sheets.find((s) => s.id === activeSheetId)!;
     expect(sheet.figures).toMatchObject([
       {
-        data: {
-          chartId,
-          ...TEST_CHART_DATA[chartType],
-        },
         id: "figureId",
         height: 335,
         tag: "chart",
         width: 536,
         col: 0,
         row: 0,
-        offset: {
-          x: 0,
-          y: 0,
-        },
+        offset: { x: 0, y: 0 },
       },
     ]);
+    expect(sheet.charts).toMatchObject({
+      chartId: {
+        figureId: "figureId",
+        chart: {
+          ...TEST_CHART_DATA[chartType],
+        },
+      },
+    });
   });
 
   test.each(TEST_CHART_TYPES)("charts have a menu button", async (chartType) => {
@@ -2272,6 +2273,7 @@ describe("charts with multiple sheets", () => {
   beforeEach(async () => {
     mockChartData = mockChart();
     const data = {
+      version: "18.4.1",
       sheets: [
         {
           name: "Sheet1",

--- a/tests/figures/image/image_file_store.test.ts
+++ b/tests/figures/image/image_file_store.test.ts
@@ -318,13 +318,18 @@ describe("image file store", () => {
         col: 0,
         row: 0,
         offset: { x: 0, y: 0 },
-        data: {
+      },
+    ];
+    data.sheets[0].images = {
+      imageId: {
+        figureId: "imageId",
+        image: {
           path: "/image/1",
           size: { width: 100, height: 100 },
           mimetype: "image/jpeg",
         },
       },
-    ];
+    };
     new Model(
       data,
       {

--- a/tests/figures/image/image_plugin.test.ts
+++ b/tests/figures/image/image_plugin.test.ts
@@ -161,15 +161,15 @@ describe("test image import & export", function () {
         tag: "image",
         height: 300,
         width: 400,
-        offset: {
-          x: 0,
-          y: 0,
-        },
+        offset: { x: 0, y: 0 },
         col: 0,
         row: 0,
-        data: model.getters.getImage(imageId),
       },
     ]);
+    expect(sheet.images[imageId]).toEqual({
+      figureId: imageId,
+      image: model.getters.getImage(imageId),
+    });
   });
   test("can import an image", () => {
     const model = new Model();

--- a/tests/model/data.test.ts
+++ b/tests/model/data.test.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_REVISION_ID } from "../../src/constants";
-import { getCurrentVersion, load } from "../../src/migrations/data";
+import { createEmptySheet, getCurrentVersion, load } from "../../src/migrations/data";
 import { DEFAULT_LOCALE } from "../../src/types";
 
 describe("load data", () => {
@@ -108,42 +108,8 @@ describe("load data", () => {
         ],
       }).sheets
     ).toEqual([
-      {
-        id: "1",
-        name: "Sheet1",
-        cells: {},
-        styles: {},
-        borders: {},
-        formats: {},
-        colNumber: 26,
-        rowNumber: 100,
-        cols: {},
-        rows: {},
-        merges: ["A1:B2"],
-        conditionalFormats: [],
-        dataValidationRules: [],
-        figures: [],
-        tables: [],
-        isVisible: true,
-      },
-      {
-        id: "asdf",
-        name: "Sheet2",
-        cells: {},
-        styles: {},
-        borders: {},
-        formats: {},
-        colNumber: 26,
-        rowNumber: 100,
-        cols: {},
-        rows: {},
-        merges: ["C3:D4"],
-        conditionalFormats: [],
-        dataValidationRules: [],
-        figures: [],
-        tables: [],
-        isVisible: true,
-      },
+      { ...createEmptySheet("1", "Sheet1"), merges: ["A1:B2"] },
+      { ...createEmptySheet("asdf", "Sheet2"), merges: ["C3:D4"] },
     ]);
   });
 

--- a/tests/model/model_import_export.test.ts
+++ b/tests/model/model_import_export.test.ts
@@ -8,7 +8,7 @@ import {
 } from "../../src/constants";
 import { toCartesian, toZone } from "../../src/helpers";
 import { DEFAULT_TABLE_CONFIG } from "../../src/helpers/table_presets";
-import { getCurrentVersion } from "../../src/migrations/data";
+import { createEmptySheet, getCurrentVersion } from "../../src/migrations/data";
 import {
   BorderDescr,
   ColorScaleRule,
@@ -16,6 +16,7 @@ import {
   DEFAULT_LOCALES,
   IconSetRule,
 } from "../../src/types";
+import { BarChartDefinition } from "../../src/types/chart";
 import {
   activateSheet,
   resizeColumns,
@@ -171,8 +172,7 @@ describe("Migrations", () => {
     });
 
     const data = model.exportData();
-    expect(data.sheets[0].figures[0].data).toEqual({
-      chartId: "1",
+    expect(data.sheets[0].charts["1"].chart).toEqual({
       type: "line",
       title: { text: "demo chart" },
       labelRange: "'My sheet'!A27:A35",
@@ -183,8 +183,7 @@ describe("Migrations", () => {
       stacked: false,
       humanize: true,
     });
-    expect(data.sheets[0].figures[1].data).toEqual({
-      chartId: "2",
+    expect(data.sheets[0].charts["2"].chart).toEqual({
       type: "bar",
       title: { text: "demo chart 2" },
       labelRange: "'My sheet'!A27:A35",
@@ -195,8 +194,7 @@ describe("Migrations", () => {
       stacked: false,
       humanize: true,
     });
-    expect(data.sheets[0].figures[2].data).toEqual({
-      chartId: "3",
+    expect(data.sheets[0].charts["3"].chart).toEqual({
       type: "bar",
       title: { text: "demo chart 3" },
       labelRange: "'My sheet'!A27",
@@ -207,8 +205,7 @@ describe("Migrations", () => {
       stacked: false,
       humanize: true,
     });
-    expect(data.sheets[0].figures[3].data).toEqual({
-      chartId: "4",
+    expect(data.sheets[0].charts["4"].chart).toEqual({
       type: "bar",
       title: { text: "demo chart 4" },
       labelRange: "'My sheet'!A27",
@@ -220,6 +217,7 @@ describe("Migrations", () => {
       humanize: true,
     });
   });
+
   test.each(FORBIDDEN_SHEETNAME_CHARS)("migrate version 7: sheet Names", (char) => {
     const model = new Model({
       version: 7,
@@ -294,12 +292,9 @@ describe("Migrations", () => {
     const cells = data.sheets[1].cells;
     expect(cells.A1!).toBe("=sheetName_!A2");
 
-    const figures = data.sheets[1].figures;
-    expect(figures[0].data?.dataSets).toEqual([
-      { dataRange: "A1:A2" },
-      { dataRange: "'My sheet'!A1:A2" },
-    ]);
-    expect(figures[0].data?.labelRange).toBe("sheetName_!B1:B2");
+    const chart = data.sheets[1].charts["1"].chart as BarChartDefinition;
+    expect(chart?.dataSets).toEqual([{ dataRange: "A1:A2" }, { dataRange: "'My sheet'!A1:A2" }]);
+    expect(chart?.labelRange).toBe("sheetName_!B1:B2");
 
     const cfs = data.sheets[1].conditionalFormats;
     const rule1 = cfs[0].rule as ColorScaleRule;
@@ -760,7 +755,7 @@ describe("Migrations", () => {
   });
 });
 
-test("migrate version 18.5.1: chartId is added to figure data", () => {
+test("migrate version 18.5.1: figure data is split between image and chart", () => {
   const data = {
     version: "18.4.2",
     sheets: [
@@ -768,16 +763,47 @@ test("migrate version 18.5.1: chartId is added to figure data", () => {
         id: "sh1",
         figures: [
           {
-            id: "someuuid",
+            id: "chartId",
             tag: "chart",
+            height: 380,
+            width: 380,
+            col: 0,
+            row: 0,
+            offset: { x: 0, y: 0 },
             data: { type: "line", title: "demo chart", labelRange: "", dataSets: [] },
+          },
+          {
+            id: "imageId",
+            tag: "image",
+            height: 380,
+            width: 380,
+            col: 0,
+            row: 0,
+            offset: { x: 0, y: 0 },
+            data: { path: "/image/1", size: { width: 100, height: 100 }, mimetype: "image/jpeg" },
           },
         ],
       },
     ],
   };
   const model = new Model(data);
-  expect(model.exportData().sheets[0].figures[0].data.chartId).toBe("someuuid");
+  const exportedData = model.exportData();
+  expect(exportedData.sheets[0].figures).toMatchObject([
+    { id: "chartId", tag: "chart" },
+    { id: "imageId", tag: "image" },
+  ]);
+  expect(exportedData.sheets[0].charts).toMatchObject({
+    chartId: {
+      chart: { type: "line", title: "demo chart" },
+      figureId: "chartId",
+    },
+  });
+  expect(exportedData.sheets[0].images).toMatchObject({
+    imageId: {
+      image: { path: "/image/1", size: { width: 100, height: 100 }, mimetype: "image/jpeg" },
+      figureId: "imageId",
+    },
+  });
 });
 
 describe("Import", () => {
@@ -910,9 +936,7 @@ test("complete import, then export", () => {
     revisionId: DEFAULT_REVISION_ID,
     sheets: [
       {
-        id: "someuuid",
-        colNumber: 10,
-        rowNumber: 10,
+        ...createEmptySheet("someuuid", "My sheet"),
         merges: ["A1:A2"],
         cols: {
           0: { size: 42 },
@@ -939,35 +963,16 @@ test("complete import, then export", () => {
           B1: 2,
         },
         name: "My sheet",
-        conditionalFormats: [],
-        dataValidationRules: [],
-        figures: [],
-        tables: [],
         areGridLinesVisible: true,
-        isVisible: true,
         panes: { ySplit: 1, xSplit: 5 },
         headerGroups: { COL: [], ROW: [] },
       },
       {
-        id: "someuuid_2",
-        colNumber: 10,
-        rowNumber: 10,
-        merges: [],
-        cols: {},
-        rows: {},
+        ...createEmptySheet("someuuid_2", "My sheet 2"),
         cells: {
           A1: "hello",
         },
-        styles: {},
-        formats: {},
-        borders: {},
-        name: "My sheet 2",
-        conditionalFormats: [],
-        dataValidationRules: [],
-        figures: [],
-        tables: [],
         areGridLinesVisible: false,
-        isVisible: true,
         headerGroups: { COL: [], ROW: [] },
       },
     ],
@@ -1041,19 +1046,7 @@ test("import then export (figures)", () => {
     revisionId: DEFAULT_REVISION_ID,
     sheets: [
       {
-        id: "someuuid",
-        colNumber: 10,
-        rowNumber: 10,
-        merges: [],
-        cols: {},
-        rows: {},
-        cells: {},
-        styles: {},
-        formats: {},
-        borders: {},
-        name: "My sheet",
-        conditionalFormats: [],
-        dataValidationRules: [],
+        ...createEmptySheet("someuuid", "My sheet"),
         figures: [
           {
             id: "otheruuid",
@@ -1064,9 +1057,7 @@ test("import then export (figures)", () => {
             height: 100,
           },
         ],
-        tables: [],
         areGridLinesVisible: true,
-        isVisible: true,
         headerGroups: { COL: [], ROW: [] },
       },
     ],

--- a/tests/test_helpers/xlsx.ts
+++ b/tests/test_helpers/xlsx.ts
@@ -1,5 +1,13 @@
 import { isSheetNameEqual, toCartesian, toXC, toZone } from "../../src/helpers";
-import { Border, Color, ConditionalFormat, Style } from "../../src/types";
+import {
+  Border,
+  ChartDefinition,
+  Color,
+  ConditionalFormat,
+  Figure,
+  Style,
+  UID,
+} from "../../src/types";
 import { DEFAULT_CELL_HEIGHT, DEFAULT_CELL_WIDTH } from "./../../src/constants";
 import { DataValidationRuleData, SheetData, WorkbookData } from "./../../src/types/workbook_data";
 
@@ -98,4 +106,21 @@ export function getRowPosition(row: number, sheetData: SheetData) {
     position += sheetData.rows[i]?.size || DEFAULT_CELL_HEIGHT;
   }
   return position;
+}
+
+export function getWorkbookChartWithTitle(
+  sheet: SheetData,
+  chartTitle: string
+): { chartId: UID; figureId: UID; chart: ChartDefinition; figure: Figure } {
+  const chartId = Object.keys(sheet.charts).find(
+    (id) => sheet.charts[id].chart.title.text === chartTitle
+  )!;
+  const figureId = sheet.charts[chartId].figureId;
+  const figure = sheet.figures.find((figure) => figure.id === figureId)!;
+  return {
+    chartId,
+    figureId,
+    chart: sheet.charts[chartId].chart,
+    figure,
+  };
 }

--- a/tests/xlsx/__snapshots__/xlsx_export.test.ts.snap
+++ b/tests/xlsx/__snapshots__/xlsx_export.test.ts.snap
@@ -28218,7 +28218,7 @@ exports[`Test XLSX export Images image larger than the sheet 1`] = `
     },
     {
       "imageSrc": "image path",
-      "path": "xl/media/image7.jpeg",
+      "path": "xl/media/image1.jpeg",
     },
     {
       "content": "<xdr:wsDr xmlns:xdr="http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
@@ -28253,7 +28253,7 @@ exports[`Test XLSX export Images image larger than the sheet 1`] = `
         </xdr:to>
         <xdr:pic>
             <xdr:nvPicPr>
-                <xdr:cNvPr id="7" name="Image 7" title="Image"/>
+                <xdr:cNvPr id="1" name="Image 1" title="Image"/>
                 <xdr:cNvPicPr preferRelativeResize="0"/>
             </xdr:nvPicPr>
             <xdr:blipFill>
@@ -28402,7 +28402,7 @@ exports[`Test XLSX export Images image larger than the sheet 1`] = `
     },
     {
       "content": "<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
-    <Relationship Id="rId1" Target="../media/image7.jpeg" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image"/>
+    <Relationship Id="rId1" Target="../media/image1.jpeg" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/drawings/_rels/drawing0.xml.rels",
@@ -28462,7 +28462,7 @@ exports[`Test XLSX export Images image overflowing outside the sheet 1`] = `
     },
     {
       "imageSrc": "image path",
-      "path": "xl/media/image6.jpeg",
+      "path": "xl/media/image1.jpeg",
     },
     {
       "content": "<xdr:wsDr xmlns:xdr="http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
@@ -28497,7 +28497,7 @@ exports[`Test XLSX export Images image overflowing outside the sheet 1`] = `
         </xdr:to>
         <xdr:pic>
             <xdr:nvPicPr>
-                <xdr:cNvPr id="6" name="Image 6" title="Image"/>
+                <xdr:cNvPr id="1" name="Image 1" title="Image"/>
                 <xdr:cNvPicPr preferRelativeResize="0"/>
             </xdr:nvPicPr>
             <xdr:blipFill>
@@ -28646,7 +28646,7 @@ exports[`Test XLSX export Images image overflowing outside the sheet 1`] = `
     },
     {
       "content": "<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
-    <Relationship Id="rId1" Target="../media/image6.jpeg" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image"/>
+    <Relationship Id="rId1" Target="../media/image1.jpeg" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/drawings/_rels/drawing0.xml.rels",
@@ -28707,7 +28707,7 @@ exports[`Test XLSX export Images images in different sheets 1`] = `
     },
     {
       "imageSrc": "image path",
-      "path": "xl/media/image4.jpeg",
+      "path": "xl/media/image1.jpeg",
     },
     {
       "content": "<xdr:wsDr xmlns:xdr="http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
@@ -28742,7 +28742,7 @@ exports[`Test XLSX export Images images in different sheets 1`] = `
         </xdr:to>
         <xdr:pic>
             <xdr:nvPicPr>
-                <xdr:cNvPr id="4" name="Image 4" title="Image"/>
+                <xdr:cNvPr id="1" name="Image 1" title="Image"/>
                 <xdr:cNvPicPr preferRelativeResize="0"/>
             </xdr:nvPicPr>
             <xdr:blipFill>
@@ -28810,7 +28810,7 @@ exports[`Test XLSX export Images images in different sheets 1`] = `
     },
     {
       "imageSrc": "image path",
-      "path": "xl/media/image5.jpeg",
+      "path": "xl/media/image2.jpeg",
     },
     {
       "content": "<xdr:wsDr xmlns:xdr="http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
@@ -28845,7 +28845,7 @@ exports[`Test XLSX export Images images in different sheets 1`] = `
         </xdr:to>
         <xdr:pic>
             <xdr:nvPicPr>
-                <xdr:cNvPr id="5" name="Image 5" title="Image"/>
+                <xdr:cNvPr id="2" name="Image 2" title="Image"/>
                 <xdr:cNvPicPr preferRelativeResize="0"/>
             </xdr:nvPicPr>
             <xdr:blipFill>
@@ -28996,7 +28996,7 @@ exports[`Test XLSX export Images images in different sheets 1`] = `
     },
     {
       "content": "<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
-    <Relationship Id="rId1" Target="../media/image4.jpeg" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image"/>
+    <Relationship Id="rId1" Target="../media/image1.jpeg" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/drawings/_rels/drawing0.xml.rels",
@@ -29010,7 +29010,7 @@ exports[`Test XLSX export Images images in different sheets 1`] = `
     },
     {
       "content": "<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
-    <Relationship Id="rId1" Target="../media/image5.jpeg" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image"/>
+    <Relationship Id="rId1" Target="../media/image2.jpeg" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/drawings/_rels/drawing1.xml.rels",
@@ -29072,11 +29072,11 @@ exports[`Test XLSX export Images multiple images in the same sheet 1`] = `
     },
     {
       "imageSrc": "image path",
-      "path": "xl/media/image2.jpeg",
+      "path": "xl/media/image1.jpeg",
     },
     {
       "imageSrc": "image path",
-      "path": "xl/media/image3.jpeg",
+      "path": "xl/media/image2.jpeg",
     },
     {
       "content": "<xdr:wsDr xmlns:xdr="http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
@@ -29111,7 +29111,7 @@ exports[`Test XLSX export Images multiple images in the same sheet 1`] = `
         </xdr:to>
         <xdr:pic>
             <xdr:nvPicPr>
-                <xdr:cNvPr id="2" name="Image 2" title="Image"/>
+                <xdr:cNvPr id="1" name="Image 1" title="Image"/>
                 <xdr:cNvPicPr preferRelativeResize="0"/>
             </xdr:nvPicPr>
             <xdr:blipFill>
@@ -29163,7 +29163,7 @@ exports[`Test XLSX export Images multiple images in the same sheet 1`] = `
         </xdr:to>
         <xdr:pic>
             <xdr:nvPicPr>
-                <xdr:cNvPr id="3" name="Image 3" title="Image"/>
+                <xdr:cNvPr id="2" name="Image 2" title="Image"/>
                 <xdr:cNvPicPr preferRelativeResize="0"/>
             </xdr:nvPicPr>
             <xdr:blipFill>
@@ -29312,8 +29312,8 @@ exports[`Test XLSX export Images multiple images in the same sheet 1`] = `
     },
     {
       "content": "<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
-    <Relationship Id="rId1" Target="../media/image2.jpeg" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image"/>
-    <Relationship Id="rId2" Target="../media/image3.jpeg" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image"/>
+    <Relationship Id="rId1" Target="../media/image1.jpeg" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image"/>
+    <Relationship Id="rId2" Target="../media/image2.jpeg" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/drawings/_rels/drawing0.xml.rels",

--- a/tests/xlsx/__snapshots__/xlsx_export.test.ts.snap
+++ b/tests/xlsx/__snapshots__/xlsx_export.test.ts.snap
@@ -1,5 +1,442 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Test XLSX export Carousel is exported as multiple chart figures 1`] = `
+{
+  "files": [
+    {
+      "content": "<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+    <sheets>
+        <sheet state="visible" name="Sheet1" sheetId="1" r:id="rId1"/>
+    </sheets>
+</workbook>",
+      "contentType": "workbook",
+      "path": "xl/workbook.xml",
+    },
+    {
+      "content": "<c:chartSpace xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+    <c:roundedCorners val="0"/>
+    <!-- <manualLayout/> to manually position the chart in the figure container -->
+    <c:spPr>
+        <a:solidFill>
+            <a:srgbClr val="FFFFFF"/>
+        </a:solidFill>
+        <a:ln cmpd="sng">
+            <a:solidFill>
+                <a:srgbClr val="000000"/>
+            </a:solidFill>
+        </a:ln>
+    </c:spPr>
+    <c:chart>
+        <c:autoTitleDeleted val="0"/>
+        <c:plotArea>
+            <!-- how the chart element is placed on the chart -->
+            <c:layout/>
+            <c:spPr>
+                <a:solidFill>
+                    <a:srgbClr val="FFFFFF"/>
+                </a:solidFill>
+            </c:spPr>
+        </c:plotArea>
+        <c:legend>
+            <c:legendPos val="t"/>
+            <c:overlay val="0"/>
+            <c:txPr>
+                <a:bodyPr/>
+                <a:lstStyle/>
+                <a:p>
+                    <a:pPr lvl="0">
+                        <a:defRPr b="0" i="0" sz="1000">
+                            <a:solidFill>
+                                <a:srgbClr val="000000"/>
+                            </a:solidFill>
+                            <a:latin typeface="+mn-lt"/>
+                        </a:defRPr>
+                    </a:pPr>
+                </a:p>
+            </c:txPr>
+        </c:legend>
+    </c:chart>
+</c:chartSpace>",
+      "contentType": "chart",
+      "path": "xl/charts/chart1.xml",
+    },
+    {
+      "content": "<c:chartSpace xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+    <c:roundedCorners val="0"/>
+    <!-- <manualLayout/> to manually position the chart in the figure container -->
+    <c:spPr>
+        <a:solidFill>
+            <a:srgbClr val="FFFFFF"/>
+        </a:solidFill>
+        <a:ln cmpd="sng">
+            <a:solidFill>
+                <a:srgbClr val="000000"/>
+            </a:solidFill>
+        </a:ln>
+    </c:spPr>
+    <c:chart>
+        <c:autoTitleDeleted val="0"/>
+        <c:plotArea>
+            <!-- how the chart element is placed on the chart -->
+            <c:layout/>
+            <c:spPr>
+                <a:solidFill>
+                    <a:srgbClr val="FFFFFF"/>
+                </a:solidFill>
+            </c:spPr>
+        </c:plotArea>
+        <c:legend>
+            <c:legendPos val="t"/>
+            <c:overlay val="0"/>
+            <c:txPr>
+                <a:bodyPr/>
+                <a:lstStyle/>
+                <a:p>
+                    <a:pPr lvl="0">
+                        <a:defRPr b="0" i="0" sz="1000">
+                            <a:solidFill>
+                                <a:srgbClr val="000000"/>
+                            </a:solidFill>
+                            <a:latin typeface="+mn-lt"/>
+                        </a:defRPr>
+                    </a:pPr>
+                </a:p>
+            </c:txPr>
+        </c:legend>
+    </c:chart>
+</c:chartSpace>",
+      "contentType": "chart",
+      "path": "xl/charts/chart2.xml",
+    },
+    {
+      "imageSrc": "data:image/png;base64,randomDataThatIsActuallyABase64Image",
+      "path": "xl/media/image1.png",
+    },
+    {
+      "content": "<xdr:wsDr xmlns:xdr="http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+    <xdr:twoCellAnchor>
+        <xdr:from>
+            <xdr:col>
+                0
+            </xdr:col>
+            <xdr:colOff>
+                9525
+            </xdr:colOff>
+            <xdr:row>
+                0
+            </xdr:row>
+            <xdr:rowOff>
+                9525
+            </xdr:rowOff>
+        </xdr:from>
+        <xdr:to>
+            <xdr:col>
+                1
+            </xdr:col>
+            <xdr:colOff>
+                47625
+            </xdr:colOff>
+            <xdr:row>
+                4
+            </xdr:row>
+            <xdr:rowOff>
+                85725
+            </xdr:rowOff>
+        </xdr:to>
+        <xdr:graphicFrame>
+            <xdr:nvGraphicFramePr>
+                <xdr:cNvPr id="1" name="Chart 1" title="Chart"/>
+                <xdr:cNvGraphicFramePr/>
+            </xdr:nvGraphicFramePr>
+            <xdr:xfrm>
+                <a:off x="0" y="0"/>
+                <a:ext cx="0" cy="0"/>
+            </xdr:xfrm>
+            <a:graphic>
+                <a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/chart">
+                    <c:chart r:id="rId1"/>
+                </a:graphicData>
+            </a:graphic>
+        </xdr:graphicFrame>
+        <xdr:clientData fLocksWithSheet="0"/>
+    </xdr:twoCellAnchor>
+    <xdr:twoCellAnchor>
+        <xdr:from>
+            <xdr:col>
+                0
+            </xdr:col>
+            <xdr:colOff>
+                104775
+            </xdr:colOff>
+            <xdr:row>
+                0
+            </xdr:row>
+            <xdr:rowOff>
+                104775
+            </xdr:rowOff>
+        </xdr:from>
+        <xdr:to>
+            <xdr:col>
+                1
+            </xdr:col>
+            <xdr:colOff>
+                142875
+            </xdr:colOff>
+            <xdr:row>
+                4
+            </xdr:row>
+            <xdr:rowOff>
+                180975
+            </xdr:rowOff>
+        </xdr:to>
+        <xdr:graphicFrame>
+            <xdr:nvGraphicFramePr>
+                <xdr:cNvPr id="2" name="Chart 2" title="Chart"/>
+                <xdr:cNvGraphicFramePr/>
+            </xdr:nvGraphicFramePr>
+            <xdr:xfrm>
+                <a:off x="0" y="0"/>
+                <a:ext cx="0" cy="0"/>
+            </xdr:xfrm>
+            <a:graphic>
+                <a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/chart">
+                    <c:chart r:id="rId2"/>
+                </a:graphicData>
+            </a:graphic>
+        </xdr:graphicFrame>
+        <xdr:clientData fLocksWithSheet="0"/>
+    </xdr:twoCellAnchor>
+    <xdr:twoCellAnchor editAs="oneCell">
+        <xdr:from>
+            <xdr:col>
+                0
+            </xdr:col>
+            <xdr:colOff>
+                200025
+            </xdr:colOff>
+            <xdr:row>
+                0
+            </xdr:row>
+            <xdr:rowOff>
+                200025
+            </xdr:rowOff>
+        </xdr:from>
+        <xdr:to>
+            <xdr:col>
+                1
+            </xdr:col>
+            <xdr:colOff>
+                238125
+            </xdr:colOff>
+            <xdr:row>
+                5
+            </xdr:row>
+            <xdr:rowOff>
+                57150
+            </xdr:rowOff>
+        </xdr:to>
+        <xdr:pic>
+            <xdr:nvPicPr>
+                <xdr:cNvPr id="1" name="Image 1" title="Image"/>
+                <xdr:cNvPicPr preferRelativeResize="0"/>
+            </xdr:nvPicPr>
+            <xdr:blipFill>
+                <a:blip cstate="print" r:embed="rId3"/>
+                <a:stretch>
+                    <a:fillRect/>
+                </a:stretch>
+            </xdr:blipFill>
+            <xdr:spPr>
+                <a:xfrm>
+                    <a:ext cx="952500" cy="952500"/>
+                </a:xfrm>
+                <a:prstGeom prst="rect">
+                    <a:avLst/>
+                </a:prstGeom>
+                <a:noFill/>
+            </xdr:spPr>
+        </xdr:pic>
+        <xdr:clientData fLocksWithSheet="0"/>
+    </xdr:twoCellAnchor>
+</xdr:wsDr>",
+      "contentType": "drawing",
+      "path": "xl/drawings/drawing0.xml",
+    },
+    {
+      "content": "<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+    <sheetViews>
+        <sheetView showGridLines="1" workbookViewId="0">
+        </sheetView>
+    </sheetViews>
+    <sheetFormatPr defaultRowHeight="17.25" defaultColWidth="13.73"/>
+    <cols>
+        <col min="1" max="1" width="13.73" customWidth="1" hidden="0"/>
+        <col min="2" max="2" width="13.73" customWidth="1" hidden="0"/>
+        <col min="3" max="3" width="13.73" customWidth="1" hidden="0"/>
+        <col min="4" max="4" width="13.73" customWidth="1" hidden="0"/>
+        <col min="5" max="5" width="13.73" customWidth="1" hidden="0"/>
+        <col min="6" max="6" width="13.73" customWidth="1" hidden="0"/>
+        <col min="7" max="7" width="13.73" customWidth="1" hidden="0"/>
+        <col min="8" max="8" width="13.73" customWidth="1" hidden="0"/>
+        <col min="9" max="9" width="13.73" customWidth="1" hidden="0"/>
+        <col min="10" max="10" width="13.73" customWidth="1" hidden="0"/>
+        <col min="11" max="11" width="13.73" customWidth="1" hidden="0"/>
+        <col min="12" max="12" width="13.73" customWidth="1" hidden="0"/>
+        <col min="13" max="13" width="13.73" customWidth="1" hidden="0"/>
+        <col min="14" max="14" width="13.73" customWidth="1" hidden="0"/>
+        <col min="15" max="15" width="13.73" customWidth="1" hidden="0"/>
+        <col min="16" max="16" width="13.73" customWidth="1" hidden="0"/>
+        <col min="17" max="17" width="13.73" customWidth="1" hidden="0"/>
+        <col min="18" max="18" width="13.73" customWidth="1" hidden="0"/>
+        <col min="19" max="19" width="13.73" customWidth="1" hidden="0"/>
+        <col min="20" max="20" width="13.73" customWidth="1" hidden="0"/>
+        <col min="21" max="21" width="13.73" customWidth="1" hidden="0"/>
+        <col min="22" max="22" width="13.73" customWidth="1" hidden="0"/>
+        <col min="23" max="23" width="13.73" customWidth="1" hidden="0"/>
+        <col min="24" max="24" width="13.73" customWidth="1" hidden="0"/>
+        <col min="25" max="25" width="13.73" customWidth="1" hidden="0"/>
+        <col min="26" max="26" width="13.73" customWidth="1" hidden="0"/>
+    </cols>
+    <sheetData>
+    </sheetData>
+    <drawing r:id="rId1"/>
+</worksheet>",
+      "contentType": "sheet",
+      "path": "xl/worksheets/sheet0.xml",
+    },
+    {
+      "content": "<metadata xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:xda="http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray">
+    <metadataTypes count="1">
+        <metadataType name="XLDAPR" minSupportedVersion="120000" copy="1" pasteAll="1" pasteValues="1" merge="1" splitFirst="1" rowColShift="1" clearFormats="1" clearComments="1" assign="1" coerce="1" cellMeta="1"/>
+    </metadataTypes>
+    <futureMetadata name="XLDAPR" count="1">
+        <bk>
+            <extLst>
+                <ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}">
+                    <xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>
+                </ext>
+            </extLst>
+        </bk>
+    </futureMetadata>
+    <cellMetadata count="1">
+        <bk>
+            <rc t="1" v="0"/>
+        </bk>
+    </cellMetadata>
+</metadata>",
+      "contentType": "metadata",
+      "path": "xl/metadata.xml",
+    },
+    {
+      "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+    <numFmts count="0">
+    </numFmts>
+    <fonts count="1">
+        <font>
+            <sz val="10"/>
+            <color rgb="000000"/>
+            <name val="Arial"/>
+        </font>
+    </fonts>
+    <fills count="2">
+        <fill>
+            <patternFill patternType="none"/>
+        </fill>
+        <fill>
+            <patternFill patternType="gray125"/>
+        </fill>
+    </fills>
+    <borders count="1">
+        <border>
+            <left>
+            </left>
+            <right>
+            </right>
+            <top>
+            </top>
+            <bottom>
+            </bottom>
+            <diagonal>
+            </diagonal>
+        </border>
+    </borders>
+    <cellXfs count="1">
+        <xf numFmtId="0" fillId="0" fontId="0" borderId="0"/>
+    </cellXfs>
+    <dxfs count="0">
+    </dxfs>
+</styleSheet>",
+      "contentType": "styles",
+      "path": "xl/styles.xml",
+    },
+    {
+      "content": "<sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" count="0" uniqueCount="0">
+</sst>",
+      "contentType": "sharedStrings",
+      "path": "xl/sharedStrings.xml",
+    },
+    {
+      "content": "<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+    <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
+    <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
+    <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+    <Relationship Id="rId4" Target="metadata.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"/>
+</Relationships>",
+      "contentType": undefined,
+      "path": "xl/_rels/workbook.xml.rels",
+    },
+    {
+      "content": "<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+    <Relationship Id="rId1" Target="../charts/chart1.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart"/>
+    <Relationship Id="rId2" Target="../charts/chart2.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart"/>
+    <Relationship Id="rId3" Target="../media/image1.png" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image"/>
+</Relationships>",
+      "contentType": undefined,
+      "path": "xl/drawings/_rels/drawing0.xml.rels",
+    },
+    {
+      "content": "<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+    <Relationship Id="rId1" Target="../drawings/drawing0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/drawing"/>
+</Relationships>",
+      "contentType": undefined,
+      "path": "xl/worksheets/_rels/sheet0.xml.rels",
+    },
+    {
+      "content": "<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+    <Default Extension="avif" ContentType="image/avif"/>
+    <Default Extension="bmp" ContentType="image/bmp"/>
+    <Default Extension="gif" ContentType="image/gif"/>
+    <Default Extension="ico" ContentType="image/vnd.microsoft.icon"/>
+    <Default Extension="jpeg" ContentType="image/jpeg"/>
+    <Default Extension="png" ContentType="image/png"/>
+    <Default Extension="tiff" ContentType="image/tiff"/>
+    <Default Extension="webp" ContentType="image/webp"/>
+    <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+    <Default Extension="xml" ContentType="application/xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml" PartName="/xl/workbook.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml" PartName="/xl/charts/chart1.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml" PartName="/xl/charts/chart2.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.drawing+xml" PartName="/xl/drawings/drawing0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml" PartName="/xl/metadata.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
+</Types>",
+      "contentType": undefined,
+      "path": "[Content_Types].xml",
+    },
+    {
+      "content": "<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+    <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>",
+      "contentType": undefined,
+      "path": "_rels/.rels",
+    },
+  ],
+  "name": "my_spreadsheet.xlsx",
+}
+`;
+
 exports[`Test XLSX export Charts Chart legend is set to none position 1`] = `
 {
   "files": [

--- a/tests/xlsx/xlsx_export.test.ts
+++ b/tests/xlsx/xlsx_export.test.ts
@@ -1263,7 +1263,7 @@ describe("Test XLSX export", () => {
         "2"
       );
       const exported = getExportedExcelData(model);
-      expect(exported.sheets[0].charts[0].data).toEqual(exported.sheets[0].charts[1].data);
+      expect(exported.sheets[0].charts["1"].chart).toEqual(exported.sheets[0].charts["2"].chart);
     });
 
     test("multiple charts in the same sheet", async () => {
@@ -1340,8 +1340,8 @@ describe("Test XLSX export", () => {
         const model = new Model();
         createChart(model, { aggregated: true, type }, "1");
         const exportedData = getExportedExcelData(model);
-        expect(exportedData.sheets[0].charts.length).toBe(1);
-        expect(exportedData.sheets[0].images.length).toBe(0);
+        expect(Object.keys(exportedData.sheets[0].charts).length).toBe(1);
+        expect(Object.keys(exportedData.sheets[0].images).length).toBe(0);
       }
     );
 
@@ -1350,8 +1350,9 @@ describe("Test XLSX export", () => {
         sheets: chartData.sheets,
       });
       createScorecardChart(model, TEST_CHART_DATA.scorecard);
-      expect(getExportedExcelData(model).sheets[0].charts.length).toBe(0);
-      expect(getExportedExcelData(model).sheets[0].images.length).toBe(1);
+      const exportedData = getExportedExcelData(model);
+      expect(Object.keys(exportedData.sheets[0].charts).length).toBe(0);
+      expect(Object.keys(exportedData.sheets[0].images).length).toBe(1);
     });
 
     test("Gauge Chart is exported as an image", () => {
@@ -1359,8 +1360,9 @@ describe("Test XLSX export", () => {
         sheets: chartData.sheets,
       });
       createGaugeChart(model, TEST_CHART_DATA.gauge);
-      expect(getExportedExcelData(model).sheets[0].charts.length).toBe(0);
-      expect(getExportedExcelData(model).sheets[0].images.length).toBe(1);
+      const exportedData = getExportedExcelData(model);
+      expect(Object.keys(exportedData.sheets[0].charts).length).toBe(0);
+      expect(Object.keys(exportedData.sheets[0].images).length).toBe(1);
     });
 
     test("stacked bar chart", async () => {
@@ -1904,11 +1906,15 @@ describe("Test XLSX export", () => {
     createSheet(model, { name: longSheetNameWithSpaces });
     createSheet(model, { name: longSheetName });
     setCellContent(model, "A1", `='${longSheetNameWithSpaces}'!A1`);
-    createChart(model, {
-      type: "bar",
-      dataSets: [{ dataRange: `${longSheetName}!A1:A4` }],
-      labelRange: `${longSheetName}!A1:A4`,
-    });
+    createChart(
+      model,
+      {
+        type: "bar",
+        dataSets: [{ dataRange: `${longSheetName}!A1:A4` }],
+        labelRange: `${longSheetName}!A1:A4`,
+      },
+      "chartId"
+    );
 
     const fixedSheetName = "a".repeat(31);
     const fixedSheetNameWithSpaces = "Hey " + "a".repeat(27);
@@ -1916,8 +1922,10 @@ describe("Test XLSX export", () => {
     expect(exportedData.sheets[1].name).toBe(fixedSheetName);
     expect(exportedData.sheets[0].cells["A1"]).toBe(`='${fixedSheetNameWithSpaces}'!A1`);
     expect(exportedData.sheets[0].cells["A1"]).toBe(`='${fixedSheetNameWithSpaces}'!A1`);
-    expect(exportedData.sheets[0].charts[0].data.labelRange).toBe(`${fixedSheetName}!A2:A4`);
-    expect(exportedData.sheets[0].charts[0].data.dataSets[0]).toEqual({
+    expect(exportedData.sheets[0].charts["chartId"].chart.labelRange).toBe(
+      `${fixedSheetName}!A2:A4`
+    );
+    expect(exportedData.sheets[0].charts["chartId"].chart.dataSets[0]).toEqual({
       label: {
         reference: `${fixedSheetName}!A1`,
       },


### PR DESCRIPTION
wip 

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo