### PR TITLE
[FIX] data_validation: should not hide dv suggations on mouse up

### DIFF
--- a/src/components/composer/composer/abstract_composer_store.ts
+++ b/src/components/composer/composer/abstract_composer_store.ts
@@ -115,7 +115,12 @@ export abstract class AbstractComposerStore extends SpreadsheetStore {
   abstract stopEdition(direction?: Direction): void;
 
   private handleEvent(event: SelectionEvent) {
-    this.hideHelp();
+    const hasSelectionChanged =
+      event.mode === "commitSelection" && !isEqual(event.anchor.zone, event.previousAnchor.zone);
+    if (hasSelectionChanged) {
+      this.hideHelp();
+    }
+
     const sheetId = this.getters.getActiveSheetId();
     let unboundedZone: UnboundedZone;
     if (event.options.unbounded) {

--- a/src/components/grid/grid.xml
+++ b/src/components/grid/grid.xml
@@ -16,6 +16,7 @@
         onGridMoved.bind="moveCanvas"
         gridOverlayDimensions="gridOverlayDimensions"
         getGridSize="props.getGridSize"
+        composerEditionMode="composerFocusStore.activeComposer.editionMode"
       />
       <HeadersOverlay onOpenContextMenu="(type, x, y) => this.toggleContextMenu(type, x, y)"/>
       <GridComposer

--- a/src/components/grid_overlay/grid_overlay.ts
+++ b/src/components/grid_overlay/grid_overlay.ts
@@ -1,3 +1,4 @@
+import { EditionMode } from "@odoo/o-spreadsheet-engine/types/misc";
 import { SpreadsheetChildEnv } from "@odoo/o-spreadsheet-engine/types/spreadsheet_env";
 import { Component, onMounted, onWillUnmount, useExternalListener, useRef } from "@odoo/owl";
 import { deepEquals, positionToZone } from "../../helpers";
@@ -149,6 +150,7 @@ interface Props {
   onGridMoved: (deltaX: Pixel, deltaY: Pixel) => void;
   gridOverlayDimensions: string;
   getGridSize: () => { width: number; height: number };
+  composerEditionMode: EditionMode;
 }
 
 export class GridOverlay extends Component<Props, SpreadsheetChildEnv> {
@@ -162,6 +164,7 @@ export class GridOverlay extends Component<Props, SpreadsheetChildEnv> {
     gridOverlayDimensions: String,
     slots: { type: Object, optional: true },
     getGridSize: Function,
+    composerEditionMode: { type: String, optional: true },
   };
   static components = {
     FiguresContainer,
@@ -325,6 +328,6 @@ export class GridOverlay extends Component<Props, SpreadsheetChildEnv> {
 
       return isPointInsideRect(x, y, this.env.model.getters.getCellIconRect(icon, cellRect));
     });
-    return icon?.onClick ? icon : undefined;
+    return icon?.onClick && this.props.composerEditionMode !== "selecting" ? icon : undefined;
   }
 }

--- a/tests/composer/composer_integration_component.test.ts
+++ b/tests/composer/composer_integration_component.test.ts
@@ -12,6 +12,7 @@ import { colors, toHex, toZone } from "../../src/helpers";
 import { Store } from "../../src/store_engine";
 import {
   activateSheet,
+  addDataValidation,
   copy,
   createSheet,
   createTable,
@@ -29,6 +30,7 @@ import { FR_LOCALE } from "../test_helpers/constants";
 import {
   click,
   clickCell,
+  clickGridIcon,
   getComposerColors,
   getElComputedStyle,
   gridMouseEvent,
@@ -626,6 +628,16 @@ describe("Grid composer", () => {
     activateSheet(model, baseSheetId);
     await nextTick();
     expect(composerStore.editionMode).not.toBe("inactive");
+  });
+
+  test("grid icon click behaves like a grid selection in composer selecting mode", async () => {
+    const composerStore = env.getStore(CellComposerStore);
+    addDataValidation(model, "A1", "id", { type: "isBoolean", values: [] });
+    selectCell(model, "A2");
+    await typeInComposerGrid("=");
+    expect(composerStore.editionMode).toBe("selecting");
+    await clickGridIcon(model, "A1");
+    expect(composerStore.currentContent).toBe("=A1");
   });
 
   test("the composer should keep the focus after changing sheet", async () => {

--- a/tests/data_validation/data_validation_list_component.test.ts
+++ b/tests/data_validation/data_validation_list_component.test.ts
@@ -23,8 +23,10 @@ import {
   click,
   clickGridIcon,
   getElComputedStyle,
+  getGridIconEventPosition,
   keyDown,
   setInputValueAndTrigger,
+  triggerMouseEvent,
 } from "../test_helpers/dom_helper";
 import { getCellContent, getCellIcons } from "../test_helpers/getters_helpers";
 import {
@@ -492,6 +494,22 @@ describe("Selection arrow icon in grid", () => {
     expect(suggestions[0].textContent).toBe("ok");
     expect(suggestions[1].textContent).toBe("hello");
     expect(suggestions[2].textContent).toBe("okay");
+  });
+
+  test("Clicking grid icon keeps suggestions open on pointer up", async () => {
+    ({ fixture, env } = await mountSpreadsheet({ model }));
+    const composerStore = env.getStore(CellComposerStore);
+    const { x, y } = getGridIconEventPosition(model, "A1");
+
+    triggerMouseEvent(".o-grid-overlay", "pointerdown", x, y);
+    await nextTick();
+    triggerMouseEvent(".o-grid-overlay", "pointerup", x, y);
+    await nextTick();
+
+    expect(composerStore.editionMode).toBe("editing");
+    expect(composerStore.currentEditedCell).toEqual({ sheetId, col: 0, row: 0 });
+    const suggestions = fixture.querySelectorAll(".o-autocomplete-dropdown .o-autocomplete-value");
+    expect(suggestions.length).toBe(3);
   });
 
   test("Icon is not displayed when display style is plainText", () => {


### PR DESCRIPTION
## Description:
Current behavior before PR:
- Allowing zone de-selection introduced commitSelection on mouse up,
  which recalculates the selection and updates the zone.
- As a result, data validation suggestions were hidden on mouse up.

Desired behavior after PR is merged:
- Suggestions are hidden only when the zone actually changes during
  commitSelection.

Task: [5392156](https://www.odoo.com/odoo/2328/tasks/5392156)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo