### PR TITLE
[IMP] rendering : add dark mode for grid and chart

### DIFF
--- a/demo/main.js
+++ b/demo/main.js
@@ -62,7 +62,7 @@ let start;
 
 class Demo extends Component {
   setup() {
-    this.state = useState({ key: 0, displayHeader: false, colorScheme: "light" });
+    this.state = useState({ key: 0, displayHeader: false });
     this.stateUpdateMessages = [];
     this.client = {
       id: UuidGenerator.uuidv4(),
@@ -107,9 +107,11 @@ class Demo extends Component {
       name: "Toggle dark mode",
       sequence: 12.5,
       isReadonlyAllowed: true,
-      execute: () =>
-        (this.state.colorScheme = this.state.colorScheme === "dark" ? "light" : "dark"),
-
+      execute: () => {
+        this.model.dispatch("UPDATE_COLOR_SCHEME", {
+          colorScheme: this.model.getters.isDarkMode() ? "light" : "dark",
+        });
+      },
       icon: "o-spreadsheet-Icon.DARK_MODE",
       isEnabledOnLockedSheet: true,
     });
@@ -406,11 +408,11 @@ Demo.template = xml/* xml */ `
   <div t-if="state.displayHeader" class="d-flex flex flex-column justify-content w-100 h-100">
     <div class="p-3 border-bottom">A header</div>
     <div class="flex-fill">
-      <Spreadsheet model="model" notifyUser="notifyUser" t-key="state.key" colorScheme="state.colorScheme"/>
+      <Spreadsheet model="model" notifyUser="notifyUser" t-key="state.key"/>
     </div>
   </div>
   <div t-else="" class="w-100 h-100">
-    <Spreadsheet model="model" t-key="state.key" notifyUser="notifyUser" colorScheme="state.colorScheme"/>
+    <Spreadsheet model="model" t-key="state.key" notifyUser="notifyUser"/>
   </div>
 `;
 Demo.components = { Spreadsheet };

--- a/src/components/color_picker/color_picker.css
+++ b/src/components/color_picker/color_picker.css
@@ -36,7 +36,7 @@
       height: calc(var(--os-item-edge-length) + (2 * var(--os-item-border-width)));
       margin: 0px;
       border-radius: 50px;
-      border: var(--os-item-border-width) solid light-dark(var(--os-gray-600), transparent);
+      border: var(--os-item-border-width) solid light-dark(var(--os-gray-600), #c0c0c0);
       padding: 0px;
       font-size: 16px;
       &:hover {
@@ -87,7 +87,7 @@
         z-index: 2;
       }
       .saturation {
-        background: linear-gradient(to right, var(--os-white) 0%, transparent 100%);
+        background: linear-gradient(to right, #fff 0%, transparent 100%);
       }
       .lightness {
         background: linear-gradient(to top, #000 0%, transparent 100%);

--- a/src/components/color_picker/color_picker.xml
+++ b/src/components/color_picker/color_picker.xml
@@ -8,7 +8,7 @@
             t-foreach="COLORS"
             t-as="color"
             t-key="color"
-            class="o-color-picker-line-item"
+            class="o-color-picker-line-item os-theme-dependant"
             t-att-data-color="color"
             t-on-click="() => this.onColorClick(color)"
             t-attf-style="background-color:{{color}};">
@@ -36,7 +36,7 @@
             t-foreach="env.model.getters.getCustomColors()"
             t-as="color"
             t-key="color"
-            class="o-color-picker-line-item"
+            class="o-color-picker-line-item os-theme-dependant"
             t-att-data-color="color"
             t-attf-style="background-color:{{color}};"
             t-on-click="() => this.onColorClick(color)">
@@ -50,7 +50,7 @@
         </div>
         <div t-if="state.showGradient" class="o-custom-selector">
           <div
-            class="o-gradient"
+            class="o-gradient os-theme-dependant"
             t-on-click.stop=""
             t-on-pointerdown="dragGradientPointer"
             t-att-style="gradientHueStyle">
@@ -60,7 +60,7 @@
           </div>
           <div class="o-hue-container" t-on-pointerdown="dragHuePointer">
             <div class="o-hue-picker border rounded" t-on-click.stop=""/>
-            <div class="o-hue-slider pe-none" t-att-style="sliderStyle">
+            <div class="o-hue-slider pe-none os-theme-dependant" t-att-style="sliderStyle">
               <t t-call="o-spreadsheet-Icon.CARET_UP"/>
             </div>
           </div>
@@ -73,7 +73,10 @@
               t-att-value="state.customHexColor"
               t-on-input="setHexColor"
             />
-            <div class="o-color-preview border rounded" t-att-style="colorPreviewStyle"/>
+            <div
+              class="o-color-preview border rounded os-theme-dependant"
+              t-att-style="colorPreviewStyle"
+            />
           </div>
           <div class="o-custom-input-buttons">
             <button

--- a/src/components/color_picker/color_picker_widget.css
+++ b/src/components/color_picker/color_picker_widget.css
@@ -19,11 +19,11 @@
     }
 
     .o-color-picker-button {
-      > span {
-        border-bottom: 4px solid;
+      > div {
         height: 20px;
-        margin-top: 2px;
-        display: block;
+      }
+      .o-colored-border {
+        border-bottom: 4px solid;
       }
       &[disabled] {
         pointer-events: none;

--- a/src/components/color_picker/color_picker_widget.xml
+++ b/src/components/color_picker/color_picker_widget.xml
@@ -8,9 +8,13 @@
         t-att-title="props.title"
         t-att-class="props.class ? props.class : 'o-color-picker-button-style'"
         t-att-disabled="props.disabled">
-        <span t-att-style="iconStyle">
+        <div class="position-relative">
           <t t-call="{{props.icon}}"/>
-        </span>
+          <div
+            class="o-colored-border position-absolute bottom-0 w-100 os-theme-dependant"
+            t-att-style="iconStyle"
+          />
+        </div>
       </span>
       <ColorPicker
         t-if="props.showColorPicker"

--- a/src/components/dashboard/dashboard.xml
+++ b/src/components/dashboard/dashboard.xml
@@ -27,7 +27,7 @@
             />
           </div>
         </GridOverlay>
-        <canvas t-ref="canvas"/>
+        <canvas t-ref="canvas" class="os-theme-dependant"/>
         <GridPopover
           gridRect="getGridRect()"
           onMouseWheel.bind="onMouseWheel"

--- a/src/components/figures/chart/chartJs/chartjs_background_plugin.ts
+++ b/src/components/figures/chart/chartJs/chartjs_background_plugin.ts
@@ -1,5 +1,4 @@
 import { ChartType, Plugin } from "chart.js";
-import { BACKGROUND_CHART_COLOR } from "../../../../constants";
 
 export interface ChartBackgroundPluginOptions {
   color: string | undefined;
@@ -18,7 +17,7 @@ export const chartBackgroundPlugin: Plugin = {
     const { ctx } = chart;
     ctx.save();
     ctx.globalCompositeOperation = "destination-over";
-    ctx.fillStyle = options.color || BACKGROUND_CHART_COLOR;
+    ctx.fillStyle = options.color || "#FFFFFF";
     ctx.fillRect(0, 0, chart.width, chart.height);
     ctx.restore();
   },

--- a/src/components/figures/chart/chartJs/chartjs_calendar_chart.ts
+++ b/src/components/figures/chart/chartJs/chartjs_calendar_chart.ts
@@ -7,7 +7,6 @@ import {
   Chart,
   ChartComponent,
 } from "chart.js";
-import { BACKGROUND_CHART_COLOR } from "../../../../constants";
 
 export function getCalendarChartController(): ChartComponent & {
   prototype: BarController;
@@ -31,7 +30,7 @@ export function getCalendarChartController(): ChartComponent & {
 
       // Remove the element background at the start of an animation
       const chartBackground = this.chart.config.options?.plugins?.background?.color;
-      const backgroundColor = chartBackground || BACKGROUND_CHART_COLOR;
+      const backgroundColor = chartBackground;
       for (let i = start; i < start + count; i++) {
         if (mode === "reset") {
           this.updateElement(rects[i], i, { options: { backgroundColor } }, mode);

--- a/src/components/figures/chart/chart_dashboard_menu/chart_dashboard_menu.ts
+++ b/src/components/figures/chart/chart_dashboard_menu/chart_dashboard_menu.ts
@@ -1,6 +1,5 @@
 import { Component, useState } from "@odoo/owl";
 import { getChartMenuActions } from "../../../../actions/figure_menu_actions";
-import { BACKGROUND_CHART_COLOR } from "../../../../constants";
 import { isDefined } from "../../../../helpers/misc";
 import { useStore } from "../../../../store_engine/store_hooks";
 import { _t } from "../../../../translation";
@@ -46,7 +45,9 @@ export class ChartDashboardMenu extends Component<Props, SpreadsheetChildEnv> {
 
   get backgroundColor() {
     const color = this.env.model.getters.getChartDefinition(this.props.chartId).background;
-    return "background-color: " + (color || BACKGROUND_CHART_COLOR);
+    return (
+      "background-color: " + (color || this.env.model.getters.getSpreadsheetTheme().backgroundColor)
+    );
   }
 
   openContextMenu(ev: MouseEvent) {

--- a/src/components/figures/figure/figure.xml
+++ b/src/components/figures/figure/figure.xml
@@ -1,7 +1,7 @@
 <templates>
   <t t-name="o-spreadsheet-FigureComponent">
     <div
-      class="o-figure-wrapper"
+      class="o-figure-wrapper os-theme-dependant"
       t-att-class="{'o-figure-selected': isSelected}"
       t-att-style="wrapperStyle"
       t-ref="figureWrapper">

--- a/src/components/figures/figure_carousel/figure_carousel.ts
+++ b/src/components/figures/figure_carousel/figure_carousel.ts
@@ -1,6 +1,6 @@
 import { Component, useEffect, useRef, useState } from "@odoo/owl";
 import { ActionSpec, createActions } from "../../../actions/action";
-import { BACKGROUND_CHART_COLOR, DEFAULT_CAROUSEL_TITLE_STYLE } from "../../../constants";
+import { DEFAULT_CAROUSEL_TITLE_STYLE } from "../../../constants";
 import { getCarouselItemTitle } from "../../../helpers/carousel_helpers";
 import { chartStyleToCellStyle, deepEquals } from "../../../helpers/misc";
 import { chartComponentRegistry } from "../../../registries/chart_component_registry";
@@ -107,16 +107,17 @@ export class CarouselFigure extends Component<Props, SpreadsheetChildEnv> {
 
   get headerStyle(): string {
     const cssProperties: CSSProperties = {};
+    const backgroundColor = this.env.model.getters.getSpreadsheetTheme().backgroundColor;
     if (this.selectedCarouselItem?.type === "chart") {
       const chart = this.env.model.getters.getChartRuntime(this.selectedCarouselItem.chartId);
       if ("background" in chart && chart.background) {
         cssProperties["background-color"] = chart.background;
       } else if ("chartJsConfig" in chart) {
         cssProperties["background-color"] =
-          chart.chartJsConfig.options?.plugins?.background?.color || BACKGROUND_CHART_COLOR;
+          chart.chartJsConfig.options?.plugins?.background?.color || backgroundColor;
       }
     } else {
-      cssProperties["background-color"] = BACKGROUND_CHART_COLOR;
+      cssProperties["background-color"] = backgroundColor;
     }
     return cssPropertiesToCss(cssProperties);
   }

--- a/src/components/full_screen_figure/full_screen_figure.xml
+++ b/src/components/full_screen_figure/full_screen_figure.xml
@@ -13,7 +13,7 @@
       </button>
       <div class="flex-fill">
         <div
-          class="o-fullscreen-figure o-figure position-relative border rounded shadow"
+          class="o-fullscreen-figure os-theme-dependant o-figure position-relative border rounded shadow"
           tabindex="1"
           t-ref="fullScreenFigure"
           t-on-click.stop=""

--- a/src/components/grid/grid.xml
+++ b/src/components/grid/grid.xml
@@ -21,7 +21,7 @@
         gridDims="env.model.getters.getSheetViewDimensionWithHeaders()"
         onInputContextMenu.bind="onInputContextMenu"
       />
-      <canvas t-ref="canvas"/>
+      <canvas t-ref="canvas" class="os-theme-dependant pe-none"/>
       <t t-set="focused" t-value="focusedClients"/>
       <t
         t-foreach="env.model.getters.getClientsToDisplay()"

--- a/src/components/grid_add_rows_footer/grid_add_rows_footer.ts
+++ b/src/components/grid_add_rows_footer/grid_add_rows_footer.ts
@@ -36,6 +36,7 @@ export class GridAddRowsFooter extends Component<Props, SpreadsheetChildEnv> {
 
     return cssPropertiesToCss({
       top: `${top}px`,
+      ["z-index"]: "1",
     });
   }
 

--- a/src/components/grid_add_rows_footer/grid_add_rows_footer.xml
+++ b/src/components/grid_add_rows_footer/grid_add_rows_footer.xml
@@ -1,7 +1,7 @@
 <templates>
   <t t-name="o-spreadsheet-GridAddRowsFooter">
     <div
-      class="o-grid-add-rows mt-2 ms-2 w-100 d-flex position-relative align-items-center"
+      class="o-grid-add-rows mt-2 ms-2 w-100 d-flex position-relative align-items-center os-theme-dependant"
       t-att-style="addRowsPosition"
       t-on-pointerdown.stop.prevent="">
       <button

--- a/src/components/icon_picker/icon_picker.xml
+++ b/src/components/icon_picker/icon_picker.xml
@@ -2,7 +2,7 @@
   <t t-name="o-spreadsheet-IconPicker">
     <div class="o-icon-picker bg-white">
       <t t-foreach="iconSets" t-as="iconSet" t-key="iconSet">
-        <div class="o-cf-icon-line">
+        <div class="o-cf-icon-line os-theme-dependant">
           <div
             class="o-icon-picker-item p-1"
             t-on-click="() => this.onIconClick(iconSets[iconSet].good)">

--- a/src/components/icons/icons.ts
+++ b/src/components/icons/icons.ts
@@ -137,29 +137,45 @@ export function getHoveredCaretDownSvg(color: Style): ImageSVG {
   };
 }
 
-export const CHECKBOX_UNCHECKED: ImageSVG = {
+export const getThemeCheckboxUncheckedSvg = (isDarkMode: boolean): ImageSVG => ({
   name: "CHECKBOX_UNCHECKED",
   width: 512,
   height: 512,
-  paths: [{ fillColor: GRAY_300, path: "M45,45 h422 v422 h-422 v-422 m30,30 v362 h362 v-362" }],
-};
+  paths: [
+    {
+      fillColor: isDarkMode ? GRAY_300 : "#91959d",
+      path: "M45,45 h422 v422 h-422 v-422 m30,30 v362 h362 v-362",
+    },
+  ],
+});
 
-export const CHECKBOX_UNCHECKED_HOVERED: ImageSVG = {
+export const getThemeCheckboxUncheckedHoveredSvg = (isDarkMode: boolean): ImageSVG => ({
   name: "CHECKBOX_UNCHECKED",
   width: 512,
   height: 512,
-  paths: [{ fillColor: ACTION_COLOR, path: "M45,45 h422 v422 h-422 v-422 m30,30 v362 h362 v-362" }],
-};
+  paths: [
+    {
+      fillColor: isDarkMode ? "#82d1d5" : ACTION_COLOR,
+      path: "M45,45 h422 v422 h-422 v-422 m30,30 v362 h362 v-362",
+    },
+  ],
+});
 
-export const CHECKBOX_CHECKED: ImageSVG = {
+export const getThemeCheckboxCheckedSvg = (isDarkMode: boolean): ImageSVG => ({
   name: "CHECKBOX_CHECKED",
   width: 512,
   height: 512,
   paths: [
-    { fillColor: ACTION_COLOR, path: "M45,45 h422 v422 h-422 v-422" },
-    { fillColor: "#FFF", path: "M165,240 l45,45 l135,-135 h60 l-195,195 l-105,-105" },
+    {
+      fillColor: isDarkMode ? "#82d1d5" : ACTION_COLOR,
+      path: "M45,45 h422 v422 h-422 v-422",
+    },
+    {
+      fillColor: isDarkMode ? "#505050" : "#FFF",
+      path: "M165,240 l45,45 l135,-135 h60 l-195,195 l-105,-105",
+    },
   ],
-};
+});
 
 export function getPivotIconSvg(isCollapsed: boolean, isHovered: boolean): ImageSVG {
   const symbolPath = isCollapsed

--- a/src/components/side_panel/chart/building_blocks/color_scale/color_scale_picker.xml
+++ b/src/components/side_panel/chart/building_blocks/color_scale/color_scale_picker.xml
@@ -9,7 +9,7 @@
             <t t-out="currentColorScaleLabel"/>
           </span>
           <div
-            class="color-scale-preview w-100"
+            class="color-scale-preview w-100 os-theme-dependant"
             t-att-data-test-colorscale="selectedColorScale"
             t-att-style="currentColorScaleStyle"
           />
@@ -25,7 +25,7 @@
               <td class="p-1 text-end">Custom</td>
               <td class="w-100 p-1">
                 <div
-                  class="color-scale-preview o-checkers-background"
+                  class="color-scale-preview o-checkers-background os-theme-dependant"
                   data-test-id="custom-color-scale"
                 />
               </td>
@@ -40,7 +40,7 @@
                 </td>
                 <td class="w-100 p-1">
                   <div
-                    class="color-scale-preview"
+                    class="color-scale-preview os-theme-dependant"
                     t-att-data-test-id="colorScale.className"
                     t-att-style="colorScalePreviewStyle(colorScale.value)"
                   />

--- a/src/components/side_panel/components/round_color_picker/round_color_picker.xml
+++ b/src/components/side_panel/components/round_color_picker/round_color_picker.xml
@@ -1,7 +1,7 @@
 <templates>
   <t t-name="o-spreadsheet.RoundColorPicker">
     <div
-      class="o-round-color-picker-button rounded-circle border"
+      class="o-round-color-picker-button rounded-circle border os-theme-dependant"
       t-ref="colorPickerButton"
       t-on-click.stop="togglePicker"
       t-att-title="props.title"

--- a/src/components/side_panel/conditional_formatting/cf_editor/cell_is_rule_editor.xml
+++ b/src/components/side_panel/conditional_formatting/cf_editor/cell_is_rule_editor.xml
@@ -21,7 +21,7 @@
       <div class="o-section-subtitle pt-3">Formatting style</div>
 
       <div
-        class="o-cf-preview-display border"
+        class="o-cf-preview-display border os-theme-dependant"
         t-attf-style="font-weight:{{this.rule.style.bold ?'bold':'normal'}};
                        text-decoration:{{this.getTextDecoration(this.rule.style)}};
                        font-style:{{this.rule.style.italic?'italic':'normal'}};

--- a/src/components/side_panel/conditional_formatting/cf_editor/color_scale_rule_editor.xml
+++ b/src/components/side_panel/conditional_formatting/cf_editor/color_scale_rule_editor.xml
@@ -2,7 +2,9 @@
   <t t-name="o-spreadsheet-ColorScaleRuleEditor">
     <div class="o-cf-color-scale-editor">
       <div class="o-section-subtitle">Preview</div>
-      <div class="o-cf-preview-display mb-4" t-attf-style="{{this.props.store.previewGradient}}">
+      <div
+        class="o-cf-preview-display mb-4 os-theme-dependant"
+        t-attf-style="{{this.props.store.previewGradient}}">
         Preview text
       </div>
       <div class="o-section-subtitle">Minpoint</div>

--- a/src/components/side_panel/conditional_formatting/cf_editor/icon_set_rule_editor.xml
+++ b/src/components/side_panel/conditional_formatting/cf_editor/icon_set_rule_editor.xml
@@ -5,7 +5,7 @@
         <div class="o-section-subtitle">Icons</div>
         <div class="o-cf-iconsets d-flex flex-row">
           <div
-            class="o-cf-iconset o-cf-clickable-icon d-flex flex-row justify-content-between border rounded"
+            class="o-cf-iconset o-cf-clickable-icon d-flex flex-row justify-content-between border rounded os-theme-dependant"
             t-foreach="['arrows', 'smiley', 'dots']"
             t-as="iconSet"
             t-key="iconSet"
@@ -30,7 +30,8 @@
           <tr>
             <td>
               <div t-on-click.stop="() => this.props.store.toggleMenu('iconSet-upperIcon')">
-                <div class="o-cf-icon-button o-cf-clickable-icon me-3 border rounded">
+                <div
+                  class="o-cf-icon-button o-cf-clickable-icon me-3 border rounded os-theme-dependant">
                   <t t-call="{{this.getIconTemplate(this.rule.icons.upper)}}"/>
                 </div>
               </div>

--- a/src/components/side_panel/conditional_formatting/cf_preview/cf_preview.xml
+++ b/src/components/side_panel/conditional_formatting/cf_preview/cf_preview.xml
@@ -13,7 +13,7 @@
       </div>
       <t t-if="cf.rule.type==='IconSetRule'">
         <div
-          class="o-cf-preview-icon d-flex justify-content-around align-items-center me-3 bg-white border">
+          class="o-cf-preview-icon d-flex justify-content-around align-items-center me-3 border os-theme-dependant">
           <t t-call="o-spreadsheet-Icon.{{icons[cf.rule.icons.upper].template}}"/>
           <t t-call="o-spreadsheet-Icon.{{icons[cf.rule.icons.middle].template}}"/>
           <t t-call="o-spreadsheet-Icon.{{icons[cf.rule.icons.lower].template}}"/>
@@ -22,7 +22,7 @@
       <t t-else="">
         <div
           t-att-style="previewImageStyle"
-          class="o-cf-preview-icon d-flex justify-content-around align-items-center me-3 flex-shrink-0 border">
+          class="o-cf-preview-icon d-flex justify-content-around align-items-center me-3 flex-shrink-0 border os-theme-dependant">
           123
         </div>
       </t>

--- a/src/components/spreadsheet/spreadsheet.css
+++ b/src/components/spreadsheet/spreadsheet.css
@@ -193,20 +193,21 @@
   .o-grid {
     position: relative;
     overflow: hidden;
-    background-color: var(--os-background-gray-color);
+    background-color: light-dark(var(--os-background-gray-color), #1e1f29);
     &:focus {
       outline: none;
     }
 
     > canvas {
       box-sizing: content-box;
-      border-bottom: 1px solid var(--os-grid-border-color);
-      border-right: 1px solid var(--os-grid-border-color);
+      border-bottom: 1px solid var(--os-canvas-border-color);
+      border-right: 1px solid var(--os-canvas-border-color);
     }
 
     .o-grid-overlay {
       position: absolute;
       outline: none;
+      z-index: 1;
     }
   }
 
@@ -290,5 +291,10 @@
 
   .o-checkers-background {
     background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='10'><path fill='#d9d9d9' d='M5 5h5v5H5zH0V0h5'/></svg>");
+  }
+  &.dark {
+    .os-theme-dependant {
+      filter: var(--os-dark-mode-filter);
+    }
   }
 }

--- a/src/components/spreadsheet/spreadsheet.ts
+++ b/src/components/spreadsheet/spreadsheet.ts
@@ -11,6 +11,7 @@ import {
   useSubEnv,
 } from "@odoo/owl";
 import { GROUP_LAYER_WIDTH, MAXIMAL_FREEZABLE_RATIO } from "../../constants";
+import { DARK_MODE_FILTER_STRING } from "../../helpers/color";
 import { unregisterChartJsExtensions } from "../../helpers/figures/charts/chart_js_extension";
 import { ImageProvider } from "../../helpers/figures/images/image_provider";
 import { batched } from "../../helpers/misc";
@@ -60,7 +61,6 @@ import { instantiateClipboard } from "./../../helpers/clipboard/navigator_clipbo
 
 export interface SpreadsheetProps extends Partial<NotificationStoreMethods> {
   model: Model;
-  colorScheme?: "dark" | "light";
 }
 
 export class Spreadsheet extends Component<SpreadsheetProps, SpreadsheetChildEnv> {
@@ -70,7 +70,6 @@ export class Spreadsheet extends Component<SpreadsheetProps, SpreadsheetChildEnv
     notifyUser: { type: Function, optional: true },
     raiseError: { type: Function, optional: true },
     askConfirmation: { type: Function, optional: true },
-    colorScheme: { type: String, optional: true },
   };
   static components = {
     TopBar,
@@ -104,7 +103,8 @@ export class Spreadsheet extends Component<SpreadsheetProps, SpreadsheetChildEnv
     const properties: CSSProperties = {};
     const scrollbarWidth = this.env.model.getters.getScrollBarWidth();
     properties["--os-scrollbar-width"] = `${scrollbarWidth}px`;
-    properties["color-scheme"] = this.props.colorScheme;
+    properties["--os-dark-mode-filter"] = DARK_MODE_FILTER_STRING;
+    properties["color-scheme"] = this.props.model.getters.isDarkMode() ? "dark" : "light";
 
     if (this.state.printModeEnabled) {
       properties["display"] = `block`;
@@ -351,7 +351,7 @@ export class Spreadsheet extends Component<SpreadsheetProps, SpreadsheetChildEnv
   getSpreadSheetClasses() {
     return [
       this.env.isSmall ? "o-spreadsheet-mobile" : "",
-      this.props.colorScheme === "dark" ? "dark" : "",
+      this.props.model.getters.isDarkMode() ? "dark" : "",
     ].join(" ");
   }
 

--- a/src/components/standalone_grid_canvas/figure_renderer_store.ts
+++ b/src/components/standalone_grid_canvas/figure_renderer_store.ts
@@ -1,4 +1,4 @@
-import { BACKGROUND_CHART_COLOR, DEFAULT_CAROUSEL_TITLE_STYLE, GRAY_400 } from "../../constants";
+import { DEFAULT_CAROUSEL_TITLE_STYLE, GRAY_400 } from "../../constants";
 import { drawChartOnCanvas } from "../../helpers/figures/charts/chart_ui_common";
 import { chartStyleToCellStyle, deepCopy } from "../../helpers/misc";
 import { computeTextFont } from "../../helpers/text_helper";
@@ -109,7 +109,8 @@ export class FigureRendererStore extends DisposableStore {
     } else if (title.text) {
       ctx.save();
 
-      ctx.fillStyle = chartDefinition?.background || BACKGROUND_CHART_COLOR;
+      ctx.fillStyle =
+        chartDefinition?.background || this.getters.getSpreadsheetTheme().backgroundColor;
       ctx.fillRect(x, y, figure.width, headerSize);
 
       const font = computeTextFont(chartStyleToCellStyle(title));

--- a/src/components/tables/table_style_preview/table_canvas_helpers.ts
+++ b/src/components/tables/table_style_preview/table_canvas_helpers.ts
@@ -26,7 +26,11 @@ function drawBackgrounds(
   ctx.save();
   for (let col = 0; col < numberOfCols; col++) {
     for (let row = 0; row < numberOfRows; row++) {
-      ctx.fillStyle = tableStyle.styles[col][row].fillColor || "#fff";
+      const fillColor = tableStyle.styles[col][row].fillColor;
+      if (!fillColor) {
+        continue;
+      }
+      ctx.fillStyle = fillColor;
 
       // We also want to fill the last pixel corresponding to the outside border if there is no border
       const width = col === numberOfCols - 1 ? colWidth + 1 : colWidth;

--- a/src/components/tables/table_style_preview/table_style_preview.xml
+++ b/src/components/tables/table_style_preview/table_style_preview.xml
@@ -8,7 +8,7 @@
       t-on-click="props.onClick"
       t-on-contextmenu.prevent="(ev) => this.onContextMenu(ev)">
       <div class="o-table-preview">
-        <canvas t-ref="canvas" class="w-100 h-100"/>
+        <canvas t-ref="canvas" class="w-100 h-100 os-theme-dependant"/>
       </div>
       <div
         class="o-table-style-edit-button position-absolute d-none bg-white border"

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,14 +6,7 @@ export const CANVAS_SHIFT = 0.5;
 
 // Colors
 export const HIGHLIGHT_COLOR = "#017E84";
-export const BACKGROUND_HEADER_COLOR = "#F8F9FA";
-export const BACKGROUND_HEADER_SELECTED_COLOR = "#E8EAED";
-export const BACKGROUND_HEADER_ACTIVE_COLOR = "#595959";
-export const TEXT_HEADER_COLOR = "#666666";
 export const SELECTION_BORDER_COLOR = "#3266ca";
-export const HEADER_BORDER_COLOR = "#C0C0C0";
-export const CELL_BORDER_COLOR = "#E2E3E3";
-export const BACKGROUND_CHART_COLOR = "#FFFFFF";
 export const DEFAULT_COLOR_SCALE_MIDPOINT_COLOR = 0xb6d7a8;
 export const LINK_COLOR = HIGHLIGHT_COLOR;
 export const FILTERS_COLOR = "#188038";

--- a/src/helpers/color.ts
+++ b/src/helpers/color.ts
@@ -402,6 +402,87 @@ export function lightenColor(color: Color, percentage: number): Color {
   return hslaToHex(hsla);
 }
 
+export const DARK_MODE_FILTER = {
+  invert: 1,
+  hueRotate: 170,
+  contrast: 0.85,
+  brightness: 1.2,
+};
+
+export const DARK_MODE_FILTER_STRING = `invert(${DARK_MODE_FILTER.invert}) hue-rotate(${DARK_MODE_FILTER.hueRotate}deg) contrast(${DARK_MODE_FILTER.contrast}) brightness(${DARK_MODE_FILTER.brightness})`;
+
+/**
+ * Computes the 3x3 matrix for a hue-rotate filter.
+ * https://www.w3.org/TR/filter-effects-1/#feColorMatrixElement
+ */
+function getHueRotateMatrix(degrees: number): number[][] {
+  const radians = (degrees * Math.PI) / 180;
+  const cos = Math.cos(radians);
+  const sin = Math.sin(radians);
+  return [
+    [
+      0.213 + cos * 0.787 - sin * 0.213,
+      0.715 - cos * 0.715 - sin * 0.715,
+      0.072 - cos * 0.072 + sin * 0.928,
+    ],
+    [
+      0.213 - cos * 0.213 + sin * 0.143,
+      0.715 + cos * 0.285 + sin * 0.14,
+      0.072 - cos * 0.072 - sin * 0.283,
+    ],
+    [
+      0.213 - cos * 0.213 - sin * 0.787,
+      0.715 - cos * 0.715 + sin * 0.715,
+      0.072 + cos * 0.928 + sin * 0.072,
+    ],
+  ];
+}
+
+/**
+ * Converts a desired "displayed" color into the pre-inverted color that must be
+ * stored in the theme so that, after the dark-mode CSS filter is applied, the
+ * desired color is actually shown.
+ *
+ * This function computes the exact inverse of the DARK_MODE_FILTER chain.
+ */
+export function adaptForDarkMode(displayedColor: Color): Color {
+  const { r, g, b, a } = colorToRGBA(displayedColor);
+
+  // Normalize RGB channels to [0, 1]
+  let rn = r / 255;
+  let gn = g / 255;
+  let bn = b / 255;
+
+  // Step 1 – reverse brightness: c = c / brightness
+  rn /= DARK_MODE_FILTER.brightness;
+  gn /= DARK_MODE_FILTER.brightness;
+  bn /= DARK_MODE_FILTER.brightness;
+
+  // Step 2 – reverse contrast: c = (c - 0.5) / contrast + 0.5
+  rn = (rn - 0.5) / DARK_MODE_FILTER.contrast + 0.5;
+  gn = (gn - 0.5) / DARK_MODE_FILTER.contrast + 0.5;
+  bn = (bn - 0.5) / DARK_MODE_FILTER.contrast + 0.5;
+
+  // Clamp to [0, 1] (contrast reversal can push very dark channels below 0)
+  rn = Math.max(0, Math.min(1, rn));
+  gn = Math.max(0, Math.min(1, gn));
+  bn = Math.max(0, Math.min(1, bn));
+
+  // Step 3 – reverse hue-rotate(θ) by applying hue-rotate(-θ)
+  const matrix = getHueRotateMatrix(-DARK_MODE_FILTER.hueRotate);
+  const hr = Math.max(0, Math.min(1, matrix[0][0] * rn + matrix[0][1] * gn + matrix[0][2] * bn));
+  const hg = Math.max(0, Math.min(1, matrix[1][0] * rn + matrix[1][1] * gn + matrix[1][2] * bn));
+  const hb = Math.max(0, Math.min(1, matrix[2][0] * rn + matrix[2][1] * gn + matrix[2][2] * bn));
+
+  // Step 4 – reverse invert(1): c = 1 - c (self-inverse) and convert back to [0, 255]
+  return rgbaToHex({
+    r: Math.round((1 - hr) * 255),
+    g: Math.round((1 - hg) * 255),
+    b: Math.round((1 - hb) * 255),
+    a,
+  });
+}
+
 export function darkenColor(color: Color, percentage: number): Color {
   const hsla = hexToHSLA(color);
   if (percentage === 1) {

--- a/src/helpers/figures/charts/bar_chart.ts
+++ b/src/helpers/figures/charts/bar_chart.ts
@@ -1,5 +1,4 @@
 import type { ChartConfiguration } from "chart.js";
-import { BACKGROUND_CHART_COLOR } from "../../../constants";
 import { ChartTypeBuilder } from "../../../registries/chart_registry";
 import { BarChartRuntime } from "../../../types/chart/bar_chart";
 import { CommandResult } from "../../../types/commands";
@@ -71,7 +70,7 @@ export const BarChart: ChartTypeBuilder<"bar"> = {
   getDefinitionForExcel(getters, definition, { dataSets, labelRange }) {
     return {
       ...definition,
-      backgroundColor: toXlsxHexColor(definition.background || BACKGROUND_CHART_COLOR),
+      backgroundColor: toXlsxHexColor(definition.background || "#FFFFFF"),
       fontColor: toXlsxHexColor(chartFontColor(definition.background)),
       dataSets,
       labelRange,
@@ -98,7 +97,7 @@ export const BarChart: ChartTypeBuilder<"bar"> = {
           legend: getBarChartLegend(definition, chartData),
           tooltip: getBarChartTooltip(definition, chartData),
           chartShowValuesPlugin: getChartShowValues(definition, chartData),
-          background: { color: definition.background },
+          background: { color: chartData.background },
         },
         ...eventHandlers,
       },

--- a/src/helpers/figures/charts/calendar_chart.ts
+++ b/src/helpers/figures/charts/calendar_chart.ts
@@ -108,7 +108,7 @@ export const CalendarChart: ChartTypeBuilder<"calendar"> = {
           tooltip: getCalendarChartTooltip(definition, chartData),
           chartShowValuesPlugin: getCalendarChartShowValues(definition, chartData),
           chartColorScalePlugin: getCalendarColorScale(definition, chartData),
-          background: { color: definition.background },
+          background: { color: chartData.background },
         },
       },
     };

--- a/src/helpers/figures/charts/chart_common.ts
+++ b/src/helpers/figures/charts/chart_common.ts
@@ -380,3 +380,14 @@ export function truncateLabel(label: string | undefined, maxLen: number = MAX_CH
 export function isTrendLineAxis(axisID: string) {
   return axisID === TREND_LINE_XAXIS_ID || axisID === MOVING_AVERAGE_TREND_LINE_XAXIS_ID;
 }
+
+export function getChartBackgroundColor(
+  { background }: { background?: Color },
+  getters: Getters
+): Color {
+  const defaultColor = getters.getSpreadsheetTheme().backgroundColor;
+  if (!background) {
+    return defaultColor;
+  }
+  return background;
+}

--- a/src/helpers/figures/charts/combo_chart.ts
+++ b/src/helpers/figures/charts/combo_chart.ts
@@ -1,5 +1,4 @@
 import { ChartConfiguration } from "chart.js";
-import { BACKGROUND_CHART_COLOR } from "../../../constants";
 import { ChartTypeBuilder } from "../../../registries/chart_registry";
 import { ComboChartDataSetStyle, ComboChartRuntime } from "../../../types/chart/combo_chart";
 import { CommandResult } from "../../../types/commands";
@@ -49,7 +48,7 @@ export const ComboChart: ChartTypeBuilder<"combo"> = {
   getDefinitionForExcel(getters, definition, { dataSets, labelRange }) {
     return {
       ...definition,
-      backgroundColor: toXlsxHexColor(definition.background || BACKGROUND_CHART_COLOR),
+      backgroundColor: toXlsxHexColor(definition.background || "#FFFFFF"),
       fontColor: toXlsxHexColor(chartFontColor(definition.background)),
       dataSets,
       labelRange,
@@ -103,7 +102,7 @@ export const ComboChart: ChartTypeBuilder<"combo"> = {
           legend: getComboChartLegend(definition, chartData),
           tooltip: getBarChartTooltip(definition, chartData),
           chartShowValuesPlugin: getChartShowValues(definition, chartData),
-          background: { color: definition.background },
+          background: { color: chartData.background },
         },
         ...eventHandlers,
       },

--- a/src/helpers/figures/charts/funnel_chart.ts
+++ b/src/helpers/figures/charts/funnel_chart.ts
@@ -84,7 +84,7 @@ export const FunnelChart: ChartTypeBuilder<"funnel"> = {
           legend: { display: false },
           tooltip: getFunnelChartTooltip(definition, chartData),
           chartShowValuesPlugin: getChartShowValues(definition, chartData),
-          background: { color: definition.background },
+          background: { color: chartData.background },
         },
         ...eventHandlers,
       },

--- a/src/helpers/figures/charts/geo_chart.ts
+++ b/src/helpers/figures/charts/geo_chart.ts
@@ -72,7 +72,7 @@ export const GeoChart: ChartTypeBuilder<"geo"> = {
           title: getChartTitle(definition, getters),
           tooltip: getGeoChartTooltip(definition, chartData),
           legend: { display: false },
-          background: { color: definition.background },
+          background: { color: chartData.background },
         },
         ...eventHandlers,
       },

--- a/src/helpers/figures/charts/line_chart.ts
+++ b/src/helpers/figures/charts/line_chart.ts
@@ -1,5 +1,4 @@
 import { ChartConfiguration } from "chart.js";
-import { BACKGROUND_CHART_COLOR } from "../../../constants";
 import { ChartTypeBuilder } from "../../../registries/chart_registry";
 import { LineChartRuntime } from "../../../types/chart/line_chart";
 import { CommandResult } from "../../../types/commands";
@@ -75,7 +74,7 @@ export const LineChart: ChartTypeBuilder<"line"> = {
   getDefinitionForExcel(getters, definition, { dataSets, labelRange }) {
     return {
       ...definition,
-      backgroundColor: toXlsxHexColor(definition.background || BACKGROUND_CHART_COLOR),
+      backgroundColor: toXlsxHexColor(definition.background || "#FFFFFF"),
       fontColor: toXlsxHexColor(chartFontColor(definition.background)),
       dataSets,
       labelRange,
@@ -102,7 +101,7 @@ export const LineChart: ChartTypeBuilder<"line"> = {
           legend: getLineChartLegend(definition, chartData),
           tooltip: getLineChartTooltip(definition, chartData),
           chartShowValuesPlugin: getChartShowValues(definition, chartData),
-          background: { color: definition.background },
+          background: { color: chartData.background },
         },
         ...eventHandlers,
       },

--- a/src/helpers/figures/charts/pie_chart.ts
+++ b/src/helpers/figures/charts/pie_chart.ts
@@ -1,5 +1,4 @@
 import type { ChartConfiguration } from "chart.js";
-import { BACKGROUND_CHART_COLOR } from "../../../constants";
 import { ChartTypeBuilder } from "../../../registries/chart_registry";
 import { PieChartRuntime } from "../../../types/chart/pie_chart";
 import { CommandResult } from "../../../types/commands";
@@ -65,7 +64,7 @@ export const PieChart: ChartTypeBuilder<"pie"> = {
   getDefinitionForExcel(getters, definition, { dataSets, labelRange }) {
     return {
       ...definition,
-      backgroundColor: toXlsxHexColor(definition.background || BACKGROUND_CHART_COLOR),
+      backgroundColor: toXlsxHexColor(definition.background || "#FFFFFF"),
       fontColor: toXlsxHexColor(chartFontColor(definition.background)),
       dataSets,
       labelRange,
@@ -94,7 +93,7 @@ export const PieChart: ChartTypeBuilder<"pie"> = {
           legend: getPieChartLegend(definition, chartData),
           tooltip: getPieChartTooltip(definition, chartData),
           chartShowValuesPlugin: getChartShowValues(definition, chartData),
-          background: { color: definition.background },
+          background: { color: chartData.background },
         },
         ...eventHandlers,
       },

--- a/src/helpers/figures/charts/pyramid_chart.ts
+++ b/src/helpers/figures/charts/pyramid_chart.ts
@@ -1,5 +1,4 @@
 import { ChartConfiguration } from "chart.js";
-import { BACKGROUND_CHART_COLOR } from "../../../constants";
 import { ChartTypeBuilder } from "../../../registries/chart_registry";
 import { PyramidChartRuntime } from "../../../types/chart/pyramid_chart";
 import { CommandResult } from "../../../types/commands";
@@ -87,8 +86,8 @@ export const PyramidChart: ChartTypeBuilder<"pyramid"> = {
     return {
       ...definition,
       horizontal: true,
-      backgroundColor: toXlsxHexColor(definition.background || BACKGROUND_CHART_COLOR),
-      fontColor: toXlsxHexColor(chartFontColor(definition.background)),
+      backgroundColor: toXlsxHexColor(chartData.background || "#FFFFFF"),
+      fontColor: toXlsxHexColor(chartFontColor(chartData.background)),
       dataSets,
       labelRange,
       verticalAxis: getDefinedAxis(definition),
@@ -116,7 +115,7 @@ export const PyramidChart: ChartTypeBuilder<"pyramid"> = {
           legend: getBarChartLegend(definition, chartData),
           tooltip: getPyramidChartTooltip(definition, chartData),
           chartShowValuesPlugin: getPyramidChartShowValues(definition, chartData),
-          background: { color: definition.background },
+          background: { color: chartData.background },
         },
         ...eventHandlers,
       },

--- a/src/helpers/figures/charts/radar_chart.ts
+++ b/src/helpers/figures/charts/radar_chart.ts
@@ -1,5 +1,4 @@
 import { ChartConfiguration } from "chart.js";
-import { BACKGROUND_CHART_COLOR } from "../../../constants";
 import { ChartTypeBuilder } from "../../../registries/chart_registry";
 import { RadarChartRuntime } from "../../../types/chart/radar_chart";
 import { CommandResult } from "../../../types/commands";
@@ -66,7 +65,7 @@ export const RadarChart: ChartTypeBuilder<"radar"> = {
   getDefinitionForExcel(getters, definition, { dataSets, labelRange }) {
     return {
       ...definition,
-      backgroundColor: toXlsxHexColor(definition.background || BACKGROUND_CHART_COLOR),
+      backgroundColor: toXlsxHexColor(definition.background || "#FFFFFF"),
       fontColor: toXlsxHexColor(chartFontColor(definition.background)),
       dataSets,
       labelRange,
@@ -92,7 +91,7 @@ export const RadarChart: ChartTypeBuilder<"radar"> = {
           legend: getRadarChartLegend(definition, chartData),
           tooltip: getRadarChartTooltip(definition, chartData),
           chartShowValuesPlugin: getChartShowValues(definition, chartData),
-          background: { color: definition.background },
+          background: { color: chartData.background },
         },
         ...eventHandlers,
       },

--- a/src/helpers/figures/charts/runtime/chart_data_extractor.ts
+++ b/src/helpers/figures/charts/runtime/chart_data_extractor.ts
@@ -45,6 +45,7 @@ import { timeFormatLuxonCompatible } from "../../../chart_date";
 import { DAYS, formatValue, isDateTimeFormat, MONTHS } from "../../../format/format";
 import { deepCopy, findNextDefinedValue, range } from "../../../misc";
 import { createDate } from "../../../pivot/spreadsheet_pivot/date_spreadsheet_pivot";
+import { getChartBackgroundColor } from "../chart_common";
 
 const EMPTY = Object.freeze({ value: null });
 const ZERO = Object.freeze({ value: 0 });
@@ -89,6 +90,7 @@ export function getBarChartData(
     labels,
     locale: getters.getLocale(),
     topPadding: getTopPaddingForDashboard(definition, getters),
+    background: getChartBackgroundColor(definition, getters),
   };
 }
 
@@ -206,6 +208,7 @@ export function getCalendarChartData(
     labels: labels.map(({ value }) => String(value ?? "")),
     locale: getters.getLocale(),
     topPadding: getTopPaddingForDashboard(definition, getters),
+    background: getChartBackgroundColor(definition, getters),
   };
 }
 
@@ -292,6 +295,7 @@ export function getLineChartData(
     trendDataSetsValues,
     axisType,
     topPadding: getTopPaddingForDashboard(definition, getters),
+    background: getChartBackgroundColor(definition, getters),
   };
 }
 
@@ -320,6 +324,7 @@ export function getPieChartData(
     labels,
     locale: getters.getLocale(),
     topPadding: getTopPaddingForDashboard(definition, getters),
+    background: getChartBackgroundColor(definition, getters),
   };
 }
 
@@ -347,6 +352,7 @@ export function getRadarChartData(
     axisFormats,
     labels,
     locale: getters.getLocale(),
+    background: getChartBackgroundColor(definition, getters),
   };
 }
 
@@ -373,6 +379,7 @@ export function getGeoChartData(
     availableRegions: getters.getGeoChartAvailableRegions(),
     geoFeatureNameToId: getters.geoFeatureNameToId,
     getGeoJsonFeatures: getters.getGeoJsonFeatures,
+    background: getChartBackgroundColor(definition, getters),
   };
 }
 
@@ -401,6 +408,7 @@ export function getFunnelChartData(
     axisFormats: { x: format },
     labels,
     locale: getters.getLocale(),
+    background: getChartBackgroundColor(definition, getters),
   };
 }
 
@@ -419,6 +427,7 @@ export function getHierarchalChartData(
     axisFormats: { y: getChartLabelFormat(labels) },
     labels: labels.map(({ value }) => String(value ?? "")),
     locale: getters.getLocale(),
+    background: getChartBackgroundColor(definition, getters),
   };
 }
 

--- a/src/helpers/figures/charts/runtime/chartjs_dataset.ts
+++ b/src/helpers/figures/charts/runtime/chartjs_dataset.ts
@@ -1,6 +1,5 @@
 import { ChartDataset, Point } from "chart.js";
 import {
-  BACKGROUND_CHART_COLOR,
   CHART_WATERFALL_NEGATIVE_COLOR,
   CHART_WATERFALL_POSITIVE_COLOR,
   CHART_WATERFALL_SUBTOTAL_COLOR,
@@ -73,7 +72,7 @@ export function getBarChartDatasets(
   definition: GenericDefinition<BarChartDefinition>,
   args: ChartRuntimeGenerationArgs
 ): ChartDataset<"bar" | "line">[] {
-  const { dataSetsValues } = args;
+  const { dataSetsValues, background } = args;
 
   const dataSets: ChartDataset<"bar" | "line">[] = [];
   const colors = getChartColorsGenerator(definition.dataSetStyles, dataSetsValues);
@@ -88,7 +87,7 @@ export function getBarChartDatasets(
       label,
       data: data.map((cell) => (isNumberResult(cell) ? cell.value : NaN)),
       hidden,
-      borderColor: definition.background || BACKGROUND_CHART_COLOR,
+      borderColor: definition.background || background,
       borderWidth: definition.stacked ? 1 : 0,
       backgroundColor,
       yAxisID: definition.horizontal ? "y" : definition.dataSetStyles?.[dataSetId]?.yAxisId ?? "y",
@@ -119,7 +118,7 @@ export function getCalendarChartDatasetAndLabels(
   datasets: ChartDataset<"calendar">[];
   labels: string[];
 } {
-  const { labels, dataSetsValues } = args;
+  const { labels, dataSetsValues, background } = args;
 
   const values = dataSetsValues
     .map((ds) => ds.data)
@@ -143,7 +142,7 @@ export function getCalendarChartDatasetAndLabels(
       backgroundColor: dataSetValues.data.map((v) =>
         isNumberResult(v) ? colorMap(v.value) : definition.missingValueColor || COLOR_TRANSPARENT
       ),
-      borderColor: definition.background || BACKGROUND_CHART_COLOR,
+      borderColor: definition.background || background,
       borderSkipped: false,
       borderWidth: 1,
       barPercentage: 1,
@@ -450,7 +449,7 @@ export function getFunnelChartDatasets(
   args: ChartRuntimeGenerationArgs
 ): ChartDataset<"bar">[] {
   const dataSetsValues = args.dataSetsValues[0];
-  const labels = args.labels;
+  const { labels, background } = args;
   if (!dataSetsValues) {
     return [];
   }
@@ -472,7 +471,7 @@ export function getFunnelChartDatasets(
     xAxisID: "x",
     barPercentage: 1,
     categoryPercentage: 1,
-    borderColor: definition.background || BACKGROUND_CHART_COLOR,
+    borderColor: definition.background || background,
     borderWidth: 3,
   };
 
@@ -488,7 +487,7 @@ export function getSunburstChartDatasets(
   definition: GenericDefinition<SunburstChartDefinition>,
   args: ChartRuntimeGenerationArgs
 ): SunburstChartJSDataset[] {
-  const { dataSetsValues, labels } = args;
+  const { dataSetsValues, labels, background } = args;
 
   const tree = getSunburstTree(dataSetsValues, labels);
   const data = pyramidizeTree(tree);
@@ -511,7 +510,7 @@ export function getSunburstChartDatasets(
         if (!data || data.label === GHOST_SUNBURST_VALUE) {
           return COLOR_TRANSPARENT;
         }
-        return definition.background || BACKGROUND_CHART_COLOR;
+        return definition.background || background;
       },
       backgroundColor: (ctx) => {
         const data = ctx.type === "data" ? (ctx.raw as SunburstChartRawData) : undefined;

--- a/src/helpers/figures/charts/scatter_chart.ts
+++ b/src/helpers/figures/charts/scatter_chart.ts
@@ -1,5 +1,4 @@
 import { ChartConfiguration } from "chart.js";
-import { BACKGROUND_CHART_COLOR } from "../../../constants";
 import { ChartTypeBuilder } from "../../../registries/chart_registry";
 import { ScatterChartRuntime } from "../../../types/chart/scatter_chart";
 import { CommandResult } from "../../../types/commands";
@@ -64,7 +63,7 @@ export const ScatterChart: ChartTypeBuilder<"scatter"> = {
   getDefinitionForExcel(getters, definition, { dataSets, labelRange }) {
     return {
       ...definition,
-      backgroundColor: toXlsxHexColor(definition.background || BACKGROUND_CHART_COLOR),
+      backgroundColor: toXlsxHexColor(definition.background || "#FFFFFF"),
       fontColor: toXlsxHexColor(chartFontColor(definition.background)),
       dataSets,
       labelRange,
@@ -93,7 +92,7 @@ export const ScatterChart: ChartTypeBuilder<"scatter"> = {
           legend: getScatterChartLegend(definition, chartData),
           tooltip: getLineChartTooltip(definition, chartData),
           chartShowValuesPlugin: getChartShowValues(definition, chartData),
-          background: { color: definition.background },
+          background: { color: chartData.background },
         },
         ...eventHandlers,
       },

--- a/src/helpers/figures/charts/sunburst_chart.ts
+++ b/src/helpers/figures/charts/sunburst_chart.ts
@@ -92,7 +92,7 @@ export const SunburstChart: ChartTypeBuilder<"sunburst"> = {
           tooltip: getSunburstChartTooltip(definition, chartData),
           sunburstLabelsPlugin: getSunburstShowValues(definition, chartData),
           sunburstHoverPlugin: { enabled: true },
-          background: { color: definition.background },
+          background: { color: chartData.background },
         },
         ...eventHandlers,
       },

--- a/src/helpers/figures/charts/tree_map_chart.ts
+++ b/src/helpers/figures/charts/tree_map_chart.ts
@@ -90,7 +90,7 @@ export const TreeMapChart: ChartTypeBuilder<"treemap"> = {
           title: getChartTitle(definition, getters),
           legend: { display: false },
           tooltip: getTreeMapChartTooltip(definition, chartData),
-          background: { color: definition.background },
+          background: { color: chartData.background },
         },
         ...eventHandlers,
       },

--- a/src/helpers/figures/charts/waterfall_chart.ts
+++ b/src/helpers/figures/charts/waterfall_chart.ts
@@ -92,7 +92,7 @@ export const WaterfallChart: ChartTypeBuilder<"waterfall"> = {
           tooltip: getWaterfallChartTooltip(definition, chartData),
           chartShowValuesPlugin: getWaterfallChartShowValues(definition, chartData),
           waterfallLinesPlugin: { showConnectorLines: definition.showConnectorLines },
-          background: { color: definition.background },
+          background: { color: chartData.background },
         },
         ...eventHandlers,
       },

--- a/src/migrations/migration_steps.ts
+++ b/src/migrations/migration_steps.ts
@@ -1,4 +1,4 @@
-import { BACKGROUND_CHART_COLOR, FORMULA_REF_IDENTIFIER } from "../constants";
+import { FORMULA_REF_IDENTIFIER } from "../constants";
 import { toXC } from "../helpers/coordinates";
 import { getItemId } from "../helpers/data_normalization";
 import { getUniqueText, sanitizeSheetName } from "../helpers/misc";
@@ -166,7 +166,7 @@ migrationStepRegistry
     migrate(data: any): any {
       for (const sheet of data.sheets || []) {
         for (const chart of sheet.figures || []) {
-          chart.data.background = BACKGROUND_CHART_COLOR;
+          chart.data.background = "#FFFFFF";
           chart.data.verticalAxisPosition = "left";
           chart.data.legendPosition = "top";
           chart.data.stacked = false;

--- a/src/model.ts
+++ b/src/model.ts
@@ -441,6 +441,7 @@ export class Model extends EventBus<any> implements CommandDispatcher {
       defaultCurrency: this.config.defaultCurrency,
       customColors: this.config.customColors || [],
       external: this.config.external,
+      colorScheme: this.config.colorScheme,
     };
   }
 

--- a/src/plugins/plugin_registries.ts
+++ b/src/plugins/plugin_registries.ts
@@ -35,6 +35,7 @@ import { AutomaticSumPlugin } from "./ui_feature/automatic_sum";
 import { CellComputedStylePlugin } from "./ui_feature/cell_computed_style";
 import { CheckboxTogglePlugin } from "./ui_feature/checkbox_toggle";
 import { CollaborativePlugin } from "./ui_feature/collaborative";
+import { ColorThemeUIPlugin } from "./ui_feature/color_theme";
 import { DataCleanupPlugin } from "./ui_feature/data_cleanup";
 import { DataValidationInsertionPlugin } from "./ui_feature/datavalidation_insertion";
 import { DynamicTranslate } from "./ui_feature/dynamic_translate";
@@ -102,7 +103,8 @@ export const featurePluginRegistry = new Registry<UIPluginConstructor>()
   .add("checkbox_toggle", CheckboxTogglePlugin)
   .add("dynamic_translate", DynamicTranslate)
   .add("geo_features", GeoFeaturePlugin)
-  .add("data_cleanup", DataCleanupPlugin);
+  .add("data_cleanup", DataCleanupPlugin)
+  .add("color_theme", ColorThemeUIPlugin);
 
 // Plugins which have a state, but which should not be shared in collaborative
 export const statefulUIPluginRegistry = new Registry<UIPluginConstructor>()

--- a/src/plugins/ui_core_views/evaluation_chart.ts
+++ b/src/plugins/ui_core_views/evaluation_chart.ts
@@ -1,5 +1,4 @@
 import { ChartConfiguration } from "chart.js";
-import { BACKGROUND_CHART_COLOR } from "../../constants";
 import { SpreadsheetChart } from "../../helpers/figures/chart";
 import { chartFontColor } from "../../helpers/figures/charts/chart_common";
 import { chartToImageUrl } from "../../helpers/figures/charts/chart_ui_common";
@@ -77,20 +76,21 @@ export class EvaluationChartPlugin extends CoreViewPlugin<EvaluationChartState> 
     chartBackground: Color | undefined,
     mainRange: Range | undefined
   ): EvaluationChartStyle {
+    const themeBackground = this.getters.getSpreadsheetTheme().backgroundColor;
     if (chartBackground) {
       return { background: chartBackground, fontColor: chartFontColor(chartBackground) };
     }
     if (!mainRange) {
       return {
-        background: BACKGROUND_CHART_COLOR,
-        fontColor: chartFontColor(BACKGROUND_CHART_COLOR),
+        background: themeBackground,
+        fontColor: chartFontColor(themeBackground),
       };
     }
     const col = mainRange.zone.left;
     const row = mainRange.zone.top;
     const sheetId = mainRange.sheetId;
     const style = this.getters.getCellComputedStyle({ sheetId, col, row });
-    const background = style.fillColor || BACKGROUND_CHART_COLOR;
+    const background = style.fillColor || themeBackground;
     return {
       background,
       fontColor: style.textColor || chartFontColor(background),

--- a/src/plugins/ui_feature/color_theme.ts
+++ b/src/plugins/ui_feature/color_theme.ts
@@ -1,0 +1,77 @@
+import { GridRenderingTheme } from "../..";
+import { adaptForDarkMode } from "../../helpers/color";
+import { Command } from "../../types/commands";
+import { UIPlugin, UIPluginConfig } from "../ui_plugin";
+
+const FROZEN_PANE_HEADER_BORDER_COLOR = "#BCBCBC";
+const FROZEN_PANE_BORDER_COLOR = "#DADFE8";
+const HEADER_BORDER_COLOR = "#C0C0C0";
+const TEXT_HEADER_COLOR = "#666666";
+const BACKGROUND_HEADER_COLOR = "#F8F9FA";
+export const CELL_BORDER_COLOR = "#E2E3E3";
+export const BACKGROUND_HEADER_SELECTED_COLOR = "#E8EAED";
+export const BACKGROUND_HEADER_ACTIVE_COLOR = "#595959";
+
+export const COLOR_THEMES: Record<string, GridRenderingTheme> = {
+  light: {
+    backgroundColor: "#FFFFFF",
+    gridBorderColor: CELL_BORDER_COLOR,
+    headerBackgroundColor: BACKGROUND_HEADER_COLOR,
+    headerActiveBackgroundColor: BACKGROUND_HEADER_ACTIVE_COLOR,
+    headerSelectedBackgroundColor: BACKGROUND_HEADER_SELECTED_COLOR,
+    headerTextColor: TEXT_HEADER_COLOR,
+    headerBorderColor: HEADER_BORDER_COLOR,
+    frozenPaneBorderColor: FROZEN_PANE_BORDER_COLOR,
+    frozenPaneHeaderBorderColor: FROZEN_PANE_HEADER_BORDER_COLOR,
+    singleCellSelectionBackgroundColor: "#F3F7FE",
+    multipleCellsSelectionBackgroundColor: "#E9F0FF",
+  },
+  dark: {
+    backgroundColor: adaptForDarkMode("#1A1C2E"),
+    gridBorderColor: adaptForDarkMode("#4A4E55"),
+    headerBackgroundColor: adaptForDarkMode("#262A36"),
+    headerActiveBackgroundColor: adaptForDarkMode("#3A4052"),
+    headerSelectedBackgroundColor: adaptForDarkMode("#4E566E"),
+    headerTextColor: adaptForDarkMode("#A1A6B3"),
+    headerBorderColor: adaptForDarkMode("#7A7F91"),
+    frozenPaneBorderColor: adaptForDarkMode("#7A7F91"),
+    frozenPaneHeaderBorderColor: adaptForDarkMode("#9FA5BD"),
+    singleCellSelectionBackgroundColor: adaptForDarkMode("#696E8044"),
+    multipleCellsSelectionBackgroundColor: adaptForDarkMode("#828AA044"),
+  },
+};
+export class ColorThemeUIPlugin extends UIPlugin {
+  static getters = ["isDarkMode", "getSpreadsheetTheme"] as const;
+  private colorScheme?: "light" | "dark";
+
+  constructor(config: UIPluginConfig) {
+    super(config);
+    this.colorScheme = config.colorScheme;
+  }
+
+  handle(command: Command): void {
+    if (command.type === "UPDATE_COLOR_SCHEME") {
+      this.colorScheme = command.colorScheme;
+    }
+  }
+
+  isDarkMode(): boolean {
+    return this.colorScheme === "dark";
+  }
+
+  /* This getters returns the colors to be used in the spreadsheet depending on the current theme (dark or light)
+   * The colors are based on the default Odoo spreadsheet theme, but adapted for dark mode using the adaptForDarkMode
+   * helper function that adjusts the color to obtain the desired color for elements that have a filter CSS properties.
+   * These colors should then be used only on the elements that have the os-theme-dependant class, to avoid unexpected
+   * colors inversion on other elements that don't have the filter CSS properties.
+   */
+  getSpreadsheetTheme(): GridRenderingTheme {
+    switch (this.colorScheme) {
+      case "dark":
+        return COLOR_THEMES.dark;
+      case "light":
+      default:
+        return COLOR_THEMES.light;
+    }
+  }
+}

--- a/src/plugins/ui_plugin.ts
+++ b/src/plugins/ui_plugin.ts
@@ -25,6 +25,7 @@ export interface UIPluginConfig {
   readonly defaultCurrency?: Partial<Currency>;
   readonly customColors: Color[];
   readonly external: ModelConfig["external"];
+  readonly colorScheme: ModelConfig["colorScheme"];
 }
 
 export interface UIPluginConstructor {

--- a/src/plugins/ui_stateful/selection.ts
+++ b/src/plugins/ui_stateful/selection.ts
@@ -887,15 +887,20 @@ export class GridSelectionPlugin extends UIPlugin {
     // at the wrong position. We should think of a way to improve that.
     const { ctx, thinLineWidth, viewports, sheetId, selectedZones: zones } = renderingContext;
     // selection
-    ctx.fillStyle = "#f3f7fe";
+    const theme = this.getters.getSpreadsheetTheme();
     const onlyOneCell =
       zones.length === 1 && zones[0].left === zones[0].right && zones[0].top === zones[0].bottom;
-    ctx.fillStyle = onlyOneCell ? "#f3f7fe" : "#e9f0ff";
+    ctx.fillStyle = onlyOneCell
+      ? theme.singleCellSelectionBackgroundColor
+      : theme.multipleCellsSelectionBackgroundColor;
     ctx.strokeStyle = SELECTION_BORDER_COLOR;
     ctx.lineWidth = 1.5 * thinLineWidth;
+    const isDarkMode = this.getters.isDarkMode();
     for (const zone of zones) {
       const { x, y, width, height } = viewports.getVisibleRect(sheetId, zone);
-      ctx.globalCompositeOperation = "multiply";
+      if (!isDarkMode) {
+        ctx.globalCompositeOperation = "multiply";
+      }
       ctx.fillRect(x, y, width, height);
       ctx.globalCompositeOperation = "source-over";
       ctx.strokeRect(x, y, width, height);

--- a/src/registries/icons_on_cell_registry.ts
+++ b/src/registries/icons_on_cell_registry.ts
@@ -1,11 +1,11 @@
 import {
-  CHECKBOX_CHECKED,
-  CHECKBOX_UNCHECKED,
-  CHECKBOX_UNCHECKED_HOVERED,
   getCaretDownSvg,
   getCaretUpSvg,
   getHoveredCaretDownSvg,
   getPivotIconSvg,
+  getThemeCheckboxCheckedSvg,
+  getThemeCheckboxUncheckedHoveredSvg,
+  getThemeCheckboxUncheckedSvg,
   ICONS,
 } from "../components/icons/icons";
 import {
@@ -49,9 +49,19 @@ iconsOnCellRegistry.add("data_validation_checkbox", (getters, position) => {
   const hasIcon = getters.isCellValidCheckbox(position);
   if (hasIcon) {
     const value = !!getters.getEvaluatedCell(position).value;
+    const isDark = getters.isDarkMode();
+    let svg: ImageSVG;
+    let hoverSvg: ImageSVG;
+    if (value) {
+      svg = getThemeCheckboxCheckedSvg(isDark);
+      hoverSvg = getThemeCheckboxCheckedSvg(isDark);
+    } else {
+      svg = getThemeCheckboxUncheckedSvg(isDark);
+      hoverSvg = getThemeCheckboxUncheckedHoveredSvg(isDark);
+    }
     return {
-      svg: value ? CHECKBOX_CHECKED : CHECKBOX_UNCHECKED,
-      hoverSvg: value ? CHECKBOX_CHECKED : CHECKBOX_UNCHECKED_HOVERED,
+      svg,
+      hoverSvg,
       priority: 2,
       horizontalAlign: "center",
       size: GRID_ICON_EDGE_LENGTH,

--- a/src/stores/grid_renderer_store.ts
+++ b/src/stores/grid_renderer_store.ts
@@ -2,23 +2,15 @@ import { HoveredIconStore } from "../components/grid_overlay/hovered_icon_store"
 import { getPath2D } from "../components/icons/icons";
 import { HoveredTableStore } from "../components/tables/hovered_table_store";
 import {
-  BACKGROUND_HEADER_ACTIVE_COLOR,
-  BACKGROUND_HEADER_COLOR,
-  BACKGROUND_HEADER_SELECTED_COLOR,
   CANVAS_SHIFT,
-  CELL_BORDER_COLOR,
   DATA_VALIDATION_CHIP_MARGIN,
   DEFAULT_FONT,
-  FROZEN_PANE_BORDER_COLOR,
-  FROZEN_PANE_HEADER_BORDER_COLOR,
-  HEADER_BORDER_COLOR,
   HEADER_FONT_SIZE,
   HEADER_HEIGHT,
   HEADER_WIDTH,
   MIN_CELL_TEXT_MARGIN,
-  TEXT_HEADER_COLOR,
 } from "../constants";
-import { blendColors } from "../helpers/color";
+import { blendColors, toHex } from "../helpers/color";
 import { numberToLetters } from "../helpers/coordinates";
 import { formatHasRepeatedChar } from "../helpers/format/format";
 import { deepCopy, deepEquals } from "../helpers/misc";
@@ -204,7 +196,7 @@ export class GridRenderer extends DisposableStore {
     const { width, height } = viewports.getSheetViewDimensionWithHeaders();
 
     // white background
-    ctx.fillStyle = "#ffffff";
+    ctx.fillStyle = this.getters.getSpreadsheetTheme().backgroundColor;
     ctx.fillRect(0, 0, width + CANVAS_SHIFT, height + CANVAS_SHIFT);
   }
 
@@ -217,11 +209,12 @@ export class GridRenderer extends DisposableStore {
     const inset = areGridLinesVisible ? 0.1 * thinLineWidth : 0;
 
     if (areGridLinesVisible) {
+      const theme = this.getters.getSpreadsheetTheme();
+      ctx.strokeStyle = theme.gridBorderColor;
       for (const box of boxes) {
         if (box.style.hideGridLines) {
           continue;
         }
-        ctx.strokeStyle = CELL_BORDER_COLOR;
         ctx.lineWidth = thinLineWidth;
         ctx.strokeRect(box.x + inset, box.y + inset, box.width - 2 * inset, box.height - 2 * inset);
       }
@@ -232,8 +225,9 @@ export class GridRenderer extends DisposableStore {
     const { ctx } = renderingContext;
     for (const box of boxes) {
       const style = box.style;
-      if (style.fillColor && style.fillColor !== "#ffffff") {
-        ctx.fillStyle = style.fillColor || "#ffffff";
+      const fillColor = toHex(style.fillColor || "#ffffff");
+      if (fillColor !== "#FFFFFF") {
+        ctx.fillStyle = fillColor;
         // We shift the canvas by CANVAS_SHIFT to avoid blurry lines (lines are drawn between pixels), but fillRect
         // are drawn at the exact pixel position, so we need to compensate this shift here. We also want to extend
         // the fill by 1px to draw over the gridLines.
@@ -251,7 +245,7 @@ export class GridRenderer extends DisposableStore {
         ctx.fillRect(box.x, box.y, width, box.height);
       }
       if (box.overlayColor) {
-        ctx.fillStyle = blendColors(style.fillColor || "#ffffff", box.overlayColor);
+        ctx.fillStyle = blendColors(fillColor, box.overlayColor);
         ctx.fillRect(
           box.x - CANVAS_SHIFT,
           box.y - CANVAS_SHIFT,
@@ -304,7 +298,7 @@ export class GridRenderer extends DisposableStore {
             (box.clipRect?.x || box.x + box.width / 2 - box.content.width / 2) + thinLineWidth / 2;
           width = clipWidth - 2 * thinLineWidth;
         }
-        ctx.fillStyle = "#ffffff";
+        ctx.fillStyle = this.getters.getSpreadsheetTheme().backgroundColor;
         ctx.fillRect(x, y, width, height);
       }
     }
@@ -509,11 +503,12 @@ export class GridRenderer extends DisposableStore {
     const activeCols = renderingContext.activeCols;
     const activeRows = renderingContext.activeRows;
 
+    const theme = this.getters.getSpreadsheetTheme();
     ctx.font = `400 ${HEADER_FONT_SIZE}px ${DEFAULT_FONT}`;
     ctx.textAlign = "center";
     ctx.textBaseline = "middle";
     ctx.lineWidth = thinLineWidth;
-    ctx.strokeStyle = "#333";
+    ctx.strokeStyle = theme.headerTextColor;
 
     // Columns headers background
     for (const col of visibleCols) {
@@ -522,11 +517,11 @@ export class GridRenderer extends DisposableStore {
       const isColActive = activeCols.has(col);
       const isColSelected = selectedCols.has(col);
       if (isColActive) {
-        ctx.fillStyle = BACKGROUND_HEADER_ACTIVE_COLOR;
+        ctx.fillStyle = theme.headerActiveBackgroundColor;
       } else if (isColSelected) {
-        ctx.fillStyle = BACKGROUND_HEADER_SELECTED_COLOR;
+        ctx.fillStyle = theme.headerSelectedBackgroundColor;
       } else {
-        ctx.fillStyle = BACKGROUND_HEADER_COLOR;
+        ctx.fillStyle = theme.headerBackgroundColor;
       }
       ctx.fillRect(x, 0, width, HEADER_HEIGHT);
     }
@@ -539,11 +534,11 @@ export class GridRenderer extends DisposableStore {
       const isRowActive = activeRows.has(row);
       const isRowSelected = selectedRows.has(row);
       if (isRowActive) {
-        ctx.fillStyle = BACKGROUND_HEADER_ACTIVE_COLOR;
+        ctx.fillStyle = theme.headerActiveBackgroundColor;
       } else if (isRowSelected) {
-        ctx.fillStyle = BACKGROUND_HEADER_SELECTED_COLOR;
+        ctx.fillStyle = theme.headerSelectedBackgroundColor;
       } else {
-        ctx.fillStyle = BACKGROUND_HEADER_COLOR;
+        ctx.fillStyle = theme.headerBackgroundColor;
       }
       ctx.fillRect(0, y, HEADER_WIDTH, height);
     }
@@ -554,13 +549,13 @@ export class GridRenderer extends DisposableStore {
     ctx.lineTo(HEADER_WIDTH, height);
     ctx.moveTo(0, HEADER_HEIGHT);
     ctx.lineTo(width, HEADER_HEIGHT);
-    ctx.strokeStyle = HEADER_BORDER_COLOR;
+    ctx.strokeStyle = theme.headerBorderColor;
     ctx.stroke();
 
     // column text + separator
     for (const col of visibleCols) {
       const colName = numberToLetters(col);
-      ctx.fillStyle = activeCols.has(col) ? "#fff" : TEXT_HEADER_COLOR;
+      ctx.fillStyle = activeCols.has(col) ? "#fff" : theme.headerTextColor;
       const zone = { left: col, right: col, top: top, bottom: top };
       const { x: colStart, width: colSize } = viewports.getRect(sheetId, zone);
       const { x, width } = viewports.getVisibleRect(sheetId, zone);
@@ -578,7 +573,7 @@ export class GridRenderer extends DisposableStore {
 
     // row text + separator
     for (const row of visibleRows) {
-      ctx.fillStyle = activeRows.has(row) ? "#fff" : TEXT_HEADER_COLOR;
+      ctx.fillStyle = activeRows.has(row) ? "#fff" : theme.headerTextColor;
       const zone = { top: row, bottom: row, left: left, right: left };
       const { y: rowStart, height: rowSize } = viewports.getRect(sheetId, zone);
       const { y, height } = viewports.getVisibleRect(sheetId, zone);
@@ -604,7 +599,7 @@ export class GridRenderer extends DisposableStore {
     const widthCorrection = viewports.getGridOffsetX();
     const heightCorrection = viewports.getGridOffsetY();
     ctx.lineWidth = 6 * thinLineWidth;
-    ctx.strokeStyle = FROZEN_PANE_HEADER_BORDER_COLOR;
+    ctx.strokeStyle = this.getters.getSpreadsheetTheme().frozenPaneHeaderBorderColor;
     ctx.beginPath();
     if (offsetCorrectionX) {
       ctx.moveTo(widthCorrection + offsetCorrectionX, 0);
@@ -635,7 +630,7 @@ export class GridRenderer extends DisposableStore {
     const widthCorrection = viewports.getGridOffsetX();
     const heightCorrection = viewports.getGridOffsetY();
     ctx.lineWidth = 6 * thinLineWidth;
-    ctx.strokeStyle = FROZEN_PANE_BORDER_COLOR;
+    ctx.strokeStyle = this.getters.getSpreadsheetTheme().frozenPaneBorderColor;
     ctx.beginPath();
     if (offsetCorrectionX) {
       ctx.moveTo(widthCorrection + offsetCorrectionX, heightCorrection);

--- a/src/types/chart/chart.ts
+++ b/src/types/chart/chart.ts
@@ -281,6 +281,7 @@ export interface ChartRuntimeGenerationArgs {
   trendDataSetsValues?: (Point[] | undefined)[];
   axisType?: AxisType;
   topPadding?: number;
+  background: Color;
 }
 
 /** Generic definition of chart to create a runtime: omit the chart type*/

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -1201,6 +1201,11 @@ export interface ToggleCheckboxCommand extends TargetDependentCommand {
   type: "TOGGLE_CHECKBOX";
 }
 
+export interface UpdateColorSchemeCommand {
+  type: "UPDATE_COLOR_SCHEME";
+  colorScheme: "light" | "dark";
+}
+
 export type CoreCommand =
   // /** History */
   // | SelectiveUndoCommand
@@ -1371,7 +1376,8 @@ export type LocalCommand =
   | DuplicateCarouselChartCommand
   | UpdateCarouselActiveItemCommand
   | PopOutChartFromCarouselCommand
-  | UpdateChartRegionCommand;
+  | UpdateChartRegionCommand
+  | UpdateColorSchemeCommand;
 
 export type Command = CoreCommand | LocalCommand;
 

--- a/src/types/getters.ts
+++ b/src/types/getters.ts
@@ -14,6 +14,7 @@ import { AutomaticSumPlugin } from "../plugins/ui_feature/automatic_sum";
 import { CellComputedStylePlugin } from "../plugins/ui_feature/cell_computed_style";
 import { CheckboxTogglePlugin } from "../plugins/ui_feature/checkbox_toggle";
 import { CollaborativePlugin } from "../plugins/ui_feature/collaborative";
+import { ColorThemeUIPlugin } from "../plugins/ui_feature/color_theme";
 import { DynamicTranslate } from "../plugins/ui_feature/dynamic_translate";
 import { GeoFeaturePlugin } from "../plugins/ui_feature/geo_features";
 import { HeaderVisibilityUIPlugin } from "../plugins/ui_feature/header_visibility_ui";
@@ -78,7 +79,8 @@ export type RenderingGetters = {
   PluginGetters<typeof DynamicTranslate> &
   PluginGetters<typeof FormulaTrackerPlugin> &
   PluginGetters<typeof LockSheetPlugin> &
-  PluginGetters<typeof CarouselUIPlugin>;
+  PluginGetters<typeof CarouselUIPlugin> &
+  PluginGetters<typeof ColorThemeUIPlugin>;
 
 export type Getters = RenderingGetters &
   PluginGetters<typeof SheetViewPlugin> &

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -32,6 +32,7 @@ export interface ModelConfig {
   readonly notifyUI: (payload: InformationNotification) => void;
   readonly raiseBlockingErrorUI: (text: string) => void;
   readonly customColors: Color[];
+  readonly colorScheme?: "light" | "dark";
 }
 
 export interface ModelExternalConfig {

--- a/src/types/rendering.ts
+++ b/src/types/rendering.ts
@@ -93,6 +93,20 @@ export interface SheetDOMScrollInfo {
   scrollY: Pixel;
 }
 
+export interface GridRenderingTheme {
+  backgroundColor: string;
+  gridBorderColor: string;
+  headerBackgroundColor: string;
+  headerActiveBackgroundColor: string;
+  headerSelectedBackgroundColor: string;
+  headerTextColor: string;
+  headerBorderColor: string;
+  frozenPaneBorderColor: string;
+  frozenPaneHeaderBorderColor: string;
+  singleCellSelectionBackgroundColor: string;
+  multipleCellsSelectionBackgroundColor: string;
+}
+
 export type GridRenderingContext = {
   ctx: CanvasRenderingContext2D;
   dpr: number;

--- a/src/variables.css
+++ b/src/variables.css
@@ -12,7 +12,7 @@
   --os-white: light-dark(#ffffff, #000000);
   --os-black: light-dark(#000000, #ffffff);
   --os-white-bg: light-dark(#ffffff, var(--os-gray-200));
-  --os-popover-bg: light-dark(#ffffff, var(--os-gray-300));
+  --os-popover-bg: light-dark(#ffffff, var(--os-gray-200));
 
   --os-default-font: "Roboto", "Arial";
   --os-default-font-size: 10px;
@@ -48,7 +48,11 @@
   --os-background-gray-color: light-dark(#f5f5f5, var(--os-white-bg));
   --os-background-gray-color-hover: light-dark(rgba(0, 0, 0, 0.08), #ffffff40);
   --os-frozen-pane-header-border-color: #bcbcbc; /* FROZEN_PANE_HEADER_BORDER_COLOR */
-  --os-grid-border-color: light-dark(#e2e3e3, var(--os-gray-200));
+  --os-grid-border-color: light-dark(#e2e3e3, var(--os-gray-400));
+  --os-canvas-border-color: light-dark(
+    #e2e3e3,
+    var(--os-gray-800)
+  ); /* CANVAS_BORDER_COLOR: Dark mode color will be inverted */
   --os-green-arrow-color: #6aa84f; /* Same color as CF arrow icon */
   --os-red-arrow-color: #e06666; /* Same color as CF arrow icon */
   --os-active-sheet-bg: light-dark(#ffffff, var(--os-gray-300));

--- a/tests/__snapshots__/top_bar_component.test.ts.snap
+++ b/tests/__snapshots__/top_bar_component.test.ts.snap
@@ -429,8 +429,8 @@ exports[`TopBar component simple rendering 1`] = `
                 class="o-color-picker-button o-hoverable-button o-menu-item-button o-toolbar-button"
                 title="Text Color"
               >
-                <span
-                  style="border-color: #000000"
+                <div
+                  class="position-relative"
                 >
                   <svg
                     class="o-icon"
@@ -442,7 +442,12 @@ exports[`TopBar component simple rendering 1`] = `
                       fill="currentColor"
                     />
                   </svg>
-                </span>
+                  
+                  <div
+                    class="o-colored-border position-absolute bottom-0 w-100 os-theme-dependant"
+                    style="border-color: #000000"
+                  />
+                </div>
               </span>
               
             </div>
@@ -468,8 +473,8 @@ exports[`TopBar component simple rendering 1`] = `
                 class="o-color-picker-button o-hoverable-button o-menu-item-button o-toolbar-button"
                 title="Fill Color"
               >
-                <span
-                  style="border-color: #ffffff"
+                <div
+                  class="position-relative"
                 >
                   <svg
                     class="o-icon"
@@ -481,7 +486,12 @@ exports[`TopBar component simple rendering 1`] = `
                       fill="currentColor"
                     />
                   </svg>
-                </span>
+                  
+                  <div
+                    class="o-colored-border position-absolute bottom-0 w-100 os-theme-dependant"
+                    style="border-color: #ffffff"
+                  />
+                </div>
               </span>
               
             </div>

--- a/tests/collaborative/collaborative_sheet_manipulations.test.ts
+++ b/tests/collaborative/collaborative_sheet_manipulations.test.ts
@@ -1,5 +1,4 @@
 import { CellIsRule, FormulaCell, LiteralCell, Model } from "../../src";
-import { BACKGROUND_CHART_COLOR } from "../../src/constants";
 import { lettersToNumber, numberToLetters } from "../../src/helpers/coordinates";
 import { range } from "../../src/helpers/misc";
 import { toZone } from "../../src/helpers/zones";
@@ -699,7 +698,7 @@ describe("Collaborative Sheet manipulation", () => {
       title: { text: "chart title" },
       type: "bar",
       stacked: false,
-      background: BACKGROUND_CHART_COLOR,
+      background: "#FFFFFF",
       legendPosition: "top",
       aggregated: false,
       humanize: false,

--- a/tests/colors/__snapshots__/color_picker_component.test.ts.snap
+++ b/tests/colors/__snapshots__/color_picker_component.test.ts.snap
@@ -14,7 +14,7 @@ exports[`Color Picker buttons Full component rendering 1`] = `
     class="colors-grid"
   >
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#000000"
       style="background-color:#000000;"
     >
@@ -26,397 +26,397 @@ exports[`Color Picker buttons Full component rendering 1`] = `
       </div>
     </div>
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#434343"
       style="background-color:#434343;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#666666"
       style="background-color:#666666;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#999999"
       style="background-color:#999999;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#B7B7B7"
       style="background-color:#B7B7B7;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#CCCCCC"
       style="background-color:#CCCCCC;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#D9D9D9"
       style="background-color:#D9D9D9;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#EFEFEF"
       style="background-color:#EFEFEF;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#F3F3F3"
       style="background-color:#F3F3F3;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#FFFFFF"
       style="background-color:#FFFFFF;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#980000"
       style="background-color:#980000;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#FF0000"
       style="background-color:#FF0000;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#FF9900"
       style="background-color:#FF9900;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#FFFF00"
       style="background-color:#FFFF00;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#00FF00"
       style="background-color:#00FF00;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#00FFFF"
       style="background-color:#00FFFF;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#4A86E8"
       style="background-color:#4A86E8;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#0000FF"
       style="background-color:#0000FF;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#9900FF"
       style="background-color:#9900FF;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#FF00FF"
       style="background-color:#FF00FF;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#E6B8AF"
       style="background-color:#E6B8AF;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#F4CCCC"
       style="background-color:#F4CCCC;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#FCE5CD"
       style="background-color:#FCE5CD;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#FFF2CC"
       style="background-color:#FFF2CC;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#D9EAD3"
       style="background-color:#D9EAD3;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#D0E0E3"
       style="background-color:#D0E0E3;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#C9DAF8"
       style="background-color:#C9DAF8;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#CFE2F3"
       style="background-color:#CFE2F3;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#D9D2E9"
       style="background-color:#D9D2E9;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#EAD1DC"
       style="background-color:#EAD1DC;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#DD7E6B"
       style="background-color:#DD7E6B;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#EA9999"
       style="background-color:#EA9999;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#F9CB9C"
       style="background-color:#F9CB9C;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#FFE599"
       style="background-color:#FFE599;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#B6D7A8"
       style="background-color:#B6D7A8;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#A2C4C9"
       style="background-color:#A2C4C9;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#A4C2F4"
       style="background-color:#A4C2F4;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#9FC5E8"
       style="background-color:#9FC5E8;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#B4A7D6"
       style="background-color:#B4A7D6;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#D5A6BD"
       style="background-color:#D5A6BD;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#CC4125"
       style="background-color:#CC4125;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#E06666"
       style="background-color:#E06666;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#F6B26B"
       style="background-color:#F6B26B;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#FFD966"
       style="background-color:#FFD966;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#93C47D"
       style="background-color:#93C47D;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#76A5AF"
       style="background-color:#76A5AF;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#6D9EEB"
       style="background-color:#6D9EEB;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#6FA8DC"
       style="background-color:#6FA8DC;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#8E7CC3"
       style="background-color:#8E7CC3;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#C27BA0"
       style="background-color:#C27BA0;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#A61C00"
       style="background-color:#A61C00;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#CC0000"
       style="background-color:#CC0000;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#E69138"
       style="background-color:#E69138;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#F1C232"
       style="background-color:#F1C232;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#6AA84F"
       style="background-color:#6AA84F;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#45818E"
       style="background-color:#45818E;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#3C78D8"
       style="background-color:#3C78D8;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#3D85C6"
       style="background-color:#3D85C6;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#674EA7"
       style="background-color:#674EA7;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#A64D79"
       style="background-color:#A64D79;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#85200C"
       style="background-color:#85200C;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#990000"
       style="background-color:#990000;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#B45F06"
       style="background-color:#B45F06;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#BF9000"
       style="background-color:#BF9000;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#38761D"
       style="background-color:#38761D;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#134F5C"
       style="background-color:#134F5C;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#1155CC"
       style="background-color:#1155CC;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#0B5394"
       style="background-color:#0B5394;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#351C75"
       style="background-color:#351C75;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#741B47"
       style="background-color:#741B47;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#5B0F00"
       style="background-color:#5B0F00;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#660000"
       style="background-color:#660000;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#783F04"
       style="background-color:#783F04;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#7F6000"
       style="background-color:#7F6000;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#274E13"
       style="background-color:#274E13;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#0C343D"
       style="background-color:#0C343D;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#1C4587"
       style="background-color:#1C4587;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#073763"
       style="background-color:#073763;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#20124D"
       style="background-color:#20124D;"
     />
     <div
-      class="o-color-picker-line-item"
+      class="o-color-picker-line-item os-theme-dependant"
       data-color="#4C1130"
       style="background-color:#4C1130;"
     />
@@ -460,7 +460,7 @@ exports[`Color Picker buttons Full component rendering 1`] = `
     class="o-custom-selector"
   >
     <div
-      class="o-gradient"
+      class="o-gradient os-theme-dependant"
       style="background:hsl(0 100% 50%); "
     >
       <div
@@ -481,7 +481,7 @@ exports[`Color Picker buttons Full component rendering 1`] = `
         class="o-hue-picker border rounded"
       />
       <div
-        class="o-hue-slider pe-none"
+        class="o-hue-slider pe-none os-theme-dependant"
         style="margin-left:-8px; "
       >
         <div
@@ -501,7 +501,7 @@ exports[`Color Picker buttons Full component rendering 1`] = `
         type="text"
       />
       <div
-        class="o-color-preview border rounded"
+        class="o-color-preview border rounded os-theme-dependant"
         style="background-color:#000000; "
       />
     </div>

--- a/tests/colors/color_helpers.test.ts
+++ b/tests/colors/color_helpers.test.ts
@@ -1,5 +1,6 @@
 import { Color, HSLA, RGBA } from "../../src";
 import {
+  adaptForDarkMode,
   colorToNumber,
   colorToRGBA,
   getColorScale,
@@ -261,4 +262,14 @@ test("setColorAlpha", () => {
   expect(setColorAlpha("light-dark(rgb(0,0,0),    rgba(0,255,255,0.5))", 0.4)).toEqual(
     "light-dark(#00000066, #00FFFF66)"
   );
+});
+
+describe("adaptForDarkMode", () => {
+  test("basic functionality", () => {
+    expect(adaptForDarkMode("#FFFFFF")).toBeSameColorAs("#1C1B1B");
+    expect(adaptForDarkMode("#000000")).toBeSameColorAs("#FFFFFF");
+    expect(adaptForDarkMode("#1A1C2E")).toBeSameColorAs("#F9F7FF");
+    expect(adaptForDarkMode("#4EA7F2")).toBeSameColorAs("#4586E1");
+    expect(adaptForDarkMode("#EA6175")).toBeSameColorAs("#FD7D7C");
+  });
 });

--- a/tests/conditional_formatting/__snapshots__/conditional_formatting_panel_component.test.ts.snap
+++ b/tests/conditional_formatting/__snapshots__/conditional_formatting_panel_component.test.ts.snap
@@ -48,7 +48,7 @@ exports[`UI of conditional formats Conditional formatting list panel simple snap
         </div>
         
         <div
-          class="o-cf-preview-icon d-flex justify-content-around align-items-center me-3 flex-shrink-0 border"
+          class="o-cf-preview-icon d-flex justify-content-around align-items-center me-3 flex-shrink-0 border os-theme-dependant"
           style="background:#FF0000; "
         >
            123 
@@ -131,7 +131,7 @@ exports[`UI of conditional formats Conditional formatting list panel simple snap
         </div>
         
         <div
-          class="o-cf-preview-icon d-flex justify-content-around align-items-center me-3 flex-shrink-0 border"
+          class="o-cf-preview-icon d-flex justify-content-around align-items-center me-3 flex-shrink-0 border os-theme-dependant"
           style="background-image: linear-gradient(to right, #FF00FF, #123456)"
         >
            123 

--- a/tests/data_validation/data_validation_checkbox_component.test.ts
+++ b/tests/data_validation/data_validation_checkbox_component.test.ts
@@ -1,5 +1,8 @@
 import { Model } from "../../src";
-import { CHECKBOX_CHECKED, CHECKBOX_UNCHECKED } from "../../src/components/icons/icons";
+import {
+  getThemeCheckboxCheckedSvg,
+  getThemeCheckboxUncheckedSvg,
+} from "../../src/components/icons/icons";
 import {
   addDataValidation,
   createTableWithFilter,
@@ -10,6 +13,9 @@ import {
 import { clickGridIcon, keyDown } from "../test_helpers/dom_helper";
 import { getCellContent, getCellIcons, getStyle } from "../test_helpers/getters_helpers";
 import { mountSpreadsheet } from "../test_helpers/helpers";
+
+const CHECKBOX_UNCHECKED = getThemeCheckboxUncheckedSvg(false);
+const CHECKBOX_CHECKED = getThemeCheckboxCheckedSvg(false);
 
 describe("Checkbox in model", () => {
   let model: Model;

--- a/tests/figures/__snapshots__/figure_component.test.ts.snap
+++ b/tests/figures/__snapshots__/figure_component.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`figures selected figure snapshot 1`] = `
 <div
-  class="o-figure-wrapper o-figure-selected"
+  class="o-figure-wrapper os-theme-dependant o-figure-selected"
   style="left:1px; top:1px; width:100px; height:100px; "
 >
   <div

--- a/tests/figures/chart/__snapshots__/chart_plugin.test.ts.snap
+++ b/tests/figures/chart/__snapshots__/chart_plugin.test.ts.snap
@@ -56,7 +56,7 @@ exports[`datasource tests create a chart with stacked bar 1`] = `
       "onClick": [Function],
       "plugins": {
         "background": {
-          "color": undefined,
+          "color": "#FFFFFF",
         },
         "chartShowValuesPlugin": {
           "background": [Function],
@@ -202,7 +202,7 @@ exports[`datasource tests create a chart with stacked bar 1`] = `
       "onClick": [Function],
       "plugins": {
         "background": {
-          "color": undefined,
+          "color": "#FFFFFF",
         },
         "chartShowValuesPlugin": undefined,
         "legend": {
@@ -335,7 +335,7 @@ exports[`datasource tests create chart with column datasets 1`] = `
       "onClick": [Function],
       "plugins": {
         "background": {
-          "color": undefined,
+          "color": "#FFFFFF",
         },
         "chartShowValuesPlugin": {
           "background": [Function],
@@ -503,7 +503,7 @@ exports[`datasource tests create chart with column datasets 1`] = `
       "onClick": [Function],
       "plugins": {
         "background": {
-          "color": undefined,
+          "color": "#FFFFFF",
         },
         "chartShowValuesPlugin": undefined,
         "legend": {

--- a/tests/figures/chart/bar_chart_plugin.test.ts
+++ b/tests/figures/chart/bar_chart_plugin.test.ts
@@ -1,6 +1,5 @@
 import { ChartConfiguration } from "chart.js";
 import { ChartCreationContext, Model } from "../../../src";
-import { BACKGROUND_CHART_COLOR } from "../../../src/constants";
 import { BarChartRuntime } from "../../../src/types/chart/bar_chart";
 import {
   GENERAL_CHART_CREATION_CONTEXT,
@@ -256,7 +255,7 @@ describe("bar chart", () => {
       "chartId"
     );
     let runtime = model.getters.getChartRuntime("chartId") as BarChartRuntime;
-    expect(runtime.chartJsConfig.data.datasets[0].borderColor).toBe(BACKGROUND_CHART_COLOR);
+    expect(runtime.chartJsConfig.data.datasets[0].borderColor).toBe("#FFFFFF");
 
     updateChart(model, "chartId", { background: "#f00" });
     runtime = model.getters.getChartRuntime("chartId") as BarChartRuntime;

--- a/tests/figures/chart/charts_component.test.ts
+++ b/tests/figures/chart/charts_component.test.ts
@@ -3049,7 +3049,7 @@ describe("Default background on runtime tests", () => {
     model = new Model();
   });
 
-  test("Creating a 'basicChart' without background should have no background on runtime", async () => {
+  test("Creating a 'basicChart' without background should have white background on runtime", async () => {
     createChart(
       model,
       { type: "bar", ...toChartDataSource({ dataSets: [{ dataRange: "A1" }] }) },
@@ -3058,8 +3058,9 @@ describe("Default background on runtime tests", () => {
     );
     expect(model.getters.getChartDefinition(chartId)?.background).toBeUndefined();
     const runtime = model.getters.getChartRuntime(chartId) as BarChartRuntime;
-    expect(runtime.chartJsConfig.options?.plugins?.background?.color).toBeUndefined();
+    expect(runtime.chartJsConfig.options?.plugins?.background?.color).toBe("#FFFFFF");
   });
+
   test("Creating a 'basicChart' without background and updating its type should have default background on runtime", async () => {
     createChart(
       model,
@@ -3070,8 +3071,9 @@ describe("Default background on runtime tests", () => {
     updateChart(model, chartId, { type: "line" }, sheetId);
     const runtime = model.getters.getChartRuntime(chartId) as BarChartRuntime;
     expect(model.getters.getChartDefinition(chartId)?.background).toBeUndefined();
-    expect(runtime.chartJsConfig.options?.plugins?.background?.color).toBe(undefined);
+    expect(runtime.chartJsConfig.options?.plugins?.background?.color).toBe("#FFFFFF");
   });
+
   test("Creating a 'basicChart' on a single cell with style and converting into scorecard should have cell background as chart background", () => {
     setFormatting(model, "A1", { fillColor: "#FA0000" }, sheetId);
     createChart(

--- a/tests/figures/chart/common_chart_plugin.test.ts
+++ b/tests/figures/chart/common_chart_plugin.test.ts
@@ -1,5 +1,4 @@
 import { Color, Model, UID } from "../../../src";
-import { BACKGROUND_CHART_COLOR } from "../../../src/constants";
 import { GaugeChartRuntime } from "../../../src/types/chart/gauge_chart";
 import { ScorecardChartRuntime } from "../../../src/types/chart/scorecard_chart";
 import {
@@ -53,11 +52,11 @@ describe("Single cell chart background color", () => {
     "chart %s background color change with main cell CF background color",
     (chartType: string) => {
       createTestChart(chartType, "A1");
-      expect(getGaugeOrScorecardRuntime(model, chartId).background).toEqual(BACKGROUND_CHART_COLOR);
+      expect(getGaugeOrScorecardRuntime(model, chartId).background).toEqual("#FFFFFF");
       addCfToA1("#FF0000");
       expect(getGaugeOrScorecardRuntime(model, chartId).background).toEqual("#FF0000");
       setCellContent(model, "A1", "random value not in CF");
-      expect(getGaugeOrScorecardRuntime(model, chartId).background).toEqual(BACKGROUND_CHART_COLOR);
+      expect(getGaugeOrScorecardRuntime(model, chartId).background).toEqual("#FFFFFF");
     }
   );
 
@@ -65,7 +64,7 @@ describe("Single cell chart background color", () => {
     "chart %s background color change with main cell background color",
     (chartType: string) => {
       createTestChart(chartType, "A1");
-      expect(getGaugeOrScorecardRuntime(model, chartId).background).toEqual(BACKGROUND_CHART_COLOR);
+      expect(getGaugeOrScorecardRuntime(model, chartId).background).toEqual("#FFFFFF");
       addFillToA1("#00FF00");
       expect(getGaugeOrScorecardRuntime(model, chartId).background).toEqual("#00FF00");
     }

--- a/tests/grid/__snapshots__/dashboard_grid_component.test.ts.snap
+++ b/tests/grid/__snapshots__/dashboard_grid_component.test.ts.snap
@@ -33,6 +33,7 @@ exports[`Grid component in dashboard mode simple dashboard rendering snapshot 1`
     </div>
     
     <canvas
+      class="os-theme-dependant"
       height="1011"
       style="width:1033px; height:1011px; "
       width="1033"

--- a/tests/grid/__snapshots__/grid_component.test.ts.snap
+++ b/tests/grid/__snapshots__/grid_component.test.ts.snap
@@ -24,8 +24,8 @@ exports[`Grid component simple rendering snapshot 1`] = `
   >
     
     <div
-      class="o-grid-add-rows mt-2 ms-2 w-100 d-flex position-relative align-items-center"
-      style="top:2300px; "
+      class="o-grid-add-rows mt-2 ms-2 w-100 d-flex position-relative align-items-center os-theme-dependant"
+      style="top:2300px; z-index:1; "
     >
       <button
         class="o-button flex-grow-0 me-2"
@@ -102,6 +102,7 @@ exports[`Grid component simple rendering snapshot 1`] = `
   </div>
   
   <canvas
+    class="os-theme-dependant pe-none"
     height="1011"
     style="width:1033px; height:1011px; "
     width="1033"

--- a/tests/grid/dashboard_grid_component.test.ts
+++ b/tests/grid/dashboard_grid_component.test.ts
@@ -1,5 +1,5 @@
 import { Align, Spreadsheet } from "../../src";
-import { CHECKBOX_CHECKED } from "../../src/components/icons/icons";
+import { getThemeCheckboxCheckedSvg } from "../../src/components/icons/icons";
 import {
   DEFAULT_CELL_HEIGHT,
   DEFAULT_CELL_WIDTH,
@@ -247,7 +247,7 @@ describe("Grid component in dashboard mode", () => {
     type: "debug_icon",
     position: { sheetId: "s1", col: 0, row: 0 },
     priority: 1,
-    svg: CHECKBOX_CHECKED,
+    svg: getThemeCheckboxCheckedSvg(false),
     onClick: () => {},
   };
 

--- a/tests/model/model_import_export.test.ts
+++ b/tests/model/model_import_export.test.ts
@@ -9,7 +9,6 @@ import {
   schemeToColorScale,
 } from "../../src";
 import {
-  BACKGROUND_CHART_COLOR,
   DEFAULT_CELL_HEIGHT,
   DEFAULT_CELL_WIDTH,
   DEFAULT_REVISION_ID,
@@ -189,7 +188,7 @@ describe("Migrations", () => {
         dataSets: [{ dataRange: "B26:B35" }, { dataRange: "C26:C35" }],
         dataSetsHaveTitle: true,
       }),
-      background: BACKGROUND_CHART_COLOR,
+      background: "#FFFFFF",
       legendPosition: "top",
       stacked: false,
       humanize: true,
@@ -203,7 +202,7 @@ describe("Migrations", () => {
         dataSets: [{ dataRange: "B27:B35" }, { dataRange: "C27:C35" }],
         dataSetsHaveTitle: false,
       }),
-      background: BACKGROUND_CHART_COLOR,
+      background: "#FFFFFF",
       legendPosition: "top",
       stacked: false,
       humanize: true,
@@ -217,7 +216,7 @@ describe("Migrations", () => {
         dataSets: [{ dataRange: "B26:B27" }],
         dataSetsHaveTitle: true,
       }),
-      background: BACKGROUND_CHART_COLOR,
+      background: "#FFFFFF",
       legendPosition: "top",
       stacked: false,
       humanize: true,
@@ -231,12 +230,13 @@ describe("Migrations", () => {
         dataSets: [{ dataRange: "B27" }],
         dataSetsHaveTitle: false,
       }),
-      background: BACKGROUND_CHART_COLOR,
+      background: "#FFFFFF",
       legendPosition: "top",
       stacked: false,
       humanize: true,
     });
   });
+
   test.each(FORBIDDEN_SHEETNAME_CHARS)("migrate version 7: sheet Names", (char) => {
     const model = new Model({
       version: 7,

--- a/tests/pivots/spreadsheet_pivot/__snapshots__/spreadsheet_pivot_side_panel.test.ts.snap
+++ b/tests/pivots/spreadsheet_pivot/__snapshots__/spreadsheet_pivot_side_panel.test.ts.snap
@@ -517,7 +517,7 @@ exports[`Spreadsheet pivot side panel It should correctly be displayed 1`] = `
                         class="o-table-preview"
                       >
                         <canvas
-                          class="w-100 h-100"
+                          class="w-100 h-100 os-theme-dependant"
                         />
                       </div>
                       
@@ -532,7 +532,7 @@ exports[`Spreadsheet pivot side panel It should correctly be displayed 1`] = `
                         class="o-table-preview"
                       >
                         <canvas
-                          class="w-100 h-100"
+                          class="w-100 h-100 os-theme-dependant"
                         />
                       </div>
                       
@@ -547,7 +547,7 @@ exports[`Spreadsheet pivot side panel It should correctly be displayed 1`] = `
                         class="o-table-preview"
                       >
                         <canvas
-                          class="w-100 h-100"
+                          class="w-100 h-100 os-theme-dependant"
                         />
                       </div>
                       
@@ -562,7 +562,7 @@ exports[`Spreadsheet pivot side panel It should correctly be displayed 1`] = `
                         class="o-table-preview"
                       >
                         <canvas
-                          class="w-100 h-100"
+                          class="w-100 h-100 os-theme-dependant"
                         />
                       </div>
                       
@@ -577,7 +577,7 @@ exports[`Spreadsheet pivot side panel It should correctly be displayed 1`] = `
                         class="o-table-preview"
                       >
                         <canvas
-                          class="w-100 h-100"
+                          class="w-100 h-100 os-theme-dependant"
                         />
                       </div>
                       
@@ -592,7 +592,7 @@ exports[`Spreadsheet pivot side panel It should correctly be displayed 1`] = `
                         class="o-table-preview"
                       >
                         <canvas
-                          class="w-100 h-100"
+                          class="w-100 h-100 os-theme-dependant"
                         />
                       </div>
                       
@@ -607,7 +607,7 @@ exports[`Spreadsheet pivot side panel It should correctly be displayed 1`] = `
                         class="o-table-preview"
                       >
                         <canvas
-                          class="w-100 h-100"
+                          class="w-100 h-100 os-theme-dependant"
                         />
                       </div>
                       
@@ -622,7 +622,7 @@ exports[`Spreadsheet pivot side panel It should correctly be displayed 1`] = `
                         class="o-table-preview"
                       >
                         <canvas
-                          class="w-100 h-100"
+                          class="w-100 h-100 os-theme-dependant"
                         />
                       </div>
                       
@@ -637,7 +637,7 @@ exports[`Spreadsheet pivot side panel It should correctly be displayed 1`] = `
                         class="o-table-preview"
                       >
                         <canvas
-                          class="w-100 h-100"
+                          class="w-100 h-100 os-theme-dependant"
                         />
                       </div>
                       
@@ -652,7 +652,7 @@ exports[`Spreadsheet pivot side panel It should correctly be displayed 1`] = `
                         class="o-table-preview"
                       >
                         <canvas
-                          class="w-100 h-100"
+                          class="w-100 h-100 os-theme-dependant"
                         />
                       </div>
                       
@@ -667,7 +667,7 @@ exports[`Spreadsheet pivot side panel It should correctly be displayed 1`] = `
                         class="o-table-preview"
                       >
                         <canvas
-                          class="w-100 h-100"
+                          class="w-100 h-100 os-theme-dependant"
                         />
                       </div>
                       
@@ -682,7 +682,7 @@ exports[`Spreadsheet pivot side panel It should correctly be displayed 1`] = `
                         class="o-table-preview"
                       >
                         <canvas
-                          class="w-100 h-100"
+                          class="w-100 h-100 os-theme-dependant"
                         />
                       </div>
                       
@@ -697,7 +697,7 @@ exports[`Spreadsheet pivot side panel It should correctly be displayed 1`] = `
                         class="o-table-preview"
                       >
                         <canvas
-                          class="w-100 h-100"
+                          class="w-100 h-100 os-theme-dependant"
                         />
                       </div>
                       
@@ -712,7 +712,7 @@ exports[`Spreadsheet pivot side panel It should correctly be displayed 1`] = `
                         class="o-table-preview"
                       >
                         <canvas
-                          class="w-100 h-100"
+                          class="w-100 h-100 os-theme-dependant"
                         />
                       </div>
                       
@@ -727,7 +727,7 @@ exports[`Spreadsheet pivot side panel It should correctly be displayed 1`] = `
                         class="o-table-preview"
                       >
                         <canvas
-                          class="w-100 h-100"
+                          class="w-100 h-100 os-theme-dependant"
                         />
                       </div>
                       
@@ -742,7 +742,7 @@ exports[`Spreadsheet pivot side panel It should correctly be displayed 1`] = `
                         class="o-table-preview"
                       >
                         <canvas
-                          class="w-100 h-100"
+                          class="w-100 h-100 os-theme-dependant"
                         />
                       </div>
                       
@@ -757,7 +757,7 @@ exports[`Spreadsheet pivot side panel It should correctly be displayed 1`] = `
                         class="o-table-preview"
                       >
                         <canvas
-                          class="w-100 h-100"
+                          class="w-100 h-100 os-theme-dependant"
                         />
                       </div>
                       
@@ -772,7 +772,7 @@ exports[`Spreadsheet pivot side panel It should correctly be displayed 1`] = `
                         class="o-table-preview"
                       >
                         <canvas
-                          class="w-100 h-100"
+                          class="w-100 h-100 os-theme-dependant"
                         />
                       </div>
                       
@@ -787,7 +787,7 @@ exports[`Spreadsheet pivot side panel It should correctly be displayed 1`] = `
                         class="o-table-preview"
                       >
                         <canvas
-                          class="w-100 h-100"
+                          class="w-100 h-100 os-theme-dependant"
                         />
                       </div>
                       
@@ -802,7 +802,7 @@ exports[`Spreadsheet pivot side panel It should correctly be displayed 1`] = `
                         class="o-table-preview"
                       >
                         <canvas
-                          class="w-100 h-100"
+                          class="w-100 h-100 os-theme-dependant"
                         />
                       </div>
                       
@@ -817,7 +817,7 @@ exports[`Spreadsheet pivot side panel It should correctly be displayed 1`] = `
                         class="o-table-preview"
                       >
                         <canvas
-                          class="w-100 h-100"
+                          class="w-100 h-100 os-theme-dependant"
                         />
                       </div>
                       
@@ -832,7 +832,7 @@ exports[`Spreadsheet pivot side panel It should correctly be displayed 1`] = `
                         class="o-table-preview"
                       >
                         <canvas
-                          class="w-100 h-100"
+                          class="w-100 h-100 os-theme-dependant"
                         />
                       </div>
                       
@@ -847,7 +847,7 @@ exports[`Spreadsheet pivot side panel It should correctly be displayed 1`] = `
                         class="o-table-preview"
                       >
                         <canvas
-                          class="w-100 h-100"
+                          class="w-100 h-100 os-theme-dependant"
                         />
                       </div>
                       
@@ -862,7 +862,7 @@ exports[`Spreadsheet pivot side panel It should correctly be displayed 1`] = `
                         class="o-table-preview"
                       >
                         <canvas
-                          class="w-100 h-100"
+                          class="w-100 h-100 os-theme-dependant"
                         />
                       </div>
                       
@@ -877,7 +877,7 @@ exports[`Spreadsheet pivot side panel It should correctly be displayed 1`] = `
                         class="o-table-preview"
                       >
                         <canvas
-                          class="w-100 h-100"
+                          class="w-100 h-100 os-theme-dependant"
                         />
                       </div>
                       
@@ -892,7 +892,7 @@ exports[`Spreadsheet pivot side panel It should correctly be displayed 1`] = `
                         class="o-table-preview"
                       >
                         <canvas
-                          class="w-100 h-100"
+                          class="w-100 h-100 os-theme-dependant"
                         />
                       </div>
                       
@@ -907,7 +907,7 @@ exports[`Spreadsheet pivot side panel It should correctly be displayed 1`] = `
                         class="o-table-preview"
                       >
                         <canvas
-                          class="w-100 h-100"
+                          class="w-100 h-100 os-theme-dependant"
                         />
                       </div>
                       
@@ -922,7 +922,7 @@ exports[`Spreadsheet pivot side panel It should correctly be displayed 1`] = `
                         class="o-table-preview"
                       >
                         <canvas
-                          class="w-100 h-100"
+                          class="w-100 h-100 os-theme-dependant"
                         />
                       </div>
                       
@@ -937,7 +937,7 @@ exports[`Spreadsheet pivot side panel It should correctly be displayed 1`] = `
                         class="o-table-preview"
                       >
                         <canvas
-                          class="w-100 h-100"
+                          class="w-100 h-100 os-theme-dependant"
                         />
                       </div>
                       
@@ -1471,7 +1471,7 @@ exports[`Spreadsheet pivot side panel It should display only the selection input
                         class="o-table-preview"
                       >
                         <canvas
-                          class="w-100 h-100"
+                          class="w-100 h-100 os-theme-dependant"
                         />
                       </div>
                       
@@ -1486,7 +1486,7 @@ exports[`Spreadsheet pivot side panel It should display only the selection input
                         class="o-table-preview"
                       >
                         <canvas
-                          class="w-100 h-100"
+                          class="w-100 h-100 os-theme-dependant"
                         />
                       </div>
                       
@@ -1501,7 +1501,7 @@ exports[`Spreadsheet pivot side panel It should display only the selection input
                         class="o-table-preview"
                       >
                         <canvas
-                          class="w-100 h-100"
+                          class="w-100 h-100 os-theme-dependant"
                         />
                       </div>
                       
@@ -1516,7 +1516,7 @@ exports[`Spreadsheet pivot side panel It should display only the selection input
                         class="o-table-preview"
                       >
                         <canvas
-                          class="w-100 h-100"
+                          class="w-100 h-100 os-theme-dependant"
                         />
                       </div>
                       
@@ -1531,7 +1531,7 @@ exports[`Spreadsheet pivot side panel It should display only the selection input
                         class="o-table-preview"
                       >
                         <canvas
-                          class="w-100 h-100"
+                          class="w-100 h-100 os-theme-dependant"
                         />
                       </div>
                       
@@ -1546,7 +1546,7 @@ exports[`Spreadsheet pivot side panel It should display only the selection input
                         class="o-table-preview"
                       >
                         <canvas
-                          class="w-100 h-100"
+                          class="w-100 h-100 os-theme-dependant"
                         />
                       </div>
                       
@@ -1561,7 +1561,7 @@ exports[`Spreadsheet pivot side panel It should display only the selection input
                         class="o-table-preview"
                       >
                         <canvas
-                          class="w-100 h-100"
+                          class="w-100 h-100 os-theme-dependant"
                         />
                       </div>
                       
@@ -1576,7 +1576,7 @@ exports[`Spreadsheet pivot side panel It should display only the selection input
                         class="o-table-preview"
                       >
                         <canvas
-                          class="w-100 h-100"
+                          class="w-100 h-100 os-theme-dependant"
                         />
                       </div>
                       
@@ -1591,7 +1591,7 @@ exports[`Spreadsheet pivot side panel It should display only the selection input
                         class="o-table-preview"
                       >
                         <canvas
-                          class="w-100 h-100"
+                          class="w-100 h-100 os-theme-dependant"
                         />
                       </div>
                       
@@ -1606,7 +1606,7 @@ exports[`Spreadsheet pivot side panel It should display only the selection input
                         class="o-table-preview"
                       >
                         <canvas
-                          class="w-100 h-100"
+                          class="w-100 h-100 os-theme-dependant"
                         />
                       </div>
                       
@@ -1621,7 +1621,7 @@ exports[`Spreadsheet pivot side panel It should display only the selection input
                         class="o-table-preview"
                       >
                         <canvas
-                          class="w-100 h-100"
+                          class="w-100 h-100 os-theme-dependant"
                         />
                       </div>
                       
@@ -1636,7 +1636,7 @@ exports[`Spreadsheet pivot side panel It should display only the selection input
                         class="o-table-preview"
                       >
                         <canvas
-                          class="w-100 h-100"
+                          class="w-100 h-100 os-theme-dependant"
                         />
                       </div>
                       
@@ -1651,7 +1651,7 @@ exports[`Spreadsheet pivot side panel It should display only the selection input
                         class="o-table-preview"
                       >
                         <canvas
-                          class="w-100 h-100"
+                          class="w-100 h-100 os-theme-dependant"
                         />
                       </div>
                       
@@ -1666,7 +1666,7 @@ exports[`Spreadsheet pivot side panel It should display only the selection input
                         class="o-table-preview"
                       >
                         <canvas
-                          class="w-100 h-100"
+                          class="w-100 h-100 os-theme-dependant"
                         />
                       </div>
                       
@@ -1681,7 +1681,7 @@ exports[`Spreadsheet pivot side panel It should display only the selection input
                         class="o-table-preview"
                       >
                         <canvas
-                          class="w-100 h-100"
+                          class="w-100 h-100 os-theme-dependant"
                         />
                       </div>
                       
@@ -1696,7 +1696,7 @@ exports[`Spreadsheet pivot side panel It should display only the selection input
                         class="o-table-preview"
                       >
                         <canvas
-                          class="w-100 h-100"
+                          class="w-100 h-100 os-theme-dependant"
                         />
                       </div>
                       
@@ -1711,7 +1711,7 @@ exports[`Spreadsheet pivot side panel It should display only the selection input
                         class="o-table-preview"
                       >
                         <canvas
-                          class="w-100 h-100"
+                          class="w-100 h-100 os-theme-dependant"
                         />
                       </div>
                       
@@ -1726,7 +1726,7 @@ exports[`Spreadsheet pivot side panel It should display only the selection input
                         class="o-table-preview"
                       >
                         <canvas
-                          class="w-100 h-100"
+                          class="w-100 h-100 os-theme-dependant"
                         />
                       </div>
                       
@@ -1741,7 +1741,7 @@ exports[`Spreadsheet pivot side panel It should display only the selection input
                         class="o-table-preview"
                       >
                         <canvas
-                          class="w-100 h-100"
+                          class="w-100 h-100 os-theme-dependant"
                         />
                       </div>
                       
@@ -1756,7 +1756,7 @@ exports[`Spreadsheet pivot side panel It should display only the selection input
                         class="o-table-preview"
                       >
                         <canvas
-                          class="w-100 h-100"
+                          class="w-100 h-100 os-theme-dependant"
                         />
                       </div>
                       
@@ -1771,7 +1771,7 @@ exports[`Spreadsheet pivot side panel It should display only the selection input
                         class="o-table-preview"
                       >
                         <canvas
-                          class="w-100 h-100"
+                          class="w-100 h-100 os-theme-dependant"
                         />
                       </div>
                       
@@ -1786,7 +1786,7 @@ exports[`Spreadsheet pivot side panel It should display only the selection input
                         class="o-table-preview"
                       >
                         <canvas
-                          class="w-100 h-100"
+                          class="w-100 h-100 os-theme-dependant"
                         />
                       </div>
                       
@@ -1801,7 +1801,7 @@ exports[`Spreadsheet pivot side panel It should display only the selection input
                         class="o-table-preview"
                       >
                         <canvas
-                          class="w-100 h-100"
+                          class="w-100 h-100 os-theme-dependant"
                         />
                       </div>
                       
@@ -1816,7 +1816,7 @@ exports[`Spreadsheet pivot side panel It should display only the selection input
                         class="o-table-preview"
                       >
                         <canvas
-                          class="w-100 h-100"
+                          class="w-100 h-100 os-theme-dependant"
                         />
                       </div>
                       
@@ -1831,7 +1831,7 @@ exports[`Spreadsheet pivot side panel It should display only the selection input
                         class="o-table-preview"
                       >
                         <canvas
-                          class="w-100 h-100"
+                          class="w-100 h-100 os-theme-dependant"
                         />
                       </div>
                       
@@ -1846,7 +1846,7 @@ exports[`Spreadsheet pivot side panel It should display only the selection input
                         class="o-table-preview"
                       >
                         <canvas
-                          class="w-100 h-100"
+                          class="w-100 h-100 os-theme-dependant"
                         />
                       </div>
                       
@@ -1861,7 +1861,7 @@ exports[`Spreadsheet pivot side panel It should display only the selection input
                         class="o-table-preview"
                       >
                         <canvas
-                          class="w-100 h-100"
+                          class="w-100 h-100 os-theme-dependant"
                         />
                       </div>
                       
@@ -1876,7 +1876,7 @@ exports[`Spreadsheet pivot side panel It should display only the selection input
                         class="o-table-preview"
                       >
                         <canvas
-                          class="w-100 h-100"
+                          class="w-100 h-100 os-theme-dependant"
                         />
                       </div>
                       
@@ -1891,7 +1891,7 @@ exports[`Spreadsheet pivot side panel It should display only the selection input
                         class="o-table-preview"
                       >
                         <canvas
-                          class="w-100 h-100"
+                          class="w-100 h-100 os-theme-dependant"
                         />
                       </div>
                       

--- a/tests/plugins/color_theme_plugin.test.ts
+++ b/tests/plugins/color_theme_plugin.test.ts
@@ -1,0 +1,57 @@
+import { Model } from "../../src/model";
+import { COLOR_THEMES } from "../../src/plugins/ui_feature/color_theme";
+import { MockTransportService } from "../__mocks__/transport_service";
+
+const expectedLightTheme = COLOR_THEMES.light;
+const expectedDarkTheme = COLOR_THEMES.dark;
+
+const THEME_KEYS = Object.keys(expectedLightTheme);
+describe("ColorThemeUIPlugin via Model getters", () => {
+  test("getSpreadsheetTheme returns correct colors in light mode", () => {
+    const model = new Model(
+      {},
+      {
+        transportService: new MockTransportService(),
+        client: { id: "test", name: "Test" },
+        colorScheme: "light",
+      }
+    );
+    const theme = model.getters.getSpreadsheetTheme();
+    for (const key of THEME_KEYS) {
+      expect(theme[key].toUpperCase()).toBe(expectedLightTheme[key]);
+    }
+  });
+
+  test("getSpreadsheetTheme returns correct colors in dark mode", async () => {
+    const model = new Model(
+      {},
+      {
+        transportService: new MockTransportService(),
+        client: { id: "test", name: "Test" },
+        colorScheme: "dark",
+      }
+    );
+    const theme = model.getters.getSpreadsheetTheme();
+    for (const key of THEME_KEYS) {
+      expect(theme[key].toUpperCase()).toBe(expectedDarkTheme[key]);
+    }
+  });
+
+  test("getSpreadsheetTheme is updated when color scheme changes", async () => {
+    const model = new Model(
+      {},
+      {
+        transportService: new MockTransportService(),
+        client: { id: "test", name: "Test" },
+        colorScheme: "light",
+      }
+    );
+    let theme = model.getters.getSpreadsheetTheme();
+    expect(theme.backgroundColor.toUpperCase()).toBe(expectedLightTheme.backgroundColor);
+
+    // Simulate color scheme change
+    model.dispatch("UPDATE_COLOR_SCHEME", { colorScheme: "dark" });
+    theme = model.getters.getSpreadsheetTheme();
+    expect(theme.backgroundColor.toUpperCase()).toBe(expectedDarkTheme.backgroundColor);
+  });
+});

--- a/tests/renderer/renderer_store.test.ts
+++ b/tests/renderer/renderer_store.test.ts
@@ -12,10 +12,7 @@ import {
 } from "../../src";
 import { HoveredTableStore } from "../../src/components/tables/hovered_table_store";
 import {
-  BACKGROUND_HEADER_ACTIVE_COLOR,
-  BACKGROUND_HEADER_SELECTED_COLOR,
   CANVAS_SHIFT,
-  CELL_BORDER_COLOR,
   DEFAULT_CELL_HEIGHT,
   DEFAULT_CELL_WIDTH,
   HEADER_HEIGHT,
@@ -29,6 +26,11 @@ import {
 import { blendColors, toHex } from "../../src/helpers/color";
 import { fontSizeInPixels, getContextFontSize } from "../../src/helpers/text_helper";
 import { toZone } from "../../src/helpers/zones";
+import {
+  BACKGROUND_HEADER_ACTIVE_COLOR,
+  BACKGROUND_HEADER_SELECTED_COLOR,
+  CELL_BORDER_COLOR,
+} from "../../src/plugins/ui_feature/color_theme";
 import { FormulaFingerprintStore } from "../../src/stores/formula_fingerprints_store";
 import { GridRenderer } from "../../src/stores/grid_renderer_store";
 import { RendererStore } from "../../src/stores/renderer_store";

--- a/tests/side_panels/building_blocks/__snapshots__/chart_title.test.ts.snap
+++ b/tests/side_panels/building_blocks/__snapshots__/chart_title.test.ts.snap
@@ -156,8 +156,8 @@ exports[`Chart title Can render a chart title component 1`] = `
             class="o-color-picker-button o-hoverable-button o-menu-item-button"
             title="Text color"
           >
-            <span
-              style="border-bottom-style: hidden"
+            <div
+              class="position-relative"
             >
               <svg
                 class="o-icon"
@@ -169,7 +169,12 @@ exports[`Chart title Can render a chart title component 1`] = `
                   fill="currentColor"
                 />
               </svg>
-            </span>
+              
+              <div
+                class="o-colored-border position-absolute bottom-0 w-100 os-theme-dependant"
+                style="border-bottom-style: hidden"
+              />
+            </div>
           </span>
           
         </div>

--- a/tests/side_panels/building_blocks/__snapshots__/round_color_picker.test.ts.snap
+++ b/tests/side_panels/building_blocks/__snapshots__/round_color_picker.test.ts.snap
@@ -6,7 +6,7 @@ exports[`Panel color picker Can render a panel color picker component 1`] = `
     class="o-spreadsheet"
   >
     <div
-      class="o-round-color-picker-button rounded-circle border"
+      class="o-round-color-picker-button rounded-circle border os-theme-dependant"
       style=""
     />
     

--- a/tests/spreadsheet/__snapshots__/spreadsheet_component.test.ts.snap
+++ b/tests/spreadsheet/__snapshots__/spreadsheet_component.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
 <div
   class="o-spreadsheet h-100 w-100"
-  style="--os-scrollbar-width:15px; grid-template-rows:min-content auto min-content; grid-template-columns:auto auto; "
+  style="--os-scrollbar-width:15px; --os-dark-mode-filter:invert(1) hue-rotate(170deg) contrast(0.85) brightness(1.2); color-scheme:light; grid-template-rows:min-content auto min-content; grid-template-columns:auto auto; "
 >
   
   
@@ -438,8 +438,8 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
                     class="o-color-picker-button o-hoverable-button o-menu-item-button o-toolbar-button"
                     title="Text Color"
                   >
-                    <span
-                      style="border-color: #000000"
+                    <div
+                      class="position-relative"
                     >
                       <svg
                         class="o-icon"
@@ -451,7 +451,12 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
                           fill="currentColor"
                         />
                       </svg>
-                    </span>
+                      
+                      <div
+                        class="o-colored-border position-absolute bottom-0 w-100 os-theme-dependant"
+                        style="border-color: #000000"
+                      />
+                    </div>
                   </span>
                   
                 </div>
@@ -477,8 +482,8 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
                     class="o-color-picker-button o-hoverable-button o-menu-item-button o-toolbar-button"
                     title="Fill Color"
                   >
-                    <span
-                      style="border-color: #ffffff"
+                    <div
+                      class="position-relative"
                     >
                       <svg
                         class="o-icon"
@@ -490,7 +495,12 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
                           fill="currentColor"
                         />
                       </svg>
-                    </span>
+                      
+                      <div
+                        class="o-colored-border position-absolute bottom-0 w-100 os-theme-dependant"
+                        style="border-color: #ffffff"
+                      />
+                    </div>
                   </span>
                   
                 </div>
@@ -880,8 +890,8 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
         >
           
           <div
-            class="o-grid-add-rows mt-2 ms-2 w-100 d-flex position-relative align-items-center"
-            style="top:2300px; "
+            class="o-grid-add-rows mt-2 ms-2 w-100 d-flex position-relative align-items-center os-theme-dependant"
+            style="top:2300px; z-index:1; "
           >
             <button
               class="o-button flex-grow-0 me-2"
@@ -958,6 +968,7 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
         </div>
         
         <canvas
+          class="os-theme-dependant pe-none"
           height="985"
           style="width:985px; height:985px; "
           width="985"
@@ -1157,7 +1168,7 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
 exports[`components take the small screen into account 1`] = `
 <div
   class="o-spreadsheet h-100 w-100 o-spreadsheet-mobile"
-  style="--os-scrollbar-width:15px; grid-template-rows:min-content auto min-content; grid-template-columns:auto auto; "
+  style="--os-scrollbar-width:15px; --os-dark-mode-filter:invert(1) hue-rotate(170deg) contrast(0.85) brightness(1.2); color-scheme:light; grid-template-rows:min-content auto min-content; grid-template-columns:auto auto; "
 >
   
   
@@ -1541,8 +1552,8 @@ exports[`components take the small screen into account 1`] = `
                     class="o-color-picker-button o-hoverable-button o-menu-item-button o-toolbar-button"
                     title="Text Color"
                   >
-                    <span
-                      style="border-color: #000000"
+                    <div
+                      class="position-relative"
                     >
                       <svg
                         class="o-icon"
@@ -1554,7 +1565,12 @@ exports[`components take the small screen into account 1`] = `
                           fill="currentColor"
                         />
                       </svg>
-                    </span>
+                      
+                      <div
+                        class="o-colored-border position-absolute bottom-0 w-100 os-theme-dependant"
+                        style="border-color: #000000"
+                      />
+                    </div>
                   </span>
                   
                 </div>
@@ -1580,8 +1596,8 @@ exports[`components take the small screen into account 1`] = `
                     class="o-color-picker-button o-hoverable-button o-menu-item-button o-toolbar-button"
                     title="Fill Color"
                   >
-                    <span
-                      style="border-color: #ffffff"
+                    <div
+                      class="position-relative"
                     >
                       <svg
                         class="o-icon"
@@ -1593,7 +1609,12 @@ exports[`components take the small screen into account 1`] = `
                           fill="currentColor"
                         />
                       </svg>
-                    </span>
+                      
+                      <div
+                        class="o-colored-border position-absolute bottom-0 w-100 os-theme-dependant"
+                        style="border-color: #ffffff"
+                      />
+                    </div>
                   </span>
                   
                 </div>
@@ -1940,8 +1961,8 @@ exports[`components take the small screen into account 1`] = `
         >
           
           <div
-            class="o-grid-add-rows mt-2 ms-2 w-100 d-flex position-relative align-items-center"
-            style="top:2300px; "
+            class="o-grid-add-rows mt-2 ms-2 w-100 d-flex position-relative align-items-center os-theme-dependant"
+            style="top:2300px; z-index:1; "
           >
             <button
               class="o-button flex-grow-0 me-2"
@@ -2018,6 +2039,7 @@ exports[`components take the small screen into account 1`] = `
         </div>
         
         <canvas
+          class="os-theme-dependant pe-none"
           height="985"
           style="width:485px; height:985px; "
           width="485"

--- a/tests/spreadsheet/spreadsheet_component.test.ts
+++ b/tests/spreadsheet/spreadsheet_component.test.ts
@@ -492,8 +492,8 @@ test("components take the small screen into account", async () => {
 });
 
 test("Spreadsheet color scheme can be set to dark", async () => {
-  const model = new Model();
-  await mountSpreadsheet({ model, colorScheme: "dark" });
+  const model = new Model({}, { colorScheme: "dark" });
+  await mountSpreadsheet({ model });
   expect(".o-spreadsheet").toHaveStyle({ "color-scheme": "dark" });
 });
 

--- a/tests/test_helpers/constants.ts
+++ b/tests/test_helpers/constants.ts
@@ -9,7 +9,7 @@ import {
   SpreadsheetPivotTable,
   TableStyle,
 } from "../../src";
-import { BACKGROUND_CHART_COLOR, DEFAULT_BORDER_DESC } from "../../src/constants";
+import { DEFAULT_BORDER_DESC } from "../../src/constants";
 import { DEFAULT_TABLE_CONFIG } from "../../src/helpers/table_presets";
 import { toZone } from "../../src/helpers/zones";
 import { PivotCoreDefinition } from "../../src/types/pivot";
@@ -30,7 +30,7 @@ export const TEST_CHART_DATA = {
       dataSetsHaveTitle: true,
     }),
     title: { text: "hello" },
-    background: BACKGROUND_CHART_COLOR,
+    background: "#FFFFFF",
     stacked: false,
     legendPosition: "top" as const,
     humanize: true,
@@ -47,7 +47,7 @@ export const TEST_CHART_DATA = {
       dataSetsHaveTitle: true,
     }),
     title: { text: "hello" },
-    background: BACKGROUND_CHART_COLOR,
+    background: "#FFFFFF",
     legendPosition: "top" as const,
     humanize: true,
   },
@@ -92,7 +92,7 @@ export const TEST_CHART_DATA = {
       labelRange: "A1",
     }),
     title: { text: "hello" },
-    background: BACKGROUND_CHART_COLOR,
+    background: "#FFFFFF",
   },
 };
 

--- a/tests/test_helpers/dom_helper.ts
+++ b/tests/test_helpers/dom_helper.ts
@@ -582,7 +582,7 @@ export async function changeRoundColorPickerColor(selector: string, color: strin
 export function getColorPickerWidgetColor(selector: string, widgetTitle: string) {
   const el = document
     .querySelector<HTMLElement>(selector)!
-    .querySelector<HTMLElement>(`.o-color-picker-button[title="${widgetTitle}"] span`);
+    .querySelector<HTMLElement>(`.o-color-picker-button[title="${widgetTitle}"] .o-colored-border`);
 
   const color = el?.style.borderColor;
   return toHex(color ?? "");


### PR DESCRIPTION
This commit adds the isDarkMode in the configuration of the model. We then use a getters isDarkMode() to know if we are in a dark mode rendering, and a new plugin ColorThemeUIPlugin to adapt the colors we want to draw/use according to the current color theme. This getters is then used in the color picker and in the grid renderer for cell text, background, border, DV, table and CF.

For the grid (border, background, headers, frozen pane), a theme has been fixed with colors depending on the current color scheme.

For the chart, we currently keep all the colors set by the user as is, and all default colors (scale, grid, title, legend, default background) are updated.

## Related Task:

- Task: [5245940](https://www.odoo.com/odoo/2328/tasks/5245940)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo