### PR TITLE
[FIX] model: ensure chart ID unicity

### DIFF
--- a/src/migrations/data.ts
+++ b/src/migrations/data.ts
@@ -158,6 +158,7 @@ function forceUnicityOfFigure(data: Partial<WorkbookData>): Partial<WorkbookData
     return data;
   }
   const figureIds = new Set();
+  const chartIds = new Set();
   const uuidGenerator = new UuidGenerator();
   for (const sheet of data.sheets || []) {
     for (const figure of sheet.figures || []) {
@@ -165,6 +166,13 @@ function forceUnicityOfFigure(data: Partial<WorkbookData>): Partial<WorkbookData
         figure.id += uuidGenerator.smallUuid();
       }
       figureIds.add(figure.id);
+
+      if (figure.tag === "chart") {
+        if (chartIds.has(figure.data?.chartId)) {
+          figure.data.chartId += uuidGenerator.smallUuid();
+        }
+        chartIds.add(figure.data?.chartId);
+      }
     }
   }
 

--- a/tests/figures/chart/chart_plugin.test.ts
+++ b/tests/figures/chart/chart_plugin.test.ts
@@ -804,6 +804,30 @@ describe("datasource tests", function () {
     expect(cmd3).toBeCancelledBecause(CommandResult.DuplicatedChartId);
   });
 
+  test("Cannot have duplicate chart id at model creation", () => {
+    const figure = { id: "figureId", tag: "chart", width: 400, height: 300, x: 100, y: 100 };
+    const model = new Model({
+      version: 7,
+      sheets: [
+        {
+          id: "sh1",
+          figures: [
+            { ...figure, data: { type: "line", dataSets: [], labelRange: "A1:A2" } },
+            { ...figure, data: { type: "line", dataSets: [], labelRange: "A1:A2" } },
+          ],
+        },
+      ],
+    });
+
+    const figures = model.getters.getFigures("sh1");
+    expect(figures).toHaveLength(2);
+    expect(figures[0].id).not.toEqual(figures[1].id);
+
+    const chartIds = model.getters.getChartIds("sh1");
+    expect(chartIds).toHaveLength(2);
+    expect(chartIds[0]).not.toEqual(chartIds[1]);
+  });
+
   test("reject updates that target a inexistent chart", () => {
     createChart(
       model,


### PR DESCRIPTION
## Description

We have a function `forceUnicityOfFigure` that repair the spreadsheet data at import to force the figure ID unicity. But since the introduction of carousels, we also need to ensure the chart ID unicity (after the migration, chart ID and figure ID are the same).

Task: [5153264](https://www.odoo.com/odoo/2328/tasks/5153264)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo