### PR TITLE
[FIX] regexextract : invalid regex throw error

### DIFF
--- a/src/functions/module_text.ts
+++ b/src/functions/module_text.ts
@@ -335,7 +335,12 @@ export const REGEXEXTRACT = {
     }
 
     const flags = _caseSensitivity === 1 ? "gi" : "g";
-    const regex = new RegExp(_pattern, flags);
+    let regex: RegExp;
+    try {
+      regex = new RegExp(_pattern, flags);
+    } catch (e) {
+      return new EvaluationError(_t("Invalid regular expression"));
+    }
     const matches = [..._text.matchAll(regex)];
 
     if (matches.length === 0) {

--- a/tests/functions/module_text.test.ts
+++ b/tests/functions/module_text.test.ts
@@ -472,6 +472,10 @@ describe("REGEXEXTRACT function", () => {
       ).toEqual(expectedResult);
     }
   );
+
+  test("invalid regex raise an error", () => {
+    expect(evaluateCell("A1", { A1: '=REGEXEXTRACT("Hello there", "[a-z+")' })).toBe("#ERROR");
+  });
 });
 
 describe("REPLACE formula", () => {


### PR DESCRIPTION
It should throw an error if the regex is invalid

How to reproduce:
=REGEXEXTRACT("bjr","[a-z*")

Task: [5892417](https://www.odoo.com/odoo/2328/tasks/5892417)

Original task  [4943443](https://www.odoo.com/odoo/2328/tasks/4943443)

Already done for regextest et regexreplace in task  [5411453](https://www.odoo.com/odoo/2328/tasks/5411453)




## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo