### PR TITLE
[FIX] *: fix Safari detection

### DIFF
--- a/src/components/helpers/dom_helpers.ts
+++ b/src/components/helpers/dom_helpers.ts
@@ -238,14 +238,18 @@ export function downloadFile(dataUrl: string, fileName: string) {
 }
 
 /**
- * Detects if the current browser is Firefox
+ * Detects the current browser brand and subsequent rendering engine
  */
 export function isBrowserFirefox() {
   return /Firefox/i.test(navigator.userAgent);
 }
 
+function isBrowserChrome() {
+  return /Chrome/i.test(navigator.userAgent);
+}
+
 export function isBrowserSafari() {
-  return /Safari/i.test(navigator.userAgent);
+  return !isBrowserChrome() && /Safari/i.test(navigator.userAgent);
 }
 
 // Mobile detection


### PR DESCRIPTION
The userAgent on Chrome-based browser looks something like `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36` and somehow refers to Safari.
Our helper to detect safari (more specifically Webkit-based) browsers was not able to make that distinction.

Task: 0

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo