### PR TITLE
[FIX] TopbarMenu: specify `isReadonlyAllowed`

### DIFF
--- a/src/registries/menus/topbar_menu_registry.ts
+++ b/src/registries/menus/topbar_menu_registry.ts
@@ -21,6 +21,7 @@ topbarMenuRegistry
   .add("file", {
     name: _t("File"),
     sequence: 10,
+    isReadonlyAllowed: true,
   })
   .addChild("settings", ["file"], {
     name: _t("Settings"),
@@ -37,6 +38,7 @@ topbarMenuRegistry
   .add("edit", {
     name: _t("Edit"),
     sequence: 20,
+    isReadonlyAllowed: true,
   })
   .addChild("undo", ["edit"], {
     ...ACTION_EDIT.undo,
@@ -123,6 +125,7 @@ topbarMenuRegistry
   .add("view", {
     name: _t("View"),
     sequence: 30,
+    isReadonlyAllowed: true,
   })
   .addChild("unfreeze_panes", ["view"], {
     ...ACTION_VIEW.unFreezePane,
@@ -216,6 +219,7 @@ topbarMenuRegistry
   .add("insert", {
     name: _t("Insert"),
     sequence: 40,
+    isReadonlyAllowed: true,
   })
   .addChild("insert_row", ["insert"], {
     ...ACTION_INSERT.insertRow,
@@ -329,7 +333,11 @@ topbarMenuRegistry
   // FORMAT MENU ITEMS
   // ---------------------------------------------------------------------
 
-  .add("format", { name: _t("Format"), sequence: 50 })
+  .add("format", {
+    name: _t("Format"),
+    sequence: 50,
+    isReadonlyAllowed: true,
+  })
   .addChild("format_number", ["format"], {
     ...formatNumberMenuItemSpec,
     name: _t("Number"),
@@ -423,6 +431,7 @@ topbarMenuRegistry
   .add("data", {
     name: _t("Data"),
     sequence: 60,
+    isReadonlyAllowed: true,
   })
   .addChild("sort_range", ["data"], {
     ...ACTION_DATA.sortRange,

--- a/tests/bottom_bar/small_bottom_bar_component.test.ts
+++ b/tests/bottom_bar/small_bottom_bar_component.test.ts
@@ -100,6 +100,13 @@ describe("Small Bottom Bar", () => {
       await click(fixture, ".o-ribbon-menu .o-menu-item[title='Copy']");
       expect(fixture.querySelector(".o-ribbon-menu")).toBeNull();
     });
+
+    test("Can open the top-levels menu in readonly mode", async () => {
+      model.updateMode("readonly");
+      await click(fixture, ".bottom-bar-menu .ribbon-toggler");
+      await click(fixture, ".o-ribbon-menu .o-menu-item[title='View']");
+      expect(fixture.querySelectorAll(".o-ribbon-menu .o-menu-item")).toHaveLength(4);
+    });
   });
 
   test("scroll is reset when navigating through ribbon menu", async () => {


### PR DESCRIPTION
The logic that displays the top-level items of the topbarmenu is isolated from the `Menu` component logic. More specifically, it never checks if the item can be used in readonly and as such, we never took the time to define the key `isReadonlyAllowed` on those menu items.

However `RibbonMenu` relies on the logic of `Menu` so in order to display the topbar menu items properly in mobile mode, we need the key `isReadonlyAllowed` to be defined.


Task: [5245432](https://www.odoo.com/odoo/2328/tasks/5245432)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo