### PR TITLE
[FIX] helpers: export chart check type from runtime config

### DIFF
--- a/packages/o-spreadsheet-engine/src/helpers/figures/charts/chart_ui_common.ts
+++ b/packages/o-spreadsheet-engine/src/helpers/figures/charts/chart_ui_common.ts
@@ -48,16 +48,16 @@ export async function chartToImageUrl(
     if (!extensionsLoaded) {
       registerChartJSExtensions();
     }
-    if (!globalThis.Chart.registry.controllers.get(type)) {
-      console.log(`Chart of type "${type}" is not registered in Chart.js library.`);
+
+    const config = deepCopy(runtime.chartJsConfig);
+    config.plugins = [backgroundColorChartJSPlugin];
+    if (!globalThis.Chart.registry.controllers.get(config.type)) {
+      console.log(`Chart of type "${config.type}" is not registered in Chart.js library.`);
       if (!extensionsLoaded) {
         unregisterChartJsExtensions();
       }
       return imageUrl;
     }
-
-    const config = deepCopy(runtime.chartJsConfig);
-    config.plugins = [backgroundColorChartJSPlugin];
 
     const chart = new globalThis.Chart(
       canvas as unknown as HTMLCanvasElement,
@@ -106,16 +106,16 @@ export async function chartToImageFile(
     if (!extensionsLoaded) {
       registerChartJSExtensions();
     }
-    if (!globalThis.Chart.registry.controllers.get(type)) {
-      console.log(`Chart of type "${type}" is not registered in Chart.js library.`);
+
+    const config = deepCopy(runtime.chartJsConfig);
+    config.plugins = [backgroundColorChartJSPlugin];
+    if (!globalThis.Chart.registry.controllers.get(config.type)) {
+      console.log(`Chart of type "${config.type}" is not registered in Chart.js library.`);
       if (!extensionsLoaded) {
         unregisterChartJsExtensions();
       }
       return chartBlob;
     }
-
-    const config = deepCopy(runtime.chartJsConfig);
-    config.plugins = [backgroundColorChartJSPlugin];
 
     const chart = new globalThis.Chart(
       canvas as unknown as HTMLCanvasElement,


### PR DESCRIPTION
## Description:

Current behavior before PR:
- Chart image generation could fail when the provided chart type was
  not a valid Chart.js controller (e.g. combo, waterfall, geo, ...).
- Helpers previously relied on given chart types, which do not always
  map to generic Chart.js types, causing image export to return undefined.

Desired behavior after PR is merged:
- The export logic now uses the runtime config type, which resolves to a
  valid Chart.js controller and fixes image and XLSX exports for all
  chart types.

Task: [5446988](https://www.odoo.com/odoo/2328/tasks/5446988)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo