### PR TITLE
[FIX] reference_type: add single quotes for sheet names with spaces

### DIFF
--- a/src/helpers/reference_type.ts
+++ b/src/helpers/reference_type.ts
@@ -2,6 +2,7 @@
 import { Token } from "../formulas";
 import { EnrichedToken, composerTokenize } from "../formulas/composer_tokenizer";
 import { Locale } from "../types";
+import { getCanonicalSymbolName } from "./misc";
 import { getFullReference, splitReference } from "./references";
 
 type FixedReferenceType = "col" | "row" | "colrow" | "none";
@@ -53,7 +54,7 @@ function getTokenNextReferenceType(xc: string): string {
 export function setXcToFixedReferenceType(xc: string, referenceType: FixedReferenceType): string {
   let sheetName;
   ({ sheetName, xc } = splitReference(xc));
-  sheetName = sheetName ? sheetName + "!" : "";
+  sheetName = sheetName ? getCanonicalSymbolName(sheetName) + "!" : "";
 
   xc = xc.replace(/\$/g, "");
   const splitIndex = xc.indexOf(":");

--- a/tests/composer/standalone_composer_component.test.ts
+++ b/tests/composer/standalone_composer_component.test.ts
@@ -149,6 +149,14 @@ describe("Spreadsheet integrations tests", () => {
     expect(composerEl.textContent).toBe("=Sheet1!A1");
   });
 
+  test("content with references from another sheet having space in name adds single quotes", async () => {
+    await openSidePanelWithComposer({ defaultStatic: true });
+    await editStandaloneComposer(composerSelector, "=", { confirm: false });
+    createSheet(model, { sheetId: "sheet2", name: "second sheet", activate: true });
+    await simulateClick(".o-grid-overlay", 300, 200);
+    expect(composerEl.textContent).toBe("='second sheet'!$D$9");
+  });
+
   test("display the content from the props when inactive", async () => {
     await openSidePanelWithComposer({ composerContent: "content from props" });
     await editStandaloneComposer(composerSelector, "edited", { confirm: false });


### PR DESCRIPTION
## Description:

Before this commit:
- `splitReference` removed single quotes from sheet names.

After this commit:
- Applied `getCanonicalSymbolName` after `splitReference` to ensure sheet 
Names with spaces keep their quotes.

Task: [5244798](https://www.odoo.com/odoo/2328/tasks/5244798)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo