### PR TITLE
[IMP] carousel: add context menu button

### DIFF
--- a/src/components/figures/figure/figure.ts
+++ b/src/components/figures/figure/figure.ts
@@ -336,7 +336,7 @@ export class FigureComponent extends Component<Props, SpreadsheetChildEnv> {
     this.openContextMenu(getRefBoundingRect(this.menuButtonRef));
   }
 
-  private openContextMenu(anchorRect: Rect) {
+  openContextMenu(anchorRect: Rect) {
     this.menuState.isOpen = true;
     this.menuState.anchorRect = anchorRect;
     this.menuState.menuItems = figureRegistry

--- a/src/components/figures/figure/figure.xml
+++ b/src/components/figures/figure/figure.xml
@@ -19,6 +19,7 @@
           onFigureDeleted="props.onFigureDeleted"
           figureUI="props.figureUI"
           editFigureStyle.bind="editWrapperStyle"
+          openContextMenu.bind="openContextMenu"
         />
         <div class="o-figure-menu position-absolute m-2" t-if="!env.isDashboard()">
           <div

--- a/src/components/figures/figure_carousel/figure_carousel.scss
+++ b/src/components/figures/figure_carousel/figure_carousel.scss
@@ -46,6 +46,10 @@
         margin: 1px;
       }
 
+      &.o-carousel-menu-button {
+        padding: 3px 5px;
+      }
+
       &.active,
       &:hover {
         background-color: $os-button-hover-bg;

--- a/src/components/figures/figure_carousel/figure_carousel.ts
+++ b/src/components/figures/figure_carousel/figure_carousel.ts
@@ -12,6 +12,7 @@ import {
   CarouselItem,
   FigureUI,
   MenuMouseEvent,
+  Rect,
   SpreadsheetChildEnv,
 } from "../../../types";
 import { FullScreenFigureStore } from "../../full_screen_figure/full_screen_figure_store";
@@ -26,6 +27,7 @@ interface Props {
   onFigureDeleted: () => void;
   editFigureStyle?: (properties: CSSProperties) => void;
   isFullScreen?: boolean;
+  openContextMenu?: (anchorRect: Rect, onClose?: () => void) => void;
 }
 
 export class CarouselFigure extends Component<Props, SpreadsheetChildEnv> {
@@ -35,6 +37,7 @@ export class CarouselFigure extends Component<Props, SpreadsheetChildEnv> {
     onFigureDeleted: Function,
     editFigureStyle: { type: Function, optional: true },
     isFullScreen: { type: Boolean, optional: true },
+    openContextMenu: { type: Function, optional: true },
   };
   static components = { ChartDashboardMenu, MenuPopover };
 
@@ -194,5 +197,12 @@ export class CarouselFigure extends Component<Props, SpreadsheetChildEnv> {
     return this.carousel.items.filter((item) =>
       item.type === "carouselDataView" && this.props.isFullScreen ? false : true
     );
+  }
+
+  openContextMenu(event: MouseEvent) {
+    const target = event.currentTarget as HTMLElement;
+    if (target) {
+      this.props.openContextMenu?.(getBoundingRectAsPOJO(target));
+    }
   }
 }

--- a/src/components/figures/figure_carousel/figure_carousel.xml
+++ b/src/components/figures/figure_carousel/figure_carousel.xml
@@ -51,6 +51,11 @@
           }"
           t-on-click="toggleFullScreen"
         />
+        <div
+          t-if="!env.isDashboard()"
+          class="o-carousel-menu-button o-carousel-button fa fa-ellipsis-v rounded ms-1"
+          t-on-click="openContextMenu"
+        />
       </div>
       <div
         t-if="!selectedItem"

--- a/src/components/figures/figure_chart/figure_chart.ts
+++ b/src/components/figures/figure_chart/figure_chart.ts
@@ -1,6 +1,6 @@
 import { Component } from "@odoo/owl";
 import { chartComponentRegistry } from "../../../registries/chart_types";
-import { ChartType, CSSProperties, FigureUI, SpreadsheetChildEnv, UID } from "../../../types";
+import { ChartType, CSSProperties, FigureUI, Rect, SpreadsheetChildEnv, UID } from "../../../types";
 import { ChartDashboardMenu } from "../chart/chart_dashboard_menu/chart_dashboard_menu";
 
 interface Props {
@@ -10,6 +10,7 @@ interface Props {
   onFigureDeleted: () => void;
   editFigureStyle?: (properties: CSSProperties) => void;
   isFullScreen?: boolean;
+  openContextMenu?: (anchorRect: Rect, onClose?: () => void) => void;
 }
 
 export class ChartFigure extends Component<Props, SpreadsheetChildEnv> {
@@ -19,6 +20,7 @@ export class ChartFigure extends Component<Props, SpreadsheetChildEnv> {
     onFigureDeleted: Function,
     editFigureStyle: { type: Function, optional: true },
     isFullScreen: { type: Boolean, optional: true },
+    openContextMenu: { type: Function, optional: true },
   };
   static components = { ChartDashboardMenu };
 

--- a/src/components/figures/figure_image/figure_image.ts
+++ b/src/components/figures/figure_image/figure_image.ts
@@ -1,10 +1,11 @@
 import { Component } from "@odoo/owl";
-import { CSSProperties, FigureUI, SpreadsheetChildEnv, UID } from "../../../types";
+import { CSSProperties, FigureUI, Rect, SpreadsheetChildEnv, UID } from "../../../types";
 
 interface Props {
   figureUI: FigureUI;
   onFigureDeleted: () => void;
   editFigureStyle?: (properties: CSSProperties) => void;
+  openContextMenu?: (anchorRect: Rect, onClose?: () => void) => void;
 }
 
 export class ImageFigure extends Component<Props, SpreadsheetChildEnv> {
@@ -13,6 +14,7 @@ export class ImageFigure extends Component<Props, SpreadsheetChildEnv> {
     figureUI: Object,
     onFigureDeleted: Function,
     editFigureStyle: { type: Function, optional: true },
+    openContextMenu: { type: Function, optional: true },
   };
   static components = {};
 

--- a/tests/figures/carousel/carousel_figure_component.test.ts
+++ b/tests/figures/carousel/carousel_figure_component.test.ts
@@ -257,6 +257,21 @@ describe("Carousel figure component", () => {
     });
   });
 
+  test("Can open carousel context menu with both right click and the menu icon", async () => {
+    createCarousel(model, { items: [] }, "carouselId");
+    const { fixture } = await mountSpreadsheet({ model });
+
+    triggerMouseEvent(".o-figure", "contextmenu");
+    await nextTick();
+    expect(".o-popover .o-menu").toHaveCount(1);
+
+    await click(fixture, ".o-grid"); // close the menu
+    expect(".o-popover .o-menu").toHaveCount(0);
+
+    await click(fixture, ".o-figure .o-carousel-menu-button");
+    expect(".o-popover .o-menu").toHaveCount(1);
+  });
+
   describe("Carousel menu items", () => {
     let env: SpreadsheetChildEnv;
     let openSidePanel: jest.Mock;


### PR DESCRIPTION
## Description

This commit adds a button to open the context menu of a carousel, in addition to the right-click which is not discoverable.

Task: [5081771](https://www.odoo.com/odoo/2328/tasks/5081771)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo