### PR TITLE
[IMP] pivot: add menu items to collapse/expand all groups

### DIFF
--- a/src/components/menu/menu.ts
+++ b/src/components/menu/menu.ts
@@ -58,7 +58,10 @@ export class Menu extends Component<MenuProps, SpreadsheetChildEnv> {
     const menuItemsAndSeparators: MenuItemOrSeparator[] = [];
     for (let i = 0; i < this.props.menuItems.length; i++) {
       const menuItem = this.props.menuItems[i];
-      if (menuItem.isVisible(this.env)) {
+      if (
+        menuItem.isVisible(this.env) &&
+        (!this.isRoot(menuItem) || this.hasVisibleChildren(menuItem))
+      ) {
         menuItemsAndSeparators.push(menuItem);
       }
       if (
@@ -107,6 +110,10 @@ export class Menu extends Component<MenuProps, SpreadsheetChildEnv> {
 
   isRoot(menu: Action) {
     return !menu.execute;
+  }
+
+  private hasVisibleChildren(menu: Action) {
+    return menu.children(this.env).some((child) => child.isVisible(this.env));
   }
 
   isEnabled(menu: Action) {

--- a/src/helpers/pivot/pivot_menu_items.ts
+++ b/src/helpers/pivot/pivot_menu_items.ts
@@ -5,16 +5,18 @@ import {
   PivotCoreDefinition,
   PivotCustomGroup,
   PivotCustomGroupedField,
+  PivotDomain,
   PivotField,
   PivotFields,
   PivotHeaderCell,
   SortDirection,
   SpreadsheetChildEnv,
+  UID,
 } from "../..";
 import { ActionSpec } from "../../actions/action";
 import { _t } from "../../translation";
 import { CellValueType } from "../../types";
-import { deepCopy } from "../misc";
+import { deepCopy, deepEquals } from "../misc";
 import { cellPositions } from "../zones";
 import { domainToColRowDomain } from "./pivot_domain_helpers";
 import {
@@ -22,6 +24,7 @@ import {
   getCustomFieldWithParentField,
   getUniquePivotGroupName,
   removePivotGroupsContainingValues,
+  togglePivotCollapse,
 } from "./pivot_helpers";
 import { pivotRegistry } from "./pivot_registry";
 
@@ -208,6 +211,145 @@ export const ungroupPivotHeadersAction: ActionSpec = {
     return areFieldValuesInGroups(definition, values, field, pivot.getFields());
   },
 };
+
+export const toggleCollapsePivotGroupAction: ActionSpec = {
+  name: (env) => {
+    const position = env.model.getters.getActivePosition();
+    const pivotCellState = getPivotCellCollapseState(env.model.getters, position);
+    if (pivotCellState.isPivotGroup) {
+      return pivotCellState.isCollapsed ? _t("Expand") : _t("Collapse");
+    }
+    return "";
+  },
+  execute(env) {
+    const position = env.model.getters.getActivePosition();
+    togglePivotCollapse(position, env);
+  },
+  isVisible: (env) => {
+    const position = env.model.getters.getActivePosition();
+    const pivotCellState = getPivotCellCollapseState(env.model.getters, position);
+    return pivotCellState.isPivotGroup;
+  },
+};
+
+export const collapseAllPivotGroupAction: ActionSpec = {
+  name: _t("Collapse all"),
+  execute(env) {
+    const position = env.model.getters.getActivePosition();
+    const pivotCellState = getPivotCellCollapseState(env.model.getters, position);
+    if (!pivotCellState.isPivotGroup) {
+      return;
+    }
+    const { pivotCell, pivotId, siblingDomains } = pivotCellState;
+
+    const definition = deepCopy(env.model.getters.getPivotCoreDefinition(pivotId));
+    definition.collapsedDomains = definition.collapsedDomains || { COL: [], ROW: [] };
+    const newCollapsed = [
+      ...(definition.collapsedDomains[pivotCell.dimension] || []),
+      ...siblingDomains,
+    ];
+
+    const filteredCollapsed = newCollapsed.filter(
+      (domain, index) => index === newCollapsed.findIndex((d) => deepEquals(d, domain))
+    );
+
+    definition.collapsedDomains[pivotCell.dimension] = filteredCollapsed;
+    env.model.dispatch("UPDATE_PIVOT", { pivotId, pivot: definition });
+  },
+  isVisible: (env) => {
+    const position = env.model.getters.getActivePosition();
+    const pivotCellState = getPivotCellCollapseState(env.model.getters, position);
+    if (!pivotCellState.isPivotGroup) {
+      return false;
+    }
+
+    const { pivotCell, pivotId, siblingDomains } = pivotCellState;
+    const definition = env.model.getters.getPivotCoreDefinition(pivotId);
+
+    return !siblingDomains.every((domain) =>
+      (definition.collapsedDomains?.[pivotCell.dimension] || []).some((d) => deepEquals(d, domain))
+    );
+  },
+};
+
+export const expandAllPivotGroupAction: ActionSpec = {
+  name: _t("Expand all"),
+  execute(env) {
+    const position = env.model.getters.getActivePosition();
+    const pivotCellState = getPivotCellCollapseState(env.model.getters, position);
+    if (!pivotCellState.isPivotGroup) {
+      return;
+    }
+    const { pivotCell, pivotId, siblingDomains } = pivotCellState;
+
+    const definition = deepCopy(env.model.getters.getPivotCoreDefinition(pivotId));
+    definition.collapsedDomains = definition.collapsedDomains || { COL: [], ROW: [] };
+
+    const domains = definition.collapsedDomains[pivotCell.dimension] || [];
+    const filteredDomains = domains.filter(
+      (domain) => !siblingDomains.find((d) => deepEquals(d, domain))
+    );
+
+    definition.collapsedDomains[pivotCell.dimension] = filteredDomains;
+    env.model.dispatch("UPDATE_PIVOT", { pivotId, pivot: definition });
+  },
+  isVisible: (env) => {
+    const position = env.model.getters.getActivePosition();
+    const pivotCellState = getPivotCellCollapseState(env.model.getters, position);
+    if (!pivotCellState.isPivotGroup) {
+      return false;
+    }
+
+    const { pivotCell, pivotId, siblingDomains } = pivotCellState;
+    const definition = env.model.getters.getPivotCoreDefinition(pivotId);
+    const collapsedDomains = definition.collapsedDomains?.[pivotCell.dimension] || [];
+    return collapsedDomains.some((domain) => siblingDomains.some((d) => deepEquals(d, domain)));
+  },
+};
+
+function getPivotCellCollapseState(
+  getters: Getters,
+  position: CellPosition
+):
+  | { isPivotGroup: false }
+  | {
+      isPivotGroup: true;
+      isCollapsed: boolean;
+      pivotCell: PivotHeaderCell;
+      pivotId: UID;
+      siblingDomains: PivotDomain[];
+    } {
+  if (!getters.isSpillPivotFormula(position)) {
+    return { isPivotGroup: false };
+  }
+  const pivotCell = getters.getPivotCellFromPosition(position);
+  const pivotId = getters.getPivotIdFromPosition(position);
+
+  if (pivotCell.type !== "HEADER" || !pivotId || !pivotCell.domain.length) {
+    return { isPivotGroup: false };
+  }
+  const definition = getters.getPivotCoreDefinition(pivotId);
+  const isDashboard = getters.isDashboard();
+
+  const fields = pivotCell.dimension === "COL" ? definition.columns : definition.rows;
+  const hasIcon = !isDashboard && pivotCell.domain.length !== fields.length;
+  if (!hasIcon) {
+    return { isPivotGroup: false };
+  }
+
+  const domains = definition.collapsedDomains?.[pivotCell.dimension] ?? [];
+  const isCollapsed = domains.some((domain) => deepEquals(domain, pivotCell.domain));
+
+  const pivot = getters.getPivot(pivotId);
+  const table = pivot.getExpandedTableStructure();
+  const depth = pivotCell.domain.length - 1;
+  const siblingDomains =
+    pivotCell.dimension === "ROW"
+      ? table.getRowDomainsAtDepth(depth)
+      : table.getColumnDomainsAtDepth(depth);
+
+  return { isPivotGroup: true, isCollapsed, pivotCell, pivotId, siblingDomains };
+}
 
 export function canSortPivot(getters: Getters, position: CellPosition): boolean {
   const pivotId = getters.getPivotIdFromPosition(position);

--- a/src/helpers/pivot/table_spreadsheet_pivot.ts
+++ b/src/helpers/pivot/table_spreadsheet_pivot.ts
@@ -410,6 +410,20 @@ export class SpreadsheetPivotTable {
   get numberOfCells() {
     return this.rows.length * this.getNumberOfDataColumns();
   }
+
+  getColumnDomainsAtDepth(depth: number) {
+    if (depth < 0 || depth >= this.columns.length - 1) {
+      return [];
+    }
+    return this.columns[depth].map((col) => this.getDomain(col)).filter((d) => d.length);
+  }
+
+  getRowDomainsAtDepth(depth: number) {
+    if (depth < 0 || depth > this.maxIndent) {
+      return [];
+    }
+    return this.rows.filter((row) => row.indent === depth + 1).map((row) => this.getDomain(row));
+  }
 }
 
 export const EMPTY_PIVOT_CELL = { type: "EMPTY" } as const;

--- a/src/registries/icons_on_cell_registry.ts
+++ b/src/registries/icons_on_cell_registry.ts
@@ -20,6 +20,7 @@ import {
   PIVOT_INDENT,
 } from "../constants";
 import { computeTextFontSizeInPixels, deepEquals, relativeLuminance } from "../helpers";
+import { togglePivotCollapse } from "../helpers/pivot/pivot_helpers";
 import { Align, CellPosition, Getters, SpreadsheetChildEnv } from "../types";
 import { ImageSVG } from "../types/image";
 import { Registry } from "./registry";
@@ -205,34 +206,6 @@ iconsOnCellRegistry.add("pivot_collapse", (getters, position) => {
   }
   return undefined;
 });
-
-function togglePivotCollapse(position: CellPosition, env: SpreadsheetChildEnv) {
-  const pivotCell = env.model.getters.getPivotCellFromPosition(position);
-  const pivotId = env.model.getters.getPivotIdFromPosition(position);
-  if (!pivotId || pivotCell.type !== "HEADER") {
-    return;
-  }
-  const definition = env.model.getters.getPivotCoreDefinition(pivotId);
-
-  const collapsedDomains = definition.collapsedDomains?.[pivotCell.dimension]
-    ? [...definition.collapsedDomains[pivotCell.dimension]]
-    : [];
-  const index = collapsedDomains.findIndex((domain) => deepEquals(domain, pivotCell.domain));
-  if (index !== -1) {
-    collapsedDomains.splice(index, 1);
-  } else {
-    collapsedDomains.push(pivotCell.domain);
-  }
-
-  const newDomains = definition.collapsedDomains
-    ? { ...definition.collapsedDomains }
-    : { COL: [], ROW: [] };
-  newDomains[pivotCell.dimension] = collapsedDomains;
-  env.model.dispatch("UPDATE_PIVOT", {
-    pivotId,
-    pivot: { ...definition, collapsedDomains: newDomains },
-  });
-}
 
 iconsOnCellRegistry.add("pivot_dashboard_sorting", (getters, position) => {
   if (!getters.isDashboard()) {

--- a/src/registries/menus/cell_menu_registry.ts
+++ b/src/registries/menus/cell_menu_registry.ts
@@ -122,6 +122,23 @@ cellMenuRegistry
     icon: "o-spreadsheet-Icon.MINUS_IN_BOX",
     ...ACTIONS_PIVOT.ungroupPivotHeadersAction,
   })
+  .add("collapse_pivot", {
+    sequence: 156,
+    name: _t("Expand/Collapse"),
+    icon: "o-spreadsheet-Icon.COLLAPSE",
+  })
+  .addChild("toggle_collapse_pivot_cell", ["collapse_pivot"], {
+    sequence: 10,
+    ...ACTIONS_PIVOT.toggleCollapsePivotGroupAction,
+  })
+  .addChild("collapse_all_pivot", ["collapse_pivot"], {
+    sequence: 20,
+    ...ACTIONS_PIVOT.collapseAllPivotGroupAction,
+  })
+  .addChild("expand_all_pivot", ["collapse_pivot"], {
+    sequence: 30,
+    ...ACTIONS_PIVOT.expandAllPivotGroupAction,
+  })
   .add("pivot_sorting", {
     name: _t("Sort pivot"),
     sequence: 155,

--- a/tests/menus/context_menu_component.test.ts
+++ b/tests/menus/context_menu_component.test.ts
@@ -609,6 +609,21 @@ describe("Context MenuPopover internal tests", () => {
     expect(fixture.querySelector(".o-menu div[data-name='invisible_submenu_1']")).toBeFalsy();
   });
 
+  test("Parent menu is not visible if all its children are invisible", async () => {
+    const menuItems = createActions([
+      makeTestMenuItem("root", {
+        children: [
+          makeTestMenuItem("menu_1", {
+            children: [makeTestMenuItem("invisible_submenu_1", { isVisible: () => false })],
+          }),
+        ],
+      }),
+    ]);
+    await renderContextMenu(300, 300, { menuItems });
+    await mouseOverMenuElement(".o-menu div[data-name='root']");
+    expect(".o-menu div[data-name='menu_1']").toHaveCount(0);
+  });
+
   test("Enabled menus are updated at each render", async () => {
     let enabled = true;
     const menuItems: Action[] = createActions([
@@ -685,6 +700,7 @@ describe("Context MenuPopover internal tests", () => {
         name: "menuItem",
         onStartHover,
         onStopHover,
+        execute: () => {},
       },
     ]);
     await renderContextMenu(300, 300, { menuItems });
@@ -702,6 +718,7 @@ describe("Context MenuPopover internal tests", () => {
         id: "menuItem",
         name: "menuItem",
         onStopHover,
+        execute: () => {},
       },
     ]);
     await renderContextMenu(300, 300, { menuItems });
@@ -917,6 +934,7 @@ describe("Context menu separator", () => {
       name,
       isVisible: () => !options?.hidden,
       separator: options?.separator,
+      execute: () => {},
     };
   }
 

--- a/tests/menus/menu_component.test.ts
+++ b/tests/menus/menu_component.test.ts
@@ -11,6 +11,7 @@ describe("Menu component", () => {
         id: "test_menu",
         name: "Test Menu",
         isEnabled: () => false,
+        execute: () => {},
       },
     ]);
 

--- a/tests/select_menu_component.test.ts
+++ b/tests/select_menu_component.test.ts
@@ -4,8 +4,8 @@ import { click } from "./test_helpers/dom_helper";
 import { mountComponentWithPortalTarget } from "./test_helpers/helpers";
 
 const testMenuItems: Action[] = createActions([
-  { name: "item1", id: "item1" },
-  { name: "item2", id: "item2" },
+  { name: "item1", id: "item1", execute: () => {} },
+  { name: "item2", id: "item2", execute: () => {} },
 ]);
 
 describe("data validation sidePanel component", () => {

--- a/tests/top_bar_component.test.ts
+++ b/tests/top_bar_component.test.ts
@@ -985,18 +985,22 @@ test("The menu items are orderer by their sequence", async () => {
   addToRegistry(topbarMenuRegistry, "test", {
     sequence: 1,
     name: "test",
+    execute: () => {},
   });
   topbarMenuRegistry.addChild("second", ["test"], {
     name: "second",
     sequence: 2,
+    execute: () => {},
   });
   topbarMenuRegistry.addChild("first", ["test"], {
     name: "first",
     sequence: 1,
+    execute: () => {},
   });
   topbarMenuRegistry.addChild("third", ["test"], {
     name: "third",
     sequence: 3,
+    execute: () => {},
   });
   const { fixture } = await mountSpreadsheet();
   await click(fixture, ".o-topbar-menu[data-id='test']");


### PR DESCRIPTION
### [IMP] menu: hide parent menu if empty

A menu item would still be displayed if all its children were hidden,
opening an empty submenu. We had to manually add a `isVisible` logic
to all parent menu items to avoid this.

This commit make it so that a parent menu item is automatically
hidden if all its children are hidden.

### [IMP] pivot: add menu items to collapse/expand all groups

This commit adds menu item int he right click context menu to:
- collapse/expand a pivot group
- collapse/expand all pivot groups

Task: [4942260](https://www.odoo.com/odoo/2328/tasks/4942260)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo