### PR TITLE
[IMP] Menu: Delegate enabled to children items

### DIFF
--- a/src/actions/view_actions.ts
+++ b/src/actions/view_actions.ts
@@ -131,7 +131,6 @@ export const unFreezeRows: ActionSpec = {
     env.model.dispatch("UNFREEZE_ROWS", {
       sheetId: env.model.getters.getActiveSheetId(),
     }),
-  isReadonlyAllowed: true,
   isVisible: (env) =>
     !!env.model.getters.getPaneDivisions(env.model.getters.getActiveSheetId()).ySplit,
 };
@@ -139,13 +138,11 @@ export const unFreezeRows: ActionSpec = {
 export const freezeFirstRow: ActionSpec = {
   name: _t("1 row"),
   execute: (env) => interactiveFreezeColumnsRows(env, "ROW", 1),
-  isReadonlyAllowed: true,
 };
 
 export const freezeSecondRow: ActionSpec = {
   name: _t("2 rows"),
   execute: (env) => interactiveFreezeColumnsRows(env, "ROW", 2),
-  isReadonlyAllowed: true,
 };
 
 export const freezeCurrentRow: ActionSpec = {
@@ -154,7 +151,6 @@ export const freezeCurrentRow: ActionSpec = {
     const { bottom } = env.model.getters.getSelectedZone();
     interactiveFreezeColumnsRows(env, "ROW", bottom + 1);
   },
-  isReadonlyAllowed: true,
 };
 
 export const unFreezeCols: ActionSpec = {
@@ -163,7 +159,6 @@ export const unFreezeCols: ActionSpec = {
     env.model.dispatch("UNFREEZE_COLUMNS", {
       sheetId: env.model.getters.getActiveSheetId(),
     }),
-  isReadonlyAllowed: true,
   isVisible: (env) =>
     !!env.model.getters.getPaneDivisions(env.model.getters.getActiveSheetId()).xSplit,
 };
@@ -171,13 +166,11 @@ export const unFreezeCols: ActionSpec = {
 export const freezeFirstCol: ActionSpec = {
   name: _t("1 column"),
   execute: (env) => interactiveFreezeColumnsRows(env, "COL", 1),
-  isReadonlyAllowed: true,
 };
 
 export const freezeSecondCol: ActionSpec = {
   name: _t("2 columns"),
   execute: (env) => interactiveFreezeColumnsRows(env, "COL", 2),
-  isReadonlyAllowed: true,
 };
 
 export const freezeCurrentCol: ActionSpec = {
@@ -186,7 +179,6 @@ export const freezeCurrentCol: ActionSpec = {
     const { right } = env.model.getters.getSelectedZone();
     interactiveFreezeColumnsRows(env, "COL", right + 1);
   },
-  isReadonlyAllowed: true,
 };
 
 export const viewGridlines: ActionSpec = {

--- a/src/components/menu/menu.css
+++ b/src/components/menu/menu.css
@@ -12,15 +12,26 @@
           var(--os-desktop-menu-item-height) - 2 * var(--os-menu-item-padding-vertical)
         );
       }
-      &:not(.disabled) {
+      & {
         &:hover,
         &.o-menu-item-active {
           background-color: var(--os-button-active-bg);
           color: var(--os-button-active-text-color);
         }
+        .o-menu-item-icon {
+          .o-icon {
+            color: var(--os-icons-color);
+          }
+        }
+        .o-menu-item-description {
+          color: grey;
+        }
       }
       &.disabled {
-        color: var(--os-disabled-text-color);
+        &,
+        .o-menu-item-description {
+          color: var(--os-disabled-text-color);
+        }
       }
       .o-menu-item-name {
         min-width: 40%;
@@ -28,12 +39,6 @@
       .o-menu-item-icon {
         display: inline-block;
         margin: 0px 8px 0px 0px;
-      }
-      .o-menu-item-description {
-        color: grey;
-      }
-      &.disabled {
-        cursor: not-allowed;
       }
     }
   }

--- a/src/components/menu/menu.ts
+++ b/src/components/menu/menu.ts
@@ -118,10 +118,15 @@ export class Menu extends Component<MenuProps, SpreadsheetChildEnv> {
   }
 
   isEnabled(menu: Action) {
-    if (menu.isEnabled(this.env)) {
-      return this.env.model.getters.isReadonly() ? menu.isReadonlyAllowed : true;
+    const children = menu.children?.(this.env);
+    if (children.length) {
+      return children.some((child) => this.isEnabled(child));
+    } else {
+      if (menu.isEnabled(this.env)) {
+        return this.env.model.getters.isReadonly() ? menu.isReadonlyAllowed : true;
+      }
+      return false;
     }
-    return false;
   }
 
   get menuStyle() {

--- a/src/components/menu_popover/menu_popover.ts
+++ b/src/components/menu_popover/menu_popover.ts
@@ -245,17 +245,15 @@ export class MenuPopover extends Component<Props, SpreadsheetChildEnv> {
   }
 
   onMouseOver(menu: Action, ev: MouseEvent) {
-    if (this.isEnabled(menu)) {
-      if (this.isParentMenu(this.subMenu, menu)) {
-        this.openingTimeOut.clear();
-        return;
-      }
-      const currentTarget = ev.currentTarget as HTMLElement;
-      if (this.isRoot(menu)) {
-        this.openingTimeOut.schedule(() => {
-          this.openSubMenu(menu, currentTarget);
-        }, TIMEOUT_DELAY);
-      }
+    if (this.isParentMenu(this.subMenu, menu)) {
+      this.openingTimeOut.clear();
+      return;
+    }
+    const currentTarget = ev.currentTarget as HTMLElement;
+    if (this.isRoot(menu)) {
+      this.openingTimeOut.schedule(() => {
+        this.openSubMenu(menu, currentTarget);
+      }, TIMEOUT_DELAY);
     }
   }
 

--- a/src/registries/menus/number_format_menu_registry.ts
+++ b/src/registries/menus/number_format_menu_registry.ts
@@ -1,7 +1,7 @@
 import { Registry } from "@odoo/o-spreadsheet-engine/registries/registry";
 import { _t } from "@odoo/o-spreadsheet-engine/translation";
 import { SpreadsheetChildEnv } from "@odoo/o-spreadsheet-engine/types/spreadsheet_env";
-import { ActionSpec, createActions } from "../../actions/action";
+import { ActionSpec } from "../../actions/action";
 import * as ACTION_FORMAT from "../../actions/format_actions";
 import { isDateTimeFormat, memoize } from "../../helpers";
 import { Format } from "../../types";
@@ -138,7 +138,7 @@ export const formatNumberMenuItemSpec: ActionSpec = {
       if (customFormats.length > 0) {
         customFormats[customFormats.length - 1].separator = true;
       }
-      return createActions([...numberFormatMenuRegistry.getAll(), ...customFormats]);
+      return [...numberFormatMenuRegistry.getAll(), ...customFormats];
     },
   ],
 };

--- a/src/registries/menus/topbar_menu_registry.ts
+++ b/src/registries/menus/topbar_menu_registry.ts
@@ -22,7 +22,6 @@ topbarMenuRegistry
   .add("file", {
     name: _t("File"),
     sequence: 10,
-    isReadonlyAllowed: true,
   })
   .addChild("settings", ["file"], {
     name: _t("Settings"),
@@ -39,7 +38,6 @@ topbarMenuRegistry
   .add("edit", {
     name: _t("Edit"),
     sequence: 20,
-    isReadonlyAllowed: true,
   })
   .addChild("undo", ["edit"], {
     ...ACTION_EDIT.undo,
@@ -126,7 +124,6 @@ topbarMenuRegistry
   .add("view", {
     name: _t("View"),
     sequence: 30,
-    isReadonlyAllowed: true,
   })
   .addChild("unfreeze_panes", ["view"], {
     ...ACTION_VIEW.unFreezePane,
@@ -225,7 +222,6 @@ topbarMenuRegistry
   .add("insert", {
     name: _t("Insert"),
     sequence: 40,
-    isReadonlyAllowed: true,
   })
   .addChild("insert_row", ["insert"], {
     ...ACTION_INSERT.insertRow,
@@ -346,7 +342,6 @@ topbarMenuRegistry
   .add("format", {
     name: _t("Format"),
     sequence: 50,
-    isReadonlyAllowed: true,
   })
   .addChild("format_number", ["format"], {
     ...formatNumberMenuItemSpec,
@@ -441,7 +436,6 @@ topbarMenuRegistry
   .add("data", {
     name: _t("Data"),
     sequence: 60,
-    isReadonlyAllowed: true,
   })
   .addChild("sort_range", ["data"], {
     ...ACTION_DATA.sortRange,

--- a/tests/menus/menu_component.test.ts
+++ b/tests/menus/menu_component.test.ts
@@ -1,3 +1,4 @@
+import { Model } from "@odoo/o-spreadsheet-engine";
 import { createActions } from "../../src/actions/action";
 import { Menu } from "../../src/components/menu/menu";
 import { simulateClick } from "../test_helpers/dom_helper";
@@ -18,6 +19,30 @@ describe("Menu component", () => {
     const selector = ".o-menu div[data-name='test_menu']";
     const { fixture } = await mountComponent(Menu, {
       props: { menuItems, onClose: () => {}, onClickMenu: () => callback() },
+    });
+
+    expect(fixture.querySelector(selector)!.classList).toContain("disabled");
+    await simulateClick(selector);
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  test("Execute is not called when menu item is ont readonly allowed", async () => {
+    const callback = jest.fn();
+    const menuItems = createActions([
+      {
+        id: "test_menu",
+        name: "Test Menu",
+        isEnabled: () => true,
+        execute: () => {},
+      },
+    ]);
+
+    const selector = ".o-menu div[data-name='test_menu']";
+    const model = new Model();
+    model.updateMode("readonly");
+    const { fixture } = await mountComponent(Menu, {
+      props: { menuItems, onClose: () => {}, onClickMenu: () => callback() },
+      env: { model },
     });
 
     expect(fixture.querySelector(selector)!.classList).toContain("disabled");


### PR DESCRIPTION
Currently, if a menu is evaluated as disabled, we disable it and prevent the possibility to see its children by hover. However, there are some issues with this:
- the user is mislead because we keep showing the arrow that suggest the presence of children items
- the user can simply not navigate through the submenus to see what kind of feature could be available
- if a menu has several children some of which are readonlyAllowed, then the readonlyAllowed condition has to be set on the parent as well; the 'enabling' condition therefore becomes a combination set on both the parent and children
- if a parent menu is computed as 'enabled' it will not be greyed out (suggests that it has useful children) even if the said children are not enabled.

This revision changes the computation of 'enabled' state of item by looking at the full tree of children and applies the following logic; A parent menu is disabled if every leaf of the tree is disabled. A single 'enabled' leaf (that is a child without children of its own) will make all its parent enabled as well, up to the root. We also allow all submenus to be opened regardless of the state of the parent.

The user will therefore have a visual hint that there are active submenus or not (if all children are disabled, so will be the parent) and they will also have the possibility to have a look at all children to explore the possibilities.

Task: 5331717

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo