### PR TITLE
[FIX] chart: fix zoom plugin

### DIFF
--- a/src/components/figures/chart/chartJs/chartjs.ts
+++ b/src/components/figures/chart/chartJs/chartjs.ts
@@ -21,6 +21,7 @@ import { chartShowValuesPlugin } from "./chartjs_show_values_plugin";
 import { sunburstHoverPlugin } from "./chartjs_sunburst_hover_plugin";
 import { sunburstLabelsPlugin } from "./chartjs_sunburst_labels_plugin";
 import { waterfallLinesPlugin } from "./chartjs_waterfall_plugin";
+import { zoomWindowPlugin } from "./zoomable_chart/zoomable_chartjs_plugins";
 
 interface Props {
   chartId: UID;
@@ -63,6 +64,10 @@ chartJsExtensionRegistry.add("chartColorScalePlugin", {
 chartJsExtensionRegistry.add("calendarController", {
   register: (Chart) => Chart.register(getCalendarChartController()),
   unregister: (Chart) => Chart.unregister(getCalendarChartController()),
+});
+chartJsExtensionRegistry.add("zoomWindowPlugin", {
+  register: (Chart) => Chart.register(zoomWindowPlugin),
+  unregister: (Chart) => Chart.unregister(zoomWindowPlugin),
 });
 
 export class ChartJsComponent extends Component<Props, SpreadsheetChildEnv> {

--- a/src/components/figures/chart/chartJs/zoomable_chart/zoomable_chartjs.ts
+++ b/src/components/figures/chart/chartJs/zoomable_chart/zoomable_chartjs.ts
@@ -5,19 +5,12 @@ import {
 } from "@odoo/o-spreadsheet-engine/helpers/figures/charts/chart_common";
 import { useRef } from "@odoo/owl";
 import { Chart, ChartConfiguration } from "chart.js/auto";
-import { chartJsExtensionRegistry } from "../../../../../../packages/o-spreadsheet-engine/src/helpers/figures/charts/chart_js_extension";
 import { clip } from "../../../../../helpers";
 import { Store, useStore } from "../../../../../store_engine";
 import { ChartJSRuntime } from "../../../../../types";
 import { withZoom } from "../../../../helpers/zoom";
 import { ChartJsComponent } from "../chartjs";
 import { Boundaries, ZoomableChartStore } from "./zoomable_chart_store";
-import { zoomWindowPlugin } from "./zoomable_chartjs_plugins";
-
-chartJsExtensionRegistry.add("zoomWindowPlugin", {
-  register: (Chart) => Chart.register(zoomWindowPlugin),
-  unregister: (Chart) => Chart.unregister(zoomWindowPlugin),
-});
 
 export class ZoomableChartJsComponent extends ChartJsComponent {
   static template = "o-spreadsheet-ZoomableChartJsComponent";


### PR DESCRIPTION
## Task Description

This commit aims to fix the usage of the `zoomWindowPlugin`, which draws the zoomed window boundaries on the master chart in a chart.
Due to file order, when first calling the `registerChartJsExtensions` method, the `zoomWindowPlugin` wasn't added in the `chartJsExtensionRegistry` yet, and was therefore not added. Unfortunately, each following call to `registerChartJsExtension` were ignored by the early-return checking if the `chartShowValuesPlugin`
was already registered, which is the case.

This fix adds the `zoomWindowPlugin` in the registry at the same time as the others plugins, fixing this issue by ensuring every plugin is in the registry when we first call the `registerChartJsExtension` method.

## Related Task

N./A.