### PR TITLE
[Data filter] Trim whitespace

### DIFF
--- a/packages/o-spreadsheet-engine/src/helpers/text_helper.ts
+++ b/packages/o-spreadsheet-engine/src/helpers/text_helper.ts
@@ -316,9 +316,9 @@ export function getFontSizeMatchingWidth(
   return fontSize;
 }
 
-/** Transform a string to lower case. If the string is undefined, return an empty string */
-export function toLowerCase(str: string | undefined): string {
-  return str ? str.toLowerCase() : "";
+/** Transform a string to lowercase and removes whitespace from both ends of the string*/
+export function toTrimmedLowerCase(str: string | undefined): string {
+  return str ? str.toLowerCase().trim() : "";
 }
 
 /**

--- a/packages/o-spreadsheet-engine/src/plugins/ui_stateful/filter_evaluation.ts
+++ b/packages/o-spreadsheet-engine/src/plugins/ui_stateful/filter_evaluation.ts
@@ -2,7 +2,7 @@ import { isMultipleElementMatrix, toScalar } from "../../functions/helper_matric
 import { parseLiteral } from "../../helpers/cells/cell_evaluation";
 import { toXC } from "../../helpers/coordinates";
 import { deepCopy, getUniqueText, range } from "../../helpers/misc";
-import { toLowerCase } from "../../helpers/text_helper";
+import { toTrimmedLowerCase } from "../../helpers/text_helper";
 import { positions, toZone, zoneToDimension } from "../../helpers/zones";
 import { criterionEvaluatorRegistry } from "../../registries/criterion_registry";
 import { Command, CommandResult, LocalCommand, UpdateFilterCommand } from "../../types/commands";
@@ -176,7 +176,7 @@ export class FilterEvaluationPlugin extends UIPlugin {
         continue;
       }
       if (filterValue.filterType === "values") {
-        const filteredValues = filterValue.hiddenValues?.map(toLowerCase);
+        const filteredValues = filterValue.hiddenValues?.map(toTrimmedLowerCase);
         if (!filteredValues) {
           continue;
         }
@@ -227,7 +227,7 @@ export class FilterEvaluationPlugin extends UIPlugin {
 
   private getCellValueAsString(sheetId: UID, col: number, row: number): string {
     const value = this.getters.getEvaluatedCell({ sheetId, col, row }).formattedValue;
-    return value.toLowerCase();
+    return toTrimmedLowerCase(value);
   }
 
   exportForExcel(data: ExcelWorkbookData) {

--- a/src/components/filters/filter_menu_value_list/filter_menu_value_list.ts
+++ b/src/components/filters/filter_menu_value_list/filter_menu_value_list.ts
@@ -1,6 +1,6 @@
 import { SpreadsheetChildEnv } from "@odoo/o-spreadsheet-engine/types/spreadsheet_env";
 import { Component, onWillUpdateProps, useRef, useState } from "@odoo/owl";
-import { deepEquals, positions, toLowerCase } from "../../../helpers";
+import { deepEquals, positions, toTrimmedLowerCase } from "../../../helpers";
 import { fuzzyLookup } from "../../../helpers/search";
 import { Position } from "../../../types";
 import { FilterMenuValueItem } from "../filter_menu_item/filter_menu_value_item";
@@ -76,12 +76,12 @@ export class FilterMenuValueList extends Component<Props, SpreadsheetChildEnv> {
 
     const cellValues = cells.map((val) => val.cellValue);
     const filterValues = filterValue?.filterType === "values" ? filterValue.hiddenValues : [];
-    const normalizedFilteredValues = new Set(filterValues.map(toLowerCase));
+    const normalizedFilteredValues = new Set(filterValues.map(toTrimmedLowerCase));
 
     const set = new Set<string>();
     const values: (Value & { normalizedValue: string })[] = [];
     const addValue = (value: string) => {
-      const normalizedValue = toLowerCase(value);
+      const normalizedValue = toTrimmedLowerCase(value);
       if (!set.has(normalizedValue)) {
         values.push({
           string: value || "",

--- a/tests/data_validation/data_validation_registry.test.ts
+++ b/tests/data_validation/data_validation_registry.test.ts
@@ -123,6 +123,7 @@ describe("Data validation registry", () => {
       ["hello there", "hello", false],
       ["hell", "hello", false],
       ["hello", "hello", true],
+      ["   hello", "hello", false],
       ["HeLlO", "hello", true],
       ["1125", "1125", true],
       ["TRUE", "true", true],

--- a/tests/table/filter_evaluation_plugin.test.ts
+++ b/tests/table/filter_evaluation_plugin.test.ts
@@ -161,6 +161,16 @@ describe("Filter Evaluation", () => {
     expect(model.getters.isRowHidden(sheetId, 2)).toEqual(true);
   });
 
+  test("Filters ignore whitespaces", () => {
+    setCellContent(model, "A2", "a");
+    setCellContent(model, "A3", " a");
+    setCellContent(model, "A4", "a ");
+    updateFilter(model, "A2", ["a"]);
+    expect(model.getters.isRowHidden(sheetId, 1)).toEqual(true);
+    expect(model.getters.isRowHidden(sheetId, 2)).toEqual(true);
+    expect(model.getters.isRowHidden(sheetId, 3)).toEqual(true);
+  });
+
   test("Header is not filtered", () => {
     updateFilter(model, "A1", ["A1"]);
     expect(model.getters.isRowHidden(sheetId, 0)).toEqual(false);
@@ -371,6 +381,29 @@ describe("Filter criterion test", () => {
       updateFilterCriterion(model, "A1", {
         type: type as FilterCriterionType,
         values: criterionValues,
+      });
+
+      expect(getFilteredRows()).toEqual(expectedFilteredRows);
+    }
+  );
+
+  test.each([
+    ["beginsWithText", [2]],
+    ["endsWithText", [3]],
+    ["isEqualText", [2, 3]],
+  ])(
+    "Filters based on a text criterion %s do not ignore whitespaces",
+    (type: string, expectedFilteredRows: number[]) => {
+      const grid = {
+        A2: "a",
+        A3: " a",
+        A4: "a ",
+      };
+      setGrid(model, grid);
+      createTableWithFilter(model, "A1:A4");
+      updateFilterCriterion(model, "A1", {
+        type: type as FilterCriterionType,
+        values: ["a"],
       });
 
       expect(getFilteredRows()).toEqual(expectedFilteredRows);


### PR DESCRIPTION
## Description:

[Data filter] Trim whitespace and don't bother of caps vs low case when filtering

Task: [5375214](https://www.odoo.com/odoo/2328/tasks/5375214)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo