### PR TITLE
[FIX] format: wrong internal format conversion

### DIFF
--- a/src/helpers/format/format_parser.ts
+++ b/src/helpers/format/format_parser.ts
@@ -282,7 +282,7 @@ function tokensToTextInternalFormat(
  * Replace in place tokens "mm" and "m" that denote minutes in date format with "MM" to avoid confusion with months.
  *
  * As per OpenXML specification, in date formats if a date token "m" or "mm" is followed by a date token "s" or
- * preceded by a data token "h", then it's not a month but an minute.
+ * preceded by a data token "h", then it's not a month but a minute.
  */
 function convertTokensToMinutesInDateFormat(tokens: DateInternalFormat["tokens"]) {
   const dateParts = tokens.filter((token) => token.type === "DATE_PART") as DatePartToken[];
@@ -329,6 +329,9 @@ function internalFormatPartToFormat(
         break;
       case "REPEATED_CHAR":
         format += "*" + token.value;
+        break;
+      case "DATE_PART":
+        format += token.value === "MM" ? "mm" : token.value; // Convert "MM" back to "mm" for minutes
         break;
       default:
         format += token.value;

--- a/tests/formats/format_helpers.test.ts
+++ b/tests/formats/format_helpers.test.ts
@@ -1053,6 +1053,7 @@ describe("rounding format", () => {
     expect(roundFormat("ddd-mm-yyyy")).toBe("ddd-mm-yyyy");
     expect(roundFormat("#,##0,,")).toBe("#,##0,,");
     expect(roundFormat("#,##0.00,")).toBe("#,##0,");
+    expect(roundFormat("hh:mm:ss")).toBe("hh:mm:ss");
   });
 
   test("Round multi part format", () => {


### PR DESCRIPTION
## Description

In internal format, the "mm" of minutes is converted to "MM", to be distinct from "mm" of months. But the conversion wasn't done when converting back to a format string.

Task: [5126306](https://www.odoo.com/odoo/2328/tasks/5126306)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo