### PR TITLE
[FIX] find_and_replace_store: crash after sheet deletion

### DIFF
--- a/src/components/side_panel/find_and_replace/find_and_replace_store.ts
+++ b/src/components/side_panel/find_and_replace/find_and_replace_store.ts
@@ -119,6 +119,15 @@ export class FindAndReplaceStore extends SpreadsheetStore implements HighlightPr
           });
         }
         break;
+      case "DELETE_SHEET":
+        if (
+          this.searchOptions.searchScope === "specificRange" &&
+          this.searchOptions.specificRange?.sheetId === cmd.sheetId
+        ) {
+          this.searchOptions = { ...this.searchOptions, specificRange: undefined };
+        }
+        this.isSearchDirty = true;
+        break;
       case "REPLACE_SEARCH":
         for (const match of cmd.matches) {
           this.replaceMatch(match, cmd.searchString, cmd.replaceWith, cmd.searchOptions);

--- a/tests/find_and_replace/find_and_replace_store.test.ts
+++ b/tests/find_and_replace/find_and_replace_store.test.ts
@@ -13,6 +13,7 @@ import {
   createSheet,
   createTable,
   deleteRows,
+  deleteSheet,
   deleteTable,
   hideRows,
   redo,
@@ -189,6 +190,32 @@ describe("basic search", () => {
     expect(model.getters.getActiveSheetId()).toBe(sheetId2);
     expect(store.selectedMatchIndex).toStrictEqual(0);
     expect(store.searchMatches).toStrictEqual([match(sheetId2, "A2")]);
+  });
+
+  test("search is refreshed when active sheet is deleted", () => {
+    setCellContent(model, "A1", "test");
+    createSheet(model, { sheetId: sheetId2 });
+
+    updateSearch(model, "test", { searchScope: "activeSheet" });
+    expect(store.searchMatches).toStrictEqual([match(sheetId1, "A1")]);
+    expect(store.selectedMatchIndex).toStrictEqual(0);
+
+    deleteSheet(model, sheetId1);
+    expect(store.searchMatches).toStrictEqual([]);
+    expect(store.selectedMatchIndex).toStrictEqual(null);
+  });
+
+  test("specific range is cleared when its sheet is deleted", () => {
+    createSheet(model, { sheetId: sheetId2 });
+    updateSearch(model, "test", {
+      searchScope: "specificRange",
+      specificRange: model.getters.getRangeFromSheetXC(sheetId1, "A1:B2"),
+    });
+
+    expect(store.searchOptions.specificRange?.sheetId).toBe(sheetId1);
+    deleteSheet(model, sheetId1);
+
+    expect(store.searchOptions.specificRange).toBeUndefined();
   });
 
   test("refresh search when cell is updated", async () => {


### PR DESCRIPTION
## Description:

Steps:
- Create 2 sheets
- Focus Sheet1
- Open Find & Replace side panel
- Select a specific range
- Type "Sheet1!A1" and search a term
- Delete Sheet1 -> crash

Fix:
- If a specific range targets the deleted sheet, clear the range.

Related issue:
- If "Search in current sheet" is enabled and that sheet is deleted, search is not marked dirty, so the new active sheet highlights old matches.

Fix:
- Mark search as dirty when a sheet is deleted and "Search in current sheet" is enabled.

Task: [5453311](https://www.odoo.com/odoo/2328/tasks/5453311)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo