### PR TITLE
[FIX] export: image charts as base64

### DIFF
--- a/packages/o-spreadsheet-engine/src/helpers/figures/charts/chart_ui_common.ts
+++ b/packages/o-spreadsheet-engine/src/helpers/figures/charts/chart_ui_common.ts
@@ -127,7 +127,11 @@ async function canvasToObjectUrl(canvas: OffscreenCanvas): Promise<string | unde
   if (!blob) {
     return undefined;
   }
-  if (!URL.createObjectURL)
-    throw new Error("URL.createObjectURL is not supported in this environment");
-  return URL.createObjectURL(blob);
+  return new Promise((resolve) => {
+    const f = new FileReader();
+    f.addEventListener("load", () => {
+      resolve(f.result as string);
+    });
+    f.readAsDataURL(blob);
+  });
 }


### PR DESCRIPTION
During the split of the model, we changed the way the image generated for charts were handled. It worked well, except when exporting with Odoo because the zipping is done server side and the image definition was only available server side though URL.createObjectIrl()

This fix uses the standard fileReader to obtrain a true base64 image as text, like before

Task: 5253880

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo