### PR TITLE
[FIX] composer: Enter/Tab confirm when assistant is force-closed

### DIFF
--- a/src/components/composer/composer/abstract_composer_store.ts
+++ b/src/components/composer/composer/abstract_composer_store.ts
@@ -930,10 +930,15 @@ export abstract class AbstractComposerStore extends SpreadsheetStore {
     this.autoComplete.hide();
   }
 
-  autoCompleteOrStop(direction: Direction) {
+  autoCompleteOrStop(direction: Direction, assistantForcedClosed: boolean = false) {
     if (this.editionMode !== "inactive") {
       const autoComplete = this.autoComplete;
-      if (autoComplete.provider && autoComplete.selectedIndex !== undefined) {
+      const suppressAutocomplete = assistantForcedClosed && this.canBeToggled;
+      if (
+        !suppressAutocomplete &&
+        autoComplete.provider &&
+        autoComplete.selectedIndex !== undefined
+      ) {
         const autoCompleteValue = autoComplete.provider.proposals[autoComplete.selectedIndex]?.text;
         if (autoCompleteValue) {
           this.autoComplete.provider?.selectProposal(autoCompleteValue);

--- a/src/components/composer/composer/composer.ts
+++ b/src/components/composer/composer/composer.ts
@@ -385,17 +385,13 @@ export class Composer extends Component<CellComposerProps, SpreadsheetChildEnv> 
   private processTabKey(ev: KeyboardEvent, direction: Direction) {
     ev.preventDefault();
     ev.stopPropagation();
-    if (!this.assistant.forcedClosed) {
-      this.props.composerStore.autoCompleteOrStop(direction);
-    }
+    this.props.composerStore.autoCompleteOrStop(direction, this.assistant.forcedClosed);
   }
 
   private processEnterKey(ev: KeyboardEvent, direction: Direction) {
     ev.preventDefault();
     ev.stopPropagation();
-    if (!this.assistant.forcedClosed) {
-      this.props.composerStore.autoCompleteOrStop(direction);
-    }
+    this.props.composerStore.autoCompleteOrStop(direction, this.assistant.forcedClosed);
   }
 
   private processNewLineEvent(ev: KeyboardEvent) {


### PR DESCRIPTION
## Description:

When the formula assistant was force-closed, Enter/Tab were swallowed and no action occurred. Users could not confirm edits (including plain text).

Composer now tells the store when the assistant is force-closed. Enter/Tab confirm the edit if the assistant is open; otherwise, they stop the edition.

Task: [5153666](https://www.odoo.com/odoo/project/2328/tasks/5153666)


## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo