### PR TITLE
[FIX] chart: zoomable chart should be animated

### DIFF
--- a/src/components/figures/chart/chartJs/chartjs.ts
+++ b/src/components/figures/chart/chartJs/chartjs.ts
@@ -127,7 +127,7 @@ export class ChartJsComponent extends Component<Props, SpreadsheetChildEnv> {
     this.chart?.destroy();
   }
 
-  protected get shouldAnimate(): boolean {
+  private get shouldAnimate(): boolean {
     return this.env.model.getters.isDashboard();
   }
 

--- a/src/components/figures/chart/chartJs/zoomable_chart/zoomable_chartjs.ts
+++ b/src/components/figures/chart/chartJs/zoomable_chart/zoomable_chartjs.ts
@@ -139,10 +139,6 @@ export class ZoomableChartJsComponent extends ChartJsComponent {
     return { xMin, xMax };
   }
 
-  protected get shouldAnimate() {
-    return this.env.model.getters.isDashboard() && !this.sliceable;
-  }
-
   protected createChart(chartRuntime: ChartJSRuntime) {
     const chartData = chartRuntime.chartJsConfig as ChartConfiguration<any>;
     this.isBarChart = chartData.type === "bar";
@@ -168,6 +164,9 @@ export class ZoomableChartJsComponent extends ChartJsComponent {
       this.getMasterChartConfiguration(chartRuntime["masterChartConfig"] as ChartConfiguration<any>)
     );
     this.resetAxesLimits();
+    if (this.chart?.options) {
+      this.chart.options.animation = false;
+    }
   }
 
   protected updateChartJs(chartRuntime: ChartJSRuntime) {
@@ -206,6 +205,9 @@ export class ZoomableChartJsComponent extends ChartJsComponent {
       }
     }
     this.resetAxesLimits();
+    if (this.chart?.options) {
+      this.chart.options.animation = false;
+    }
   }
 
   private resetAxesLimits() {
@@ -312,7 +314,7 @@ export class ZoomableChartJsComponent extends ChartJsComponent {
   onPointerDownInMasterChart(ev: PointerEvent) {
     this.removeEventListeners();
     const position = ev.offsetX;
-    if (!this.masterChart?.chartArea || !this.chart?.scales.x) {
+    if (!this.masterChart?.chartArea || !this.chart?.scales?.x) {
       return;
     }
     const { left, right, top, bottom } = this.masterChart.chartArea;

--- a/tests/figures/chart/charts_zoom.test.ts
+++ b/tests/figures/chart/charts_zoom.test.ts
@@ -16,9 +16,6 @@ import {
 import { extendMockGetBoundingClientRect } from "../../test_helpers/mock_helpers";
 
 extendMockGetBoundingClientRect({
-  "o-popover": () => ({ height: 0, width: 0 }),
-  "o-figure-menu-item": () => ({ top: 500, left: 500 }),
-  "o-figure-zoom-icons": () => ({ top: 500, left: 400 }),
   "o-master-chart-canvas": () => ({ top: 0, left: 0, width: 100, height: 50 }),
 });
 


### PR DESCRIPTION
## Task Description

Currently, animations are fully desactivated for zoomable chart as soon as the slicer is visible. This PR aims to allow the animations for chart when editing the chart data (global filter update) or opening the chart in full screen

## Reated Task

- Task: [5079057](https://www.odoo.com/odoo/2328/tasks/5079057)