### PR TITLE
[IMP] Errors: Add error origin position for #SPILL errors

### DIFF
--- a/src/helpers/cells/cell_evaluation.ts
+++ b/src/helpers/cells/cell_evaluation.ts
@@ -2,6 +2,7 @@ import { isEvaluationError, toString } from "../../functions/helpers";
 import {
   BooleanCell,
   Cell,
+  CellPosition,
   CellValue,
   CellValueType,
   DEFAULT_LOCALE,
@@ -88,12 +89,12 @@ function _createEvaluatedCell(
   locale: Locale,
   cell?: Cell
 ): EvaluatedCell {
-  let { value, format, message } = functionResult;
+  let { value, format, message, errorOriginPosition } = functionResult;
   format = cell?.format || format;
 
   const formattedValue = formatValue(value, { format, locale });
   if (isEvaluationError(value)) {
-    return errorCell(value, message);
+    return errorCell(value, message, errorOriginPosition);
   }
   if (value === null) {
     return emptyCell(format);
@@ -185,7 +186,7 @@ function booleanCell(
   };
 }
 
-function errorCell(value: string, message?: string): ErrorCell {
+function errorCell(value: string, message?: string, errorOriginPosition?: CellPosition): ErrorCell {
   return {
     value,
     formattedValue: value,
@@ -193,5 +194,6 @@ function errorCell(value: string, message?: string): ErrorCell {
     type: CellValueType.error,
     isAutoSummable: false,
     defaultAlign: "center",
+    errorOriginPosition,
   };
 }

--- a/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
@@ -6,7 +6,6 @@ import {
   excludeTopLeft,
   lazy,
   positionToZone,
-  toXC,
   union,
 } from "../../../helpers";
 import { createEvaluatedCell, evaluateLiteral } from "../../../helpers/cells";
@@ -358,6 +357,7 @@ export class Evaluator {
     } catch (e) {
       e.value = e?.value || CellErrorType.GenericError;
       e.message = e?.message || implementationErrorMessage;
+      e.errorOriginPosition = e?.errorOriginPosition;
       return createEvaluatedCell(e);
     } finally {
       this.cellsBeingComputed.delete(cellId);
@@ -504,10 +504,8 @@ export class Evaluator {
       ) {
         this.blockedArrayFormulas.add(formulaPosition);
         throw new SplillBlockedError(
-          _t(
-            "Array result was not expanded because it would overwrite data in %s.",
-            toXC(position.col, position.row)
-          )
+          _t("Array result was not expanded because it would overwrite data."),
+          position
         );
       }
       this.blockedArrayFormulas.delete(formulaPosition);

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -1,4 +1,5 @@
 import { _t } from "../translation";
+import { CellPosition } from "./misc";
 
 export const CellErrorType = {
   NotAvailable: "#N/A",
@@ -53,7 +54,10 @@ export class UnknownFunctionError extends EvaluationError {
 }
 
 export class SplillBlockedError extends EvaluationError {
-  constructor(message = _t("Spill range is not empty")) {
+  constructor(
+    message = _t("Spill range is not empty"),
+    readonly errorOriginPosition?: CellPosition
+  ) {
     super(message, CellErrorType.SpilledBlocked);
   }
 }

--- a/tests/evaluation/evaluation_formula_array.test.ts
+++ b/tests/evaluation/evaluation_formula_array.test.ts
@@ -18,7 +18,7 @@ import {
   unMerge,
 } from "../test_helpers/commands_helpers";
 import { getCellContent, getCellError, getEvaluatedCell } from "../test_helpers/getters_helpers";
-import { restoreDefaultFunctions } from "../test_helpers/helpers";
+import { restoreDefaultFunctions, toCellPosition } from "../test_helpers/helpers";
 
 let model: Model;
 let sheetId: UID;
@@ -250,18 +250,25 @@ describe("evaluate formulas that return an array", () => {
 
   describe("result array can collides with other cell", () => {
     test("throw error on the formula when collide with cell having content", () => {
+      const sheetId = model.getters.getActiveSheetId();
       setCellContent(model, "B2", "kikou");
       setCellContent(model, "A1", "=MFILL(2,2, 42)");
       expect(getEvaluatedCell(model, "A1").value).toBe("#SPILL!");
       expect(getCellError(model, "A1")).toBe(
-        "Array result was not expanded because it would overwrite data in B2."
+        "Array result was not expanded because it would overwrite data."
+      );
+      expect(getEvaluatedCell(model, "A1").errorOriginPosition).toStrictEqual(
+        toCellPosition(sheetId, "B2")
       );
 
       setCellContent(model, "A4", "kikou");
       setCellContent(model, "A3", "=MFILL(2,2, 42)");
       expect(getEvaluatedCell(model, "A3").value).toBe("#SPILL!");
       expect(getCellError(model, "A3")).toBe(
-        "Array result was not expanded because it would overwrite data in A4."
+        "Array result was not expanded because it would overwrite data."
+      );
+      expect(getEvaluatedCell(model, "A1").errorOriginPosition).toStrictEqual(
+        toCellPosition(sheetId, "B2")
       );
     });
 
@@ -270,7 +277,10 @@ describe("evaluate formulas that return an array", () => {
       setCellContent(model, "A1", "=MFILL(2,2, 42)");
       expect(getEvaluatedCell(model, "A1").value).toBe("#SPILL!");
       expect(getCellError(model, "A1")).toBe(
-        "Array result was not expanded because it would overwrite data in B2."
+        "Array result was not expanded because it would overwrite data."
+      );
+      expect(getEvaluatedCell(model, "A1").errorOriginPosition).toStrictEqual(
+        toCellPosition(sheetId, "B2")
       );
       expect(getEvaluatedCell(model, "A2").value).toBe(null);
       expect(getEvaluatedCell(model, "B1").value).toBe(null);
@@ -283,7 +293,10 @@ describe("evaluate formulas that return an array", () => {
       setCellContent(model, "A3", "kikou");
       expect(getEvaluatedCell(model, "A1").value).toBe("#SPILL!");
       expect(getCellError(model, "A1")).toBe(
-        "Array result was not expanded because it would overwrite data in A2."
+        "Array result was not expanded because it would overwrite data."
+      );
+      expect(getEvaluatedCell(model, "A1").errorOriginPosition).toStrictEqual(
+        toCellPosition(sheetId, "A2")
       );
     });
 
@@ -293,7 +306,10 @@ describe("evaluate formulas that return an array", () => {
       setCellContent(model, "C1", "kikou");
       expect(getEvaluatedCell(model, "A1").value).toBe("#SPILL!");
       expect(getCellError(model, "A1")).toBe(
-        "Array result was not expanded because it would overwrite data in B1."
+        "Array result was not expanded because it would overwrite data."
+      );
+      expect(getEvaluatedCell(model, "A1").errorOriginPosition).toStrictEqual(
+        toCellPosition(sheetId, "B1")
       );
     });
 
@@ -818,7 +834,10 @@ describe("evaluate formulas that return an array", () => {
       expect(getEvaluatedCell(model, "B1").value).toBe(42);
       expect(getEvaluatedCell(model, "A2").value).toBe("#SPILL!");
       expect(getCellError(model, "A2")).toBe(
-        "Array result was not expanded because it would overwrite data in B2."
+        "Array result was not expanded because it would overwrite data."
+      );
+      expect(getEvaluatedCell(model, "A2").errorOriginPosition).toStrictEqual(
+        toCellPosition(sheetId, "B2")
       );
     });
 
@@ -828,7 +847,10 @@ describe("evaluate formulas that return an array", () => {
       expect(getEvaluatedCell(model, "B1").value).toBe("#SPILL!");
       expect(getEvaluatedCell(model, "A2").value).toBe(42);
       expect(getCellError(model, "B1")).toBe(
-        "Array result was not expanded because it would overwrite data in B2."
+        "Array result was not expanded because it would overwrite data."
+      );
+      expect(getEvaluatedCell(model, "B1").errorOriginPosition).toStrictEqual(
+        toCellPosition(sheetId, "B2")
       );
     });
 
@@ -838,7 +860,10 @@ describe("evaluate formulas that return an array", () => {
       expect(getEvaluatedCell(model, "B1").value).toBe("#SPILL!");
       expect(getEvaluatedCell(model, "A2").value).toBe(42);
       expect(getCellError(model, "B1")).toBe(
-        "Array result was not expanded because it would overwrite data in B2."
+        "Array result was not expanded because it would overwrite data."
+      );
+      expect(getEvaluatedCell(model, "B1").errorOriginPosition).toStrictEqual(
+        toCellPosition(sheetId, "B2")
       );
     });
 

--- a/tests/popover/error_tooltip_component.test.ts
+++ b/tests/popover/error_tooltip_component.test.ts
@@ -75,6 +75,14 @@ describe("Error tooltip component", () => {
     expect(".fst-italic").toHaveText(" Caused by A1");
   });
 
+  test("can display error origin position on a spill error", async () => {
+    const model = new Model();
+    setCellContent(model, "A1", "=RANDARRAY(2,2)");
+    setCellContent(model, "A2", "2");
+    await mountErrorTooltip(model, "A1");
+    expect(".fst-italic").toHaveText(" Caused by A2");
+  });
+
   test("Do not display error origin position in dashboard", async () => {
     const model = new Model();
     setCellContent(model, "A1", "=1/0");


### PR DESCRIPTION
Currently, Errors that spill because they would collide with other cells content have an error message that references the problematic cell but the link to jump to that cell is missing.

Task: 5959985

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo