### PR TITLE
[REF] lint: enforce braces for all control statements

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -15,6 +15,7 @@ export default tseslint.config(
       "no-unsafe-optional-chaining": "error", // ban unsafe optional chaining
       eqeqeq: "error", // ban non-strict equal
       "@typescript-eslint/no-non-null-asserted-optional-chain": "error", // ban non-null assertion in optional chain
+      curly: ["error", "all"], // enforce curly braces for all control statements
     },
   }
 );

--- a/package.json
+++ b/package.json
@@ -171,8 +171,8 @@
   },
   "lint-staged": {
     "*": [
-      "prettier --write",
-      "eslint --fix"
+      "eslint --fix",
+      "prettier --write"
     ]
   },
   "publishConfig": {

--- a/packages/o-spreadsheet-engine/src/collaborative/session.ts
+++ b/packages/o-spreadsheet-engine/src/collaborative/session.ts
@@ -100,7 +100,9 @@ export class Session extends EventBus<CollaborativeEvent> {
    * It will be transmitted to all other connected clients.
    */
   save(rootCommand: Command, commands: CoreCommand[], changes: HistoryChange[]) {
-    if (!commands.length || !changes.length || !this.canApplyOptimisticUpdate()) return;
+    if (!commands.length || !changes.length || !this.canApplyOptimisticUpdate()) {
+      return;
+    }
     const revision = new Revision(
       this.uuidGenerator.uuidv4(),
       this.clientId,
@@ -286,7 +288,9 @@ export class Session extends EventBus<CollaborativeEvent> {
    * session.
    */
   private onMessageReceived(message: CollaborationMessage) {
-    if (this.isAlreadyProcessed(message)) return;
+    if (this.isAlreadyProcessed(message)) {
+      return;
+    }
     if (this.isWrongServerRevisionId(message)) {
       this.trigger("unexpected-revision-id");
       return;
@@ -417,7 +421,9 @@ export class Session extends EventBus<CollaborativeEvent> {
    */
   private sendPendingMessage() {
     let message = this.pendingMessages[0];
-    if (!message) return;
+    if (!message) {
+      return;
+    }
     if (message.type === "REMOTE_REVISION") {
       let revision = this.revisions.get(message.nextRevisionId);
       if (revision.commands.length === 0) {

--- a/packages/o-spreadsheet-engine/src/components/helpers/css.ts
+++ b/packages/o-spreadsheet-engine/src/components/helpers/css.ts
@@ -27,7 +27,9 @@ export function getTextDecoration({
  */
 export function cellStyleToCss(style: Style | undefined): CSSProperties {
   const attributes = cellTextStyleToCss(style);
-  if (!style) return attributes;
+  if (!style) {
+    return attributes;
+  }
 
   if (style.fillColor) {
     attributes["background"] = style.fillColor;
@@ -41,7 +43,9 @@ export function cellStyleToCss(style: Style | undefined): CSSProperties {
  */
 export function cellTextStyleToCss(style: Style | undefined): CSSProperties {
   const attributes: Record<string, string> = {};
-  if (!style) return attributes;
+  if (!style) {
+    return attributes;
+  }
 
   if (style.bold) {
     attributes["font-weight"] = "bold";

--- a/packages/o-spreadsheet-engine/src/formulas/formula_formatter.ts
+++ b/packages/o-spreadsheet-engine/src/formulas/formula_formatter.ts
@@ -222,7 +222,9 @@ function fits(width: number, linkedString: LinkedString | null): boolean {
       return true;
     }
     width -= linkedString.subString.length;
-    if (width < 0) return false;
+    if (width < 0) {
+      return false;
+    }
     linkedString = linkedString.next;
   }
   return true;

--- a/packages/o-spreadsheet-engine/src/functions/helper_parser.ts
+++ b/packages/o-spreadsheet-engine/src/functions/helper_parser.ts
@@ -279,7 +279,9 @@ export function getTranslatedCategory(key: string): string {
 
 export function getTransformation(key: string): Unit | undefined {
   for (const [prefix, value] of Object.entries(UNIT_PREFIXES)) {
-    if (prefix && !key.startsWith(prefix)) continue;
+    if (prefix && !key.startsWith(prefix)) {
+      continue;
+    }
     const _key = key.slice(prefix.length);
     let conversion = UNITS[_key];
     if (!conversion && UNITS_ALIASES[_key]) {

--- a/packages/o-spreadsheet-engine/src/functions/helpers.ts
+++ b/packages/o-spreadsheet-engine/src/functions/helpers.ts
@@ -599,12 +599,16 @@ function conditionalVisitArgs(
       const lenCol = arg[0].length;
       for (let y = 0; y < lenCol; y++) {
         for (let x = 0; x < lenRow; x++) {
-          if (!cellCb(arg[x][y] ?? undefined)) return;
+          if (!cellCb(arg[x][y] ?? undefined)) {
+            return;
+          }
         }
       }
     } else {
       // arg is set directly in the formula function
-      if (!dataCb(arg)) return;
+      if (!dataCb(arg)) {
+        return;
+      }
     }
   }
 }

--- a/packages/o-spreadsheet-engine/src/functions/module_filter.ts
+++ b/packages/o-spreadsheet-engine/src/functions/module_filter.ts
@@ -350,7 +350,9 @@ export const UNIQUE = {
       result.push(row.data);
     }
 
-    if (!result.length) return new EvaluationError(_t("No unique values found"));
+    if (!result.length) {
+      return new EvaluationError(_t("No unique values found"));
+    }
 
     return _byColumn ? result : transposeMatrix(result);
   },

--- a/packages/o-spreadsheet-engine/src/functions/module_financial.ts
+++ b/packages/o-spreadsheet-engine/src/functions/module_financial.ts
@@ -1400,8 +1400,12 @@ export const IRR = {
     visitNumbers(
       [cashFlowAmounts],
       ({ value: amount }) => {
-        if (amount > 0) positive = true;
-        if (amount < 0) negative = true;
+        if (amount > 0) {
+          positive = true;
+        }
+        if (amount < 0) {
+          negative = true;
+        }
         amounts.push(amount);
       },
       this.locale
@@ -1843,7 +1847,9 @@ function ppmt(
     throw new EvaluationError(expectPeriodBetweenOneAndNumberOfPeriods(n));
   }
   const payment = pmt(r, n, pValue, fValue, t);
-  if (t === 1 && per === 1) return payment;
+  if (t === 1 && per === 1) {
+    return payment;
+  }
   const eqPeriod = t === 0 ? per - 1 : per - 2;
   const eqPv = pValue + payment * t;
   const capitalAtPeriod = -fv(r, eqPeriod, payment, eqPv, 0);
@@ -2750,7 +2756,9 @@ export const VDB = {
       return new EvaluationError(expectDeprecationFactorStrictlyPositive(_factor));
     }
 
-    if (_cost === 0) return 0;
+    if (_cost === 0) {
+      return 0;
+    }
     if (_salvage >= _cost) {
       return _startPeriod < 1 ? _cost - _salvage : 0;
     }
@@ -2838,8 +2846,11 @@ export const XIRR = {
     const map = new Map<number, number>();
     for (const i of range(0, _dates.length)) {
       const date = _dates[i];
-      if (map.has(date)) map.set(date, map.get(date)! + _cashFlows[i]);
-      else map.set(date, _cashFlows[i]);
+      if (map.has(date)) {
+        map.set(date, map.get(date)! + _cashFlows[i]);
+      } else {
+        map.set(date, _cashFlows[i]);
+      }
     }
     const dates = Array.from(map.keys());
     const values = dates.map((date) => map.get(date)!);
@@ -2878,7 +2889,9 @@ export const XIRR = {
     };
     const nanFallback = (previousFallback: number | undefined) => {
       // -0.9 => -0.99 => -0.999 => ...
-      if (!previousFallback) return -0.9;
+      if (!previousFallback) {
+        return -0.9;
+      }
       return previousFallback / 10 - 0.9;
     };
 
@@ -2928,14 +2941,19 @@ export const XNPV = {
       return new EvaluationError(expectRateStrictlyPositive(rate));
     }
 
-    if (_cashFlows.length === 1) return _cashFlows[0];
+    if (_cashFlows.length === 1) {
+      return _cashFlows[0];
+    }
 
     // aggregate values of the same date
     const map = new Map<number, number>();
     for (const i of range(0, _dates.length)) {
       const date = _dates[i];
-      if (map.has(date)) map.set(date, map.get(date)! + _cashFlows[i]);
-      else map.set(date, _cashFlows[i]);
+      if (map.has(date)) {
+        map.set(date, map.get(date)! + _cashFlows[i]);
+      } else {
+        map.set(date, _cashFlows[i]);
+      }
     }
     const dates = Array.from(map.keys());
     const values = dates.map((date) => map.get(date)!);

--- a/packages/o-spreadsheet-engine/src/functions/module_math.ts
+++ b/packages/o-spreadsheet-engine/src/functions/module_math.ts
@@ -1399,14 +1399,20 @@ export const SUBTOTAL = {
       const sheetName = splitReference(ref0.value).sheetName;
       const sheetId = sheetName ? this.getters.getSheetIdByName(sheetName) : this.__originSheetId;
 
-      if (!sheetId) continue;
+      if (!sheetId) {
+        continue;
+      }
       const { top, left } = toZone(ref0.value);
       const right = left + ref.length - 1;
       const bottom = top + ref[0].length - 1;
 
       for (let row = top; row <= bottom; row++) {
-        if (this.getters.isRowFiltered(sheetId, row)) continue;
-        if (!acceptHiddenCells && this.getters.isRowHiddenByUser(sheetId, row)) continue;
+        if (this.getters.isRowFiltered(sheetId, row)) {
+          continue;
+        }
+        if (!acceptHiddenCells && this.getters.isRowHiddenByUser(sheetId, row)) {
+          continue;
+        }
 
         for (let col = left; col <= right; col++) {
           const cell = this.getters.getCorrespondingFormulaCell({ sheetId, col, row });

--- a/packages/o-spreadsheet-engine/src/functions/module_web.ts
+++ b/packages/o-spreadsheet-engine/src/functions/module_web.ts
@@ -23,7 +23,9 @@ export const HYPERLINK = {
   ): string {
     const processedUrl = toString(url).trim();
     const processedLabel = toString(linkLabel) || processedUrl;
-    if (processedUrl === "") return processedLabel;
+    if (processedUrl === "") {
+      return processedLabel;
+    }
     return markdownLink(processedLabel, processedUrl);
   },
   isExported: true,

--- a/packages/o-spreadsheet-engine/src/helpers/color.ts
+++ b/packages/o-spreadsheet-engine/src/helpers/color.ts
@@ -165,11 +165,21 @@ export function rgbaToHex(rgba: RGBA): Color {
   let b = rgba.b.toString(16);
   let a = Math.round(rgba.a * 255).toString(16);
 
-  if (r.length === 1) r = "0" + r;
-  if (g.length === 1) g = "0" + g;
-  if (b.length === 1) b = "0" + b;
-  if (a.length === 1) a = "0" + a;
-  if (a === "ff") a = "";
+  if (r.length === 1) {
+    r = "0" + r;
+  }
+  if (g.length === 1) {
+    g = "0" + g;
+  }
+  if (b.length === 1) {
+    b = "0" + b;
+  }
+  if (a.length === 1) {
+    a = "0" + a;
+  }
+  if (a === "ff") {
+    a = "";
+  }
 
   return ("#" + r + g + b + a).toUpperCase();
 }
@@ -273,18 +283,28 @@ export function rgbaToHSLA(rgba: RGBA): HSLA {
 
   // Calculate hue
   // No difference
-  if (delta === 0) h = 0;
+  if (delta === 0) {
+    h = 0;
+  }
   // Red is max
-  else if (cMax === r) h = ((g - b) / delta) % 6;
+  else if (cMax === r) {
+    h = ((g - b) / delta) % 6;
+  }
   // Green is max
-  else if (cMax === g) h = (b - r) / delta + 2;
+  else if (cMax === g) {
+    h = (b - r) / delta + 2;
+  }
   // Blue is max
-  else h = (r - g) / delta + 4;
+  else {
+    h = (r - g) / delta + 4;
+  }
 
   h = Math.round(h * 60);
 
   // Make negative hues positive behind 360°
-  if (h < 0) h += 360;
+  if (h < 0) {
+    h += 360;
+  }
 
   l = (cMax + cMin) / 2;
 

--- a/packages/o-spreadsheet-engine/src/helpers/coordinates.ts
+++ b/packages/o-spreadsheet-engine/src/helpers/coordinates.ts
@@ -60,7 +60,9 @@ export function consumeSpaces(chars: TokenizingChars) {
 }
 
 export function consumeLetters(chars: TokenizingChars): number {
-  if (chars.current === "$") chars.advanceBy(1);
+  if (chars.current === "$") {
+    chars.advanceBy(1);
+  }
   if (!chars.current || !isCharALetter(chars.current)) {
     return -1;
   }
@@ -72,7 +74,9 @@ export function consumeLetters(chars: TokenizingChars): number {
 }
 
 export function consumeDigits(chars: TokenizingChars): number {
-  if (chars.current === "$") chars.advanceBy(1);
+  if (chars.current === "$") {
+    chars.advanceBy(1);
+  }
   if (!chars.current || !isCharADigit(chars.current)) {
     return -1;
   }

--- a/packages/o-spreadsheet-engine/src/helpers/data_normalization.ts
+++ b/packages/o-spreadsheet-engine/src/helpers/data_normalization.ts
@@ -58,15 +58,23 @@ export function* iterateItemIdsPositions(sheetId: UID, itemIdsByZones: Record<st
 }
 
 export function getCanonicalRepresentation(item: any): string {
-  if (item === null) return "null";
-  if (item === undefined) return "undefined";
-  if (typeof item !== "object") return String(item);
+  if (item === null) {
+    return "null";
+  }
+  if (item === undefined) {
+    return "undefined";
+  }
+  if (typeof item !== "object") {
+    return String(item);
+  }
 
   if (Array.isArray(item)) {
     const len = item.length;
     let result = "[";
     for (let i = 0; i < len; i++) {
-      if (i > 0) result += ",";
+      if (i > 0) {
+        result += ",";
+      }
       result += getCanonicalRepresentation(item[i]);
     }
     return result + "]";

--- a/packages/o-spreadsheet-engine/src/helpers/dates.ts
+++ b/packages/o-spreadsheet-engine/src/helpers/dates.ts
@@ -548,8 +548,12 @@ export function getYearFrac(startDate: number, endDate: number, _dayCountConvent
   switch (_dayCountConvention) {
     // 30/360 US convention --------------------------------------------------
     case 0:
-      if (dayStart === 31) dayStart = 30;
-      if (dayStart === 30 && dayEnd === 31) dayEnd = 30;
+      if (dayStart === 31) {
+        dayStart = 30;
+      }
+      if (dayStart === 30 && dayEnd === 31) {
+        dayEnd = 30;
+      }
       // If jsStartDate is the last day of February
       if (monthStart === 1 && dayStart === (isLeapYear(yearStart) ? 29 : 28)) {
         dayStart = 30;
@@ -635,8 +639,12 @@ export function getYearFrac(startDate: number, endDate: number, _dayCountConvent
 
     // 30/360 European convention --------------------------------------------
     case 4:
-      if (dayStart === 31) dayStart = 30;
-      if (dayEnd === 31) dayEnd = 30;
+      if (dayStart === 31) {
+        dayStart = 30;
+      }
+      if (dayEnd === 31) {
+        dayEnd = 30;
+      }
       yearsStart = yearStart + (monthStart * 30 + dayStart) / 360;
       yearsEnd = yearEnd + (monthEnd * 30 + dayEnd) / 360;
       break;

--- a/packages/o-spreadsheet-engine/src/helpers/figures/charts/chart_common.ts
+++ b/packages/o-spreadsheet-engine/src/helpers/figures/charts/chart_common.ts
@@ -308,7 +308,9 @@ export function toExcelLabelRange(
   labelRange: Range | undefined,
   shouldRemoveFirstLabel?: boolean
 ) {
-  if (!labelRange) return undefined;
+  if (!labelRange) {
+    return undefined;
+  }
   const zone = {
     ...labelRange.zone,
   };
@@ -402,9 +404,15 @@ export function shouldRemoveFirstLabel(
   dataset: DataSet | undefined,
   dataSetsHaveTitle: boolean
 ) {
-  if (!dataSetsHaveTitle) return false;
-  if (!labelRange) return false;
-  if (!dataset) return true;
+  if (!dataSetsHaveTitle) {
+    return false;
+  }
+  if (!labelRange) {
+    return false;
+  }
+  if (!dataset) {
+    return true;
+  }
   const datasetLength = getZoneArea(dataset.dataRange.zone);
   const labelLength = getZoneArea(labelRange.zone);
   if (labelLength < datasetLength) {
@@ -461,7 +469,9 @@ export function formatChartDatasetValue(
 export function formatTickValue(localeFormat: LocaleFormat, humanizeNumbers: boolean = false) {
   return (value: any) => {
     value = Number(value);
-    if (isNaN(value)) return value;
+    if (isNaN(value)) {
+      return value;
+    }
     const { locale, format } = localeFormat;
     const formattedValue = humanizeNumbers
       ? humanizeNumber({ value, format }, locale)

--- a/packages/o-spreadsheet-engine/src/helpers/figures/charts/chart_ui_common.ts
+++ b/packages/o-spreadsheet-engine/src/helpers/figures/charts/chart_ui_common.ts
@@ -74,10 +74,11 @@ export async function chartToImageUrl(
   }
   // TODO: make a registry of chart types to their rendering functions
   else {
-    if (!globalThis.OffscreenCanvas)
+    if (!globalThis.OffscreenCanvas) {
       throw new Error(
         `converting a ${type} chart to an image using OffscreenCanvas is not supported in this environment`
       );
+    }
     if (type === "scorecard") {
       const design = getScorecardConfiguration(figure, runtime as ScorecardChartRuntime);
       drawScoreChart(design, canvas);
@@ -130,10 +131,11 @@ export async function chartToImageFile(
       }
     }
   } else {
-    if (!globalThis.OffscreenCanvas)
+    if (!globalThis.OffscreenCanvas) {
       throw new Error(
         `converting a ${type} chart to an image using OffscreenCanvas is not supported in this environment`
       );
+    }
     if (type === "scorecard") {
       const design = getScorecardConfiguration(figure, runtime as ScorecardChartRuntime);
       drawScoreChart(design, canvas);

--- a/packages/o-spreadsheet-engine/src/helpers/format/format.ts
+++ b/packages/o-spreadsheet-engine/src/helpers/format/format.ts
@@ -291,7 +291,9 @@ function applyIntegerFormat(
     if (digitType === "0") {
       digit = digit || "0";
     }
-    if (!digit) return;
+    if (!digit) {
+      return;
+    }
 
     const digitIndex = integerDigits.length - 1 - indexInIntegerString;
     if (thousandsSeparator && digitIndex > 0 && digitIndex % 3 === 0) {
@@ -384,7 +386,9 @@ function splitNumber(
   maxDecimals: number = MAX_DECIMAL_PLACES
 ): { integerDigits: string; decimalDigits: string | undefined } {
   const asString = value.toString();
-  if (asString.includes("e")) return splitNumberIntl(value, maxDecimals);
+  if (asString.includes("e")) {
+    return splitNumberIntl(value, maxDecimals);
+  }
 
   if (Number.isInteger(value)) {
     return { integerDigits: asString, decimalDigits: undefined };
@@ -613,7 +617,9 @@ export const getDecimalNumberRegex = memoize(function getDecimalNumberRegex(loca
  */
 export function createDefaultFormat(value: number): Format {
   let { integerDigits, decimalDigits } = splitNumber(value);
-  if (!decimalDigits) return "0";
+  if (!decimalDigits) {
+    return "0";
+  }
 
   const digitsInIntegerPart = integerDigits.replace("-", "").length;
 
@@ -930,7 +936,9 @@ export function isExcelCompatible(format: Format): boolean {
 }
 
 export function isTextFormat(format: Format | undefined): boolean {
-  if (!format) return false;
+  if (!format) {
+    return false;
+  }
   try {
     const internalFormat = parseFormat(format);
     return internalFormat.positive.type === "text";

--- a/packages/o-spreadsheet-engine/src/helpers/misc.ts
+++ b/packages/o-spreadsheet-engine/src/helpers/misc.ts
@@ -252,7 +252,9 @@ export function isNotNull<T>(argument: T | null): argument is T {
  * Check if all the values of an object, and all the values of the objects inside of it, are undefined.
  */
 export function isObjectEmptyRecursive<T extends object>(argument: T | undefined): boolean {
-  if (argument === undefined) return true;
+  if (argument === undefined) {
+    return true;
+  }
   return Object.values(argument).every((value) =>
     typeof value === "object" ? isObjectEmptyRecursive(value) : !value
   );
@@ -385,18 +387,30 @@ export function getAddHeaderStartIndex(position: "before" | "after", base: numbe
  */
 
 export function deepEquals(...o: any[]): boolean {
-  if (o.length <= 1) return true;
+  if (o.length <= 1) {
+    return true;
+  }
   for (let index = 1; index < o.length; index++) {
-    if (!_deepEquals(o[0], o[index])) return false;
+    if (!_deepEquals(o[0], o[index])) {
+      return false;
+    }
   }
   return true;
 }
 
 function _deepEquals(o1: any, o2: any): boolean {
-  if (o1 === o2) return true;
-  if ((o1 && !o2) || (o2 && !o1)) return false;
-  if (typeof o1 !== typeof o2) return false;
-  if (typeof o1 !== "object") return false;
+  if (o1 === o2) {
+    return true;
+  }
+  if ((o1 && !o2) || (o2 && !o1)) {
+    return false;
+  }
+  if (typeof o1 !== typeof o2) {
+    return false;
+  }
+  if (typeof o1 !== "object") {
+    return false;
+  }
 
   // Objects can have different keys if the values are undefined
   for (const key in o2) {
@@ -406,11 +420,17 @@ function _deepEquals(o1: any, o2: any): boolean {
   }
 
   for (const key in o1) {
-    if (typeof o1[key] !== typeof o2[key]) return false;
+    if (typeof o1[key] !== typeof o2[key]) {
+      return false;
+    }
     if (typeof o1[key] === "object") {
-      if (!_deepEquals(o1[key], o2[key])) return false;
+      if (!_deepEquals(o1[key], o2[key])) {
+        return false;
+      }
     } else {
-      if (o1[key] !== o2[key]) return false;
+      if (o1[key] !== o2[key]) {
+        return false;
+      }
     }
   }
 
@@ -451,7 +471,9 @@ export function includesAll<T>(arr: T[], values: T[]): boolean {
  * Return an object with all the keys in the object that have a falsy value removed.
  */
 export function removeFalsyAttributes<T extends Object | undefined | null>(obj: T): T {
-  if (!obj) return obj;
+  if (!obj) {
+    return obj;
+  }
   const cleanObject = { ...obj };
   Object.keys(cleanObject).forEach((key) => !cleanObject[key] && delete cleanObject[key]);
   return cleanObject;
@@ -488,7 +510,9 @@ export const whiteSpaceCharacters = specialWhiteSpaceSpecialCharacters.concat(["
  * Replace all different newlines characters by \n.
  */
 export function replaceNewLines(text: string | undefined): string {
-  if (!text) return "";
+  if (!text) {
+    return "";
+  }
   return text.replace(newLineRegexp, NEWLINE);
 }
 
@@ -577,7 +601,9 @@ export function getSearchRegex(searchStr: string, searchOptions: SearchOptions):
 export function largeMax(array: number[]) {
   let len = array.length;
 
-  if (len < 100_000) return Math.max(...array);
+  if (len < 100_000) {
+    return Math.max(...array);
+  }
 
   let max: number = -Infinity;
   while (len--) {
@@ -593,7 +619,9 @@ export function largeMax(array: number[]) {
 export function largeMin(array: number[]) {
   let len = array.length;
 
-  if (len < 100_000) return Math.min(...array);
+  if (len < 100_000) {
+    return Math.min(...array);
+  }
 
   let min: number = +Infinity;
   while (len--) {

--- a/packages/o-spreadsheet-engine/src/helpers/numbers.ts
+++ b/packages/o-spreadsheet-engine/src/helpers/numbers.ts
@@ -52,7 +52,9 @@ const getNumberRegex = memoize(function getNumberRegex(locale: Locale) {
  * Note that "" (empty string) does not count as a number string
  */
 export function isNumber(value: string | undefined, locale: Locale): boolean {
-  if (!value) return false;
+  if (!value) {
+    return false;
+  }
   // TO DO: add regexp for DATE string format (ex match: "28 02 2020")
   return getNumberRegex(locale).test(value.trim());
 }

--- a/packages/o-spreadsheet-engine/src/helpers/pivot/spreadsheet_pivot/spreadsheet_pivot.ts
+++ b/packages/o-spreadsheet-engine/src/helpers/pivot/spreadsheet_pivot/spreadsheet_pivot.ts
@@ -502,7 +502,9 @@ export class SpreadsheetPivot implements Pivot<SpreadsheetPivotRuntimeDefinition
       }
       for (const customFieldName in this.definition.customFields || {}) {
         const customField = this.definition.customFields?.[customFieldName];
-        if (!customField) continue;
+        if (!customField) {
+          continue;
+        }
         const baseValue = entry[customField.parentField];
         const parentField = this.fields[customField.parentField];
         if (!baseValue || !parentField) {

--- a/packages/o-spreadsheet-engine/src/helpers/range.ts
+++ b/packages/o-spreadsheet-engine/src/helpers/range.ts
@@ -186,7 +186,9 @@ export function createValidRange(
   sheetId: UID,
   xc?: string
 ): Range | undefined {
-  if (!xc) return;
+  if (!xc) {
+    return;
+  }
   const range = getters.getRangeFromSheetXC(sheetId, xc);
   return !(range.invalidSheetName || range.invalidXc) ? range : undefined;
 }

--- a/packages/o-spreadsheet-engine/src/helpers/references.ts
+++ b/packages/o-spreadsheet-engine/src/helpers/references.ts
@@ -62,7 +62,9 @@ type FixedReferenceType = "col" | "row" | "colrow" | "none";
  *   A1:$B$1 => $A$1:B$1 => A$1:$B1 => $A1:B1 => A1:$B$1
  */
 export function loopThroughReferenceType(token: Readonly<Token>): Token {
-  if (token.type !== "REFERENCE") return token;
+  if (token.type !== "REFERENCE") {
+    return token;
+  }
   const { xc, sheetName } = splitReference(token.value);
   const [left, right] = xc.split(":") as [string, string | undefined];
 
@@ -121,13 +123,19 @@ function _setXcToFixedReferenceType(xc: string, referenceType: FixedReferenceTyp
   const hasRow = indexOfNumber >= 0;
   switch (referenceType) {
     case "col":
-      if (!hasCol) return xc;
+      if (!hasCol) {
+        return xc;
+      }
       return "$" + xc;
     case "row":
-      if (!hasRow) return xc;
+      if (!hasRow) {
+        return xc;
+      }
       return xc.slice(0, indexOfNumber) + "$" + xc.slice(indexOfNumber);
     case "colrow":
-      if (!hasRow || !hasCol) return "$" + xc;
+      if (!hasRow || !hasCol) {
+        return "$" + xc;
+      }
       return "$" + xc.slice(0, indexOfNumber) + "$" + xc.slice(indexOfNumber);
     case "none":
       return xc;

--- a/packages/o-spreadsheet-engine/src/helpers/table_helpers.ts
+++ b/packages/o-spreadsheet-engine/src/helpers/table_helpers.ts
@@ -85,7 +85,9 @@ function getAllTableBorders(
 
   for (const tableElement of TABLE_ELEMENTS_BY_PRIORITY) {
     const styleBorder = style[tableElement]?.border;
-    if (!styleBorder) continue;
+    if (!styleBorder) {
+      continue;
+    }
 
     const zones = getTableElementZones(tableElement, tableConfig, nOfCols, nOfRows);
     for (const zone of zones) {
@@ -228,41 +230,57 @@ function getTableElementZones(
       zones.push({ top: 0, left: 0, bottom: lastRow, right: lastCol });
       break;
     case "firstColumn":
-      if (!tableConfig.firstColumn) break;
+      if (!tableConfig.firstColumn) {
+        break;
+      }
       zones.push({ top: 0, left: 0, bottom: lastRow, right: 0 });
       break;
     case "lastColumn":
-      if (!tableConfig.lastColumn) break;
+      if (!tableConfig.lastColumn) {
+        break;
+      }
       zones.push({ top: 0, left: lastCol, bottom: lastRow, right: lastCol });
       break;
     case "headerRow":
-      if (!tableConfig.numberOfHeaders) break;
+      if (!tableConfig.numberOfHeaders) {
+        break;
+      }
       zones.push({ top: 0, left: 0, bottom: headerRows - 1, right: lastCol });
       break;
     case "totalRow":
-      if (!tableConfig.totalRow) break;
+      if (!tableConfig.totalRow) {
+        break;
+      }
       zones.push({ top: lastRow, left: 0, bottom: lastRow, right: lastCol });
       break;
     case "firstRowStripe":
-      if (!tableConfig.bandedRows) break;
+      if (!tableConfig.bandedRows) {
+        break;
+      }
       for (let i = headerRows; i < numberOfRows - totalRows; i += 2) {
         zones.push({ top: i, left: 0, bottom: i, right: lastCol });
       }
       break;
     case "secondRowStripe":
-      if (!tableConfig.bandedRows) break;
+      if (!tableConfig.bandedRows) {
+        break;
+      }
       for (let i = headerRows + 1; i < numberOfRows - totalRows; i += 2) {
         zones.push({ top: i, left: 0, bottom: i, right: lastCol });
       }
       break;
     case "firstColumnStripe":
-      if (!tableConfig.bandedColumns) break;
+      if (!tableConfig.bandedColumns) {
+        break;
+      }
       for (let i = 0; i < numberOfCols; i += 2) {
         zones.push({ top: headerRows, left: i, bottom: lastRow - totalRows, right: i });
       }
       break;
     case "secondColumnStripe":
-      if (!tableConfig.bandedColumns) break;
+      if (!tableConfig.bandedColumns) {
+        break;
+      }
       for (let i = 1; i < numberOfCols; i += 2) {
         zones.push({ top: headerRows, left: i, bottom: lastRow - totalRows, right: i });
       }

--- a/packages/o-spreadsheet-engine/src/helpers/text_helper.ts
+++ b/packages/o-spreadsheet-engine/src/helpers/text_helper.ts
@@ -63,7 +63,9 @@ export function computeMultilineTextSize(
   style: Style = {},
   fontUnit: "px" | "pt" = "pt"
 ) {
-  if (!textLines.length) return { width: 0, height: 0 };
+  if (!textLines.length) {
+    return { width: 0, height: 0 };
+  }
   const font = computeTextFont(style, fontUnit);
   const sizes = textLines.map((line) => computeCachedTextDimension(context, line, font));
   const height = computeTextLinesHeight(sizes[0].height, textLines.length);
@@ -194,8 +196,12 @@ export function splitTextToWidth(
   style: Style | undefined,
   width: number | undefined
 ): string[] {
-  if (!style) style = {};
-  if (isMarkdownLink(text)) text = parseMarkdownLink(text).label;
+  if (!style) {
+    style = {};
+  }
+  if (isMarkdownLink(text)) {
+    text = parseMarkdownLink(text).label;
+  }
   const brokenText: string[] = [];
 
   // Checking if text contains NEWLINE before split makes it very slightly slower if text contains it,
@@ -270,8 +276,12 @@ export function getFontSizeMatchingWidth(
   precision = 0.25
 ) {
   let minFontSize = 1;
-  if (getTextWidth(minFontSize) > lineWidth) return minFontSize;
-  if (getTextWidth(maxFontSize) < lineWidth) return maxFontSize;
+  if (getTextWidth(minFontSize) > lineWidth) {
+    return minFontSize;
+  }
+  if (getTextWidth(maxFontSize) < lineWidth) {
+    return maxFontSize;
+  }
 
   // Dichotomic search
   let fontSize = (minFontSize + maxFontSize) / 2;

--- a/packages/o-spreadsheet-engine/src/helpers/zones.ts
+++ b/packages/o-spreadsheet-engine/src/helpers/zones.ts
@@ -307,7 +307,9 @@ export function reduceZoneOnDeletion<Z extends UnboundedZone | Zone>(
   for (const removedElement of elements.sort((a, b) => b - a)) {
     if (zone[start] > removedElement) {
       newStart--;
-      if (newEnd !== undefined) newEnd--;
+      if (newEnd !== undefined) {
+        newEnd--;
+      }
     }
     if (
       zoneEnd !== undefined &&
@@ -386,7 +388,9 @@ export function isEqual(z1: UnboundedZone, z2: UnboundedZone): boolean {
  * Returns the adjacent size of z1 as well as the indexes of the header by which they are adjacent.
  */
 export function adjacent(z1: UnboundedZone, z2: Zone): AdjacentEdge | undefined {
-  if (intersection(z1, z2)) return undefined;
+  if (intersection(z1, z2)) {
+    return undefined;
+  }
   let adjacentEdge: AdjacentEdge | undefined = undefined;
   if (z1.left === z2.right + 1) {
     adjacentEdge = {
@@ -730,7 +734,9 @@ export function boundUnboundedZone(
  * including cells outside the zones
  * */
 export function areZonesContinuous(zones: Zone[]): boolean {
-  if (zones.length < 2) return true;
+  if (zones.length < 2) {
+    return true;
+  }
   return recomputeZones(zones).length === 1;
 }
 
@@ -832,7 +838,9 @@ export function mergeContiguousZones(zones: Zone[]) {
 
 export function splitIfAdjacent(zone: UnboundedZone, zoneToRemove: Zone): UnboundedZone[] {
   const adjacentEdge = adjacent(zone, zoneToRemove);
-  if (!adjacentEdge) return [zone];
+  if (!adjacentEdge) {
+    return [zone];
+  }
   const newZones: UnboundedZone[] = [];
   switch (adjacentEdge.position) {
     case "bottom":

--- a/packages/o-spreadsheet-engine/src/history/branch.ts
+++ b/packages/o-spreadsheet-engine/src/history/branch.ts
@@ -37,8 +37,12 @@ export class Branch<T> {
    */
   getFirstOperationAmong(op1: UID, op2: UID): UID {
     for (const operation of this.operations) {
-      if (operation.id === op1) return op1;
-      if (operation.id === op2) return op2;
+      if (operation.id === op1) {
+        return op1;
+      }
+      if (operation.id === op2) {
+        return op2;
+      }
     }
     throw new Error(`Operation ${op1} and ${op2} not found`);
   }

--- a/packages/o-spreadsheet-engine/src/history/repeat_commands/repeat_commands_generic.ts
+++ b/packages/o-spreadsheet-engine/src/history/repeat_commands/repeat_commands_generic.ts
@@ -10,13 +10,17 @@ export const genericRepeatsTransforms = [
 ];
 
 export function repeatSheetDependantCommand<T extends Command>(getters: Getters, command: T): T {
-  if (!("sheetId" in command)) return command;
+  if (!("sheetId" in command)) {
+    return command;
+  }
 
   return { ...deepCopy(command), sheetId: getters.getActiveSheetId() };
 }
 
 export function repeatTargetDependantCommand<T extends Command>(getters: Getters, command: T): T {
-  if (!("target" in command) || !Array.isArray(command.target)) return command;
+  if (!("target" in command) || !Array.isArray(command.target)) {
+    return command;
+  }
 
   return {
     ...deepCopy(command),
@@ -25,7 +29,9 @@ export function repeatTargetDependantCommand<T extends Command>(getters: Getters
 }
 
 export function repeatZoneDependantCommand<T extends Command>(getters: Getters, command: T): T {
-  if (!("zone" in command)) return command;
+  if (!("zone" in command)) {
+    return command;
+  }
 
   return {
     ...deepCopy(command),
@@ -34,14 +40,18 @@ export function repeatZoneDependantCommand<T extends Command>(getters: Getters, 
 }
 
 export function repeatPositionDependantCommand<T extends Command>(getters: Getters, command: T): T {
-  if (!("row" in command) || !("col" in command)) return command;
+  if (!("row" in command) || !("col" in command)) {
+    return command;
+  }
 
   const { col, row } = getters.getActivePosition();
   return { ...deepCopy(command), col, row };
 }
 
 export function repeatRangeDependantCommand<T extends Command>(getters: Getters, command: T): T {
-  if (!("ranges" in command)) return command;
+  if (!("ranges" in command)) {
+    return command;
+  }
 
   return {
     ...deepCopy(command),

--- a/packages/o-spreadsheet-engine/src/history/tree.ts
+++ b/packages/o-spreadsheet-engine/src/history/tree.ts
@@ -148,7 +148,9 @@ export class Tree<T = unknown> {
    */
   redo(branch: Branch<T>) {
     const removedBranch = this.nextBranch(branch);
-    if (!removedBranch) return;
+    if (!removedBranch) {
+      return;
+    }
     const nextBranch = this.nextBranch(removedBranch);
     this.removeBranchFromTree(removedBranch);
 
@@ -205,7 +207,9 @@ export class Tree<T = unknown> {
    */
   private rebaseUp(branch: Branch<T>) {
     const { previousBranch, branchingOperation } = this.findPreviousBranchingOperation(branch);
-    if (!previousBranch || !branchingOperation) return;
+    if (!previousBranch || !branchingOperation) {
+      return;
+    }
     const rebaseTransformation = this.buildTransformation.without(branchingOperation.data);
     const newBranch = previousBranch.fork(branchingOperation.id);
     this.branchingOperationIds.set(newBranch, this.branchingOperationIds.get(branch));
@@ -313,7 +317,9 @@ export class Tree<T = unknown> {
    */
   private insertPrevious(branch: Branch<T>, newOperation: Operation<T>, insertAfter: UID) {
     const { previousBranch, branchingOperation } = this.findPreviousBranchingOperation(branch);
-    if (!previousBranch || !branchingOperation) return;
+    if (!previousBranch || !branchingOperation) {
+      return;
+    }
     const transformation = this.buildTransformation.with(branchingOperation.data);
     const branchTail = branch.fork(insertAfter);
     branchTail.transform(transformation);
@@ -328,9 +334,13 @@ export class Tree<T = unknown> {
     branchingOperation?: Operation<T>;
   } {
     const previousBranch = this.previousBranch(branch);
-    if (!previousBranch) return { previousBranch: undefined, branchingOperation: undefined };
+    if (!previousBranch) {
+      return { previousBranch: undefined, branchingOperation: undefined };
+    }
     const previousBranchingId = this.branchingOperationIds.get(previousBranch);
-    if (!previousBranchingId) return { previousBranch: undefined, branchingOperation: undefined };
+    if (!previousBranchingId) {
+      return { previousBranch: undefined, branchingOperation: undefined };
+    }
     return {
       previousBranch,
       branchingOperation: previousBranch.getOperation(previousBranchingId),

--- a/packages/o-spreadsheet-engine/src/plugins/core/borders.ts
+++ b/packages/o-spreadsheet-engine/src/plugins/core/borders.ts
@@ -89,7 +89,9 @@ export class BordersPlugin extends CorePlugin<BordersPluginState> implements Bor
         this.history.update("borders", allBorders);
         break;
       case "SET_BORDER":
-        if (cmd.border) this.addBorders(cmd.sheetId, [positionToZone(cmd)], cmd.border);
+        if (cmd.border) {
+          this.addBorders(cmd.sheetId, [positionToZone(cmd)], cmd.border);
+        }
         break;
       case "SET_BORDERS_ON_TARGET":
         for (const zone of cmd.target) {
@@ -224,7 +226,9 @@ export class BordersPlugin extends CorePlugin<BordersPluginState> implements Bor
     for (const border of this.borders[sheetId] ?? []) {
       const { zone: bzone, style: bstyle } = border;
       const inter = intersection(bzone, zone);
-      if (!inter) continue;
+      if (!inter) {
+        continue;
+      }
       for (let col = inter.left; col <= inter.right; col++) {
         for (let row = inter.top; row <= inter.bottom; row++) {
           const cell = borders.get({ sheetId, col, row }) ?? {};
@@ -243,7 +247,9 @@ export class BordersPlugin extends CorePlugin<BordersPluginState> implements Bor
     const colors: Set<Color> = new Set<Color>();
     for (const border of this.borders[sheetId] ?? []) {
       for (const style of Object.values(border.style)) {
-        if (style?.color) colors.add(style.color);
+        if (style?.color) {
+          colors.add(style.color);
+        }
       }
     }
     return [...colors];
@@ -289,10 +295,16 @@ export class BordersPlugin extends CorePlugin<BordersPluginState> implements Bor
 
   private borderIsClear(border: ZoneBorder) {
     const style = border.style;
-    if (style.left || style.right || style.bottom || style.top) return false;
+    if (style.left || style.right || style.bottom || style.top) {
+      return false;
+    }
     const zone = border.zone;
-    if ((zone.bottom === undefined || zone.top < zone.bottom) && style.horizontal) return false;
-    if ((zone.right === undefined || zone.left < zone.right) && style.vertical) return false;
+    if ((zone.bottom === undefined || zone.top < zone.bottom) && style.horizontal) {
+      return false;
+    }
+    if ((zone.right === undefined || zone.left < zone.right) && style.vertical) {
+      return false;
+    }
     return true;
   }
 
@@ -455,7 +467,9 @@ export class BordersPlugin extends CorePlugin<BordersPluginState> implements Bor
   }
 
   private ensureHasBorder(cmd: SetBorderCommand | SetZoneBordersCommand) {
-    if (!cmd.border) return CommandResult.NoChanges;
+    if (!cmd.border) {
+      return CommandResult.NoChanges;
+    }
     return CommandResult.Success;
   }
 

--- a/packages/o-spreadsheet-engine/src/plugins/core/cell.ts
+++ b/packages/o-spreadsheet-engine/src/plugins/core/cell.ts
@@ -619,7 +619,9 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
   private checkCellOutOfSheet(cmd: PositionDependentCommand): CommandResult {
     const { sheetId, col, row } = cmd;
     const sheet = this.getters.tryGetSheet(sheetId);
-    if (!sheet) return CommandResult.InvalidSheetId;
+    if (!sheet) {
+      return CommandResult.InvalidSheetId;
+    }
     const sheetZone = this.getters.getSheetZone(sheetId);
     return isInside(col, row, sheetZone) ? CommandResult.Success : CommandResult.TargetOutOfSheet;
   }
@@ -627,7 +629,9 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
   private checkUselessClearCell(cmd: ClearCellCommand): CommandResult {
     const cell = this.getters.getCell(cmd);
     const style = this.getters.getCellStyle(cmd);
-    if (!cell) return CommandResult.NoChanges;
+    if (!cell) {
+      return CommandResult.NoChanges;
+    }
     if (!cell.content && !style && !cell.format) {
       return CommandResult.NoChanges;
     }

--- a/packages/o-spreadsheet-engine/src/plugins/core/conditional_format.ts
+++ b/packages/o-spreadsheet-engine/src/plugins/core/conditional_format.ts
@@ -428,9 +428,13 @@ export class ConditionalFormatPlugin
   }
 
   private checkValidPriorityChange(cfId: string, delta: number, sheetId: string) {
-    if (!this.cfRules[sheetId]) return CommandResult.InvalidSheetId;
+    if (!this.cfRules[sheetId]) {
+      return CommandResult.InvalidSheetId;
+    }
     const ruleIndex = this.cfRules[sheetId].findIndex((cf) => cf.id === cfId);
-    if (ruleIndex === -1) return CommandResult.InvalidConditionalFormatId;
+    if (ruleIndex === -1) {
+      return CommandResult.InvalidConditionalFormatId;
+    }
 
     const cfIndex2 = ruleIndex - delta;
     if (cfIndex2 < 0 || cfIndex2 >= this.cfRules[sheetId].length) {
@@ -539,7 +543,9 @@ export class ConditionalFormatPlugin
     threshold: ColorScaleThreshold | ColorScaleMidPointThreshold | IconThreshold,
     thresholdName: string
   ) {
-    if (threshold.type !== "formula") return CommandResult.Success;
+    if (threshold.type !== "formula") {
+      return CommandResult.Success;
+    }
     const compiledFormula = compile(threshold.value || "");
     if (compiledFormula.isBadExpression) {
       switch (thresholdName) {
@@ -629,7 +635,9 @@ export class ConditionalFormatPlugin
 
   private checkCFValues(rule: CellIsRule) {
     for (const value of rule.values) {
-      if (!value.startsWith("=")) continue;
+      if (!value.startsWith("=")) {
+        continue;
+      }
       const compiledFormula = compile(value || "");
       if (compiledFormula.isBadExpression) {
         return CommandResult.ValueCellIsInvalidFormula;

--- a/packages/o-spreadsheet-engine/src/plugins/core/data_validation.ts
+++ b/packages/o-spreadsheet-engine/src/plugins/core/data_validation.ts
@@ -203,7 +203,9 @@ export class DataValidationPlugin
 
   cellHasListDataValidationIcon(cellPosition: CellPosition): boolean {
     const rule = this.getValidationRuleForCell(cellPosition);
-    if (!rule) return false;
+    if (!rule) {
+      return false;
+    }
 
     return (
       (rule.criterion.type === "isValueInList" || rule.criterion.type === "isValueInRange") &&

--- a/packages/o-spreadsheet-engine/src/plugins/core/merge.ts
+++ b/packages/o-spreadsheet-engine/src/plugins/core/merge.ts
@@ -93,7 +93,9 @@ export class MergePlugin extends CorePlugin<MergeState> implements MergeState {
         break;
       case "DUPLICATE_SHEET":
         const merges = this.merges[cmd.sheetId];
-        if (!merges) break;
+        if (!merges) {
+          break;
+        }
         for (const range of Object.values(merges).filter(isDefined)) {
           this.addMerge(cmd.sheetIdTo, range.zone);
         }
@@ -133,7 +135,9 @@ export class MergePlugin extends CorePlugin<MergeState> implements MergeState {
 
   getMergesInZone(sheetId: UID, zone: Zone): Merge[] {
     const sheetMap = this.mergeCellMap[sheetId];
-    if (!sheetMap) return [];
+    if (!sheetMap) {
+      return [];
+    }
     const mergeIds = new Set<number>();
 
     for (let col = zone.left; col <= zone.right; col++) {
@@ -326,7 +330,9 @@ export class MergePlugin extends CorePlugin<MergeState> implements MergeState {
 
   private checkDestructiveMerge({ sheetId, target }: AddMergeCommand): CommandResult {
     const sheet = this.getters.tryGetSheet(sheetId);
-    if (!sheet) return CommandResult.Success;
+    if (!sheet) {
+      return CommandResult.Success;
+    }
     const isDestructive = target.some((zone) => this.isMergeDestructive(sheetId, zone));
     return isDestructive ? CommandResult.MergeIsDestructive : CommandResult.Success;
   }
@@ -344,7 +350,9 @@ export class MergePlugin extends CorePlugin<MergeState> implements MergeState {
 
   private checkFrozenPanes({ sheetId, target }: AddMergeCommand): CommandResult {
     const sheet = this.getters.tryGetSheet(sheetId);
-    if (!sheet) return CommandResult.Success;
+    if (!sheet) {
+      return CommandResult.Success;
+    }
     const { xSplit, ySplit } = this.getters.getPaneDivisions(sheetId);
     if (doesAnyZoneCrossFrozenPane(target, xSplit, ySplit)) {
       return CommandResult.FrozenPaneOverlap;

--- a/packages/o-spreadsheet-engine/src/plugins/core/sheet.ts
+++ b/packages/o-spreadsheet-engine/src/plugins/core/sheet.ts
@@ -112,9 +112,12 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
         return this.checkValidations(cmd, this.checkSheetName, this.checkSheetPosition);
       }
       case "DUPLICATE_SHEET": {
-        if (this.sheets[cmd.sheetIdTo]) return CommandResult.DuplicatedSheetId;
-        if (this.orderedSheetIds.map(this.getSheetName.bind(this)).includes(cmd.sheetNameTo))
+        if (this.sheets[cmd.sheetIdTo]) {
+          return CommandResult.DuplicatedSheetId;
+        }
+        if (this.orderedSheetIds.map(this.getSheetName.bind(this)).includes(cmd.sheetNameTo)) {
           return CommandResult.DuplicatedSheetName;
+        }
         return CommandResult.Success;
       }
       case "MOVE_SHEET":
@@ -535,7 +538,9 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
    * not outside the sheet.
    */
   checkZonesExistInSheet(sheetId: UID, zones: Zone[]): CommandResult {
-    if (!zones.every(isZoneValid)) return CommandResult.InvalidRange;
+    if (!zones.every(isZoneValid)) {
+      return CommandResult.InvalidRange;
+    }
 
     if (zones.length) {
       const sheetZone = this.getSheetZone(sheetId);
@@ -1037,7 +1042,9 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
    * not outside the sheet.
    */
   private checkZonesAreInSheet(cmd: CoreCommand): CommandResult {
-    if (!("sheetId" in cmd)) return CommandResult.Success;
+    if (!("sheetId" in cmd)) {
+      return CommandResult.Success;
+    }
     if (
       "ranges" in cmd &&
       cmd.ranges.some(

--- a/packages/o-spreadsheet-engine/src/plugins/core/style.ts
+++ b/packages/o-spreadsheet-engine/src/plugins/core/style.ts
@@ -274,7 +274,9 @@ export class StylePlugin extends CorePlugin<StylePluginState> implements StylePl
     const styles = new PositionMap<Style>();
     for (const { zone: z, style } of this.styles[sheetId] ?? []) {
       const inter = intersection(z, zone);
-      if (!inter) continue;
+      if (!inter) {
+        continue;
+      }
       for (let col = inter.left; col <= inter.right; col++) {
         for (let row = inter.top; row <= inter.bottom; row++) {
           styles.set({ sheetId, col, row }, style);
@@ -288,7 +290,9 @@ export class StylePlugin extends CorePlugin<StylePluginState> implements StylePl
     const styles: ZoneStyle[] = [];
     for (const style of this.styles[sheetId] ?? []) {
       const inter = intersection(style.zone, zone);
-      if (inter) styles.push({ zone: inter, style: style.style });
+      if (inter) {
+        styles.push({ zone: inter, style: style.style });
+      }
     }
     return styles;
   }

--- a/packages/o-spreadsheet-engine/src/plugins/ui_core_views/cell_evaluation/evaluation_plugin.ts
+++ b/packages/o-spreadsheet-engine/src/plugins/ui_core_views/cell_evaluation/evaluation_plugin.ts
@@ -253,7 +253,9 @@ export class EvaluationPlugin extends CoreViewPlugin {
    */
   getRangeFormattedValues(range: Range): FormattedValue[] {
     const sheet = this.getters.tryGetSheet(range.sheetId);
-    if (sheet === undefined) return [];
+    if (sheet === undefined) {
+      return [];
+    }
     return this.mapVisiblePositions(range, (p) => this.getters.getEvaluatedCell(p).formattedValue);
   }
 
@@ -262,7 +264,9 @@ export class EvaluationPlugin extends CoreViewPlugin {
    */
   getRangeValues(range: Range): CellValue[] {
     const sheet = this.getters.tryGetSheet(range.sheetId);
-    if (sheet === undefined) return [];
+    if (sheet === undefined) {
+      return [];
+    }
     return this.mapVisiblePositions(range, (p) => this.getters.getEvaluatedCell(p).value);
   }
 
@@ -271,7 +275,9 @@ export class EvaluationPlugin extends CoreViewPlugin {
    */
   getRangeFormats(range: Range): (Format | undefined)[] {
     const sheet = this.getters.tryGetSheet(range.sheetId);
-    if (sheet === undefined) return [];
+    if (sheet === undefined) {
+      return [];
+    }
     return this.getters.getEvaluatedCellsInZone(sheet.id, range.zone).map((cell) => cell.format);
   }
 

--- a/packages/o-spreadsheet-engine/src/plugins/ui_core_views/dynamic_tables.ts
+++ b/packages/o-spreadsheet-engine/src/plugins/ui_core_views/dynamic_tables.ts
@@ -66,14 +66,18 @@ export class DynamicTablesPlugin extends CoreViewPlugin {
 
     // First we create the static tables, so we can use them to compute collision with dynamic tables
     for (const table of coreTables) {
-      if (table.type === "dynamic") continue;
+      if (table.type === "dynamic") {
+        continue;
+      }
       tables.push(table);
     }
     const staticTables = [...tables];
 
     // Then we create the dynamic tables
     for (const coreTable of coreTables) {
-      if (coreTable.type !== "dynamic") continue;
+      if (coreTable.type !== "dynamic") {
+        continue;
+      }
       const table = this.coreTableToTable(sheetId, coreTable);
       let tableZone = table.range.zone;
       // Reduce the zone to avoid collision with static tables. Per design, dynamic tables can't overlap with other

--- a/packages/o-spreadsheet-engine/src/plugins/ui_core_views/evaluation_chart.ts
+++ b/packages/o-spreadsheet-engine/src/plugins/ui_core_views/evaluation_chart.ts
@@ -77,8 +77,9 @@ export class EvaluationChartPlugin extends CoreViewPlugin<EvaluationChartState> 
     chartBackground: Color | undefined,
     mainRange: Range | undefined
   ): EvaluationChartStyle {
-    if (chartBackground)
+    if (chartBackground) {
       return { background: chartBackground, fontColor: chartFontColor(chartBackground) };
+    }
     if (!mainRange) {
       return {
         background: BACKGROUND_CHART_COLOR,

--- a/packages/o-spreadsheet-engine/src/plugins/ui_core_views/evaluation_conditional_format.ts
+++ b/packages/o-spreadsheet-engine/src/plugins/ui_core_views/evaluation_conditional_format.ts
@@ -142,7 +142,9 @@ export class EvaluationConditionalFormatPlugin extends CoreViewPlugin {
                 if (
                   this.getRuleResultForTarget(target, { ...cf.rule, values }, preComputedCriterion)
                 ) {
-                  if (!computedStyle[col]) computedStyle[col] = [];
+                  if (!computedStyle[col]) {
+                    computedStyle[col] = [];
+                  }
                   // we must combine all the properties of all the CF rules applied to the given cell
                   computedStyle[col][row] = Object.assign(
                     computedStyle[col]?.[row] || {},
@@ -161,7 +163,9 @@ export class EvaluationConditionalFormatPlugin extends CoreViewPlugin {
   private getComputedIcons(sheetId: UID): ComputedIcons {
     const computedIcons = {};
     for (const cf of this.getters.getConditionalFormats(sheetId).reverse()) {
-      if (cf.rule.type !== "IconSetRule") continue;
+      if (cf.rule.type !== "IconSetRule") {
+        continue;
+      }
 
       for (const range of cf.ranges) {
         this.applyIcon(sheetId, range, cf.rule, computedIcons);
@@ -173,7 +177,9 @@ export class EvaluationConditionalFormatPlugin extends CoreViewPlugin {
   private getComputedDataBars(sheetId: UID): ComputedDataBars {
     const computedDataBars: ComputedDataBars = {};
     for (const cf of this.getters.getConditionalFormats(sheetId).reverse()) {
-      if (cf.rule.type !== "DataBarRule") continue;
+      if (cf.rule.type !== "DataBarRule") {
+        continue;
+      }
 
       for (const range of cf.ranges) {
         this.applyDataBar(sheetId, range, cf.rule, computedDataBars);
@@ -315,7 +321,9 @@ export class EvaluationConditionalFormatPlugin extends CoreViewPlugin {
           // values negatives or 0 are ignored
           continue;
         }
-        if (!computedDataBars[col]) computedDataBars[col] = [];
+        if (!computedDataBars[col]) {
+          computedDataBars[col] = [];
+        }
         computedDataBars[col][row] = {
           color: colorNumberToHex(color),
           percentage: (cell.value * 100) / max,
@@ -356,7 +364,9 @@ export class EvaluationConditionalFormatPlugin extends CoreViewPlugin {
         const cell = this.getters.getEvaluatedCell({ sheetId, col, row });
         if (cell.type === CellValueType.number) {
           const value = clip(cell.value, minValue, maxValue);
-          if (!computedStyle[col]) computedStyle[col] = [];
+          if (!computedStyle[col]) {
+            computedStyle[col] = [];
+          }
           computedStyle[col][row] = computedStyle[col]?.[row] || {};
           computedStyle[col][row]!.fillColor = colorScale(value);
         }

--- a/packages/o-spreadsheet-engine/src/plugins/ui_feature/cell_computed_style.ts
+++ b/packages/o-spreadsheet-engine/src/plugins/ui_feature/cell_computed_style.ts
@@ -68,7 +68,9 @@ export class CellComputedStylePlugin extends UIPlugin {
     for (let col = zone.left; col <= zone.right; col++) {
       for (let row = zone.top; row <= zone.bottom; row++) {
         const position = { sheetId, col, row };
-        if (this.borders.get(position) !== undefined) continue;
+        if (this.borders.get(position) !== undefined) {
+          continue;
+        }
         const cellBorder = borders.get(position);
         const cellTableBorder = tableBorders.get(position);
         const border = {
@@ -100,7 +102,9 @@ export class CellComputedStylePlugin extends UIPlugin {
     for (let col = zone.left; col <= zone.right; col++) {
       for (let row = zone.top; row <= zone.bottom; row++) {
         const position = { sheetId, col, row };
-        if (this.styles.get(position) !== undefined) continue;
+        if (this.styles.get(position) !== undefined) {
+          continue;
+        }
         const computedStyle = {
           ...removeFalsyAttributes(tableStyles.get(position)),
           ...removeFalsyAttributes(this.getters.getDataValidationCellStyle(position)),

--- a/packages/o-spreadsheet-engine/src/plugins/ui_feature/local_history.ts
+++ b/packages/o-spreadsheet-engine/src/plugins/ui_feature/local_history.ts
@@ -102,7 +102,9 @@ export class HistoryPlugin extends UIPlugin {
   }
 
   canRedo(): boolean {
-    if (this.redoStack.length > 0) return true;
+    if (this.redoStack.length > 0) {
+      return true;
+    }
     const lastNonRedoRevision = this.getPossibleRevisionToRepeat();
     return canRepeatRevision(lastNonRedoRevision);
   }

--- a/packages/o-spreadsheet-engine/src/plugins/ui_feature/sort.ts
+++ b/packages/o-spreadsheet-engine/src/plugins/ui_feature/sort.ts
@@ -99,7 +99,9 @@ export class SortPlugin extends UIPlugin {
    *
    */
   private hasHeader(sheetId: UID, items: Position[][]): boolean {
-    if (items[0].length === 1) return false;
+    if (items[0].length === 1) {
+      return false;
+    }
     let cells: CellValueType[][] = items.map((col) =>
       col.map(({ col, row }) => this.getters.getEvaluatedCell({ sheetId, col, row }).type)
     );

--- a/packages/o-spreadsheet-engine/src/plugins/ui_feature/subtotal_evaluation.ts
+++ b/packages/o-spreadsheet-engine/src/plugins/ui_feature/subtotal_evaluation.ts
@@ -21,9 +21,13 @@ export class SubtotalEvaluationPlugin extends UIPlugin {
         break;
       }
       case "UPDATE_CELL": {
-        if (!("content" in cmd)) return;
+        if (!("content" in cmd)) {
+          return;
+        }
         const cell = this.getters.getCell(cmd);
-        if (!cell) return;
+        if (!cell) {
+          return;
+        }
         if (isSubtotalCell(cell)) {
           this.subtotalCells.add(cell.id);
         } else {

--- a/packages/o-spreadsheet-engine/src/plugins/ui_feature/table_resize_ui.ts
+++ b/packages/o-spreadsheet-engine/src/plugins/ui_feature/table_resize_ui.ts
@@ -26,10 +26,14 @@ export class TableResizeUI extends UIPlugin {
         const table = this.getters.getCoreTableMatchingTopLeft(cmd.sheetId, cmd.zone);
         this.dispatch("UPDATE_TABLE", { ...cmd });
 
-        if (!table) return;
+        if (!table) {
+          return;
+        }
         const newTableZone = this.getters.getRangeFromRangeData(cmd.newTableRange).zone;
         this.selection.selectCell(newTableZone.right, newTableZone.bottom);
-        if (!table.config.automaticAutofill) return;
+        if (!table.config.automaticAutofill) {
+          return;
+        }
         const oldTableZone = table.range.zone;
 
         if (newTableZone.bottom >= oldTableZone.bottom) {

--- a/packages/o-spreadsheet-engine/src/plugins/ui_feature/ui_sheet.ts
+++ b/packages/o-spreadsheet-engine/src/plugins/ui_feature/ui_sheet.ts
@@ -294,7 +294,9 @@ export class SheetUIPlugin extends UIPlugin {
         sheetId,
         this.getters.getRowsZone(sheetId, row, row)
       )) {
-        if (evaluatedCell.value === undefined) continue;
+        if (evaluatedCell.value === undefined) {
+          continue;
+        }
         const colSize = this.getters.getColSize(sheetId, position.col);
         const style = this.getters.getCellStyle(position);
 

--- a/packages/o-spreadsheet-engine/src/plugins/ui_stateful/filter_evaluation.ts
+++ b/packages/o-spreadsheet-engine/src/plugins/ui_stateful/filter_evaluation.ts
@@ -108,7 +108,9 @@ export class FilterEvaluationPlugin extends UIPlugin {
   getFilterHiddenValues(position: CellPosition): string[] {
     const id = this.getters.getFilterId(position);
     const sheetId = position.sheetId;
-    if (!id || !this.filterValues[sheetId]) return [];
+    if (!id || !this.filterValues[sheetId]) {
+      return [];
+    }
     const value = this.filterValues[sheetId][id] || [];
     return value.filterType === "values" ? value.hiddenValues : [];
   }
@@ -116,17 +118,23 @@ export class FilterEvaluationPlugin extends UIPlugin {
   getFilterCriterionValue(position: CellPosition): CriterionFilter {
     const id = this.getters.getFilterId(position);
     const sheetId = position.sheetId;
-    if (!id || !this.filterValues[sheetId]) return EMPTY_CRITERION;
+    if (!id || !this.filterValues[sheetId]) {
+      return EMPTY_CRITERION;
+    }
     const value = this.filterValues[sheetId][id];
     return value && value.filterType === "criterion" ? value : EMPTY_CRITERION;
   }
 
   isFilterActive(position: CellPosition): boolean {
     const id = this.getters.getFilterId(position);
-    if (!id) return false;
+    if (!id) {
+      return false;
+    }
     const sheetId = position.sheetId;
     const value = this.filterValues[sheetId]?.[id];
-    if (!value) return false;
+    if (!value) {
+      return false;
+    }
     return value.filterType === "values" ? value.hiddenValues.length > 0 : value.type !== "none";
   }
 
@@ -138,8 +146,12 @@ export class FilterEvaluationPlugin extends UIPlugin {
 
   private updateFilter({ col, row, value, sheetId }: UpdateFilterCommand) {
     const id = this.getters.getFilterId({ sheetId, col, row });
-    if (!id) return;
-    if (!this.filterValues[sheetId]) this.filterValues[sheetId] = {};
+    if (!id) {
+      return;
+    }
+    if (!this.filterValues[sheetId]) {
+      this.filterValues[sheetId] = {};
+    }
     this.filterValues[sheetId][id] = value;
   }
 
@@ -165,7 +177,9 @@ export class FilterEvaluationPlugin extends UIPlugin {
       }
       if (filterValue.filterType === "values") {
         const filteredValues = filterValue.hiddenValues?.map(toLowerCase);
-        if (!filteredValues) continue;
+        if (!filteredValues) {
+          continue;
+        }
         const filteredValuesSet = new Set(filteredValues);
         for (let row = filteredZone.top; row <= filteredZone.bottom; row++) {
           const value = this.getCellValueAsString(sheetId, filter.col, row);
@@ -174,7 +188,9 @@ export class FilterEvaluationPlugin extends UIPlugin {
           }
         }
       } else {
-        if (filterValue.type === "none") continue;
+        if (filterValue.type === "none") {
+          continue;
+        }
         const evaluator = criterionEvaluatorRegistry.get(filterValue.type);
         const preComputedCriterion = evaluator.preComputeCriterion?.(
           filterValue as GenericCriterion,

--- a/packages/o-spreadsheet-engine/src/plugins/ui_stateful/sheetview.ts
+++ b/packages/o-spreadsheet-engine/src/plugins/ui_stateful/sheetview.ts
@@ -875,7 +875,9 @@ export class SheetViewPlugin extends UIPlugin {
    * It returns -1 if no col is found.
    */
   private getColIndexLeftOfMainViewport(x: Pixel): HeaderIndex {
-    if (x >= 0) return -1;
+    if (x >= 0) {
+      return -1;
+    }
     const sheetId = this.getters.getActiveSheetId();
     let col = this.getActiveMainViewport().left;
     let colStart =
@@ -892,7 +894,9 @@ export class SheetViewPlugin extends UIPlugin {
    * It returns -1 if no row is found.
    */
   private getRowIndexTopOfMainViewport(y: Pixel): HeaderIndex {
-    if (y >= 0) return -1;
+    if (y >= 0) {
+      return -1;
+    }
     const sheetId = this.getters.getActiveSheetId();
     let row = this.getActiveMainViewport().top;
     let rowStart =

--- a/packages/o-spreadsheet-engine/src/xlsx/conversion/cf_conversion.ts
+++ b/packages/o-spreadsheet-engine/src/xlsx/conversion/cf_conversion.ts
@@ -28,7 +28,9 @@ export function convertConditionalFormats(
   const cfs: ConditionalFormat[] = [];
   let cfId = 1;
   for (const cf of xlsxCfs) {
-    if (cf.cfRules.length === 0) continue;
+    if (cf.cfRules.length === 0) {
+      continue;
+    }
 
     addCfConversionWarnings(cf, dxfs, warningManager);
 
@@ -40,8 +42,9 @@ export function convertConditionalFormats(
     if (
       rule.dxfId === undefined &&
       !(rule.type === "colorScale" || rule.type === "iconSet" || rule.type === "dataBar")
-    )
+    ) {
       continue;
+    }
     switch (rule.type) {
       case "aboveAverage":
       case "containsErrors":
@@ -73,12 +76,16 @@ export function convertConditionalFormats(
       case "notContainsText":
       case "beginsWith":
       case "endsWith":
-        if (!rule.text) continue;
+        if (!rule.text) {
+          continue;
+        }
         operator = CF_TYPE_CONVERSION_MAP[rule.type]!;
         values.push(rule.text);
         break;
       case "expression":
-        if (!rule.formula?.length) continue;
+        if (!rule.formula?.length) {
+          continue;
+        }
         operator = CF_TYPE_CONVERSION_MAP[rule.type]!;
         values.push(`=${rule.formula[0]}`);
         break;
@@ -87,7 +94,9 @@ export function convertConditionalFormats(
         operator = CF_TYPE_CONVERSION_MAP[rule.type]!;
         break;
       case "cellIs":
-        if (!rule.operator || !rule.formula || rule.formula.length === 0) continue;
+        if (!rule.operator || !rule.formula || rule.formula.length === 0) {
+          continue;
+        }
         operator = CF_OPERATOR_TYPE_CONVERSION_MAP[rule.operator];
         values.push(prefixFormulaWithEqual(rule.formula[0]));
         if (rule.formula.length === 2) {
@@ -95,7 +104,9 @@ export function convertConditionalFormats(
         }
         break;
       case "top10":
-        if (rule.rank === undefined) continue;
+        if (rule.rank === undefined) {
+          continue;
+        }
         operator = CF_OPERATOR_TYPE_CONVERSION_MAP[rule.type];
         values.push(rule.rank.toString());
         if (rule.percent) {
@@ -129,7 +140,9 @@ export function convertConditionalFormats(
 
 function convertDataBar(id: number, xlsxCf: XLSXConditionalFormat): ConditionalFormat | undefined {
   const dataBar = xlsxCf.cfRules[0].dataBar;
-  if (!dataBar) return undefined;
+  if (!dataBar) {
+    return undefined;
+  }
 
   const color = hexaToInt(convertColor(dataBar.color) || "#FFFFFF");
 
@@ -196,7 +209,9 @@ function convertIconSet(
   warningManager: XLSXImportWarningManager
 ): ConditionalFormat | undefined {
   const xlsxIconSet = xlsxCf.cfRules[0].iconSet;
-  if (!xlsxIconSet) return undefined;
+  if (!xlsxIconSet) {
+    return undefined;
+  }
   let cfVos = xlsxIconSet.cfvos;
   let cfIcons = xlsxIconSet.cfIcons;
   if (cfVos.length < 3 || (cfIcons && cfIcons.length < 3)) {
@@ -277,7 +292,9 @@ function convertIconSet(
  */
 function convertIcons(xlsxIconSet: ExcelIconSet, index: number): string {
   const iconSet = ICON_SET_CONVERSION_MAP[xlsxIconSet];
-  if (!iconSet) return "";
+  if (!iconSet) {
+    return "";
+  }
 
   return index === 0
     ? ICON_SETS[iconSet].bad

--- a/packages/o-spreadsheet-engine/src/xlsx/conversion/color_conversion.ts
+++ b/packages/o-spreadsheet-engine/src/xlsx/conversion/color_conversion.ts
@@ -54,7 +54,9 @@ export function convertColor(xlsxColor: XLSXColor | undefined): Color | undefine
  * representation #RRGGBBAA
  */
 function xlsxColorToHEXA(color: Color): Color {
-  if (color.length === 6) return "#" + color + "FF";
+  if (color.length === 6) {
+    return "#" + color + "FF";
+  }
   return "#" + color.slice(2) + color.slice(0, 2);
 }
 

--- a/packages/o-spreadsheet-engine/src/xlsx/conversion/sheet_conversion.ts
+++ b/packages/o-spreadsheet-engine/src/xlsx/conversion/sheet_conversion.ts
@@ -72,9 +72,13 @@ function convertCols(
   for (let i = 1; i < numberOfCols + 1; i++) {
     const col = sheet.cols.find((col) => col.min <= i && i <= col.max);
     let colSize: number;
-    if (col && col.width) colSize = col.width;
-    else if (sheet.sheetFormat?.defaultColWidth) colSize = sheet.sheetFormat.defaultColWidth;
-    else colSize = EXCEL_DEFAULT_COL_WIDTH;
+    if (col && col.width) {
+      colSize = col.width;
+    } else if (sheet.sheetFormat?.defaultColWidth) {
+      colSize = sheet.sheetFormat.defaultColWidth;
+    } else {
+      colSize = EXCEL_DEFAULT_COL_WIDTH;
+    }
     // In xlsx there is no difference between hidden columns and columns inside a folded group.
     // But in o-spreadsheet folded columns are not considered hidden.
     const colIndex = i - 1;
@@ -99,9 +103,13 @@ function convertRows(
   for (let i = 1; i < numberOfRows + 1; i++) {
     const row = sheet.rows.find((row) => row.index === i);
     let rowSize: number;
-    if (row && row.height) rowSize = row.height;
-    else if (sheet.sheetFormat?.defaultRowHeight) rowSize = sheet.sheetFormat.defaultRowHeight;
-    else rowSize = EXCEL_DEFAULT_ROW_HEIGHT;
+    if (row && row.height) {
+      rowSize = row.height;
+    } else if (sheet.sheetFormat?.defaultRowHeight) {
+      rowSize = sheet.sheetFormat.defaultRowHeight;
+    } else {
+      rowSize = EXCEL_DEFAULT_ROW_HEIGHT;
+    }
     // In xlsx there is no difference between hidden rows and rows inside a folded group.
     // But in o-spreadsheet folded rows are not considered hidden.
     const rowIndex = i - 1;

--- a/packages/o-spreadsheet-engine/src/xlsx/conversion/style_conversion.ts
+++ b/packages/o-spreadsheet-engine/src/xlsx/conversion/style_conversion.ts
@@ -53,7 +53,9 @@ function convertBorderDescr(
   borderDescr: XLSXBorderDescr | undefined,
   warningManager: XLSXImportWarningManager
 ): BorderDescr | undefined {
-  if (!borderDescr) return undefined;
+  if (!borderDescr) {
+    return undefined;
+  }
 
   addBorderDescrWarnings(borderDescr, warningManager);
 

--- a/packages/o-spreadsheet-engine/src/xlsx/conversion/table_conversion.ts
+++ b/packages/o-spreadsheet-engine/src/xlsx/conversion/table_conversion.ts
@@ -15,8 +15,12 @@ import { XLSXImportData, XLSXPivotTable, XLSXTable, XLSXWorksheet } from "../../
 export function convertTables(convertedData: WorkbookData, xlsxData: XLSXImportData) {
   for (const xlsxSheet of xlsxData.sheets) {
     const sheet = convertedData.sheets.find((sheet) => sheet.name === xlsxSheet.sheetName);
-    if (!sheet) continue;
-    if (!sheet.tables) sheet.tables = [];
+    if (!sheet) {
+      continue;
+    }
+    if (!sheet.tables) {
+      sheet.tables = [];
+    }
 
     for (const table of xlsxSheet.tables) {
       sheet.tables.push({ range: table.ref, config: convertTableConfig(table) });

--- a/packages/o-spreadsheet-engine/src/xlsx/extraction/base_extractor.ts
+++ b/packages/o-spreadsheet-engine/src/xlsx/extraction/base_extractor.ts
@@ -36,8 +36,12 @@ class AttributeValue {
   }
 
   asBool(): boolean {
-    if (this.value === "true") return true; // for files exported from Libre Office
-    if (this.value === "false") return false;
+    if (this.value === "true") {
+      return true;
+    } // for files exported from Libre Office
+    if (this.value === "false") {
+      return false;
+    }
     return Boolean(Number(this.value));
   }
 
@@ -179,7 +183,9 @@ export class XlsxBaseExtractor {
   ): ExtractAttrType<T> {
     const attribute = e.attributes[attName];
 
-    if (!attribute) this.handleMissingValue(e, `attribute "${attName}"`, optionalArgs);
+    if (!attribute) {
+      this.handleMissingValue(e, `attribute "${attName}"`, optionalArgs);
+    }
 
     const value = attribute?.value ? attribute.value : optionalArgs?.default;
     return (value === undefined ? undefined : new AttributeValue(value)) as ExtractAttrType<T>;
@@ -341,11 +347,15 @@ export class XlsxBaseExtractor {
    * Returns the xml file targeted by a relationship.
    */
   protected getTargetXmlFile(relationship: XLSXRel): XLSXImportFile {
-    if (!relationship) throw new Error("Undefined target file");
+    if (!relationship) {
+      throw new Error("Undefined target file");
+    }
     const target = this.processRelationshipTargetName(relationship.target);
     // Use "endsWith" because targets are relative paths, and we know the files by their absolute path.
     const f = this.getListOfXMLFiles().find((f) => f.file.fileName.endsWith(target));
-    if (!f || !f.file) throw new Error("Cannot find target file");
+    if (!f || !f.file) {
+      throw new Error("Cannot find target file");
+    }
     return f;
   }
 
@@ -353,11 +363,15 @@ export class XlsxBaseExtractor {
    * Returns the image parameters targeted by a relationship.
    */
   protected getTargetImageFile(relationship: XLSXRel): XLSXImageFile {
-    if (!relationship) throw new Error("Undefined target file");
+    if (!relationship) {
+      throw new Error("Undefined target file");
+    }
     const target = this.processRelationshipTargetName(relationship.target);
     // Use "endsWith" because targets are relative paths, and we know the files by their absolute path.
     const f = this.xlsxFileStructure.images.find((f) => f.fileName.endsWith(target));
-    if (!f) throw new Error("Cannot find target file");
+    if (!f) {
+      throw new Error("Cannot find target file");
+    }
     return f;
   }
 

--- a/packages/o-spreadsheet-engine/src/xlsx/extraction/cf_extractor.ts
+++ b/packages/o-spreadsheet-engine/src/xlsx/extraction/cf_extractor.ts
@@ -107,7 +107,9 @@ export class XlsxCfExtractor extends XlsxBaseExtractor {
     theme: XLSXTheme | undefined
   ): XLSXColorScale | undefined {
     const colorScaleElement = this.querySelector(cfRulesElement, "colorScale");
-    if (!colorScaleElement) return undefined;
+    if (!colorScaleElement) {
+      return undefined;
+    }
 
     return {
       colors: this.mapOnElements(
@@ -125,7 +127,9 @@ export class XlsxCfExtractor extends XlsxBaseExtractor {
     theme: XLSXTheme | undefined
   ): XLSXDataBar | undefined {
     const dataBarElement = this.querySelector(cfRulesElement, "dataBar");
-    if (!dataBarElement) return undefined;
+    if (!dataBarElement) {
+      return undefined;
+    }
     return {
       color: this.extractColor(dataBarElement.querySelector("color"), theme, "EFF7FF"),
       // TODO ATM, we only support color for dataBar, not the minimum and maximum fill percentage
@@ -135,7 +139,9 @@ export class XlsxCfExtractor extends XlsxBaseExtractor {
 
   private extractCfIconSet(cfRulesElement: Element): XLSXIconSet | undefined {
     const iconSetElement = this.querySelector(cfRulesElement, "iconSet, x14:iconSet");
-    if (!iconSetElement) return undefined;
+    if (!iconSetElement) {
+      return undefined;
+    }
 
     return {
       iconSet: this.extractAttr(iconSetElement, "iconSet", {

--- a/packages/o-spreadsheet-engine/src/xlsx/extraction/sheet_extractor.ts
+++ b/packages/o-spreadsheet-engine/src/xlsx/extraction/sheet_extractor.ts
@@ -232,7 +232,9 @@ export class XlsxSheetExtractor extends XlsxBaseExtractor {
 
   private extractSheetFormat(worksheet: Element): XLSXSheetFormat | undefined {
     const formatElement = this.querySelector(worksheet, "sheetFormatPr");
-    if (!formatElement) return undefined;
+    if (!formatElement) {
+      return undefined;
+    }
 
     return {
       defaultColWidth: this.extractAttr(formatElement, "defaultColWidth", {
@@ -246,7 +248,9 @@ export class XlsxSheetExtractor extends XlsxBaseExtractor {
 
   private extractSheetProperties(worksheet: Element): XLSXSheetProperties | undefined {
     const propertiesElement = this.querySelector(worksheet, "sheetPr");
-    if (!propertiesElement) return undefined;
+    if (!propertiesElement) {
+      return undefined;
+    }
 
     return {
       outlinePr: this.extractSheetOutlineProperties(propertiesElement),
@@ -258,7 +262,9 @@ export class XlsxSheetExtractor extends XlsxBaseExtractor {
     sheetProperties: Element
   ): XLSXOutlineProperties | undefined {
     const properties = this.querySelector(sheetProperties, "outlinePr");
-    if (!properties) return undefined;
+    if (!properties) {
+      return undefined;
+    }
 
     return {
       summaryBelow: this.extractAttr(properties, "summaryBelow", { default: true }).asBool()!,
@@ -333,7 +339,9 @@ export class XlsxSheetExtractor extends XlsxBaseExtractor {
 
   private extractCellFormula(cellElement: Element): XLSXFormula | undefined {
     const formulaElement = this.querySelector(cellElement, "f");
-    if (!formulaElement) return undefined;
+    if (!formulaElement) {
+      return undefined;
+    }
     const content = this.extractTextContent(formulaElement);
     const sharedIndex = this.extractAttr(formulaElement, "si")?.asNum();
     const ref = this.extractAttr(formulaElement, "ref")?.asString();

--- a/packages/o-spreadsheet-engine/src/xlsx/extraction/style_extractor.ts
+++ b/packages/o-spreadsheet-engine/src/xlsx/extraction/style_extractor.ts
@@ -140,7 +140,9 @@ export class XlsxStyleExtractor extends XlsxBaseExtractor {
     theme: XLSXTheme | undefined
   ): XLSXBorderDescr | undefined {
     const directionElement = this.querySelector(borderElement, direction);
-    if (!directionElement || !directionElement.attributes["style"]) return undefined;
+    if (!directionElement || !directionElement.attributes["style"]) {
+      return undefined;
+    }
     return {
       style: this.extractAttr(directionElement, "style", {
         required: true,

--- a/packages/o-spreadsheet-engine/src/xlsx/functions/charts.ts
+++ b/packages/o-spreadsheet-engine/src/xlsx/functions/charts.ts
@@ -225,7 +225,9 @@ function extractTrendline(
   trend: ExcelChartDataset["trend"],
   dataSetColor: XlsxHexColor
 ): XMLString {
-  if (!trend) return escapeXml/*xml*/ ``;
+  if (!trend) {
+    return escapeXml/*xml*/ ``;
+  }
   const { type, order, window } = trend;
   const trendLineNodes: XMLString[] = [];
   switch (type) {

--- a/packages/o-spreadsheet-engine/src/xlsx/functions/worksheet.ts
+++ b/packages/o-spreadsheet-engine/src/xlsx/functions/worksheet.ts
@@ -230,7 +230,9 @@ export function addMerges(merges: string[]): XMLString {
         ${joinXmlNodes(mergeNodes)}
       </mergeCells>
     `;
-  } else return escapeXml``;
+  } else {
+    return escapeXml``;
+  }
 }
 
 export function addSheetViews(sheet: ExcelSheetData) {

--- a/packages/o-spreadsheet-engine/src/xlsx/helpers/content_helpers.ts
+++ b/packages/o-spreadsheet-engine/src/xlsx/helpers/content_helpers.ts
@@ -113,12 +113,16 @@ export function convertWidthToExcel(width: number): number {
 }
 
 export function convertHeightFromExcel(height: number | undefined): number | undefined {
-  if (!height) return height;
+  if (!height) {
+    return height;
+  }
   return Math.round((height / HEIGHT_FACTOR) * 100) / 100;
 }
 
 export function convertWidthFromExcel(width: number | undefined): number | undefined {
-  if (!width) return width;
+  if (!width) {
+    return width;
+  }
   return Math.round((width / WIDTH_FACTOR) * 100) / 100;
 }
 

--- a/packages/o-spreadsheet-engine/src/xlsx/xlsx_writer.ts
+++ b/packages/o-spreadsheet-engine/src/xlsx/xlsx_writer.ts
@@ -155,10 +155,14 @@ function createWorksheets(data: ExcelWorkbookData, construct: XLSXStructure): XL
 
     for (const image of sheet.images) {
       const mimeType = image.data.mimetype;
-      if (mimeType === undefined) continue;
+      if (mimeType === undefined) {
+        continue;
+      }
       const extension = IMAGE_MIMETYPE_TO_EXTENSION_MAPPING[mimeType];
       // only support exporting images with mimetypes specified in the mapping
-      if (extension === undefined) continue;
+      if (extension === undefined) {
+        continue;
+      }
       const xlsxImageId = convertImageId(image.id);
       const imageFileName = `image${xlsxImageId}.${extension}`;
 
@@ -266,7 +270,9 @@ function createTablesForSheet(
   files: XLSXExportFile[]
 ): XMLString {
   let currentTableId = startingTableId;
-  if (!sheetData.tables.length) return new XMLString("");
+  if (!sheetData.tables.length) {
+    return new XMLString("");
+  }
 
   const sheetRelFile = `xl/worksheets/_rels/sheet${sheetId}.xml.rels`;
 

--- a/src/clipboard_handlers/borders_clipboard.ts
+++ b/src/clipboard_handlers/borders_clipboard.ts
@@ -85,12 +85,13 @@ export class BorderClipboardHandler extends AbstractCellClipboardHandler<
         bottom: (border.zone.bottom && border.zone.bottom + row) || border.zone.top + row,
       };
       for (const [position, style] of this.getOptimalBorderCommands(border.style)) {
-        if (style)
+        if (style) {
           this.dispatch("SET_ZONE_BORDERS", {
             sheetId,
             target: [zone],
             border: { position, ...style },
           });
+        }
       }
     }
   }

--- a/src/components/animation/ripple.ts
+++ b/src/components/animation/ripple.ts
@@ -79,7 +79,9 @@ class RippleEffect extends Component<RippleEffectProps, SpreadsheetChildEnv> {
     let animation: Animation | undefined = undefined;
     onMounted(() => {
       const rippleEl = this.rippleRef.el;
-      if (!rippleEl || !rippleEl.animate) return;
+      if (!rippleEl || !rippleEl.animate) {
+        return;
+      }
       animation = rippleEl.animate(RIPPLE_KEY_FRAMES, {
         duration: this.props.duration,
         easing: "ease-out",
@@ -144,9 +146,13 @@ export class Ripple extends Component<RippleProps, SpreadsheetChildEnv> {
   private currentId = 1;
 
   onClick(ev: MouseEvent) {
-    if (!this.props.enabled) return;
+    if (!this.props.enabled) {
+      return;
+    }
     const containerEl = this.childContainer.el;
-    if (!containerEl) return;
+    if (!containerEl) {
+      return;
+    }
 
     const rect = this.getRippleChildRectInfo();
     const { x, y, width, height } = rect;
@@ -179,7 +185,9 @@ export class Ripple extends Component<RippleProps, SpreadsheetChildEnv> {
 
   private getRippleChildRectInfo(): RectWithMargins {
     const el = this.childContainer.el;
-    if (!el) throw new Error("No child container element found");
+    if (!el) {
+      throw new Error("No child container element found");
+    }
 
     if (el.childElementCount !== 1 || !el.firstElementChild) {
       const boundingRect = getBoundingRectAsPOJO(el);
@@ -199,13 +207,17 @@ export class Ripple extends Component<RippleProps, SpreadsheetChildEnv> {
 
   private removeRipple(id: number) {
     const index = this.state.ripples.findIndex((r) => r.id === id);
-    if (index === -1) return;
+    if (index === -1) {
+      return;
+    }
     this.state.ripples.splice(index, 1);
   }
 
   getRippleEffectProps(id: number): RippleEffectProps {
     const rect = this.state.ripples.find((r) => r.id === id)?.rippleRect;
-    if (!rect) throw new Error("Cannot find a ripple with the id " + id);
+    if (!rect) {
+      throw new Error("Cannot find a ripple with the id " + id);
+    }
     return {
       color: this.props.color,
       opacity: this.props.opacity,

--- a/src/components/bottom_bar/bottom_bar.ts
+++ b/src/components/bottom_bar/bottom_bar.ts
@@ -158,15 +158,23 @@ export class BottomBar extends Component<Props, SpreadsheetChildEnv> {
   }
 
   onArrowLeft(ev: MouseEvent) {
-    if (!this.state.isSheetListScrollableLeft) return;
-    if (!this.targetScroll) this.targetScroll = this.sheetListCurrentScroll;
+    if (!this.state.isSheetListScrollableLeft) {
+      return;
+    }
+    if (!this.targetScroll) {
+      this.targetScroll = this.sheetListCurrentScroll;
+    }
     const newScroll = this.targetScroll - this.sheetListWidth;
     this.scrollSheetListTo(Math.max(0, newScroll));
   }
 
   onArrowRight(ev: MouseEvent) {
-    if (!this.state.isSheetListScrollableRight) return;
-    if (!this.targetScroll) this.targetScroll = this.sheetListCurrentScroll;
+    if (!this.state.isSheetListScrollableRight) {
+      return;
+    }
+    if (!this.targetScroll) {
+      this.targetScroll = this.sheetListCurrentScroll;
+    }
     const newScroll = this.targetScroll + this.sheetListWidth;
     this.scrollSheetListTo(Math.min(this.sheetListMaxScroll, newScroll));
   }
@@ -177,13 +185,17 @@ export class BottomBar extends Component<Props, SpreadsheetChildEnv> {
   }
 
   private scrollSheetListTo(scroll: number) {
-    if (!this.sheetListRef.el) return;
+    if (!this.sheetListRef.el) {
+      return;
+    }
     this.targetScroll = scroll;
     this.sheetListRef.el.scrollTo({ top: 0, left: scroll, behavior: "smooth" });
   }
 
   onSheetMouseDown(sheetId: UID, event: MouseEvent) {
-    if (event.button !== 0 || this.env.model.getters.isReadonly()) return;
+    if (event.button !== 0 || this.env.model.getters.isReadonly()) {
+      return;
+    }
     this.closeMenu();
 
     if (this.env.isMobile()) {
@@ -234,17 +246,23 @@ export class BottomBar extends Component<Props, SpreadsheetChildEnv> {
   }
 
   get sheetListCurrentScroll() {
-    if (!this.sheetListRef.el) return 0;
+    if (!this.sheetListRef.el) {
+      return 0;
+    }
     return this.sheetListRef.el.scrollLeft;
   }
 
   get sheetListWidth() {
-    if (!this.sheetListRef.el) return 0;
+    if (!this.sheetListRef.el) {
+      return 0;
+    }
     return this.sheetListRef.el.clientWidth;
   }
 
   get sheetListMaxScroll() {
-    if (!this.sheetListRef.el) return 0;
+    if (!this.sheetListRef.el) {
+      return 0;
+    }
     return this.sheetListRef.el.scrollWidth - this.sheetListRef.el.clientWidth;
   }
 }

--- a/src/components/bottom_bar/bottom_bar_sheet/bottom_bar_sheet.ts
+++ b/src/components/bottom_bar/bottom_bar_sheet/bottom_bar_sheet.ts
@@ -67,7 +67,9 @@ export class BottomBarSheet extends Component<Props, SpreadsheetChildEnv> {
   }
 
   private focusInputAndSelectContent() {
-    if (!this.state.isEditing || !this.sheetNameRef.el) return;
+    if (!this.state.isEditing || !this.sheetNameRef.el) {
+      return;
+    }
 
     this.sheetNameRef.el.focus();
     const selection = window.getSelection();
@@ -125,7 +127,9 @@ export class BottomBarSheet extends Component<Props, SpreadsheetChildEnv> {
   }
 
   onKeyDown(ev: KeyboardEvent) {
-    if (!this.state.isEditing) return;
+    if (!this.state.isEditing) {
+      return;
+    }
     if (ev.key === "Enter") {
       ev.preventDefault();
       this.stopEdition();
@@ -138,7 +142,9 @@ export class BottomBarSheet extends Component<Props, SpreadsheetChildEnv> {
   }
 
   onMouseEventSheetName(ev: MouseEvent) {
-    if (this.state.isEditing) ev.stopPropagation();
+    if (this.state.isEditing) {
+      ev.stopPropagation();
+    }
   }
 
   private startEdition() {
@@ -147,7 +153,9 @@ export class BottomBarSheet extends Component<Props, SpreadsheetChildEnv> {
   }
 
   private stopEdition() {
-    if (!this.state.isEditing || !this.sheetNameRef.el) return;
+    if (!this.state.isEditing || !this.sheetNameRef.el) {
+      return;
+    }
 
     this.state.isEditing = false;
     this.editionState = "initializing";
@@ -184,7 +192,9 @@ export class BottomBarSheet extends Component<Props, SpreadsheetChildEnv> {
   }
 
   private setInputContent(content: string) {
-    if (this.sheetNameRef.el) this.sheetNameRef.el.textContent = content;
+    if (this.sheetNameRef.el) {
+      this.sheetNameRef.el.textContent = content;
+    }
   }
 
   onColorPicked(color: string) {

--- a/src/components/composer/composer/abstract_composer_store.ts
+++ b/src/components/composer/composer/abstract_composer_store.ts
@@ -281,7 +281,9 @@ export abstract class AbstractComposerStore extends SpreadsheetStore {
   }
 
   toggleEditionMode() {
-    if (this.editionMode === "inactive") return;
+    if (this.editionMode === "inactive") {
+      return;
+    }
     const start = Math.min(this.selectionStart, this.selectionEnd);
     const end = Math.max(this.selectionStart, this.selectionEnd);
     const refToken = [...this.currentTokens]
@@ -649,7 +651,9 @@ export abstract class AbstractComposerStore extends SpreadsheetStore {
     const refSheet = sheetName ? this.model.getters.getSheetIdByName(sheetName) : this.sheetId;
 
     const highlight = this.highlights.find((highlight) => {
-      if (highlight.range.sheetId !== refSheet) return false;
+      if (highlight.range.sheetId !== refSheet) {
+        return false;
+      }
 
       const range = this.model.getters.getRangeFromSheetXC(refSheet, xc);
       let zone = range.zone;
@@ -756,7 +760,9 @@ export abstract class AbstractComposerStore extends SpreadsheetStore {
     const usedIndexes = new Set(Object.values(colorsToKeep));
     let currentIndex = 0;
     const nextIndex = () => {
-      while (usedIndexes.has(currentIndex)) currentIndex++;
+      while (usedIndexes.has(currentIndex)) {
+        currentIndex++;
+      }
       usedIndexes.add(currentIndex);
       return currentIndex;
     };

--- a/src/components/composer/composer/composer.ts
+++ b/src/components/composer/composer/composer.ts
@@ -545,7 +545,9 @@ export class Composer extends Component<CellComposerProps, SpreadsheetChildEnv> 
     if (isValidFormula) {
       const tokens = this.props.composerStore.currentTokens;
       const currentSelection = this.contentHelper.getCurrentSelection();
-      if (currentSelection.start === currentSelection.end) return;
+      if (currentSelection.start === currentSelection.end) {
+        return;
+      }
 
       const currentSelectedText = composerContent.substring(
         currentSelection.start,
@@ -573,12 +575,16 @@ export class Composer extends Component<CellComposerProps, SpreadsheetChildEnv> 
   }
 
   closeAssistant() {
-    if (!this.props.composerStore.canBeToggled) return;
+    if (!this.props.composerStore.canBeToggled) {
+      return;
+    }
     this.assistant.forcedClosed = true;
   }
 
   openAssistant() {
-    if (!this.props.composerStore.canBeToggled) return;
+    if (!this.props.composerStore.canBeToggled) {
+      return;
+    }
     this.assistant.forcedClosed = false;
   }
 

--- a/src/components/composer/content_editable_helper.ts
+++ b/src/components/composer/content_editable_helper.ts
@@ -50,9 +50,15 @@ export class ContentEditableHelper {
         console.warn(
           `wrong selection asked start ${start}, end ${end}, text content length ${textLength}`
         );
-        if (start < 0) start = 0;
-        if (end > textLength) end = textLength;
-        if (start > textLength) start = textLength;
+        if (start < 0) {
+          start = 0;
+        }
+        if (end > textLength) {
+          end = textLength;
+        }
+        if (start > textLength) {
+          start = textLength;
+        }
       }
       const startNode = this.findChildAtCharacterIndex(start);
       const endNode = this.findChildAtCharacterIndex(end);
@@ -156,7 +162,9 @@ export class ContentEditableHelper {
         }
         // this is an empty line in the content
         if (!content.value && !content.classes?.length) {
-          if (child) p.removeChild(child);
+          if (child) {
+            p.removeChild(child);
+          }
           continue;
         }
         const span = document.createElement("span");
@@ -209,7 +217,9 @@ export class ContentEditableHelper {
 
   scrollSelectionIntoView() {
     const focusedNode = document.getSelection()?.focusNode;
-    if (!focusedNode || !this.el.contains(focusedNode)) return;
+    if (!focusedNode || !this.el.contains(focusedNode)) {
+      return;
+    }
     const element = focusedNode instanceof HTMLElement ? focusedNode : focusedNode.parentElement;
     element?.scrollIntoView?.({ block: "nearest" });
   }
@@ -283,10 +293,16 @@ const brNode = doc.parseFromString("<br>", "text/html").body.firstChild;
 const spanBrNode = doc.parseFromString("<span><br></span>", "text/html").body.firstChild;
 
 function isEmptyParagraph(node: Node) {
-  if (node.childNodes.length > 1) return false;
+  if (node.childNodes.length > 1) {
+    return false;
+  }
   const node2 = node.firstChild?.cloneNode(true);
-  if (!node2) return true;
-  if (!(node2 instanceof Element)) return false;
+  if (!node2) {
+    return true;
+  }
+  if (!(node2 instanceof Element)) {
+    return false;
+  }
   node2.removeAttribute("class");
   node2.removeAttribute("style");
   return node2.isEqualNode(brNode) || node2.isEqualNode(spanBrNode) || false;

--- a/src/components/figures/figure/figure.ts
+++ b/src/components/figures/figure/figure.ts
@@ -72,7 +72,9 @@ export class FigureComponent extends Component<Props, SpreadsheetChildEnv> {
   }
 
   private getBorderWidth(): Pixel {
-    if (this.env.isDashboard()) return 0;
+    if (this.env.isDashboard()) {
+      return 0;
+    }
     return this.isSelected ? ACTIVE_BORDER_WIDTH : this.borderWidth;
   }
 
@@ -239,7 +241,9 @@ export class FigureComponent extends Component<Props, SpreadsheetChildEnv> {
   }
 
   onContextMenu(ev: MouseEvent) {
-    if (this.env.isDashboard()) return;
+    if (this.env.isDashboard()) {
+      return;
+    }
     const zoomedMouseEvent = withZoom(this.env, ev);
     this.openContextMenu({
       x: zoomedMouseEvent.clientX,

--- a/src/components/figures/figure_container/figure_container.ts
+++ b/src/components/figures/figure_container/figure_container.ts
@@ -463,12 +463,16 @@ export class FiguresContainer extends Component<Props, SpreadsheetChildEnv> {
 
   private getDndFigure(): FigureUI {
     const figure = this.dnd.draggedFigure;
-    if (!figure) throw new Error("Dnd figure not found");
+    if (!figure) {
+      throw new Error("Dnd figure not found");
+    }
     return figure;
   }
 
   getFigureStyle(figureUI: FigureUI): string {
-    if (figureUI.id !== this.dnd.draggedFigure?.id) return "";
+    if (figureUI.id !== this.dnd.draggedFigure?.id) {
+      return "";
+    }
     return cssPropertiesToCss({
       opacity: this.dnd.overlappingCarousel?.id ? "0.6" : "0.9",
       cursor: "grabbing",
@@ -476,14 +480,18 @@ export class FiguresContainer extends Component<Props, SpreadsheetChildEnv> {
   }
 
   getFigureClass(figureUI: FigureUI): string {
-    if (figureUI.id !== this.dnd.overlappingCarousel?.id) return "";
+    if (figureUI.id !== this.dnd.overlappingCarousel?.id) {
+      return "";
+    }
     return "o-add-to-carousel";
   }
 
   private getSnap<T extends HFigureAxisType | VFigureAxisType>(
     snapLine: SnapLine<T> | undefined
   ): Snap<T> | undefined {
-    if (!snapLine || !this.dnd.draggedFigure) return undefined;
+    if (!snapLine || !this.dnd.draggedFigure) {
+      return undefined;
+    }
     const { scrollX, scrollY } = this.env.model.getters.getActiveSheetScrollInfo();
     const figureVisibleRects = snapLine.matchedFigIds
       .map((id) => this.getVisibleFigures().find((figureUI) => figureUI.id === id))
@@ -516,7 +524,9 @@ export class FiguresContainer extends Component<Props, SpreadsheetChildEnv> {
     snapLine: SnapLine<HFigureAxisType | VFigureAxisType> | undefined,
     containerRect: Rect
   ): string {
-    if (!snapLine) return "";
+    if (!snapLine) {
+      return "";
+    }
     const { scrollX, scrollY } = this.env.model.getters.getActiveSheetScrollInfo();
     if (["top", "vCenter", "bottom"].includes(snapLine.snappedAxisType)) {
       return cssPropertiesToCss({

--- a/src/components/filters/filter_menu_value_list/filter_menu_value_list.ts
+++ b/src/components/filters/filter_menu_value_list/filter_menu_value_list.ts
@@ -155,7 +155,9 @@ export class FilterMenuValueList extends Component<Props, SpreadsheetChildEnv> {
   onKeyDown(ev: KeyboardEvent) {
     const displayedValues = this.state.displayedValues;
 
-    if (displayedValues.length === 0) return;
+    if (displayedValues.length === 0) {
+      return;
+    }
 
     let selectedIndex: number | undefined = undefined;
     if (this.state.selectedValue !== undefined) {

--- a/src/components/full_screen_figure/full_screen_figure.ts
+++ b/src/components/full_screen_figure/full_screen_figure.ts
@@ -42,7 +42,9 @@ export class FullScreenFigure extends Component<{}, SpreadsheetChildEnv> {
   }
 
   get chartId() {
-    if (!this.figureUI) return undefined;
+    if (!this.figureUI) {
+      return undefined;
+    }
     return this.env.model.getters.getChartIdFromFigureId(this.figureUI?.id);
   }
 
@@ -59,7 +61,9 @@ export class FullScreenFigure extends Component<{}, SpreadsheetChildEnv> {
   }
 
   get figureComponent(): (new (...args: any) => Component) | undefined {
-    if (!this.figureUI) return undefined;
+    if (!this.figureUI) {
+      return undefined;
+    }
     return figureRegistry.get(this.figureUI.tag).Component;
   }
 }

--- a/src/components/generic_input/generic_input.ts
+++ b/src/components/generic_input/generic_input.ts
@@ -49,7 +49,9 @@ export class GenericInput<T extends GenericInputProps> extends Component<T, Spre
       }
     });
     onMounted(() => {
-      if (this.inputRef.el) this.inputRef.el.value = this.props.value.toString();
+      if (this.inputRef.el) {
+        this.inputRef.el.value = this.props.value.toString();
+      }
     });
   }
 

--- a/src/components/headers_overlay/headers_overlay.ts
+++ b/src/components/headers_overlay/headers_overlay.ts
@@ -335,7 +335,9 @@ abstract class AbstractResizer extends Component<ResizerProps, SpreadsheetChildE
   onContextMenu(ev: MouseEvent) {
     ev.preventDefault();
     const index = this._getElementIndex(this._getEvOffset(withZoom(this.env, ev)));
-    if (index < 0) return;
+    if (index < 0) {
+      return;
+    }
     if (!this._getActiveElements().has(index)) {
       this._selectElement(index, false);
     }

--- a/src/components/helpers/dom_helpers.ts
+++ b/src/components/helpers/dom_helpers.ts
@@ -10,7 +10,9 @@ const MODIFIER_KEYS = ["Shift", "Control", "Alt", "Meta"];
  * a child element.
  */
 export function isChildEvent(parent: HTMLElement | null | undefined, ev: Event): boolean {
-  if (!parent) return false;
+  if (!parent) {
+    return false;
+  }
   return !!ev.target && parent!.contains(ev.target as Node);
 }
 
@@ -197,9 +199,15 @@ export function keyboardEventToShortcutString(
 ): string {
   let keyDownString = "";
   if (!MODIFIER_KEYS.includes(ev.key)) {
-    if (isCtrlKey(ev)) keyDownString += "Ctrl+";
-    if (ev.altKey) keyDownString += "Alt+";
-    if (ev.shiftKey) keyDownString += "Shift+";
+    if (isCtrlKey(ev)) {
+      keyDownString += "Ctrl+";
+    }
+    if (ev.altKey) {
+      keyDownString += "Alt+";
+    }
+    if (ev.shiftKey) {
+      keyDownString += "Shift+";
+    }
   }
   const key = mode === "key" ? ev.key : ev.code;
   keyDownString += letterRegex.test(key) ? key.toUpperCase() : key;

--- a/src/components/helpers/drag_and_drop_dom_items_hook.ts
+++ b/src/components/helpers/drag_and_drop_dom_items_hook.ts
@@ -50,7 +50,9 @@ export function useDragAndDropListItems() {
   const start = (direction: Direction, args: DndPartialArgs) => {
     const onChange = () => {
       document.body.style.cursor = "move";
-      if (!dndHelper) return;
+      if (!dndHelper) {
+        return;
+      }
       Object.assign(state.itemsStyle, dndHelper.getItemStyles());
       args.onChange?.();
     };
@@ -265,7 +267,9 @@ class DOMDndHelper {
   }
 
   private startEdgeScroll(direction: -1 | 1) {
-    if (this.edgeScrollIntervalId) return;
+    if (this.edgeScrollIntervalId) {
+      return;
+    }
     this.edgeScrollIntervalId = window.setInterval(() => {
       const offset = direction * 3;
       this.container.scroll += offset;
@@ -282,8 +286,12 @@ class DOMDndHelper {
    * If the mouse is outside the container, return the first or last item index.
    */
   private getHoveredItemIndex(mousePosition: Pixel, items: DragAndDropItems[]): number {
-    if (mousePosition <= this.minPosition) return 0;
-    if (mousePosition >= this.maxPosition) return items.length - 1;
+    if (mousePosition <= this.minPosition) {
+      return 0;
+    }
+    if (mousePosition >= this.maxPosition) {
+      return items.length - 1;
+    }
     return items.findIndex((item) => item.position + item.size >= mousePosition);
   }
 

--- a/src/components/helpers/figure_snap_helper.ts
+++ b/src/components/helpers/figure_snap_helper.ts
@@ -59,8 +59,11 @@ export function snapForMove(
     const isBaseFigFrozenY = figureToSnap.y < viewportY;
     const isSnappedFrozenY = figureToSnap.y < viewportY;
 
-    if (isBaseFigFrozenY && !isSnappedFrozenY) figureToSnap.y += scrollY;
-    else if (!isBaseFigFrozenY && isSnappedFrozenY) figureToSnap.y -= scrollY;
+    if (isBaseFigFrozenY && !isSnappedFrozenY) {
+      figureToSnap.y += scrollY;
+    } else if (!isBaseFigFrozenY && isSnappedFrozenY) {
+      figureToSnap.y -= scrollY;
+    }
   }
 
   if (verticalSnapLine) {
@@ -69,8 +72,11 @@ export function snapForMove(
     const isBaseFigFrozenX = figureToSnap.x < viewportX;
     const isSnappedFrozenX = figureToSnap.x < viewportX;
 
-    if (isBaseFigFrozenX && !isSnappedFrozenX) figureToSnap.x += scrollX;
-    else if (!isBaseFigFrozenX && isSnappedFrozenX) figureToSnap.x -= scrollX;
+    if (isBaseFigFrozenX && !isSnappedFrozenX) {
+      figureToSnap.x += scrollX;
+    } else if (!isBaseFigFrozenX && isSnappedFrozenX) {
+      figureToSnap.x -= scrollX;
+    }
   }
 
   return { snappedFigure: figureToSnap, verticalSnapLine, horizontalSnapLine };
@@ -156,14 +162,18 @@ function isAxisVisible<T extends HFigureAxisType | VFigureAxisType>(
     case "top":
     case "bottom":
     case "vCenter":
-      if (figureUI.y < mainViewportY) return true;
+      if (figureUI.y < mainViewportY) {
+        return true;
+      }
       axisStartEndPositions.push({ x: figureUI.x, y: axis.position });
       axisStartEndPositions.push({ x: figureUI.x + figureUI.width, y: axis.position });
       break;
     case "left":
     case "right":
     case "hCenter":
-      if (figureUI.x < mainViewportX) return true;
+      if (figureUI.x < mainViewportX) {
+        return true;
+      }
       axisStartEndPositions.push({ x: axis.position, y: figureUI.y });
       axisStartEndPositions.push({ x: axis.position, y: figureUI.y + figureUI.height });
       break;
@@ -198,7 +208,9 @@ function getSnapLine<T extends HFigureAxisType[] | VFigureAxisType[]>(
     const axesOfOtherFig = getVisibleAxes(getters, otherFigure, otherAxesTypes);
     for (const axisOfFigure of axesOfFigure) {
       for (const axisOfOtherFig of axesOfOtherFig) {
-        if (!canSnap(axisOfFigure.position, axisOfOtherFig.position)) continue;
+        if (!canSnap(axisOfFigure.position, axisOfOtherFig.position)) {
+          continue;
+        }
 
         const snapOffset = axisOfFigure.position - axisOfOtherFig.position;
 

--- a/src/components/helpers/touch_scroll_hook.ts
+++ b/src/components/helpers/touch_scroll_hook.ts
@@ -34,7 +34,9 @@ export function useTouchScroll(
   }
 
   function onTouchMove(event: TouchEvent) {
-    if (!isMouseDown) return;
+    if (!isMouseDown) {
+      return;
+    }
 
     if (resetTimeout) {
       clearTimeout(resetTimeout);

--- a/src/components/helpers/zoom.ts
+++ b/src/components/helpers/zoom.ts
@@ -26,7 +26,9 @@ export function withZoom<T extends MouseEvent>(
   if (originalTargetPosition === undefined) {
     originalTargetPosition = getZoomTargetPosition(ev, zoomLevel);
   }
-  if (!originalTargetPosition) return withNoZoom(ev);
+  if (!originalTargetPosition) {
+    return withNoZoom(ev);
+  }
   const baseOffsetX = ev.clientX - originalTargetPosition.x;
   const baseOffsetY = ev.clientY - originalTargetPosition.y;
   const offsetX = baseOffsetX / zoomLevel;

--- a/src/components/link/link_display/link_display.ts
+++ b/src/components/link/link_display/link_display.ts
@@ -76,7 +76,9 @@ export const LinkCellPopoverBuilder: PopoverBuilders = {
     const cell = getters.getEvaluatedCell(position);
     const shouldDisplayLink =
       !getters.isDashboard() && cell.link && getters.isVisibleInViewport(position);
-    if (!shouldDisplayLink) return { isOpen: false };
+    if (!shouldDisplayLink) {
+      return { isOpen: false };
+    }
     return {
       isOpen: true,
       Component: LinkDisplay,

--- a/src/components/popover/popover.ts
+++ b/src/components/popover/popover.ts
@@ -81,7 +81,9 @@ export class Popover extends Component<PopoverProps, SpreadsheetChildEnv> {
   }
 
   private computePopoverPosition() {
-    if (!this.containerRect) throw new Error("Popover container is not defined");
+    if (!this.containerRect) {
+      throw new Error("Popover container is not defined");
+    }
     const el = this.popoverRef.el!;
     const contentEl = this.popoverContentRef.el!;
 
@@ -93,7 +95,9 @@ export class Popover extends Component<PopoverProps, SpreadsheetChildEnv> {
     el.style.display = newDisplay;
     this.currentDisplayValue = newDisplay;
 
-    if (!anchor) return;
+    if (!anchor) {
+      return;
+    }
 
     const propsMaxSize = { width: this.props.maxWidth, height: this.props.maxHeight };
     let elDims = {
@@ -238,9 +242,15 @@ abstract class PopoverPositionContext {
     const shouldRenderAtBottom = this.shouldRenderAtBottom(elDims.height);
     const shouldRenderAtRight = this.shouldRenderAtRight(elDims.width);
 
-    if (shouldRenderAtBottom && shouldRenderAtRight) return "bottom-right";
-    if (shouldRenderAtBottom && !shouldRenderAtRight) return "bottom-left";
-    if (!shouldRenderAtBottom && shouldRenderAtRight) return "top-right";
+    if (shouldRenderAtBottom && shouldRenderAtRight) {
+      return "bottom-right";
+    }
+    if (shouldRenderAtBottom && !shouldRenderAtRight) {
+      return "bottom-left";
+    }
+    if (!shouldRenderAtBottom && shouldRenderAtRight) {
+      return "top-right";
+    }
     return "top-left";
   }
 }

--- a/src/components/side_panel/carousel_panel/carousel_panel.ts
+++ b/src/components/side_panel/carousel_panel/carousel_panel.ts
@@ -118,7 +118,9 @@ export class CarouselPanel extends Component<Props, SpreadsheetChildEnv> {
   }
 
   popOutCarouselItem(item: CarouselItem) {
-    if (item.type !== "chart") return;
+    if (item.type !== "chart") {
+      return;
+    }
     this.env.model.dispatch("POPOUT_CHART_FROM_CAROUSEL", {
       sheetId: this.carouselSheetId,
       carouselId: this.props.figureId,
@@ -127,7 +129,9 @@ export class CarouselPanel extends Component<Props, SpreadsheetChildEnv> {
   }
 
   duplicateCarouselChart(item: CarouselItem) {
-    if (item.type !== "chart") return;
+    if (item.type !== "chart") {
+      return;
+    }
     this.env.model.dispatch("DUPLICATE_CAROUSEL_CHART", {
       sheetId: this.carouselSheetId,
       carouselId: this.props.figureId,
@@ -137,7 +141,9 @@ export class CarouselPanel extends Component<Props, SpreadsheetChildEnv> {
   }
 
   onDragHandleMouseDown(item: CarouselItem, event: MouseEvent) {
-    if (event.button !== 0) return;
+    if (event.button !== 0) {
+      return;
+    }
     const previewRects = Array.from(this.previewListRef.el!.children).map((previewEl) =>
       getBoundingRectAsPOJO(previewEl)
     );

--- a/src/components/side_panel/chart/building_blocks/series_design/series_design_editor.ts
+++ b/src/components/side_panel/chart/building_blocks/series_design/series_design_editor.ts
@@ -42,7 +42,9 @@ export class SeriesDesignEditor extends Component<Props, SpreadsheetChildEnv> {
 
   updateDataSeriesColor(color: string) {
     const dataSets = this.props.definition.dataSets;
-    if (!dataSets?.[this.state.index]) return;
+    if (!dataSets?.[this.state.index]) {
+      return;
+    }
     dataSets[this.state.index] = {
       ...dataSets[this.state.index],
       backgroundColor: color,
@@ -52,7 +54,9 @@ export class SeriesDesignEditor extends Component<Props, SpreadsheetChildEnv> {
 
   getDataSeriesColor() {
     const dataSets = this.props.definition.dataSets;
-    if (!dataSets?.[this.state.index]) return "";
+    if (!dataSets?.[this.state.index]) {
+      return "";
+    }
     const color = dataSets[this.state.index].backgroundColor;
     return color
       ? toHex(color)
@@ -62,7 +66,9 @@ export class SeriesDesignEditor extends Component<Props, SpreadsheetChildEnv> {
   updateDataSeriesLabel(ev: Event) {
     const label = (ev.target as HTMLInputElement).value;
     const dataSets = this.props.definition.dataSets;
-    if (!dataSets?.[this.state.index]) return;
+    if (!dataSets?.[this.state.index]) {
+      return;
+    }
     dataSets[this.state.index] = {
       ...dataSets[this.state.index],
       label,

--- a/src/components/side_panel/chart/building_blocks/series_design/series_with_axis_design_editor.ts
+++ b/src/components/side_panel/chart/building_blocks/series_design/series_with_axis_design_editor.ts
@@ -141,7 +141,9 @@ export class SeriesWithAxisDesignEditor extends Component<Props, SpreadsheetChil
 
   getDataSeriesColor(index: number) {
     const dataSets = this.props.definition.dataSets;
-    if (!dataSets?.[index]) return "";
+    if (!dataSets?.[index]) {
+      return "";
+    }
     const color = dataSets[index].backgroundColor;
     return color
       ? toHex(color)

--- a/src/components/side_panel/conditional_formatting/cf_preview_list/cf_preview_list.ts
+++ b/src/components/side_panel/conditional_formatting/cf_preview_list/cf_preview_list.ts
@@ -36,7 +36,9 @@ export class ConditionalFormatPreviewList extends Component<Props, SpreadsheetCh
   }
 
   onPreviewMouseDown(cf: ConditionalFormat, event: MouseEvent) {
-    if (event.button !== 0) return;
+    if (event.button !== 0) {
+      return;
+    }
     const previewRects = Array.from(this.cfListRef.el!.children).map((previewEl) =>
       getBoundingRectAsPOJO(previewEl)
     );

--- a/src/components/side_panel/data_validation/data_validation_panel.ts
+++ b/src/components/side_panel/data_validation/data_validation_panel.ts
@@ -22,7 +22,9 @@ export class DataValidationPanel extends Component<Props, SpreadsheetChildEnv> {
   }
 
   localizeDVRule(rule?: DataValidationRule): DataValidationRule | undefined {
-    if (!rule) return rule;
+    if (!rule) {
+      return rule;
+    }
     const locale = this.env.model.getters.getLocale();
     return localizeDataValidationRule(rule, locale);
   }

--- a/src/components/side_panel/settings/settings_panel.ts
+++ b/src/components/side_panel/settings/settings_panel.ts
@@ -24,7 +24,9 @@ export class SettingsPanel extends Component<Props, SpreadsheetChildEnv> {
 
   onLocaleChange(code: LocaleCode) {
     const locale = this.loadedLocales.find((l) => l.code === code);
-    if (!locale) return;
+    if (!locale) {
+      return;
+    }
     this.env.model.dispatch("UPDATE_LOCALE", { locale });
   }
 

--- a/src/components/side_panel/split_to_columns_panel/split_to_columns_panel.ts
+++ b/src/components/side_panel/split_to_columns_panel/split_to_columns_panel.ts
@@ -67,7 +67,9 @@ export class SplitIntoColumnsPanel extends Component<Props, SpreadsheetChildEnv>
   }
 
   updateCustomSeparator(ev: InputEvent) {
-    if (!ev.target) return;
+    if (!ev.target) {
+      return;
+    }
     this.state.customSeparator = (ev.target as HTMLInputElement).value;
   }
 

--- a/src/components/tables/table_resizer/table_resizer.ts
+++ b/src/components/tables/table_resizer/table_resizer.ts
@@ -51,7 +51,9 @@ export class TableResizer extends Component<Props, SpreadsheetChildEnv> {
     const onMouseUp = () => {
       document.body.style.cursor = "";
       const newTableZone = this.state.highlightZone;
-      if (!newTableZone) return;
+      if (!newTableZone) {
+        return;
+      }
       const sheetId = this.props.table.range.sheetId;
       this.env.model.dispatch("RESIZE_TABLE", {
         sheetId,
@@ -73,7 +75,9 @@ export class TableResizer extends Component<Props, SpreadsheetChildEnv> {
   }
 
   get highlights(): Highlight[] {
-    if (!this.state.highlightZone) return [];
+    if (!this.state.highlightZone) {
+      return [];
+    }
     return [
       {
         range: this.env.model.getters.getRangeFromZone(

--- a/src/helpers/figures/charts/runtime/chart_data_extractor.ts
+++ b/src/helpers/figures/charts/runtime/chart_data_extractor.ts
@@ -953,7 +953,9 @@ export function getChartLabelFormat(
   range: Range | undefined,
   shouldRemoveFirstLabel: boolean
 ): Format | undefined {
-  if (!range) return undefined;
+  if (!range) {
+    return undefined;
+  }
 
   const { sheetId, zone } = range;
 
@@ -1022,7 +1024,9 @@ function getChartDatasetFormat(
   for (const ds of dataSets) {
     const formatsInDataset = getters.getRangeFormats(ds.dataRange);
     const format = formatsInDataset.find((f) => f !== undefined && !isDateTimeFormat(f));
-    if (format) return format;
+    if (format) {
+      return format;
+    }
   }
   return undefined;
 }

--- a/src/helpers/figures/charts/runtime/chartjs_dataset.ts
+++ b/src/helpers/figures/charts/runtime/chartjs_dataset.ts
@@ -279,7 +279,9 @@ export function getPieChartDatasets(
   const dataSetsLength = Math.max(0, ...dataSetsValues.map((ds) => ds?.data?.length ?? 0));
   const backgroundColor = getPieColors(new ColorGenerator(dataSetsLength), dataSetsValues);
   for (const { label, data, hidden } of dataSetsValues) {
-    if (hidden) continue;
+    if (hidden) {
+      continue;
+    }
     const dataset: ChartDataset<"pie"> = {
       label,
       data,

--- a/src/helpers/rectangle.ts
+++ b/src/helpers/rectangle.ts
@@ -23,7 +23,9 @@ function rectToZone(rect: Rect): Zone {
 }
 
 function zoneToRect(zone: Zone | undefined): Rect | undefined {
-  if (!zone) return undefined;
+  if (!zone) {
+    return undefined;
+  }
   return {
     x: zone.left,
     y: zone.top,

--- a/src/registries/cell_clickable_registry.ts
+++ b/src/registries/cell_clickable_registry.ts
@@ -26,7 +26,9 @@ clickableCellRegistry.add("link", {
     openLink(env.model.getters.getEvaluatedCell(position).link!, env, isMiddleClick),
   title: (position, getters) => {
     const link = getters.getEvaluatedCell(position).link;
-    if (!link) return "";
+    if (!link) {
+      return "";
+    }
     if (link.isExternal) {
       return _t("Go to url: %(url)s", { url: link.url });
     } else {

--- a/src/registries/menu_items_registry.ts
+++ b/src/registries/menu_items_registry.ts
@@ -64,7 +64,9 @@ export class MenuItemRegistry extends Registry<ActionSpec> {
     if ("id" in value) {
       const valueIndex = children.findIndex((elt) => "id" in elt && elt.id === value.id);
       if (valueIndex > -1) {
-        if (!options.force) throw new Error(`A child with the id "${value.id}" already exists.`);
+        if (!options.force) {
+          throw new Error(`A child with the id "${value.id}" already exists.`);
+        }
         node.children.splice(valueIndex, 1, value);
         return this;
       }

--- a/src/stores/grid_renderer_store.ts
+++ b/src/stores/grid_renderer_store.ts
@@ -197,7 +197,9 @@ export class GridRenderer extends SpreadsheetStore {
 
     if (areGridLinesVisible) {
       for (const box of boxes) {
-        if (box.skipCellGridLines) continue;
+        if (box.skipCellGridLines) {
+          continue;
+        }
         ctx.strokeStyle = CELL_BORDER_COLOR;
         ctx.lineWidth = thinLineWidth;
         ctx.strokeRect(box.x + inset, box.y + inset, box.width - 2 * inset, box.height - 2 * inset);

--- a/tests/autofill/autofill_component.test.ts
+++ b/tests/autofill/autofill_component.test.ts
@@ -405,7 +405,9 @@ describe("Autofill edge scrolling", () => {
 });
 
 function isVisibleInViewport(element: HTMLElement | null, model: Model) {
-  if (element === null) return false;
+  if (element === null) {
+    return false;
+  }
   const activeSheetViewDimension = model.getters.getSheetViewDimensionWithHeaders();
   const top = getStylePropertyInPx(element, "top") || -Infinity;
   const left = getStylePropertyInPx(element, "left") || -Infinity;

--- a/tests/bottom_bar/bottom_bar_component.test.ts
+++ b/tests/bottom_bar/bottom_bar_component.test.ts
@@ -500,7 +500,9 @@ describe("BottomBar component", () => {
     jest
       .spyOn(Element.prototype, "clientWidth", "get")
       .mockImplementation(function (this: HTMLDivElement) {
-        if (this.classList.contains("o-sheet-list")) return 300;
+        if (this.classList.contains("o-sheet-list")) {
+          return 300;
+        }
         return 0;
       });
 
@@ -893,8 +895,11 @@ describe("BottomBar component", () => {
       extendMockGetBoundingClientRect({
         "o-sheet-list": () => ({ x: 0, width: 500 }),
         "o-sheet": (el: HTMLElement) => {
-          if (el.dataset.id === "Sheet1") return { x: 0, width: 100 };
-          else if (el.dataset.id === "Sheet2") return { x: 100, width: 300 };
+          if (el.dataset.id === "Sheet1") {
+            return { x: 0, width: 100 };
+          } else if (el.dataset.id === "Sheet2") {
+            return { x: 100, width: 300 };
+          }
           return { x: model.getters.getSheetIds().indexOf(el.dataset.id!) * 100 + 200, width: 100 };
         },
       });

--- a/tests/grid/grid_component.test.ts
+++ b/tests/grid/grid_component.test.ts
@@ -1837,7 +1837,9 @@ describe("Copy paste keyboard shortcut", () => {
     document.body.dispatchEvent(getClipboardEvent("copy", clipboardData));
     await nextTick();
     const clipboard = await parent.env.clipboard.read!();
-    if (clipboard.status === "ok") clipboardData.content = clipboard.content;
+    if (clipboard.status === "ok") {
+      clipboardData.content = clipboard.content;
+    }
     const clipboardContent = clipboardData.content;
     const cbPlugin = getPlugin(model, ClipboardPlugin);
     //@ts-ignore
@@ -1858,7 +1860,9 @@ describe("Copy paste keyboard shortcut", () => {
     document.body.dispatchEvent(getClipboardEvent("cut", clipboardData));
     await nextTick();
     const clipboard = await parent.env.clipboard.read!();
-    if (clipboard.status === "ok") clipboardData.content = clipboard.content;
+    if (clipboard.status === "ok") {
+      clipboardData.content = clipboard.content;
+    }
     const clipboardContent = clipboardData.content;
     const cbPlugin = getPlugin(model, ClipboardPlugin);
     //@ts-ignore
@@ -1881,7 +1885,9 @@ describe("Copy paste keyboard shortcut", () => {
     document.body.dispatchEvent(getClipboardEvent("cut", clipboardData));
     await nextTick();
     const clipboard = await parent.env.clipboard.read!();
-    if (clipboard.status === "ok") clipboardData.content = clipboard.content;
+    if (clipboard.status === "ok") {
+      clipboardData.content = clipboard.content;
+    }
     setCellContent(model, "A1", "new content");
     setStyle(model, "A1", { bold: false });
     selectCell(model, "A2");
@@ -1899,7 +1905,9 @@ describe("Copy paste keyboard shortcut", () => {
     document.body.dispatchEvent(getClipboardEvent("cut", clipboardData));
     await nextTick();
     const clipboard = await parent.env.clipboard.read!();
-    if (clipboard.status === "ok") clipboardData.content = clipboard.content;
+    if (clipboard.status === "ok") {
+      clipboardData.content = clipboard.content;
+    }
     const clipboardContent = clipboardData.content;
     expect(clipboardContent[ClipboardMIMEType.PlainText]).toEqual(getCellContent(model, "A1"));
     model.dispatch("SET_FORMULA_VISIBILITY", { show: false });
@@ -1915,7 +1923,9 @@ describe("Copy paste keyboard shortcut", () => {
     document.body.dispatchEvent(getClipboardEvent("cut", clipboardData));
     await nextTick();
     let clipboard = await parent.env.clipboard.read!();
-    if (clipboard.status === "ok") clipboardData.content = clipboard.content;
+    if (clipboard.status === "ok") {
+      clipboardData.content = clipboard.content;
+    }
     let clipboardContent = clipboardData.content;
     expect(clipboardContent[ClipboardMIMEType.PlainText]).toEqual(
       getEvaluatedCell(model, "A1").formattedValue
@@ -1931,7 +1941,9 @@ describe("Copy paste keyboard shortcut", () => {
     document.body.dispatchEvent(getClipboardEvent("cut", clipboardData));
     await nextTick();
     clipboard = await parent.env.clipboard.read!();
-    if (clipboard.status === "ok") clipboardData.content = clipboard.content;
+    if (clipboard.status === "ok") {
+      clipboardData.content = clipboard.content;
+    }
     clipboardContent = clipboardData.content;
     expect(clipboardContent[ClipboardMIMEType.PlainText]).toEqual(
       getEvaluatedCell(model, "B1").formattedValue
@@ -1952,7 +1964,9 @@ describe("Copy paste keyboard shortcut", () => {
     document.body.dispatchEvent(ev);
     await nextTick();
     const clipboard = await parent.env.clipboard.read!();
-    if (clipboard.status === "ok") clipboardData.content = clipboard.content;
+    if (clipboard.status === "ok") {
+      clipboardData.content = clipboard.content;
+    }
     // Fake OS clipboard should have the same content
     // to make paste come from spreadsheet clipboard
     // which support paste as values
@@ -2054,7 +2068,9 @@ describe("Copy paste keyboard shortcut", () => {
     document.body.dispatchEvent(getClipboardEvent("copy", clipboardData));
     await nextTick();
     const clipboard = await parent.env.clipboard.read!();
-    if (clipboard.status === "ok") clipboardData.content = clipboard.content;
+    if (clipboard.status === "ok") {
+      clipboardData.content = clipboard.content;
+    }
     const clipboardContent = clipboardData.content;
     expect(clipboardContent).toMatchObject({
       "text/plain": "\t",
@@ -2071,7 +2087,9 @@ describe("Copy paste keyboard shortcut", () => {
     document.body.dispatchEvent(getClipboardEvent("cut", clipboardData));
     await nextTick();
     const clipboard = await parent.env.clipboard.read!();
-    if (clipboard.status === "ok") clipboardData.content = clipboard.content;
+    if (clipboard.status === "ok") {
+      clipboardData.content = clipboard.content;
+    }
     const clipboardContent = clipboardData.content;
     expect(clipboardContent).toMatchObject({
       "text/plain": "\t",

--- a/tests/menus/context_menu_component.test.ts
+++ b/tests/menus/context_menu_component.test.ts
@@ -212,7 +212,9 @@ beforeEach(() => {
       const parentPosition = getElPosition(el.parentElement!.parentElement!);
       let offset = MENU_VERTICAL_PADDING;
       for (const e of el.parentElement!.children) {
-        if (e === el) break;
+        if (e === el) {
+          break;
+        }
 
         if (el.classList.contains("o-menu-item")) {
           offset += DESKTOP_MENU_ITEM_HEIGHT;

--- a/tests/renderer/renderer_store.test.ts
+++ b/tests/renderer/renderer_store.test.ts
@@ -1824,7 +1824,9 @@ describe("renderer", () => {
     function getCellOverflowingBackgroundDims() {
       // first draw of white rectangle is the spreadsheet's background
       const instruction = fillWhiteRectInstructions[1];
-      if (!instruction) return undefined;
+      if (!instruction) {
+        return undefined;
+      }
       return {
         x: instruction[0],
         y: instruction[1],
@@ -1844,7 +1846,9 @@ describe("renderer", () => {
           drawingWhiteBackground = key === "fillStyle" && toHex(value) === "#FFFFFF";
         },
         onFunctionCall: (key, args) => {
-          if (key !== "fillRect" || !drawingWhiteBackground) return;
+          if (key !== "fillRect" || !drawingWhiteBackground) {
+            return;
+          }
           fillWhiteRectInstructions.push(args);
         },
       });

--- a/tests/test_helpers/dom_helper.ts
+++ b/tests/test_helpers/dom_helper.ts
@@ -303,7 +303,9 @@ export function triggerKeyboardEvent(
 function dispatchEvent(selector: string | EventTarget, ev: Event) {
   if (typeof selector === "string") {
     const el = document.querySelector(selector);
-    if (!el) throw new Error(`"${selector}" does not match any element.`);
+    if (!el) {
+      throw new Error(`"${selector}" does not match any element.`);
+    }
     el.dispatchEvent(ev);
   } else {
     selector.dispatchEvent(ev);
@@ -383,7 +385,9 @@ export function getElComputedStyle(selector: DOMTarget, style: string): string {
 
 export function getElStyle(selector: string, style: string): string {
   const element = document.querySelector<HTMLElement>(selector);
-  if (!element) throw new Error(`No element matching selector "${selector}"`);
+  if (!element) {
+    throw new Error(`No element matching selector "${selector}"`);
+  }
   return element.style[style];
 }
 
@@ -501,7 +505,9 @@ export function triggerTouchEvent(
   extra: Partial<Touch>
 ) {
   const target = typeof selector === "string" ? document.querySelector(selector) : selector;
-  if (!target) throw new Error(`"${selector}" does not match any element.`);
+  if (!target) {
+    throw new Error(`"${selector}" does not match any element.`);
+  }
 
   const ev = new TouchEvent(type, {
     cancelable: true,

--- a/tests/test_helpers/helpers.ts
+++ b/tests/test_helpers/helpers.ts
@@ -426,21 +426,27 @@ export function getGridStyle(model: Model): GridStyleDescr {
 
 export function setGrid(model: Model, grid: GridDescr) {
   for (const [xc, value] of Object.entries(grid)) {
-    if (value === undefined) continue;
+    if (value === undefined) {
+      continue;
+    }
     setCellContent(model, xc, value);
   }
 }
 
 export function setGridFormat(model: Model, grid: GridFormatDescr) {
   for (const [xc, format] of Object.entries(grid)) {
-    if (format === undefined) continue;
+    if (format === undefined) {
+      continue;
+    }
     setFormat(model, xc, format);
   }
 }
 
 export function setGridStyle(model: Model, grid: GridStyleDescr) {
   for (const [xc, style] of Object.entries(grid)) {
-    if (style === undefined) continue;
+    if (style === undefined) {
+      continue;
+    }
     setStyle(model, xc, style);
   }
 }
@@ -645,7 +651,9 @@ export function XCToMergeCellMap(
   for (const mergeXC of mergeXCList) {
     const { col, row } = toCartesian(mergeXC);
     const merge = model.getters.getMerge({ sheetId, col, row });
-    if (!mergeCellMap[col]) mergeCellMap[col] = [];
+    if (!mergeCellMap[col]) {
+      mergeCellMap[col] = [];
+    }
     mergeCellMap[col][row] = merge ? merge.id : undefined;
   }
   return mergeCellMap;
@@ -847,7 +855,9 @@ function insertText(el: HTMLElement, text: string) {
  */
 export function textContentAll(cssSelector: string): string[] {
   const nodes = document.querySelectorAll(cssSelector);
-  if (!nodes) return [];
+  if (!nodes) {
+    return [];
+  }
   return [...nodes].map((node) => node.textContent).filter((text): text is string => text !== null);
 }
 
@@ -963,9 +973,15 @@ export const mockGeoJsonService: ModelExternalConfig["geoJsonService"] = {
     ],
   }),
   geoFeatureNameToId: (region: string, territoryName: string) => {
-    if (territoryName === "France") return "FR";
-    if (territoryName === "Germany") return "DE";
-    if (territoryName === "Spain") return "ES";
+    if (territoryName === "France") {
+      return "FR";
+    }
+    if (territoryName === "Germany") {
+      return "DE";
+    }
+    if (territoryName === "Spain") {
+      return "ES";
+    }
     return "";
   },
 };
@@ -1065,7 +1081,9 @@ export function getFigureDefinition(
 /** Extract a property of the style of the given html element and return its size in pixel */
 export function getStylePropertyInPx(el: HTMLElement, property: string): number | undefined {
   const styleProperty = el.style[property] as string;
-  if (!styleProperty) return undefined;
+  if (!styleProperty) {
+    return undefined;
+  }
   return Number(styleProperty.replace("px", ""));
 }
 

--- a/tests/test_helpers/mock_helpers.ts
+++ b/tests/test_helpers/mock_helpers.ts
@@ -48,14 +48,18 @@ function populateDOMRect(partialRect: Partial<DOMRect>): Partial<DOMRect> {
   rect.y = rect.y ?? rect.top;
   rect.left = rect.left ?? rect.x;
   rect.top = rect.top ?? rect.y;
-  if (rect.width !== undefined && rect.x !== undefined && !rect.right)
+  if (rect.width !== undefined && rect.x !== undefined && !rect.right) {
     rect.right = rect.x + rect.width;
-  if (rect.height !== undefined && rect.y !== undefined && !rect.bottom)
+  }
+  if (rect.height !== undefined && rect.y !== undefined && !rect.bottom) {
     rect.bottom = rect.y + rect.height;
-  if (rect.left !== undefined && rect.right !== undefined && !rect.width)
+  }
+  if (rect.left !== undefined && rect.right !== undefined && !rect.width) {
     rect.width = rect.right - rect.left;
-  if (rect.top !== undefined && rect.bottom !== undefined && !rect.height)
+  }
+  if (rect.top !== undefined && rect.bottom !== undefined && !rect.height) {
     rect.height = rect.bottom - rect.top;
+  }
 
   return rect;
 }


### PR DESCRIPTION
patterns like `if (foo) foo++;`, `if (foo) continue;` or `if (foo) return;` are less readable then the version with braces.

`continue` or `return` are easy to miss when it's too far right on the line after a long `if (...a long condition...)`

It also improves code style consistency across the codebase, which always improves readability.

I changed the order of eslint and prettier in the precommit hook. because eslint rewrites `if (foo) return;` to `if (foo) {return;}`, which then needs to be prettified.

> [!TIP]
> **The pre-commit hook automatically re-writes the pattern**. FLDA, you can still write one-liner :wink: 

I'm sorry FLDA and ADRM (but not really sorry)

Task: 0

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo