### PR TITLE
[IMP] actions: align dropdown flow with other data validations

### DIFF
--- a/src/actions/insert_actions.ts
+++ b/src/actions/insert_actions.ts
@@ -322,7 +322,12 @@ export const insertDropdown: ActionSpec = {
     if (!rule) {
       return;
     }
-    env.openSidePanel("DataValidationEditor", { ruleId });
+    env.openSidePanel("DataValidationEditor", {
+      ruleId,
+      onCancel: () => {
+        env.model.dispatch("REMOVE_DATA_VALIDATION_RULE", { sheetId, id: ruleId });
+      },
+    });
   },
   isEnabled: (env) => !env.isSmall,
   icon: "o-spreadsheet-Icon.INSERT_DROPDOWN",

--- a/src/components/side_panel/data_validation/dv_editor/dv_editor.ts
+++ b/src/components/side_panel/data_validation/dv_editor/dv_editor.ts
@@ -28,6 +28,7 @@ import { SelectMenu } from "../../select_menu/select_menu";
 
 interface Props {
   ruleId: UID;
+  onCancel?: () => void;
   onCloseSidePanel: () => void;
 }
 
@@ -40,7 +41,11 @@ interface State {
 export class DataValidationEditor extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-DataValidationEditor";
   static components = { SelectionInput, SelectMenu, Section, ValidationMessages };
-  static props = { ruleId: String, onCloseSidePanel: Function };
+  static props = {
+    ruleId: String,
+    onCancel: { type: Function, optional: true },
+    onCloseSidePanel: Function,
+  };
 
   state = useState<State>({
     rule: this.defaultDataValidationRule,
@@ -85,6 +90,7 @@ export class DataValidationEditor extends Component<Props, SpreadsheetChildEnv> 
   }
 
   onCancel() {
+    this.props.onCancel?.();
     this.env.replaceSidePanel("DataValidation", `DataValidationEditor_${this.props.ruleId}`);
   }
 

--- a/tests/top_bar_component.test.ts
+++ b/tests/top_bar_component.test.ts
@@ -950,6 +950,17 @@ describe("TopBar - CF", () => {
   });
 });
 
+test("onCancel of dropdown dv editor removes the data validation rule", async () => {
+  const { fixture } = await mountSpreadsheet();
+  await click(fixture, ".o-topbar-menu[data-id='insert']");
+  await click(fixture, ".o-menu-item[data-name='insert_dropdown']");
+  expect(fixture.querySelector(".o-sidePanel .o-dv-form")).toBeTruthy();
+
+  await click(fixture, ".o-sidePanel .o-dv-cancel");
+  expect(fixture.querySelector(".o-dv")).toBeTruthy();
+  expect(fixture.querySelectorAll(".o-dv-preview")).toHaveLength(0);
+});
+
 describe("Topbar - menu item resizing with viewport", () => {
   test("color picker of fill color in top bar is resized with screen size change", async () => {
     const { model, fixture } = await mountParent();


### PR DESCRIPTION
## Description:

Before this commit:
- When inserting a dropdown from the top bar and cancel/discard from the editor,
the dropdown data validation was still applied and not removed.

After this commit:
- The dropdown data validation is now removed when cancel/discard from
the data validation editor, aligning its behavior with other data validations.

Task: [5423990](https://www.odoo.com/odoo/2328/tasks/5423990)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo