### PR TITLE
[REV] xlsx: make import verbose

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -190,7 +190,7 @@ export class Model extends EventBus<any> implements CommandDispatcher {
     config: Partial<ModelConfig> = {},
     stateUpdateMessages: StateUpdateMessage[] = [],
     uuidGenerator: UuidGenerator = new UuidGenerator(),
-    verboseImport = true
+    verboseImport = false
   ) {
     const start = performance.now();
     console.debug("##### Model creation #####");

--- a/tests/model/model.test.ts
+++ b/tests/model/model.test.ts
@@ -374,16 +374,10 @@ describe("Model", () => {
     const transport = new MockTransportService();
     const spy = jest.spyOn(transport, "sendMessage");
     const xlsxData = await getTextXlsxFiles();
-    new Model(
-      xlsxData,
-      {
-        transportService: transport,
-        client: { id: "test", name: "Test" },
-      },
-      undefined,
-      undefined,
-      false
-    );
+    new Model(xlsxData, {
+      transportService: transport,
+      client: { id: "test", name: "Test" },
+    });
     expect(spy).toHaveBeenCalledWith({
       type: "SNAPSHOT",
       version: MESSAGE_VERSION,
@@ -397,17 +391,11 @@ describe("Model", () => {
     const transport = new MockTransportService();
     const spy = jest.spyOn(transport, "sendMessage");
     const xlsxData = await getTextXlsxFiles();
-    new Model(
-      xlsxData,
-      {
-        transportService: transport,
-        client: { id: "test", name: "Test" },
-        mode: "readonly",
-      },
-      undefined,
-      undefined,
-      false
-    );
+    new Model(xlsxData, {
+      transportService: transport,
+      client: { id: "test", name: "Test" },
+      mode: "readonly",
+    });
     expect(spy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
This reverts commit e726d26b09531aa4ae671322706e8eb7c6eefd2f as this flag makes runbot red due to warnings.

Task: 0

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo