### PR TITLE
[FIX] logging: log "ms"

### DIFF
--- a/packages/o-spreadsheet-engine/src/plugins/core/cell.ts
+++ b/packages/o-spreadsheet-engine/src/plugins/core/cell.ts
@@ -295,7 +295,7 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
         }
       }
     }
-    console.debug("cells imported in ", performance.now() - start);
+    console.debug("cells imported in", performance.now() - start, "ms");
   }
 
   export(data: WorkbookData, shouldSquish: boolean) {


### PR DESCRIPTION
Our performance measuring tool extract the times with a regex looking for

"something something <a number> ms"

https://github.com/rrahir/spreadsheet-tools/blob/cfb91324f89d2edcb6a57762421e5e3c2ab7777e/benchmark/benchmark_worker.js#L39

This commit adds the missing "ms" units for the extraction to work.

Task: 5959504

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo