### PR TITLE
[FIX] Evaluation: Provide cell position on single formula evaluation

### DIFF
--- a/src/components/composer/composer/cell_composer_store.ts
+++ b/src/components/composer/composer/cell_composer_store.ts
@@ -244,7 +244,11 @@ export class CellComposerStore extends AbstractComposerStore {
       return;
     }
 
-    const evaluated = this.getters.evaluateFormula(this.sheetId, content);
+    const evaluated = this.getters.evaluateFormula(this.sheetId, content, {
+      sheetId: this.sheetId,
+      col: this.col,
+      row: this.row,
+    });
     if (!isMatrix(evaluated)) {
       return;
     }

--- a/src/plugins/ui_core_views/cell_evaluation/evaluation_plugin.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluation_plugin.ts
@@ -218,8 +218,12 @@ export class EvaluationPlugin extends UIPlugin {
   // Getters
   // ---------------------------------------------------------------------------
 
-  evaluateFormula(sheetId: UID, formulaString: string): CellValue | Matrix<CellValue> {
-    const result = this.evaluateFormulaResult(sheetId, formulaString);
+  evaluateFormula(
+    sheetId: UID,
+    formulaString: string,
+    originCellPosition?: CellPosition
+  ): CellValue | Matrix<CellValue> {
+    const result = this.evaluateFormulaResult(sheetId, formulaString, originCellPosition);
     if (isMatrix(result)) {
       return matrixMap(result, (cell) => cell.value);
     }
@@ -228,9 +232,10 @@ export class EvaluationPlugin extends UIPlugin {
 
   evaluateFormulaResult(
     sheetId: UID,
-    formulaString: string
+    formulaString: string,
+    originCellPosition?: CellPosition
   ): Matrix<FunctionResultObject> | FunctionResultObject {
-    return this.evaluator.evaluateFormulaResult(sheetId, formulaString);
+    return this.evaluator.evaluateFormulaResult(sheetId, formulaString, originCellPosition);
   }
 
   evaluateCompiledFormula(

--- a/tests/composer/composer_store.test.ts
+++ b/tests/composer/composer_store.test.ts
@@ -1086,6 +1086,28 @@ describe("edition", () => {
     expect(getCellContent(model, cellOnLastCol)).toBe("0");
   });
 
+  describe("Row addition works with position dependant functions", () => {
+    test("Adding rows below with ROW function", () => {
+      const sheetId = model.getters.getActiveSheetId();
+      const numberOfRows = model.getters.getNumberRows(sheetId);
+
+      const cellOnLastRow = toXC(0, numberOfRows - 1);
+      editCell(model, cellOnLastRow, "=MUNIT(ROW())");
+      expect(model.getters.getNumberRows(sheetId)).toBe(numberOfRows * 2 + 50 - 1);
+      expect(getCellContent(model, cellOnLastRow)).toBe("1");
+    });
+
+    test("Adding rows below with ROW function", () => {
+      const sheetId = model.getters.getActiveSheetId();
+      const numberOfCols = model.getters.getNumberCols(sheetId);
+
+      const cellOnLastCols = toXC(numberOfCols - 1, 0);
+      editCell(model, cellOnLastCols, "=MUNIT(COLUMN())");
+      expect(model.getters.getNumberCols(sheetId)).toBe(numberOfCols * 2 + 20 - 1);
+      expect(getCellContent(model, cellOnLastCols)).toBe("1");
+    });
+  });
+
   test("Can undo/redo after adding a spreading formula at the end of the sheet", () => {
     const sheetId = model.getters.getActiveSheetId();
     const numberOfCols = model.getters.getNumberCols(sheetId);


### PR DESCRIPTION
How to reproduce:

- in a spreadsheet, go to the last row
- in a cell of the last row, write the formula `=MUNIT(ROW())` -> the formula is in #SPILL error because we did not extend the size of the spreadsheet

Some formulas, like ROW & COLUMN need to know the coordinates of the cell on which  they are applied to be computed and we did not provide those in the evaluation context when evaluating isolated formulas.

Task: 5798610

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo