### PR TITLE
[IMP] spreadsheet: improve handling of context menu events

### DIFF
--- a/src/components/bottom_bar/bottom_bar.xml
+++ b/src/components/bottom_bar/bottom_bar.xml
@@ -3,8 +3,7 @@
     <div
       class="o-spreadsheet-bottom-bar o-two-columns d-flex flex-fill align-items-center overflow-hidden border-top"
       t-on-click="props.onClick"
-      t-ref="bottomBar"
-      t-on-contextmenu.prevent="">
+      t-ref="bottomBar">
       <Ripple class="'add-sheet-container'">
         <div
           class="o-sheet-item o-add-sheet me-2 p-1"

--- a/src/components/bottom_bar/bottom_bar_sheet/bottom_bar_sheet.ts
+++ b/src/components/bottom_bar/bottom_bar_sheet/bottom_bar_sheet.ts
@@ -235,9 +235,13 @@ export class BottomBarSheet extends Component<Props, SpreadsheetChildEnv> {
   }
 
   onContextMenu(ev: MouseEvent) {
+    if ((ev.target as HTMLElement).isContentEditable) {
+      return;
+    }
     if (!this.isSheetActive) {
       this.activateSheet();
     }
+    ev.preventDefault();
     this.props.openContextMenu(this.contextMenuRegistry, ev);
   }
 

--- a/src/components/bottom_bar/bottom_bar_sheet/bottom_bar_sheet.xml
+++ b/src/components/bottom_bar/bottom_bar_sheet/bottom_bar_sheet.xml
@@ -7,7 +7,7 @@
         composerFocusableElement="true"
         t-on-pointerdown="(ev) => this.onMouseDown(ev)"
         t-on-click="onClick"
-        t-on-contextmenu.prevent="(ev) => this.onContextMenu(ev)"
+        t-on-contextmenu="(ev) => this.onContextMenu(ev)"
         t-ref="sheetDiv"
         t-key="sheetName"
         t-att-style="props.style"

--- a/src/components/dashboard/dashboard.xml
+++ b/src/components/dashboard/dashboard.xml
@@ -19,7 +19,6 @@
             t-att-title="clickableCell.title"
             t-on-click="(ev) => this.selectClickableCell(ev, clickableCell)"
             t-on-auxclick="(ev) => this.selectClickableCell(ev, clickableCell)"
-            t-on-contextmenu.prevent=""
             t-att-style="getCellClickableStyle(clickableCell.coordinates)">
             <t
               t-if="clickableCell.component"

--- a/src/components/headers_overlay/headers_overlay.ts
+++ b/src/components/headers_overlay/headers_overlay.ts
@@ -183,6 +183,9 @@ abstract class AbstractResizer extends Component<ResizerProps, SpreadsheetChildE
   }
 
   onMouseDown(ev: MouseEvent) {
+    if (ev.button !== 0) {
+      return;
+    }
     this.state.isResizing = true;
     this.state.delta = 0;
     const zoomedMouseEvent = withZoom(this.env, ev);

--- a/src/components/headers_overlay/headers_overlay.xml
+++ b/src/components/headers_overlay/headers_overlay.xml
@@ -32,7 +32,6 @@
           class="o-handle"
           t-on-pointerdown="onMouseDown"
           t-on-dblclick="onDblClick"
-          t-on-contextmenu.prevent=""
           t-attf-style="top:{{state.draggerLinePosition - 2}}px;">
           <div class="dragging-resizer" t-if="state.isResizing"/>
         </div>
@@ -75,7 +74,6 @@
           class="o-handle"
           t-on-pointerdown="onMouseDown"
           t-on-dblclick="onDblClick"
-          t-on-contextmenu.prevent=""
           t-attf-style="left:{{state.draggerLinePosition - 2}}px;">
           <div class="dragging-resizer" t-if="state.isResizing"/>
         </div>

--- a/src/components/menu/menu.xml
+++ b/src/components/menu/menu.xml
@@ -7,8 +7,7 @@
       t-on-scroll="props.onScroll"
       t-on-wheel.stop=""
       t-on-pointerdown.prevent=""
-      t-on-click.stop=""
-      t-on-contextmenu.prevent="">
+      t-on-click.stop="">
       <t t-foreach="props.menuItems" t-as="menuItem" t-key="menuItem_index">
         <div t-if="menuItem === 'separator'" class="o-separator border-bottom"/>
         <t t-else="">


### PR DESCRIPTION
## Description

Our handling of context menu event is all over the place. Some components prevent the default behavior (eg. bottom bar, menu) while some others do not (eg. top bar, side panels).

With this commit, the spreadsheet component intercepts all the context
menu events. It prevent the default behavior, except for editable
elements so the user can copy/paste with the browser context menu.

Task: [5499550](https://www.odoo.com/odoo/2328/tasks/5499550)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo