### PR TITLE
[FIX] package: add swc binaries to optional dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "@prettier/plugin-xml": "^2.2.0",
         "@rollup/plugin-node-resolve": "^15.2.0",
         "@rollup/plugin-terser": "^0.4.3",
-        "@swc/jest": "^0.2.36",
+        "@swc/core": "1.6.7",
+        "@swc/jest": "0.2.36",
         "@types/jest": "^27.0.1",
         "@types/node": "^13.13.23",
         "@types/rbush": "^3.0.3",
@@ -51,6 +52,18 @@
         "typedoc-plugin-markdown": "3.17.1",
         "typescript": "^5.4.3",
         "xml-formatter": "^2.4.0"
+      },
+      "optionalDependencies": {
+        "@swc/core-darwin-arm64": "1.6.7",
+        "@swc/core-darwin-x64": "1.6.7",
+        "@swc/core-linux-arm-gnueabihf": "1.6.7",
+        "@swc/core-linux-arm64-gnu": "1.6.7",
+        "@swc/core-linux-arm64-musl": "1.6.7",
+        "@swc/core-linux-x64-gnu": "1.6.7",
+        "@swc/core-linux-x64-musl": "1.6.7",
+        "@swc/core-win32-arm64-msvc": "1.6.7",
+        "@swc/core-win32-ia32-msvc": "1.6.7",
+        "@swc/core-win32-x64-msvc": "1.6.7"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1412,15 +1425,15 @@
       }
     },
     "node_modules/@swc/core": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.7.1.tgz",
-      "integrity": "sha512-M4gxJcvzZCH+QQJGVJDF3kT46C05IUPTFcA1wA65WAdg87MDzpr1mwtB/FmPsdcRFRbJIxET6uCsWgubn+KnJQ==",
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.6.7.tgz",
+      "integrity": "sha512-BBzORL9qWz5hZqAZ83yn+WNaD54RH5eludjqIOboolFOK/Pw+2l00/H77H4CEBJnzCIBQszsyqtITmrn4evp0g==",
       "dev": true,
       "hasInstallScript": true,
-      "peer": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3",
-        "@swc/types": "^0.1.12"
+        "@swc/types": "^0.1.9"
       },
       "engines": {
         "node": ">=10"
@@ -1430,16 +1443,16 @@
         "url": "https://opencollective.com/swc"
       },
       "optionalDependencies": {
-        "@swc/core-darwin-arm64": "1.7.1",
-        "@swc/core-darwin-x64": "1.7.1",
-        "@swc/core-linux-arm-gnueabihf": "1.7.1",
-        "@swc/core-linux-arm64-gnu": "1.7.1",
-        "@swc/core-linux-arm64-musl": "1.7.1",
-        "@swc/core-linux-x64-gnu": "1.7.1",
-        "@swc/core-linux-x64-musl": "1.7.1",
-        "@swc/core-win32-arm64-msvc": "1.7.1",
-        "@swc/core-win32-ia32-msvc": "1.7.1",
-        "@swc/core-win32-x64-msvc": "1.7.1"
+        "@swc/core-darwin-arm64": "1.6.7",
+        "@swc/core-darwin-x64": "1.6.7",
+        "@swc/core-linux-arm-gnueabihf": "1.6.7",
+        "@swc/core-linux-arm64-gnu": "1.6.7",
+        "@swc/core-linux-arm64-musl": "1.6.7",
+        "@swc/core-linux-x64-gnu": "1.6.7",
+        "@swc/core-linux-x64-musl": "1.6.7",
+        "@swc/core-win32-arm64-msvc": "1.6.7",
+        "@swc/core-win32-ia32-msvc": "1.6.7",
+        "@swc/core-win32-x64-msvc": "1.6.7"
       },
       "peerDependencies": {
         "@swc/helpers": "*"
@@ -1448,6 +1461,166 @@
         "@swc/helpers": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@swc/core-darwin-arm64": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.6.7.tgz",
+      "integrity": "sha512-sNb+ghP2OhZyUjS7E5Mf3PqSvoXJ5gY6GBaH2qp8WQxx9VL7ozC4HVo6vkeFJBN5cmYqUCLnhrM3HU4W+7yMSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-darwin-x64": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.6.7.tgz",
+      "integrity": "sha512-LQwYm/ATYN5fYSYVPMfComPiFo5i8jh75h1ASvNWhXtS+/+k1dq1zXTJWZRuojd5NXgW3bb6mJtJ2evwYIgYbA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm-gnueabihf": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.6.7.tgz",
+      "integrity": "sha512-kEDzVhNci38LX3kdY99t68P2CDf+2QFDk5LawVamXH0iN5DRAO/+wjOhxL8KOHa6wQVqKEt5WrhD+Rrvk/34Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-gnu": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.6.7.tgz",
+      "integrity": "sha512-SyOBUGfl31xLGpIJ/Jd6GKHtkfZyHBXSwFlK7FmPN//MBQLtTBm4ZaWTnWnGo4aRsJwQdXWDKPyqlMBtnIl1nQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-musl": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.6.7.tgz",
+      "integrity": "sha512-1fOAXkDFbRfItEdMZPxT3du1QWYhgToa4YsnqTujjE8EqJW8K27hIcHRIkVuzp7PNhq8nLBg0JpJM4g27EWD7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-gnu": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.6.7.tgz",
+      "integrity": "sha512-Gp7uCwPsNO5ATxbyvfTyeNCHUGD9oA+xKMm43G1tWCy+l07gLqWMKp7DIr3L3qPD05TfAVo3OuiOn2abpzOFbw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-musl": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.6.7.tgz",
+      "integrity": "sha512-QeruGBZJ15tadqEMQ77ixT/CYGk20MtlS8wmvJiV+Wsb8gPW5LgCjtupzcLLnoQzDG54JGNCeeZ0l/T8NYsOvA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-arm64-msvc": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.6.7.tgz",
+      "integrity": "sha512-ouRqgSnT95lTCiU/6kJRNS5b1o+p8I/V9jxtL21WUj/JOVhsFmBErqQ0MZyCu514noWiR5BIqOrZXR8C1Knx6Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-ia32-msvc": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.6.7.tgz",
+      "integrity": "sha512-eZAP/EmJ0IcfgAx6B4/SpSjq3aT8gr0ooktfMqw/w0/5lnNrbMl2v+2kvxcneNcF7bp8VNcYZnoHlsP+LvmVbA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-x64-msvc": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.6.7.tgz",
+      "integrity": "sha512-QOdE+7GQg1UQPS6p0KxzJOh/8GLbJ5zI1vqKArCCB0unFqUfKIjYb2TaH0geEBy3w9qtXxe3ZW6hzxtZSS9lDg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@swc/counter": {
@@ -1478,7 +1651,6 @@
       "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.12.tgz",
       "integrity": "sha512-wBJA+SdtkbFhHjTMYH+dEH1y4VpfGdAc2Kw/LK09i9bXd/K6j6PkDcFCEzb6iVfZMkPRrl/q0e3toqTAJdkIVA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3"
       }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
     "@prettier/plugin-xml": "^2.2.0",
     "@rollup/plugin-node-resolve": "^15.2.0",
     "@rollup/plugin-terser": "^0.4.3",
-    "@swc/jest": "^0.2.36",
+    "@swc/jest": "0.2.36",
+    "@swc/core": "1.6.7",
     "@types/jest": "^27.0.1",
     "@types/node": "^13.13.23",
     "@types/rbush": "^3.0.3",
@@ -92,6 +93,18 @@
     "typedoc-plugin-markdown": "3.17.1",
     "typescript": "^5.4.3",
     "xml-formatter": "^2.4.0"
+  },
+  "optionalDependencies": {
+    "@swc/core-darwin-arm64": "1.6.7",
+    "@swc/core-darwin-x64": "1.6.7",
+    "@swc/core-linux-arm-gnueabihf": "1.6.7",
+    "@swc/core-linux-arm64-gnu": "1.6.7",
+    "@swc/core-linux-arm64-musl": "1.6.7",
+    "@swc/core-linux-x64-gnu": "1.6.7",
+    "@swc/core-linux-x64-musl": "1.6.7",
+    "@swc/core-win32-arm64-msvc": "1.6.7",
+    "@swc/core-win32-ia32-msvc": "1.6.7",
+    "@swc/core-win32-x64-msvc": "1.6.7"
   },
   "prettier": {
     "printWidth": 100,


### PR DESCRIPTION
Release commit 8c68f3d54422d40b3204f7073d7f8e4a2cc170a5 has been done with Node.js v22.19.0 and NPM v10.9.3.
But in the meantime, NPM had an issue that affected the package-lock.json by pruning OS optional dependencies (See https://github.com/npm/cli/issues/7961). The issue has been fixed (https://github.com/npm/cli/pull/8184) in NPM v11.3 but not backported.

During the release process, we ran `npm install`, and so the package-lock.json was updated to remove the optional dependencies for swc binaries. Which caused issues for users each time they run `npm install` as they were not present anymore in the package-lock.json.

This commit adds the swc binaries to the optional dependencies of this project to avoid them being pruned again in the future.

Task: 0

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo