### PR TITLE
[FIX] functions: wrong error message for `SORT`

### DIFF
--- a/src/functions/module_filter.ts
+++ b/src/functions/module_filter.ts
@@ -23,13 +23,11 @@ function sortMatrix(
   locale: Locale,
   ...criteria: Arg[]
 ): Matrix<ValueAndFormat> {
-  for (const [i, value] of criteria.entries()) {
+  for (let i = 0; i < criteria.length; i++) {
+    const param = i % 2 === 0 ? "sort_column" : "is_ascending";
     assert(
-      () => value !== undefined,
-      _t(
-        "Value for parameter %d is missing, while the function [[FUNCTION_NAME]] expect a number or a range.",
-        i + 1
-      )
+      () => criteria[i] !== undefined,
+      _t("Value for parameter %s is missing in [[FUNCTION_NAME]].", param)
     );
   }
   const sortingOrders: ("ascending" | "descending")[] = [];

--- a/tests/functions/module_filter.test.ts
+++ b/tests/functions/module_filter.test.ts
@@ -219,6 +219,20 @@ describe("UNIQUE function", () => {
 });
 
 describe("SORT function", () => {
+  test("SORT error messages", () => {
+    const grid = {
+      A1: "=SORT()",
+      A2: "=SORT(B1:B5, ,FALSE)",
+      A3: "=SORT(B1:B5, C1:C5, )",
+    };
+    const model = createModelFromGrid(grid);
+    expect(getCellError(model, "A1")).toBe(
+      "Invalid number of arguments for the SORT function. Expected 1 minimum, but got 0 instead."
+    );
+    expect(getCellError(model, "A2")).toBe("Value for parameter sort_column is missing in SORT.");
+    expect(getCellError(model, "A3")).toBe("Value for parameter is_ascending is missing in SORT.");
+  });
+
   test("Sorting a single column of numbers", () => {
     //prettier-ignore
     const grid = {
@@ -742,6 +756,20 @@ describe("SORT function", () => {
 });
 
 describe("SORTN function", () => {
+  test("SORTN error messages", () => {
+    const grid = {
+      A1: "=SORTN()",
+      A2: "=SORTN(B1:B5, 5, 0, ,FALSE)",
+      A3: "=SORTN(B1:B5, 5, 0, C1:C5, )",
+    };
+    const model = createModelFromGrid(grid);
+    expect(getCellError(model, "A1")).toBe(
+      "Invalid number of arguments for the SORTN function. Expected 1 minimum, but got 0 instead."
+    );
+    expect(getCellError(model, "A2")).toBe("Value for parameter sort_column is missing in SORTN.");
+    expect(getCellError(model, "A3")).toBe("Value for parameter is_ascending is missing in SORTN.");
+  });
+
   test("Sorting a single column of numbers", () => {
     //prettier-ignore
     const grid = {


### PR DESCRIPTION
## Description

There was a bunch of problems in the errors messages of the `SORT` and `SORTN` functions:

- we were using %d, which isn't supported
- the index displayed is always wrong
- we display the same index for both `SORT` and `SORTN` while they have different number of mandatory arguments
- the message said we expected `a number or a range` while `is_ascending`

Task: [5085267](https://www.odoo.com/odoo/2328/tasks/5085267)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo