### PR TITLE
[FIX] dynamic_tables: trim overlap on the correct side

### DIFF
--- a/src/plugins/ui_core_views/dynamic_tables.ts
+++ b/src/plugins/ui_core_views/dynamic_tables.ts
@@ -88,8 +88,14 @@ export class DynamicTablesPlugin extends UIPlugin {
       // Reduce the zone to avoid collision with static tables. Per design, dynamic tables can't overlap with other
       // dynamic tables, because formulas cannot spread on the same area, so we don't need to check for that.
       for (const staticTable of staticTables) {
-        if (overlap(tableZone, staticTable.range.zone)) {
-          tableZone = { ...tableZone, right: staticTable.range.zone.left - 1 };
+        const staticTableZone = staticTable.range.zone;
+        if (!overlap(tableZone, staticTableZone)) {
+          continue;
+        }
+        if (staticTableZone.left > tableZone.left) {
+          tableZone = { ...tableZone, right: Math.min(tableZone.right, staticTableZone.left - 1) };
+        } else {
+          tableZone = { ...tableZone, bottom: Math.min(tableZone.bottom, staticTableZone.top - 1) };
         }
       }
       tables.push({ ...table, range: this.getters.getRangeFromZone(sheetId, tableZone) });

--- a/tests/table/dynamic_table_plugin.test.ts
+++ b/tests/table/dynamic_table_plugin.test.ts
@@ -117,6 +117,20 @@ describe("Dynamic tables", () => {
     expect(getTables(model, sheetId)).toMatchObject([{ zone: "C2:C3" }, { zone: "A1:B3" }]);
   });
 
+  test("Dynamic tables are trimmed down when static table overlaps on the bottom", () => {
+    createTable(model, "C3:F7");
+    setCellContent(model, "D1", "=MUNIT(3)");
+    createDynamicTable(model, "D1");
+    expect(getTables(model, sheetId)).toMatchObject([{ zone: "C3:F7" }, { zone: "D1:F2" }]);
+  });
+
+  test("Dynamic tables are trimmed right when static table overlaps on the right", () => {
+    createTable(model, "C3:F7");
+    setCellContent(model, "A2", "=MUNIT(3)");
+    createDynamicTable(model, "A2");
+    expect(getTables(model, sheetId)).toMatchObject([{ zone: "C3:F7" }, { zone: "A2:B4" }]);
+  });
+
   test("Can delete a dynamic table", () => {
     setCellContent(model, "A1", "=MUNIT(3)");
     createDynamicTable(model, "A1");


### PR DESCRIPTION
## Description:

When reducing a dynamic table to avoid overlap with a static table, we always trimmed the right edge.

That is wrong when the static table overlaps the dynamic anchor column: the computed zone can become invalid (`right < left`), which later crashes table style computation.

Trim logic is now directional:
- trim `right` only when the static table starts to the right of the anchor
- otherwise trim `bottom`

Task: [5905900](https://www.odoo.com/odoo/2328/tasks/5905900)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo