### PR TITLE
[Measure] Display Show as on measure tile

### DIFF
--- a/packages/o-spreadsheet-engine/src/components/translations_terms.ts
+++ b/packages/o-spreadsheet-engine/src/components/translations_terms.ts
@@ -3,6 +3,7 @@ import { _t } from "../translation";
 import { ChartColorScale } from "../types/chart";
 import { CommandResult } from "../types/commands";
 import { Locale } from "../types/locale";
+import { NEXT_VALUE, PREVIOUS_VALUE } from "../types/pivot";
 
 export const CfTerms = {
   Errors: {
@@ -206,13 +207,39 @@ export const measureDisplayTerms = {
     "%_of_grand_total": () => _t("Displayed as % of grand total"),
     "%_of_col_total": () => _t("Displayed as % of column total"),
     "%_of_row_total": () => _t("Displayed as % of row total"),
-    "%_of": (field: string) => _t('Displayed as % of "%s"', field),
-    "%_of_parent_row_total": (field: string) =>
-      _t('Displayed as % of parent row total of "%s"', field),
+    "%_of": (field: string, value: string) => {
+      switch (value) {
+        case NEXT_VALUE:
+          return _t('Displayed as % of next "%s"', field);
+        case PREVIOUS_VALUE:
+          return _t('Displayed as % of previous "%s"', field);
+        default:
+          return _t('Displayed as % of "%s" : %s', field, value);
+      }
+    },
+    "%_of_parent_row_total": () => _t("Displayed as % of parent row total"),
     "%_of_parent_col_total": () => _t("Displayed as % of parent column total"),
     "%_of_parent_total": (field: string) => _t('Displayed as % of parent "%s" total', field),
-    difference_from: (field: string) => _t('Displayed as difference from "%s"', field),
-    "%_difference_from": (field: string) => _t('Displayed as % difference from "%s"', field),
+    difference_from: (field: string, value: string) => {
+      switch (value) {
+        case NEXT_VALUE:
+          return _t('Displayed as difference from next "%s"', field);
+        case PREVIOUS_VALUE:
+          return _t('Displayed as difference from previous "%s"', field);
+        default:
+          return _t('Displayed as difference from "%s" : %s', field, value);
+      }
+    },
+    "%_difference_from": (field: string, value: string) => {
+      switch (value) {
+        case NEXT_VALUE:
+          return _t('Displayed as % difference from next "%s"', field);
+        case PREVIOUS_VALUE:
+          return _t('Displayed as % difference from previous "%s"', field);
+        default:
+          return _t('Displayed as % difference from "%s" : %s', field, value);
+      }
+    },
     running_total: (field: string) => _t('Displayed as running total based on "%s"', field),
     "%_running_total": (field: string) => _t('Displayed as % running total based on "%s"', field),
     rank_asc: (field: string) =>

--- a/src/components/side_panel/pivot/pivot_layout_configurator/pivot_layout_configurator.ts
+++ b/src/components/side_panel/pivot/pivot_layout_configurator/pivot_layout_configurator.ts
@@ -1,7 +1,5 @@
-import { measureDisplayTerms } from "@odoo/o-spreadsheet-engine/components/translations_terms";
 import {
   AGGREGATORS,
-  getFieldDisplayName,
   isDateOrDatetimeField,
 } from "@odoo/o-spreadsheet-engine/helpers/pivot/pivot_helpers";
 import { PivotRuntimeDefinition } from "@odoo/o-spreadsheet-engine/helpers/pivot/pivot_runtime_definition";
@@ -320,20 +318,6 @@ export class PivotLayoutConfigurator extends Component<Props, SpreadsheetChildEn
         return col;
       }),
     });
-  }
-
-  getMeasureDescription(measure: PivotMeasure) {
-    const measureDisplay = measure.display;
-    if (!measureDisplay || measureDisplay.type === "no_calculations") {
-      return "";
-    }
-    const pivot = this.env.model.getters.getPivot(this.props.pivotId);
-    const field = [...pivot.definition.columns, ...pivot.definition.rows].find(
-      (f) => f.nameWithGranularity === measureDisplay.fieldNameWithGranularity
-    );
-    const fieldName = field ? getFieldDisplayName(field) : "";
-
-    return measureDisplayTerms.descriptions[measureDisplay.type](fieldName);
   }
 
   getHugeDimensionErrorMessage(dimension: PivotDimensionType) {

--- a/src/components/side_panel/pivot/pivot_layout_configurator/pivot_measure/pivot_measure.ts
+++ b/src/components/side_panel/pivot/pivot_layout_configurator/pivot_measure/pivot_measure.ts
@@ -1,7 +1,9 @@
 import { _t } from "@odoo/o-spreadsheet-engine";
+import { measureDisplayTerms } from "@odoo/o-spreadsheet-engine/components/translations_terms";
 import { PIVOT_TOKEN_COLOR } from "@odoo/o-spreadsheet-engine/constants";
 import { compile } from "@odoo/o-spreadsheet-engine/formulas/compiler";
 import { Token } from "@odoo/o-spreadsheet-engine/formulas/tokenizer";
+import { getFieldDisplayName } from "@odoo/o-spreadsheet-engine/helpers/pivot/pivot_helpers";
 import { PivotRuntimeDefinition } from "@odoo/o-spreadsheet-engine/helpers/pivot/pivot_runtime_definition";
 import { Component } from "@odoo/owl";
 import { unquote } from "../../../../../helpers";
@@ -121,5 +123,19 @@ export class PivotMeasureEditor extends Component<Props> {
       return [...options, { value: "", label: _t("Compute from totals") }];
     }
     return options;
+  }
+
+  getMeasureDescription(measure: PivotMeasure) {
+    const measureDisplay = measure.display;
+    if (!measureDisplay || measureDisplay.type === "no_calculations") {
+      return "";
+    }
+    const pivot = this.env.model.getters.getPivot(this.props.pivotId);
+    const field = [...pivot.definition.columns, ...pivot.definition.rows].find(
+      (f) => f.nameWithGranularity === measureDisplay.fieldNameWithGranularity
+    );
+    const fieldName = field ? getFieldDisplayName(field) : "";
+    const value = measureDisplay.value?.toString() || "";
+    return measureDisplayTerms.descriptions[measureDisplay.type](fieldName, value);
   }
 }

--- a/src/components/side_panel/pivot/pivot_layout_configurator/pivot_measure/pivot_measure.xml
+++ b/src/components/side_panel/pivot/pivot_layout_configurator/pivot_measure/pivot_measure.xml
@@ -40,6 +40,11 @@
           />
         </div>
       </div>
+      <div class="d-flex flex-row">
+        <div class="d-flex py-1 px-2 w-100 small text-muted o-measure-description">
+          <i t-esc="getMeasureDescription(measure)"/>
+        </div>
+      </div>
     </PivotDimension>
   </t>
 </templates>

--- a/tests/pivots/pivot_side_panel.test.ts
+++ b/tests/pivots/pivot_side_panel.test.ts
@@ -229,4 +229,58 @@ describe("Pivot side panel", () => {
     expect(definition.columns).toHaveLength(1);
     expect(definition.collapsedDomains?.COL).toHaveLength(1);
   });
+
+  test("display the description of the show as", async () => {
+    //prettier-ignore
+    const grid = {
+      A1: "Customer", B1: "Price", C1: "Year",
+      A2: "Alice",    B2: "10",    C2: "2020",
+      A3: "Alice",    B3: "20",    C3: "2021",
+	  };
+    setGrid(model, grid);
+    updatePivot(model, "1", {
+      columns: [{ fieldName: "Customer" }, { fieldName: "Year" }],
+      rows: [],
+      measures: [
+        {
+          id: "Price",
+          fieldName: "Price",
+          aggregator: "sum",
+          display: { type: "%_of", fieldNameWithGranularity: "Customer", value: "Alice" },
+        },
+      ],
+      dataSet: { sheetId: model.getters.getActiveSheetId(), zone: toZone("A1:C3") },
+    });
+
+    env.openSidePanel("PivotSidePanel", { pivotId: "1" });
+    await nextTick();
+    expect(".o-measure-description").toHaveText(`Displayed as % of "Customer" : Alice`);
+  });
+
+  test(`display the description of the show as with "previous" item`, async () => {
+    //prettier-ignore
+    const grid = {
+      A1: "Customer", B1: "Price", C1: "Year",
+      A2: "Alice",    B2: "10",    C2: "2020",
+      A3: "Alice",    B3: "20",    C3: "2021",
+	  };
+    setGrid(model, grid);
+    updatePivot(model, "1", {
+      columns: [{ fieldName: "Customer" }, { fieldName: "Year" }],
+      rows: [],
+      measures: [
+        {
+          id: "Price",
+          fieldName: "Price",
+          aggregator: "sum",
+          display: { type: "%_of", fieldNameWithGranularity: "Customer", value: "(previous)" },
+        },
+      ],
+      dataSet: { sheetId: model.getters.getActiveSheetId(), zone: toZone("A1:C3") },
+    });
+
+    env.openSidePanel("PivotSidePanel", { pivotId: "1" });
+    await nextTick();
+    expect(".o-measure-description").toHaveText(`Displayed as % of previous "Customer"`);
+  });
 });


### PR DESCRIPTION
## Description:

When a Show as is set on a measure, there is no indication that it is set. The idea would be to display it on the tile so that it's clearer.

Task: [5502479](https://www.odoo.com/odoo/2328/tasks/5502479)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo