### PR TITLE
[FIX] Selection: Ignore keyboard events when selecting range in the grid

### DIFF
--- a/src/components/helpers/drag_and_drop_grid_hook.ts
+++ b/src/components/helpers/drag_and_drop_grid_hook.ts
@@ -26,6 +26,10 @@ export function useDragAndDropBeyondTheViewport(env: SpreadsheetChildEnv) {
   let scrollDirection: DnDDirection = "all";
   const getters = env.model.getters;
 
+  const blockKeyboard = (ev: KeyboardEvent) => ev.preventDefault();
+  const cleanUpBlockKeyboard = () =>
+    removeEventListener("keydown", blockKeyboard, { capture: true });
+
   let cleanUpFns: (() => void)[] = [];
 
   const cleanUp = () => {
@@ -156,7 +160,9 @@ export function useDragAndDropBeyondTheViewport(env: SpreadsheetChildEnv) {
     pointerMoveCallback = onPointerMove;
     pointerUpCallback = onPointerUp;
 
-    cleanUpFns.push(startDnd(pointerMoveHandler, pointerUpHandler));
+    // block keyboard events during pointer interaction to avoid conflicts
+    addEventListener("keydown", blockKeyboard, { capture: true });
+    cleanUpFns.push(startDnd(pointerMoveHandler, pointerUpHandler), cleanUpBlockKeyboard);
   };
 
   onWillUnmount(() => {

--- a/tests/composer/composer_integration_component.test.ts
+++ b/tests/composer/composer_integration_component.test.ts
@@ -577,6 +577,16 @@ describe("Composer interactions", () => {
     createTable(model, "A1");
     expect(getTable(model, "A1")).toBeTruthy();
   });
+
+  test("keyboard inputs are disabled when selecting a range for the composer", async () => {
+    await typeInComposerGrid("=");
+    gridMouseEvent(model, "pointerdown", "C8");
+    gridMouseEvent(model, "pointermove", "B8");
+    await keyDown({ key: "A" });
+    gridMouseEvent(model, "pointerup", "B8");
+    await nextTick();
+    expect(composerStore.currentContent).toBe("=B8:C8");
+  });
 });
 
 describe("Grid composer", () => {

--- a/tests/test_helpers/dom_helper.ts
+++ b/tests/test_helpers/dom_helper.ts
@@ -218,7 +218,7 @@ export function getGridIconEventPosition(model: Model, xc: string) {
 
 export async function clickGridIcon(model: Model, xc: string) {
   const { x, y } = getGridIconEventPosition(model, xc);
-  triggerMouseEvent(".o-grid-overlay", "pointerdown", x, y);
+  simulateClick(".o-grid-overlay", x, y);
   await nextTick();
 }
 
@@ -297,6 +297,7 @@ export function triggerKeyboardEvent(
 ) {
   const ev = new KeyboardEvent(type, { bubbles: true, cancelable: true, ...eventArgs });
   dispatchEvent(selector, ev);
+  return ev;
 }
 
 function dispatchEvent(selector: string | EventTarget, ev: Event) {


### PR DESCRIPTION
Currently, users can modify the input of a composer/selection input while selecting a range in the grid. Those inputs can have side-effect that are difficult to account for as the selection is managed in a hook which is not aware of the related feature that it handles (selection, cell reference, pivot reference, selection input). A recent work to fix that: https://github.com/odoo/o-spreadsheet/pull/7400

Overall, there is no added value to be able to mix writing text while selecting ranges inside the grid so we simply disable that possibility altogether.

Task: 5347297

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo