### PR TITLE
[FIX] icons: add missing o-icon class to SVG elements

### DIFF
--- a/src/components/icons/icons.xml
+++ b/src/components/icons/icons.xml
@@ -804,7 +804,7 @@
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.COG">
-    <svg fill="currentColor" viewBox="0 0 16 16">
+    <svg class="o-icon" fill="currentColor" viewBox="0 0 16 16">
       <path
         d="M8 4.754a3.246 3.246 0 1 0 0 6.492 3.246 3.246 0 0 0 0-6.492zM5.754 8a2.246 2.246 0 1 1 4.492 0 2.246 2.246 0 0 1-4.492 0z"
       />
@@ -897,7 +897,7 @@
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.EDIT_TABLE">
-    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18">
+    <svg class="o-icon" xmlns="http://www.w3.org/2000/svg" width="18" height="18">
       <path
         fill="currentColor"
         d="M2.5 1A1.5 1.5 0 0 0 1 2.5v11A1.5 1.5 0 0 0 2.5 15H7l1.5-1.5H7v-2.75h3.5v.75l2.25-2.25H12v-2.5h3.5v.75c.1-.2.45-.05.5.02l1 1V2.5A1.5 1.5 0 0 0 15.5 1m-13 1.5h13v2.75h-13m0 1.5h3v2.5h-3M7 6.75h3.5v2.5H7m-4.5 1.5h3v2.75h-3 M8.2 15.7v1.8h1.8l5.4-5.4-1.8-1.8-5.4 5.4Zm8.8-5.2a.5.5 0 0 0 0-.7l-1.1-1.1a.5.5 0 0 0-.7 0l-.9.9 1.8 1.8.9-.9Z"
@@ -905,7 +905,7 @@
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.DELETE_TABLE">
-    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18">
+    <svg class="o-icon" xmlns="http://www.w3.org/2000/svg" width="18" height="18">
       <path
         fill="currentColor"
         d="M2.5 1A1.5 1.5 0 0 0 1 2.5v11A1.5 1.5 0 0 0 2.5 15H7l1.5-1.5H7V6.75h3.5v.75L12 9V6.75h3.5l1.5 1.5V2.5A1.5 1.5 0 0 0 15.5 1m-13 1.5h13v2.75h-13m0 1.5h3v2.5h-3m0 1.5h3v2.75h-3m10-2.25 3-3 1.5 1.5-3 3 3 3-1.5 1.5-3-3-3 3-1.5-1.5 3-3-3-3 1.5-1.5"
@@ -913,7 +913,7 @@
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.PAINT_TABLE">
-    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18">
+    <svg class="o-icon" xmlns="http://www.w3.org/2000/svg" width="18" height="18">
       <path
         fill="currentColor"
         d="M2.5 1A1.5 1.5 0 0 0 1 2.5v11A1.5 1.5 0 0 0 2.5 15h5c0-.5 0-1 .5-1.5H7v-2.75h3.5v.75l2.25-2.25H12v-2.5h3.5v.75c1-.7 1.5-.4 1.5-.4V2.5A1.5 1.5 0 0 0 15.5 1m-13 1.5h13v2.75h-13m0 1.5h3v2.5h-3M7 6.75h3.5v2.5H7m-4.5 1.5h3v2.75h-3m7.5-.3c.7-.3 1.5-.1 2.1.6.6.7.8 1.4.5 1.9-.6 1.4-3.7 1.6-4 1.7l-.6.1.3-.5s.5-.8.5-2.1c0-.7.5-1.4 1.1-1.7Zm6.7-5.1a.9.9 0 0 1 1 1c-.1 1.3-2.5 3.7-4.3 5.3a3.9 3.9 0 0 0-.6-1.1c-.4-.4-.8-.7-1.3-.8 1.5-1.7 4-4.3 5.4-4.4"

--- a/tests/__snapshots__/top_bar_component.test.ts.snap
+++ b/tests/__snapshots__/top_bar_component.test.ts.snap
@@ -589,6 +589,7 @@ exports[`TopBar component can set cell format 1`] = `
                     style=""
                   >
                     <svg
+                      class="o-icon"
                       height="18"
                       width="18"
                       xmlns="http://www.w3.org/2000/svg"
@@ -1708,6 +1709,7 @@ exports[`TopBar component simple rendering 1`] = `
                 style=""
               >
                 <svg
+                  class="o-icon"
                   height="18"
                   width="18"
                   xmlns="http://www.w3.org/2000/svg"

--- a/tests/spreadsheet/__snapshots__/spreadsheet_component.test.ts.snap
+++ b/tests/spreadsheet/__snapshots__/spreadsheet_component.test.ts.snap
@@ -592,6 +592,7 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
                     style=""
                   >
                     <svg
+                      class="o-icon"
                       height="18"
                       width="18"
                       xmlns="http://www.w3.org/2000/svg"
@@ -1562,6 +1563,7 @@ exports[`components take the small screen into account 1`] = `
                     style=""
                   >
                     <svg
+                      class="o-icon"
                       height="18"
                       width="18"
                       xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
Task: 5089798

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo