### PR TITLE
[FIX] XLSXImport: Fix crash on incomplete xlsx file with external ref…

### DIFF
--- a/src/xlsx/conversion/formula_conversion.ts
+++ b/src/xlsx/conversion/formula_conversion.ts
@@ -65,10 +65,10 @@ function convertFormula(formula: string, data: XLSXImportData): string {
   formula = formula.replace(externalReferenceRegex, (match, externalRefId, sheetName, cellRef) => {
     externalRefId = Number(externalRefId) - 1;
     cellRef = cellRef.replace(/\$/g, "");
-
-    const sheetIndex = data.externalBooks[externalRefId].sheetNames.findIndex((name) =>
-      isSheetNameEqual(name, sheetName)
-    );
+    const sheetIndex =
+      data.externalBooks[externalRefId]?.sheetNames.findIndex((name) =>
+        isSheetNameEqual(name, sheetName)
+      ) ?? -1;
     if (sheetIndex === -1) {
       return match;
     }


### PR DESCRIPTION
…erence

In Excel, there is a mecanism for spreadsheets to cross-reference themselves, with cells of the form `[otherSpreadsheetFileName]Sheet1!A1`. Luckily, the saved files contain a cache of the values from other spreadsheets and we use this cache during our import process to replace the cross-sheet references with their cached value.

Google sheet, and possibly other spreadsheets engines, do not support xlsx files with cross references to other spreadsheets. More specifically, they let them *as is* even though the reference will not work, and they throw the cache away. This means that an xlsx file generated from Google Sheet will not contain the cache either.

The code was designed with the assumption that the cache would always be present, which led to crashes when trying to upload an xlsx file (with cross-references) that was obtain through Google Sheets.

Task: 5499753

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo