### PR TITLE
[REL] 18.2.34

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@odoo/o-spreadsheet",
-  "version": "18.2.33",
+  "version": "18.2.34",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@odoo/o-spreadsheet",
-      "version": "18.2.33",
+      "version": "18.2.34",
       "license": "LGPL-3.0-or-later",
       "dependencies": {
         "@odoo/owl": "2.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@odoo/o-spreadsheet",
-  "version": "18.2.33",
+  "version": "18.2.34",
   "description": "A spreadsheet component",
   "type": "module",
   "main": "dist/o-spreadsheet.cjs.js",


### PR DESCRIPTION
### Contains the following commits:

https://github.com/odoo/o-spreadsheet/commit/157169f2b [FIX] composer: set editionMode to inactive when composer is unmounted [Task: 5149215](https://www.odoo.com/odoo/2328/tasks/5149215)
https://github.com/odoo/o-spreadsheet/commit/63b5b6e8a [FIX] filter menu: truncate long filter values [Task: 5219611](https://www.odoo.com/odoo/2328/tasks/5219611)
https://github.com/odoo/o-spreadsheet/commit/d9f2982fb [FIX] charts: crash when converting empty chart to scorecard/gauge [Task: 5181741](https://www.odoo.com/odoo/2328/tasks/5181741)
https://github.com/odoo/o-spreadsheet/commit/7e0b25bd8 [FIX] helpers: setXcToFixedReferenceType support all xc [Task: 5165969](https://www.odoo.com/odoo/2328/tasks/5165969)
https://github.com/odoo/o-spreadsheet/commit/832bfd4fd [FIX] range: invalid sheet name with special character [Task: 5125762](https://www.odoo.com/odoo/2328/tasks/5125762)
https://github.com/odoo/o-spreadsheet/commit/0379cc229 [FIX] Package: update owl to 2.8.1 [](https://www.odoo.com/odoo/2328/tasks/)

Task: 0
