### PR TITLE
[FIX] pivot: can add the same granularity

### DIFF
--- a/src/components/side_panel/pivot/pivot_side_panel/pivot_side_panel_store.ts
+++ b/src/components/side_panel/pivot/pivot_side_panel/pivot_side_panel_store.ts
@@ -241,8 +241,7 @@ export class PivotSidePanelStore extends SpreadsheetStore {
     for (const dimension of columnsWithGranularity.concat(rowsWithGranularity)) {
       const fieldType = fields[dimension.fieldName]?.type;
       if ((fieldType === "date" || fieldType === "datetime") && !dimension.granularity) {
-        const granularity =
-          unusedGranularities[dimension.fieldName]?.values().next().value || "year";
+        const granularity = unusedGranularities[dimension.fieldName]?.values().next().value;
         unusedGranularities[dimension.fieldName]?.delete(granularity);
         dimension.granularity = granularity;
       }
@@ -272,7 +271,7 @@ export class PivotSidePanelStore extends SpreadsheetStore {
       );
     }
     for (const field of dateFields) {
-      granularitiesPerFields[field.fieldName].delete(field.granularity || "month");
+      granularitiesPerFields[field.fieldName].delete(field.granularity);
     }
     return granularitiesPerFields;
   }

--- a/src/helpers/pivot/pivot_registry.ts
+++ b/src/helpers/pivot/pivot_registry.ts
@@ -52,11 +52,18 @@ const dateGranularities = [
   "day_of_week",
 ];
 
+export const datetimeGranularities = [
+  ...dateGranularities,
+  "hour_number",
+  "minute_number",
+  "second_number",
+];
+
 pivotRegistry.add("SPREADSHEET", {
   ui: SpreadsheetPivot,
   definition: SpreadsheetPivotRuntimeDefinition,
   dateGranularities: [...dateGranularities],
-  datetimeGranularities: [...dateGranularities, "hour_number", "minute_number", "second_number"],
+  datetimeGranularities: [...datetimeGranularities],
   isMeasureCandidate: (field: PivotField) => !["datetime", "boolean"].includes(field.type),
   isGroupable: () => true,
   adaptRanges: (getters, definition, applyChange) => {

--- a/tests/pivots/spreadsheet_pivot/spreadsheet_pivot_side_panel.test.ts
+++ b/tests/pivots/spreadsheet_pivot/spreadsheet_pivot_side_panel.test.ts
@@ -1,6 +1,7 @@
 import { Model, SpreadsheetChildEnv } from "../../../src";
 import { PIVOT_TABLE_CONFIG } from "../../../src/constants";
 import { toXC, toZone } from "../../../src/helpers";
+import { datetimeGranularities } from "../../../src/helpers/pivot/pivot_registry";
 import { SpreadsheetPivot } from "../../../src/helpers/pivot/spreadsheet_pivot/spreadsheet_pivot";
 import { topbarMenuRegistry } from "../../../src/registries";
 import { NotificationStore } from "../../../src/stores/notification_store";
@@ -468,6 +469,43 @@ describe("Spreadsheet pivot side panel", () => {
       { fieldName: "Date", granularity: "year" },
       { fieldName: "Date", granularity: "quarter_number" },
     ]);
+  });
+
+  test("All granularities are displayed in order and not more than once", async () => {
+    setCellContent(model, "G1", "=PIVOT(1)"); // TODO: remove once task 4781740 is done
+    setCellContent(model, "A1", "Date");
+    setCellContent(model, "A2", "2023-01-01");
+    setCellContent(model, "A3", "2023-01-02");
+    updatePivot(model, "1", {
+      columns: [],
+      measures: [{ id: "Amount:sum", fieldName: "Amount", aggregator: "sum" }],
+    });
+    await nextTick();
+
+    for (let i = 0; i < datetimeGranularities.length; i++) {
+      await click(fixture.querySelector(".add-dimension")!);
+      await click(fixture.querySelectorAll(".o-autocomplete-value")[0]);
+    }
+
+    expect(model.getters.getPivotCoreDefinition("1").columns).toMatchObject([
+      { fieldName: "Date", granularity: "year" },
+      { fieldName: "Date", granularity: "quarter_number" },
+      { fieldName: "Date", granularity: "month_number" },
+      { fieldName: "Date", granularity: "month" },
+      { fieldName: "Date", granularity: "iso_week_number" },
+      { fieldName: "Date", granularity: "day_of_month" },
+      { fieldName: "Date", granularity: "day" },
+      { fieldName: "Date", granularity: "day_of_week" },
+      { fieldName: "Date", granularity: "hour_number" },
+      { fieldName: "Date", granularity: "minute_number" },
+      { fieldName: "Date", granularity: "second_number" },
+    ]);
+
+    await click(fixture.querySelector(".add-dimension")!);
+    const availableFields = [...fixture.querySelectorAll(".o-autocomplete-value")].map(
+      (el) => el.textContent
+    );
+    expect(availableFields).not.toContain("Date");
   });
 
   test("Date dimensions with undefined granularity is correctly displayed as month", async () => {


### PR DESCRIPTION
we can add multiple time the same date granularity
 it shouldn't be possible

Task: [5949522](https://www.odoo.com/odoo/2328/tasks/5949522)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo