### PR TITLE
[PERF] table: fix table rendering

### DIFF
--- a/packages/o-spreadsheet-engine/src/plugins/ui_feature/cell_computed_style.ts
+++ b/packages/o-spreadsheet-engine/src/plugins/ui_feature/cell_computed_style.ts
@@ -98,15 +98,7 @@ export class CellComputedStylePlugin extends UIPlugin {
   private computeCellStyle(position: CellPosition): Style {
     const cell = this.getters.getCell(position);
     const cfStyle = this.getters.getCellConditionalFormatStyle(position);
-    // const tableStyle = this.getters.getCellTableStyle(position);
-    const tableStyle = this.getters
-      .getCellTableStyleZone(position.sheetId, {
-        left: position.col,
-        right: position.col,
-        top: position.row,
-        bottom: position.row,
-      })
-      .get(position);
+    const tableStyle = this.getters.getCellTableStyle(position);
     const dataValidationStyle = this.getters.getDataValidationCellStyle(position);
     const computedStyle = {
       ...removeFalsyAttributes(tableStyle),

--- a/packages/o-spreadsheet-engine/src/plugins/ui_feature/table_computed_style.ts
+++ b/packages/o-spreadsheet-engine/src/plugins/ui_feature/table_computed_style.ts
@@ -18,12 +18,7 @@ interface TableRuntime {
 }
 
 export class TableComputedStylePlugin extends UIPlugin {
-  static getters = [
-    "getCellTableStyle",
-    "getCellTableBorder",
-    "getCellTableBorderZone",
-    "getCellTableStyleZone",
-  ] as const;
+  static getters = ["getCellTableStyle", "getCellTableBorder", "getCellTableBorderZone"] as const;
 
   private tableStyles: Record<UID, Record<TableId, Lazy<ComputedTableStyle>>> = {};
 
@@ -75,24 +70,6 @@ export class TableComputedStylePlugin extends UIPlugin {
       return undefined;
     }
     return this.tableStyles[position.sheetId][table.id]().borders[position.col]?.[position.row];
-  }
-
-  getCellTableStyleZone(sheetId: UID, zone: Zone): PositionMap<Style> {
-    const map = new PositionMap<Style>();
-    for (const table of this.getters.getTablesOverlappingZones(sheetId, [zone])) {
-      const tableStyles = this.tableStyles[sheetId][table.id]().styles;
-      for (const colIdx of Object.keys(tableStyles)) {
-        const colStyle = tableStyles[colIdx];
-        const col = parseInt(colIdx);
-        for (const rowIdx of Object.keys(colStyle)) {
-          const cellStyle = colStyle[rowIdx];
-          if (cellStyle) {
-            map.set({ sheetId, col, row: parseInt(rowIdx) }, cellStyle);
-          }
-        }
-      }
-    }
-    return map;
   }
 
   getCellTableBorderZone(sheetId: UID, zone: Zone): PositionMap<Border> {


### PR DESCRIPTION
Steps to reproduce:
- create a new sheet
- add 10_000 rows
- add a table on A:P

Reload the spreadsheet and switch to the new sheet with the table

before: >3s
after: <100ms

This is a left over from 49d514299c37b33c43e9de03f9ddce0ec921fdef that was reverted by 1e3f3158285b6ef10b16b689d3c2830d1e57e24c but only partially.

Task: 0

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo