### PR TITLE
[FIX] selection_input: disable spill references

### DIFF
--- a/packages/o-spreadsheet-engine/src/plugins/ui_stateful/selection.ts
+++ b/packages/o-spreadsheet-engine/src/plugins/ui_stateful/selection.ts
@@ -452,9 +452,13 @@ export class GridSelectionPlugin extends UIPlugin {
   /**
    * Same as `getRangeString` but add:
    * - all necessary merge to the range to make it a valid selection
-   * - the "#" suffix if the range is a spilled reference
+   * - the "#" suffix if the range is a spilled reference if `allowSpilledReferences` is true
    */
-  getSelectionRangeString(range: Range, forSheetId: UID): string {
+  getSelectionRangeString(
+    range: Range,
+    forSheetId: UID,
+    { allowSpilledReferences } = { allowSpilledReferences: false }
+  ): string {
     const expandedZone = this.getters.expandZone(range.sheetId, range.zone);
     const expandedRange = createRange(
       {
@@ -473,17 +477,20 @@ export class GridSelectionPlugin extends UIPlugin {
       return getFullReference(sheetName, xc.split(":")[0]);
     }
 
-    const spreaderPosition = this.getters.getArrayFormulaSpreadingOn({
-      sheetId: expandedRange.sheetId,
-      col: expandedRange.zone.left,
-      row: expandedRange.zone.top,
-    });
+    if (allowSpilledReferences) {
+      const spreaderPosition = this.getters.getArrayFormulaSpreadingOn({
+        sheetId: expandedRange.sheetId,
+        col: expandedRange.zone.left,
+        row: expandedRange.zone.top,
+      });
 
-    const spreadZone =
-      spreaderPosition && this.getters.getSpreadZone(spreaderPosition, { ignoreSpillError: true });
-    if (spreadZone && isEqual(spreadZone, expandedRange.zone)) {
-      const { sheetName, xc } = splitReference(rangeString);
-      return getFullReference(sheetName, xc.split(":")[0]) + "#";
+      const spreadZone =
+        spreaderPosition &&
+        this.getters.getSpreadZone(spreaderPosition, { ignoreSpillError: true });
+      if (spreadZone && isEqual(spreadZone, expandedRange.zone)) {
+        const { sheetName, xc } = splitReference(rangeString);
+        return getFullReference(sheetName, xc.split(":")[0]) + "#";
+      }
     }
 
     return rangeString;

--- a/src/components/composer/composer/abstract_composer_store.ts
+++ b/src/components/composer/composer/abstract_composer_store.ts
@@ -595,13 +595,17 @@ export abstract class AbstractComposerStore extends SpreadsheetStore {
     const inputSheetId = this.sheetId;
     const sheetId = this.getters.getActiveSheetId();
     const range = this.getters.getRangeFromZone(sheetId, zone);
-    return this.getters.getSelectionRangeString(range, inputSheetId);
+    return this.getters.getSelectionRangeString(range, inputSheetId, {
+      allowSpilledReferences: true,
+    });
   }
 
   private getRangeReference(range: Range, fixedParts: Readonly<RangePart[]>) {
     const _fixedParts = [...fixedParts];
     const newRange = { ...range, parts: _fixedParts };
-    return this.getters.getSelectionRangeString(newRange, this.sheetId);
+    return this.getters.getSelectionRangeString(newRange, this.sheetId, {
+      allowSpilledReferences: true,
+    });
   }
 
   /**

--- a/tests/selection_input/selection_input_store.test.ts
+++ b/tests/selection_input/selection_input_store.test.ts
@@ -92,6 +92,15 @@ describe("selection input plugin", () => {
     expect(highlightedZones(container)).toStrictEqual(["A2:A4"]);
   });
 
+  test("selecting the range of a spilled formula does not create a spill reference", () => {
+    const { store, model } = makeStore(SelectionInputStore);
+    setCellContent(model, "A1", "=MUNIT(2)");
+    store.focusById(idOfRange(store, 0));
+    setSelection(model, ["A1:B2"]);
+    expect(store.selectionInputs[0].xc).not.toBe("A1#");
+    expect(store.selectionInputs[0].xc).toBe("A1:B2");
+  });
+
   test("focus input which is already focused", () => {
     const { store } = makeStore(SelectionInputStore);
     store.focusById(idOfRange(store, 0));


### PR DESCRIPTION
## Description

The selection input were replacing classical range strings with spilled references (eg. `A1#`), but those type of ranges are not supported in side panels/charts/pivots/etc..

This commit disable spilled references in selection inputs, we'll see in the future is we want to support them or not.

Task: [5945112](https://www.odoo.com/odoo/2328/tasks/5945112)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo