### PR TITLE
[IMP] formula assistant: avoid information overload in the header.

### DIFF
--- a/src/components/composer/formula_assistant/formula_assistant.ts
+++ b/src/components/composer/formula_assistant/formula_assistant.ts
@@ -72,16 +72,19 @@ export class FunctionDescriptionProvider extends Component<Props, SpreadsheetChi
         if (displayBrackets) {
           result.push({ content: "]" });
         }
-        result.push({ content: argSeparator + "[" });
-        for (let idx = 0; idx < repeatingArgNames.length; idx++) {
-          const name = repeatingArgNames[idx];
-          result.push({ content: name + ((repeatingArgGroupIndex ?? 0) + 2) });
-          // Add separator after each element except the last
-          if (idx < repeatingArgNames.length - 1) {
-            result.push({ content: argSeparator });
+        if (functionDescription.nbrArgRepeating <= 1) {
+          result.push({ content: argSeparator + "[" });
+          for (let idx = 0; idx < repeatingArgNames.length; idx++) {
+            const name = repeatingArgNames[idx];
+            result.push({ content: name + ((repeatingArgGroupIndex ?? 0) + 2) });
+            // Add separator after each element except the last
+            if (idx < repeatingArgNames.length - 1) {
+              result.push({ content: argSeparator });
+            }
           }
+          result.push({ content: "]" });
         }
-        result.push({ content: "]" + argSeparator + "... " });
+        result.push({ content: argSeparator + "... " });
 
         // Skip the processed repeating args
         i += functionDescription.nbrArgRepeating - 1;

--- a/tests/composer/formula_assistant_component.test.ts
+++ b/tests/composer/formula_assistant_component.test.ts
@@ -319,6 +319,35 @@ describe("formula assistant", () => {
         expect(fixture.querySelectorAll(".o-formula-assistant-head")[0].textContent).toBe(
           "FUNC3 ( f3ArgA, f3ArgB1, [f3ArgB2], ...  )"
         );
+
+        await typeInComposer(", ,", false);
+        expect(fixture.querySelectorAll(".o-formula-assistant-head")[0].textContent).toBe(
+          "FUNC3 ( f3ArgA, ... , [f3ArgB2], [f3ArgB3], ...  )"
+        );
+      });
+
+      test("function with repeatable argument optional", async () => {
+        await typeInComposer("=FUNC3BIS(");
+        expect(fixture.querySelectorAll(".o-formula-assistant-head")[0].textContent).toBe(
+          "FUNC3BIS ( f3bisArgA, [f3bisArgB1], [f3bisArgB2], ...  )"
+        );
+
+        await typeInComposer(", ,", false);
+        expect(fixture.querySelectorAll(".o-formula-assistant-head")[0].textContent).toBe(
+          "FUNC3BIS ( f3bisArgA, ... , [f3bisArgB2], [f3bisArgB3], ...  )"
+        );
+      });
+
+      test("function with multiple repeatable arguments", async () => {
+        await typeInComposer("=UPTOWNFUNC(");
+        expect(fixture.querySelectorAll(".o-formula-assistant-head")[0].textContent).toBe(
+          "UPTOWNFUNC ( f4ArgA, f4ArgB1, f4ArgC1, ...  )"
+        );
+
+        await typeInComposer(", , ,", false);
+        expect(fixture.querySelectorAll(".o-formula-assistant-head")[0].textContent).toBe(
+          "UPTOWNFUNC ( f4ArgA, ... , [f4ArgB2, f4ArgC2], ...  )"
+        );
       });
 
       test("arguments separator is localized", async () => {


### PR DESCRIPTION
Avoid overload in the helper UI header when multiple arguments are repeated. 
Task: [5358748](https://www.odoo.com/odoo/2328/tasks/5358748)