### PR TITLE
[FIX] charts: prevent unnecessary treemap animations

### DIFF
--- a/src/helpers/misc.ts
+++ b/src/helpers/misc.ts
@@ -389,7 +389,7 @@ export function getAddHeaderStartIndex(position: "before" | "after", base: numbe
 /**
  * Compares two objects.
  */
-export function deepEquals(o1: any, o2: any): boolean {
+export function deepEquals(o1: any, o2: any, ignoreFunctions?: "ignoreFunctions"): boolean {
   if (o1 === o2) return true;
   if ((o1 && !o2) || (o2 && !o1)) return false;
   if (typeof o1 !== typeof o2) return false;
@@ -405,8 +405,9 @@ export function deepEquals(o1: any, o2: any): boolean {
   for (const key in o1) {
     if (typeof o1[key] !== typeof o2[key]) return false;
     if (typeof o1[key] === "object") {
-      if (!deepEquals(o1[key], o2[key])) return false;
+      if (!deepEquals(o1[key], o2[key], ignoreFunctions)) return false;
     } else {
+      if (ignoreFunctions && typeof o1[key] === "function") return true;
       if (o1[key] !== o2[key]) return false;
     }
   }


### PR DESCRIPTION
## Description

Charts animations are played every time the chart data changes in dashboards. But the treemap data contains callbacks, which mess up the `deepEqual` we use to check if the data changed, since new callbacks are created each time.

This adds an argument to `deepEqual` to ignore functions.

Task: [5003595](https://www.odoo.com/odoo/2328/tasks/5003595)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo