### PR TITLE
[FIX] charts: remove zoom slicer for scatter plot

### DIFF
--- a/src/components/side_panel/chart/index.ts
+++ b/src/components/side_panel/chart/index.ts
@@ -22,7 +22,6 @@ import { ScorecardChartDesignPanel } from "./scorecard_chart_panel/scorecard_cha
 import { SunburstChartDesignPanel } from "./sunburst_chart/sunburst_chart_design_panel";
 import { TreeMapChartDesignPanel } from "./treemap_chart/treemap_chart_design_panel";
 import { WaterfallChartDesignPanel } from "./waterfall_chart/waterfall_chart_design_panel";
-import { GenericZoomableChartDesignPanel } from "./zoomable_chart/design_panel";
 
 export { BarConfigPanel } from "./bar_chart/bar_chart_config_panel";
 export { GenericChartConfigPanel } from "./building_blocks/generic_side_panel/config_panel";
@@ -47,7 +46,7 @@ chartSidePanelComponentRegistry
   })
   .add("scatter", {
     configuration: ScatterConfigPanel,
-    design: GenericZoomableChartDesignPanel,
+    design: ChartWithAxisDesignPanel,
   })
   .add("bar", {
     configuration: BarConfigPanel,

--- a/src/helpers/figures/charts/scatter_chart.ts
+++ b/src/helpers/figures/charts/scatter_chart.ts
@@ -63,7 +63,6 @@ export class ScatterChart extends AbstractChart {
   readonly dataSetDesign?: DatasetDesign[];
   readonly axesDesign?: AxesDesign;
   readonly showValues?: boolean;
-  readonly zoomable?: boolean;
 
   constructor(definition: ScatterChartDefinition, sheetId: UID, getters: CoreGetters) {
     super(definition, sheetId, getters);
@@ -82,7 +81,6 @@ export class ScatterChart extends AbstractChart {
     this.dataSetDesign = definition.dataSets;
     this.axesDesign = definition.axesDesign;
     this.showValues = definition.showValues;
-    this.zoomable = definition.zoomable;
   }
 
   static validateChartDefinition(
@@ -113,7 +111,6 @@ export class ScatterChart extends AbstractChart {
       aggregated: context.aggregated ?? false,
       axesDesign: context.axesDesign,
       showValues: context.showValues,
-      zoomable: context.zoomable,
       humanize: context.humanize,
     };
   }
@@ -148,7 +145,6 @@ export class ScatterChart extends AbstractChart {
       aggregated: this.aggregated,
       axesDesign: this.axesDesign,
       showValues: this.showValues,
-      zoomable: this.zoomable,
       humanize: this.humanize,
     };
   }

--- a/src/registries/chart_types.ts
+++ b/src/registries/chart_types.ts
@@ -237,7 +237,7 @@ chartComponentRegistry.add("bar", ZoomableChartJsComponent);
 chartComponentRegistry.add("combo", ZoomableChartJsComponent);
 chartComponentRegistry.add("pie", ChartJsComponent);
 chartComponentRegistry.add("gauge", GaugeChartComponent);
-chartComponentRegistry.add("scatter", ZoomableChartJsComponent);
+chartComponentRegistry.add("scatter", ChartJsComponent);
 chartComponentRegistry.add("scorecard", ScorecardChartComponent);
 chartComponentRegistry.add("waterfall", ZoomableChartJsComponent);
 chartComponentRegistry.add("pyramid", ChartJsComponent);

--- a/src/types/chart/scatter_chart.ts
+++ b/src/types/chart/scatter_chart.ts
@@ -1,7 +1,7 @@
 import { LineChartDefinition, LineChartRuntime } from "./line_chart";
 
 export interface ScatterChartDefinition
-  extends Omit<LineChartDefinition, "type" | "stacked" | "cumulative"> {
+  extends Omit<LineChartDefinition, "type" | "stacked" | "cumulative" | "zoomable"> {
   readonly type: "scatter";
 }
 

--- a/tests/figures/chart/bar_chart_plugin.test.ts
+++ b/tests/figures/chart/bar_chart_plugin.test.ts
@@ -37,7 +37,7 @@ describe("bar chart", () => {
       axesDesign: {},
       showValues: false,
       horizontal: false,
-      zoomable: false,
+      zoomable: true,
       humanize: false,
     });
   });

--- a/tests/figures/chart/combo_chart_plugin.test.ts
+++ b/tests/figures/chart/combo_chart_plugin.test.ts
@@ -33,7 +33,7 @@ describe("combo chart", () => {
       axesDesign: {},
       showValues: false,
       hideDataMarkers: false,
-      zoomable: false,
+      zoomable: true,
       humanize: false,
     });
   });

--- a/tests/figures/chart/line_chart_plugin.test.ts
+++ b/tests/figures/chart/line_chart_plugin.test.ts
@@ -31,7 +31,7 @@ describe("line chart", () => {
       fillArea: true,
       showValues: false,
       hideDataMarkers: false,
-      zoomable: false,
+      zoomable: true,
       humanize: false,
     });
   });

--- a/tests/figures/chart/scatter_chart_plugin.test.ts
+++ b/tests/figures/chart/scatter_chart_plugin.test.ts
@@ -1,0 +1,27 @@
+import { ChartCreationContext } from "../../../src";
+import { ScatterChart } from "../../../src/helpers/figures/charts/scatter_chart";
+import { GENERAL_CHART_CREATION_CONTEXT } from "../../test_helpers/chart_helpers";
+
+describe("scatter chart", () => {
+  test("create scatter chart from creation context", () => {
+    const context: Required<ChartCreationContext> = {
+      ...GENERAL_CHART_CREATION_CONTEXT,
+      range: [{ dataRange: "Sheet1!B1:B4", yAxisId: "y1" }],
+    };
+    const definition = ScatterChart.getDefinitionFromContextCreation(context);
+    expect(definition).toEqual({
+      aggregated: true,
+      type: "scatter",
+      background: "#123456",
+      title: { text: "hello there" },
+      dataSets: [{ dataRange: "Sheet1!B1:B4", yAxisId: "y1" }],
+      labelRange: "Sheet1!A1:A4",
+      legendPosition: "bottom",
+      dataSetsHaveTitle: true,
+      labelsAsText: true,
+      axesDesign: {},
+      showValues: false,
+      humanize: false,
+    });
+  });
+});

--- a/tests/figures/chart/waterfall/waterfall_chart_plugin.test.ts
+++ b/tests/figures/chart/waterfall/waterfall_chart_plugin.test.ts
@@ -323,7 +323,7 @@ describe("Waterfall chart", () => {
       axesDesign: {},
       verticalAxisPosition: "left",
       showValues: false,
-      zoomable: false,
+      zoomable: true,
       humanize: false,
     });
   });

--- a/tests/test_helpers/chart_helpers.ts
+++ b/tests/test_helpers/chart_helpers.ts
@@ -133,6 +133,6 @@ export const GENERAL_CHART_CREATION_CONTEXT: Required<ChartCreationContext> = {
   headerDesign: { bold: false },
   treemapColoringOptions: { type: "categoryColor", colors: [], useValueBasedGradient: true },
   showHeaders: true,
-  zoomable: false,
+  zoomable: true,
   humanize: false,
 };


### PR DESCRIPTION
## Task Description

This PR aims to remove the zoomable feature for the scatter plot, as it's kind of non-sense to be able to zoom on an axis and not on the other for this type of chart. Moreover, we will soon be able to manually set the min/max of each axis manually (in master).

## Related Task
- Task: [5388389](https://www.odoo.com/odoo/2328/tasks/5388389)