### PR TITLE
[FIX] side_panel: reset format type to Automatic on unformatted cells

### DIFF
--- a/src/components/side_panel/more_formats/more_formats_store.ts
+++ b/src/components/side_panel/more_formats/more_formats_store.ts
@@ -35,6 +35,7 @@ export class MoreFormatsStore extends SpreadsheetStore {
   ] as const;
 
   invalidFormat = false;
+  isApplyingFormatFromPanel = false;
   currentFormat = this.formatInSelection;
   category: CustomFormatCategory = this.detectFormatCategory(this.formatInSelection);
 
@@ -61,20 +62,22 @@ export class MoreFormatsStore extends SpreadsheetStore {
   }
 
   handle() {
-    const selectedFormat = this.formatInSelection;
-    if (selectedFormat && this.lastFormatInSelection !== selectedFormat) {
-      this.setActiveFormat(selectedFormat);
-      this.lastFormatInSelection = selectedFormat;
+    if (!this.isApplyingFormatFromPanel) {
+      this.syncActiveFormat();
     }
   }
 
   handleSelectionEvent() {
     if (this.getters.isGridSelectionActive()) {
-      const selectedFormat = this.formatInSelection;
-      if (selectedFormat && selectedFormat !== this.lastFormatInSelection) {
-        this.setActiveFormat(selectedFormat);
-        this.lastFormatInSelection = selectedFormat;
-      }
+      this.syncActiveFormat();
+    }
+  }
+
+  private syncActiveFormat() {
+    const selectedFormat = this.formatInSelection;
+    if (selectedFormat !== this.lastFormatInSelection) {
+      this.setActiveFormat(selectedFormat);
+      this.lastFormatInSelection = selectedFormat;
     }
   }
 
@@ -253,11 +256,13 @@ export class MoreFormatsStore extends SpreadsheetStore {
 
     if (!this.invalidFormat) {
       this.lastFormatInSelection = format;
+      this.isApplyingFormatFromPanel = true;
       this.model.dispatch("SET_FORMATTING_WITH_PIVOT", {
         sheetId: this.getters.getActiveSheetId(),
         target: this.getters.getSelectedZones(),
         format: format || "",
       });
+      this.isApplyingFormatFromPanel = false;
     }
   }
 

--- a/tests/formats/more_formats_side_panel.test.ts
+++ b/tests/formats/more_formats_side_panel.test.ts
@@ -126,7 +126,7 @@ describe("more formats side panel component", () => {
     expect(getExampleValues()).toEqual(["1234.56", "(1234.56)", "-", "Text olà"]);
   });
 
-  test("Changing the cell format updates the side panel", async () => {
+  test("Side panel stays in sync when the cell format changes, including reset to Automatic", async () => {
     setFormat(model, "A1", "0.00%");
     // mount whole spreadsheet because onWillUpdateProps doesn't trigger on render if mounting only MoreFormatsPanel
     const { env } = await mountSpreadsheet({ model });
@@ -137,5 +137,24 @@ describe("more formats side panel component", () => {
     setFormat(model, "A1", "#.##");
     await nextTick();
     expect(".o-custom-format-section input").toHaveValue("#.##");
+
+    setFormat(model, "A1", "");
+    await nextTick();
+    expect(".format-preview.active").toHaveText("Automatic");
+    expect(".o-custom-format-section input").toHaveValue("");
+  });
+
+  test("Focusing a cell without format resets the side panel to Automatic", async () => {
+    setFormat(model, "A1", "0.00%");
+
+    const { env } = await mountSpreadsheet({ model });
+    env.openSidePanel("MoreFormats");
+    await nextTick();
+    expect(".o-custom-format-section input").toHaveValue("0.00%");
+
+    selectCell(model, "B1");
+    await nextTick();
+    expect(".format-preview.active").toHaveText("Automatic");
+    expect(".o-custom-format-section input").toHaveValue("");
   });
 });


### PR DESCRIPTION
## Description:
Current behavior before PR:
- Opening the More Formats panel on a formatted cell correctly updated the selected format type.
- Changing the selection to an unformatted cell kept the previously selected format type.
- The format type did not reset to Automatic, unlike the top bar.

Desired behavior after PR is merged:
- Focusing a cell without any format resets the format type to Automatic.
- The panel stays in sync with the current selection and matches the top bar behavior.

Task: [5398649](https://www.odoo.com/odoo/2328/tasks/5398649)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo