### PR TITLE
[FIX] session: recover from errors when sending messages

### DIFF
--- a/src/collaborative/session.ts
+++ b/src/collaborative/session.ts
@@ -267,11 +267,17 @@ export class Session extends EventBus<CollaborativeEvent> {
     const type = currentPosition ? "CLIENT_MOVED" : "CLIENT_JOINED";
     const client = this.getCurrentClient();
     this.clients[this.clientId] = { ...client, position };
-    this.transportService.sendMessage({
-      type,
-      version: MESSAGE_VERSION,
-      client: { ...client, position },
-    });
+    this.transportService
+      .sendMessage({
+        type,
+        version: MESSAGE_VERSION,
+        client: { ...client, position },
+      })
+      .then(() => {
+        if (this.pendingMessages.length > 0 && !this.waitingAck) {
+          this.sendPendingMessage();
+        }
+      });
   }
 
   /**
@@ -427,10 +433,17 @@ export class Session extends EventBus<CollaborativeEvent> {
       ${JSON.stringify(message)}`);
     }
     this.waitingAck = true;
-    this.transportService.sendMessage({
-      ...message,
-      serverRevisionId: this.serverRevisionId,
-    });
+    this.transportService
+      .sendMessage({
+        ...message,
+        serverRevisionId: this.serverRevisionId,
+      })
+      .catch((e: Error) => {
+        if (!(e instanceof ClientDisconnectedError)) {
+          throw e.cause || e;
+        }
+        this.waitingAck = false;
+      });
   }
 
   private acknowledge(message: CollaborationMessage) {

--- a/tests/__mocks__/transport_service.ts
+++ b/tests/__mocks__/transport_service.ts
@@ -8,10 +8,10 @@ import {
 } from "../../src/types/collaborative/transport_service";
 
 export class MockTransportService implements TransportService<CollaborationMessage> {
-  private listeners: { id: UID; callback: NewMessageCallback }[] = [];
+  protected listeners: { id: UID; callback: NewMessageCallback }[] = [];
   private pendingMessages: CollaborationMessage[] = [];
   private isConcurrent: boolean = false;
-  private serverRevisionId: string = DEFAULT_REVISION_ID;
+  protected serverRevisionId: string = DEFAULT_REVISION_ID;
   snapshot?: WorkbookData;
 
   onNewMessage(id: UID, callback: NewMessageCallback) {

--- a/tests/__mocks__/transport_service_async.ts
+++ b/tests/__mocks__/transport_service_async.ts
@@ -1,0 +1,12 @@
+import { CollaborationMessage } from "../../src/types/collaborative/transport_service";
+import { MockTransportService } from "./transport_service";
+
+export class MockTransportServiceAsync extends MockTransportService {
+  async notifyListeners(message: CollaborationMessage) {
+    return Promise.all(
+      this.listeners.map(({ callback }) => {
+        return Promise.resolve().then((x) => callback(message));
+      })
+    );
+  }
+}

--- a/tests/collaborative/collaborative_helpers.ts
+++ b/tests/collaborative/collaborative_helpers.ts
@@ -17,8 +17,11 @@ interface CollaborativeEnv {
  * first, meaning she will also resend her pending messages first.
  * Similarly, Bob's messages are resent before Charlie's.
  */
-export function setupCollaborativeEnv(modelData?: any): CollaborativeEnv {
-  const network = new MockTransportService();
+export function setupCollaborativeEnv(
+  modelData?: any,
+  mockTransportService?: MockTransportService
+): CollaborativeEnv {
+  const network = mockTransportService || new MockTransportService();
   const emptySheetData = new Model(modelData).exportData();
   const alice = new Model(deepCopy(emptySheetData), {
     transportService: network,

--- a/tests/collaborative/reconnection.test.ts
+++ b/tests/collaborative/reconnection.test.ts
@@ -1,0 +1,76 @@
+import { ClientDisconnectedError, CoreCommand, Model } from "../../src";
+import { MockTransportService } from "../__mocks__/transport_service";
+import { MockTransportServiceAsync } from "../__mocks__/transport_service_async";
+import { getCellContent } from "../test_helpers";
+import { nextTick } from "../test_helpers/helpers";
+import { setupCollaborativeEnv } from "./collaborative_helpers";
+
+describe("reconnection recovery", () => {
+  let network: MockTransportService;
+  let alice: Model;
+  let bob: Model;
+
+  beforeEach(() => {
+    ({ network, alice, bob } = setupCollaborativeEnv(undefined, new MockTransportServiceAsync()));
+  });
+
+  test("disconnecting than reconnecting re-send all messages and swallows the error", async () => {
+    const commandWhileOnline: CoreCommand = {
+      type: "UPDATE_CELL",
+      sheetId: alice.getters.getActiveSheetId(),
+      col: 0,
+      row: 0,
+      content: "first command",
+    };
+    const commandWhileOFFLINE: CoreCommand = {
+      type: "UPDATE_CELL",
+      sheetId: alice.getters.getActiveSheetId(),
+      col: 0,
+      row: 1,
+      content: "second command",
+    };
+    const commandWhileOFFLINE2: CoreCommand = {
+      type: "UPDATE_CELL",
+      sheetId: alice.getters.getActiveSheetId(),
+      col: 0,
+      row: 1,
+      content: "third command",
+    };
+
+    const commandWhileBackOnline: CoreCommand = {
+      type: "UPDATE_CELL",
+      sheetId: alice.getters.getActiveSheetId(),
+      col: 0,
+      row: 2,
+      content: "fourth command",
+    };
+
+    alice.dispatch("UPDATE_CELL", commandWhileOnline);
+    await nextTick();
+
+    const backupSendMessage = network.sendMessage;
+    network.sendMessage = () => {
+      return Promise.reject(new ClientDisconnectedError("network error"));
+    };
+
+    alice.dispatch("UPDATE_CELL", commandWhileOFFLINE);
+    await nextTick();
+    alice.dispatch("UPDATE_CELL", commandWhileOFFLINE2);
+    await nextTick();
+
+    network.sendMessage = backupSendMessage;
+    alice.dispatch("UPDATE_CELL", commandWhileBackOnline);
+
+    await nextTick();
+    await nextTick();
+    await nextTick();
+
+    expect(getCellContent(alice, "A1")).toBe("first command");
+    expect(getCellContent(alice, "A2")).toBe("third command");
+    expect(getCellContent(alice, "A3")).toBe("fourth command");
+
+    expect(getCellContent(bob, "A1")).toBe("first command");
+    expect(getCellContent(bob, "A2")).toBe("third command");
+    expect(getCellContent(bob, "A3")).toBe("fourth command");
+  });
+});


### PR DESCRIPTION
If, for any reason, the sending of a revision creates an error b.e. when the user is disconnected, we never reset the "waitingForAck" flag, and all future messages will be queued but never send. The result of this behavior was that any user action during any disconnection will set the spreadsheet in a state where all changes from that point are lost.

This fix handles the error while sending a message and always reset the flag, so that at next change, we will try to re-send the same message until it works.

Task: 5469116