### PR TITLE
[FIX] selection: keep anchor consistent on mouse up

### DIFF
--- a/packages/o-spreadsheet-engine/src/plugins/ui_stateful/selection.ts
+++ b/packages/o-spreadsheet-engine/src/plugins/ui_stateful/selection.ts
@@ -4,6 +4,7 @@ import { getClipboardDataPositions } from "../../helpers/clipboard/clipboard_hel
 import { clip, deepCopy, range } from "../../helpers/misc";
 import {
   isEqual,
+  isInside,
   isZoneInside,
   positionToZone,
   splitZone,
@@ -152,9 +153,11 @@ export class GridSelectionPlugin extends UIPlugin {
             .concat(splittedZones);
         }
         zones = uniqueZones(zones);
+
         const lastZone = zones[zones.length - 1];
+        const isAnchorCellInLastZone = isInside(anchor.cell.col, anchor.cell.row, lastZone);
         anchor = {
-          cell: { col: lastZone.left, row: lastZone.top },
+          cell: isAnchorCellInLastZone ? anchor.cell : { col: lastZone.left, row: lastZone.top },
           zone: lastZone,
         };
         break;

--- a/tests/grid/grid_component.test.ts
+++ b/tests/grid/grid_component.test.ts
@@ -2324,4 +2324,13 @@ describe("Can select de-select zones", () => {
       toZone("A1:D1"),
     ]);
   });
+
+  test("Selecting a zone from the bottom-right to top left leaves the anchor in the bottom-right", () => {
+    gridMouseEvent(model, "pointerdown", "B2");
+    gridMouseEvent(model, "pointermove", "A1");
+    gridMouseEvent(model, "pointerup", "A1");
+
+    expect(model.getters.getSelectedZones()).toEqual([toZone("A1:B2")]);
+    expect(model.getters.getActivePosition()).toMatchObject({ col: 1, row: 1 });
+  });
 });


### PR DESCRIPTION
## Description

If you try to select a range starting from its bottom-left corner, on mouseup the anchor cell would be changed to the top-left corner, instead of staying at the bottom-left corner.

Task: [5431585](https://www.odoo.com/odoo/2328/tasks/5431585)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo