### PR TITLE
[FIX] Composer: Capture the correct selection on `F2`

### DIFF
--- a/src/components/composer/composer/abstract_composer_store.ts
+++ b/src/components/composer/composer/abstract_composer_store.ts
@@ -284,7 +284,7 @@ export abstract class AbstractComposerStore extends SpreadsheetStore {
     this.model.selection.capture(
       this,
       {
-        cell: { col: col ?? zone.left, row: row ?? zone.right },
+        cell: { col: col ?? zone.left, row: row ?? zone.top },
         zone,
       },
       {

--- a/tests/composer/composer_component.test.ts
+++ b/tests/composer/composer_component.test.ts
@@ -985,12 +985,18 @@ describe("composer", () => {
   });
 
   test("Pressing F2 will toggle edition mode on ranges", async () => {
-    await startComposition("=A1+A2");
+    await startComposition("=G4+F9");
     expect(composerStore.editionMode).toBe("editing");
     await keyDown({ key: "F2" });
     expect(composerStore.editionMode).toBe("selecting");
+    await keyDown({ key: "ArrowDown" });
+    expect(composerStore.currentContent).toEqual("=G4+F10");
     await keyDown({ key: "F2" });
     expect(composerStore.editionMode).toBe("editing");
+    await keyDown({ key: "F2" });
+    expect(composerStore.editionMode).toBe("selecting");
+    await keyDown({ key: "ArrowRight" });
+    expect(composerStore.currentContent).toEqual("=G4+G10");
   });
 });
 


### PR DESCRIPTION
How to reproduce:
- Write =F9 in a composer
- close and reopen it
- press `F2` to edit the range
- press `arrowDown`

-> the range should be edited to F10 and is set to F7 instead.

Task: 5462713

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo