### PR TITLE
[IMP] error: better wording for number too large

### DIFF
--- a/packages/o-spreadsheet-engine/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
+++ b/packages/o-spreadsheet-engine/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
@@ -7,8 +7,8 @@ import {
   BadExpressionError,
   CellErrorType,
   CircularDependencyError,
+  NumberTooLargeError,
   SplillBlockedError,
-  TooBigNumberError,
 } from "../../../types/errors";
 import { buildCompilationParameters, CompilationParameters } from "./compilation_parameters";
 import { FormulaDependencyGraph } from "./formula_dependency_graph";
@@ -619,7 +619,7 @@ function nullValueToZeroValue(functionResult: FunctionResultObject): FunctionRes
 
 function validateNumberValue(data: FunctionResultObject): FunctionResultObject {
   return typeof data.value === "number" && Math.abs(data.value) > Number.MAX_VALUE
-    ? new TooBigNumberError()
+    ? new NumberTooLargeError()
     : nullValueToZeroValue(data);
 }
 

--- a/packages/o-spreadsheet-engine/src/types/errors.ts
+++ b/packages/o-spreadsheet-engine/src/types/errors.ts
@@ -7,7 +7,7 @@ export const CellErrorType = {
   CircularDependency: "#CYCLE",
   UnknownFunction: "#NAME?",
   DivisionByZero: "#DIV/0!",
-  TooBigNumber: "#NUM!",
+  InvalidNumber: "#NUM!",
   SpilledBlocked: "#SPILL!",
   GenericError: "#ERROR",
   NullError: "#NULL!",
@@ -67,8 +67,8 @@ export class DivisionByZeroError extends EvaluationError {
   }
 }
 
-export class TooBigNumberError extends EvaluationError {
-  constructor(message = _t("Too big number")) {
-    super(message, CellErrorType.TooBigNumber);
+export class NumberTooLargeError extends EvaluationError {
+  constructor(message = _t("Number too large")) {
+    super(message, CellErrorType.InvalidNumber);
   }
 }

--- a/tests/evaluation/evaluation.test.ts
+++ b/tests/evaluation/evaluation.test.ts
@@ -45,7 +45,7 @@ describe("evaluateCells", () => {
       C1: "1.2e4",
       C2: "1e5",
       C3: "-1e3",
-      C4: "1E309", // too big number
+      C4: "1E309", // number too large
       D1: "1.1.1", // not a number
     };
     expect(evaluateGrid(grid)).toEqual({
@@ -81,7 +81,7 @@ describe("evaluateCells", () => {
       C4: "=1.2E4",
       C5: "=1E5",
       C6: "=-1E3",
-      C7: "=1E309", // too big number
+      C7: "=1E309", // number too large
 
       D1: "=1.1.1", // not a number
     };
@@ -1274,7 +1274,7 @@ describe("evaluateCells", () => {
     });
   });
 
-  describe("too big number", () => {
+  describe("number too large", () => {
     test("in a formula", () => {
       const grid = {
         A1: "1E200",


### PR DESCRIPTION
Steps to reproduce:
- in any cell: =1e315 => the error message is "Too big number"

It is not correct English

Task: 5421599

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo