### PR TITLE
[FIX] xlsx: export formula that returns an error

### DIFF
--- a/src/plugins/ui_core_views/cell_evaluation/evaluation_plugin.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluation_plugin.ts
@@ -1,6 +1,7 @@
 import { isExportableToExcel } from "../../../formulas/index";
 import { matrixMap } from "../../../functions/helpers";
 import { getItemId, positions, toXC } from "../../../helpers/index";
+import { CellErrorType } from "../../../types/errors";
 import {
   CellPosition,
   CellValue,
@@ -383,7 +384,10 @@ export class EvaluationPlugin extends CoreViewPlugin {
         content = !isExported ? newContent : exportedCellData;
       }
       exportedSheetData.cells[xc] = content;
-      exportedSheetData.cellValues[xc] = evaluatedCell.type !== "error" ? value : undefined;
+      // Don't export #BAD_EXPR as a formula because it's not a valid formula.
+      // Export it as a string instead, which is also what Excel will do when
+      // it encounters a formula with a syntax error.
+      exportedSheetData.cellValues[xc] = value === CellErrorType.BadExpression ? undefined : value;
       const spillZone = this.getSpreadZone(position);
       if (spillZone) {
         exportedSheetData.formulaSpillRanges[xc] = this.getters.getRangeString(

--- a/tests/xlsx/__snapshots__/xlsx_export.test.ts.snap
+++ b/tests/xlsx/__snapshots__/xlsx_export.test.ts.snap
@@ -24872,9 +24872,12 @@ exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Simple model 
             </c>
         </row>
         <row r="39">
-            <c r="A39" t="s">
+            <c r="A39" cm="1" t="str">
+                <f t="array" ref="A39">
+                    A39
+                </f>
                 <v>
-                    27
+                    #CYCLE
                 </v>
             </c>
         </row>
@@ -24889,9 +24892,12 @@ exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Simple model 
             </c>
         </row>
         <row r="41">
-            <c r="A41" t="s">
+            <c r="A41" cm="1" t="str">
+                <f t="array" ref="A41">
+                    #REF!+5
+                </f>
                 <v>
-                    28
+                    #REF!
                 </v>
             </c>
         </row>
@@ -25156,7 +25162,7 @@ exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Simple model 
       "path": "xl/styles.xml",
     },
     {
-      "content": "<sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" count="29" uniqueCount="29">
+      "content": "<sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" count="27" uniqueCount="27">
     <si>
         <t>
             Owl is awesome
@@ -25290,16 +25296,6 @@ exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Simple model 
     <si>
         <t>
             test 'single quot'
-        </t>
-    </si>
-    <si>
-        <t>
-            =A39
-        </t>
-    </si>
-    <si>
-        <t>
-            =#REF + 5
         </t>
     </si>
 </sst>",
@@ -30275,9 +30271,12 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             </c>
         </row>
         <row r="162">
-            <c r="A162" t="s">
+            <c r="A162" cm="1" t="str">
+                <f t="array" ref="A162">
+                    NA()
+                </f>
                 <v>
-                    20
+                    #N/A
                 </v>
             </c>
         </row>
@@ -30420,7 +30419,7 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
       "path": "xl/styles.xml",
     },
     {
-      "content": "<sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" count="21" uniqueCount="21">
+      "content": "<sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" count="20" uniqueCount="20">
     <si>
         <t>
             evaluation
@@ -30519,11 +30518,6 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
     <si>
         <t>
             &gt;25
-        </t>
-    </si>
-    <si>
-        <t>
-            =NA()
         </t>
     </si>
 </sst>",
@@ -30829,9 +30823,12 @@ exports[`Test XLSX export formulas All non-exportable formulas 1`] = `
             </c>
         </row>
         <row r="23">
-            <c r="A23" t="s">
+            <c r="A23" cm="1" t="str">
+                <f t="array" ref="A23">
+                    SUM(A3:A100)
+                </f>
                 <v>
-                    0
+                    #CYCLE
                 </v>
             </c>
         </row>
@@ -31219,12 +31216,7 @@ exports[`Test XLSX export formulas All non-exportable formulas 1`] = `
       "path": "xl/styles.xml",
     },
     {
-      "content": "<sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" count="1" uniqueCount="1">
-    <si>
-        <t>
-            =SUM(A3:A100)
-        </t>
-    </si>
+      "content": "<sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" count="0" uniqueCount="0">
 </sst>",
       "contentType": "sharedStrings",
       "path": "xl/sharedStrings.xml",
@@ -33502,9 +33494,12 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             </c>
         </row>
         <row r="162">
-            <c r="A162" t="s">
+            <c r="A162" cm="1" t="str">
+                <f t="array" ref="A162">
+                    NA()
+                </f>
                 <v>
-                    20
+                    #N/A
                 </v>
             </c>
         </row>
@@ -33698,7 +33693,7 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
       "path": "xl/styles.xml",
     },
     {
-      "content": "<sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" count="21" uniqueCount="21">
+      "content": "<sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" count="20" uniqueCount="20">
     <si>
         <t>
             evaluation
@@ -33797,11 +33792,6 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
     <si>
         <t>
             &gt;25
-        </t>
-    </si>
-    <si>
-        <t>
-            =NA()
         </t>
     </si>
 </sst>",

--- a/tests/xlsx/xlsx_export.test.ts
+++ b/tests/xlsx/xlsx_export.test.ts
@@ -1066,6 +1066,20 @@ describe("Test XLSX export", () => {
       });
       expect(await exportPrettifiedXlsx(model)).toMatchSnapshot();
     });
+
+    test("#BAD_EXPR formula is exported as a string, not a formula", async () => {
+      const model = new Model();
+      setCellContent(model, "A1", "=THISISBAD())))");
+      const xlsx = await exportPrettifiedXlsx(model);
+      const sheetFile = xlsx.files.find((file) => file.path === "xl/worksheets/sheet0.xml");
+      const stringsFile = xlsx.files.find((file) => file.path === "xl/sharedStrings.xml");
+      const sheetXml = parseXML(new XMLString((sheetFile as XLSXExportXMLFile)?.content));
+      const sharedStringsXml = parseXML(new XMLString((stringsFile as XLSXExportXMLFile)?.content));
+      expect(sheetXml.querySelector("c[r='A1'] v")?.textContent?.trim()).toBe("0"); // 1st string = index 0
+      expect(sharedStringsXml.querySelectorAll("si t")[0].textContent?.trim()).toBe(
+        "=THISISBAD())))"
+      );
+    });
   });
 
   describe("Charts", () => {


### PR DESCRIPTION
Steps to reproduce:
- in A1: "hello"
- in A2: =A1+1
- export to xlsx file
- import to excel

⮕ the formula in A2 is recognized as a string rather than a formula

Because the value was set to `undefined`, the export later treats it as string rather than a formula

Task: 6008904

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo