### PR TITLE
[FIX] pivot: error on removing max number of columns/rows

### DIFF
--- a/src/components/side_panel/pivot/pivot_side_panel/pivot_design_panel/pivot_design_panel.ts
+++ b/src/components/side_panel/pivot/pivot_side_panel/pivot_design_panel/pivot_design_panel.ts
@@ -3,6 +3,7 @@ import { SpreadsheetChildEnv } from "@odoo/o-spreadsheet-engine/types/spreadshee
 import { Component } from "@odoo/owl";
 import { Store, useLocalStore } from "../../../../../store_engine";
 import { PivotStyle, UID } from "../../../../../types";
+import { NumberInput } from "../../../../number_input/number_input";
 import { Checkbox } from "../../../components/checkbox/checkbox";
 import { Section } from "../../../components/section/section";
 import { PivotSidePanelStore } from "../pivot_side_panel_store";
@@ -14,12 +15,17 @@ interface Props {
 export class PivotDesignPanel extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-PivotDesignPanel";
   static props = { pivotId: String };
-  static components = { Section, Checkbox };
+  static components = { Section, Checkbox, NumberInput };
 
   store!: Store<PivotSidePanelStore>;
 
   setup() {
     this.store = useLocalStore(PivotSidePanelStore, this.props.pivotId, "neverDefer");
+  }
+
+  updatePivotStyleNumberProperty(valueStr: string, key: keyof PivotStyle) {
+    const value = parseInt(valueStr);
+    this.store.update({ style: { ...this.pivotStyle, [key]: isNaN(value) ? undefined : value } });
   }
 
   updatePivotStyleProperty(key: keyof PivotStyle, value: PivotStyle[keyof PivotStyle]) {

--- a/src/components/side_panel/pivot/pivot_side_panel/pivot_design_panel/pivot_design_panel.xml
+++ b/src/components/side_panel/pivot/pivot_side_panel/pivot_design_panel/pivot_design_panel.xml
@@ -6,24 +6,22 @@
           <div class="row mb-2 align-items-center">
             <div class="col-6">Max rows:</div>
             <div class="col-6 d-flex align-items-center">
-              <input
-                t-att-value="pivotStyle.numberOfRows ?? ''"
-                type="number"
-                class="o-pivot-n-of-rows o-input"
-                placeholder="e.g. 10"
-                t-on-change="(ev) => this.updatePivotStyleProperty('numberOfRows', ev.target.valueAsNumber)"
+              <NumberInput
+                value="pivotStyle.numberOfRows ?? ''"
+                class="'o-pivot-n-of-rows'"
+                placeholder.translate="e.g. 10"
+                onChange="(value) => this.updatePivotStyleNumberProperty(value, 'numberOfRows')"
               />
             </div>
           </div>
           <div class="row mb-2 align-items-center">
             <div class="col-6">Max columns:</div>
             <div class="col-6 d-flex align-items-center">
-              <input
-                t-att-value="pivotStyle.numberOfColumns ?? ''"
-                type="number"
-                class="o-pivot-n-of-columns o-input"
-                placeholder="e.g. 5"
-                t-on-change="(ev) => this.updatePivotStyleProperty('numberOfColumns', ev.target.valueAsNumber)"
+              <NumberInput
+                value="pivotStyle.numberOfColumns ?? ''"
+                class="'o-pivot-n-of-columns'"
+                placeholder.translate="e.g. 5"
+                onChange="(value) => this.updatePivotStyleNumberProperty(value, 'numberOfColumns')"
               />
             </div>
           </div>

--- a/tests/pivots/pivot_design_side_panel.test.ts
+++ b/tests/pivots/pivot_design_side_panel.test.ts
@@ -94,4 +94,20 @@ describe("Spreadsheet pivot side panel", () => {
     await setInputValueAndTrigger("input.o-pivot-n-of-rows", "12");
     expect(model.getters.getPivotCoreDefinition("1").style?.numberOfRows).toBe(12);
   });
+
+  test("Editing a number input with a non-number value make the property undefined and not NaN", async () => {
+    updatePivot(model, "1", { style: { numberOfRows: 5, numberOfColumns: 10 } });
+    await nextTick();
+
+    jest.useFakeTimers();
+    setInputValueAndTrigger("input.o-pivot-n-of-rows", "olà");
+    setInputValueAndTrigger("input.o-pivot-n-of-columns", "");
+    jest.advanceTimersByTime(1000);
+
+    expect(model.getters.getPivotCoreDefinition("1").style).toEqual({
+      numberOfRows: undefined,
+      numberOfColumns: undefined,
+    });
+    jest.useRealTimers();
+  });
 });


### PR DESCRIPTION
## Description

When deleting the pivot style numberOfRows or numberOfColumns in the pivot design panel, the pivot would be in error. This was because we didn't handle the cases where the content on the input was not a number, and would set `NaN` values.

Task: [5220970](https://www.odoo.com/odoo/2328/tasks/5220970)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo