### PR TITLE
[FIX] Migration: Fix chart migration after 18.5.1

### DIFF
--- a/tests/collaborative/collaborative_history.test.ts
+++ b/tests/collaborative/collaborative_history.test.ts
@@ -3,7 +3,6 @@ import { DEFAULT_REVISION_ID, MESSAGE_VERSION } from "../../src/constants";
 import { toZone } from "../../src/helpers";
 import { pivotRegistry } from "../../src/helpers/pivot/pivot_registry";
 import { CommandResult, UpdateCellCommand } from "../../src/types";
-import { LineChartDefinition } from "../../src/types/chart/line_chart";
 import { StateUpdateMessage } from "../../src/types/collaborative/transport_service";
 import { MockTransportService } from "../__mocks__/transport_service";
 import {
@@ -424,92 +423,6 @@ describe("Collaborative local history", () => {
     };
     const model = new Model(data, {}, initialMessages);
     expect(getCell(model, "A1")?.format).toBeUndefined();
-  });
-
-  test("Update chart revisions contain the full definition", () => {
-    const initialMessages: StateUpdateMessage[] = [
-      {
-        type: "REMOTE_REVISION",
-        version: MESSAGE_VERSION,
-        nextRevisionId: "1",
-        clientId: "bob",
-        commands: [
-          {
-            type: "UPDATE_CHART",
-            figureId: "fig1",
-            chartId: "chart1",
-            //@ts-ignore the old command would handle a partial definition
-            definition: { dataSets: [{ dataRange: "A1:A3" }] },
-          },
-          {
-            type: "CREATE_CHART",
-            sheetId: "sheet1",
-            figureId: "fig2",
-            chartId: "chart2",
-            col: 0,
-            row: 0,
-            offset: {
-              x: 0,
-              y: 0,
-            },
-            size: {
-              width: 100,
-              height: 100,
-            },
-            definition: {
-              title: { text: "" },
-              dataSets: [{ dataRange: "A1", yAxisId: "y" }],
-              type: "bar",
-              stacked: false,
-              dataSetsHaveTitle: false,
-              legendPosition: "none",
-            },
-          },
-          {
-            type: "UPDATE_CHART",
-            figureId: "fig2",
-            chartId: "chart2",
-            //@ts-ignore the old command would handle a partial definition
-            definition: { dataSets: [{ dataRange: "B1:B3" }] },
-          },
-        ],
-        serverRevisionId: "initial_revision",
-      },
-    ];
-    const data = {
-      revisionId: "initial_revision",
-      version: "18.5.1",
-      sheets: [
-        {
-          id: "sheet1",
-          figures: [
-            {
-              id: "fig1",
-              tag: "chart",
-              width: 400,
-              height: 300,
-              x: 100,
-              y: 100,
-              data: {
-                chartId: "chart1",
-                type: "line",
-                dataSetsHaveTitle: false,
-                dataSets: [{ dataRange: "Sheet1!B26:B35" }, { dataRange: "Sheet1!C26:C35" }],
-                legendPosition: "top",
-                title: "Line",
-                stacked: false,
-                cumulative: false,
-              },
-            },
-          ],
-        },
-      ],
-    };
-    const model = new Model(data, {}, initialMessages);
-    const definition1 = model.getters.getChartDefinition("chart1") as LineChartDefinition;
-    expect(definition1.dataSets).toEqual([{ dataRange: "A1:A3" }]);
-    const definition2 = model.getters.getChartDefinition("chart2") as LineChartDefinition;
-    expect(definition2.dataSets).toEqual([{ dataRange: "B1:B3" }]);
   });
 
   test("Undo/redo your own change only", () => {

--- a/tests/model/model_import_export.test.ts
+++ b/tests/model/model_import_export.test.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_CELL_WIDTH,
   DEFAULT_REVISION_ID,
   FORBIDDEN_SHEETNAME_CHARS,
+  MESSAGE_VERSION,
 } from "../../src/constants";
 import { toCartesian, toZone } from "../../src/helpers";
 import { DEFAULT_TABLE_CONFIG } from "../../src/helpers/table_presets";
@@ -16,6 +17,8 @@ import {
   DEFAULT_LOCALES,
   IconSetRule,
 } from "../../src/types";
+import { LineChartDefinition } from "../../src/types/chart";
+import { StateUpdateMessage } from "../../src/types/collaborative/transport_service";
 import {
   activateSheet,
   resizeColumns,
@@ -1129,4 +1132,89 @@ test("Can import spreadsheet with only version", () => {
   new Model({ version: 1 });
   // We expect the model to be loaded without traceback
   expect(true).toBeTruthy();
+});
+
+test("Update chart revisions contain the full definition pre 18.5.1", () => {
+  const initialMessages: StateUpdateMessage[] = [
+    {
+      type: "REMOTE_REVISION",
+      version: MESSAGE_VERSION,
+      nextRevisionId: "1",
+      clientId: "bob",
+      commands: [
+        {
+          type: "UPDATE_CHART",
+          figureId: "fig1",
+          chartId: "fig1",
+          //@ts-ignore the old command would handle a partial definition
+          definition: { dataSets: [{ dataRange: "A1:A3" }] },
+        },
+        {
+          type: "CREATE_CHART",
+          sheetId: "sheet1",
+          figureId: "fig2",
+          chartId: "fig2",
+          col: 0,
+          row: 0,
+          offset: {
+            x: 0,
+            y: 0,
+          },
+          size: {
+            width: 100,
+            height: 100,
+          },
+          definition: {
+            title: { text: "" },
+            dataSets: [{ dataRange: "A1", yAxisId: "y" }],
+            type: "bar",
+            stacked: false,
+            dataSetsHaveTitle: false,
+            legendPosition: "none",
+          },
+        },
+        {
+          type: "UPDATE_CHART",
+          figureId: "fig2",
+          chartId: "fig2",
+          //@ts-ignore the old command would handle a partial definition
+          definition: { dataSets: [{ dataRange: "B1:B3" }] },
+        },
+      ],
+      serverRevisionId: "initial_revision",
+    },
+  ];
+  const data = {
+    revisionId: "initial_revision",
+    version: "18.4.3",
+    sheets: [
+      {
+        id: "sheet1",
+        figures: [
+          {
+            id: "fig1",
+            tag: "chart",
+            width: 400,
+            height: 300,
+            x: 100,
+            y: 100,
+            data: {
+              type: "line",
+              dataSetsHaveTitle: false,
+              dataSets: [{ dataRange: "Sheet1!B26:B35" }, { dataRange: "Sheet1!C26:C35" }],
+              legendPosition: "top",
+              title: "Line",
+              stacked: false,
+              cumulative: false,
+            },
+          },
+        ],
+      },
+    ],
+  };
+  const model = new Model(data, {}, initialMessages);
+  const definition1 = model.getters.getChartDefinition("fig1") as LineChartDefinition;
+  expect(definition1.dataSets).toEqual([{ dataRange: "A1:A3" }]);
+  const definition2 = model.getters.getChartDefinition("fig2") as LineChartDefinition;
+  expect(definition2.dataSets).toEqual([{ dataRange: "B1:B3" }]);
 });


### PR DESCRIPTION
The current introduction of the carousels came required a change of data structure regarding the charts, namely, split their id from the one of their container.

Some migration tools (repairInitialMessages) were adapted accordingly but there were some mmistakes in the adaptation:
- the condition set on the versions was inverted
- the test was adapted but only acounted for the versions that came after the refactoring, hiding the previous issue
- the handler  `fixChartDefinitions` did not account for chart definitions existing in the carousels

The handler `fixChartDefinitions` was added to level partial definitions in old chart related commands that were issued around version 16.0 This means that if a user were to create a model with data that come from version 18.5.1, the data necessarily have been upgraded (snapshotted) and it is therefore guaranteed that the changes of those commands have been incorporated in the loaded data, which means the `fixChartDefinition` no longer makes sense.

This revision fixes the aforementioned issues by skipping `fixChartDefinitions` for data above 18.5.1. The tests have also been adapted to ensure previous versions are still properly adapted.

Task: 5365954

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo