### PR TITLE
[FIX] topbar: fix readonly banner  on mobile

### DIFF
--- a/src/components/top_bar/top_bar.xml
+++ b/src/components/top_bar/top_bar.xml
@@ -30,12 +30,12 @@
         t-att-class="{'o-topbar-responsive': !env.model.getters.isReadonly()}"
         t-ref="toolBarContainer">
         <div
-          class="o-topbar-toolbar d-flex"
+          class="o-topbar-toolbar d-flex flex-grow-1"
           t-att-class="{'flex-shrink-0': env.model.getters.isReadonly()}">
           <!-- Toolbar -->
           <div
             t-if="env.model.getters.isReadonly()"
-            class="o-readonly-toolbar d-flex align-items-center text-muted">
+            class="o-readonly-toolbar d-flex flex-grow-1 align-items-center text-muted">
             <span>
               <i class="fa fa-eye"/>
               Readonly Access

--- a/tests/__snapshots__/top_bar_component.test.ts.snap
+++ b/tests/__snapshots__/top_bar_component.test.ts.snap
@@ -65,7 +65,7 @@ exports[`TopBar component can set cell format 1`] = `
         class="d-flex o-topbar-responsive"
       >
         <div
-          class="o-topbar-toolbar d-flex"
+          class="o-topbar-toolbar d-flex flex-grow-1"
         >
           <!-- Toolbar -->
           
@@ -1201,7 +1201,7 @@ exports[`TopBar component simple rendering 1`] = `
     class="d-flex o-topbar-responsive"
   >
     <div
-      class="o-topbar-toolbar d-flex"
+      class="o-topbar-toolbar d-flex flex-grow-1"
     >
       <!-- Toolbar -->
       

--- a/tests/spreadsheet/__snapshots__/spreadsheet_component.test.ts.snap
+++ b/tests/spreadsheet/__snapshots__/spreadsheet_component.test.ts.snap
@@ -69,7 +69,7 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
         class="d-flex o-topbar-responsive"
       >
         <div
-          class="o-topbar-toolbar d-flex"
+          class="o-topbar-toolbar d-flex flex-grow-1"
         >
           <!-- Toolbar -->
           
@@ -1055,7 +1055,7 @@ exports[`components take the small screen into account 1`] = `
         class="d-flex o-topbar-responsive"
       >
         <div
-          class="o-topbar-toolbar d-flex"
+          class="o-topbar-toolbar d-flex flex-grow-1"
         >
           <!-- Toolbar -->
           


### PR DESCRIPTION
## Description

When the spreadsheet is in readonly mode, the readonly banner wasn't taking the full width of the topbar.

Task: [5342571](https://www.odoo.com/odoo/2328/tasks/5342571)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo