### PR TITLE
[FIX] Evaluation: remove spread relations

### DIFF
--- a/src/plugins/ui_core_views/cell_evaluation/r_tree.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/r_tree.ts
@@ -1,5 +1,6 @@
 import RBush from "rbush";
 
+import { deepEquals } from "../../../helpers";
 import { UID, Zone } from "../../../types";
 
 /**
@@ -132,12 +133,12 @@ export class SpreadsheetRTree<T> {
 
   rtreeItemComparer(left: RTreeItem<T>, right: RTreeItem<T>) {
     return (
-      left.data == right.data &&
       left.boundingBox.sheetId === right.boundingBox.sheetId &&
       left.boundingBox?.zone.left === right.boundingBox.zone.left &&
       left.boundingBox?.zone.top === right.boundingBox.zone.top &&
       left.boundingBox?.zone.right === right.boundingBox.zone.right &&
-      left.boundingBox?.zone.bottom === right.boundingBox.zone.bottom
+      left.boundingBox?.zone.bottom === right.boundingBox.zone.bottom &&
+      deepEquals(left.data, right.data)
     );
   }
 }

--- a/tests/evaluation/evaluation_formula_array.test.ts
+++ b/tests/evaluation/evaluation_formula_array.test.ts
@@ -132,6 +132,14 @@ describe("evaluate formulas that return an array", () => {
     expect(getEvaluatedCell(model, "B1").value).toBe(42);
   });
 
+  test("Spreading relations are properly cleared upon cell content change", () => {
+    setCellContent(model, "A1", "=MUNIT(1)");
+    const positionA1 = model.getters.getActivePosition();
+    expect(model.getters.getArrayFormulaSpreadingOn(positionA1)).toBeDefined();
+    setCellContent(model, "A1", "42");
+    expect(model.getters.getArrayFormulaSpreadingOn(positionA1)).not.toBeDefined();
+  });
+
   describe("spread matrix with format", () => {
     test("can spread matrix of values with matrix of format", () => {
       functionRegistry.add("MATRIX.2.2", {


### PR DESCRIPTION
The performance improvement to compare rTreeItems was not properly adapted to the structure change of the tree - the data stored passed from a BigInt to a POJO. The comparer would apply a loose comparison which does not work on different objects.

This revision reinstates the use of deepEquals to compare the data POJO.

Task: 5105030

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo