### PR TITLE
[FIX] pivot: carry forward running totals for missing date buckets

### DIFF
--- a/packages/o-spreadsheet-engine/src/types/pivot.ts
+++ b/packages/o-spreadsheet-engine/src/types/pivot.ts
@@ -180,12 +180,14 @@ export interface PivotTimeAdapterNotNull<T> {
   normalizeFunctionValue: (value: Exclude<CellValue, null>) => T;
   toValueAndFormat: (normalizedValue: T, locale?: Locale) => FunctionResultObject;
   toFunctionValue: (normalizedValue: T) => string;
+  toComparableValue?: (normalizedValue: T) => number;
 }
 
 export interface PivotTimeAdapter<T> {
   normalizeFunctionValue: (value: CellValue) => T | null;
   toValueAndFormat: (normalizedValue: T, locale?: Locale) => FunctionResultObject;
   toFunctionValue: (normalizedValue: T) => string;
+  toComparableValue?: (normalizedValue: T | null) => number | undefined;
 }
 
 export interface PivotNode {

--- a/src/index.ts
+++ b/src/index.ts
@@ -138,6 +138,7 @@ import {
 } from "@odoo/o-spreadsheet-engine/helpers/pivot/pivot_helpers";
 import { pivotRegistry } from "@odoo/o-spreadsheet-engine/helpers/pivot/pivot_registry";
 import {
+  periodYearToComparable,
   pivotTimeAdapter,
   pivotTimeAdapterRegistry,
 } from "@odoo/o-spreadsheet-engine/helpers/pivot/pivot_time_adapter";
@@ -399,6 +400,7 @@ export const helpers = {
   parseDimension,
   isDateOrDatetimeField,
   makeFieldProposal,
+  periodYearToComparable,
   insertTokenAfterArgSeparator,
   insertTokenAfterLeftParenthesis,
   mergeContiguousZones,


### PR DESCRIPTION
## Description:

When a measure is displayed as "running total" and the pivot is grouped by a date granularity (month/day/etc), PIVOT.VALUE returned an empty value for a requested bucket that does not exist in the pivot. This happened because the running-total cache only stores values for materialized pivot buckets, so a missing date key had no direct lookup.

With this commit, for date/datetime dimensions, we build an ordered index of existing buckets per secondary domain and running-total group, and use a binary search to find the nearest previous bucket. If found, we return its cumulative value (carry-forward); if the requested bucket is before the first one, we return empty.

Task: [5420999](https://www.odoo.com/odoo/2328/tasks/5420999)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo