### PR TITLE
[FIX] CorePlugins: Prevent dispatch during adaptRange

### DIFF
--- a/src/helpers/pivot/pivot_registry.ts
+++ b/src/helpers/pivot/pivot_registry.ts
@@ -1,6 +1,6 @@
 import { ModelConfig } from "../../model";
 import { Registry } from "../../registries/registry";
-import { CoreGetters, Getters } from "../../types";
+import { ApplyRangeChange, CoreGetters, Getters, Range } from "../../types";
 import { PivotCoreDefinition, PivotField, PivotFields } from "../../types/pivot";
 import { Pivot } from "../../types/pivot_runtime";
 import { PivotRuntimeDefinition } from "./pivot_runtime_definition";
@@ -32,6 +32,11 @@ export interface PivotRegistryItem {
   datetimeGranularities: string[];
   isMeasureCandidate: (field: PivotField) => boolean;
   isGroupable: (field: PivotField) => boolean;
+  adaptRanges?: (
+    getters: CoreGetters,
+    definition: PivotCoreDefinition,
+    applyChange: ApplyRangeChange
+  ) => PivotCoreDefinition;
 }
 
 export const pivotRegistry = new Registry<PivotRegistryItem>();
@@ -54,4 +59,40 @@ pivotRegistry.add("SPREADSHEET", {
   datetimeGranularities: [...dateGranularities, "hour_number", "minute_number", "second_number"],
   isMeasureCandidate: (field: PivotField) => !["datetime", "boolean"].includes(field.type),
   isGroupable: () => true,
+  adaptRanges: (getters, definition, applyChange) => {
+    if (definition.type !== "SPREADSHEET" || !definition.dataSet) {
+      return definition;
+    }
+    const { sheetId, zone } = definition.dataSet;
+    const range = getters.getRangeFromZone(sheetId, zone);
+    const adaptedRange = adaptPivotRange(range, applyChange);
+
+    if (adaptedRange === range) {
+      return definition;
+    }
+
+    const dataSet = adaptedRange && {
+      sheetId: adaptedRange.sheetId,
+      zone: adaptedRange.zone,
+    };
+    return { ...definition, dataSet };
+  },
 });
+
+function adaptPivotRange(
+  range: Range | undefined,
+  applyChange: ApplyRangeChange
+): Range | undefined {
+  if (!range) {
+    return undefined;
+  }
+  const change = applyChange(range);
+  switch (change.changeType) {
+    case "NONE":
+      return range;
+    case "REMOVE":
+      return undefined;
+    default:
+      return change.range;
+  }
+}

--- a/src/plugins/core/pivot.ts
+++ b/src/plugins/core/pivot.ts
@@ -1,6 +1,7 @@
 import { compile } from "../../formulas";
 import { deepCopy, deepEquals } from "../../helpers";
 import { createPivotFormula, getMaxObjectId } from "../../helpers/pivot/pivot_helpers";
+import { pivotRegistry } from "../../helpers/pivot/pivot_registry";
 import { SpreadsheetPivotTable } from "../../helpers/pivot/table_spreadsheet_pivot";
 import {
   ApplyRangeChange,
@@ -132,6 +133,18 @@ export class PivotCorePlugin extends CorePlugin<CoreState> implements CoreState 
   }
 
   adaptRanges(applyChange: ApplyRangeChange) {
+    for (const pivotId in this.pivots) {
+      const definition = deepCopy(this.pivots[pivotId]?.definition);
+      if (!definition) {
+        continue;
+      }
+      const newDefinition = pivotRegistry
+        .get(definition.type)
+        ?.adaptRanges?.(this.getters, definition, applyChange);
+      if (newDefinition && !deepEquals(definition, newDefinition)) {
+        this.history.update("pivots", pivotId, "definition", newDefinition);
+      }
+    }
     for (const sheetId in this.compiledMeasureFormulas) {
       for (const formulaString in this.compiledMeasureFormulas[sheetId]) {
         const compiledFormula = this.compiledMeasureFormulas[sheetId][formulaString];
@@ -314,19 +327,19 @@ export class PivotCorePlugin extends CorePlugin<CoreState> implements CoreState 
       if (!pivot) {
         continue;
       }
-      const def = deepCopy(pivot.definition);
 
-      for (const measure of def.measures) {
+      for (const measure of pivot.definition.measures) {
         if (measure.computedBy?.formula === formulaString) {
-          const measureIndex = def.measures.indexOf(measure);
-          if (measureIndex !== -1) {
-            def.measures[measureIndex].computedBy = {
-              formula: newFormulaString,
-              sheetId,
-            };
-          }
-
-          this.dispatch("UPDATE_PIVOT", { pivotId, pivot: def });
+          const measureIndex = pivot.definition.measures.indexOf(measure);
+          this.history.update(
+            "pivots",
+            pivotId,
+            "definition",
+            "measures",
+            measureIndex,
+            "computedBy",
+            { formula: newFormulaString, sheetId }
+          );
         }
       }
     }

--- a/src/plugins/core/range.ts
+++ b/src/plugins/core/range.ts
@@ -42,6 +42,7 @@ interface RangeStringOptions {
 export class RangeAdapter implements CommandHandler<CoreCommand> {
   private getters: CoreGetters;
   private providers: Array<RangeProvider["adaptRanges"]> = [];
+  private isAdaptingRanges: boolean = false;
   constructor(getters: CoreGetters) {
     this.getters = getters;
   }
@@ -73,6 +74,9 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
   beforeHandle(command: Command) {}
 
   handle(cmd: Command) {
+    if (this.isAdaptingRanges) {
+      throw new Error("Plugins cannot dispatch commands during adaptRanges phase");
+    }
     switch (cmd.type) {
       case "REMOVE_COLUMNS_ROWS": {
         let start: "left" | "top" = cmd.dimension === "COL" ? "left" : "top";
@@ -243,10 +247,12 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
   }
 
   private executeOnAllRanges(adaptRange: ApplyRangeChange, sheetId?: UID) {
+    this.isAdaptingRanges = true;
     const func = this.verifyRangeRemoved(adaptRange);
     for (const provider of this.providers) {
       provider(func, sheetId);
     }
+    this.isAdaptingRanges = false;
   }
 
   /**

--- a/src/plugins/core/spreadsheet_pivot.ts
+++ b/src/plugins/core/spreadsheet_pivot.ts
@@ -1,30 +1,6 @@
 import { isZoneValid } from "../../helpers";
-import {
-  ApplyRangeChange,
-  CommandResult,
-  CoreCommand,
-  PivotCoreDefinition,
-  Range,
-} from "../../types";
+import { CommandResult, CoreCommand, PivotCoreDefinition } from "../../types";
 import { CorePlugin } from "../core_plugin";
-
-function adaptPivotRange(
-  range: Range | undefined,
-  applyChange: ApplyRangeChange
-): Range | undefined {
-  if (!range) {
-    return undefined;
-  }
-  const change = applyChange(range);
-  switch (change.changeType) {
-    case "NONE":
-      return range;
-    case "REMOVE":
-      return undefined;
-    default:
-      return change.range;
-  }
-}
 
 export class SpreadsheetPivotCorePlugin extends CorePlugin {
   allowDispatch(cmd: CoreCommand) {
@@ -35,30 +11,6 @@ export class SpreadsheetPivotCorePlugin extends CorePlugin {
         return this.checkDataSetValidity(definition);
     }
     return CommandResult.Success;
-  }
-
-  adaptRanges(applyChange: ApplyRangeChange) {
-    for (const pivotId of this.getters.getPivotIds()) {
-      const definition = this.getters.getPivotCoreDefinition(pivotId);
-      if (definition.type !== "SPREADSHEET") {
-        continue;
-      }
-      if (definition.dataSet) {
-        const { sheetId, zone } = definition.dataSet;
-        const range = this.getters.getRangeFromZone(sheetId, zone);
-        const adaptedRange = adaptPivotRange(range, applyChange);
-
-        if (adaptedRange === range) {
-          return;
-        }
-
-        const dataSet = adaptedRange && {
-          sheetId: adaptedRange.sheetId,
-          zone: adaptedRange.zone,
-        };
-        this.dispatch("UPDATE_PIVOT", { pivotId, pivot: { ...definition, dataSet } });
-      }
-    }
   }
 
   private checkDataSetValidity(definition: PivotCoreDefinition) {

--- a/tests/range_plugin.test.ts
+++ b/tests/range_plugin.test.ts
@@ -745,3 +745,17 @@ test.each([
   const adaptedRange = model.getters.createAdaptedRanges([range], 1, 1, sheetId);
   expect(model.getters.getRangeString(adaptedRange[0], sheetId)).toBe(expected);
 });
+
+test("Plugins cannot dispatch a command during adaptRanges", () => {
+  class PluginDispatchInAdaptRanges extends CorePlugin {
+    adaptRanges() {
+      this.dispatch("DELETE_SHEET", { sheetId: "s1" });
+    }
+  }
+  addTestPlugin(corePluginRegistry, PluginDispatchInAdaptRanges);
+
+  const model = new Model({});
+  expect(() => {
+    addColumns(model, "before", "A", 1);
+  }).toThrowError("Plugins cannot dispatch commands during adaptRanges phase");
+});


### PR DESCRIPTION
The method `adaptRange` was originally designed for each plugin to update their own ranges, whithout having to manually react to the different commands that alter the sheets structure.

We have abused the system when we introduced the spreadsheet pivots to allow the modification of a pivot dataset (which is stored in PivotCorePlugin) from another entry point `SpreadsheetPivotCorePlugin`) by dispatching an UPDATE_PIVOT command but there are some side effects that we did not account for, the dispatched command is forwarded to EVERY other plugin. Meaning that during an adaptRange, which should only concern a specific plugin, we end up notifying a change to the whole core/coreview stack.

This revision removes the access to 'dispatch' during the handling of `adaptRange` so we ensure that the changes are kept locally.

Task: 5380747

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo