### PR TITLE
[FIX] pivot: ensure pivot reevaluation occurs after evaluation

### DIFF
--- a/src/helpers/pivot/pivot_registry.ts
+++ b/src/helpers/pivot/pivot_registry.ts
@@ -32,6 +32,7 @@ export interface PivotRegistryItem {
   datetimeGranularities: string[];
   isMeasureCandidate: (field: PivotField) => boolean;
   isGroupable: (field: PivotField) => boolean;
+  isGridDependent: boolean;
   adaptRanges?: (
     getters: CoreGetters,
     definition: PivotCoreDefinition,
@@ -59,6 +60,7 @@ pivotRegistry.add("SPREADSHEET", {
   datetimeGranularities: [...dateGranularities, "hour_number", "minute_number", "second_number"],
   isMeasureCandidate: (field: PivotField) => !["datetime", "boolean"].includes(field.type),
   isGroupable: () => true,
+  isGridDependent: true,
   adaptRanges: (getters, definition, applyChange) => {
     if (definition.type !== "SPREADSHEET" || !definition.dataSet) {
       return definition;

--- a/src/helpers/pivot/spreadsheet_pivot/spreadsheet_pivot.ts
+++ b/src/helpers/pivot/spreadsheet_pivot/spreadsheet_pivot.ts
@@ -100,6 +100,11 @@ export class SpreadsheetPivot implements Pivot<SpreadsheetPivotRuntimeDefinition
    */
   needsReevaluation: boolean = true;
 
+  /**
+   * Marks the type of reload that should be done on next init
+   */
+  private reloadType: ReloadType = ReloadType.ALL;
+
   constructor(custom: ModelConfig["custom"], params: SpreadsheetPivotParams) {
     this.getters = params.getters;
     this.coreDefinition = params.definition;
@@ -107,9 +112,13 @@ export class SpreadsheetPivot implements Pivot<SpreadsheetPivotRuntimeDefinition
 
   init(params: InitPivotParams = {}) {
     if (!this._definition || params.reload) {
-      this.reload(ReloadType.ALL);
+      this.reloadType = ReloadType.ALL;
+    }
+    this.reload(this.reloadType);
+    if (params.reload) {
       this.needsReevaluation = false;
     }
+    this.reloadType = ReloadType.NONE;
   }
 
   reload(type: ReloadType) {
@@ -135,7 +144,7 @@ export class SpreadsheetPivot implements Pivot<SpreadsheetPivotRuntimeDefinition
         this.computeShouldReload(actualDefinition, nextDefinition),
         ReloadType.NONE
       );
-      this.reload(reloadType);
+      this.reloadType = Math.max(this.reloadType, reloadType);
     }
   }
 

--- a/src/plugins/ui_core_views/pivot_ui.ts
+++ b/src/plugins/ui_core_views/pivot_ui.ts
@@ -115,6 +115,18 @@ export class PivotUIPlugin extends UIPlugin {
     }
   }
 
+  finalize() {
+    for (const pivotId of this.getters.getPivotIds()) {
+      if (
+        this.getters.isExistingPivot(pivotId) &&
+        this.getters.isPivotUnused(pivotId) &&
+        pivotRegistry.get(this.getters.getPivotCoreDefinition(pivotId).type)?.isGridDependent
+      ) {
+        this.getters.getPivot(pivotId).init();
+      }
+    }
+  }
+
   // ---------------------------------------------------------------------
   // Getters
   // ---------------------------------------------------------------------

--- a/tests/pivots/spreadsheet_pivot/spreadsheet_pivot.test.ts
+++ b/tests/pivots/spreadsheet_pivot/spreadsheet_pivot.test.ts
@@ -4,6 +4,7 @@ import { DEFAULT_LOCALES } from "../../../src/types/locale";
 import {
   addRows,
   createSheet,
+  deleteColumns,
   deleteContent,
   deleteSheet,
   redo,
@@ -2311,5 +2312,23 @@ describe("Spreadsheet arguments parsing", () => {
       ["",            "Price",  "Price", "Price"],
       ["Total",       "10",     "20",    "30"],
     ]);
+  });
+
+  test("Pivot is reevaluated even if there is no pivot cell (it could have a sidepanel)", () => {
+    // prettier-ignore
+    const grid = {
+      A1: "Customer", B1: "Amount", C1: 'Price',
+      A2: "Alice",    B2: "10",     C2: '10',
+      A3: "Bob",      B3: "30",     C3: '30',
+    };
+    const model = createModelFromGrid(grid);
+    addPivot(model, "A1:C3", {
+      columns: [{ fieldName: "Customer" }],
+      rows: [{ fieldName: "Price" }],
+      measures: [{ id: "amount:sum", fieldName: "Amount", aggregator: "sum" }],
+    });
+    expect(model.getters.getPivot("1").getMeasure("amount:sum").isValid).toBe(true);
+    deleteColumns(model, ["B"]);
+    expect(model.getters.getPivot("1").getMeasure("amount:sum").isValid).toBe(false);
   });
 });

--- a/tests/pivots/spreadsheet_pivot/spreadsheet_pivot_side_panel.test.ts
+++ b/tests/pivots/spreadsheet_pivot/spreadsheet_pivot_side_panel.test.ts
@@ -7,6 +7,7 @@ import { NotificationStore } from "../../../src/stores/notification_store";
 import {
   activateSheet,
   createSheet,
+  deleteColumns,
   selectCell,
   setCellContent,
   setViewportOffset,
@@ -755,5 +756,17 @@ describe("Spreadsheet pivot side panel", () => {
     env.openSidePanel("PivotSidePanel", { pivotId: "1" });
     await nextTick();
     expect(1).toBe(1);
+  });
+
+  test("Pivot is reevaluated if there is no pivot cell but the side panel opened", async () => {
+    updatePivot(model, "1", {
+      columns: [],
+      measures: [{ id: "Product:sum", fieldName: "Product", aggregator: "sum" }],
+    });
+    // Force evaluation
+    model.getters.getPivot("1").init({ reload: true });
+    expect(model.getters.getPivot("1").getMeasure("Product:sum").isValid).toBe(true);
+    deleteColumns(model, ["B"]);
+    expect(model.getters.getPivot("1").getMeasure("Product:sum").isValid).toBe(false);
   });
 });


### PR DESCRIPTION
Before this commit, when a pivot's definition changed, the pivot was immediately reloaded during the definition change handling. This could lead to issues where the pivot was re-evaluated before the overall spreadsheet evaluation was complete, potentially causing inconsistencies in the pivot's data.

Now, the pivot's reload is deferred until after the entire evaluation process is complete (finalize). This ensures that all data is up-to-date before the pivot is re-evaluated.

Steps to reproduce:
- Create a spreadsheet pivot with a field "Hello" in the range
- Remove all occurence of pivot formula in the cells
- Rename the cell "Hello" to "World"
- In the pivot side panel, try to add a dimension
- "Hello" is still in the propositions. Not "World"

Task: 4781740

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo