### PR TITLE
[FIX] pivot style: mark pivot table styles as non editable

### DIFF
--- a/packages/o-spreadsheet-engine/src/plugins/core/table_style.ts
+++ b/packages/o-spreadsheet-engine/src/plugins/core/table_style.ts
@@ -94,7 +94,7 @@ export class TableStylePlugin extends CorePlugin<TableStylesState> implements Ta
   }
 
   isTableStyleEditable(styleId: string): boolean {
-    return !TABLE_PRESETS[styleId];
+    return !TABLE_PRESETS[styleId] && !PIVOT_TABLE_PRESETS[styleId];
   }
 
   import(data: WorkbookData) {

--- a/src/components/tables/table_style_preview/table_style_preview.ts
+++ b/src/components/tables/table_style_preview/table_style_preview.ts
@@ -107,7 +107,7 @@ export class TableStylePreview extends Component<Props, SpreadsheetChildEnv> {
   }
 
   get isStyleEditable(): boolean {
-    if (!this.props.styleId || this.props.type !== "table") {
+    if (!this.props.styleId) {
       return false;
     }
     return this.env.model.getters.isTableStyleEditable(this.props.styleId);

--- a/tests/pivots/pivot_table_style.test.ts
+++ b/tests/pivots/pivot_table_style.test.ts
@@ -339,4 +339,9 @@ describe("Pivot table style", () => {
 
     expect(getTables(model, sheetId)).toHaveLength(0);
   });
+
+  test("Pivot table style are not editable", () => {
+    expect(model.getters.isTableStyleEditable("TestStyle")).toBe(false);
+    expect(model.getters.isTableStyleEditable("PivotTableStyleLight1")).toBe(false);
+  });
 });


### PR DESCRIPTION
## Description

The pivot table styles were marked as editable by the getter `isTableStyleEditable`. This allowed to open a context menu to edit/delete them, which is not supported.

Task: [5865092](https://www.odoo.com/odoo/2328/tasks/5865092)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo