### PR TITLE
[FIX] Package: ensure we ship style sheets in releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "files": [
     "dist/*.js",
     "dist/*.d.ts",
-    "dist/*.xml"
+    "dist/*.xml",
+    "dist/*.css"
   ],
   "scripts": {
     "serve-static": "live-server --open=demo --watch=build/o_spreadsheet.iife.js,build/o_spreadsheet.xml,build/o_spreadsheet.css,main.css,demo",


### PR DESCRIPTION
Ever since we started using external style sheets in addition to our inline css, we never updated the package.json file to ensure it got added to the release on npm.

Task: 0

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo