### PR TITLE
[FIX] pivot: raise pivot size limit

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -316,7 +316,7 @@ export const PIVOT_TABLE_CONFIG = {
 };
 export const PIVOT_INDENT = 15;
 export const PIVOT_COLLAPSE_ICON_SIZE = 12;
-export const PIVOT_MAX_NUMBER_OF_CELLS = 1e5;
+export const PIVOT_MAX_NUMBER_OF_CELLS = 5e5;
 
 export const DEFAULT_CURRENCY: Currency = {
   symbol: "$",


### PR DESCRIPTION


## Description:

Currently, if a dynamic pivot table is more than 100k cells, the pivot is not displayed and the formula is in error.

When we upgraded odoo.com, we had to wait ~0 minute before finding important spreadsheets where the limit was reached.

This commit increase the limit from 100k to 500k

If it's not enough/too much, we'll add a setting to allow users to tune it.

Task: 0
## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo