### PR TITLE
[FIX] figures: fix non-deterministic figure order export

### DIFF
--- a/src/plugins/core/figures.ts
+++ b/src/plugins/core/figures.ts
@@ -124,7 +124,8 @@ export class FigurePlugin extends CorePlugin<FigureState> implements FigureState
         }
         break;
       case "DUPLICATE_SHEET": {
-        for (const figureId in this.figures[cmd.sheetId]) {
+        for (const figure of this.getFigures(cmd.sheetId)) {
+          const figureId = figure.id;
           const fig = this.figures[cmd.sheetId]?.[figureId];
           if (!fig) {
             continue;


### PR DESCRIPTION
In a3ddce5367f58535aa211f04bee9b68dbe4ff0c2, we introduced a way to ensure deterministic order of figures when exporting a sheet. However, this way was not applied when duplicating sheets, which could lead to non-deterministic order of figures in the duplicated sheet.

Task: 5092281

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo