### PR TITLE
[FIX] functions: ignore vectorized SUBTOTAL

### DIFF
--- a/src/functions/module_math.ts
+++ b/src/functions/module_math.ts
@@ -1442,7 +1442,7 @@ export const SUBTOTAL = {
         if (!acceptHiddenCells && this.getters.isRowHiddenByUser(sheetId, row)) continue;
 
         for (let col = left; col <= right; col++) {
-          const cell = this.getters.getCell({ sheetId, col, row });
+          const cell = this.getters.getCorrespondingFormulaCell({ sheetId, col, row });
           if (!cell || !isSubtotalCell(cell)) {
             evaluatedCellToKeep.push(this.getters.getEvaluatedCell({ sheetId, col, row }));
           }

--- a/tests/functions/module_math.test.ts
+++ b/tests/functions/module_math.test.ts
@@ -3129,6 +3129,18 @@ describe("SUBTOTAL formula", () => {
     expect(gridResult.A7).toBe(4);
   });
 
+  test("SUBTOTAL ignores spilled SUBTOTAL", () => {
+    const grid = {
+      A1: "1",
+      A2: "1",
+      A3: "=SUBTOTAL(9, A1:A2) + A1:A2",
+      A5: "=SUBTOTAL(9, A4)",
+    };
+    const gridResult = evaluateGrid(grid);
+    expect(gridResult.A3).toBe(3);
+    expect(gridResult.A5).toBe(0);
+  });
+
   describe("ignoring filtered rows", () => {
     test("write the SUBTOTAL formula after updating filter", () => {
       const model = new Model();


### PR DESCRIPTION
SUBTOTAL should ignore SUBTOTAL values from a spilled formula

A1: "1"
A2: "1"
A3: "=SUBTOTAL(9, A1:A2) + A1:A2"
A5: "=SUBTOTAL(9, A4)"

=> A5 should be zero because the value in A4 comes from a SUBTOTAL formula and it should be ignored

Task: 5261987

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo