### PR TITLE
[IMP] added shortcut in the ActionSpec

### DIFF
--- a/src/actions/action.ts
+++ b/src/actions/action.ts
@@ -12,6 +12,7 @@ export interface ActionSpec {
    */
   name: string | ((env: SpreadsheetChildEnv) => string);
   description?: string | ((env: SpreadsheetChildEnv) => string);
+  shortcut?: string;
   /**
    * which represents its position inside the
    * menus (the lower sequence it has, the upper it is in the menu)
@@ -69,6 +70,7 @@ export interface ActionSpec {
 export interface Action {
   name: (env: SpreadsheetChildEnv) => string;
   description: (env: SpreadsheetChildEnv) => string;
+  shortcut: string;
   sequence: number;
   id: string;
   isVisible: (env: SpreadsheetChildEnv) => boolean;
@@ -99,6 +101,7 @@ export function createAction(item: ActionSpec): Action {
   const name = item.name;
   const children = item.children;
   const description = item.description;
+  const shortcut = item.shortcut;
   const icon = item.icon;
   const secondaryIcon = item.secondaryIcon;
   const itemId = item.id || nextItemId++;
@@ -131,6 +134,7 @@ export function createAction(item: ActionSpec): Action {
     iconColor: item.iconColor,
     secondaryIcon: typeof secondaryIcon === "function" ? secondaryIcon : () => secondaryIcon || "",
     description: typeof description === "function" ? description : () => description || "",
+    shortcut: shortcut || "",
     textColor: item.textColor,
     sequence: item.sequence || 0,
     onStartHover: item.onStartHover,

--- a/src/actions/edit_actions.ts
+++ b/src/actions/edit_actions.ts
@@ -9,7 +9,7 @@ import * as ACTIONS from "./menu_items_actions";
 
 export const undo: ActionSpec = {
   name: _t("Undo"),
-  description: "Ctrl+Z",
+  shortcut: "Ctrl+Z",
   execute: (env) => env.model.dispatch("REQUEST_UNDO"),
   isEnabled: (env) => env.model.getters.canUndo(),
   icon: "o-spreadsheet-Icon.UNDO",
@@ -17,7 +17,7 @@ export const undo: ActionSpec = {
 
 export const redo: ActionSpec = {
   name: _t("Redo"),
-  description: "Ctrl+Y",
+  shortcut: "Ctrl+Y",
   execute: (env) => env.model.dispatch("REQUEST_REDO"),
   isEnabled: (env) => env.model.getters.canRedo(),
   icon: "o-spreadsheet-Icon.REDO",
@@ -25,7 +25,7 @@ export const redo: ActionSpec = {
 
 export const copy: ActionSpec = {
   name: _t("Copy"),
-  description: "Ctrl+C",
+  shortcut: "Ctrl+C",
   isReadonlyAllowed: true,
   execute: async (env) => {
     env.model.dispatch("COPY");
@@ -36,7 +36,7 @@ export const copy: ActionSpec = {
 
 export const cut: ActionSpec = {
   name: _t("Cut"),
-  description: "Ctrl+X",
+  shortcut: "Ctrl+X",
   execute: async (env) => {
     interactiveCut(env);
     await env.clipboard.write(await env.model.getters.getClipboardTextAndImageContent());
@@ -46,7 +46,7 @@ export const cut: ActionSpec = {
 
 export const paste: ActionSpec = {
   name: _t("Paste"),
-  description: "Ctrl+V",
+  shortcut: "Ctrl+V",
   execute: ACTIONS.PASTE_ACTION,
   icon: "o-spreadsheet-Icon.PASTE",
 };
@@ -61,7 +61,7 @@ export const pasteSpecial: ActionSpec = {
 
 export const pasteSpecialValue: ActionSpec = {
   name: _t("Paste as value"),
-  description: "Ctrl+Shift+V",
+  shortcut: "Ctrl+Shift+V",
   execute: ACTIONS.PASTE_AS_VALUE_ACTION,
 };
 
@@ -72,7 +72,7 @@ export const pasteSpecialFormat: ActionSpec = {
 
 export const findAndReplace: ActionSpec = {
   name: _t("Find and replace"),
-  description: "Ctrl+H",
+  shortcut: "Ctrl+H",
   isReadonlyAllowed: true,
   execute: (env) => {
     env.openSidePanel("FindAndReplace", {});

--- a/src/actions/figure_menu_actions.ts
+++ b/src/actions/figure_menu_actions.ts
@@ -182,7 +182,7 @@ function getCopyMenuItem(
   return {
     id: "copy",
     name: _t("Copy"),
-    description: "Ctrl+C",
+    shortcut: "Ctrl+C",
     execute: async () => {
       env.model.dispatch("SELECT_FIGURE", { figureId });
       env.model.dispatch("COPY");
@@ -200,7 +200,7 @@ function getCutMenuItem(figureId: UID, env: SpreadsheetChildEnv): ActionSpec {
   return {
     id: "cut",
     name: _t("Cut"),
-    description: "Ctrl+X",
+    shortcut: "Ctrl+X",
     execute: async () => {
       env.model.dispatch("SELECT_FIGURE", { figureId });
       env.model.dispatch("CUT");

--- a/src/actions/format_actions.ts
+++ b/src/actions/format_actions.ts
@@ -188,7 +188,7 @@ export const decreaseDecimalPlaces: ActionSpec = {
 
 export const formatBold: ActionSpec = {
   name: _t("Bold"),
-  description: "Ctrl+B",
+  shortcut: "Ctrl+B",
   execute: (env) => setStyle(env, { bold: !env.model.getters.getCurrentStyle().bold }),
   icon: "o-spreadsheet-Icon.BOLD",
   isActive: (env) => !!env.model.getters.getCurrentStyle().bold,
@@ -196,7 +196,7 @@ export const formatBold: ActionSpec = {
 
 export const formatItalic: ActionSpec = {
   name: _t("Italic"),
-  description: "Ctrl+I",
+  shortcut: "Ctrl+I",
   execute: (env) => setStyle(env, { italic: !env.model.getters.getCurrentStyle().italic }),
   icon: "o-spreadsheet-Icon.ITALIC",
   isActive: (env) => !!env.model.getters.getCurrentStyle().italic,
@@ -204,7 +204,7 @@ export const formatItalic: ActionSpec = {
 
 export const formatUnderline: ActionSpec = {
   name: _t("Underline"),
-  description: "Ctrl+U",
+  shortcut: "Ctrl+U",
   execute: (env) => setStyle(env, { underline: !env.model.getters.getCurrentStyle().underline }),
   icon: "o-spreadsheet-Icon.UNDERLINE",
   isActive: (env) => !!env.model.getters.getCurrentStyle().underline,
@@ -289,7 +289,7 @@ export const formatAlignmentHorizontal: ActionSpec = {
 
 export const formatAlignmentLeft: ActionSpec = {
   name: _t("Left"),
-  description: "Ctrl+Shift+L",
+  shortcut: "Ctrl+Shift+L",
   execute: (env) => ACTIONS.setStyle(env, { align: "left" }),
   isActive: (env) => getHorizontalAlign(env) === "left",
   icon: "o-spreadsheet-Icon.ALIGN_LEFT",
@@ -297,7 +297,7 @@ export const formatAlignmentLeft: ActionSpec = {
 
 export const formatAlignmentCenter: ActionSpec = {
   name: _t("Center"),
-  description: "Ctrl+Shift+E",
+  shortcut: "Ctrl+Shift+E",
   execute: (env) => ACTIONS.setStyle(env, { align: "center" }),
   isActive: (env) => getHorizontalAlign(env) === "center",
   icon: "o-spreadsheet-Icon.ALIGN_CENTER",
@@ -305,7 +305,7 @@ export const formatAlignmentCenter: ActionSpec = {
 
 export const formatAlignmentRight: ActionSpec = {
   name: _t("Right"),
-  description: "Ctrl+Shift+R",
+  shortcut: "Ctrl+Shift+R",
   execute: (env) => ACTIONS.setStyle(env, { align: "right" }),
   isActive: (env) => getHorizontalAlign(env) === "right",
   icon: "o-spreadsheet-Icon.ALIGN_RIGHT",
@@ -387,7 +387,7 @@ export const formatCF: ActionSpec = {
 
 export const clearFormat: ActionSpec = {
   name: _t("Clear formatting"),
-  description: "Ctrl+<",
+  shortcut: "Ctrl+<",
   execute: (env) =>
     env.model.dispatch("CLEAR_FORMATTING", {
       sheetId: env.model.getters.getActiveSheetId(),

--- a/src/actions/insert_actions.ts
+++ b/src/actions/insert_actions.ts
@@ -194,7 +194,7 @@ export const insertPivot: ActionSpec = {
 
 export const insertImage: ActionSpec = {
   name: _t("Image"),
-  description: "Ctrl+O",
+  shortcut: "Ctrl+O",
   execute: ACTIONS.CREATE_IMAGE,
   isVisible: (env) => env.imageProvider !== undefined,
   isEnabled: (env) => !env.isSmall,

--- a/src/components/action_button/action_button.ts
+++ b/src/components/action_button/action_button.ts
@@ -45,7 +45,7 @@ export class ActionButton extends Component<Props, SpreadsheetChildEnv> {
 
   get title() {
     const name = this.actionButton.name(this.env);
-    const description = this.actionButton.description(this.env);
+    const description = this.actionButton.description(this.env) || this.actionButton.shortcut;
     return name + (description ? ` (${description})` : "");
   }
 

--- a/src/components/menu/menu.xml
+++ b/src/components/menu/menu.xml
@@ -33,7 +33,7 @@
                 <t t-if="getIconName(menuItem)" t-call="{{getIconName(menuItem)}}"/>
               </div>
               <div class="o-menu-item-name align-middle text-truncate" t-esc="getName(menuItem)"/>
-              <t t-set="description" t-value="menuItem.description(env)"/>
+              <t t-set="description" t-value="menuItem.description(env) or menuItem.shortcut"/>
               <div
                 t-if="description"
                 class="o-menu-item-description ms-auto text-truncate"


### PR DESCRIPTION
## Description:

In order to add the shortcuts in the menu when using  Ctrl+K in Odoo, we needed to add shortcut additionaly to description in the ActionSpec

Task: [5474239](https://www.odoo.com/odoo/2328/tasks/5474239)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo