### PR TITLE
[FIX] array_formula_highlight: avoid false spill outline

### DIFF
--- a/src/plugins/ui_core_views/cell_evaluation/evaluation_plugin.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluation_plugin.ts
@@ -157,6 +157,7 @@ export class EvaluationPlugin extends UIPlugin {
     "getEvaluatedCellsPositions",
     "getSpreadZone",
     "getArrayFormulaSpreadingOn",
+    "isArrayFormulaSpillBlocked",
     "isEmpty",
   ] as const;
 
@@ -296,6 +297,10 @@ export class EvaluationPlugin extends UIPlugin {
 
   getArrayFormulaSpreadingOn(position: CellPosition): CellPosition | undefined {
     return this.evaluator.getArrayFormulaSpreadingOn(position);
+  }
+
+  isArrayFormulaSpillBlocked(position: CellPosition): boolean {
+    return this.evaluator.isArrayFormulaSpillBlocked(position);
   }
 
   /**

--- a/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
@@ -104,6 +104,10 @@ export class Evaluator {
     return Array.from(arrayFormulas).find((position) => !this.blockedArrayFormulas.has(position));
   }
 
+  isArrayFormulaSpillBlocked(position: CellPosition): boolean {
+    return this.blockedArrayFormulas.has(position);
+  }
+
   updateDependencies(position: CellPosition) {
     // removing dependencies is slow because it requires
     // to traverse the entire r-tree.

--- a/src/stores/array_formula_highlight.ts
+++ b/src/stores/array_formula_highlight.ts
@@ -1,6 +1,5 @@
 import { Get } from "../store_engine";
-import { Highlight, Zone } from "../types";
-import { CellErrorType } from "../types/errors";
+import { Highlight } from "../types";
 import { HighlightStore } from "./highlight_store";
 import { SpreadsheetStore } from "./spreadsheet_store";
 
@@ -13,21 +12,22 @@ export class ArrayFormulaHighlight extends SpreadsheetStore {
   }
 
   get highlights(): Highlight[] {
-    let zone: Zone | undefined;
     const position = this.model.getters.getActivePosition();
-    const cell = this.getters.getEvaluatedCell(position);
     const spreader = this.model.getters.getArrayFormulaSpreadingOn(position);
-    zone = spreader
+    const zone = spreader
       ? this.model.getters.getSpreadZone(spreader, { ignoreSpillError: true })
       : this.model.getters.getSpreadZone(position, { ignoreSpillError: true });
     if (!zone) {
       return [];
     }
+    const isArrayFormulaBlocked = this.model.getters.isArrayFormulaSpillBlocked(
+      spreader ?? position
+    );
     return [
       {
         sheetId: position.sheetId,
         zone,
-        dashed: cell.value === CellErrorType.SpilledBlocked,
+        dashed: isArrayFormulaBlocked,
         color: "#17A2B8",
         noFill: true,
         thinLine: true,

--- a/tests/grid/array_formula_highlights_store.test.ts
+++ b/tests/grid/array_formula_highlights_store.test.ts
@@ -49,4 +49,23 @@ describe("array function highlights", () => {
     selectCell(model, "A2");
     expect(getHighlightsFromStore(container)).toEqual([]);
   });
+
+  test("Array formula using a spill error is not highlighted as blocked", () => {
+    const { model, container } = makeStore(ArrayFormulaHighlight);
+    setCellContent(model, "A1", "=MUNIT(2)");
+    setCellContent(model, "A2", "5"); // block the spread of A1
+    setCellContent(model, "A4", "=A1:B2");
+
+    const highlight = {
+      sheetId: model.getters.getActiveSheetId(),
+      zone: toZone("A4:B5"),
+      color: "#17A2B8",
+      noFill: true,
+      thinLine: true,
+      dashed: false,
+    };
+
+    selectCell(model, "A4");
+    expect(getHighlightsFromStore(container)).toEqual([highlight]);
+  });
 });


### PR DESCRIPTION
## Description:

How to reproduce:
- Type =MUNIT(2) in A1, and 5 in A2 so that A1 has a #SPILL error
- In A4 type =A1:B2
- When the selection is in A4, the highlight of the array formula becomes a SPILL highlight (dotted line). But it shouldn't, the formula in A4 is spilled correctly

This PR tracks true spill-block status instead of relying on the evaluated value, expose a spill-block getter, and use it in the highlight store so spilled formulas that return #SPILL! as data stay solid-highlighted.

Task: [5403906](https://www.odoo.com/odoo/2328/tasks/5403906)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo