### PR TITLE
[FIX] NumberEditor: drop unused rule

### DIFF
--- a/src/components/number_editor/number_editor.css
+++ b/src/components/number_editor/number_editor.css
@@ -1,7 +1,7 @@
 .o-spreadsheet {
   .o-number-editor {
     width: max-content !important;
-    height: calc(100% - 4px);
+
     input.o-font-size {
       outline: none;
       height: 20px;


### PR DESCRIPTION
The rule `height: calc(100%-4px)` was never actually used. Before we forced a switch to .css files, the rule was overriden by a flat `height:30px` and this was meant to be.

The shift to .css files activated that unused rule by accident only because it was always conflicting and the change of loading order of the css files.

Concretely, the related component `NumberEditor` is only used in two places:
- `Topbar`, in which all items should have a size of 30 px,
- `TextStyler`, where we add a class that forces the size to 30px as well.

So apparently don't use it at all.

Task: 0

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo