### PR TITLE
[FIX] cf: fix background color of conditional formatting preview

### DIFF
--- a/src/components/side_panel/conditional_formatting/cf_preview/cf_preview.xml
+++ b/src/components/side_panel/conditional_formatting/cf_preview/cf_preview.xml
@@ -24,7 +24,7 @@
         <t t-else="">
           <div
             t-att-style="getPreviewImageStyle(cf.rule)"
-            class="o-cf-preview-icon d-flex justify-content-around align-items-center me-2 bg-white border">
+            class="o-cf-preview-icon d-flex justify-content-around align-items-center me-2 border">
             123
           </div>
         </t>

--- a/tests/conditional_formatting/__snapshots__/conditional_formatting_panel_component.test.ts.snap
+++ b/tests/conditional_formatting/__snapshots__/conditional_formatting_panel_component.test.ts.snap
@@ -54,7 +54,7 @@ exports[`UI of conditional formats Conditional format list simple snapshot 1`] =
             </div>
             
             <div
-              class="o-cf-preview-icon d-flex justify-content-around align-items-center me-2 bg-white border"
+              class="o-cf-preview-icon d-flex justify-content-around align-items-center me-2 border"
               style="background:#FF0000; "
             >
                123 
@@ -141,7 +141,7 @@ exports[`UI of conditional formats Conditional format list simple snapshot 1`] =
             </div>
             
             <div
-              class="o-cf-preview-icon d-flex justify-content-around align-items-center me-2 bg-white border"
+              class="o-cf-preview-icon d-flex justify-content-around align-items-center me-2 border"
               style="background-image: linear-gradient(to right, #FF00FF, #123456)"
             >
                123 


### PR DESCRIPTION
## Description

The color of the background of the conditional formatting preview was not correct because of a wrongly placed `bg-white`.

Task: [5343875](https://www.odoo.com/odoo/2328/tasks/5343875)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo