### PR TITLE
[FIX] session: clear move timeout

### DIFF
--- a/src/collaborative/session.ts
+++ b/src/collaborative/session.ts
@@ -22,6 +22,7 @@ import {
   StateUpdateMessage,
   TransportService,
 } from "../types/collaborative/transport_service";
+import { DebouncedFunction } from "../types/misc";
 import { Command } from "./../types/commands";
 import { transformAll } from "./ot/ot";
 import { Revision } from "./revisions";
@@ -38,7 +39,7 @@ export class Session extends EventBus<CollaborativeEvent> {
   /**
    * Id of the server revision
    */
-  private debouncedMove: Session["move"];
+  private debouncedMove: DebouncedFunction<Session["move"]>;
   private pendingMessages: StateUpdateMessage[] = [];
 
   private waitingAck: boolean = false;
@@ -79,7 +80,7 @@ export class Session extends EventBus<CollaborativeEvent> {
   ) {
     super();
 
-    this.debouncedMove = debounce(this._move.bind(this), DEBOUNCE_TIME) as Session["move"];
+    this.debouncedMove = debounce(this._move.bind(this), DEBOUNCE_TIME);
   }
 
   canApplyOptimisticUpdate() {
@@ -175,6 +176,7 @@ export class Session extends EventBus<CollaborativeEvent> {
    * Notify the server that the user client left the collaborative session
    */
   async leave(data?: Lazy<WorkbookData>) {
+    this.debouncedMove.stopDebounce();
     if (
       data &&
       Object.keys(this.clients).length === 1 &&


### PR DESCRIPTION
When you instantiate a new model, a reference to the session it kept by the `debounce` timeout.

Session itself has references to the entire history and basically the entire model.

This means the model cannot be GC'ed for at least 200ms (until the debounced function is executed). It's even worse if the code creating the model is synchronous: it doesn't let a chance for the timeout to be executed.

/!\ To ensure the reference is released and everything is GC'ed, you have to

`await model.leaveSession();` !!!!!!!!

In tests, this is not an issue: `debounce` is patched in `mock_misc_helpers.ts`

I do not fix this in 17.0 because `.stopDebounced()` was only introduced in 17.2

Task: 0

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo