### PR TITLE
[FIX] range: invalid sheet name with special character

### DIFF
--- a/src/plugins/core/range.ts
+++ b/src/plugins/core/range.ts
@@ -357,7 +357,7 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
     let sheetName: string = "";
     if (prefixSheet) {
       if (rangeImpl.invalidSheetName) {
-        sheetName = rangeImpl.invalidSheetName;
+        sheetName = getCanonicalSheetName(rangeImpl.invalidSheetName);
       } else {
         sheetName = getCanonicalSheetName(this.getters.getSheetName(rangeImpl.sheetId));
       }

--- a/tests/model/model_import_export.test.ts
+++ b/tests/model/model_import_export.test.ts
@@ -287,7 +287,7 @@ describe("Migrations", () => {
 
     const cfs = data.sheets[1].conditionalFormats;
     const rule1 = cfs[0].rule as ColorScaleRule;
-    expect(cfs[0].ranges).toEqual(["=sheetName_!A1:A2"]);
+    expect(cfs[0].ranges).toEqual(["'=sheetName_'!A1:A2"]);
     expect(rule1.minimum.value).toEqual("=sheetName_!B1");
     expect(rule1.midpoint?.value).toEqual("=sheetName_!B1");
     expect(rule1.maximum.value).toEqual("=sheetName_!B1");
@@ -298,7 +298,7 @@ describe("Migrations", () => {
     expect(rule2.upperInflectionPoint.value).toEqual("=sheetName_!B1");
 
     const rule3 = cfs[2].rule as ColorScaleRule;
-    expect(cfs[2].ranges).toEqual(["=sheetName_!A1:A2"]);
+    expect(cfs[2].ranges).toEqual(["'=sheetName_'!A1:A2"]);
     expect(rule3.minimum.value).toEqual("33");
     expect(rule3.midpoint?.value).toEqual("13");
     expect(rule3.maximum.value).toBeUndefined();

--- a/tests/range_plugin.test.ts
+++ b/tests/range_plugin.test.ts
@@ -551,11 +551,16 @@ describe("range plugin", () => {
       }
     );
 
+    test("invalid sheet name with special character", () => {
+      const range = m.getters.getRangeFromSheetXC("s1", "'Invalid Sheet Name'!A1");
+      expect(m.getters.getRangeString(range, "s1")).toBe("'Invalid Sheet Name'!A1");
+    });
+
     test.each([
       ["s1!!!A1:A9", "'s1!!'!A1:A9"],
       ["'s1!!'!A1:A9", "'s1!!'!A1:A9"],
-      ["s1!!!A1:s1!!!A9", "s1!!!A1:s1!!!A9"],
-      ["s1!!!A1:s1!!!A9", "s1!!!A1:s1!!!A9"],
+      ["s1!!!A1:s1!!!A9", "'s1!!!A1:s1!!'!A9"],
+      ["s1!!!A1:s1!!!A9", "'s1!!!A1:s1!!'!A9"],
     ])(
       "xc with more than one exclamation mark does not throw error",
       (rangeString, expectedString) => {


### PR DESCRIPTION
## Description

If we have a range with an invalid sheet name, the sheet name is not escaped with quotes when it contains special characters when converting the range back to a string.

Task: [5125762](https://www.odoo.com/odoo/2328/tasks/5125762)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo