### PR TITLE
[FIX] pivot: add deferred calculated measure

### DIFF
--- a/src/components/side_panel/pivot/pivot_layout_configurator/pivot_measure/pivot_measure.ts
+++ b/src/components/side_panel/pivot/pivot_layout_configurator/pivot_measure/pivot_measure.ts
@@ -1,4 +1,5 @@
 import { Component } from "@odoo/owl";
+import { compile } from "../../../../../formulas";
 import { PivotRuntimeDefinition } from "../../../../../helpers/pivot/pivot_runtime_definition";
 import { createMeasureAutoComplete } from "../../../../../registries/auto_completes/pivot_dimension_auto_complete";
 import { PivotMeasure } from "../../../../../types";
@@ -83,6 +84,6 @@ export class PivotMeasureEditor extends Component<Props> {
   }
 
   get isCalculatedMeasureInvalid(): boolean {
-    return this.env.model.getters.getMeasureCompiledFormula(this.props.measure).isBadExpression;
+    return compile(this.props.measure.computedBy?.formula ?? "").isBadExpression;
   }
 }

--- a/tests/pivots/spreadsheet_pivot/spreadsheet_pivot_side_panel.test.ts
+++ b/tests/pivots/spreadsheet_pivot/spreadsheet_pivot_side_panel.test.ts
@@ -384,6 +384,20 @@ describe("Spreadsheet pivot side panel", () => {
     expect(fixture.querySelectorAll(".pivot-dimension")).toHaveLength(0);
   });
 
+  test("can add a calculated measure with defer update", async () => {
+    await click(fixture.querySelector(".pivot-defer-update input")!);
+    await click(fixture.querySelectorAll(".add-dimension")[2]);
+    await click(fixture, ".add-calculated-measure");
+
+    await editStandaloneComposer(".pivot-dimension .o-composer", "=1+");
+    await click(fixture.querySelector(".sp_apply_update")!);
+    expect(".o-standalone-composer.o-invalid").toHaveCount(1);
+
+    await editStandaloneComposer(".pivot-dimension .o-composer", "=1+1");
+    await click(fixture.querySelector(".sp_apply_update")!);
+    expect(model.getters.getPivotCoreDefinition("1").measures[0].computedBy?.formula).toBe("=1+1");
+  });
+
   test("filter unsupported measures", async () => {
     setCellContent(model, "A1", "integer");
     setCellContent(model, "A2", "10");


### PR DESCRIPTION
Steps to reproduce:
- Open a pivot side panel
- click on "Defer update"
- add a calculated measure

=> boom

It's looking for the compiled formula in the plugin, but it doesn't exist since the pivot was not updated yet.
It's ok to (re)compile the formula everytime in the side panel, it's only one formula and it's not a hot path.

Task: 5096156

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo