### PR TITLE
[IMP] formulas: add spilled range operator

### DIFF
--- a/packages/o-spreadsheet-engine/src/formulas/compiler.ts
+++ b/packages/o-spreadsheet-engine/src/formulas/compiler.ts
@@ -33,6 +33,7 @@ export const UNARY_OPERATOR_MAP = {
   "-": "UMINUS",
   "+": "UPLUS",
   "%": "UNARY.PERCENT",
+  "#": "SPILLED.RANGE",
 };
 
 interface LiteralValues {
@@ -208,7 +209,11 @@ function compileTokensOrThrow(tokens: Token[]): CompiledFormula {
         }
         case "UNARY_OPERATION": {
           const fnName = UNARY_OPERATOR_MAP[ast.value];
-          const operand = compileAST(ast.operand, false, false).assignResultToVariable();
+          const { isMeta, hasRange } =
+            ast.value === "#"
+              ? { isMeta: true, hasRange: true } // hasRange is true to avoid vectorization of SPILLED.RANGE
+              : { isMeta: false, hasRange: false };
+          const operand = compileAST(ast.operand, isMeta, hasRange).assignResultToVariable();
           code.append(operand);
           return code.return(`ctx['${fnName}'](${operand.returnExpression})`);
         }

--- a/packages/o-spreadsheet-engine/src/formulas/parser.ts
+++ b/packages/o-spreadsheet-engine/src/formulas/parser.ts
@@ -8,7 +8,7 @@ import { Token } from "./tokenizer";
 const functionRegex = /[a-zA-Z0-9\_]+(\.[a-zA-Z0-9\_]+)*/;
 
 const UNARY_OPERATORS_PREFIX = ["-", "+"];
-const UNARY_OPERATORS_POSTFIX = ["%"];
+const UNARY_OPERATORS_POSTFIX = ["%", "#"];
 
 interface RichToken extends Token {
   tokenIndex: number;
@@ -114,6 +114,7 @@ export type AST =
   | ASTEmpty;
 
 export const OP_PRIORITY = {
+  "#": 40,
   "%": 40,
   "^": 30,
   "*": 20,

--- a/packages/o-spreadsheet-engine/src/formulas/tokenizer.ts
+++ b/packages/o-spreadsheet-engine/src/formulas/tokenizer.ts
@@ -28,7 +28,7 @@ import { NEWLINE } from "../constants";
  */
 
 export const POSTFIX_UNARY_OPERATORS = ["%"];
-const OPERATORS = "+,-,*,/,:,=,<>,>=,>,<=,<,^,&".split(",").concat(POSTFIX_UNARY_OPERATORS);
+const OPERATORS = "+,-,*,/,:,=,<>,>=,>,<=,<,^,&,#".split(",").concat(POSTFIX_UNARY_OPERATORS);
 
 type TokenType =
   | "OPERATOR"
@@ -68,10 +68,10 @@ export function tokenize(str: string, locale = DEFAULT_LOCALE): Token[] {
       tokenizeArgsSeparator(chars, locale) ||
       tokenizeBraces(chars) ||
       tokenizeParenthesis(chars) ||
+      tokenizeInvalidRange(chars) ||
       tokenizeOperator(chars) ||
       tokenizeString(chars) ||
       tokenizeDebugger(chars) ||
-      tokenizeInvalidRange(chars) ||
       tokenizeNumber(chars, locale) ||
       tokenizeSymbol(chars);
 

--- a/packages/o-spreadsheet-engine/src/plugins/core/merge.ts
+++ b/packages/o-spreadsheet-engine/src/plugins/core/merge.ts
@@ -1,7 +1,5 @@
-import { getFullReference, splitReference } from "../../helpers";
 import { toXC } from "../../helpers/coordinates";
 import { clip, deepEquals, isDefined } from "../../helpers/misc";
-import { createRange, isFullColRange, isFullRowRange } from "../../helpers/range";
 import {
   doesAnyZoneCrossFrozenPane,
   isEqual,
@@ -46,7 +44,6 @@ export class MergePlugin extends CorePlugin<MergeState> implements MergeState {
     "getMerge",
     "getMergesInZone",
     "isSingleCellOrMerge",
-    "getSelectionRangeString",
     "isMainCellPosition",
   ] as const;
 
@@ -152,30 +149,6 @@ export class MergePlugin extends CorePlugin<MergeState> implements MergeState {
     return Array.from(mergeIds)
       .map((mergeId) => this.getMergeById(sheetId, mergeId))
       .filter(isDefined);
-  }
-
-  /**
-   * Same as `getRangeString` but add all necessary merge to the range to make it a valid selection
-   */
-  getSelectionRangeString(range: Range, forSheetId: UID): string {
-    const expandedZone = this.getters.expandZone(range.sheetId, range.zone);
-    const expandedRange = createRange(
-      {
-        ...range,
-        zone: {
-          ...expandedZone,
-          bottom: isFullColRange(range) ? undefined : expandedZone.bottom,
-          right: isFullRowRange(range) ? undefined : expandedZone.right,
-        },
-      },
-      this.getters.getSheetSize
-    );
-    const rangeString = this.getters.getRangeString(expandedRange, forSheetId);
-    if (this.isSingleCellOrMerge(range.sheetId, range.zone)) {
-      const { sheetName, xc } = splitReference(rangeString);
-      return getFullReference(sheetName, xc.split(":")[0]);
-    }
-    return rangeString;
   }
 
   /**

--- a/tests/composer/composer_component.test.ts
+++ b/tests/composer/composer_component.test.ts
@@ -497,6 +497,23 @@ describe("ranges and highlights", () => {
       await nextTick();
       expect(composerEl.textContent).toBe("=SUM($B$1:$B$2)");
     });
+
+    test("changing highlight to a spilled range adds the spill operator", async () => {
+      setCellContent(model, "C3", "=MUNIT(2)");
+      composerEl = await typeInComposer("=SUM(B2)");
+      model.dispatch("START_CHANGE_HIGHLIGHT", {
+        zone: toZone("B2"),
+      });
+      model.selection.selectZone(
+        { cell: toCartesian("C3"), zone: toZone("C3:D4") },
+        { unbounded: true }
+      );
+
+      await nextTick();
+      expect(composerEl.textContent).toBe("=SUM(C3#)");
+      expect(composerStore.highlights).toHaveLength(1);
+      expect(composerStore.highlights[0].range.zone).toMatchObject(toZone("C3:D4"));
+    });
   });
 
   test("Can select full column as unbounded zone", async () => {

--- a/tests/composer/composer_store.test.ts
+++ b/tests/composer/composer_store.test.ts
@@ -478,6 +478,32 @@ describe("edition", () => {
     expect(composerStore.currentContent).toBe("=D4");
   });
 
+  test("alter selection updates composer content when selecting a spilled range", () => {
+    setCellContent(model, "A1", "=SEQUENCE(2, 2)");
+
+    selectCell(model, "C1");
+    composerStore.startEdition("=");
+
+    selectCell(model, "A1");
+    expect(composerStore.currentContent).toBe("=A1");
+    resizeAnchorZone(model, "down");
+    resizeAnchorZone(model, "right");
+    expect(composerStore.currentContent).toBe("=A1#");
+  });
+
+  test("remove the spilled range operator after selecting simple range", () => {
+    setCellContent(model, "A1", "=SEQUENCE(2, 2)");
+
+    selectCell(model, "C1");
+    composerStore.startEdition("=");
+    selectCell(model, "A1");
+    setAnchorCorner(model, "B2");
+
+    expect(composerStore.currentContent).toBe("=A1#");
+    resizeAnchorZone(model, "left");
+    expect(composerStore.currentContent).toBe("=A1:A2");
+  });
+
   test("enable selection mode reset to initial position only when selecting on the edition sheet", () => {
     selectCell(model, "D3");
     composerStore.startEdition("=");

--- a/tests/evaluation/__snapshots__/compiler.test.ts.snap
+++ b/tests/evaluation/__snapshots__/compiler.test.ts.snap
@@ -135,6 +135,24 @@ return ctx['ADD'](_3, _4);
 }"
 `;
 
+exports[`expression compiler expression with cell# 1`] = `
+"function anonymous(deps,ref,range,getSymbolValue,ctx
+) {
+// =|C|#
+const _1 = range(deps[0], true);
+return ctx['SPILLED.RANGE'](_1);
+}"
+`;
+
+exports[`expression compiler expression with range# 1`] = `
+"function anonymous(deps,ref,range,getSymbolValue,ctx
+) {
+// =|R|#
+const _1 = range(deps[0], true);
+return ctx['SPILLED.RANGE'](_1);
+}"
+`;
+
 exports[`expression compiler expression with references with a sheet 1`] = `
 "function anonymous(deps,ref,range,getSymbolValue,ctx
 ) {

--- a/tests/evaluation/compiler.test.ts
+++ b/tests/evaluation/compiler.test.ts
@@ -87,6 +87,16 @@ describe("expression compiler", () => {
     const compiledFormula = compiledBaseFunction("={1;2;3;4}");
     expect(compiledFormula.execute.toString()).toMatchSnapshot();
   });
+
+  test("expression with cell#", () => {
+    const compiledFormula = compiledBaseFunction("=A1#");
+    expect(compiledFormula.execute.toString()).toMatchSnapshot();
+  });
+
+  test("expression with range#", () => {
+    const compiledFormula = compiledBaseFunction("=A1:B2#");
+    expect(compiledFormula.execute.toString()).toMatchSnapshot();
+  });
 });
 
 describe("compile functions", () => {

--- a/tests/evaluation/composer_tokenizer.test.ts
+++ b/tests/evaluation/composer_tokenizer.test.ts
@@ -341,4 +341,11 @@ describe("composerTokenizer base tests", () => {
       { start: 1, end: 7, length: 6, type: "SYMBOL", value: "trueee", parenthesesCode: "" },
     ]);
   });
+
+  test("spill range operator", () => {
+    expect(composerTokenize("=A1#", DEFAULT_LOCALE)).toEqual([
+      { end: 1, length: 1, parenthesesCode: "", start: 0, type: "OPERATOR", value: "=" },
+      { end: 4, length: 3, parenthesesCode: "", start: 1, type: "REFERENCE", value: "A1#" },
+    ]);
+  });
 });

--- a/tests/evaluation/evaluation_formula_array.test.ts
+++ b/tests/evaluation/evaluation_formula_array.test.ts
@@ -65,6 +65,12 @@ describe("evaluate formulas that use/return an array", () => {
     expect(getEvaluatedCell(model, "A1").value).toBe(168);
   });
 
+  test("can reference spilled range with spill operator", () => {
+    setCellContent(model, "A1", "=MFILL(2, 2, 5)");
+    setCellContent(model, "D1", "=SUM(A1#)");
+    expect(getEvaluatedCell(model, "D1").value).toBe(20);
+  });
+
   test("can use result array in formula that accept scalar only (vectorization)", () => {
     setCellContent(model, "A1", "=ABS(MFILL(2, 2, -42))");
     expect(getEvaluatedCell(model, "A1").value).toBe(42);

--- a/tests/evaluation/parser.test.ts
+++ b/tests/evaluation/parser.test.ts
@@ -549,6 +549,7 @@ describe("Converting AST to string", () => {
     expect(astToFormula(parse("1%"))).toBe("1%");
     expect(astToFormula(parse("(1+2)%"))).toBe("(1+2)%");
     expect(astToFormula(parse("={1,2;3,4}"))).toBe("{1,2;3,4}");
+    expect(astToFormula(parse("A1#"))).toBe("A1#");
   });
   test("Convert binary operator", () => {
     expect(astToFormula(parse("89-45"))).toBe("89-45");

--- a/tests/evaluation/range_tokenizer.test.ts
+++ b/tests/evaluation/range_tokenizer.test.ts
@@ -296,6 +296,14 @@ describe("knows what is a reference and what is not", () => {
       { type: "SYMBOL", value: "Sheet3!A" },
     ]);
   });
+
+  test("ref with spill range operator", () => {
+    expect(rangeTokenize("=A1#")).toEqual([
+      { type: "OPERATOR", value: "=" },
+      { type: "REFERENCE", value: "A1" },
+      { type: "OPERATOR", value: "#" },
+    ]);
+  });
 });
 
 describe("tokenize ranges", () => {

--- a/tests/evaluation/tokenizer.test.ts
+++ b/tests/evaluation/tokenizer.test.ts
@@ -140,6 +140,14 @@ describe("tokenizer", () => {
     ]);
   });
 
+  test("spill range operator", () => {
+    expect(tokenize("=A1#")).toEqual([
+      { type: "OPERATOR", value: "=" },
+      { type: "REFERENCE", value: "A1" },
+      { type: "OPERATOR", value: "#" },
+    ]);
+  });
+
   test("String", () => {
     expect(tokenize('"hello"')).toEqual([{ type: "STRING", value: '"hello"' }]);
     expect(tokenize("'hello'")).toEqual([{ type: "SYMBOL", value: "'hello'" }]);


### PR DESCRIPTION
This commit introduces the `#` spilled range operator.

Instead of extending the range syntax, `#` is implemented as a regular postfix unary operator.
This allows it to be used on any expression that returns a reference, not only on static
cell references. For example, constructs like `=IF(condition, A1, H10)#` become possible,
where `#` applies to the result of the formula rather than to a single literal reference.

On the UI side, the composer still tokenizes `<ref>#` as a single token so that users can
select it as a whole, while the engine compiles `#` as a normal unary operator bound to
SPILLED_RANGE formula.

Task: [5365642](https://www.odoo.com/odoo/2328/tasks/5365642)
