### PR TITLE
[FIX] chart: tooltip has wrong format for date chart

### DIFF
--- a/src/helpers/chart_date.ts
+++ b/src/helpers/chart_date.ts
@@ -64,6 +64,7 @@ export function getChartTimeOptions(
     parser: luxonFormat,
     displayFormats,
     unit: timeUnit ?? false,
+    tooltipFormat: luxonFormat,
   };
 }
 

--- a/tests/figures/chart/__snapshots__/chart_plugin.test.ts.snap
+++ b/tests/figures/chart/__snapshots__/chart_plugin.test.ts.snap
@@ -201,6 +201,7 @@ exports[`Linear/Time charts snapshot test of chartJS configuration for date char
               "day": "M/d/yyyy",
             },
             "parser": "M/d/yyyy",
+            "tooltipFormat": "M/d/yyyy",
             "unit": "day",
           },
           "type": "time",

--- a/tests/figures/chart/chart_plugin.test.ts
+++ b/tests/figures/chart/chart_plugin.test.ts
@@ -1908,12 +1908,14 @@ describe("Linear/Time charts", () => {
       },
       chartId
     );
-    let chart = (model.getters.getChartRuntime(chartId) as LineChartRuntime).chartJsConfig;
-    expect(chart.options?.scales?.x?.type).toEqual("time");
-
-    updateChart(model, chartId, { type: "bar" });
-    model.getters.getChartRuntime(chartId)!;
-    expect(chart.options?.scales?.x?.type).toEqual("time");
+    const scale = (model.getters.getChartRuntime(chartId) as any).chartJsConfig.options.scales.x;
+    expect(scale.type).toEqual("time");
+    expect(scale.time).toEqual({
+      displayFormats: { day: "M/d/yyyy" }, // luxon format
+      parser: "M/d/yyyy",
+      tooltipFormat: "M/d/yyyy",
+      unit: "day",
+    });
   });
 
   test("time axis for line/bar chart with formulas w/ date format as labels", () => {


### PR DESCRIPTION
## Description

The tooltip doesn't have the same format as the date format of the cells of the chart. We were missing the `tooltipFormat` option.

Task: [5126261](https://www.odoo.com/odoo/2328/tasks/5126261)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo