### PR TITLE
[FIX] evaluation: prevent empty matrix

### DIFF
--- a/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
@@ -311,6 +311,13 @@ export class Evaluator {
 
     const nbColumns = formulaReturn.length;
     const nbRows = formulaReturn[0].length;
+    if (nbRows === 0) {
+      // empty matrix
+      return createEvaluatedCell(null, {
+        format: cellData.format,
+        locale: this.getters.getLocale(),
+      });
+    }
 
     forEachSpreadPositionInMatrix(nbColumns, nbRows, this.updateSpreadRelation(formulaPosition));
     forEachSpreadPositionInMatrix(nbColumns, nbRows, this.checkCollision(formulaPosition));

--- a/tests/functions/module_array.test.ts
+++ b/tests/functions/module_array.test.ts
@@ -102,6 +102,14 @@ describe("ARRAY.CONSTRAIN function", () => {
     setCellContent(model, "D1", '=ARRAY.CONSTRAIN("oi", 2, 2)');
     expect(getRangeValuesAsMatrix(model, "D1")).toEqual([["oi"]]);
   });
+
+  test("constraint range outside of the sheet", () => {
+    const grid = {
+      A1: "=ARRAY.CONSTRAIN(A1000:B1000, 2, 2)",
+    };
+    const model = createModelFromGrid(grid);
+    expect(getRangeValuesAsMatrix(model, "A1")).toEqual([[0]]); // ideally, it should be an array of the same size as the constraint, but for now, we just return 0
+  });
 });
 
 describe("CHOOSECOLS function", () => {


### PR DESCRIPTION
## Description:

The evaluation doesn't support well empty matrices (`[[]]`). A range is always at least one value and the result of a function should be at least one value.

There are plenty of uses of patterns like `array[0].length` which throws an exception if the array is empty.

This is not robust.

This commit ensures the input of a function is never an empty matrix. If a `compute` returns an empty matrix, it's transformed to an empty value.

Task: [5421196](https://www.odoo.com/odoo/2328/tasks/5421196)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo