### PR TITLE
[FIX] carousel: missing color for empty carousel header

### DIFF
--- a/src/components/figures/figure_carousel/figure_carousel.ts
+++ b/src/components/figures/figure_carousel/figure_carousel.ts
@@ -103,11 +103,11 @@ export class CarouselFigure extends Component<Props, SpreadsheetChildEnv> {
 
   get headerStyle(): string {
     const cssProperties: CSSProperties = {};
-    if (this.selectedCarouselItem?.type === "carouselDataView") {
-      cssProperties["background-color"] = "#ffffff";
-    } else if (this.selectedCarouselItem?.type === "chart") {
+    if (this.selectedCarouselItem?.type === "chart") {
       const chart = this.env.model.getters.getChartRuntime(this.selectedCarouselItem.chartId);
       cssProperties["background-color"] = chart.background;
+    } else {
+      cssProperties["background-color"] = "#ffffff";
     }
     return cssPropertiesToCss(cssProperties);
   }

--- a/tests/figures/carousel/carousel_figure_component.test.ts
+++ b/tests/figures/carousel/carousel_figure_component.test.ts
@@ -9,6 +9,7 @@ import {
   createCarousel,
   createChart,
   paste,
+  selectCarouselItem,
   updateCarousel,
 } from "../../test_helpers/commands_helpers";
 import { click, clickAndDrag, getElStyle, triggerMouseEvent } from "../../test_helpers/dom_helper";
@@ -162,6 +163,25 @@ describe("Carousel figure component", () => {
     expect(".o-figure .o-carousel-title").toHaveText("Title1");
     expect(getElStyle(".o-figure .o-carousel-title", "font-size")).toBe("20px");
     expect(getElStyle(".o-figure .o-carousel-title", "font-weight")).toBe("bold");
+  });
+
+  test("Carousel header has the correct background color", async () => {
+    createCarousel(model, { items: [], title: { text: "Title" } }, "carouselId");
+    await mountSpreadsheet({ model });
+
+    // Empty carousel
+    expect(".o-carousel-header").toHaveStyle({ "background-color": "#FFFFFF" });
+
+    // Carousel with data view
+    updateCarousel(model, "carouselId", { items: [{ type: "carouselDataView" }] });
+    await nextTick();
+    expect(".o-carousel-header").toHaveStyle({ "background-color": "#FFFFFF" });
+
+    // Carousel with chart
+    const chartId = addNewChartToCarousel(model, "carouselId", { background: "#123456" });
+    selectCarouselItem(model, "carouselId", { type: "chart", chartId });
+    await nextTick();
+    expect(".o-carousel-header").toHaveStyle({ "background-color": "#123456" });
   });
 
   test("display chart menu", async () => {

--- a/tests/setup/jest_extend.ts
+++ b/tests/setup/jest_extend.ts
@@ -1,5 +1,5 @@
 import { Model } from "../../src";
-import { isSameColor } from "../../src/helpers/color";
+import { isSameColor, toHex } from "../../src/helpers/color";
 import { toXC } from "../../src/helpers/coordinates";
 import { deepEquals } from "../../src/helpers/misc";
 import { positions } from "../../src/helpers/zones";
@@ -308,6 +308,9 @@ CancelledReasons: ${this.utils.printReceived(dispatchResult.reasons)}
     const receivedStyle: Record<string, string> = {};
     for (const key of Object.keys(expectedStyle)) {
       receivedStyle[key] = element.style.getPropertyValue(key);
+      if (receivedStyle[key].startsWith("rgb")) {
+        receivedStyle[key] = toHex(receivedStyle[key]);
+      }
     }
     const pass = this.equals(receivedStyle, expectedStyle, [this.utils.iterableEquality]);
     const message = () =>


### PR DESCRIPTION

The header for an empty carousel with a title was missing a background
color, making it transparent.

Task: [5082459](https://www.odoo.com/odoo/2328/tasks/5082459)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo