### PR TITLE
[FIX] vectorization: fix error message on size mismatch

### DIFF
--- a/tests/functions/vectorization.test.ts
+++ b/tests/functions/vectorization.test.ts
@@ -3,6 +3,7 @@ import { functionRegistry } from "../../src/functions";
 import { toScalar } from "../../src/functions/helper_matrices";
 import { toString } from "../../src/functions/helpers";
 import { setCellContent } from "../test_helpers/commands_helpers";
+import { getEvaluatedCell } from "../test_helpers/getters_helpers";
 import {
   checkFunctionDoesntSpreadBeyondRange,
   createModelFromGrid,
@@ -128,11 +129,17 @@ describe("vectorization", () => {
     const model = createModelFromGrid(grid);
     setCellContent(model, "D1", "=FUNCTION.WITHOUT.RANGE.ARGS(A1:B1, A2:C2)");
     expect(getRangeValuesAsMatrix(model, "D1:F1")).toEqual([["A1A2", "B1B2", "#N/A"]]);
+    expect(getEvaluatedCell(model, "F1").message).toBe(
+      "Array arguments to FUNCTION.WITHOUT.RANGE.ARGS are of different size."
+    );
     expect(checkFunctionDoesntSpreadBeyondRange(model, "D1:F1")).toBeTruthy();
 
     setCellContent(model, "D2", "=FUNCTION.WITHOUT.RANGE.ARGS(A1:A2, B1:B3)");
     expect(getRangeValuesAsMatrix(model, "D2:D4")).toEqual([["A1B1"], ["A2B2"], ["#N/A"]]);
     expect(checkFunctionDoesntSpreadBeyondRange(model, "D2:D4")).toBeTruthy();
+    expect(getEvaluatedCell(model, "D4").message).toBe(
+      "Array arguments to FUNCTION.WITHOUT.RANGE.ARGS are of different size."
+    );
   });
 
   test("vectorization of array formula will only return the first value of the array", () => {


### PR DESCRIPTION
## Description

When we try to vectorize formulas with mismatched sizes (eg. `=A1:A3 + B1:B2`), the error message shown to the user would still contain the error placeholder `[[FUNCTION_NAME]]`.

Task: [5331324](https://www.odoo.com/odoo/2328/tasks/5331324)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo