### PR TITLE
[IMP] Find&Replace: Allow to leave sidepanel with keystrokes

### DIFF
--- a/src/components/side_panel/find_and_replace/find_and_replace.ts
+++ b/src/components/side_panel/find_and_replace/find_and_replace.ts
@@ -106,6 +106,14 @@ export class FindAndReplacePanel extends Component<Props, SpreadsheetChildEnv> {
     this.updateSearchContent((ev.target as HTMLInputElement).value);
   }
 
+  onKeydownPanel(ev: KeyboardEvent) {
+    if (ev.key === "Escape") {
+      ev.preventDefault();
+      ev.stopPropagation();
+      this.props.onCloseSidePanel();
+    }
+  }
+
   onKeydownSearch(ev: KeyboardEvent) {
     if (ev.key === "Enter") {
       ev.preventDefault();

--- a/src/components/side_panel/find_and_replace/find_and_replace.xml
+++ b/src/components/side_panel/find_and_replace/find_and_replace.xml
@@ -1,6 +1,6 @@
 <templates>
   <t t-name="o-spreadsheet-FindAndReplacePanel">
-    <div class="o-find-and-replace">
+    <div class="o-find-and-replace" t-on-keydown="onKeydownPanel">
       <Section title.translate="Search">
         <div class="o-input-search-container">
           <input

--- a/tests/find_and_replace/find_replace_side_panel_component.test.ts
+++ b/tests/find_and_replace/find_replace_side_panel_component.test.ts
@@ -108,6 +108,24 @@ describe("find and replace sidePanel component", () => {
         (document.querySelector(selectors.replaceAllButton) as HTMLButtonElement).disabled
       ).toBe(true);
     });
+
+    test("pressing Escape closes the sidepanel", async () => {
+      const panelSelectors = [
+        selectors.inputSearch,
+        selectors.inputReplace,
+        selectors.checkBoxMatchingCase,
+        selectors.checkBoxExactMatch,
+        selectors.checkBoxSearchFormulas,
+      ];
+      for (const selector of panelSelectors) {
+        // reopen the side panel for each selector test
+        parent.env.openSidePanel("FindAndReplace");
+        await nextTick();
+        expect(document.querySelectorAll(".o-sidePanel").length).toBe(1);
+        await focusAndKeyDown(selector, { key: "Escape" });
+        expect(document.querySelectorAll(".o-sidePanel").length).toBe(0);
+      }
+    });
   });
 
   describe("basic search", () => {


### PR DESCRIPTION
Currrently, a user can open the Find&replace sidepanel with `Ctrl+F` but it forces the focus inside the sidepanel and there is no way to close it and get back to the grid. The situation differs from other sidepanels where the users need to use their mouse to start a sidepanel interaction.

Task: 5438930

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo