### PR TITLE
[FIX] table: create dynamic table on #SPILL! errors

### DIFF
--- a/src/plugins/ui_core_views/dynamic_tables.ts
+++ b/src/plugins/ui_core_views/dynamic_tables.ts
@@ -9,6 +9,7 @@ import {
   zoneToXc,
 } from "../../helpers";
 import { createFilter } from "../../helpers/table_helpers";
+import { CellErrorType } from "../../types/errors";
 import {
   CellPosition,
   Command,
@@ -170,7 +171,10 @@ export class DynamicTablesPlugin extends CoreViewPlugin {
 
     const parentSpreadingCell = this.getters.getArrayFormulaSpreadingOn(topLeft);
     if (!parentSpreadingCell) {
-      return false;
+      const evaluatedCell = this.getters.getEvaluatedCell(topLeft);
+      return (
+        evaluatedCell.value === CellErrorType.SpilledBlocked && !evaluatedCell.errorOriginPosition
+      );
     } else if (deepEquals(parentSpreadingCell, topLeft) && getZoneArea(unionZone) === 1) {
       return true;
     }

--- a/tests/menus/menu_items_registry.test.ts
+++ b/tests/menus/menu_items_registry.test.ts
@@ -1674,6 +1674,29 @@ describe("Menu Item actions", () => {
         });
       });
 
+      test("Insert -> Table creates a dynamic table if it's called on a #SPILL! error", () => {
+        setCellContent(model, "A1", "=MUNIT(500)");
+        setSelection(model, ["A1"]);
+        expect(getEvaluatedCell(model, "A1")?.value).toBe("#SPILL!");
+        doAction(insertTablePath, env);
+        expect(model.getters.getCoreTable({ sheetId, row: 0, col: 0 })).toMatchObject({
+          range: { zone: toZone("A1") },
+          type: "dynamic",
+        });
+      });
+
+      test("Insert -> Table do not creates a dynamic table if it's called on cell referencing a #SPILL! error", () => {
+        setCellContent(model, "A1", "=A3");
+        setCellContent(model, "A3", "=MUNIT(500)");
+        expect(getEvaluatedCell(model, "A1")?.value).toBe("#SPILL!");
+        setSelection(model, ["A1"]);
+        doAction(insertTablePath, env);
+        expect(model.getters.getCoreTable({ sheetId, row: 0, col: 0 })).toMatchObject({
+          range: { zone: toZone("A1") },
+          type: "static",
+        });
+      });
+
       test("Edit -> Table (topbar)", () => {
         const spyOpenSidePanel = jest.spyOn(env, "openSidePanel");
         createTable(model, "A1:A5");


### PR DESCRIPTION
Steps to reproduce:
- add an array formula
- add some content on the spill zone
- select the cell with #SPILL! error
- add a table on that cell

=> the created table is not dynamic

Task: 5102771

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo