### PR TITLE
[FIX] charts: chart have wrong background at copy/download

### DIFF
--- a/packages/o-spreadsheet-engine/src/helpers/figures/charts/chart_ui_common.ts
+++ b/packages/o-spreadsheet-engine/src/helpers/figures/charts/chart_ui_common.ts
@@ -50,7 +50,6 @@ export async function chartToImageUrl(
     }
 
     const config = deepCopy(runtime.chartJsConfig);
-    config.plugins = [backgroundColorChartJSPlugin];
     if (!globalThis.Chart.registry.controllers.get(config.type)) {
       console.log(`Chart of type "${config.type}" is not registered in Chart.js library.`);
       if (!extensionsLoaded) {
@@ -109,7 +108,6 @@ export async function chartToImageFile(
     }
 
     const config = deepCopy(runtime.chartJsConfig);
-    config.plugins = [backgroundColorChartJSPlugin];
     if (!globalThis.Chart.registry.controllers.get(config.type)) {
       console.log(`Chart of type "${config.type}" is not registered in Chart.js library.`);
       if (!extensionsLoaded) {
@@ -147,22 +145,6 @@ export async function chartToImageFile(
   }
   return chartBlob;
 }
-
-/**
- * Custom chart.js plugin to set the background color of the canvas
- * https://github.com/chartjs/Chart.js/blob/8fdf76f8f02d31684d34704341a5d9217e977491/docs/configuration/canvas-background.md
- */
-const backgroundColorChartJSPlugin = {
-  id: "customCanvasBackgroundColor",
-  beforeDraw: (chart) => {
-    const { ctx } = chart;
-    ctx.save();
-    ctx.globalCompositeOperation = "destination-over";
-    ctx.fillStyle = "#ffffff";
-    ctx.fillRect(0, 0, chart.width, chart.height);
-    ctx.restore();
-  },
-};
 
 function createRenderingSurface(width: number, height: number): OffscreenCanvas {
   return new OffscreenCanvas(width, height);

--- a/packages/o-spreadsheet-engine/src/types/chart/bar_chart.ts
+++ b/packages/o-spreadsheet-engine/src/types/chart/bar_chart.ts
@@ -1,5 +1,4 @@
 import { ChartConfiguration } from "chart.js";
-import { Color } from "../misc";
 import { CommonChartDefinition } from "./index";
 
 export interface BarChartDefinition extends CommonChartDefinition {
@@ -12,5 +11,4 @@ export interface BarChartDefinition extends CommonChartDefinition {
 export type BarChartRuntime = {
   chartJsConfig: ChartConfiguration<"bar" | "line">;
   masterChartConfig?: ChartConfiguration<"bar">;
-  background: Color;
 };

--- a/packages/o-spreadsheet-engine/src/types/chart/calendar_chart.ts
+++ b/packages/o-spreadsheet-engine/src/types/chart/calendar_chart.ts
@@ -27,5 +27,4 @@ export interface CalendarChartDefinition extends CommonChartDefinition {
 
 export type CalendarChartRuntime = {
   chartJsConfig: ChartConfiguration;
-  background: Color;
 };

--- a/packages/o-spreadsheet-engine/src/types/chart/combo_chart.ts
+++ b/packages/o-spreadsheet-engine/src/types/chart/combo_chart.ts
@@ -1,5 +1,4 @@
 import { ChartConfiguration } from "chart.js";
-import { Color } from "../misc";
 import { CustomizedDataSet } from "./chart";
 import { CommonChartDefinition } from "./common_chart";
 
@@ -15,5 +14,4 @@ export type ComboChartDataSet = CustomizedDataSet & { type?: "bar" | "line" };
 export type ComboChartRuntime = {
   chartJsConfig: ChartConfiguration;
   masterChartConfig?: ChartConfiguration;
-  background: Color;
 };

--- a/packages/o-spreadsheet-engine/src/types/chart/funnel_chart.ts
+++ b/packages/o-spreadsheet-engine/src/types/chart/funnel_chart.ts
@@ -22,7 +22,6 @@ export interface FunnelChartDefinition {
 
 export type FunnelChartRuntime = {
   chartJsConfig: ChartConfiguration;
-  background: Color;
 };
 
 export type FunnelChartColors = (Color | undefined)[];

--- a/packages/o-spreadsheet-engine/src/types/chart/geo_chart.ts
+++ b/packages/o-spreadsheet-engine/src/types/chart/geo_chart.ts
@@ -13,7 +13,6 @@ export interface GeoChartDefinition extends CommonChartDefinition {
 
 export type GeoChartRuntime = {
   chartJsConfig: ChartConfiguration;
-  background: Color;
 };
 
 export type GeoChartProjection =

--- a/packages/o-spreadsheet-engine/src/types/chart/line_chart.ts
+++ b/packages/o-spreadsheet-engine/src/types/chart/line_chart.ts
@@ -1,5 +1,4 @@
 import type { ChartConfiguration } from "chart.js";
-import { Color } from "../misc";
 import { CommonChartDefinition } from "./common_chart";
 
 export interface LineChartDefinition extends CommonChartDefinition {
@@ -16,5 +15,4 @@ export interface LineChartDefinition extends CommonChartDefinition {
 export type LineChartRuntime = {
   chartJsConfig: ChartConfiguration<"line">;
   masterChartConfig?: ChartConfiguration<"line">;
-  background: Color;
 };

--- a/packages/o-spreadsheet-engine/src/types/chart/pie_chart.ts
+++ b/packages/o-spreadsheet-engine/src/types/chart/pie_chart.ts
@@ -1,5 +1,4 @@
 import type { ChartConfiguration } from "chart.js";
-import { Color } from "../misc";
 import { CommonChartDefinition } from "./common_chart";
 
 export interface PieChartDefinition extends CommonChartDefinition {
@@ -12,5 +11,4 @@ export interface PieChartDefinition extends CommonChartDefinition {
 
 export type PieChartRuntime = {
   chartJsConfig: ChartConfiguration<"pie" | "doughnut">;
-  background: Color;
 };

--- a/packages/o-spreadsheet-engine/src/types/chart/pyramid_chart.ts
+++ b/packages/o-spreadsheet-engine/src/types/chart/pyramid_chart.ts
@@ -1,5 +1,4 @@
 import { ChartConfiguration } from "chart.js";
-import { Color } from "../misc";
 import { BarChartDefinition } from "./bar_chart";
 
 export interface PyramidChartDefinition extends Omit<BarChartDefinition, "type" | "zoomable"> {
@@ -8,5 +7,4 @@ export interface PyramidChartDefinition extends Omit<BarChartDefinition, "type" 
 
 export type PyramidChartRuntime = {
   chartJsConfig: ChartConfiguration;
-  background: Color;
 };

--- a/packages/o-spreadsheet-engine/src/types/chart/radar_chart.ts
+++ b/packages/o-spreadsheet-engine/src/types/chart/radar_chart.ts
@@ -1,5 +1,4 @@
 import { ChartConfiguration } from "chart.js";
-import { Color } from "../misc";
 import { CommonChartDefinition } from "./common_chart";
 
 export interface RadarChartDefinition extends CommonChartDefinition {
@@ -13,5 +12,4 @@ export interface RadarChartDefinition extends CommonChartDefinition {
 
 export type RadarChartRuntime = {
   chartJsConfig: ChartConfiguration;
-  background: Color;
 };

--- a/packages/o-spreadsheet-engine/src/types/chart/sunburst_chart.ts
+++ b/packages/o-spreadsheet-engine/src/types/chart/sunburst_chart.ts
@@ -21,7 +21,6 @@ export interface SunburstChartDefinition {
 
 export type SunburstChartRuntime = {
   chartJsConfig: ChartConfiguration<"doughnut">;
-  background: Color;
 };
 
 export type SunburstChartRawData = {

--- a/packages/o-spreadsheet-engine/src/types/chart/tree_map_chart.ts
+++ b/packages/o-spreadsheet-engine/src/types/chart/tree_map_chart.ts
@@ -45,7 +45,6 @@ export type TreeMapColoringOptions = TreeMapCategoryColorOptions | TreeMapColorS
 
 export type TreeMapChartRuntime = {
   chartJsConfig: ChartConfiguration;
-  background: Color;
 };
 
 export type TreeMapItem = {

--- a/packages/o-spreadsheet-engine/src/types/chart/waterfall_chart.ts
+++ b/packages/o-spreadsheet-engine/src/types/chart/waterfall_chart.ts
@@ -17,5 +17,4 @@ export interface WaterfallChartDefinition extends CommonChartDefinition {
 
 export type WaterfallChartRuntime = {
   chartJsConfig: ChartConfiguration;
-  background: Color;
 };

--- a/src/components/figures/chart/chartJs/chartjs.ts
+++ b/src/components/figures/chart/chartJs/chartjs.ts
@@ -10,6 +10,7 @@ import { deepCopy, deepEquals } from "../../../../helpers";
 import { Store, useStore } from "../../../../store_engine";
 import { UID } from "../../../../types";
 import { ChartAnimationStore } from "./chartjs_animation_store";
+import { chartBackgroundPlugin } from "./chartjs_background_plugin";
 import { getCalendarChartController } from "./chartjs_calendar_chart";
 import { chartColorScalePlugin } from "./chartjs_colorscale_plugin";
 import {
@@ -69,6 +70,10 @@ chartJsExtensionRegistry.add("zoomWindowPlugin", {
   register: (Chart) => Chart.register(zoomWindowPlugin),
   unregister: (Chart) => Chart.unregister(zoomWindowPlugin),
 });
+chartJsExtensionRegistry.add("chartBackgroundPlugin", {
+  register: (Chart) => Chart.register(chartBackgroundPlugin),
+  unregister: (Chart) => Chart.unregister(chartBackgroundPlugin),
+});
 
 export class ChartJsComponent extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ChartJsComponent";
@@ -83,14 +88,6 @@ export class ChartJsComponent extends Component<Props, SpreadsheetChildEnv> {
   protected animationStore: Store<ChartAnimationStore> | undefined;
 
   private currentDevicePixelRatio = window.devicePixelRatio;
-
-  get background(): string {
-    return this.chartRuntime.background;
-  }
-
-  get canvasStyle() {
-    return `background-color: ${this.background}`;
-  }
 
   get chartRuntime(): ChartJSRuntime {
     const runtime = this.env.model.getters.getChartRuntime(this.props.chartId);

--- a/src/components/figures/chart/chartJs/chartjs.xml
+++ b/src/components/figures/chart/chartJs/chartjs.xml
@@ -1,5 +1,5 @@
 <templates>
   <t t-name="o-spreadsheet-ChartJsComponent">
-    <canvas class="o-figure-canvas w-100 h-100" t-att-style="canvasStyle" t-ref="graphContainer"/>
+    <canvas class="o-figure-canvas w-100 h-100" t-ref="graphContainer"/>
   </t>
 </templates>

--- a/src/components/figures/chart/chartJs/chartjs_background_plugin.ts
+++ b/src/components/figures/chart/chartJs/chartjs_background_plugin.ts
@@ -1,0 +1,25 @@
+import { BACKGROUND_CHART_COLOR } from "@odoo/o-spreadsheet-engine/constants";
+import { ChartType, Plugin } from "chart.js";
+
+export interface ChartBackgroundPluginOptions {
+  color: string | undefined;
+}
+
+declare module "chart.js" {
+  interface PluginOptionsByType<TType extends ChartType> {
+    background?: ChartBackgroundPluginOptions;
+  }
+}
+
+/** This is a chartJS plugin that will draw a background of a chart */
+export const chartBackgroundPlugin: Plugin = {
+  id: "background",
+  beforeDraw(chart: any, args, options: ChartBackgroundPluginOptions) {
+    const { ctx } = chart;
+    ctx.save();
+    ctx.globalCompositeOperation = "destination-over";
+    ctx.fillStyle = options.color || BACKGROUND_CHART_COLOR;
+    ctx.fillRect(0, 0, chart.width, chart.height);
+    ctx.restore();
+  },
+};

--- a/src/components/figures/chart/chartJs/chartjs_calendar_chart.ts
+++ b/src/components/figures/chart/chartJs/chartjs_calendar_chart.ts
@@ -1,3 +1,4 @@
+import { BACKGROUND_CHART_COLOR } from "@odoo/o-spreadsheet-engine/constants";
 import {
   BarController,
   BarControllerChartOptions,
@@ -29,8 +30,8 @@ export function getCalendarChartController(): ChartComponent & {
       super.updateElements(rects, start, count, mode);
 
       // Remove the element background at the start of an animation
-      const chartBackground = (this.chart.config as any).options?.chartBackground;
-      const backgroundColor = chartBackground || "#ffffff";
+      const chartBackground = this.chart.config.options?.plugins?.background?.color;
+      const backgroundColor = chartBackground || BACKGROUND_CHART_COLOR;
       for (let i = start; i < start + count; i++) {
         if (mode === "reset") {
           this.updateElement(rects[i], i, { options: { backgroundColor } }, mode);
@@ -43,7 +44,7 @@ export function getCalendarChartController(): ChartComponent & {
 declare module "chart.js" {
   interface ChartTypeRegistry {
     calendar: {
-      chartOptions: BarControllerChartOptions & { chartBackground: string };
+      chartOptions: BarControllerChartOptions;
       datasetOptions: BarControllerDatasetOptions & { values: number[] };
       defaultDataPoint: number | null;
       metaExtensions: {};

--- a/src/components/figures/figure_carousel/figure_carousel.ts
+++ b/src/components/figures/figure_carousel/figure_carousel.ts
@@ -1,5 +1,8 @@
 import { _t } from "@odoo/o-spreadsheet-engine";
-import { DEFAULT_CAROUSEL_TITLE_STYLE } from "@odoo/o-spreadsheet-engine/constants";
+import {
+  BACKGROUND_CHART_COLOR,
+  DEFAULT_CAROUSEL_TITLE_STYLE,
+} from "@odoo/o-spreadsheet-engine/constants";
 import { getCarouselItemTitle } from "@odoo/o-spreadsheet-engine/helpers/carousel_helpers";
 import { SpreadsheetChildEnv } from "@odoo/o-spreadsheet-engine/types/spreadsheet_env";
 import { Component, useEffect, useRef, useState } from "@odoo/owl";
@@ -113,9 +116,14 @@ export class CarouselFigure extends Component<Props, SpreadsheetChildEnv> {
     const cssProperties: CSSProperties = {};
     if (this.selectedCarouselItem?.type === "chart") {
       const chart = this.env.model.getters.getChartRuntime(this.selectedCarouselItem.chartId);
-      cssProperties["background-color"] = chart.background;
+      if ("background" in chart && chart.background) {
+        cssProperties["background-color"] = chart.background;
+      } else if ("chartJsConfig" in chart) {
+        cssProperties["background-color"] =
+          chart.chartJsConfig.options?.plugins?.background?.color || BACKGROUND_CHART_COLOR;
+      }
     } else {
-      cssProperties["background-color"] = "#ffffff";
+      cssProperties["background-color"] = BACKGROUND_CHART_COLOR;
     }
     return cssPropertiesToCss(cssProperties);
   }

--- a/src/helpers/figures/charts/bar_chart.ts
+++ b/src/helpers/figures/charts/bar_chart.ts
@@ -240,9 +240,10 @@ export function createBarChartRuntime(chart: BarChart, getters: Getters): BarCha
         legend: getBarChartLegend(definition, chartData),
         tooltip: getBarChartTooltip(definition, chartData),
         chartShowValuesPlugin: getChartShowValues(definition, chartData),
+        background: { color: chart.background },
       },
     },
   };
 
-  return { chartJsConfig: config, background: chart.background || BACKGROUND_CHART_COLOR };
+  return { chartJsConfig: config };
 }

--- a/src/helpers/figures/charts/calendar_chart.ts
+++ b/src/helpers/figures/charts/calendar_chart.ts
@@ -1,5 +1,4 @@
 import { CoreGetters, RangeAdapterFunctions, Validator } from "@odoo/o-spreadsheet-engine";
-import { BACKGROUND_CHART_COLOR } from "@odoo/o-spreadsheet-engine/constants";
 import { AbstractChart } from "@odoo/o-spreadsheet-engine/helpers/figures/charts/abstract_chart";
 import {
   checkDataset,
@@ -238,10 +237,10 @@ export function createCalendarChartRuntime(
         tooltip: getCalendarChartTooltip(definition, chartData),
         chartShowValuesPlugin: getCalendarChartShowValues(definition, chartData),
         chartColorScalePlugin: getCalendarColorScale(definition, chartData),
+        background: { color: chart.background },
       },
-      chartBackground: definition.background || BACKGROUND_CHART_COLOR,
     },
   };
 
-  return { chartJsConfig: config, background: chart.background || BACKGROUND_CHART_COLOR };
+  return { chartJsConfig: config };
 }

--- a/src/helpers/figures/charts/combo_chart.ts
+++ b/src/helpers/figures/charts/combo_chart.ts
@@ -244,9 +244,10 @@ export function createComboChartRuntime(chart: ComboChart, getters: Getters): Co
         legend: getComboChartLegend(definition, chartData),
         tooltip: getBarChartTooltip(definition, chartData),
         chartShowValuesPlugin: getChartShowValues(definition, chartData),
+        background: { color: chart.background },
       },
     },
   };
 
-  return { chartJsConfig: config, background: chart.background || BACKGROUND_CHART_COLOR };
+  return { chartJsConfig: config };
 }

--- a/src/helpers/figures/charts/funnel_chart.ts
+++ b/src/helpers/figures/charts/funnel_chart.ts
@@ -1,5 +1,4 @@
 import { CoreGetters, RangeAdapterFunctions, Validator } from "@odoo/o-spreadsheet-engine";
-import { BACKGROUND_CHART_COLOR } from "@odoo/o-spreadsheet-engine/constants";
 import { AbstractChart } from "@odoo/o-spreadsheet-engine/helpers/figures/charts/abstract_chart";
 import {
   checkDataset,
@@ -220,9 +219,10 @@ export function createFunnelChartRuntime(chart: FunnelChart, getters: Getters): 
         legend: { display: false },
         tooltip: getFunnelChartTooltip(definition, chartData),
         chartShowValuesPlugin: getChartShowValues(definition, chartData),
+        background: { color: chart.background },
       },
     },
   };
 
-  return { chartJsConfig: config, background: chart.background || BACKGROUND_CHART_COLOR };
+  return { chartJsConfig: config };
 }

--- a/src/helpers/figures/charts/geo_chart.ts
+++ b/src/helpers/figures/charts/geo_chart.ts
@@ -1,5 +1,4 @@
 import { CoreGetters, RangeAdapterFunctions, Validator } from "@odoo/o-spreadsheet-engine";
-import { BACKGROUND_CHART_COLOR } from "@odoo/o-spreadsheet-engine/constants";
 import { AbstractChart } from "@odoo/o-spreadsheet-engine/helpers/figures/charts/abstract_chart";
 import {
   checkDataset,
@@ -200,9 +199,10 @@ export function createGeoChartRuntime(chart: GeoChart, getters: Getters): GeoCha
         title: getChartTitle(definition, getters),
         tooltip: getGeoChartTooltip(definition, chartData),
         legend: { display: false },
+        background: { color: chart.background },
       },
     },
   };
 
-  return { chartJsConfig: config, background: chart.background || BACKGROUND_CHART_COLOR };
+  return { chartJsConfig: config };
 }

--- a/src/helpers/figures/charts/line_chart.ts
+++ b/src/helpers/figures/charts/line_chart.ts
@@ -246,12 +246,10 @@ export function createLineChartRuntime(chart: LineChart, getters: Getters): Char
         legend: getLineChartLegend(definition, chartData),
         tooltip: getLineChartTooltip(definition, chartData),
         chartShowValuesPlugin: getChartShowValues(definition, chartData),
+        background: { color: chart.background },
       },
     },
   };
 
-  return {
-    chartJsConfig: config,
-    background: chart.background || BACKGROUND_CHART_COLOR,
-  };
+  return { chartJsConfig: config };
 }

--- a/src/helpers/figures/charts/pie_chart.ts
+++ b/src/helpers/figures/charts/pie_chart.ts
@@ -212,9 +212,10 @@ export function createPieChartRuntime(chart: PieChart, getters: Getters): PieCha
         legend: getPieChartLegend(definition, chartData),
         tooltip: getPieChartTooltip(definition, chartData),
         chartShowValuesPlugin: getChartShowValues(definition, chartData),
+        background: { color: chart.background },
       },
     },
   };
 
-  return { chartJsConfig: config, background: chart.background || BACKGROUND_CHART_COLOR };
+  return { chartJsConfig: config };
 }

--- a/src/helpers/figures/charts/pyramid_chart.ts
+++ b/src/helpers/figures/charts/pyramid_chart.ts
@@ -241,9 +241,10 @@ export function createPyramidChartRuntime(
         legend: getBarChartLegend(definition, chartData),
         tooltip: getPyramidChartTooltip(definition, chartData),
         chartShowValuesPlugin: getPyramidChartShowValues(definition, chartData),
+        background: { color: chart.background },
       },
     },
   };
 
-  return { chartJsConfig: config, background: chart.background || BACKGROUND_CHART_COLOR };
+  return { chartJsConfig: config };
 }

--- a/src/helpers/figures/charts/radar_chart.ts
+++ b/src/helpers/figures/charts/radar_chart.ts
@@ -236,9 +236,10 @@ export function createRadarChartRuntime(chart: RadarChart, getters: Getters): Ra
         legend: getRadarChartLegend(definition, chartData),
         tooltip: getRadarChartTooltip(definition, chartData),
         chartShowValuesPlugin: getChartShowValues(definition, chartData),
+        background: { color: chart.background },
       },
     },
   };
 
-  return { chartJsConfig: config, background: chart.background || BACKGROUND_CHART_COLOR };
+  return { chartJsConfig: config };
 }

--- a/src/helpers/figures/charts/scatter_chart.ts
+++ b/src/helpers/figures/charts/scatter_chart.ts
@@ -243,12 +243,10 @@ export function createScatterChartRuntime(
         legend: getScatterChartLegend(definition, chartData),
         tooltip: getLineChartTooltip(definition, chartData),
         chartShowValuesPlugin: getChartShowValues(definition, chartData),
+        background: { color: chart.background },
       },
     },
   };
 
-  return {
-    chartJsConfig: config,
-    background: chart.background || BACKGROUND_CHART_COLOR,
-  };
+  return { chartJsConfig: config };
 }

--- a/src/helpers/figures/charts/sunburst_chart.ts
+++ b/src/helpers/figures/charts/sunburst_chart.ts
@@ -1,5 +1,4 @@
 import { CoreGetters, RangeAdapterFunctions, Validator } from "@odoo/o-spreadsheet-engine";
-import { BACKGROUND_CHART_COLOR } from "@odoo/o-spreadsheet-engine/constants";
 import { AbstractChart } from "@odoo/o-spreadsheet-engine/helpers/figures/charts/abstract_chart";
 import {
   checkDataset,
@@ -211,9 +210,10 @@ export function createSunburstChartRuntime(
         tooltip: getSunburstChartTooltip(definition, chartData),
         sunburstLabelsPlugin: getSunburstShowValues(definition, chartData),
         sunburstHoverPlugin: { enabled: true },
+        background: { color: chart.background },
       },
     },
   };
 
-  return { chartJsConfig: config, background: chart.background || BACKGROUND_CHART_COLOR };
+  return { chartJsConfig: config };
 }

--- a/src/helpers/figures/charts/tree_map_chart.ts
+++ b/src/helpers/figures/charts/tree_map_chart.ts
@@ -220,9 +220,10 @@ export function createTreeMapChartRuntime(
         title: getChartTitle(definition, getters),
         legend: { display: false },
         tooltip: getTreeMapChartTooltip(definition, chartData),
+        background: { color: chart.background },
       },
     },
   };
 
-  return { chartJsConfig: config, background: chart.background || BACKGROUND_CHART_COLOR };
+  return { chartJsConfig: config };
 }

--- a/src/helpers/figures/charts/waterfall_chart.ts
+++ b/src/helpers/figures/charts/waterfall_chart.ts
@@ -1,5 +1,4 @@
 import { CoreGetters, RangeAdapterFunctions, Validator } from "@odoo/o-spreadsheet-engine";
-import { BACKGROUND_CHART_COLOR } from "@odoo/o-spreadsheet-engine/constants";
 import { AbstractChart } from "@odoo/o-spreadsheet-engine/helpers/figures/charts/abstract_chart";
 import {
   checkDataset,
@@ -244,9 +243,10 @@ export function createWaterfallChartRuntime(
         tooltip: getWaterfallChartTooltip(definition, chartData),
         chartShowValuesPlugin: getWaterfallChartShowValues(definition, chartData),
         waterfallLinesPlugin: { showConnectorLines: definition.showConnectorLines },
+        background: { color: chart.background },
       },
     },
   };
 
-  return { chartJsConfig: config, background: chart.background || BACKGROUND_CHART_COLOR };
+  return { chartJsConfig: config };
 }

--- a/tests/figures/chart/__snapshots__/chart_plugin.test.ts.snap
+++ b/tests/figures/chart/__snapshots__/chart_plugin.test.ts.snap
@@ -2,7 +2,6 @@
 
 exports[`datasource tests create a chart with stacked bar 1`] = `
 {
-  "background": "#FFFFFF",
   "chartJsConfig": {
     "data": {
       "datasets": [
@@ -55,6 +54,9 @@ exports[`datasource tests create a chart with stacked bar 1`] = `
       },
       "maintainAspectRatio": false,
       "plugins": {
+        "background": {
+          "color": undefined,
+        },
         "chartShowValuesPlugin": {
           "background": [Function],
           "callback": [Function],
@@ -186,6 +188,9 @@ exports[`datasource tests create a chart with stacked bar 1`] = `
       },
       "maintainAspectRatio": false,
       "plugins": {
+        "background": {
+          "color": undefined,
+        },
         "chartShowValuesPlugin": undefined,
         "legend": {
           "display": false,
@@ -240,7 +245,6 @@ exports[`datasource tests create a chart with stacked bar 1`] = `
 
 exports[`datasource tests create chart with column datasets 1`] = `
 {
-  "background": "#FFFFFF",
   "chartJsConfig": {
     "data": {
       "datasets": [
@@ -311,6 +315,9 @@ exports[`datasource tests create chart with column datasets 1`] = `
       },
       "maintainAspectRatio": false,
       "plugins": {
+        "background": {
+          "color": undefined,
+        },
         "chartShowValuesPlugin": {
           "background": [Function],
           "callback": [Function],
@@ -459,6 +466,9 @@ exports[`datasource tests create chart with column datasets 1`] = `
       },
       "maintainAspectRatio": false,
       "plugins": {
+        "background": {
+          "color": undefined,
+        },
         "chartShowValuesPlugin": undefined,
         "legend": {
           "display": false,

--- a/tests/figures/chart/common_chart_plugin.test.ts
+++ b/tests/figures/chart/common_chart_plugin.test.ts
@@ -1,4 +1,5 @@
 import { BACKGROUND_CHART_COLOR } from "@odoo/o-spreadsheet-engine/constants";
+import { GaugeChartRuntime, ScorecardChartRuntime } from "@odoo/o-spreadsheet-engine/types/chart";
 import { Model } from "../../../src";
 import { Color, UID } from "../../../src/types";
 import {
@@ -16,6 +17,13 @@ describe("Single cell chart background color", () => {
   let model: Model;
   let sheetId: UID;
   const chartId = "thisIsAnId";
+
+  function getGaugeOrScorecardRuntime(
+    model: Model,
+    chartId: UID
+  ): GaugeChartRuntime | ScorecardChartRuntime {
+    return model.getters.getChartRuntime(chartId) as GaugeChartRuntime | ScorecardChartRuntime;
+  }
 
   beforeEach(() => {
     model = new Model();
@@ -47,11 +55,11 @@ describe("Single cell chart background color", () => {
     "chart %s background color change with main cell CF background color",
     (chartType: string) => {
       createTestChart(chartType, "A1");
-      expect(model.getters.getChartRuntime(chartId).background).toEqual(BACKGROUND_CHART_COLOR);
+      expect(getGaugeOrScorecardRuntime(model, chartId).background).toEqual(BACKGROUND_CHART_COLOR);
       addCfToA1("#FF0000");
-      expect(model.getters.getChartRuntime(chartId).background).toEqual("#FF0000");
+      expect(getGaugeOrScorecardRuntime(model, chartId).background).toEqual("#FF0000");
       setCellContent(model, "A1", "random value not in CF");
-      expect(model.getters.getChartRuntime(chartId).background).toEqual(BACKGROUND_CHART_COLOR);
+      expect(getGaugeOrScorecardRuntime(model, chartId).background).toEqual(BACKGROUND_CHART_COLOR);
     }
   );
 
@@ -59,9 +67,9 @@ describe("Single cell chart background color", () => {
     "chart %s background color change with main cell background color",
     (chartType: string) => {
       createTestChart(chartType, "A1");
-      expect(model.getters.getChartRuntime(chartId).background).toEqual(BACKGROUND_CHART_COLOR);
+      expect(getGaugeOrScorecardRuntime(model, chartId).background).toEqual(BACKGROUND_CHART_COLOR);
       addFillToA1("#00FF00");
-      expect(model.getters.getChartRuntime(chartId).background).toEqual("#00FF00");
+      expect(getGaugeOrScorecardRuntime(model, chartId).background).toEqual("#00FF00");
     }
   );
 
@@ -71,7 +79,7 @@ describe("Single cell chart background color", () => {
       addCfToA1("#FF0000");
       addFillToA1("#00FF00");
       createTestChart(chartType, "A1");
-      expect(model.getters.getChartRuntime(chartId).background).toEqual("#FF0000");
+      expect(getGaugeOrScorecardRuntime(model, chartId).background).toEqual("#FF0000");
     }
   );
 
@@ -80,7 +88,7 @@ describe("Single cell chart background color", () => {
     (chartType: string) => {
       addCfToA1("#FF0000");
       createTestChart(chartType, "A1", "#0000FF");
-      expect(model.getters.getChartRuntime(chartId).background).toEqual("#0000FF");
+      expect(getGaugeOrScorecardRuntime(model, chartId).background).toEqual("#0000FF");
     }
   );
 
@@ -97,7 +105,7 @@ describe("Single cell chart background color", () => {
       });
       const sheet1Name = model.getters.getSheetName(sheetId);
       createTestChart(chartType, `${sheet1Name}!A1`);
-      expect(model.getters.getChartRuntime(chartId).background).toEqual("#000FFF");
+      expect(getGaugeOrScorecardRuntime(model, chartId).background).toEqual("#000FFF");
     }
   );
 

--- a/tests/figures/chart/treemap/treemap_chart_plugin.test.ts
+++ b/tests/figures/chart/treemap/treemap_chart_plugin.test.ts
@@ -246,7 +246,8 @@ describe("TreeMap chart", () => {
       background: "#123456",
       dataSets: [{ dataRange: "A1" }],
     });
-    expect(model.getters.getChartRuntime(chartId)?.background).toEqual("#123456");
+    const runtime = model.getters.getChartRuntime(chartId) as TreeMapChartRuntime;
+    expect(runtime?.chartJsConfig?.options?.plugins?.background?.color).toEqual("#123456");
   });
 
   test("TreeMap header style", () => {


### PR DESCRIPTION
## Description

The background of the charts are usually set in the CSS of the
`ChartJsComponent`. But for some features, we need to convert the chart
into an image (copy to clipboard, download as image, xlsx export, ...).

In this case, we added on the fly a `chartBackgroundPlugin` to the runtime that would draw the background color. But we were always drawing a white background.

With this commit, we always draw the correct background in chartJS, so it works in both the component and the exported image.

Task: [5925821](https://www.odoo.com/odoo/2328/tasks/5925821)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo