### PR TITLE
[REV] grid: close popovers on external clicks

### DIFF
--- a/src/components/dashboard/dashboard.ts
+++ b/src/components/dashboard/dashboard.ts
@@ -1,4 +1,4 @@
-import { Component, useChildSubEnv, useExternalListener, useRef, useState } from "@odoo/owl";
+import { Component, useChildSubEnv, useRef, useState } from "@odoo/owl";
 import { positionToZone } from "../../helpers/zones";
 import { clickableCellRegistry } from "../../registries/cell_clickable_registry";
 import {
@@ -15,7 +15,6 @@ import { FilterIconsOverlay } from "../filters/filter_icons_overlay/filter_icons
 import { GridOverlay } from "../grid_overlay/grid_overlay";
 import { GridPopover } from "../grid_popover/grid_popover";
 import { css, cssPropertiesToCss } from "../helpers/css";
-import { isChildEvent } from "../helpers/dom_helpers";
 import { useGridDrawing } from "../helpers/draw_grid_hook";
 import { useAbsoluteBoundingRect } from "../helpers/position_hook";
 import { useWheelHandler } from "../helpers/wheel_hook";
@@ -52,15 +51,13 @@ export class SpreadsheetDashboard extends Component<Props, SpreadsheetChildEnv> 
   canvasPosition!: DOMCoordinates;
   hoveredCell!: Partial<Position>;
 
-  private gridRef = useRef("grid");
-
   setup() {
-    this.canvasPosition = useAbsoluteBoundingRect(this.gridRef);
+    const gridRef = useRef("grid");
+    this.canvasPosition = useAbsoluteBoundingRect(gridRef);
     this.hoveredCell = useState({ col: undefined, row: undefined });
 
     useChildSubEnv({ getPopoverContainerRect: () => this.getGridRect() });
     useGridDrawing("canvas", this.env.model, () => this.env.model.getters.getSheetViewDimension());
-    useExternalListener(window, "click", this.onExternalClick, { capture: true });
     this.onMouseWheel = useWheelHandler((deltaX, deltaY) => {
       this.moveCanvas(deltaX, deltaY);
       this.hoveredCell.col = undefined;
@@ -166,16 +163,6 @@ export class SpreadsheetDashboard extends Component<Props, SpreadsheetChildEnv> 
 
   private getGridRect(): Rect {
     return { ...this.canvasPosition, ...this.env.model.getters.getSheetViewDimensionWithHeaders() };
-  }
-
-  private onExternalClick(ev: MouseEvent) {
-    const el = this.gridRef.el;
-    if ((el && isChildEvent(el, ev)) || (ev.target as HTMLElement)?.closest(".o-popover")) {
-      return;
-    }
-    if (this.env.model.getters.hasOpenedPopover()) {
-      this.onClosePopover();
-    }
   }
 }
 

--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -59,7 +59,7 @@ import { GridOverlay } from "../grid_overlay/grid_overlay";
 import { GridPopover } from "../grid_popover/grid_popover";
 import { HeadersOverlay } from "../headers_overlay/headers_overlay";
 import { cssPropertiesToCss } from "../helpers";
-import { isChildEvent, isCtrlKey } from "../helpers/dom_helpers";
+import { isCtrlKey } from "../helpers/dom_helpers";
 import { dragAndDropBeyondTheViewport } from "../helpers/drag_and_drop";
 import { useGridDrawing } from "../helpers/draw_grid_hook";
 import { useAbsoluteBoundingRect } from "../helpers/position_hook";
@@ -149,7 +149,6 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
     useChildSubEnv({ getPopoverContainerRect: () => this.getGridRect() });
     useExternalListener(document.body, "cut", this.copy.bind(this, true));
     useExternalListener(document.body, "copy", this.copy.bind(this, false));
-    useExternalListener(window, "click", this.onExternalClick, { capture: true });
     useExternalListener(document.body, "paste", this.paste);
     onMounted(() => this.focusDefaultElement());
     this.props.exposeFocus(() => this.focusDefaultElement());
@@ -767,13 +766,6 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
         break;
       }
     }
-  }
-
-  private onExternalClick(ev: MouseEvent) {
-    if (isChildEvent(this.gridEl, ev) || (ev.target as HTMLElement)?.closest(".o-popover")) {
-      return;
-    }
-    this.onClosePopover();
   }
 }
 

--- a/tests/data_filter/filter_menu_component.test.ts
+++ b/tests/data_filter/filter_menu_component.test.ts
@@ -335,18 +335,4 @@ describe("Filter menu component", () => {
       [...fixture.querySelectorAll(".o-filter-menu-item")].map((el) => el.textContent)
     ).toEqual(["✓(Blanks)"]);
   });
-
-  test("Filter menu is closed when clicking outside of it", async () => {
-    createFilter(model, "A10:B15");
-    await nextTick();
-    await openFilterMenu();
-
-    // Clicking inside the filter menu does not close it
-    await simulateClick(".o-filter-menu");
-    expect(fixture.querySelector(".o-filter-menu")).not.toBeNull();
-
-    // Clicking outside the filter menu closes it
-    await simulateClick("body");
-    expect(fixture.querySelector(".o-filter-menu")).toBeNull();
-  });
 });

--- a/tests/grid/dashboard_grid_component.test.ts
+++ b/tests/grid/dashboard_grid_component.test.ts
@@ -96,20 +96,6 @@ describe("Grid component in dashboard mode", () => {
     expect(fixture.querySelectorAll(".o-filter-menu")).toHaveLength(0);
   });
 
-  test("Clicking outside of the dashboard closes the filter popover", async () => {
-    createFilter(model, "A1:A2");
-    model.updateMode("dashboard");
-    await nextTick();
-    await simulateClick(".o-filter-icon");
-    expect(fixture.querySelectorAll(".o-filter-menu")).toHaveLength(1);
-
-    await simulateClick(".o-filter-menu");
-    expect(fixture.querySelectorAll(".o-filter-menu")).toHaveLength(1);
-
-    await simulateClick("body");
-    expect(fixture.querySelectorAll(".o-filter-menu")).toHaveLength(0);
-  });
-
   test("When filter menu is open, clicking on a random grid correctly closes filter popover", async () => {
     createFilter(model, "A1:A2");
     model.updateMode("dashboard");

--- a/tests/link/link_editor_component.test.ts
+++ b/tests/link/link_editor_component.test.ts
@@ -272,16 +272,4 @@ describe("link editor component", () => {
       expect(getCell(model, "A1")).toBeDefined();
     }
   );
-
-  test("Link editor is closed when clicking outside of it", async () => {
-    await openLinkEditor(model, "A1");
-
-    // Clicking inside the link editor does not close it
-    await simulateClick(".o-link-editor");
-    expect(fixture.querySelector(".o-link-editor")).not.toBeNull();
-
-    // Clicking outside the link editor closes it
-    await simulateClick("body");
-    expect(fixture.querySelector(".o-link-editor")).toBeNull();
-  });
 });


### PR DESCRIPTION
This reverts commit 45a24fdf1e9c3f46b14a558d8395a120b5d3fb81.

It causes issues with odoo link, so we revert it for now until a better solution is found.

Task: 0

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo