### PR TITLE
[IMP] Excel: export link colors

### DIFF
--- a/packages/o-spreadsheet-engine/src/plugins/ui_feature/cell_computed_style.ts
+++ b/packages/o-spreadsheet-engine/src/plugins/ui_feature/cell_computed_style.ts
@@ -1,6 +1,10 @@
 import { LINK_COLOR } from "../../constants";
 import { PositionMap } from "../../helpers/cells/position_map";
+import { toCartesian } from "../../helpers/coordinates";
+import { getItemId } from "../../helpers/data_normalization";
 import { isObjectEmptyRecursive, removeFalsyAttributes } from "../../helpers/misc";
+import { recomputeZones } from "../../helpers/recompute_zones";
+import { isZoneInside, toZone, zoneToXc } from "../../helpers/zones";
 import {
   Command,
   invalidateBordersCommands,
@@ -8,6 +12,7 @@ import {
   invalidateEvaluationCommands,
 } from "../../types/commands";
 import { Border, CellPosition, Style } from "../../types/misc";
+import { ExcelWorkbookData } from "../../types/workbook_data";
 import { UIPlugin } from "../ui_plugin";
 import { doesCommandInvalidatesTableStyle } from "./table_computed_style";
 
@@ -71,22 +76,79 @@ export class CellComputedStylePlugin extends UIPlugin {
   }
 
   private computeCellStyle(position: CellPosition): Style {
+    const evaluatedCell = this.getters.getEvaluatedCell(position);
+    const computedStyle = this.getComputedStyle(position);
+    if (evaluatedCell.link && !computedStyle.textColor) {
+      computedStyle.textColor = LINK_COLOR;
+    }
+    return computedStyle;
+  }
+
+  private getComputedStyle(position: CellPosition): Style {
     const cell = this.getters.getCell(position);
     const cfStyle = this.getters.getCellConditionalFormatStyle(position);
     const tableStyle = this.getters.getCellTableStyle(position);
     const dataValidationStyle = this.getters.getDataValidationCellStyle(position);
-    const computedStyle = {
+    return {
       ...removeFalsyAttributes(tableStyle),
       ...removeFalsyAttributes(dataValidationStyle),
       ...removeFalsyAttributes(cell?.style),
       ...removeFalsyAttributes(cfStyle),
     };
-    const evaluatedCell = this.getters.getEvaluatedCell(position);
-    if (evaluatedCell.link && !computedStyle.textColor) {
-      computedStyle.textColor = LINK_COLOR;
-    }
+  }
 
-    return computedStyle;
+  exportForExcel(data: ExcelWorkbookData) {
+    for (const sheet of data.sheets) {
+      // Collect all link cells that need LINK_COLOR, grouped by their containing style zone to avoid O(n^2) calls to `recomputeZones`
+      const linkCellsByStyleZone: Record<string, string[]> = {};
+      // Some link cells might not be part of any style zone, handled separately
+      const linkCellsWithoutStyleZone: string[] = [];
+
+      for (const xc in sheet.cells) {
+        const position = { sheetId: sheet.id, ...toCartesian(xc) };
+        const evaluatedCell = this.getters.getEvaluatedCell(position);
+        const computedStyle = this.getComputedStyle(position);
+        if (!evaluatedCell.link || computedStyle.textColor) {
+          continue;
+        }
+        const styleXc = Object.keys(sheet.styles).find((styleXc) =>
+          isZoneInside(toZone(xc), toZone(styleXc))
+        );
+        if (styleXc) {
+          if (!linkCellsByStyleZone[styleXc]) {
+            linkCellsByStyleZone[styleXc] = [];
+          }
+          linkCellsByStyleZone[styleXc].push(xc);
+        } else {
+          linkCellsWithoutStyleZone.push(xc);
+        }
+      }
+
+      for (const [styleXc, linkXcs] of Object.entries(linkCellsByStyleZone)) {
+        const existingStyleId = sheet.styles[styleXc];
+        if (data.styles[existingStyleId].textColor) {
+          continue;
+        }
+        const existingStyle = data.styles[existingStyleId];
+        const linkZones = linkXcs.map(toZone);
+        const remainingZones = recomputeZones([toZone(styleXc)], linkZones);
+
+        delete sheet.styles[styleXc];
+
+        for (const zone of remainingZones) {
+          sheet.styles[zoneToXc(zone)] = existingStyleId;
+        }
+        const linkStyleId = getItemId({ ...existingStyle, textColor: LINK_COLOR }, data.styles);
+        for (const xc of linkXcs) {
+          sheet.styles[xc] = linkStyleId;
+        }
+      }
+
+      for (const xc of linkCellsWithoutStyleZone) {
+        const cell = this.getters.getCell({ sheetId: sheet.id, ...toCartesian(xc) });
+        sheet.styles[xc] = getItemId({ ...cell?.style, textColor: LINK_COLOR }, data.styles);
+      }
+    }
   }
 
   private computeCellBorder(position: CellPosition): Border | null {

--- a/tests/xlsx/__snapshots__/xlsx_export.test.ts.snap
+++ b/tests/xlsx/__snapshots__/xlsx_export.test.ts.snap
@@ -33788,7 +33788,7 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="165">
-            <c r="A165" cm="1" t="str">
+            <c r="A165" s="1" cm="1" t="str">
                 <f t="array" ref="A165">
                     HYPERLINK("https://www.odoo.com","Odoo")
                 </f>
@@ -33867,10 +33867,15 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
-    <fonts count="1">
+    <fonts count="2">
         <font>
             <sz val="10"/>
             <color rgb="000000"/>
+            <name val="Arial"/>
+        </font>
+        <font>
+            <sz val="10"/>
+            <color rgb="017E84"/>
             <name val="Arial"/>
         </font>
     </fonts>
@@ -33896,8 +33901,9 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </diagonal>
         </border>
     </borders>
-    <cellXfs count="1">
+    <cellXfs count="2">
         <xf numFmtId="0" fillId="0" fontId="0" borderId="0"/>
+        <xf numFmtId="0" fillId="0" fontId="1" borderId="0"/>
     </cellXfs>
     <dxfs count="0">
     </dxfs>
@@ -37183,7 +37189,7 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="165">
-            <c r="A165" cm="1" t="str">
+            <c r="A165" s="1" cm="1" t="str">
                 <f t="array" ref="A165">
                     HYPERLINK("https://www.odoo.com","Odoo")
                 </f>
@@ -37313,10 +37319,15 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
-    <fonts count="1">
+    <fonts count="2">
         <font>
             <sz val="10"/>
             <color rgb="000000"/>
+            <name val="Arial"/>
+        </font>
+        <font>
+            <sz val="10"/>
+            <color rgb="017E84"/>
             <name val="Arial"/>
         </font>
     </fonts>
@@ -37342,8 +37353,9 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </diagonal>
         </border>
     </borders>
-    <cellXfs count="1">
+    <cellXfs count="2">
         <xf numFmtId="0" fillId="0" fontId="0" borderId="0"/>
+        <xf numFmtId="0" fillId="0" fontId="1" borderId="0"/>
     </cellXfs>
     <dxfs count="0">
     </dxfs>
@@ -37891,35 +37903,35 @@ exports[`Test XLSX export link cells 1`] = `
     </cols>
     <sheetData>
         <row r="1">
-            <c r="A1" t="s">
+            <c r="A1" s="1" t="s">
                 <v>
                     0
                 </v>
             </c>
         </row>
         <row r="2">
-            <c r="A2" t="s">
+            <c r="A2" s="1" t="s">
                 <v>
                     0
                 </v>
             </c>
         </row>
         <row r="3">
-            <c r="A3" t="s">
+            <c r="A3" s="1" t="s">
                 <v>
                     1
                 </v>
             </c>
         </row>
         <row r="4">
-            <c r="A4" t="s">
+            <c r="A4" s="1" t="s">
                 <v>
                     2
                 </v>
             </c>
         </row>
         <row r="5">
-            <c r="A5" t="s">
+            <c r="A5" s="1" t="s">
                 <v>
                     1
                 </v>
@@ -37964,10 +37976,15 @@ exports[`Test XLSX export link cells 1`] = `
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
-    <fonts count="1">
+    <fonts count="2">
         <font>
             <sz val="10"/>
             <color rgb="000000"/>
+            <name val="Arial"/>
+        </font>
+        <font>
+            <sz val="10"/>
+            <color rgb="017E84"/>
             <name val="Arial"/>
         </font>
     </fonts>
@@ -37993,8 +38010,9 @@ exports[`Test XLSX export link cells 1`] = `
             </diagonal>
         </border>
     </borders>
-    <cellXfs count="1">
+    <cellXfs count="2">
         <xf numFmtId="0" fillId="0" fontId="0" borderId="0"/>
+        <xf numFmtId="0" fillId="0" fontId="1" borderId="0"/>
     </cellXfs>
     <dxfs count="0">
     </dxfs>
@@ -38477,7 +38495,7 @@ exports[`Test XLSX export multiple elements are exported in the correct order 1`
     </cols>
     <sheetData>
         <row r="1">
-            <c r="A1" t="s">
+            <c r="A1" s="1" t="s">
                 <v>
                     0
                 </v>
@@ -38529,10 +38547,15 @@ exports[`Test XLSX export multiple elements are exported in the correct order 1`
       "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
     <numFmts count="0">
     </numFmts>
-    <fonts count="1">
+    <fonts count="2">
         <font>
             <sz val="10"/>
             <color rgb="000000"/>
+            <name val="Arial"/>
+        </font>
+        <font>
+            <sz val="10"/>
+            <color rgb="017E84"/>
             <name val="Arial"/>
         </font>
     </fonts>
@@ -38558,8 +38581,9 @@ exports[`Test XLSX export multiple elements are exported in the correct order 1`
             </diagonal>
         </border>
     </borders>
-    <cellXfs count="1">
+    <cellXfs count="2">
         <xf numFmtId="0" fillId="0" fontId="0" borderId="0"/>
+        <xf numFmtId="0" fillId="0" fontId="1" borderId="0"/>
     </cellXfs>
     <dxfs count="1">
         <dxf>

--- a/tests/xlsx/xlsx_import_export.test.ts
+++ b/tests/xlsx/xlsx_import_export.test.ts
@@ -1,3 +1,4 @@
+import { LINK_COLOR } from "@odoo/o-spreadsheet-engine/constants";
 import { isXLSXExportXMLFile } from "@odoo/o-spreadsheet-engine/xlsx/helpers/xlsx_helper";
 import { Model } from "../../src";
 import { buildSheetLink, toZone } from "../../src/helpers";
@@ -31,6 +32,7 @@ import {
   getCell,
   getCellRawContent,
   getEvaluatedCell,
+  getStyle,
 } from "../test_helpers/getters_helpers";
 import { toRangesData } from "../test_helpers/helpers";
 
@@ -430,6 +432,17 @@ describe("Export data to xlsx then import it", () => {
     const sheetLink2 = buildSheetLink(newSheetId!);
     expect(cell.link?.label).toBe("my label");
     expect(cell.link?.url).toBe(sheetLink2);
+  });
+
+  test("hyperlinks are exported with their own style", async () => {
+    const sheetLink = buildSheetLink("42");
+    setCellContent(model, "A1", `[my label](${sheetLink})`);
+    setFormatting(model, "A1:A3", { fillColor: "#FF0000" });
+    const importedModel = await exportToXlsxThenImport(model);
+    expect(getStyle(importedModel, "A1")).toMatchObject({
+      fillColor: "#FF0000",
+      textColor: LINK_COLOR,
+    });
   });
 
   test("Image", async () => {


### PR DESCRIPTION
Currently, cells that contain a hyperlink are given a default color
after evaluation but this coloration is not propagated when we export
the data as xlsx file.

This revision adds the default link color to the excel export.

Task: 5410289

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [5410289](https://www.odoo.com/odoo/2328/tasks/5410289)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo