### PR TITLE
[FIX] tests: do not dispatch `UDPATE_CELL_POSITION` in monkey party

### DIFF
--- a/tests/test_helpers/constants.ts
+++ b/tests/test_helpers/constants.ts
@@ -118,7 +118,7 @@ export const TEST_COMMANDS: CommandMapping = {
   },
   UPDATE_CELL_POSITION: {
     type: "UPDATE_CELL_POSITION",
-    cellId: 1,
+    cellId: -1, // Makes this command always rejected in monkey party
     sheetId: "Sheet1",
     row: 0,
     col: 0,


### PR DESCRIPTION
Since 2ceff21c29327c748209113231deff6d7b44fb4f, the command `UPDATE_CELL_POSITION` is not rejected anymore in the monkey party. As this command is designed to be a sub-command, it makes some test failing.

The easy fix is to make this command invalid.

Task: 0

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo