### PR TITLE
[FIx] data validation: fix date criterion

### DIFF
--- a/src/helpers/data_validation_helpers.ts
+++ b/src/helpers/data_validation_helpers.ts
@@ -1,22 +1,44 @@
 import { tryToNumber } from "../functions/helpers";
 import { DataValidationCriterion, DateCriterionValue, Locale } from "../types";
-import { DateTime, jsDateToNumber, valueToDateNumber } from "./dates";
+import { DateTime, getDaysInMonth, jsDateToNumber, valueToDateNumber } from "./dates";
 
 function toCriterionDateNumber(dateValue: Exclude<DateCriterionValue, "exactDate">): number {
   const today = DateTime.now();
   switch (dateValue) {
     case "today":
-      return jsDateToNumber(today);
-    case "yesterday":
-      return jsDateToNumber(DateTime.fromTimestamp(today.setDate(today.getDate() - 1)));
-    case "tomorrow":
-      return jsDateToNumber(DateTime.fromTimestamp(today.setDate(today.getDate() + 1)));
+      return Math.floor(jsDateToNumber(today));
+    case "yesterday": {
+      today.setDate(today.getDate() - 1);
+      return Math.floor(jsDateToNumber(today));
+    }
+    case "tomorrow": {
+      today.setDate(today.getDate() + 1);
+      return Math.floor(jsDateToNumber(today));
+    }
     case "lastWeek":
-      return jsDateToNumber(DateTime.fromTimestamp(today.setDate(today.getDate() - 7)));
-    case "lastMonth":
-      return jsDateToNumber(DateTime.fromTimestamp(today.setMonth(today.getMonth() - 1)));
+      today.setDate(today.getDate() - 6);
+      return Math.floor(jsDateToNumber(today));
+    case "lastMonth": {
+      const lastMonth = today.getMonth() === 0 ? 11 : today.getMonth() - 1;
+      const dateInLastMonth = new DateTime(today.getFullYear(), lastMonth, 1);
+      if (today.getDate() > getDaysInMonth(dateInLastMonth)) {
+        today.setDate(1);
+      } else {
+        today.setDate(today.getDate() + 1);
+        today.setMonth(today.getMonth() - 1);
+      }
+      return Math.floor(jsDateToNumber(today));
+    }
     case "lastYear":
-      return jsDateToNumber(DateTime.fromTimestamp(today.setFullYear(today.getFullYear() - 1)));
+      // Handle leap year case
+      if (today.getMonth() === 1 && today.getDate() === 29) {
+        today.setDate(28);
+        today.setFullYear(today.getFullYear() - 1);
+      } else {
+        today.setDate(today.getDate() + 1);
+        today.setFullYear(today.getFullYear() - 1);
+      }
+      return Math.floor(jsDateToNumber(today));
   }
 }
 

--- a/src/registries/data_validation_registry.ts
+++ b/src/registries/data_validation_registry.ts
@@ -13,7 +13,7 @@ import {
   isDateStrictlyBefore,
   isNotNull,
   isNumberBetween,
-  jsDateToRoundNumber,
+  jsDateToNumber,
   valueToDateNumber,
 } from "../helpers";
 import { parseLiteral } from "../helpers/cells";
@@ -173,7 +173,7 @@ dataValidationEvaluatorRegistry.add("dateIs", {
     }
 
     if (["lastWeek", "lastMonth", "lastYear"].includes(criterion.dateValue)) {
-      const today = jsDateToRoundNumber(DateTime.now());
+      const today = Math.floor(jsDateToNumber(DateTime.now()));
       return isDateBetween(dateValue, today, criterionValue);
     }
 


### PR DESCRIPTION
## Description

The relative date criterion 'pastWeek/pastMonth/pastYear' were not correct. For example the 'pastWeek' criterion would span a period of 8 days instead of 7. The dates numbers were also not always rounded down, which could lead to some issues.

Task: [5343580](https://www.odoo.com/odoo/2328/tasks/5343580)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo