### PR TITLE
[FIX] package: node 22 in package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,9 @@
         "typescript-eslint": "^8.30.1",
         "xml-formatter": "^2.4.0"
       },
+      "engines": {
+        "node": ">=22.0.0"
+      },
       "optionalDependencies": {
         "@swc/core-darwin-arm64": "1.6.7",
         "@swc/core-darwin-x64": "1.6.7",


### PR DESCRIPTION
Commit forced node 22, but didn't update the package-lock.json file. As a result, it's updated everytime someone run `npm install` on his local machine.

Task: 0

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo