### PR TITLE
[IMP] dark mode: improve contrasts

### DIFF
--- a/src/components/border_editor/border_editor.css
+++ b/src/components/border_editor/border_editor.css
@@ -3,7 +3,6 @@
     padding: 4px;
 
     .o-divider {
-      border-right: 1px solid var(--os-gray-300);
       margin: 0 6px;
     }
 

--- a/src/components/border_editor/border_editor.xml
+++ b/src/components/border_editor/border_editor.xml
@@ -24,7 +24,7 @@
             </span>
           </div>
         </div>
-        <div class="o-divider"/>
+        <div class="o-divider border-end"/>
         <div class="o-border-selector-section">
           <div
             class="m-0 p-0 d-flex align-items-center justify-content-center o-with-color o-hoverable-button"

--- a/src/components/bottom_bar/bottom_bar.css
+++ b/src/components/bottom_bar/bottom_bar.css
@@ -1,7 +1,6 @@
 .o-spreadsheet {
   .o-spreadsheet-bottom-bar {
     font-size: 15px;
-    border-top: 1px solid var(--os-gray-400);
     background-color: var(--os-background-gray-color);
     padding-left: var(--os-header-width);
 

--- a/src/components/bottom_bar/bottom_bar.xml
+++ b/src/components/bottom_bar/bottom_bar.xml
@@ -1,7 +1,7 @@
 <templates>
   <t t-name="o-spreadsheet-BottomBar">
     <div
-      class="o-spreadsheet-bottom-bar o-two-columns d-flex flex-fill align-items-center overflow-hidden"
+      class="o-spreadsheet-bottom-bar o-two-columns d-flex flex-fill align-items-center overflow-hidden border-top"
       t-on-click="props.onClick"
       t-ref="bottomBar"
       t-on-contextmenu.prevent="">

--- a/src/components/bottom_bar/bottom_bar_sheet/bottom_bar_sheet.css
+++ b/src/components/bottom_bar/bottom_bar_sheet/bottom_bar_sheet.css
@@ -3,8 +3,6 @@
     padding: 0 15px;
     padding-right: 10px;
     height: var(--os-desktop-bottombar-height);
-    border-left: 1px solid var(--os-gray-400);
-    border-right: 1px solid var(--os-gray-400);
     margin-left: -1px;
     cursor: pointer;
     &:hover {

--- a/src/components/bottom_bar/bottom_bar_sheet/bottom_bar_sheet.xml
+++ b/src/components/bottom_bar/bottom_bar_sheet/bottom_bar_sheet.xml
@@ -2,7 +2,7 @@
   <t t-name="o-spreadsheet-BottomBarSheet">
     <Ripple>
       <div
-        class="o-sheet d-flex align-items-center user-select-none text-nowrap "
+        class="o-sheet d-flex align-items-center user-select-none text-nowrap border-start border-end"
         tabindex="-1"
         composerFocusableElement="true"
         t-on-pointerdown="(ev) => this.onMouseDown(ev)"

--- a/src/components/color_picker/color_picker.css
+++ b/src/components/color_picker/color_picker.css
@@ -49,30 +49,21 @@
       padding: var(--os-picker-padding);
       display: flex;
       .o-cancel {
-        border: var(--os-item-border-width) solid var(--os-gray-300);
         width: 100%;
         padding: 5px;
         font-size: 14px;
         background-color: var(--os-white-bg);
-        border-radius: 4px;
         &:hover:enabled {
           background-color: var(--os-background-gray-color-hover);
         }
       }
     }
     .o-add-button {
-      border: var(--os-item-border-width) solid var(--os-gray-300);
       padding: 4px;
       background-color: var(--os-white-bg);
-      border-radius: 4px;
       &:hover:enabled {
         background-color: var(--os-background-gray-color-hover);
       }
-    }
-    .o-separator {
-      border-bottom: var(--os-menu-separator-border-width) solid var(--os-separator-color);
-      margin-top: var(--os-menu-separator-padding);
-      margin-bottom: var(--os-menu-separator-padding);
     }
 
     .o-custom-selector {
@@ -102,10 +93,8 @@
         background: linear-gradient(to top, #000 0%, transparent 100%);
       }
       .o-hue-picker {
-        border: var(--os-item-border-width) solid var(--os-gray-300);
         width: 100%;
         height: 12px;
-        border-radius: 4px;
         background: linear-gradient(
           to right,
           hsl(0, 100%, 50%) 0%,
@@ -130,10 +119,8 @@
         display: flex;
         input {
           width: 50%;
-          border-radius: 4px;
           padding: 4px 23px 4px 10px;
           height: 24px;
-          border: 1px solid var(--os-gray-300);
           margin-right: 2px;
         }
         .o-wrong-color {
@@ -152,8 +139,6 @@
         justify-content: end;
       }
       .o-color-preview {
-        border: 1px solid var(--os-gray-300);
-        border-radius: 4px;
         width: 50%;
       }
     }

--- a/src/components/color_picker/color_picker.xml
+++ b/src/components/color_picker/color_picker.xml
@@ -20,7 +20,7 @@
             </div>
           </div>
         </div>
-        <div class="o-separator"/>
+        <div class="o-separator border-bottom"/>
         <div
           class="o-color-picker-section-name o-color-picker-toggler"
           t-on-click="toggleColorPicker">
@@ -59,7 +59,7 @@
             <div class="magnifier pe-none" t-att-style="pointerStyle"/>
           </div>
           <div class="o-hue-container" t-on-pointerdown="dragHuePointer">
-            <div class="o-hue-picker" t-on-click.stop=""/>
+            <div class="o-hue-picker border rounded" t-on-click.stop=""/>
             <div class="o-hue-slider pe-none" t-att-style="sliderStyle">
               <t t-call="o-spreadsheet-Icon.CARET_UP"/>
             </div>
@@ -67,16 +67,17 @@
           <div class="o-custom-input-preview">
             <input
               type="text"
+              class="border rounded"
               t-att-class="{'o-wrong-color': !isHexColorInputValid }"
               t-on-click.stop=""
               t-att-value="state.customHexColor"
               t-on-input="setHexColor"
             />
-            <div class="o-color-preview" t-att-style="colorPreviewStyle"/>
+            <div class="o-color-preview border rounded" t-att-style="colorPreviewStyle"/>
           </div>
           <div class="o-custom-input-buttons">
             <button
-              class="o-add-button"
+              class="o-add-button border rounded"
               t-att-class="{'o-disabled': !state.customHexColor or !isHexColorInputValid}"
               t-on-click.stop="addCustomColor">
               Add
@@ -84,9 +85,9 @@
           </div>
         </div>
         <t t-if="!props.disableNoColor">
-          <div class="o-separator"/>
+          <div class="o-separator border-bottom"/>
           <div class="o-buttons">
-            <button t-on-click="resetColor" class="o-cancel">No Color</button>
+            <button t-on-click="resetColor" class="o-cancel border rounded">No Color</button>
           </div>
         </t>
       </div>

--- a/src/components/composer/formula_assistant/formula_assistant.css
+++ b/src/components/composer/formula_assistant/formula_assistant.css
@@ -3,9 +3,6 @@
     background-color: var(--os-composer-assistant-background);
     padding: 10px;
   }
-  .o-formula-assistant-core {
-    border-bottom: 1px solid gray;
-  }
   .o-formula-assistant-arg-description {
     font-size: 85%;
   }

--- a/src/components/composer/formula_assistant/formula_assistant.xml
+++ b/src/components/composer/formula_assistant/formula_assistant.xml
@@ -23,7 +23,7 @@
         </div>
 
         <Collapse isCollapsed="state.isCollapsed">
-          <div class="o-formula-assistant-core pb-3 m-3">
+          <div class="o-formula-assistant-core pb-3 m-3 border-bottom">
             <div class="o-formula-assistant-gray">ABOUT</div>
             <div t-esc="context.functionDescription.description"/>
           </div>

--- a/src/components/composer/grid_composer/grid_composer.css
+++ b/src/components/composer/grid_composer/grid_composer.css
@@ -17,6 +17,5 @@
     font-size: 12px;
     line-height: 14px;
     padding: 6px 7px;
-    border-radius: 4px;
   }
 }

--- a/src/components/composer/grid_composer/grid_composer.xml
+++ b/src/components/composer/grid_composer/grid_composer.xml
@@ -1,7 +1,7 @@
 <templates>
   <t t-name="o-spreadsheet-GridComposer">
     <div
-      class="o-cell-reference"
+      class="o-cell-reference rounded"
       t-if="shouldDisplayCellReference"
       t-att-style="cellReferenceStyle"
       t-esc="cellReference"

--- a/src/components/composer/speech_bubble/speech_bubble.css
+++ b/src/components/composer/speech_bubble/speech_bubble.css
@@ -3,7 +3,6 @@
     background-color: var(--os-white-bg);
     box-sizing: border-box;
     box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
-    border: 1px solid var(--os-gray-400);
     z-index: var(--os-components-importance-popover);
 
     &::after {
@@ -16,8 +15,8 @@
       width: var(--os-bubble-arrow-size);
       transform-origin: top left;
       transform: translate(0, -67%) rotate(45deg);
-      border-right: 1px solid var(--os-gray-400);
-      border-bottom: 1px solid var(--os-gray-400);
+      border-right: 1px solid var(--os-border-color);
+      border-bottom: 1px solid var(--os-border-color);
       box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
     }
   }

--- a/src/components/composer/speech_bubble/speech_bubble.xml
+++ b/src/components/composer/speech_bubble/speech_bubble.xml
@@ -1,7 +1,7 @@
 <templates>
   <t t-name="o-spreadsheet-SpeechBubble">
     <t t-portal="'.o-spreadsheet'">
-      <div class="o-speech-bubble position-absolute px-3" t-ref="bubble">
+      <div class="o-speech-bubble position-absolute px-3 border" t-ref="bubble">
         <div class="o-speech-content text-truncate pb-1" t-esc="props.content"/>
       </div>
     </t>

--- a/src/components/composer/standalone_composer/standalone_composer.css
+++ b/src/components/composer/standalone_composer/standalone_composer.css
@@ -2,11 +2,8 @@
   .o-standalone-composer {
     min-height: 24px;
 
-    border-bottom: 1px solid;
-    border-color: var(--os-gray-300);
-
     &.active {
-      border-color: var(--os-action-color);
+      border-color: var(--os-action-color) !important;
     }
 
     &.o-invalid {

--- a/src/components/composer/standalone_composer/standalone_composer.xml
+++ b/src/components/composer/standalone_composer/standalone_composer.xml
@@ -1,7 +1,7 @@
 <templates>
   <t t-name="o-spreadsheet-StandaloneComposer">
     <div
-      class="o-standalone-composer"
+      class="o-standalone-composer border-bottom"
       t-on-click.stop=""
       t-att-class="containerClass"
       t-att-title="props.title">

--- a/src/components/composer/top_bar_composer/top_bar_composer.css
+++ b/src/components/composer/top_bar_composer/top_bar_composer.css
@@ -7,16 +7,14 @@
     height: fit-content;
     margin-top: -1px;
     margin-bottom: -1px;
-    border: 1px solid;
     font-family: var(--os-default-font);
 
     &.o-topbar-composer-inactive {
-      border-color: var(--os-separator-color);
-      border-right: none;
+      border-right: none !important;
     }
 
     &.o-topbar-composer-active {
-      border-color: var(--os-selection-border-color);
+      border-color: var(--os-selection-border-color) !important;
       z-index: var(--os-components-importance-top-bar-composer);
     }
   }

--- a/src/components/composer/top_bar_composer/top_bar_composer.xml
+++ b/src/components/composer/top_bar_composer/top_bar_composer.xml
@@ -2,7 +2,7 @@
   <t t-name="o-spreadsheet-TopBarComposer">
     <div class="o-topbar-composer-container w-100">
       <div
-        class="o-topbar-composer position-relative bg-white user-select-text d-flex"
+        class="o-topbar-composer position-relative bg-white user-select-text d-flex border"
         t-att-class="{
           'o-topbar-composer-readonly': env.model.getters.isReadonly(),
           'o-topbar-composer-active': focus !== 'inactive',

--- a/src/components/filters/filter_menu/filter_menu.xml
+++ b/src/components/filters/filter_menu/filter_menu.xml
@@ -16,7 +16,7 @@
         </div>
       </t>
       <div class="o-filter-menu-content">
-        <div class="o-separator"/>
+        <div class="o-separator border-bottom"/>
         <SidePanelCollapsible
           isInitiallyCollapsed="filterValueType !== 'criterion'"
           title.translate="Filter by criterion">

--- a/src/components/filters/filter_menu_value_list/filter_menu_value_list.css
+++ b/src/components/filters/filter_menu_value_list/filter_menu_value_list.css
@@ -20,7 +20,6 @@
   .o-filter-menu-list {
     flex: auto;
     overflow-y: auto;
-    border: 1px solid var(--os-gray-300);
     height: 130px;
   }
 }

--- a/src/components/filters/filter_menu_value_list/filter_menu_value_list.xml
+++ b/src/components/filters/filter_menu_value_list/filter_menu_value_list.xml
@@ -18,7 +18,7 @@
       </i>
     </div>
     <div
-      class="o-filter-menu-list d-flex flex-column"
+      class="o-filter-menu-list d-flex flex-column border"
       t-ref="filterValueList"
       t-on-click="this.clearScrolledToValue"
       t-on-scroll="this.clearScrolledToValue">

--- a/src/components/grid/grid.xml
+++ b/src/components/grid/grid.xml
@@ -64,7 +64,7 @@
       </t>
       <VerticalScrollBar topOffset="HEADER_HEIGHT"/>
       <HorizontalScrollBar leftOffset="HEADER_WIDTH"/>
-      <div class="o-scrollbar corner"/>
+      <div class="o-scrollbar corner border-top border-start"/>
     </div>
   </t>
 </templates>

--- a/src/components/grid_add_rows_footer/grid_add_rows_footer.css
+++ b/src/components/grid_add_rows_footer/grid_add_rows_footer.css
@@ -1,5 +1,7 @@
 .o-spreadsheet {
   .o-grid-add-rows {
+    color-scheme: light;
+    color: var(--os-text-body);
     input.o-input {
       width: 60px;
       height: 30px;

--- a/src/components/link/link_display/link_display.css
+++ b/src/components/link/link_display/link_display.css
@@ -3,7 +3,6 @@
     font-size: 13px;
     box-shadow: 0 1px 4px 3px rgba(60, 64, 67, 0.15);
     padding: 6px 12px;
-    border-radius: 4px;
     display: flex;
     justify-content: space-between;
     height: var(--os-link-tooltip-height);

--- a/src/components/link/link_display/link_display.xml
+++ b/src/components/link/link_display/link_display.xml
@@ -1,6 +1,6 @@
 <templates>
   <t t-name="o-spreadsheet-LinkDisplay">
-    <div class="o-link-tool d-flex align-items-center bg-white">
+    <div class="o-link-tool d-flex align-items-center bg-white rounded">
       <!-- t-key to prevent owl from re-using the previous img element when the link changes.
     The wrong/previous image would be displayed while the new one loads -->
       <img

--- a/src/components/link/link_editor/link_editor.css
+++ b/src/components/link/link_editor/link_editor.css
@@ -5,7 +5,6 @@
     padding: 12px;
     display: flex;
     flex-direction: column;
-    border-radius: 4px;
     width: calc(340 + 2 * 12) px;
 
     .o-section {

--- a/src/components/link/link_editor/link_editor.xml
+++ b/src/components/link/link_editor/link_editor.xml
@@ -1,7 +1,7 @@
 <templates>
   <t t-name="o-spreadsheet-LinkEditor">
     <div
-      class="o-link-editor bg-white"
+      class="o-link-editor bg-white rounded"
       t-on-click.stop="() => this.menu.isOpen=false"
       t-on-keydown="onKeyDown">
       <div class="o-section">

--- a/src/components/menu/menu.xml
+++ b/src/components/menu/menu.xml
@@ -10,7 +10,7 @@
       t-on-click.stop=""
       t-on-contextmenu.prevent="">
       <t t-foreach="menuItemsAndSeparators" t-as="menuItem" t-key="menuItem_index">
-        <div t-if="menuItem === 'separator'" class="o-separator"/>
+        <div t-if="menuItem === 'separator'" class="o-separator border-bottom"/>
         <t t-else="">
           <t t-set="isMenuRoot" t-value="isRoot(menuItem)"/>
           <t t-set="isMenuEnabled" t-value="isEnabled(menuItem)"/>

--- a/src/components/pivot_html_renderer/pivot_html_renderer.css
+++ b/src/components/pivot_html_renderer/pivot_html_renderer.css
@@ -9,7 +9,7 @@
 
     td,
     th {
-      border: 1px solid var(--os-gray-300);
+      border: 1px solid var(--os-border-color);
       background-color: var(--os-white-bg);
       padding: 0.3rem;
       white-space: nowrap;

--- a/src/components/popover/popover.css
+++ b/src/components/popover/popover.css
@@ -11,6 +11,6 @@
 
 .o-spreadsheet.dark {
   .o-popover {
-    border: 1px solid var(--os-gray-400);
+    border: 1px solid var(--os-border-color);
   }
 }

--- a/src/components/scrollbar/scrollbar.css
+++ b/src/components/scrollbar/scrollbar.css
@@ -10,8 +10,6 @@
       bottom: 0px;
       height: var(--os-scrollbar-width);
       width: var(--os-scrollbar-width);
-      border-top: 1px solid var(--os-gray-400);
-      border-left: 1px solid var(--os-gray-400);
     }
   }
 }

--- a/src/components/side_panel/chart/building_blocks/text_styler/text_styler.css
+++ b/src/components/side_panel/chart/building_blocks/text_styler/text_styler.css
@@ -8,7 +8,6 @@
     }
 
     .o-divider {
-      border-right: 1px solid var(--os-gray-300);
       margin: 0px 4px;
       height: 14px;
     }

--- a/src/components/side_panel/chart/building_blocks/text_styler/text_styler.xml
+++ b/src/components/side_panel/chart/building_blocks/text_styler/text_styler.xml
@@ -5,7 +5,10 @@
       t-att-class="props.class">
       <ActionButton action="boldButtonAction" class="'o-hoverable-button'"/>
       <ActionButton action="italicButtonAction" class="'o-hoverable-button'"/>
-      <div class="o-divider" t-if="props.hasHorizontalAlign || props.hasVerticalAlign"/>
+      <div
+        class="o-divider border-start"
+        t-if="props.hasHorizontalAlign || props.hasVerticalAlign"
+      />
       <div class="o-dropdown position-relative" t-if="props.hasHorizontalAlign">
         <ActionButton
           action="horizontalAlignButtonAction"
@@ -44,13 +47,13 @@
           </div>
         </div>
       </div>
-      <div class="o-divider"/>
+      <div class="o-divider border-start"/>
       <FontSizeEditor
         currentFontSize="currentFontSize"
         onFontSizeChanged.bind="this.updateFontSize"
         class="'o-hoverable-button'"
       />
-      <div class="o-divider"/>
+      <div class="o-divider border-start"/>
       <ColorPickerWidget
         currentColor="props.style.color ?? props.defaultStyle?.color"
         toggleColorPicker="(ev) => this.toggleDropdownTool('fillChartColorTool', ev)"

--- a/src/components/side_panel/components/checkbox/checkbox.css
+++ b/src/components/side_panel/components/checkbox/checkbox.css
@@ -9,7 +9,6 @@
       height: 14px;
       vertical-align: top;
       outline: none;
-      border: 1px solid var(--os-gray-300);
       cursor: pointer;
 
       &:hover {

--- a/src/components/side_panel/components/checkbox/checkbox.xml
+++ b/src/components/side_panel/components/checkbox/checkbox.xml
@@ -7,7 +7,7 @@
       t-att-class="{'text-muted': props.disabled }"
       t-attf-class="{{props.className}}">
       <input
-        class="me-2 flex-shrink-0"
+        class="me-2 flex-shrink-0 border"
         type="checkbox"
         t-att-disabled="props.disabled"
         t-att-name="props.name"

--- a/src/components/side_panel/components/radio_selection/radio_selection.css
+++ b/src/components/side_panel/components/radio_selection/radio_selection.css
@@ -6,15 +6,13 @@
       -moz-appearance: none;
       width: 14px;
       height: 14px;
-      border: 1px solid var(--os-gray-300);
       outline: none;
-      border-radius: 8px;
       flex-shrink: 0;
 
       &:checked {
         background: url("data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20viewBox%3D%27-4%20-4%208%208%27%3E%3Ccircle%20r%3D%222%22%20fill%3D%22%23FFF%22/%3E%3C/svg%3E");
         background-color: var(--os-action-color);
-        border-color: var(--os-action-color);
+        border-color: var(--os-action-color) !important;
       }
     }
   }

--- a/src/components/side_panel/components/radio_selection/radio_selection.xml
+++ b/src/components/side_panel/components/radio_selection/radio_selection.xml
@@ -8,6 +8,7 @@
       <t t-foreach="props.choices" t-as="choice" t-key="choice.value">
         <label class="o-radio d-flex align-items-center me-4">
           <input
+            class="border rounded-circle"
             t-att-class="{
               'me-1': props.direction === 'horizontal',
               'me-2': props.direction === 'vertical'}"

--- a/src/components/side_panel/components/round_color_picker/round_color_picker.css
+++ b/src/components/side_panel/components/round_color_picker/round_color_picker.css
@@ -3,7 +3,6 @@
     width: 20px;
     height: 20px;
     cursor: pointer;
-    border: 1px solid var(--os-gray-300);
     background-position: 1px 1px;
     background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20width%3D%2210%22%20height%3D%2210%22%3E%3Cpath%20fill%3D%22%23d9d9d9%22%20d%3D%22M5%205h5v5H5zH0V0h5%22/%3E%3C/svg%3E");
   }

--- a/src/components/side_panel/components/round_color_picker/round_color_picker.xml
+++ b/src/components/side_panel/components/round_color_picker/round_color_picker.xml
@@ -1,7 +1,7 @@
 <templates>
   <t t-name="o-spreadsheet.RoundColorPicker">
     <div
-      class="o-round-color-picker-button rounded-circle"
+      class="o-round-color-picker-button rounded-circle border"
       t-ref="colorPickerButton"
       t-on-click.stop="togglePicker"
       t-att-title="props.title"

--- a/src/components/side_panel/conditional_formatting/cf_editor/cell_is_rule_editor.xml
+++ b/src/components/side_panel/conditional_formatting/cf_editor/cell_is_rule_editor.xml
@@ -1,7 +1,7 @@
 <templates>
   <t t-name="o-spreadsheet-CellIsRuleEditorPreview">
     <div
-      class="o-cf-preview-display"
+      class="o-cf-preview-display border"
       t-attf-style="font-weight:{{currentStyle.bold ?'bold':'normal'}};
                        text-decoration:{{getTextDecoration(currentStyle)}};
                        font-style:{{currentStyle.italic?'italic':'normal'}};
@@ -75,7 +75,7 @@
           icon="'o-spreadsheet-Icon.TEXT_COLOR'"
           class="'o-hoverable-button o-menu-item-button'"
         />
-        <div class="o-divider"/>
+        <div class="o-divider border-end"/>
         <ColorPickerWidget
           currentColor="rule.style.fillColor"
           toggleColorPicker="(ev) => this.toggleMenu('cellIsRule-fillColor', ev)"

--- a/src/components/side_panel/conditional_formatting/cf_editor/cf_editor.css
+++ b/src/components/side_panel/conditional_formatting/cf_editor/cf_editor.css
@@ -1,13 +1,11 @@
 .o-spreadsheet {
   .o-cf-ruleEditor {
     .o-cf-preview-display {
-      border: 1px solid var(--os-gray-300);
       padding: 10px;
     }
 
     .o-cf-cell-is-rule {
       .o-divider {
-        border-right: 1px solid var(--os-gray-300);
         margin: 4px 6px;
       }
     }
@@ -25,11 +23,9 @@
     }
     .o-cf-iconset-rule {
       .o-cf-clickable-icon {
-        border: 1px solid var(--os-gray-300);
-        border-radius: 4px;
         cursor: pointer;
         &:hover {
-          border-color: var(--os-action-color);
+          border-color: var(--os-action-color) !important;
           background-color: var(--os-badge-selected-color);
         }
         .o-icon {

--- a/src/components/side_panel/conditional_formatting/cf_editor/icon_set_rule_editor.xml
+++ b/src/components/side_panel/conditional_formatting/cf_editor/icon_set_rule_editor.xml
@@ -4,7 +4,7 @@
       <div class="o-section-subtitle">Icons</div>
       <div class="o-cf-iconsets d-flex flex-row">
         <div
-          class="o-cf-iconset o-cf-clickable-icon d-flex flex-row justify-content-between"
+          class="o-cf-iconset o-cf-clickable-icon d-flex flex-row justify-content-between border rounded"
           t-foreach="['arrows', 'smiley', 'dots']"
           t-as="iconSet"
           t-key="iconSet"
@@ -27,7 +27,7 @@
     <tr>
       <td>
         <div t-on-click.stop="(ev) => this.toggleMenu('iconSet-'+icon+'Icon', ev)">
-          <div class="o-cf-icon-button o-cf-clickable-icon me-3">
+          <div class="o-cf-icon-button o-cf-clickable-icon me-3 border rounded">
             <t t-call="o-spreadsheet-Icon.{{icons[iconValue].template}}"/>
           </div>
         </div>
@@ -110,7 +110,7 @@
         <tr>
           <td>
             <div t-on-click.stop="(ev) => this.toggleMenu('iconSet-lowerIcon', ev)">
-              <div class="o-cf-icon-button o-cf-clickable-icon me-3">
+              <div class="o-cf-icon-button o-cf-clickable-icon me-3 border rounded">
                 <t t-call="o-spreadsheet-Icon.{{icons[rule.icons.lower].template}}"/>
               </div>
             </div>

--- a/src/components/side_panel/conditional_formatting/cf_preview/cf_preview.css
+++ b/src/components/side_panel/conditional_formatting/cf_preview/cf_preview.css
@@ -4,7 +4,6 @@
       cursor: pointer;
     }
 
-    border-bottom: 1px solid var(--os-gray-300);
     height: 80px;
     padding: 10px;
     position: relative;
@@ -18,7 +17,6 @@
       display: none;
     }
     .o-cf-preview-icon {
-      border: 1px solid var(--os-gray-300);
       position: absolute;
       height: 50px;
       width: 50px;

--- a/src/components/side_panel/conditional_formatting/cf_preview/cf_preview.xml
+++ b/src/components/side_panel/conditional_formatting/cf_preview/cf_preview.xml
@@ -2,7 +2,7 @@
   <t t-name="o-spreadsheet-ConditionalFormatPreview">
     <t t-set="cf" t-value="props.conditionalFormat"/>
     <div
-      class="o-cf-preview w-100"
+      class="o-cf-preview w-100 border-bottom"
       t-ref="cfPreview"
       t-att-class="props.class"
       t-att-data-id="cf.id"
@@ -15,7 +15,7 @@
         </div>
         <t t-if="cf.rule.type==='IconSetRule'">
           <div
-            class="o-cf-preview-icon d-flex justify-content-around align-items-center me-2 bg-white">
+            class="o-cf-preview-icon d-flex justify-content-around align-items-center me-2 bg-white border">
             <t t-call="o-spreadsheet-Icon.{{icons[cf.rule.icons.upper].template}}"/>
             <t t-call="o-spreadsheet-Icon.{{icons[cf.rule.icons.middle].template}}"/>
             <t t-call="o-spreadsheet-Icon.{{icons[cf.rule.icons.lower].template}}"/>
@@ -24,7 +24,7 @@
         <t t-else="">
           <div
             t-att-style="getPreviewImageStyle(cf.rule)"
-            class="o-cf-preview-icon d-flex justify-content-around align-items-center me-2 bg-white">
+            class="o-cf-preview-icon d-flex justify-content-around align-items-center me-2 bg-white border">
             123
           </div>
         </t>

--- a/src/components/side_panel/data_validation/dv_preview/dv_preview.css
+++ b/src/components/side_panel/data_validation/dv_preview/dv_preview.css
@@ -3,7 +3,6 @@
     .o-dv-preview {
       height: 70px;
       cursor: pointer;
-      border-bottom: 1px solid var(--os-figure-border-color);
 
       .o-dv-container {
         min-width: 0; /* otherwise flex won't shrink correctly */

--- a/src/components/side_panel/data_validation/dv_preview/dv_preview.xml
+++ b/src/components/side_panel/data_validation/dv_preview/dv_preview.xml
@@ -1,6 +1,6 @@
 <templates>
   <t t-name="o-spreadsheet-DataValidationPreview">
-    <div class="o-dv-preview p-3" t-on-click="props.onClick" t-ref="dvPreview">
+    <div class="o-dv-preview p-3 border-bottom" t-on-click="props.onClick" t-ref="dvPreview">
       <div class="d-flex justify-content-between">
         <div class="o-dv-container d-flex flex-column">
           <div class="o-dv-preview-description o-fw-bold text-truncate" t-esc="descriptionString"/>

--- a/src/components/side_panel/more_formats/more_formats.css
+++ b/src/components/side_panel/more_formats/more_formats.css
@@ -1,14 +1,12 @@
 .o-spreadsheet {
   .o-more-formats-panel {
     .o-format-proposals {
-      border: 1px solid var(--os-gray-300);
       max-height: 320px;
       font-size: 12px;
     }
 
     .o-format-examples {
-      background: light-dark(var(--os-gray-100), var(--os-gray-200));
-      border: 1px solid var(--os-gray-300);
+      background: light-dark(var(--os-gray-100), var(--os-gray-300));
     }
 
     table {

--- a/src/components/side_panel/more_formats/more_formats.xml
+++ b/src/components/side_panel/more_formats/more_formats.xml
@@ -11,7 +11,7 @@
       <t t-if="store.category === 'currency'" t-call="o-spreadsheet-CustomCurrencySection"/>
       <t t-set="proposals" t-value="store.formatProposals"/>
       <Section title.translate="Type" t-if="proposals.length">
-        <div class="o-format-proposals overflow-auto">
+        <div class="o-format-proposals overflow-auto border">
           <div
             t-foreach="proposals"
             t-as="proposal"
@@ -34,7 +34,7 @@
           errorMessage="store.invalidFormatMessage"
         />
         <t t-set="examples" t-value="store.formatExamples"/>
-        <div class="o-format-examples mt-4 p-2 rounded" t-if="examples.length">
+        <div class="o-format-examples mt-4 p-2 rounded border" t-if="examples.length">
           <table class="w-100">
             <t t-foreach="examples" t-as="example" t-key="example_index">
               <tr>

--- a/src/components/side_panel/pivot/pivot_layout_configurator/pivot_dimension/pivot_dimension.css
+++ b/src/components/side_panel/pivot/pivot_layout_configurator/pivot_dimension/pivot_dimension.css
@@ -1,7 +1,6 @@
 .o-spreadsheet {
   .pivot-dimension {
-    border: 1px solid var(--os-gray-300);
-    border-radius: 4px;
+    background-color: light-dark(var(--os-white), var(--os-gray-300));
 
     select.o-input {
       height: inherit;

--- a/src/components/side_panel/pivot/pivot_layout_configurator/pivot_dimension/pivot_dimension.xml
+++ b/src/components/side_panel/pivot/pivot_layout_configurator/pivot_dimension/pivot_dimension.xml
@@ -1,7 +1,7 @@
 <templates>
   <t t-name="o-spreadsheet-PivotDimension">
     <div
-      class="py-1 px-2 d-flex flex-column shadow-sm pivot-dimension bg-white"
+      class="py-1 px-2 d-flex flex-column shadow-sm pivot-dimension border rounded"
       t-att-class="{'pivot-dimension-invalid': !props.dimension.isValid}">
       <div class="d-flex flex-row justify-content-between align-items-center">
         <div class="d-flex align-items-center overflow-hidden text-nowrap">

--- a/src/components/side_panel/pivot/pivot_layout_configurator/pivot_sort_section/pivot_sort_section.css
+++ b/src/components/side_panel/pivot/pivot_layout_configurator/pivot_sort_section/pivot_sort_section.css
@@ -3,7 +3,6 @@
     .o-sort-card {
       width: fit-content;
       background-color: var(--os-gray-100);
-      border: 1px solid var(--os-gray-300);
 
       .o-sort-value {
         color: var(--os-primary-button-bg);

--- a/src/components/side_panel/pivot/pivot_layout_configurator/pivot_sort_section/pivot_sort_section.xml
+++ b/src/components/side_panel/pivot/pivot_layout_configurator/pivot_sort_section/pivot_sort_section.xml
@@ -5,7 +5,7 @@
       <div t-esc="sortDescription" class="pb-2"/>
       <div class="d-flex flex-column gap-2">
         <t t-foreach="sortValuesAndFields" t-as="valueAndField" t-key="valueAndField_index">
-          <div class="o-sort-card d-flex gap-1 px-2">
+          <div class="o-sort-card d-flex gap-1 px-2 border">
             <t t-if="valueAndField.field">
               <span class="fw-bolder" t-esc="valueAndField.field"/>
               =

--- a/src/components/side_panel/pivot/pivot_measure_display_panel/pivot_measure_display_panel.css
+++ b/src/components/side_panel/pivot/pivot_measure_display_panel/pivot_measure_display_panel.css
@@ -2,14 +2,13 @@
   .o-sidePanel {
     .o-pivot-measure-display-field,
     .o-pivot-measure-display-value {
-      border: solid 1px var(--os-gray-300);
       border-radius: 3px;
     }
 
     .o-pivot-measure-display-description {
       white-space: pre-wrap;
       color: dimgray;
-      border-left: 2px solid var(--os-gray-300);
+      border-left-width: 2px !important;
     }
   }
 }

--- a/src/components/side_panel/pivot/pivot_measure_display_panel/pivot_measure_display_panel.xml
+++ b/src/components/side_panel/pivot/pivot_measure_display_panel/pivot_measure_display_panel.xml
@@ -13,13 +13,13 @@
         </t>
       </select>
       <div
-        class="o-pivot-measure-display-description mt-3 ps-3"
+        class="o-pivot-measure-display-description mt-3 ps-3 border-start"
         t-esc="measureDisplayDescription[store.measureDisplay.type]"
       />
     </Section>
 
     <Section t-if="store.doesDisplayNeedsField" title.translate="Base field:">
-      <div class="o-pivot-measure-display-field w-100 py-1 px-3">
+      <div class="o-pivot-measure-display-field w-100 py-1 px-3 border">
         <t t-if="store.fields.length">
           <RadioSelection
             choices="fieldChoices"
@@ -37,7 +37,7 @@
 
     <t t-set="values" t-value="store.values"/>
     <Section t-if="store.doesDisplayNeedsValue and values.length" title.translate="Base item:">
-      <div class="o-pivot-measure-display-value w-100 py-1 px-3">
+      <div class="o-pivot-measure-display-value w-100 py-1 px-3 border">
         <RadioSelection
           choices="values"
           selectedValue="store.measureDisplay.value"

--- a/src/components/side_panel/settings/settings_panel.css
+++ b/src/components/side_panel/settings/settings_panel.css
@@ -1,6 +1,5 @@
 .o-spreadsheet {
   .o-locale-preview {
-    border: 1px solid var(--os-gray-300);
-    background-color: var(--os-gray-100);
+    background-color: light-dark(var(--os-gray-100), var(--os-gray-300));
   }
 }

--- a/src/components/side_panel/settings/settings_panel.xml
+++ b/src/components/side_panel/settings/settings_panel.xml
@@ -12,7 +12,7 @@
             t-att-selected="currentLocale.code === locale.code"
           />
         </select>
-        <div class="o-locale-preview mt-4 p-3 rounded">
+        <div class="o-locale-preview mt-4 p-3 rounded border">
           <div>
             <span class="o-fw-bold me-1">Number:</span>
             <span t-esc="numberFormatPreview"/>

--- a/src/components/side_panel/side_panel/side_panel.css
+++ b/src/components/side_panel/side_panel/side_panel.css
@@ -3,8 +3,6 @@
     display: flex;
     flex-direction: column;
     overflow-x: hidden;
-    border: solid var(--os-gray-300);
-    border-width: 1px 0 0 1px;
     user-select: none;
     color: var(--os-text-body);
     &.collapsed {
@@ -21,7 +19,6 @@
     }
     .o-sidePanelHeader {
       padding: 8px;
-      border-bottom: 1px solid var(--os-gray-300);
     }
     .o-sidePanelAction {
       padding: 5px 10px;
@@ -92,12 +89,12 @@
     .o-sidePanel-tab {
       padding: 8px 0px;
       cursor: pointer;
-      border-right: 1px solid var(--os-gray-300);
+      border-right: 1px solid var(--os-border-color);
 
       &.inactive {
         color: var(--os-text-body);
         background-color: var(--os-gray-100);
-        border-bottom: 1px solid var(--os-gray-300);
+        border-bottom: 1px solid var(--os-border-color);
       }
 
       &:not(.inactive) {

--- a/src/components/side_panel/side_panel/side_panel.xml
+++ b/src/components/side_panel/side_panel/side_panel.xml
@@ -5,8 +5,9 @@
   </t>
 
   <t t-name="o-spreadsheet-SidePanelExtended">
-    <div class="o-sidePanel h-100 bg-white">
-      <div class="o-sidePanelHeader d-flex align-items-center justify-content-between">
+    <div class="o-sidePanel h-100 bg-white border-top border-start">
+      <div
+        class="o-sidePanelHeader d-flex align-items-center justify-content-between border-bottom">
         <div
           t-if="props.onToggleCollapsePanel"
           class="o-collapse-panel o-sidePanelAction rounded"

--- a/src/components/small_bottom_bar/small_bottom_bar.css
+++ b/src/components/small_bottom_bar/small_bottom_bar.css
@@ -12,7 +12,6 @@
   }
 
   .o-small-composer {
-    border: var(--os-gray-400) solid 1px;
     line-height: 26px;
     display: flex;
     z-index: var(--os-components-importance-top-bar-composer);
@@ -20,8 +19,6 @@
 
   .bottom-bar-menu {
     background-color: var(--os-background-gray-color);
-    border-top: 1px solid var(--os-gray-400);
-    border-bottom: 1px solid var(--os-gray-400);
   }
 
   .o-spreadsheet-bottom-bar {

--- a/src/components/small_bottom_bar/small_bottom_bar.xml
+++ b/src/components/small_bottom_bar/small_bottom_bar.xml
@@ -5,7 +5,7 @@
         <RibbonMenu onClose="() => this.menuState.isOpen=false"/>
       </t>
       <t t-else="">
-        <div class="o-small-composer px-2 py-2 position-relative bg-white">
+        <div class="o-small-composer px-2 py-2 position-relative bg-white border">
           <div class="w-100" t-ref="bottombarComposer">
             <Composer t-props="composerProps"/>
             <span
@@ -37,7 +37,7 @@
             composerFocusableElement="true"
           />
         </div>
-        <div class="d-flex flex-fill align-items-center bottom-bar-menu">
+        <div class="d-flex flex-fill align-items-center bottom-bar-menu border-top border-bottom">
           <Ripple>
             <div class="py-1 px-1 mx-2 ribbon-toggler" t-on-click="toggleRibbon">
               <i class="o-icon fa fa-cog"/>

--- a/src/components/spreadsheet/spreadsheet.css
+++ b/src/components/spreadsheet/spreadsheet.css
@@ -1,8 +1,32 @@
 .o-spreadsheet {
+  .border {
+    border: 1px solid var(--os-border-color) !important;
+  }
+
+  .border-bottom {
+    border-bottom: 1px solid var(--os-border-color) !important;
+  }
+
+  .border-top {
+    border-top: 1px solid var(--os-border-color) !important;
+  }
+
+  .border-start {
+    border-left: 1px solid var(--os-border-color) !important;
+  }
+
+  .border-end {
+    border-right: 1px solid var(--os-border-color) !important;
+  }
+
   color: var(--os-text-body);
 
   .bg-white {
     background-color: var(--os-white-bg) !important;
+  }
+
+  .bg-white-contrasted {
+    background-color: light-dark(var(--os-white), var(--os-gray-300));
   }
 
   select > option {
@@ -10,7 +34,7 @@
   }
 
   input {
-    background-color: var(--os-white-bg);
+    background-color: transparent;
   }
 
   &.o-spreadsheet-mobile .o-spreadsheet-topbar-wrapper,
@@ -41,7 +65,6 @@
     direction: ltr;
   }
   .o-separator {
-    border-bottom: var(--os-menu-separator-border-width) solid var(--os-separator-color);
     margin-top: var(--os-menu-separator-padding);
     margin-bottom: var(--os-menu-separator-padding);
   }
@@ -97,7 +120,7 @@
     padding: 1px 0;
     width: 100%;
     outline: none;
-    border-color: var(--os-gray-300);
+    border-color: var(--os-border-color);
     color: var(--os-gray-900);
 
     &::placeholder {
@@ -173,7 +196,6 @@
   }
 
   .o-button {
-    border: 1px solid;
     border-radius: 4px;
     font-weight: 500;
     font-size: 14px;

--- a/src/components/tables/table_style_picker/table_style_picker.css
+++ b/src/components/tables/table_style_picker/table_style_picker.css
@@ -1,11 +1,6 @@
 .o-spreadsheet {
   .o-table-style-picker {
-    border: 1px solid var(--os-gray-300);
-    border-radius: 3px;
-
     .o-table-style-picker-arrow {
-      border-left: 1px solid var(--os-gray-300);
-
       &:hover {
         background: var(--os-button-hover-bg);
         cursor: pointer;

--- a/src/components/tables/table_style_picker/table_style_picker.xml
+++ b/src/components/tables/table_style_picker/table_style_picker.xml
@@ -1,6 +1,6 @@
 <templates>
   <t t-name="o-spreadsheet-TableStylePicker">
-    <div class="o-table-style-picker d-flex flew-row justify-content-between ps-1">
+    <div class="o-table-style-picker d-flex flew-row justify-content-between ps-1 border rounded">
       <div class="d-flex flex-row overflow-hidden ps-2">
         <t t-foreach="getDisplayedTableStyles()" t-as="styleId" t-key="styleId">
           <TableStylePreview
@@ -14,7 +14,7 @@
         </t>
       </div>
       <div
-        class="o-table-style-picker-arrow d-flex align-items-center px-1"
+        class="o-table-style-picker-arrow d-flex align-items-center px-1 border-start"
         t-on-click.stop="onArrowButtonClick">
         <t t-call="o-spreadsheet-Icon.CARET_DOWN"/>
       </div>

--- a/src/components/tables/table_style_preview/table_style_preview.css
+++ b/src/components/tables/table_style_preview/table_style_preview.css
@@ -14,7 +14,6 @@
         right: 0;
         top: 0;
         cursor: pointer;
-        border: 1px solid var(--os-gray-300);
         padding: 1px 1px 1px 2px;
         .o-icon {
           font-size: 12px;

--- a/src/components/tables/table_style_preview/table_style_preview.xml
+++ b/src/components/tables/table_style_preview/table_style_preview.xml
@@ -11,7 +11,7 @@
         <canvas t-ref="canvas" class="w-100 h-100"/>
       </div>
       <div
-        class="o-table-style-edit-button position-absolute d-none bg-white"
+        class="o-table-style-edit-button position-absolute d-none bg-white border"
         t-if="isStyleEditable"
         t-on-click="this.editTableStyle"
         title="Edit custom table style">

--- a/src/components/tables/table_styles_popover/table_styles_popover.css
+++ b/src/components/tables/table_styles_popover/table_styles_popover.css
@@ -10,7 +10,6 @@
 
       .o-notebook-tab {
         padding: 5px 15px;
-        border: 1px solid var(--os-gray-300);
         margin-bottom: -1px;
         margin-left: -1px;
         color: var(--os-text-body);
@@ -18,8 +17,8 @@
         transition: color 0.2s, border-color 0.2s;
 
         &.selected {
-          border-bottom-color: var(--os-white);
-          border-top-color: var(--os-primary-button-bg);
+          border-bottom-color: var(--os-white-bg) !important;
+          border-top-color: var(--os-primary-button-bg) !important;
           color: var(--os-button-active-text-color);
         }
       }

--- a/src/components/tables/table_styles_popover/table_styles_popover.xml
+++ b/src/components/tables/table_styles_popover/table_styles_popover.xml
@@ -10,7 +10,7 @@
             t-foreach="Object.keys(categories)"
             t-as="category"
             t-key="category"
-            class="o-notebook-tab d-flex align-items-center"
+            class="o-notebook-tab d-flex align-items-center border"
             t-att-class="{ 'selected': state.selectedCategory === category }"
             t-on-click="() => state.selectedCategory = category"
             t-att-data-id="category"

--- a/src/components/text_input/text_input.css
+++ b/src/components/text_input/text_input.css
@@ -8,7 +8,7 @@
   }
   .os-input:hover,
   .os-input.o-input-border {
-    border-color: var(--os-gray-300);
+    border-color: var(--os-border-color);
   }
   .os-input:focus {
     border-color: var(--os-action-color);

--- a/src/components/top_bar/top_bar.css
+++ b/src/components/top_bar/top_bar.css
@@ -19,7 +19,6 @@
   }
 
   .o-topbar-divider {
-    border-right: 1px solid var(--os-separator-color);
     width: 0;
     margin: 0 6px;
     height: 30px;
@@ -35,7 +34,6 @@
     font-weight: 500;
 
     .o-topbar-top {
-      border-bottom: 1px solid var(--os-separator-color);
       padding: 2px 10px;
 
       /* Menus */
@@ -53,7 +51,6 @@
     }
 
     .topbar-banner {
-      border-top: 1px solid var(--os-separator-color);
       height: var(--os-desktop-topbar-toolbar-height);
 
       .alert-info {
@@ -87,7 +84,7 @@
       height: var(--os-mobile-topbar-toolbar-height);
     }
     .o-topbar-divider {
-      border-width: 2px;
+      border-width: 2px !important;
       border-radius: 4px;
     }
 

--- a/src/components/top_bar/top_bar.xml
+++ b/src/components/top_bar/top_bar.xml
@@ -3,7 +3,7 @@
     <div
       class="o-spreadsheet-topbar d-flex flex-column user-select-none bg-white"
       t-on-click="props.onClick">
-      <div t-if="!env.isSmall" class="o-topbar-top d-flex justify-content-between">
+      <div t-if="!env.isSmall" class="o-topbar-top d-flex justify-content-between border-bottom">
         <!-- Menus -->
         <div class="o-topbar-topleft d-flex">
           <t t-foreach="menus" t-as="menu" t-key="menu_index">
@@ -54,7 +54,7 @@
                 t-key="toolbarAction_index">
                 <t t-component="toolbarAction.component" t-props="toolbarAction.props"/>
               </t>
-              <div t-if="showDivider(category_index)" class="o-topbar-divider"/>
+              <div t-if="showDivider(category_index)" class="o-topbar-divider border-end"/>
             </div>
             <div
               t-ref="moreToolsContainer"
@@ -72,7 +72,7 @@
       </div>
       <div
         t-if="this.fingerprints.isEnabled"
-        class="topbar-banner irregularity-map d-flex align-items-center justify-content-between">
+        class="topbar-banner irregularity-map d-flex align-items-center justify-content-between border-top">
         <div
           t-on-click="() => this.fingerprints.disable()"
           role="button"
@@ -118,7 +118,7 @@
           </t>
           <div
             t-if="category_index &lt; state.invisibleToolsCategories.length-1"
-            class="o-topbar-divider"
+            class="o-topbar-divider border-end"
           />
         </t>
       </div>

--- a/src/variables.css
+++ b/src/variables.css
@@ -11,7 +11,7 @@
 
   --os-white: light-dark(#ffffff, #000000);
   --os-black: light-dark(#000000, #ffffff);
-  --os-white-bg: light-dark(#ffffff, #1b1d26);
+  --os-white-bg: light-dark(#ffffff, var(--os-gray-200));
 
   --os-default-font: "Roboto", "Arial";
   --os-default-font-size: 10px;
@@ -32,6 +32,7 @@
   --os-primary-button-text-color: light-dark(#ffffff, #ffffff);
   --os-action-color: var(--os-link-color); /* ACTION_COLOR */
   --os-action-color-hover: var(--os-link-hover-color);
+  --os-border-color: light-dark(var(--os-gray-300), var(--os-gray-400));
 
   --os-composer-placeholder-color: light-dark(#bdbdbd, #757a89);
   --os-composer-assistant-color: #9b359b; /* COMPOSER_ASSISTANT_COLOR */
@@ -57,7 +58,7 @@
   --os-alert-danger-bg: light-dark(#d44c591a, #3a0b0f);
   --os-alert-danger-border: light-dark(#c34a41, #a23c36);
   --os-alert-danger-text-color: light-dark(#c34a41, #ffb3a9);
-  --os-alert-info-bg: light-dark(#cdedf1, #062a30);
+  --os-alert-info-bg: light-dark(#cdedf1, #18535e);
   --os-alert-info-border: light-dark(#98dbe2, #22747e);
   --os-alert-info-text-color: light-dark(#09414a, #9ee3ec);
 
@@ -102,7 +103,6 @@
     var(--os-color-picker-width) - 30px - (2 * var(--os-item-border-width))
   );
   --os-container-width: calc(var(--os-color-picker-width) + (2 * var(--os-picker-padding)));
-  --os-menu-separator-border-width: 1px;
   --os-menu-separator-padding: 5px;
 
   --os-components-importance-grid: 0;

--- a/tests/__snapshots__/top_bar_component.test.ts.snap
+++ b/tests/__snapshots__/top_bar_component.test.ts.snap
@@ -5,7 +5,7 @@ exports[`TopBar component simple rendering 1`] = `
   class="o-spreadsheet-topbar d-flex flex-column user-select-none bg-white"
 >
   <div
-    class="o-topbar-top d-flex justify-content-between"
+    class="o-topbar-top d-flex justify-content-between border-bottom"
   >
     <!-- Menus -->
     <div
@@ -180,7 +180,7 @@ exports[`TopBar component simple rendering 1`] = `
           
           
           <div
-            class="o-topbar-divider"
+            class="o-topbar-divider border-end"
           />
           
         </div>
@@ -270,7 +270,7 @@ exports[`TopBar component simple rendering 1`] = `
           
           
           <div
-            class="o-topbar-divider"
+            class="o-topbar-divider border-end"
           />
           
         </div>
@@ -307,7 +307,7 @@ exports[`TopBar component simple rendering 1`] = `
           
           
           <div
-            class="o-topbar-divider"
+            class="o-topbar-divider border-end"
           />
           
         </div>
@@ -405,7 +405,7 @@ exports[`TopBar component simple rendering 1`] = `
           
           
           <div
-            class="o-topbar-divider"
+            class="o-topbar-divider border-end"
           />
           
         </div>
@@ -484,7 +484,7 @@ exports[`TopBar component simple rendering 1`] = `
           
           
           <div
-            class="o-topbar-divider"
+            class="o-topbar-divider border-end"
           />
           
         </div>
@@ -594,7 +594,7 @@ exports[`TopBar component simple rendering 1`] = `
           
           
           <div
-            class="o-topbar-divider"
+            class="o-topbar-divider border-end"
           />
           
         </div>
@@ -698,7 +698,7 @@ exports[`TopBar component simple rendering 1`] = `
       class="o-topbar-composer-container w-100"
     >
       <div
-        class="o-topbar-composer position-relative bg-white user-select-text d-flex o-topbar-composer-inactive"
+        class="o-topbar-composer position-relative bg-white user-select-text d-flex border o-topbar-composer-inactive"
       >
         <div
           class="o-composer-container w-100 h-100"

--- a/tests/bottom_bar/__snapshots__/bottom_bar_component.test.ts.snap
+++ b/tests/bottom_bar/__snapshots__/bottom_bar_component.test.ts.snap
@@ -137,7 +137,7 @@ exports[`BottomBar component Can open the list of statistics 1`] = `
 
 exports[`BottomBar component simple rendering 1`] = `
 <div
-  class="o-spreadsheet-bottom-bar o-two-columns d-flex flex-fill align-items-center overflow-hidden"
+  class="o-spreadsheet-bottom-bar o-two-columns d-flex flex-fill align-items-center overflow-hidden border-top"
 >
   <div
     class="o-ripple-container position-relative add-sheet-container"
@@ -233,7 +233,7 @@ exports[`BottomBar component simple rendering 1`] = `
           class="position-relative"
         >
           <div
-            class="o-sheet d-flex align-items-center user-select-none text-nowrap active"
+            class="o-sheet d-flex align-items-center user-select-none text-nowrap border-start border-end active"
             composerfocusableelement="true"
             data-id="Sheet1"
             style=""

--- a/tests/colors/__snapshots__/color_picker_component.test.ts.snap
+++ b/tests/colors/__snapshots__/color_picker_component.test.ts.snap
@@ -423,7 +423,7 @@ exports[`Color Picker buttons Full component rendering 1`] = `
     
   </div>
   <div
-    class="o-separator"
+    class="o-separator border-bottom"
   />
   <div
     class="o-color-picker-section-name o-color-picker-toggler"
@@ -478,7 +478,7 @@ exports[`Color Picker buttons Full component rendering 1`] = `
       class="o-hue-container"
     >
       <div
-        class="o-hue-picker"
+        class="o-hue-picker border rounded"
       />
       <div
         class="o-hue-slider pe-none"
@@ -497,10 +497,11 @@ exports[`Color Picker buttons Full component rendering 1`] = `
       class="o-custom-input-preview"
     >
       <input
+        class="border rounded"
         type="text"
       />
       <div
-        class="o-color-preview"
+        class="o-color-preview border rounded"
         style="background-color:#000000; "
       />
     </div>
@@ -508,7 +509,7 @@ exports[`Color Picker buttons Full component rendering 1`] = `
       class="o-custom-input-buttons"
     >
       <button
-        class="o-add-button"
+        class="o-add-button border rounded"
       >
          Add 
       </button>
@@ -516,13 +517,13 @@ exports[`Color Picker buttons Full component rendering 1`] = `
   </div>
   
   <div
-    class="o-separator"
+    class="o-separator border-bottom"
   />
   <div
     class="o-buttons"
   >
     <button
-      class="o-cancel"
+      class="o-cancel border rounded"
     >
       No Color
     </button>

--- a/tests/components/__snapshots__/pivot_html_renderer.test.ts.snap
+++ b/tests/components/__snapshots__/pivot_html_renderer.test.ts.snap
@@ -10,7 +10,7 @@ exports[`Pivot HTML Renderer Rendering a simple pivot table 1`] = `
       role="button"
     >
       <input
-        class="me-2 flex-shrink-0"
+        class="me-2 flex-shrink-0 border"
         name="missing_values"
         type="checkbox"
       />

--- a/tests/composer/__snapshots__/formula_assistant_component.test.ts.snap
+++ b/tests/composer/__snapshots__/formula_assistant_component.test.ts.snap
@@ -57,7 +57,7 @@ exports[`formula assistant appearance simple snapshot with =FUNC1( 1`] = `
       class="os-collapse d-none"
     >
       <div
-        class="o-formula-assistant-core pb-3 m-3"
+        class="o-formula-assistant-core pb-3 m-3 border-bottom"
       >
         <div
           class="o-formula-assistant-gray"

--- a/tests/conditional_formatting/__snapshots__/conditional_formatting_panel_component.test.ts.snap
+++ b/tests/conditional_formatting/__snapshots__/conditional_formatting_panel_component.test.ts.snap
@@ -15,7 +15,7 @@ exports[`UI of conditional formats Conditional format list simple snapshot 1`] =
         style=""
       >
         <div
-          class="o-cf-preview w-100"
+          class="o-cf-preview w-100 border-bottom"
           data-id="1"
         >
           <div
@@ -54,7 +54,7 @@ exports[`UI of conditional formats Conditional format list simple snapshot 1`] =
             </div>
             
             <div
-              class="o-cf-preview-icon d-flex justify-content-around align-items-center me-2 bg-white"
+              class="o-cf-preview-icon d-flex justify-content-around align-items-center me-2 bg-white border"
               style="background:#FF0000; "
             >
                123 
@@ -102,7 +102,7 @@ exports[`UI of conditional formats Conditional format list simple snapshot 1`] =
         style=""
       >
         <div
-          class="o-cf-preview w-100"
+          class="o-cf-preview w-100 border-bottom"
           data-id="2"
         >
           <div
@@ -141,7 +141,7 @@ exports[`UI of conditional formats Conditional format list simple snapshot 1`] =
             </div>
             
             <div
-              class="o-cf-preview-icon d-flex justify-content-around align-items-center me-2 bg-white"
+              class="o-cf-preview-icon d-flex justify-content-around align-items-center me-2 bg-white border"
               style="background-image: linear-gradient(to right, #FF00FF, #123456)"
             >
                123 

--- a/tests/grid/__snapshots__/grid_component.test.ts.snap
+++ b/tests/grid/__snapshots__/grid_component.test.ts.snap
@@ -143,7 +143,7 @@ exports[`Grid component simple rendering snapshot 1`] = `
   </div>
   
   <div
-    class="o-scrollbar corner"
+    class="o-scrollbar corner border-top border-start"
   />
 </div>
 `;

--- a/tests/link/__snapshots__/link_display_component.test.ts.snap
+++ b/tests/link/__snapshots__/link_display_component.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`link display component simple snapshot 1`] = `
-"<div class="o-popover rounded o-popover-grid-index" style="display: block; max-height: 962px; max-width: 985px; top: 49px; left: 48px;"><div class="o-popover-content"><div class="o-link-tool d-flex align-items-center bg-white"><!-- t-key to prevent owl from re-using the previous img element when the link changes.
+"<div class="o-popover rounded o-popover-grid-index" style="display: block; max-height: 962px; max-width: 985px; top: 49px; left: 48px;"><div class="o-popover-content"><div class="o-link-tool d-flex align-items-center bg-white rounded"><!-- t-key to prevent owl from re-using the previous img element when the link changes.
     The wrong/previous image would be displayed while the new one loads --><img src="https://www.google.com/s2/favicons?sz=16&amp;domain=https://url.com"><a class="o-link" target="_blank" href="https://url.com" title="https://url.com">https://url.com</a><span class="o-link-icon o-unlink" title="Remove link"><div class="o-icon"><i class="fa fa-chain-broken"></i></div></span><span class="o-link-icon o-edit-link" title="Edit link"><div class="o-icon"><i class="fa fa-pencil-square-o"></i></div></span></div></div></div>"
 `;

--- a/tests/menus/__snapshots__/context_menu_component.test.ts.snap
+++ b/tests/menus/__snapshots__/context_menu_component.test.ts.snap
@@ -170,7 +170,7 @@ exports[`Context MenuPopover integration tests context menu simple rendering 1`]
     </div>
   </div>
   <div
-    class="o-separator"
+    class="o-separator border-bottom"
   />
   
   
@@ -290,7 +290,7 @@ exports[`Context MenuPopover integration tests context menu simple rendering 1`]
     </div>
   </div>
   <div
-    class="o-separator"
+    class="o-separator border-bottom"
   />
   
   
@@ -404,7 +404,7 @@ exports[`Context MenuPopover integration tests context menu simple rendering 1`]
     </div>
   </div>
   <div
-    class="o-separator"
+    class="o-separator border-bottom"
   />
   
   

--- a/tests/pivots/spreadsheet_pivot/__snapshots__/spreadsheet_pivot_side_panel.test.ts.snap
+++ b/tests/pivots/spreadsheet_pivot/__snapshots__/spreadsheet_pivot_side_panel.test.ts.snap
@@ -2,10 +2,10 @@
 
 exports[`Spreadsheet pivot side panel It should correctly be displayed 1`] = `
 <div
-  class="o-sidePanel h-100 bg-white"
+  class="o-sidePanel h-100 bg-white border-top border-start"
 >
   <div
-    class="o-sidePanelHeader d-flex align-items-center justify-content-between"
+    class="o-sidePanelHeader d-flex align-items-center justify-content-between border-bottom"
   >
     <div
       class="o-collapse-panel o-sidePanelAction rounded"
@@ -250,7 +250,7 @@ exports[`Spreadsheet pivot side panel It should correctly be displayed 1`] = `
                   title="Changing the pivot definition requires to reload the data. It may take some time."
                 >
                   <input
-                    class="me-2 flex-shrink-0"
+                    class="me-2 flex-shrink-0 border"
                     type="checkbox"
                   />
                   <span
@@ -336,7 +336,7 @@ exports[`Spreadsheet pivot side panel It should correctly be displayed 1`] = `
                         role="button"
                       >
                         <input
-                          class="me-2 flex-shrink-0"
+                          class="me-2 flex-shrink-0 border"
                           name="displayTotals"
                           type="checkbox"
                         />
@@ -360,7 +360,7 @@ exports[`Spreadsheet pivot side panel It should correctly be displayed 1`] = `
                         role="button"
                       >
                         <input
-                          class="me-2 flex-shrink-0"
+                          class="me-2 flex-shrink-0 border"
                           name="displayColumnHeaders"
                           type="checkbox"
                         />
@@ -384,7 +384,7 @@ exports[`Spreadsheet pivot side panel It should correctly be displayed 1`] = `
                         role="button"
                       >
                         <input
-                          class="me-2 flex-shrink-0"
+                          class="me-2 flex-shrink-0 border"
                           name="displayMeasuresRow"
                           type="checkbox"
                         />
@@ -407,10 +407,10 @@ exports[`Spreadsheet pivot side panel It should correctly be displayed 1`] = `
 
 exports[`Spreadsheet pivot side panel It should display only the selection input when the dataSet is not valid 1`] = `
 <div
-  class="o-sidePanel h-100 bg-white"
+  class="o-sidePanel h-100 bg-white border-top border-start"
 >
   <div
-    class="o-sidePanelHeader d-flex align-items-center justify-content-between"
+    class="o-sidePanelHeader d-flex align-items-center justify-content-between border-bottom"
   >
     <div
       class="o-collapse-panel o-sidePanelAction rounded"
@@ -640,7 +640,7 @@ exports[`Spreadsheet pivot side panel It should display only the selection input
                   title="Changing the pivot definition requires to reload the data. It may take some time."
                 >
                   <input
-                    class="me-2 flex-shrink-0"
+                    class="me-2 flex-shrink-0 border"
                     type="checkbox"
                   />
                   <span
@@ -726,7 +726,7 @@ exports[`Spreadsheet pivot side panel It should display only the selection input
                         role="button"
                       >
                         <input
-                          class="me-2 flex-shrink-0"
+                          class="me-2 flex-shrink-0 border"
                           name="displayTotals"
                           type="checkbox"
                         />
@@ -750,7 +750,7 @@ exports[`Spreadsheet pivot side panel It should display only the selection input
                         role="button"
                       >
                         <input
-                          class="me-2 flex-shrink-0"
+                          class="me-2 flex-shrink-0 border"
                           name="displayColumnHeaders"
                           type="checkbox"
                         />
@@ -774,7 +774,7 @@ exports[`Spreadsheet pivot side panel It should display only the selection input
                         role="button"
                       >
                         <input
-                          class="me-2 flex-shrink-0"
+                          class="me-2 flex-shrink-0 border"
                           name="displayMeasuresRow"
                           type="checkbox"
                         />

--- a/tests/side_panels/building_blocks/__snapshots__/chart_title.test.ts.snap
+++ b/tests/side_panels/building_blocks/__snapshots__/chart_title.test.ts.snap
@@ -72,7 +72,7 @@ exports[`Chart title Can render a chart title component 1`] = `
         </span>
         
         <div
-          class="o-divider"
+          class="o-divider border-start"
         />
         
         <div
@@ -112,7 +112,7 @@ exports[`Chart title Can render a chart title component 1`] = `
         
         
         <div
-          class="o-divider"
+          class="o-divider border-start"
         />
         <div
           class="o-dropdown"
@@ -142,7 +142,7 @@ exports[`Chart title Can render a chart title component 1`] = `
         </div>
         
         <div
-          class="o-divider"
+          class="o-divider border-start"
         />
         <div
           class="o-color-picker-widget"

--- a/tests/side_panels/building_blocks/__snapshots__/label_range.test.ts.snap
+++ b/tests/side_panels/building_blocks/__snapshots__/label_range.test.ts.snap
@@ -49,7 +49,7 @@ exports[`Label range Can add options to the label range component 1`] = `
       role="button"
     >
       <input
-        class="me-2 flex-shrink-0"
+        class="me-2 flex-shrink-0 border"
         name="my_option"
         type="checkbox"
       />

--- a/tests/side_panels/building_blocks/__snapshots__/round_color_picker.test.ts.snap
+++ b/tests/side_panels/building_blocks/__snapshots__/round_color_picker.test.ts.snap
@@ -6,7 +6,7 @@ exports[`Panel color picker Can render a panel color picker component 1`] = `
     class="o-spreadsheet"
   >
     <div
-      class="o-round-color-picker-button rounded-circle"
+      class="o-round-color-picker-button rounded-circle border"
       style=""
     />
     

--- a/tests/side_panels/components/__snapshots__/checkbox.test.ts.snap
+++ b/tests/side_panels/components/__snapshots__/checkbox.test.ts.snap
@@ -7,7 +7,7 @@ exports[`Checkbox Can render a checkbox 1`] = `
     role="button"
   >
     <input
-      class="me-2 flex-shrink-0"
+      class="me-2 flex-shrink-0 border"
       type="checkbox"
     />
     

--- a/tests/spreadsheet/__snapshots__/spreadsheet_component.test.ts.snap
+++ b/tests/spreadsheet/__snapshots__/spreadsheet_component.test.ts.snap
@@ -13,7 +13,7 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
       class="o-spreadsheet-topbar d-flex flex-column user-select-none bg-white"
     >
       <div
-        class="o-topbar-top d-flex justify-content-between"
+        class="o-topbar-top d-flex justify-content-between border-bottom"
       >
         <!-- Menus -->
         <div
@@ -188,7 +188,7 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
               
               
               <div
-                class="o-topbar-divider"
+                class="o-topbar-divider border-end"
               />
               
             </div>
@@ -278,7 +278,7 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
               
               
               <div
-                class="o-topbar-divider"
+                class="o-topbar-divider border-end"
               />
               
             </div>
@@ -315,7 +315,7 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
               
               
               <div
-                class="o-topbar-divider"
+                class="o-topbar-divider border-end"
               />
               
             </div>
@@ -413,7 +413,7 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
               
               
               <div
-                class="o-topbar-divider"
+                class="o-topbar-divider border-end"
               />
               
             </div>
@@ -492,7 +492,7 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
               
               
               <div
-                class="o-topbar-divider"
+                class="o-topbar-divider border-end"
               />
               
             </div>
@@ -602,7 +602,7 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
               
               
               <div
-                class="o-topbar-divider"
+                class="o-topbar-divider border-end"
               />
               
             </div>
@@ -706,7 +706,7 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
           class="o-topbar-composer-container w-100"
         >
           <div
-            class="o-topbar-composer position-relative bg-white user-select-text d-flex o-topbar-composer-inactive"
+            class="o-topbar-composer position-relative bg-white user-select-text d-flex border o-topbar-composer-inactive"
           >
             <div
               class="o-composer-container w-100 h-100"
@@ -914,7 +914,7 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
         </div>
         
         <div
-          class="o-scrollbar corner"
+          class="o-scrollbar corner border-top border-start"
         />
       </div>
     </div>
@@ -925,7 +925,7 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
   >
     
     <div
-      class="o-spreadsheet-bottom-bar o-two-columns d-flex flex-fill align-items-center overflow-hidden"
+      class="o-spreadsheet-bottom-bar o-two-columns d-flex flex-fill align-items-center overflow-hidden border-top"
     >
       <div
         class="o-ripple-container position-relative add-sheet-container"
@@ -1021,7 +1021,7 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
               class="position-relative"
             >
               <div
-                class="o-sheet d-flex align-items-center user-select-none text-nowrap active"
+                class="o-sheet d-flex align-items-center user-select-none text-nowrap border-start border-end active"
                 composerfocusableelement="true"
                 data-id="sh1"
                 style=""
@@ -1203,7 +1203,7 @@ exports[`components take the small screen into account 1`] = `
               
               
               <div
-                class="o-topbar-divider"
+                class="o-topbar-divider border-end"
               />
               
             </div>
@@ -1293,7 +1293,7 @@ exports[`components take the small screen into account 1`] = `
               
               
               <div
-                class="o-topbar-divider"
+                class="o-topbar-divider border-end"
               />
               
             </div>
@@ -1330,7 +1330,7 @@ exports[`components take the small screen into account 1`] = `
               
               
               <div
-                class="o-topbar-divider"
+                class="o-topbar-divider border-end"
               />
               
             </div>
@@ -1428,7 +1428,7 @@ exports[`components take the small screen into account 1`] = `
               
               
               <div
-                class="o-topbar-divider"
+                class="o-topbar-divider border-end"
               />
               
             </div>
@@ -1507,7 +1507,7 @@ exports[`components take the small screen into account 1`] = `
               
               
               <div
-                class="o-topbar-divider"
+                class="o-topbar-divider border-end"
               />
               
             </div>
@@ -1617,7 +1617,7 @@ exports[`components take the small screen into account 1`] = `
               
               
               <div
-                class="o-topbar-divider"
+                class="o-topbar-divider border-end"
               />
               
             </div>
@@ -1886,7 +1886,7 @@ exports[`components take the small screen into account 1`] = `
         </div>
         
         <div
-          class="o-scrollbar corner"
+          class="o-scrollbar corner border-top border-start"
         />
       </div>
     </div>
@@ -1900,7 +1900,7 @@ exports[`components take the small screen into account 1`] = `
     >
       
       <div
-        class="o-small-composer px-2 py-2 position-relative bg-white"
+        class="o-small-composer px-2 py-2 position-relative bg-white border"
       >
         <div
           class="w-100"
@@ -1945,7 +1945,7 @@ exports[`components take the small screen into account 1`] = `
       </div>
       
       <div
-        class="d-flex flex-fill align-items-center bottom-bar-menu"
+        class="d-flex flex-fill align-items-center bottom-bar-menu border-top border-bottom"
       >
         <div
           class="o-ripple-container position-relative"
@@ -1969,7 +1969,7 @@ exports[`components take the small screen into account 1`] = `
         </div>
         
         <div
-          class="o-spreadsheet-bottom-bar o-two-columns d-flex flex-fill align-items-center overflow-hidden"
+          class="o-spreadsheet-bottom-bar o-two-columns d-flex flex-fill align-items-center overflow-hidden border-top"
         >
           <div
             class="o-ripple-container position-relative add-sheet-container"
@@ -2065,7 +2065,7 @@ exports[`components take the small screen into account 1`] = `
                   class="position-relative"
                 >
                   <div
-                    class="o-sheet d-flex align-items-center user-select-none text-nowrap active"
+                    class="o-sheet d-flex align-items-center user-select-none text-nowrap border-start border-end active"
                     composerfocusableelement="true"
                     data-id="Sheet1"
                     style=""

--- a/tests/table/__snapshots__/filter_menu_component.test.ts.snap
+++ b/tests/table/__snapshots__/filter_menu_component.test.ts.snap
@@ -21,7 +21,7 @@ exports[`Filter menu component Filter Tests Filter menu is correctly rendered 1`
     class="o-filter-menu-content"
   >
     <div
-      class="o-separator"
+      class="o-separator border-bottom"
     />
     <div>
       <div
@@ -153,7 +153,7 @@ exports[`Filter menu component Filter Tests Filter menu is correctly rendered 1`
             </i>
           </div>
           <div
-            class="o-filter-menu-list d-flex flex-column"
+            class="o-filter-menu-list d-flex flex-column border"
           >
             <div
               class="o-filter-menu-item o-filter-menu-value"
@@ -165,7 +165,7 @@ exports[`Filter menu component Filter Tests Filter menu is correctly rendered 1`
                 title="(Blanks)"
               >
                 <input
-                  class="me-2 flex-shrink-0"
+                  class="me-2 flex-shrink-0 border"
                   name="(Blanks)"
                   type="checkbox"
                 />
@@ -188,7 +188,7 @@ exports[`Filter menu component Filter Tests Filter menu is correctly rendered 1`
                 title="1"
               >
                 <input
-                  class="me-2 flex-shrink-0"
+                  class="me-2 flex-shrink-0 border"
                   name="1"
                   type="checkbox"
                 />
@@ -211,7 +211,7 @@ exports[`Filter menu component Filter Tests Filter menu is correctly rendered 1`
                 title="2"
               >
                 <input
-                  class="me-2 flex-shrink-0"
+                  class="me-2 flex-shrink-0 border"
                   name="2"
                   type="checkbox"
                 />


### PR DESCRIPTION
## Description

With this commit, the main background of the dark mode changed from `os-gray-100` to `os-gray-200`. The border colors were also changed to have an higher contrast with the new background color.

Task: [5265478](https://www.odoo.com/odoo/2328/tasks/5265478)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo