### PR TITLE
[FIX] helpers: setXcToFixedReferenceType support all xc

### DIFF
--- a/src/components/side_panel/data_validation/dv_criterion_form/dv_input/dv_input.ts
+++ b/src/components/side_panel/data_validation/dv_criterion_form/dv_input/dv_input.ts
@@ -97,6 +97,7 @@ export class DataValidationInput extends Component<Props, SpreadsheetChildEnv> {
       placeholder: this.placeholder,
       class: "o-sidePanel-composer",
       defaultRangeSheetId: this.env.model.getters.getActiveSheetId(),
+      defaultStatic: true,
     };
   }
 


### PR DESCRIPTION
## Description:

Backport of task [4743563](https://www.odoo.com/odoo/2328/tasks/4743563) from saas-18.4. Ensures both parts of an xc 
reference are treated as static in the standalone composer.

Current behavior before PR:
- The static reference only considered the part before ':'.

Desired behavior after PR is merged:
- Both the part before and after ':' are now correctly treated as static.

Task: [5165969](https://www.odoo.com/odoo/2328/tasks/5165969)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo