### PR TITLE
[FIX] chart-panel: reset when changing panel

### DIFF
--- a/src/components/selection_input/selection_input.ts
+++ b/src/components/selection_input/selection_input.ts
@@ -131,7 +131,10 @@ export class SelectionInput extends Component<Props, SpreadsheetChildEnv> {
     );
     useEffect(() => {
       // Check the offsetParent to know if the input or an ancestor is `display: none` (eg. when changing side panel tab)
-      if (this.store.hasFocus && this.selectionRef.el?.offsetParent === null) {
+      if (
+        (this.store.isResettable || this.store.hasFocus) &&
+        this.selectionRef.el?.offsetParent === null
+      ) {
         this.reset();
       }
     });

--- a/src/components/selection_input/selection_input.xml
+++ b/src/components/selection_input/selection_input.xml
@@ -58,13 +58,12 @@
         <button class="o-button o-add-selection" t-if="canAddRange" t-on-click="addEmptyInput">
           Add range
         </button>
-        <div class="ms-auto" t-if="store.hasFocus">
+        <div class="ms-auto" t-if="store.hasFocus or isResettable">
           <button class="o-button o-selection-ko" t-if="isResettable" t-on-click="reset">
             Reset
           </button>
           <button
             class="o-button primary ms-2 o-selection-ok"
-            t-if="store.hasFocus"
             t-att-disabled="!isConfirmable"
             t-on-click="confirm">
             Confirm

--- a/tests/figures/chart/charts_component.test.ts
+++ b/tests/figures/chart/charts_component.test.ts
@@ -1145,6 +1145,24 @@ describe("charts", () => {
     expect(highlightStore.highlights.length).toBe(0);
   });
 
+  test("confirm buttons stay displayed if input is changed and unconfirmed and then selections input are closed and reset when switching tab", async () => {
+    createTestChart("basicChart");
+    await mountChartSidePanel();
+
+    const element = document.querySelector(".o-data-series .o-selection-input input");
+    await simulateClick(element);
+    expect(".o-selection-ok").toHaveCount(1);
+    await setInputValueAndTrigger(element, "C1:C4");
+
+    await simulateClick(".o-data-labels .o-selection-input input");
+    expect(".o-selection-ok").toHaveCount(2);
+
+    await openChartDesignSidePanel(model, env, fixture, chartId);
+    await nextTick(); // the check is done in a `useEffect`, we need to wait for the next render
+
+    expect(".o-selection-ok").toHaveCount(0);
+  });
+
   describe.each(TEST_CHART_TYPES)("selecting other chart will adapt sidepanel", (chartType) => {
     test.each(["click", "SELECT_FIGURE command"])("when using %s", async (selectMethod: string) => {
       createTestChart(chartType);

--- a/tests/pivots/spreadsheet_pivot/__snapshots__/spreadsheet_pivot_side_panel.test.ts.snap
+++ b/tests/pivots/spreadsheet_pivot/__snapshots__/spreadsheet_pivot_side_panel.test.ts.snap
@@ -420,7 +420,6 @@ exports[`Spreadsheet pivot side panel It should display only the selection input
                     >
                        Confirm 
                     </button>
-                    
                   </div>
                   
                 </div>


### PR DESCRIPTION
Also the buttons stay visibles if the user changes an input without confirming (even if the focus is elsewhere)

Task: [5926661](https://www.odoo.com/odoo/2328/tasks/5926661)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo