### PR TITLE
[FIX] dom_helpers: wait for document ready

### DIFF
--- a/src/components/helpers/dom_helpers.ts
+++ b/src/components/helpers/dom_helpers.ts
@@ -1,5 +1,6 @@
 import { Ref } from "@odoo/o-spreadsheet-engine/types/misc";
 import { DOMCoordinates, Rect } from "@odoo/o-spreadsheet-engine/types/rendering";
+import { whenReady } from "@odoo/owl";
 
 const macRegex = /Mac/i;
 
@@ -13,7 +14,7 @@ function defineZoomCssImpactOnBoundingRect() {
   document.body.removeChild(div);
 }
 
-defineZoomCssImpactOnBoundingRect();
+whenReady(defineZoomCssImpactOnBoundingRect);
 
 const MODIFIER_KEYS = ["Shift", "Control", "Alt", "Meta"];
 


### PR DESCRIPTION
Since 777f823a91c2ff11388b456f5e1f2b1d22fde24f, `defineZoomCssImpactOnBoundingRect` could be called before the document was ready, which could lead to error when accessing `document.body`.
This commit adds a `whenReady` to ensure the document is loaded.

Task: 0

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo