### PR TITLE
[IMP] table : "autofill auto" option

### DIFF
--- a/src/components/side_panel/table_panel/table_panel.xml
+++ b/src/components/side_panel/table_panel/table_panel.xml
@@ -84,9 +84,10 @@
         <Checkbox
           label="getCheckboxLabel('automaticAutofill')"
           name="'automaticAutofill'"
-          value="tableConfig.automaticAutofill"
+          value="tableConfig.automaticAutofill and props.table.type !== 'dynamic'"
           onChange="(val) => this.updateTableConfig('automaticAutofill', val)"
           className="'mb-1'"
+          disabled="props.table.type === 'dynamic'"
         />
         <div class="d-flex flex-row align-items-center">
           <Checkbox

--- a/tests/table/table_panel_component.test.ts
+++ b/tests/table/table_panel_component.test.ts
@@ -258,6 +258,18 @@ describe("Table side panel", () => {
     expect(fixture.querySelector(".o-table-panel")).toBeNull();
   });
 
+  test("automaticAutofill checkbox is disabled when the table is dynamic", async () => {
+    setCellContent(model, "A1", "=MUNIT(3)");
+    await nextTick();
+    expect(
+      fixture.querySelector<HTMLInputElement>(`input[name="automaticAutofill"]`)?.disabled
+    ).toBeFalsy();
+    await click(fixture, "input[name='isDynamic']");
+    expect(
+      fixture.querySelector<HTMLInputElement>(`input[name="automaticAutofill"]`)?.disabled
+    ).toBeTruthy();
+  });
+
   test("IsDynamic checkbox is disabled when the table cannot be dynamic", async () => {
     expect(
       fixture.querySelector<HTMLInputElement>(`input[name="isDynamic"]`)?.disabled


### PR DESCRIPTION
The option is disabled if the table is dynamic

Task: [5959986](https://www.odoo.com/odoo/2328/tasks/5959986)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo