### PR TITLE
[FIX] composer: keep edition mode inactive on cursor selection change

### DIFF
--- a/src/plugins/ui_stateful/edition.ts
+++ b/src/plugins/ui_stateful/edition.ts
@@ -144,7 +144,9 @@ export class EditionPlugin extends UIPlugin {
       case "CHANGE_COMPOSER_CURSOR_SELECTION":
         this.selectionStart = cmd.start;
         this.selectionEnd = cmd.end;
-        this.mode = "editing";
+        if (this.isSelectingForComposer()) {
+          this.mode = "editing";
+        }
         break;
       case "STOP_COMPOSER_RANGE_SELECTION":
         if (this.isSelectingForComposer()) {

--- a/tests/composer/composer_integration_component.test.ts
+++ b/tests/composer/composer_integration_component.test.ts
@@ -27,6 +27,7 @@ import {
   getElComputedStyle,
   gridMouseEvent,
   keyDown,
+  keyUp,
   rightClickCell,
   selectColumnByClicking,
   simulateClick,
@@ -336,6 +337,15 @@ describe("Composer interactions", () => {
     composerEl.dispatchEvent(new Event("keyup"));
     await clickCell(model, "C8");
     expect(getSelectionAnchorCellXc(model)).toBe("C8");
+    expect(model.getters.getEditionMode()).toBe("inactive");
+  });
+
+  test("should switch topbar composer from editing to inactive when pressing Escape on cell A1 containing '=A2'", async () => {
+    setCellContent(model, "A1", "=A2");
+    await click(fixture, ".o-spreadsheet-topbar .o-composer");
+    expect(model.getters.getEditionMode()).toBe("editing");
+    keyDown({ key: "Escape" });
+    keyUp({ key: "Escape" });
     expect(model.getters.getEditionMode()).toBe("inactive");
   });
 

--- a/tests/composer/edition_plugin.test.ts
+++ b/tests/composer/edition_plugin.test.ts
@@ -103,6 +103,13 @@ describe("edition", () => {
     expect(model.getters.getEditionMode()).toBe("inactive");
   });
 
+  test("should keep edition mode inactive when selection changes while composer is inactive", () => {
+    const model = new Model();
+    expect(model.getters.getEditionMode()).toBe("inactive");
+    model.dispatch("CHANGE_COMPOSER_CURSOR_SELECTION", { start: 0, end: 0 });
+    expect(model.getters.getEditionMode()).toBe("inactive");
+  });
+
   test("should switch to editing mode when composer cursor selection changes", () => {
     const model = new Model();
     model.dispatch("START_EDITION", { text: "=sum(" });


### PR DESCRIPTION
## Description:

Current behavior before PR:
- Changing the composer cursor selection triggered a switch to edition mode,
even when the composer was inactive.
- This caused unwanted activation of editing while simply moving the selection.

Desired behavior after PR is merged:
- Selection changes no longer modify the edition mode when the composer is inactive,
ensuring the edition state remains stable.

Task: [5354541](https://www.odoo.com/odoo/2328/tasks/5354541)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo