### PR TITLE
[PERF] sheet: find sheet by name faster

### DIFF
--- a/src/helpers/range.ts
+++ b/src/helpers/range.ts
@@ -24,7 +24,6 @@ import { CellErrorType } from "../types/errors";
 import { numberToLetters } from "./coordinates";
 import { getCanonicalSymbolName, groupConsecutive, largeMax, largeMin } from "./misc";
 import { isRowReference, splitReference } from "./references";
-import { isSheetNameEqual } from "./sheet";
 import {
   boundUnboundedZone,
   createAdaptedZone,
@@ -350,7 +349,7 @@ function getApplyRangeChangeRemoveColRow(cmd: RemoveColumnsRowsCommand): ApplyRa
 
   const groups = groupConsecutive(elements);
   return (range: Range) => {
-    if (!isSheetNameEqual(range.sheetId, cmd.sheetId)) {
+    if (range.sheetId !== cmd.sheetId) {
       return { changeType: "NONE" };
     }
     let newRange = range;

--- a/src/helpers/sheet.ts
+++ b/src/helpers/sheet.ts
@@ -1,6 +1,6 @@
 import { _t } from "../translation";
 import { HeaderIndex, Row } from "../types";
-import { getUnquotedSheetName, isDefined } from "./misc";
+import { getUnquotedSheetName, isDefined, memoize } from "./misc";
 
 export function createDefaultRows(rowNumber: number): Row[] {
   const rows: Row[] = [];
@@ -66,12 +66,15 @@ export function getDuplicateSheetName(nameToDuplicate: string, existingNames: st
   return name;
 }
 
+export const toStandardizedSheetName = memoize(function toStandardizedSheetName(
+  name: string
+): string {
+  return getUnquotedSheetName(name.trim().toUpperCase());
+});
+
 export function isSheetNameEqual(name1: string | undefined, name2: string | undefined): boolean {
   if (name1 === undefined || name2 === undefined) {
     return false;
   }
-  return (
-    getUnquotedSheetName(name1.trim().toUpperCase()) ===
-    getUnquotedSheetName(name2.trim().toUpperCase())
-  );
+  return toStandardizedSheetName(name1) === toStandardizedSheetName(name2);
 }

--- a/src/plugins/core/sheet.ts
+++ b/src/plugins/core/sheet.ts
@@ -4,7 +4,6 @@ import {
   deepCopy,
   getDuplicateSheetName,
   getNextSheetName,
-  getUnquotedSheetName,
   groupConsecutive,
   includesAll,
   isColorValid,
@@ -16,7 +15,7 @@ import {
   range,
   toCartesian,
 } from "../../helpers/index";
-import { isSheetNameEqual } from "../../helpers/sheet";
+import { isSheetNameEqual, toStandardizedSheetName } from "../../helpers/sheet";
 import {
   Cell,
   CellPosition,
@@ -186,7 +185,7 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
           cmd.rows || 100,
           cmd.position
         );
-        this.history.update("sheetIdsMapName", sheet.name, sheet.id);
+        this.history.update("sheetIdsMapName", toStandardizedSheetName(sheet.name), sheet.id);
         break;
       case "MOVE_SHEET":
         this.moveSheet(cmd.sheetId, cmd.delta);
@@ -254,7 +253,7 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
     // that depends on a sheet not already imported will not be able to be
     // compiled
     for (const sheet of data.sheets) {
-      this.sheetIdsMapName[sheet.name] = sheet.id;
+      this.sheetIdsMapName[toStandardizedSheetName(sheet.name)] = sheet.id;
     }
 
     for (const sheetData of data.sheets) {
@@ -358,12 +357,7 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
 
   getSheetIdByName(name: string | undefined): UID | undefined {
     if (name) {
-      const unquotedName = getUnquotedSheetName(name);
-      for (const key in this.sheetIdsMapName) {
-        if (isSheetNameEqual(key, unquotedName)) {
-          return this.sheetIdsMapName[key];
-        }
-      }
+      return this.sheetIdsMapName[toStandardizedSheetName(name)];
     }
     return undefined;
   }
@@ -714,8 +708,8 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
     const oldName = sheet.name;
     this.history.update("sheets", sheet.id, "name", name.trim());
     const sheetIdsMapName = Object.assign({}, this.sheetIdsMapName);
-    delete sheetIdsMapName[oldName];
-    sheetIdsMapName[name] = sheet.id;
+    delete sheetIdsMapName[toStandardizedSheetName(oldName)];
+    sheetIdsMapName[toStandardizedSheetName(name)] = sheet.id;
     this.history.update("sheetIdsMapName", sheetIdsMapName);
   }
 
@@ -758,7 +752,7 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
     }
 
     const sheetIdsMapName = Object.assign({}, this.sheetIdsMapName);
-    sheetIdsMapName[newSheet.name] = newSheet.id;
+    sheetIdsMapName[toStandardizedSheetName(newSheet.name)] = newSheet.id;
     this.history.update("sheetIdsMapName", sheetIdsMapName);
   }
 
@@ -779,7 +773,7 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
 
     this.history.update("orderedSheetIds", orderedSheetIds);
     const sheetIdsMapName = Object.assign({}, this.sheetIdsMapName);
-    delete sheetIdsMapName[name];
+    delete sheetIdsMapName[toStandardizedSheetName(name)];
     this.history.update("sheetIdsMapName", sheetIdsMapName);
   }
 


### PR DESCRIPTION
`getters.getSheetIdByName` is terribly inefficient.

First, it loops over all sheets to find the correct one. Then, it uses `isSheetNameEqual` which allocates strings over and over again to unquote, trim and uppercase the name.

I was looking at a spreadsheet[^1] on odoo.com which contains 10 sheets, with lots of references.
Before this commit, `isSheetNameEqual` was called 5M times !

Benchmark Results:

Core plugins imported in (~19% faster)
  before Mean=2425 ms, StdErr=35.28 ms, n=15
  after  Mean=1975 ms, StdErr=23.43 ms, n=15 *

Model created in (~12% faster)
  before Mean=3886 ms, StdErr=51.90 ms, n=15
  after  Mean=3425 ms, StdErr=69.72 ms, n=15 *

[^1]: https://www.odoo.com/odoo/documents/spreadsheet/256374?debug=1

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo