### PR TITLE
[FIX] functions: fix LINEST error massage

### DIFF
--- a/src/functions/helpers.ts
+++ b/src/functions/helpers.ts
@@ -78,13 +78,24 @@ export function tryCastAsNumberMatrix(data: Matrix<any>, argName: string): Matri
   data.forEach((row) => {
     row.forEach((cell) => {
       if (typeof cell !== "number") {
-        throw new Error(
-          _t(
-            "Function [[FUNCTION_NAME]] expects number values for %s, but got a %s.",
-            typeof cell,
+        let message = "";
+        if (typeof cell === "object") {
+          message = _t(
+            "Function [[FUNCTION_NAME]] expects number values for %s, but got an empty value.",
             argName
-          )
-        );
+          );
+        } else if (typeof cell === "string") {
+          message = _t(
+            "Function [[FUNCTION_NAME]] expects number values for %s, but got a string.",
+            argName
+          );
+        } else if (typeof cell === "boolean") {
+          message = _t(
+            "Function [[FUNCTION_NAME]] expects number values for %s, but got a boolean.",
+            argName
+          );
+        }
+        throw new Error(message);
       }
     });
   });

--- a/src/functions/module_statistical.ts
+++ b/src/functions/module_statistical.ts
@@ -832,9 +832,9 @@ export const GROWTH: AddFunctionDescription = {
     assertNonEmptyMatrix(knownDataY, "known_data_y");
     return expM(
       predictLinearValues(
-        logM(tryCastAsNumberMatrix(knownDataY, "the first argument (known_data_y)")),
-        tryCastAsNumberMatrix(knownDataX, "the second argument (known_data_x)"),
-        tryCastAsNumberMatrix(newDataX, "the third argument (new_data_y)"),
+        logM(tryCastAsNumberMatrix(knownDataY, "known_data_y")),
+        tryCastAsNumberMatrix(knownDataX, "known_data_x"),
+        tryCastAsNumberMatrix(newDataX, "new_data_y"),
         toBoolean(b)
       )
     );
@@ -944,8 +944,8 @@ export const LINEST: AddFunctionDescription = {
   ): (number | string)[][] {
     assertNonEmptyMatrix(dataY, "data_y");
     return fullLinearRegression(
-      tryCastAsNumberMatrix(dataX, "the first argument (data_y)"),
-      tryCastAsNumberMatrix(dataY, "the second argument (data_x)"),
+      tryCastAsNumberMatrix(dataX, "data_x"),
+      tryCastAsNumberMatrix(dataY, "data_y"),
       toBoolean(calculateB),
       toBoolean(verbose)
     );
@@ -987,8 +987,8 @@ export const LOGEST: AddFunctionDescription = {
   ): (number | string)[][] {
     assertNonEmptyMatrix(dataY, "data_y");
     const coeffs = fullLinearRegression(
-      tryCastAsNumberMatrix(dataX, "the second argument (data_x)"),
-      logM(tryCastAsNumberMatrix(dataY, "the first argument (data_y)")),
+      tryCastAsNumberMatrix(dataX, "data_x"),
+      logM(tryCastAsNumberMatrix(dataY, "data_y")),
       toBoolean(calculateB),
       toBoolean(verbose)
     );
@@ -1883,9 +1883,9 @@ export const TREND: AddFunctionDescription = {
   ): Matrix<number> {
     assertNonEmptyMatrix(knownDataY, "known_data_y");
     return predictLinearValues(
-      tryCastAsNumberMatrix(knownDataY, "the first argument (known_data_y)"),
-      tryCastAsNumberMatrix(knownDataX, "the second argument (known_data_x)"),
-      tryCastAsNumberMatrix(newDataX, "the third argument (new_data_y)"),
+      tryCastAsNumberMatrix(knownDataY, "known_data_y"),
+      tryCastAsNumberMatrix(knownDataX, "known_data_x"),
+      tryCastAsNumberMatrix(newDataX, "new_data_y"),
       toBoolean(b)
     );
   },

--- a/tests/functions/module_statistical.test.ts
+++ b/tests/functions/module_statistical.test.ts
@@ -3551,6 +3551,13 @@ describe("LINEST formula", () => {
     const model = createModelFromGrid(grid);
     expect(getEvaluatedCell(model, "A10").value).toBe("#ERROR");
   });
+
+  test("Error message with empty values is correct", () => {
+    const model = createModelFromGrid({ A1: "=LINEST(C1:C2)" });
+    expect((getEvaluatedCell(model, "A1") as ErrorCell).error.message).toBe(
+      "Function LINEST expects number values for data_y, but got an empty value."
+    );
+  });
 });
 
 describe("LOGEST formula", () => {


### PR DESCRIPTION
## Description

The functions using the helper `tryCastAsNumberMatrix` had a wrong error message:

- the two arguments in the translated string were inverted
- an argument of `_t` was `typeof cell`, which isn't translated
- the other argument of the `_t` was something like `the first argument (data_y)`, which wasn't translated either

Task: [5059375](https://www.odoo.com/odoo/2328/tasks/5059375)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo