### PR TITLE
[FIX] composer: prevent autocomplete from closing on grid icon drag

### DIFF
--- a/src/components/composer/composer/abstract_composer_store.ts
+++ b/src/components/composer/composer/abstract_composer_store.ts
@@ -124,7 +124,6 @@ export abstract class AbstractComposerStore extends SpreadsheetStore {
   abstract stopEdition(direction?: Direction): void;
 
   private handleEvent(event: SelectionEvent) {
-    this.hideHelp();
     const sheetId = this.getters.getActiveSheetId();
     let unboundedZone: UnboundedZone;
     if (event.options.unbounded) {
@@ -518,6 +517,7 @@ export abstract class AbstractComposerStore extends SpreadsheetStore {
     this.colorIndexByRange = {};
     this.hoveredTokens = [];
     this.hoveredContentEvaluation = "";
+    this.hideHelp();
   }
 
   /**

--- a/tests/data_validation/data_validation_list_component.test.ts
+++ b/tests/data_validation/data_validation_list_component.test.ts
@@ -1,6 +1,7 @@
 import { Model } from "../../src";
 import { CellComposerStore } from "../../src/components/composer/composer/cell_composer_store";
 import {
+  DEFAULT_CELL_HEIGHT,
   DEFAULT_CELL_WIDTH,
   GRAY_200,
   GRID_ICON_EDGE_LENGTH,
@@ -22,8 +23,11 @@ import {
   click,
   clickGridIcon,
   getElComputedStyle,
+  getGridIconEventPosition,
+  gridMouseEvent,
   keyDown,
   setInputValueAndTrigger,
+  triggerMouseEvent,
 } from "../test_helpers/dom_helper";
 import { getCellContent, getCellIcons } from "../test_helpers/getters_helpers";
 import {
@@ -473,6 +477,46 @@ describe("Selection arrow icon in grid", () => {
     expect(suggestions[0].textContent).toBe("ok");
     expect(suggestions[1].textContent).toBe("hello");
     expect(suggestions[2].textContent).toBe("okay");
+  });
+
+  test("Clicking another cell hides autocomplete", async () => {
+    ({ fixture, env } = await mountSpreadsheet({ model }));
+    const composerStore = env.getStore(CellComposerStore);
+    const hideHelpSpy = jest.spyOn(composerStore, "hideHelp");
+    await clickGridIcon(model, "A1");
+    expect(composerStore.editionMode).toBe("editing");
+    expect(hideHelpSpy).not.toHaveBeenCalled();
+
+    gridMouseEvent(model, "pointerdown", "B2");
+    gridMouseEvent(model, "pointerup", "B2");
+    expect(composerStore.editionMode).toBe("inactive");
+  });
+
+  test("Click-and-drag on grid icon does not hide autocomplete", async () => {
+    ({ fixture, env } = await mountSpreadsheet({ model }));
+    const composerStore = env.getStore(CellComposerStore);
+    const { x, y } = getGridIconEventPosition(model, "A1");
+
+    triggerMouseEvent(".o-grid-overlay", "pointerdown", x, y);
+    await nextTick();
+    triggerMouseEvent(
+      ".o-grid-overlay",
+      "pointermove",
+      x + DEFAULT_CELL_WIDTH,
+      y + DEFAULT_CELL_HEIGHT
+    );
+    await nextTick();
+    triggerMouseEvent(
+      ".o-grid-overlay",
+      "pointerup",
+      x + DEFAULT_CELL_WIDTH,
+      y + DEFAULT_CELL_HEIGHT
+    );
+    await nextTick();
+
+    expect(composerStore.editionMode).toBe("editing");
+    expect(composerStore.currentEditedCell).toEqual({ sheetId, col: 0, row: 0 });
+    expect(fixture.querySelectorAll(".o-autocomplete-value")).toHaveLength(3);
   });
 
   test("Icon is not displayed when display style is plainText", () => {


### PR DESCRIPTION
## Description:

Current behavior before PR:
- Pointer movement after clicking the grid icon triggered 'hideHelp()', 
  closing autocomplete even though the edited cell did not change.

Desired behavior after PR is merged:
- Autocomplete remains open during click-and-drag on the grid icon.
- 'hideHelp()' is now called from '_cancelEdition()', such as when
  switching to another cell or leaving edit mode.

Task: [5392156](https://www.odoo.com/odoo/2328/tasks/5392156)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo