### PR TITLE
[FIX] chart: clip show value text to chart area

### DIFF
--- a/src/components/figures/chart/chartJs/chartjs_show_values_plugin.ts
+++ b/src/components/figures/chart/chartJs/chartjs_show_values_plugin.ts
@@ -32,6 +32,10 @@ export const chartShowValuesPlugin: Plugin = {
     }
     const ctx = chart.ctx as CanvasRenderingContext2D;
     ctx.save();
+    const { left, top, height, width } = chart.chartArea;
+    ctx.beginPath();
+    ctx.rect(left, top, width, height);
+    ctx.clip();
 
     ctx.textAlign = "center";
     ctx.textBaseline = "middle";


### PR DESCRIPTION
## Description

The text of the "Show Value" feature can go out of the chart and overlap with the legend/title. This commit clips the text to the chart area.

Task: [5125970](https://www.odoo.com/odoo/2328/tasks/5125970)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo