### PR TITLE
[IMP] pivot: truncate dimension display name and add title

### DIFF
--- a/src/components/side_panel/pivot/pivot_layout_configurator/pivot_dimension/pivot_dimension.ts
+++ b/src/components/side_panel/pivot/pivot_layout_configurator/pivot_dimension/pivot_dimension.ts
@@ -1,15 +1,16 @@
 import { Component } from "@odoo/owl";
-import { PivotCoreDimension, PivotCoreMeasure } from "../../../../..";
+import { PivotDimension as PivotDimensionType, PivotMeasure } from "../../../../..";
 import { GRAY_300 } from "../../../../../constants";
+import { collapseHierarchicalDisplayName } from "../../../../../helpers/pivot/pivot_helpers";
 import { SpreadsheetChildEnv } from "../../../../../types";
 import { css } from "../../../../helpers";
 import { TextInput } from "../../../../text_input/text_input";
 import { CogWheelMenu } from "../../../components/cog_wheel_menu/cog_wheel_menu";
 
 interface Props {
-  dimension: PivotCoreDimension | PivotCoreMeasure;
-  onRemoved: (dimension: PivotCoreDimension | PivotCoreMeasure) => void;
-  onNameUpdated?: (dimension: PivotCoreDimension | PivotCoreMeasure, name?: string) => void;
+  dimension: PivotDimensionType | PivotMeasure;
+  onRemoved: (dimension: PivotDimensionType | PivotMeasure) => void;
+  onNameUpdated?: (dimension: PivotDimensionType | PivotMeasure, name?: string) => void;
   type: "row" | "col" | "measure";
 }
 
@@ -58,5 +59,10 @@ export class PivotDimension extends Component<Props, SpreadsheetChildEnv> {
       this.props.dimension,
       name === "" || name.startsWith("=") ? undefined : name
     );
+  }
+
+  get dimensionDisplayName() {
+    const displayName = this.props.dimension.displayName;
+    return collapseHierarchicalDisplayName(displayName);
   }
 }

--- a/src/components/side_panel/pivot/pivot_layout_configurator/pivot_dimension/pivot_dimension.xml
+++ b/src/components/side_panel/pivot/pivot_layout_configurator/pivot_dimension/pivot_dimension.xml
@@ -4,7 +4,9 @@
       class="py-1 px-2 d-flex flex-column shadow-sm pivot-dimension"
       t-att-class="{'pivot-dimension-invalid': !props.dimension.isValid}">
       <div class="d-flex flex-row justify-content-between align-items-center">
-        <div class="d-flex align-items-center overflow-hidden text-nowrap">
+        <div
+          class="d-flex align-items-center overflow-hidden text-nowrap"
+          t-att-title="props.dimension.displayName">
           <span class="text-danger me-1" t-if="!props.dimension.isValid">
             <t t-call="o-spreadsheet-Icon.TRIANGLE_EXCLAMATION"/>
           </span>
@@ -14,7 +16,7 @@
             onChange.bind="updateName"
             class="'o-fw-bold'"
           />
-          <span t-else="1" class="o-fw-bold" t-esc="props.dimension.displayName"/>
+          <span t-else="1" class="o-fw-bold text-truncate" t-esc="dimensionDisplayName"/>
         </div>
         <div class="d-flex flex-rows" t-on-pointerdown.stop="">
           <t t-slot="upper-right-icons"/>

--- a/src/helpers/pivot/pivot_helpers.ts
+++ b/src/helpers/pivot/pivot_helpers.ts
@@ -422,3 +422,22 @@ export function getCustomFieldWithParentField(
     }
   );
 }
+
+/**
+ * Collapse a hierarchical display name by keeping only the first and last parts.
+ * Example: "Sales > Europe > France" → "Sales > … > France"
+ */
+export function collapseHierarchicalDisplayName(
+  displayName: string,
+  splitter: string = ">"
+): string {
+  const firstIndex = displayName.indexOf(splitter);
+  const lastIndex = displayName.lastIndexOf(splitter);
+  if (!displayName || !firstIndex || firstIndex === lastIndex) {
+    return displayName;
+  }
+
+  const firstPart = displayName.slice(0, firstIndex + 1);
+  const lastPart = displayName.slice(lastIndex);
+  return `${firstPart} … ${lastPart}`;
+}

--- a/tests/pivots/pivot_helpers.test.ts
+++ b/tests/pivots/pivot_helpers.test.ts
@@ -1,6 +1,7 @@
 import { PivotDomain, PivotSortedColumn } from "../../src";
 import { isDomainIsInPivot } from "../../src/helpers/pivot/pivot_domain_helpers";
 import {
+  collapseHierarchicalDisplayName,
   isSortedColumnValid,
   toFunctionPivotValue,
   toNormalizedPivotValue,
@@ -321,4 +322,12 @@ test("isDomainInPivot", () => {
     { field: "Date:month_number", value: 1, type: "datetime" },
   ];
   expect(isDomainIsInPivot(pivot, domain)).toBe(true);
+});
+
+test("collapseHierarchicalDisplayName", () => {
+  expect(collapseHierarchicalDisplayName("")).toBe("");
+  expect(collapseHierarchicalDisplayName("first")).toBe("first");
+  expect(collapseHierarchicalDisplayName("first > second")).toBe("first > second");
+  expect(collapseHierarchicalDisplayName("first > second > third")).toBe("first > … > third");
+  expect(collapseHierarchicalDisplayName("a > b > c > d > e > f > g > h")).toBe("a > … > h");
 });


### PR DESCRIPTION
## Description:

Current behavior before PR:
- Long dimension display names were cropped and not fully readable.

Desired behavior after PR is merged:
- Dimension display names are truncated using text-truncate and include
  a title attribute to show the full value on hover.
- Only the first and last fields are displayed in the format
  `first field > ... > last field`, as these are the most relevant.
  
Technical:
- Update the type of dimension props to include displayName to ensure proper
  type safety.

Task: [5895856](https://www.odoo.com/odoo/2328/tasks/5895856)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo