### PR TITLE
[FIX] upgrade: half-versions are missing in mapping

### DIFF
--- a/src/migrations/data.ts
+++ b/src/migrations/data.ts
@@ -80,8 +80,10 @@ const LEGACY_VERSION_MAPPING = {
   17: "17.4",
   16: "17.3",
   15: "17.2",
+  "14.5": "16.4.1",
   14: "16.4",
   13: "16.3",
+  "12.5": "15.4.1",
   12: "15.4",
 
   // not accurate starting at this point


### PR DESCRIPTION
Commit 4d671ebd47a05 didn't add intermediary versions 12.5 and 14.5 in the mapping.

As a result, `data.version` was transformed to `undefined` and the data would go through every upgrade steps from the very begining, which could obviously lead to crashes and corrupted data.

Task: 5116401

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo