### PR TITLE
[FIX] spreadsheet: fix zoomable chart cursor

### DIFF
--- a/src/components/figures/chart/chartJs/zoomable_chart/zoomable_chartjs.ts
+++ b/src/components/figures/chart/chartJs/zoomable_chart/zoomable_chartjs.ts
@@ -455,6 +455,7 @@ export class ZoomableChartJsComponent extends ChartJsComponent {
       }
       this.updateAxisLimits(min, max);
       this.mode = undefined;
+      this.updateMasterChartCursor(ev);
     };
     this.removeEventListeners = () => {
       window.removeEventListener("pointermove", onMasterChartDrag, true);
@@ -465,7 +466,7 @@ export class ZoomableChartJsComponent extends ChartJsComponent {
     window.addEventListener("pointerup", onMasterChartPointerUp, true);
   }
 
-  onMasterChartPointerMove(ev: PointerEvent) {
+  updateMasterChartCursor(ev: PointerEvent) {
     const { offsetX: x, offsetY: y, target } = ev;
     if (!target || !this.isMasterChartAllowed) {
       return;

--- a/src/components/figures/chart/chartJs/zoomable_chart/zoomable_chartjs.xml
+++ b/src/components/figures/chart/chartJs/zoomable_chart/zoomable_chartjs.xml
@@ -13,7 +13,7 @@
           t-ref="masterChartCanvas"
           t-on-dblclick="onMasterChartDoubleClick"
           t-on-pointerdown="onMasterChartPointerDown"
-          t-on-pointermove="onMasterChartPointerMove"
+          t-on-pointermove="updateMasterChartCursor"
           t-on-mouseleave="onMasterChartMouseLeave"
         />
       </div>


### PR DESCRIPTION
## Commit Description

This PR aims to fix the display of the cursor for the pointer in the chart zoom slicer, which was only updated when moving the cursor on it.

## Related Task

- Task: 5012198

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo