### PR TITLE
[FIX] menu: can open empty menu popover

### DIFF
--- a/src/actions/action.ts
+++ b/src/actions/action.ts
@@ -1,5 +1,7 @@
 import { Color, SpreadsheetChildEnv } from "../types";
 
+export type MenuItemOrSeparator = Action | "separator";
+
 /*
  * An Action represent a menu item for the menus of the top bar
  * and the context menu in the grid. It can also represent a button
@@ -136,4 +138,31 @@ export function createAction(item: ActionSpec): Action {
     onStartHover: item.onStartHover,
     onStopHover: item.onStopHover,
   };
+}
+
+export function getMenuItemsAndSeparators(
+  env: SpreadsheetChildEnv,
+  actions: Action[]
+): MenuItemOrSeparator[] {
+  const menuItemsAndSeparators: MenuItemOrSeparator[] = [];
+  for (let i = 0; i < actions.length; i++) {
+    const menuItem = actions[i];
+    if (menuItem.isVisible(env)) {
+      menuItemsAndSeparators.push(menuItem);
+    }
+    if (
+      menuItem.separator &&
+      i !== actions.length - 1 && // no separator at the end
+      menuItemsAndSeparators[menuItemsAndSeparators.length - 1] !== "separator" // no double separator
+    ) {
+      menuItemsAndSeparators.push("separator");
+    }
+  }
+  if (menuItemsAndSeparators[menuItemsAndSeparators.length - 1] === "separator") {
+    menuItemsAndSeparators.pop();
+  }
+  if (menuItemsAndSeparators.length === 1 && menuItemsAndSeparators[0] === "separator") {
+    return [];
+  }
+  return menuItemsAndSeparators;
 }

--- a/src/components/menu/menu.ts
+++ b/src/components/menu/menu.ts
@@ -1,5 +1,5 @@
 import { Component, onWillUnmount } from "@odoo/owl";
-import { Action } from "../../actions/action";
+import { Action, MenuItemOrSeparator } from "../../actions/action";
 import {
   BUTTON_ACTIVE_BG,
   BUTTON_ACTIVE_TEXT_COLOR,
@@ -68,13 +68,11 @@ css/* scss */ `
   }
 `;
 
-type MenuItemOrSeparator = Action | "separator";
-
 export interface MenuProps {
-  menuItems: Action[];
+  menuItems: MenuItemOrSeparator[];
   onClose: () => void;
   onScroll?: (ev: CustomEvent) => void;
-  onClickMenu?: (menu: Action, ev: CustomEvent) => void;
+  onClickMenu?: (menu: Action, ev: PointerEvent) => void;
   onMouseEnter?: (menu: Action, ev: PointerEvent) => void;
   onMouseOver?: (menu: Action, ev: PointerEvent) => void;
   onMouseLeave?: (menu: Action, ev: PointerEvent) => void;
@@ -115,32 +113,10 @@ export class Menu extends Component<MenuProps, SpreadsheetChildEnv> {
     });
   }
 
-  get menuItemsAndSeparators(): MenuItemOrSeparator[] {
-    const menuItemsAndSeparators: MenuItemOrSeparator[] = [];
-    for (let i = 0; i < this.props.menuItems.length; i++) {
-      const menuItem = this.props.menuItems[i];
-      if (menuItem.isVisible(this.env)) {
-        menuItemsAndSeparators.push(menuItem);
-      }
-      if (
-        menuItem.separator &&
-        i !== this.props.menuItems.length - 1 && // no separator at the end
-        menuItemsAndSeparators[menuItemsAndSeparators.length - 1] !== "separator" // no double separator
-      ) {
-        menuItemsAndSeparators.push("separator");
-      }
-    }
-    if (menuItemsAndSeparators[menuItemsAndSeparators.length - 1] === "separator") {
-      menuItemsAndSeparators.pop();
-    }
-    if (menuItemsAndSeparators.length === 1 && menuItemsAndSeparators[0] === "separator") {
-      return [];
-    }
-    return menuItemsAndSeparators;
-  }
-
   get childrenHaveIcon(): boolean {
-    return this.props.menuItems.some((menuItem) => !!this.getIconName(menuItem));
+    return this.props.menuItems.some(
+      (menuItem) => menuItem !== "separator" && !!this.getIconName(menuItem)
+    );
   }
 
   getIconName(menu: Action) {
@@ -193,7 +169,7 @@ export class Menu extends Component<MenuProps, SpreadsheetChildEnv> {
     this.props.onMouseLeave?.(menu, ev);
   }
 
-  onClickMenu(menu: Action, ev: CustomEvent) {
+  onClickMenu(menu: Action, ev: PointerEvent) {
     if (!this.isEnabled(menu)) {
       return;
     }

--- a/src/components/menu/menu.xml
+++ b/src/components/menu/menu.xml
@@ -9,7 +9,7 @@
       t-on-pointerdown.prevent=""
       t-on-click.stop=""
       t-on-contextmenu.prevent="">
-      <t t-foreach="menuItemsAndSeparators" t-as="menuItem" t-key="menuItem_index">
+      <t t-foreach="props.menuItems" t-as="menuItem" t-key="menuItem_index">
         <div t-if="menuItem === 'separator'" class="o-separator"/>
         <t t-else="">
           <t t-set="isMenuRoot" t-value="isRoot(menuItem)"/>

--- a/src/components/menu_popover/menu_popover.ts
+++ b/src/components/menu_popover/menu_popover.ts
@@ -6,7 +6,7 @@ import {
   useRef,
   useState,
 } from "@odoo/owl";
-import { Action } from "../../actions/action";
+import { Action, getMenuItemsAndSeparators } from "../../actions/action";
 import { DESKTOP_MENU_ITEM_HEIGHT, MENU_VERTICAL_PADDING, MENU_WIDTH } from "../../constants";
 import { MenuMouseEvent, Pixel, Rect, SpreadsheetChildEnv, UID } from "../../types";
 import { PopoverPropsPosition } from "../../types/cell_popovers";
@@ -103,9 +103,8 @@ export class MenuPopover extends Component<Props, SpreadsheetChildEnv> {
 
   get menuProps(): MenuProps {
     return {
-      menuItems: this.props.menuItems,
+      menuItems: this.menuItems,
       onClose: this.close.bind(this),
-      // @ts-ignore
       onClickMenu: this.onClickMenu.bind(this),
       onMouseOver: this.onMouseOver.bind(this),
       onMouseLeave: this.onMouseLeave.bind(this),
@@ -182,6 +181,10 @@ export class MenuPopover extends Component<Props, SpreadsheetChildEnv> {
     this.close();
   }
 
+  get menuItems() {
+    return getMenuItemsAndSeparators(this.env, this.props.menuItems);
+  }
+
   getName(menu: Action) {
     return menu.name(this.env);
   }
@@ -238,7 +241,7 @@ export class MenuPopover extends Component<Props, SpreadsheetChildEnv> {
     this.subMenu.parentMenu = undefined;
   }
 
-  onClickMenu(menu: Action, ev: MouseEvent) {
+  onClickMenu(menu: Action, ev: PointerEvent) {
     if (this.isRoot(menu)) {
       this.openSubMenu(menu, ev.currentTarget as HTMLElement);
     } else {

--- a/src/components/menu_popover/menu_popover.xml
+++ b/src/components/menu_popover/menu_popover.xml
@@ -1,6 +1,6 @@
 <templates>
   <t t-name="o-spreadsheet-Menu-Popover">
-    <Popover t-if="props.menuItems" t-props="popoverProps">
+    <Popover t-if="menuItems.length" t-props="popoverProps">
       <div t-ref="menu" class="o-menu-wrapper" t-on-mouseover="() => this.onMouseOverMainMenu()">
         <Menu t-props="menuProps"/>
       </div>

--- a/src/components/small_bottom_bar/ribbon_menu/ribbon_menu.ts
+++ b/src/components/small_bottom_bar/ribbon_menu/ribbon_menu.ts
@@ -1,5 +1,5 @@
 import { Component, onMounted, useExternalListener, useRef, useState } from "@odoo/owl";
-import { Action } from "../../../actions/action";
+import { Action, getMenuItemsAndSeparators } from "../../../actions/action";
 import { topbarMenuRegistry } from "../../../registries/menus";
 import { _t } from "../../../translation";
 import { SpreadsheetChildEnv } from "../../../types";
@@ -65,7 +65,7 @@ export class RibbonMenu extends Component<RibbonMenuProps, SpreadsheetChildEnv> 
 
   get menuProps(): MenuProps {
     return {
-      menuItems: this.state.menuItems,
+      menuItems: getMenuItemsAndSeparators(this.env, this.state.menuItems),
       onClose: this.props.onClose,
       onClickMenu: this.onClickMenu.bind(this),
     };

--- a/tests/menus/menu_component.test.ts
+++ b/tests/menus/menu_component.test.ts
@@ -1,7 +1,8 @@
 import { createActions } from "../../src/actions/action";
 import { Menu } from "../../src/components/menu/menu";
+import { MenuPopover } from "../../src/components/menu_popover/menu_popover";
 import { simulateClick } from "../test_helpers/dom_helper";
-import { mountComponent } from "../test_helpers/helpers";
+import { mountComponent, mountComponentWithPortalTarget } from "../test_helpers/helpers";
 
 describe("Menu component", () => {
   test("Execute is not called when menu item is disabled", async () => {
@@ -22,5 +23,23 @@ describe("Menu component", () => {
     expect(fixture.querySelector(selector)!.classList).toContain("disabled");
     await simulateClick(selector);
     expect(callback).not.toHaveBeenCalled();
+  });
+
+  test("Opening a menu popover with no visible menu items does not open a popover", async () => {
+    const menuItems = createActions([
+      { name: "Test Menu", id: "test_menu", isVisible: () => false },
+    ]);
+
+    await mountComponentWithPortalTarget(MenuPopover, {
+      props: {
+        menuItems,
+        onClose: () => {},
+        anchorRect: { x: 0, y: 0, width: 0, height: 0 },
+        popoverPositioning: "bottom-left",
+        depth: 0,
+      },
+    });
+
+    expect(".o-popover").toHaveCount(0);
   });
 });


### PR DESCRIPTION
## Description

Since the split of `Menu` and `MenuPopover`, we can open an empty menu, which is not desired.

Two issues:
- the `t-if` condition was plainly wrong, checking for the existence of the array rather than it's length.
- the logic to know what menus are visible or not was in the `Menu` component, but is needed in the parent `MenuPopover` component to know if we should open the popover or not.

Task: [5863077](https://www.odoo.com/odoo/2328/tasks/5863077)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo