### PR TITLE
[FIX] GridOverlay: Prevent mousedown default when selecting range

### DIFF
--- a/src/components/grid_overlay/grid_overlay.ts
+++ b/src/components/grid_overlay/grid_overlay.ts
@@ -228,6 +228,7 @@ export class GridOverlay extends Component<Props, SpreadsheetChildEnv> {
       // not main button, probably a context menu
       return;
     }
+    ev.preventDefault();
     const [col, row] = this.getCartesianCoordinates(ev);
     this.props.onCellClicked(col, row, {
       expandZone: ev.shiftKey,


### PR DESCRIPTION
When selecting a range in the grid and the composer is open, passing your selection around the composer will see its content selected as if we were actually selecting text inside the composer.

This behaviour is a direct effect of the default behaviour of the mousedown event that starts the selection. Since the focus is kept on the composer at all times, the browser behaves as if we had clicked on the composer itself even if from a user point of view, it makes little sense.

Task: 5344285

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo