### PR TITLE
[FIX] SidePanel: reset initial props on model change

### DIFF
--- a/src/components/side_panel/side_panel/side_panel_store.ts
+++ b/src/components/side_panel/side_panel/side_panel_store.ts
@@ -10,6 +10,7 @@ interface OpenSidePanel {
   isOpen: true;
   props?: SidePanelProps;
   key?: string;
+  updatedProps?: SidePanelProps;
 }
 
 interface ClosedSidePanel {
@@ -98,7 +99,11 @@ export class SidePanelStore extends SpreadsheetStore {
         props: panelProps,
       };
     } else {
-      return customComputeState(this.getters, panelProps);
+      const state = customComputeState(this.getters, panelProps);
+      if (state.isOpen) {
+        this.initialPanelProps = state.updatedProps ?? this.initialPanelProps;
+      }
+      return state;
     }
   }
 }

--- a/src/registries/side_panel_registry_entries.ts
+++ b/src/registries/side_panel_registry_entries.ts
@@ -37,7 +37,7 @@ sidePanelRegistry.add("ChartPanel", {
     if (!getters.isChartDefined(figureId)) {
       return { isOpen: false };
     }
-    return { isOpen: true, props: { figureId } };
+    return { isOpen: true, props: { figureId }, updatedProps: { figureId } };
   },
 });
 

--- a/tests/figures/chart/charts_component.test.ts
+++ b/tests/figures/chart/charts_component.test.ts
@@ -1,5 +1,6 @@
 import { CommandResult, Model, Spreadsheet } from "../../../src";
 import { ChartPanel } from "../../../src/components/side_panel/chart/main_chart_panel/main_chart_panel";
+import { SidePanelStore } from "../../../src/components/side_panel/side_panel/side_panel_store";
 import { ChartTerms } from "../../../src/components/translations_terms";
 import { BACKGROUND_CHART_COLOR } from "../../../src/constants";
 import { toHex, toZone } from "../../../src/helpers";
@@ -1343,6 +1344,29 @@ describe("charts", () => {
       { dataRange: "B2:B4", backgroundColor: "#FF0000", label: "MyLabel", yAxisId: "y1" },
       { dataRange: "C2:C4", yAxisId: "y1" },
     ]);
+  });
+
+  test("Deleting the second chart after selecting it closes the side panel", async () => {
+    createTestChart("basicChart", chartId);
+    createTestChart("basicChart", "secondChartId");
+    await mountSpreadsheet();
+    await openChartConfigSidePanel(model, env, chartId);
+    const store = env.getStore(SidePanelStore);
+    const sheetId = model.getters.getActiveSheetId();
+
+    const figures = model.getters.getFigures(sheetId);
+    expect(store.panelProps.figureId).toBe(figures[0].id);
+    expect(fixture.querySelector(".o-sidePanel")).not.toBeNull();
+
+    model.dispatch("SELECT_FIGURE", { id: figures[1].id });
+    await nextTick();
+    expect(store.panelProps.figureId).toBe(figures[1].id);
+    expect(fixture.querySelector(".o-sidePanel")).not.toBeNull();
+
+    model.dispatch("DELETE_FIGURE", { sheetId, id: figures[1].id });
+    await nextTick();
+    expect(store.isOpen).toBeFalsy();
+    expect(fixture.querySelector(".o-sidePanel")).toBeNull();
   });
 
   describe("Scorecard specific tests", () => {


### PR DESCRIPTION
Currently, we store the initial props with which the sidepanel was open. This specifically occurs for charts sidepanel where we want the stat to update when we select another chart BUT we also want it to stay open when clicking the grid (hence - no active chart left).

However the moment we click on another chart than the first one, then it is supposed to become the new "default" chart.

How to reproduce:
- open the sidepanel of the first chart
- select the second chart
- delete the second chart

=> the sidepanel is still open and falls back on the first chart instead of closing.

Task: 5059484

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo