### PR TITLE
[IMP] selection_stream_processor: cycle within selection on Tab/Enter

### DIFF
--- a/packages/o-spreadsheet-engine/src/plugins/ui_stateful/sheetview.ts
+++ b/packages/o-spreadsheet-engine/src/plugins/ui_stateful/sheetview.ts
@@ -2,7 +2,7 @@ import { getDefaultSheetViewSize, SCROLLBAR_WIDTH } from "../../constants";
 import { clip, isDefined, range } from "../../helpers";
 import { scrollDelay } from "../../helpers/edge_scrolling";
 import { InternalViewport } from "../../helpers/internal_viewport";
-import { findCellInNewZone, positionToZone } from "../../helpers/zones";
+import { findCellInNewZone, isEqual, positionToZone } from "../../helpers/zones";
 import {
   Command,
   CommandResult,
@@ -160,10 +160,13 @@ export class SheetViewPlugin extends UIPlugin {
   private handleEvent(event: SelectionEvent) {
     const sheetId = this.getters.getActiveSheetId();
     if (event.options.scrollIntoView) {
-      let { col, row } = findCellInNewZone(event.previousAnchor.zone, event.anchor.zone);
-      if (event.mode === "updateAnchor") {
-        const oldZone = event.previousAnchor.zone;
-        const newZone = event.anchor.zone;
+      const oldZone = event.previousAnchor.zone;
+      const newZone = event.anchor.zone;
+      const isUpdateAnchorEvent = event.mode === "updateAnchor";
+      const sameZone = isEqual(oldZone, newZone);
+      let { col, row } =
+        isUpdateAnchorEvent && sameZone ? event.anchor.cell : findCellInNewZone(oldZone, newZone);
+      if (isUpdateAnchorEvent && !sameZone) {
         // altering a zone should not move the viewport in a dimension that wasn't changed
         const { top, bottom, left, right } = this.getMainInternalViewport(sheetId);
         if (oldZone.left === newZone.left && oldZone.right === newZone.right) {

--- a/packages/o-spreadsheet-engine/src/selection_stream/selection_stream_processor.ts
+++ b/packages/o-spreadsheet-engine/src/selection_stream/selection_stream_processor.ts
@@ -139,6 +139,21 @@ export class SelectionStreamProcessorImpl implements SelectionStreamProcessor {
   }
 
   /**
+   * Update the anchor cell while keeping the current anchor zone unchanged.
+   */
+  updateAnchorCell(
+    col: HeaderIndex,
+    row: HeaderIndex,
+    options: SelectionEventOptions = { scrollIntoView: true }
+  ): DispatchResult {
+    return this.processEvent({
+      mode: "updateAnchor",
+      anchor: { zone: this.anchor.zone, cell: { col, row } },
+      options,
+    });
+  }
+
+  /**
    * Update the current anchor such that it includes the given
    * cell position.
    */

--- a/packages/o-spreadsheet-engine/src/types/selection_stream_processor.ts
+++ b/packages/o-spreadsheet-engine/src/types/selection_stream_processor.ts
@@ -24,6 +24,8 @@ interface SelectionProcessor {
 
   moveAnchorCell(direction: Direction, step: SelectionStep): DispatchResult;
 
+  updateAnchorCell(col: number, row: number, options?: SelectionEventOptions): DispatchResult;
+
   setAnchorCorner(col: number, row: number): DispatchResult;
 
   addCellToSelection(col: number, row: number): DispatchResult;

--- a/src/components/composer/composer/cell_composer_store.ts
+++ b/src/components/composer/composer/cell_composer_store.ts
@@ -32,6 +32,7 @@ import {
   RemoveColumnsRowsCommand,
   isMatrix,
 } from "../../../types";
+import { moveAnchorWithinSelection } from "../../helpers/selection_helpers";
 import { AbstractComposerStore, ComposerSelection } from "./abstract_composer_store";
 
 const CELL_DELETED_MESSAGE = _t("The cell you are trying to edit has been deleted.");
@@ -49,7 +50,11 @@ export class CellComposerStore extends AbstractComposerStore {
     if (canStopEdition) {
       this._stopEdition();
       if (direction) {
-        this.model.selection.moveAnchorCell(direction, 1);
+        if (this.getters.isSingleCellOrMerge(this.sheetId, this.getters.getSelectedZone())) {
+          this.model.selection.moveAnchorCell(direction, 1);
+        } else {
+          moveAnchorWithinSelection(this.getters, this.model.selection, direction);
+        }
       }
       return;
     }

--- a/src/components/helpers/selection_helpers.ts
+++ b/src/components/helpers/selection_helpers.ts
@@ -1,4 +1,6 @@
 import { SelectionStreamProcessor } from "@odoo/o-spreadsheet-engine/types/selection_stream_processor";
+import { getZoneArea } from "../../helpers";
+import { Direction, Getters, Position, Zone } from "../../types";
 import { isCtrlKey } from "./dom_helpers";
 
 const arrowMap = {
@@ -18,4 +20,78 @@ export function updateSelectionWithArrowKeys(
   } else {
     selection.moveAnchorCell(direction, isCtrlKey(ev) ? "end" : 1);
   }
+}
+
+export function moveAnchorWithinSelection(
+  getters: Getters,
+  selection: SelectionStreamProcessor,
+  direction: Direction
+) {
+  const {
+    anchor: { zone, cell },
+  } = getters.getSelection();
+  let currentPosition = { ...cell };
+  let remaining = getZoneArea(zone);
+  do {
+    currentPosition = getNextCellInZone(currentPosition, zone, direction);
+    remaining--;
+  } while (remaining > 0 && !isNavigablePosition(getters, currentPosition));
+  if (remaining > 0) {
+    selection.updateAnchorCell(currentPosition.col, currentPosition.row, { scrollIntoView: true });
+  }
+}
+
+function getNextCellInZone(position: Position, zone: Zone, direction: Direction): Position {
+  let { col, row } = position;
+  switch (direction) {
+    case "right":
+      if (col < zone.right) {
+        col++;
+      } else {
+        col = zone.left;
+        row = row < zone.bottom ? row + 1 : zone.top;
+      }
+      break;
+    case "left":
+      if (col > zone.left) {
+        col--;
+      } else {
+        col = zone.right;
+        row = row > zone.top ? row - 1 : zone.bottom;
+      }
+      break;
+    case "down":
+      if (row < zone.bottom) {
+        row++;
+      } else {
+        row = zone.top;
+        col = col < zone.right ? col + 1 : zone.left;
+      }
+      break;
+    case "up":
+      if (row > zone.top) {
+        row--;
+      } else {
+        row = zone.bottom;
+        col = col > zone.left ? col - 1 : zone.right;
+      }
+      break;
+  }
+  return { col, row };
+}
+
+function isNavigablePosition(getters: Getters, position: Position): boolean {
+  const sheetId = getters.getActiveSheetId();
+  if (
+    getters.isHeaderHidden(sheetId, "COL", position.col) ||
+    getters.isHeaderHidden(sheetId, "ROW", position.row)
+  ) {
+    return false;
+  }
+  const mainCell = getters.getMainCellPosition({
+    sheetId,
+    col: position.col,
+    row: position.row,
+  });
+  return mainCell.col === position.col && mainCell.row === position.row;
 }

--- a/tests/composer/composer_integration_component.test.ts
+++ b/tests/composer/composer_integration_component.test.ts
@@ -282,6 +282,26 @@ describe("Composer interactions", () => {
     expect(document.activeElement).toBe(fixture.querySelector(".o-grid div.o-composer")!);
   });
 
+  test("pressing TAB in edit mode cycles within the selection", async () => {
+    setSelection(model, ["A1:B2"], { anchor: "B1" });
+    await keyDown({ key: "F2" });
+    expect(composerStore.editionMode).toBe("editing");
+    await keyDown({ key: "Tab" });
+    expect(getSelectionAnchorCellXc(model)).toBe("A2");
+    expect(model.getters.getSelectedZone()).toEqual(toZone("A1:B2"));
+    expect(composerStore.editionMode).toBe("inactive");
+  });
+
+  test("pressing ENTER in edit mode cycles within the selection", async () => {
+    setSelection(model, ["A1:B2"], { anchor: "A2" });
+    await keyDown({ key: "F2" });
+    expect(composerStore.editionMode).toBe("editing");
+    await keyDown({ key: "Enter" });
+    expect(getSelectionAnchorCellXc(model)).toBe("B1");
+    expect(model.getters.getSelectedZone()).toEqual(toZone("A1:B2"));
+    expect(composerStore.editionMode).toBe("inactive");
+  });
+
   test("Starting the edition should not display the cell reference", async () => {
     setSelection(model, ["A1:A2"]);
     await startComposition();

--- a/tests/grid/grid_component.test.ts
+++ b/tests/grid/grid_component.test.ts
@@ -481,6 +481,59 @@ describe("Grid component", () => {
     });
 
     test.each([
+      { label: "Tab", key: "Tab", shiftKey: false, anchor: "B1", expected: "A2" },
+      { label: "Shift+Tab", key: "Tab", shiftKey: true, anchor: "A1", expected: "B2" },
+      { label: "Enter", key: "Enter", shiftKey: false, anchor: "A2", expected: "B1" },
+      { label: "Shift+Enter", key: "Enter", shiftKey: true, anchor: "A1", expected: "B2" },
+    ])(
+      "pressing $label cycles within the selection",
+      async ({ key, shiftKey, anchor, expected }) => {
+        setSelection(model, ["A1:B2"], { anchor });
+        await keyDown({ key, shiftKey });
+        expect(getSelectionAnchorCellXc(model)).toBe(expected);
+        expect(zoneToXc(model.getters.getSelectedZone())).toBe("A1:B2");
+      }
+    );
+
+    test("pressing TAB skips hidden columns in the selection", async () => {
+      setSelection(model, ["A1:C1"]);
+      hideColumns(model, ["B"]);
+      await keyDown({ key: "Tab" });
+      expect(getSelectionAnchorCellXc(model)).toBe("C1");
+      expect(zoneToXc(model.getters.getSelectedZone())).toBe("A1:C1");
+    });
+
+    test("pressing ENTER skips hidden rows in the selection", async () => {
+      setSelection(model, ["A1:A3"]);
+      hideRows(model, [1]);
+      await keyDown({ key: "Enter" });
+      expect(getSelectionAnchorCellXc(model)).toBe("A3");
+      expect(zoneToXc(model.getters.getSelectedZone())).toBe("A1:A3");
+    });
+
+    test("pressing TAB skips merge interior cells in the selection", async () => {
+      merge(model, "B1:B3");
+      setSelection(model, ["A1:B3"], { anchor: "A1" });
+      await keyDown({ key: "Tab" });
+      expect(getSelectionAnchorCellXc(model)).toBe("B1");
+      keyDown({ key: "Tab" });
+      expect(getSelectionAnchorCellXc(model)).toBe("A2");
+      keyDown({ key: "Tab" });
+      expect(getSelectionAnchorCellXc(model)).toBe("A3");
+    });
+
+    test("pressing ENTER skips merge interior cells in the selection", async () => {
+      merge(model, "A2:C2");
+      setSelection(model, ["A1:C2"], { anchor: "A1" });
+      await keyDown({ key: "Enter" });
+      expect(getSelectionAnchorCellXc(model)).toBe("A2");
+      keyDown({ key: "Enter" });
+      expect(getSelectionAnchorCellXc(model)).toBe("B1");
+      keyDown({ key: "Enter" });
+      expect(getSelectionAnchorCellXc(model)).toBe("C1");
+    });
+
+    test.each([
       { key: "F4", ctrlKey: false },
       { key: "Y", ctrlKey: true },
     ])("can undo/redo with keyboard CTRL+Z/%s", async (redoKey) => {

--- a/tests/sheet/sheetview_plugin.test.ts
+++ b/tests/sheet/sheetview_plugin.test.ts
@@ -138,6 +138,24 @@ describe("Viewport of Simple sheet", () => {
     });
   });
 
+  test("updateAnchor scrolls to the anchor cell when zone is unchanged", () => {
+    model = new Model({ sheets: [{ colNumber: 5, rowNumber: 120 }] });
+    setSelection(model, ["A1:A100"]);
+    setViewportOffset(model, 0, 0);
+
+    const { top: initialTop, bottom: initialBottom } = model.getters.getActiveMainViewport();
+    const targetRow = initialBottom + 5;
+    model.selection.updateAnchorCell(0, targetRow);
+    expect(model.getters.getSelection().anchor.cell).toEqual({ col: 0, row: targetRow });
+
+    const expectedTop = initialTop + 5;
+    const expectedBottom = initialBottom + 5;
+    expect(model.getters.getActiveMainViewport()).toMatchObject({
+      top: expectedTop,
+      bottom: expectedBottom,
+    });
+  });
+
   test("Can Undo/Redo action that alters viewport structure (add/delete rows or cols)", () => {
     model.getters.getActiveMainViewport();
     addRows(model, "before", 0, 70);


### PR DESCRIPTION
## Description:

When one or more zones are selected, pressing **Tab** or **Enter** moves the anchor **within the current selection**, rather than extending the selection or replacing it.

In-selection navigation:

- Tab / Shift+Tab: traverse horizontally (right/left), wrap to next row
- Enter / Shift+Enter: traverse vertically (down/up), wrap to next col
- With multiple zones, jump to the next zone entry in navigation order
- Merges are treated as a single target (visited once)

Task: [4647116](https://www.odoo.com/odoo/project/2328/tasks/4647116)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo