### PR TITLE
[IMP] export: squish consecutive numbers

### DIFF
--- a/packages/o-spreadsheet-engine/src/plugins/core/cell.ts
+++ b/packages/o-spreadsheet-engine/src/plugins/core/cell.ts
@@ -333,7 +333,7 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
       }
       _sheet.styles = groupItemIdsByZones(positionsByStyle);
       _sheet.formats = groupItemIdsByZones(positionsByFormat);
-      _sheet.cells = shouldSquish ? squisher.squishSheet(cells) : cells;
+      _sheet.cells = shouldSquish ? squisher.squishSheet(cells, _sheet.id) : cells;
     }
     data.styles = styles;
     data.formats = formats;

--- a/packages/o-spreadsheet-engine/src/plugins/core/squisher.ts
+++ b/packages/o-spreadsheet-engine/src/plugins/core/squisher.ts
@@ -42,6 +42,8 @@ export class Squisher {
   // whether the base formula was already transformed. Formulas that have already been transformed must continue to be transformed
   private baseFormulaWasTransformed: boolean = false;
 
+  private baseNumber: number | undefined = undefined;
+
   constructor(getters: CoreGetters) {
     this.getters = getters;
   }
@@ -84,10 +86,11 @@ export class Squisher {
     this.alreadyAppliedNumberOffsets = formula.literalValues.numbers.map((_) => 0);
     this.previousStrings = formula.literalValues.strings.map((x) => x.value);
     this.baseFormulaWasTransformed = false;
+    this.baseNumber = undefined;
   }
 
   /** Reset the base formula to undefined, resetting all offsets */
-  resetBase() {
+  resetBaseFormula() {
     if (this.baseFormula) {
       this.baseFormula = undefined;
       this.alreadyAppliedNumberOffsets = [];
@@ -110,42 +113,62 @@ export class Squisher {
    *     - for references: returns a relative change (+Ck or +Rk) if possible, else the full reference or "=" if unchanged
    * */
   squish(cell: Cell, forSheetId: UID): SquishedCell {
-    if (!cell.isFormula) {
-      this.resetBase();
-      return cell.content;
-    }
+    if (cell.isFormula) {
+      let numbers: string[] = [];
+      let strings: string[] = [];
+      let references: string[] = [];
 
-    let numbers: string[] = [];
-    let strings: string[] = [];
-    let references: string[] = [];
-
-    if (
-      !this.baseFormula ||
-      this.baseFormula.normalizedFormula !== cell.compiledFormula.normalizedFormula
-    ) {
-      this.resetBaseTo(cell.compiledFormula);
-      return cell.compiledFormula.toFormulaString(this.getters);
-    } else {
       if (
-        !this.baseFormulaWasTransformed &&
-        deepEquals(cell.compiledFormula.literalValues, this.baseFormula.literalValues) &&
-        deepEquals(cell.compiledFormula.rangeDependencies, this.baseFormula.rangeDependencies)
+        !this.baseFormula ||
+        this.baseFormula.normalizedFormula !== cell.compiledFormula.normalizedFormula
       ) {
+        this.resetBaseTo(cell.compiledFormula);
         return cell.compiledFormula.toFormulaString(this.getters);
+      } else {
+        if (
+          !this.baseFormulaWasTransformed &&
+          deepEquals(cell.compiledFormula.literalValues, this.baseFormula.literalValues) &&
+          deepEquals(cell.compiledFormula.rangeDependencies, this.baseFormula.rangeDependencies)
+        ) {
+          return cell.compiledFormula.toFormulaString(this.getters);
+        }
+        numbers = this.squishNumbers(cell.compiledFormula.literalValues.numbers);
+        strings = this.squishStrings(cell.compiledFormula.literalValues.strings);
+        references = this.squishReferences(cell.compiledFormula.rangeDependencies, forSheetId);
+        this.baseFormulaWasTransformed = true;
       }
-      numbers = this.squishNumbers(cell.compiledFormula.literalValues.numbers);
-      strings = this.squishStrings(cell.compiledFormula.literalValues.strings);
-      references = this.squishReferences(cell.compiledFormula.rangeDependencies, forSheetId);
-      this.baseFormulaWasTransformed = true;
+      return this.buildResult(numbers, strings, references);
     }
-    return this.buildResult(numbers, strings, references);
+
+    if (typeof cell.parsedValue === "number" && cell.parsedValue % 1 === 0) {
+      this.resetBaseFormula();
+      // for number cells, we can also apply squishing to get relative change if needed. We will treat them as formulas with only one number and no references or strings, and we will not set them as the base formula because they are not formulas.
+      const numberValue = cell.parsedValue;
+      if (this.baseNumber === undefined) {
+        this.baseNumber = numberValue;
+        return cell.content;
+      }
+      const numberOffset = numberValue - this.baseNumber;
+      if (numberOffset === 0) {
+        return cell.content;
+      } else {
+        this.baseNumber = numberValue;
+        return { N: (numberOffset > 0 ? "+" : "") + numberOffset.toString() };
+      }
+    }
+    this.resetBaseFormula();
+    this.baseNumber = undefined;
+    return cell.content;
   }
 
   /**
    * Read all the consecutive cells with either the same content or the same transformation and merge their key into one zone
    * Do not join cells from different columns
    * */
-  squishSheet(cells: { [key: string]: string | SquishedCell }): {
+  squishSheet(
+    cells: { [key: string]: string | SquishedCell },
+    sheetId: UID
+  ): {
     [key: string]: string | SquishedCell;
   } {
     const allKeys = Object.keys(cells);
@@ -171,7 +194,16 @@ export class Squisher {
         result[rangeKey] = cells[allKeys[startIndex]];
         startIndex += offset;
       } else {
-        result[allKeys[startIndex]] = cells[allKeys[startIndex]];
+        const originalCell = this.getters.getCell({
+          sheetId,
+          col: startKey.col,
+          row: startKey.row,
+        });
+        if (!originalCell?.isFormula && typeof originalCell?.parsedValue === "number") {
+          result[allKeys[startIndex]] = originalCell.content;
+        } else {
+          result[allKeys[startIndex]] = cells[allKeys[startIndex]];
+        }
       }
     }
 
@@ -269,14 +301,13 @@ export class Squisher {
   private squishNumbers(numbers: { value: number }[]) {
     const result: string[] = numbers.map((x) => NO_CHANGE);
     for (let i = 0; i < numbers.length; i++) {
-      const diff =
-        numbers[i].value -
-        (this.baseFormula!.literalValues.numbers[i].value + this.alreadyAppliedNumberOffsets[i] ||
-          0);
-
+      const previousValue = this.baseFormula!.literalValues.numbers[i].value;
+      const currentValue = numbers[i].value;
+      const previousOffset = this.alreadyAppliedNumberOffsets[i] || 0;
+      const diff = currentValue - (previousValue + previousOffset);
       if (diff !== 0) {
         result[i] = "+" + diff.toString();
-        this.alreadyAppliedNumberOffsets[i] = (this.alreadyAppliedNumberOffsets[i] || 0) + diff;
+        this.alreadyAppliedNumberOffsets[i] = previousOffset + diff;
       }
     }
     return result;

--- a/packages/o-spreadsheet-engine/src/plugins/core/unsquisher.ts
+++ b/packages/o-spreadsheet-engine/src/plugins/core/unsquisher.ts
@@ -1,7 +1,9 @@
 import { CompiledFormula } from "../../formulas/compiler";
 import { toCartesian } from "../../helpers/coordinates";
 import { expandRange, expandXc } from "../../helpers/expand_range";
+import { isNumber, parseNumber } from "../../helpers/numbers";
 import { CoreGetters } from "../../types/core_getters";
+import { DEFAULT_LOCALE } from "../../types/locale";
 import { Position, UID } from "../../types/misc";
 import { Range } from "../../types/range";
 import { NO_CHANGE, SEPARATOR, SquishedCell, SquishedFormula } from "./squisher";
@@ -9,9 +11,10 @@ import { NO_CHANGE, SEPARATOR, SquishedCell, SquishedFormula } from "./squisher"
 type UnsquishMethod =
   | "NOT_A_FORMULA"
   | "NEW_FORMULA"
-  | "COMBINE_OFFSET"
+  | "NEW_NUMBER"
   | "FIRST_OFFSET"
-  | "NO_CHANGE";
+  | "COMBINE_OFFSET"
+  | "OFFSET_NUMBER";
 
 export class Unsquisher {
   private previousCell: CompiledFormula | undefined;
@@ -19,6 +22,16 @@ export class Unsquisher {
   private previousString: string[] = [];
   private alreadyAppliedReferenceOffset: Range[] = [];
   private previousOffset: SquishedFormula | undefined = undefined;
+  private previousNumber: number | undefined = undefined;
+
+  rebase() {
+    this.previousCell = undefined;
+    this.alreadyAppliedNumberOffset = [];
+    this.previousString = [];
+    this.alreadyAppliedReferenceOffset = [];
+    this.previousOffset = undefined;
+    this.previousNumber = undefined;
+  }
 
   /**
    * Expands a squished sheet object back to a full cell map.
@@ -67,19 +80,34 @@ export class Unsquisher {
           this.previousString = compiled.literalValues.strings.map((s) => s.value);
           this.alreadyAppliedReferenceOffset = [...compiled.rangeDependencies];
           this.previousOffset = undefined;
+          this.previousNumber = undefined;
+        } else if (isNumber(current, DEFAULT_LOCALE)) {
+          strategy = "NEW_NUMBER";
+          this.rebase();
+          this.previousNumber = parseNumber(current, DEFAULT_LOCALE);
         } else {
+          this.rebase();
           strategy = "NOT_A_FORMULA";
         }
       } else {
         // the current cell is an object, let's see if there is a transformation
         if (current.N || current.S || current.R) {
-          if (!strategy || strategy === "NEW_FORMULA") {
-            strategy = "FIRST_OFFSET";
-          } else {
-            strategy = "COMBINE_OFFSET";
+          switch (strategy) {
+            case "NEW_FORMULA":
+              strategy = "FIRST_OFFSET";
+              break;
+            case "NEW_NUMBER":
+              if (current.R || current.S) {
+                throw new Error(
+                  "Invalid squished format: cannot have string or reference offsets for a number"
+                );
+              }
+              strategy = "OFFSET_NUMBER";
+              break;
+            case "FIRST_OFFSET":
+              strategy = "COMBINE_OFFSET";
+              break;
           }
-        } else {
-          strategy = "NO_CHANGE";
         }
       }
 
@@ -87,7 +115,6 @@ export class Unsquisher {
       const positionsOfKey = parts.length === 1 ? expandXc(key) : expandRange(parts[0], parts[1]);
       switch (strategy) {
         case "NEW_FORMULA":
-        case "NO_CHANGE":
           for (const position of positionsOfKey) {
             yield { position, compiled: this.previousCell };
           }
@@ -118,6 +145,30 @@ export class Unsquisher {
           for (const position of positionsOfKey) {
             const result = this.unsquish(this.previousOffset, sheetId, getters);
             yield { position, compiled: result };
+          }
+          break;
+        case "NEW_NUMBER":
+          for (const position of positionsOfKey) {
+            yield { position, content: current as string | undefined };
+          }
+          break;
+        case "OFFSET_NUMBER":
+          /*A2:A15 : {N: "+1"}*/
+          const offset = (current as SquishedFormula).N;
+          if (offset === undefined || this.previousNumber === undefined) {
+            throw new Error(
+              `No ${offset} provided for OFFSET_NUMBER strategy, previous ${
+                this.previousNumber
+              } for ${JSON.stringify(current)} ${sheetId} ${key}`
+            );
+          }
+          const offsetValue = parseFloat(offset);
+
+          for (const position of positionsOfKey) {
+            yield {
+              position,
+              content: (this.previousNumber += offsetValue).toString(),
+            };
           }
           break;
       }

--- a/tests/model/squish.test.ts
+++ b/tests/model/squish.test.ts
@@ -54,8 +54,7 @@ describe("squish - unsquish", () => {
           A5: '=IF(AND(F20819<=Sheet1!$M$1,F20819>=Sheet1!$L$1),IFERROR(MID(C20819,SEARCH("(",C20819)+1,SEARCH(")",C20819)-SEARCH("(",C20819)-1),""))',
           "A6:A7": { N: "=|=", R: "+R1|=|+R1|=|+R1|+R1|+R1|+R1", S: ["=", "=", "=", "="] },
           B1: "1",
-          B2: "2",
-          B3: "3",
+          "B2:B3": { N: "+1" },
           C1: "=B1",
           "C2:C3": { R: "+R1" },
           C4: "=B4+2",
@@ -426,6 +425,115 @@ describe("squish - unsquish specific cases", () => {
     ],
   ])(
     "same formulas at following positions are grouped on the same range %s",
+    (sheetContent, squishedContent) => {
+      const model = createModelFromGrid(sheetContent);
+      const exportSquished = model._exportData(true);
+      expect(exportSquished.sheets[0].cells).toEqual(squishedContent);
+
+      const importedFromSquished = new Model(exportSquished);
+      const exportUnSquished = importedFromSquished._exportData(false);
+      expect(exportUnSquished.sheets[0].cells).toEqual(sheetContent);
+    }
+  );
+
+  test.each([
+    // identical numbers
+    [
+      { A1: "14", A2: "14", A3: "14", B1: "14" },
+      { "A1:A3": "14", B1: "14" },
+    ],
+    // identical transformations
+    [
+      { A1: "14", A2: "15", A3: "16" },
+      { A1: "14", "A2:A3": { N: "+1" } },
+    ],
+    // identical transformations and positions not following each other
+    [
+      { A1: "14", A2: "15", A4: "16", A5: "17" },
+      { A1: "14", A2: "15", "A4:A5": { N: "+1" } },
+    ],
+
+    // numbers followed by string (not formula) followed by same formula interrupt squishing
+    [
+      { A1: "14", A2: "coucou", A3: "15" },
+      { A1: "14", A2: "coucou", A3: "15" },
+    ],
+    [
+      { A1: "=14", A2: "coucou", A3: "=15" },
+      { A1: "=14", A2: "coucou", A3: "=15" },
+    ],
+    [
+      { A1: "14", A2: "coucou", B1: "14" },
+      { A1: "14", A2: "coucou", B1: "14" },
+    ],
+    [
+      { A1: "14", B1: "coucou", B2: "15" },
+      { A1: "14", B1: "coucou", B2: "15" },
+    ],
+
+    // numbers followed by formula followed by same number should not be squished
+    [
+      { A1: "14", A2: "=SUM(B1)", A3: "14" },
+      { A1: "14", A2: "=SUM(B1)", A3: "14" },
+    ],
+    [
+      { A1: "14", B1: "=SUM(B1)", B2: "14" },
+      { A1: "14", B1: "=SUM(B1)", B2: "14" },
+    ],
+    [
+      { A1: "=1", A2: "=2", A3: "=3", A4: "=4" },
+      { A1: "=1", "A2:A4": { N: "+1" } },
+    ],
+    // numbers who are not formulas are also squished if there is a pattern
+    [
+      { A1: "1", A2: "2", A3: "3", A4: "4" },
+      { A1: "1", "A2:A4": { N: "+1" } },
+    ],
+    // numbers that would be squished on only 1 cell are not squished
+    [
+      { A1: "1", A2: "2", A3: "5", A4: "10" },
+      { A1: "1", A2: "2", A3: "5", A4: "10" },
+    ],
+    // numbers interleaved with formulas are not squished
+    [
+      { A1: "1", A2: "=2", A3: "3", A4: "=4" },
+      { A1: "1", A2: "=2", A3: "3", A4: "=4" },
+    ],
+    // numbers interleaved with strings are not squished
+    [
+      { A1: "1", A2: "hello", A3: "3", A4: "4" },
+      { A1: "1", A2: "hello", A3: "3", A4: "4" },
+    ],
+    // formulas that are numbers followed by actual numbers are not mixed together
+    [
+      { A1: "=1", A2: "=2", A3: "3", A4: "4", A5: "5" },
+      { A1: "=1", A2: { N: "+1" }, A3: "3", "A4:A5": { N: "+1" } },
+    ],
+    // decimal numbers are not squished
+    [
+      { A1: "1", A2: "1.25", A3: "1.5", A4: "1.75" },
+      { A1: "1", A2: "1.25", A3: "1.5", A4: "1.75" },
+    ],
+    [
+      { A1: "=1", A2: "1.25", A3: "=2" },
+      { A1: "=1", A2: "1.25", A3: "=2" },
+    ],
+    // number squishing with 0
+    [
+      { A1: "0", A2: "1", A3: "2", A4: "3" },
+      { A1: "0", "A2:A4": { N: "+1" } },
+    ],
+    [
+      { A1: "-2", A2: "0", A3: "2", A4: "4" },
+      { A1: "-2", "A2:A4": { N: "+2" } },
+    ],
+    // number followed by decimal followed by numbers that would be squished should not squish
+    [
+      { A1: "1", A2: "1.5", A3: "2", A4: "3" },
+      { A1: "1", A2: "1.5", A3: "2", A4: "3" }, // No squish, A2 split the sequence
+    ],
+  ])(
+    "compress numbers at following positions are grouped on the same range %s",
     (sheetContent, squishedContent) => {
       const model = createModelFromGrid(sheetContent);
       const exportSquished = model._exportData(true);


### PR DESCRIPTION
When snapshotting a spreadsheet, we collapse all the numbers that are
the same or the same increment into a single entry in the JSON.

Example:
Before:
{
    "A1": 1,
    "A2": 3,
    "A3": 5,
    "A4": 7,
    "A5": 9,
}
After:
{
    "A1": 1,
    "A2:A5": "+2",
}


Task: 5959334
## Description:

Task: [5959334](https://www.odoo.com/odoo/2328/tasks/5959334)
