### PR TITLE
[IMP] evaluation: selectively invalidate chart runtimes

### DIFF
--- a/packages/o-spreadsheet-engine/src/helpers/figures/charts/abstract_chart.ts
+++ b/packages/o-spreadsheet-engine/src/helpers/figures/charts/abstract_chart.ts
@@ -97,6 +97,12 @@ export abstract class AbstractChart {
    */
   abstract getContextCreation(): ChartCreationContext;
 
+  /**
+   * Returns all the data ranges the chart reads from (datasets and label range).
+   * Used to determine if a chart runtime needs to be invalidated when cells are re-evaluated.
+   */
+  abstract getDataRanges(): Range[];
+
   protected getCommonDataSetAttributesForExcel(
     labelRange: Range | undefined,
     dataSets: DataSet[],

--- a/packages/o-spreadsheet-engine/src/helpers/figures/charts/scorecard_chart.ts
+++ b/packages/o-spreadsheet-engine/src/helpers/figures/charts/scorecard_chart.ts
@@ -254,6 +254,10 @@ export class ScorecardChart extends AbstractChart {
     return this.getDefinitionWithSpecificRanges(this.baseline, this.keyValue);
   }
 
+  getDataRanges(): Range[] {
+    return [this.keyValue, this.baseline].filter((r): r is Range => r !== undefined);
+  }
+
   getContextCreation(): ChartCreationContext {
     return {
       ...this,

--- a/packages/o-spreadsheet-engine/src/plugins/ui_core_views/cell_evaluation/evaluation_plugin.ts
+++ b/packages/o-spreadsheet-engine/src/plugins/ui_core_views/cell_evaluation/evaluation_plugin.ts
@@ -21,7 +21,7 @@ import {
   UID,
   Zone,
 } from "../../../types/misc";
-import { Range } from "../../../types/range";
+import { BoundedRange, Range } from "../../../types/range";
 import { ExcelWorkbookData } from "../../../types/workbook_data";
 import { FormulaCellWithDependencies } from "../../core/cell";
 import { CoreViewPlugin, CoreViewPluginConfig } from "../../core_view_plugin";
@@ -159,12 +159,15 @@ export class EvaluationPlugin extends CoreViewPlugin {
     "getArrayFormulaSpreadingOn",
     "isArrayFormulaSpillBlocked",
     "isEmpty",
+    "getLastEvaluatedRanges",
   ] as const;
 
   private shouldRebuildDependenciesGraph = true;
+  private fullEvaluationDone = false;
 
   private evaluator: Evaluator;
   private positionsToUpdate: CellPosition[] = [];
+  private lastEvaluatedRanges: BoundedRange[] | null = [];
 
   constructor(config: CoreViewPluginConfig) {
     super(config);
@@ -204,6 +207,7 @@ export class EvaluationPlugin extends CoreViewPlugin {
           }
         } else {
           this.evaluator.evaluateAllCells();
+          this.fullEvaluationDone = true;
         }
         break;
     }
@@ -213,10 +217,17 @@ export class EvaluationPlugin extends CoreViewPlugin {
     if (this.shouldRebuildDependenciesGraph) {
       this.evaluator.buildDependencyGraph();
       this.evaluator.evaluateAllCells();
+      this.lastEvaluatedRanges = null; // full re-evaluation
       this.shouldRebuildDependenciesGraph = false;
+    } else if (this.fullEvaluationDone) {
+      this.lastEvaluatedRanges = null; // full re-evaluation (EVALUATE_CELLS without cellIds)
     } else if (this.positionsToUpdate.length) {
-      this.evaluator.evaluateCells(this.positionsToUpdate);
+      const computed = this.evaluator.evaluateCells(this.positionsToUpdate);
+      this.lastEvaluatedRanges = [...computed];
+    } else {
+      this.lastEvaluatedRanges = []; // nothing was evaluated
     }
+    this.fullEvaluationDone = false;
     this.positionsToUpdate = [];
   }
 
@@ -313,6 +324,16 @@ export class EvaluationPlugin extends CoreViewPlugin {
 
   isArrayFormulaSpillBlocked(position: CellPosition): boolean {
     return this.evaluator.isArrayFormulaSpillBlocked(position);
+  }
+
+  /**
+   * Returns the ranges that were re-evaluated during the last evaluation cycle,
+   * or null if all cells were re-evaluated (full evaluation).
+   * An empty array means nothing was evaluated.
+   * Used by EvaluationChartPlugin to selectively invalidate chart runtimes.
+   */
+  getLastEvaluatedRanges(): BoundedRange[] | null {
+    return this.lastEvaluatedRanges;
   }
 
   /**

--- a/packages/o-spreadsheet-engine/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
+++ b/packages/o-spreadsheet-engine/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
@@ -152,7 +152,7 @@ export class Evaluator {
     return new PositionSet(sheetSizes);
   }
 
-  evaluateCells(positions: CellPosition[]) {
+  evaluateCells(positions: CellPosition[]): RangeSet {
     const start = performance.now();
     const rangesToCompute = new RangeSet();
     rangesToCompute.addManyPositions(positions);
@@ -162,6 +162,7 @@ export class Evaluator {
     rangesToCompute.addMany(this.getCellsDependingOn(arrayFormulasPositions));
     this.evaluate(rangesToCompute);
     console.debug("evaluate Cells", performance.now() - start, "ms");
+    return rangesToCompute;
   }
 
   private getArrayFormulasImpactedByChangesOf(positions: Iterable<CellPosition>): RangeSet {

--- a/packages/o-spreadsheet-engine/src/plugins/ui_core_views/evaluation_chart.ts
+++ b/packages/o-spreadsheet-engine/src/plugins/ui_core_views/evaluation_chart.ts
@@ -2,14 +2,14 @@ import { BACKGROUND_CHART_COLOR } from "../../constants";
 import { chartFontColor } from "../../helpers/figures/charts/chart_common";
 import { chartRuntimeFactory } from "../../helpers/figures/charts/chart_factory";
 import { chartToImageUrl } from "../../helpers/figures/charts/chart_ui_common";
+import { overlap } from "../../helpers/zones";
 import { ChartRuntime, ExcelChartDefinition } from "../../types/chart";
 import {
   CoreViewCommand,
   invalidateCFEvaluationCommands,
-  invalidateChartEvaluationCommands,
   invalidateEvaluationCommands,
 } from "../../types/commands";
-import { Color, UID } from "../../types/misc";
+import { Color, UID, Zone } from "../../types/misc";
 import { Range } from "../../types/range";
 import { ExcelWorkbookData, FigureData } from "../../types/workbook_data";
 import { CoreViewPlugin } from "../core_view_plugin";
@@ -31,10 +31,11 @@ export class EvaluationChartPlugin extends CoreViewPlugin<EvaluationChartState> 
   private createRuntimeChart = chartRuntimeFactory(this.getters);
 
   handle(cmd: CoreViewCommand) {
+    // Commands that require full invalidation of all chart runtimes
     if (
       invalidateEvaluationCommands.has(cmd.type) ||
-      invalidateCFEvaluationCommands.has(cmd.type) ||
-      invalidateChartEvaluationCommands.has(cmd.type)
+      (invalidateCFEvaluationCommands.has(cmd.type) && cmd.type !== "EVALUATE_CELLS") ||
+      cmd.type === "EVALUATE_CHARTS"
     ) {
       for (const chartId in this.charts) {
         this.charts[chartId] = undefined;
@@ -56,6 +57,112 @@ export class EvaluationChartPlugin extends CoreViewPlugin<EvaluationChartState> 
           }
         }
         break;
+      // Selectively invalidate only charts whose data ranges overlap the hidden/shown headers
+      case "HIDE_COLUMNS_ROWS":
+      case "UNHIDE_COLUMNS_ROWS": {
+        const nRows = this.getters.getNumberRows(cmd.sheetId);
+        const nCols = this.getters.getNumberCols(cmd.sheetId);
+        for (const element of cmd.elements) {
+          const zone: Zone =
+            cmd.dimension === "COL"
+              ? { left: element, right: element, top: 0, bottom: nRows - 1 }
+              : { left: 0, right: nCols - 1, top: element, bottom: element };
+          this.invalidateChartsOverlappingZone(cmd.sheetId, zone);
+        }
+        break;
+      }
+      // Selectively invalidate only charts whose data ranges overlap the grouped header range
+      case "GROUP_HEADERS":
+      case "UNGROUP_HEADERS":
+      case "FOLD_HEADER_GROUP":
+      case "UNFOLD_HEADER_GROUP": {
+        const nRows = this.getters.getNumberRows(cmd.sheetId);
+        const nCols = this.getters.getNumberCols(cmd.sheetId);
+        const zone: Zone =
+          cmd.dimension === "COL"
+            ? { left: cmd.start, right: cmd.end, top: 0, bottom: nRows - 1 }
+            : { left: 0, right: nCols - 1, top: cmd.start, bottom: cmd.end };
+        this.invalidateChartsOverlappingZone(cmd.sheetId, zone);
+        break;
+      }
+      // All header groups in a dimension are folded/unfolded: treat as the entire sheet on that sheet
+      case "FOLD_ALL_HEADER_GROUPS":
+      case "UNFOLD_ALL_HEADER_GROUPS": {
+        const nRows = this.getters.getNumberRows(cmd.sheetId);
+        const nCols = this.getters.getNumberCols(cmd.sheetId);
+        this.invalidateChartsOverlappingZone(cmd.sheetId, {
+          left: 0,
+          right: nCols - 1,
+          top: 0,
+          bottom: nRows - 1,
+        });
+        break;
+      }
+      // Selectively invalidate only charts whose data ranges overlap the zone's columns/rows
+      case "FOLD_HEADER_GROUPS_IN_ZONE":
+      case "UNFOLD_HEADER_GROUPS_IN_ZONE": {
+        const nRows = this.getters.getNumberRows(cmd.sheetId);
+        const nCols = this.getters.getNumberCols(cmd.sheetId);
+        const zone: Zone =
+          cmd.dimension === "COL"
+            ? { left: cmd.zone.left, right: cmd.zone.right, top: 0, bottom: nRows - 1 }
+            : { left: 0, right: nCols - 1, top: cmd.zone.top, bottom: cmd.zone.bottom };
+        this.invalidateChartsOverlappingZone(cmd.sheetId, zone);
+        break;
+      }
+      // Selectively invalidate only charts whose data ranges overlap the updated table zone
+      case "UPDATE_TABLE":
+        this.invalidateChartsOverlappingZone(cmd.sheetId, cmd.zone);
+        break;
+      // Selectively invalidate only charts whose data ranges overlap the filter's table zone
+      case "UPDATE_FILTER": {
+        const table = this.getters.getCoreTable({
+          sheetId: cmd.sheetId,
+          col: cmd.col,
+          row: cmd.row,
+        });
+        if (table) {
+          this.invalidateChartsOverlappingZone(cmd.sheetId, table.range.zone);
+        }
+        break;
+      }
+    }
+  }
+
+  finalize() {
+    const lastEvaluated = this.getters.getLastEvaluatedRanges();
+
+    if (lastEvaluated === null) {
+      // Full re-evaluation: invalidate all chart runtimes
+      for (const chartId in this.charts) {
+        this.charts[chartId] = undefined;
+      }
+      return;
+    }
+
+    if (lastEvaluated.length === 0) {
+      return;
+    }
+
+    for (const chartId in this.charts) {
+      if (this.charts[chartId] === undefined) {
+        continue;
+      }
+      const chart = this.getters.getChart(chartId);
+      if (!chart) {
+        continue;
+      }
+      const isDirty = chart
+        .getDataRanges()
+        .some((chartRange) =>
+          lastEvaluated.some(
+            (evalRange) =>
+              evalRange.sheetId === chartRange.sheetId && overlap(evalRange.zone, chartRange.zone)
+          )
+        );
+      if (isDirty) {
+        this.charts[chartId] = undefined;
+      }
     }
   }
 
@@ -142,6 +249,24 @@ export class EvaluationChartPlugin extends CoreViewPlugin<EvaluationChartState> 
         }
       }
       sheet.charts = figures;
+    }
+  }
+
+  private invalidateChartsOverlappingZone(sheetId: UID, zone: Zone) {
+    for (const chartId in this.charts) {
+      if (this.charts[chartId] === undefined) {
+        continue;
+      }
+      const chart = this.getters.getChart(chartId);
+      if (!chart) {
+        continue;
+      }
+      const isDirty = chart
+        .getDataRanges()
+        .some((chartRange) => chartRange.sheetId === sheetId && overlap(chartRange.zone, zone));
+      if (isDirty) {
+        this.charts[chartId] = undefined;
+      }
     }
   }
 }

--- a/src/helpers/figures/charts/bar_chart.ts
+++ b/src/helpers/figures/charts/bar_chart.ts
@@ -115,6 +115,12 @@ export class BarChart extends AbstractChart {
     };
   }
 
+  getDataRanges(): Range[] {
+    return [this.labelRange, ...this.dataSets.map((ds) => ds.dataRange)].filter(
+      (r): r is Range => r !== undefined
+    );
+  }
+
   getContextCreation(): ChartCreationContext {
     const range: CustomizedDataSet[] = [];
     for (const [i, dataSet] of this.dataSets.entries()) {

--- a/src/helpers/figures/charts/calendar_chart.ts
+++ b/src/helpers/figures/charts/calendar_chart.ts
@@ -130,6 +130,12 @@ export class CalendarChart extends AbstractChart {
     };
   }
 
+  getDataRanges(): Range[] {
+    return [this.labelRange, ...this.dataSets.map((ds) => ds.dataRange)].filter(
+      (r): r is Range => r !== undefined
+    );
+  }
+
   getContextCreation(): ChartCreationContext {
     const range: CustomizedDataSet[] = [
       { dataRange: this.getters.getRangeString(this.dataSets[0].dataRange, this.sheetId) },

--- a/src/helpers/figures/charts/combo_chart.ts
+++ b/src/helpers/figures/charts/combo_chart.ts
@@ -98,6 +98,12 @@ export class ComboChart extends AbstractChart {
     return validator.checkValidations(definition, checkDataset, checkLabelRange);
   }
 
+  getDataRanges(): Range[] {
+    return [this.labelRange, ...this.dataSets.map((ds) => ds.dataRange)].filter(
+      (r): r is Range => r !== undefined
+    );
+  }
+
   getContextCreation(): ChartCreationContext {
     const range: CustomizedDataSet[] = [];
     for (const [i, dataSet] of this.dataSets.entries()) {

--- a/src/helpers/figures/charts/funnel_chart.ts
+++ b/src/helpers/figures/charts/funnel_chart.ts
@@ -108,6 +108,12 @@ export class FunnelChart extends AbstractChart {
     };
   }
 
+  getDataRanges(): Range[] {
+    return [this.labelRange, ...this.dataSets.map((ds) => ds.dataRange)].filter(
+      (r): r is Range => r !== undefined
+    );
+  }
+
   getContextCreation(): ChartCreationContext {
     const range: CustomizedDataSet[] = [];
     for (const [i, dataSet] of this.dataSets.entries()) {

--- a/src/helpers/figures/charts/gauge_chart.ts
+++ b/src/helpers/figures/charts/gauge_chart.ts
@@ -272,6 +272,10 @@ export class GaugeChart extends AbstractChart {
     return undefined;
   }
 
+  getDataRanges(): Range[] {
+    return this.dataRange ? [this.dataRange] : [];
+  }
+
   getContextCreation(): ChartCreationContext {
     return {
       ...this,

--- a/src/helpers/figures/charts/geo_chart.ts
+++ b/src/helpers/figures/charts/geo_chart.ts
@@ -94,6 +94,12 @@ export class GeoChart extends AbstractChart {
     };
   }
 
+  getDataRanges(): Range[] {
+    return [this.labelRange, ...this.dataSets.map((ds) => ds.dataRange)].filter(
+      (r): r is Range => r !== undefined
+    );
+  }
+
   getContextCreation(): ChartCreationContext {
     const range: CustomizedDataSet[] = [];
     for (const [i, dataSet] of this.dataSets.entries()) {

--- a/src/helpers/figures/charts/line_chart.ts
+++ b/src/helpers/figures/charts/line_chart.ts
@@ -158,6 +158,12 @@ export class LineChart extends AbstractChart {
     };
   }
 
+  getDataRanges(): Range[] {
+    return [this.labelRange, ...this.dataSets.map((ds) => ds.dataRange)].filter(
+      (r): r is Range => r !== undefined
+    );
+  }
+
   getContextCreation(): ChartCreationContext {
     const range: CustomizedDataSet[] = [];
     for (const [i, dataSet] of this.dataSets.entries()) {

--- a/src/helpers/figures/charts/pie_chart.ts
+++ b/src/helpers/figures/charts/pie_chart.ts
@@ -103,6 +103,12 @@ export class PieChart extends AbstractChart {
     return this.getDefinitionWithSpecificDataSets(this.dataSets, this.labelRange);
   }
 
+  getDataRanges(): Range[] {
+    return [this.labelRange, ...this.dataSets.map((ds) => ds.dataRange)].filter(
+      (r): r is Range => r !== undefined
+    );
+  }
+
   getContextCreation(): ChartCreationContext {
     return {
       ...this,

--- a/src/helpers/figures/charts/pyramid_chart.ts
+++ b/src/helpers/figures/charts/pyramid_chart.ts
@@ -107,6 +107,12 @@ export class PyramidChart extends AbstractChart {
     };
   }
 
+  getDataRanges(): Range[] {
+    return [this.labelRange, ...this.dataSets.map((ds) => ds.dataRange)].filter(
+      (r): r is Range => r !== undefined
+    );
+  }
+
   getContextCreation(): ChartCreationContext {
     const range: CustomizedDataSet[] = [];
     for (const [i, dataSet] of this.dataSets.entries()) {

--- a/src/helpers/figures/charts/radar_chart.ts
+++ b/src/helpers/figures/charts/radar_chart.ts
@@ -114,6 +114,12 @@ export class RadarChart extends AbstractChart {
     };
   }
 
+  getDataRanges(): Range[] {
+    return [this.labelRange, ...this.dataSets.map((ds) => ds.dataRange)].filter(
+      (r): r is Range => r !== undefined
+    );
+  }
+
   getContextCreation(): ChartCreationContext {
     const range: CustomizedDataSet[] = [];
     for (const [i, dataSet] of this.dataSets.entries()) {

--- a/src/helpers/figures/charts/scatter_chart.ts
+++ b/src/helpers/figures/charts/scatter_chart.ts
@@ -147,6 +147,12 @@ export class ScatterChart extends AbstractChart {
     };
   }
 
+  getDataRanges(): Range[] {
+    return [this.labelRange, ...this.dataSets.map((ds) => ds.dataRange)].filter(
+      (r): r is Range => r !== undefined
+    );
+  }
+
   getContextCreation(): ChartCreationContext {
     const range: CustomizedDataSet[] = [];
     for (const [i, dataSet] of this.dataSets.entries()) {

--- a/src/helpers/figures/charts/sunburst_chart.ts
+++ b/src/helpers/figures/charts/sunburst_chart.ts
@@ -110,6 +110,12 @@ export class SunburstChart extends AbstractChart {
     return this.getDefinitionWithSpecificDataSets(this.dataSets, this.labelRange);
   }
 
+  getDataRanges(): Range[] {
+    return [this.labelRange, ...this.dataSets.map((ds) => ds.dataRange)].filter(
+      (r): r is Range => r !== undefined
+    );
+  }
+
   getContextCreation(): ChartCreationContext {
     const leafRange = this.dataSets.at(-1)?.dataRange;
     return {

--- a/src/helpers/figures/charts/tree_map_chart.ts
+++ b/src/helpers/figures/charts/tree_map_chart.ts
@@ -116,6 +116,12 @@ export class TreeMapChart extends AbstractChart {
     };
   }
 
+  getDataRanges(): Range[] {
+    return [this.labelRange, ...this.dataSets.map((ds) => ds.dataRange)].filter(
+      (r): r is Range => r !== undefined
+    );
+  }
+
   getContextCreation(): ChartCreationContext {
     const leafRange = this.dataSets.at(-1)?.dataRange;
     return {

--- a/src/helpers/figures/charts/waterfall_chart.ts
+++ b/src/helpers/figures/charts/waterfall_chart.ts
@@ -122,6 +122,12 @@ export class WaterfallChart extends AbstractChart {
     };
   }
 
+  getDataRanges(): Range[] {
+    return [this.labelRange, ...this.dataSets.map((ds) => ds.dataRange)].filter(
+      (r): r is Range => r !== undefined
+    );
+  }
+
   getContextCreation(): ChartCreationContext {
     const range: CustomizedDataSet[] = [];
     for (const [i, dataSet] of this.dataSets.entries()) {

--- a/tests/figures/chart/chart_animations.test.ts
+++ b/tests/figures/chart/chart_animations.test.ts
@@ -62,12 +62,13 @@ describe("Chart animations in dashboard", () => {
 
     expect(mockedChart.config.options.animation).toEqual({ animateRotate: true });
 
-    // Dispatch a command that doesn't change the chart data
+    // Dispatch a command that doesn't change the chart data: runtime is not re-created,
+    // so the animation state is unchanged (still { animateRotate: true } from first render)
     setCellContent(model, "A50", "6");
     await nextTick();
-    expect(mockedChart.config.options.animation).toBe(false);
+    expect(mockedChart.config.options.animation).toEqual({ animateRotate: true });
 
-    // Change the chart data
+    // Change the chart data: runtime is re-created with new data, animation plays again
     setCellContent(model, "A2", "6");
     await nextTick();
     expect(mockedChart.config.options.animation).toEqual({ animateRotate: true });
@@ -75,7 +76,7 @@ describe("Chart animations in dashboard", () => {
     readonlyAllowedCommands.delete("UPDATE_CELL");
   });
 
-  test("Treemap animation are not replayed when data does not change but runtime is re-created", async () => {
+  test("Treemap animation is not replayed when a cell outside the chart range changes", async () => {
     readonlyAllowedCommands.add("UPDATE_CELL");
 
     const model = new Model();
@@ -86,9 +87,10 @@ describe("Chart animations in dashboard", () => {
 
     expect(mockedChart.config.options.animation).toEqual({ animateRotate: true });
 
+    // B1 is outside the chart range: runtime is not re-created, animation is unchanged
     setCellContent(model, "B1", "6");
     await nextTick();
-    expect(mockedChart.config.options.animation).toBe(false);
+    expect(mockedChart.config.options.animation).toEqual({ animateRotate: true });
 
     readonlyAllowedCommands.delete("UPDATE_CELL");
   });

--- a/tests/figures/chart/chart_runtime_invalidation.test.ts
+++ b/tests/figures/chart/chart_runtime_invalidation.test.ts
@@ -1,0 +1,177 @@
+import { Model } from "../../../src";
+import { UID } from "../../../src/types";
+import {
+  createChart,
+  createGaugeChart,
+  createScorecardChart,
+  setCellContent,
+  undo,
+} from "../../test_helpers/commands_helpers";
+
+/**
+ * Tests for selective chart runtime invalidation.
+ *
+ * Chart runtimes should only be re-computed when a cell within the chart's
+ * data ranges (or a cell that transitively feeds into them via formulas)
+ * is re-evaluated. Editing a cell that has no relation to a chart should
+ * not invalidate its cached runtime.
+ */
+describe("Chart runtime selective invalidation", () => {
+  let model: Model;
+  let sheetId: UID;
+  const chartId = "chartId";
+
+  beforeEach(() => {
+    model = new Model();
+    sheetId = model.getters.getActiveSheetId();
+  });
+
+  function getRuntime() {
+    return model.getters.getChartRuntime(chartId);
+  }
+
+  describe("Bar/line/pie charts (dataSets + labelRange)", () => {
+    beforeEach(() => {
+      createChart(
+        model,
+        { type: "bar", dataSets: [{ dataRange: "B1:B5" }], labelRange: "A1:A5" },
+        chartId
+      );
+    });
+
+    test("runtime is not re-created when a cell outside the chart ranges changes", () => {
+      const runtime1 = getRuntime();
+      setCellContent(model, "C1", "999");
+      const runtime2 = getRuntime();
+      expect(runtime2).toBe(runtime1);
+    });
+
+    test("runtime is re-created when a cell inside the data range changes", () => {
+      const runtime1 = getRuntime();
+      setCellContent(model, "B2", "42");
+      const runtime2 = getRuntime();
+      expect(runtime2).not.toBe(runtime1);
+    });
+
+    test("runtime is re-created when a cell inside the label range changes", () => {
+      const runtime1 = getRuntime();
+      setCellContent(model, "A3", "new label");
+      const runtime2 = getRuntime();
+      expect(runtime2).not.toBe(runtime1);
+    });
+
+    test("runtime is re-created via transitive formula dependency", () => {
+      // B10 feeds into B2 (which is in the chart range)
+      setCellContent(model, "B2", "=B10");
+      const runtime1 = getRuntime();
+      // Modifying B10 should invalidate the chart (B10 → B2 → chart)
+      setCellContent(model, "B10", "99");
+      const runtime2 = getRuntime();
+      expect(runtime2).not.toBe(runtime1);
+    });
+
+    test("runtime is not re-created when a formula outside the chart changes", () => {
+      // C2 is not in any chart range
+      setCellContent(model, "C2", "=D5+1");
+      const runtime1 = getRuntime();
+      setCellContent(model, "D5", "10");
+      const runtime2 = getRuntime();
+      expect(runtime2).toBe(runtime1);
+    });
+
+    test("runtime is re-created on UNDO", () => {
+      setCellContent(model, "B2", "42");
+      const runtimeAfterEdit = getRuntime();
+      undo(model);
+      const runtimeAfterUndo = getRuntime();
+      expect(runtimeAfterUndo).not.toBe(runtimeAfterEdit);
+    });
+
+    test("multiple charts: only the affected chart is re-created", () => {
+      const otherChartId = "otherChart";
+      createChart(model, { type: "bar", dataSets: [{ dataRange: "D1:D5" }] }, otherChartId);
+
+      const runtime1 = getRuntime();
+      const otherRuntime1 = model.getters.getChartRuntime(otherChartId);
+
+      // Modify a cell only in the first chart's range
+      setCellContent(model, "B3", "77");
+
+      const runtime2 = getRuntime();
+      const otherRuntime2 = model.getters.getChartRuntime(otherChartId);
+
+      expect(runtime2).not.toBe(runtime1); // first chart invalidated
+      expect(otherRuntime2).toBe(otherRuntime1); // second chart untouched
+    });
+  });
+
+  describe("Gauge chart (dataRange)", () => {
+    beforeEach(() => {
+      createGaugeChart(model, { dataRange: "B1" }, chartId);
+    });
+
+    test("runtime is not re-created when a cell outside the data range changes", () => {
+      const runtime1 = getRuntime();
+      setCellContent(model, "C5", "10");
+      const runtime2 = getRuntime();
+      expect(runtime2).toBe(runtime1);
+    });
+
+    test("runtime is re-created when the data range cell changes", () => {
+      const runtime1 = getRuntime();
+      setCellContent(model, "B1", "50");
+      const runtime2 = getRuntime();
+      expect(runtime2).not.toBe(runtime1);
+    });
+  });
+
+  describe("Scorecard chart (keyValue + baseline)", () => {
+    beforeEach(() => {
+      createScorecardChart(model, { keyValue: "B1", baseline: "B2" }, chartId);
+    });
+
+    test("runtime is not re-created when a cell outside both ranges changes", () => {
+      const runtime1 = getRuntime();
+      setCellContent(model, "C5", "10");
+      const runtime2 = getRuntime();
+      expect(runtime2).toBe(runtime1);
+    });
+
+    test("runtime is re-created when the keyValue cell changes", () => {
+      const runtime1 = getRuntime();
+      setCellContent(model, "B1", "500");
+      const runtime2 = getRuntime();
+      expect(runtime2).not.toBe(runtime1);
+    });
+
+    test("runtime is re-created when the baseline cell changes", () => {
+      const runtime1 = getRuntime();
+      setCellContent(model, "B2", "400");
+      const runtime2 = getRuntime();
+      expect(runtime2).not.toBe(runtime1);
+    });
+  });
+
+  describe("Multi-sheet charts", () => {
+    test("runtime is re-created when a cell on the chart's data sheet changes", () => {
+      const sheet2Id = "sheet2";
+      model.dispatch("CREATE_SHEET", { sheetId: sheet2Id, position: 1 });
+      setCellContent(model, "A1", "10", sheet2Id);
+      createChart(model, { type: "bar", dataSets: [{ dataRange: "Sheet2!A1:A5" }] }, chartId);
+      const runtime1 = getRuntime();
+      setCellContent(model, "A1", "99", sheet2Id);
+      const runtime2 = getRuntime();
+      expect(runtime2).not.toBe(runtime1);
+    });
+
+    test("runtime is not re-created when a cell on an unrelated sheet changes", () => {
+      const sheet2Id = "sheet2";
+      model.dispatch("CREATE_SHEET", { sheetId: sheet2Id, position: 1 });
+      createChart(model, { type: "bar", dataSets: [{ dataRange: "A1:A5" }] }, chartId);
+      const runtime1 = getRuntime();
+      setCellContent(model, "A1", "99", sheet2Id);
+      const runtime2 = getRuntime();
+      expect(runtime2).toBe(runtime1);
+    });
+  });
+});


### PR DESCRIPTION
Previously, any UPDATE_CELL or EVALUATE_CELLS
command would invalidate all chart runtimes,
causing every chart to be fully re-computed even
when the edited cell had no relation to any chart.

Chart runtimes are now only invalidated when the
re-evaluated cells actually overlap with the
chart's data ranges (datasets and label range).

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo