### PR TITLE
[FIX] style_clipboard: remove style from cell clipboard

### DIFF
--- a/packages/o-spreadsheet-engine/src/plugins/ui_core_views/header_sizes_ui.ts
+++ b/packages/o-spreadsheet-engine/src/plugins/ui_core_views/header_sizes_ui.ts
@@ -110,7 +110,7 @@ export class HeaderSizeUIPlugin extends CoreViewPlugin<HeaderSizeState> implemen
         }
         break;
       case "SET_FORMATTING":
-        if (cmd.style && ("fontSize" in cmd.style || "wrapping" in cmd.style)) {
+        if ("style" in cmd && (!cmd.style || "fontSize" in cmd.style || "wrapping" in cmd.style)) {
           for (const zone of cmd.target) {
             // TODO FLDA use rangeSet
             this.updateRowSizeForZoneChange(cmd.sheetId, zone);

--- a/src/clipboard_handlers/cell_clipboard.ts
+++ b/src/clipboard_handlers/cell_clipboard.ts
@@ -90,7 +90,6 @@ export class CellClipboardHandler extends AbstractCellClipboardHandler<
           tokens: cell?.isFormula
             ? cell.compiledFormula.tokens.map(({ value, type }) => ({ value, type }))
             : [],
-          border: this.getters.getCellBorder(position) || undefined,
           evaluatedCell,
           position,
         });
@@ -249,7 +248,6 @@ export class CellClipboardHandler extends AbstractCellClipboardHandler<
     if (clipboardOption?.pasteOption === "onlyFormat") {
       this.dispatch("UPDATE_CELL", {
         ...target,
-        style: origin?.style ?? null,
         format: originFormat ?? targetCell.format,
       });
       return;
@@ -270,11 +268,10 @@ export class CellClipboardHandler extends AbstractCellClipboardHandler<
         origin.tokens
       );
     }
-    if (content !== "" || origin?.format || origin?.style) {
+    if (content !== "" || origin?.format) {
       this.dispatch("UPDATE_CELL", {
         ...target,
         content,
-        style: origin?.style || null,
         format: origin?.format,
       });
     } else if (targetCell) {

--- a/src/clipboard_handlers/index.ts
+++ b/src/clipboard_handlers/index.ts
@@ -22,8 +22,8 @@ clipboardHandlersRegistries.cellHandlers
   .add("cell", CellClipboardHandler)
   .add("sheet", SheetClipboardHandler)
   .add("merge", MergeClipboardHandler)
+  .add("style", StyleClipboardHandler)
   .add("table", TableClipboardHandler)
   .add("conditionalFormat", ConditionalFormatClipboardHandler)
   .add("references", ReferenceClipboardHandler)
-  .add("border", BorderClipboardHandler)
-  .add("style", StyleClipboardHandler);
+  .add("border", BorderClipboardHandler);

--- a/src/clipboard_handlers/style_clipboard.ts
+++ b/src/clipboard_handlers/style_clipboard.ts
@@ -63,6 +63,7 @@ export class StyleClipboardHandler extends AbstractCellClipboardHandler<
     }
     const zones = target.zones;
     if (!options.isCutOperation) {
+      this.dispatch("SET_FORMATTING", { sheetId, target: zones, style: undefined });
       for (const zone of zones) {
         for (const pasteZone of splitZoneForPaste(zone, content.width, content.height)) {
           this.pasteStyleZone(sheetId, pasteZone.left, pasteZone.top, content.styles);
@@ -70,6 +71,7 @@ export class StyleClipboardHandler extends AbstractCellClipboardHandler<
       }
     } else {
       const { left, top } = zones[0];
+      this.dispatch("SET_FORMATTING", { sheetId, target: [zones[0]], style: undefined });
       this.pasteStyleZone(sheetId, left, top, content.styles);
     }
   }


### PR DESCRIPTION
## Description:

Fix an issue where the table style was copy/paste by the cell clipboard.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo