### PR TITLE
[FIX] chart: wrong position for chart menu in dashboard

### DIFF
--- a/src/components/figures/chart/chart_dashboard_menu/chart_dashboard_menu.ts
+++ b/src/components/figures/chart/chart_dashboard_menu/chart_dashboard_menu.ts
@@ -7,6 +7,7 @@ import { Store, useStore } from "../../../../store_engine";
 import { _t } from "../../../../translation";
 import { ChartDefinition, ChartType, FigureUI, SpreadsheetChildEnv } from "../../../../types";
 import { FullScreenChartStore } from "../../../full_screen_chart/full_screen_chart_store";
+import { getBoundingRectAsPOJO } from "../../../helpers/dom_helpers";
 import { MenuPopover, MenuState } from "../../../menu_popover/menu_popover";
 
 interface Props {
@@ -118,7 +119,7 @@ export class ChartDashboardMenu extends Component<Props, SpreadsheetChildEnv> {
 
   openContextMenu(ev: MouseEvent) {
     this.menuState.isOpen = true;
-    this.menuState.anchorRect = { x: ev.clientX, y: ev.clientY, width: 0, height: 0 };
+    this.menuState.anchorRect = getBoundingRectAsPOJO(ev.currentTarget as HTMLElement);
     this.menuState.menuItems = getChartMenuActions(this.props.figureUI.id, () => {}, this.env);
   }
 

--- a/tests/figures/chart/chart_menu_dashboard_component.test.ts
+++ b/tests/figures/chart/chart_menu_dashboard_component.test.ts
@@ -2,8 +2,9 @@ import { Model } from "../../../src";
 import { CHART_PADDING_TOP } from "../../../src/constants";
 import { LineChartDefinition } from "../../../src/types/chart";
 import { createChart, updateChart } from "../../test_helpers/commands_helpers";
-import { click, triggerMouseEvent } from "../../test_helpers/dom_helper";
+import { click, getElStyle, triggerMouseEvent } from "../../test_helpers/dom_helper";
 import { mockChart, mountSpreadsheet, nextTick } from "../../test_helpers/helpers";
+import { extendMockGetBoundingClientRect } from "../../test_helpers/mock_helpers";
 
 mockChart();
 
@@ -65,6 +66,9 @@ describe("chart menu for dashboard", () => {
   });
 
   test("Can open menu to copy/download chart in dashboard mode", async () => {
+    extendMockGetBoundingClientRect({
+      "fa-ellipsis-v": () => ({ x: 100, y: 100, width: 20, height: 20 }),
+    });
     createChart(model, { type: "bar" }, chartId);
     model.updateMode("dashboard");
     const { fixture } = await mountSpreadsheet({ model });
@@ -74,6 +78,8 @@ describe("chart menu for dashboard", () => {
     expect(".o-menu-item").toHaveCount(0);
 
     await click(fixture, ".o-figure .fa-ellipsis-v");
+    expect(getElStyle(".o-popover", "top")).toBe("100px");
+    expect(getElStyle(".o-popover", "left")).toBe("120px");
     const menuItems = [...document.querySelectorAll<HTMLElement>(".o-menu-item")].map(
       (item) => item.dataset.name
     );


### PR DESCRIPTION
## Description

When opening the chart menu in dashboard mode, the menu appeared at the cursor position instead of at the top-right of the menu button.

Task: [5153929](https://www.odoo.com/odoo/2328/tasks/5153929)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo