### PR TITLE
[FIX] SheetView: dirtify sheet viewport at UPDATE_CELL

### DIFF
--- a/src/plugins/ui_stateful/header_positions.ts
+++ b/src/plugins/ui_stateful/header_positions.ts
@@ -23,6 +23,8 @@ export class HeaderPositionsUIPlugin extends UIPlugin {
         }
         break;
       case "UPDATE_CELL":
+        // Either the content, format or style can impact the header sizes of a sheet
+        // As such, every command can have a potential effect on the viewport
         this.headerPositions = {};
         this.isDirty = true;
         break;

--- a/src/plugins/ui_stateful/sheetview.ts
+++ b/src/plugins/ui_stateful/sheetview.ts
@@ -228,11 +228,10 @@ export class SheetViewPlugin extends UIPlugin {
         this.sheetsWithDirtyViewports.add(cmd.sheetId);
         break;
       case "UPDATE_CELL":
-        // update cell content or format can change hidden rows because of data filters
-        if ("content" in cmd || "format" in cmd || cmd.style?.fontSize !== undefined) {
-          for (const sheetId of this.getters.getSheetIds()) {
-            this.sheetsWithDirtyViewports.add(sheetId);
-          }
+        // Either the content, format or style can impact the header sizes of a sheet
+        // As such, every command can have a potential effect on the viewport
+        for (const sheetId of this.getters.getSheetIds()) {
+          this.sheetsWithDirtyViewports.add(sheetId);
         }
         break;
       case "DELETE_SHEET":

--- a/tests/autofill/autofill_plugin.test.ts
+++ b/tests/autofill/autofill_plugin.test.ts
@@ -13,6 +13,7 @@ import {
   merge,
   selectCell,
   setCellContent,
+  setFormat,
   setSelection,
 } from "../test_helpers/commands_helpers";
 import {
@@ -715,5 +716,13 @@ describe("Autofill", () => {
   test("link tooltip is formatted", () => {
     setCellContent(model, "A1", "[label](url)");
     expect(autofillTooltip("A1", "A2")).toBe("label");
+  });
+
+  test("Autofill that triggers no change does not crash", () => {
+    addDataValidation(model, "A1:A2", "1", { type: "isBoolean", values: [] });
+    setCellContent(model, "A1", "FALSE");
+    setCellContent(model, "A2", "FALSE");
+    setFormat(model, "0.00%", [toZone("A1:A2")]);
+    autofill("A1", "A2"); // A1 and A2 are exactly the same
   });
 });

--- a/tests/sheet/sheetview_plugin.test.ts
+++ b/tests/sheet/sheetview_plugin.test.ts
@@ -895,7 +895,18 @@ describe("Viewport of Simple sheet", () => {
       right: 10,
       top: 0,
     });
-    setStyle(model, "A1:A20", { fontSize: 8 });
+    setStyle(model, "A1:A20", { fontSize: 24 });
+    expect(model.getters.getActiveMainViewport()).toEqual({
+      bottom: 30,
+      left: 0,
+      right: 10,
+      top: 0,
+    });
+
+    const sheetId = model.getters.getActiveSheetId();
+    for (let i = 0; i < 20; ++i) {
+      model.dispatch("UPDATE_CELL", { sheetId, col: 0, row: i, style: {} });
+    }
     expect(model.getters.getActiveMainViewport()).toEqual({
       bottom: 43,
       left: 0,


### PR DESCRIPTION
the issue was found through an autofill bug. To reproduce:

- Add a data validation checkbox to A1:A2
- Add a format (like `%`) to A1:A2
- autofill A1 into A2

-> crash

What happens?

For starters, the plugin `SheetViewPlugin` is always listening to selection events and will update the viewports 'scroll' value accordingly.

During the autofill handling of the command, a bunch of `UPDATE_CELL` commands are dispatched, which invalidates the whole state of `HeaderPositionsUIPlugin`.
After that dispatch, the plugin  also updates the selection, which triggers `SheetViewPlugin` to update its viewports but this manipulation relies on the state of `HeaderPositionsUIPlugin`, which was just invalidated!

It was already known that during a command dispatch, the general state of plugins might be unstable and `SheetViewPlugin` accounted for it by *tagging* sheets that might have an unstable state and it would skip the viewport `scroll` update after selection events.
However, we limited the *tagging* for specific payloads of `UPDATE_CELL` and the condition set on the style was incorrect. Indeed, a style object without the `fontSize` does not mean that we do not update the fontsize but rather that we reset it to its default value which has a direct impact on the header size and position (hence the invalidation of state in `HeaderPositionsUIPlugin`.

All-in-all, The presence of the `style` key in the `UPDATE_CELL` command payload is enough to tag a sheet as invalid.

A side note:
While changing the content or format of a cell can have cross-sheet impact due to the evaluation process (a cell will take the format of its reference without a format on its own), it is not the case for the style. As such, we could make separate cases for commands that update the content/format, which might theoretically impact every sheet, and commands that only impact the style, which only impacts the targetted sheet. Such improvement can target the master dev branch.

Task: 5953775

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [5953775](https://www.odoo.com/odoo/2328/tasks/5953775)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo