### PR TITLE
[FIX] session: always return a Promise

### DIFF
--- a/src/collaborative/readonly_transport_filter.ts
+++ b/src/collaborative/readonly_transport_filter.ts
@@ -14,7 +14,7 @@ export class ReadonlyTransportFilter implements TransportService<CollaborationMe
       message.type === "CLIENT_LEFT" ||
       message.type === "CLIENT_MOVED"
     ) {
-      this.transportService.sendMessage(message);
+      await this.transportService.sendMessage(message);
     }
     // ignore all other messages
   }

--- a/src/collaborative/session.ts
+++ b/src/collaborative/session.ts
@@ -195,7 +195,7 @@ export class Session extends EventBus<CollaborativeEvent> {
     }
     delete this.clients[this.clientId];
     this.transportService.leave(this.clientId);
-    this.transportService.sendMessage({
+    this.sendToTransport({
       type: "CLIENT_LEFT",
       clientId: this.clientId,
       version: MESSAGE_VERSION,
@@ -210,7 +210,7 @@ export class Session extends EventBus<CollaborativeEvent> {
       return;
     }
     const snapshotId = this.uuidGenerator.uuidv4();
-    await this.transportService.sendMessage({
+    await this.sendToTransport({
       type: "SNAPSHOT",
       nextRevisionId: snapshotId,
       serverRevisionId: this.serverRevisionId,
@@ -267,17 +267,15 @@ export class Session extends EventBus<CollaborativeEvent> {
     const type = currentPosition ? "CLIENT_MOVED" : "CLIENT_JOINED";
     const client = this.getCurrentClient();
     this.clients[this.clientId] = { ...client, position };
-    this.transportService
-      .sendMessage({
-        type,
-        version: MESSAGE_VERSION,
-        client: { ...client, position },
-      })
-      .then(() => {
-        if (this.pendingMessages.length > 0 && !this.waitingAck) {
-          this.sendPendingMessage();
-        }
-      });
+    this.sendToTransport({
+      type,
+      version: MESSAGE_VERSION,
+      client: { ...client, position },
+    }).then(() => {
+      if (this.pendingMessages.length > 0 && !this.waitingAck) {
+        this.sendPendingMessage();
+      }
+    });
   }
 
   /**
@@ -382,7 +380,7 @@ export class Session extends EventBus<CollaborativeEvent> {
       if (client) {
         const { position } = client;
         if (position) {
-          this.transportService.sendMessage({
+          this.sendToTransport({
             type: "CLIENT_MOVED",
             version: MESSAGE_VERSION,
             client: { ...client, position },
@@ -404,6 +402,11 @@ export class Session extends EventBus<CollaborativeEvent> {
       return;
     }
     this.sendPendingMessage();
+  }
+
+  private async sendToTransport(message: CollaborationMessage) {
+    // wrap in an async function to ensure it returns a promise
+    return this.transportService.sendMessage(message);
   }
 
   /**
@@ -433,17 +436,15 @@ export class Session extends EventBus<CollaborativeEvent> {
       ${JSON.stringify(message)}`);
     }
     this.waitingAck = true;
-    this.transportService
-      .sendMessage({
-        ...message,
-        serverRevisionId: this.serverRevisionId,
-      })
-      .catch((e: Error) => {
-        if (!(e instanceof ClientDisconnectedError)) {
-          throw e.cause || e;
-        }
-        this.waitingAck = false;
-      });
+    this.sendToTransport({
+      ...message,
+      serverRevisionId: this.serverRevisionId,
+    }).catch((e: Error) => {
+      if (!(e instanceof ClientDisconnectedError)) {
+        throw e.cause || e;
+      }
+      this.waitingAck = false;
+    });
   }
 
   private acknowledge(message: CollaborationMessage) {


### PR DESCRIPTION
If the implementation of `transportService` doesn't return a Promise when calling `sendMessage`, the session breaks.

With this commit, we ensure we always get a Promise which allows to safely call `.then` or `.catch`

Task: 0

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo