### PR TITLE
[PERF] clipboard: OS HTML parsing on internal paste

### DIFF
--- a/packages/o-spreadsheet-engine/src/helpers/clipboard/clipboard_helpers.ts
+++ b/packages/o-spreadsheet-engine/src/helpers/clipboard/clipboard_helpers.ts
@@ -100,6 +100,15 @@ export function parseOSClipboardContent(content: OSClipboardContent): ParsedOSCl
   return osClipboardContent;
 }
 
+/**
+ * Fast-path extraction used to detect an internal o-spreadsheet paste without
+ * instantiating a DOMParser on large HTML payloads. Reads the dedicated
+ * `data-osheet-clipboard-id` marker instead of parsing the embedded JSON.
+ */
+export function getOSheetClipboardIdFromHTML(htmlContent: string | undefined): string | undefined {
+  return htmlContent?.match(/<div data-osheet-clipboard-id=(['"])([^'"]+)\1/)?.[2];
+}
+
 function getOSheetDataFromHTML(htmlDocument: Document) {
   const attributes = [...htmlDocument.documentElement.attributes];
   // Check if it's a Microsoft Office clipboard data (it will have some namespaces defined in the root element)

--- a/packages/o-spreadsheet-engine/src/plugins/ui_stateful/clipboard.ts
+++ b/packages/o-spreadsheet-engine/src/plugins/ui_stateful/clipboard.ts
@@ -532,7 +532,6 @@ export class ClipboardPlugin extends UIPlugin {
   private getSheetData(): SpreadsheetClipboardData {
     const data = {
       version: getCurrentVersion(),
-      clipboardId: this.clipboardId,
     };
     if (this.copiedData && "figureId" in this.copiedData) {
       return data;
@@ -602,7 +601,9 @@ export class ClipboardPlugin extends UIPlugin {
       innerHTML = htmlTable;
     }
     const serializedData = JSON.stringify(this.getSheetData());
-    return `<div data-osheet-clipboard='${xmlEscape(serializedData)}'>${innerHTML}</div>`;
+    return `<div data-osheet-clipboard-id='${this.clipboardId}' data-osheet-clipboard='${xmlEscape(
+      serializedData
+    )}'>${innerHTML}</div>`;
   }
 
   private readFileAsDataURL(blob: Blob) {

--- a/src/actions/menu_items_actions.ts
+++ b/src/actions/menu_items_actions.ts
@@ -4,7 +4,10 @@ import {
   DEFAULT_FIGURE_WIDTH,
   PIVOT_MAX_NUMBER_OF_CELLS,
 } from "@odoo/o-spreadsheet-engine/constants";
-import { parseOSClipboardContent } from "@odoo/o-spreadsheet-engine/helpers/clipboard/clipboard_helpers";
+import {
+  getOSheetClipboardIdFromHTML,
+  parseOSClipboardContent,
+} from "@odoo/o-spreadsheet-engine/helpers/clipboard/clipboard_helpers";
 import {
   centerFigurePosition,
   getMaxFigureSize,
@@ -64,15 +67,15 @@ async function paste(env: SpreadsheetChildEnv, pasteOption?: ClipboardPasteOptio
   switch (osClipboard.status) {
     case "ok":
       const clipboardId = env.model.getters.getClipboardId();
-      const osClipboardContent = parseOSClipboardContent(osClipboard.content);
-      const osClipboardId = osClipboardContent.data?.clipboardId;
-
       const target = env.model.getters.getSelectedZones();
-
-      if (clipboardId !== osClipboardId) {
-        await interactivePasteFromOS(env, target, osClipboardContent, pasteOption);
-      } else {
+      const htmlClipboardId = getOSheetClipboardIdFromHTML(
+        osClipboard.content[ClipboardMIMEType.Html]
+      );
+      if (clipboardId === htmlClipboardId) {
         interactivePaste(env, target, pasteOption);
+      } else {
+        const osClipboardContent = parseOSClipboardContent(osClipboard.content);
+        await interactivePasteFromOS(env, target, osClipboardContent, pasteOption);
       }
       if (env.model.getters.isCutOperation() && pasteOption !== "asValue") {
         await env.clipboard.write({ [ClipboardMIMEType.PlainText]: "" });

--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -3,7 +3,10 @@ import {
   HEADER_HEIGHT,
   HEADER_WIDTH,
 } from "@odoo/o-spreadsheet-engine/constants";
-import { parseOSClipboardContent } from "@odoo/o-spreadsheet-engine/helpers/clipboard/clipboard_helpers";
+import {
+  getOSheetClipboardIdFromHTML,
+  parseOSClipboardContent,
+} from "@odoo/o-spreadsheet-engine/helpers/clipboard/clipboard_helpers";
 import { openLink } from "@odoo/o-spreadsheet-engine/helpers/links";
 import { isStaticTable } from "@odoo/o-spreadsheet-engine/helpers/table_helpers";
 import { AllowedImageMimeTypes } from "@odoo/o-spreadsheet-engine/types/image";
@@ -757,11 +760,13 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
     const isCutOperation = this.env.model.getters.isCutOperation();
 
     const clipboardId = this.env.model.getters.getClipboardId();
-    const osClipboardContent = parseOSClipboardContent(osClipboard.content);
-    const osClipboardId = osClipboardContent.data?.clipboardId;
-    if (clipboardId === osClipboardId) {
+    const htmlClipboardId = getOSheetClipboardIdFromHTML(
+      osClipboard.content[ClipboardMIMEType.Html]
+    );
+    if (clipboardId === htmlClipboardId) {
       interactivePaste(this.env, target);
     } else {
+      const osClipboardContent = parseOSClipboardContent(osClipboard.content);
       await interactivePasteFromOS(this.env, target, osClipboardContent);
     }
     if (isCutOperation) {

--- a/tests/clipboard/clipboard_plugin.test.ts
+++ b/tests/clipboard/clipboard_plugin.test.ts
@@ -1,6 +1,7 @@
 import { DEFAULT_BORDER_DESC, LINK_COLOR } from "@odoo/o-spreadsheet-engine/constants";
 import {
   getClipboardDataPositions,
+  getOSheetClipboardIdFromHTML,
   parseOSClipboardContent,
 } from "@odoo/o-spreadsheet-engine/helpers/clipboard/clipboard_helpers";
 import { urlRepresentation } from "@odoo/o-spreadsheet-engine/helpers/links";
@@ -580,8 +581,9 @@ describe("clipboard", () => {
       const osClipboardContent = await model.getters.getClipboardTextAndImageContent();
       const htmlContent = osClipboardContent[ClipboardMIMEType.Html]!;
       const cbPlugin = getPlugin(model, ClipboardPlugin);
+      const clipboardId = model.getters.getClipboardId();
       const clipboardData = JSON.stringify(cbPlugin["getSheetData"]());
-      const expectedHtmlContent = `<div data-osheet-clipboard='${xmlEscape(
+      const expectedHtmlContent = `<div data-osheet-clipboard-id='${clipboardId}' data-osheet-clipboard='${xmlEscape(
         clipboardData
       )}'><table border="1" style="border-collapse:collapse"><tr><td style="">1</td><td style="">2</td></tr><tr><td style="">3</td><td style=""></td></tr></table></div>`;
       expect(htmlContent).toBe(expectedHtmlContent);
@@ -656,10 +658,13 @@ describe("clipboard", () => {
       setCellContent(model, "A1", "1");
       copy(model, "A1");
       const cbPlugin = getPlugin(model, ClipboardPlugin);
+      const clipboardId = model.getters.getClipboardId();
       const clipboardData = JSON.stringify(cbPlugin["getSheetData"]());
       const osClipboardContent = await model.getters.getClipboardTextAndImageContent();
       expect(osClipboardContent[ClipboardMIMEType.Html]).toBe(
-        `<div data-osheet-clipboard='${xmlEscape(clipboardData)}'>1</div>`
+        `<div data-osheet-clipboard-id='${clipboardId}' data-osheet-clipboard='${xmlEscape(
+          clipboardData
+        )}'>1</div>`
       );
     });
   });
@@ -3175,6 +3180,16 @@ describe("cross spreadsheet copy/paste", () => {
     });
     pasteFromOSClipboard(modelB, "D2", content);
     expect(getCellContent(modelB, "D2")).toBe("newContent");
+  });
+
+  test("can extract o-spreadsheet clipboard id from HTML without parsing DOM", () => {
+    const clipboardId = "1234-uuid";
+    expect(
+      getOSheetClipboardIdFromHTML(
+        `<div data-osheet-clipboard-id='${clipboardId}' data-osheet-clipboard='{}'>x</div>`
+      )
+    ).toBe(clipboardId);
+    expect(getOSheetClipboardIdFromHTML(`<div data-osheet-clipboard='{}'>x</div>`)).toBeUndefined();
   });
 });
 

--- a/tests/grid/grid_component.test.ts
+++ b/tests/grid/grid_component.test.ts
@@ -1908,9 +1908,12 @@ describe("Copy paste keyboard shortcut", () => {
     const cbPlugin = getPlugin(model, ClipboardPlugin);
     //@ts-ignore
     const clipboardHtmlData = JSON.stringify(cbPlugin.getSheetData());
+    const clipboardId = model.getters.getClipboardId();
     expect(clipboardContent).toMatchObject({
       "text/plain": "things",
-      "text/html": `<div data-osheet-clipboard='${xmlEscape(clipboardHtmlData)}'>things</div>`,
+      "text/html": `<div data-osheet-clipboard-id='${clipboardId}' data-osheet-clipboard='${xmlEscape(
+        clipboardHtmlData
+      )}'>things</div>`,
     });
     selectCell(model, "A2");
     document.body.dispatchEvent(getClipboardEvent("paste", clipboardData));
@@ -1931,9 +1934,12 @@ describe("Copy paste keyboard shortcut", () => {
     const cbPlugin = getPlugin(model, ClipboardPlugin);
     //@ts-ignore
     const clipboardHtmlData = JSON.stringify(cbPlugin.getSheetData());
+    const clipboardId = model.getters.getClipboardId();
     expect(clipboardContent).toMatchObject({
       "text/plain": "things",
-      "text/html": `<div data-osheet-clipboard='${xmlEscape(clipboardHtmlData)}'>things</div>`,
+      "text/html": `<div data-osheet-clipboard-id='${clipboardId}' data-osheet-clipboard='${xmlEscape(
+        clipboardHtmlData
+      )}'>things</div>`,
     });
     selectCell(model, "A2");
     document.body.dispatchEvent(getClipboardEvent("paste", clipboardData));
@@ -2215,10 +2221,13 @@ describe("Copy paste keyboard shortcut", () => {
       const cbPlugin = getPlugin(model, ClipboardPlugin);
       //@ts-ignore
       const clipboardHtmlData = JSON.stringify(cbPlugin.getSheetData());
+      const clipboardId = model.getters.getClipboardId();
 
       expect(clipboardContent).toMatchObject({
         "text/plain": "\t",
-        "text/html": `<div data-osheet-clipboard='${xmlEscape(clipboardHtmlData)}'>\t</div>`,
+        "text/html": `<div data-osheet-clipboard-id='${clipboardId}' data-osheet-clipboard='${xmlEscape(
+          clipboardHtmlData
+        )}'>\t</div>`,
       });
     }
   );
@@ -2245,6 +2254,7 @@ describe("Copy paste keyboard shortcut", () => {
       const cbPlugin = getPlugin(model, ClipboardPlugin);
       //@ts-ignore
       const clipboardHtmlData = JSON.stringify(cbPlugin.getSheetData());
+      const clipboardId = model.getters.getClipboardId();
       //@ts-ignore
       const imgData = (await cbPlugin.readFileAsDataURL(
         new Blob([], { type: "image/png" })
@@ -2252,7 +2262,7 @@ describe("Copy paste keyboard shortcut", () => {
 
       expect(clipboardContent).toMatchObject({
         "text/plain": "\t",
-        "text/html": `<div data-osheet-clipboard='${xmlEscape(
+        "text/html": `<div data-osheet-clipboard-id='${clipboardId}' data-osheet-clipboard='${xmlEscape(
           clipboardHtmlData
         )}'><img src="${xmlEscape(imgData)}" /></div>`,
         "image/png": expect.any(Blob),


### PR DESCRIPTION
## Description:

Before this change, paste always parsed OS clipboard HTML (`DOMParser` + `JSON.parse`) to decide whether the paste was internal or external.

For internal paste, this is unnecessary because the spreadsheet clipboard data is already in memory after COPY/CUT. We only need a quick check to know if the OS clipboard still belongs to this spreadsheet instance.

This change uses a fast clipboard id check to detect internal paste and dispatch `PASTE` directly.

If the clipboard id does not match, we keep the existing fallback path and use `PASTE_FROM_OS_CLIPBOARD`.

Perf setup:
- `this.createModel(makeLargeDataset(26, 500, ["numbers"]))`
- 26x500 numeric dataset (no style/format)
- measured internal paste `A1:A500 -> A501:A1000` (`n=20`)

Paste (internal, A1:Z500 -> A501:Z1000)
- before: Mean: 983.98 ms, StdErr: 9.66 ms, n=20
- after:    Mean: 355.63 ms, StdErr: 4.63 ms, n=20 (-63.86%)

Task: [5959666](https://www.odoo.com/odoo/2328/tasks/5959666)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo