### PR TITLE
[FIX] chart: don't crash treemap without visible data

### DIFF
--- a/src/helpers/figures/charts/runtime/chartjs_dataset.ts
+++ b/src/helpers/figures/charts/runtime/chartjs_dataset.ts
@@ -692,6 +692,9 @@ function getTreeMapGroupColors(
 }
 
 function getTreeMapColorScale(tree: SunburstTreeNode[], coloringOption: TreeMapColorScaleOptions) {
+  if (tree.length === 0) {
+    return undefined;
+  }
   const treeNodesByLevel = pyramidizeTree(tree);
   const nodes = treeNodesByLevel[treeNodesByLevel.length - 1];
   const minValue = Math.min(...nodes.map((node) => node.value));

--- a/tests/figures/chart/treemap/treemap_chart_plugin.test.ts
+++ b/tests/figures/chart/treemap/treemap_chart_plugin.test.ts
@@ -5,6 +5,7 @@ import { TreeMapChartRuntime } from "../../../../src/types/chart/tree_map_chart"
 import {
   createSunburstChart,
   createTreeMapChart,
+  hideColumns,
   setCellContent,
   setFormat,
   updateChart,
@@ -429,6 +430,28 @@ describe("TreeMap chart", () => {
       expect(getColor(getTreeMapElement({ value: 3000, depth: 1, isLeaf: true }))).toEqual(
         "#778899"
       );
+    });
+
+    test("TreeMap color scale with no visible data", () => {
+      const grid = {
+        A1: "Year",
+        B1: "2025",
+      };
+      setGrid(model, grid);
+      const chartId = createTreeMapChart(model, {
+        dataSets: [{ dataRange: "A1" }],
+        labelRange: "B1",
+        dataSetsHaveTitle: false,
+        coloringOptions: {
+          type: "colorScale",
+          minColor: "#112233",
+          midColor: "#445566",
+          maxColor: "#778899",
+        },
+      });
+      expect(getTreeMapDatasetConfig(chartId).tree).toHaveLength(1);
+      hideColumns(model, ["B"]);
+      expect(getTreeMapDatasetConfig(chartId).tree).toHaveLength(0);
     });
 
     test("TreeMap category colors with single level", () => {


### PR DESCRIPTION
Steps to reproduce:
- in A1: "Year"
- in B1: "2025"
- create a tree map chart with Hierachy: A1 and Values: B1
- go to the design panel
- change it to "Color scale"
- hide column B

=> Crash

Task: 5365419
opw-5166581

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo