### PR TITLE
[FIX] header_size: wrong row size from wrapped number

### DIFF
--- a/src/plugins/ui_core_views/header_sizes_ui.ts
+++ b/src/plugins/ui_core_views/header_sizes_ui.ts
@@ -53,6 +53,7 @@ export class HeaderSizeUIPlugin extends UIPlugin<HeaderSizeState> implements Hea
   handle(cmd: Command) {
     switch (cmd.type) {
       case "START":
+      case "UPDATE_LOCALE":
         for (const sheetId of this.getters.getSheetIds()) {
           this.initializeSheet(sheetId);
         }
@@ -173,7 +174,7 @@ export class HeaderSizeUIPlugin extends UIPlugin<HeaderSizeState> implements Hea
     const cell = this.getters.getCell(position);
 
     const colSize = this.getters.getColSize(position.sheetId, position.col);
-    return getDefaultCellHeight(this.ctx, cell, colSize);
+    return getDefaultCellHeight(this.ctx, cell, this.getters.getLocale(), colSize);
   }
 
   private isInMultiRowMerge(position: CellPosition): boolean {

--- a/tests/collaborative/collaborative.test.ts
+++ b/tests/collaborative/collaborative.test.ts
@@ -3,7 +3,13 @@ import { DEFAULT_REVISION_ID, MESSAGE_VERSION } from "../../src/constants";
 import { functionRegistry } from "../../src/functions";
 import { getDefaultCellHeight, range, toCartesian, toZone, zoneToXc } from "../../src/helpers";
 import { featurePluginRegistry } from "../../src/plugins";
-import { Command, CommandResult, CoreCommand, DataValidationCriterion } from "../../src/types";
+import {
+  Command,
+  CommandResult,
+  CoreCommand,
+  DEFAULT_LOCALE,
+  DataValidationCriterion,
+} from "../../src/types";
 import { CollaborationMessage } from "../../src/types/collaborative/transport_service";
 import { MockTransportService } from "../__mocks__/transport_service";
 import {
@@ -1083,7 +1089,7 @@ describe("Multi users synchronisation", () => {
     const ctx = document.createElement("canvas").getContext("2d")!;
     expect([alice, bob, charlie]).toHaveSynchronizedValue(
       (user) => user.getters.getRowSize("sheet2", 0),
-      getDefaultCellHeight(ctx, getCell(alice, "A1"), colSize)
+      getDefaultCellHeight(ctx, getCell(alice, "A1"), DEFAULT_LOCALE, colSize)
     );
   });
 

--- a/tests/headers/resizing_plugin.test.ts
+++ b/tests/headers/resizing_plugin.test.ts
@@ -6,7 +6,7 @@ import {
 } from "../../src/constants";
 import { getDefaultCellHeight as getDefaultCellHeightHelper, toXC } from "../../src/helpers";
 import { Model } from "../../src/model";
-import { Cell, CommandResult, Sheet, Wrapping } from "../../src/types";
+import { Cell, CommandResult, DEFAULT_LOCALE, Sheet, Wrapping } from "../../src/types";
 import {
   activateSheet,
   addColumns,
@@ -22,15 +22,22 @@ import {
   resizeColumns,
   resizeRows,
   setCellContent,
+  setFormat,
   setStyle,
   unMerge,
   undo,
+  updateLocale,
 } from "../test_helpers/commands_helpers";
-import { getCell } from "../test_helpers/getters_helpers";
+import { getCell, getCellContent } from "../test_helpers/getters_helpers";
+import { target } from "../test_helpers/helpers";
 
 const ctx = document.createElement("canvas").getContext("2d")!;
-function getDefaultCellHeight(cell: Cell | undefined, colSize = DEFAULT_CELL_WIDTH) {
-  return Math.round(getDefaultCellHeightHelper(ctx, cell, colSize));
+function getDefaultCellHeight(
+  cell: Cell | undefined,
+  colSize = DEFAULT_CELL_WIDTH,
+  locale = DEFAULT_LOCALE
+) {
+  return Math.round(getDefaultCellHeightHelper(ctx, cell, locale, colSize));
 }
 
 describe("Model resizer", () => {
@@ -439,6 +446,37 @@ describe("Model resizer", () => {
 
       expect(wrappedCellHeight).toBeGreaterThan(initialCellHeight);
       expect(model.getters.getRowSize(sheet.id, 0)).toBe(wrappedCellHeight);
+    });
+
+    test("wrapped formatted text updates the row size", () => {
+      setStyle(model, "C1", { fontSize: 10, wrapping: "wrap" });
+      resizeColumns(model, ["C"], 100);
+      setCellContent(model, "C1", "200");
+
+      expect(model.getters.getRowSize(sheet.id, 0)).toBe(DEFAULT_CELL_HEIGHT);
+
+      setFormat(model, "0[$long escaped string in the format that will be wrapped]", target("C1"));
+      const cell = getCell(model, "C1");
+      const expectedHeight = getDefaultCellHeight(cell, 100);
+      expect(expectedHeight).toBeGreaterThan(DEFAULT_CELL_HEIGHT);
+      expect(model.getters.getRowSize(sheet.id, 0)).toBe(expectedHeight);
+    });
+
+    test("updating locale updates the row size", () => {
+      setStyle(model, "C1", { fontSize: 10, wrapping: "wrap" });
+      resizeColumns(model, ["C"], 100);
+      setCellContent(model, "C1", "2000");
+      setFormat(model, "#,##", target("C1"));
+
+      expect(model.getters.getRowSize(sheet.id, 0)).toBe(DEFAULT_CELL_HEIGHT);
+      const locale = { ...DEFAULT_LOCALE, thousandsSeparator: "garbageLongThousandSeparator" };
+      updateLocale(model, locale);
+
+      const cell = getCell(model, "C1");
+      const expectedHeight = getDefaultCellHeight(cell, 100, model.getters.getLocale());
+      expect(getCellContent(model, "C1")).toBe("2garbageLongThousandSeparator000");
+      expect(expectedHeight).toBeGreaterThan(DEFAULT_CELL_HEIGHT);
+      expect(model.getters.getRowSize(sheet.id, 0)).toBe(expectedHeight);
     });
 
     test.each<Wrapping>(["overflow", "clip"])(


### PR DESCRIPTION
## Description

If a literal cell containing a number was wrapped (because the number was large, or because it had a long format), the row height was wrong.

Task: [4878338](https://www.odoo.com/odoo/2328/tasks/4878338)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo