### PR TITLE
[IMP] filter_menu: show separator only when sortable exists

### DIFF
--- a/src/components/filters/filter_menu/filter_menu.css
+++ b/src/components/filters/filter_menu/filter_menu.css
@@ -8,10 +8,6 @@
       padding: 0 16px;
     }
 
-    .o-sort-item {
-      padding-left: 34px;
-    }
-
     .o_side_panel_collapsible_title {
       font-size: inherit;
       padding: 0 0 4px 0 !important;

--- a/src/components/filters/filter_menu/filter_menu.xml
+++ b/src/components/filters/filter_menu/filter_menu.xml
@@ -1,22 +1,18 @@
 <templates>
   <t t-name="o-spreadsheet-FilterMenu">
     <div class="o-filter-menu d-flex flex-column bg-white" t-on-wheel.stop="">
-      <t t-if="isSortable">
-        <div>
-          <div
-            class="o-filter-menu-item o-sort-item py-2 mb-1"
-            t-on-click="() => this.sortFilterZone('asc')">
-            Sort ascending (A ⟶ Z)
-          </div>
-          <div
-            class="o-filter-menu-item o-sort-item py-2"
-            t-on-click="() => this.sortFilterZone('desc')">
-            Sort descending (Z ⟶ A)
-          </div>
+      <div t-if="isSortable" class="o-filter-menu-content">
+        <div
+          class="o-filter-menu-item py-2 ps-4 mb-1"
+          t-on-click="() => this.sortFilterZone('asc')">
+          Sort ascending (A ⟶ Z)
         </div>
-      </t>
-      <div class="o-filter-menu-content">
+        <div class="o-filter-menu-item py-2 ps-4" t-on-click="() => this.sortFilterZone('desc')">
+          Sort descending (Z ⟶ A)
+        </div>
         <div class="o-separator border-bottom"/>
+      </div>
+      <div class="o-filter-menu-content">
         <SidePanelCollapsible
           isInitiallyCollapsed="filterValueType !== 'criterion'"
           title.translate="Filter by criterion">

--- a/tests/table/__snapshots__/filter_menu_component.test.ts.snap
+++ b/tests/table/__snapshots__/filter_menu_component.test.ts.snap
@@ -4,25 +4,27 @@ exports[`Filter menu component Filter Tests Filter menu is correctly rendered 1`
 <div
   class="o-filter-menu d-flex flex-column bg-white"
 >
-  <div>
+  <div
+    class="o-filter-menu-content"
+  >
     <div
-      class="o-filter-menu-item o-sort-item py-2 mb-1"
+      class="o-filter-menu-item py-2 ps-4 mb-1"
     >
        Sort ascending (A ⟶ Z) 
     </div>
     <div
-      class="o-filter-menu-item o-sort-item py-2"
+      class="o-filter-menu-item py-2 ps-4"
     >
        Sort descending (Z ⟶ A) 
     </div>
+    <div
+      class="o-separator border-bottom"
+    />
   </div>
   
   <div
     class="o-filter-menu-content"
   >
-    <div
-      class="o-separator border-bottom"
-    />
     <div>
       <div
         class="o_side_panel_collapsible_title o-fw-bold d-flex align-items-center"


### PR DESCRIPTION
## Description:

Current behavior before PR:
- The filter menu always displayed a separator, even when the table filter
was not sortable, which made the UI appear incomplete.

Desired behavior after PR is merged:
- This commit updates the behavior so the separator is shown only when sorting
is available. It also removes redundant CSS and unnecessary xml hierarchy.

Task: [5959950](https://www.odoo.com/odoo/2328/tasks/5959950)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo