### PR TITLE
[FIX] chart: fix button hover background in dashboard menu

### DIFF
--- a/src/components/figures/chart/chart_dashboard_menu/chart_dashboard_menu.scss
+++ b/src/components/figures/chart/chart_dashboard_menu/chart_dashboard_menu.scss
@@ -10,15 +10,13 @@
     }
 
     .o-chart-dashboard-item {
-      filter: grayscale(1);
-
       &.active,
       &:hover,
       &:target {
-        filter: grayscale(0);
         color: $os-gray-900 !important;
-        background: $os-button-active-bg;
+        background: rgba(0, 0, 0, 0.1);
       }
+
       .o-chart-preview {
         stroke-width: 2px;
         transform: scale(1.1);


### PR DESCRIPTION
## Description

The buttons in the chart dashboard menu were set to have a light-gray background when hovered. This is ugly when the chart has a dark background.

This commit replaces it by something transparent.

Task: [5082189](https://www.odoo.com/odoo/2328/tasks/5082189)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo