### PR TITLE
[FIX] chart_data_extractor: do not translate template strings

### DIFF
--- a/src/helpers/figures/charts/runtime/chart_data_extractor.ts
+++ b/src/helpers/figures/charts/runtime/chart_data_extractor.ts
@@ -112,10 +112,10 @@ function getDateTimeLabel(value: number, stamp: CalendarChartGranularity): strin
     }
     case "iso_week_number": {
       const weekNumber = String(value).padStart(2, "0");
-      return _t(`W%(weekNumber)s`, { weekNumber });
+      return _t("W%(weekNumber)s", { weekNumber });
     }
     case "quarter_number": {
-      return _t(`Q%(value)s`, { value });
+      return _t("Q%(value)s", { value });
     }
     default: {
       return value.toString();


### PR DESCRIPTION
This commit removes the use of template strings in translation that triggers error on Odoo runbot.

Task: 0

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo