### PR TITLE
[FIX] translation: dynamic translation for chart terms

### DIFF
--- a/src/components/figures/chart/scorecard/chart_scorecard.ts
+++ b/src/components/figures/chart/scorecard/chart_scorecard.ts
@@ -1,7 +1,6 @@
 import { Component, useEffect, useRef } from "@odoo/owl";
 import { drawScoreChart } from "../../../../helpers/figures/charts/scorecard_chart";
 import { getScorecardConfiguration } from "../../../../helpers/figures/charts/scorecard_chart_config_builder";
-import { _t } from "../../../../translation";
 import { SpreadsheetChildEnv, UID } from "../../../../types";
 import { ScorecardChartRuntime } from "../../../../types/chart/scorecard_chart";
 
@@ -21,9 +20,8 @@ export class ScorecardChart extends Component<Props, SpreadsheetChildEnv> {
   }
 
   get title(): string {
-    const title = this.env.model.getters.getChartDefinition(this.props.chartId).title.text ?? "";
-    // chart titles are extracted from .json files and they are translated at runtime here
-    return _t(title);
+    const title = this.env.model.getters.getChartDefinition(this.props.chartId).title.text;
+    return title ? this.env.model.getters.dynamicTranslate(title) : "";
   }
 
   setup() {

--- a/src/components/side_panel/chart/scorecard_chart_panel/scorecard_chart_design_panel.ts
+++ b/src/components/side_panel/chart/scorecard_chart_panel/scorecard_chart_design_panel.ts
@@ -58,8 +58,8 @@ export class ScorecardChartDesignPanel extends Component<Props, SpreadsheetChild
     return SCORECARD_CHART_TITLE_FONT_SIZE;
   }
 
-  translate(term) {
-    return _t(term);
+  translate(term: string): string {
+    return this.env.model.getters.dynamicTranslate(term);
   }
 
   setColor(color: Color, colorPickerId: ColorPickerId) {

--- a/src/components/side_panel/custom_currency/custom_currency.ts
+++ b/src/components/side_panel/custom_currency/custom_currency.ts
@@ -133,7 +133,7 @@ export class CustomCurrencyPanel extends Component<Props, SpreadsheetChildEnv> {
     }
 
     const emptyCurrency: Currency = {
-      name: _t(CustomCurrencyTerms.Custom),
+      name: CustomCurrencyTerms.Custom,
       code: "",
       symbol: "",
       decimalPlaces: 2,

--- a/src/helpers/figures/charts/bar_chart.ts
+++ b/src/helpers/figures/charts/bar_chart.ts
@@ -239,7 +239,7 @@ export function createBarChartRuntime(chart: BarChart, getters: Getters): BarCha
       layout: getChartLayout(definition, chartData),
       scales: getBarChartScales(definition, chartData),
       plugins: {
-        title: getChartTitle(definition),
+        title: getChartTitle(definition, getters),
         legend: getBarChartLegend(definition, chartData),
         tooltip: getBarChartTooltip(definition, chartData),
         chartShowValuesPlugin: getChartShowValues(definition, chartData),

--- a/src/helpers/figures/charts/combo_chart.ts
+++ b/src/helpers/figures/charts/combo_chart.ts
@@ -238,7 +238,7 @@ export function createComboChartRuntime(chart: ComboChart, getters: Getters): Co
       layout: getChartLayout(definition, chartData),
       scales: getBarChartScales(definition, chartData),
       plugins: {
-        title: getChartTitle(definition),
+        title: getChartTitle(definition, getters),
         legend: getComboChartLegend(definition, chartData),
         tooltip: getBarChartTooltip(definition, chartData),
         chartShowValuesPlugin: getChartShowValues(definition, chartData),

--- a/src/helpers/figures/charts/funnel_chart.ts
+++ b/src/helpers/figures/charts/funnel_chart.ts
@@ -225,7 +225,7 @@ export function createFunnelChartRuntime(chart: FunnelChart, getters: Getters): 
       layout: getChartLayout(definition, chartData),
       scales: getFunnelChartScales(definition, chartData),
       plugins: {
-        title: getChartTitle(definition),
+        title: getChartTitle(definition, getters),
         legend: { display: false },
         tooltip: getFunnelChartTooltip(definition, chartData),
         chartShowValuesPlugin: getChartShowValues(definition, chartData),

--- a/src/helpers/figures/charts/gauge_chart.ts
+++ b/src/helpers/figures/charts/gauge_chart.ts
@@ -6,7 +6,6 @@ import {
 import { isMultipleElementMatrix, toScalar } from "../../../functions/helper_matrices";
 import { tryToNumber } from "../../../functions/helpers";
 import { BasePlugin } from "../../../plugins/base_plugin";
-import { _t } from "../../../translation";
 import {
   AdaptSheetName,
   ApplyRangeChange,
@@ -367,8 +366,7 @@ export function createGaugeChartRuntime(chart: GaugeChart, getters: Getters): Ga
     background: getters.getStyleOfSingleCellChart(chart.background, dataRange).background,
     title: {
       ...chart.title,
-      // chart titles are extracted from .json files and they are translated at runtime here
-      text: _t(chart.title.text ?? ""),
+      text: chart.title.text ? getters.dynamicTranslate(chart.title.text) : "",
     },
     minValue: {
       value: minValue,

--- a/src/helpers/figures/charts/geo_chart.ts
+++ b/src/helpers/figures/charts/geo_chart.ts
@@ -206,7 +206,7 @@ export function createGeoChartRuntime(chart: GeoChart, getters: Getters): GeoCha
       layout: getChartLayout(definition, chartData),
       scales: getGeoChartScales(definition, chartData),
       plugins: {
-        title: getChartTitle(definition),
+        title: getChartTitle(definition, getters),
         tooltip: getGeoChartTooltip(definition, chartData),
         legend: { display: false },
       },

--- a/src/helpers/figures/charts/line_chart.ts
+++ b/src/helpers/figures/charts/line_chart.ts
@@ -251,7 +251,7 @@ export function createLineChartRuntime(chart: LineChart, getters: Getters): Char
       layout: getChartLayout(definition, chartData),
       scales: getLineChartScales(definition, chartData),
       plugins: {
-        title: getChartTitle(definition),
+        title: getChartTitle(definition, getters),
         legend: getLineChartLegend(definition, chartData),
         tooltip: getLineChartTooltip(definition, chartData),
         chartShowValuesPlugin: getChartShowValues(definition, chartData),

--- a/src/helpers/figures/charts/pie_chart.ts
+++ b/src/helpers/figures/charts/pie_chart.ts
@@ -210,7 +210,7 @@ export function createPieChartRuntime(chart: PieChart, getters: Getters): PieCha
           : undefined,
       layout: getChartLayout(definition, chartData),
       plugins: {
-        title: getChartTitle(definition),
+        title: getChartTitle(definition, getters),
         legend: getPieChartLegend(definition, chartData),
         tooltip: getPieChartTooltip(definition, chartData),
         chartShowValuesPlugin: getChartShowValues(definition, chartData),

--- a/src/helpers/figures/charts/pyramid_chart.ts
+++ b/src/helpers/figures/charts/pyramid_chart.ts
@@ -243,7 +243,7 @@ export function createPyramidChartRuntime(
       layout: getChartLayout(definition, chartData),
       scales: getPyramidChartScales(definition, chartData),
       plugins: {
-        title: getChartTitle(definition),
+        title: getChartTitle(definition, getters),
         legend: getBarChartLegend(definition, chartData),
         tooltip: getPyramidChartTooltip(definition, chartData),
         chartShowValuesPlugin: getPyramidChartShowValues(definition, chartData),

--- a/src/helpers/figures/charts/radar_chart.ts
+++ b/src/helpers/figures/charts/radar_chart.ts
@@ -231,7 +231,7 @@ export function createRadarChartRuntime(chart: RadarChart, getters: Getters): Ra
       layout: getChartLayout(definition, chartData),
       scales: getRadarChartScales(definition, chartData),
       plugins: {
-        title: getChartTitle(definition),
+        title: getChartTitle(definition, getters),
         legend: getRadarChartLegend(definition, chartData),
         tooltip: getRadarChartTooltip(definition, chartData),
         chartShowValuesPlugin: getChartShowValues(definition, chartData),

--- a/src/helpers/figures/charts/runtime/chartjs_title.ts
+++ b/src/helpers/figures/charts/runtime/chartjs_title.ts
@@ -1,18 +1,19 @@
 import { TitleOptions } from "chart.js";
 import { _DeepPartialObject } from "chart.js/dist/types/utils";
 import { CHART_PADDING, CHART_TITLE_FONT_SIZE } from "../../../../constants";
-import { _t } from "../../../../translation";
+import { Getters } from "../../../../types";
 import { ChartWithDataSetDefinition } from "../../../../types/chart";
 import { chartMutedFontColor } from "../chart_common";
 
 export function getChartTitle(
-  definition: ChartWithDataSetDefinition
+  definition: ChartWithDataSetDefinition,
+  getters: Getters
 ): _DeepPartialObject<TitleOptions> {
   const chartTitle = definition.title;
   const fontColor = chartMutedFontColor(definition.background);
   return {
     display: !!chartTitle.text,
-    text: _t(chartTitle.text!),
+    text: chartTitle.text ? getters.dynamicTranslate(chartTitle.text) : "",
     color: chartTitle?.color ?? fontColor,
     align:
       chartTitle.align === "center" ? "center" : chartTitle.align === "right" ? "end" : "start",

--- a/src/helpers/figures/charts/scatter_chart.ts
+++ b/src/helpers/figures/charts/scatter_chart.ts
@@ -245,7 +245,7 @@ export function createScatterChartRuntime(
       layout: getChartLayout(definition, chartData),
       scales: getScatterChartScales(definition, chartData),
       plugins: {
-        title: getChartTitle(definition),
+        title: getChartTitle(definition, getters),
         legend: getScatterChartLegend(definition, chartData),
         tooltip: getLineChartTooltip(definition, chartData),
         chartShowValuesPlugin: getChartShowValues(definition, chartData),

--- a/src/helpers/figures/charts/scorecard_chart.ts
+++ b/src/helpers/figures/charts/scorecard_chart.ts
@@ -5,7 +5,6 @@ import {
   DEFAULT_SCORECARD_BASELINE_MODE,
 } from "../../../constants";
 import { toNumber } from "../../../functions/helpers";
-import { _t } from "../../../translation";
 import {
   ApplyRangeChange,
   CellValueType,
@@ -474,13 +473,10 @@ export function createScorecardChartRuntime(
   return {
     title: {
       ...chart.title,
-      // chart titles are extracted from .json files and they are translated at runtime here
-      text: chart.title.text ? _t(chart.title.text) : "",
+      text: chart.title.text ? getters.dynamicTranslate(chart.title.text) : "",
     },
     keyValue: formattedKeyValue,
-    keyDescr: chart.keyDescr?.text
-      ? _t(chart.keyDescr.text) // descriptions are extracted from .json files and they are translated at runtime here
-      : "",
+    keyDescr: chart.keyDescr?.text ? getters.dynamicTranslate(chart.keyDescr.text) : "",
     baselineDisplay,
     baselineArrow: getBaselineArrowDirection(baselineCell, keyValueCell, chart.baselineMode),
     baselineColor: getBaselineColor(
@@ -492,7 +488,7 @@ export function createScorecardChartRuntime(
     ),
     baselineDescr:
       chart.baselineMode !== "progress" && chart.baselineDescr?.text
-        ? _t(chart.baselineDescr.text) // descriptions are extracted from .json files and they are translated at runtime here
+        ? getters.dynamicTranslate(chart.baselineDescr.text)
         : "",
     fontColor,
     background,

--- a/src/helpers/figures/charts/sunburst_chart.ts
+++ b/src/helpers/figures/charts/sunburst_chart.ts
@@ -212,7 +212,7 @@ export function createSunburstChartRuntime(
       ...(CHART_COMMON_OPTIONS as ChartOptions<"doughnut">),
       layout: getChartLayout(definition, chartData),
       plugins: {
-        title: getChartTitle(definition),
+        title: getChartTitle(definition, getters),
         legend: getSunburstChartLegend(definition, chartData),
         tooltip: getSunburstChartTooltip(definition, chartData),
         sunburstLabelsPlugin: getSunburstShowValues(definition, chartData),

--- a/src/helpers/figures/charts/tree_map_chart.ts
+++ b/src/helpers/figures/charts/tree_map_chart.ts
@@ -226,7 +226,7 @@ export function createTreeMapChartRuntime(
       ...CHART_COMMON_OPTIONS,
       layout: getChartLayout(definition, chartData),
       plugins: {
-        title: getChartTitle(definition),
+        title: getChartTitle(definition, getters),
         legend: { display: false },
         tooltip: getTreeMapChartTooltip(definition, chartData),
       },

--- a/src/helpers/figures/charts/waterfall_chart.ts
+++ b/src/helpers/figures/charts/waterfall_chart.ts
@@ -245,7 +245,7 @@ export function createWaterfallChartRuntime(
       layout: getChartLayout(definition, chartData),
       scales: getWaterfallChartScales(definition, chartData),
       plugins: {
-        title: getChartTitle(definition),
+        title: getChartTitle(definition, getters),
         legend: getWaterfallChartLegend(definition, chartData),
         tooltip: getWaterfallChartTooltip(definition, chartData),
         chartShowValuesPlugin: getWaterfallChartShowValues(definition, chartData),

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -48,6 +48,7 @@ import {
 import { CellComputedStylePlugin } from "./ui_feature/cell_computed_style";
 import { CheckboxTogglePlugin } from "./ui_feature/checkbox_toggle";
 import { DataValidationInsertionPlugin } from "./ui_feature/datavalidation_insertion";
+import { DynamicTranslate } from "./ui_feature/dynamic_translate";
 import { HistoryPlugin } from "./ui_feature/local_history";
 import { PivotPresencePlugin } from "./ui_feature/pivot_presence_plugin";
 import { SplitToColumnsPlugin } from "./ui_feature/split_to_columns";
@@ -104,6 +105,7 @@ export const featurePluginRegistry = new Registry<UIPluginConstructor>()
   .add("table_ui_resize", TableResizeUI)
   .add("datavalidation_insert", DataValidationInsertionPlugin)
   .add("checkbox_toggle", CheckboxTogglePlugin)
+  .add("dynamic_translate", DynamicTranslate)
   .add("geo_features", GeoFeaturePlugin);
 
 // Plugins which have a state, but which should not be shared in collaborative

--- a/src/plugins/ui_feature/dynamic_translate.ts
+++ b/src/plugins/ui_feature/dynamic_translate.ts
@@ -1,0 +1,17 @@
+import { UIPlugin } from "../ui_plugin";
+
+/**
+ * This plugin provides dynamic translation getter. In o-spreadsheet, it has
+ * no implementation, but this plugin can be replaced by another one to provide
+ * a real implementation.
+ *
+ * For example, in Odoo, the plugin is replaced by a plugin that used the
+ * module namespace to dynamically translate terms.
+ */
+export class DynamicTranslate extends UIPlugin {
+  static getters = ["dynamicTranslate"] as const;
+
+  dynamicTranslate(term: string) {
+    return term;
+  }
+}

--- a/src/types/getters.ts
+++ b/src/types/getters.ts
@@ -31,6 +31,7 @@ import { AutomaticSumPlugin } from "../plugins/ui_feature/automatic_sum";
 import { CellComputedStylePlugin } from "../plugins/ui_feature/cell_computed_style";
 import { CheckboxTogglePlugin } from "../plugins/ui_feature/checkbox_toggle";
 import { CollaborativePlugin } from "../plugins/ui_feature/collaborative";
+import { DynamicTranslate } from "../plugins/ui_feature/dynamic_translate";
 import { HeaderVisibilityUIPlugin } from "../plugins/ui_feature/header_visibility_ui";
 import { HistoryPlugin } from "../plugins/ui_feature/local_history";
 import { PivotPresencePlugin } from "../plugins/ui_feature/pivot_presence_plugin";
@@ -157,4 +158,5 @@ export type Getters = {
   PluginGetters<typeof TableComputedStylePlugin> &
   PluginGetters<typeof CheckboxTogglePlugin> &
   PluginGetters<typeof CellIconPlugin> &
+  PluginGetters<typeof DynamicTranslate> &
   PluginGetters<typeof CarouselUIPlugin>;


### PR DESCRIPTION
Since https://github.com/odoo/odoo/pull/223171 in Odoo, terms are now translated dynamically with a namespace at runtime. This commit adapts o-spreadsheet codebase to allow to override a translation method for dynamic translated terms. The newly introduced plugin is meant to be overriden in Odoo.

Task: 5076040

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo