### PR TITLE
[FIX] dynamic_tables: enable total row style only when total is visible

### DIFF
--- a/packages/o-spreadsheet-engine/src/plugins/ui_core_views/dynamic_tables.ts
+++ b/packages/o-spreadsheet-engine/src/plugins/ui_core_views/dynamic_tables.ts
@@ -134,13 +134,19 @@ export class DynamicTablesPlugin extends CoreViewPlugin {
   ): TableConfig {
     const pivot = this.getters.getPivot(pivotId);
     const pivotTable = pivot.getCollapsedTableStructure();
+    const { numberOfRows, numberOfHeaderRows } = pivotTable.getPivotTableDimensions(pivotStyle);
+    const lastVisibleCell = pivotTable.getPivotCells(pivotStyle)[0]?.[numberOfRows - 1];
+    const hasVisibleTotalRow =
+      pivotStyle.displayTotals &&
+      lastVisibleCell?.type === "HEADER" &&
+      lastVisibleCell.domain.length === 0;
 
     return {
       hasFilters: pivotStyle.hasFilters,
-      totalRow: pivotStyle.displayTotals,
+      totalRow: hasVisibleTotalRow,
       firstColumn: true,
       lastColumn: true,
-      numberOfHeaders: pivotTable.getPivotTableDimensions(pivotStyle).numberOfHeaderRows,
+      numberOfHeaders: numberOfHeaderRows,
       bandedRows: pivotStyle.bandedRows,
       bandedColumns: pivotStyle.bandedColumns,
       styleId: pivotStyle.tableStyleId,

--- a/tests/pivots/pivot_table_style.test.ts
+++ b/tests/pivots/pivot_table_style.test.ts
@@ -216,6 +216,30 @@ describe("Pivot table style", () => {
     });
   });
 
+  test("Total style is not applied when row limit truncates the total row", () => {
+    tableStyle.wholeTable = { style: wholePivotStyle };
+    tableStyle.headerRow = { style: headerRowStyle };
+    tableStyle.totalRow = { style: totalRowStyle };
+
+    updatePivot(model, "1", {
+      rows: [{ fieldName: "Stage" }],
+      style: { tableStyleId: "TestStyle", numberOfRows: 2, displayTotals: true },
+    });
+
+    expect(getTables(model, sheetId)[0]).toMatchObject({
+      zone: "A25:B28",
+      config: { totalRow: false },
+    });
+
+    // prettier-ignore
+    expect(getGridStyle(model, "A25:B28")).toEqual({
+      A25: headerRowStyle,          B25: headerRowStyle,
+      A26: headerRowStyle,          B26: headerRowStyle,
+      A27: wholePivotStyle,         B27: wholePivotStyle,
+      A28: wholePivotStyle,         B28: wholePivotStyle,
+    });
+  });
+
   test("Can display banded row style", () => {
     tableStyle.wholeTable = { style: wholePivotStyle };
     tableStyle.headerRow = { style: headerRowStyle };


### PR DESCRIPTION
## Description:

Pivot table styling relies on `table.config.totalRow` to style the last row. With a limited `numberOfRows`, the grand total row can be truncated while `totalRow` was still derived from `displayTotals`, so the last data row got total styling.

Compute `totalRow` from the rendered pivot output and set it only when the last visible row is the grand total row.

Task: [5920830](https://www.odoo.com/odoo/2328/tasks/5920830)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo