### PR TITLE
[FIX] charts: crash when converting empty chart to scorecard/gauge

### DIFF
--- a/src/helpers/figures/charts/gauge_chart.ts
+++ b/src/helpers/figures/charts/gauge_chart.ts
@@ -181,7 +181,7 @@ export class GaugeChart extends AbstractChart {
       background: context.background,
       title: context.title || { text: "" },
       type: "gauge",
-      dataRange: context.range ? context.range[0].dataRange : undefined,
+      dataRange: context.range?.[0]?.dataRange,
       sectionRule: {
         colors: {
           lowerColor: DEFAULT_GAUGE_LOWER_COLOR,

--- a/src/helpers/figures/charts/scorecard_chart.ts
+++ b/src/helpers/figures/charts/scorecard_chart.ts
@@ -196,7 +196,7 @@ export class ScorecardChart extends AbstractChart {
     return {
       background: context.background,
       type: "scorecard",
-      keyValue: context.range ? context.range[0].dataRange : undefined,
+      keyValue: context.range?.[0]?.dataRange,
       title: context.title || { text: "" },
       baselineMode: DEFAULT_SCORECARD_BASELINE_MODE,
       baselineColorUp: DEFAULT_SCORECARD_BASELINE_COLOR_UP,

--- a/tests/figures/chart/charts_component.test.ts
+++ b/tests/figures/chart/charts_component.test.ts
@@ -11,7 +11,11 @@ import {
   ChartWithAxisDefinition,
   SpreadsheetChildEnv,
 } from "../../../src/types";
-import { PieChartRuntime } from "../../../src/types/chart";
+import {
+  GaugeChartDefinition,
+  PieChartRuntime,
+  ScorecardChartDefinition,
+} from "../../../src/types/chart";
 import { BarChartDefinition, BarChartRuntime } from "../../../src/types/chart/bar_chart";
 import { LineChartDefinition } from "../../../src/types/chart/line_chart";
 import {
@@ -2154,5 +2158,33 @@ describe("Change chart type", () => {
     updateChart(model, chartId, { horizontal: false }, sheetId);
     await nextTick();
     expect(fixture.querySelector("label.o-checkbox")!.textContent).toBe("Stacked column chart");
+  });
+
+  test("Changing an empty bar chart to scorecard does not crash and leaves keyValue undefined", async () => {
+    createChart(model, { type: "bar", dataSets: [] }, chartId);
+    await mountChartSidePanel(chartId);
+
+    await changeChartType("scorecard");
+    await nextTick();
+
+    expect(fixture.querySelector(".o-chart")).toBeTruthy();
+
+    const def = model.getters.getChartDefinition(chartId) as ScorecardChartDefinition;
+    expect(def.type).toBe("scorecard");
+    expect(def.keyValue).toBeUndefined();
+  });
+
+  test("Changing an empty bar chart to gauge does not crash and leaves data range undefined", async () => {
+    createChart(model, { type: "bar", dataSets: [] }, chartId);
+    await mountChartSidePanel(chartId);
+
+    await changeChartType("gauge");
+    await nextTick();
+
+    expect(fixture.querySelector(".o-chart")).toBeTruthy();
+
+    const def = model.getters.getChartDefinition(chartId) as GaugeChartDefinition;
+    expect(def.type).toBe("gauge");
+    expect(def.dataRange).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Description:

When creating a Scorecard or Gauge from an empty carousel/chart, `context.range` can be an empty array.
Accessing `context.range[0].dataRange` crashed.

This PR adds a check to ensure that `context.range` has at least one element before accessing `context.range[0].dataRange`.

Task: [5181741](https://www.odoo.com/odoo/project/2328/tasks/5181741)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo