### PR TITLE
[FIX] chart: wrong label format for date chart

### DIFF
--- a/src/helpers/figures/charts/runtime/chartjs_scales.ts
+++ b/src/helpers/figures/charts/runtime/chartjs_scales.ts
@@ -104,6 +104,7 @@ export function getLineChartScales(
     };
     Object.assign(scales!.x!, axis);
     scales!.x!.ticks!.maxTicksLimit = 15;
+    delete scales?.x?.ticks?.callback;
   } else if (axisType === "linear") {
     scales!.x!.type = "linear";
     scales!.x!.ticks!.callback = (value) => formatValue(value, { format: labelFormat, locale });

--- a/tests/figures/chart/__snapshots__/chart_plugin.test.ts.snap
+++ b/tests/figures/chart/__snapshots__/chart_plugin.test.ts.snap
@@ -264,7 +264,6 @@ exports[`Linear/Time charts snapshot test of chartJS configuration for date char
           },
           "stacked": undefined,
           "ticks": {
-            "callback": [Function],
             "color": "#000000",
             "maxTicksLimit": 15,
             "padding": 5,

--- a/tests/figures/chart/chart_plugin.test.ts
+++ b/tests/figures/chart/chart_plugin.test.ts
@@ -2661,6 +2661,7 @@ describe("Linear/Time charts", () => {
     );
     let config = getChartConfiguration(model, chartId);
     expect(config.options?.scales?.x?.type).toEqual("time");
+    expect(config.options?.scales?.x?.ticks?.callback).toBeUndefined();
   });
 
   test("time axis for line/bar chart with formulas w/ date format as labels", () => {


### PR DESCRIPTION
## Description

Date charts would always have a datetime format for the labels, no matter the format of the data. They would also be truncated, which we probably don't want for dates.

The issue is that the date charts had a callback for the ticks using `truncateLabel`, and `getLabelForValue` which seems bugged in date charts[1].

This commit removes the tick callback for date charts, letting the luxon time adapter format the dates.

[1] https://github.com/chartjs/Chart.js/issues/12128

Task: [4908471](https://www.odoo.com/odoo/2328/tasks/4908471)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo