### PR TITLE
[IMP] pivot: add tabular form

### DIFF
--- a/packages/o-spreadsheet-engine/src/functions/module_lookup.ts
+++ b/packages/o-spreadsheet-engine/src/functions/module_lookup.ts
@@ -953,13 +953,6 @@ export const PIVOT = {
     }
     const cells = table.getPivotCells(pivotStyle);
 
-    let headerRows = 0;
-    if (pivotStyle.displayColumnHeaders) {
-      headerRows = table.columns.length - 1;
-    }
-    if (pivotStyle.displayMeasuresRow) {
-      headerRows++;
-    }
     const pivotTitle = this.getters.getPivotName(pivotId);
     const { numberOfCols, numberOfRows } = table.getPivotTableDimensions(pivotStyle);
     if (numberOfRows === 0) {
@@ -984,10 +977,19 @@ export const PIVOT = {
           case "VALUE":
             result[col].push(pivot.getPivotCellValueAndFormat(pivotCell.measure, pivotCell.domain));
             break;
+          case "ROW_GROUP_NAME":
+            const fieldName = pivot.definition.rows.find(
+              (row) => row.nameWithGranularity === pivotCell.rowField
+            )?.displayName;
+            result[col].push({ value: fieldName || "" });
+            break;
         }
       }
     }
-    if (pivotStyle.displayColumnHeaders || pivotStyle.displayMeasuresRow) {
+    if (
+      (pivotStyle.displayColumnHeaders || pivotStyle.displayMeasuresRow) &&
+      cells[0][0].type === "EMPTY"
+    ) {
       result[0][0] = { value: pivotTitle };
     }
     return result;

--- a/packages/o-spreadsheet-engine/src/helpers/pivot/pivot_helpers.ts
+++ b/packages/o-spreadsheet-engine/src/helpers/pivot/pivot_helpers.ts
@@ -44,6 +44,7 @@ export const DEFAULT_PIVOT_STYLE: Required<PivotStyle> = {
   bandedRows: false,
   bandedColumns: false,
   hasFilters: false,
+  tabularForm: false,
 };
 
 const AGGREGATOR_NAMES = {
@@ -503,6 +504,7 @@ export function getPivotStyleFromFnArgs(
     bandedRows: style?.bandedRows ?? DEFAULT_PIVOT_STYLE.bandedRows,
     bandedColumns: style?.bandedColumns ?? DEFAULT_PIVOT_STYLE.bandedColumns,
     hasFilters: style?.hasFilters ?? DEFAULT_PIVOT_STYLE.hasFilters,
+    tabularForm: style?.tabularForm ?? DEFAULT_PIVOT_STYLE.tabularForm,
   };
 }
 

--- a/packages/o-spreadsheet-engine/src/helpers/pivot/spreadsheet_pivot/spreadsheet_pivot.ts
+++ b/packages/o-spreadsheet-engine/src/helpers/pivot/spreadsheet_pivot/spreadsheet_pivot.ts
@@ -305,6 +305,9 @@ export class SpreadsheetPivot implements Pivot<SpreadsheetPivotRuntimeDefinition
     if (!this.isValid()) {
       throw new Error("Pivot is not valid !");
     }
+    if (this.coreDefinition.style?.tabularForm) {
+      return this.getExpandedTableStructure();
+    }
     if (!this.collapsedTable) {
       this.collapsedTable = dataEntriesToSpreadsheetPivotTable(
         this.dataEntries,

--- a/packages/o-spreadsheet-engine/src/helpers/pivot/table_spreadsheet_pivot.ts
+++ b/packages/o-spreadsheet-engine/src/helpers/pivot/table_spreadsheet_pivot.ts
@@ -64,6 +64,7 @@ interface CollapsiblePivotTableColumn extends PivotTableColumn {
 export class SpreadsheetPivotTable {
   readonly columns: CollapsiblePivotTableColumn[][];
   rows: PivotTableRow[];
+  readonly rowFields: string[];
   readonly measures: string[];
   readonly fieldsType: Record<string, string | undefined>;
   readonly maxIndent: number;
@@ -87,9 +88,7 @@ export class SpreadsheetPivotTable {
       columns = this.removeCollapsedColumns(columns, measures, collapsedDomains.COL);
     }
     this.columns = columns.map((cols) => {
-      // offset in the pivot table
-      // starts at 1 because the first column is the row title
-      let offset = 1;
+      let offset = 0;
       return cols.map((col) => {
         col = { ...col, offset };
         offset += col.width;
@@ -98,6 +97,9 @@ export class SpreadsheetPivotTable {
     });
 
     this.rows = rows.filter((row) => !this.isParentCollapsed(collapsedDomains.ROW, row));
+    const numberOfRowGroupings = Math.max(...rows.map((row) => row.fields.length));
+    const rowAtMaxDepth = rows.find((row) => row.fields.length === numberOfRowGroupings);
+    this.rowFields = rowAtMaxDepth ? [...rowAtMaxDepth.fields] : [];
     this.maxIndent = Math.max(...this.rows.map((row) => row.indent));
     this.rowTree = lazy(() => this.buildRowsTree());
     this.colTree = lazy(() => this.buildColumnsTree());
@@ -159,13 +161,23 @@ export class SpreadsheetPivotTable {
 
   private getSkippedRows(pivotStyle: Required<PivotStyle>) {
     const skippedRows: Set<number> = new Set();
+    const colHeadersHeight = this.getColHeadersHeight();
     if (!pivotStyle.displayColumnHeaders) {
-      for (let i = 0; i < this.columns.length - 1; i++) {
+      for (let i = 0; i < colHeadersHeight - 1; i++) {
         skippedRows.add(i);
       }
     }
     if (!pivotStyle.displayMeasuresRow) {
-      skippedRows.add(this.columns.length - 1);
+      skippedRows.add(colHeadersHeight - 1);
+    }
+    // Skip sub-total rows in tabular form
+    if (pivotStyle.tabularForm) {
+      for (let i = 0; i < this.rows.length; i++) {
+        const indent = this.rows[i].indent;
+        if (indent !== 0 && indent !== this.maxIndent) {
+          skippedRows.add(i + colHeadersHeight);
+        }
+      }
     }
     return skippedRows;
   }
@@ -176,8 +188,8 @@ export class SpreadsheetPivotTable {
       const { displayTotals } = pivotStyle;
       const numberOfDataRows = this.rows.length;
       const numberOfDataColumns = this.getNumberOfDataColumns();
-      let pivotHeight = this.columns.length + numberOfDataRows;
-      let pivotWidth = 1 /*(row headers)*/ + numberOfDataColumns;
+      let pivotHeight = numberOfDataRows + this.getColHeadersHeight();
+      let pivotWidth = numberOfDataColumns + this.getRowHeadersWidth(pivotStyle);
       if (!displayTotals && numberOfDataRows !== 1) {
         pivotHeight -= 1;
       }
@@ -192,7 +204,8 @@ export class SpreadsheetPivotTable {
           if (skippedRows.has(row)) {
             continue;
           }
-          domainArray[col].push(this.getPivotCell(col, row, displayTotals));
+          const cell = this.getPivotCell(col, row, pivotStyle);
+          domainArray[col].push(cell);
         }
       }
       this.pivotCells[key] = domainArray;
@@ -212,38 +225,58 @@ export class SpreadsheetPivotTable {
     return this.rows[index].indent !== this.maxIndent;
   }
 
-  private getPivotCell(col: number, row: number, includeTotal = true): PivotTableCell {
-    const colHeadersHeight = this.columns.length;
-    if (col > 0 && row === colHeadersHeight - 1) {
-      const domain = this.getColHeaderDomain(col, row);
+  private getPivotCell(col: number, row: number, pivotStyle: Required<PivotStyle>): PivotTableCell {
+    const colHeadersHeight = this.getColHeadersHeight();
+    const rowHeadersWidth = this.getRowHeadersWidth(pivotStyle);
+
+    const isTabularForm = pivotStyle.tabularForm;
+    const isColHeader = row < colHeadersHeight - 1 && col >= rowHeadersWidth;
+    const isMeasureHeader = row === colHeadersHeight - 1 && col >= rowHeadersWidth;
+    const isRowHeader = row > colHeadersHeight - 1 && col < rowHeadersWidth;
+    const isPivotValue = row > colHeadersHeight - 1 && col >= rowHeadersWidth;
+    const isRowGroupName = isTabularForm && row === colHeadersHeight - 1 && col < rowHeadersWidth;
+
+    if (isTabularForm && isRowHeader) {
+      const rowIndex = row - colHeadersHeight;
+      const domain = this.getDomain(this.rows[rowIndex]).slice(0, col + 1);
+      if (domain.length === 0 && col !== 0) {
+        return EMPTY_PIVOT_CELL;
+      }
+      return { type: "HEADER", domain, dimension: "ROW" };
+    } else if (isTabularForm && isRowGroupName) {
+      return { type: "ROW_GROUP_NAME", rowField: this.rowFields[col] };
+    } else if (isMeasureHeader) {
+      const colIndex = col - rowHeadersWidth;
+      const domain = this.getColHeaderDomain(colIndex, row);
       if (!domain) {
         return EMPTY_PIVOT_CELL;
       }
       const measure = domain.at(-1)?.value?.toString() || "";
       return { type: "MEASURE_HEADER", domain: domain.slice(0, -1), measure };
-    } else if (row <= colHeadersHeight - 1) {
-      const domain = this.getColHeaderDomain(col, row);
+    } else if (isColHeader) {
+      const colIndex = col - rowHeadersWidth;
+      const domain = this.getColHeaderDomain(colIndex, row);
       return domain ? { type: "HEADER", domain, dimension: "COL" } : EMPTY_PIVOT_CELL;
-    } else if (col === 0) {
+    } else if (isRowHeader) {
       const rowIndex = row - colHeadersHeight;
       const domain = this.getDomain(this.rows[rowIndex]);
       return { type: "HEADER", domain, dimension: "ROW" };
-    } else {
+    } else if (isPivotValue) {
       const rowIndex = row - colHeadersHeight;
-      if (!includeTotal && this.isTotalRow(rowIndex)) {
+      const colIndex = col - rowHeadersWidth;
+      if (!pivotStyle.displayTotals && this.isTotalRow(rowIndex)) {
         return EMPTY_PIVOT_CELL;
       }
-      const domain = [...this.getDomain(this.rows[rowIndex]), ...this.getColDomain(col)];
-      const measure = this.getColMeasure(col);
+      const domain = [...this.getDomain(this.rows[rowIndex]), ...this.getColDomain(colIndex)];
+      const measure = this.getColMeasure(colIndex);
       return { type: "VALUE", domain, measure };
     }
+
+    return EMPTY_PIVOT_CELL;
   }
 
-  private getColHeaderDomain(col: number, row: number) {
-    if (col === 0) {
-      return undefined;
-    }
-    const pivotCol = this.columns[row].find((pivotCol) => pivotCol.offset === col);
+  private getColHeaderDomain(colIndex: number, row: number) {
+    const pivotCol = this.columns[row].find((pivotCol) => pivotCol.offset === colIndex);
     if (!pivotCol || pivotCol.collapsedHeader) {
       return undefined;
     }
@@ -273,18 +306,26 @@ export class SpreadsheetPivotTable {
     });
   }
 
-  private getColDomain(col: number) {
-    const domain = this.getColHeaderDomain(col, this.columns.length - 1);
+  private getColDomain(colIndex: number) {
+    const domain = this.getColHeaderDomain(colIndex, this.getColHeadersHeight() - 1);
     return domain ? domain.slice(0, -1) : []; // slice: remove measure and value
   }
 
-  private getColMeasure(col: number) {
-    const domain = this.getColHeaderDomain(col, this.columns.length - 1);
+  private getColMeasure(colIndex: number) {
+    const domain = this.getColHeaderDomain(colIndex, this.getColHeadersHeight() - 1);
     const measure = domain?.at(-1)?.value;
     if (measure === undefined || measure === null) {
       throw new Error("Measure is missing");
     }
     return measure.toString();
+  }
+
+  private getRowHeadersWidth(pivotStyle: Required<PivotStyle>) {
+    return pivotStyle.tabularForm ? this.rowFields.length : 1;
+  }
+
+  private getColHeadersHeight() {
+    return this.columns.length;
   }
 
   buildRowsTree(): DimensionTree {
@@ -406,7 +447,7 @@ export class SpreadsheetPivotTable {
   }
 
   getColumnDomainsAtDepth(depth: number) {
-    if (depth < 0 || depth >= this.columns.length - 1) {
+    if (depth < 0 || depth >= this.getColHeadersHeight() - 1) {
       return [];
     }
     return this.columns[depth].map((col) => this.getDomain(col)).filter((d) => d.length);
@@ -423,14 +464,17 @@ export class SpreadsheetPivotTable {
     const cells = this.getPivotCells(pivotStyle);
     let numberOfHeaderRows = 0;
     if (pivotStyle.displayColumnHeaders) {
-      numberOfHeaderRows = this.columns.length - 1;
+      numberOfHeaderRows = this.getColHeadersHeight() - 1;
     }
     if (pivotStyle.displayMeasuresRow) {
       numberOfHeaderRows++;
     }
 
     return {
-      numberOfCols: Math.min(1 + pivotStyle.numberOfColumns, cells.length),
+      numberOfCols: Math.min(
+        this.getRowHeadersWidth(pivotStyle) + pivotStyle.numberOfColumns,
+        cells.length
+      ),
       numberOfRows: Math.min(numberOfHeaderRows + pivotStyle.numberOfRows, cells[0].length),
       numberOfHeaderRows,
     };

--- a/packages/o-spreadsheet-engine/src/helpers/table_helpers.ts
+++ b/packages/o-spreadsheet-engine/src/helpers/table_helpers.ts
@@ -281,24 +281,43 @@ function getTableElementZones(
       break;
     }
     case "mainSubHeaderRow":
-      for (const row of tableMetaData.mainSubHeaderRows || []) {
-        zones.push({ top: row, bottom: row, left: 0, right: tableMetaData.numberOfCols - 1 });
+      if (tableMetaData.isTabular) {
+        for (const col of tableMetaData.mainSubHeaderRows || []) {
+          zones.push({ top: headerRows, bottom: lastRow - totalRows, left: col, right: col });
+        }
+      } else {
+        for (const row of tableMetaData.mainSubHeaderRows || []) {
+          zones.push({ top: row, bottom: row, left: 0, right: numberOfCols - 1 });
+        }
       }
       break;
     case "firstAlternatingSubHeaderRow":
-      for (const row of tableMetaData.firstAlternatingSubHeaderRows || []) {
-        zones.push({ top: row, bottom: row, left: 0, right: tableMetaData.numberOfCols - 1 });
+      if (tableMetaData.isTabular) {
+        for (const col of tableMetaData.firstAlternatingSubHeaderIndexes || []) {
+          zones.push({ top: headerRows, bottom: lastRow - totalRows, left: col, right: col });
+        }
+      } else {
+        for (const row of tableMetaData.firstAlternatingSubHeaderIndexes || []) {
+          zones.push({ top: row, bottom: row, left: 0, right: numberOfCols - 1 });
+        }
       }
       break;
     case "secondAlternatingSubHeaderRow":
-      for (const row of tableMetaData.secondAlternatingSubHeaderRows || []) {
-        zones.push({ top: row, bottom: row, left: 0, right: tableMetaData.numberOfCols - 1 });
+      if (tableMetaData.isTabular) {
+        for (const col of tableMetaData.secondAlternatingSubHeaderIndexes || []) {
+          zones.push({ top: headerRows, bottom: lastRow - totalRows, left: col, right: col });
+        }
+      } else {
+        for (const row of tableMetaData.secondAlternatingSubHeaderIndexes || []) {
+          zones.push({ top: row, bottom: row, left: 0, right: numberOfCols - 1 });
+        }
       }
       break;
     case "measureHeader":
-      if (tableMetaData.measureRow !== undefined && tableMetaData.numberOfCols > 1) {
+      if (tableMetaData.measureRow !== undefined && numberOfCols > 1) {
         const row = tableMetaData.measureRow;
-        zones.push({ top: row, bottom: row, left: 1, right: tableMetaData.numberOfCols - 1 });
+        const left = tableMetaData.isTabular ? 0 : 1;
+        zones.push({ top: row, bottom: row, left, right: numberOfCols - 1 });
       }
       break;
   }

--- a/packages/o-spreadsheet-engine/src/plugins/ui_core_views/pivot_ui.ts
+++ b/packages/o-spreadsheet-engine/src/plugins/ui_core_views/pivot_ui.ts
@@ -295,7 +295,12 @@ export class PivotUIPlugin extends CoreViewPlugin {
   getPivotCellSortDirection(position: CellPosition): SortDirection | "none" | undefined {
     const pivotId = this.getters.getPivotIdFromPosition(position);
     const pivotCell = this.getters.getPivotCellFromPosition(position);
-    if (pivotCell.type === "EMPTY" || pivotCell.type === "HEADER" || !pivotId) {
+    if (
+      pivotCell.type === "EMPTY" ||
+      pivotCell.type === "HEADER" ||
+      pivotCell.type === "ROW_GROUP_NAME" ||
+      !pivotId
+    ) {
       return undefined;
     }
     const pivot = this.getters.getPivot(pivotId);
@@ -369,6 +374,7 @@ export class PivotUIPlugin extends CoreViewPlugin {
   getPivotStyleAtPosition(
     position: CellPosition
   ): { pivotStyle: Required<PivotStyle>; pivotId: UID } | undefined {
+    position = this.getters.getArrayFormulaSpreadingOn(position) || position;
     const cell = this.getters.getCell(position);
     if (!cell || !cell.isFormula || !this.isMainFunctionPivotSpreadFunction(cell)) {
       return undefined;

--- a/packages/o-spreadsheet-engine/src/plugins/ui_feature/table_computed_style.ts
+++ b/packages/o-spreadsheet-engine/src/plugins/ui_feature/table_computed_style.ts
@@ -129,30 +129,51 @@ export class TableComputedStylePlugin extends UIPlugin {
     const pivot = this.getters.getPivot(pivotInfo.pivotId);
     const pivotStyle = pivotInfo.pivotStyle;
     const maxRowDepth = pivot.getExpandedTableStructure().getNumberOfRowGroupBys();
-    const pivotCells = pivot.getCollapsedTableStructure().getPivotCells(pivotStyle);
+    const pivotTable = pivot.getCollapsedTableStructure();
+    const pivotCells = pivotTable.getPivotCells(pivotStyle);
 
     const mainSubHeaderRows = new Set<number>();
-    const firstAlternatingSubHeaderRows = new Set<number>();
-    const secondAlternatingSubHeaderRows = new Set<number>();
-    let hiddenRowsOffset = 0;
+    const firstAlternatingSubHeaderIndexes = new Set<number>();
+    const secondAlternatingSubHeaderIndexes = new Set<number>();
+    const numberOfHeaderCols = pivotTable.getNumberOfRowGroupBys();
 
-    for (let row = 0; row < pivotCells[0].length; row++) {
-      const isRowHidden = this.getters.isRowHidden(sheetId, row + table.range.zone.top);
-      if (isRowHidden) {
-        hiddenRowsOffset++;
-        continue;
-      }
+    if (!pivotStyle.tabularForm) {
+      let hiddenRowsOffset = 0;
+      for (let row = 0; row < pivotCells[0].length; row++) {
+        const isRowHidden = this.getters.isRowHidden(sheetId, row + table.range.zone.top);
+        if (isRowHidden) {
+          hiddenRowsOffset++;
+          continue;
+        }
 
-      const cell = pivotCells[0][row];
-      if (cell.type !== "HEADER" || cell.domain.length === 0) {
-        continue;
+        const cell = pivotCells[0][row];
+        if (cell.type !== "HEADER" || cell.domain.length === 0) {
+          continue;
+        }
+        if (cell.domain.length === 1 && maxRowDepth > 1) {
+          mainSubHeaderRows.add(row - hiddenRowsOffset);
+        } else if (cell.domain.length % 2 === 0 && maxRowDepth > cell.domain.length) {
+          firstAlternatingSubHeaderIndexes.add(row - hiddenRowsOffset);
+        } else if (cell.domain.length % 2 === 1 && maxRowDepth > cell.domain.length) {
+          secondAlternatingSubHeaderIndexes.add(row - hiddenRowsOffset);
+        }
       }
-      if (cell.domain.length === 1 && maxRowDepth > 1) {
-        mainSubHeaderRows.add(row - hiddenRowsOffset);
-      } else if (cell.domain.length % 2 === 0 && maxRowDepth > cell.domain.length) {
-        firstAlternatingSubHeaderRows.add(row - hiddenRowsOffset);
-      } else if (cell.domain.length % 2 === 1 && maxRowDepth > cell.domain.length) {
-        secondAlternatingSubHeaderRows.add(row - hiddenRowsOffset);
+    } else {
+      let hiddenColsOffset = 0;
+      for (let col = 0; col < numberOfHeaderCols; col++) {
+        const isColHidden = this.getters.isColHidden(sheetId, col + table.range.zone.left);
+        if (isColHidden) {
+          hiddenColsOffset++;
+          continue;
+        }
+
+        if (col === 0 && maxRowDepth > 1) {
+          mainSubHeaderRows.add(0);
+        } else if (col % 2 === 1) {
+          firstAlternatingSubHeaderIndexes.add(col - hiddenColsOffset);
+        } else if (col % 2 === 0) {
+          secondAlternatingSubHeaderIndexes.add(col - hiddenColsOffset);
+        }
       }
     }
 
@@ -165,9 +186,10 @@ export class TableComputedStylePlugin extends UIPlugin {
       numberOfCols,
       numberOfRows,
       mainSubHeaderRows,
-      firstAlternatingSubHeaderRows,
-      secondAlternatingSubHeaderRows,
+      firstAlternatingSubHeaderIndexes,
+      secondAlternatingSubHeaderIndexes,
       measureRow: hasMeasureRow ? config.numberOfHeaders - 1 : undefined,
+      isTabular: pivotStyle.tabularForm,
     };
 
     return { tableMetaData, config };

--- a/packages/o-spreadsheet-engine/src/registries/icons_on_cell_registry.ts
+++ b/packages/o-spreadsheet-engine/src/registries/icons_on_cell_registry.ts
@@ -16,7 +16,7 @@ import {
   PIVOT_INDENT,
 } from "../constants";
 import { deepEquals } from "../helpers/misc";
-import { togglePivotCollapse } from "../helpers/pivot/pivot_helpers";
+import { DEFAULT_PIVOT_STYLE, togglePivotCollapse } from "../helpers/pivot/pivot_helpers";
 import { computeTextFontSizeInPixels } from "../helpers/text_helper";
 import { Getters } from "../types/getters";
 import { ImageSVG } from "../types/image";
@@ -119,14 +119,15 @@ iconsOnCellRegistry.add("conditional_formatting", (getters, position) => {
 });
 
 iconsOnCellRegistry.add("pivot_collapse", (getters, position) => {
-  if (!getters.isSpillPivotFormula(position)) {
+  const pivotId = getters.getPivotIdFromPosition(position);
+  if (!getters.isSpillPivotFormula(position) || !pivotId) {
     return undefined;
   }
   const pivotCell = getters.getPivotCellFromPosition(position);
-  const pivotId = getters.getPivotIdFromPosition(position);
+  const definition = getters.getPivotCoreDefinition(pivotId);
+  const tabularForm = definition.style?.tabularForm ?? DEFAULT_PIVOT_STYLE.tabularForm;
 
-  if (pivotCell.type === "HEADER" && pivotId && pivotCell.domain.length) {
-    const definition = getters.getPivotCoreDefinition(pivotId);
+  if (!tabularForm && pivotCell.type === "HEADER" && pivotId && pivotCell.domain.length) {
     const isDashboard = getters.isDashboard();
 
     const fields = pivotCell.dimension === "COL" ? definition.columns : definition.rows;

--- a/packages/o-spreadsheet-engine/src/types/pivot.ts
+++ b/packages/o-spreadsheet-engine/src/types/pivot.ts
@@ -154,6 +154,11 @@ export interface PivotHeaderCell {
   dimension: Dimension;
 }
 
+export interface PivotGroupNameCell {
+  type: "ROW_GROUP_NAME";
+  rowField: string;
+}
+
 export interface PivotMeasureHeaderCell {
   type: "MEASURE_HEADER";
   domain: PivotDomain;
@@ -172,6 +177,7 @@ export interface PivotEmptyCell {
 
 export type PivotTableCell =
   | PivotHeaderCell
+  | PivotGroupNameCell
   | PivotMeasureHeaderCell
   | PivotValueCell
   | PivotEmptyCell;
@@ -251,4 +257,5 @@ export interface PivotStyle {
   bandedRows?: boolean;
   bandedColumns?: boolean;
   hasFilters?: boolean;
+  tabularForm?: boolean;
 }

--- a/packages/o-spreadsheet-engine/src/types/table.ts
+++ b/packages/o-spreadsheet-engine/src/types/table.ts
@@ -51,8 +51,9 @@ export interface TableMetaData {
   numberOfRows: number;
   measureRow?: number;
   mainSubHeaderRows?: Set<number>;
-  firstAlternatingSubHeaderRows?: Set<number>;
-  secondAlternatingSubHeaderRows?: Set<number>;
+  firstAlternatingSubHeaderIndexes?: Set<number>;
+  secondAlternatingSubHeaderIndexes?: Set<number>;
+  isTabular?: boolean;
 }
 
 export interface ComputedTableStyle {

--- a/src/components/side_panel/pivot/pivot_side_panel/pivot_design_panel/pivot_design_panel.xml
+++ b/src/components/side_panel/pivot/pivot_side_panel/pivot_design_panel/pivot_design_panel.xml
@@ -55,6 +55,16 @@
               />
             </div>
           </div>
+          <div class="row mb-2 align-items-center">
+            <div class="col-6">Use tabular form:</div>
+            <div class="col-6 d-flex align-items-center">
+              <Checkbox
+                name="'tabularForm'"
+                value="pivotStyle.tabularForm ?? defaultStyle.tabularForm"
+                onChange="(val) => this.updatePivotStyleProperty('tabularForm', val)"
+              />
+            </div>
+          </div>
         </div>
       </div>
     </Section>

--- a/src/helpers/pivot/pivot_menu_items.ts
+++ b/src/helpers/pivot/pivot_menu_items.ts
@@ -228,7 +228,8 @@ export const toggleCollapsePivotGroupAction: ActionSpec = {
   isVisible: (env) => {
     const position = env.model.getters.getActivePosition();
     const pivotCellState = getPivotCellCollapseState(env.model.getters, position);
-    return pivotCellState.isPivotGroup;
+    const pivotStyle = env.model.getters.getPivotStyleAtPosition(position);
+    return pivotCellState.isPivotGroup && !pivotStyle?.pivotStyle.tabularForm;
   },
 };
 
@@ -259,7 +260,8 @@ export const collapseAllPivotGroupAction: ActionSpec = {
   isVisible: (env) => {
     const position = env.model.getters.getActivePosition();
     const pivotCellState = getPivotCellCollapseState(env.model.getters, position);
-    if (!pivotCellState.isPivotGroup) {
+    const pivotStyle = env.model.getters.getPivotStyleAtPosition(position);
+    if (!pivotCellState.isPivotGroup || pivotStyle?.pivotStyle.tabularForm) {
       return false;
     }
 
@@ -296,7 +298,8 @@ export const expandAllPivotGroupAction: ActionSpec = {
   isVisible: (env) => {
     const position = env.model.getters.getActivePosition();
     const pivotCellState = getPivotCellCollapseState(env.model.getters, position);
-    if (!pivotCellState.isPivotGroup) {
+    const pivotStyle = env.model.getters.getPivotStyleAtPosition(position);
+    if (!pivotCellState.isPivotGroup || pivotStyle?.pivotStyle.tabularForm) {
       return false;
     }
 
@@ -371,7 +374,12 @@ export function sortPivot(
 ) {
   const pivotId = env.model.getters.getPivotIdFromPosition(position);
   const pivotCell = env.model.getters.getPivotCellFromPosition(position);
-  if (pivotCell.type === "EMPTY" || pivotCell.type === "HEADER" || !pivotId) {
+  if (
+    pivotCell.type === "EMPTY" ||
+    pivotCell.type === "HEADER" ||
+    pivotCell.type === "ROW_GROUP_NAME" ||
+    !pivotId
+  ) {
     return;
   }
 

--- a/tests/pivots/pivot_menu_items.test.ts
+++ b/tests/pivots/pivot_menu_items.test.ts
@@ -1245,6 +1245,32 @@ describe("Pivot (un)collapse menu items", () => {
     expect(expandAllMenuItem.isVisible!(env)).toBe(true);
   });
 
+  test("Expand/collapse menu items not visible in tabular pivot", () => {
+    const collapseAllPath = ["collapse_pivot", "collapse_all_pivot"];
+    const expandAllPath = ["collapse_pivot", "expand_all_pivot"];
+    const collapsePath = ["collapse_pivot", "toggle_collapse_pivot_cell"];
+    const collapseAllMenuItem = getNode(collapseAllPath, env, cellMenuRegistry);
+    const expandAllMenuItem = getNode(expandAllPath, env, cellMenuRegistry);
+    const collapseMenuItem = getNode(collapsePath, env, cellMenuRegistry);
+    updatePivot(model, pivotId, {
+      rows: [{ fieldName: "Salesperson" }, { fieldName: "Stage" }],
+      collapsedDomains: {
+        ROW: [[{ field: "Salesperson", value: "Kevin", type: "char" }]],
+        COL: [],
+      },
+    });
+
+    setSelection(model, ["A27"]); // "Kevin" Salesperson header
+    expect(collapseAllMenuItem.isVisible!(env)).toBe(true);
+    expect(expandAllMenuItem.isVisible!(env)).toBe(true);
+    expect(collapseMenuItem.isVisible!(env)).toBe(true);
+
+    updatePivot(model, pivotId, { style: { tabularForm: true } });
+    expect(collapseAllMenuItem.isVisible!(env)).toBe(false);
+    expect(expandAllMenuItem.isVisible!(env)).toBe(false);
+    expect(collapseMenuItem.isVisible!(env)).toBe(false);
+  });
+
   test("Can collapse all/expand all pivot groups", () => {
     const collapseAllPath = ["collapse_pivot", "collapse_all_pivot"];
     const expandAllPath = ["collapse_pivot", "expand_all_pivot"];

--- a/tests/pivots/spreadsheet_pivot/__snapshots__/spreadsheet_pivot_side_panel.test.ts.snap
+++ b/tests/pivots/spreadsheet_pivot/__snapshots__/spreadsheet_pivot_side_panel.test.ts.snap
@@ -384,6 +384,30 @@ exports[`Spreadsheet pivot side panel It should correctly be displayed 1`] = `
                       </label>
                     </div>
                   </div>
+                  <div
+                    class="row mb-2 align-items-center"
+                  >
+                    <div
+                      class="col-6"
+                    >
+                      Use tabular form:
+                    </div>
+                    <div
+                      class="col-6 d-flex align-items-center"
+                    >
+                      <label
+                        class="o-checkbox d-flex align-items-center"
+                        role="button"
+                      >
+                        <input
+                          class="me-2 flex-shrink-0 border"
+                          name="tabularForm"
+                          type="checkbox"
+                        />
+                        
+                      </label>
+                    </div>
+                  </div>
                 </div>
               </div>
               
@@ -1305,6 +1329,30 @@ exports[`Spreadsheet pivot side panel It should display only the selection input
                         <input
                           class="me-2 flex-shrink-0 border"
                           name="displayMeasuresRow"
+                          type="checkbox"
+                        />
+                        
+                      </label>
+                    </div>
+                  </div>
+                  <div
+                    class="row mb-2 align-items-center"
+                  >
+                    <div
+                      class="col-6"
+                    >
+                      Use tabular form:
+                    </div>
+                    <div
+                      class="col-6 d-flex align-items-center"
+                    >
+                      <label
+                        class="o-checkbox d-flex align-items-center"
+                        role="button"
+                      >
+                        <input
+                          class="me-2 flex-shrink-0 border"
+                          name="tabularForm"
                           type="checkbox"
                         />
                         

--- a/tests/table/table_helpers.test.ts
+++ b/tests/table/table_helpers.test.ts
@@ -280,8 +280,8 @@ describe("Table cell style", () => {
     });
 
     test("Can display a style on sub-sub-header rows", () => {
-      tableMetaData.firstAlternatingSubHeaderRows = new Set([1, 3]);
-      tableMetaData.secondAlternatingSubHeaderRows = new Set([2, 4]);
+      tableMetaData.firstAlternatingSubHeaderIndexes = new Set([1, 3]);
+      tableMetaData.secondAlternatingSubHeaderIndexes = new Set([2, 4]);
       tableStyle.firstAlternatingSubHeaderRow = { style: firstAlternatingSubHeaderRow };
       tableStyle.secondAlternatingSubHeaderRow = { style: secondAlternatingSubHeaderRow };
 
@@ -523,8 +523,8 @@ describe("Table cell borders", () => {
 
     test("Can display a border on sub-sub-header rows", () => {
       const border2: BorderDescr = { color: "#00f", style: "dashed" };
-      tableMetaData.firstAlternatingSubHeaderRows = new Set([1, 3]);
-      tableMetaData.secondAlternatingSubHeaderRows = new Set([2, 4]);
+      tableMetaData.firstAlternatingSubHeaderIndexes = new Set([1, 3]);
+      tableMetaData.secondAlternatingSubHeaderIndexes = new Set([2, 4]);
       tableStyle.firstAlternatingSubHeaderRow = { border: { top: border } };
       tableStyle.secondAlternatingSubHeaderRow = { border: { top: border2 } };
 


### PR DESCRIPTION
## Description

This commit adds a new setting for pivot: whether to use tabular form. In tabular form, each level of row header is displayed in a separate column.

Task: [4794334](https://www.odoo.com/odoo/2328/tasks/4794334)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo