### PR TITLE
[FIX] pivot cell style copied twice

### DIFF
--- a/src/clipboard_handlers/tables_clipboard.ts
+++ b/src/clipboard_handlers/tables_clipboard.ts
@@ -92,6 +92,13 @@ export class TableClipboardHandler extends AbstractCellClipboardHandler<
             type: coreTable.type,
           };
         }
+        if (table.isPivotTable) {
+          const isTopLeft = table.range.zone.top === row && table.range.zone.left === col;
+          const isWholePivotSelected = zones.some((z) => isZoneInside(table.range.zone, z));
+          if (isTopLeft || isWholePivotSelected) {
+            copiedTablesIds.add(table.id);
+          }
+        }
         if (mode !== "shiftCells") {
           tableCellsInRow.push({
             table: copiedTable,

--- a/tests/pivots/pivot_insert.test.ts
+++ b/tests/pivots/pivot_insert.test.ts
@@ -1,9 +1,9 @@
 import { PIVOT_INSERT_TABLE_STYLE_ID } from "@odoo/o-spreadsheet-engine/constants";
 import { Model } from "../../src";
 import { toZone } from "../../src/helpers";
-import { insertPivot } from "../test_helpers/commands_helpers";
-import { getCellText, getTable } from "../test_helpers/getters_helpers";
-import { setGrid } from "../test_helpers/helpers";
+import { copy, insertPivot, paste } from "../test_helpers/commands_helpers";
+import { getCell, getCellText, getTable } from "../test_helpers/getters_helpers";
+import { createModelFromGrid, setGrid } from "../test_helpers/helpers";
 
 describe("Insert pivot command", () => {
   test("Can insert a pivot in a cell", () => {
@@ -27,20 +27,41 @@ describe("Insert pivot command", () => {
   });
 
   test("Can insert a pivot from a contiguous zone", () => {
-    const model = new Model({
-      sheets: [
-        {
-          id: "Sheet1",
-          cells: {
-            A1: "1",
-            A2: "2",
-            B1: "3",
-            B2: "4",
-          },
-        },
-      ],
-    });
+    const model = createModelFromGrid({ A1: "1", A2: "2", B1: "3", B2: "4" });
     insertPivot(model, "A1", "pivot1", "Sheet2");
     expect(model.getters.getPivotCoreDefinition("pivot1")["dataSet"].zone).toEqual(toZone("A1:B2"));
+  });
+});
+
+describe("Check the style when copying and pasting a pivot table", () => {
+  test("copy/paste the top left cell", () => {
+    const model = createModelFromGrid({ A1: "1", A2: "2" });
+    insertPivot(model, "A1:A2", "pivot1", "Sheet2");
+    copy(model, "A1");
+    paste(model, "C1");
+    expect(getCell(model, "C1")?.style).toBe(undefined);
+    expect(model.getters.getTables("Sheet2")).toHaveLength(2);
+  });
+
+  test("copy/paste the whole table", () => {
+    const model = createModelFromGrid({ A1: "1", A2: "2" });
+    insertPivot(model, "A1:A2", "pivot1", "Sheet2");
+    copy(model, "A1:A3");
+    paste(model, "C1");
+    expect(getCell(model, "C1")?.style).toBe(undefined);
+    expect(model.getters.getTables("Sheet2")).toHaveLength(2);
+  });
+
+  test("copy/paste a random cell", () => {
+    const model = createModelFromGrid({ A1: "1", A2: "2" });
+    insertPivot(model, "A1:A2", "pivot1", "Sheet2");
+    copy(model, "A2");
+    paste(model, "C1");
+    expect(getCell(model, "C1")?.style).toStrictEqual({
+      bold: true,
+      fillColor: "#6C4E65",
+      textColor: "#FFFFFF",
+    });
+    expect(model.getters.getTables("Sheet2")).toHaveLength(1);
   });
 });


### PR DESCRIPTION
If we copy the top left cell or the all pivot table, we should not copy the style of the cell

Task: [5909138](https://www.odoo.com/odoo/2328/tasks/5909138)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo