### PR TITLE
[IMP] data: add column analysis functionnality

### DIFF
--- a/packages/o-spreadsheet-engine/src/functions/helper_statistical.ts
+++ b/packages/o-spreadsheet-engine/src/functions/helper_statistical.ts
@@ -47,6 +47,28 @@ export function average(values: Arg[], locale: Locale) {
   return sum / count;
 }
 
+export function median(values: Arg[], locale: Locale) {
+  const nums: number[] = [];
+  visitNumbers(
+    values,
+    (a) => {
+      nums.push(a.value);
+    },
+    locale
+  );
+  nums.sort((a, b) => a - b);
+  const len = nums.length;
+  if (len === 0) {
+    return undefined;
+  }
+  const mid = Math.floor(len / 2);
+  if (len % 2 === 0) {
+    return (nums[mid - 1] + nums[mid]) / 2;
+  } else {
+    return nums[mid];
+  }
+}
+
 export function countNumbers(values: Arg[], locale: Locale) {
   let count = 0;
   for (const n of values) {

--- a/packages/o-spreadsheet-engine/src/helpers/color.ts
+++ b/packages/o-spreadsheet-engine/src/helpers/color.ts
@@ -404,9 +404,10 @@ export function chipTextColor(chipBackgroundColor: Color): Color {
     ? lightenColor(chipBackgroundColor, 0.9)
     : darkenColor(chipBackgroundColor, 0.75);
 }
+export const FIRST_CHART_COLOR = "#4EA7F2";
 
 const COLORS_SM = [
-  "#4EA7F2", // Blue
+  FIRST_CHART_COLOR, // Blue
   "#EA6175", // Red
   "#43C5B1", // Teal
   "#F4A261", // Orange
@@ -414,7 +415,7 @@ const COLORS_SM = [
   "#FFD86D", // Yellow
 ];
 const COLORS_MD = [
-  "#4EA7F2", // Blue #1
+  FIRST_CHART_COLOR, // Blue #1
   "#3188E6", // Blue #2
   "#43C5B1", // Teal #1
   "#00A78D", // Teal #2
@@ -428,7 +429,7 @@ const COLORS_MD = [
   "#FFBC2C", // Yellow #2
 ];
 const COLORS_LG = [
-  "#4EA7F2", // Blue #1
+  FIRST_CHART_COLOR, // Blue #1
   "#3188E6", // Blue #2
   "#056BD9", // Blue #3
   "#A76DBC", // Violet #1
@@ -454,7 +455,7 @@ const COLORS_LG = [
   "#C08A16", // Yellow #3
 ];
 const COLORS_XL = [
-  "#4EA7F2", // Blue #1
+  FIRST_CHART_COLOR, // Blue #1
   "#3188E6", // Blue #2
   "#056BD9", // Blue #3
   "#155193", // Blue #4
@@ -491,7 +492,7 @@ const COLORS_XL = [
 // Same as above but with alternating colors
 
 const ALTERNATING_COLORS_MD = [
-  "#4EA7F2", // Blue    #1
+  FIRST_CHART_COLOR, // Blue    #1
   "#43C5B1", // Teal    #1
   "#EA6175", // Red     #1
   "#F4A261", // Orange  #1
@@ -505,7 +506,7 @@ const ALTERNATING_COLORS_MD = [
   "#FFBC2C", // Yellow  #2
 ];
 const ALTERNATING_COLORS_LG = [
-  "#4EA7F2", // Blue    #1
+  FIRST_CHART_COLOR, // Blue    #1
   "#A76DBC", // Violet  #1
   "#EA6175", // Red     #1
   "#43C5B1", // Teal    #1
@@ -531,7 +532,7 @@ const ALTERNATING_COLORS_LG = [
   "#C08A16", // Yellow  #3
 ];
 const ALTERNATING_COLORS_XL = [
-  "#4EA7F2", // Blue    #1
+  FIRST_CHART_COLOR, // Blue    #1
   "#A76DBC", // Violet  #1
   "#EA6175", // Red     #1
   "#43C5B1", // Teal    #1

--- a/src/actions/data_actions.ts
+++ b/src/actions/data_actions.ts
@@ -70,6 +70,12 @@ export const splitToColumns: ActionSpec = {
   icon: "o-spreadsheet-Icon.SPLIT_TEXT",
 };
 
+export const columnStatistics: ActionSpec = {
+  name: _t("Column statistics"),
+  execute: (env) => env.openSidePanel("ColumnStats", {}),
+  icon: "o-spreadsheet-Icon.COLUMN_STATS",
+};
+
 export const reinsertDynamicPivotMenu: ActionSpec = {
   id: "reinsert_dynamic_pivot",
   name: _t("Re-insert dynamic pivot"),

--- a/src/components/bottom_bar/bottom_bar_statistic/bottom_bar_statistic.ts
+++ b/src/components/bottom_bar/bottom_bar_statistic/bottom_bar_statistic.ts
@@ -29,7 +29,9 @@ export class BottomBarStatistic extends Component<Props, SpreadsheetChildEnv> {
   setup() {
     this.store = useStore(AggregateStatisticsStore);
     onWillUpdateProps(() => {
-      if (Object.values(this.store.statisticFnResults).every((result) => result === undefined)) {
+      if (
+        Object.values(this.store.statisticFnResults).every((result) => result?.value === undefined)
+      ) {
         this.props.closeContextMenu();
       }
     });
@@ -37,7 +39,9 @@ export class BottomBarStatistic extends Component<Props, SpreadsheetChildEnv> {
 
   getSelectedStatistic() {
     // don't display button if no function has a result
-    if (Object.values(this.store.statisticFnResults).every((result) => result === undefined)) {
+    if (
+      Object.values(this.store.statisticFnResults).every((result) => result?.value === undefined)
+    ) {
       return undefined;
     }
     if (this.selectedStatisticFn === "") {
@@ -68,6 +72,10 @@ export class BottomBarStatistic extends Component<Props, SpreadsheetChildEnv> {
   private getComposedFnName(fnName: string): string {
     const locale = this.env.model.getters.getLocale();
     const fnValue = this.store.statisticFnResults[fnName];
-    return fnName + ": " + (fnValue !== undefined ? formatValue(fnValue(), { locale }) : "__");
+    return (
+      fnName +
+      ": " +
+      (fnValue?.value !== undefined ? formatValue(fnValue.value(), { locale }) : "__")
+    );
   }
 }

--- a/src/components/icons/icons.xml
+++ b/src/components/icons/icons.xml
@@ -962,6 +962,26 @@
       </svg>
     </div>
   </t>
+  <t t-name="o-spreadsheet-Icon.ANGLE_RIGHT">
+    <div class="o-icon">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 224 256">
+        <path
+          fill="currentColor"
+          d="M161 139c6-6 6-16 0-23L81 36c-6-6-16-6-23 0s-6 16 0 23l69 69-69 69c-6 6-6 16 0 23s16 6 23 0l80-80z"
+        />
+      </svg>
+    </div>
+  </t>
+  <t t-name="o-spreadsheet-Icon.ANGLE_LEFT">
+    <div class="o-icon">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 224 256">
+        <path
+          fill="currentColor"
+          d="M59 116c-6 6-6 16 0 23l80 80c6 6 16 6 23 0s6-16 0-23L93 127l69-69c6-6 6-16 0-23s-16-6-23 0l-80 80z"
+        />
+      </svg>
+    </div>
+  </t>
   <t t-name="o-spreadsheet-Icon.INSERT_PIVOT">
     <svg class="o-icon">
       <defs>
@@ -1119,5 +1139,37 @@
     <div class="o-icon">
       <i class="fa fa-unlock"/>
     </div>
+  </t>
+  <t t-name="o-spreadsheet-Icon.COLUMN_STATS">
+    <svg width="18px" height="18px" viewBox="0 0 512 512">
+      <path
+        d="M319 174c71 0 129 58 129 129 0 27-8 52-23 73l66 66-33 33-66-66c-21 14-46 23-73 23-71 0-129-58-129-129s57-129 129-129m0 47c-45 0-82 37-82 82s36 82 82 82 82-37 82-82-37-82-82-82m-152 70a155 155 0 0 0 0 12c0 12 1 24 4 35H25v-47zM119 33v235H49V33zm94 94v66c-21 20-36 46-43 75h-28V127zm94-47v71a152 152 0 0 0-70 24V80zm94 23v71a152 152 0 0 0-70-24v-47z"
+        fill="currentColor"
+      />
+    </svg>
+  </t>
+  <t t-name="o-spreadsheet-Icon.DESCENDING_SORT">
+    <svg width="20px" height="16px" viewBox="0 0 20 16">
+      <path
+        d="M9.9 11.4h3.9a.9.9 0 0 0 .9-.9V6.24a.9.9 0 0 0-1.8 0V8.4L8.1 3.6s-.6-.6-1.2 0L5.1 5.4 1.5 1.8A.9.9 0 0 0 .3 3l4.2 4.2s.6.6 1.2 0l1.8-1.8 4.2 4.2H9.6a.9.9 0 0 0 0 1.8z"
+        fill="currentColor"
+      />
+    </svg>
+  </t>
+  <t t-name="o-spreadsheet-Icon.ASCENDING_SORT">
+    <svg width="20px" height="16px" viewBox="0 0 20 16">
+      <path
+        d="M9.9 3h3.9a.9.9 0 0 1 .9.9v4.26a.9.9 0 0 1-1.8 0V6l-4.8 4.8s-.6.6-1.2 0L5.1 9l-3.6 3.6a.9.9 0 0 1-1.2-1.2l4.2-4.2s.6-.6 1.2 0L7.5 9l4.2-4.2H9.6a.9.9 0 0 1 0-1.8z"
+        fill="currentColor"
+      />
+    </svg>
+  </t>
+  <t t-name="o-spreadsheet-Icon.COUNT_CHART">
+    <svg width="20px" height="16px" viewBox="0 0 20 16">
+      <path
+        fill="currentColor"
+        d="M.747 1.05h2.24v9.707H.747zM4.48 5.53h2.24v5.227H4.48zm7.467-1.493h2.24v6.72h-2.24zM8.213 2.543h2.24v8.214h-2.24zM0 11.503h14.933v1.494H0z"
+      />
+    </svg>
   </t>
 </templates>

--- a/src/components/side_panel/column_stats/column_stats_panel.css
+++ b/src/components/side_panel/column_stats/column_stats_panel.css
@@ -1,0 +1,24 @@
+.o-spreadsheet {
+  .o-column-stats-title {
+    font-size: 16px;
+  }
+  .o-row-switcher {
+    cursor: pointer;
+  }
+  .o-column-stats-row {
+    padding: 1px 0;
+  }
+  .o-column-stats-row:nth-child(even) {
+    background: var(--os-gray-100);
+  }
+  .o-column-frequencies-row {
+    cursor: pointer;
+  }
+  .o-column-frequencies-row:hover span {
+    font-weight: bold;
+  }
+
+  .o-column-stats-chart {
+    height: 200px;
+  }
+}

--- a/src/components/side_panel/column_stats/column_stats_panel.ts
+++ b/src/components/side_panel/column_stats/column_stats_panel.ts
@@ -1,0 +1,316 @@
+import { Highlight } from "@odoo/o-spreadsheet-engine";
+import { _t } from "@odoo/o-spreadsheet-engine/translation";
+import { SpreadsheetChildEnv } from "@odoo/o-spreadsheet-engine/types/spreadsheet_env";
+import { Component, onWillUnmount, useEffect, useRef, useState } from "@odoo/owl";
+import { Chart, ChartConfiguration } from "chart.js/auto";
+import {
+  clipTextWithEllipsis,
+  FIRST_CHART_COLOR,
+  numberToLetters,
+  positionToZone,
+} from "../../../helpers";
+import { Store, useStore } from "../../../store_engine";
+import { useHighlights } from "../../helpers/highlight_hook";
+import { NumberInput } from "../../number_input/number_input";
+import { BadgeSelection } from "../components/badge_selection/badge_selection";
+import { SidePanelCollapsible } from "../components/collapsible/side_panel_collapsible";
+import { Section } from "../components/section/section";
+import { ColumnStatisticsStore } from "./column_stats_store";
+
+interface Props {
+  onCloseSidePanel: () => void;
+}
+
+export class ColumnStatsPanel extends Component<Props, SpreadsheetChildEnv> {
+  static template = "o-spreadsheet-ColumnStatsPanel";
+  static props = { onCloseSidePanel: Function };
+  static components = { NumberInput, SidePanelCollapsible, BadgeSelection, Section };
+
+  state = useState({
+    currentChart: "count",
+    currentFrequencyOrder: "descending",
+    highlightPositions: [] as { row: number; col: number }[],
+  });
+
+  store!: Store<ColumnStatisticsStore>;
+  private chartCanvas = useRef("columnStatsChart");
+  private chart?: Chart;
+
+  setup() {
+    this.store = useStore(ColumnStatisticsStore);
+    useHighlights(this);
+    onWillUnmount(() => this.destroyChart());
+    useEffect(
+      () => {
+        this.updateChart();
+      },
+      () => [this.store.countChartData, this.store.histogramData]
+    );
+  }
+
+  get columnLabel(): string {
+    if (this.store.selectedColumn === undefined) {
+      return "";
+    }
+    const cell = this.env.model.getters.getEvaluatedCell({
+      sheetId: this.env.model.getters.getActiveSheetId(),
+      col: this.store.selectedColumn,
+      row: 0,
+    });
+    if (cell?.type === "text" && cell.value.trim() !== "") {
+      return cell.value;
+    }
+    return _t("Column %s", numberToLetters(this.store.selectedColumn));
+  }
+
+  get charts() {
+    return [
+      { value: "count", label: _t("Count"), icon: "o-spreadsheet-Icon.COUNT_CHART" },
+      { value: "histogram", label: _t("Distribution"), icon: "o-spreadsheet-Icon.COUNT_CHART" },
+    ];
+  }
+
+  get frequencyOrders() {
+    return [
+      { value: "descending", label: _t("Descending"), icon: "o-spreadsheet-Icon.DESCENDING_SORT" },
+      { value: "ascending", label: _t("Ascending"), icon: "o-spreadsheet-Icon.ASCENDING_SORT" },
+    ];
+  }
+
+  get shouldShowChart(): boolean {
+    if (this.state.currentChart === "histogram") {
+      return this.store.numericValues.length > 0;
+    } else if (this.state.currentChart === "count") {
+      return this.store.values.length > 0;
+    }
+    return false;
+  }
+
+  get chartErrorMessage(): string | null {
+    if (this.state.currentChart === "histogram" && this.store.numericValues.length === 0) {
+      return _t("No numeric values to display.");
+    }
+    if (this.state.currentChart === "count" && this.store.values.length === 0) {
+      return _t("No values to display.");
+    }
+    return null;
+  }
+
+  private getChartConfiguration(): ChartConfiguration<"bar" | "line"> | null {
+    switch (this.state.currentChart) {
+      case "histogram":
+        return this.getHistogramChartConfiguration();
+      case "count":
+        return this.getCountChartConfiguration();
+    }
+    return null;
+  }
+
+  private createChart() {
+    if (!globalThis.Chart) {
+      throw new Error("Chart.js library is not loaded");
+    }
+    const canvas = this.chartCanvas.el as HTMLCanvasElement | null;
+    if (!canvas) {
+      return;
+    }
+    const ctx = canvas.getContext("2d");
+    if (!ctx) {
+      return;
+    }
+    const config = this.getChartConfiguration();
+    if (!config) {
+      return;
+    }
+    this.chart = new globalThis.Chart!(ctx, config);
+  }
+
+  private getCountChartConfiguration(): ChartConfiguration<"bar"> | null {
+    const count = this.store.countChartData;
+    if (!count) {
+      return null;
+    }
+
+    return {
+      type: "bar",
+      data: {
+        labels: count.labels.map(this.clipTextWithEllipsis.bind(this)),
+        datasets: [
+          {
+            type: "bar",
+            data: count.data,
+            backgroundColor: FIRST_CHART_COLOR,
+            borderSkipped: false,
+            borderWidth: 1,
+            barPercentage: 1,
+            categoryPercentage: 1,
+          },
+        ],
+      },
+      options: {
+        animation: false,
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: {
+          legend: { display: false },
+          tooltip: { enabled: true },
+        },
+        scales: {
+          x: {
+            display: true,
+            ticks: {
+              maxRotation: 90,
+              minRotation: 90,
+            },
+          },
+          y: { display: true, beginAtZero: true },
+        },
+      },
+    };
+  }
+
+  private getHistogramChartConfiguration(): ChartConfiguration<"bar" | "line"> | null {
+    const histogram = this.store.histogramData;
+    if (!histogram) {
+      return null;
+    }
+    return {
+      type: "line",
+      data: {
+        labels: histogram.tooltipLabels,
+        datasets: [
+          {
+            type: "bar",
+            data: histogram.data,
+            backgroundColor: FIRST_CHART_COLOR,
+            borderSkipped: false,
+            borderWidth: 1,
+            barPercentage: 1,
+            categoryPercentage: 1,
+          },
+        ],
+      },
+      options: {
+        animation: false,
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: {
+          legend: { display: false },
+          tooltip: { enabled: true },
+        },
+        scales: {
+          x: { display: false, stacked: true, position: "top" },
+          y: { display: true },
+          x2: {
+            type: "linear",
+            position: "bottom",
+            display: true,
+            min: 0,
+            max: histogram.tooltipLabels.length,
+            ticks: {
+              callback: (value: any) =>
+                Math.floor(value) !== value
+                  ? ""
+                  : this.clipTextWithEllipsis(histogram.tickLabels?.[value]),
+              maxRotation: 90,
+              minRotation: 90,
+            },
+          },
+        },
+      },
+    };
+  }
+
+  private clipTextWithEllipsis(text: string | undefined): string {
+    if (!text) {
+      return "";
+    }
+    const canvas = this.chartCanvas.el as HTMLCanvasElement | null;
+    if (!canvas) {
+      return text;
+    }
+    const ctx = canvas.getContext("2d");
+    if (!ctx) {
+      return text;
+    }
+    return clipTextWithEllipsis(ctx, text, 75);
+  }
+
+  private updateChart() {
+    const config = this.getChartConfiguration();
+    if (!config) {
+      this.destroyChart();
+      return;
+    }
+    if (!this.chart) {
+      this.createChart();
+      return;
+    }
+    this.chart.config.options = config.options;
+    this.chart.data = config.data;
+    this.chart.update();
+  }
+
+  private destroyChart() {
+    this.chart?.destroy();
+    this.chart = undefined;
+  }
+
+  switchChart(chartType: string) {
+    this.state.currentChart = chartType;
+    this.destroyChart();
+    this.createChart();
+  }
+
+  switchFrequencyOrder(order: string) {
+    this.state.currentFrequencyOrder = order;
+  }
+
+  updateIgnoredRows(ignoredRowsStr: string) {
+    const ignoredRows = parseInt(ignoredRowsStr, 10);
+    this.store.updateIgnoredRows(isNaN(ignoredRows) ? 0 : Math.max(0, ignoredRows));
+  }
+
+  get valueFrequencies(): { value: string; count: number }[] {
+    const orderingCriterion =
+      this.state.currentFrequencyOrder === "ascending"
+        ? (a: { count: number }, b: { count: number }) => a.count - b.count
+        : (a: { count: number }, b: { count: number }) => b.count - a.count;
+    return this.store.valueFrequencies.sort(orderingCriterion).slice(0, 5);
+  }
+
+  get highlights(): Highlight[] {
+    const column = this.store.selectedColumn;
+    if (column === undefined) {
+      return [];
+    }
+    return [
+      {
+        range: this.env.model.getters.getRangeFromZone(this.env.model.getters.getActiveSheetId(), {
+          top: this.store.ignoredRows,
+          left: column,
+          bottom: undefined,
+          right: column,
+        }),
+        color: "#a3e9a39a",
+        interactive: false,
+      },
+      ...this.state.highlightPositions.map((position) => ({
+        range: this.env.model.getters.getRangeFromZone(
+          this.env.model.getters.getActiveSheetId(),
+          positionToZone(position)
+        ),
+        color: "#ffeb3b9a",
+        interactive: false,
+      })),
+    ];
+  }
+
+  highlightFrequencyPositions(positions: { row: number; col: number }[]) {
+    this.state.highlightPositions = positions;
+  }
+
+  clearHighlights() {
+    this.state.highlightPositions = [];
+  }
+}

--- a/src/components/side_panel/column_stats/column_stats_panel.xml
+++ b/src/components/side_panel/column_stats/column_stats_panel.xml
@@ -1,0 +1,94 @@
+<templates>
+  <t t-name="o-spreadsheet-ColumnStatsPanel">
+    <div class="o-column-stats-panel">
+      <t t-if="store.hasSingleColumn">
+        <Section>
+          <div class="d-flex justify-content-between align-items-center o-panel-header mb-1">
+            <span class="o-fw-bold w-100 o-column-stats-title" t-esc="columnLabel"/>
+            <span
+              class="p-1 o-row-switcher"
+              data-test-id="previous-column-button"
+              title="Switch to previous column"
+              t-on-click="store.selectPreviousColumn">
+              <t t-call="o-spreadsheet-Icon.ANGLE_LEFT"/>
+            </span>
+            <span
+              class="p-1 o-row-switcher"
+              title="Switch to next column"
+              data-test-id="next-column-button"
+              t-on-click="store.selectNextColumn">
+              <t t-call="o-spreadsheet-Icon.ANGLE_RIGHT"/>
+            </span>
+          </div>
+          <div class="mt-3">
+            <div class="o-sidePanel-label mb-1">Rows to ignore</div>
+            <NumberInput
+              value="store.ignoredRows"
+              class="'o-ignored-rows-input'"
+              min="0"
+              onChange.bind="updateIgnoredRows"
+            />
+          </div>
+        </Section>
+        <SidePanelCollapsible title.translate="Data visualization" isInitiallyCollapsed="false">
+          <t t-set-slot="content">
+            <div class="mx-4 mb-2">
+              <BadgeSelection
+                choices="charts"
+                onChange.bind="switchChart"
+                selectedValue="state.currentChart"
+              />
+              <t t-if="shouldShowChart">
+                <div class="o-column-stats-chart mx-2 mt-2">
+                  <canvas class="w-100 h-100" t-ref="columnStatsChart"/>
+                </div>
+              </t>
+              <t t-else="">
+                <div class="text-muted mt-4" t-esc="chartErrorMessage"/>
+              </t>
+            </div>
+          </t>
+        </SidePanelCollapsible>
+        <SidePanelCollapsible title.translate="General statistics" isInitiallyCollapsed="false">
+          <t t-set-slot="content">
+            <div class="o-column-global-stats d-flex flex-column gap-2 mb-2">
+              <t t-foreach="store.statItems" t-as="stat" t-key="stat.name">
+                <div class="o-column-stats-row d-flex justify-content-between">
+                  <span class="text-muted" t-esc="stat.name"/>
+                  <span class="o-fw-bold" t-att-data-test-id="stat.name" t-esc="stat.value"/>
+                </div>
+              </t>
+            </div>
+          </t>
+        </SidePanelCollapsible>
+        <SidePanelCollapsible title.translate="Frequency" isInitiallyCollapsed="true">
+          <t t-set-slot="content">
+            <div class="mx-4 mb-2">
+              <BadgeSelection
+                choices="frequencyOrders"
+                onChange.bind="switchFrequencyOrder"
+                selectedValue="state.currentFrequencyOrder"
+              />
+            </div>
+            <div class="o-column-global-stats d-flex flex-column mx-4 mb-2">
+              <t t-foreach="valueFrequencies" t-as="value" t-key="value.value">
+                <div
+                  class="o-column-stats-row o-column-frequencies-row d-flex justify-content-between"
+                  t-on-mouseenter="() => this.highlightFrequencyPositions(value.positions)"
+                  t-on-mouseleave="() => this.clearHighlights()">
+                  <span class="frequency-label text-muted" t-esc="value.value"/>
+                  <span class="frequency-value o-fw-bold" t-esc="value.count"/>
+                </div>
+              </t>
+            </div>
+          </t>
+        </SidePanelCollapsible>
+      </t>
+      <t t-else="">
+        <div class="o-column-stats-empty text-muted p-4">
+          Select a single column to view statistics.
+        </div>
+      </t>
+    </div>
+  </t>
+</templates>

--- a/src/components/side_panel/column_stats/column_stats_store.ts
+++ b/src/components/side_panel/column_stats/column_stats_store.ts
@@ -1,0 +1,347 @@
+import { sum } from "@odoo/o-spreadsheet-engine/functions/helper_math";
+import { average, max, median, min } from "@odoo/o-spreadsheet-engine/functions/helper_statistical";
+import { _t } from "@odoo/o-spreadsheet-engine/translation";
+import { formatValue, isDefined } from "../../../helpers";
+import {
+  computeStatisticFnResults,
+  SelectionStatisticFunction,
+  StatisticFnResults,
+} from "../../../helpers/selection_statistic_functions";
+import { Get } from "../../../store_engine";
+import { SpreadsheetStore } from "../../../stores";
+import {
+  CellValue,
+  CellValueType,
+  Command,
+  EvaluatedCell,
+  invalidateEvaluationCommands,
+  LocaleFormat,
+  Position,
+} from "../../../types";
+
+const columnStatisticFunctions: SelectionStatisticFunction[] = [
+  {
+    name: _t("Total rows"),
+    types: Object.values(CellValueType),
+    compute: (values, locale) => values.length,
+    format: "0",
+  },
+  {
+    name: _t("Unique values"),
+    types: [CellValueType.number, CellValueType.text, CellValueType.boolean, CellValueType.error],
+    compute: (values, locale) => {
+      const uniqueValues = new Set<string | number | boolean>();
+      for (const cell of values) {
+        uniqueValues.add(cell.value as string | number | boolean);
+      }
+      return uniqueValues.size;
+    },
+    format: "0",
+  },
+  {
+    name: _t("Sum"),
+    types: [CellValueType.number],
+    compute: (values, locale) => sum([[values]], locale),
+  },
+  {
+    name: _t("Average"),
+    types: [CellValueType.number],
+    compute: (values, locale) => average([[values]], locale),
+  },
+  {
+    name: _t("Median"),
+    types: [CellValueType.number],
+    compute: (values, locale) => median([[values]], locale) ?? "",
+  },
+  {
+    name: _t("Minimum value"),
+    types: [CellValueType.number],
+    compute: (values, locale) => min([[values]], locale).value,
+  },
+  {
+    name: _t("Maximum value"),
+    types: [CellValueType.number],
+    compute: (values, locale) => max([[values]], locale).value,
+  },
+];
+
+function buildEmptyStatisticFnResults(
+  selectionStatisticFunctions: SelectionStatisticFunction[]
+): StatisticFnResults {
+  const statisticFnResults: StatisticFnResults = {};
+  for (const fn of selectionStatisticFunctions) {
+    statisticFnResults[fn.name] = undefined;
+  }
+  return statisticFnResults;
+}
+
+interface CountChartData {
+  data: number[];
+  labels: string[];
+  positions: Position[][];
+}
+
+interface HistogramData {
+  data: number[];
+  tooltipLabels: string[];
+  tickLabels: string[];
+}
+
+interface PositionedValue<T> extends Position {
+  value: T;
+}
+
+export class ColumnStatisticsStore extends SpreadsheetStore {
+  mutators = ["updateIgnoredRows", "selectNextColumn", "selectPreviousColumn"] as const;
+  statisticFnResults: StatisticFnResults = buildEmptyStatisticFnResults(columnStatisticFunctions);
+  selectedColumn?: number;
+  numericValues: PositionedValue<number>[] = [];
+  values: PositionedValue<CellValue>[] = [];
+  dataFormat?: string;
+  countChartData?: CountChartData;
+  histogramData?: HistogramData;
+  private isDirty = false;
+  ignoredRows = 0;
+
+  constructor(get: Get) {
+    super(get);
+    this.model.selection.observe(this, {
+      handleEvent: this.refreshStatistics.bind(this),
+    });
+    this.onDispose(() => {
+      this.model.selection.unobserve(this);
+    });
+    this.refreshStatistics();
+  }
+
+  handle(cmd: Command) {
+    if (
+      invalidateEvaluationCommands.has(cmd.type) ||
+      (cmd.type === "UPDATE_CELL" && ("content" in cmd || "format" in cmd))
+    ) {
+      this.isDirty = true;
+    }
+    switch (cmd.type) {
+      case "HIDE_COLUMNS_ROWS":
+      case "UNHIDE_COLUMNS_ROWS":
+      case "GROUP_HEADERS":
+      case "UNGROUP_HEADERS":
+      case "ACTIVATE_SHEET":
+      case "ACTIVATE_NEXT_SHEET":
+      case "ACTIVATE_PREVIOUS_SHEET":
+      case "EVALUATE_CELLS":
+      case "UNDO":
+      case "REDO":
+        this.isDirty = true;
+    }
+  }
+
+  finalize() {
+    if (this.isDirty) {
+      this.isDirty = false;
+      this.refreshStatistics();
+    }
+  }
+
+  get hasSingleColumn(): boolean {
+    return this.selectedColumn !== undefined;
+  }
+
+  private computeCountChartData(): CountChartData | undefined {
+    if (this.selectedColumn === undefined) {
+      return undefined;
+    }
+    const values = this.numericValues.length ? this.numericValues : this.values;
+    if (!values.length) {
+      return undefined;
+    }
+    const countMap = new Map<string, { positions: Position[]; count: number; value: CellValue }>();
+    for (const val of values) {
+      if (val.value === null || val.value === undefined) {
+        continue;
+      }
+      const formattedValue =
+        typeof val.value === "number"
+          ? formatValue(val.value, this.localeFormat)
+          : val.value.toString();
+      if (!countMap.has(formattedValue)) {
+        countMap.set(formattedValue, { positions: [], count: 0, value: val.value });
+      }
+      countMap.get(formattedValue)!.positions.push({ row: val.row, col: val.col });
+      countMap.get(formattedValue)!.count += 1;
+    }
+    const data: number[] = [];
+    const positions: Position[][] = [];
+    const labels: string[] = [];
+    Array.from(countMap.entries())
+      .sort((a, b) => b[1].count - a[1].count)
+      .forEach(([val, count]) => {
+        labels.push(val);
+        data.push(count.count);
+        positions.push(count.positions);
+      });
+
+    return { data, labels, positions };
+  }
+
+  private computeHistogramData(): HistogramData | undefined {
+    const values = this.numericValues.map((v) => v.value);
+    if (!values.length) {
+      return undefined;
+    }
+
+    const barCount = 1 + Math.floor(Math.log2(values.length)); // Sturge's formula for optimal bin count
+    const minValue = Math.min(...values);
+    const maxValue = Math.max(...values);
+    const range = maxValue - minValue;
+    const step = range / barCount;
+    const data = new Array(barCount).fill(0);
+
+    if (range === 0) {
+      data[0] = values.length;
+    } else {
+      for (const value of values) {
+        const ratio = (value - minValue) / range;
+        const rawIndex = Math.floor(ratio * barCount);
+        const index = Math.min(barCount - 1, rawIndex);
+        data[index] += 1;
+      }
+    }
+
+    const localeFormat = this.localeFormat;
+
+    const tickLabels: string[] = [];
+    const tooltipLabels: string[] = [];
+    for (let i = 0; i <= barCount; i++) {
+      tickLabels.push(formatValue(minValue + i * step, localeFormat));
+      if (i !== 0) {
+        const value = minValue + (i - 1) * step;
+        tooltipLabels.push(
+          `${formatValue(value, localeFormat)}-${formatValue(value + step, localeFormat)}`
+        );
+      }
+    }
+
+    return { data, tooltipLabels, tickLabels };
+  }
+
+  get valueFrequencies(): {
+    value: string;
+    count: number;
+    positions: Position[];
+  }[] {
+    const count = this.countChartData;
+    if (!count) {
+      return [];
+    }
+    return count.labels.map((value, index) => ({
+      value,
+      count: count.data[index],
+      positions: count.positions[index],
+    }));
+  }
+
+  updateIgnoredRows(ignoredRows: number) {
+    this.ignoredRows = ignoredRows;
+    this.refreshStatistics();
+  }
+
+  private refreshStatistics() {
+    const getters = this.getters;
+    if (!getters.isSingleColSelected()) {
+      this.selectedColumn = undefined;
+      this.numericValues = [];
+      this.values = [];
+      this.statisticFnResults = buildEmptyStatisticFnResults(columnStatisticFunctions);
+      this.dataFormat = undefined;
+      this.countChartData = undefined;
+      this.histogramData = undefined;
+      return;
+    }
+
+    const { sheetId, col } = getters.getActivePosition();
+    this.selectedColumn = col;
+    const formatsInDataset = getters.getRangeFormats(
+      getters.getRangeFromZone(sheetId, {
+        top: 0,
+        left: col,
+        bottom: getters.getNumberRows(sheetId) - 1,
+        right: col,
+      })
+    );
+    this.dataFormat = formatsInDataset.find(isDefined) ?? "0.00";
+
+    const numberOfRows = getters.getNumberRows(sheetId);
+    const cells: EvaluatedCell[] = [];
+    const numericValues: { row: number; col: number; value: number }[] = [];
+    const values: { row: number; col: number; value: EvaluatedCell["value"] }[] = [];
+
+    let ignoredRowsCount = 0;
+
+    for (let row = 0; row < numberOfRows; row++) {
+      if (getters.isRowHidden(sheetId, row) || getters.isColHidden(sheetId, col)) {
+        continue;
+      }
+      if (ignoredRowsCount < this.ignoredRows) {
+        ignoredRowsCount++;
+        continue;
+      }
+
+      const evaluatedCell = getters.getEvaluatedCell({ sheetId, col: col, row });
+      cells.push(evaluatedCell);
+      if (
+        evaluatedCell.type !== CellValueType.empty &&
+        evaluatedCell.type !== CellValueType.error
+      ) {
+        values.push({ row, col, value: evaluatedCell.value });
+        if (evaluatedCell.type === CellValueType.number) {
+          numericValues.push({ row, col, value: evaluatedCell.value });
+        }
+      }
+    }
+
+    const locale = getters.getLocale();
+    this.statisticFnResults = computeStatisticFnResults(columnStatisticFunctions, cells, locale);
+    this.numericValues = numericValues;
+    this.values = values;
+    this.countChartData = this.computeCountChartData();
+    this.histogramData = this.computeHistogramData();
+  }
+
+  selectPreviousColumn() {
+    if (this.selectedColumn === undefined) {
+      return;
+    }
+    this.model.selection.moveAnchorCell("left", 1);
+  }
+
+  selectNextColumn() {
+    if (this.selectedColumn === undefined) {
+      return;
+    }
+    this.model.selection.moveAnchorCell("right", 1);
+  }
+
+  private get localeFormat(): LocaleFormat {
+    return { locale: this.getters.getLocale(), format: this.dataFormat };
+  }
+
+  get statItems(): {
+    name: string;
+    value: string;
+  }[] {
+    const localeFormat = this.localeFormat;
+    return Object.entries(this.statisticFnResults).map(([name, fnValue]) => {
+      if (fnValue?.value === undefined) {
+        return { name, value: "—" };
+      }
+      return {
+        name,
+        value: formatValue(fnValue.value(), {
+          locale: localeFormat.locale,
+          format: fnValue.format ?? localeFormat.format,
+        }),
+      };
+    });
+  }
+}

--- a/src/components/side_panel/components/badge_selection/badge_selection.ts
+++ b/src/components/side_panel/components/badge_selection/badge_selection.ts
@@ -5,6 +5,7 @@ import { SpreadsheetChildEnv } from "@odoo/o-spreadsheet-engine/types/spreadshee
 interface Choice {
   value: string;
   label: string;
+  icon?: string;
 }
 
 interface Props {

--- a/src/components/side_panel/components/badge_selection/badge_selection.xml
+++ b/src/components/side_panel/components/badge_selection/badge_selection.xml
@@ -4,11 +4,12 @@
       <t t-foreach="props.choices" t-as="choice" t-key="choice.value">
         <button
           class="flex-grow-1 o-button"
-          t-esc="choice.label"
           t-att-class="{ 'selected': props.selectedValue === choice.value }"
           t-on-click="() => props.onChange(choice.value)"
-          t-att-data-id="choice.value"
-        />
+          t-att-data-id="choice.value">
+          <t t-if="choice.icon" t-call="{{choice.icon}}"/>
+          <t t-esc="choice.label"/>
+        </button>
       </t>
     </div>
   </t>

--- a/src/helpers/selection_statistic_functions.ts
+++ b/src/helpers/selection_statistic_functions.ts
@@ -1,0 +1,43 @@
+import { lazy, memoize } from "@odoo/o-spreadsheet-engine/helpers/misc";
+import { CellValueType, EvaluatedCell, Lazy, Locale } from "../types";
+
+export interface StatisticFnResults {
+  [name: string]:
+    | {
+        value: Lazy<number | string> | undefined;
+        format?: string;
+      }
+    | undefined;
+}
+
+export interface SelectionStatisticFunction {
+  name: string;
+  compute: (data: EvaluatedCell[], locale: Locale) => number | string;
+  types: CellValueType[];
+  format?: string;
+}
+
+export function computeStatisticFnResults(
+  selectionStatisticFunctions: SelectionStatisticFunction[],
+  cells: EvaluatedCell[],
+  locale: Locale
+): StatisticFnResults {
+  const statisticFnResults: StatisticFnResults = {};
+  const getCells = memoize((typeStr: string) => {
+    const types = typeStr.split(",");
+    return cells.filter((c) => types.includes(c.type));
+  });
+
+  for (const fn of selectionStatisticFunctions) {
+    let fnResult: Lazy<number | string> | undefined = undefined;
+    const evaluatedCells = getCells(fn.types.sort().join(","));
+    if (evaluatedCells.length) {
+      fnResult = lazy(() => fn.compute(evaluatedCells, locale));
+    }
+    statisticFnResults[fn.name] = {
+      value: fnResult,
+      format: fn.format,
+    };
+  }
+  return statisticFnResults;
+}

--- a/src/registries/menus/col_menu_registry.ts
+++ b/src/registries/menus/col_menu_registry.ts
@@ -50,6 +50,11 @@ colMenuRegistry
     ...ACTION_DATA.sortDescending,
     sequence: 20,
   })
+  .add("column_statistics", {
+    ...ACTION_DATA.columnStatistics,
+    sequence: 60,
+    separator: true,
+  })
   .add("add_column_before", {
     ...ACTION_INSERT.colInsertColsBefore,
     sequence: 70,

--- a/src/registries/menus/topbar_menu_registry.ts
+++ b/src/registries/menus/topbar_menu_registry.ts
@@ -471,6 +471,10 @@ topbarMenuRegistry
     ...ACTION_DATA.splitToColumns,
     sequence: 20,
   })
+  .addChild("column_statistics", ["data"], {
+    ...ACTION_DATA.columnStatistics,
+    sequence: 25,
+  })
   .addChild("data_validation", ["data"], {
     name: _t("Data Validation"),
     execute: (env) => {

--- a/src/registries/side_panel_registry.ts
+++ b/src/registries/side_panel_registry.ts
@@ -4,6 +4,7 @@ import { _t } from "@odoo/o-spreadsheet-engine/translation";
 import { SpreadsheetChildEnv } from "@odoo/o-spreadsheet-engine/types/spreadsheet_env";
 import { CarouselPanel } from "../components/side_panel/carousel_panel/carousel_panel";
 import { ChartPanel } from "../components/side_panel/chart/main_chart_panel/main_chart_panel";
+import { ColumnStatsPanel } from "../components/side_panel/column_stats/column_stats_panel";
 import { ConditionalFormattingEditor } from "../components/side_panel/conditional_formatting/cf_editor/cf_editor";
 import { ConditionalFormatPreviewList } from "../components/side_panel/conditional_formatting/cf_preview_list/cf_preview_list";
 import { DataValidationPanel } from "../components/side_panel/data_validation/data_validation_panel";
@@ -112,6 +113,11 @@ sidePanelRegistry.add("DataValidationEditor", {
 sidePanelRegistry.add("MoreFormats", {
   title: _t("More formats"),
   Body: MoreFormatsPanel,
+});
+
+sidePanelRegistry.add("ColumnStats", {
+  title: _t("Column statistics"),
+  Body: ColumnStatsPanel,
 });
 
 sidePanelRegistry.add("TableSidePanel", {

--- a/tests/bottom_bar/aggregate_statistics_store.test.ts
+++ b/tests/bottom_bar/aggregate_statistics_store.test.ts
@@ -26,7 +26,7 @@ describe("Aggregate statistic functions", () => {
 
     setSelection(model, ["A1:A2"]);
     let statisticFnResults = store.statisticFnResults;
-    expect(statisticFnResults["Count"]?.()).toBe(2);
+    expect(statisticFnResults["Count"]?.value?.()).toBe(2);
 
     // expand selection with the range A3:A2
     addCellToSelection(model, "A3");
@@ -34,7 +34,7 @@ describe("Aggregate statistic functions", () => {
 
     // A2 is now present in two selection
     statisticFnResults = store.statisticFnResults;
-    expect(statisticFnResults["Count"]?.()).toBe(3);
+    expect(statisticFnResults["Count"]?.value?.()).toBe(3);
   });
 
   test("statistic function should not include hidden rows/columns in calculations", () => {
@@ -45,11 +45,11 @@ describe("Aggregate statistic functions", () => {
 
     setSelection(model, ["A1:A4"]);
     let statisticFnResults = store.statisticFnResults;
-    expect(statisticFnResults["Sum"]?.()).toBe(6);
+    expect(statisticFnResults["Sum"]?.value?.()).toBe(6);
 
     hideRows(model, [1, 2]);
     statisticFnResults = store.statisticFnResults;
-    expect(statisticFnResults["Sum"]?.()).toBe(1);
+    expect(statisticFnResults["Sum"]?.value?.()).toBe(1);
   });
 
   describe("return undefined if the types handled by the function are not present among the types of the selected cells", () => {
@@ -70,11 +70,11 @@ describe("Aggregate statistic functions", () => {
       selectCell(model, "A1");
       setAnchorCorner(model, "A7");
       let statisticFnResults = store.statisticFnResults;
-      expect(statisticFnResults["Sum"]?.()).toBe(66);
+      expect(statisticFnResults["Sum"]?.value?.()).toBe(66);
 
       selectCell(model, "A7");
       statisticFnResults = store.statisticFnResults;
-      expect(statisticFnResults["Sum"]).toBe(undefined);
+      expect(statisticFnResults["Sum"]?.value).toBe(undefined);
     });
 
     test('return the "Avg" result only on cells interpreted as number', () => {
@@ -82,11 +82,11 @@ describe("Aggregate statistic functions", () => {
       selectCell(model, "A1");
       setAnchorCorner(model, "A7");
       let statisticFnResults = store.statisticFnResults;
-      expect(statisticFnResults["Avg"]?.()).toBe(22);
+      expect(statisticFnResults["Avg"]?.value?.()).toBe(22);
 
       selectCell(model, "A7");
       statisticFnResults = store.statisticFnResults;
-      expect(statisticFnResults["Avg"]).toBe(undefined);
+      expect(statisticFnResults["Avg"]?.value).toBe(undefined);
     });
 
     test('return "Min" value only on cells interpreted as number', () => {
@@ -94,11 +94,11 @@ describe("Aggregate statistic functions", () => {
       selectCell(model, "A1");
       setAnchorCorner(model, "A7");
       let statisticFnResults = store.statisticFnResults;
-      expect(statisticFnResults["Min"]?.()).toBe(0);
+      expect(statisticFnResults["Min"]?.value?.()).toBe(0);
 
       selectCell(model, "A7");
       statisticFnResults = store.statisticFnResults;
-      expect(statisticFnResults["Min"]).toBe(undefined);
+      expect(statisticFnResults["Min"]?.value).toBe(undefined);
     });
 
     test('return the "Max" value only on cells interpreted as number', () => {
@@ -106,11 +106,11 @@ describe("Aggregate statistic functions", () => {
       selectCell(model, "A1");
       setAnchorCorner(model, "A7");
       let statisticFnResults = store.statisticFnResults;
-      expect(statisticFnResults["Max"]?.()).toBe(42);
+      expect(statisticFnResults["Max"]?.value?.()).toBe(42);
 
       selectCell(model, "A7");
       statisticFnResults = store.statisticFnResults;
-      expect(statisticFnResults["Max"]).toBe(undefined);
+      expect(statisticFnResults["Max"]?.value).toBe(undefined);
     });
 
     test('return the "Count" value on all types of interpreted cells except on cells interpreted as empty', () => {
@@ -118,39 +118,39 @@ describe("Aggregate statistic functions", () => {
       selectCell(model, "A1");
       setAnchorCorner(model, "A7");
       let statisticFnResults = store.statisticFnResults;
-      expect(statisticFnResults["Count"]?.()).toBe(6);
+      expect(statisticFnResults["Count"]?.value?.()).toBe(6);
 
       selectCell(model, "A7");
       statisticFnResults = store.statisticFnResults;
-      expect(statisticFnResults["Count"]).toBe(undefined);
+      expect(statisticFnResults["Count"]?.value).toBe(undefined);
     });
 
     test('return the "Count numbers" value on all types of interpreted cells except on cells interpreted as empty', () => {
       selectCell(model, "A1");
       let statisticFnResults = store.statisticFnResults;
-      expect(statisticFnResults["Count Numbers"]?.()).toBe(1);
+      expect(statisticFnResults["Count Numbers"]?.value?.()).toBe(1);
 
       selectCell(model, "A2");
       statisticFnResults = store.statisticFnResults;
-      expect(statisticFnResults["Count Numbers"]?.()).toBe(1);
+      expect(statisticFnResults["Count Numbers"]?.value?.()).toBe(1);
 
       selectCell(model, "A3");
       statisticFnResults = store.statisticFnResults;
-      expect(statisticFnResults["Count Numbers"]?.()).toBe(0);
+      expect(statisticFnResults["Count Numbers"]?.value?.()).toBe(0);
 
       selectCell(model, "A4");
       statisticFnResults = store.statisticFnResults;
-      expect(statisticFnResults["Count Numbers"]?.()).toBe(0);
+      expect(statisticFnResults["Count Numbers"]?.value?.()).toBe(0);
 
       selectCell(model, "A5");
       statisticFnResults = store.statisticFnResults;
-      expect(statisticFnResults["Count Numbers"]?.()).toBe(0);
+      expect(statisticFnResults["Count Numbers"]?.value?.()).toBe(0);
 
       // select the range A6:A7
       selectCell(model, "A6");
       setAnchorCorner(model, "A7");
       statisticFnResults = store.statisticFnResults;
-      expect(statisticFnResults["Count"]?.()).toBe(1);
+      expect(statisticFnResults["Count"]?.value?.()).toBe(1);
     });
   });
 
@@ -186,13 +186,13 @@ describe("Aggregate statistic functions", () => {
     createSheet(model, { sheetId: sId2 });
     setCellContent(model, "A2", "4", sId2);
     setCellContent(model, "A3", "4", sId2);
-    expect(store.statisticFnResults["Count"]?.()).toBe(3);
+    expect(store.statisticFnResults["Count"]?.value?.()).toBe(3);
     activateSheet(model, sId2);
     selectAll(model);
-    expect(store.statisticFnResults["Count"]?.()).toBe(2);
+    expect(store.statisticFnResults["Count"]?.value?.()).toBe(2);
     activateSheet(model, sId1);
     selectAll(model);
-    expect(store.statisticFnResults["Count"]?.()).toBe(3);
+    expect(store.statisticFnResults["Count"]?.value?.()).toBe(3);
   });
 
   test("statistic is updated when a cell format changes", () => {
@@ -200,9 +200,9 @@ describe("Aggregate statistic functions", () => {
     setCellContent(model, "A1", '=IF(CELL("format",B1)="0.00%",3,0)');
     setSelection(model, ["A1"]);
 
-    expect(store.statisticFnResults["Sum"]?.()).toBe(0);
+    expect(store.statisticFnResults["Sum"]?.value?.()).toBe(0);
 
     setFormat(model, "B1", "0.00%");
-    expect(store.statisticFnResults["Sum"]?.()).toBe(3);
+    expect(store.statisticFnResults["Sum"]?.value?.()).toBe(3);
   });
 });

--- a/tests/column_statistics/column_statistics_side_panel.test.ts
+++ b/tests/column_statistics/column_statistics_side_panel.test.ts
@@ -1,0 +1,129 @@
+import { SpreadsheetChildEnv } from "@odoo/o-spreadsheet-engine/types/spreadsheet_env";
+import { Model } from "../../src";
+import { ColumnStatisticsStore } from "../../src/components/side_panel/column_stats/column_stats_store";
+import { SidePanels } from "../../src/components/side_panel/side_panels/side_panels";
+import { click } from "../test_helpers";
+import { selectCell, setCellContent, setSelection } from "../test_helpers/commands_helpers";
+import {
+  mockChart,
+  mountComponentWithPortalTarget,
+  nextTick,
+  setGrid,
+} from "../test_helpers/helpers";
+
+mockChart();
+
+describe("column statistics sidePanel component", () => {
+  let model: Model;
+  let env: SpreadsheetChildEnv;
+  let fixture: HTMLElement;
+
+  beforeEach(async () => {
+    ({ model, env, fixture } = await mountComponentWithPortalTarget(SidePanels));
+  });
+
+  test("Column stats side panel is correctly filled", async () => {
+    setGrid(model, { A1: "10", A2: "20", A3: "30", A4: "40", A5: "50", A6: "10" });
+    selectCell(model, "A1");
+    env.openSidePanel("ColumnStats");
+    await nextTick();
+
+    expect('[data-test-id="Total rows"]').toHaveText("100");
+    expect('[data-test-id="Unique values"]').toHaveText("5");
+    expect('[data-test-id="Sum"]').toHaveText("160.00");
+    expect('[data-test-id="Average"]').toHaveText("26.67");
+    expect('[data-test-id="Median"]').toHaveText("25.00");
+    expect('[data-test-id="Minimum value"]').toHaveText("10.00");
+    expect('[data-test-id="Maximum value"]').toHaveText("50.00");
+
+    const labels = Array.from(fixture.querySelectorAll(".frequency-label")).map(
+      (el) => el.textContent
+    );
+    const values = Array.from(fixture.querySelectorAll(".frequency-value")).map(
+      (el) => el.textContent
+    );
+    expect(labels).toEqual(["10.00", "20.00", "30.00", "40.00", "50.00"]);
+    expect(values).toEqual(["2", "1", "1", "1", "1"]);
+  });
+
+  test("Column stats side panel is showing an error message when selecting multiple columns", async () => {
+    setGrid(model, { A1: "10", A2: "20", B1: "30", B2: "40" });
+    setSelection(model, ["A1", "B1"]);
+    env.openSidePanel("ColumnStats");
+    await nextTick();
+
+    expect('[data-test-id="Total rows"]').toHaveCount(0);
+    expect(".o-column-stats-empty").toHaveText(" Select a single column to view statistics. ");
+  });
+
+  test("Can switch to the next/previous column", async () => {
+    selectCell(model, "A1");
+    env.openSidePanel("ColumnStats");
+    await nextTick();
+
+    const columnStatsStore = env.getStore(ColumnStatisticsStore);
+    expect(columnStatsStore.selectedColumn).toBe(0);
+
+    await click(fixture, '[data-test-id="next-column-button"]');
+    expect(columnStatsStore.selectedColumn).toBe(1);
+
+    await click(fixture, '[data-test-id="previous-column-button"]');
+    expect(columnStatsStore.selectedColumn).toBe(0);
+  });
+
+  test("Can ignore header rows", async () => {
+    setGrid(model, { A1: "Header", A2: "Header 2", A3: "a", A4: "b", A5: "c" });
+    selectCell(model, "A1");
+    env.openSidePanel("ColumnStats");
+    await nextTick();
+
+    expect('[data-test-id="Unique values"]').toHaveText("5");
+    const labels = Array.from(fixture.querySelectorAll(".frequency-label")).map(
+      (el) => el.textContent
+    );
+    expect(labels).toEqual(["Header", "Header 2", "a", "b", "c"]);
+
+    const input = fixture.querySelector("input.o-ignored-rows-input") as HTMLInputElement;
+    input.value = "2";
+    input.dispatchEvent(new Event("change"));
+    input.dispatchEvent(new Event("blur")); // trigger save if present
+    await nextTick();
+
+    expect('[data-test-id="Unique values"]').toHaveText("3");
+    const labelsAfter = Array.from(fixture.querySelectorAll(".frequency-label")).map(
+      (el) => el.textContent
+    );
+    expect(labelsAfter).toEqual(["a", "b", "c"]);
+  });
+
+  test("Content of the first row is set as side panel title if string", async () => {
+    setGrid(model, { A1: "10", A2: "20" });
+    selectCell(model, "A1");
+    env.openSidePanel("ColumnStats");
+    await nextTick();
+
+    expect(".o-column-stats-title").toHaveText("Column A");
+
+    setCellContent(model, "A1", "Header");
+    await nextTick();
+
+    expect(".o-column-stats-title").toHaveText("Header");
+  });
+
+  test("Can change the order of frequency table", async () => {
+    setGrid(model, { A1: "b", A2: "a", A3: "c", A4: "a", A5: "b", A6: "a" });
+    selectCell(model, "A1");
+    env.openSidePanel("ColumnStats");
+    await nextTick();
+
+    let labels = Array.from(fixture.querySelectorAll(".frequency-label")).map(
+      (el) => el.textContent
+    );
+    expect(labels).toEqual(["a", "b", "c"]);
+
+    await click(fixture, 'button[data-id="ascending"]');
+
+    labels = Array.from(fixture.querySelectorAll(".frequency-label")).map((el) => el.textContent);
+    expect(labels).toEqual(["c", "b", "a"]);
+  });
+});

--- a/tests/column_statistics/column_statistics_store.test.ts
+++ b/tests/column_statistics/column_statistics_store.test.ts
@@ -1,0 +1,180 @@
+import { SpreadsheetChildEnv } from "@odoo/o-spreadsheet-engine/types/spreadsheet_env";
+import { Store } from "@odoo/o-spreadsheet-engine/types/store_engine";
+import { Model } from "../../src";
+import { ColumnStatisticsStore } from "../../src/components/side_panel/column_stats/column_stats_store";
+import { formatValue } from "../../src/helpers";
+import {
+  deleteRows,
+  selectCell,
+  setCellContent,
+  setCellFormat,
+} from "../test_helpers/commands_helpers";
+import { mountSpreadsheet, setGrid } from "../test_helpers/helpers";
+
+function getStoreStatistics(
+  store: Store<ColumnStatisticsStore>
+): Record<string, number | string | undefined> {
+  const results: Record<string, number | string | undefined> = {};
+  for (const [fnName, result] of Object.entries(store.statisticFnResults)) {
+    results[fnName] = result?.value?.();
+  }
+  return results;
+}
+
+describe("column statistics sidePanel store", () => {
+  let model: Model;
+  let env: SpreadsheetChildEnv;
+
+  beforeEach(async () => {
+    ({ model, env } = await mountSpreadsheet());
+  });
+
+  test("Store computes correct statistics for numerical data", async () => {
+    setGrid(model, { A1: "10", A2: "20", A3: "30", A4: "40", A5: "50", A6: "10" });
+    selectCell(model, "A1");
+    const store = env.getStore(ColumnStatisticsStore);
+    const statistics = getStoreStatistics(store);
+
+    expect(statistics["Total rows"]).toBe(100);
+    expect(statistics["Unique values"]).toBe(5);
+    expect(statistics["Sum"]).toBe(160);
+    expect(statistics["Average"]).toBeCloseTo(26.67, 2);
+    expect(statistics["Median"]).toBe(25);
+    expect(statistics["Minimum value"]).toBe(10);
+    expect(statistics["Maximum value"]).toBe(50);
+
+    const frequency = store.valueFrequencies;
+    expect(frequency).toEqual([
+      { value: "10.00", count: 2, positions: expect.any(Array) },
+      { value: "20.00", count: 1, positions: expect.any(Array) },
+      { value: "30.00", count: 1, positions: expect.any(Array) },
+      { value: "40.00", count: 1, positions: expect.any(Array) },
+      { value: "50.00", count: 1, positions: expect.any(Array) },
+    ]);
+  });
+
+  test("Store computes correct statistics for string data", async () => {
+    setGrid(model, { A1: "a", A2: "b", A3: "c", A4: "d", A5: "e", A6: "a" });
+    selectCell(model, "A1");
+    const store = env.getStore(ColumnStatisticsStore);
+    const statistics = getStoreStatistics(store);
+
+    expect(statistics["Total rows"]).toBe(100);
+    expect(statistics["Unique values"]).toBe(5);
+    expect(statistics["Sum"]).toBeUndefined();
+    expect(statistics["Average"]).toBeUndefined();
+    expect(statistics["Median"]).toBeUndefined();
+    expect(statistics["Minimum value"]).toBeUndefined();
+    expect(statistics["Maximum value"]).toBeUndefined();
+
+    const frequency = store.valueFrequencies;
+    expect(frequency).toEqual([
+      { value: "a", count: 2, positions: expect.any(Array) },
+      { value: "b", count: 1, positions: expect.any(Array) },
+      { value: "c", count: 1, positions: expect.any(Array) },
+      { value: "d", count: 1, positions: expect.any(Array) },
+      { value: "e", count: 1, positions: expect.any(Array) },
+    ]);
+  });
+
+  test("Store computes correct statistics for empty data", async () => {
+    selectCell(model, "A1");
+    const store = env.getStore(ColumnStatisticsStore);
+    const statistics = getStoreStatistics(store);
+
+    expect(statistics["Total rows"]).toBe(100);
+    expect(statistics["Unique values"]).toBeUndefined();
+    expect(statistics["Sum"]).toBeUndefined();
+    expect(statistics["Average"]).toBeUndefined();
+    expect(statistics["Median"]).toBeUndefined();
+    expect(statistics["Minimum value"]).toBeUndefined();
+    expect(statistics["Maximum value"]).toBeUndefined();
+
+    const frequency = store.valueFrequencies;
+    expect(frequency).toEqual([]);
+  });
+
+  test("String data are ignored in the store when there is numerical data in the same column", async () => {
+    setGrid(model, { A1: "a", A2: "10", A3: "20", A4: "30", A5: "b", A6: "c" });
+    selectCell(model, "A1");
+    const store = env.getStore(ColumnStatisticsStore);
+    const statistics = getStoreStatistics(store);
+
+    expect(statistics["Total rows"]).toBe(100);
+    expect(statistics["Unique values"]).toBe(6);
+    expect(statistics["Sum"]).toBe(60);
+    expect(statistics["Average"]).toBe(20);
+    expect(statistics["Median"]).toBe(20);
+    expect(statistics["Minimum value"]).toBe(10);
+    expect(statistics["Maximum value"]).toBe(30);
+
+    const frequency = store.valueFrequencies;
+    expect(frequency).toEqual([
+      { value: "10.00", count: 1, positions: expect.any(Array) },
+      { value: "20.00", count: 1, positions: expect.any(Array) },
+      { value: "30.00", count: 1, positions: expect.any(Array) },
+    ]);
+  });
+
+  test("Store reacts to change of selected column", async () => {
+    setGrid(model, { A1: "10", A2: "20", B1: "30", B2: "40" });
+    selectCell(model, "A1");
+    const store = env.getStore(ColumnStatisticsStore);
+
+    expect(store.statisticFnResults["Sum"]?.value?.()).toBe(30);
+
+    selectCell(model, "B1");
+
+    expect(store.statisticFnResults["Sum"]?.value?.()).toBe(70);
+  });
+
+  test("Store take into account ignored rows", async () => {
+    setGrid(model, { A1: "10", A2: "20", A3: "30", A4: "40" });
+    selectCell(model, "A1");
+    const store = env.getStore(ColumnStatisticsStore);
+
+    expect(store.statisticFnResults["Sum"]?.value?.()).toBe(100);
+
+    store.updateIgnoredRows(2);
+
+    expect(store.statisticFnResults["Sum"]?.value?.()).toBe(70);
+  });
+
+  test("Store reacts to change of cell content", async () => {
+    setGrid(model, { A1: "10", A2: "20" });
+    selectCell(model, "A1");
+    const store = env.getStore(ColumnStatisticsStore);
+
+    expect(store.statisticFnResults["Sum"]?.value?.()).toBe(30);
+
+    setCellContent(model, "A3", "30");
+
+    expect(store.statisticFnResults["Sum"]?.value?.()).toBe(60);
+  });
+
+  test("Store reacts to deletion of row", async () => {
+    setGrid(model, { A1: "10", A2: "20", A3: "30" });
+    selectCell(model, "A1");
+    const store = env.getStore(ColumnStatisticsStore);
+
+    expect(store.statisticFnResults["Unique values"]?.value?.()).toBe(3);
+
+    deleteRows(model, [1]);
+
+    expect(store.statisticFnResults["Unique values"]?.value?.()).toBe(2);
+  });
+
+  test("Store use correct number format", async () => {
+    setGrid(model, { A1: "10.5", A2: "20.3", A3: "30.7" });
+    setCellFormat(model, "A1", "[$$]#,##0.00");
+    selectCell(model, "A1");
+    const store = env.getStore(ColumnStatisticsStore);
+
+    const localeFormat = { locale: model.getters.getLocale(), format: "[$$]#,##0.00" };
+    expect(store.valueFrequencies).toEqual([
+      { value: formatValue(10.5, localeFormat), count: 1, positions: expect.any(Array) },
+      { value: formatValue(20.3, localeFormat), count: 1, positions: expect.any(Array) },
+      { value: formatValue(30.7, localeFormat), count: 1, positions: expect.any(Array) },
+    ]);
+  });
+});


### PR DESCRIPTION
## Task Description

This PR aims to add a new side panel accessible from the data menu or from a column header context menu. In this side panel, we can add statistical analysis of the data in the column : 
* Count chart of distribution (if applicable (ie if the data are all numbers))
* Sum, Min, max, mean, median values (if applicable (numbers))
* Number of (uniques) value, number of empty cell, number of cell most/least frequent values

## Related Task

Task: [[Stats] add column statistical analysis](https://www.odoo.com/odoo/2328/tasks/5410989)