### PR TITLE
[IMP] top_bar: export TopBar component for Odoo trash banner integration

### DIFF
--- a/src/components/top_bar/top_bar.css
+++ b/src/components/top_bar/top_bar.css
@@ -6,7 +6,7 @@
   }
 
   @media (max-width: 768px) {
-    .irregularity-map span {
+    .topbar-banner span {
       overflow: auto;
       align-items: normal !important;
     }
@@ -53,7 +53,7 @@
       }
     }
 
-    .irregularity-map {
+    .topbar-banner {
       border-top: 1px solid var(--os-separator-color);
       height: var(--os-desktop-topbar-toolbar-height);
 

--- a/src/components/top_bar/top_bar.xml
+++ b/src/components/top_bar/top_bar.xml
@@ -72,7 +72,7 @@
       </div>
       <div
         t-if="this.fingerprints.isEnabled"
-        class="irregularity-map d-flex align-items-center justify-content-between">
+        class="topbar-banner irregularity-map d-flex align-items-center justify-content-between">
         <div
           t-on-click="() => this.fingerprints.disable()"
           role="button"

--- a/src/index.ts
+++ b/src/index.ts
@@ -336,6 +336,7 @@ import {
 import { chartSubtypeRegistry } from "@odoo/o-spreadsheet-engine/registries/chart_subtype_registry";
 import { clipboardHandlersRegistries } from "@odoo/o-spreadsheet-engine/registries/clipboardHandlersRegistries";
 import "./clipboard_handlers";
+import { TopBar } from "./components/top_bar/top_bar";
 
 export const helpers = {
   arg,
@@ -466,6 +467,7 @@ export const components = {
   ChartDashboardMenu,
   FullScreenFigure,
   NumberInput,
+  TopBar,
 };
 
 export const hooks = {


### PR DESCRIPTION
## Description:

Exported the TopBar component to allow injection of the trash banner from the Odoo side.
Renamed the irregularity map CSS class to enable reuse from Odoo.

Task: [5030282](https://www.odoo.com/odoo/2328/tasks/5030282)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo