### PR TITLE
[IMP] cfs: Add conditional format on duplicate/unique values

### DIFF
--- a/packages/o-spreadsheet-engine/src/helpers/locale.ts
+++ b/packages/o-spreadsheet-engine/src/helpers/locale.ts
@@ -292,6 +292,8 @@ function changeCFRuleLocale(
         case "notContainsText":
         case "isEmpty":
         case "isNotEmpty":
+        case "uniqueValues":
+        case "duplicateValues":
           return rule;
       }
     case "DataBarRule":

--- a/packages/o-spreadsheet-engine/src/types/conditional_formatting.ts
+++ b/packages/o-spreadsheet-engine/src/types/conditional_formatting.ts
@@ -172,6 +172,8 @@ const cfOperators = [
   "dateIsOnOrBefore",
   "dateIsOnOrAfter",
   "top10",
+  "uniqueValues",
+  "duplicateValues",
 ] as const;
 
 export type ConditionalFormattingOperatorValues = (typeof cfOperators)[number];

--- a/packages/o-spreadsheet-engine/src/types/data_validation.ts
+++ b/packages/o-spreadsheet-engine/src/types/data_validation.ts
@@ -145,6 +145,16 @@ export type Top10Criterion = {
   isBottom?: boolean;
 };
 
+export type UniqueValuesCriterion = {
+  type: "uniqueValues";
+  values: string[];
+};
+
+export type DuplicateValuesCriterion = {
+  type: "duplicateValues";
+  values: string[];
+};
+
 export type CustomFormulaCriterion = {
   type: "customFormula";
   values: string[];

--- a/packages/o-spreadsheet-engine/src/types/generic_criterion.ts
+++ b/packages/o-spreadsheet-engine/src/types/generic_criterion.ts
@@ -39,7 +39,9 @@ export type GenericCriterionType =
   | "endsWithText"
   | "isNotEmpty"
   | "isEmpty"
-  | "top10";
+  | "top10"
+  | "uniqueValues"
+  | "duplicateValues";
 
 export type DateCriterionValue =
   | "today"

--- a/packages/o-spreadsheet-engine/src/types/xlsx.ts
+++ b/packages/o-spreadsheet-engine/src/types/xlsx.ts
@@ -448,8 +448,7 @@ export type XLSXCfOperatorType =
   | "lessThanOrEqual"
   | "notBetween"
   | "notContains"
-  | "notEqual"
-  | "top10";
+  | "notEqual";
 
 export type XLSXDataValidationOperatorType =
   | "between"

--- a/packages/o-spreadsheet-engine/src/xlsx/conversion/cf_conversion.ts
+++ b/packages/o-spreadsheet-engine/src/xlsx/conversion/cf_conversion.ts
@@ -49,8 +49,6 @@ export function convertConditionalFormats(
       case "aboveAverage":
       case "containsErrors":
       case "notContainsErrors":
-      case "duplicateValues":
-      case "uniqueValues":
       case "timePeriod":
         // Not supported
         continue;
@@ -89,6 +87,8 @@ export function convertConditionalFormats(
         operator = CF_TYPE_CONVERSION_MAP[rule.type]!;
         values.push(`=${rule.formula[0]}`);
         break;
+      case "duplicateValues":
+      case "uniqueValues":
       case "containsBlanks":
       case "notContainsBlanks":
         operator = CF_TYPE_CONVERSION_MAP[rule.type]!;
@@ -107,7 +107,7 @@ export function convertConditionalFormats(
         if (rule.rank === undefined) {
           continue;
         }
-        operator = CF_OPERATOR_TYPE_CONVERSION_MAP[rule.type];
+        operator = CF_TYPE_CONVERSION_MAP[rule.type];
         values.push(rule.rank.toString());
         if (rule.percent) {
           cfAdditionalProperties.isPercent = true;

--- a/packages/o-spreadsheet-engine/src/xlsx/conversion/conversion_maps.ts
+++ b/packages/o-spreadsheet-engine/src/xlsx/conversion/conversion_maps.ts
@@ -120,7 +120,6 @@ export const CF_OPERATOR_TYPE_CONVERSION_MAP: Record<
   greaterThanOrEqual: "isGreaterOrEqualTo",
   lessThan: "isLessThan",
   lessThanOrEqual: "isLessOrEqualTo",
-  top10: "top10",
 };
 
 /** Conversion map CF types in XLSX <=> Cf types in o_spreadsheet */
@@ -134,9 +133,9 @@ export const CF_TYPE_CONVERSION_MAP: Record<
   colorScale: undefined, // exist but isn't an operator in o_spreadsheet
   dataBar: undefined,
   iconSet: undefined, // exist but isn't an operator in o_spreadsheet
-  top10: undefined,
-  uniqueValues: undefined,
-  duplicateValues: undefined,
+  top10: "top10",
+  uniqueValues: "uniqueValues",
+  duplicateValues: "duplicateValues",
   containsText: "containsText",
   notContainsText: "notContainsText",
   beginsWith: "beginsWithText",

--- a/packages/o-spreadsheet-engine/src/xlsx/functions/conditional_formatting.ts
+++ b/packages/o-spreadsheet-engine/src/xlsx/functions/conditional_formatting.ts
@@ -167,6 +167,8 @@ function cellRuleFormula(ranges: string[], rule: CellIsRule): string[] {
           throw new Error("dateValue should be defined");
       }
     case "top10":
+    case "uniqueValues":
+    case "duplicateValues":
       return [];
   }
 }
@@ -184,6 +186,8 @@ function cellRuleTypeAttributes(rule: CellIsRule): XMLAttributes {
       ];
     case "isEmpty":
     case "isNotEmpty":
+    case "uniqueValues":
+    case "duplicateValues":
       return [["type", operator]];
     case "isEqual":
     case "isNotEqual":

--- a/packages/o-spreadsheet-engine/src/xlsx/helpers/content_helpers.ts
+++ b/packages/o-spreadsheet-engine/src/xlsx/helpers/content_helpers.ts
@@ -84,6 +84,10 @@ export function convertOperator(operator: ConditionalFormattingOperatorValues): 
       return "lessThanOrEqual";
     case "top10":
       return "top10";
+    case "uniqueValues":
+      return "uniqueValues";
+    case "duplicateValues":
+      return "duplicateValues";
   }
 }
 

--- a/src/registries/criterion_component_registry.ts
+++ b/src/registries/criterion_component_registry.ts
@@ -238,6 +238,20 @@ criterionComponentRegistry.add("top10", {
   sequence: 7,
 });
 
+criterionComponentRegistry.add("uniqueValues", {
+  type: "uniqueValues",
+  component: undefined,
+  category: "relative",
+  sequence: 8,
+});
+
+criterionComponentRegistry.add("duplicateValues", {
+  type: "duplicateValues",
+  component: undefined,
+  category: "relative",
+  sequence: 9,
+});
+
 export function getCriterionValueAndLabels(
   availableTypes: Set<GenericCriterionType>
 ): ValueAndLabel[] {

--- a/tests/conditional_formatting/conditional_formatting_panel_component.test.ts
+++ b/tests/conditional_formatting/conditional_formatting_panel_component.test.ts
@@ -22,9 +22,9 @@ import {
   updateLocale,
 } from "../test_helpers/commands_helpers";
 import {
-  DOMTarget,
   click,
   clickAndDrag,
+  DOMTarget,
   editSelectComponent,
   getTarget,
   keyDown,
@@ -744,6 +744,23 @@ describe("UI of conditional formats", () => {
         isPercent: true,
         values: ["3"],
         style: { bold: true },
+      });
+    });
+
+    test("Can select a uniqueValues/duplicateValues CF", async () => {
+      await click(fixture, selectors.buttonAdd);
+      await nextTick();
+
+      await changeRuleOperatorType(fixture, "uniqueValues");
+      expect(model.getters.getConditionalFormats(sheetId)[0]?.rule).toMatchObject({
+        type: "CellIsRule",
+        operator: "uniqueValues",
+      });
+
+      await changeRuleOperatorType(fixture, "duplicateValues");
+      expect(model.getters.getConditionalFormats(sheetId)[0]?.rule).toMatchObject({
+        type: "CellIsRule",
+        operator: "duplicateValues",
       });
     });
 

--- a/tests/conditional_formatting/conditional_formatting_plugin.test.ts
+++ b/tests/conditional_formatting/conditional_formatting_plugin.test.ts
@@ -1819,6 +1819,38 @@ describe("conditional formats types", () => {
       expect(getStyle(model, "A4")).toEqual(cfStyle);
     });
 
+    test("Operator uniqueValues", () => {
+      const cfStyle = { fillColor: "#ff0f0f", italic: true };
+      setGrid(model, { A1: "Hello", A2: "hello", A3: "bonjour", A4: "22" });
+      addCfRule(model, "A1:A4", {
+        type: "CellIsRule",
+        operator: "uniqueValues",
+        values: [],
+        style: cfStyle,
+      });
+
+      expect(getStyle(model, "A1")).toEqual({});
+      expect(getStyle(model, "A2")).toEqual({});
+      expect(getStyle(model, "A3")).toEqual(cfStyle);
+      expect(getStyle(model, "A4")).toEqual(cfStyle);
+    });
+
+    test("Operator duplicateValues", () => {
+      const cfStyle = { fillColor: "#ff0f0f", italic: true };
+      setGrid(model, { A1: "Hello", A2: "hello", A3: "bonjour", A4: "22" });
+      addCfRule(model, "A1:A4", {
+        type: "CellIsRule",
+        operator: "duplicateValues",
+        values: [],
+        style: cfStyle,
+      });
+
+      expect(getStyle(model, "A1")).toEqual(cfStyle);
+      expect(getStyle(model, "A2")).toEqual(cfStyle);
+      expect(getStyle(model, "A3")).toEqual({});
+      expect(getStyle(model, "A4")).toEqual({});
+    });
+
     test.each([
       ["isEmpty", ["", ""]],
       ["isEmpty", []],

--- a/tests/xlsx/xlsx_import.test.ts
+++ b/tests/xlsx/xlsx_import.test.ts
@@ -282,7 +282,7 @@ describe("Import xlsx data", () => {
     ["cellIs lessThanOrEqual", "B21"],
     ["cellIs between", "B22"],
     ["cellIs notBetween", "B23"],
-  ])("Can import conditional format '%s'", (cfDescription, cfStartRange) => {
+  ])("Can import conditional format %s", (cfDescription, cfStartRange) => {
     const testSheet = getWorkbookSheet("jestCfs", convertedData)!;
     const split = cfDescription.split(" ");
     const cfType = split[0];
@@ -296,8 +296,6 @@ describe("Import xlsx data", () => {
       case "notContainsErrors":
       case "timePeriod":
       case "aboveAverage":
-      case "uniqueValues":
-      case "duplicateValues":
       case "dataBar":
         // Unsupported CF types
         expect(cf).toBeUndefined();
@@ -315,6 +313,8 @@ describe("Import xlsx data", () => {
         break;
       case "containsBlanks":
       case "notContainsBlanks":
+      case "uniqueValues":
+      case "duplicateValues":
         operator = CF_TYPE_CONVERSION_MAP[cfType]!;
         break;
       case "cellIs":
@@ -325,7 +325,7 @@ describe("Import xlsx data", () => {
         }
         break;
       case "top10":
-        operator = "top10";
+        operator = CF_TYPE_CONVERSION_MAP[cfType]!;
         values.push("50");
         expect(cf.rule["isPercent"]).toBe(true);
         expect(cf.rule["isBottom"]).toBe(true);


### PR DESCRIPTION
## Description

This commit introduces new conditional formatting criteria to highlight duplicate and unique values within a specified range.

Task: [5784262](https://www.odoo.com/odoo/2328/tasks/5784262)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo