### PR TITLE
[IMP] topbar: number editor closes on right click

### DIFF
--- a/src/components/border_editor/border_editor.ts
+++ b/src/components/border_editor/border_editor.ts
@@ -42,6 +42,8 @@ export interface BorderEditorProps {
   onBorderPositionPicked: (position: BorderPosition) => void;
   maxHeight?: Pixel;
   anchorRect: Rect;
+  onClose?: (ev: MouseEvent) => void;
+  rootElement?: HTMLElement | null;
 }
 
 // -----------------------------------------------------------------------------
@@ -60,6 +62,8 @@ export class BorderEditor extends Component<BorderEditorProps, SpreadsheetChildE
     onBorderPositionPicked: Function,
     maxHeight: { type: Number, optional: true },
     anchorRect: Object,
+    onClose: { type: Function, optional: true },
+    rootElement: { type: HTMLElement, optional: true },
   };
   static components = { ColorPickerWidget, Popover };
   BORDER_POSITIONS = BORDER_POSITIONS;
@@ -95,10 +99,13 @@ export class BorderEditor extends Component<BorderEditorProps, SpreadsheetChildE
   }
 
   get lineStylePickerPopoverProps(): PopoverProps {
+    const rootElement = this.lineStyleButtonRef.el;
     return {
       anchorRect: this.lineStylePickerAnchorRect,
       positioning: "bottom-left",
       verticalOffset: 0,
+      onClose: this.closeDropdown.bind(this),
+      rootElement,
     };
   }
 
@@ -108,6 +115,8 @@ export class BorderEditor extends Component<BorderEditorProps, SpreadsheetChildE
       maxHeight: this.props.maxHeight,
       positioning: "bottom-left",
       verticalOffset: 0,
+      onClose: this.props.onClose,
+      rootElement: this.props.rootElement,
     };
   }
 

--- a/src/components/border_editor/border_editor.xml
+++ b/src/components/border_editor/border_editor.xml
@@ -34,11 +34,12 @@
               currentColor="props.currentBorderColor"
               toggleColorPicker="(ev) => this.toggleDropdownTool('borderColorTool')"
               showColorPicker="state.activeTool === 'borderColorTool'"
-              onColorPicked="(color) => this.setBorderColor(color)"
+              onColorPicked.bind="this.setBorderColor"
               title="border_color"
               icon="props.currentBorderColor === '' ? 'o-spreadsheet-Icon.BORDER_NO_COLOR' : 'o-spreadsheet-Icon.BORDER_COLOR'"
               dropdownMaxHeight="this.props.dropdownMaxHeight"
               class="'o-dropdown-button o-border-picker-button'"
+              onClose.bind="this.closeDropdown"
             />
             <t t-call="o-spreadsheet-Icon.CARET_DOWN"/>
           </div>

--- a/src/components/border_editor/border_editor_widget.xml
+++ b/src/components/border_editor/border_editor_widget.xml
@@ -23,6 +23,8 @@
         currentBorderPosition="state.currentPosition"
         maxHeight="dropdownMaxHeight"
         anchorRect="borderEditorAnchorRect"
+        onClose.bind="this.topBarToolStore.closeDropdowns"
+        rootElement="this.borderEditorButtonRef.el"
       />
     </div>
   </t>

--- a/src/components/bottom_bar/bottom_bar.ts
+++ b/src/components/bottom_bar/bottom_bar.ts
@@ -112,10 +112,14 @@ export class BottomBar extends Component<Props, SpreadsheetChildEnv> {
     const target = ev.currentTarget as HTMLElement;
     const { left } = target.getBoundingClientRect();
     const top = this.bottomBarRef.el!.getBoundingClientRect().top;
-    this.openContextMenu(left, top, "listSheets", registry);
+    this.toggleContextMenu(left, top, "listSheets", registry);
   }
 
-  openContextMenu(x: Pixel, y: Pixel, menuId: UID, registry: MenuItemRegistry) {
+  toggleContextMenu(x: Pixel, y: Pixel, menuId: UID, registry: MenuItemRegistry) {
+    if (this.menuState.isOpen && this.menuState.menuId === menuId) {
+      this.closeMenu();
+      return;
+    }
     this.menuState.isOpen = true;
     this.menuState.menuId = menuId;
     this.menuState.menuItems = registry.getMenuItems();
@@ -129,7 +133,7 @@ export class BottomBar extends Component<Props, SpreadsheetChildEnv> {
       this.closeMenu();
       return;
     }
-    this.openContextMenu(left, top, sheetId, registry);
+    this.toggleContextMenu(left, top, sheetId, registry);
   }
 
   closeMenu() {

--- a/src/components/bottom_bar/bottom_bar.xml
+++ b/src/components/bottom_bar/bottom_bar.xml
@@ -79,7 +79,7 @@
           </Ripple>
         </div>
         <BottomBarStatistic
-          openContextMenu="(x, y, registry) => this.openContextMenu(x, y, 'listSelectionStatistics', registry)"
+          openContextMenu="(x, y, registry) => this.toggleContextMenu(x, y, 'listSelectionStatistics', registry)"
           closeContextMenu="() => this.closeContextMenuWithId('listSelectionStatistics')"
         />
       </t>

--- a/src/components/bottom_bar/bottom_bar_sheet/bottom_bar_sheet.ts
+++ b/src/components/bottom_bar/bottom_bar_sheet/bottom_bar_sheet.ts
@@ -4,7 +4,6 @@ import {
   onPatched,
   onWillUnmount,
   useEffect,
-  useExternalListener,
   useRef,
   useState,
 } from "@odoo/owl";
@@ -78,7 +77,6 @@ export class BottomBarSheet extends Component<Props, SpreadsheetChildEnv> {
       }
     });
     this.DOMFocusableElementStore = useStore(DOMFocusableElementStore);
-    useExternalListener(window, "click", () => (this.state.pickerOpened = false));
 
     useEffect(
       (sheetId) => {
@@ -118,6 +116,10 @@ export class BottomBarSheet extends Component<Props, SpreadsheetChildEnv> {
     onWillUnmount(() => {
       this.env.model.off("command-rejected", this);
     });
+  }
+
+  closePicker() {
+    this.state.pickerOpened = false;
   }
 
   private focusInputAndSelectContent() {

--- a/src/components/bottom_bar/bottom_bar_sheet/bottom_bar_sheet.xml
+++ b/src/components/bottom_bar/bottom_bar_sheet/bottom_bar_sheet.xml
@@ -47,6 +47,7 @@
       t-if="state.pickerOpened"
       anchorRect="colorPickerAnchorRect"
       onColorPicked.bind="onColorPicked"
+      onClose.bind="this.closePicker"
       currentColor="props.currentColor"
     />
   </t>

--- a/src/components/color_picker/color_picker.ts
+++ b/src/components/color_picker/color_picker.ts
@@ -32,8 +32,10 @@ export interface ColorPickerProps {
   anchorRect: Rect;
   maxHeight?: Pixel;
   onColorPicked: (color: Color) => void;
+  onClose?: () => void;
   currentColor: Color;
   disableNoColor?: boolean;
+  rootElement?: HTMLElement | null;
 }
 
 interface State {
@@ -46,10 +48,12 @@ export class ColorPicker extends Component<ColorPickerProps, SpreadsheetChildEnv
   static template = "o-spreadsheet-ColorPicker";
   static props = {
     onColorPicked: Function,
+    onClose: { type: Function, optional: true },
     currentColor: { type: String, optional: true },
     maxHeight: { type: Number, optional: true },
     anchorRect: Object,
     disableNoColor: { type: Boolean, optional: true },
+    rootElement: { type: HTMLElement, optional: true },
   };
   static defaultProps = { currentColor: "" };
   static components = { Popover };
@@ -77,6 +81,8 @@ export class ColorPicker extends Component<ColorPickerProps, SpreadsheetChildEnv
       maxHeight: this.props.maxHeight,
       positioning: "bottom-left",
       verticalOffset: 0,
+      onClose: this.props.onClose,
+      rootElement: this.props.rootElement,
     };
   }
 

--- a/src/components/color_picker/color_picker.xml
+++ b/src/components/color_picker/color_picker.xml
@@ -1,7 +1,7 @@
 <templates>
   <t t-name="o-spreadsheet-ColorPicker">
     <Popover t-props="popoverProps">
-      <div class="o-color-picker" t-on-click.stop="" t-att-style="colorPickerStyle">
+      <div class="o-color-picker" t-att-style="colorPickerStyle">
         <div class="o-color-picker-section-name">Standard</div>
         <div class="colors-grid">
           <div
@@ -51,7 +51,6 @@
         <div t-if="state.showGradient" class="o-custom-selector">
           <div
             class="o-gradient"
-            t-on-click.stop=""
             t-on-pointerdown="dragGradientPointer"
             t-att-style="gradientHueStyle">
             <div class="saturation w-100 h-100 position-absolute pe-none"/>
@@ -69,7 +68,6 @@
               type="text"
               class="border rounded"
               t-att-class="{'o-wrong-color': !isHexColorInputValid }"
-              t-on-click.stop=""
               t-att-value="state.customHexColor"
               t-on-input="setHexColor"
             />
@@ -79,7 +77,7 @@
             <button
               class="o-add-button border rounded"
               t-att-class="{'o-disabled': !state.customHexColor or !isHexColorInputValid}"
-              t-on-click.stop="addCustomColor">
+              t-on-click="this.addCustomColor">
               Add
             </button>
           </div>

--- a/src/components/color_picker/color_picker_widget.ts
+++ b/src/components/color_picker/color_picker_widget.ts
@@ -13,6 +13,8 @@ interface Props {
   disabled?: boolean;
   dropdownMaxHeight?: Pixel;
   class?: string;
+  onClose?: () => void;
+  rootElement?: HTMLElement | null;
 }
 
 export class ColorPickerWidget extends Component<Props, SpreadsheetChildEnv> {
@@ -27,6 +29,8 @@ export class ColorPickerWidget extends Component<Props, SpreadsheetChildEnv> {
     disabled: { type: Boolean, optional: true },
     dropdownMaxHeight: { type: Number, optional: true },
     class: { type: String, optional: true },
+    onClose: { type: Function, optional: true },
+    rootElement: { type: HTMLElement, optional: true },
   };
   static components = { ColorPicker };
 
@@ -47,5 +51,9 @@ export class ColorPickerWidget extends Component<Props, SpreadsheetChildEnv> {
       width: buttonRect.width,
       height: buttonRect.height,
     };
+  }
+
+  get colorPickerRootElement() {
+    return this.colorPickerButtonRef.el;
   }
 }

--- a/src/components/color_picker/color_picker_widget.xml
+++ b/src/components/color_picker/color_picker_widget.xml
@@ -18,6 +18,8 @@
         onColorPicked="props.onColorPicked"
         currentColor="props.currentColor"
         maxHeight="props.dropdownMaxHeight"
+        rootElement="this.props.rootElement || this.colorPickerRootElement"
+        onClose="this.props.onClose"
       />
     </div>
   </t>

--- a/src/components/composer/top_bar_composer/top_bar_composer.xml
+++ b/src/components/composer/top_bar_composer/top_bar_composer.xml
@@ -7,8 +7,7 @@
           'o-topbar-composer-readonly': env.model.getters.isReadonly(),
           'o-topbar-composer-active': focus !== 'inactive',
           'o-topbar-composer-inactive': focus === 'inactive',
-        }"
-        t-on-click.stop="">
+        }">
         <Composer
           focus="focus"
           inputStyle="composerStyle"

--- a/src/components/figures/figure/figure.xml
+++ b/src/components/figures/figure/figure.xml
@@ -10,7 +10,7 @@
         t-att-class="props.class"
         t-on-pointerdown.stop="(ev) => this.onMouseDown(ev)"
         t-on-click="onClick"
-        t-on-contextmenu.prevent.stop="(ev) => !env.model.getters.isReadonly() and this.onContextMenu(ev)"
+        t-on-contextmenu.prevent="(ev) => !env.model.getters.isReadonly() and this.onContextMenu(ev)"
         t-ref="figure"
         t-att-style="props.style"
         t-att-data-id="props.figureUI.id"
@@ -30,7 +30,7 @@
             t-if="!env.model.getters.isReadonly() and props.figureUI.tag !== 'carousel'"
             t-on-click="showMenu"
             t-ref="menuButton"
-            t-on-contextmenu.prevent.stop="showMenu">
+            t-on-contextmenu.prevent="this.showMenu">
             <t t-call="o-spreadsheet-Icon.LIST"/>
           </div>
           <MenuPopover

--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -491,6 +491,10 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
     return this.gridRef.el;
   }
 
+  get popoverRootElement(): HTMLElement | undefined {
+    return this.gridRef.el?.querySelector<HTMLElement>(".o-grid-overlay") || undefined;
+  }
+
   getAutofillPosition() {
     const zone = this.env.model.getters.getSelectedZone();
     const rect = this.env.model.getters.getVisibleRect(zone);

--- a/src/components/grid/grid.xml
+++ b/src/components/grid/grid.xml
@@ -38,6 +38,7 @@
       <GridPopover
         t-if="!menuState.isOpen"
         gridRect="getGridRect()"
+        rootElement="popoverRootElement || undefined"
         onMouseWheel.bind="onMouseWheel"
         onClosePopover.bind="onClosePopover"
       />

--- a/src/components/grid_overlay/grid_overlay.xml
+++ b/src/components/grid_overlay/grid_overlay.xml
@@ -12,7 +12,7 @@
       t-on-pointermove="onPointerMove"
       t-on-click="onClick"
       t-on-dblclick.self="onDoubleClick"
-      t-on-contextmenu.stop.prevent="onContextMenu">
+      t-on-contextmenu.prevent="this.onContextMenu">
       <GridAddRowsFooter
         t-if="!env.model.getters.isReadonly()"
         t-key="env.model.getters.getActiveSheetId()"

--- a/src/components/grid_popover/grid_popover.ts
+++ b/src/components/grid_popover/grid_popover.ts
@@ -10,6 +10,7 @@ import { Popover } from "../popover/popover";
 
 interface Props {
   gridRect: Rect;
+  rootElement?: HTMLElement | null;
   onClosePopover: () => void;
   onMouseWheel: (ev: WheelEvent) => void;
 }
@@ -19,6 +20,7 @@ export class GridPopover extends Component<Props, SpreadsheetChildEnv> {
     onClosePopover: Function,
     onMouseWheel: Function,
     gridRect: Object,
+    rootElement: { type: HTMLElement, optional: true },
   };
   static components = { Popover };
   protected cellPopovers!: Store<CellPopoverStore>;

--- a/src/components/grid_popover/grid_popover.xml
+++ b/src/components/grid_popover/grid_popover.xml
@@ -7,6 +7,8 @@
       maxWidth="cellPopover.Component.size and cellPopover.Component.size.maxWidth"
       anchorRect="cellPopover.anchorRect"
       containerRect="env.getPopoverContainerRect()"
+      rootElement="this.props.rootElement"
+      onClose.bind="this.props.onClosePopover"
       onMouseWheel="props.onMouseWheel"
       class="'o-popover-grid-index'">
       <t

--- a/src/components/menu_popover/menu_popover.ts
+++ b/src/components/menu_popover/menu_popover.ts
@@ -3,7 +3,6 @@ import {
   onWillUnmount,
   onWillUpdateProps,
   useEffect,
-  useExternalListener,
   useRef,
   useState,
 } from "@odoo/owl";
@@ -112,8 +111,6 @@ export class MenuPopover extends Component<Props, SpreadsheetChildEnv> {
       }
     });
 
-    useExternalListener(window, "click", this.onExternalClick, { capture: true });
-    useExternalListener(window, "contextmenu", this.onExternalClick, { capture: true });
     onWillUpdateProps((nextProps: Props) => {
       if (nextProps.menuItems !== this.props.menuItems) {
         this.closeSubMenu();
@@ -165,6 +162,7 @@ export class MenuPopover extends Component<Props, SpreadsheetChildEnv> {
       verticalOffset: isRoot ? 0 : MENU_VERTICAL_PADDING,
       onPopoverHidden: () => this.closeSubMenu(),
       onPopoverMoved: () => this.closeSubMenu(),
+      onClose: (ev) => this.onExternalClick(ev as MenuMouseEvent),
       maxHeight: this.props.maxHeight,
     };
   }

--- a/src/components/number_editor/number_editor.css
+++ b/src/components/number_editor/number_editor.css
@@ -2,7 +2,7 @@
   .o-number-editor {
     width: max-content !important;
 
-    input.o-font-size {
+    input {
       outline: none;
       height: 20px;
       width: 31px;

--- a/src/components/number_editor/number_editor.ts
+++ b/src/components/number_editor/number_editor.ts
@@ -1,17 +1,9 @@
-import {
-  Component,
-  onMounted,
-  onWillUpdateProps,
-  useExternalListener,
-  useRef,
-  useState,
-} from "@odoo/owl";
+import { Component, onMounted, onWillUpdateProps, useRef, useState } from "@odoo/owl";
 import { clip } from "../../helpers/index";
 import { Store, useStore } from "../../store_engine";
 import { DOMFocusableElementStore } from "../../stores/DOM_focus_store";
 import { Ref } from "../../types";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
-import { isChildEvent } from "../helpers/dom_helpers";
 import { Popover, PopoverProps } from "../popover";
 
 interface State {
@@ -56,14 +48,11 @@ export class NumberEditor extends Component<Props, SpreadsheetChildEnv> {
 
   private inputRef: Ref<HTMLInputElement> = useRef("inputNumber");
   private rootEditorRef = useRef("NumberEditor");
-  private valueListRef = useRef("numberList");
 
   private DOMFocusableElementStore!: Store<DOMFocusableElementStore>;
 
   setup() {
     this.DOMFocusableElementStore = useStore(DOMFocusableElementStore);
-
-    useExternalListener(window, "click", this.onExternalClick, { capture: true });
     onWillUpdateProps((nextProps) => {
       if (this.inputRef.el && document.activeElement !== this.inputRef.el) {
         this.inputRef.el.value = nextProps.currentValue;
@@ -83,13 +72,9 @@ export class NumberEditor extends Component<Props, SpreadsheetChildEnv> {
       anchorRect: { x, y, width, height },
       positioning: "bottom-left",
       verticalOffset: 0,
+      rootElement: this.rootEditorRef.el,
+      onClose: () => this.closeList(),
     };
-  }
-
-  onExternalClick(ev: MouseEvent) {
-    if (!isChildEvent(this.valueListRef.el!, ev) && !isChildEvent(this.rootEditorRef.el!, ev)) {
-      this.closeList();
-    }
   }
 
   toggleList() {

--- a/src/components/number_editor/number_editor.xml
+++ b/src/components/number_editor/number_editor.xml
@@ -10,7 +10,7 @@
           type="number"
           t-att-min="props.min"
           t-att-max="props.max"
-          class="o-font-size o-number-input bg-transparent border-0"
+          class="o-number-input bg-transparent border-0"
           t-on-keydown="onInputKeydown"
           t-on-wheel.prevent.stop=""
           t-on-click.stop="props.onFocusInput"
@@ -24,7 +24,7 @@
         </span>
       </div>
       <Popover t-if="dropdown.isOpen" t-props="popoverProps">
-        <div class="o-text-options" t-on-click.stop="" t-ref="numberList">
+        <div class="o-text-options">
           <t t-foreach="props.valueList" t-as="value" t-key="value">
             <div t-att-data-size="value" t-on-click="() => this.setValueFromList(value)">
               <t t-out="value"/>

--- a/src/components/popover/popover.ts
+++ b/src/components/popover/popover.ts
@@ -1,4 +1,12 @@
-import { Component, onMounted, onWillUnmount, useEffect, useRef } from "@odoo/owl";
+import {
+  Component,
+  onMounted,
+  onWillUnmount,
+  useChildSubEnv,
+  useEffect,
+  useExternalListener,
+  useRef,
+} from "@odoo/owl";
 import { rectIntersection } from "../../helpers/rectangle";
 import { DOMCoordinates, DOMDimension, Pixel, Rect } from "../../types";
 import { PopoverPropsPosition } from "../../types/cell_popovers";
@@ -29,8 +37,19 @@ export interface PopoverProps {
   onPopoverMoved?: () => void;
   onPopoverHidden?: () => void;
 
+  /** Callback to be called when the popover should be closed (e.g. click outside) */
+  onClose?: (ev: MouseEvent) => void;
+
+  /**
+   * Element that should not trigger the onClose callback when clicked.
+   * Useful to prevent the toggle button from triggering an outside click.
+   */
+  rootElement?: HTMLElement | null;
+
   class?: string;
 }
+
+let popoverId = 1;
 
 export class Popover extends Component<PopoverProps, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-Popover";
@@ -44,6 +63,8 @@ export class Popover extends Component<PopoverProps, SpreadsheetChildEnv> {
     onMouseWheel: { type: Function, optional: true },
     onPopoverHidden: { type: Function, optional: true },
     onPopoverMoved: { type: Function, optional: true },
+    onClose: { type: Function, optional: true },
+    rootElement: { type: HTMLElement, optional: true },
     zIndex: { type: Number, optional: true },
     class: { type: String, optional: true },
     slots: Object,
@@ -54,18 +75,28 @@ export class Popover extends Component<PopoverProps, SpreadsheetChildEnv> {
     onMouseWheel: () => {},
     onPopoverMoved: () => {},
     onPopoverHidden: () => {},
+    onClose: () => {},
   };
 
   private popoverRef = useRef("popover");
   private popoverContentRef = useRef("popoverContent");
   private currentPosition: PopoverPosition | undefined = undefined;
   private currentDisplayValue: DisplayValue | undefined = undefined;
+  popoverId = "";
+  parentPopoverId: string | undefined;
 
   private spreadsheetRect = useSpreadsheetRect();
   private containerRect: Rect | undefined;
 
   setup() {
+    this.popoverId = `popover-${popoverId++}`;
+    this.parentPopoverId = this.env.parentPopoverId;
+    useChildSubEnv({ parentPopoverId: this.popoverId });
+
     this.containerRect = usePopoverContainer();
+
+    useExternalListener(window, "click", this.onExternalClick, { capture: true });
+    useExternalListener(window, "contextmenu", this.onExternalClick, { capture: true });
 
     const resizeObserver = new ResizeObserver(this.computePopoverPosition.bind(this));
     onMounted(() => {
@@ -78,6 +109,36 @@ export class Popover extends Component<PopoverProps, SpreadsheetChildEnv> {
     // useEffect occurs after the DOM is created and the element width/height are computed, but before
     // the element in rendered, so we can still set its position
     useEffect(this.computePopoverPosition.bind(this));
+  }
+
+  private onExternalClick(ev: MouseEvent) {
+    if (!this.popoverRef.el) {
+      return;
+    }
+    const target = ev.target as HTMLElement;
+    if (this.popoverRef.el.contains(target) || this.props.rootElement?.contains(target)) {
+      return;
+    }
+
+    // Don't close if the click is inside a descendant popover.
+    const targetPopover = target.closest<HTMLElement>(".o-popover");
+    if (targetPopover?.dataset.id && this.isDescendantPopover(targetPopover)) {
+      return;
+    }
+
+    this.props.onClose?.(ev);
+  }
+
+  private isDescendantPopover(popoverEl: HTMLElement): boolean {
+    let parentId = popoverEl.dataset.parentId;
+    while (parentId) {
+      if (parentId === this.popoverId) {
+        return true;
+      }
+      parentId = document.querySelector<HTMLElement>(`.o-popover[data-id="${parentId}"]`)?.dataset
+        .parentId;
+    }
+    return false;
   }
 
   private computePopoverPosition() {

--- a/src/components/popover/popover.xml
+++ b/src/components/popover/popover.xml
@@ -4,6 +4,8 @@
       <div
         class="o-popover rounded"
         t-att-class="props.class"
+        t-att-data-id="this.popoverId"
+        t-att-data-parent-id="this.parentPopoverId"
         t-ref="popover"
         t-on-wheel="props.onMouseWheel"
         t-on-click.stop="">

--- a/src/components/select/select.ts
+++ b/src/components/select/select.ts
@@ -1,7 +1,7 @@
-import { Component, useEffect, useExternalListener, useRef, useState } from "@odoo/owl";
+import { Component, useEffect, useRef, useState } from "@odoo/owl";
 import { ValueAndLabel } from "../../types";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
-import { getRefBoundingRect, isChildEvent } from "../helpers/dom_helpers";
+import { getRefBoundingRect } from "../helpers/dom_helpers";
 import { Popover, PopoverProps } from "../popover/popover";
 
 export interface SelectProps {
@@ -38,8 +38,6 @@ export class Select extends Component<SelectProps, SpreadsheetChildEnv> {
   private state = useState<State>({ isPopoverOpen: false, hoveredValue: undefined });
 
   setup() {
-    useExternalListener(window, "pointerdown", this.onExternalClick, { capture: true });
-
     useEffect(() => {
       if (this.dropdownRef.el) {
         this.dropdownRef.el.style.width = `${this.selectRef.el?.offsetWidth}px`;
@@ -91,12 +89,6 @@ export class Select extends Component<SelectProps, SpreadsheetChildEnv> {
     }
   }
 
-  onExternalClick(ev: MouseEvent) {
-    if (!isChildEvent(this.selectRef.el, ev) && !isChildEvent(this.dropdownRef.el, ev)) {
-      this.closeDropdown();
-    }
-  }
-
   onOptionClick(value: string) {
     if (value !== this.props.selectedValue) {
       this.props.onChange(value);
@@ -122,6 +114,8 @@ export class Select extends Component<SelectProps, SpreadsheetChildEnv> {
       anchorRect: getRefBoundingRect(this.selectRef),
       positioning: "bottom-left",
       verticalOffset: 0,
+      onClose: () => this.closeDropdown(),
+      rootElement: this.selectRef.el,
     };
   }
 

--- a/src/components/side_panel/chart/building_blocks/color_scale/color_scale_picker.ts
+++ b/src/components/side_panel/chart/building_blocks/color_scale/color_scale_picker.ts
@@ -1,4 +1,4 @@
-import { Component, useExternalListener, useRef, useState } from "@odoo/owl";
+import { Component, useRef, useState } from "@odoo/owl";
 import { DEFAULT_CHART_COLOR_SCALE } from "../../../../../constants";
 import { ColorScale, COLORSCALES, COLORSCHEMES } from "../../../../../helpers";
 import { ChartColorScale, Color, schemeToColorScale } from "../../../../../types";
@@ -39,10 +39,6 @@ export class ColorScalePicker extends Component<Props, SpreadsheetChildEnv> {
 
   state = useState<ColorScalePickerState>({ popoverProps: undefined, popoverStyle: "" });
   popoverRef = useRef("popoverRef");
-
-  setup() {
-    useExternalListener(window, "click", this.closePopover);
-  }
 
   get currentColorScale(): ChartColorScale {
     return this.props.definition.colorScale || schemeToColorScale("oranges");
@@ -88,6 +84,7 @@ export class ColorScalePicker extends Component<Props, SpreadsheetChildEnv> {
       anchorRect: { x: right, y: bottom, width: 0, height: 0 },
       positioning: "top-right",
       verticalOffset: 0,
+      onClose: () => this.closePopover(),
     };
     this.state.popoverStyle = cssPropertiesToCss({ width: `${width}px` });
   }

--- a/src/components/side_panel/chart/building_blocks/color_scale/color_scale_picker.xml
+++ b/src/components/side_panel/chart/building_blocks/color_scale/color_scale_picker.xml
@@ -4,7 +4,7 @@
       <div class="w-100" style="position:relative">
         <div
           class="color-scale-container d-flex justify-content-end"
-          t-on-click.stop="onPointerDown">
+          t-on-click="this.onPointerDown">
           <span class="color-scale-label">
             <t t-out="currentColorScaleLabel"/>
           </span>

--- a/src/components/side_panel/chart/building_blocks/text_styler/text_styler.ts
+++ b/src/components/side_panel/chart/building_blocks/text_styler/text_styler.ts
@@ -37,7 +37,8 @@ export class TextStyler extends Component<Props, SpreadsheetChildEnv> {
   openedEl: HTMLElement | null = null;
 
   setup() {
-    useExternalListener(window, "click", this.onExternalClick);
+    useExternalListener(window, "click", this.onExternalClick, { capture: true });
+    useExternalListener(window, "contextmenu", this.onExternalClick, { capture: true });
   }
 
   state = useState({

--- a/src/components/side_panel/chart/building_blocks/text_styler/text_styler.xml
+++ b/src/components/side_panel/chart/building_blocks/text_styler/text_styler.xml
@@ -19,8 +19,7 @@
         <div
           class="o-dropdown-content position-absolute top-100 start-0 bg-white"
           t-if="state.activeTool === 'horizontalAlignTool'"
-          t-att-style="dropdownStyle"
-          t-on-click.stop="">
+          t-att-style="dropdownStyle">
           <div class="o-dropdown-line d-flex">
             <t t-foreach="horizontalAlignActions" t-as="action" t-key="action_index">
               <ActionButton action="action" class="'o-hoverable-button'"/>
@@ -38,8 +37,7 @@
         <div
           class="o-dropdown-content position-absolute top-100 start-0 bg-white"
           t-if="state.activeTool === 'verticalAlignTool'"
-          t-att-style="dropdownStyle"
-          t-on-click.stop="">
+          t-att-style="dropdownStyle">
           <div class="o-dropdown-line d-flex">
             <t t-foreach="verticalAlignActions" t-as="action" t-key="action_index">
               <ActionButton action="action" class="'o-hoverable-button'"/>
@@ -50,7 +48,8 @@
       <div class="o-divider border-start"/>
       <FontSizeEditor
         currentFontSize="currentFontSize"
-        onFontSizeChanged.bind="this.updateFontSize"
+        onFontSizeChanged.bind="updateFontSize"
+        onToggle.bind="closeMenus"
         class="'o-hoverable-button'"
       />
       <div class="o-divider border-start"/>
@@ -62,6 +61,7 @@
         title.translate="Text color"
         icon="'o-spreadsheet-Icon.TEXT_COLOR'"
         class="'o-hoverable-button o-menu-item-button'"
+        onClose="() => this.closeMenus()"
       />
       <ColorPickerWidget
         t-if="props.hasBackgroundColor"
@@ -72,6 +72,7 @@
         title.translate="Fill color"
         icon="'o-spreadsheet-Icon.FILL_COLOR'"
         class="'o-hoverable-button o-menu-item-button'"
+        onClose="() => this.closeMenus()"
       />
     </div>
   </t>

--- a/src/components/side_panel/chart/chart_type_picker/chart_type_picker.ts
+++ b/src/components/side_panel/chart/chart_type_picker/chart_type_picker.ts
@@ -1,4 +1,4 @@
-import { Component, useExternalListener, useRef, useState } from "@odoo/owl";
+import { Component, useRef, useState } from "@odoo/owl";
 import { chartSubtypeRegistry } from "../../../../registries/chart_subtype_registry";
 import {
   chartCategories,
@@ -7,7 +7,6 @@ import {
 import { ChartDefinition, ChartType, UID } from "../../../../types/index";
 import { SpreadsheetChildEnv } from "../../../../types/spreadsheet_env";
 import { cssPropertiesToCss } from "../../../helpers/css";
-import { isChildEvent } from "../../../helpers/dom_helpers";
 import { Popover, PopoverProps } from "../../../popover";
 import { Section } from "../../components/section/section";
 import { MainChartPanelStore } from "../main_chart_panel/main_chart_panel_store";
@@ -36,7 +35,6 @@ export class ChartTypePicker extends Component<Props, SpreadsheetChildEnv> {
   state = useState<ChartTypePickerState>({ popoverProps: undefined, popoverStyle: "" });
 
   setup(): void {
-    useExternalListener(window, "pointerdown", this.onExternalClick, { capture: true });
     const chart = this.env.model.getters.getChart(this.props.chartId);
     const supportedTypes = chart?.getSupportedChartTypes() ?? new Set<ChartType>();
 
@@ -50,16 +48,6 @@ export class ChartTypePicker extends Component<Props, SpreadsheetChildEnv> {
         this.chartTypeByCategories[subtypeProperties.category] = [subtypeProperties];
       }
     }
-  }
-
-  onExternalClick(ev: MouseEvent) {
-    if (
-      isChildEvent(this.popoverRef.el?.parentElement, ev) ||
-      isChildEvent(this.selectRef.el, ev)
-    ) {
-      return;
-    }
-    this.closePopover();
   }
 
   onTypeChange(type: ChartType) {
@@ -90,6 +78,8 @@ export class ChartTypePicker extends Component<Props, SpreadsheetChildEnv> {
       anchorRect: { x: right, y: bottom, width: 0, height: 0 },
       positioning: "top-right",
       verticalOffset: 0,
+      onClose: this.closePopover.bind(this),
+      rootElement: this.selectRef.el,
     };
 
     this.state.popoverStyle = cssPropertiesToCss({ width: `${width}px` });

--- a/src/components/side_panel/components/round_color_picker/round_color_picker.ts
+++ b/src/components/side_panel/components/round_color_picker/round_color_picker.ts
@@ -1,4 +1,4 @@
-import { Component, useExternalListener, useRef, useState } from "@odoo/owl";
+import { Component, useRef, useState } from "@odoo/owl";
 import { Rect } from "../../../../types";
 import { SpreadsheetChildEnv } from "../../../../types/spreadsheet_env";
 import { ColorPicker } from "../../../color_picker/color_picker";
@@ -13,8 +13,8 @@ interface State {
 interface Props {
   currentColor?: string;
   onColorPicked: (color: string) => void;
-  title?: string;
   disableNoColor?: boolean;
+  onClose?: () => void;
 }
 
 // FIXME Encoding version used in css
@@ -32,6 +32,7 @@ export class RoundColorPicker extends Component<Props, SpreadsheetChildEnv> {
     title: { type: String, optional: true },
     onColorPicked: Function,
     disableNoColor: { type: Boolean, optional: true },
+    onClose: { type: Function, optional: true },
   };
 
   colorPickerButtonRef = useRef("colorPickerButton");
@@ -40,7 +41,6 @@ export class RoundColorPicker extends Component<Props, SpreadsheetChildEnv> {
 
   setup() {
     this.state = useState({ pickerOpened: false });
-    useExternalListener(window as any, "click", this.closePicker);
   }
 
   closePicker() {

--- a/src/components/side_panel/components/round_color_picker/round_color_picker.xml
+++ b/src/components/side_panel/components/round_color_picker/round_color_picker.xml
@@ -10,9 +10,11 @@
     <ColorPicker
       t-if="state.pickerOpened"
       anchorRect="colorPickerAnchorRect"
+      rootElement="colorPickerButtonRef.el"
       onColorPicked.bind="onColorPicked"
       currentColor="props.currentColor"
       disableNoColor="props.disableNoColor"
+      onClose="props.onClose || (() => this.closePicker())"
     />
   </t>
 </templates>

--- a/src/components/side_panel/conditional_formatting/cf_editor/cell_is_rule_editor.xml
+++ b/src/components/side_panel/conditional_formatting/cf_editor/cell_is_rule_editor.xml
@@ -67,6 +67,7 @@
           title.translate="Text Color"
           icon="'o-spreadsheet-Icon.TEXT_COLOR'"
           class="'o-hoverable-button o-menu-item-button'"
+          onClose="() => this.props.store.closeMenus()"
         />
         <div class="o-divider border-end"/>
         <ColorPickerWidget
@@ -77,6 +78,7 @@
           title.translate="Fill Color"
           icon="'o-spreadsheet-Icon.FILL_COLOR'"
           class="'o-hoverable-button o-menu-item-button'"
+          onClose="() => this.props.store.closeMenus()"
         />
       </div>
     </div>

--- a/src/components/side_panel/conditional_formatting/cf_editor/cf_editor.ts
+++ b/src/components/side_panel/conditional_formatting/cf_editor/cf_editor.ts
@@ -1,4 +1,4 @@
-import { Component, useEffect, useExternalListener } from "@odoo/owl";
+import { Component, useEffect } from "@odoo/owl";
 import { deepCopy } from "../../../../helpers";
 import { useLocalStore } from "../../../../store_engine";
 import { _t } from "../../../../translation";
@@ -56,7 +56,6 @@ export class ConditionalFormattingEditor extends Component<Props, SpreadsheetChi
       },
       () => [this.env.model.getters.getActiveSheetId(), this.isEditedCfRemoved]
     );
-    useExternalListener(window as any, "click", () => this.store.closeMenus());
   }
 
   get isEditedCfRemoved() {

--- a/src/components/side_panel/pivot/pivot_layout_configurator/add_dimension_button/add_dimension_button.ts
+++ b/src/components/side_panel/pivot/pivot_layout_configurator/add_dimension_button/add_dimension_button.ts
@@ -1,4 +1,4 @@
-import { Component, useExternalListener, useRef, useState } from "@odoo/owl";
+import { Component, useRef, useState } from "@odoo/owl";
 import { COMPOSER_ASSISTANT_COLOR } from "../../../../../constants";
 import { fuzzyLookup } from "../../../../../helpers";
 import {
@@ -37,12 +37,11 @@ export class AddDimensionButton extends Component<Props, SpreadsheetChildEnv> {
   setup() {
     this.autoComplete = useLocalStore(AutoCompleteStore);
     this.autoComplete.useProvider(this.getProvider());
-    useExternalListener(window, "click", (ev) => {
-      if (ev.target !== this.buttonRef.el) {
-        this.popover.isOpen = false;
-      }
-    });
     useAutofocus({ refName: "autofocus" });
+  }
+
+  private closePopover() {
+    this.popover.isOpen = false;
   }
 
   getProvider(): AutoCompleteProvider {
@@ -83,10 +82,13 @@ export class AddDimensionButton extends Component<Props, SpreadsheetChildEnv> {
   }
 
   get popoverProps() {
-    const { x, y, width, height } = this.buttonRef.el!.getBoundingClientRect();
+    const rootElement = this.buttonRef.el;
+    const { x, y, width, height } = rootElement!.getBoundingClientRect();
     return {
       anchorRect: { x, y, width, height },
       positioning: "bottom-left",
+      onClose: () => this.closePopover(),
+      rootElement,
     };
   }
 

--- a/src/components/side_panel/table_style_editor_panel/table_style_editor_panel.ts
+++ b/src/components/side_panel/table_style_editor_panel/table_style_editor_panel.ts
@@ -1,4 +1,4 @@
-import { Component, useExternalListener, useState } from "@odoo/owl";
+import { Component, useState } from "@odoo/owl";
 import { isColorValid } from "../../../helpers";
 import { TABLE_STYLES_TEMPLATES, buildTableStyle } from "../../../helpers/table_presets";
 import { Color, TableConfig, TableStyle, TableStyleTemplateName } from "../../../types";
@@ -36,10 +36,6 @@ export class TableStyleEditorPanel extends Component<
   };
 
   state = useState<State>(this.getInitialState());
-
-  setup() {
-    useExternalListener(window as any, "click", () => (this.state.pickerOpened = false));
-  }
 
   getInitialState(): State {
     const editedStyle = this.props.styleId

--- a/src/components/side_panel/table_style_editor_panel/table_style_editor_panel.xml
+++ b/src/components/side_panel/table_style_editor_panel/table_style_editor_panel.xml
@@ -9,6 +9,7 @@
           currentColor="state.primaryColor"
           onColorPicked.bind="onColorPicked"
           disableNoColor="true"
+          onClose="() => this.state.pickerOpened = false"
         />
       </Section>
       <Section class="'pt-1'" title.translate="Style template">

--- a/src/components/tables/table_dropdown_button/table_dropdown_button.ts
+++ b/src/components/tables/table_dropdown_button/table_dropdown_button.ts
@@ -70,6 +70,8 @@ export class TableDropdownButton extends Component<Props, SpreadsheetChildEnv> {
       anchorRect: { x: left, y: bottom, width: 0, height: 0 },
       positioning: "bottom-left",
       verticalOffset: 0,
+      rootElement: target,
+      onClose: this.closePopover.bind(this),
     };
   }
 

--- a/src/components/tables/table_style_picker/table_style_picker.ts
+++ b/src/components/tables/table_style_picker/table_style_picker.ts
@@ -62,6 +62,8 @@ export class TableStylePicker extends Component<TableStylePickerProps, Spreadshe
       anchorRect: { x: right, y: bottom, width: 0, height: 0 },
       positioning: "top-right",
       verticalOffset: 0,
+      rootElement: target,
+      onClose: this.closePopover.bind(this),
     };
   }
 

--- a/src/components/tables/table_styles_popover/table_styles_popover.ts
+++ b/src/components/tables/table_styles_popover/table_styles_popover.ts
@@ -1,9 +1,8 @@
-import { Component, useExternalListener, useRef, useState } from "@odoo/owl";
+import { Component, useState } from "@odoo/owl";
 import { TABLE_STYLE_CATEGORIES } from "../../../helpers/table_presets";
 import { _t } from "../../../translation";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
 import { TableConfig, TableStyle } from "../../../types/table";
-import { isChildEvent } from "../../helpers/dom_helpers";
 import { Popover, PopoverProps } from "../../popover/popover";
 import { TableStylePreview } from "../table_style_preview/table_style_preview";
 
@@ -36,19 +35,7 @@ export class TableStylesPopover extends Component<TableStylesPopoverProps, Sprea
     type: String,
   };
 
-  private tableStyleListRef = useRef("tableStyleList");
   state = useState<State>({ selectedCategory: this.initialSelectedCategory });
-
-  setup(): void {
-    useExternalListener(window, "click", this.onExternalClick, { capture: true });
-  }
-
-  onExternalClick(ev: CustomTablePopoverMouseEvent) {
-    if (this.tableStyleListRef.el && !isChildEvent(this.tableStyleListRef.el, ev)) {
-      this.props.closePopover();
-      ev.hasClosedTableStylesPopover = true;
-    }
-  }
 
   get displayedStyles(): string[] {
     const styles = this.props.tableStyles;

--- a/src/components/tables/table_styles_popover/table_styles_popover.xml
+++ b/src/components/tables/table_styles_popover/table_styles_popover.xml
@@ -1,10 +1,7 @@
 <templates>
   <t t-name="o-spreadsheet-TableStylesPopover">
     <Popover t-if="props.popoverProps" t-props="props.popoverProps">
-      <div
-        class="o-table-style-popover d-flex flex-column py-3"
-        t-ref="tableStyleList"
-        t-on-contextmenu.prevent="">
+      <div class="o-table-style-popover d-flex flex-column py-3" t-on-contextmenu.prevent="">
         <div class="d-flex o-notebook ps-4 mb-3">
           <div
             t-foreach="Object.keys(categories)"

--- a/src/components/top_bar/color_editor/color_editor.xml
+++ b/src/components/top_bar/color_editor/color_editor.xml
@@ -11,6 +11,7 @@
         title="props.title"
         icon="props.icon"
         class="props.class"
+        onClose="() => this.topBarToolStore.closeDropdowns()"
       />
     </div>
   </t>

--- a/src/components/top_bar/dropdown_action/dropdown_action.ts
+++ b/src/components/top_bar/dropdown_action/dropdown_action.ts
@@ -50,6 +50,8 @@ export class DropdownAction extends Component<Props, SpreadsheetChildEnv> {
       positioning: "bottom-left",
       verticalOffset: 0,
       class: "rounded",
+      onClose: () => this.topBarToolStore.closeDropdowns(),
+      rootElement: this.actionRef.el,
     };
   }
 }

--- a/src/components/top_bar/number_formats_tool/number_formats_tool.xml
+++ b/src/components/top_bar/number_formats_tool/number_formats_tool.xml
@@ -10,7 +10,7 @@
       t-if="isActive"
       anchorRect="state.anchorRect"
       menuItems="state.menuItems"
-      onClose="() => {}"
+      onClose.bind="toggleMenu"
       popoverPositioning="'bottom-left'"
     />
   </div>

--- a/src/components/top_bar/top_bar.ts
+++ b/src/components/top_bar/top_bar.ts
@@ -1,4 +1,4 @@
-import { Component, useEffect, useExternalListener, useRef, useState } from "@odoo/owl";
+import { Component, useEffect, useRef, useState } from "@odoo/owl";
 import { Action } from "../../actions/action";
 import { setStyle } from "../../actions/menu_items_actions";
 import { DEFAULT_FONT_SIZE } from "../../constants";
@@ -80,8 +80,6 @@ export class TopBar extends Component<Props, SpreadsheetChildEnv> {
     this.composerFocusStore = useStore(ComposerFocusStore);
     this.fingerprints = useStore(FormulaFingerprintStore);
     this.topBarToolStore = useStore(TopBarToolStore);
-
-    useExternalListener(window, "click", this.onExternalClick);
     this.menus = topbarMenuRegistry.getMenuItems();
 
     useEffect(
@@ -142,18 +140,6 @@ export class TopBar extends Component<Props, SpreadsheetChildEnv> {
 
   get currentFontSize(): number {
     return this.env.model.getters.getCurrentStyle().fontSize || DEFAULT_FONT_SIZE;
-  }
-
-  onExternalClick(ev: MouseEvent) {
-    // TODO : manage click events better. We need this piece of code
-    // otherwise the event opening the menu would close it on the same frame.
-    // And we cannot stop the event propagation because it's used in an
-    // external listener of the MenuPopover component to close the context menu when
-    // clicking on the top bar
-    if (this.openedEl === ev.target) {
-      return;
-    }
-    this.closeMenus();
   }
 
   onClick() {
@@ -237,6 +223,8 @@ export class TopBar extends Component<Props, SpreadsheetChildEnv> {
       verticalOffset: 0,
       class: "rounded",
       maxWidth: 300,
+      rootElement: this.moreToolsButtonRef.el,
+      onClose: this.closeMenus.bind(this),
     };
   }
 

--- a/src/types/spreadsheet_env.ts
+++ b/src/types/spreadsheet_env.ts
@@ -8,6 +8,7 @@ import { NotificationStoreMethods } from "./stores/notification_store_methods";
 
 export interface SpreadsheetChildEnv extends NotificationStoreMethods {
   model: Model;
+  parentPopoverId?: string;
   imageProvider?: ImageProviderInterface;
   isDashboard: () => boolean;
   openSidePanel: (panel: string, panelProps?: any) => void;

--- a/tests/__snapshots__/top_bar_component.test.ts.snap
+++ b/tests/__snapshots__/top_bar_component.test.ts.snap
@@ -196,7 +196,7 @@ exports[`TopBar component simple rendering 1`] = `
                 title="Zoom"
               >
                 <input
-                  class="o-font-size o-number-input bg-transparent border-0"
+                  class="o-number-input bg-transparent border-0"
                   max="300"
                   min="25"
                   type="number"
@@ -326,7 +326,7 @@ exports[`TopBar component simple rendering 1`] = `
               title="Font Size"
             >
               <input
-                class="o-font-size o-number-input bg-transparent border-0"
+                class="o-number-input bg-transparent border-0"
                 max="400"
                 min="1"
                 type="number"

--- a/tests/bottom_bar/bottom_bar_component.test.ts
+++ b/tests/bottom_bar/bottom_bar_component.test.ts
@@ -142,6 +142,20 @@ describe("BottomBar component", () => {
     expect(fixture.querySelectorAll(".o-menu")).toHaveLength(0);
   });
 
+  test("Right-click on the bottom bar closes the sheet color picker", async () => {
+    await mountBottomBar();
+    expect(fixture.querySelectorAll(".o-menu")).toHaveLength(0);
+    triggerMouseEvent(".o-sheet", "contextmenu");
+    await nextTick();
+    expect(fixture.querySelectorAll(".o-menu")).toHaveLength(1);
+    await click(fixture, "div[title='Change color']");
+    expect(fixture.querySelectorAll(".o-color-picker")).toHaveLength(1);
+
+    triggerMouseEvent(".o-spreadsheet-bottom-bar", "contextmenu");
+    await nextTick();
+    expect(fixture.querySelectorAll(".o-color-picker")).toHaveLength(0);
+  });
+
   test("Can open context menu of a sheet with the arrow if another menu is already open", async () => {
     await mountBottomBar();
 

--- a/tests/conditional_formatting/conditional_formatting_panel_component.test.ts
+++ b/tests/conditional_formatting/conditional_formatting_panel_component.test.ts
@@ -332,6 +332,14 @@ describe("UI of conditional formats", () => {
       expect(fixture.querySelector(".o-color-picker")).toBeFalsy();
     });
 
+    test("color-picker closes when right-click elsewhere", async () => {
+      await click(fixture.querySelectorAll(selectors.ruleEditor.editor.colorDropdown)[0]);
+      expect(fixture.querySelector(".o-color-picker")).toBeTruthy();
+      triggerMouseEvent(fixture, "contextmenu");
+      await nextTick();
+      expect(fixture.querySelector(".o-color-picker")).toBeFalsy();
+    });
+
     test("will not dispatch if minvalue > maxvalue", async () => {
       await click(fixture.querySelectorAll(selectors.cfTabSelector)[1]);
 

--- a/tests/figures/chart/chart_type_picker.test.ts
+++ b/tests/figures/chart/chart_type_picker.test.ts
@@ -37,7 +37,7 @@ describe("Chart type picker component", () => {
     await pointerDown(".o-chart-select-popover");
     expect(fixture.querySelector(".o-chart-select-popover")).not.toBeNull();
 
-    await pointerDown(document.body);
+    await click(document.body);
     expect(fixture.querySelector(".o-chart-select-popover")).toBeNull();
   });
 

--- a/tests/grid/grid_component.test.ts
+++ b/tests/grid/grid_component.test.ts
@@ -1081,6 +1081,16 @@ describe("Grid component", () => {
       await clickGridIcon(model, "A1");
       expect(fixture.querySelectorAll(".o-filter-menu")).toHaveLength(1);
     });
+
+    test("Opening another menu closes the filter popover", async () => {
+      createTableWithFilter(model, "A1:A2");
+      await nextTick();
+      await clickGridIcon(model, "A1");
+      expect(".o-filter-menu").toHaveCount(1);
+
+      await simulateClick(".o-topbar-menu[data-id='insert']");
+      expect(".o-filter-menu").toHaveCount(0);
+    });
   });
 
   describe("Grid Scroll", () => {

--- a/tests/link/__snapshots__/link_display_component.test.ts.snap
+++ b/tests/link/__snapshots__/link_display_component.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`link display component simple snapshot 1`] = `
-"<div class="o-popover rounded o-popover-grid-index" style="display: block; max-height: 962px; max-width: 985px; top: 49px; left: 48px;"><div class="o-popover-content"><div class="o-link-tool d-flex align-items-center rounded"><!-- t-key to prevent owl from re-using the previous img element when the link changes.
+"<div class="o-popover rounded o-popover-grid-index" data-id="popover-1" style="display: block; max-height: 962px; max-width: 985px; top: 49px; left: 48px;"><div class="o-popover-content"><div class="o-link-tool d-flex align-items-center rounded"><!-- t-key to prevent owl from re-using the previous img element when the link changes.
     The wrong/previous image would be displayed while the new one loads --><img src="https://www.google.com/s2/favicons?sz=16&amp;domain=https://url.com"><a class="o-link" target="_blank" href="https://url.com" title="https://url.com">https://url.com</a><span class="o-link-icon o-unlink" title="Remove link"><div class="o-icon"><i class="fa fa-chain-broken"></i></div></span><span class="o-link-icon o-edit-link" title="Edit link"><div class="o-icon"><i class="fa fa-pencil-square-o"></i></div></span></div></div></div>"
 `;

--- a/tests/pivots/add_dimension_button.test.ts
+++ b/tests/pivots/add_dimension_button.test.ts
@@ -1,6 +1,11 @@
 import { AddDimensionButton } from "../../src/components/side_panel/pivot/pivot_layout_configurator/add_dimension_button/add_dimension_button";
-import { click, keyDown, setInputValueAndTrigger } from "../test_helpers/dom_helper";
-import { mountComponentWithPortalTarget } from "../test_helpers/helpers";
+import {
+  click,
+  keyDown,
+  setInputValueAndTrigger,
+  triggerMouseEvent,
+} from "../test_helpers/dom_helper";
+import { mountComponentWithPortalTarget, nextTick } from "../test_helpers/helpers";
 
 async function mountAddDimensionButton(
   props: Partial<AddDimensionButton["props"]>
@@ -63,5 +68,23 @@ describe("Add dimension button", () => {
     const options = [...fixture.querySelectorAll(".o-popover .o-autocomplete-dropdown > div")];
     expect(options.length).toBe(1);
     expect(options[0].textContent?.trim()).toBe("Amount");
+  });
+
+  test("closes on right-click", async () => {
+    const fields = [{ name: "Date", string: "Date", type: "date" }];
+
+    const { fixture } = await mountComponentWithPortalTarget(AddDimensionButton, {
+      props: {
+        fields: fields as any,
+        onFieldPicked: () => {},
+      },
+    });
+
+    await click(fixture, ".add-dimension");
+    expect(".o-popover").toHaveCount(1);
+
+    triggerMouseEvent(fixture, "contextmenu");
+    await nextTick();
+    expect(".o-popover").toHaveCount(0);
   });
 });

--- a/tests/side_panels/building_blocks/__snapshots__/chart_title.test.ts.snap
+++ b/tests/side_panels/building_blocks/__snapshots__/chart_title.test.ts.snap
@@ -126,7 +126,7 @@ exports[`Chart title Can render a chart title component 1`] = `
             title="Font Size"
           >
             <input
-              class="o-font-size o-number-input bg-transparent border-0"
+              class="o-number-input bg-transparent border-0"
               max="400"
               min="1"
               type="number"

--- a/tests/side_panels/building_blocks/color_scale_picker.test.ts
+++ b/tests/side_panels/building_blocks/color_scale_picker.test.ts
@@ -1,0 +1,29 @@
+import { ColorScalePicker } from "../../../src/components/side_panel/chart/building_blocks/color_scale/color_scale_picker";
+import { click, triggerMouseEvent } from "../../test_helpers/dom_helper";
+import { mountComponentWithPortalTarget, nextTick } from "../../test_helpers/helpers";
+
+let fixture: HTMLElement;
+
+describe("ColorScalePicker", () => {
+  test("closes on right-click", async () => {
+    ({ fixture } = await mountComponentWithPortalTarget(ColorScalePicker, {
+      props: {
+        definition: {
+          colorScale: {
+            midColor: "#ffffff",
+            minColor: "#ffffff",
+            maxColor: "#ffffff",
+          },
+        },
+        onUpdateColorScale: () => {},
+      },
+    }));
+
+    await click(fixture, ".color-scale-container");
+    expect(".o-popover").toHaveCount(1);
+
+    triggerMouseEvent(fixture, "contextmenu");
+    await nextTick();
+    expect(".o-popover").toHaveCount(0);
+  });
+});

--- a/tests/side_panels/building_blocks/round_color_picker.test.ts
+++ b/tests/side_panels/building_blocks/round_color_picker.test.ts
@@ -1,6 +1,6 @@
 import { RoundColorPicker } from "../../../src/components/side_panel/components/round_color_picker/round_color_picker";
-import { click } from "../../test_helpers/dom_helper";
-import { mountComponentWithPortalTarget } from "../../test_helpers/helpers";
+import { click, triggerMouseEvent } from "../../test_helpers/dom_helper";
+import { mountComponentWithPortalTarget, nextTick } from "../../test_helpers/helpers";
 
 let fixture: HTMLElement;
 
@@ -40,5 +40,15 @@ describe("Panel color picker", () => {
     await click(fixture, ".o-round-color-picker-button");
     await click(fixture, ".o-color-picker-line-item[data-color='#EFEFEF'");
     expect(onColorPicked).toHaveBeenCalledWith("#EFEFEF");
+  });
+
+  test("Right-click outside color picker should close it", async () => {
+    await mountChartColor({ onColorPicked: () => {} });
+    await click(fixture, ".o-round-color-picker-button");
+    expect(".o-color-picker").toHaveCount(1);
+
+    triggerMouseEvent(".o-spreadsheet", "contextmenu");
+    await nextTick();
+    expect(".o-color-picker").toHaveCount(0);
   });
 });

--- a/tests/spreadsheet/__snapshots__/spreadsheet_component.test.ts.snap
+++ b/tests/spreadsheet/__snapshots__/spreadsheet_component.test.ts.snap
@@ -205,7 +205,7 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
                     title="Zoom"
                   >
                     <input
-                      class="o-font-size o-number-input bg-transparent border-0"
+                      class="o-number-input bg-transparent border-0"
                       max="300"
                       min="25"
                       type="number"
@@ -335,7 +335,7 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
                   title="Font Size"
                 >
                   <input
-                    class="o-font-size o-number-input bg-transparent border-0"
+                    class="o-number-input bg-transparent border-0"
                     max="400"
                     min="1"
                     type="number"
@@ -1308,7 +1308,7 @@ exports[`components take the small screen into account 1`] = `
                     title="Zoom"
                   >
                     <input
-                      class="o-font-size o-number-input bg-transparent border-0"
+                      class="o-number-input bg-transparent border-0"
                       max="300"
                       min="25"
                       type="number"
@@ -1438,7 +1438,7 @@ exports[`components take the small screen into account 1`] = `
                   title="Font Size"
                 >
                   <input
-                    class="o-font-size o-number-input bg-transparent border-0"
+                    class="o-number-input bg-transparent border-0"
                     max="400"
                     min="1"
                     type="number"

--- a/tests/table/table_styles_popover_component.test.ts
+++ b/tests/table/table_styles_popover_component.test.ts
@@ -1,4 +1,5 @@
 import { Model } from "../../src";
+import { PopoverProps } from "../../src/components/popover/popover";
 import {
   TableStylesPopover,
   TableStylesPopoverProps,
@@ -12,19 +13,24 @@ let model: Model;
 let fixture: HTMLElement;
 let openSidePanel: jest.Mock;
 
-async function mountPopover(partialProps: Partial<TableStylesPopoverProps> = {}) {
+async function mountPopover(
+  partialProps: Omit<Partial<TableStylesPopoverProps>, "popoverProps"> & {
+    popoverProps?: Partial<PopoverProps>;
+  } = {}
+) {
   const props: TableStylesPopoverProps = {
     tableConfig: DEFAULT_TABLE_CONFIG,
     closePopover: () => {},
     onStylePicked: () => {},
+    tableStyles: model.getters.getTableStyles(),
+    type: "table",
+    ...partialProps,
     popoverProps: {
       anchorRect: { x: 0, y: 0, width: 0, height: 0 },
       positioning: "top-right",
       verticalOffset: 0,
+      ...partialProps.popoverProps,
     },
-    tableStyles: model.getters.getTableStyles(),
-    type: "table",
-    ...partialProps,
   };
   openSidePanel = jest.fn();
   const env = { openSidePanel };
@@ -119,5 +125,13 @@ describe("Table style popover", () => {
       await click(fixture, ".o-menu-item[data-name='deleteTableStyle'");
       expect(Object.keys(model.getters.getTableStyles())).not.toContain("MyStyle");
     });
+  });
+
+  test("Right-click outside close the popover", async () => {
+    const closePopover = jest.fn();
+    await mountPopover({ popoverProps: { onClose: closePopover } });
+    triggerMouseEvent(fixture, "contextmenu");
+    await nextTick();
+    expect(closePopover).toHaveBeenCalled();
   });
 });

--- a/tests/top_bar_component.test.ts
+++ b/tests/top_bar_component.test.ts
@@ -444,7 +444,9 @@ describe("TopBar component", () => {
 
   test("can set font size", async () => {
     const { model } = await mountParent();
-    const fontSizeText = fixture.getElementsByClassName("o-font-size")[1]! as HTMLInputElement;
+    const fontSizeText = fixture.querySelector(
+      ".o-number-editor[title='Font Size'] > input"
+    ) as HTMLInputElement;
     expect(fontSizeText.value.trim()).toBe(DEFAULT_FONT_SIZE.toString());
     await click(fontSizeText.parentElement!);
     // ensure the input is no longer selected (not automaticly done by click in jsdom)
@@ -456,7 +458,9 @@ describe("TopBar component", () => {
 
   test("Tab from font size editor closes the dropdown and moves focus to grid", async () => {
     const { fixture } = await mountSpreadsheet();
-    const input = fixture.querySelector("input.o-font-size") as HTMLInputElement;
+    const input = fixture.querySelector(
+      ".o-number-editor[title='Font Size'] > input"
+    ) as HTMLInputElement;
     input.focus();
     await nextTick();
     expect(fixture.querySelector(".o-popover .o-text-options")).toBeTruthy();
@@ -466,17 +470,35 @@ describe("TopBar component", () => {
     expect(document.activeElement).toBe(composerEl);
   });
 
+  test("Right-click somewhere should close the number editor popover", async () => {
+    const { fixture } = await mountSpreadsheet();
+
+    const element = fixture.querySelector(
+      ".o-number-editor[title='Font Size'] > input"
+    ) as HTMLInputElement;
+    element.focus();
+    await nextTick();
+    expect(".o-popover .o-text-options").toHaveCount(1);
+
+    triggerMouseEvent(".o-sheet", "contextmenu");
+    await nextTick();
+    expect(".o-popover .o-text-options").toHaveCount(0);
+  });
+
   test("Clicking the number editor dropdown arrow focuses the input", async () => {
     const { fixture } = await mountSpreadsheet();
-    const input = fixture.querySelector("input.o-font-size") as HTMLInputElement;
-    const icon = fixture.querySelectorAll(".o-number-editor .o-icon")[0] as HTMLElement;
+    const fontSizeEditor = fixture.querySelector(".o-number-editor[title='Font Size']")!;
+    const input = fontSizeEditor.querySelector("input") as HTMLInputElement;
+    const icon = fontSizeEditor.querySelectorAll(".o-icon")[0] as HTMLElement;
     await click(icon);
     expect(document.activeElement).toBe(input);
   });
 
   test("prevents default behavior of mouse wheel event on font size input", async () => {
     await mountParent();
-    const fontSizeInput = fixture.querySelector("input.o-font-size") as HTMLInputElement;
+    const fontSizeInput = fixture.querySelector(
+      ".o-number-editor[title='Font Size'] > input"
+    ) as HTMLInputElement;
 
     const event = new WheelEvent("wheel", { deltaY: 100 });
     const preventDefaultSpy = jest.spyOn(event, "preventDefault");


### PR DESCRIPTION
## Task Description

Currently, if we right-click on the zoom editor, then on the font size editor and then somewhere else, we will end with both number editors open and a context menu from the last click. This commit aims to fix this behavior for all the menus/popovers/widgets that rely on the click detection to close their submenu/subpopover, extending this behavior to the right-click as well

## Related Task

* Task: [5900107](https://www.odoo.com/odoo/2328/tasks/5900107)