### PR TITLE
[FIX] Actions: ensure the sequence is applied on action children

### DIFF
--- a/src/actions/action.ts
+++ b/src/actions/action.ts
@@ -101,7 +101,8 @@ export function createAction(item: ActionSpec): Action {
           return children
             .map((child) => (typeof child === "function" ? child(env) : child))
             .flat()
-            .map(createAction);
+            .map(createAction)
+            .sort((a, b) => a.sequence - b.sequence);
         }
       : () => [],
     isReadonlyAllowed: item.isReadonlyAllowed || false,

--- a/tests/menus/menu_items_registry.test.ts
+++ b/tests/menus/menu_items_registry.test.ts
@@ -1,4 +1,5 @@
 import { Model } from "../../src";
+import { createActions } from "../../src/actions/action";
 import { FONT_SIZES } from "../../src/constants";
 import { functionRegistry } from "../../src/functions";
 import { zoneToXc } from "../../src/helpers";
@@ -63,6 +64,7 @@ describe("Menu Item Registry", () => {
         id: name,
         name: name,
         execute: () => {},
+        sequence: 1,
       }));
     });
     const env = makeTestEnv();
@@ -1742,4 +1744,33 @@ describe("Menu Item actions", () => {
       expect(unfreezeAllAction.isVisible(env)).toBe(true);
     });
   });
+});
+
+test("Menu children are sorted by sequence", async () => {
+  const env = makeTestEnv();
+  const menuItems = createActions([
+    {
+      id: "menu_1",
+      name: "Menu 1",
+      sequence: 20,
+      children: [
+        {
+          id: "secondItem",
+          name: "bigger sequence Item",
+          sequence: 30,
+          execute: () => {},
+        },
+        {
+          id: "firstItem",
+          name: "lower sequence Item",
+          sequence: 10,
+          execute: () => {},
+        },
+      ],
+    },
+  ]);
+
+  const children = menuItems[0].children(env);
+  expect(children[0].id).toBe("firstItem");
+  expect(children[1].id).toBe("secondItem");
 });


### PR DESCRIPTION
Currently, the helper 'createActions' pre-sorts a list of menuRegistry entries but this sort is not applied to the children (which can be generated dynamically). It never showed up as we rarely add children entries from different sources and their sequence often matches the order of insertion in the registry.

Task: 5452669

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [5452669](https://www.odoo.com/odoo/2328/tasks/5452669)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo