### PR TITLE
[FIX] Pivot: ignore invalid dependencies

### DIFF
--- a/src/functions/helper_lookup.ts
+++ b/src/functions/helper_lookup.ts
@@ -63,7 +63,9 @@ export function addPivotDependencies(
   for (const measure of forMeasures) {
     if (measure.computedBy) {
       const formula = evalContext.getters.getMeasureCompiledFormula(measure);
-      dependencies.push(...formula.dependencies.filter((range) => !range.invalidXc));
+      dependencies.push(
+        ...formula.dependencies.filter((range) => !range.invalidXc && !range.invalidSheetName)
+      );
     }
   }
   const originPosition = evalContext.__originCellPosition;


### PR DESCRIPTION
When adding the dependencies of the computed measures, we would not filter out references to inexistant sheets. This added wrong dependencies to the graph and would trigger false positives for the invalidation of the concerned pivot.

Task: 0

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo