### PR TITLE
[FIX] clipboard: paste as value with empty format string

### DIFF
--- a/src/clipboard_handlers/cell_clipboard.ts
+++ b/src/clipboard_handlers/cell_clipboard.ts
@@ -237,7 +237,7 @@ export class CellClipboardHandler extends AbstractCellClipboardHandler<
   ) {
     const { sheetId, col, row } = target;
     const targetCell = this.getters.getEvaluatedCell(target);
-    const originFormat = origin?.format ?? origin.evaluatedCell.format;
+    const originFormat = origin?.format || origin.evaluatedCell.format;
 
     if (clipboardOption?.pasteOption === "asValue") {
       this.dispatch("UPDATE_CELL", {

--- a/tests/clipboard/clipboard_plugin.test.ts
+++ b/tests/clipboard/clipboard_plugin.test.ts
@@ -1283,6 +1283,22 @@ describe("clipboard", () => {
     expect(getCellContent(model, "C3")).toBe("45.10%");
   });
 
+  test("paste as value works with both no core format and empty string core format", () => {
+    const model = new Model();
+    setCellContent(model, "D4", "=DATE(2024,6,5)");
+
+    copy(model, "D4");
+    paste(model, "E4", "asValue");
+    expect(getCell(model, "E4")).toMatchObject({ content: "45448", format: "m/d/yyyy" });
+
+    setFormat(model, "D4", ""); // An empty string format is equivalent to no format
+    expect(getCellContent(model, "D4")).toBe("6/5/2024");
+
+    copy(model, "D4");
+    paste(model, "E5", "asValue");
+    expect(getCell(model, "E5")).toMatchObject({ content: "45448", format: "m/d/yyyy" });
+  });
+
   test("can copy a formula and paste as value", () => {
     const model = new Model();
     setCellContent(model, "A1", "=SUM(1+2)");


### PR DESCRIPTION
## Description

Our paste as value keeps the format from the origin cell, removing only the formula. But if the origin cell had an empty format string, it would copy this empty string instead of the evaluated cell format.

Note: we get empty string format as result of, for example, auto-fill an `=TODAY()` formula. It can be argued that we should have `undefined` core format rather than an empty string, but every other place in the codebase handles all falsy format values the same way. The clipboard was the only place where we would make the distinction between `""` and `undefined` with `??`.

Task: [5156459](https://www.odoo.com/odoo/2328/tasks/5156459)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo