### PR TITLE
[FIX] Pivots: update the dataset of each pivot on adaptRanges

### DIFF
--- a/src/plugins/core/spreadsheet_pivot.ts
+++ b/src/plugins/core/spreadsheet_pivot.ts
@@ -49,7 +49,7 @@ export class SpreadsheetPivotCorePlugin extends CorePlugin {
         const adaptedRange = adaptPivotRange(range, applyChange);
 
         if (adaptedRange === range) {
-          return;
+          continue;
         }
 
         const dataSet = adaptedRange && {

--- a/tests/pivots/spreadsheet_pivot/spreadsheet_pivot.test.ts
+++ b/tests/pivots/spreadsheet_pivot/spreadsheet_pivot.test.ts
@@ -2,6 +2,7 @@ import { CellErrorType, FunctionResultObject, Model } from "../../../src";
 import { resetMapValueDimensionDate } from "../../../src/helpers/pivot/spreadsheet_pivot/date_spreadsheet_pivot";
 import { DEFAULT_LOCALES } from "../../../src/types/locale";
 import {
+  addColumns,
   addRows,
   createSheet,
   deleteContent,
@@ -665,6 +666,22 @@ describe("Spreadsheet Pivot", () => {
     redo(model);
     expect(model.getters.getPivot("1").isValid()).toBeTruthy();
     expect(getEvaluatedCell(model, "A27").value).toEqual("(#1) My pivot");
+  });
+
+  test("Each pivot is adapted following a sheet structure change", () => {
+    const model = createModelWithPivot("A1:F5");
+    addPivot(model, "G1:I5", {}, "2");
+    const sheetId = model.getters.getActiveSheetId();
+    createSheet(model, { activate: true });
+    setCellContent(model, "A1", `=pivot(1)`);
+    setCellContent(model, "A50", `=pivot(2)`);
+    expect(model.getters.getPivot("1").isValid()).toBeTruthy();
+    expect(model.getters.getPivot("2").isValid()).toBeTruthy();
+    expect(getEvaluatedCell(model, "A1").value).toEqual("(#1) My pivot");
+    expect(getEvaluatedCell(model, "A50").value).toEqual("(#2) Pivot");
+    addColumns(model, "before", "G", 1, sheetId);
+    expect(model.getters.getPivot("1").isValid()).toBeTruthy();
+    expect(model.getters.getPivot("2").isValid()).toBeTruthy();
   });
 
   test("Sum with a field that contains a string should work", () => {


### PR DESCRIPTION
The recent fix in #7534 introduced an error. The method to adapt the datasets of spreadsheet pivots would early return after processing a pivot which dataset was left unchanged. The following pivots would never be adapted.

Task: 5379776

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo