### PR TITLE
[IMP] evaluation: allow to bypass evaluation

### DIFF
--- a/src/actions/data_actions.ts
+++ b/src/actions/data_actions.ts
@@ -95,3 +95,20 @@ export const reinsertStaticPivotMenu: ActionSpec = {
   isVisible: (env) =>
     env.model.getters.getPivotIds().some((id) => env.model.getters.getPivot(id).isValid()),
 };
+
+export const calculationMode: ActionSpec = {
+  name: _t("Calculation"),
+  icon: "o-spreadsheet-Icon.CALCULATOR",
+};
+
+export const automaticCalculation: ActionSpec = {
+  name: _t("Automatic"),
+  execute: (env) => env.model.dispatch("SET_AUTOMATIC_EVALUATION", { enabled: true }),
+  isActive: (env) => env.model.getters.isAutomaticEvaluationEnabled(),
+};
+
+export const manualCalculation: ActionSpec = {
+  name: _t("Manual"),
+  execute: (env) => env.model.dispatch("SET_AUTOMATIC_EVALUATION", { enabled: false }),
+  isActive: (env) => !env.model.getters.isAutomaticEvaluationEnabled(),
+};

--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -278,6 +278,7 @@ export class Grid extends Component<SpreadsheetChildEnv> {
     "Ctrl+Z": () => this.env.model.dispatch("REQUEST_UNDO"),
     "Ctrl+Y": () => this.env.model.dispatch("REQUEST_REDO"),
     F4: () => this.env.model.dispatch("REQUEST_REDO"),
+    F9: () => this.env.model.dispatch("EVALUATE_CELLS"),
     "Ctrl+B": () =>
       this.env.model.dispatch("SET_FORMATTING", {
         sheetId: this.env.model.getters.getActiveSheetId(),

--- a/src/components/icons/icons.xml
+++ b/src/components/icons/icons.xml
@@ -1200,4 +1200,9 @@
       />
     </svg>
   </t>
+  <t t-name="o-spreadsheet-Icon.CALCULATOR">
+    <div class="o-icon">
+      <i class="fa fa-calculator"/>
+    </div>
+  </t>
 </templates>

--- a/src/components/top_bar/top_bar.css
+++ b/src/components/top_bar/top_bar.css
@@ -58,6 +58,10 @@
       .alert-info {
         border-left: 3px solid var(--os-alert-info-border);
       }
+
+      .alert-warning {
+        border-left: 3px solid var(--os-alert-warning-border, #ffc107);
+      }
     }
 
     .o-topbar-composer {

--- a/src/components/top_bar/top_bar.xml
+++ b/src/components/top_bar/top_bar.xml
@@ -106,6 +106,25 @@
           </div>
         </div>
       </div>
+      <div
+        t-if="!this.env.model.getters.isAutomaticEvaluationEnabled()"
+        class="topbar-banner manual-evaluation d-flex align-items-center justify-content-between border-top">
+        <div class="h-100 d-flex align-items-center text-warning px-3">
+          <i class="fa fa-pause-circle me-1"/>
+          Manual calculation
+        </div>
+        <div
+          class="ps-3 h-100 flex-fill d-flex justify-content-between rounded-0 alert alert-warning ps-0 py-0 my-0">
+          <span class="d-flex align-items-center">
+            Automatic evaluation is disabled. Press F9 to recalculate.
+          </span>
+          <div
+            class="ps-3 btn btn-link flex-shrink-0"
+            t-on-click="() => this.env.model.dispatch('SET_AUTOMATIC_EVALUATION', { enabled: true })">
+            Re-enable
+          </div>
+        </div>
+      </div>
     </div>
     <MenuPopover
       t-if="this.state.menuState.isOpen"

--- a/src/plugins/ui_core_views/cell_evaluation/evaluation_plugin.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluation_plugin.ts
@@ -162,6 +162,7 @@ export class EvaluationPlugin extends CoreViewPlugin {
   ] as const;
 
   private shouldRebuildDependenciesGraph = true;
+  private forceEvaluation = false;
 
   private evaluator: Evaluator;
   private positionsToUpdate: CellPosition[] = [];
@@ -176,6 +177,7 @@ export class EvaluationPlugin extends CoreViewPlugin {
   // ---------------------------------------------------------------------------
 
   beforeHandle(cmd: Command) {
+    this.forceEvaluation = false;
     if (
       invalidateEvaluationCommands.has(cmd.type) ||
       invalidateDependenciesCommands.has(cmd.type)
@@ -198,7 +200,12 @@ export class EvaluationPlugin extends CoreViewPlugin {
         }
         break;
       case "EVALUATE_CELLS":
-        if (cmd.cellIds) {
+        this.forceEvaluation = true;
+        if (!this.getters.isAutomaticEvaluationEnabled()) {
+          // When automatic evaluation is disabled, EVALUATE_CELLS should rebuild dependencies
+          // and evaluate all cells to ensure consistency
+          this.shouldRebuildDependenciesGraph = true;
+        } else if (cmd.cellIds) {
           for (let i = 0; i < cmd.cellIds.length; i++) {
             this.positionsToUpdate.push(this.getters.getCellPosition(cmd.cellIds[i]));
           }
@@ -210,6 +217,16 @@ export class EvaluationPlugin extends CoreViewPlugin {
   }
 
   finalize() {
+    if (!this.shouldPerformEvaluation()) {
+      // When automatic evaluation is disabled, still evaluate directly modified cells
+      // so the user can see the result of what they typed, without cascading to dependents.
+      if (this.positionsToUpdate.length) {
+        this.evaluator.evaluateCellsWithoutCascade(this.positionsToUpdate);
+      }
+      this.positionsToUpdate = [];
+      return;
+    }
+
     if (this.shouldRebuildDependenciesGraph) {
       this.evaluator.buildDependencyGraph();
       this.evaluator.evaluateAllCells();
@@ -309,6 +326,10 @@ export class EvaluationPlugin extends CoreViewPlugin {
 
   getPerfProfile(): PerfProfile | undefined {
     return this.evaluator.getPerfProfile();
+  }
+
+  shouldPerformEvaluation(): boolean {
+    return this.forceEvaluation || this.getters.isAutomaticEvaluationEnabled();
   }
 
   /**

--- a/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
@@ -199,6 +199,17 @@ export class Evaluator {
     console.debug("evaluate Cells", performance.now() - start, "ms");
   }
 
+  /**
+   * Evaluates the given cells without propagating to their dependents.
+   * Used when automatic evaluation is disabled, to show the result of a
+   * directly modified cell without triggering a potentially expensive cascade.
+   */
+  evaluateCellsWithoutCascade(positions: CellPosition[]) {
+    const rangesToCompute = new RangeSet();
+    rangesToCompute.addManyPositions(positions);
+    this.evaluate(rangesToCompute);
+  }
+
   private getArrayFormulasImpactedByChangesOf(positions: Iterable<CellPosition>): RangeSet {
     const impactedRanges = new RangeSet();
 

--- a/src/plugins/ui_feature/ui_options.ts
+++ b/src/plugins/ui_feature/ui_options.ts
@@ -2,8 +2,9 @@ import { Command } from "../../types/commands";
 import { UIPlugin } from "../ui_plugin";
 
 export class UIOptionsPlugin extends UIPlugin {
-  static getters = ["shouldShowFormulas"] as const;
+  static getters = ["shouldShowFormulas", "isAutomaticEvaluationEnabled"] as const;
   private showFormulas: boolean = false;
+  private automaticEvaluation: boolean = true;
 
   // ---------------------------------------------------------------------------
   // Command Handling
@@ -14,6 +15,15 @@ export class UIOptionsPlugin extends UIPlugin {
       case "SET_FORMULA_VISIBILITY":
         this.showFormulas = cmd.show;
         break;
+      case "SET_AUTOMATIC_EVALUATION":
+        const wasDisabled = !this.automaticEvaluation;
+        this.automaticEvaluation = cmd.enabled;
+        // When re-enabling automatic evaluation, trigger a full evaluation
+        // to update all cells, charts, pivots, etc. that may have changed
+        if (wasDisabled && cmd.enabled) {
+          this.dispatch("EVALUATE_CELLS");
+        }
+        break;
     }
   }
 
@@ -23,5 +33,13 @@ export class UIOptionsPlugin extends UIPlugin {
 
   shouldShowFormulas(): boolean {
     return this.showFormulas;
+  }
+
+  /**
+   * Returns whether automatic evaluation is enabled.
+   * When disabled, cells are only re-evaluated on explicit EVALUATE_CELLS commands (F9).
+   */
+  isAutomaticEvaluationEnabled(): boolean {
+    return this.automaticEvaluation;
   }
 }

--- a/src/registries/menus/topbar_menu_registry.ts
+++ b/src/registries/menus/topbar_menu_registry.ts
@@ -511,6 +511,18 @@ topbarMenuRegistry
     sequence: 35,
     separator: true,
   })
+  .addChild("calculation_mode", ["data"], {
+    ...ACTION_DATA.calculationMode,
+    sequence: 35,
+  })
+  .addChild("automatic_calculation", ["data", "calculation_mode"], {
+    ...ACTION_DATA.automaticCalculation,
+    sequence: 10,
+  })
+  .addChild("manual_calculation", ["data", "calculation_mode"], {
+    ...ACTION_DATA.manualCalculation,
+    sequence: 20,
+  })
   .addChild("add_remove_data_filter", ["data"], {
     ...ACTION_DATA.createRemoveFilter,
     sequence: 40,

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -211,6 +211,7 @@ export const readonlyAllowedCommands = new Set<CommandTypes>([
   "EVALUATE_CHARTS",
 
   "SET_FORMULA_VISIBILITY",
+  "SET_AUTOMATIC_EVALUATION",
 
   "UPDATE_FILTER",
   "UPDATE_CHART",
@@ -1028,6 +1029,11 @@ export interface ShowFormulaCommand {
   show: boolean;
 }
 
+export interface SetAutomaticEvaluationCommand {
+  type: "SET_AUTOMATIC_EVALUATION";
+  enabled: boolean;
+}
+
 export interface DeleteContentCommand {
   type: "DELETE_CONTENT";
   sheetId: UID;
@@ -1379,6 +1385,7 @@ export type LocalCommand =
   | SortCommand
   | SetDecimalCommand
   | SetContextualFormatCommand
+  | SetAutomaticEvaluationCommand
   | ResizeViewportCommand
   | SetZoomCommand
   | SumSelectionCommand

--- a/tests/__snapshots__/top_bar_component.test.ts.snap
+++ b/tests/__snapshots__/top_bar_component.test.ts.snap
@@ -797,5 +797,6 @@ exports[`TopBar component simple rendering 1`] = `
     
   </div>
   
+  
 </div>
 `;

--- a/tests/evaluation/evaluation.test.ts
+++ b/tests/evaluation/evaluation.test.ts
@@ -1526,3 +1526,99 @@ describe("evaluate formula getter", () => {
     expect(model.getters.getEvaluatedCells(sheetId)).toHaveLength(0);
   });
 });
+
+describe("Automatic evaluation", () => {
+  test("Can toggle automatic evaluation on and off", () => {
+    const model = new Model();
+    expect(model.getters.isAutomaticEvaluationEnabled()).toBe(true);
+    model.dispatch("SET_AUTOMATIC_EVALUATION", { enabled: false });
+    expect(model.getters.isAutomaticEvaluationEnabled()).toBe(false);
+    model.dispatch("SET_AUTOMATIC_EVALUATION", { enabled: true });
+    expect(model.getters.isAutomaticEvaluationEnabled()).toBe(true);
+  });
+
+  test("Directly modified cell is evaluated even when automatic evaluation is disabled", () => {
+    const model = new Model();
+    setCellContent(model, "A1", "1");
+    expect(getEvaluatedCell(model, "A1").value).toBe(1);
+
+    model.dispatch("SET_AUTOMATIC_EVALUATION", { enabled: false });
+    setCellContent(model, "A1", "=1+1");
+    // The modified cell itself should be evaluated
+    expect(getEvaluatedCell(model, "A1").value).toBe(2);
+  });
+
+  test("Dependent cells are not re-evaluated when automatic evaluation is disabled", () => {
+    const model = new Model();
+    setCellContent(model, "A1", "1");
+    setCellContent(model, "A2", "=A1");
+    expect(getEvaluatedCell(model, "A2").value).toBe(1);
+
+    model.dispatch("SET_AUTOMATIC_EVALUATION", { enabled: false });
+    setCellContent(model, "A1", "2");
+    // Directly modified cell A1 is evaluated
+    expect(getEvaluatedCell(model, "A1").value).toBe(2);
+    // Dependent cell A2 should still show the old value (no cascade)
+    expect(getEvaluatedCell(model, "A2").value).toBe(1);
+  });
+
+  test("F9 (EVALUATE_CELLS) forces evaluation even when automatic evaluation is disabled", () => {
+    const model = new Model();
+    setCellContent(model, "A1", "1");
+    setCellContent(model, "A2", "=A1");
+    expect(getEvaluatedCell(model, "A2").value).toBe(1);
+
+    model.dispatch("SET_AUTOMATIC_EVALUATION", { enabled: false });
+    setCellContent(model, "A1", "2");
+    expect(getEvaluatedCell(model, "A2").value).toBe(1);
+
+    // Force evaluation with F9
+    model.dispatch("EVALUATE_CELLS");
+    expect(getEvaluatedCell(model, "A2").value).toBe(2);
+  });
+
+  test("Re-enabling automatic evaluation triggers evaluation", () => {
+    const model = new Model();
+    setCellContent(model, "A1", "1");
+    setCellContent(model, "A2", "=A1");
+    expect(getEvaluatedCell(model, "A2").value).toBe(1);
+
+    model.dispatch("SET_AUTOMATIC_EVALUATION", { enabled: false });
+    setCellContent(model, "A1", "2");
+    expect(getEvaluatedCell(model, "A2").value).toBe(1);
+
+    // Re-enable automatic evaluation
+    model.dispatch("SET_AUTOMATIC_EVALUATION", { enabled: true });
+    expect(getEvaluatedCell(model, "A2").value).toBe(2);
+  });
+
+  test("EVALUATE_CELLS does a full rebuild when automatic evaluation is disabled", () => {
+    const model = new Model();
+    setCellContent(model, "A1", "1");
+    setCellContent(model, "A2", "=A1");
+
+    model.dispatch("SET_AUTOMATIC_EVALUATION", { enabled: false });
+    setCellContent(model, "A1", "2");
+    expect(getEvaluatedCell(model, "A2").value).toBe(1);
+
+    // Even with cellIds, a full rebuild is performed in manual mode
+    const cell = getCell(model, "A2");
+    model.dispatch("EVALUATE_CELLS", { cellIds: [cell!.id] });
+    expect(getEvaluatedCell(model, "A2").value).toBe(2);
+  });
+
+  test("EVALUATE_CELLS with cellIds re-evaluates cells outside cellIds in manual mode", () => {
+    const model = new Model();
+    setCellContent(model, "A1", "1");
+    setCellContent(model, "A2", "=A1");
+    setCellContent(model, "B1", "42");
+
+    model.dispatch("SET_AUTOMATIC_EVALUATION", { enabled: false });
+    setCellContent(model, "A1", "2");
+    expect(getEvaluatedCell(model, "A2").value).toBe(1);
+
+    const unrelatedCell = getCell(model, "B1")!;
+    model.dispatch("EVALUATE_CELLS", { cellIds: [unrelatedCell.id] });
+    expect(getEvaluatedCell(model, "A2").value).toBe(2);
+  });
+});

--- a/tests/grid/grid_component.test.ts
+++ b/tests/grid/grid_component.test.ts
@@ -18,6 +18,7 @@ import {
   MIN_CELL_TEXT_MARGIN,
   SCROLLBAR_WIDTH,
 } from "../../src/constants";
+import { functionRegistry } from "../../src/functions/function_registry";
 import { toCartesian } from "../../src/helpers/coordinates";
 import { buildSheetLink } from "../../src/helpers/misc";
 import { handleCopyPasteResult } from "../../src/helpers/ui/paste_interactive";
@@ -99,6 +100,7 @@ import {
   getStyle,
 } from "../test_helpers/getters_helpers";
 import {
+  addToRegistry,
   flattenHighlightRange,
   getPlugin,
   mockChart,
@@ -1032,6 +1034,20 @@ describe("Grid component", () => {
     test("pressing Ctrl+K opens the link editor", async () => {
       await keyDown({ key: "k", shiftKey: true, ctrlKey: true });
       expect(fixture.querySelector(".o-link-editor")).not.toBeNull();
+    });
+
+    test("pressing F9 triggers a full re-evaluation of all cells", async () => {
+      let value = 1;
+      addToRegistry(functionRegistry, "GETVALUE", {
+        description: "Get value",
+        compute: () => value,
+        args: [],
+      });
+      setCellContent(model, "A1", "=GETVALUE()");
+      expect(getEvaluatedCell(model, "A1").value).toBe(1);
+      value = 2;
+      await keyDown({ key: "F9" });
+      expect(getEvaluatedCell(model, "A1").value).toBe(2);
     });
 
     test("Filter icon is correctly rendered", () => {

--- a/tests/spreadsheet/__snapshots__/spreadsheet_component.test.ts.snap
+++ b/tests/spreadsheet/__snapshots__/spreadsheet_component.test.ts.snap
@@ -806,6 +806,7 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
         
       </div>
       
+      
     </div>
     
     
@@ -1839,6 +1840,7 @@ exports[`components take the small screen into account 1`] = `
         </div>
         
       </div>
+      
       
     </div>
     

--- a/tests/top_bar_component.test.ts
+++ b/tests/top_bar_component.test.ts
@@ -319,6 +319,17 @@ describe("TopBar component", () => {
     expect(".irregularity-map btn").toHaveCount(0);
   });
 
+  test("manual evaluation banner appears and can re-enable automatic evaluation", async () => {
+    const { model } = await mountParent();
+    expect(".manual-evaluation").toHaveCount(0);
+    model.dispatch("SET_AUTOMATIC_EVALUATION", { enabled: false });
+    await nextTick();
+    expect(".manual-evaluation").toHaveCount(1);
+    await click(fixture, ".manual-evaluation .btn");
+    expect(".manual-evaluation").toHaveCount(0);
+    expect(model.getters.isAutomaticEvaluationEnabled()).toBe(true);
+  });
+
   describe("Paint format tools", () => {
     test("Single click to activate paint format (once)", async () => {
       const { parent } = await mountParent();


### PR DESCRIPTION
For big spreadsheets, manipulating big data sources could lead to a lot
of time lost in evaluation.

With this commit, users can put the spreadsheet in a mode where the
evaluation is bypassed.

Task: 4220236