### PR TITLE
[IMP] add_dimension_button: allow to fuzzy search on technical names

### DIFF
--- a/src/components/side_panel/pivot/pivot_layout_configurator/add_dimension_button/add_dimension_button.ts
+++ b/src/components/side_panel/pivot/pivot_layout_configurator/add_dimension_button/add_dimension_button.ts
@@ -61,7 +61,9 @@ export class AddDimensionButton extends Component<Props, SpreadsheetChildEnv> {
   get proposals(): AutoCompleteProposal[] {
     let fields: PivotField[];
     if (this.search.input) {
-      fields = fuzzyLookup(this.search.input, this.props.fields, (field) => field.string);
+      fields = fuzzyLookup(this.search.input, this.props.fields, (field) =>
+        field.string === field.name ? field.string : field.string + field.name
+      );
     } else {
       fields = this.props.fields;
     }

--- a/tests/pivots/add_dimension_button.test.ts
+++ b/tests/pivots/add_dimension_button.test.ts
@@ -1,5 +1,5 @@
 import { AddDimensionButton } from "../../src/components/side_panel/pivot/pivot_layout_configurator/add_dimension_button/add_dimension_button";
-import { click, keyDown } from "../test_helpers/dom_helper";
+import { click, keyDown, setInputValueAndTrigger } from "../test_helpers/dom_helper";
 import { mountComponentWithPortalTarget } from "../test_helpers/helpers";
 
 async function mountAddDimensionButton(
@@ -47,5 +47,21 @@ describe("Add dimension button", () => {
 
     await keyDown({ key: "Enter" });
     expect(onFieldPicked).toHaveBeenCalledWith("Amount");
+  });
+
+  test("Can fuzzy lookup on name and string", async () => {
+    const onFieldPicked = jest.fn();
+    const { fixture } = await mountAddDimensionButton({
+      fields: [
+        { name: "technical", type: "integer", string: "Amount" },
+        { name: "Product", type: "char", string: "Product" },
+      ],
+      onFieldPicked,
+    });
+    await click(fixture.querySelector(".add-dimension")!);
+    await setInputValueAndTrigger(fixture.querySelector("input")!, "tech");
+    const options = [...fixture.querySelectorAll(".o-popover .o-autocomplete-dropdown > div")];
+    expect(options.length).toBe(1);
+    expect(options[0].textContent?.trim()).toBe("Amount");
   });
 });


### PR DESCRIPTION
This commit adds a way to give a custom function to compute fuzzy search keys. It will be used in Odoo to provide better fuzzy search results by taking into account the technical names of the fields.

Task: 5226786

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo