### PR TITLE
Pivot : filter dimensions

### DIFF
--- a/src/components/filters/filter_menu/filter_menu.ts
+++ b/src/components/filters/filter_menu/filter_menu.ts
@@ -1,7 +1,9 @@
-import { onWillUpdateProps } from "@odoo/owl";
+import { onWillUpdateProps, proxy } from "@odoo/owl";
 import { isDateTimeFormat } from "../../../helpers/format/format";
-import { deepEquals } from "../../../helpers/misc";
+import { deepCopy, deepEquals } from "../../../helpers/misc";
 import { interactiveSort } from "../../../helpers/sort_interactive";
+import { toTrimmedLowerCase } from "../../../helpers/text_helper";
+import { positions } from "../../../helpers/zones";
 import { Component } from "../../../owl3_compatibility_layer";
 import { CellPopoverComponent, PopoverBuilders } from "../../../types/cell_popovers";
 import { CellValueType } from "../../../types/cells";
@@ -23,6 +25,16 @@ interface Props {
   onClosed?: () => void;
 }
 
+interface State {
+  values: Value[];
+}
+
+interface Value {
+  checked: boolean;
+  string: string;
+  scrolledTo?: "top" | "bottom" | undefined;
+}
+
 type CriterionCategory = "text" | "number" | "date";
 
 export class FilterMenu extends Component<Props, SpreadsheetChildEnv> {
@@ -32,7 +44,7 @@ export class FilterMenu extends Component<Props, SpreadsheetChildEnv> {
     onClosed: { type: Function, optional: true },
   };
   static components = { FilterMenuValueList, SidePanelCollapsible, FilterMenuCriterion };
-
+  private state!: State;
   private criterionCategory: CriterionCategory = "text";
   private updatedCriterionValue: DataFilterValue | undefined;
 
@@ -41,7 +53,11 @@ export class FilterMenu extends Component<Props, SpreadsheetChildEnv> {
       if (!deepEquals(nextProps.filterPosition, this.props.filterPosition)) {
         this.updatedCriterionValue = undefined;
         this.criterionCategory = this.getCriterionCategory(nextProps.filterPosition);
+        this.state.values = this.getFilterHiddenValues(nextProps.filterPosition);
       }
+    });
+    this.state = proxy({
+      values: this.getFilterHiddenValues(this.props.filterPosition),
     });
     this.criterionCategory = this.getCriterionCategory(this.props.filterPosition);
   }
@@ -150,6 +166,62 @@ export class FilterMenu extends Component<Props, SpreadsheetChildEnv> {
     const sortOptions = { emptyCellAsZero: true, sortHeaders: true };
     interactiveSort(this.env, sheetId, sortAnchor, contentZone, sortDirection, sortOptions);
     this.props.onClosed?.();
+  }
+
+  private getFilterHiddenValues(position: Position): Value[] {
+    const sheetId = this.env.model.getters.getActiveSheetId();
+    const filter = this.env.model.getters.getFilter({ sheetId, ...position });
+    if (!filter?.filteredRange) {
+      return [];
+    }
+    const filterValue = this.env.model.getters.getFilterValue({ sheetId, ...position });
+    let cellPositions = positions(filter.filteredRange.zone);
+    if (filterValue?.filterType !== "criterion") {
+      cellPositions = cellPositions.filter(
+        (currentPosition) => !this.env.model.getters.isRowHidden(sheetId, currentPosition.row)
+      );
+    }
+    const cellValues = cellPositions.map(
+      (currentPosition) =>
+        this.env.model.getters.getEvaluatedCell({ sheetId, ...currentPosition }).formattedValue
+    );
+
+    const filterValues = filterValue?.filterType === "values" ? filterValue.hiddenValues : [];
+    const normalizedFilteredValues = new Set(filterValues.map(toTrimmedLowerCase));
+
+    const normalizedValues = new Set<string>();
+    const allValues: (Value & { normalizedValue: string })[] = [];
+    const addValue = (value: string) => {
+      const normalizedValue = toTrimmedLowerCase(value);
+      if (!normalizedValues.has(normalizedValue)) {
+        allValues.push({
+          string: value || "",
+          checked:
+            filterValue?.filterType !== "criterion"
+              ? !normalizedFilteredValues.has(normalizedValue)
+              : false,
+          normalizedValue,
+        });
+        normalizedValues.add(normalizedValue);
+      }
+    };
+    cellValues.forEach(addValue);
+    filterValues.forEach(addValue);
+
+    return allValues.sort((val1, val2) =>
+      val1.normalizedValue.localeCompare(val2.normalizedValue, undefined, {
+        numeric: true,
+        sensitivity: "base",
+      })
+    );
+  }
+
+  getFilterCriterionValue(position: Position): CriterionFilter {
+    const sheetId = this.env.model.getters.getActiveSheetId();
+    const filterValue = this.env.model.getters.getFilterCriterionValue({ sheetId, ...position });
+    return filterValue?.filterType === "criterion"
+      ? deepCopy(filterValue)
+      : { filterType: "criterion", type: "none", values: [] };
   }
 }
 

--- a/src/components/filters/filter_menu_criterion/filter_menu_criterion.ts
+++ b/src/components/filters/filter_menu_criterion/filter_menu_criterion.ts
@@ -1,5 +1,5 @@
 import { onWillUpdateProps, proxy } from "@odoo/owl";
-import { deepCopy, deepEquals } from "../../../helpers/misc";
+import { deepEquals } from "../../../helpers/misc";
 import { Component, ComponentConstructor } from "../../../owl3_compatibility_layer";
 import {
   criterionComponentRegistry,
@@ -7,13 +7,13 @@ import {
 } from "../../../registries/criterion_component_registry";
 import { _t } from "../../../translation";
 import { GenericCriterionType } from "../../../types/generic_criterion";
-import { Position, ValueAndLabel } from "../../../types/misc";
+import { ValueAndLabel } from "../../../types/misc";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
 import { CriterionFilter } from "../../../types/table";
 import { Select } from "../../select/select";
 
 interface Props {
-  filterPosition: Position;
+  criterion: CriterionFilter;
   criterionOperators: GenericCriterionType[];
   onCriterionChanged: (criterion: CriterionFilter) => void;
 }
@@ -25,7 +25,7 @@ interface State {
 export class FilterMenuCriterion extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-FilterMenuCriterion";
   static props = {
-    filterPosition: Object,
+    criterion: Object,
     onCriterionChanged: Function,
     criterionOperators: Array,
   };
@@ -35,22 +35,14 @@ export class FilterMenuCriterion extends Component<Props, SpreadsheetChildEnv> {
 
   setup() {
     onWillUpdateProps((nextProps: Props) => {
-      if (!deepEquals(nextProps.filterPosition, this.props.filterPosition)) {
-        this.state.criterion = this.getFilterCriterionValue(nextProps.filterPosition);
+      if (!deepEquals(nextProps.criterion, this.props.criterion)) {
+        this.state.criterion = nextProps.criterion;
       }
     });
 
     this.state = proxy({
-      criterion: this.getFilterCriterionValue(this.props.filterPosition),
+      criterion: this.props.criterion,
     });
-  }
-
-  private getFilterCriterionValue(position: Position): CriterionFilter {
-    const sheetId = this.env.model.getters.getActiveSheetId();
-    const filterValue = this.env.model.getters.getFilterCriterionValue({ sheetId, ...position });
-    return filterValue?.filterType === "criterion"
-      ? deepCopy(filterValue)
-      : { filterType: "criterion", type: "none", values: [] };
   }
 
   get criterionOptions(): ValueAndLabel[] {

--- a/src/components/filters/filter_menu_value_list/filter_menu_value_list.ts
+++ b/src/components/filters/filter_menu_value_list/filter_menu_value_list.ts
@@ -1,15 +1,12 @@
 import { onWillUpdateProps, proxy, signal } from "@odoo/owl";
 import { deepEquals } from "../../../helpers/misc";
 import { fuzzyLookup } from "../../../helpers/search";
-import { toTrimmedLowerCase } from "../../../helpers/text_helper";
-import { positions } from "../../../helpers/zones";
 import { Component } from "../../../owl3_compatibility_layer";
-import { Position } from "../../../types/misc";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
 import { FilterMenuValueItem } from "../filter_menu_item/filter_menu_value_item";
 
 interface Props {
-  filterPosition: Position;
+  values: Value[];
   onUpdateHiddenValues: (values: string[]) => void;
 }
 
@@ -20,7 +17,6 @@ interface Value {
 }
 
 interface State {
-  values: Value[];
   displayedValues: Value[];
   textFilter: string;
   selectedValue: string | undefined;
@@ -31,13 +27,12 @@ interface State {
 export class FilterMenuValueList extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-FilterMenuValueList";
   static props = {
-    filterPosition: Object,
+    values: Object,
     onUpdateHiddenValues: Function,
   };
   static components = { FilterMenuValueItem };
 
   private state: State = proxy({
-    values: [],
     displayedValues: [],
     textFilter: "",
     selectedValue: undefined,
@@ -49,63 +44,11 @@ export class FilterMenuValueList extends Component<Props, SpreadsheetChildEnv> {
 
   setup() {
     onWillUpdateProps((nextProps: Props) => {
-      if (!deepEquals(nextProps.filterPosition, this.props.filterPosition)) {
-        this.state.values = this.getFilterHiddenValues(nextProps.filterPosition);
-        this.computeDisplayedValues();
+      if (!deepEquals(nextProps.values, this.props.values)) {
+        this.computeDisplayedValues(nextProps);
       }
     });
-
-    this.state.values = this.getFilterHiddenValues(this.props.filterPosition);
-    this.computeDisplayedValues();
-  }
-
-  private getFilterHiddenValues(position: Position): Value[] {
-    const sheetId = this.env.model.getters.getActiveSheetId();
-    const filter = this.env.model.getters.getFilter({ sheetId, ...position });
-    if (!filter) {
-      return [];
-    }
-    const filterValue = this.env.model.getters.getFilterValue({ sheetId, ...position });
-
-    let cells = (filter.filteredRange ? positions(filter.filteredRange.zone) : []).map(
-      (position) => ({
-        position,
-        cellValue: this.env.model.getters.getEvaluatedCell({ sheetId, ...position }).formattedValue,
-      })
-    );
-    if (filterValue?.filterType !== "criterion") {
-      cells = cells.filter((val) => !this.env.model.getters.isRowHidden(sheetId, val.position.row));
-    }
-
-    const cellValues = cells.map((val) => val.cellValue);
-    const filterValues = filterValue?.filterType === "values" ? filterValue.hiddenValues : [];
-    const normalizedFilteredValues = new Set(filterValues.map(toTrimmedLowerCase));
-
-    const set = new Set<string>();
-    const values: (Value & { normalizedValue: string })[] = [];
-    const addValue = (value: string) => {
-      const normalizedValue = toTrimmedLowerCase(value);
-      if (!set.has(normalizedValue)) {
-        values.push({
-          string: value || "",
-          checked:
-            filterValue?.filterType !== "criterion"
-              ? !normalizedFilteredValues.has(normalizedValue)
-              : false,
-          normalizedValue,
-        });
-        set.add(normalizedValue);
-      }
-    };
-    cellValues.forEach(addValue);
-    filterValues.forEach(addValue);
-
-    return values.sort((val1, val2) =>
-      val1.normalizedValue.localeCompare(val2.normalizedValue, undefined, {
-        numeric: true,
-        sensitivity: "base",
-      })
-    );
+    this.computeDisplayedValues(this.props);
   }
 
   checkValue(value: Value) {
@@ -119,15 +62,15 @@ export class FilterMenuValueList extends Component<Props, SpreadsheetChildEnv> {
     this.state.selectedValue = value.string;
   }
 
-  private getSearchedValues(): Value[] {
+  private getSearchedValues(props: Props): Value[] {
     return !this.state.textFilter
-      ? this.state.values
-      : fuzzyLookup(this.state.textFilter, this.state.values, (val) => val.string);
+      ? props.values
+      : fuzzyLookup(this.state.textFilter, props.values, (val) => val.string);
   }
 
   setAllChecked(checked: boolean) {
-    const searchedValues = new Set(this.getSearchedValues());
-    for (const value of this.state.values) {
+    const searchedValues = new Set(this.getSearchedValues(this.props));
+    for (const value of this.props.values) {
       if (searchedValues.has(value)) {
         value.checked = checked;
       }
@@ -144,7 +87,7 @@ export class FilterMenuValueList extends Component<Props, SpreadsheetChildEnv> {
   }
 
   updateHiddenValues() {
-    const hiddenValues = this.state.values.filter((val) => !val.checked).map((val) => val.string);
+    const hiddenValues = this.props.values.filter((val) => !val.checked).map((val) => val.string);
     this.props.onUpdateHiddenValues(hiddenValues);
   }
 
@@ -152,18 +95,18 @@ export class FilterMenuValueList extends Component<Props, SpreadsheetChildEnv> {
     const target = ev.target as HTMLInputElement;
     this.state.textFilter = target.value;
     this.state.selectedValue = undefined;
-    this.computeDisplayedValues();
+    this.computeDisplayedValues(this.props);
   }
 
-  computeDisplayedValues() {
-    const searchedValues = this.getSearchedValues();
+  computeDisplayedValues(props: Props) {
+    const searchedValues = this.getSearchedValues(props);
     this.state.displayedValues = searchedValues.slice(0, this.state.numberOfDisplayedValues);
     this.state.hasMoreValues = searchedValues.length > this.state.numberOfDisplayedValues;
   }
 
   loadMoreValues() {
     this.state.numberOfDisplayedValues += 100;
-    this.computeDisplayedValues();
+    this.computeDisplayedValues(this.props);
   }
 
   onKeyDown(ev: KeyboardEvent) {
@@ -215,12 +158,12 @@ export class FilterMenuValueList extends Component<Props, SpreadsheetChildEnv> {
   }
 
   clearScrolledToValue() {
-    this.state.values.forEach((val) => (val.scrolledTo = undefined));
+    this.props.values.forEach((val) => (val.scrolledTo = undefined));
   }
 
   private scrollListToSelectedValue(arrow: "ArrowUp" | "ArrowDown") {
     this.clearScrolledToValue();
-    const selectedValue = this.state.values.find((val) => val.string === this.state.selectedValue);
+    const selectedValue = this.props.values.find((val) => val.string === this.state.selectedValue);
     if (selectedValue) {
       selectedValue.scrolledTo = arrow === "ArrowUp" ? "top" : "bottom";
     }

--- a/src/components/filters/pivot_filter_menu/pivot_filter_menu.ts
+++ b/src/components/filters/pivot_filter_menu/pivot_filter_menu.ts
@@ -1,0 +1,105 @@
+import { onWillUpdateProps } from "@odoo/owl";
+import { deepCopy, deepEquals } from "../../../helpers/misc";
+import { SpreadsheetPivotRuntimeDefinition } from "../../../helpers/pivot/spreadsheet_pivot/runtime_definition_spreadsheet_pivot";
+import { Component } from "../../../owl3_compatibility_layer";
+import { UID } from "../../../types/misc";
+import { PivotFilter } from "../../../types/pivot";
+import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
+import {
+  CriterionFilter,
+  DataFilterValue,
+  filterDateCriterionOperators,
+  filterNumberCriterionOperators,
+  filterTextCriterionOperators,
+} from "../../../types/table";
+import { SidePanelCollapsible } from "../../side_panel/components/collapsible/side_panel_collapsible";
+import { FilterMenuCriterion } from "../filter_menu_criterion/filter_menu_criterion";
+import { FilterMenuValueList } from "../filter_menu_value_list/filter_menu_value_list";
+
+interface Props {
+  pivotId: UID;
+  definition: SpreadsheetPivotRuntimeDefinition;
+  filter: PivotFilter;
+  values: Value[];
+  onClosed?: () => void;
+  onConfirmed: (updatedCriterionValue: DataFilterValue) => void;
+}
+
+interface Value {
+  checked: boolean;
+  string: string;
+  scrolledTo?: "top" | "bottom" | undefined;
+}
+
+type CriterionCategory = "char" | "boolean" | "integer" | "datetime";
+
+export class PivotFilterMenu extends Component<Props, SpreadsheetChildEnv> {
+  static template = "o-spreadsheet-PivotFilterMenu";
+  static props = {
+    pivotId: String,
+    definition: Object,
+    filter: Object,
+    values: Object,
+    onClosed: { type: Function, optional: true },
+    onConfirmed: Function,
+  };
+
+  static components = { FilterMenuValueList, SidePanelCollapsible, FilterMenuCriterion };
+
+  private criterionCategory: CriterionCategory = "char";
+  private updatedCriterionValue: DataFilterValue | undefined;
+
+  setup() {
+    onWillUpdateProps((nextProps: Props) => {
+      if (!deepEquals(nextProps.definition, this.props.definition)) {
+        this.updatedCriterionValue = undefined;
+        this.criterionCategory = this.getCriterionCategory();
+      }
+    });
+    this.criterionCategory = this.getCriterionCategory();
+  }
+
+  private getCriterionCategory(): CriterionCategory {
+    const pivot = this.env.model.getters.getPivot(this.props.pivotId);
+    const fields = pivot.getFields();
+    const criterionCategory = fields[this.props.filter.fieldName]?.type;
+    return (criterionCategory || "char") as CriterionCategory;
+  }
+
+  onUpdateHiddenValues(values: string[]) {
+    this.updatedCriterionValue = { filterType: "values", hiddenValues: values };
+  }
+
+  onCriterionChanged(criterion: CriterionFilter) {
+    this.updatedCriterionValue = criterion;
+  }
+
+  confirm() {
+    if (!this.updatedCriterionValue) {
+      this.props.onClosed?.();
+      return;
+    }
+    this.props.onConfirmed(this.updatedCriterionValue);
+    this.props.onClosed?.();
+  }
+
+  get criterionOperators() {
+    if (this.criterionCategory === "datetime") {
+      return filterDateCriterionOperators;
+    } else if (this.criterionCategory === "integer") {
+      return filterNumberCriterionOperators;
+    }
+    return filterTextCriterionOperators;
+  }
+
+  cancel() {
+    this.props.onClosed?.();
+  }
+
+  getFilterCriterionValue(): CriterionFilter {
+    const filterValue = this.props.filter;
+    return filterValue.filterType === "criterion"
+      ? deepCopy(filterValue)
+      : { filterType: "criterion", type: "none", values: [] };
+  }
+}

--- a/src/components/filters/pivot_filter_menu/pivot_filter_menu.xml
+++ b/src/components/filters/pivot_filter_menu/pivot_filter_menu.xml
@@ -1,24 +1,13 @@
 <templates>
-  <t t-name="o-spreadsheet-FilterMenu">
-    <div class="o-filter-menu d-flex flex-column py-3" t-on-wheel.stop="">
-      <div t-if="this.isSortable" class="o-filter-menu-content">
-        <div
-          class="o-filter-menu-item py-2 ps-4 mb-1"
-          t-on-click="() => this.sortFilterZone('asc')">
-          Sort ascending (A ⟶ Z)
-        </div>
-        <div class="o-filter-menu-item py-2 ps-4" t-on-click="() => this.sortFilterZone('desc')">
-          Sort descending (Z ⟶ A)
-        </div>
-        <div class="o-separator border-bottom"/>
-      </div>
+  <t t-name="o-spreadsheet-PivotFilterMenu">
+    <div class="o-filter-menu d-flex flex-column bg-white py-3" t-on-wheel.stop="">
       <div class="o-filter-menu-content">
         <SidePanelCollapsible
-          isInitiallyCollapsed="this.filterValueType !== 'criterion'"
+          isInitiallyCollapsed="this.props.filter.filterType !== 'criterion'"
           title.translate="Filter by criterion">
           <t t-set-slot="content">
             <FilterMenuCriterion
-              criterion="this.getFilterCriterionValue(this.props.filterPosition)"
+              criterion="this.getFilterCriterionValue()"
               onCriterionChanged.bind="this.onCriterionChanged"
               criterionOperators="this.criterionOperators"
             />
@@ -27,11 +16,11 @@
         </SidePanelCollapsible>
 
         <SidePanelCollapsible
-          isInitiallyCollapsed="this.filterValueType === 'criterion'"
+          isInitiallyCollapsed="this.props.filter.filterType === 'criterion'"
           title.translate="Filter by values">
           <t t-set-slot="content">
             <FilterMenuValueList
-              values="this.state.values"
+              values="this.props.values"
               onUpdateHiddenValues.bind="this.onUpdateHiddenValues"
             />
           </t>

--- a/src/components/side_panel/pivot/pivot_filter/pivot_filter.ts
+++ b/src/components/side_panel/pivot/pivot_filter/pivot_filter.ts
@@ -1,0 +1,181 @@
+import { onWillUpdateProps, proxy, signal } from "@odoo/owl";
+import { CellPosition, GenericCriterion, UID } from "../../../..";
+import { deepEquals } from "../../../../helpers/misc";
+import { SpreadsheetPivotRuntimeDefinition } from "../../../../helpers/pivot/spreadsheet_pivot/runtime_definition_spreadsheet_pivot";
+import { SpreadsheetPivot } from "../../../../helpers/pivot/spreadsheet_pivot/spreadsheet_pivot";
+import { toTrimmedLowerCase } from "../../../../helpers/text_helper";
+import { Component, useExternalListener } from "../../../../owl3_compatibility_layer";
+import { criterionEvaluatorRegistry } from "../../../../registries/criterion_registry";
+import { _t } from "../../../../translation";
+import { Cell } from "../../../../types/cells";
+import { PivotFilter, SpreadsheetPivotCoreDefinition } from "../../../../types/pivot";
+import { SpreadsheetChildEnv } from "../../../../types/spreadsheet_env";
+import { DataFilterValue } from "../../../../types/table";
+import { PivotFilterMenu } from "../../../filters/pivot_filter_menu/pivot_filter_menu";
+import { isChildEvent } from "../../../helpers/dom_helpers";
+import { Popover } from "../../../popover/popover";
+import { PivotDimension } from "../pivot_layout_configurator/pivot_dimension/pivot_dimension";
+
+interface Props {
+  pivotId: UID;
+  definition: SpreadsheetPivotRuntimeDefinition;
+  filter: PivotFilter;
+  onFiltersUpdated: (definition: Partial<SpreadsheetPivotCoreDefinition>) => void;
+}
+
+interface Value {
+  checked: boolean;
+  string: string;
+  scrolledTo?: "top" | "bottom" | undefined;
+}
+
+interface State {
+  values: Value[];
+}
+
+export class PivotFilterEditor extends Component<Props, SpreadsheetChildEnv> {
+  static template = "o-spreadsheet-PivotFilterEditor";
+  static components = {
+    PivotDimension,
+    Popover,
+    PivotFilterMenu,
+  };
+  static props = {
+    pivotId: String,
+    definition: Object,
+    filter: Object,
+    onFiltersUpdated: Function,
+  };
+
+  private state!: State;
+
+  private buttonFilter = signal<HTMLElement | null>(null);
+  private popover!: { isOpen: boolean };
+
+  setup() {
+    useExternalListener(window, "click", (ev) => {
+      if (!isChildEvent(this.buttonFilter(), ev)) {
+        this.popover.isOpen = false;
+      }
+    });
+    onWillUpdateProps((nextProps: Props) => {
+      if (!deepEquals(nextProps.definition, this.props.definition)) {
+        this.state.values = this.getFilterHiddenValues(nextProps);
+      }
+    });
+    this.popover = proxy({ isOpen: false });
+    this.state = proxy({
+      values: this.getFilterHiddenValues(this.props),
+    });
+  }
+
+  filterCaption() {
+    if (this.props.filter.filterType === "criterion") {
+      if (this.props.filter.type === "none") {
+        return _t("showing all items");
+      }
+      return criterionEvaluatorRegistry
+        .get(this.props.filter.type)
+        .getPreview(this.props.filter as GenericCriterion, this.env.model.getters);
+    }
+
+    const numberOfHiddenValues = this.props.filter.hiddenValues.length;
+    const totalValues = this.state.values.length;
+    const numberOfShownValues = totalValues - numberOfHiddenValues;
+    if (numberOfHiddenValues === 0) {
+      return _t("showing all items");
+    } else if (numberOfShownValues === 1) {
+      return _t("showing 1 item");
+    } else {
+      return _t("showing %s items", numberOfShownValues);
+    }
+  }
+
+  private getFilterHiddenValues(props: Props): Value[] {
+    const pivot = this.env.model.getters.getPivot(props.pivotId) as SpreadsheetPivot;
+    if (pivot.type !== "SPREADSHEET") {
+      throw new Error("Filters are only available on spreadsheet pivot table");
+    }
+    const dataEntries = pivot.getDataEntries();
+    const field = props.filter.fieldName;
+    const set = new Set<string>();
+    const values: (Value & { normalizedValue: string })[] = [];
+    for (const dataEntry of dataEntries) {
+      const value = dataEntry[field] ? dataEntry[field].formattedValue.toString() : "";
+      if (!set.has(value)) {
+        values.push({
+          string: value,
+          checked:
+            props.filter.filterType === "criterion"
+              ? true
+              : !props.filter.hiddenValues.includes(value),
+          normalizedValue: toTrimmedLowerCase(value),
+        });
+        set.add(value);
+      }
+    }
+    return values.sort((val1, val2) =>
+      val1.normalizedValue.localeCompare(val2.normalizedValue, undefined, {
+        numeric: true,
+        sensitivity: "base",
+      })
+    );
+  }
+
+  get popoverProps() {
+    const { x, y, width, height } = this.buttonFilter()?.getBoundingClientRect() ?? {
+      x: 0,
+      y: 0,
+      width: 0,
+      height: 0,
+    };
+    return {
+      anchorRect: { x, y, width, height },
+      positioning: "bottom-left",
+    };
+  }
+
+  getCell(position: CellPosition): Cell | undefined {
+    return this.env.model.getters.getCell(position);
+  }
+
+  removeFilter(filter: PivotFilter) {
+    const { filters } = this.props.definition;
+    this.props.onFiltersUpdated({
+      filters: (filters ?? []).filter((f) => f.fieldName !== filter.fieldName),
+    });
+  }
+
+  openMenuFilter() {
+    this.popover.isOpen = !this.popover.isOpen;
+  }
+
+  closeMenuFilter() {
+    this.popover.isOpen = false;
+  }
+
+  isActive() {
+    const filter = this.props.filter;
+    if (filter.filterType === "criterion") {
+      return filter.type !== "none";
+    }
+    return filter.hiddenValues.length > 0;
+  }
+
+  updateFilterData(updatedCriterionValue: DataFilterValue) {
+    const { filters } = this.props.definition;
+    const filter = this.props.filter;
+    const updatedFilters = (filters ?? []).map((f) => {
+      if (f.fieldName === filter.fieldName) {
+        return {
+          ...f,
+          ...updatedCriterionValue,
+        };
+      }
+      return f;
+    });
+    this.props.onFiltersUpdated({
+      filters: updatedFilters,
+    });
+  }
+}

--- a/src/components/side_panel/pivot/pivot_filter/pivot_filter.xml
+++ b/src/components/side_panel/pivot/pivot_filter/pivot_filter.xml
@@ -1,0 +1,30 @@
+<templates>
+  <t t-name="o-spreadsheet-PivotFilterEditor">
+    <div class="pt-1">
+      <PivotDimension dimension="this.props.filter" onRemoved.bind="this.removeFilter">
+        <Popover t-if="this.popover.isOpen" t-props="this.popoverProps">
+          <PivotFilterMenu
+            pivotId="this.props.pivotId"
+            definition="this.props.definition"
+            filter="this.props.filter"
+            values="this.state.values"
+            onClosed.bind="this.closeMenuFilter"
+            onConfirmed.bind="this.updateFilterData"
+          />
+        </Popover>
+        <div class="d-flex">
+          <i class="o-pivot-filter-caption">
+            <t t-esc="this.filterCaption()"/>
+          </i>
+          <div
+            class="o-button-icon o-pivot-filter-icon pe-1 ps-2"
+            t-ref="this.buttonFilter"
+            t-on-click="this.openMenuFilter">
+            <t t-if="this.isActive()" t-call="o-spreadsheet-Icon.FILTER_ICON_ACTIVE"/>
+            <t t-else="" t-call="o-spreadsheet-Icon.FILTER_ICON"/>
+          </div>
+        </div>
+      </PivotDimension>
+    </div>
+  </t>
+</templates>

--- a/src/components/side_panel/pivot/pivot_layout_configurator/pivot_dimension/pivot_dimension.ts
+++ b/src/components/side_panel/pivot/pivot_layout_configurator/pivot_dimension/pivot_dimension.ts
@@ -1,15 +1,22 @@
 import { collapseHierarchicalDisplayName } from "../../../../../helpers/pivot/pivot_helpers";
-import { PivotDimension as PivotDimensionType, PivotMeasure } from "../../../../../types/pivot";
+import {
+  PivotDimension as PivotDimensionType,
+  PivotFilter,
+  PivotMeasure,
+} from "../../../../../types/pivot";
 import { SpreadsheetChildEnv } from "../../../../../types/spreadsheet_env";
 import { TextInput } from "../../../../text_input/text_input";
 import { CogWheelMenu } from "../../../components/cog_wheel_menu/cog_wheel_menu";
 
 import { Component } from "../../../../../owl3_compatibility_layer";
 interface Props {
-  dimension: PivotDimensionType | PivotMeasure;
-  onRemoved: (dimension: PivotDimensionType | PivotMeasure) => void;
-  onNameUpdated?: (dimension: PivotDimensionType | PivotMeasure, name?: string) => void;
-  type: "row" | "col" | "measure";
+  dimension: PivotDimensionType | PivotMeasure | PivotFilter;
+  onRemoved: (dimension: PivotDimensionType | PivotMeasure | PivotFilter) => void;
+  onNameUpdated?: (
+    dimension: PivotDimensionType | PivotMeasure | PivotFilter,
+    name?: string
+  ) => void;
+  type: "row" | "col" | "measure" | "filter";
 }
 
 export class PivotDimension extends Component<Props, SpreadsheetChildEnv> {

--- a/src/components/side_panel/pivot/pivot_layout_configurator/pivot_layout_configurator.ts
+++ b/src/components/side_panel/pivot/pivot_layout_configurator/pivot_layout_configurator.ts
@@ -24,6 +24,7 @@ import { SpreadsheetChildEnv } from "../../../../types/spreadsheet_env";
 import { Store } from "../../../../types/store_engine";
 import { ComposerFocusStore } from "../../../composer/composer_focus_store";
 import { useDragAndDropListItems } from "../../../helpers/drag_and_drop_dom_items_hook";
+import { SidePanelCollapsible } from "../../components/collapsible/side_panel_collapsible";
 import { PivotCustomGroupsCollapsible } from "../pivot_custom_groups_collapsible/pivot_custom_groups_collapsible";
 import { AddDimensionButton } from "./add_dimension_button/add_dimension_button";
 import { PivotDimension } from "./pivot_dimension/pivot_dimension";
@@ -35,6 +36,7 @@ import { PivotSortSection } from "./pivot_sort_section/pivot_sort_section";
 interface Props {
   definition: PivotRuntimeDefinition;
   onDimensionsUpdated: (definition: Partial<PivotCoreDefinition>) => void;
+  onFiltersUpdated: (definition: Partial<PivotCoreDefinition>) => void;
   unusedGroupableFields: PivotField[];
   measureFields: PivotField[];
   unusedGranularities: Record<string, Set<string>>;
@@ -54,10 +56,12 @@ export class PivotLayoutConfigurator extends Component<Props, SpreadsheetChildEn
     PivotMeasureEditor,
     PivotSortSection,
     PivotCustomGroupsCollapsible,
+    SidePanelCollapsible,
   };
   static props = {
     definition: Object,
     onDimensionsUpdated: Function,
+    onFiltersUpdated: Function,
     unusedGroupableFields: Array,
     measureFields: Array,
     unusedGranularities: Object,

--- a/src/components/side_panel/pivot/pivot_side_panel/pivot_side_panel_store.ts
+++ b/src/components/side_panel/pivot/pivot_side_panel/pivot_side_panel_store.ts
@@ -123,6 +123,15 @@ export class PivotSidePanelStore extends SpreadsheetStore {
       .sort((a, b) => a.string.localeCompare(b.string));
   }
 
+  get unusedFilterFields() {
+    const filterFields = Object.values(this.fields).filter((field) => field !== undefined);
+    const { filters } = this.definition;
+    const currentlyUsed = (filters ?? []).map((field) => field.fieldName);
+    return filterFields
+      .filter((field) => !currentlyUsed.includes(field.name))
+      .sort((a, b) => a.string.localeCompare(b.string));
+  }
+
   get datetimeGranularities() {
     return pivotRegistry.get(this.pivot.type).datetimeGranularities;
   }
@@ -222,6 +231,21 @@ export class PivotSidePanelStore extends SpreadsheetStore {
         format: measure.format,
         display: measure.display,
       })),
+      filters: (definition.filters ?? []).map((filter) =>
+        filter.filterType === "values"
+          ? {
+              fieldName: filter.fieldName,
+              filterType: filter.filterType,
+              hiddenValues: filter.hiddenValues,
+            }
+          : {
+              fieldName: filter.fieldName,
+              filterType: filter.filterType,
+              type: filter.type,
+              values: filter.values,
+              dateValue: filter.dateValue,
+            }
+      ),
       sortedColumn: this.shouldKeepSortedColumn(definition) ? definition.sortedColumn : undefined,
     };
     if (cleanedDefinition.collapsedDomains) {

--- a/src/components/side_panel/pivot/pivot_side_panel/pivot_spreadsheet_side_panel/pivot_spreadsheet_side_panel.ts
+++ b/src/components/side_panel/pivot/pivot_side_panel/pivot_spreadsheet_side_panel/pivot_spreadsheet_side_panel.ts
@@ -11,6 +11,8 @@ import { SelectionInput } from "../../../../selection_input/selection_input";
 import { Checkbox } from "../../../components/checkbox/checkbox";
 import { Section } from "../../../components/section/section";
 import { PivotDeferUpdate } from "../../pivot_defer_update/pivot_defer_update";
+import { PivotFilterEditor } from "../../pivot_filter/pivot_filter";
+import { AddDimensionButton } from "../../pivot_layout_configurator/add_dimension_button/add_dimension_button";
 import { PivotLayoutConfigurator } from "../../pivot_layout_configurator/pivot_layout_configurator";
 import { PivotTitleSection } from "../../pivot_title_section/pivot_title_section";
 import { PivotSidePanelStore } from "../pivot_side_panel_store";
@@ -33,6 +35,8 @@ export class PivotSpreadsheetSidePanel extends Component<Props, SpreadsheetChild
     Checkbox,
     PivotDeferUpdate,
     PivotTitleSection,
+    AddDimensionButton,
+    PivotFilterEditor,
   };
   store!: Store<PivotSidePanelStore>;
 
@@ -109,5 +113,22 @@ export class PivotSpreadsheetSidePanel extends Component<Props, SpreadsheetChild
 
   onDimensionsUpdated(definition: Partial<SpreadsheetPivotCoreDefinition>) {
     this.store.update(definition);
+  }
+
+  onFiltersUpdated(definition: Partial<SpreadsheetPivotCoreDefinition>) {
+    this.store.update(definition);
+  }
+
+  addFilter(fieldName: string) {
+    const { filters } = this.env.model.getters.getPivotCoreDefinition(this.props.pivotId);
+    this.onFiltersUpdated({
+      filters: (filters ?? []).concat([
+        {
+          fieldName: fieldName,
+          filterType: "values",
+          hiddenValues: [],
+        },
+      ]),
+    });
   }
 }

--- a/src/components/side_panel/pivot/pivot_side_panel/pivot_spreadsheet_side_panel/pivot_spreadsheet_side_panel.xml
+++ b/src/components/side_panel/pivot/pivot_side_panel/pivot_spreadsheet_side_panel/pivot_spreadsheet_side_panel.xml
@@ -34,9 +34,30 @@
             datetimeGranularities="this.store.datetimeGranularities"
             definition="this.definition"
             onDimensionsUpdated.bind="this.onDimensionsUpdated"
+            onFiltersUpdated.bind="this.onFiltersUpdated"
             getScrollableContainerEl.bind="this.getScrollableContainerEl"
             pivotId="this.props.pivotId"
           />
+          <t t-if="!this.pivot.isInvalidRange">
+            <Section class="'pt-0'">
+              <div
+                class="o-fw-bold pt-0 pb-1 d-flex flex-row justify-content-between align-items-center o-section-title">
+                Domain
+                <AddDimensionButton
+                  onFieldPicked.bind="this.addFilter"
+                  fields="this.store.unusedFilterFields"
+                />
+              </div>
+              <t t-foreach="this.definition.filters" t-as="filter" t-key="filter_index">
+                <PivotFilterEditor
+                  pivotId="this.props.pivotId"
+                  definition="this.definition"
+                  filter="filter"
+                  onFiltersUpdated.bind="this.onFiltersUpdated"
+                />
+              </t>
+            </Section>
+          </t>
         </div>
       </div>
       <PivotDeferUpdate

--- a/src/helpers/filter_helpers.ts
+++ b/src/helpers/filter_helpers.ts
@@ -1,0 +1,55 @@
+import { UID } from "..";
+import { isMultipleElementMatrix, toScalar } from "../functions/helper_matrices";
+import { criterionEvaluatorRegistry } from "../registries/criterion_registry";
+import { Getters } from "../types/getters";
+import { DEFAULT_LOCALE } from "../types/locale";
+import { DataFilterValue } from "../types/table";
+import { parseLiteral } from "./cells/cell_evaluation";
+import { FieldValue } from "./pivot/spreadsheet_pivot/data_entry_spreadsheet_pivot";
+import { toTrimmedLowerCase } from "./text_helper";
+
+/**
+ *Determines whether a given value should be filtered out (hidden)
+ */
+export function isValueFiltered(
+  getters: Getters,
+  sheetId: UID,
+  data: FieldValue,
+  filter: DataFilterValue,
+  preComputedCriterion?: unknown
+): boolean {
+  if (filter.filterType === "values") {
+    const filteredValues = filter.hiddenValues?.map(toTrimmedLowerCase);
+    if (!filteredValues) {
+      return false;
+    }
+    const filteredValuesSet = new Set(filteredValues);
+    if (filteredValuesSet.has(toTrimmedLowerCase(data.formattedValue))) {
+      return true;
+    }
+  } else {
+    if (filter.type === "none") {
+      return false;
+    }
+    const evaluator = criterionEvaluatorRegistry.get(filter.type);
+
+    const evaluatedCriterionValues = filter.values.map((value) => {
+      if (!value.startsWith("=")) {
+        return parseLiteral(value, DEFAULT_LOCALE);
+      }
+      return getters.evaluateFormula(sheetId, value) ?? "";
+    });
+    if (evaluatedCriterionValues.some(isMultipleElementMatrix)) {
+      return false;
+    }
+    const evaluatedCriterion = {
+      type: filter.type,
+      values: evaluatedCriterionValues.map(toScalar),
+      dateValue: filter.dateValue,
+    };
+    if (!evaluator.isValueValid(data.value, evaluatedCriterion, preComputedCriterion)) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/src/helpers/pivot/pivot_runtime_definition.ts
+++ b/src/helpers/pivot/pivot_runtime_definition.ts
@@ -4,10 +4,12 @@ import {
   CommonPivotCoreDefinition,
   PivotCollapsedDomains,
   PivotCoreDimension,
+  PivotCoreFilter,
   PivotCoreMeasure,
   PivotCustomGroupedField,
   PivotDimension,
   PivotFields,
+  PivotFilter,
   PivotMeasure,
   PivotSortedColumn,
 } from "../../types/pivot";
@@ -22,6 +24,7 @@ export class PivotRuntimeDefinition {
   readonly measures: PivotMeasure[];
   readonly columns: PivotDimension[];
   readonly rows: PivotDimension[];
+  readonly filters?: PivotFilter[];
   readonly sortedColumn?: PivotSortedColumn;
   readonly collapsedDomains?: PivotCollapsedDomains;
   readonly customFields?: Record<string, PivotCustomGroupedField>;
@@ -32,6 +35,9 @@ export class PivotRuntimeDefinition {
     );
     this.rows = definition.rows.map((dimension) => this.createPivotDimension(fields, dimension));
     this.measures = definition.measures.map((measure) => this.createMeasure(fields, measure));
+    this.filters = (definition.filters ?? []).map((filter) =>
+      this.createPivotFilter(fields, filter)
+    );
     this.sortedColumn = definition.sortedColumn;
     this.collapsedDomains = definition.collapsedDomains;
     this.customFields = definition.customFields;
@@ -152,6 +158,15 @@ export class PivotRuntimeDefinition {
       isCustomField: !!field?.isCustomField,
       customGroups: field?.customGroups,
       parentField: field?.parentField,
+    };
+  }
+
+  private createPivotFilter(fields: PivotFields, filter: PivotCoreFilter): PivotFilter {
+    const field = fields[filter.fieldName];
+    return {
+      ...filter,
+      displayName: field?.name ?? filter.fieldName,
+      isValid: !!field,
     };
   }
 }

--- a/src/helpers/pivot/spreadsheet_pivot/spreadsheet_pivot.ts
+++ b/src/helpers/pivot/spreadsheet_pivot/spreadsheet_pivot.ts
@@ -19,6 +19,7 @@ import {
 import { InitPivotParams, Pivot } from "../../../types/pivot_runtime";
 import { Range } from "../../../types/range";
 import { toXC } from "../../coordinates";
+import { isValueFiltered } from "../../filter_helpers";
 import { formatValue, isDateTimeFormat } from "../../format/format";
 import { deepEquals, isDefined } from "../../misc";
 import {
@@ -75,10 +76,16 @@ export class SpreadsheetPivot implements Pivot<SpreadsheetPivotRuntimeDefinition
   private coreDefinition: SpreadsheetPivotCoreDefinition;
   private metaData: MetaData = { fields: {}, fieldKeys: [] };
   /**
-   * This array contains the data entries of the pivot. Each entry is an object
+   * This array contains the complete set of original data entries. Each entry is an object
    * that contains the values of the fields for a row.
    */
-  private dataEntries: DataEntries = [];
+  private unfilteredDataEntries: DataEntries = [];
+  /**
+   * Data entries after filters have been applied.
+   * This is the subset used for rendering and pivot calculations.
+   */
+  private filteredDataEntries: DataEntries = [];
+
   /**
    * This object contains the pivot table structure. It is created from the
    * data entries and the pivot definition.
@@ -117,7 +124,8 @@ export class SpreadsheetPivot implements Pivot<SpreadsheetPivotRuntimeDefinition
       this._definition = this.loadRuntimeDefinition();
     }
     if (type >= ReloadType.DATA) {
-      this.dataEntries = this.loadData();
+      this.unfilteredDataEntries = this.loadDataEntries();
+      this.filteredDataEntries = this.loadFilteredDataEntries(this.unfilteredDataEntries);
     }
     if (type >= ReloadType.TABLE) {
       this.collapsedTable = undefined;
@@ -184,6 +192,11 @@ export class SpreadsheetPivot implements Pivot<SpreadsheetPivotRuntimeDefinition
         return false;
       }
     }
+    for (const filter of this.definition.filters ?? []) {
+      if (!filter.isValid) {
+        return false;
+      }
+    }
     return true;
   }
 
@@ -193,14 +206,16 @@ export class SpreadsheetPivot implements Pivot<SpreadsheetPivotRuntimeDefinition
         if (this.invalidRangeError) {
           throw this.invalidRangeError;
         } else {
-          throw new EvaluationError(_t("At least one measure and/or dimension is not correct."));
+          throw new EvaluationError(
+            _t("At least one measure/dimension and/or filter is not correct.")
+          );
         }
       }
       return {
         value: CellErrorType.GenericError,
         message:
           this.invalidRangeError?.message ??
-          _t("At least one measure and/or dimension is not correct."),
+          _t("At least one measure/dimension and/or filter is not correct."),
       };
     }
     return undefined;
@@ -248,7 +263,7 @@ export class SpreadsheetPivot implements Pivot<SpreadsheetPivotRuntimeDefinition
       return { value: _t("Total") };
     }
     const dimension = this.getDimension(lastNode.field);
-    const cells = this.filterDataEntriesFromDomain(this.dataEntries, domain);
+    const cells = this.filterDataEntriesFromDomain(this.filteredDataEntries, domain);
     const finalCell = cells[0]?.[dimension.nameWithGranularity];
     if (dimension.type === "datetime") {
       const adapter = pivotTimeAdapter((dimension.granularity || "month") as Granularity);
@@ -264,7 +279,7 @@ export class SpreadsheetPivot implements Pivot<SpreadsheetPivotRuntimeDefinition
   }
 
   getPivotCellValueAndFormat(measureId: string, domain: PivotDomain): FunctionResultObject {
-    const dataEntries = this.filterDataEntriesFromDomain(this.dataEntries, domain);
+    const dataEntries = this.filterDataEntriesFromDomain(this.filteredDataEntries, domain);
     if (dataEntries.length === 0) {
       return { value: "" };
     }
@@ -288,9 +303,13 @@ export class SpreadsheetPivot implements Pivot<SpreadsheetPivotRuntimeDefinition
     }
   }
 
+  getDataEntries(): DataEntries {
+    return this.unfilteredDataEntries;
+  }
+
   getPossibleFieldValues(dimension: PivotDimension): ValueAndLabel<string | number | boolean>[] {
     const values: ValueAndLabel<string | number | boolean>[] = [];
-    const groups = groupPivotDataEntriesBy(this.dataEntries, dimension);
+    const groups = groupPivotDataEntriesBy(this.filteredDataEntries, dimension);
     const orderedKeys = orderDataEntriesKeys(groups, dimension);
     for (const key of orderedKeys) {
       values.push({
@@ -310,7 +329,7 @@ export class SpreadsheetPivot implements Pivot<SpreadsheetPivotRuntimeDefinition
     }
     if (!this.collapsedTable) {
       this.collapsedTable = dataEntriesToSpreadsheetPivotTable(
-        this.dataEntries,
+        this.filteredDataEntries,
         this.definition,
         "collapsed"
       );
@@ -324,7 +343,7 @@ export class SpreadsheetPivot implements Pivot<SpreadsheetPivotRuntimeDefinition
     }
     if (!this.expandedTable) {
       this.expandedTable = dataEntriesToSpreadsheetPivotTable(
-        this.dataEntries,
+        this.filteredDataEntries,
         this.definition,
         "expanded"
       );
@@ -368,9 +387,33 @@ export class SpreadsheetPivot implements Pivot<SpreadsheetPivotRuntimeDefinition
     return new SpreadsheetPivotRuntimeDefinition(this.coreDefinition, this.fields, this.getters);
   }
 
-  private loadData() {
+  private loadDataEntries() {
     const range = this._definition?.range;
     return this.isValid() && range ? this.extractDataEntriesFromRange(range) : [];
+  }
+
+  private loadFilteredDataEntries(dataEntries: DataEntries): DataEntries {
+    const sheetId = this._definition?.range?.sheetId;
+    if (!sheetId) {
+      return [];
+    }
+    if (this._definition && this._definition.filters) {
+      dataEntries = dataEntries.filter((dataEntry) => {
+        let passesAllFilters = true;
+        for (const filter of this._definition?.filters ?? []) {
+          const fieldData = dataEntry[filter.fieldName];
+          if (!fieldData) {
+            continue;
+          }
+          if (isValueFiltered(this.getters, sheetId, fieldData, filter)) {
+            passesAllFilters = false;
+            break;
+          }
+        }
+        return passesAllFilters;
+      });
+    }
+    return dataEntries;
   }
 
   private getTypeOfDimension(fieldWithGranularity: string): string {

--- a/src/plugins/ui_feature/insert_pivot.ts
+++ b/src/plugins/ui_feature/insert_pivot.ts
@@ -65,6 +65,7 @@ export class InsertPivotPlugin extends UIPlugin {
         columns: [],
         rows: [],
         measures: [],
+        filters: [],
         name: _t("New pivot"),
         type: "SPREADSHEET",
         style: { tableStyleId: PIVOT_INSERT_TABLE_STYLE_ID },

--- a/src/plugins/ui_stateful/filter_evaluation.ts
+++ b/src/plugins/ui_stateful/filter_evaluation.ts
@@ -1,13 +1,10 @@
-import { isMultipleElementMatrix, toScalar } from "../../functions/helper_matrices";
-import { parseLiteral } from "../../helpers/cells/cell_evaluation";
 import { toXC } from "../../helpers/coordinates";
+import { isValueFiltered } from "../../helpers/filter_helpers";
 import { deepCopy, getUniqueText, range } from "../../helpers/misc";
-import { toTrimmedLowerCase } from "../../helpers/text_helper";
 import { positions, toZone, zoneToDimension } from "../../helpers/zones";
 import { criterionEvaluatorRegistry } from "../../registries/criterion_registry";
 import { Command, CommandResult, LocalCommand, UpdateFilterCommand } from "../../types/commands";
 import { GenericCriterion } from "../../types/generic_criterion";
-import { DEFAULT_LOCALE } from "../../types/locale";
 import { CellPosition, FilterId, UID } from "../../types/misc";
 import { CriterionFilter, DataFilterValue, Table } from "../../types/table";
 import { ExcelFilterData, ExcelWorkbookData } from "../../types/workbook_data";
@@ -175,59 +172,32 @@ export class FilterEvaluationPlugin extends UIPlugin {
       ) {
         continue;
       }
-      if (filterValue.filterType === "values") {
-        const filteredValues = filterValue.hiddenValues?.map(toTrimmedLowerCase);
-        if (!filteredValues) {
-          continue;
-        }
-        const filteredValuesSet = new Set(filteredValues);
-        for (let row = filteredZone.top; row <= filteredZone.bottom; row++) {
-          const value = this.getCellValueAsString(sheetId, filter.col, row);
-          if (filteredValuesSet.has(value)) {
-            hiddenRows.add(row);
-          }
-        }
-      } else {
+
+      let preComputedCriterion: unknown;
+
+      if (filterValue.filterType === "criterion") {
         if (filterValue.type === "none") {
           continue;
         }
         const evaluator = criterionEvaluatorRegistry.get(filterValue.type);
-        const preComputedCriterion = evaluator.preComputeCriterion?.(
+        preComputedCriterion = evaluator.preComputeCriterion?.(
           filterValue as GenericCriterion,
           [filter.filteredRange],
           this.getters
         );
+      }
 
-        const evaluatedCriterionValues = filterValue.values.map((value) => {
-          if (!value.startsWith("=")) {
-            return parseLiteral(value, DEFAULT_LOCALE);
-          }
-          return this.getters.evaluateFormula(sheetId, value) ?? "";
-        });
-        if (evaluatedCriterionValues.some(isMultipleElementMatrix)) {
-          continue;
-        }
-
-        const evaluatedCriterion = {
-          type: filterValue.type,
-          values: evaluatedCriterionValues.map(toScalar),
-          dateValue: filterValue.dateValue,
-        };
-        for (let row = filteredZone.top; row <= filteredZone.bottom; row++) {
-          const position = { sheetId, col: filter.col, row };
-          const value = this.getters.getEvaluatedCell(position).value ?? "";
-          if (!evaluator.isValueValid(value, evaluatedCriterion, preComputedCriterion)) {
-            hiddenRows.add(row);
-          }
+      for (let row = filteredZone.top; row <= filteredZone.bottom; row++) {
+        const position = { sheetId, col: filter.col, row };
+        const evaluatedCell = this.getters.getEvaluatedCell(position);
+        if (
+          isValueFiltered(this.getters, sheetId, evaluatedCell, filterValue, preComputedCriterion)
+        ) {
+          hiddenRows.add(row);
         }
       }
     }
     this.hiddenRows[sheetId] = hiddenRows;
-  }
-
-  private getCellValueAsString(sheetId: UID, col: number, row: number): string {
-    const value = this.getters.getEvaluatedCell({ sheetId, col, row }).formattedValue;
-    return toTrimmedLowerCase(value);
   }
 
   exportForExcel(data: ExcelWorkbookData) {

--- a/src/types/pivot.ts
+++ b/src/types/pivot.ts
@@ -2,6 +2,7 @@ import { CellValue } from "./cells";
 import { Format } from "./format";
 import { Locale } from "./locale";
 import { Dimension, FunctionResultObject, SortDirection, UID, Zone } from "./misc";
+import { CriterionFilter, ValuesFilter } from "./table";
 
 export type Aggregator =
   | "array_agg"
@@ -51,10 +52,26 @@ export interface PivotCoreMeasure {
   display?: PivotMeasureDisplay;
 }
 
+export type PivotCoreFilter = PivotValuesFilter | PivotCriterionFilter;
+
+export type PivotFilter = PivotCoreFilter & {
+  displayName: string;
+  isValid: boolean;
+};
+
+export interface PivotValuesFilter extends ValuesFilter {
+  fieldName: string;
+}
+
+export interface PivotCriterionFilter extends CriterionFilter {
+  fieldName: string;
+}
+
 export interface CommonPivotCoreDefinition {
   columns: PivotCoreDimension[];
   rows: PivotCoreDimension[];
   measures: PivotCoreMeasure[];
+  filters?: PivotCoreFilter[];
   name: string;
   deferUpdates?: boolean;
   sortedColumn?: PivotSortedColumn;

--- a/tests/collaborative/collaborative_history.test.ts
+++ b/tests/collaborative/collaborative_history.test.ts
@@ -961,6 +961,7 @@ describe("Collaborative local history", () => {
           rows: [],
           columns: [],
           measures: [{ id: "Price:sum", fieldName: "Price", aggregator: "sum" }],
+          filters: [],
         },
       },
     };

--- a/tests/pivots/pivot_plugin.test.ts
+++ b/tests/pivots/pivot_plugin.test.ts
@@ -242,6 +242,7 @@ describe("Pivot plugin", () => {
         columns: [],
         rows: [],
         measures: [],
+        filters: [],
         name: "Pivot",
         type: "SPREADSHEET",
       },

--- a/tests/pivots/spreadsheet_pivot/__snapshots__/spreadsheet_pivot_side_panel.test.ts.snap
+++ b/tests/pivots/spreadsheet_pivot/__snapshots__/spreadsheet_pivot_side_panel.test.ts.snap
@@ -231,6 +231,26 @@ exports[`Spreadsheet pivot side panel It should correctly be displayed 1`] = `
                   </div>
                   
                   
+                  <div
+                    class="o-section pt-0"
+                  >
+                    
+                    <div
+                      class="o-fw-bold pt-0 pb-1 d-flex flex-row justify-content-between align-items-center o-section-title"
+                    >
+                       Domain 
+                      <button
+                        class="add-dimension o-button"
+                      >
+                         Add 
+                      </button>
+                      
+                      
+                    </div>
+                    
+                    
+                  </div>
+                  
                 </div>
               </div>
               <div
@@ -1188,6 +1208,7 @@ exports[`Spreadsheet pivot side panel It should display only the selection input
                     </span>
                     
                   </div>
+                  
                   
                   
                 </div>

--- a/tests/pivots/spreadsheet_pivot/pivot_filter/pivot_filter_component.test.ts
+++ b/tests/pivots/spreadsheet_pivot/pivot_filter/pivot_filter_component.test.ts
@@ -1,0 +1,173 @@
+import { SidePanels } from "../../../../src/components/side_panel/side_panels/side_panels";
+import {
+  click,
+  deleteColumns,
+  setInputValueAndTrigger,
+  simulateClick,
+} from "../../../test_helpers";
+import { mountComponentWithPortalTarget, nextTick, setGrid } from "../../../test_helpers/helpers";
+import { addPivot } from "../../../test_helpers/pivot_helpers";
+
+async function setupPivotWithFilter() {
+  const { env, model, fixture } = await mountComponentWithPortalTarget(SidePanels, {});
+  // prettier-ignore
+  const grid = {
+      A1: "Customer", B1: "Product", C1: "Amount", D1: "Date",
+      A2: "Alice", B2: "Chair", C2: "10", D2: "1/1/2001",
+      A3: "Bob", B3: "Table", C3: "20", D3: "2/2/2002",
+      A4: "=PIVOT(1)"
+    };
+  setGrid(model, grid);
+  addPivot(model, "A1:D3", {
+    rows: [{ fieldName: "Customer", order: "asc" }],
+    columns: [],
+    measures: [{ id: "amount", fieldName: "Amount", aggregator: "sum" }],
+    filters: [{ fieldName: "Amount", filterType: "values", hiddenValues: [] }],
+  });
+  return { model, fixture, env };
+}
+
+describe("Spreadsheet pivot side panel", () => {
+  test("can only have a filter on a field once", async () => {
+    const { fixture, env } = await setupPivotWithFilter();
+    env.openSidePanel("PivotSidePanel", { pivotId: "1" });
+    await nextTick();
+    await click(fixture.querySelectorAll(".add-dimension")[3]);
+    expect(".o-autocomplete-value").toHaveCount(3);
+    const fields = fixture.querySelectorAll(".o-autocomplete-value");
+    expect(fields[0]).toHaveText("Customer");
+    expect(fields[1]).toHaveText("Date");
+    expect(fields[2]).toHaveText("Product");
+    await click(fields[0]);
+    await click(fixture.querySelectorAll(".add-dimension")[3]);
+    expect(".o-autocomplete-value").toHaveCount(2);
+  });
+
+  test("shows a warning when there is a filter on a deleted field", async () => {
+    const { model, env } = await setupPivotWithFilter();
+    env.openSidePanel("PivotSidePanel", { pivotId: "1" });
+    await nextTick();
+    deleteColumns(model, ["C"]);
+    expect(model.getters.getPivot("1").definition.filters).toEqual([
+      {
+        fieldName: "Amount",
+        displayName: "Amount",
+        filterType: "values",
+        hiddenValues: [],
+        isValid: false,
+      },
+    ]);
+  });
+
+  test("can add a filter", async () => {
+    const { model, fixture, env } = await setupPivotWithFilter();
+    env.openSidePanel("PivotSidePanel", { pivotId: "1" });
+    await nextTick();
+    await click(fixture.querySelectorAll(".add-dimension")[3]);
+    await click(fixture.querySelectorAll(".o-autocomplete-value")[0]);
+    expect(model.getters.getPivotCoreDefinition("1").filters).toEqual([
+      {
+        fieldName: "Amount",
+        filterType: "values",
+        hiddenValues: [],
+      },
+      {
+        fieldName: "Customer",
+        filterType: "values",
+        hiddenValues: [],
+      },
+    ]);
+  });
+
+  test("can remove a filter", async () => {
+    const { model, fixture, env } = await setupPivotWithFilter();
+    env.openSidePanel("PivotSidePanel", { pivotId: "1" });
+    await nextTick();
+    await click(fixture.querySelectorAll(".fa-trash")[2]);
+    expect(model.getters.getPivotCoreDefinition("1").filters).toEqual([]);
+  });
+
+  test("the list of values is correct", async () => {
+    const { fixture, env } = await setupPivotWithFilter();
+    env.openSidePanel("PivotSidePanel", { pivotId: "1" });
+    await nextTick();
+    await click(fixture.querySelector(".o-pivot-filter-icon")!);
+    expect(".o-popover").toHaveCount(1);
+    expect(".o-filter-menu-item").toHaveCount(2);
+    const firstValue = fixture.querySelectorAll(".o-filter-menu-item")[0].textContent;
+    const secondValue = fixture.querySelectorAll(".o-filter-menu-item")[1].textContent;
+    expect([firstValue, secondValue]).toEqual(["10", "20"]);
+  });
+
+  test("can update the hidden values of a values filter (caption and icon are updated as well)", async () => {
+    const { model, fixture, env } = await setupPivotWithFilter();
+    env.openSidePanel("PivotSidePanel", { pivotId: "1" });
+    await nextTick();
+    expect(".o-pivot-filter-caption").toHaveText("showing all items");
+    expect(".o-pivot-filter-icon .filter-icon").toHaveCount(1);
+    await click(fixture.querySelector(".o-pivot-filter-icon")!);
+    await click(fixture.querySelectorAll(".o-filter-menu-item .o-checkbox")[0]);
+    await click(fixture, ".o-filter-menu-confirm");
+    expect(".o-popover").toHaveCount(0);
+    expect(model.getters.getPivotCoreDefinition("1").filters).toEqual([
+      {
+        fieldName: "Amount",
+        filterType: "values",
+        hiddenValues: ["10"],
+      },
+    ]);
+    expect(".o-pivot-filter-caption").toHaveText("showing 1 item");
+    expect(".o-pivot-filter-icon .filter-icon-active").toHaveCount(1);
+  });
+
+  test("can update the criterion of a criterion filter", async () => {
+    const { model, fixture, env } = await setupPivotWithFilter();
+    env.openSidePanel("PivotSidePanel", { pivotId: "1" });
+    await nextTick();
+    await click(fixture.querySelector(".o-pivot-filter-icon")!);
+    await simulateClick(".o-filter-criterion-type");
+    await simulateClick(fixture.querySelectorAll(".o-select-option")[1]);
+    await setInputValueAndTrigger(".o-dv-input .o-input ", "10");
+    await click(fixture, ".o-filter-menu-confirm");
+    expect(model.getters.getPivotCoreDefinition("1").filters).toEqual([
+      {
+        fieldName: "Amount",
+        filterType: "criterion",
+        type: "isEqual",
+        values: ["10"],
+        dateValue: undefined,
+      },
+    ]);
+    expect(".o-pivot-filter-caption").toHaveText("Value is equal to 10");
+    expect(".o-pivot-filter-icon .filter-icon-active").toHaveCount(1);
+  });
+
+  test("can update the criterion of a criterion filter with date type", async () => {
+    const { model, fixture, env } = await setupPivotWithFilter();
+    env.openSidePanel("PivotSidePanel", { pivotId: "1" });
+    await nextTick();
+    await click(fixture.querySelectorAll(".add-dimension")[3]);
+    await click(fixture.querySelectorAll(".o-autocomplete-value")[1]);
+    await click(fixture.querySelectorAll(".o-pivot-filter-icon")[1]);
+    await simulateClick(".o-filter-criterion-type");
+    await simulateClick(fixture.querySelectorAll(".o-select-option")[1]);
+    await setInputValueAndTrigger(".o-dv-input .o-input ", "1/1/2001");
+    await click(fixture, ".o-filter-menu-confirm");
+    expect(model.getters.getPivotCoreDefinition("1").filters).toEqual([
+      {
+        fieldName: "Amount",
+        filterType: "values",
+        hiddenValues: [],
+      },
+      {
+        fieldName: "Date",
+        filterType: "criterion",
+        type: "dateIs",
+        values: ["1/1/2001"],
+        dateValue: "exactDate",
+      },
+    ]);
+    expect(fixture.querySelectorAll(".o-pivot-filter-caption")[1]).toHaveText("Date is 1/1/2001");
+    expect(".o-pivot-filter-icon .filter-icon-active").toHaveCount(1);
+  });
+});

--- a/tests/pivots/spreadsheet_pivot/pivot_filter/pivot_filter_plugin.test.ts
+++ b/tests/pivots/spreadsheet_pivot/pivot_filter/pivot_filter_plugin.test.ts
@@ -1,0 +1,215 @@
+import { Model, SpreadsheetPivotCoreDefinition } from "../../../../src";
+import { getEvaluatedGrid } from "../../../test_helpers";
+import { createModelFromGrid } from "../../../test_helpers/helpers";
+import { addPivot, createModelWithTestPivotDataset } from "../../../test_helpers/pivot_helpers";
+
+describe("pivot table with filters", () => {
+  test("Hide a value with a values filter", () => {
+    // prettier-ignore
+    const grid = {
+      A1: "Customer",   B1: "Price", C1: "=PIVOT(1)",
+      A2: "Alice",      B2: "10",
+      A3: "Bob",        B3: "20",
+      A4: "Olaf",       B4: "30",
+    };
+    const model = createModelFromGrid(grid);
+    addPivot(model, "A1:B4", {
+      rows: [{ fieldName: "Customer", order: "asc" }],
+      columns: [],
+      measures: [{ id: "price", fieldName: "Price", aggregator: "sum" }],
+      filters: [{ fieldName: "Customer", filterType: "values", hiddenValues: ["Alice"] }],
+    });
+    // prettier-ignore
+    expect(getEvaluatedGrid(model, "C1:C5")).toEqual([
+      ["Pivot"],
+      [""],
+      ["Bob"],
+      ["Olaf"],
+      ["Total"]
+    ]);
+  });
+
+  test("Hide all values with a values filter", () => {
+    // prettier-ignore
+    const grid = {
+      A1: "Customer", B1: "Price", C1: "=PIVOT(1)",
+      A2: "Alice", B2: "10",
+      A3: "Bob", B3: "20",
+      A4: "Olaf", B4: "30",
+    };
+    const model = createModelFromGrid(grid);
+    addPivot(model, "A1:B4", {
+      rows: [{ fieldName: "Customer", order: "asc" }],
+      columns: [],
+      measures: [{ id: "price", fieldName: "Price", aggregator: "sum" }],
+      filters: [
+        { fieldName: "Customer", filterType: "values", hiddenValues: ["Alice", "Bob", "Olaf"] },
+      ],
+    });
+    // prettier-ignore
+    expect(getEvaluatedGrid(model, "C1:C2")).toEqual([
+      ["Pivot"],
+      [""],
+    ]);
+  });
+
+  test("Hide no values with a values filter", () => {
+    // prettier-ignore
+    const grid = {
+      A1: "Customer", B1: "Price", C1: "=PIVOT(1)",
+      A2: "Alice", B2: "10",
+      A3: "Bob", B3: "20",
+      A4: "Olaf", B4: "30",
+    };
+    const model = createModelFromGrid(grid);
+    addPivot(model, "A1:B4", {
+      rows: [{ fieldName: "Customer", order: "asc" }],
+      columns: [],
+      measures: [{ id: "price", fieldName: "Price", aggregator: "sum" }],
+      filters: [{ fieldName: "Customer", filterType: "values", hiddenValues: [] }],
+    });
+    // prettier-ignore
+    expect(getEvaluatedGrid(model, "C1:C5")).toEqual([
+      ["Pivot"],
+      [""],
+      ["Alice"],
+      ["Bob"],
+      ["Olaf"],
+    ]);
+  });
+
+  test("Hide values with a text criterion filter", () => {
+    // prettier-ignore
+    const grid = {
+      A1: "Customer", B1: "Price", C1: "=PIVOT(1)",
+      A2: "Alice", B2: "10",
+      A3: "Bob", B3: "20",
+      A4: "Olaf", B4: "30",
+    };
+    const model = createModelFromGrid(grid);
+    addPivot(model, "A1:B4", {
+      rows: [{ fieldName: "Customer", order: "asc" }],
+      columns: [],
+      measures: [{ id: "price", fieldName: "Price", aggregator: "sum" }],
+      filters: [
+        { fieldName: "Customer", filterType: "criterion", type: "beginsWithText", values: ["a"] },
+      ],
+    });
+    // prettier-ignore
+    expect(getEvaluatedGrid(model, "C1:C4")).toEqual([
+      ["Pivot"],
+      [""],
+      ["Alice"],
+      ["Total"],
+    ]);
+  });
+
+  test("Hide values with a number criterion filter", () => {
+    // prettier-ignore
+    const grid = {
+      A1: "Customer", B1: "Price", C1: "=PIVOT(1)",
+      A2: "Alice", B2: "10",
+      A3: "Bob", B3: "20",
+      A4: "Olaf", B4: "30",
+    };
+    const model = createModelFromGrid(grid);
+    addPivot(model, "A1:B4", {
+      rows: [{ fieldName: "Customer", order: "asc" }],
+      columns: [],
+      measures: [{ id: "price", fieldName: "Price", aggregator: "sum" }],
+      filters: [
+        { fieldName: "Price", filterType: "criterion", type: "isLessThan", values: ["25"] },
+      ],
+    });
+    // prettier-ignore
+    expect(getEvaluatedGrid(model, "C1:D5")).toEqual([
+      ["Pivot", "Total"],
+      ["", "Price"],
+      ["Alice", "10"],
+      ["Bob", "20"],
+      ["Total", "30"]
+    ]);
+  });
+
+  test("Hide values with a date criterion filter", () => {
+    // prettier-ignore
+    const grid = {
+      A1: "Customer", B1: "Price", C1: "Date", D1: "=PIVOT(1)",
+      A2: "Alice", B2: "10", C2: "1/1/2001",
+      A3: "Bob", B3: "20", C3: "2/2/2002",
+      A4: "Olaf", B4: "30", C4: "3/3/2003"
+    };
+    const model = createModelFromGrid(grid);
+    addPivot(model, "A1:C4", {
+      rows: [{ fieldName: "Customer", order: "asc" }],
+      columns: [],
+      measures: [{ id: "price", fieldName: "Price", aggregator: "sum" }],
+      filters: [
+        {
+          fieldName: "Date",
+          filterType: "criterion",
+          type: "dateIsBefore",
+          values: ["2/2/2002"],
+          dateValue: "exactDate",
+        },
+      ],
+    });
+    // prettier-ignore
+    expect(getEvaluatedGrid(model, "D1:E4")).toEqual([
+      ["Pivot", "Total"],
+      ["", "Price"],
+      ["Alice", "10"],
+      ["Total", "10"]
+    ]);
+  });
+});
+
+test("migration", () => {
+  const data = {
+    version: "19.1.0",
+    pivots: {
+      1: {
+        type: "SPREADSHEET",
+        columns: [],
+        domain: [],
+        measures: [{ id: "probability:sum", fieldName: "probability", aggregator: "sum" }],
+        model: "partner",
+        rows: [{ fieldName: "bar" }],
+        sortedColumn: {
+          measure: "foo",
+          order: "asc",
+        },
+        name: "A pivot",
+        formulaId: "1",
+      },
+    },
+  };
+  const model = new Model(data);
+  expect(model.getters.getPivot("1").definition.filters).toEqual([]);
+});
+
+test("Import/export", () => {
+  const pivotDefinition: Partial<SpreadsheetPivotCoreDefinition> = {
+    columns: [{ fieldName: "Salesperson" }],
+    filters: [{ fieldName: "Active", filterType: "values", hiddenValues: ["FALSE"] }],
+  };
+  const model = createModelWithTestPivotDataset(pivotDefinition);
+  const exported = model.exportData();
+  expect(exported.pivots["pivotId"].filters).toEqual([
+    {
+      fieldName: "Active",
+      filterType: "values",
+      hiddenValues: ["FALSE"],
+    },
+  ]);
+  const importedModel = new Model(exported);
+  expect(importedModel.getters.getPivot("pivotId").definition.filters).toEqual([
+    {
+      fieldName: "Active",
+      displayName: "Active",
+      isValid: true,
+      filterType: "values",
+      hiddenValues: ["FALSE"],
+    },
+  ]);
+});

--- a/tests/test_helpers/constants.ts
+++ b/tests/test_helpers/constants.ts
@@ -119,6 +119,7 @@ const PIVOT: PivotCoreDefinition = {
       fieldName: "computed",
     },
   ],
+  filters: [],
   name: "pivot",
   type: "SPREADSHEET",
 };

--- a/tests/test_helpers/pivot_helpers.ts
+++ b/tests/test_helpers/pivot_helpers.ts
@@ -20,6 +20,7 @@ function defaultPivotDefinition(sheetId: UID): SpreadsheetPivotCoreDefinition {
     },
     rows: [],
     columns: [],
+    filters: [],
     measures: [],
   };
 }
@@ -116,6 +117,7 @@ export function createModelWithTestPivotDataset(
     columns: [{ fieldName: "Salesperson", order: "asc" }],
     rows: [{ fieldName: "Created on", granularity: "month_number", order: "asc" }],
     measures: [{ fieldName: "Expected Revenue", aggregator: "sum", id: measureId }],
+    filters: [],
     ...pivotDefinition,
   };
   addPivot(model, "A1:E18", pivotDefinition, pivotId);


### PR DESCRIPTION
## Description:
    
 In order to ease users' spreadsheet pivot setup, it would be nice to be able to filter each pivot created from a source range so that a same range could be used for multiple pivot.


Task: [4273959](https://www.odoo.com/odoo/2328/tasks/4273959)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo