### PR TITLE
[FIX] Evaluation: Provide cell position for isolated formula evaluation

### DIFF
--- a/src/components/composer/composer/abstract_composer_store.ts
+++ b/src/components/composer/composer/abstract_composer_store.ts
@@ -324,9 +324,13 @@ export abstract class AbstractComposerStore extends SpreadsheetStore {
       hoveredFormula = `=${hoveredFormula}`;
     }
     const canonicalFormula = canonicalizeNumberContent(hoveredFormula, this.getters.getLocale());
-    const result = this.getters.evaluateFormulaResult(this.sheetId, canonicalFormula);
+    const result = this.evaluateCanonicalFormula(canonicalFormula);
     this.hoveredTokens = hoveredContextTokens;
     this.hoveredContentEvaluation = this.evaluationResultToDisplayString(result);
+  }
+
+  protected evaluateCanonicalFormula(canonicalFormula: string) {
+    return this.getters.evaluateFormulaResult(this.sheetId, canonicalFormula);
   }
 
   private getRelatedTokens(tokens: EnrichedToken[], tokenIndex: number): EnrichedToken[] {

--- a/src/components/composer/composer/cell_composer_store.ts
+++ b/src/components/composer/composer/cell_composer_store.ts
@@ -245,7 +245,11 @@ export class CellComposerStore extends AbstractComposerStore {
       return;
     }
 
-    const evaluated = this.getters.evaluateFormula(this.sheetId, content);
+    const evaluated = this.getters.evaluateFormula(this.sheetId, content, {
+      sheetId: this.sheetId,
+      col: this.col,
+      row: this.row,
+    });
     if (!isMatrix(evaluated)) {
       return;
     }
@@ -294,5 +298,13 @@ export class CellComposerStore extends AbstractComposerStore {
       return false;
     }
     return true;
+  }
+
+  protected evaluateCanonicalFormula(canonicalFormula: string) {
+    return this.getters.evaluateFormulaResult(this.sheetId, canonicalFormula, {
+      sheetId: this.sheetId,
+      col: this.col,
+      row: this.row,
+    });
   }
 }

--- a/src/components/composer/composer/composer.ts
+++ b/src/components/composer/composer/composer.ts
@@ -26,8 +26,7 @@ import { AutoCompleteStore } from "../autocomplete_dropdown/autocomplete_dropdow
 import { ContentEditableHelper } from "../content_editable_helper";
 import { FunctionDescriptionProvider } from "../formula_assistant/formula_assistant";
 import { SpeechBubble } from "../speech_bubble/speech_bubble";
-import { DEFAULT_TOKEN_COLOR } from "./abstract_composer_store";
-import { CellComposerStore } from "./cell_composer_store";
+import { AbstractComposerStore, DEFAULT_TOKEN_COLOR } from "./abstract_composer_store";
 
 const functions = functionRegistry.content;
 
@@ -133,7 +132,7 @@ export interface CellComposerProps {
   onComposerCellFocused?: (content: String) => void;
   onInputContextMenu?: (event: MouseEvent) => void;
   isDefaultFocus?: boolean;
-  composerStore: Store<CellComposerStore>;
+  composerStore: Store<AbstractComposerStore>;
   placeholder?: string;
 }
 

--- a/src/components/composer/standalone_composer/standalone_composer_store.ts
+++ b/src/components/composer/standalone_composer/standalone_composer_store.ts
@@ -84,4 +84,12 @@ export class StandaloneComposerStore extends AbstractComposerStore {
     }
     return super.getTokenColor(token);
   }
+
+  hoverToken() {
+    /**
+     * Some functions can only be evaluated in the context of the grid, which is not feasible
+     * in the standalone composer.
+     */
+    return;
+  }
 }

--- a/src/plugins/ui_core_views/cell_evaluation/evaluation_plugin.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluation_plugin.ts
@@ -217,8 +217,12 @@ export class EvaluationPlugin extends CoreViewPlugin {
   // Getters
   // ---------------------------------------------------------------------------
 
-  evaluateFormula(sheetId: UID, formulaString: string): CellValue | Matrix<CellValue> {
-    const result = this.evaluateFormulaResult(sheetId, formulaString);
+  evaluateFormula(
+    sheetId: UID,
+    formulaString: string,
+    cellPosition?: CellPosition
+  ): CellValue | Matrix<CellValue> {
+    const result = this.evaluateFormulaResult(sheetId, formulaString, cellPosition);
     if (isMatrix(result)) {
       return matrixMap(result, (cell) => cell.value);
     }
@@ -227,9 +231,10 @@ export class EvaluationPlugin extends CoreViewPlugin {
 
   evaluateFormulaResult(
     sheetId: UID,
-    formulaString: string
+    formulaString: string,
+    cellPosition?: CellPosition
   ): Matrix<FunctionResultObject> | FunctionResultObject {
-    return this.evaluator.evaluateFormulaResult(sheetId, formulaString);
+    return this.evaluator.evaluateFormulaResult(sheetId, formulaString, cellPosition);
   }
 
   evaluateCompiledFormula(

--- a/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
@@ -125,6 +125,22 @@ export class Evaluator {
     }
   }
 
+  private updateCompilationParametersForIsolatedFormula(originCellPosition?: CellPosition) {
+    this.compilationParams = buildCompilationParameters(
+      this.context,
+      this.getters,
+      this.computeAndSave.bind(this)
+    );
+    this.compilationParams.evalContext.__originCellPosition = originCellPosition;
+    this.compilationParams.evalContext.updateDependencies = undefined;
+    this.compilationParams.evalContext.addDependencies = undefined;
+    this.compilationParams.evalContext.lookupCaches = this.compilationParams.evalContext
+      .lookupCaches || {
+      forwardSearch: new Map(),
+      reverseSearch: new Map(),
+    };
+  }
+
   private updateCompilationParameters() {
     // rebuild the compilation parameters (with a clean cache)
     this.compilationParams = buildCompilationParameters(
@@ -217,14 +233,15 @@ export class Evaluator {
 
   evaluateFormulaResult(
     sheetId: UID,
-    formulaString: string
+    formulaString: string,
+    originCellPosition?: CellPosition
   ): FunctionResultObject | Matrix<FunctionResultObject> {
     const compiledFormula = compile(formulaString);
 
     const ranges: Range[] = compiledFormula.dependencies.map((xc) =>
       this.getters.getRangeFromSheetXC(sheetId, xc)
     );
-    this.updateCompilationParameters();
+    this.updateCompilationParametersForIsolatedFormula(originCellPosition);
     return this.evaluateCompiledFormula(sheetId, {
       ...compiledFormula,
       dependencies: ranges,

--- a/tests/composer/composer_store.test.ts
+++ b/tests/composer/composer_store.test.ts
@@ -1086,6 +1086,28 @@ describe("edition", () => {
     expect(getCellContent(model, cellOnLastCol)).toBe("0");
   });
 
+  describe("Row addition works with position dependant functions", () => {
+    test("Adding rows below with ROW function", () => {
+      const sheetId = model.getters.getActiveSheetId();
+      const numberOfRows = model.getters.getNumberRows(sheetId);
+
+      const cellOnLastRow = toXC(0, numberOfRows - 1);
+      editCell(model, cellOnLastRow, "=MUNIT(ROW())");
+      expect(model.getters.getNumberRows(sheetId)).toBe(numberOfRows * 2 + 50 - 1);
+      expect(getCellContent(model, cellOnLastRow)).toBe("1");
+    });
+
+    test("Adding rows below with ROW function", () => {
+      const sheetId = model.getters.getActiveSheetId();
+      const numberOfCols = model.getters.getNumberCols(sheetId);
+
+      const cellOnLastCols = toXC(numberOfCols - 1, 0);
+      editCell(model, cellOnLastCols, "=MUNIT(COLUMN())");
+      expect(model.getters.getNumberCols(sheetId)).toBe(numberOfCols * 2 + 20 - 1);
+      expect(getCellContent(model, cellOnLastCols)).toBe("1");
+    });
+  });
+
   test("Can undo/redo after adding a spreading formula at the end of the sheet", () => {
     const sheetId = model.getters.getActiveSheetId();
     const numberOfCols = model.getters.getNumberCols(sheetId);


### PR DESCRIPTION
Some formulas, like ROW & COLUMN need to know the coordinates of the cell on which they are applied to be computed and we did not provide those in the evaluation context when evaluating isolated formulas.

How to reproduce:

- in a spreadsheet, go to the last row
- in a cell of the last row, write the formula `=MUNIT(ROW())` -> the formula is in #SPILL error because we did not extend the size of the spreadsheet

This also cause issues in standalone composers in which the hovered result displays an error.

How to reproduce:

- in a standalone composer, write =ROW()
- hover the ROW function -> it displays #ERROR

Task: 5798610

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [5798610](https://www.odoo.com/odoo/2328/tasks/5798610)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo