### PR TITLE
[FIX] Model: reject data that postdate the library version

### DIFF
--- a/src/migrations/data.ts
+++ b/src/migrations/data.ts
@@ -134,7 +134,14 @@ function compareVersions(v1: string, v2: string): number {
 function migrate(data: any): WorkbookData {
   const start = performance.now();
   const versions = getSortedVersions();
-  const index = versions.findIndex((v) => v === data.version);
+  const index = versions.findIndex((v) => compareVersions(v, data.version) >= 0);
+  if (index === -1) {
+    throw new Error(
+      `Data version ${
+        data.version
+      } postdates the current version of o-spreadsheet (version ${getCurrentVersion()}). It cannot be loaded.`
+    );
+  }
   for (let i = index + 1; i < versions.length; i++) {
     const nextVersion = versions[i];
     data = migrationStepRegistry.get(nextVersion).migrate(data);

--- a/tests/model/model_import_export.test.ts
+++ b/tests/model/model_import_export.test.ts
@@ -981,3 +981,15 @@ test("Can import spreadsheet with only version", () => {
   // We expect the model to be loaded without traceback
   expect(true).toBeTruthy();
 });
+
+test("Reject data import from data with a subsequent version", () => {
+  const futureVersion = (parseFloat(getCurrentVersion()) + 1).toString();
+  expect(() => new Model({ version: futureVersion })).toThrow(
+    `Data version ${futureVersion} postdates the current version of o-spreadsheet (version ${getCurrentVersion()}). It cannot be loaded.`
+  );
+});
+
+test("Accept data that predates the latest version while not being present in the migration steps", () => {
+  const previousVersion = "16.3.1";
+  expect(() => new Model({ version: previousVersion })).not.toThrow();
+});


### PR DESCRIPTION
Currently, if we try to load data that postdate tjhe library version, the code will consider the data as "versionless" and will apply every migration step to it, which makes no sense as the data already went through those changes.

With this revision, we reject the data that postdate the library version.

Task: 5895572

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [5895572](https://www.odoo.com/odoo/2328/tasks/5895572)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo