### PR TITLE
[FIX] Demo: Fix wrapper style

### DIFF
--- a/demo/main.css
+++ b/demo/main.css
@@ -6,4 +6,6 @@ body {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Ubuntu,
     "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
     "Noto Color Emoji" !important;
+  height: 100dvh !important;
+  width: 100dvw !important;
 }

--- a/demo/main.js
+++ b/demo/main.js
@@ -326,13 +326,13 @@ class Demo extends Component {
 }
 
 Demo.template = xml/* xml */ `
-  <div t-if="state.displayHeader" class="d-flex flex flex-column justify-content">
+  <div t-if="state.displayHeader" class="d-flex flex flex-column justify-content w-100 h-100">
     <div class="p-3 border-bottom">A header</div>
-    <div class="flex-fill" style="height: 100dvh !important;width: 100dvw !important;">
+    <div class="flex-fill">
       <Spreadsheet model="model" notifyUser="notifyUser" t-key="state.key"/>
     </div>
   </div>
-  <div t-else="" style="height: 100dvh !important;width: 100dvw !important;">
+  <div t-else="" class="w-100 h-100">
     <Spreadsheet model="model" t-key="state.key" notifyUser="notifyUser"/>
   </div>
 `;


### PR DESCRIPTION
When we introduced the mobile mode, we started relying on the dynamic vewport height (dvh) to account for the resizing of the viewport when the virtual keyboard of a smarphone would pop up.

However, the rule we chose was to set the height of spreadsheet wrapper to 100dvh, which stands for 100% of the dynamic viewport height. As such, if we were to add some header before the Spreadsheet component, the latter would keep its size as 100% of the viewport, meaning that the full component is pushed downwards and it overflows from the page.

This revision places the 100dvh rule over the full page to account for any header that could be added in the future.

Task: 5212448

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo