### PR TITLE
[PERF] evaluation: zonify evaluation

### DIFF
--- a/demo/data.js
+++ b/demo/data.js
@@ -3976,15 +3976,16 @@ function computeStringCells(cols, rows) {
 
 function computeSplitVlookup(rows) {
   /*
-* in A1 write =SPLIT("1 2", " ")
-in C1, writ e=B2
-write a VLOOKUP that search in column C --> slow
-* */
+   * in A1 write =SPLIT("1 2", " ")
+   * in C1, write=B2
+   * write a VLOOKUP that search in column C --> slow
+   */
   const cells = {};
-  for (let row = 0; row < rows; row++) {
+  for (let row = 1; row < rows; row++) {
     cells["A" + row] = { content: `=SPLIT("1 2", " ")` };
     cells["C" + row] = { content: `=B${row}` };
-    cells["D" + row] = { content: `=vlookup("2",a1:c${rows},3)` };
+    cells["D" + row] = { content: `=VLOOKUP("2",C1:C${rows},1)` };
+    cells["F" + row] = { content: `=D${row}` };
   }
   return cells;
 }

--- a/src/helpers/range.ts
+++ b/src/helpers/range.ts
@@ -2,6 +2,7 @@ import { Registry } from "../registries/registry";
 import {
   AddColumnsRowsCommand,
   ApplyRangeChange,
+  BoundedRange,
   CellPosition,
   ChangeType,
   CoreCommand,
@@ -226,6 +227,11 @@ function getRangeParts(xc: string, zone: UnboundedZone): RangePart[] {
   }
 
   return parts;
+}
+
+export function positionToBoundedRange(position: CellPosition): BoundedRange {
+  const zone = { left: position.col, top: position.row, right: position.col, bottom: position.row };
+  return { sheetId: position.sheetId, zone };
 }
 
 /**

--- a/src/helpers/recompute_zones.ts
+++ b/src/helpers/recompute_zones.ts
@@ -178,7 +178,35 @@ export function modifyProfiles<T extends Zone | UnboundedZone>( // export for te
   }
 }
 
-function findIndexAndCreateProfile(
+export function profilesContainsZone(
+  profilesStartingPosition: number[],
+  profiles: Map<number, number[]>,
+  zone: Zone
+): boolean {
+  const leftValue = zone.left;
+  const rightValue = zone.right;
+  const topValue = zone.top;
+  const bottomValue = zone.bottom + 1;
+  const leftIndex = binaryPredecessorSearch(profilesStartingPosition, leftValue, 0);
+  const rightIndex = binaryPredecessorSearch(profilesStartingPosition, rightValue, leftIndex);
+  if (leftIndex === -1 || rightIndex === -1) {
+    return false;
+  }
+  for (let i = leftIndex; i <= rightIndex; i++) {
+    const profile = profiles.get(profilesStartingPosition[i])!;
+    const topPredIndex = binaryPredecessorSearch(profile, topValue, 0, true);
+    const bottomSuccIndex = binarySuccessorSearch(profile, bottomValue, 0, true);
+    if (topPredIndex === -1 || topPredIndex % 2 !== 0) {
+      return false;
+    }
+    if (topValue < profile[topPredIndex] || bottomValue > profile[bottomSuccIndex]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export function findIndexAndCreateProfile(
   profilesStartingPosition: number[],
   profiles: Map<number, number[]>,
   value: number | undefined,
@@ -277,7 +305,17 @@ function modifyProfile(
 
   // add the top and bottom value to the profile and
   // remove all information between the top and bottom index
-  profile.splice(topPredIndex + 1, bottomSuccIndex - topPredIndex - 1, ...newPoints);
+  const toDelete = bottomSuccIndex - topPredIndex - 1;
+  const toInsert = newPoints.length;
+  const start = topPredIndex + 1;
+  // fast path and slow path
+  if (start === profile.length - 1 && toDelete === 1 && toInsert === 1) {
+    // fast path: we just need to replace the last element
+    profile[start] = newPoints[0] ?? newPoints[1];
+  } else {
+    // equivalent but slower and with memory allocation
+    profile.splice(start, toDelete, ...newPoints);
+  }
 }
 
 function removeContiguousProfiles(
@@ -301,7 +339,7 @@ function removeContiguousProfiles(
   }
 }
 
-function constructZonesFromProfiles<T extends UnboundedZone | Zone>(
+export function constructZonesFromProfiles<T extends UnboundedZone | Zone>(
   profilesStartingPosition: number[],
   profiles: Map<number, number[]>
 ): T[] {
@@ -333,8 +371,10 @@ function constructZonesFromProfiles<T extends UnboundedZone | Zone>(
         left,
         bottom,
         right,
-        hasHeader: (bottom === undefined && top !== 0) || (right === undefined && left !== 0),
       };
+      if ((bottom === undefined && top !== 0) || (right === undefined && left !== 0)) {
+        profileZone.hasHeader = true;
+      }
 
       let findCorrespondingZone = false;
       for (let j = pendingZones.length - 1; j >= 0; j--) {

--- a/src/helpers/zones.ts
+++ b/src/helpers/zones.ts
@@ -502,20 +502,6 @@ export function excludeTopLeft(zone: Zone): Zone[] {
   return [leftColumnZone, rightPartZone];
 }
 
-export function aggregatePositionsToZones(positions: Iterable<CellPosition>): {
-  [sheetId: string]: Zone[];
-} {
-  const result: { [sheetId: string]: Zone[] } = {};
-  for (const position of positions) {
-    result[position.sheetId] ??= [];
-    result[position.sheetId].push(positionToZone(position));
-  }
-  for (const sheetId in result) {
-    result[sheetId] = recomputeZones(result[sheetId]);
-  }
-  return result;
-}
-
 /**
  * Array of all positions in the zone.
  */

--- a/src/plugins/ui_core_views/cell_evaluation/dependencies_r_tree.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/dependencies_r_tree.ts
@@ -1,0 +1,140 @@
+import { BoundedRange, UID } from "../../../types";
+import { RTreeBoundingBox, RTreeItem, SpreadsheetRTree } from "./r_tree";
+import { RangeSet } from "./range_set";
+
+interface RangeSetItem {
+  boundingBox: RTreeBoundingBox;
+  data: RangeSet;
+}
+
+type RTreeRangeItem = RTreeItem<BoundedRange>;
+
+/**
+ * R-Tree of ranges, mapping zones (r-tree bounding boxes) to ranges (data of the r-tree item).
+ * Ranges associated to the exact same bounding box are grouped together
+ * to reduce the number of nodes in the R-tree.
+ */
+export class DependenciesRTree {
+  private readonly rTree: SpreadsheetRTree<RangeSet>;
+
+  constructor(items: RTreeRangeItem[] = []) {
+    const compactedBoxes = groupSameBoundingBoxes(items);
+    this.rTree = new SpreadsheetRTree(compactedBoxes);
+  }
+
+  insert(item: RTreeRangeItem) {
+    const data = this.rTree.search(item.boundingBox);
+    const itemBoundingBox = item.boundingBox;
+    const exactBoundingBox = data.find(
+      ({ boundingBox }) =>
+        boundingBox.sheetId === itemBoundingBox.sheetId &&
+        boundingBox.zone.left === itemBoundingBox.zone.left &&
+        boundingBox.zone.top === itemBoundingBox.zone.top &&
+        boundingBox.zone.right === itemBoundingBox.zone.right &&
+        boundingBox.zone.bottom === itemBoundingBox.zone.bottom
+    );
+    if (exactBoundingBox) {
+      exactBoundingBox.data.add(item.data);
+    } else {
+      this.rTree.insert({ ...item, data: new RangeSet([item.data]) });
+    }
+  }
+
+  search({ zone, sheetId }: RTreeBoundingBox): RangeSet {
+    const results: RangeSet = new RangeSet();
+    for (const { data } of this.rTree.search({ zone, sheetId })) {
+      results.addMany(data);
+    }
+    return results;
+  }
+
+  remove(item: RTreeRangeItem) {
+    const data = this.rTree.search(item.boundingBox);
+    const itemBoundingBox = item.boundingBox;
+    const exactBoundingBox = data.find(
+      ({ boundingBox }) =>
+        boundingBox.sheetId === itemBoundingBox.sheetId &&
+        boundingBox.zone.left === itemBoundingBox.zone.left &&
+        boundingBox.zone.top === itemBoundingBox.zone.top &&
+        boundingBox.zone.right === itemBoundingBox.zone.right &&
+        boundingBox.zone.bottom === itemBoundingBox.zone.bottom
+    );
+    if (exactBoundingBox) {
+      exactBoundingBox.data.delete(item.data);
+    } else {
+      this.rTree.remove({ ...item, data: new RangeSet([item.data]) });
+    }
+  }
+}
+
+/**
+ * Group together all formulas pointing to the exact same dependency (bounding box).
+ * The goal is to optimize the following case:
+ * - if any cell in B1:B1000 changes, C1 must be recomputed
+ * - if any cell in B1:B1000 changes, C2 must be recomputed
+ * - if any cell in B1:B1000 changes, C3 must be recomputed
+ * ...
+ * - if any cell in B1:B1000 changes, C1000 must be recomputed
+ *
+ * Instead of having 1000 entries in the R-tree, we want to have a single entry
+ * with B1:B1000 (bounding box) pointing to C1:C1000 (formulas).
+ */
+function groupSameBoundingBoxes(items: RTreeRangeItem[]): RangeSetItem[] {
+  // Important: this function must be as fast as possible. It is on the evaluation hot path.
+  let maxCol = 0;
+  let maxRow = 0;
+  for (let i = 0; i < items.length; i++) {
+    const zone = items[i].boundingBox.zone;
+    if (zone.right > maxCol) {
+      maxCol = zone.right;
+    }
+    if (zone.bottom > maxRow) {
+      maxRow = zone.bottom;
+    }
+  }
+  maxCol += 1;
+  maxRow += 1;
+
+  // in most real-world cases, we can use a fast numeric key
+  // but if the zones are too far right or bottom, we fallback to a slower string key
+  const maxPossibleKey = (((maxRow + 1) * maxCol + 1) * maxRow + 1) * maxCol;
+  const useFastKey = maxPossibleKey <= Number.MAX_SAFE_INTEGER;
+  if (!useFastKey) {
+    console.warn("Max col/row size exceeded, using slow zone key");
+  }
+  const groupedByBBox: Record<UID, Record<string, RangeSetItem>> = {};
+  for (const item of items) {
+    const sheetId = item.boundingBox.sheetId;
+    if (!groupedByBBox[sheetId]) {
+      groupedByBBox[sheetId] = {};
+    }
+    const bBox = item.boundingBox.zone;
+    let bBoxKey: number | string = 0;
+    if (useFastKey) {
+      bBoxKey =
+        bBox.left +
+        bBox.top * maxCol +
+        bBox.right * maxCol * maxRow +
+        bBox.bottom * maxCol * maxRow * maxCol;
+    } else {
+      bBoxKey = `${bBox.left},${bBox.top},${bBox.right},${bBox.bottom}`;
+    }
+    if (groupedByBBox[sheetId][bBoxKey]) {
+      const ranges = groupedByBBox[sheetId][bBoxKey].data;
+      ranges.add(item.data);
+    } else {
+      groupedByBBox[sheetId][bBoxKey] = {
+        boundingBox: item.boundingBox,
+        data: new RangeSet([item.data]),
+      };
+    }
+  }
+  const result: RangeSetItem[] = [];
+  for (const sheetId in groupedByBBox) {
+    const map = groupedByBBox[sheetId];
+    for (const key in map) {
+      result.push(map[key]);
+    }
+  }
+  return result;
+}

--- a/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
@@ -1,20 +1,14 @@
 import { compile } from "../../../formulas";
 import { handleError, implementationErrorMessage } from "../../../functions";
 import { matrixMap } from "../../../functions/helpers";
-import {
-  aggregatePositionsToZones,
-  excludeTopLeft,
-  lazy,
-  positionToZone,
-  toXC,
-  union,
-} from "../../../helpers";
+import { excludeTopLeft, lazy, positionToZone, toXC, union } from "../../../helpers";
 import { createEvaluatedCell, evaluateLiteral } from "../../../helpers/cells";
 import { PositionMap } from "../../../helpers/cells/position_map";
 import { ModelConfig } from "../../../model";
 import { onIterationEndEvaluationRegistry } from "../../../registries/evaluation_registry";
 import { _t } from "../../../translation";
 import {
+  BoundedRange,
   CellPosition,
   CellValueType,
   EvaluatedCell,
@@ -38,7 +32,8 @@ import {
 import { CompilationParameters, buildCompilationParameters } from "./compilation_parameters";
 import { FormulaDependencyGraph } from "./formula_dependency_graph";
 import { PositionSet, SheetSizes } from "./position_set";
-import { RTreeBoundingBox } from "./r_tree";
+import { RTreeItem } from "./r_tree";
+import { RangeSet } from "./range_set";
 import { SpreadingRelation } from "./spreading_relation";
 
 const MAX_ITERATION = 30;
@@ -52,9 +47,7 @@ export class Evaluator {
   private compilationParams: CompilationParameters;
 
   private evaluatedCells: PositionMap<EvaluatedCell> = new PositionMap();
-  private formulaDependencies = lazy(
-    new FormulaDependencyGraph(this.createEmptyPositionSet.bind(this))
-  );
+  private formulaDependencies = lazy(new FormulaDependencyGraph());
   private blockedArrayFormulas = new PositionSet({});
   private spreadingRelations = new SpreadingRelation();
 
@@ -103,7 +96,7 @@ export class Evaluator {
       position.sheetId,
       positionToZone(position)
     );
-    return Array.from(arrayFormulas).find((position) => !this.blockedArrayFormulas.has(position));
+    return arrayFormulas.find((position) => !this.blockedArrayFormulas.has(position));
   }
 
   updateDependencies(position: CellPosition) {
@@ -156,65 +149,76 @@ export class Evaluator {
 
   evaluateCells(positions: CellPosition[]) {
     const start = performance.now();
-    const cellsToCompute = this.createEmptyPositionSet();
-    cellsToCompute.addMany(positions);
+    const rangesToCompute = new RangeSet();
+    rangesToCompute.addManyPositions(positions);
     const arrayFormulasPositions = this.getArrayFormulasImpactedByChangesOf(positions);
-    cellsToCompute.addMany(this.getCellsDependingOn(positions));
-    cellsToCompute.addMany(arrayFormulasPositions);
-    cellsToCompute.addMany(this.getCellsDependingOn(arrayFormulasPositions));
-    this.evaluate(cellsToCompute);
+    rangesToCompute.addMany(this.getCellsDependingOn(rangesToCompute));
+    rangesToCompute.addMany(arrayFormulasPositions);
+    rangesToCompute.addMany(this.getCellsDependingOn(arrayFormulasPositions));
+    this.evaluate(rangesToCompute);
     console.debug("evaluate Cells", performance.now() - start, "ms");
   }
 
-  private getArrayFormulasImpactedByChangesOf(
-    positions: Iterable<CellPosition>
-  ): Iterable<CellPosition> {
-    const impactedPositions = this.createEmptyPositionSet();
+  private getArrayFormulasImpactedByChangesOf(positions: Iterable<CellPosition>): RangeSet {
+    const impactedRanges = new RangeSet();
 
     for (const position of positions) {
       const content = this.getters.getCell(position)?.content;
       const arrayFormulaPosition = this.getArrayFormulaSpreadingOn(position);
       if (arrayFormulaPosition !== undefined) {
         // take into account new collisions.
-        impactedPositions.add(arrayFormulaPosition);
+        impactedRanges.addPosition(arrayFormulaPosition);
       }
       if (!content) {
         // The previous content could have blocked some array formulas
-        impactedPositions.add(position);
+        impactedRanges.addPosition(position);
       }
     }
-    const zonesBySheetIds = aggregatePositionsToZones(impactedPositions);
-    for (const sheetId in zonesBySheetIds) {
-      for (const zone of zonesBySheetIds[sheetId]) {
-        impactedPositions.addMany(this.getArrayFormulasBlockedBy(sheetId, zone));
-      }
+    for (const range of [...impactedRanges]) {
+      impactedRanges.addMany(this.getArrayFormulasBlockedBy(range.sheetId, range.zone));
     }
-    return impactedPositions;
+    return impactedRanges;
   }
 
   buildDependencyGraph() {
     this.blockedArrayFormulas = this.createEmptyPositionSet();
     this.spreadingRelations = new SpreadingRelation();
     this.formulaDependencies = lazy(() => {
-      const dependencies = [...this.getAllCells()].flatMap((position) =>
-        this.getDirectDependencies(position)
-          .filter((range) => !range.invalidSheetName && !range.invalidXc)
-          .map((range) => ({
-            data: position,
-            boundingBox: {
-              zone: range.zone,
-              sheetId: range.sheetId,
-            },
-          }))
-      );
-      return new FormulaDependencyGraph(this.createEmptyPositionSet.bind(this), dependencies);
+      const rTreeItems: RTreeItem<BoundedRange>[] = [];
+      for (const sheetId of this.getters.getSheetIds()) {
+        const cells = this.getters.getCells(sheetId);
+        for (const cellId in cells) {
+          const cell = cells[cellId];
+          if (cell.isFormula) {
+            const directDependencies = cell.compiledFormula.dependencies;
+            for (const range of directDependencies) {
+              if (range.invalidSheetName || range.invalidXc) {
+                continue;
+              }
+              rTreeItems.push({
+                data: {
+                  sheetId,
+                  zone: positionToZone(this.getters.getCellPosition(cellId)),
+                },
+                boundingBox: { sheetId: range.sheetId, zone: range.zone },
+              });
+            }
+          }
+        }
+      }
+      return new FormulaDependencyGraph(rTreeItems);
     });
   }
 
   evaluateAllCells() {
     const start = performance.now();
     this.evaluatedCells = new PositionMap();
-    this.evaluate(this.getAllCells());
+    const ranges: BoundedRange[] = [];
+    for (const sheetId of this.getters.getSheetIds()) {
+      const zone = this.getters.getSheetZone(sheetId);
+      ranges.push({ sheetId, zone });
+    }
+    this.evaluate(ranges);
     console.debug("evaluate all cells", performance.now() - start, "ms");
   }
 
@@ -256,60 +260,69 @@ export class Evaluator {
     }
   }
 
-  private getAllCells(): PositionSet {
-    const positions = this.createEmptyPositionSet();
-    positions.fillAllPositions();
-    return positions;
-  }
-
   /**
    * Return the position of formulas blocked by the given positions
    * as well as all their dependencies.
    */
-  private getArrayFormulasBlockedBy(sheetId: UID, zone: Zone): Iterable<CellPosition> {
-    const arrayFormulaPositions = this.createEmptyPositionSet();
+  private getArrayFormulasBlockedBy(sheetId: UID, zone: Zone): RangeSet {
+    const arrayFormulaPositions = new RangeSet();
     const arrayFormulas = this.spreadingRelations.searchFormulaPositionsSpreadingOn(sheetId, zone);
-    arrayFormulaPositions.addMany(arrayFormulas);
+    arrayFormulaPositions.addManyPositions(arrayFormulas);
     const spilledPositions = [...arrayFormulas].filter(
       (position) => !this.blockedArrayFormulas.has(position)
     );
     if (spilledPositions.length) {
       // ignore the formula spreading on the position. Keep only the blocked ones
-      arrayFormulaPositions.deleteMany(spilledPositions);
+      arrayFormulaPositions.deleteManyPositions(spilledPositions);
     }
     arrayFormulaPositions.addMany(this.getCellsDependingOn(arrayFormulaPositions));
     return arrayFormulaPositions;
   }
 
-  private nextPositionsToUpdate = new PositionSet({});
+  private nextRangesToUpdate = new RangeSet();
   private cellsBeingComputed = new Set<UID>();
   private symbolsBeingComputed = new Set<string>();
 
-  private evaluate(positions: PositionSet) {
+  private evaluate(ranges: Iterable<BoundedRange>) {
     this.cellsBeingComputed = new Set<UID>();
-    this.nextPositionsToUpdate = positions;
+    this.nextRangesToUpdate = new RangeSet(ranges);
 
     let currentIteration = 0;
-    while (!this.nextPositionsToUpdate.isEmpty() && currentIteration++ < MAX_ITERATION) {
+    while (!this.nextRangesToUpdate.isEmpty() && currentIteration++ < MAX_ITERATION) {
       this.updateCompilationParameters();
-      const positions = this.nextPositionsToUpdate.clear();
-      for (let i = 0; i < positions.length; ++i) {
-        this.evaluatedCells.delete(positions[i]);
-      }
-      for (let i = 0; i < positions.length; ++i) {
-        const position = positions[i];
-        if (this.nextPositionsToUpdate.has(position)) {
-          continue;
-        }
-        const evaluatedCell = this.computeCell(position);
-        if (evaluatedCell !== EMPTY_CELL) {
-          this.evaluatedCells.set(position, evaluatedCell);
+      const ranges = [...this.nextRangesToUpdate];
+      this.nextRangesToUpdate.clear();
+      this.clearEvaluatedRanges(ranges);
+      for (const range of ranges) {
+        const { left, bottom, right, top } = range.zone;
+        for (let col = left; col <= right; col++) {
+          for (let row = top; row <= bottom; row++) {
+            const position = { sheetId: range.sheetId, col, row };
+            if (this.nextRangesToUpdate.hasPosition(position)) {
+              continue;
+            }
+            const evaluatedCell = this.computeCell(position);
+            if (evaluatedCell !== EMPTY_CELL) {
+              this.evaluatedCells.set(position, evaluatedCell);
+            }
+          }
         }
       }
       onIterationEndEvaluationRegistry.getAll().forEach((callback) => callback(this.getters));
     }
     if (currentIteration >= MAX_ITERATION) {
       console.warn("Maximum iteration reached while evaluating cells");
+    }
+  }
+
+  private clearEvaluatedRanges(ranges: Iterable<BoundedRange>) {
+    for (const range of ranges) {
+      const { left, bottom, right, top } = range.zone;
+      for (let col = left; col <= right; col++) {
+        for (let row = top; row <= bottom; row++) {
+          this.evaluatedCells.delete({ sheetId: range.sheetId, col, row });
+        }
+      }
     }
   }
 
@@ -412,12 +425,11 @@ export class Evaluator {
 
   private invalidatePositionsDependingOnSpread(sheetId: UID, resultZone: Zone) {
     // the result matrix is split in 2 zones to exclude the array formula position
-    const invalidatedPositions = this.formulaDependencies().getCellsDependingOn(
-      excludeTopLeft(resultZone).map((zone) => ({ sheetId, zone })),
-      this.nextPositionsToUpdate
+    const invalidatedPositions = this.getCellsDependingOn(
+      excludeTopLeft(resultZone).map((zone) => ({ sheetId, zone }))
     );
-    invalidatedPositions.delete({ sheetId, col: resultZone.left, row: resultZone.top });
-    this.nextPositionsToUpdate.addMany(invalidatedPositions);
+    invalidatedPositions.delete({ sheetId, zone: resultZone });
+    this.nextRangesToUpdate.addMany(invalidatedPositions);
   }
 
   private assertSheetHasEnoughSpaceToSpreadFormulaResult(
@@ -532,7 +544,7 @@ export class Evaluator {
     }
     const sheetId = position.sheetId;
     this.invalidatePositionsDependingOnSpread(sheetId, zone);
-    this.nextPositionsToUpdate.addMany(this.getArrayFormulasBlockedBy(sheetId, zone));
+    this.nextRangesToUpdate.addMany(this.getArrayFormulasBlockedBy(sheetId, zone));
   }
 
   /**
@@ -570,13 +582,8 @@ export class Evaluator {
     return cell.compiledFormula.dependencies;
   }
 
-  private getCellsDependingOn(positions: Iterable<CellPosition>): Iterable<CellPosition> {
-    const ranges: RTreeBoundingBox[] = [];
-    const zonesBySheetIds = aggregatePositionsToZones(positions);
-    for (const sheetId in zonesBySheetIds) {
-      ranges.push(...zonesBySheetIds[sheetId].map((zone) => ({ sheetId, zone })));
-    }
-    return this.formulaDependencies().getCellsDependingOn(ranges, this.nextPositionsToUpdate);
+  private getCellsDependingOn(ranges: Iterable<BoundedRange>): RangeSet {
+    return this.formulaDependencies().getCellsDependingOn(ranges, this.nextRangesToUpdate);
   }
 }
 

--- a/src/plugins/ui_core_views/cell_evaluation/range_set.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/range_set.ts
@@ -1,0 +1,123 @@
+import { positionToBoundedRange } from "../../../helpers";
+import { BoundedRange, CellPosition, UID } from "../../../types";
+import { ZoneSet } from "./zone_set";
+
+export class RangeSet {
+  private setsBySheetId: Record<UID, ZoneSet> = {};
+
+  constructor(ranges: Iterable<BoundedRange> = []) {
+    for (const range of ranges) {
+      this.add(range);
+    }
+  }
+
+  add(range: BoundedRange) {
+    if (!this.setsBySheetId[range.sheetId]) {
+      this.setsBySheetId[range.sheetId] = new ZoneSet();
+    }
+    this.setsBySheetId[range.sheetId].add(range.zone);
+  }
+
+  addMany(ranges: Iterable<BoundedRange>) {
+    for (const range of ranges) {
+      this.add(range);
+    }
+  }
+
+  addPosition(position: CellPosition) {
+    this.add(positionToBoundedRange(position));
+  }
+
+  addManyPositions(positions: Iterable<CellPosition>) {
+    for (const position of positions) {
+      this.addPosition(position);
+    }
+  }
+
+  has(range: BoundedRange): boolean {
+    if (!this.setsBySheetId[range.sheetId]) {
+      return false;
+    }
+    return this.setsBySheetId[range.sheetId].has(range.zone);
+  }
+
+  hasPosition(position: CellPosition): boolean {
+    return this.has(positionToBoundedRange(position));
+  }
+
+  delete(range: BoundedRange) {
+    if (!this.setsBySheetId[range.sheetId]) {
+      return;
+    }
+    this.setsBySheetId[range.sheetId].delete(range.zone);
+  }
+
+  deleteMany(ranges: Iterable<BoundedRange>) {
+    for (const range of ranges) {
+      this.delete(range);
+    }
+  }
+
+  deleteManyPositions(positions: Iterable<CellPosition>) {
+    for (const position of positions) {
+      this.delete(positionToBoundedRange(position));
+    }
+  }
+
+  difference(other: RangeSet): RangeSet {
+    const result = new RangeSet();
+    for (const sheetId in this.setsBySheetId) {
+      result.setsBySheetId[sheetId] = this.setsBySheetId[sheetId];
+    }
+    for (const sheetId in other.setsBySheetId) {
+      if (result.setsBySheetId[sheetId]) {
+        result.setsBySheetId[sheetId] = result.setsBySheetId[sheetId].difference(
+          other.setsBySheetId[sheetId]
+        );
+      }
+    }
+    return result;
+  }
+
+  copy(): RangeSet {
+    const result = new RangeSet();
+    for (const sheetId in this.setsBySheetId) {
+      result.setsBySheetId[sheetId] = this.setsBySheetId[sheetId].copy();
+    }
+    return result;
+  }
+
+  clear() {
+    this.setsBySheetId = {};
+  }
+
+  size(): number {
+    let size = 0;
+    for (const sheetId in this.setsBySheetId) {
+      size += this.setsBySheetId[sheetId].size();
+    }
+    return size;
+  }
+
+  isEmpty(): boolean {
+    for (const sheetId in this.setsBySheetId) {
+      if (!this.setsBySheetId[sheetId].isEmpty()) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * iterator of all the ranges in the RangeSet
+   */
+  [Symbol.iterator](): IterableIterator<BoundedRange> {
+    const result: BoundedRange[] = [];
+    for (const sheetId in this.setsBySheetId) {
+      for (const zone of this.setsBySheetId[sheetId]) {
+        result.push({ sheetId: sheetId, zone });
+      }
+    }
+    return result[Symbol.iterator]();
+  }
+}

--- a/src/plugins/ui_core_views/cell_evaluation/spreading_relation.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/spreading_relation.ts
@@ -50,7 +50,7 @@ export class SpreadingRelation {
   private readonly resultsToArrayFormulas = new SpreadsheetRTree<CellPosition>();
   private readonly arrayFormulasToResults: PositionMap<Zone> = new PositionMap();
 
-  searchFormulaPositionsSpreadingOn(sheetId: UID, zone: Zone): Iterable<CellPosition> {
+  searchFormulaPositionsSpreadingOn(sheetId: UID, zone: Zone): CellPosition[] {
     return (
       this.resultsToArrayFormulas.search({ sheetId, zone }).map((node) => node.data) || EMPTY_ARRAY
     );

--- a/src/plugins/ui_core_views/cell_evaluation/zone_set.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/zone_set.ts
@@ -1,0 +1,64 @@
+import { Zone } from "../../..";
+import { constructZonesFromProfiles, modifyProfiles, profilesContainsZone } from "../../../helpers";
+
+export class ZoneSet {
+  private profilesStartingPosition: number[] = [0];
+  private profiles = new Map<number, number[]>([[0, []]]);
+
+  constructor(zones: Iterable<Zone> = []) {
+    for (const zone of zones) {
+      this.add(zone);
+    }
+  }
+
+  isEmpty(): boolean {
+    return this.profiles.size === 1 && this.profiles.get(0)?.length === 0;
+  }
+
+  add(zone: Zone) {
+    modifyProfiles(this.profilesStartingPosition, this.profiles, [zone]);
+  }
+
+  delete(zone: Zone) {
+    modifyProfiles(this.profilesStartingPosition, this.profiles, [zone], true);
+  }
+
+  has(zone: Zone): boolean {
+    return profilesContainsZone(this.profilesStartingPosition, this.profiles, zone);
+  }
+
+  difference(other: ZoneSet): ZoneSet {
+    const result = this.copy();
+    for (const zone of other) {
+      result.delete(zone);
+    }
+    return result;
+  }
+
+  copy(): ZoneSet {
+    const result = new ZoneSet();
+    result.profilesStartingPosition = [...this.profilesStartingPosition];
+    result.profiles = new Map<number, number[]>();
+    for (const [key, value] of this.profiles) {
+      result.profiles.set(key, [...value]);
+    }
+    return result;
+  }
+
+  size() {
+    let size = 0;
+    for (const profile of this.profiles.values()) {
+      size += profile.length;
+    }
+    return size / 2;
+  }
+
+  /**
+   * iterator of all the zones in the ZoneSet
+   */
+  [Symbol.iterator](): IterableIterator<Zone> {
+    return constructZonesFromProfiles<Zone>(this.profilesStartingPosition, this.profiles)[
+      Symbol.iterator
+    ]();
+  }
+}

--- a/src/types/range.ts
+++ b/src/types/range.ts
@@ -18,6 +18,11 @@ export interface Range {
   readonly sheetId: UID;
 }
 
+export interface BoundedRange {
+  sheetId: UID;
+  zone: Zone;
+}
+
 export interface RangeStringOptions {
   useBoundedReference?: boolean;
   useFixedReference?: boolean;

--- a/tests/helpers/dependencies_r_tree.test.ts
+++ b/tests/helpers/dependencies_r_tree.test.ts
@@ -1,0 +1,95 @@
+import { DependenciesRTree } from "../../src/plugins/ui_core_views/cell_evaluation/dependencies_r_tree";
+import { toBoundedRange } from "../test_helpers/helpers";
+
+describe("DependenciesRTree", () => {
+  test("insert and search a single cell", () => {
+    const rTree = new DependenciesRTree([
+      {
+        boundingBox: toBoundedRange("Sheet1", "A1:A3"),
+        data: toBoundedRange("Sheet1", "B1"),
+      },
+    ]);
+    expect(Array.from(rTree.search(toBoundedRange("Sheet1", "A2")))).toEqual([
+      toBoundedRange("Sheet1", "B1"),
+    ]);
+  });
+
+  test("group data with identical bounding boxes", () => {
+    const rTree = new DependenciesRTree([
+      {
+        boundingBox: toBoundedRange("Sheet1", "A1:B1"),
+        data: toBoundedRange("Sheet1", "C1"),
+      },
+      {
+        boundingBox: toBoundedRange("Sheet1", "A1:B1"),
+        data: toBoundedRange("Sheet1", "D1"),
+      },
+    ]);
+    expect(Array.from(rTree.search(toBoundedRange("Sheet1", "A1")))).toEqual([
+      toBoundedRange("Sheet1", "C1:D1"),
+    ]);
+  });
+
+  test("insert with identical existing bounding box", () => {
+    const rTree = new DependenciesRTree([
+      {
+        boundingBox: toBoundedRange("Sheet1", "A1:B1"),
+        data: toBoundedRange("Sheet1", "C1"),
+      },
+    ]);
+    rTree.insert({
+      boundingBox: toBoundedRange("Sheet1", "A1:B1"),
+      data: toBoundedRange("Sheet1", "D1"),
+    });
+    expect(Array.from(rTree.search(toBoundedRange("Sheet1", "A1")))).toEqual([
+      toBoundedRange("Sheet1", "C1:D1"),
+    ]);
+  });
+
+  test("insert with bounding box inside an existing one", () => {
+    const rTree = new DependenciesRTree([
+      {
+        boundingBox: toBoundedRange("Sheet1", "A1:B1"),
+        data: toBoundedRange("Sheet1", "C1"),
+      },
+    ]);
+    rTree.insert({
+      boundingBox: toBoundedRange("Sheet1", "B1"),
+      data: toBoundedRange("Sheet1", "E1"),
+    });
+    expect(Array.from(rTree.search(toBoundedRange("Sheet1", "A1")))).toEqual([
+      toBoundedRange("Sheet1", "C1"),
+    ]);
+    expect(Array.from(rTree.search(toBoundedRange("Sheet1", "B1")))).toEqual([
+      toBoundedRange("Sheet1", "C1"),
+      toBoundedRange("Sheet1", "E1"),
+    ]);
+  });
+
+  test("remove a full range", () => {
+    const item = {
+      boundingBox: toBoundedRange("Sheet1", "A1:B1"),
+      data: toBoundedRange("Sheet1", "C1"),
+    };
+    const rTree = new DependenciesRTree([item]);
+    rTree.remove(item);
+    expect(Array.from(rTree.search(toBoundedRange("Sheet1", "A1")))).toEqual([]);
+  });
+
+  test("remove part of a range", () => {
+    const rTree = new DependenciesRTree([
+      {
+        boundingBox: toBoundedRange("Sheet1", "A1:B1"),
+        data: toBoundedRange("Sheet1", "C1:C3"),
+      },
+    ]);
+    rTree.remove({
+      boundingBox: toBoundedRange("Sheet1", "A1:B1"),
+      data: toBoundedRange("Sheet1", "C2"), // remove only C2
+    });
+    expect(Array.from(rTree.search(toBoundedRange("Sheet1", "A1")))).toEqual([
+      toBoundedRange("Sheet1", "C1"),
+      toBoundedRange("Sheet1", "C3"),
+    ]);
+  });
+});

--- a/tests/helpers/range_set.test.ts
+++ b/tests/helpers/range_set.test.ts
@@ -1,0 +1,47 @@
+import { RangeSet } from "../../src/plugins/ui_core_views/cell_evaluation/range_set";
+import { toBoundedRange } from "../test_helpers/helpers";
+
+describe("RangeSet", () => {
+  test("empty RangeSet has nothing", () => {
+    const set = new RangeSet();
+    expect(set.has(toBoundedRange("Sheet1", "A1"))).toBe(false);
+    expect(Array.from(set)).toEqual([]);
+  });
+
+  test("ranges from different sheets are not mixed", () => {
+    const set = new RangeSet();
+    set.add(toBoundedRange("Sheet1", "A1"));
+    set.add(toBoundedRange("Sheet2", "A1"));
+    expect(Array.from(set)).toMatchObject([
+      toBoundedRange("Sheet1", "A1"),
+      toBoundedRange("Sheet2", "A1"),
+    ]);
+  });
+
+  test("removing from a sheet doesn't affect other sheets", () => {
+    const set = new RangeSet();
+    set.add(toBoundedRange("Sheet1", "A1"));
+    set.add(toBoundedRange("Sheet2", "A1"));
+    set.delete(toBoundedRange("Sheet1", "A1"));
+    expect(Array.from(set)).toMatchObject([toBoundedRange("Sheet2", "A1")]);
+  });
+
+  test("difference between RangeSets", () => {
+    const set1 = new RangeSet([
+      toBoundedRange("Sheet1", "A1:A3"),
+      toBoundedRange("Sheet2", "A1:B3"),
+    ]);
+    const set2 = new RangeSet([
+      toBoundedRange("Sheet1", "A2"),
+      toBoundedRange("Sheet2", "B2"),
+      toBoundedRange("Sheet2", "B3"),
+    ]);
+    const diff = set1.difference(set2);
+    expect(Array.from(diff)).toMatchObject([
+      toBoundedRange("Sheet1", "A1"),
+      toBoundedRange("Sheet1", "A3"),
+      toBoundedRange("Sheet2", "A1:A3"),
+      toBoundedRange("Sheet2", "B1"),
+    ]);
+  });
+});

--- a/tests/helpers/zone_set.test.ts
+++ b/tests/helpers/zone_set.test.ts
@@ -1,0 +1,249 @@
+import { toZone } from "../../src/helpers";
+import { ZoneSet } from "../../src/plugins/ui_core_views/cell_evaluation/zone_set";
+
+describe("ZoneSet", () => {
+  test("empty ZoneSet has nothing", () => {
+    const set = new ZoneSet();
+    expect(set.has(toZone("A1"))).toBe(false);
+    expect(Array.from(set)).toEqual([]);
+  });
+
+  test("add and remove single cell zone", () => {
+    const set = new ZoneSet();
+    set.add(toZone("B2"));
+    expect(set.has(toZone("B2"))).toBe(true);
+    set.delete(toZone("B2"));
+    expect(set.has(toZone("B2"))).toBe(false);
+    expect(Array.from(set)).toEqual([]);
+  });
+
+  test("add and remove single zone", () => {
+    const set = new ZoneSet();
+    set.add(toZone("B2:C3"));
+    expect(set.has(toZone("B2"))).toBe(true);
+    expect(set.has(toZone("C3"))).toBe(true);
+    expect(set.has(toZone("B2:B3"))).toBe(true);
+    expect(set.has(toZone("C2:C3"))).toBe(true);
+    set.delete(toZone("B2:C3"));
+    expect(set.has(toZone("B2"))).toBe(false);
+    expect(set.has(toZone("C3"))).toBe(false);
+    expect(set.has(toZone("B2:B3"))).toBe(false);
+    expect(set.has(toZone("C2:C3"))).toBe(false);
+    expect(Array.from(set)).toEqual([]);
+  });
+
+  test("zone equality: same zone added twice", () => {
+    const set = new ZoneSet();
+    set.add(toZone("A1:A5"));
+    set.add(toZone("A1:A5"));
+    expect(Array.from(set)).toEqual([toZone("A1:A5")]);
+    set.delete(toZone("A1:A5"));
+    expect(Array.from(set)).toEqual([]);
+  });
+
+  test("removing a part of a zone", () => {
+    const set = new ZoneSet();
+    set.add(toZone("B2:B4"));
+    set.delete(toZone("B3"));
+    expect(set.has(toZone("B2"))).toBe(true);
+    expect(set.has(toZone("B3"))).toBe(false);
+    expect(set.has(toZone("B4"))).toBe(true);
+    expect(Array.from(set)).toEqual([toZone("B2"), toZone("B4")]);
+  });
+
+  test("remove a bigger zone", () => {
+    const set = new ZoneSet();
+    set.add(toZone("B2:B4"));
+    set.delete(toZone("B1:B5"));
+    expect(set.has(toZone("B2:B4"))).toBe(false);
+    expect(Array.from(set)).toEqual([]);
+  });
+
+  test("difference between two sets", () => {
+    const setA = new ZoneSet();
+    setA.add(toZone("A1:A5"));
+    setA.add(toZone("B1:B5"));
+    const setB = new ZoneSet();
+    setB.add(toZone("A3:A7"));
+    setB.add(toZone("C1:C5"));
+    const difference = setA.difference(setB);
+    expect(Array.from(difference)).toEqual([toZone("A1:A2"), toZone("B1:B5")]);
+  });
+
+  test("difference with an empty set", () => {
+    const setA = new ZoneSet();
+    setA.add(toZone("A1:A5"));
+    setA.add(toZone("B1:B5"));
+    const difference = setA.difference(new ZoneSet());
+    expect(Array.from(difference)).toEqual([toZone("A1:B5")]);
+  });
+
+  test("difference creates a new set", () => {
+    const setA = new ZoneSet();
+    setA.add(toZone("A1:A5"));
+    const difference = setA.difference(new ZoneSet());
+    setA.delete(toZone("A1:A5"));
+    expect(Array.from(difference)).toEqual([toZone("A1:A5")]);
+  });
+
+  test("A1: add, has, delete", () => {
+    const set = new ZoneSet();
+    set.add(toZone("A1"));
+    expect(set.has(toZone("A1"))).toBe(true);
+    set.delete(toZone("A1"));
+    expect(set.has(toZone("A1"))).toBe(false);
+  });
+
+  test("first column: add and check", () => {
+    const set = new ZoneSet();
+    set.add(toZone("A1:A5"));
+    expect(set.has(toZone("A1"))).toBe(true);
+    expect(set.has(toZone("A5"))).toBe(true);
+    expect(set.has(toZone("A6"))).toBe(false);
+    expect(set.has(toZone("B1"))).toBe(false);
+  });
+
+  test("first row: add and check", () => {
+    const set = new ZoneSet();
+    set.add(toZone("A1:E1"));
+    expect(set.has(toZone("A1"))).toBe(true);
+    expect(set.has(toZone("E1"))).toBe(true);
+    expect(set.has(toZone("F1"))).toBe(false);
+  });
+
+  test("adjacent to A1 are not contained", () => {
+    const set = new ZoneSet();
+    set.add(toZone("A1"));
+    expect(set.has(toZone("B1"))).toBe(false);
+    expect(set.has(toZone("A2"))).toBe(false);
+    expect(set.has(toZone("B2"))).toBe(false);
+  });
+
+  test("mixing two adjacent zones on first row", () => {
+    const set = new ZoneSet();
+    set.add(toZone("C1"));
+    set.add(toZone("D1"));
+    expect(set.has(toZone("C1"))).toBe(true);
+    expect(set.has(toZone("D1"))).toBe(true);
+    expect(Array.from(set)).toEqual([toZone("C1:D1")]);
+  });
+
+  test("iterator groups adjacent zones", () => {
+    const set = new ZoneSet();
+    set.add(toZone("B2:B3"));
+    set.add(toZone("C2:C3"));
+    expect(Array.from(set)).toEqual([toZone("B2:C3")]);
+  });
+
+  test("adjacent zones are not contained", () => {
+    const set = new ZoneSet();
+    set.add(toZone("B2"));
+    expect(set.has(toZone("B1"))).toBe(false);
+    expect(set.has(toZone("A2"))).toBe(false);
+    expect(set.has(toZone("C2"))).toBe(false);
+    expect(set.has(toZone("B3"))).toBe(false);
+  });
+
+  test("contained cell zone", () => {
+    const set = new ZoneSet();
+    set.add(toZone("A1:A3"));
+    expect(set.has(toZone("A1"))).toBe(true);
+    expect(set.has(toZone("A2"))).toBe(true);
+    expect(set.has(toZone("A3"))).toBe(true);
+  });
+
+  test("two zones on the same column", () => {
+    const set = new ZoneSet();
+    set.add(toZone("A2:A3"));
+    set.add(toZone("A10:A15"));
+    expect(set.has(toZone("A2"))).toBe(true);
+    expect(set.has(toZone("A13"))).toBe(true);
+    expect(set.has(toZone("A1"))).toBe(false);
+    expect(set.has(toZone("A5"))).toBe(false);
+    expect(set.has(toZone("A16"))).toBe(false);
+  });
+
+  test("mixing two adjacent zones", () => {
+    const set = new ZoneSet();
+    set.add(toZone("B2:B3"));
+    set.add(toZone("C2:C3"));
+    expect(set.has(toZone("B2:C3"))).toBe(true);
+    expect(set.has(toZone("B2:C2"))).toBe(true);
+    expect(set.has(toZone("B3:C3"))).toBe(true);
+    expect(set.has(toZone("B1:C3"))).toBe(false);
+    expect(set.has(toZone("A2:C2"))).toBe(false);
+    expect(set.has(toZone("B2:D2"))).toBe(false);
+  });
+
+  test("removing a full zone", () => {
+    const set = new ZoneSet();
+    set.add(toZone("B2:B3"));
+    set.delete(toZone("B2:B3"));
+    expect(set.has(toZone("B2:B3"))).toBe(false);
+    expect(Array.from(set)).toEqual([]);
+  });
+
+  test("empty set is empty", () => {
+    const set = new ZoneSet();
+    expect(set.isEmpty()).toBe(true);
+    set.add(toZone("A1"));
+    expect(set.isEmpty()).toBe(false);
+    set.delete(toZone("A1"));
+    expect(set.isEmpty()).toBe(true);
+  });
+
+  test("empty when multiple zones", () => {
+    const set = new ZoneSet();
+    set.add(toZone("A1"));
+    set.add(toZone("B2"));
+    expect(set.isEmpty()).toBe(false);
+    set.delete(toZone("A1"));
+    expect(set.isEmpty()).toBe(false);
+    set.delete(toZone("B2"));
+    expect(set.isEmpty()).toBe(true);
+  });
+
+  test("size with individual cells", () => {
+    const set = new ZoneSet();
+    expect(set.size()).toBe(0);
+    set.add(toZone("A1"));
+    set.add(toZone("B2"));
+    expect(set.size()).toBe(2);
+    set.delete(toZone("A1"));
+    expect(set.size()).toBe(1);
+    set.delete(toZone("B2"));
+    expect(set.size()).toBe(0);
+  });
+
+  test("size with adjacent cells", () => {
+    const set = new ZoneSet();
+    set.add(toZone("A1"));
+    set.add(toZone("A2"));
+    expect(set.size()).toBe(1);
+    set.add(toZone("B1"));
+    set.add(toZone("B2"));
+    expect(set.size()).toBe(1);
+    set.add(toZone("B3"));
+    expect(set.size()).toBe(2);
+  });
+
+  test("size with multiple zones on the same column", () => {
+    const set = new ZoneSet();
+    set.add(toZone("A1:A3"));
+    expect(set.size()).toBe(1);
+    set.add(toZone("A5:A6"));
+    expect(set.size()).toBe(2);
+    set.add(toZone("A8:A10"));
+    expect(set.size()).toBe(3);
+  });
+
+  test("size with multiple zones on the same row", () => {
+    const set = new ZoneSet();
+    set.add(toZone("A1:C1"));
+    expect(set.size()).toBe(1);
+    set.add(toZone("E1:F1"));
+    expect(set.size()).toBe(2);
+    set.add(toZone("H1:J1"));
+    expect(set.size()).toBe(3);
+  });
+});

--- a/tests/test_helpers/helpers.ts
+++ b/tests/test_helpers/helpers.ts
@@ -15,6 +15,7 @@ import { functionRegistry } from "../../src/functions/index";
 import { ImageProvider } from "../../src/helpers/figures/images/image_provider";
 import {
   batched,
+  createRangeFromXc,
   range,
   toCartesian,
   toUnboundedZone,
@@ -657,6 +658,17 @@ export function toRangeData(sheetId: UID, xc: string): RangeData {
 
 export function toRangesData(sheetId: UID, str: string): RangeData[] {
   return str.split(",").map((xc) => toRangeData(sheetId, xc));
+}
+
+export function toBoundedRange(sheetId: UID, xc: string) {
+  const fullRange = createRangeFromXc({ xc, sheetId }, () => ({
+    numberOfRows: Number.MAX_SAFE_INTEGER,
+    numberOfCols: Number.MAX_SAFE_INTEGER,
+  }));
+  return {
+    sheetId: fullRange.sheetId,
+    zone: fullRange.zone,
+  };
 }
 
 export function createEqualCF(


### PR DESCRIPTION
This commit improves evaluation time from 5% to 20% on regular spreadsheet, depending on the spreadsheet. And even from 99% on some pathological cases

Benchmark: https://www.odoo.com/odoo/documents/d9dGIrjZRTSa9nf153wEIwo9e4c5

Let’s say you have two formulas that depend on the same reference:

A1: =C1 
A2: =C1

In the FormulaDependencyGraph, both dependencies are added independently. Specifically, the R-tree data structure ends up with two separate entries: C1 -> A1 and C1 -> A2.

Ideally, the internal R-tree structure should group these dependencies into a single node in the tree:

C1 -> [A1, A2] or even C1 -> [A1:A2] because they can be grouped into a single zone.

When this pattern occurs frequently, the R-tree becomes huged (and unbalanced) therefore sub-optimal.
- Huge: lots and lots of individual positions
- Unbalanced: this is common when using individual pivot formulas (e.g., for spreadsheet pivots), where each PIVOT.VALUE formula depends on the same range—the pivot dataset.

With this commit, the dependencies R-Tree maps bounding boxes to zones, instead of bounding boxes to positions.
To take advantage of this grouping, the entire evaluation process now uses zones as much as possible.

Task: 4936229

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo