### PR TITLE
[FIX] tests: remove or fix skipped tests

### DIFF
--- a/tests/components/number_input.test.ts
+++ b/tests/components/number_input.test.ts
@@ -78,12 +78,13 @@ describe("NumberInput", () => {
     expect(onChange).toHaveBeenCalledWith("4");
   });
 
-  test.skip("selects input content upon mouseup", async () => {
-    // not supported in jsdom
-    await mountNumberInput({ value: 10000, onChange: () => {} });
-    triggerMouseEvent("input", "pointerup");
-    expect(fixture.querySelector("input")!.selectionStart).toEqual(0);
-    expect(fixture.querySelector("input")!.selectionEnd).toEqual(5);
+  test("selects input content upon mouseup", async () => {
+    await mountNumberInput({ value: 10000, onChange: () => {}, selectContentOnFocus: true });
+    const input = fixture.querySelector("input")! as HTMLInputElement;
+
+    jest.spyOn(input, "select"); // the selection not supported in jsdom, we'll just spy the select method
+    triggerMouseEvent(input, "pointerup");
+    expect(input.select).toHaveBeenCalled();
   });
 
   test("saves the value on input blur", async () => {

--- a/tests/composer/composer_component.test.ts
+++ b/tests/composer/composer_component.test.ts
@@ -1622,8 +1622,6 @@ describe("composer highlights color", () => {
     expect(highlights[1].range.sheetId).toBe("42");
     expect(highlights[1].range.zone).toEqual({ left: 0, right: 0, top: 0, bottom: 0 });
   });
-
-  test.skip("grid composer is resized when top bar composer grows", async () => {});
 });
 
 describe("Composer string is correctly translated to DOM", () => {

--- a/tests/evaluation/evaluation.test.ts
+++ b/tests/evaluation/evaluation.test.ts
@@ -1364,20 +1364,6 @@ describe("evaluate formula getter", () => {
     expect(getEvaluatedCell(model, "A2", s[0]).value).toBe(12);
   });
 
-  test.skip("EVALUATE_CELLS with no argument re-evaluates do not reevaluate the cells if they are not modified", () => {
-    const mockCompute = jest.fn();
-
-    addToRegistry(functionRegistry, "GETVALUE", {
-      description: "Get value",
-      compute: mockCompute,
-      args: [],
-    });
-    setCellContent(model, "A1", "=GETVALUE()");
-    expect(mockCompute).toHaveBeenCalledTimes(1);
-    resetAllMocks();
-    model.dispatch("EVALUATE_CELLS");
-    expect(mockCompute).toHaveBeenCalledTimes(0);
-  });
   test("cells are re-evaluated if one of their dependency changes", () => {
     const mockCompute = jest.fn().mockReturnValue("Hi");
 

--- a/tests/figures/figure_component.test.ts
+++ b/tests/figures/figure_component.test.ts
@@ -176,7 +176,7 @@ describe("figures", () => {
     ]);
   });
 
-  test.skip("deleting a figure focuses the grid hidden input", async () => {
+  test("deleting a figure focuses the grid hidden input", async () => {
     createFigure(model);
     await nextTick();
     const figure = fixture.querySelector(".o-figure")!;


### PR DESCRIPTION
## Description

We had some skipped tests in the codebase, that should either be fixed or removed.

- `NumberInput selects input content upon mouseup`: jsdom does not support the selection, but we can check that the `select` method is called.

- `grid composer is resized when top bar composer grows`: this test is empty and AFAIK was never an actual feature ? Removed the test.

- `EVALUATE_CELLS with no argument does not reevaluate the cells if they are not modified`: the test was already skipped when it was introduced 5 years ago. This is not the expected behavior of the present `EVALUATE_CELLS` command. Removed the test.

- `deleting a figure focuses the grid hidden input`: the test works, not sure why it was skipped. Re-enabled it.

Task: [5423848](https://www.odoo.com/odoo/2328/tasks/5423848)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo