### PR TITLE
[FIX] package: fix the version of swc

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@prettier/plugin-xml": "^2.2.0",
     "@rollup/plugin-node-resolve": "^15.2.0",
     "@rollup/plugin-terser": "^0.4.3",
-    "@swc/jest": "^0.2.36",
+    "@swc/jest": "0.2.36",
     "@types/jest": "^27.0.1",
     "@types/node": "^13.13.23",
     "@types/rbush": "^3.0.3",


### PR DESCRIPTION
when switching from version to version of node, it might be that the SWC/Jest package updates from 0.2.36 to 0.2.38 on newer branches. This brakes the ability to run tests on lower branches with "cannot find bindings..." error.

