### PR TITLE
[FIX] components: prevent scroll bounce on iPhone

### DIFF
--- a/src/components/dashboard/dashboard.ts
+++ b/src/components/dashboard/dashboard.ts
@@ -57,7 +57,7 @@ export class SpreadsheetDashboard extends Component<Props, SpreadsheetChildEnv> 
 
     useTouchScroll(gridRef, this.moveCanvas.bind(this), () => {
       const { scrollY } = this.env.model.getters.getActiveSheetScrollInfo();
-      return scrollY > 0;
+      return scrollY >= 0;
     });
   }
 

--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -191,7 +191,7 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
 
     useTouchScroll(this.gridRef, this.moveCanvas.bind(this), () => {
       const { scrollY } = this.env.model.getters.getActiveSheetScrollInfo();
-      return scrollY > 0;
+      return scrollY >= 0;
     });
   }
 


### PR DESCRIPTION
Steps to reproduce:
- Open a spreadsheet on an iPhone Pro
- Try to scroll down when already at the top of the sheet => The entire page bounces instead of just the grid

Task: 5253902

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo