### PR TITLE
[IMP] format: align cell left for repeated char format

### DIFF
--- a/src/stores/grid_renderer_store.ts
+++ b/src/stores/grid_renderer_store.ts
@@ -26,6 +26,7 @@ import {
   deepCopy,
   deepEquals,
   drawDecoratedText,
+  formatHasRepeatedChar,
   getZonesCols,
   getZonesRows,
   isZoneInside,
@@ -642,6 +643,9 @@ export class GridRenderer extends SpreadsheetStore {
     }
     const { align } = this.getters.getCellStyle(position);
     const evaluatedCell = this.getters.getEvaluatedCell(position);
+    if (formatHasRepeatedChar(evaluatedCell.value, evaluatedCell.format)) {
+      return "left";
+    }
     if (isOverflowing && evaluatedCell.type === CellValueType.number) {
       return align !== "center" ? "left" : align;
     }

--- a/tests/renderer/renderer_store.test.ts
+++ b/tests/renderer/renderer_store.test.ts
@@ -42,6 +42,7 @@ import {
   resizeColumns,
   resizeRows,
   setCellContent,
+  setCellFormat,
   setFormat,
   setSelection,
   setStyle,
@@ -2409,6 +2410,24 @@ describe("renderer", () => {
     drawGridRenderer(ctx);
     box = gridRendererStore["getGridBoxes"](toZone("A1")).filter((box) => box.content)[0];
     expect(box.content?.textLines).toEqual(["1".padEnd(expectedSpaces, "c")]);
+  });
+
+  test("Cells with repeated character format are aligned to the left", () => {
+    const { drawGridRenderer, model } = setRenderer();
+    setCellContent(model, "A1", "1");
+
+    let textAligns: string[] = [];
+    const ctx = new MockGridRenderingContext(model, 1000, 1000, {
+      onSet: (key, value) => (key === "textAlign" ? textAligns.push(value) : null),
+    });
+
+    drawGridRenderer(ctx);
+    expect(textAligns).toEqual(["right", "center"]); // center for headers
+
+    textAligns = [];
+    setCellFormat(model, "A1", "dd* ");
+    drawGridRenderer(ctx);
+    expect(textAligns).toEqual(["left", "center"]); // center for headers
   });
 
   test("Each frozen pane is clipped in the grid", () => {


### PR DESCRIPTION
## Description

We have a "repeated character" format (e.g. "dd* ") that is mostly used to make sure the pivot headers are all aligned to the left, even when they contain numbers or dates.

The format repeats a character to fill the cell width. But the fit isn't perfect, and depending on the cell content it can be misaligned by a few pixels. This is very visible in pivot tables.

This commit makes it so the text alignment is always "left" when such a format is used, to avoid the misalignment. The solution isn't perfect, as now there will be misalignment to the right of the cell. But it is less problematic, and invisible when repeating spaces.

Task: [5122526](https://www.odoo.com/odoo/2328/tasks/5122526)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo