### PR TITLE
[REL] 19.0.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@odoo/o-spreadsheet",
-  "version": "19.0.9",
+  "version": "19.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@odoo/o-spreadsheet",
-      "version": "19.0.9",
+      "version": "19.0.10",
       "license": "LGPL-3.0-or-later",
       "dependencies": {
         "@odoo/owl": "2.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@odoo/o-spreadsheet",
-  "version": "19.0.9",
+  "version": "19.0.10",
   "description": "A spreadsheet component",
   "type": "module",
   "main": "dist/o-spreadsheet.cjs.js",


### PR DESCRIPTION
### Contains the following commits:

https://github.com/odoo/o-spreadsheet/commit/f172166e7 [FIX] TopbarMenu: specify `isReadonlyAllowed` [Task: 5245432](https://www.odoo.com/odoo/2328/tasks/5245432)
https://github.com/odoo/o-spreadsheet/commit/f548e0337 [FIX] range: invalid sheet name with special character [Task: 5125762](https://www.odoo.com/odoo/2328/tasks/5125762)
https://github.com/odoo/o-spreadsheet/commit/f3ddc9d59 [FIX] composer: set editionMode to inactive when composer is unmounted [Task: 5149215](https://www.odoo.com/odoo/2328/tasks/5149215)
https://github.com/odoo/o-spreadsheet/commit/a36de18d0 [FIX] filter menu: truncate long filter values [Task: 5219611](https://www.odoo.com/odoo/2328/tasks/5219611)
https://github.com/odoo/o-spreadsheet/commit/93ba425db [FIX] chart: add placeholder for axis title input [Task: 5187080](https://www.odoo.com/odoo/2328/tasks/5187080)
https://github.com/odoo/o-spreadsheet/commit/bd19f6c53 [PERF] zones: faster isZoneInside [Task: 5213090](https://www.odoo.com/odoo/2328/tasks/5213090)
https://github.com/odoo/o-spreadsheet/commit/9f2fb3c22 [PERF] Renderer: speed-up box generation [Task: 5213090](https://www.odoo.com/odoo/2328/tasks/5213090)
https://github.com/odoo/o-spreadsheet/commit/108241aef [FIX] charts: crash when converting empty chart to scorecard/gauge [Task: 5181741](https://www.odoo.com/odoo/2328/tasks/5181741)
https://github.com/odoo/o-spreadsheet/commit/126d89eb8 [FIX] charts: fix zoomable scatter chart [Task: 5143146](https://www.odoo.com/odoo/2328/tasks/5143146)
https://github.com/odoo/o-spreadsheet/commit/7ecb6f3fd [IMP] tests: add zoomable chart plugin tests [Task: 5143146](https://www.odoo.com/odoo/2328/tasks/5143146)
https://github.com/odoo/o-spreadsheet/commit/4e3d5cb7a [MOV] tests: move zoomable chart tests to a dedicated folder [Task: 5143146](https://www.odoo.com/odoo/2328/tasks/5143146)
https://github.com/odoo/o-spreadsheet/commit/f2afcc63c [FIX] Package: update owl to 2.8.1 [](https://www.odoo.com/odoo/2328/tasks/)

Task: 0
