### PR TITLE
[FIX] Composer: Fix assistant position

### DIFF
--- a/src/components/composer/composer/composer.ts
+++ b/src/components/composer/composer/composer.ts
@@ -234,7 +234,8 @@ export class Composer extends Component<CellComposerProps, SpreadsheetChildEnv> 
         assistantStyle["max-height"] = `${availableSpaceAbove - CLOSE_ICON_RADIUS}px`;
         // render top
         // We compensate 2 px of margin on the assistant style + 1px for design reasons
-        assistantStyle.transform = `translate(0, calc(-100% - ${cellHeight + 3}px))`;
+        assistantStyle.top = `-3px`;
+        assistantStyle.transform = `translate(0, -100%)`;
       }
       if (cellX + ASSISTANT_WIDTH > this.props.delimitation.width) {
         // render left

--- a/src/components/small_bottom_bar/small_bottom_bar.ts
+++ b/src/components/small_bottom_bar/small_bottom_bar.ts
@@ -8,7 +8,7 @@ import { CellComposerStore } from "../composer/composer/cell_composer_store";
 import { CellComposerProps, Composer } from "../composer/composer/composer";
 import { ComposerFocusStore, ComposerInterface } from "../composer/composer_focus_store";
 import { css, cssPropertiesToCss } from "../helpers";
-import { getBoundingRectAsPOJO, isIOS } from "../helpers/dom_helpers";
+import { getBoundingRectAsPOJO } from "../helpers/dom_helpers";
 import { RibbonMenu } from "./ribbon_menu/ribbon_menu";
 
 interface Props {
@@ -105,7 +105,7 @@ export class SmallBottomBar extends Component<Props, SpreadsheetChildEnv> {
         height: this.focus === "inactive" ? "26px" : "fit-content",
         "max-height": `130px`,
       }),
-      showAssistant: !isIOS(), // Hide assistant on iOS as it breaks visually
+      showAssistant: false, // Hide assistant in small composer as it gets cropped ATM
       placeholder: this.composerStore.placeholder,
     };
   }

--- a/tests/composer/autocomplete_dropdown_component.test.ts
+++ b/tests/composer/autocomplete_dropdown_component.test.ts
@@ -560,8 +560,9 @@ describe("composer Assistant", () => {
     expect(assistantEL).toMatchSnapshot();
     expect(assistantEL.style.width).toBe("300px");
     const containerEL = fixture.querySelector<HTMLElement>(".o-composer-assistant-container")!;
-    const marginsOffset = rect.height + 3; // 3px for the border and margin
-    expect(containerEL.style.transform).toBe(`translate(0, calc(-100% - ${marginsOffset}px))`);
+
+    expect(containerEL.style.top).toBe(`-3px`); // 3px for the border and margin
+    expect(containerEL.style.transform).toBe(`translate(0, -100%)`);
   });
 
   test("composer assistant min-width is the same as the underlying cell", async () => {


### PR DESCRIPTION
The composer assistant position was updated with the introduction of the mobile mode but there are two issues with it:
- the change of CSS rule did not account for cells with the content set on multiple lines
- the structure of the bottom bar composer (in mobile mode) still hides the formula assistant

This revision reverts the assistant position and simply hides it in mobile. A future work will try to reintroduce it with a modified aspect that suits the mobile interface.

Task: 5155838

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo