### PR TITLE
[FIX] filter menu: truncate long filter values

### DIFF
--- a/src/components/filters/filter_menu_item/filter_menu_value_item.xml
+++ b/src/components/filters/filter_menu_item/filter_menu_value_item.xml
@@ -14,8 +14,9 @@
         name="value.toString()"
         value="this.props.isChecked"
         onChange="this.props.onClick"
-        className="'p-2 w-100 pe-auto text-truncate'"
+        className="'p-2 w-100 pe-auto'"
         label="value.toString()"
+        title="value.toString()"
       />
     </div>
   </t>

--- a/src/components/side_panel/components/checkbox/checkbox.xml
+++ b/src/components/side_panel/components/checkbox/checkbox.xml
@@ -7,14 +7,14 @@
       t-att-class="{'text-muted': props.disabled }"
       t-attf-class="{{props.className}}">
       <input
-        class="me-2"
+        class="me-2 flex-shrink-0"
         type="checkbox"
         t-att-disabled="props.disabled"
         t-att-name="props.name"
         t-att-checked="props.value"
         t-on-change="onChange"
       />
-      <t t-if="props.label" t-esc="props.label"/>
+      <span class="text-truncate" t-if="props.label" t-esc="props.label"/>
     </label>
   </t>
 </templates>

--- a/tests/components/__snapshots__/pivot_html_renderer.test.ts.snap
+++ b/tests/components/__snapshots__/pivot_html_renderer.test.ts.snap
@@ -10,11 +10,15 @@ exports[`Pivot HTML Renderer Rendering a simple pivot table 1`] = `
       role="button"
     >
       <input
-        class="me-2"
+        class="me-2 flex-shrink-0"
         name="missing_values"
         type="checkbox"
       />
-      Display missing cells only
+      <span
+        class="text-truncate"
+      >
+        Display missing cells only
+      </span>
       
     </label>
     

--- a/tests/pivots/spreadsheet_pivot/__snapshots__/spreadsheet_pivot_side_panel.test.ts.snap
+++ b/tests/pivots/spreadsheet_pivot/__snapshots__/spreadsheet_pivot_side_panel.test.ts.snap
@@ -202,10 +202,14 @@ exports[`Spreadsheet pivot side panel It should correctly be displayed 1`] = `
             title="Changing the pivot definition requires to reload the data. It may take some time."
           >
             <input
-              class="me-2"
+              class="me-2 flex-shrink-0"
               type="checkbox"
             />
-            Defer updates
+            <span
+              class="text-truncate"
+            >
+              Defer updates
+            </span>
             
           </label>
           
@@ -406,10 +410,14 @@ exports[`Spreadsheet pivot side panel It should display only the selection input
             title="Changing the pivot definition requires to reload the data. It may take some time."
           >
             <input
-              class="me-2"
+              class="me-2 flex-shrink-0"
               type="checkbox"
             />
-            Defer updates
+            <span
+              class="text-truncate"
+            >
+              Defer updates
+            </span>
             
           </label>
           

--- a/tests/side_panels/building_blocks/__snapshots__/label_range.test.ts.snap
+++ b/tests/side_panels/building_blocks/__snapshots__/label_range.test.ts.snap
@@ -48,11 +48,15 @@ exports[`Label range Can add options to the label range component 1`] = `
       role="button"
     >
       <input
-        class="me-2"
+        class="me-2 flex-shrink-0"
         name="my_option"
         type="checkbox"
       />
-      My option
+      <span
+        class="text-truncate"
+      >
+        My option
+      </span>
       
     </label>
     

--- a/tests/side_panels/components/__snapshots__/checkbox.test.ts.snap
+++ b/tests/side_panels/components/__snapshots__/checkbox.test.ts.snap
@@ -7,7 +7,7 @@ exports[`Checkbox Can render a checkbox 1`] = `
     role="button"
   >
     <input
-      class="me-2"
+      class="me-2 flex-shrink-0"
       type="checkbox"
     />
     

--- a/tests/table/__snapshots__/filter_menu_component.test.ts.snap
+++ b/tests/table/__snapshots__/filter_menu_component.test.ts.snap
@@ -62,15 +62,20 @@ exports[`Filter menu component Filter Tests Filter menu is correctly rendered 1`
     >
       <!-- toString because t-set with a body creates a LazyValue instead of a string -->
       <label
-        class="o-checkbox d-flex align-items-center p-2 w-100 pe-auto text-truncate"
+        class="o-checkbox d-flex align-items-center p-2 w-100 pe-auto"
         role="button"
+        title="(Blanks)"
       >
         <input
-          class="me-2"
+          class="me-2 flex-shrink-0"
           name="(Blanks)"
           type="checkbox"
         />
-        (Blanks)
+        <span
+          class="text-truncate"
+        >
+          (Blanks)
+        </span>
         
       </label>
       
@@ -80,15 +85,20 @@ exports[`Filter menu component Filter Tests Filter menu is correctly rendered 1`
     >
       <!-- toString because t-set with a body creates a LazyValue instead of a string -->
       <label
-        class="o-checkbox d-flex align-items-center p-2 w-100 pe-auto text-truncate"
+        class="o-checkbox d-flex align-items-center p-2 w-100 pe-auto"
         role="button"
+        title="1"
       >
         <input
-          class="me-2"
+          class="me-2 flex-shrink-0"
           name="1"
           type="checkbox"
         />
-        1
+        <span
+          class="text-truncate"
+        >
+          1
+        </span>
         
       </label>
       
@@ -98,15 +108,20 @@ exports[`Filter menu component Filter Tests Filter menu is correctly rendered 1`
     >
       <!-- toString because t-set with a body creates a LazyValue instead of a string -->
       <label
-        class="o-checkbox d-flex align-items-center p-2 w-100 pe-auto text-truncate"
+        class="o-checkbox d-flex align-items-center p-2 w-100 pe-auto"
         role="button"
+        title="2"
       >
         <input
-          class="me-2"
+          class="me-2 flex-shrink-0"
           name="2"
           type="checkbox"
         />
-        2
+        <span
+          class="text-truncate"
+        >
+          2
+        </span>
         
       </label>
       


### PR DESCRIPTION
## Description

Long values in the filter menu were not truncated, causing layout issues. There was a `text-truncate` class, but it was added to the `<label>` element instead of the `<span>` containing the text.

Task: [5219611](https://www.odoo.com/odoo/2328/tasks/5219611)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo