### PR TITLE
[IMP] carousel: allow full screen toggle in carousel

### DIFF
--- a/src/components/figures/chart/chartJs/zoomable_chart/zoomable_chartjs.ts
+++ b/src/components/figures/chart/chartJs/zoomable_chart/zoomable_chartjs.ts
@@ -8,7 +8,7 @@ import {
 } from "../../../../../helpers/figures/charts/chart_common";
 import { Store, useStore } from "../../../../../store_engine";
 import { ChartJSRuntime } from "../../../../../types";
-import { FullScreenChartStore } from "../../../../full_screen_chart/full_screen_chart_store";
+import { FullScreenFigureStore } from "../../../../full_screen_figure/full_screen_figure_store";
 import { css } from "../../../../helpers";
 import { chartJsExtensionRegistry } from "../chart_js_extension";
 import { ChartJsComponent } from "../chartjs";
@@ -32,7 +32,7 @@ export class ZoomableChartJsComponent extends ChartJsComponent {
   static template = "o-spreadsheet-ZoomableChartJsComponent";
 
   private store!: Store<ZoomableChartStore>;
-  private fullScreenChartStore!: Store<FullScreenChartStore>;
+  private fullScreenChartStore!: Store<FullScreenFigureStore>;
 
   private masterChartCanvas = useRef("masterChartCanvas");
   private masterChart?: Chart;
@@ -45,7 +45,7 @@ export class ZoomableChartJsComponent extends ChartJsComponent {
 
   setup() {
     this.store = useStore(ZoomableChartStore);
-    this.fullScreenChartStore = useStore(FullScreenChartStore);
+    this.fullScreenChartStore = useStore(FullScreenFigureStore);
     super.setup();
   }
 

--- a/src/components/figures/chart/chartJs/zoomable_chart/zoomable_chartjs.ts
+++ b/src/components/figures/chart/chartJs/zoomable_chart/zoomable_chartjs.ts
@@ -8,7 +8,6 @@ import {
 } from "../../../../../helpers/figures/charts/chart_common";
 import { Store, useStore } from "../../../../../store_engine";
 import { ChartJSRuntime } from "../../../../../types";
-import { FullScreenFigureStore } from "../../../../full_screen_figure/full_screen_figure_store";
 import { css } from "../../../../helpers";
 import { chartJsExtensionRegistry } from "../chart_js_extension";
 import { ChartJsComponent } from "../chartjs";
@@ -32,7 +31,6 @@ export class ZoomableChartJsComponent extends ChartJsComponent {
   static template = "o-spreadsheet-ZoomableChartJsComponent";
 
   private store!: Store<ZoomableChartStore>;
-  private fullScreenChartStore!: Store<FullScreenFigureStore>;
 
   private masterChartCanvas = useRef("masterChartCanvas");
   private masterChart?: Chart;
@@ -45,7 +43,6 @@ export class ZoomableChartJsComponent extends ChartJsComponent {
 
   setup() {
     this.store = useStore(ZoomableChartStore);
-    this.fullScreenChartStore = useStore(FullScreenFigureStore);
     super.setup();
   }
 
@@ -63,12 +60,8 @@ export class ZoomableChartJsComponent extends ChartJsComponent {
   }
 
   get sliceable(): boolean {
-    if (this.env.isDashboard()) {
-      const fullScreenFigureId = this.fullScreenChartStore.fullScreenFigure?.id;
-      const chartFigureId = this.env.model.getters.getFigureIdFromChartId(this.props.chartId);
-      if (fullScreenFigureId === chartFigureId) {
-        return true;
-      }
+    if (this.props.isFullScreen) {
+      return true;
     }
     const definition = this.env.model.getters.getChartDefinition(this.props.chartId);
     return ("zoomable" in definition && definition?.zoomable) ?? false;

--- a/src/components/figures/chart/chart_dashboard_menu/chart_dashboard_menu.ts
+++ b/src/components/figures/chart/chart_dashboard_menu/chart_dashboard_menu.ts
@@ -5,7 +5,7 @@ import { isDefined } from "../../../../helpers";
 import { Store, useStore } from "../../../../store_engine";
 import { _t } from "../../../../translation";
 import { SpreadsheetChildEnv, UID } from "../../../../types";
-import { FullScreenChartStore } from "../../../full_screen_chart/full_screen_chart_store";
+import { FullScreenFigureStore } from "../../../full_screen_figure/full_screen_figure_store";
 import { MenuPopover, MenuState } from "../../../menu_popover/menu_popover";
 
 interface Props {
@@ -25,12 +25,12 @@ export class ChartDashboardMenu extends Component<Props, SpreadsheetChildEnv> {
   static components = { MenuPopover };
   static props = { chartId: String };
 
-  private fullScreenFigureStore!: Store<FullScreenChartStore>;
+  private fullScreenFigureStore!: Store<FullScreenFigureStore>;
 
   private menuState: MenuState = useState({ isOpen: false, anchorRect: null, menuItems: [] });
   setup() {
     super.setup();
-    this.fullScreenFigureStore = useStore(FullScreenChartStore);
+    this.fullScreenFigureStore = useStore(FullScreenFigureStore);
   }
 
   getMenuItems(): MenuItem[] {
@@ -61,7 +61,7 @@ export class ChartDashboardMenu extends Component<Props, SpreadsheetChildEnv> {
       label: isFullScreen ? _t("Exit Full Screen") : _t("Full Screen"),
       class: `text-muted fa ${isFullScreen ? "fa-compress" : "fa-expand"}`,
       onClick: () => {
-        this.fullScreenFigureStore.toggleFullScreenChart(figureId);
+        this.fullScreenFigureStore.toggleFullScreenFigure(figureId);
       },
     };
   }

--- a/src/components/figures/chart/chart_dashboard_menu/chart_dashboard_menu.ts
+++ b/src/components/figures/chart/chart_dashboard_menu/chart_dashboard_menu.ts
@@ -10,6 +10,7 @@ import { MenuPopover, MenuState } from "../../../menu_popover/menu_popover";
 
 interface Props {
   chartId: UID;
+  hasFullScreenButton: boolean;
 }
 
 interface MenuItem {
@@ -23,7 +24,8 @@ interface MenuItem {
 export class ChartDashboardMenu extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ChartDashboardMenu";
   static components = { MenuPopover };
-  static props = { chartId: String };
+  static props = { chartId: String, hasFullScreenButton: { type: Boolean, optional: true } };
+  static defaultProps = { hasFullScreenButton: true };
 
   private fullScreenFigureStore!: Store<FullScreenFigureStore>;
 
@@ -50,6 +52,9 @@ export class ChartDashboardMenu extends Component<Props, SpreadsheetChildEnv> {
   }
 
   get fullScreenMenuItem(): MenuItem | undefined {
+    if (!this.props.hasFullScreenButton) {
+      return undefined;
+    }
     const definition = this.env.model.getters.getChartDefinition(this.props.chartId);
     const figureId = this.env.model.getters.getFigureIdFromChartId(this.props.chartId);
     if (definition.type === "scorecard") {

--- a/src/components/figures/chart/scorecard/chart_scorecard.ts
+++ b/src/components/figures/chart/scorecard/chart_scorecard.ts
@@ -6,12 +6,14 @@ import { ScorecardChartRuntime } from "../../../../types/chart/scorecard_chart";
 
 interface Props {
   chartId: UID;
+  isFullScreen?: Boolean;
 }
 
 export class ScorecardChart extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ScorecardChart";
   static props = {
     chartId: String,
+    isFullScreen: { type: Boolean, optional: true },
   };
   private canvas = useRef("chartContainer");
 

--- a/src/components/figures/figure_carousel/figure_carousel.scss
+++ b/src/components/figures/figure_carousel/figure_carousel.scss
@@ -34,11 +34,17 @@
       width: 0; /* To make flex-fill work */
     }
 
-    .o-carousel-tabs-dropdown {
+    .o-carousel-button {
       cursor: pointer;
-      padding: 2px;
-      font-size: 16px;
-      line-height: 16px;
+
+      &.o-carousel-tabs-dropdown {
+        font-size: 16px;
+        line-height: 16px;
+      }
+
+      &.o-carousel-full-screen-button {
+        margin: 1px;
+      }
 
       &.active,
       &:hover {

--- a/src/components/figures/figure_carousel/figure_carousel.xml
+++ b/src/components/figures/figure_carousel/figure_carousel.xml
@@ -16,7 +16,7 @@
           t-att-style="titleStyle"
         />
         <div class="o-carousel-tabs d-flex flex-fill justify-content-end" t-ref="carouselTabs">
-          <t t-foreach="carousel.items" t-as="item" t-key="item_index">
+          <t t-foreach="visibleCarouselItems" t-as="item" t-key="item_index">
             <div
               class="o-carousel-tab text-truncate px-2 mt-1 flex-shrink-0"
               t-att-class="{ 'selected': isItemSelected(item) }"
@@ -26,7 +26,7 @@
           </t>
         </div>
         <div
-          class="o-carousel-tabs-dropdown flex-shrink-0 rounded"
+          class="o-carousel-tabs-dropdown o-carousel-button flex-shrink-0 rounded p-1"
           t-att-class="{'active': menuState.isOpen}"
           t-ref="carouselTabsDropdown"
           t-on-click="toggleMenu">
@@ -40,6 +40,17 @@
             popoverPositioning="'bottom-left'"
           />
         </div>
+        <div
+          t-if="env.isDashboard()"
+          t-att-title="fullScreenButtonTitle"
+          class="o-carousel-full-screen-button fa o-carousel-button rounded p-1 ms-1"
+          t-att-class="{
+            'fa-compress': props.isFullScreen,
+            'fa-expand': !props.isFullScreen,
+            'invisible': selectedCarouselItem?.type !== 'chart',
+          }"
+          t-on-click="toggleFullScreen"
+        />
       </div>
       <div
         t-if="!selectedItem"
@@ -53,12 +64,14 @@
           <t
             t-component="chartComponent"
             chartId="selectedItem.chartId"
+            isFullScreen="props.isFullScreen"
             t-key="selectedItem.chartId"
           />
         </div>
         <ChartDashboardMenu
           t-if="env.isDashboard()"
           chartId="selectedItem.chartId"
+          hasFullScreenButton="false"
           t-key="selectedItem.chartId"
         />
       </div>

--- a/src/components/figures/figure_chart/figure_chart.ts
+++ b/src/components/figures/figure_chart/figure_chart.ts
@@ -9,6 +9,7 @@ interface Props {
   figureUI: FigureUI;
   onFigureDeleted: () => void;
   editFigureStyle?: (properties: CSSProperties) => void;
+  isFullScreen?: boolean;
 }
 
 export class ChartFigure extends Component<Props, SpreadsheetChildEnv> {
@@ -17,6 +18,7 @@ export class ChartFigure extends Component<Props, SpreadsheetChildEnv> {
     figureUI: Object,
     onFigureDeleted: Function,
     editFigureStyle: { type: Function, optional: true },
+    isFullScreen: { type: Boolean, optional: true },
   };
   static components = { ChartDashboardMenu };
 

--- a/src/components/figures/figure_chart/figure_chart.xml
+++ b/src/components/figures/figure_chart/figure_chart.xml
@@ -1,7 +1,12 @@
 <templates>
   <t t-name="o-spreadsheet-ChartFigure">
     <div class="o-chart-container w-100 h-100" t-on-dblclick="onDoubleClick">
-      <t t-component="chartComponent" chartId="chartId" t-key="chartId"/>
+      <t
+        t-component="chartComponent"
+        chartId="chartId"
+        t-key="chartId"
+        isFullScreen="props.isFullScreen"
+      />
     </div>
     <div t-if="env.isDashboard()" class="position-absolute top-0 end-0">
       <ChartDashboardMenu chartId="chartId"/>

--- a/src/components/full_screen_figure/full_screen_figure.scss
+++ b/src/components/full_screen_figure/full_screen_figure.scss
@@ -1,5 +1,5 @@
 .o-spreadsheet {
-  .o-fullscreen-chart-overlay {
+  .o-fullscreen-figure-overlay {
     z-index: 34; /* TODO: use css variables once ComponentsImportance is available in the scss. */
     background-color: rgba(0, 0, 0, 0.4);
     padding: 60px;

--- a/src/components/full_screen_figure/full_screen_figure.ts
+++ b/src/components/full_screen_figure/full_screen_figure.ts
@@ -6,22 +6,22 @@ import { SpreadsheetChildEnv } from "../../types";
 import { ChartDashboardMenu } from "../figures/chart/chart_dashboard_menu/chart_dashboard_menu";
 import { ChartAnimationStore } from "../figures/chart/chartJs/chartjs_animation_store";
 import { useSpreadsheetRect } from "../helpers/position_hook";
-import { FullScreenChartStore } from "./full_screen_chart_store";
+import { FullScreenFigureStore } from "./full_screen_figure_store";
 
-export class FullScreenChart extends Component<{}, SpreadsheetChildEnv> {
-  static template = "o-spreadsheet-FullScreenChart";
+export class FullScreenFigure extends Component<{}, SpreadsheetChildEnv> {
+  static template = "o-spreadsheet-FullScreenFigure";
   static props = {};
   static components = { ChartDashboardMenu };
 
-  private fullScreenChartStore!: Store<FullScreenChartStore>;
-  private ref = useRef("fullScreenChart");
+  private fullScreenFigureStore!: Store<FullScreenFigureStore>;
+  private ref = useRef("fullScreenFigure");
 
   spreadsheetRect = useSpreadsheetRect();
 
   figureRegistry = figureRegistry;
 
   setup() {
-    this.fullScreenChartStore = useStore(FullScreenChartStore);
+    this.fullScreenFigureStore = useStore(FullScreenFigureStore);
 
     const animationStore = useStore(ChartAnimationStore);
     let lastFigureId: string | undefined = undefined;
@@ -39,7 +39,7 @@ export class FullScreenChart extends Component<{}, SpreadsheetChildEnv> {
   }
 
   get figureUI() {
-    return this.fullScreenChartStore.fullScreenFigure;
+    return this.fullScreenFigureStore.fullScreenFigure;
   }
 
   get chartId() {
@@ -49,7 +49,7 @@ export class FullScreenChart extends Component<{}, SpreadsheetChildEnv> {
 
   exitFullScreen() {
     if (this.figureUI) {
-      this.fullScreenChartStore.toggleFullScreenChart(this.figureUI.id);
+      this.fullScreenFigureStore.toggleFullScreenFigure(this.figureUI.id);
     }
   }
 

--- a/src/components/full_screen_figure/full_screen_figure.ts
+++ b/src/components/full_screen_figure/full_screen_figure.ts
@@ -1,17 +1,16 @@
 import { Component, onWillUpdateProps, useEffect, useRef } from "@odoo/owl";
-import { chartComponentRegistry } from "../../registries/chart_types";
 import { figureRegistry } from "../../registries/figures_registry";
 import { Store, useStore } from "../../store_engine";
 import { SpreadsheetChildEnv } from "../../types";
-import { ChartDashboardMenu } from "../figures/chart/chart_dashboard_menu/chart_dashboard_menu";
 import { ChartAnimationStore } from "../figures/chart/chartJs/chartjs_animation_store";
+import { ChartFigure } from "../figures/figure_chart/figure_chart";
 import { useSpreadsheetRect } from "../helpers/position_hook";
 import { FullScreenFigureStore } from "./full_screen_figure_store";
 
 export class FullScreenFigure extends Component<{}, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-FullScreenFigure";
   static props = {};
-  static components = { ChartDashboardMenu };
+  static components = { ChartFigure };
 
   private fullScreenFigureStore!: Store<FullScreenFigureStore>;
   private ref = useRef("fullScreenFigure");
@@ -59,13 +58,8 @@ export class FullScreenFigure extends Component<{}, SpreadsheetChildEnv> {
     }
   }
 
-  get chartComponent(): (new (...args: any) => Component) | undefined {
-    if (!this.chartId) return undefined;
-    const type = this.env.model.getters.getChartType(this.chartId);
-    const component = chartComponentRegistry.get(type);
-    if (!component) {
-      throw new Error(`Component is not defined for type ${type}`);
-    }
-    return component;
+  get figureComponent(): (new (...args: any) => Component) | undefined {
+    if (!this.figureUI) return undefined;
+    return figureRegistry.get(this.figureUI.tag).Component;
   }
 }

--- a/src/components/full_screen_figure/full_screen_figure.xml
+++ b/src/components/full_screen_figure/full_screen_figure.xml
@@ -1,6 +1,6 @@
 <templates>
-  <t t-name="o-spreadsheet-FullScreenChart">
-    <div class="position-absolute o-fullscreen-chart-overlay w-100 h-100 d-flex" t-if="chartId">
+  <t t-name="o-spreadsheet-FullScreenFigure">
+    <div class="position-absolute o-fullscreen-figure-overlay w-100 h-100 d-flex" t-if="chartId">
       <div
         class="position-absolute top-0 start-0 end-0 bottom-0"
         t-on-click="exitFullScreen"
@@ -13,9 +13,9 @@
       </button>
       <div class="flex-fill">
         <div
-          class="o-fullscreen-chart o-figure position-relative border rounded shadow"
+          class="o-fullscreen-figure o-figure position-relative border rounded shadow"
           tabindex="1"
-          t-ref="fullScreenChart"
+          t-ref="fullScreenFigure"
           t-on-click.stop=""
           t-on-keydown="(ev) => this.onKeyDown(ev)">
           <t t-component="chartComponent" chartId="chartId" isFullScreen="true" t-key="chartId"/>

--- a/src/components/full_screen_figure/full_screen_figure.xml
+++ b/src/components/full_screen_figure/full_screen_figure.xml
@@ -1,6 +1,6 @@
 <templates>
   <t t-name="o-spreadsheet-FullScreenFigure">
-    <div class="position-absolute o-fullscreen-figure-overlay w-100 h-100 d-flex" t-if="chartId">
+    <div class="position-absolute o-fullscreen-figure-overlay w-100 h-100 d-flex" t-if="figureUI">
       <div
         class="position-absolute top-0 start-0 end-0 bottom-0"
         t-on-click="exitFullScreen"
@@ -18,10 +18,15 @@
           t-ref="fullScreenFigure"
           t-on-click.stop=""
           t-on-keydown="(ev) => this.onKeyDown(ev)">
-          <t t-component="chartComponent" chartId="chartId" isFullScreen="true" t-key="chartId"/>
-          <div class="position-absolute top-0 end-0">
-            <ChartDashboardMenu chartId="chartId"/>
-          </div>
+          <t>
+            <t
+              t-component="figureComponent"
+              figureUI="figureUI"
+              isFullScreen="true"
+              onFigureDeleted="() => {}"
+              t-key="figureUI.id"
+            />
+          </t>
         </div>
       </div>
     </div>

--- a/src/components/full_screen_figure/full_screen_figure_store.ts
+++ b/src/components/full_screen_figure/full_screen_figure_store.ts
@@ -1,12 +1,12 @@
 import { SpreadsheetStore } from "../../stores";
 import { FigureUI, UID } from "../../types";
 
-export class FullScreenChartStore extends SpreadsheetStore {
-  mutators = ["toggleFullScreenChart"] as const;
+export class FullScreenFigureStore extends SpreadsheetStore {
+  mutators = ["toggleFullScreenFigure"] as const;
 
   fullScreenFigure: FigureUI | undefined = undefined;
 
-  toggleFullScreenChart(figureId: string) {
+  toggleFullScreenFigure(figureId: string) {
     if (this.fullScreenFigure?.id === figureId) {
       this.fullScreenFigure = undefined;
     } else {

--- a/src/components/spreadsheet/spreadsheet.ts
+++ b/src/components/spreadsheet/spreadsheet.ts
@@ -57,7 +57,7 @@ import { BottomBar } from "../bottom_bar/bottom_bar";
 import { ComposerFocusStore } from "../composer/composer_focus_store";
 import { SpreadsheetDashboard } from "../dashboard/dashboard";
 import { unregisterChartJsExtensions } from "../figures/chart/chartJs/chart_js_extension";
-import { FullScreenChart } from "../full_screen_chart/full_screen_chart";
+import { FullScreenFigure } from "../full_screen_figure/full_screen_figure";
 import { Grid } from "../grid/grid";
 import { HeaderGroupContainer } from "../header_group/header_group_container";
 import { css, cssPropertiesToCss } from "../helpers/css";
@@ -340,7 +340,7 @@ export class Spreadsheet extends Component<SpreadsheetProps, SpreadsheetChildEnv
     SidePanels,
     SpreadsheetDashboard,
     HeaderGroupContainer,
-    FullScreenChart,
+    FullScreenFigure,
   };
 
   sidePanel!: Store<SidePanelStore>;

--- a/src/components/spreadsheet/spreadsheet.xml
+++ b/src/components/spreadsheet/spreadsheet.xml
@@ -7,7 +7,7 @@
       t-att-style="getStyle()">
       <t t-if="env.isDashboard()">
         <SpreadsheetDashboard getGridSize.bind="getGridSize"/>
-        <FullScreenChart/>
+        <FullScreenFigure/>
       </t>
       <t t-else="">
         <div class="o-spreadsheet-topbar-wrapper o-two-columns">

--- a/src/index.ts
+++ b/src/index.ts
@@ -117,7 +117,7 @@ import { ClickableCellSortIcon } from "./components/dashboard/clickable_cell_sor
 import { chartJsExtensionRegistry } from "./components/figures/chart/chartJs/chart_js_extension";
 import { ZoomableChartJsComponent } from "./components/figures/chart/chartJs/zoomable_chart/zoomable_chartjs";
 import { ChartDashboardMenu } from "./components/figures/chart/chart_dashboard_menu/chart_dashboard_menu";
-import { FullScreenChart } from "./components/full_screen_chart/full_screen_chart";
+import { FullScreenFigure } from "./components/full_screen_figure/full_screen_figure";
 import { PivotHTMLRenderer } from "./components/pivot_html_renderer/pivot_html_renderer";
 import { ComboChartDesignPanel } from "./components/side_panel/chart/combo_chart/combo_chart_design_panel";
 import { FunnelChartDesignPanel } from "./components/side_panel/chart/funnel_chart_panel/funnel_chart_design_panel";
@@ -434,7 +434,7 @@ export const components = {
   RadioSelection,
   GeoChartRegionSelectSection,
   ChartDashboardMenu,
-  FullScreenChart,
+  FullScreenFigure,
 };
 
 export const hooks = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -117,6 +117,7 @@ import { ClickableCellSortIcon } from "./components/dashboard/clickable_cell_sor
 import { chartJsExtensionRegistry } from "./components/figures/chart/chartJs/chart_js_extension";
 import { ZoomableChartJsComponent } from "./components/figures/chart/chartJs/zoomable_chart/zoomable_chartjs";
 import { ChartDashboardMenu } from "./components/figures/chart/chart_dashboard_menu/chart_dashboard_menu";
+import { GaugeChartComponent } from "./components/figures/chart/gauge/gauge_chart_component";
 import { FullScreenFigure } from "./components/full_screen_figure/full_screen_figure";
 import { PivotHTMLRenderer } from "./components/pivot_html_renderer/pivot_html_renderer";
 import { ComboChartDesignPanel } from "./components/side_panel/chart/combo_chart/combo_chart_design_panel";
@@ -396,6 +397,7 @@ export const components = {
   Grid,
   GridOverlay,
   ScorecardChart,
+  GaugeChartComponent,
   LineConfigPanel,
   BarConfigPanel,
   PieChartDesignPanel,

--- a/tests/figures/carousel/carousel_figure_component.test.ts
+++ b/tests/figures/carousel/carousel_figure_component.test.ts
@@ -171,7 +171,7 @@ describe("Carousel figure component", () => {
     const { fixture } = await mountSpreadsheet({ model });
     expect(".o-chart-dashboard-item").toHaveCount(0); // nothing for the data view
     await click(fixture, ".o-carousel-tab:nth-child(2)");
-    expect(".o-chart-dashboard-item").toHaveCount(2); // ellipsis and fullscreen
+    expect(".o-chart-dashboard-item").toHaveCount(1); // ellipsis, no full screen
   });
 
   test("Chart animation is played at each carousel tab change", async () => {

--- a/tests/figures/carousel/carousel_full_screen.test.ts
+++ b/tests/figures/carousel/carousel_full_screen.test.ts
@@ -1,0 +1,61 @@
+import { Model } from "../../../src";
+import { addNewChartToCarousel, createCarousel } from "../../test_helpers/commands_helpers";
+import { click } from "../../test_helpers/dom_helper";
+import { mockChart, mountSpreadsheet, nextTick } from "../../test_helpers/helpers";
+
+mockChart();
+
+let model: Model;
+let fixture: HTMLElement;
+
+describe("full screen carousel", () => {
+  beforeEach(async () => {
+    model = new Model();
+    ({ fixture } = await mountSpreadsheet({ model }));
+  });
+
+  test("Can make a carousel fullscreen in dashboard", async () => {
+    createCarousel(model, { items: [] }, "carouselId");
+    addNewChartToCarousel(model, "carouselId");
+    await nextTick();
+    expect(".o-figure .o-carousel-full-screen-button").toHaveCount(0);
+
+    model.updateMode("dashboard");
+    await nextTick();
+    expect(".o-figure .o-carousel-full-screen-button").toHaveCount(1);
+
+    expect(".o-fullscreen-figure").toHaveCount(0);
+    await click(fixture, ".o-figure .o-carousel-full-screen-button");
+    expect(".o-fullscreen-figure").toHaveCount(1);
+  });
+
+  test("Can exit fullscreen mode", async () => {
+    createCarousel(model, { items: [] }, "carouselId");
+    addNewChartToCarousel(model, "carouselId");
+    model.updateMode("dashboard");
+    await nextTick();
+    expect(".o-carousel-full-screen-button").toHaveClass("fa-expand");
+
+    await click(fixture, ".o-figure .o-carousel-full-screen-button");
+    expect(".o-fullscreen-figure").toHaveCount(1);
+    expect(".o-fullscreen-figure .o-carousel-full-screen-button").toHaveClass("fa-compress");
+
+    await click(fixture, ".o-fullscreen-figure .o-carousel-full-screen-button");
+    expect(".o-fullscreen-figure").toHaveCount(0);
+  });
+
+  test("Cannot use the data view in full screen", async () => {
+    createCarousel(model, { items: [{ type: "carouselDataView" }] }, "carouselId");
+    addNewChartToCarousel(model, "carouselId", { type: "radar" });
+    model.updateMode("dashboard");
+    await nextTick();
+    expect(".o-figure .o-carousel-full-screen-button").toHaveClass("invisible");
+
+    await click(fixture, ".o-figure .o-carousel-tab:nth-child(2)");
+    expect(".o-figure .o-carousel-full-screen-button").not.toHaveClass("invisible");
+
+    await click(fixture, ".o-figure .o-carousel-full-screen-button");
+    expect(".o-fullscreen-figure .o-carousel-tab").toHaveCount(1);
+    expect(".o-fullscreen-figure .o-carousel-tab").toHaveText("Radar");
+  });
+});

--- a/tests/figures/chart/chart_full_screen.test.ts
+++ b/tests/figures/chart/chart_full_screen.test.ts
@@ -25,9 +25,9 @@ describe("chart menu for dashboard", () => {
     model.updateMode("dashboard");
     await nextTick();
 
-    expect(".o-fullscreen-chart").toHaveCount(0);
+    expect(".o-fullscreen-figure").toHaveCount(0);
     await click(fixture, ".o-figure [data-id='fullScreenChart']");
-    expect(".o-fullscreen-chart").toHaveCount(1);
+    expect(".o-fullscreen-figure").toHaveCount(1);
   });
 
   test("Expand icon changes to collapse in full screen", async () => {
@@ -36,10 +36,10 @@ describe("chart menu for dashboard", () => {
     await nextTick();
 
     expect(".o-figure .fa-expand").toHaveCount(1);
-    expect(".o-fullscreen-chart").toHaveCount(0);
+    expect(".o-fullscreen-figure").toHaveCount(0);
 
     await click(fixture, ".o-figure .fa-expand");
-    expect(".o-fullscreen-chart").toHaveCount(1);
+    expect(".o-fullscreen-figure").toHaveCount(1);
     expect(".o-figure .fa-compress").toHaveCount(2); // One in the original chart, one in the full screen overlay
   });
 
@@ -48,7 +48,7 @@ describe("chart menu for dashboard", () => {
     model.updateMode("dashboard");
     await nextTick();
 
-    expect(".o-fullscreen-chart").toHaveCount(0);
+    expect(".o-fullscreen-figure").toHaveCount(0);
     expect(".o-figure [data-id='fullScreenChart']").toHaveCount(0);
   });
 
@@ -59,27 +59,27 @@ describe("chart menu for dashboard", () => {
 
     // Click fullscreen menu item
     await click(fixture, ".o-figure [data-id='fullScreenChart']");
-    expect(".o-fullscreen-chart").toHaveCount(1);
-    await click(fixture, ".o-fullscreen-chart [data-id='fullScreenChart']");
-    expect(".o-fullscreen-chart").toHaveCount(0);
+    expect(".o-fullscreen-figure").toHaveCount(1);
+    await click(fixture, ".o-fullscreen-figure [data-id='fullScreenChart']");
+    expect(".o-fullscreen-figure").toHaveCount(0);
 
     // Click outside of the chart in the full screen overlay
     await click(fixture, ".o-figure [data-id='fullScreenChart']");
-    expect(".o-fullscreen-chart").toHaveCount(1);
-    await click(fixture, ".o-fullscreen-chart-overlay > div:first-child");
-    expect(".o-fullscreen-chart").toHaveCount(0);
+    expect(".o-fullscreen-figure").toHaveCount(1);
+    await click(fixture, ".o-fullscreen-figure-overlay > div:first-child");
+    expect(".o-fullscreen-figure").toHaveCount(0);
 
     // Click the exit button in the full screen overlay
     await click(fixture, ".o-figure [data-id='fullScreenChart']");
-    expect(".o-fullscreen-chart").toHaveCount(1);
-    await click(fixture, ".o-fullscreen-chart-overlay button.o-exit");
-    expect(".o-fullscreen-chart").toHaveCount(0);
+    expect(".o-fullscreen-figure").toHaveCount(1);
+    await click(fixture, ".o-fullscreen-figure-overlay button.o-exit");
+    expect(".o-fullscreen-figure").toHaveCount(0);
 
     // Press escape key
     await click(fixture, ".o-figure [data-id='fullScreenChart']");
-    expect(".o-fullscreen-chart").toHaveCount(1);
+    expect(".o-fullscreen-figure").toHaveCount(1);
     await keyDown({ key: "Escape" });
-    expect(".o-fullscreen-chart").toHaveCount(0);
+    expect(".o-fullscreen-figure").toHaveCount(0);
   });
 
   test("Keeps fullscreen open when pointerdown is inside and pointerup is outside", async () => {
@@ -88,10 +88,10 @@ describe("chart menu for dashboard", () => {
     await nextTick();
 
     await click(fixture, ".o-figure [data-id='fullScreenChart']");
-    expect(".o-fullscreen-chart").toHaveCount(1);
+    expect(".o-fullscreen-figure").toHaveCount(1);
 
-    const chart = fixture.querySelector(".o-fullscreen-chart")!;
-    const overlay = fixture.querySelector(".o-fullscreen-chart-overlay")!;
+    const chart = fixture.querySelector(".o-fullscreen-figure")!;
+    const overlay = fixture.querySelector(".o-fullscreen-figure-overlay")!;
     expect(chart).not.toBeNull();
     expect(overlay).not.toBeNull();
 
@@ -101,6 +101,6 @@ describe("chart menu for dashboard", () => {
     triggerMouseEvent(overlay, "click");
     await nextTick();
 
-    expect(".o-fullscreen-chart").toHaveCount(1);
+    expect(".o-fullscreen-figure").toHaveCount(1);
   });
 });


### PR DESCRIPTION

### [IMP] carousel: allow full screen toggle in carousel

This commit adds the possibility to toggle full screen mode for a
carousel figure.


### [MOV] figures: rename `fullScreenChart` to `fullScreenFigure`

The following commits will allow carousels to be displayed in full
screen mode, making it so the feature is not limited to charts only.


Task: [5078831](https://www.odoo.com/odoo/2328/tasks/5078831)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo