### PR TITLE
[IMP] Pivot: added a check in the allowdispatch

### DIFF
--- a/packages/o-spreadsheet-engine/src/plugins/core/pivot.ts
+++ b/packages/o-spreadsheet-engine/src/plugins/core/pivot.ts
@@ -46,6 +46,9 @@ export class PivotCorePlugin extends CorePlugin<CoreState> implements CoreState 
   allowDispatch(cmd: CoreCommand) {
     switch (cmd.type) {
       case "ADD_PIVOT": {
+        if (cmd.pivotId in this.pivots) {
+          return CommandResult.PivotIdTaken;
+        }
         return this.checkValidations(
           cmd.pivot,
           this.checkDuplicatedMeasureIds,

--- a/packages/o-spreadsheet-engine/src/types/commands.ts
+++ b/packages/o-spreadsheet-engine/src/types/commands.ts
@@ -1453,6 +1453,7 @@ export const enum CommandResult {
   SheetIsHidden = "SheetIsHidden",
   InvalidTableResize = "InvalidTableResize",
   PivotIdNotFound = "PivotIdNotFound",
+  PivotIdTaken = "PivotIdTaken",
   PivotInError = "PivotInError",
   EmptyName = "EmptyName",
   ValueCellIsInvalidFormula = "ValueCellIsInvalidFormula",

--- a/tests/pivots/pivot_plugin.test.ts
+++ b/tests/pivots/pivot_plugin.test.ts
@@ -247,6 +247,14 @@ describe("Pivot plugin", () => {
     expect(updateResult).toBeCancelledBecause(CommandResult.PivotIdNotFound);
   });
 
+  test("cannot add a pivot with an existing id", () => {
+    const model = new Model();
+    const createResult1 = addPivot(model, "A1:A2", {}, "1");
+    expect(createResult1.isSuccessful).toBe(true);
+    const createResult2 = addPivot(model, "A1:A2", {}, "1");
+    expect(createResult2).toBeCancelledBecause(CommandResult.PivotIdTaken);
+  });
+
   test("cannot duplicate a pivot with a wrong id", () => {
     const model = new Model();
     const updateResult = model.dispatch("DUPLICATE_PIVOT", {

--- a/tests/pivots/spreadsheet_pivot/spreadsheet_pivot_side_panel.test.ts
+++ b/tests/pivots/spreadsheet_pivot/spreadsheet_pivot_side_panel.test.ts
@@ -743,11 +743,16 @@ describe("Spreadsheet pivot side panel", () => {
   test("Invalid pivot dimensions are displayed as such in the side panel", async () => {
     setCellContent(model, "A1", "ValidDimension");
     setCellContent(model, "A2", "10");
-    addPivot(model, "A1:A2", {
-      columns: [{ fieldName: "ValidDimension" }],
-      rows: [{ fieldName: "InvalidDimension" }],
-    });
-    env.openSidePanel("PivotSidePanel", { pivotId: "1" });
+    addPivot(
+      model,
+      "A1:A2",
+      {
+        columns: [{ fieldName: "ValidDimension" }],
+        rows: [{ fieldName: "InvalidDimension" }],
+      },
+      "2"
+    );
+    env.openSidePanel("PivotSidePanel", { pivotId: "2" });
     await nextTick();
     const pivotDimensionEls = fixture.querySelectorAll<HTMLElement>(".pivot-dimension")!;
     const validDimensionEl = pivotDimensionEls[0];
@@ -875,9 +880,9 @@ describe("Spreadsheet pivot side panel", () => {
           measures: [{ id: "Amount", fieldName: "Amount", aggregator: "sum" }],
           sortedColumn,
         },
-        "1"
+        "2"
       );
-      env.openSidePanel("PivotSidePanel", { pivotId: "1" });
+      env.openSidePanel("PivotSidePanel", { pivotId: "2" });
       await nextTick();
     });
 
@@ -888,12 +893,12 @@ describe("Spreadsheet pivot side panel", () => {
     });
 
     test("Does not display sorting for pivot with no sorting or invalid sorting ", async () => {
-      updatePivot(model, "1", { sortedColumn: undefined });
-      env.openSidePanel("PivotSidePanel", { pivotId: "1" });
+      updatePivot(model, "2", { sortedColumn: undefined });
+      env.openSidePanel("PivotSidePanel", { pivotId: "2" });
       await nextTick();
       expect(".o-sidePanel .o-pivot-sort").toHaveCount(0);
 
-      updatePivot(model, "1", {
+      updatePivot(model, "2", {
         sortedColumn: { order: "asc", measure: "Yolo", domain: [] },
       });
       await nextTick();
@@ -901,16 +906,16 @@ describe("Spreadsheet pivot side panel", () => {
     });
 
     test("Pivot sorting is removed when removing the sorted measure", async () => {
-      expect(model.getters.getPivotCoreDefinition("1").sortedColumn).toEqual(sortedColumn);
+      expect(model.getters.getPivotCoreDefinition("2").sortedColumn).toEqual(sortedColumn);
       click(fixture, ".pivot-measure .fa-trash");
-      expect(model.getters.getPivotCoreDefinition("1").sortedColumn).toBeUndefined();
+      expect(model.getters.getPivotCoreDefinition("2").sortedColumn).toBeUndefined();
     });
 
     test("Pivot sorting is removed when removing a column", async () => {
-      expect(model.getters.getPivotCoreDefinition("1").sortedColumn).toEqual(sortedColumn);
+      expect(model.getters.getPivotCoreDefinition("2").sortedColumn).toEqual(sortedColumn);
       const column = fixture.querySelectorAll(".pivot-dimension")[0];
       click(column, ".fa-trash");
-      expect(model.getters.getPivotCoreDefinition("1").sortedColumn).toBeUndefined();
+      expect(model.getters.getPivotCoreDefinition("2").sortedColumn).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
## Description:

prevent the override of existing pivots through ADD_PIVOT. command

Task: [5360591](https://www.odoo.com/odoo/2328/tasks/5360591)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo