### PR TITLE
[FIX] xlsx: remove useless warnings on import

### DIFF
--- a/src/xlsx/conversion/conversion_maps.ts
+++ b/src/xlsx/conversion/conversion_maps.ts
@@ -29,7 +29,7 @@ export const SUPPORTED_HORIZONTAL_ALIGNMENTS: XLSXHorizontalAlignment[] = [
 ];
 export const SUPPORTED_VERTICAL_ALIGNMENTS: XLSXVerticalAlignment[] = ["top", "center", "bottom"];
 export const SUPPORTED_FONTS = ["Arial"];
-export const SUPPORTED_FILL_PATTERNS = ["solid"];
+export const SUPPORTED_FILL_PATTERNS = ["solid", "none"];
 export const SUPPORTED_CF_TYPES = [
   "expression",
   "cellIs",
@@ -234,7 +234,7 @@ export const SUBTOTAL_FUNCTION_CONVERSION_MAP: Record<number, string> = {
 
 /** Mapping between Excel format indexes (see XLSX_FORMAT_MAP) and some supported formats  */
 export const XLSX_FORMATS_CONVERSION_MAP: Record<number, string | undefined> = {
-  0: "",
+  0: "General",
   1: "0",
   2: "0.00",
   3: "#,#00",

--- a/src/xlsx/conversion/format_conversion.ts
+++ b/src/xlsx/conversion/format_conversion.ts
@@ -16,13 +16,13 @@ export function convertXlsxFormat(
   formats: XLSXNumFormat[],
   warningManager: XLSXImportWarningManager
 ): string | undefined {
-  if (numFmtId === 0) {
-    return undefined;
-  }
   // Format is either defined in the imported data, or the formatId is defined in openXML §18.8.30
   let format =
     XLSX_FORMATS_CONVERSION_MAP[numFmtId] || formats.find((f) => f.id === numFmtId)?.format;
 
+  if (format === "General") {
+    return undefined;
+  }
   if (format) {
     try {
       let convertedFormat = format.replace(/(.*?);.*/, "$1"); // only take first part of multi-part format


### PR DESCRIPTION
## Description

We generate some useless warnings when importing an xlsx:

- "FillStyle 'none' is not supported". We obviously support "none" fill style, as it is just the absence of fill style.

- "Number format 'General' is not supported". "General" is the default number format of a spreadsheet application, we support it. The conversion of the format was slightly wrong, as we only checked for "General" format for excel defaults format (numFmtId === 0), but not for user defined format with "General" as formatCode.

Task: [5075112](https://www.odoo.com/odoo/2328/tasks/5075112)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo