### PR TITLE
[FIX] headers_overlay: disable interaction in read-only mode

### DIFF
--- a/src/components/headers_overlay/headers_overlay.ts
+++ b/src/components/headers_overlay/headers_overlay.ts
@@ -142,7 +142,12 @@ abstract class AbstractResizer extends Component<ResizerProps, SpreadsheetChildE
   }
 
   onMouseMove(ev: MouseEvent) {
-    if (this.state.isResizing || this.state.isMoving || this.state.isSelecting) {
+    if (
+      this.env.model.getters.isReadonly() ||
+      this.state.isResizing ||
+      this.state.isMoving ||
+      this.state.isSelecting
+    ) {
       return;
     }
     this._computeHandleDisplay(ev);
@@ -198,6 +203,10 @@ abstract class AbstractResizer extends Component<ResizerProps, SpreadsheetChildE
     }
     const index = this._getElementIndex(this._getEvOffset(ev));
     if (index < 0) {
+      return;
+    }
+    if (this.env.model.getters.isReadonly()) {
+      this._selectElement(index, false);
       return;
     }
     if (this.state.waitingForMove === true) {

--- a/tests/grid/grid_overlay_component.test.ts
+++ b/tests/grid/grid_overlay_component.test.ts
@@ -27,6 +27,7 @@ import {
 import {
   edgeScrollDelay,
   selectColumnByClicking,
+  simulateClick,
   triggerMouseEvent,
 } from "../test_helpers/dom_helper";
 import { getEvaluatedCell, getSelectionAnchorCellXc } from "../test_helpers/getters_helpers";
@@ -649,6 +650,20 @@ describe("Resizer component", () => {
     await nextTick();
     expect(fixture.querySelector(".o-context-menu")).toBeFalsy();
   });
+
+  test("Can open context menu in readonly", async () => {
+    model.updateMode("readonly");
+    triggerMouseEvent(".o-overlay .o-col-resizer", "contextmenu", 10, 10);
+    await nextTick();
+    expect(fixture.querySelector(".o-menu")).toBeTruthy();
+  });
+
+  test("Cannot resize a column in readonly", async () => {
+    model.updateMode("readonly");
+    triggerMouseEvent(".o-overlay .o-col-resizer", "mousemove", DEFAULT_CELL_WIDTH, 10);
+    await nextTick();
+    expect(fixture.querySelector(".o-overlay .o-col-resizer .o-handle")).toBeNull();
+  });
 });
 describe("Hide/show columns", () => {
   beforeEach(async () => {
@@ -1113,6 +1128,15 @@ describe("move selected element(s)", () => {
       expect(getEvaluatedCell(model, "B1").value).toBe("b1");
       expect(getEvaluatedCell(model, "C1").value).toBe("c1");
       expect(getEvaluatedCell(model, "D1").value).toBe("d1");
+    });
+
+    test("Can select a column but not move it in readonly", async () => {
+      model.updateMode("readonly");
+      await selectColumnByClicking(model, "A", {});
+      expect(model.getters.getActiveCols()).toEqual(new Set([0]));
+
+      await simulateClick(".o-overlay .o-col-resizer", 10, 10);
+      expect(fixture.querySelector(".o-overlay .o-col-resizer")?.classList).not.toContain("o-grab");
     });
   });
 


### PR DESCRIPTION
## Description

The drag & drop to move headers, and the handle to resize headers were both enabled in read-only mode. This commit disable those.

Task: [5182854](https://www.odoo.com/odoo/2328/tasks/5182854)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo