### PR TITLE
[IMP] figure: add data-type attribute to figure carousel tabs

### DIFF
--- a/src/components/figures/figure_carousel/figure_carousel.xml
+++ b/src/components/figures/figure_carousel/figure_carousel.xml
@@ -20,6 +20,7 @@
             <div
               class="o-carousel-tab text-truncate px-2 mt-1 flex-shrink-0"
               t-att-class="{ 'selected': isItemSelected(item) }"
+              t-att-data-type="item.type"
               t-esc="getItemTitle(item)"
               t-on-click.stop="() => this.onCarouselTabClick(item)"
             />


### PR DESCRIPTION
## Description

This commit adds a `data-type` attribute to each tab in the figure carousel, so we can create css selector based on the carousel item type.

Task: [5447027](https://www.odoo.com/odoo/2328/tasks/5447027)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo