### PR TITLE
[FIX] find & replace: fix arrow buttons sizing

### DIFF
--- a/src/components/side_panel/find_and_replace/find_and_replace.ts
+++ b/src/components/side_panel/find_and_replace/find_and_replace.ts
@@ -42,6 +42,7 @@ css/* scss */ `
       .o-button {
         height: 19px;
         width: 19px;
+        box-sizing: content-box;
         .o-icon {
           height: 14px;
           width: 14px;


### PR DESCRIPTION
## Description

97b4232 removed the global `box-sizing: content-box;` directive, but we forgot to add it back to the find & replace buttons.

Task: [5154004](https://www.odoo.com/odoo/2328/tasks/5154004)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo