### PR TITLE
[IMP] formatting: unify the formatting with odoo chart views

### DIFF
--- a/packages/o-spreadsheet-engine/src/helpers/format/format.ts
+++ b/packages/o-spreadsheet-engine/src/helpers/format/format.ts
@@ -732,7 +732,8 @@ export function humanizeNumber({ value, format }: FunctionResultObject, locale: 
   let numberFormat: Format | undefined = format;
   if (Math.abs(numberValue) < 1000) {
     const hasDecimal = numberValue % 1 !== 0;
-    numberFormat = !format && hasDecimal ? "0.####" : format;
+    numberFormat =
+      !format && hasDecimal ? (Math.abs(numberValue) < 0.01 ? "0.00e" : "0.##") : format;
   } else {
     numberFormat = formatLargeNumber({ value, format }, undefined, locale);
   }
@@ -756,30 +757,32 @@ export function formatLargeNumber(
     const postFix = unit?.value;
     switch (postFix) {
       case "k":
-        return createLargeNumberFormat(format, 1, "k", locale);
+        return createLargeNumberFormat(format, 1, "k");
       case "m":
-        return createLargeNumberFormat(format, 2, "m", locale);
+        return createLargeNumberFormat(format, 2, "m");
       case "b":
-        return createLargeNumberFormat(format, 3, "b", locale);
+        return createLargeNumberFormat(format, 3, "b");
       default:
         throw new EvaluationError(_t("The formatting unit should be 'k', 'm' or 'b'."));
     }
   }
   if (value < 1e5) {
-    return createLargeNumberFormat(format, 0, "", locale);
+    return createLargeNumberFormat(format, 0, "");
   } else if (value < 1e8) {
-    return createLargeNumberFormat(format, 1, "k", locale);
+    return createLargeNumberFormat(format, 1, "k");
   } else if (value < 1e11) {
-    return createLargeNumberFormat(format, 2, "m", locale);
+    return createLargeNumberFormat(format, 2, "m");
+  } else if (value < 1e14) {
+    return createLargeNumberFormat(format, 3, "b");
+  } else {
+    return "0.00e";
   }
-  return createLargeNumberFormat(format, 3, "b", locale);
 }
 
 function createLargeNumberFormat(
   format: Format | undefined,
   magnitude: number,
-  postFix: string,
-  locale: Locale
+  postFix: string
 ): Format {
   const multiPartFormat = parseFormat(format || "#,##0");
   const roundedInternalFormat = {

--- a/tests/figures/chart/chart_plugin.test.ts
+++ b/tests/figures/chart/chart_plugin.test.ts
@@ -3998,12 +3998,12 @@ describe("Can make numbers human-readable", () => {
         "1"
       );
       let axis = getChartConfiguration(model, "1").options.scales.y;
-      const valuesBefore = [1e3, 1e6, 0.1, 0.123456789].map(axis.ticks.callback);
-      expect(valuesBefore).toEqual(["1,000", "1,000,000", "0.1", "0.123456789"]);
+      const valuesBefore = [1e3, 1e6, 0.1, 0.123456789, 1e-5].map(axis.ticks.callback);
+      expect(valuesBefore).toEqual(["1,000", "1,000,000", "0.1", "0.123456789", "0.00001"]);
       updateChart(model, "1", { humanize: true });
       axis = getChartConfiguration(model, "1").options.scales.y;
-      const valuesAfter = [1e3, 1e6, 0.1, 0.123456789].map(axis.ticks.callback);
-      expect(valuesAfter).toEqual(["1,000", "1,000k", "0.1", "0.1235"]);
+      const valuesAfter = [1e3, 1e6, 0.1, 0.123456789, 1e-5].map(axis.ticks.callback);
+      expect(valuesAfter).toEqual(["1,000", "1,000k", "0.1", "0.12", "1.00e-05"]);
     }
   );
 

--- a/tests/functions/module_custom.test.ts
+++ b/tests/functions/module_custom.test.ts
@@ -18,7 +18,7 @@ describe("FORMAT.LARGE.NUMBER formula", () => {
     expect(evaluateCellText("A1", { A1: "=FORMAT.LARGE.NUMBER(1000000000000)" })).toBe("1,000b");
     expect(evaluateCellText("A1", { A1: "=FORMAT.LARGE.NUMBER(10000000000000)" })).toBe("10,000b");
     expect(evaluateCellText("A1", { A1: "=FORMAT.LARGE.NUMBER(100000000000000)" })).toBe(
-      "100,000b"
+      "1.00e+14"
     );
   });
 
@@ -38,7 +38,7 @@ describe("FORMAT.LARGE.NUMBER formula", () => {
       "-10,000b"
     );
     expect(evaluateCellText("A1", { A1: "=FORMAT.LARGE.NUMBER(-100000000000000)" })).toBe(
-      "-100,000b"
+      "-1.00e+14"
     );
   });
 


### PR DESCRIPTION
## Task Description

When importing a chart from odoo to a spreadsheet, we check by default the "humanize numbers" option to make big and small numbers readable. Unfortunately, the way we make them "more readable" is not the same as in odoo chart view. This PR aims to change two behaviors :
 1. The really big numbers are now shown as scientific notation
 2. We reduce the number of digits for decimal parts.

To make sure very small positive numbers are still representable, they are also shown as scientific notation when |number| < 0.01.

## Related Task

- Task: [Odoo chart: format value](https://www.odoo.com/odoo/2328/tasks/5435022)