### PR TITLE
[IMP] Composer: select text in the formula assistant

### DIFF
--- a/src/components/composer/autocomplete_dropdown/autocomplete_dropdown.xml
+++ b/src/components/composer/autocomplete_dropdown/autocomplete_dropdown.xml
@@ -2,6 +2,7 @@
   <t t-name="o-spreadsheet-TextValueProvider">
     <div
       t-ref="autoCompleteList"
+      t-on-pointerdown.prevent=""
       t-att-class="{
           'o-autocomplete-dropdown bg-white': props.proposals.length}">
       <t t-foreach="props.proposals" t-as="proposal" t-key="proposal.text + proposal_index">

--- a/src/components/composer/composer/composer.ts
+++ b/src/components/composer/composer/composer.ts
@@ -105,6 +105,7 @@ export class Composer extends Component<CellComposerProps, SpreadsheetChildEnv> 
   private DOMFocusableElementStore!: Store<DOMFocusableElementStore>;
 
   composerRef = useRef("o_composer");
+  containerRef = useRef("composerContainer");
 
   contentHelper: ContentEditableHelper = new ContentEditableHelper(this.composerRef.el!);
 
@@ -478,6 +479,11 @@ export class Composer extends Component<CellComposerProps, SpreadsheetChildEnv> 
       this.props.composerStore.stopEdition();
       return;
     }
+
+    if (this.containerRef.el?.contains(ev.relatedTarget as Node)) {
+      return;
+    }
+
     if (target.attributes.getNamedItem("composerFocusableElement")) {
       this.contentHelper.el.focus();
       return;

--- a/src/components/composer/composer/composer.xml
+++ b/src/components/composer/composer/composer.xml
@@ -1,6 +1,6 @@
 <templates>
   <t t-name="o-spreadsheet-Composer">
-    <div class="o-composer-container w-100 h-100">
+    <div class="o-composer-container w-100 h-100" t-ref="composerContainer">
       <t t-set="autoCompleteProposals" t-value="props.composerStore.autoCompleteProposals"/>
       <t t-set="canBeToggled" t-value="props.composerStore.canBeToggled"/>
       <t
@@ -12,10 +12,9 @@
           t-if="props.focus !== 'inactive' and assistantIsAvailable and canBeToggled and assistant.forcedClosed"
           role="button"
           title="Show formula help"
-          t-on-click="openAssistant"
+          t-on-click.stop="openAssistant"
           t-on-pointerdown.prevent.stop=""
-          t-on-click.prevent.stop=""
-          t-on-pointerup.prevent.stop=""
+          t-on-pointerup.stop=""
           class="fa-stack position-absolute translate-middle force-open-assistant fs-4">
           <i class="fa fa-circle fa-stack-1x fa-inverse"/>
           <i class="fa fa-question-circle fa-stack-1x"/>
@@ -51,13 +50,14 @@
         t-att-style="assistantContainerStyle"
         t-if="props.focus !== 'inactive' and assistantIsAvailable and !(canBeToggled and assistant.forcedClosed)"
         t-on-wheel.stop=""
-        t-on-pointerdown.prevent.stop=""
-        t-on-pointerup.prevent.stop=""
-        t-on-click.prevent.stop="">
+        t-on-pointerdown.stop=""
+        t-on-pointerup.stop=""
+        t-on-click.stop="">
         <span
           t-if="canBeToggled and !assistant.forcedClosed"
           role="button"
           t-on-click="closeAssistant"
+          t-on-pointerdown.prevent.stop=""
           class="fa-stack position-absolute top-0 start-100 translate-middle fs-4">
           <i class="fa fa-circle fa-stack-1x fa-inverse"/>
           <i class="fa fa-times-circle fa-stack-1x"/>

--- a/src/components/composer/formula_assistant/formula_assistant.css
+++ b/src/components/composer/formula_assistant/formula_assistant.css
@@ -1,4 +1,5 @@
 .o-spreadsheet .o-formula-assistant {
+  outline: unset;
   .o-formula-assistant-head {
     background-color: var(--os-composer-assistant-background);
     padding: 10px;

--- a/src/components/composer/formula_assistant/formula_assistant.xml
+++ b/src/components/composer/formula_assistant/formula_assistant.xml
@@ -1,6 +1,12 @@
 <templates>
   <t t-name="o-spreadsheet-FunctionDescriptionProvider">
-    <div class="o-formula-assistant-container user-select-none shadow">
+    <div
+      class="o-formula-assistant-container shadow"
+      tabindex="-1"
+      t-on-pointerdown=""
+      t-on-pointerup.stop=""
+      t-on-keydown.stop=""
+      t-on-click.stop="">
       <t t-set="context" t-value="getContext()"/>
       <div class="o-formula-assistant bg-white" t-if="context.functionDescription.name">
         <div class="o-formula-assistant-head d-flex flex-row justify-content-between">
@@ -15,6 +21,7 @@
           <div
             class="collapsor px-2 d-flex align-items-center rounded"
             t-att-class="state.isCollapsed ? 'collapsed' : ''"
+            t-on-pointerdown.prevent=""
             t-on-click="() => this.toggle()">
             <span class="collapsor-arrow d-inline-block">
               <t t-call="o-spreadsheet-Icon.ANGLE_DOWN"/>

--- a/tests/composer/__snapshots__/formula_assistant_component.test.ts.snap
+++ b/tests/composer/__snapshots__/formula_assistant_component.test.ts.snap
@@ -2,7 +2,8 @@
 
 exports[`formula assistant appearance simple snapshot with =FUNC1( 1`] = `
 <div
-  class="o-formula-assistant-container user-select-none shadow"
+  class="o-formula-assistant-container shadow"
+  tabindex="-1"
 >
   <div
     class="o-formula-assistant bg-white"


### PR DESCRIPTION
This commit introduces the possibility for the user to select the text content of the formula assistant.

Task: 5169514

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [5169514](https://www.odoo.com/odoo/2328/tasks/5169514)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo