### PR TITLE
[REF] components: remove components importance

### DIFF
--- a/src/components/composer/top_bar_composer/top_bar_composer.scss
+++ b/src/components/composer/top_bar_composer/top_bar_composer.scss
@@ -10,6 +10,16 @@
     border: 1px solid;
     font-family: $os-default-font;
 
+    &.o-topbar-composer-inactive {
+      border-color: $os-separator-color;
+      border-right: none;
+    }
+
+    &.o-topbar-composer-active {
+      border-color: $os-selection-border-color;
+      z-index: $os-components-importance-top-bar-composer;
+    }
+
     /* In readonly we always show the fx icon if the composer is empty, not matter the focus */
     .o-composer:empty:not(:focus):not(.active)::before,
     &.o-topbar-composer-readonly .o-composer:empty::before {

--- a/src/components/composer/top_bar_composer/top_bar_composer.ts
+++ b/src/components/composer/top_bar_composer/top_bar_composer.ts
@@ -1,10 +1,5 @@
 import { Component } from "@odoo/owl";
-import {
-  ComponentsImportance,
-  DESKTOP_TOPBAR_TOOLBAR_HEIGHT,
-  SELECTION_BORDER_COLOR,
-  SEPARATOR_COLOR,
-} from "../../../constants";
+import { DESKTOP_TOPBAR_TOOLBAR_HEIGHT } from "../../../constants";
 import { Store, useStore } from "../../../store_engine";
 import { CSSProperties, ComposerFocusType, SpreadsheetChildEnv } from "../../../types/index";
 import { cssPropertiesToCss } from "../../helpers/css";
@@ -61,19 +56,6 @@ export class TopBarComposer extends Component<any, SpreadsheetChildEnv> {
     };
     style.height = this.focus === "inactive" ? `${DESKTOP_TOPBAR_TOOLBAR_HEIGHT}px` : "fit-content";
     return cssPropertiesToCss(style);
-  }
-
-  get containerStyle(): string {
-    if (this.focus === "inactive") {
-      return cssPropertiesToCss({
-        "border-color": SEPARATOR_COLOR,
-        "border-right": "none",
-      });
-    }
-    return cssPropertiesToCss({
-      "border-color": SELECTION_BORDER_COLOR,
-      "z-index": String(ComponentsImportance.TopBarComposer),
-    });
   }
 
   onFocus(selection: ComposerSelection) {

--- a/src/components/composer/top_bar_composer/top_bar_composer.xml
+++ b/src/components/composer/top_bar_composer/top_bar_composer.xml
@@ -5,9 +5,10 @@
         class="o-topbar-composer position-relative bg-white user-select-text d-flex"
         t-att-class="{
           'o-topbar-composer-readonly': env.model.getters.isReadonly(),
+          'o-topbar-composer-active': focus !== 'inactive',
+          'o-topbar-composer-inactive': focus === 'inactive',
         }"
-        t-on-click.stop=""
-        t-att-style="containerStyle">
+        t-on-click.stop="">
         <Composer
           focus="focus"
           inputStyle="composerStyle"

--- a/src/components/figures/figure/figure.scss
+++ b/src/components/figures/figure/figure.scss
@@ -18,6 +18,11 @@
     position: absolute;
     box-sizing: content-box;
     pointer-events: auto;
+    z-index: $os-components-importance-figure;
+
+    &.o-figure-selected {
+      z-index: $os-components-importance-figure-selected;
+    }
 
     .o-fig-anchor {
       z-index: $os-components-importance-figure-anchor;

--- a/src/components/figures/figure/figure.ts
+++ b/src/components/figures/figure/figure.ts
@@ -1,9 +1,5 @@
 import { Component, onWillUnmount, useEffect, useRef, useState } from "@odoo/owl";
-import {
-  ComponentsImportance,
-  FIGURE_BORDER_COLOR,
-  SELECTION_BORDER_COLOR,
-} from "../../../constants";
+import { FIGURE_BORDER_COLOR, SELECTION_BORDER_COLOR } from "../../../constants";
 import { figureRegistry } from "../../../registries/figures_registry";
 import {
   AnchorOffset,
@@ -96,7 +92,6 @@ export class FigureComponent extends Component<Props, SpreadsheetChildEnv> {
       top: `${y}px`,
       width: `${width}px`,
       height: `${height}px`,
-      "z-index": String(ComponentsImportance.Figure + (this.isSelected ? 1 : 0)),
     });
   }
 

--- a/src/components/figures/figure/figure.xml
+++ b/src/components/figures/figure/figure.xml
@@ -1,6 +1,10 @@
 <templates>
   <t t-name="o-spreadsheet-FigureComponent">
-    <div class="o-figure-wrapper" t-att-style="wrapperStyle" t-ref="figureWrapper">
+    <div
+      class="o-figure-wrapper"
+      t-att-class="{'o-figure-selected': isSelected}"
+      t-att-style="wrapperStyle"
+      t-ref="figureWrapper">
       <div
         class="o-figure w-100 h-100"
         t-att-class="props.class"

--- a/src/components/full_screen_chart/full_screen_chart.scss
+++ b/src/components/full_screen_chart/full_screen_chart.scss
@@ -1,6 +1,6 @@
 .o-spreadsheet {
   .o-fullscreen-chart-overlay {
-    z-index: 34; /* TODO: use css variables once ComponentsImportance is available in the scss. */
+    z-index: $os-components-importance-fullscreen-chart;
     background-color: rgba(0, 0, 0, 0.4);
     padding: 60px;
 

--- a/src/components/grid_popover/grid_popover.scss
+++ b/src/components/grid_popover/grid_popover.scss
@@ -1,0 +1,7 @@
+.o-spreadsheet {
+  .o-popover {
+    &.o-popover-grid-index {
+      z-index: $os-components-importance-grid-popover;
+    }
+  }
+}

--- a/src/components/grid_popover/grid_popover.ts
+++ b/src/components/grid_popover/grid_popover.ts
@@ -1,5 +1,4 @@
 import { Component } from "@odoo/owl";
-import { ComponentsImportance } from "../../constants";
 import { Store } from "../../store_engine/store";
 import { useStore } from "../../store_engine/store_hooks";
 import { Rect, SpreadsheetChildEnv } from "../../types";
@@ -21,7 +20,6 @@ export class GridPopover extends Component<Props, SpreadsheetChildEnv> {
   };
   static components = { Popover };
   protected cellPopovers!: Store<CellPopoverStore>;
-  zIndex = ComponentsImportance.GridPopover;
 
   setup() {
     this.cellPopovers = useStore(CellPopoverStore);

--- a/src/components/grid_popover/grid_popover.xml
+++ b/src/components/grid_popover/grid_popover.xml
@@ -8,7 +8,7 @@
       anchorRect="cellPopover.anchorRect"
       containerRect="env.getPopoverContainerRect()"
       onMouseWheel="props.onMouseWheel"
-      zIndex="zIndex">
+      class="'o-popover-grid-index'">
       <t
         t-component="cellPopover.Component"
         t-props="{...cellPopover.props, onClosed : () => props.onClosePopover()}"

--- a/src/components/popover/popover.ts
+++ b/src/components/popover/popover.ts
@@ -1,9 +1,7 @@
 import { Component, onMounted, onWillUnmount, useEffect, useRef } from "@odoo/owl";
-import { ComponentsImportance } from "../../constants";
 import { rectIntersection } from "../../helpers/rectangle";
 import { DOMCoordinates, DOMDimension, Pixel, Rect, SpreadsheetChildEnv } from "../../types";
 import { PopoverPropsPosition } from "../../types/cell_popovers";
-import { cssPropertiesToCss } from "../helpers/css";
 import { usePopoverContainer, useSpreadsheetRect } from "../helpers/position_hook";
 import { CSSProperties } from "./../../types/misc";
 
@@ -30,9 +28,6 @@ export interface PopoverProps {
   onPopoverMoved?: () => void;
   onPopoverHidden?: () => void;
 
-  /** Setting popover to allow dynamic zIndex */
-  zIndex?: Number;
-
   class?: string;
 }
 
@@ -58,7 +53,6 @@ export class Popover extends Component<PopoverProps, SpreadsheetChildEnv> {
     onMouseWheel: () => {},
     onPopoverMoved: () => {},
     onPopoverHidden: () => {},
-    zIndex: ComponentsImportance.Popover,
   };
 
   private popoverRef = useRef("popover");
@@ -83,12 +77,6 @@ export class Popover extends Component<PopoverProps, SpreadsheetChildEnv> {
     // useEffect occurs after the DOM is created and the element width/height are computed, but before
     // the element in rendered, so we can still set its position
     useEffect(this.computePopoverPosition.bind(this));
-  }
-
-  get popoverStyle(): string {
-    return cssPropertiesToCss({
-      "z-index": `${this.props.zIndex}`,
-    });
   }
 
   private computePopoverPosition() {

--- a/src/components/popover/popover.xml
+++ b/src/components/popover/popover.xml
@@ -6,7 +6,6 @@
         t-att-class="props.class"
         t-ref="popover"
         t-on-wheel="props.onMouseWheel"
-        t-att-style="popoverStyle"
         t-on-click.stop="">
         <div class="o-popover-content" t-ref="popoverContent">
           <t t-slot="default"/>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -234,22 +234,6 @@ export const FORBIDDEN_SHEETNAME_CHARS_IN_EXCEL_REGEX = /'|\*|\?|\/|\\|\[|\]/;
 export const FORMULA_REF_IDENTIFIER = "|";
 export const LOADING = "Loading...";
 
-// Components
-export enum ComponentsImportance {
-  Grid = 0,
-  Highlight = 5,
-  HeaderGroupingButton = 6,
-  Figure = 10,
-  ScrollBar = 15,
-  GridPopover = 19,
-  GridComposer = 20,
-  IconPicker = 25,
-  TopBarComposer = 30,
-  Popover = 35,
-  FigureAnchor = 1000,
-  FigureSnapLine = 1001,
-  FigureTooltip = 1002,
-}
 let DEFAULT_SHEETVIEW_SIZE = 0;
 
 export function getDefaultSheetViewSize() {

--- a/src/variables.scss
+++ b/src/variables.scss
@@ -3,7 +3,6 @@ $os-gray-200: #e7e9ed;
 $os-gray-300: #d8dadd;
 $os-gray-400: #ced4da;
 $os-gray-900: #111827;
-
 $os-action-color: #017e84;
 $os-action-color-hover: #01585c;
 $os-icons-color: #4a4f59;
@@ -15,7 +14,6 @@ $os-text-heading: #111827;
 $os-figure-border-color: #c9ccd2;
 $os-background-gray-color: #f5f5f5;
 $os-background-header-color: #f8f9fa;
-
 $os-text-body: #374151;
 $os-text-body-muted: #374151c2;
 $os-button-primary-bg: #714b67;
@@ -34,7 +32,6 @@ $os-primary-button-bg: #714b67;
 $os-primary-button-hover-bg: #624159;
 $os-primary-button-active-bg: #f1edf0;
 $os-button-active-text-color: #111827;
-
 $os-alert-warning-bg: #fbebcc;
 $os-alert-warning-border: #f8e2b3;
 $os-alert-warning-text-color: #946d23;
@@ -44,6 +41,9 @@ $os-alert-danger-text-color: #c34a41;
 $os-alert-info-bg: #cdedf1;
 $os-alert-info-border: #98dbe2;
 $os-alert-info-text-color: #09414a;
+$os-composer-assistant-color: #9b359b;
+$os-figure-border-color: #c9ccd2;
+$os-separator-color: #e0e2e4;
 
 $os-default-font: "Roboto", "Arial";
 $os-default-font-size: 10px;
@@ -67,13 +67,7 @@ $os-mobile-menu-item-height: 35px;
 $os-menu-item-padding-vertical: 4px;
 $os-menu-item-padding-horizontal: 11px;
 $os-menu-vertical-padding: 6px;
-
-$os-composer-assistant-color: #9b359b;
-$os-figure-border-color: #c9ccd2;
-
 $os-autofill-edge-length: 8px;
-
-/** Color Picker **/
 $os-line-vertical-padding: 1px;
 $os-picker-padding: 8px;
 $os-item-border-width: 1px;
@@ -81,7 +75,6 @@ $os-item-edge-length: 18px;
 $os-items-per-line: 10;
 $os-magnifier-edge: 16px;
 $os-item-gap: 2px;
-
 $os-color-picker-width: (
   $os-items-per-line * ($os-item-edge-length + 2 * $os-item-border-width) + ($os-items-per-line - 1) *
     $os-item-gap
@@ -91,17 +84,21 @@ $os-inner-gradient-height: $os-color-picker-width - 30 - 2 * $os-item-border-wid
 $os-container-width: $os-color-picker-width + 2 * $os-picker-padding;
 $os-menu-separator-border-width: 1px;
 $os-menu-separator-padding: 5px;
-$os-separator-color: #e0e2e4;
 
+/**
+ * Z-index values for components
+ */
 $os-components-importance-grid: 0;
 $os-components-importance-highlight: 5;
 $os-components-importance-header-grouping-button: 6;
 $os-components-importance-figure: 10;
+$os-components-importance-figure-selected: 11;
 $os-components-importance-scroll-bar: 15;
 $os-components-importance-grid-popover: 19;
 $os-components-importance-grid-composer: 20;
 $os-components-importance-icon-picker: 25;
 $os-components-importance-top-bar-composer: 30;
+$os-components-importance-fullscreen-chart: 34;
 $os-components-importance-popover: 35;
 $os-components-importance-figure-anchor: 1000;
 $os-components-importance-figure-snap-line: 1001;

--- a/tests/__snapshots__/top_bar_component.test.ts.snap
+++ b/tests/__snapshots__/top_bar_component.test.ts.snap
@@ -673,8 +673,7 @@ exports[`TopBar component can set cell format 1`] = `
           class="o-topbar-composer-container w-100"
         >
           <div
-            class="o-topbar-composer position-relative bg-white user-select-text d-flex"
-            style="border-color:#E0E2E4; border-right:none; "
+            class="o-topbar-composer position-relative bg-white user-select-text d-flex o-topbar-composer-inactive"
           >
             <div
               class="o-composer-container w-100 h-100"
@@ -705,7 +704,7 @@ exports[`TopBar component can set cell format 1`] = `
     
     <div
       class="o-popover rounded"
-      style="z-index: 35; display: block; max-height: 1000px; max-width: 1000px; top: 0px; left: 0px;"
+      style="display: block; max-height: 1000px; max-width: 1000px; top: 0px; left: 0px;"
     >
       <div
         class="o-popover-content"
@@ -1792,8 +1791,7 @@ exports[`TopBar component simple rendering 1`] = `
       class="o-topbar-composer-container w-100"
     >
       <div
-        class="o-topbar-composer position-relative bg-white user-select-text d-flex"
-        style="border-color:#E0E2E4; border-right:none; "
+        class="o-topbar-composer position-relative bg-white user-select-text d-flex o-topbar-composer-inactive"
       >
         <div
           class="o-composer-container w-100 h-100"

--- a/tests/figures/__snapshots__/figure_component.test.ts.snap
+++ b/tests/figures/__snapshots__/figure_component.test.ts.snap
@@ -2,8 +2,8 @@
 
 exports[`figures selected figure snapshot 1`] = `
 <div
-  class="o-figure-wrapper"
-  style="left:1px; top:1px; width:100px; height:100px; z-index:11; "
+  class="o-figure-wrapper o-figure-selected"
+  style="left:1px; top:1px; width:100px; height:100px; "
 >
   <div
     class="o-figure w-100 h-100"

--- a/tests/link/__snapshots__/link_display_component.test.ts.snap
+++ b/tests/link/__snapshots__/link_display_component.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`link display component simple snapshot 1`] = `
-"<div class="o-popover rounded" style="z-index: 19; display: block; max-height: 962px; max-width: 985px; top: 49px; left: 48px;"><div class="o-popover-content"><div class="o-link-tool d-flex align-items-center"><!-- t-key to prevent owl from re-using the previous img element when the link changes.
+"<div class="o-popover rounded o-popover-grid-index" style="display: block; max-height: 962px; max-width: 985px; top: 49px; left: 48px;"><div class="o-popover-content"><div class="o-link-tool d-flex align-items-center"><!-- t-key to prevent owl from re-using the previous img element when the link changes.
     The wrong/previous image would be displayed while the new one loads --><img src="https://www.google.com/s2/favicons?sz=16&amp;domain=https://url.com"><a class="o-link" target="_blank" href="https://url.com" title="https://url.com">https://url.com</a><span class="o-link-icon o-unlink" title="Remove link"><div class="o-icon"><i class="fa fa-chain-broken"></i></div></span><span class="o-link-icon o-edit-link" title="Edit link"><div class="o-icon"><i class="fa fa-pencil-square-o"></i></div></span></div></div></div>"
 `;

--- a/tests/spreadsheet/__snapshots__/spreadsheet_component.test.ts.snap
+++ b/tests/spreadsheet/__snapshots__/spreadsheet_component.test.ts.snap
@@ -676,8 +676,7 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
           class="o-topbar-composer-container w-100"
         >
           <div
-            class="o-topbar-composer position-relative bg-white user-select-text d-flex"
-            style="border-color:#E0E2E4; border-right:none; "
+            class="o-topbar-composer position-relative bg-white user-select-text d-flex o-topbar-composer-inactive"
           >
             <div
               class="o-composer-container w-100 h-100"


### PR DESCRIPTION
This commit removes the ComponentsImportance enum and replaces its usage with SCSS variables.

Task: 5091908

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo