### PR TITLE
[FIX] grid: close popovers on external clicks

### DIFF
--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -59,7 +59,7 @@ import { GridOverlay } from "../grid_overlay/grid_overlay";
 import { GridPopover } from "../grid_popover/grid_popover";
 import { HeadersOverlay } from "../headers_overlay/headers_overlay";
 import { cssPropertiesToCss } from "../helpers";
-import { isCtrlKey } from "../helpers/dom_helpers";
+import { isChildEvent, isCtrlKey } from "../helpers/dom_helpers";
 import { dragAndDropBeyondTheViewport } from "../helpers/drag_and_drop";
 import { useGridDrawing } from "../helpers/draw_grid_hook";
 import { useAbsoluteBoundingRect } from "../helpers/position_hook";
@@ -149,6 +149,7 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
     useChildSubEnv({ getPopoverContainerRect: () => this.getGridRect() });
     useExternalListener(document.body, "cut", this.copy.bind(this, true));
     useExternalListener(document.body, "copy", this.copy.bind(this, false));
+    useExternalListener(window, "click", this.onExternalClick, { capture: true });
     useExternalListener(document.body, "paste", this.paste);
     onMounted(() => this.focusDefaultElement());
     this.props.exposeFocus(() => this.focusDefaultElement());
@@ -766,6 +767,13 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
         break;
       }
     }
+  }
+
+  private onExternalClick(ev: MouseEvent) {
+    if (isChildEvent(this.gridEl, ev) || (ev.target as HTMLElement)?.closest(".o-popover")) {
+      return;
+    }
+    this.onClosePopover();
   }
 }
 

--- a/tests/data_filter/filter_menu_component.test.ts
+++ b/tests/data_filter/filter_menu_component.test.ts
@@ -335,4 +335,18 @@ describe("Filter menu component", () => {
       [...fixture.querySelectorAll(".o-filter-menu-item")].map((el) => el.textContent)
     ).toEqual(["✓(Blanks)"]);
   });
+
+  test("Filter menu is closed when clicking outside of it", async () => {
+    createFilter(model, "A10:B15");
+    await nextTick();
+    await openFilterMenu();
+
+    // Clicking inside the filter menu does not close it
+    await simulateClick(".o-filter-menu");
+    expect(fixture.querySelector(".o-filter-menu")).not.toBeNull();
+
+    // Clicking outside the filter menu closes it
+    await simulateClick("body");
+    expect(fixture.querySelector(".o-filter-menu")).toBeNull();
+  });
 });

--- a/tests/grid/dashboard_grid_component.test.ts
+++ b/tests/grid/dashboard_grid_component.test.ts
@@ -96,6 +96,20 @@ describe("Grid component in dashboard mode", () => {
     expect(fixture.querySelectorAll(".o-filter-menu")).toHaveLength(0);
   });
 
+  test("Clicking outside of the dashboard closes the filter popover", async () => {
+    createFilter(model, "A1:A2");
+    model.updateMode("dashboard");
+    await nextTick();
+    await simulateClick(".o-filter-icon");
+    expect(fixture.querySelectorAll(".o-filter-menu")).toHaveLength(1);
+
+    await simulateClick(".o-filter-menu");
+    expect(fixture.querySelectorAll(".o-filter-menu")).toHaveLength(1);
+
+    await simulateClick("body");
+    expect(fixture.querySelectorAll(".o-filter-menu")).toHaveLength(0);
+  });
+
   test("When filter menu is open, clicking on a random grid correctly closes filter popover", async () => {
     createFilter(model, "A1:A2");
     model.updateMode("dashboard");

--- a/tests/link/link_editor_component.test.ts
+++ b/tests/link/link_editor_component.test.ts
@@ -272,4 +272,16 @@ describe("link editor component", () => {
       expect(getCell(model, "A1")).toBeDefined();
     }
   );
+
+  test("Link editor is closed when clicking outside of it", async () => {
+    await openLinkEditor(model, "A1");
+
+    // Clicking inside the link editor does not close it
+    await simulateClick(".o-link-editor");
+    expect(fixture.querySelector(".o-link-editor")).not.toBeNull();
+
+    // Clicking outside the link editor closes it
+    await simulateClick("body");
+    expect(fixture.querySelector(".o-link-editor")).toBeNull();
+  });
 });


### PR DESCRIPTION
## Description

The filter menu/link editor popovers were not closing when clicking outside of the grid.

Note: the external click listener is in the `GridPopover` component, but this component does not have access to the HTMLElement of the popover (since it is rendered in a portal). We have thus rely on checking if the click target is inside a `.o-popover` element, which may not be the most robust solution. But it's probably acceptable, and is easy. Having an external click listener in each popover component would be more robust, but we'd risk forgetting it when creating new popovers components.

Also the external listener is on both `Grid` and `Dashboard` components, because we need the reference to the parent of the filter icon. Otherwise a click on an icon would first close the popover with the external click, and immediately re-open it with the icon click handler.

Task: [5418367](https://www.odoo.com/odoo/2328/tasks/5418367)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo