### PR TITLE
[FIX] f&r: the searched range should follow the active sheet

### DIFF
--- a/src/components/side_panel/find_and_replace/find_and_replace.ts
+++ b/src/components/side_panel/find_and_replace/find_and_replace.ts
@@ -166,7 +166,20 @@ export class FindAndReplacePanel extends Component<Props, SpreadsheetChildEnv> {
     this.store.updateSearchOptions({ specificRange });
   }
 
+  get specificRange(): string {
+    const range = this.store.searchOptions.specificRange;
+    return range ? this.env.model.getters.getRangeString(range, "forceSheetReference") : "";
+  }
+
   get pendingSearch() {
     return this.updateSearchContent.isDebouncePending();
+  }
+
+  get selectionInputKey() {
+    // Selections input are made to work with objects linked to a sheet id. They store the active sheet id at their creation,
+    // and have specific behaviour linked to it (eg. go back to the initial sheet after confirmation).
+    // We don't want all those behaviors here, so we force the recreation of the component when the active sheet changes.
+    // The only drawback is that the input loses focus when changing sheet.
+    return this.env.model.getters.getActiveSheetId();
   }
 }

--- a/src/components/side_panel/find_and_replace/find_and_replace.xml
+++ b/src/components/side_panel/find_and_replace/find_and_replace.xml
@@ -44,7 +44,8 @@
         </select>
         <div t-if="searchOptions.searchScope === 'specificRange'">
           <SelectionInput
-            ranges="[this.state.dataRange]"
+            t-key="selectionInputKey"
+            ranges="[specificRange]"
             onSelectionChanged="(ranges) => this.onSearchRangeChanged(ranges)"
             onSelectionConfirmed.bind="updateDataRange"
             hasSingleRange="true"

--- a/src/components/side_panel/find_and_replace/find_and_replace_store.ts
+++ b/src/components/side_panel/find_and_replace/find_and_replace_store.ts
@@ -113,6 +113,11 @@ export class FindAndReplaceStore extends SpreadsheetStore implements HighlightPr
       case "UPDATE_CELL":
       case "ACTIVATE_SHEET":
         this.isSearchDirty = true;
+        if (this.searchOptions.specificRange) {
+          this.searchOptions.specificRange = this.searchOptions.specificRange.clone({
+            sheetId: this.getters.getActiveSheetId(),
+          });
+        }
         break;
       case "REPLACE_SEARCH":
         for (const match of cmd.matches) {

--- a/tests/find_and_replace/find_and_replace_store.test.ts
+++ b/tests/find_and_replace/find_and_replace_store.test.ts
@@ -115,6 +115,24 @@ describe("basic search", () => {
     expect(store.searchMatches).toStrictEqual([match(sheetId1, "A1")]);
   });
 
+  test("Specific range is following the active sheet", async () => {
+    createSheet(model, { sheetId: sheetId2 });
+    setCellContent(model, "A1", "test");
+
+    updateSearch(model, "test", {
+      searchScope: "specificRange",
+      specificRange: model.getters.getRangeFromSheetXC(sheetId1, "A1:B1"),
+    });
+    expect(store.searchMatches).toStrictEqual([match(sheetId1, "A1")]);
+
+    activateSheet(model, sheetId2);
+    expect(store.searchMatches).toStrictEqual([]);
+    expect(store.searchOptions.specificRange?.sheetId).toBe(sheetId2);
+
+    setCellContent(model, "A1", "test", sheetId2);
+    expect(store.searchMatches).toStrictEqual([match(sheetId2, "A1")]);
+  });
+
   test("search with a regexp characters", () => {
     setCellContent(model, "A1", "hello (world).*");
     updateSearch(model, "hello (world).*");

--- a/tests/find_and_replace/find_replace_side_panel_component.test.ts
+++ b/tests/find_and_replace/find_replace_side_panel_component.test.ts
@@ -1,7 +1,7 @@
 import { Model, Spreadsheet } from "../../src";
 import { DEFAULT_CELL_HEIGHT, DEFAULT_CELL_WIDTH } from "../../src/constants";
 import { SearchOptions } from "../../src/types/find_and_replace";
-import { activateSheet, createSheet, setCellContent } from "../test_helpers/commands_helpers";
+import { createSheet, setCellContent } from "../test_helpers/commands_helpers";
 import {
   click,
   focusAndKeyDown,
@@ -219,29 +219,6 @@ describe("find and replace sidePanel component", () => {
       expect(getMatchesCount()).toMatchObject({ specificRange: 1 });
     });
 
-    test.skip("Specific range is following the active sheet", async () => {
-      //TODO : uh ? Is this test wrong ? The specific range doesn't follow the active sheet in master...
-      createSheet(model, { sheetId: "sh2" });
-      setCellContent(model, "A1", "1");
-
-      inputSearchValue("1");
-      changeSearchScope("specificRange");
-      await nextTick();
-      await nextTick(); // selection input need 2 nextTicks because ¯\_(ツ)_/¯
-      await setInputValueAndTrigger(selectors.searchRange, "A1:B2");
-      await click(fixture, selectors.confirmSearchRange);
-
-      expect(getMatchesCount()).toMatchObject({ specificRange: 1 });
-
-      activateSheet(model, "sh2");
-      await nextTick();
-      expect(getMatchesCount()).toMatchObject({ specificRange: 0 });
-
-      setCellContent(model, "A1", "1", "sh2");
-      await nextTick();
-      expect(getMatchesCount()).toMatchObject({ specificRange: 1 });
-    });
-
     test.each(["allSheets", "activeSheet"] as const)(
       "Specific range is persistent when changing scopes",
       async (scope) => {
@@ -257,7 +234,7 @@ describe("find and replace sidePanel component", () => {
         changeSearchScope("specificRange");
         await nextTick();
         expect((document.querySelector(selectors.searchRange) as HTMLInputElement).value).toBe(
-          "A1:B2"
+          "Sheet1!A1:B2"
         );
       }
     );


### PR DESCRIPTION
## Description

When searching a value in a specific range in the Find & Replace panel, the range should be updated when changing the active sheet.

We actually had a test for this behavior, but the test was skipped 2 years ago during a refactoring, and never fixed.

Task: [5423885](https://www.odoo.com/odoo/2328/tasks/5423885)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo