### PR TITLE
[FIX] data_validation: selecting range from another sheet

### DIFF
--- a/src/components/side_panel/data_validation/dv_editor/dv_editor.ts
+++ b/src/components/side_panel/data_validation/dv_editor/dv_editor.ts
@@ -10,6 +10,7 @@ import {
   DataValidationRule,
   DataValidationRuleData,
   SpreadsheetChildEnv,
+  UID,
 } from "../../../../types";
 import { css } from "../../../helpers";
 import { SelectionInput } from "../../../selection_input/selection_input";
@@ -40,14 +41,15 @@ export class DataValidationEditor extends Component<Props, SpreadsheetChildEnv> 
   static components = { SelectionInput, SelectMenu };
 
   state = useState<State>({ rule: this.defaultDataValidationRule });
+  private editingSheetId!: UID;
 
   setup() {
+    this.editingSheetId = this.env.model.getters.getActiveSheetId();
     if (this.props.rule) {
-      const sheetId = this.env.model.getters.getActiveSheetId();
       this.state.rule = {
         ...this.props.rule,
         ranges: this.props.rule.ranges.map((range) =>
-          this.env.model.getters.getRangeString(range, sheetId)
+          this.env.model.getters.getRangeString(range, this.editingSheetId)
         ),
       };
       this.state.rule.criterion.type = this.props.rule.criterion.type;
@@ -91,7 +93,6 @@ export class DataValidationEditor extends Component<Props, SpreadsheetChildEnv> 
     const criterion = rule.criterion;
     const criterionEvaluator = dataValidationEvaluatorRegistry.get(criterion.type);
 
-    const sheetId = this.env.model.getters.getActiveSheetId();
     const values = criterion.values
       .slice(0, criterionEvaluator.numberOfValues(criterion))
       .map((value) => value?.trim())
@@ -99,9 +100,9 @@ export class DataValidationEditor extends Component<Props, SpreadsheetChildEnv> 
       .map((value) => canonicalizeContent(value, locale));
     rule.criterion = { ...criterion, values };
     return {
-      sheetId,
+      sheetId: this.editingSheetId,
       ranges: this.state.rule.ranges.map((xc) =>
-        this.env.model.getters.getRangeDataFromXc(sheetId, xc)
+        this.env.model.getters.getRangeDataFromXc(this.editingSheetId, xc)
       ),
       rule,
     };


### PR DESCRIPTION
## Description:

Steps to reproduce:
- Create a new sheet (Sheet2).
- On Sheet1, open the Data Validation side panel.
- Add a DV with type "isValueInRange".
- Click on the selection input to select the range.
- Navigate to Sheet2 and select the range.
- Click on Save without confirming the ranges.

Before this PR:
- The DV was created on Sheet2 instead of remaining on Sheet1.

After this PR:
- The DV is correctly created on the original sheet (Sheet1).

Task: [4948201](https://www.odoo.com/odoo/2328/tasks/4948201)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo