### PR TITLE
[FIX] composer: set cursor on prettified formula

### DIFF
--- a/src/components/composer/composer/abstract_composer_store.ts
+++ b/src/components/composer/composer/abstract_composer_store.ts
@@ -103,7 +103,10 @@ export abstract class AbstractComposerStore extends SpreadsheetStore {
     });
   }
   protected abstract confirmEdition(content: string): void;
-  protected abstract getComposerContent(position: CellPosition): string;
+  protected abstract getComposerContent(
+    position: CellPosition,
+    selection?: ComposerSelection
+  ): { text: string; adjustedSelection?: ComposerSelection };
 
   abstract stopEdition(direction?: Direction): void;
 
@@ -150,13 +153,6 @@ export abstract class AbstractComposerStore extends SpreadsheetStore {
   }
 
   startEdition(text?: string, selection?: ComposerSelection) {
-    if (selection) {
-      const content = text || this.getComposerContent(this.getters.getActivePosition());
-      const validSelection = this.isSelectionValid(content.length, selection.start, selection.end);
-      if (!validSelection) {
-        return;
-      }
-    }
     const { col, row } = this.getters.getActivePosition();
     this.model.dispatch("SELECT_FIGURE", { figureId: null });
     this.model.dispatch("SCROLL_TO_CELL", { col, row });
@@ -220,7 +216,7 @@ export abstract class AbstractComposerStore extends SpreadsheetStore {
 
   get currentContent(): string {
     if (this.editionMode === "inactive") {
-      return this.getComposerContent(this.getters.getActivePosition());
+      return this.getComposerContent(this.getters.getActivePosition()).text;
     }
     return this._currentContent;
   }
@@ -447,8 +443,9 @@ export abstract class AbstractComposerStore extends SpreadsheetStore {
     this.sheetId = sheetId;
     this.row = row;
     this.editionMode = "editing";
-    this.initialContent = this.getComposerContent({ sheetId, col, row });
-    this.setContent(str || this.initialContent, selection);
+    const { text, adjustedSelection } = this.getComposerContent({ sheetId, col, row }, selection);
+    this.initialContent = text;
+    this.setContent(str || this.initialContent, adjustedSelection ?? selection);
     this.colorIndexByRange = {};
     const zone = positionToZone({ col: this.col, row: this.row });
     this.captureSelection(zone, col, row);

--- a/src/components/composer/composer/composer.ts
+++ b/src/components/composer/composer/composer.ts
@@ -26,6 +26,7 @@ import { TextValueProvider } from "../autocomplete_dropdown/autocomplete_dropdow
 import { ContentEditableHelper } from "../content_editable_helper";
 import { FunctionDescriptionProvider } from "../formula_assistant/formula_assistant";
 import { SpeechBubble } from "../speech_bubble/speech_bubble";
+import { ComposerSelection } from "./abstract_composer_store";
 import { CellComposerStore } from "./cell_composer_store";
 
 const functions = functionRegistry.content;
@@ -131,8 +132,8 @@ export interface CellComposerProps {
   inputStyle?: string;
   rect?: Rect;
   delimitation?: DOMDimension;
-  onComposerContentFocused: () => void;
-  onComposerCellFocused?: (content: String) => void;
+  onComposerContentFocused: (selection: ComposerSelection) => void;
+  onComposerCellFocused?: (content: string) => void;
   onInputContextMenu?: (event: MouseEvent) => void;
   isDefaultFocus?: boolean;
   composerStore: Store<CellComposerStore>;
@@ -600,11 +601,13 @@ export class Composer extends Component<CellComposerProps, SpreadsheetChildEnv> 
       return;
     }
     const newSelection = this.contentHelper.getCurrentSelection();
-
     this.props.composerStore.stopComposerRangeSelection();
-    this.props.onComposerContentFocused();
+    const isCurrentlyInactive = this.props.composerStore.editionMode === "inactive";
+    this.props.onComposerContentFocused(newSelection);
+    if (!isCurrentlyInactive) {
+      this.props.composerStore.changeComposerCursorSelection(newSelection.start, newSelection.end);
+    }
 
-    this.props.composerStore.changeComposerCursorSelection(newSelection.start, newSelection.end);
     this.processTokenAtCursor();
   }
 

--- a/src/components/composer/grid_composer/grid_composer.ts
+++ b/src/components/composer/grid_composer/grid_composer.ts
@@ -142,9 +142,10 @@ export class GridComposer extends Component<Props, SpreadsheetChildEnv> {
       },
       focus: this.focus,
       isDefaultFocus: true,
-      onComposerContentFocused: () =>
+      onComposerContentFocused: (selection) =>
         this.composerFocusStore.focusComposer(this.composerInterface, {
           focusMode: "contentFocus",
+          selection,
         }),
       onComposerCellFocused: (content: string) =>
         this.composerFocusStore.focusComposer(this.composerInterface, {

--- a/src/components/composer/standalone_composer/standalone_composer_store.ts
+++ b/src/components/composer/standalone_composer/standalone_composer_store.ts
@@ -23,7 +23,7 @@ export interface StandaloneComposerArgs {
 export class StandaloneComposerStore extends AbstractComposerStore {
   constructor(get: Get, private args: () => StandaloneComposerArgs) {
     super(get);
-    this._currentContent = this.getComposerContent();
+    this._currentContent = this.getComposerContent().text;
   }
 
   protected getAutoCompleteProviders(): AutoCompleteProviderDefinition[] {
@@ -46,7 +46,7 @@ export class StandaloneComposerStore extends AbstractComposerStore {
     return res;
   }
 
-  protected getComposerContent(): string {
+  protected getComposerContent() {
     let content = this._currentContent;
     if (this.editionMode === "inactive") {
       // References in the content might not be linked to the current active sheet
@@ -63,8 +63,7 @@ export class StandaloneComposerStore extends AbstractComposerStore {
         })
         .join("");
     }
-
-    return localizeContent(content, this.getters.getLocale());
+    return { text: localizeContent(content, this.getters.getLocale()) };
   }
 
   stopEdition() {

--- a/src/components/small_bottom_bar/small_bottom_bar.ts
+++ b/src/components/small_bottom_bar/small_bottom_bar.ts
@@ -92,9 +92,10 @@ export class SmallBottomBar extends Component<Props, SpreadsheetChildEnv> {
       },
       focus: this.focus,
       composerStore: this.composerStore,
-      onComposerContentFocused: () =>
+      onComposerContentFocused: (selection) =>
         this.composerFocusStore.focusComposer(this.composerInterface, {
           focusMode: "contentFocus",
+          selection,
         }),
       isDefaultFocus: false,
       inputStyle: cssPropertiesToCss({

--- a/tests/composer/composer_store.test.ts
+++ b/tests/composer/composer_store.test.ts
@@ -413,12 +413,6 @@ describe("edition", () => {
     expect(composerStore.currentContent).toBe("coucou");
   });
 
-  test("start edition with a wrong selection", () => {
-    composerStore.startEdition("coucou", { start: 10, end: 1 });
-    expect(composerStore.composerSelection).not.toEqual({ start: 10, end: 0 });
-    expect(composerStore.currentContent).not.toEqual("coucou");
-  });
-
   test("set value of the active cell updates the content", () => {
     expect(getActivePosition(model)).toBe("A1");
     setCellContent(model, "A1", "Hello sir");

--- a/tests/test_helpers/helpers.ts
+++ b/tests/test_helpers/helpers.ts
@@ -1071,9 +1071,9 @@ export class ComposerWrapper extends Component<ComposerWrapperProps, Spreadsheet
   get composerProps(): CellComposerProps {
     return {
       ...this.props.composerProps,
-      onComposerContentFocused: () => {
+      onComposerContentFocused: (selection) => {
         this.state.focusComposer = "contentFocus";
-        this.setEdition({});
+        this.setEdition({ selection });
       },
       focus: this.state.focusComposer,
       composerStore: this.composerStore,


### PR DESCRIPTION
Steps to reproduce:
- type a long formula, e.g. =SUM(11111111, 22222222, 33333333, 44444444, 55555555, 66666666, 77777777, 88888888)
- in the top bar composer, click somewhere that won't be on the first line when prettified (in the fours)

=> the cursor is badly positioned on the prettified formula

Task: 5095470

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo