### PR TITLE
[REF] module_filter: remove comment

### DIFF
--- a/packages/o-spreadsheet-engine/src/functions/module_filter.ts
+++ b/packages/o-spreadsheet-engine/src/functions/module_filter.ts
@@ -99,7 +99,6 @@ export const FILTER = {
   description: _t(
     "Returns a filtered version of the source range, returning only rows or columns that meet the specified conditions."
   ),
-  // TODO modify args description when vectorization on formulas is available
   args: [
     arg("range (any, range<any>)", _t("The data to be filtered.")),
     arg(


### PR DESCRIPTION
Delete a comment that doesn't belong here.
Indeed, the filtering function cannot be simplified by vectorization because it requires checking the
dimensions of the arguments and returning an error in case of incompatibility.

Task: [4776041](https://www.odoo.com/odoo/2328/tasks/4776041)