### PR TITLE
[FIX] evaluation: do not overwrite current sheet

### DIFF
--- a/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
@@ -617,13 +617,20 @@ export function updateEvalContextAndExecute(
   getSymbolValue: GetSymbolValue,
   originCellPosition: CellPosition | undefined
 ) {
-  compilationParams.evalContext.__originCellPosition = originCellPosition;
-  compilationParams.evalContext.__originSheetId = sheetId;
-  return compiledFormula.execute(
+  const evalContext = compilationParams.evalContext;
+  const currentCellPosition = evalContext.__originCellPosition;
+  const currentSheetId = evalContext.__originSheetId;
+
+  evalContext.__originCellPosition = originCellPosition;
+  evalContext.__originSheetId = sheetId;
+  const result = compiledFormula.execute(
     compiledFormula.dependencies,
     compilationParams.referenceDenormalizer,
     compilationParams.ensureRange,
     getSymbolValue,
-    compilationParams.evalContext
+    evalContext
   );
+  evalContext.__originCellPosition = currentCellPosition;
+  evalContext.__originSheetId = currentSheetId;
+  return result;
 }

--- a/tests/pivots/pivot_calculated_measure.test.ts
+++ b/tests/pivots/pivot_calculated_measure.test.ts
@@ -1282,3 +1282,30 @@ test("measure takes indirect dependency into account for recalculation", () => {
   expect(getEvaluatedCell(model, "A4").value).toEqual(43);
   expect(getEvaluatedCell(model, "A5").value).toEqual(43);
 });
+
+test("calculated measure do not break meta formula", () => {
+  const grid = {
+    A1: "Customer",
+    A2: "Alice",
+    A3: "42",
+    A4: '=INDIRECT("A3") & PIVOT.VALUE(1, "calculated") & INDIRECT("A3")',
+  };
+  const model = createModelFromGrid(grid);
+  createSheet(model, { sheetId: "sheet2" });
+  setCellContent(model, "A3", "1", "sheet2");
+  addPivot(model, "A1:A2", {
+    measures: [
+      {
+        id: "calculated",
+        fieldName: "calculated",
+        aggregator: "sum",
+        computedBy: {
+          // references A3 in sheet2
+          formula: '=INDIRECT("A3")',
+          sheetId: "sheet2",
+        },
+      },
+    ],
+  });
+  expect(getEvaluatedCell(model, "A4").value).toEqual("42142");
+});


### PR DESCRIPTION
Steps to reproduce
------------------

- Create a pivot
- add a calculated measure (the formula doesn't matter)
- create a new sheet
- on a new sheet
	- add content in A3
	- add the formula =INDIRECT("A3") & PIVOT.VALUE(1, "calculated") & INDIRECT("A3")

=> the result is broken.

Task: 5868007

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo