### PR TITLE
[FIX] GenericInput: skip focus manipulation

### DIFF
--- a/src/components/generic_input/generic_input.ts
+++ b/src/components/generic_input/generic_input.ts
@@ -83,7 +83,7 @@ export class GenericInput<T extends GenericInputProps> extends Component<T, Spre
 
   onMouseDown(ev: MouseEvent) {
     // Stop the event if the input is not focused, we handle everything in onMouseUp
-    if (ev.target !== document.activeElement) {
+    if (ev.target !== document.activeElement && this.props.selectContentOnFocus) {
       ev.preventDefault();
       ev.stopPropagation();
     }
@@ -91,7 +91,7 @@ export class GenericInput<T extends GenericInputProps> extends Component<T, Spre
 
   onMouseUp(ev: MouseEvent) {
     const target = ev.target as HTMLInputElement;
-    if (target !== document.activeElement) {
+    if (target !== document.activeElement && this.props.selectContentOnFocus) {
       target.focus();
       if (this.props.selectContentOnFocus) {
         target.select();


### PR DESCRIPTION
When providing the props `selectContentOnFocus`, we manipulate the default behaviour of the browser (mouseDown/mouseUp) to select the full content of the input. However, half of this manipulation (prevent mouseDown default) still occured even if the props `selectContentOnFocus` was set to false.

Unfortunately, this cannot be properly tested as the update of the selected range on mouseDown does not seem programatically reproductible.

Task: 5206980

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo