### PR TITLE
[PERF] formulas: Force the use of the cache for linear search functions

### DIFF
--- a/src/functions/helpers.ts
+++ b/src/functions/helpers.ts
@@ -1014,7 +1014,7 @@ export function linearSearch<T>(
       return reverseSearch ? numberOfValues - resultIndex - 1 : resultIndex;
     }
 
-    if (mode === "strict") {
+    if (mode === "strict" || mode === "wildcard") {
       return -1;
     }
   }


### PR DESCRIPTION
Searches using lookup functions were abnormally slow. Indeed, in linear search mode, the default search mode was "wildcard".

A poorly written condition still initiated linear searches in wildcard mode even though the target was not a wildcard, despite the cache having already been searched.

Task: [5956354](https://www.odoo.com/odoo/2328/tasks/5956354)