### PR TITLE
[FIX] Style: Ignore undefined style in commands

### DIFF
--- a/packages/o-spreadsheet-engine/src/plugins/core/style.ts
+++ b/packages/o-spreadsheet-engine/src/plugins/core/style.ts
@@ -68,8 +68,8 @@ export class StylePlugin extends CorePlugin<StylePluginState> implements StylePl
         }
         break;
       case "SET_FORMATTING":
-        if ("style" in cmd) {
-          if (cmd.style) {
+        if (cmd.style !== undefined) {
+          if (cmd.style !== null) {
             this.setStyles(cmd.sheetId, cmd.target, cmd.style);
           } else {
             this.clearStyle(cmd.sheetId, cmd.target);
@@ -80,8 +80,8 @@ export class StylePlugin extends CorePlugin<StylePluginState> implements StylePl
         this.clearStyle(cmd.sheetId, cmd.target);
         break;
       case "UPDATE_CELL":
-        if ("style" in cmd) {
-          if (cmd.style) {
+        if (cmd.style !== undefined) {
+          if (cmd.style !== null) {
             this.setStyles(cmd.sheetId, [positionToZone(cmd)], cmd.style);
           } else {
             this.clearStyle(cmd.sheetId, [positionToZone(cmd)]);

--- a/tests/cells/style_plugin.test.ts
+++ b/tests/cells/style_plugin.test.ts
@@ -16,7 +16,7 @@ import {
   setStyle,
   undo,
 } from "../test_helpers/commands_helpers";
-import { getCell, getCellContent, getCellStyle } from "../test_helpers/getters_helpers";
+import { getCell, getCellContent, getCellStyle, getStyle } from "../test_helpers/getters_helpers";
 import { createEqualCF, target, toRangesData } from "../test_helpers/helpers";
 
 describe("styles", () => {
@@ -188,5 +188,27 @@ describe("styles", () => {
         chipIcon.margin +
         chipIcon.size
     );
+  });
+
+  test("Style is not updated if not explicitely provided in commands", () => {
+    const model = new Model();
+    setCellContent(model, "A1", "hello");
+    setStyle(model, "A1", { fillColor: "#fefefe" });
+
+    model.dispatch("SET_FORMATTING", {
+      sheetId: model.getters.getActiveSheetId(),
+      target: target("A1"),
+      style: undefined,
+    });
+    expect(getStyle(model, "A1")).toMatchObject({ fillColor: "#fefefe" });
+
+    setStyle(model, "A1", { fillColor: "#fefefe" });
+    model.dispatch("UPDATE_CELL", {
+      sheetId: model.getters.getActiveSheetId(),
+      col: 0,
+      row: 0,
+      style: undefined,
+    });
+    expect(getStyle(model, "A1")).toMatchObject({ fillColor: "#fefefe" });
   });
 });

--- a/tests/collaborative/collaborative.test.ts
+++ b/tests/collaborative/collaborative.test.ts
@@ -293,6 +293,20 @@ describe("Multi users synchronisation", () => {
     );
   });
 
+  test("update a cell without changing its style", () => {
+    setCellContent(alice, "A1", "hello");
+    setStyle(alice, "A1", { fillColor: "#fefefe" });
+    alice.dispatch("UPDATE_CELL", {
+      sheetId: alice.getters.getActiveSheetId(),
+      col: 0,
+      row: 0,
+      style: undefined,
+    });
+    expect([alice, bob, charlie]).toHaveSynchronizedValue((user) => getCellStyle(user, "A1"), {
+      fillColor: "#fefefe",
+    });
+  });
+
   test("Merge a cell and update a cell concurrently", () => {
     const sheetId = alice.getters.getActiveSheetId();
     setCellContent(bob, "C1", "hello");


### PR DESCRIPTION
In bundle https://runbot.odoo.com/runbot/batch/2279442, in a collaborative context:
- Alice inserts link on a cell
- Alice edits the text content in the composer,

-> Alice sees the text change color
-> Bob does not see the text change color

The recent refactoring of the style plugin mis-adapted the interpretation of `style: undefined` in the style related commands.

Task: 5439120

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo