### PR TITLE
[FIX] borders: preserve side borders when combining External and All

### DIFF
--- a/tests/borders/border_plugin.test.ts
+++ b/tests/borders/border_plugin.test.ts
@@ -147,6 +147,60 @@ describe("borders", () => {
     });
   });
 
+  test("Preserves side borders when combining external and all via command", () => {
+    const model = new Model();
+    const defaultBorder = DEFAULT_BORDER_DESC;
+
+    setZoneBorders(model, { position: "all" }, ["C3"]);
+    setBordersOnTarget(model, ["C2"], {
+      top: defaultBorder,
+      right: defaultBorder,
+      left: defaultBorder,
+    });
+    setBordersOnTarget(model, ["C4"], {
+      bottom: defaultBorder,
+      left: defaultBorder,
+      right: defaultBorder,
+    });
+    setBordersOnTarget(model, ["B3"], {
+      top: defaultBorder,
+      bottom: defaultBorder,
+      left: defaultBorder,
+    });
+    setBordersOnTarget(model, ["D3"], {
+      top: defaultBorder,
+      bottom: defaultBorder,
+      right: defaultBorder,
+    });
+
+    expect(getBorder(model, "C3")).toEqual({
+      top: defaultBorder,
+      bottom: defaultBorder,
+      left: defaultBorder,
+      right: defaultBorder,
+    });
+    expect(getBorder(model, "C2")).toEqual({
+      top: defaultBorder,
+      left: defaultBorder,
+      right: defaultBorder,
+    });
+    expect(getBorder(model, "C4")).toEqual({
+      bottom: defaultBorder,
+      left: defaultBorder,
+      right: defaultBorder,
+    });
+    expect(getBorder(model, "B3")).toEqual({
+      top: defaultBorder,
+      left: defaultBorder,
+      bottom: defaultBorder,
+    });
+    expect(getBorder(model, "D3")).toEqual({
+      top: defaultBorder,
+      bottom: defaultBorder,
+      right: defaultBorder,
+    });
+  });
+
   test("can set all borders in a zone", () => {
     const model = new Model();
 


### PR DESCRIPTION
## Description:

When applying an External border on a range and then applying All borders on an inner/overlapping range, the side borders (left/right) of the inner cells were lost after re-opening the spreadsheet.

The exported border data was correct, but the BordersPlugin recomputation logic in addBorder incorrectly cleared adjacent borders on import/update. The adjacency check (adjacent(existingBorder.zone, zone)) reported the side of the existing zone, but we were deciding whether to clear it based on the same side key in the new border, instead of the opposite side (shared edge) on the new zone. As a result, importing the combination of:

C2:C4 with All borders
B2:B4 with left/top/bottom
D2:D4 with right/top/bottom

ended up clearing the left and right borders of C2:C4.

This PR adjusts the adjacent clearing logic to:

Map the adjacent side of the existing zone to the opposite side on the new zone.

Only clear the existing side if the corresponding opposite side is actually being written on the new border.

Task: [5270171](https://www.odoo.com/odoo/2328/tasks/5270171)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo