### PR TITLE
[FIX] charts: hierarchical charts should show formatted labels instead of raw

### DIFF
--- a/src/helpers/figures/charts/runtime/chart_data_extractor.ts
+++ b/src/helpers/figures/charts/runtime/chart_data_extractor.ts
@@ -13,6 +13,7 @@ import {
   CellValue,
   DEFAULT_LOCALE,
   Format,
+  FormattedValue,
   GenericDefinition,
   Getters,
   Locale,
@@ -654,20 +655,42 @@ function fixEmptyLabelsForDateCharts(
   return { labels: newLabels, dataSetsValues: newDatasets };
 }
 
+function getDatasetRange(getters: Getters, ds: DataSet): Range | undefined {
+  if (!ds.dataRange) {
+    return;
+  }
+
+  const labelCellZone = ds.labelCell ? [ds.labelCell.zone] : [];
+  const dataZone = recomputeZones([ds.dataRange.zone], labelCellZone)[0];
+  if (!dataZone) {
+    return;
+  }
+
+  return getters.getRangeFromZone(ds.dataRange.sheetId, dataZone);
+}
+
 /**
  * Get the data from a dataSet
  */
 export function getData(getters: Getters, ds: DataSet): (CellValue | undefined)[] {
-  if (ds.dataRange) {
-    const labelCellZone = ds.labelCell ? [ds.labelCell.zone] : [];
-    const dataZone = recomputeZones([ds.dataRange.zone], labelCellZone)[0];
-    if (dataZone === undefined) {
-      return [];
-    }
-    const dataRange = getters.getRangeFromZone(ds.dataRange.sheetId, dataZone);
-    return getters.getRangeValues(dataRange).map((value) => (value === "" ? undefined : value));
+  const range = getDatasetRange(getters, ds);
+  if (!range) {
+    return [];
   }
-  return [];
+
+  return getters.getRangeValues(range).map((value) => (value === "" ? undefined : value));
+}
+
+/**
+ * Get the formatted data from a dataSet
+ */
+function getFormattedData(getters: Getters, ds: DataSet): (FormattedValue | undefined)[] {
+  const range = getDatasetRange(getters, ds);
+  if (!range) {
+    return [];
+  }
+
+  return getters.getRangeFormattedValues(range).map((value) => (value === "" ? undefined : value));
 }
 
 /**
@@ -931,13 +954,13 @@ function getHierarchicalDatasetValues(getters: Getters, dataSets: DataSet[]): Da
     (ds) => !getters.isColHidden(ds.dataRange.sheetId, ds.dataRange.zone.left)
   );
   const datasetValues: DatasetValues[] = dataSets.map(() => ({ data: [], label: "" }));
-  const dataSetsData = dataSets.map((ds) => getData(getters, ds));
+  const dataSetsData = dataSets.map((ds) => getFormattedData(getters, ds));
   if (!dataSetsData.length) {
     return datasetValues;
   }
   const minLength = Math.min(...dataSetsData.map((ds) => ds.length));
 
-  let currentValues: (CellValue | undefined)[] = [];
+  let currentValues: (FormattedValue | undefined)[] = [];
   const leafDatasetIndex = dataSets.length - 1;
 
   for (let i = 0; i < minLength; i++) {

--- a/tests/figures/chart/sunburst/sunburst_chart_plugin.test.ts
+++ b/tests/figures/chart/sunburst/sunburst_chart_plugin.test.ts
@@ -129,6 +129,25 @@ describe("Sunburst chart chart", () => {
     ]);
   });
 
+  test("Sunburst chart display dataset labels in formatted form", () => {
+    // prettier-ignore
+    setGrid(model, {
+      A2: "2/3/2010",   B2: "10",
+      A3: "5/8/2015",   B3: "40",
+    })
+    const chartId = createSunburstChart(model, {
+      dataSets: [{ dataRange: "A1:A3" }],
+      labelRange: "B1:B3",
+    });
+
+    const config = getSunburstRuntime(chartId).chartJsConfig;
+    expect(config.data.datasets).toHaveLength(1);
+    expect(config.data.datasets[0].data).toMatchObject([
+      { value: 40, label: "5/8/2015", groups: ["5/8/2015"] },
+      { value: 10, label: "2/3/2010", groups: ["2/3/2010"] },
+    ]);
+  });
+
   test("Sunburst data is sorted", () => {
     // prettier-ignore
     setGrid(model, {

--- a/tests/figures/chart/treemap/treemap_chart_plugin.test.ts
+++ b/tests/figures/chart/treemap/treemap_chart_plugin.test.ts
@@ -156,6 +156,30 @@ describe("TreeMap chart", () => {
     });
   });
 
+  test("TreeMap chart display dataset labels in formatted form", () => {
+    // prettier-ignore
+    setGrid(model, {
+        A1: "Date",       B1: "Sales",
+        A2: "2/3/2010",   B2: "10",
+        A3: "5/8/2015",   B3: "40",
+      })
+    const chartId = createTreeMapChart(model, {
+      dataSets: [{ dataRange: "A1:A3" }],
+      labelRange: "B1:B3",
+      dataSetsHaveTitle: true,
+    });
+
+    const datasetConfig = getTreeMapDatasetConfig(chartId);
+    expect(datasetConfig).toMatchObject({
+      tree: [
+        { 0: "2/3/2010", value: 10 },
+        { 0: "5/8/2015", value: 40 },
+      ],
+      groups: ["0"],
+      key: "value",
+    });
+  });
+
   test("Can have a hierarchical dataset with some categories more detailed that others", () => {
     // prettier-ignore
     setGrid(model, {


### PR DESCRIPTION
## Description:

Current behavior before PR:
- Hierarchical charts interpret datasets as labels and the last column as values. dataset cells were read as raw values, which is correct for other charts but incorrect here because these values are rendered as labels.
- As a result, formatted values were displayed incorrectly in charts like Sunburst and Treemap.

Desired behavior after PR is merged:
- Dataset columns used as labels now use formatted cell values instead of raw values, ensuring dates and other formatted types display correctly in hierarchical charts.

Task: [5913296](https://www.odoo.com/odoo/2328/tasks/5913296)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo