### PR TITLE
[IMP] chart: explicit calendar granularities

### DIFF
--- a/packages/o-spreadsheet-engine/src/types/chart/calendar_chart.ts
+++ b/packages/o-spreadsheet-engine/src/types/chart/calendar_chart.ts
@@ -19,10 +19,10 @@ export type CalendarChartGranularity = (typeof CALENDAR_CHART_GRANULARITIES)[num
 
 export interface CalendarChartDefinition extends CommonChartDefinition {
   readonly type: "calendar";
+  readonly horizontalGroupBy: CalendarChartGranularity;
+  readonly verticalGroupBy: CalendarChartGranularity;
   readonly colorScale?: ChartColorScale;
   readonly missingValueColor?: Color;
-  readonly horizontalGroupBy?: CalendarChartGranularity;
-  readonly verticalGroupBy?: CalendarChartGranularity;
 }
 
 export type CalendarChartRuntime = {

--- a/src/helpers/figures/charts/calendar_chart.ts
+++ b/src/helpers/figures/charts/calendar_chart.ts
@@ -50,16 +50,10 @@ import {
 } from "./runtime";
 
 function checkDateGranularity(definition: CalendarChartDefinition): CommandResult {
-  if (
-    definition.horizontalGroupBy &&
-    !CALENDAR_CHART_GRANULARITIES.includes(definition.horizontalGroupBy)
-  ) {
+  if (!CALENDAR_CHART_GRANULARITIES.includes(definition.horizontalGroupBy)) {
     return CommandResult.InvalidChartDefinition;
   }
-  if (
-    definition.verticalGroupBy &&
-    !CALENDAR_CHART_GRANULARITIES.includes(definition.verticalGroupBy)
-  ) {
+  if (!CALENDAR_CHART_GRANULARITIES.includes(definition.verticalGroupBy)) {
     return CommandResult.InvalidChartDefinition;
   }
   return CommandResult.Success;
@@ -91,8 +85,8 @@ export class CalendarChart extends AbstractChart {
     this.showValues = definition.showValues;
     this.colorScale = definition.colorScale;
     this.axesDesign = definition.axesDesign;
-    this.horizontalGroupBy = definition.horizontalGroupBy ?? "day_of_week";
-    this.verticalGroupBy = definition.verticalGroupBy ?? "month_number";
+    this.horizontalGroupBy = definition.horizontalGroupBy;
+    this.verticalGroupBy = definition.verticalGroupBy;
     this.legendPosition = definition.legendPosition;
     this.missingValueColor = definition.missingValueColor;
   }
@@ -132,6 +126,8 @@ export class CalendarChart extends AbstractChart {
       showValues: context.showValues,
       axesDesign: context.axesDesign,
       legendPosition,
+      horizontalGroupBy: "day_of_week",
+      verticalGroupBy: "month_number",
     };
   }
 

--- a/tests/figures/chart/calendar/calendar_chart_plugin.test.ts
+++ b/tests/figures/chart/calendar/calendar_chart_plugin.test.ts
@@ -174,6 +174,8 @@ describe("calendar chart", () => {
       legendPosition: "left",
       labelRange: "Sheet1!A1:A4",
       showValues: false,
+      horizontalGroupBy: "day_of_week",
+      verticalGroupBy: "month_number",
       axesDesign: {},
     });
   });

--- a/tests/test_helpers/commands_helpers.ts
+++ b/tests/test_helpers/commands_helpers.ts
@@ -241,6 +241,8 @@ export function createChart(
     cumulative: ("cumulative" in data && data.cumulative) || false,
     showSubTotals: ("showSubTotals" in data && data.showSubTotals) || false,
     showConnectorLines: ("showConnectorLines" in data && data.showConnectorLines) || false,
+    horizontalGroupBy: ("horizontalGroupBy" in data && data.horizontalGroupBy) || "day_of_week",
+    verticalGroupBy: ("verticalGroupBy" in data && data.verticalGroupBy) || "month_number",
   };
   return model.dispatch("CREATE_CHART", {
     figureId: figureData.figureId || model.uuidGenerator.smallUuid(),
@@ -349,8 +351,8 @@ export function createCalendarChart(
       labelRange: data.labelRange,
       type: "calendar",
       background: data.background,
-      horizontalGroupBy: data.horizontalGroupBy,
-      verticalGroupBy: data.verticalGroupBy,
+      horizontalGroupBy: data.horizontalGroupBy ?? "day_of_week",
+      verticalGroupBy: data.verticalGroupBy ?? "month_number",
       legendPosition: data.legendPosition || "top",
       colorScale: data.colorScale,
     },


### PR DESCRIPTION
Using a full explicit definition is better if one day we want to change the default value (without affecting existing charts)

And I'm also simplifying chart classes in another branch where we no longer can do `... ?? "day_of_week"`

Task: 0

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo