### PR TITLE
[IMP] carousel: allow duplicating charts in carousel

### DIFF
--- a/packages/o-spreadsheet-engine/src/plugins/ui_stateful/carousel_ui.ts
+++ b/packages/o-spreadsheet-engine/src/plugins/ui_stateful/carousel_ui.ts
@@ -1,8 +1,13 @@
 import { UuidGenerator } from "../../helpers";
 import { CAROUSEL_DEFAULT_CHART_DEFINITION } from "../../helpers/carousel_helpers";
 import { AbstractChart } from "../../helpers/figures/charts/abstract_chart";
-import { deepEquals } from "../../helpers/misc";
-import { Command, CommandResult, LocalCommand } from "../../types/commands";
+import { deepEquals, insertItemsAtIndex } from "../../helpers/misc";
+import {
+  Command,
+  CommandResult,
+  DuplicateCarouselChartCommand,
+  LocalCommand,
+} from "../../types/commands";
 import { Carousel, CarouselItem } from "../../types/figure";
 import { UID } from "../../types/misc";
 import { UIPlugin } from "../ui_plugin";
@@ -24,6 +29,17 @@ export class CarouselUIPlugin extends UIPlugin {
         if (
           !this.getters.doesCarouselExist(cmd.carouselFigureId) ||
           this.getters.getFigure(cmd.sheetId, cmd.chartFigureId)?.tag !== "chart"
+        ) {
+          return CommandResult.InvalidFigureId;
+        }
+        return CommandResult.Success;
+      case "DUPLICATE_CAROUSEL_CHART":
+        if (
+          !this.getters.doesCarouselExist(cmd.carouselId) ||
+          !this.getters
+            .getCarousel(cmd.carouselId)
+            .items.some((item) => item.type === "chart" && item.chartId === cmd.chartId) ||
+          this.getters.getChart(cmd.duplicatedChartId)
         ) {
           return CommandResult.InvalidFigureId;
         }
@@ -54,6 +70,9 @@ export class CarouselUIPlugin extends UIPlugin {
         break;
       case "ADD_FIGURE_CHART_TO_CAROUSEL":
         this.addFigureChartToCarousel(cmd.carouselFigureId, cmd.chartFigureId, cmd.sheetId);
+        break;
+      case "DUPLICATE_CAROUSEL_CHART":
+        this.duplicateCarouselChart(cmd);
         break;
       case "UPDATE_CAROUSEL_ACTIVE_ITEM":
         this.carouselStates[cmd.figureId] = this.getCarouselItemId(cmd.item);
@@ -210,6 +229,45 @@ export class CarouselUIPlugin extends UIPlugin {
       definition: this.getters.getChartDefinition(chartId),
     });
     this.dispatch("DELETE_FIGURE", { sheetId, figureId: chartFigureId });
+  }
+
+  private duplicateCarouselChart({
+    carouselId,
+    chartId,
+    sheetId,
+    duplicatedChartId,
+  }: DuplicateCarouselChartCommand) {
+    const chart = this.getters.getChart(chartId);
+    if (!chart) {
+      return;
+    }
+    const carousel = this.getters.getCarousel(carouselId);
+
+    const duplicatedItemIndex = carousel.items.findIndex(
+      (item) => item.type === "chart" && item.chartId === chartId
+    );
+    if (duplicatedItemIndex === -1) {
+      return;
+    }
+
+    this.dispatch("CREATE_CHART", {
+      chartId: duplicatedChartId,
+      figureId: carouselId,
+      sheetId,
+      definition: chart.getDefinition(),
+    });
+
+    const carouselItems = insertItemsAtIndex(
+      carousel.items,
+      [{ type: "chart", chartId: duplicatedChartId }],
+      duplicatedItemIndex + 1
+    );
+
+    this.dispatch("UPDATE_CAROUSEL", {
+      sheetId,
+      figureId: carouselId,
+      definition: { ...carousel, items: carouselItems },
+    });
   }
 
   private getCarouselItemId(item: CarouselItem): UID {

--- a/packages/o-spreadsheet-engine/src/types/commands.ts
+++ b/packages/o-spreadsheet-engine/src/types/commands.ts
@@ -602,6 +602,13 @@ export interface AddFigureChartToCarouselCommand extends SheetDependentCommand {
   chartFigureId: UID;
 }
 
+export interface DuplicateCarouselChartCommand extends SheetDependentCommand {
+  type: "DUPLICATE_CAROUSEL_CHART";
+  carouselId: UID;
+  chartId: UID;
+  duplicatedChartId: UID;
+}
+
 export interface UpdateCarouselActiveItemCommand extends SheetDependentCommand {
   type: "UPDATE_CAROUSEL_ACTIVE_ITEM";
   figureId: UID;
@@ -1287,6 +1294,7 @@ export type LocalCommand =
   | ToggleCheckboxCommand
   | AddNewChartToCarouselCommand
   | AddFigureChartToCarouselCommand
+  | DuplicateCarouselChartCommand
   | UpdateCarouselActiveItemCommand
   | PopOutChartFromCarouselCommand;
 

--- a/src/components/side_panel/carousel_panel/carousel_panel.ts
+++ b/src/components/side_panel/carousel_panel/carousel_panel.ts
@@ -126,6 +126,16 @@ export class CarouselPanel extends Component<Props, SpreadsheetChildEnv> {
     });
   }
 
+  duplicateCarouselChart(item: CarouselItem) {
+    if (item.type !== "chart") return;
+    this.env.model.dispatch("DUPLICATE_CAROUSEL_CHART", {
+      sheetId: this.carouselSheetId,
+      carouselId: this.props.figureId,
+      chartId: item.chartId,
+      duplicatedChartId: this.env.model.uuidGenerator.smallUuid(),
+    });
+  }
+
   onDragHandleMouseDown(item: CarouselItem, event: MouseEvent) {
     if (event.button !== 0) return;
     const previewRects = Array.from(this.previewListRef.el!.children).map((previewEl) =>
@@ -221,6 +231,11 @@ export class CarouselPanel extends Component<Props, SpreadsheetChildEnv> {
         name: _t("Pop out chart"),
         execute: () => this.popOutCarouselItem(item),
         icon: "o-spreadsheet-Icon.EXTERNAL",
+      });
+      actions.push({
+        name: _t("Duplicate chart"),
+        execute: () => this.duplicateCarouselChart(item),
+        icon: "o-spreadsheet-Icon.COPY",
       });
     }
     actions.push({

--- a/tests/figures/carousel/carousel_panel_component.test.ts
+++ b/tests/figures/carousel/carousel_panel_component.test.ts
@@ -105,6 +105,22 @@ describe("Carousel panel component", () => {
     expect(model.getters.getChartIds(model.getters.getActiveSheetId())).toHaveLength(1);
   });
 
+  test("Can duplicate a carousel chart", async () => {
+    createCarousel(model, { items: [] }, "carouselId");
+    addNewChartToCarousel(model, "carouselId", { type: "radar" });
+
+    await mountCarouselPanel(model, "carouselId");
+    await click(fixture, ".o-carousel-preview .os-cog-wheel-menu-icon");
+    await click(fixture, '.o-menu-item[title="Duplicate chart"]');
+
+    const items = model.getters.getCarousel("carouselId").items;
+    expect(items).toHaveLength(2);
+
+    expect(model.getters.getChartDefinition(items[0]["chartId"])).toMatchObject({ type: "radar" });
+    expect(items[1]["chartId"]).not.toEqual(items[0]["chartId"]);
+    expect(model.getters.getChartDefinition(items[1]["chartId"])).toMatchObject({ type: "radar" });
+  });
+
   test("Can drag & drop carousel items to re-order them", async () => {
     createCarousel(model, { items: [] }, "carouselId");
     const radarId = addNewChartToCarousel(model, "carouselId", { type: "radar" });

--- a/tests/figures/carousel/carousel_plugin.test.ts
+++ b/tests/figures/carousel/carousel_plugin.test.ts
@@ -99,6 +99,27 @@ describe("Carousel figure", () => {
       });
       expect(result).toBeSuccessfullyDispatched();
     });
+
+    test("Cannot duplicate wrong carousel item", () => {
+      createCarousel(model, { items: [] }, "carouselId");
+      const chartId = addNewChartToCarousel(model, "carouselId");
+
+      let result = model.dispatch("DUPLICATE_CAROUSEL_CHART", {
+        carouselId: "wrongCarouselId",
+        sheetId,
+        chartId,
+        duplicatedChartId: "anyId",
+      });
+      expect(result).toBeCancelledBecause(CommandResult.InvalidFigureId);
+
+      result = model.dispatch("DUPLICATE_CAROUSEL_CHART", {
+        carouselId: "carouselId",
+        sheetId,
+        chartId: "invalidChartId",
+        duplicatedChartId: "anyId",
+      });
+      expect(result).toBeCancelledBecause(CommandResult.InvalidFigureId);
+    });
   });
 
   test("Can create a carousel figure", () => {


### PR DESCRIPTION
## Description

This commit adds a button in the cog wheel of the carousel panel to duplicate charts in the carousel.

Task: [5081788](https://www.odoo.com/odoo/2328/tasks/5081788)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo