### PR TITLE
[FIX] charts: truncate radar chart labels correctly

### DIFF
--- a/src/helpers/figures/charts/runtime/chartjs_scales.ts
+++ b/src/helpers/figures/charts/runtime/chartjs_scales.ts
@@ -226,7 +226,7 @@ export function getRadarChartScales(
       },
       pointLabels: {
         color: chartFontColor(definition.background),
-        callback: truncateLabel,
+        callback: (label: string) => truncateLabel(label),
       },
       suggestedMin: minValue < 0 ? minValue - 1 : 0,
     },

--- a/tests/figures/chart/radar_chart_plugin.test.ts
+++ b/tests/figures/chart/radar_chart_plugin.test.ts
@@ -148,6 +148,17 @@ describe("radar chart", () => {
     const runtime = model.getters.getChartRuntime("chartId") as RadarChartRuntime;
     expect(runtime.chartJsConfig.options?.scales?.r?.suggestedMin).toBe(-8);
   });
+
+  test("Radar chart point labels are truncated properly", () => {
+    const model = new Model();
+    createRadarChart(model, { dataSets: [{ dataRange: "A1:A2" }] }, "chartId");
+    const runtime = model.getters.getChartRuntime("chartId") as RadarChartRuntime;
+    const callback = (runtime.chartJsConfig.options?.scales?.r as any)?.pointLabels
+      ?.callback as Function;
+
+    expect(callback("short", 0)).toBe("short");
+    expect(callback("very very long label of radar", 1)).toBe("very very long label…");
+  });
 });
 
 test("Humanization is taken into account for the axis ticks of a radar chart", async () => {


### PR DESCRIPTION
## Description:
Current behavior before PR:
- Radar chart point labels were truncated incorrectly because Chart.js passes
extra arguments (label, index, labels) to the callback.
- As a result, truncateLabel received the index as maxLen and applied
unnecessary truncation.

Desired behavior after PR is merged:
- The callback now wraps truncateLabel to pass only the label string.
- This ensures long labels are truncated with ellipsis and short labels
remain unchanged.

Task: [5078858](https://www.odoo.com/odoo/2328/tasks/5078858)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo