### PR TITLE
[FIX] dashboard: align sort icon with text

### DIFF
--- a/src/components/dashboard/clickable_cell_sort_icon/clickable_cell_sort_icon.ts
+++ b/src/components/dashboard/clickable_cell_sort_icon/clickable_cell_sort_icon.ts
@@ -31,18 +31,20 @@ export class ClickableCellSortIcon extends Component<Props, SpreadsheetChildEnv>
     });
   }
 
-  get icon() {
-    switch (this.props.sortDirection) {
-      case "asc":
-        return "fa-sort-asc";
-      case "desc":
-        return "fa-sort-desc";
+  get verticalJustifyClass() {
+    const cellStyle = this.env.model.getters.getCellComputedStyle(this.props.position);
+    switch (cellStyle.verticalAlign) {
+      case "top":
+        return "justify-content-start";
+      case "middle":
+        return "justify-content-center";
+      case "bottom":
       default:
-        return "fa-sort";
+        return "justify-content-end";
     }
   }
 
-  getBackgroundColor(cellStyle: Style): Color {
+  private getBackgroundColor(cellStyle: Style): Color {
     const overlayColor = this.hoveredTableStore.overlayColors.get(this.props.position);
     if (overlayColor) {
       return blendColors(cellStyle.fillColor || "#FFFFFF", overlayColor);

--- a/src/components/dashboard/clickable_cell_sort_icon/clickable_cell_sort_icon.xml
+++ b/src/components/dashboard/clickable_cell_sort_icon/clickable_cell_sort_icon.xml
@@ -1,8 +1,11 @@
 <templates>
   <t t-name="o-spreadsheet-ClickableCellSortIcon">
-    <div class="w-100 h-100 d-flex flex-column align-items-end justify-content-end">
-      <span class="o-icon h-100 sorting-icon pb-1" t-att-style="style">
-        <i class="fa fa-small" t-att-class="icon"/>
+    <div class="w-100 h-100 d-flex flex-column align-items-end" t-att-class="verticalJustifyClass">
+      <span
+        t-if="props.sortDirection === 'none'"
+        class="o-icon sorting-icon pb-1"
+        t-att-style="style">
+        <i class="fa fa-small fa-sort"/>
       </span>
     </div>
   </t>

--- a/src/components/icons/icons.ts
+++ b/src/components/icons/icons.ts
@@ -138,6 +138,15 @@ export function getCaretDownSvg(color: Style): ImageSVG {
   };
 }
 
+export function getCaretUpSvg(color: Style): ImageSVG {
+  return {
+    name: "CARET_UP",
+    width: 512,
+    height: 512,
+    paths: [{ fillColor: color.textColor || TEXT_BODY_MUTED, path: "M120 325 h270 l-135 -130" }],
+  };
+}
+
 export function getHoveredCaretDownSvg(color: Style): ImageSVG {
   return {
     name: "CARET_DOWN",

--- a/src/index.ts
+++ b/src/index.ts
@@ -467,6 +467,8 @@ export const stores = {
   GridRenderer,
 };
 
+export { getCaretDownSvg, getCaretUpSvg } from "./components/icons/icons";
+
 export type { StoreConstructor, StoreParams } from "./store_engine";
 
 export function addFunction(functionName: string, functionDescription: AddFunctionDescription) {

--- a/src/registries/icons_on_cell_registry.ts
+++ b/src/registries/icons_on_cell_registry.ts
@@ -3,6 +3,7 @@ import {
   CHECKBOX_UNCHECKED,
   CHECKBOX_UNCHECKED_HOVERED,
   getCaretDownSvg,
+  getCaretUpSvg,
   getChipSvg,
   getDataFilterIcon,
   getHoveredCaretDownSvg,
@@ -232,3 +233,28 @@ function togglePivotCollapse(position: CellPosition, env: SpreadsheetChildEnv) {
     pivot: { ...definition, collapsedDomains: newDomains },
   });
 }
+
+iconsOnCellRegistry.add("pivot_dashboard_sorting", (getters, position) => {
+  if (!getters.isDashboard()) {
+    return undefined;
+  }
+  const pivotCell = getters.getPivotCellFromPosition(position);
+  if (pivotCell.type !== "MEASURE_HEADER") {
+    return undefined;
+  }
+  const sortDirection = getters.getPivotCellSortDirection(position);
+  if (sortDirection !== "asc" && sortDirection !== "desc") {
+    return undefined;
+  }
+  const cellStyle = getters.getCellComputedStyle(position);
+  return {
+    type: `pivot_dashboard_sorting_${sortDirection}`,
+    priority: 5,
+    horizontalAlign: "right",
+    size: GRID_ICON_EDGE_LENGTH,
+    margin: GRID_ICON_MARGIN,
+    svg: sortDirection === "asc" ? getCaretUpSvg(cellStyle) : getCaretDownSvg(cellStyle),
+    position,
+    onClick: undefined, // click is managed by ClickableCellSortIcon
+  };
+});


### PR DESCRIPTION
This commit is fixing two issues

1 Steps to reproduce:
- insert a dynamic pivot
- resize the row with the measure headers
- open the spreadsheet in dashboard mode
- hover a measure header to sort it

=> the icon is not aligned with the text in the cell.

2 Steps to reproduce
- insert a dynamic pivot
- resize the last column such that the text overflows on the adjacent cell (on the right)
- open the spreadsheet in dashboard mode
- sort the measure header in the last column

=> the icon hides half of the text, but it still overflows on the right. For technical limitation, this is only fixed when the measure is sorted. It's still broken with the "unsorted" icon when hovering the cell. Do currently lack the ability to display icons on the canvas depening on a hovered cell or not.

Task: 5075237

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [5075237](https://www.odoo.com/odoo/2328/tasks/5075237)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo