### PR TITLE
[FIX] gauge: transform section rule formulas

### DIFF
--- a/src/helpers/figures/charts/gauge_chart.ts
+++ b/src/helpers/figures/charts/gauge_chart.ts
@@ -30,7 +30,7 @@ import {
 } from "../../../types/chart/gauge_chart";
 import { CellErrorType } from "../../../types/errors";
 import { Validator } from "../../../types/validator";
-import { adaptStringRange } from "../../formulas";
+import { adaptFormulaStringRanges, adaptStringRange } from "../../formulas";
 import { clip, formatValue } from "../../index";
 import { createValidRange } from "../../range";
 import { rangeReference } from "../../references";
@@ -172,9 +172,13 @@ export class GaugeChart extends AbstractChart {
         dataRange = adaptedRange;
       }
     }
+    const adaptFormula = (formula: string) =>
+      adaptFormulaStringRanges(chartSheetId, formula, applyChange);
+    const sectionRule = adaptSectionRuleFormulas(definition.sectionRule, adaptFormula);
     return {
       ...definition,
       dataRange,
+      sectionRule,
     };
   }
 

--- a/tests/collaborative/ot/ot_helper.ts
+++ b/tests/collaborative/ot/ot_helper.ts
@@ -7,6 +7,7 @@ import {
   UpdateCellCommand,
 } from "../../../src";
 import { deepCopy } from "../../../src/helpers";
+import { GaugeChartDefinition } from "../../../src/types/chart";
 import { TEST_COMMANDS } from "../../test_helpers/constants";
 
 export function getFormulaStringCommands(
@@ -19,6 +20,7 @@ export function getFormulaStringCommands(
     [getCFCommand(sheetId, formulaBefore), getCFCommand(sheetId, formulaAfter)],
     [getDVCommand(sheetId, formulaBefore), getDVCommand(sheetId, formulaAfter)],
     [getPivotCommand(sheetId, formulaBefore), getPivotCommand(sheetId, formulaAfter)],
+    [getGaugeCommand(sheetId, formulaBefore), getGaugeCommand(sheetId, formulaAfter)],
   ];
 }
 
@@ -58,5 +60,28 @@ function getPivotCommand(sheetId: UID, formula: string): AddPivotCommand {
       computedBy: { sheetId, formula },
     },
   ];
+  return cmd;
+}
+
+function getGaugeCommand(sheetId: UID, formula: string) {
+  const cmd = deepCopy(TEST_COMMANDS.CREATE_CHART);
+  const definition: GaugeChartDefinition = {
+    type: "gauge",
+    title: { text: "" },
+    dataRange: "Sheet1!B1:B4",
+    sectionRule: {
+      colors: {
+        lowerColor: "#111111",
+        middleColor: "#999999",
+        upperColor: "#dddddd",
+      },
+      rangeMin: formula,
+      rangeMax: formula,
+      lowerInflectionPoint: { operator: "<", type: "percentage", value: formula },
+      upperInflectionPoint: { operator: "<", type: "number", value: formula },
+    },
+  };
+  cmd.sheetId = sheetId;
+  cmd.definition = definition;
   return cmd;
 }


### PR DESCRIPTION
Formulas in gauge section rules are not transformed against concurrent collaborative commands.


Task: [5867508](https://www.odoo.com/odoo/2328/tasks/5867508)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo