### PR TITLE
[REL] 18.3.26

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@odoo/o-spreadsheet",
-  "version": "18.3.25",
+  "version": "18.3.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@odoo/o-spreadsheet",
-      "version": "18.3.25",
+      "version": "18.3.26",
       "license": "LGPL-3.0-or-later",
       "dependencies": {
         "@odoo/owl": "2.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@odoo/o-spreadsheet",
-  "version": "18.3.25",
+  "version": "18.3.26",
   "description": "A spreadsheet component",
   "type": "module",
   "main": "dist/o-spreadsheet.cjs.js",


### PR DESCRIPTION
### Contains the following commits:

https://github.com/odoo/o-spreadsheet/commit/3bfeb2c7f [FIX] composer: set editionMode to inactive when composer is unmounted [Task: 5149215](https://www.odoo.com/odoo/2328/tasks/5149215)
https://github.com/odoo/o-spreadsheet/commit/1e94c7c0c [FIX] filter menu: truncate long filter values [Task: 5219611](https://www.odoo.com/odoo/2328/tasks/5219611)
https://github.com/odoo/o-spreadsheet/commit/12b77d011 [FIX] range: invalid sheet name with special character [Task: 5125762](https://www.odoo.com/odoo/2328/tasks/5125762)
https://github.com/odoo/o-spreadsheet/commit/0682b866f [FIX] charts: crash when converting empty chart to scorecard/gauge [Task: 5181741](https://www.odoo.com/odoo/2328/tasks/5181741)
https://github.com/odoo/o-spreadsheet/commit/9017d0700 [FIX] helpers: setXcToFixedReferenceType support all xc [Task: 5165969](https://www.odoo.com/odoo/2328/tasks/5165969)
https://github.com/odoo/o-spreadsheet/commit/49f1e4223 [FIX] Package: update owl to 2.8.1 [](https://www.odoo.com/odoo/2328/tasks/)

Task: 0
