### PR TITLE
[FIX] composer: set editionMode to inactive when composer is unmounted

### DIFF
--- a/src/components/composer/composer/abstract_composer_store.ts
+++ b/src/components/composer/composer/abstract_composer_store.ts
@@ -93,6 +93,7 @@ export abstract class AbstractComposerStore extends SpreadsheetStore {
     this.highlightStore.register(this);
     this.onDispose(() => {
       this.highlightStore.unRegister(this);
+      this._cancelEdition();
     });
   }
   protected abstract confirmEdition(content: string): void;

--- a/tests/conditional_formatting/conditional_formatting_panel_component.test.ts
+++ b/tests/conditional_formatting/conditional_formatting_panel_component.test.ts
@@ -1,5 +1,6 @@
 import { Component } from "@odoo/owl";
 import { Model } from "../../src";
+import { ComposerFocusStore } from "../../src/components/composer/composer_focus_store";
 import { ConditionalFormattingPanel } from "../../src/components/side_panel/conditional_formatting/conditional_formatting";
 import { toHex, toZone } from "../../src/helpers";
 import { ConditionalFormatPlugin } from "../../src/plugins/core/conditional_format";
@@ -1570,5 +1571,27 @@ describe("Integration tests", () => {
     await nextTick();
     expect(fixture.querySelector(selectors.ruleEditor.range)).toBeNull();
     expect(fixture.querySelector(selectors.listPreview)).toBeDefined();
+  });
+
+  test("CF standalone composer becomes inactive on sheet change", async () => {
+    const sheetId = model.getters.getActiveSheetId();
+    model.dispatch("ADD_CONDITIONAL_FORMAT", {
+      cf: createEqualCF("2", { bold: true, fillColor: "#ff0000" }, "99"),
+      ranges: toRangesData(sheetId, "A1:A2"),
+      sheetId,
+    });
+    createSheet(model, { sheetId: "42" });
+    const zone = toZone("A1:A2");
+    parent.env.openSidePanel("ConditionalFormatting", { selection: [zone] });
+    await nextTick();
+    await editStandaloneComposer(selectors.ruleEditor.editor.valueInput, "=", {
+      confirm: false,
+    });
+    const composerFocusStore = parent.env.getStore(ComposerFocusStore);
+    expect(composerFocusStore.activeComposer.id).toBe("standaloneComposer");
+    expect(composerFocusStore.activeComposer.editionMode).toBe("selecting");
+    activateSheet(model, "42");
+    await nextTick();
+    expect(composerFocusStore.activeComposer.editionMode).toBe("inactive");
   });
 });


### PR DESCRIPTION
## Description:

Steps to reproduce:
- Open the CF side panel and edit a StandaloneComposer inside a color scale.
- Switch the sheet. The panel closes, so the composer is unmounted.
- Previously, the composer remained in editing mode after unmount.

Current behavior before PR:
- Unmounting the composer did not set editionMode to inactive.
- This caused focus issues in other parts of the UI.

Desired behavior after PR is merged:
- Unmounting the composer sets editionMode to inactive.
- Focus and selection are now properly released.

Task: [5149215](https://www.odoo.com/odoo/2328/tasks/5149215)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo