### PR TITLE
[IMP] error_tooltip: add button to automatically add missing headers

### DIFF
--- a/packages/o-spreadsheet-engine/src/helpers/misc.ts
+++ b/packages/o-spreadsheet-engine/src/helpers/misc.ts
@@ -5,7 +5,17 @@ import { FORBIDDEN_SHEETNAME_CHARS_IN_EXCEL_REGEX, NEWLINE } from "../constants"
 import { Cell } from "../types/cells";
 import { ChartStyle } from "../types/chart";
 import { SearchOptions } from "../types/find_and_replace";
-import { Cloneable, ConsecutiveIndexes, DebouncedFunction, Lazy, Style, UID } from "../types/misc";
+import { Getters } from "../types/getters";
+import {
+  CellPosition,
+  Cloneable,
+  ConsecutiveIndexes,
+  DebouncedFunction,
+  isMatrix,
+  Lazy,
+  Style,
+  UID,
+} from "../types/misc";
 
 const sanitizeSheetNameRegex = new RegExp(FORBIDDEN_SHEETNAME_CHARS_IN_EXCEL_REGEX, "g");
 
@@ -766,4 +776,32 @@ export function chartStyleToCellStyle(style: ChartStyle): Style {
 
 export function doesCellContainFunction(cell: Cell, formula: string): boolean {
   return cell.isFormula && cell.compiledFormula.usesSymbol(formula);
+}
+
+/** Return the number of cols/rows missing for result of the formula to be able to spread */
+export function getMissingHeadersForSpreadResult(
+  getters: Getters,
+  position: CellPosition,
+  formula: string
+) {
+  const { sheetId, col, row } = position;
+  if (!isFormula(formula)) {
+    return;
+  }
+
+  const evaluated = getters.evaluateFormula(sheetId, formula, {
+    sheetId: sheetId,
+    col: col,
+    row: row,
+  });
+  if (!isMatrix(evaluated)) {
+    return;
+  }
+
+  const numberOfRows = getters.getNumberRows(sheetId);
+  const numberOfCols = getters.getNumberCols(sheetId);
+
+  const missingRows = row + evaluated[0].length - numberOfRows;
+  const missingCols = col + evaluated.length - numberOfCols;
+  return { missingRows, missingCols };
 }

--- a/packages/o-spreadsheet-engine/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
+++ b/packages/o-spreadsheet-engine/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
@@ -468,21 +468,7 @@ export class Evaluator {
       return;
     }
 
-    if (enoughCols) {
-      throw new SplillBlockedError(
-        _t("Result couldn't be automatically expanded. Please insert more rows.")
-      );
-    }
-
-    if (enoughRows) {
-      throw new SplillBlockedError(
-        _t("Result couldn't be automatically expanded. Please insert more columns.")
-      );
-    }
-
-    throw new SplillBlockedError(
-      _t("Result couldn't be automatically expanded. Please insert more columns and rows.")
-    );
+    throw new SplillBlockedError(_t("Result couldn't be automatically expanded."));
   }
 
   private assertNoMergedCellsInSpreadZone(

--- a/src/components/composer/composer/cell_composer_store.ts
+++ b/src/components/composer/composer/cell_composer_store.ts
@@ -10,6 +10,7 @@ import { _t } from "@odoo/o-spreadsheet-engine/translation";
 import {
   detectDateFormat,
   formatValue,
+  getMissingHeadersForSpreadResult,
   isDateTimeFormat,
   isFormula,
   markdownLink,
@@ -32,7 +33,6 @@ import {
   FormulaCell,
   Locale,
   RemoveColumnsRowsCommand,
-  isMatrix,
 } from "../../../types";
 import { moveAnchorWithinSelection } from "../../helpers/selection_helpers";
 import { AbstractComposerStore, ComposerSelection } from "./abstract_composer_store";
@@ -308,43 +308,33 @@ export class CellComposerStore extends AbstractComposerStore {
 
   /** Add headers at the end of the sheet so the formula in the composer has enough space to spread */
   private addHeadersForSpreadingFormula(content: string) {
-    if (!isFormula(content)) {
+    const missingHeaders = getMissingHeadersForSpreadResult(
+      this.getters,
+      this.currentEditedCell,
+      content
+    );
+    if (!missingHeaders) {
       return;
     }
 
-    const evaluated = this.getters.evaluateFormula(this.sheetId, content, {
-      sheetId: this.sheetId,
-      col: this.col,
-      row: this.row,
-    });
-    if (!isMatrix(evaluated)) {
-      return;
-    }
-
-    const numberOfRows = this.getters.getNumberRows(this.sheetId);
-    const numberOfCols = this.getters.getNumberCols(this.sheetId);
-
-    const missingRows = this.row + evaluated[0].length - numberOfRows;
-    const missingCols = this.col + evaluated.length - numberOfCols;
-
-    if (missingCols > 0) {
+    if (missingHeaders.missingCols > 0) {
       this.model.dispatch("ADD_COLUMNS_ROWS", {
         sheetId: this.sheetId,
         sheetName: this.getters.getSheetName(this.sheetId),
         dimension: "COL",
-        base: numberOfCols - 1,
+        base: this.getters.getNumberCols(this.sheetId) - 1,
         position: "after",
-        quantity: missingCols + 20,
+        quantity: missingHeaders.missingCols + 20,
       });
     }
-    if (missingRows > 0) {
+    if (missingHeaders.missingRows > 0) {
       this.model.dispatch("ADD_COLUMNS_ROWS", {
         sheetId: this.sheetId,
         sheetName: this.getters.getSheetName(this.sheetId),
         dimension: "ROW",
-        base: numberOfRows - 1,
+        base: this.getters.getNumberRows(this.sheetId) - 1,
         position: "after",
-        quantity: missingRows + 50,
+        quantity: missingHeaders.missingRows + 50,
       });
     }
   }

--- a/src/components/error_tooltip/error_tooltip.ts
+++ b/src/components/error_tooltip/error_tooltip.ts
@@ -1,7 +1,8 @@
+import { _t } from "@odoo/o-spreadsheet-engine";
 import { SpreadsheetChildEnv } from "@odoo/o-spreadsheet-engine/types/spreadsheet_env";
 import { Component } from "@odoo/owl";
-import { deepEquals, positionToZone } from "../../helpers";
-import { CellPosition, CellValueType } from "../../types";
+import { deepEquals, getMissingHeadersForSpreadResult, positionToZone } from "../../helpers";
+import { CellErrorType, CellPosition, CellValueType } from "../../types";
 import { CellPopoverComponent, PopoverBuilders } from "../../types/cell_popovers";
 
 const ERROR_TOOLTIP_MAX_HEIGHT = 80;
@@ -60,6 +61,65 @@ export class ErrorToolTip extends Component<ErrorToolTipProps, SpreadsheetChildE
       });
     }
     this.env.model.selection.selectCell(position.col, position.row);
+  }
+
+  get isSpillErrorBecauseOfMissingHeaders() {
+    const evaluationError = this.evaluationError;
+    return (
+      evaluationError?.value === CellErrorType.SpilledBlocked &&
+      !evaluationError.errorOriginPosition &&
+      !this.env.model.getters.getSpreadZone(this.props.cellPosition, { ignoreSpillError: true })
+    );
+  }
+
+  getMissingHeadersForSpread() {
+    if (!this.isSpillErrorBecauseOfMissingHeaders) {
+      return;
+    }
+    const cell = this.env.model.getters.getCell(this.props.cellPosition);
+    if (!cell || !cell.isFormula) {
+      return;
+    }
+    const formula = cell.compiledFormula.toFormulaString(this.env.model.getters);
+    return getMissingHeadersForSpreadResult(
+      this.env.model.getters,
+      this.props.cellPosition,
+      formula
+    );
+  }
+
+  addMissingHeaders({ missingCols, missingRows }: { missingCols: number; missingRows: number }) {
+    const sheetId = this.props.cellPosition.sheetId;
+    if (missingCols > 0) {
+      this.env.model.dispatch("ADD_COLUMNS_ROWS", {
+        sheetId,
+        sheetName: this.env.model.getters.getSheetName(sheetId),
+        dimension: "COL",
+        base: this.env.model.getters.getNumberCols(sheetId) - 1,
+        position: "after",
+        quantity: missingCols + 20,
+      });
+    }
+    if (missingRows > 0) {
+      this.env.model.dispatch("ADD_COLUMNS_ROWS", {
+        sheetId,
+        sheetName: this.env.model.getters.getSheetName(sheetId),
+        dimension: "ROW",
+        base: this.env.model.getters.getNumberRows(sheetId) - 1,
+        position: "after",
+        quantity: missingRows + 50,
+      });
+    }
+  }
+
+  getAddMissingHeadersButtonText(missingHeaders: { missingCols: number; missingRows: number }) {
+    if (missingHeaders.missingCols > 0 && missingHeaders.missingRows > 0) {
+      return _t("Add missing columns and rows");
+    } else if (missingHeaders.missingCols > 0) {
+      return _t("Add missing columns");
+    } else {
+      return _t("Add missing rows");
+    }
   }
 }
 

--- a/src/components/error_tooltip/error_tooltip.xml
+++ b/src/components/error_tooltip/error_tooltip.xml
@@ -14,6 +14,13 @@
               title="Click to select the cell"
             />
           </div>
+          <t t-set="missingHeadersForSpread" t-value="getMissingHeadersForSpread()"/>
+          <div
+            t-if="missingHeadersForSpread"
+            class="o-button-link mt-4"
+            t-on-click="() => this.addMissingHeaders(missingHeadersForSpread)"
+            t-esc="getAddMissingHeadersButtonText(missingHeadersForSpread)"
+          />
         </div>
       </t>
       <t t-if="dataValidationErrorMessage">

--- a/tests/evaluation/evaluation_formula_array.test.ts
+++ b/tests/evaluation/evaluation_formula_array.test.ts
@@ -474,25 +474,19 @@ describe("evaluate formulas that use/return an array", () => {
     test("throw error message concerning the column encountered horizontally", () => {
       setCellContent(model, "B1", "=MFILL(3,3, 42)");
       expect(getEvaluatedCell(model, "B1").value).toBe("#SPILL!");
-      expect(getCellError(model, "B1")).toBe(
-        "Result couldn't be automatically expanded. Please insert more columns."
-      );
+      expect(getCellError(model, "B1")).toBe("Result couldn't be automatically expanded.");
     });
 
     test("throw error message concerning the row encountered verticaly", () => {
       setCellContent(model, "A2", "=MFILL(3,3, 42)");
       expect(getEvaluatedCell(model, "A2").value).toBe("#SPILL!");
-      expect(getCellError(model, "A2")).toBe(
-        "Result couldn't be automatically expanded. Please insert more rows."
-      );
+      expect(getCellError(model, "A2")).toBe("Result couldn't be automatically expanded.");
     });
 
     test("throw error message concerning the row and column encountered", () => {
       setCellContent(model, "B2", "=MFILL(3,3, 42)");
       expect(getEvaluatedCell(model, "B2").value).toBe("#SPILL!");
-      expect(getCellError(model, "B2")).toBe(
-        "Result couldn't be automatically expanded. Please insert more columns and rows."
-      );
+      expect(getCellError(model, "B2")).toBe("Result couldn't be automatically expanded.");
     });
 
     test("do not spread result when collide", () => {

--- a/tests/popover/__snapshots__/error_tooltip_component.test.ts.snap
+++ b/tests/popover/__snapshots__/error_tooltip_component.test.ts.snap
@@ -17,6 +17,7 @@ exports[`Grid integration can display error tooltip 1`] = `
     >
       The divisor must be different from zero.
       
+      
     </div>
     
     

--- a/tests/popover/error_tooltip_component.test.ts
+++ b/tests/popover/error_tooltip_component.test.ts
@@ -1,6 +1,7 @@
 import { DEFAULT_CELL_HEIGHT, DEFAULT_CELL_WIDTH } from "@odoo/o-spreadsheet-engine/constants";
 import { Model } from "../../src";
 import { ErrorToolTip } from "../../src/components/error_tooltip/error_tooltip";
+import { getCellContent } from "../test_helpers";
 import {
   addDataValidation,
   createChart,
@@ -108,6 +109,35 @@ describe("Error tooltip component", () => {
     setCellContent(model, "A1", "=1/0");
     await mountErrorTooltip(model, "A1");
     expect(".fst-italic").toHaveCount(0);
+  });
+
+  test("Can add missing headers if the formula is #SPILL", async () => {
+    const model = new Model({ sheets: [{ id: "sheet1", colNumber: 1, rowNumber: 1 }] });
+    setCellContent(model, "A1", "=MUNIT(3)");
+    await mountErrorTooltip(model, "A1");
+    await click(fixture, ".o-button-link");
+    expect(model.getters.getNumberRows("sheet1")).toBe(3 + 50); // +50/+20 because we add some padding
+    expect(model.getters.getNumberCols("sheet1")).toBe(3 + 20);
+  });
+
+  test("Button to add missing header is not there for #SPILL not caused by too few headers", async () => {
+    const model = new Model();
+    setCellContent(model, "A1", "=MUNIT(3)");
+    setCellContent(model, "B1", "BlockingSpill");
+    expect(getCellContent(model, "A1")).toBe("#SPILL!");
+
+    await mountErrorTooltip(model, "A1");
+    expect(".o-button-link").toHaveCount(0);
+  });
+
+  test("Button to add missing header is not there for #SPILL of referenced cell", async () => {
+    const model = new Model({ sheets: [{ id: "sheet1", colNumber: 10, rowNumber: 1 }] });
+    setCellContent(model, "A1", "=MUNIT(3)");
+    expect(getCellContent(model, "A1")).toBe("#SPILL!");
+
+    setCellContent(model, "F1", "=A1");
+    await mountErrorTooltip(model, "F1");
+    expect(".o-button-link").toHaveCount(0);
   });
 });
 


### PR DESCRIPTION
## Description

This commit adds a button to the error tooltip to automatically add missing rows/columns on a #SPILL! error.

Task: [5959884](https://www.odoo.com/odoo/2328/tasks/5959884)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo