### PR TITLE
[FIX] chart: ignore NoChanges in gauge/scorecard side panel errors

### DIFF
--- a/src/components/side_panel/chart/gauge_chart_panel/gauge_chart_config_panel.ts
+++ b/src/components/side_panel/chart/gauge_chart_panel/gauge_chart_config_panel.ts
@@ -39,7 +39,9 @@ export class GaugeChartConfigPanel extends Component<Props, SpreadsheetChildEnv>
   private dataRange: string | undefined = this.props.definition.dataRange;
 
   get configurationErrorMessages(): string[] {
-    const cancelledReasons = [...(this.state.dataRangeDispatchResult?.reasons || [])];
+    const cancelledReasons = [...(this.state.dataRangeDispatchResult?.reasons || [])].filter(
+      (reason) => reason !== CommandResult.NoChanges
+    );
     return cancelledReasons.map(
       (error) => ChartTerms.Errors[error] || ChartTerms.Errors.Unexpected
     );

--- a/src/components/side_panel/chart/gauge_chart_panel/gauge_chart_design_panel.ts
+++ b/src/components/side_panel/chart/gauge_chart_panel/gauge_chart_design_panel.ts
@@ -101,7 +101,9 @@ export class GaugeChartDesignPanel extends Component<Props, SpreadsheetChildEnv>
   }
 
   get designErrorMessages(): string[] {
-    const cancelledReasons = [...(this.state.sectionRuleCancelledReasons || [])];
+    const cancelledReasons = [...(this.state.sectionRuleCancelledReasons || [])].filter(
+      (reason) => reason !== CommandResult.NoChanges
+    );
     return cancelledReasons.map(
       (error) => ChartTerms.Errors[error] || ChartTerms.Errors.Unexpected
     );

--- a/src/components/side_panel/chart/scorecard_chart_panel/scorecard_chart_config_panel.ts
+++ b/src/components/side_panel/chart/scorecard_chart_panel/scorecard_chart_config_panel.ts
@@ -40,7 +40,7 @@ export class ScorecardChartConfigPanel extends Component<Props, SpreadsheetChild
     const cancelledReasons = [
       ...(this.state.keyValueDispatchResult?.reasons || []),
       ...(this.state.baselineDispatchResult?.reasons || []),
-    ];
+    ].filter((reason) => reason !== CommandResult.NoChanges);
     return cancelledReasons.map(
       (error) => ChartTerms.Errors[error] || ChartTerms.Errors.Unexpected
     );

--- a/tests/figures/chart/charts_component.test.ts
+++ b/tests/figures/chart/charts_component.test.ts
@@ -1346,6 +1346,16 @@ describe("charts", () => {
       }
     );
 
+    test("Scorecard > no error when confirming unchanged key value", async () => {
+      createTestChart("scorecard");
+      await mountChartSidePanel();
+
+      expect(errorMessages()).toEqual([]);
+      await simulateClick(".o-data-series input");
+      await simulateClick(".o-data-series .o-selection-ok");
+      expect(errorMessages()).toEqual([]);
+    });
+
     test("Scorecard > error displayed on input fields", async () => {
       createTestChart("scorecard");
       await mountChartSidePanel();

--- a/tests/figures/chart/gauge/gauge_panel_component.test.ts
+++ b/tests/figures/chart/gauge/gauge_panel_component.test.ts
@@ -25,6 +25,13 @@ beforeEach(async () => {
   await openChartConfigSidePanel(model, env, chartId);
 });
 
+test("No error when confirming unchanged data range", async () => {
+  expect(textContentAll(".o-validation-error")).toHaveLength(0);
+  await simulateClick(".o-data-series input");
+  await simulateClick(".o-data-series .o-selection-ok");
+  expect(textContentAll(".o-validation-error")).toHaveLength(0);
+});
+
 test("Can change gauge inflection operator", async () => {
   await openChartDesignSidePanel(model, env, fixture, chartId);
   expect(model.getters.getChartDefinition(chartId)).toMatchObject({


### PR DESCRIPTION
## Description:

Regression from PR #6298, which added `checkChartChanged` so `UPDATE_CHART` returns `CommandResult.NoChanges` on no‑op updates to avoid extra history steps.

The side panels map any cancelled reason to a user‑facing error and did not exclude `NoChanges`, so confirming an unchanged range surfaced "The chart definition is invalid for an unknown reason."

Filter `NoChanges` out of gauge config/design and scorecard error messages so no‑op confirms do not show errors, and add UI tests for unchanged confirms.

Task: [5478288](https://www.odoo.com/odoo/2328/tasks/5478288)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo