### PR TITLE
[FIX] composer: change mode to editing when composer cursor selection changes

### DIFF
--- a/src/components/composer/composer/composer.ts
+++ b/src/components/composer/composer/composer.ts
@@ -485,10 +485,7 @@ export class Composer extends Component<ComposerProps, SpreadsheetChildEnv> {
     }
     const newSelection = this.contentHelper.getCurrentSelection();
 
-    this.env.model.dispatch("STOP_COMPOSER_RANGE_SELECTION");
     this.props.onComposerContentFocused();
-    if (this.props.focus === "inactive") {
-    }
     this.env.model.dispatch("CHANGE_COMPOSER_CURSOR_SELECTION", newSelection);
     this.processTokenAtCursor();
   }

--- a/src/plugins/ui_stateful/edition.ts
+++ b/src/plugins/ui_stateful/edition.ts
@@ -144,6 +144,7 @@ export class EditionPlugin extends UIPlugin {
       case "CHANGE_COMPOSER_CURSOR_SELECTION":
         this.selectionStart = cmd.start;
         this.selectionEnd = cmd.end;
+        this.mode = "editing";
         break;
       case "STOP_COMPOSER_RANGE_SELECTION":
         if (this.isSelectingForComposer()) {

--- a/tests/composer/autocomplete_dropdown_component.test.ts
+++ b/tests/composer/autocomplete_dropdown_component.test.ts
@@ -338,7 +338,6 @@ describe("Autocomplete parenthesis", () => {
   test("=S( + edit S with autocomplete does not add left parenthesis", async () => {
     await typeInComposer("=S(");
     // go behind the letter "S"
-    model.dispatch("STOP_COMPOSER_RANGE_SELECTION");
     model.dispatch("CHANGE_COMPOSER_CURSOR_SELECTION", { start: 2, end: 2 });
     await nextTick();
     // show autocomplete

--- a/tests/composer/edition_plugin.test.ts
+++ b/tests/composer/edition_plugin.test.ts
@@ -103,6 +103,14 @@ describe("edition", () => {
     expect(model.getters.getEditionMode()).toBe("inactive");
   });
 
+  test("should switch to editing mode when composer cursor selection changes", () => {
+    const model = new Model();
+    model.dispatch("START_EDITION", { text: "=sum(" });
+    expect(model.getters.getEditionMode()).toBe("selecting");
+    model.dispatch("CHANGE_COMPOSER_CURSOR_SELECTION", { start: 0, end: 5 });
+    expect(model.getters.getEditionMode()).toBe("editing");
+  });
+
   test("Stopping the edition should complete the missing parenthesis of a formula", async () => {
     const model = new Model();
     model.dispatch("START_EDITION", { text: "=sum(sum(1,2" });
@@ -422,10 +430,7 @@ describe("edition", () => {
     model.dispatch("START_EDITION");
     model.dispatch("SET_CURRENT_CONTENT", {
       content: "=",
-    });
-    model.dispatch("CHANGE_COMPOSER_CURSOR_SELECTION", {
-      start: 1,
-      end: 1,
+      selection: { start: 1, end: 1 },
     });
 
     setSelection(model, ["A1:A3"]);


### PR DESCRIPTION
## Description:

Current behavior before PR:
- When typing `=sum(` and pressing the Home key, selecting a range caused weird
  behavior in the composer.
- The same issue occurred when using Ctrl+A to select the entire text.

Desired behavior after PR is merged:
- Changing the cursor selection now correctly switches the mode to 'editing'.

Task: [5226615](https://www.odoo.com/odoo/2328/tasks/5226615)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo