### PR TITLE
[FIX] xlsx: do not export dynamic tables to excel

### DIFF
--- a/src/plugins/ui_core_views/dynamic_tables.ts
+++ b/src/plugins/ui_core_views/dynamic_tables.ts
@@ -1,12 +1,15 @@
 import {
   areZonesContinuous,
   deepEquals,
+  getItemId,
   getZoneArea,
   isInside,
+  isObjectEmptyRecursive,
   overlap,
+  positions,
+  toXC,
   toZone,
   union,
-  zoneToXc,
 } from "../../helpers";
 import { createFilter } from "../../helpers/table_helpers";
 import {
@@ -14,6 +17,7 @@ import {
   Command,
   CoreTable,
   DynamicTable,
+  ExcelTableData,
   ExcelWorkbookData,
   Filter,
   FilterId,
@@ -221,19 +225,57 @@ export class DynamicTablesPlugin extends UIPlugin {
     return tableId + "_" + tableCol;
   }
 
+  /** Check if a table contains array formula, as we cannot have them in a table in Excel */
+  private isTableExcelExportable(sheetId: UID, table: CoreTable): boolean {
+    if (table.type === "dynamic") {
+      return false;
+    }
+
+    return !positions(table.range.zone).some((position) =>
+      this.getters.getArrayFormulaSpreadingOn({ sheetId, ...position })
+    );
+  }
+
   exportForExcel(data: ExcelWorkbookData) {
     for (const sheet of data.sheets) {
+      const exportedTables: ExcelTableData[] = [];
       for (const tableData of sheet.tables) {
         const zone = toZone(tableData.range);
         const topLeft = { sheetId: sheet.id, col: zone.left, row: zone.top };
         const coreTable = this.getters.getCoreTable(topLeft);
         const table = this.getTable(topLeft);
 
-        if (coreTable?.type !== "dynamic" || !table) {
+        if (!coreTable || !table || this.isTableExcelExportable(sheet.id, coreTable)) {
+          exportedTables.push(tableData);
           continue;
         }
-        tableData.range = zoneToXc(table.range.zone);
+        sheet.styles = sheet.styles || {};
+        sheet.borders = sheet.borders || {};
+
+        for (const position of positions(table.range.zone)) {
+          const cellPosition = { sheetId: sheet.id, ...position };
+          const style = this.getters.getCellComputedStyle(cellPosition);
+          const border = this.getters.getCellComputedBorder(cellPosition);
+          const xc = toXC(position.col, position.row);
+          const cell = sheet.cells?.[xc] || { value: "", isFormula: false };
+          if (!sheet.cells[xc]) {
+            sheet.cells[xc] = cell;
+          }
+
+          if (!isObjectEmptyRecursive(style)) {
+            const styleId = getItemId(style, data.styles);
+            sheet.styles[xc] = styleId;
+            cell.style = styleId;
+          }
+
+          if (border) {
+            const borderId = getItemId(border, data.borders);
+            sheet.borders[xc] = borderId;
+            cell.border = borderId;
+          }
+        }
       }
+      sheet.tables = exportedTables;
     }
   }
 }

--- a/tests/table/dynamic_table_plugin.test.ts
+++ b/tests/table/dynamic_table_plugin.test.ts
@@ -1,4 +1,4 @@
-import { Model } from "../../src";
+import { BorderDescr, Model } from "../../src";
 import { toZone, zoneToXc } from "../../src/helpers";
 import { UID } from "../../src/types";
 import {
@@ -239,12 +239,50 @@ describe("Dynamic tables", () => {
       expect(getTables(model, sheetId)).toMatchObject([{ zone: "A1:B2" }]);
     });
 
-    test("Dynamic tables are transformed into static tables when exporting for excel", () => {
-      setCellContent(model, "A1", "=MUNIT(3)");
-      createDynamicTable(model, "A1");
+    test("Dynamic table is exported as individual cell style", async () => {
+      setCellContent(model, "A1", "=MUNIT(2)");
+      createDynamicTable(model, "A1", { styleId: "TableStyleLight8" });
 
       const exported = getExportedExcelData(model);
-      expect(exported.sheets[0].tables).toMatchObject([{ range: "A1:C3" }]);
+      const sheetData = exported.sheets[0];
+      expect(sheetData.tables).toHaveLength(0);
+      expect(exported.styles).toEqual({
+        "1": { fillColor: "#000000", textColor: "#FFFFFF", bold: true },
+      });
+      const border: BorderDescr = { color: "#000000", style: "thin" };
+      expect(exported.borders).toEqual({
+        "1": { top: border, left: border, bottom: border },
+        "2": { top: border, bottom: border, right: border },
+      });
+
+      expect(sheetData.cells).toMatchObject({
+        A1: { border: 1, style: 1 },
+        A2: { border: 1 },
+        B1: { border: 2, style: 1 },
+        B2: { border: 2 },
+      });
+      expect(sheetData.cells["A2"]).not.toHaveProperty("style");
+      expect(sheetData.cells["B2"]).not.toHaveProperty("style");
+
+      expect(sheetData.borders).toEqual({ A1: 1, A2: 1, B1: 2, B2: 2 });
+      expect(sheetData.styles).toEqual({ A1: 1, B1: 1 });
+    });
+
+    test("Tables that contains an array formula are also exported as individual cell styles", async () => {
+      setCellContent(model, "A2", "=MUNIT(2)");
+      createTable(model, "A1:B3", { styleId: "TableStyleLight8" });
+
+      const exported = getExportedExcelData(model);
+      const sheetData = exported.sheets[0];
+      expect(sheetData.tables).toHaveLength(0);
+      expect(exported.styles).toEqual({
+        "1": { fillColor: "#000000", textColor: "#FFFFFF", bold: true },
+      });
+
+      expect(sheetData.cells).toMatchObject({
+        A1: { style: 1 },
+        B1: { style: 1 },
+      });
     });
   });
 });


### PR DESCRIPTION
## Description

Excel does not support array formulas inside tables. With this commit, if a table contains an array formula, it will not be exported to excel but be exported as individual cell styles instead.

Task: [5214240](https://www.odoo.com/odoo/2328/tasks/5214240)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo