### PR TITLE
[FIX] side panel: close selection input when switching tab

### DIFF
--- a/src/components/selection_input/selection_input.ts
+++ b/src/components/selection_input/selection_input.ts
@@ -129,6 +129,13 @@ export class SelectionInput extends Component<Props, SpreadsheetChildEnv> {
       () => this.focusedInput.el?.focus(),
       () => [this.focusedInput.el]
     );
+    useEffect(() => {
+      // Check the offsetParent to know if the input or an ancestor is `display: none` (eg. when changing side panel tab)
+      if (this.store.hasFocus && this.selectionRef.el?.offsetParent === null) {
+        this.reset();
+      }
+    });
+
     this.store = useLocalStore(
       SelectionInputStore,
       this.props.ranges,

--- a/tests/figures/chart/charts_component.test.ts
+++ b/tests/figures/chart/charts_component.test.ts
@@ -11,6 +11,7 @@ import {
 import { toHex, toZone } from "../../../src/helpers";
 import { ScorecardChart } from "../../../src/helpers/figures/charts";
 import { getChartColorsGenerator } from "../../../src/helpers/figures/charts/runtime";
+import { HighlightStore } from "../../../src/stores/highlight_store";
 import {
   CHART_TYPES,
   ChartDefinition,
@@ -1126,6 +1127,22 @@ describe("charts", () => {
     const designTab = fixture.querySelector(".o-panel-element.inactive")!;
     await click(designTab);
     expect(chartPanel.scrollTop).toBe(100);
+  });
+
+  test("selection input is closed when switching tab", async () => {
+    createTestChart("basicChart");
+    await mountChartSidePanel();
+    const highlightStore = env.getStore(HighlightStore);
+
+    await simulateClick(".o-selection-input input");
+    expect(".o-selection-ok").toHaveCount(1);
+    expect(highlightStore.highlights.length).toBe(1);
+
+    await openChartDesignSidePanel(model, env, fixture, chartId);
+    await nextTick(); // the check is done in a `useEffect`, we need to wait for the next render
+
+    expect(".o-selection-ok").toHaveCount(0);
+    expect(highlightStore.highlights.length).toBe(0);
   });
 
   describe.each(TEST_CHART_TYPES)("selecting other chart will adapt sidepanel", (chartType) => {

--- a/tests/setup/jest.setup.ts
+++ b/tests/setup/jest.setup.ts
@@ -87,6 +87,31 @@ beforeEach(() => {
       const blob = new window.Blob([data], { type });
       setTimeout(() => callback(blob), 0);
     });
+
+  // offsetParent should return the nearest positioned ancestor, or null if an ancestor has `display: none`
+  jest
+    .spyOn(HTMLElement.prototype, "offsetParent", "get")
+    .mockImplementation(function (this: HTMLElement) {
+      for (let element: HTMLElement | null = this; element; element = element.parentElement) {
+        if (getComputedStyle(element).display === "none" || element.classList.contains("d-none")) {
+          return null;
+        }
+      }
+
+      if (
+        getComputedStyle(this).position === "fixed" ||
+        this.classList.contains("position-fixed")
+      ) {
+        return null;
+      }
+
+      if (this.tagName.toLowerCase() in ["html", "body"]) {
+        return null;
+      }
+
+      return this.parentElement; // should be nearest positioned ancestor, but simplified for tests
+    });
+
   patchSessionMove();
 });
 


### PR DESCRIPTION
When focusing the selection input in the chart side panel, changing tab would not close the selection input, even though the input isn't visible anymore.

It's because since 91c0583, changing the tab would keep the component mounted, only hiding it with `d-none` (to keep its state). Relying on the selection input `onWillUnmount` to reset the state is not enough.

We now rely on a `useEffect` that checks the `input.offsetParent` property, which is `null` when an ancestor has `display: none`.

Task: 5249165


Task: [5249165](https://www.odoo.com/odoo/2328/tasks/5249165)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo