### PR TITLE
[FIX] dashboard: properly handle grid resize in dashboard mode

### DIFF
--- a/src/components/dashboard/dashboard.xml
+++ b/src/components/dashboard/dashboard.xml
@@ -5,8 +5,7 @@
         <GridOverlay
           onGridResized.bind="onGridResized"
           onGridMoved.bind="moveCanvas"
-          gridOverlayDimensions="gridOverlayDimensions"
-          getGridSize="props.getGridSize">
+          gridOverlayDimensions="gridOverlayDimensions">
           <div
             t-foreach="getClickableCells()"
             t-as="clickableCell"

--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -459,7 +459,8 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
     return !(rect.width === 0 || rect.height === 0);
   }
 
-  onGridResized({ height, width }: DOMDimension) {
+  onGridResized() {
+    const { height, width } = this.props.getGridSize();
     this.env.model.dispatch("RESIZE_SHEETVIEW", {
       width: width - HEADER_WIDTH,
       height: height - HEADER_HEIGHT,

--- a/src/components/grid/grid.xml
+++ b/src/components/grid/grid.xml
@@ -15,7 +15,6 @@
         onGridResized.bind="onGridResized"
         onGridMoved.bind="moveCanvas"
         gridOverlayDimensions="gridOverlayDimensions"
-        getGridSize="props.getGridSize"
       />
       <HeadersOverlay onOpenContextMenu="(type, x, y) => this.toggleContextMenu(type, x, y)"/>
       <GridComposer

--- a/src/components/grid_overlay/grid_overlay.ts
+++ b/src/components/grid_overlay/grid_overlay.ts
@@ -8,7 +8,6 @@ import {
   HeaderIndex,
   Pixel,
   Position,
-  Rect,
   Ref,
   SpreadsheetChildEnv,
 } from "../../types";
@@ -151,10 +150,9 @@ interface Props {
     ev: PointerEvent | MouseEvent
   ) => void;
   onCellRightClicked: (col: HeaderIndex, row: HeaderIndex, coordinates: DOMCoordinates) => void;
-  onGridResized: (dimension: Rect) => void;
+  onGridResized: () => void;
   onGridMoved: (deltaX: Pixel, deltaY: Pixel) => void;
   gridOverlayDimensions: string;
-  getGridSize: () => { width: number; height: number };
 }
 
 export class GridOverlay extends Component<Props, SpreadsheetChildEnv> {
@@ -167,7 +165,6 @@ export class GridOverlay extends Component<Props, SpreadsheetChildEnv> {
     onGridMoved: Function,
     gridOverlayDimensions: String,
     slots: { type: Object, optional: true },
-    getGridSize: Function,
   };
   static components = {
     FiguresContainer,
@@ -187,14 +184,7 @@ export class GridOverlay extends Component<Props, SpreadsheetChildEnv> {
   setup() {
     useCellHovered(this.env, this.gridOverlay);
     const resizeObserver = new ResizeObserver(() => {
-      const boundingRect = this.gridOverlayEl.getBoundingClientRect();
-      const { width, height } = this.props.getGridSize();
-      this.props.onGridResized({
-        x: boundingRect.left,
-        y: boundingRect.top,
-        height: height,
-        width: width,
-      });
+      this.props.onGridResized();
     });
     onMounted(() => {
       resizeObserver.observe(this.gridOverlayEl);

--- a/src/components/spreadsheet/spreadsheet.ts
+++ b/src/components/spreadsheet/spreadsheet.ts
@@ -544,26 +544,25 @@ export class Spreadsheet extends Component<SpreadsheetProps, SpreadsheetChildEnv
   }
 
   getGridSize() {
-    const topBarHeight =
-      this.spreadsheetRef.el
-        ?.querySelector(".o-spreadsheet-topbar-wrapper")
-        ?.getBoundingClientRect().height || 0;
-    const bottomBarHeight =
-      this.spreadsheetRef.el
-        ?.querySelector(".o-spreadsheet-bottombar-wrapper")
-        ?.getBoundingClientRect().height || 0;
+    const el = this.spreadsheetRef.el;
+    if (!el) {
+      return { width: 0, height: 0 };
+    }
+    const getHeight = (selector) => el.querySelector(selector)?.getBoundingClientRect().height || 0;
+    const getWidth = (selector) => el.querySelector(selector)?.getBoundingClientRect().width || 0;
 
-    const gridWidth =
-      this.spreadsheetRef.el?.querySelector(".o-grid")?.getBoundingClientRect().width || 0;
-    const gridHeight =
-      (this.spreadsheetRef.el?.getBoundingClientRect().height || 0) -
-      (this.spreadsheetRef.el?.querySelector(".o-column-groups")?.getBoundingClientRect().height ||
-        0) -
-      topBarHeight -
-      bottomBarHeight;
-    return {
-      width: Math.max(gridWidth - SCROLLBAR_WIDTH, 0),
-      height: Math.max(gridHeight - SCROLLBAR_WIDTH, 0),
-    };
+    const rect = el.getBoundingClientRect();
+    const topBarHeight = getHeight(".o-spreadsheet-topbar-wrapper");
+    const bottomBarHeight = getHeight(".o-spreadsheet-bottombar-wrapper");
+    const colGroupHeight = getHeight(".o-column-groups");
+    const gridWidth = getWidth(".o-grid");
+
+    const width = Math.max(gridWidth - SCROLLBAR_WIDTH, 0);
+    const height = Math.max(
+      rect.height - topBarHeight - bottomBarHeight - colGroupHeight - SCROLLBAR_WIDTH,
+      0
+    );
+
+    return { width, height };
   }
 }


### PR DESCRIPTION
## Description:

Current behavior before PR:
- The canvas size was computed from the grid, which caused visible white margins
  after a snappy resize (commit [3c8df4b9](https://github.com/odoo/o-spreadsheet/pull/6174/commits/3c8df4b9fdd118a34eceed19d9fc96553a62b861)).
- Some unused props were being passed, creating unnecessary code clutter.

Desired behavior after PR is merged:
- The dashboard canvas size is now computed from the gridRef, ensuring only the
  visible parts are displayed and avoiding redundant canvas computations.

Task: [5223156](https://www.odoo.com/odoo/2328/tasks/5223156)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo