### PR TITLE
[REL] 18.4.17

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@odoo/o-spreadsheet",
-  "version": "18.4.16",
+  "version": "18.4.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@odoo/o-spreadsheet",
-      "version": "18.4.16",
+      "version": "18.4.17",
       "license": "LGPL-3.0-or-later",
       "dependencies": {
         "@odoo/owl": "2.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@odoo/o-spreadsheet",
-  "version": "18.4.16",
+  "version": "18.4.17",
   "description": "A spreadsheet component",
   "type": "module",
   "main": "dist/o-spreadsheet.cjs.js",


### PR DESCRIPTION
### Contains the following commits:

https://github.com/odoo/o-spreadsheet/commit/e053137c8 [FIX] TopbarMenu: specify `isReadonlyAllowed` [Task: 5245432](https://www.odoo.com/odoo/2328/tasks/5245432)
https://github.com/odoo/o-spreadsheet/commit/b5c217ff8 [FIX] range: invalid sheet name with special character [Task: 5125762](https://www.odoo.com/odoo/2328/tasks/5125762)
https://github.com/odoo/o-spreadsheet/commit/2470a53f2 [FIX] composer: set editionMode to inactive when composer is unmounted [Task: 5149215](https://www.odoo.com/odoo/2328/tasks/5149215)
https://github.com/odoo/o-spreadsheet/commit/e9ca3de5c [FIX] filter menu: truncate long filter values [Task: 5219611](https://www.odoo.com/odoo/2328/tasks/5219611)
https://github.com/odoo/o-spreadsheet/commit/a4733d2b1 [FIX] chart: add placeholder for axis title input [Task: 5187080](https://www.odoo.com/odoo/2328/tasks/5187080)
https://github.com/odoo/o-spreadsheet/commit/15da32f9d [PERF] zones: faster isZoneInside [Task: 5213090](https://www.odoo.com/odoo/2328/tasks/5213090)
https://github.com/odoo/o-spreadsheet/commit/19506f3bd [PERF] Renderer: speed-up box generation [Task: 5213090](https://www.odoo.com/odoo/2328/tasks/5213090)
https://github.com/odoo/o-spreadsheet/commit/56e9c8288 [FIX] charts: crash when converting empty chart to scorecard/gauge [Task: 5181741](https://www.odoo.com/odoo/2328/tasks/5181741)
https://github.com/odoo/o-spreadsheet/commit/cc30312f4 [FIX] Package: update owl to 2.8.1 [](https://www.odoo.com/odoo/2328/tasks/)

Task: 0
