### PR TITLE
[FIX] topbar: close font size editor dropdown and focus grid

### DIFF
--- a/src/components/font_size_editor/font_size_editor.ts
+++ b/src/components/font_size_editor/font_size_editor.ts
@@ -1,6 +1,8 @@
 import { Component, useExternalListener, useRef, useState } from "@odoo/owl";
 import { FONT_SIZES } from "../../constants";
 import { clip } from "../../helpers/index";
+import { Store, useStore } from "../../store_engine";
+import { DOMFocusableElementStore } from "../../stores/DOM_focus_store";
 import { SpreadsheetChildEnv } from "../../types/index";
 import { css } from "../helpers/css";
 import { isChildEvent } from "../helpers/dom_helpers";
@@ -62,7 +64,10 @@ export class FontSizeEditor extends Component<Props, SpreadsheetChildEnv> {
   private rootEditorRef = useRef("FontSizeEditor");
   private fontSizeListRef = useRef("fontSizeList");
 
+  private DOMFocusableElementStore!: Store<DOMFocusableElementStore>;
+
   setup() {
+    this.DOMFocusableElementStore = useStore(DOMFocusableElementStore);
     useExternalListener(window, "click", this.onExternalClick, { capture: true });
   }
 
@@ -123,6 +128,13 @@ export class FontSizeEditor extends Component<Props, SpreadsheetChildEnv> {
         target.value = `${this.props.currentFontSize}`;
       }
       this.props.onToggle?.();
+    }
+    if (ev.key === "Tab") {
+      ev.preventDefault();
+      ev.stopPropagation();
+      this.closeFontList();
+      this.DOMFocusableElementStore.focus();
+      return;
     }
   }
 }

--- a/src/components/font_size_editor/font_size_editor.xml
+++ b/src/components/font_size_editor/font_size_editor.xml
@@ -5,7 +5,7 @@
         class=" o-font-size-editor d-flex align-items-center"
         t-att-class="props.class"
         title="Font Size"
-        t-on-click="this.toggleFontList">
+        t-on-click.stop="this.toggleFontList">
         <input
           type="number"
           min="1"

--- a/src/components/grid_add_rows_footer/grid_add_rows_footer.xml
+++ b/src/components/grid_add_rows_footer/grid_add_rows_footer.xml
@@ -7,7 +7,8 @@
       <button
         t-on-click="onConfirm"
         t-att-disabled="state.errorFlag"
-        class="o-button flex-grow-0 me-2">
+        class="o-button flex-grow-0 me-2"
+        tabindex="-1">
         Add
       </button>
       <input
@@ -19,6 +20,7 @@
         t-on-keydown.stop="onKeydown"
         t-on-pointerdown.stop=""
         t-on-input.stop="onInput"
+        tabindex="-1"
       />
       <span>more rows at the bottom</span>
       <ValidationMessages t-if="state.errorFlag" messages="errorMessages" msgType="'error'"/>

--- a/tests/grid/__snapshots__/grid_component.test.ts.snap
+++ b/tests/grid/__snapshots__/grid_component.test.ts.snap
@@ -29,11 +29,13 @@ exports[`Grid component simple rendering snapshot 1`] = `
     >
       <button
         class="o-button flex-grow-0 me-2"
+        tabindex="-1"
       >
          Add 
       </button>
       <input
         class="o-grid-add-rows-input o-input mt-0 me-2"
+        tabindex="-1"
         type="text"
         value="100"
       />

--- a/tests/spreadsheet/__snapshots__/spreadsheet_component.test.ts.snap
+++ b/tests/spreadsheet/__snapshots__/spreadsheet_component.test.ts.snap
@@ -771,11 +771,13 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
           >
             <button
               class="o-button flex-grow-0 me-2"
+              tabindex="-1"
             >
                Add 
             </button>
             <input
               class="o-grid-add-rows-input o-input mt-0 me-2"
+              tabindex="-1"
               type="text"
               value="100"
             />
@@ -1713,11 +1715,13 @@ exports[`components take the small screen into account 1`] = `
           >
             <button
               class="o-button flex-grow-0 me-2"
+              tabindex="-1"
             >
                Add 
             </button>
             <input
               class="o-grid-add-rows-input o-input mt-0 me-2"
+              tabindex="-1"
               type="text"
               value="100"
             />

--- a/tests/top_bar_component.test.ts
+++ b/tests/top_bar_component.test.ts
@@ -29,6 +29,7 @@ import {
   doubleClick,
   getElComputedStyle,
   getTextNodes,
+  keyDown,
   simulateClick,
   triggerMouseEvent,
 } from "./test_helpers/dom_helper";
@@ -441,6 +442,25 @@ describe("TopBar component", () => {
     await click(fixture, '.o-text-options [data-size="8"]');
     expect(fontSizeText.value.trim()).toBe("8");
     expect(getStyle(model, "A1").fontSize).toBe(8);
+  });
+
+  test("Tab from font size editor closes the dropdown and moves focus to grid", async () => {
+    const { fixture } = await mountSpreadsheet();
+    const input = fixture.querySelector("input.o-font-size") as HTMLInputElement;
+    input.focus();
+    await nextTick();
+    expect(fixture.querySelector(".o-popover .o-text-options")).toBeTruthy();
+    await keyDown({ key: "Tab" });
+    expect(fixture.querySelector(".o-popover .o-text-options")).toBeFalsy();
+    const composerEl = fixture.querySelector<HTMLElement>(".o-grid-composer .o-composer")!;
+    expect(document.activeElement).toBe(composerEl);
+  });
+
+  test("Clicking the font size dropdown arrow focuses the input", async () => {
+    const { fixture } = await mountSpreadsheet();
+    const input = fixture.querySelector("input.o-font-size") as HTMLInputElement;
+    await click(fixture, ".o-font-size-editor .o-icon");
+    expect(document.activeElement).toBe(input);
   });
 
   test("prevents default behavior of mouse wheel event on font size input", async () => {


### PR DESCRIPTION
## Description:

Pressing Tab in the font size editor moves focus to the hidden “add more rows” footer (the next focusable element in the DOM). This caused the browser to auto-scroll to the footer while the grid viewport state remained unchanged, making the footer appear to float over the grid.

Now, when the font size editor loses focus (via blur/Tab), it closes its dropdown and redirects focus back to the grid instead of the footer.

Task: [5263792](https://www.odoo.com/odoo/2328/tasks/5263792)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo