### PR TITLE
[FIX] spreadsheet: prevent sheet name edit from losing focus

### DIFF
--- a/src/components/bottom_bar/bottom_bar_sheet/bottom_bar_sheet.xml
+++ b/src/components/bottom_bar/bottom_bar_sheet/bottom_bar_sheet.xml
@@ -18,6 +18,7 @@
           t-ref="sheetNameSpan"
           t-esc="sheetName"
           t-on-pointerdown="(ev) => this.onMouseEventSheetName(ev)"
+          t-on-click="(ev) => this.onMouseEventSheetName(ev)"
           t-on-dblclick="() => this.onDblClick()"
           t-on-focusout="() => this.onFocusOut()"
           t-on-keydown="(ev) => this.onKeyDown(ev)"

--- a/tests/bottom_bar/bottom_bar_component.test.ts
+++ b/tests/bottom_bar/bottom_bar_component.test.ts
@@ -28,7 +28,12 @@ import {
   triggerMouseEvent,
   triggerWheelEvent,
 } from "../test_helpers/dom_helper";
-import { makeTestEnv, mountComponentWithPortalTarget, nextTick } from "../test_helpers/helpers";
+import {
+  makeTestEnv,
+  mountComponentWithPortalTarget,
+  mountSpreadsheet,
+  nextTick,
+} from "../test_helpers/helpers";
 import { mockGetBoundingClientRect } from "../test_helpers/mock_helpers";
 
 let fixture: HTMLElement;
@@ -735,6 +740,26 @@ describe("BottomBar component", () => {
     await nextTick();
     expect(fixture.querySelector(".o-selection-statistic")).toBeFalsy();
     expect(fixture.querySelector(".o-menu")).toBeFalsy();
+  });
+
+  test("Do not focus out from sheet name when renaming until clicking outside", async () => {
+    ({ fixture } = await mountSpreadsheet({
+      model: new Model({ sheets: [{ id: "sh1" }] }),
+    }));
+
+    const sheetName = fixture.querySelector<HTMLElement>(".o-sheet-name")!;
+    expect(sheetName.getAttribute("contenteditable")).toEqual("false");
+
+    await doubleClick(sheetName);
+    await nextTick();
+    expect(sheetName.getAttribute("contenteditable")).toEqual("plaintext-only");
+    expect(document.activeElement).toEqual(sheetName);
+
+    await click(sheetName);
+    expect(document.activeElement).toEqual(sheetName);
+
+    await click(fixture, ".o-spreadsheet-bottom-bar");
+    expect(document.activeElement).toEqual(fixture.querySelector(".o-grid div.o-composer"));
   });
 
   describe("drag & drop sheet", () => {


### PR DESCRIPTION
## Description:

Steps to reproduce:
1. Create a new sheet.
2. Try renaming it to `Spreadsheet/dashboard` - error because of "/".
3. Click OK on the error dialog.
4. Click inside the sheet name near the "/" - edition is validated instead of moving the cursor; focus jumps to the default composer.

Issue:
The click event propagated to the parent component, which then focused the default composer and caused the loss of focus from the editable sheet name.

Fix:
Stop propagation of the click events when in editing mode, ensuring that:
- clicking positions the cursor correctly,
- editing is not validated prematurely,
- focus remains on the editable sheet name.

Task: [5109129](https://www.odoo.com/odoo/2328/tasks/5109129)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo