### PR TITLE
[PERF] evalution: compute function once

### DIFF
--- a/packages/o-spreadsheet-engine/src/formulas/compiler.ts
+++ b/packages/o-spreadsheet-engine/src/formulas/compiler.ts
@@ -356,7 +356,7 @@ function compileTokensOrThrow(tokens: Token[]): ICompiledFormula {
       const argToFocus = argTargeting(functionDefinition, args.length);
 
       for (let i = 0; i < args.length; i++) {
-        const argDefinition = functionDefinition.args[argToFocus(i).index];
+        const argDefinition = functionDefinition.args[argToFocus[i].index];
         const currentArg = args[i];
         const argTypes = argDefinition.type || [];
 

--- a/packages/o-spreadsheet-engine/src/formulas/formula_formatter.ts
+++ b/packages/o-spreadsheet-engine/src/formulas/formula_formatter.ts
@@ -246,11 +246,11 @@ function astToDoc(ast: AST): Doc {
 
     case "FUNCALL":
       const functionDescription = functionRegistry.get(ast.value.toUpperCase());
-      const getArgToFocus = argTargeting(functionDescription, ast.args.length);
+      const argsToFocus = argTargeting(functionDescription, ast.args.length);
       const docs: Doc[] = [];
       let i = 0;
       while (i < ast.args.length) {
-        const isRepeating = functionDescription.args[getArgToFocus(i).index]?.repeating;
+        const isRepeating = functionDescription.args[argsToFocus[i].index]?.repeating;
         if (isRepeating) {
           const repeatingArgSeries = ast.args.slice(i, i + functionDescription.nbrArgRepeating);
           const docsSeries = repeatingArgSeries.map((arg) => astToDoc(arg));

--- a/packages/o-spreadsheet-engine/src/functions/arguments.ts
+++ b/packages/o-spreadsheet-engine/src/functions/arguments.ts
@@ -1,3 +1,4 @@
+import { Immutable } from "..";
 import {
   AddFunctionDescription,
   ArgDefinition,
@@ -128,10 +129,7 @@ export function addMetaInfoFromArg(
   return descr;
 }
 
-type ArgToFocus = (argPosition: number) => {
-  index: number;
-  repeatingGroupIndex?: number;
-};
+type ArgToFocus = Immutable<Record<number, { index: number; repeatingGroupIndex?: number }>>;
 const cacheArgTargeting: Record<string, Record<number, ArgToFocus>> = {};
 
 /**
@@ -278,9 +276,7 @@ export function _argTargeting(
     countValueSupplied++;
   }
 
-  return (argPosition: number) => {
-    return valueIndexToArgPosition[argPosition];
-  };
+  return valueIndexToArgPosition;
 }
 
 //------------------------------------------------------------------------------

--- a/packages/o-spreadsheet-engine/src/functions/create_compute_function.ts
+++ b/packages/o-spreadsheet-engine/src/functions/create_compute_function.ts
@@ -16,10 +16,10 @@ export function createComputeFunction(
   ): FunctionResultObject | Matrix<FunctionResultObject> {
     const acceptToVectorize: boolean[] = [];
 
-    const getArgToFocus = argTargeting(descr, args.length);
+    const argsToFocus = argTargeting(descr, args.length);
     //#region Compute vectorisation limits
     for (let i = 0; i < args.length; i++) {
-      const argIndex = getArgToFocus(i).index;
+      const argIndex = argsToFocus[i].index;
       const argDefinition = descr.args[argIndex];
       const arg = args[i];
       if (!isMatrix(arg) && argDefinition.acceptMatrixOnly) {
@@ -54,10 +54,10 @@ export function createComputeFunction(
     this: EvalContext,
     ...args: Arg[]
   ): Matrix<FunctionResultObject> | FunctionResultObject {
-    const getArgToFocus = argTargeting(descr, args.length);
+    const argsToFocus = argTargeting(descr, args.length);
     for (let i = 0; i < args.length; i++) {
       const arg = args[i];
-      const argDefinition = descr.args[getArgToFocus(i).index];
+      const argDefinition = descr.args[argsToFocus[i].index];
 
       // Early exit if the argument is an error and the function does not accept errors
       // We only check scalar arguments, not matrix arguments for performance reasons.

--- a/src/components/composer/composer/composer.ts
+++ b/src/components/composer/composer/composer.ts
@@ -797,7 +797,7 @@ export class Composer extends Component<CellComposerProps, SpreadsheetChildEnv> 
       argTargeting(
         description,
         Math.max(Math.min(maxArgPossible, nbrArgSuppliedRoundedToGroupOfRepeating), minArgRequired)
-      )(argPosition).repeatingGroupIndex ?? 0
+      )[argPosition].repeatingGroupIndex ?? 0
     );
   }
 
@@ -824,7 +824,7 @@ export class Composer extends Component<CellComposerProps, SpreadsheetChildEnv> 
       const focusedArg = argTargeting(
         description,
         Math.max(Math.min(maxArgPossible, nbrArgSupplied), minArgRequired)
-      )(argPosition)?.index;
+      )[argPosition]?.index;
       return focusedArg !== undefined ? [focusedArg] : [];
     }
 
@@ -839,7 +839,7 @@ export class Composer extends Component<CellComposerProps, SpreadsheetChildEnv> 
 
     const argsToFocus: number[] = [];
     for (let i = minArgsNumberPossibility; i <= maxArgsNumberPossibility; i++) {
-      const focusedArg = argTargeting(description, i)(argPosition)?.index;
+      const focusedArg = argTargeting(description, i)[argPosition]?.index;
       if (focusedArg !== undefined) {
         argsToFocus.push(focusedArg);
       }

--- a/tests/functions/arguments.test.ts
+++ b/tests/functions/arguments.test.ts
@@ -205,9 +205,9 @@ describe("function addMetaInfoFromArg", () => {
     expect(descr.nbrArgRepeating).toBe(0);
     expect(descr.nbrOptionalNonRepeatingArgs).toBe(0);
 
-    const getArgToFocus = argTargeting(descr, 2);
-    expect(getArgToFocus(0).index).toBe(0);
-    expect(getArgToFocus(1).index).toBe(1);
+    const argsToFocus = argTargeting(descr, 2);
+    expect(argsToFocus[0].index).toBe(0);
+    expect(argsToFocus[1].index).toBe(1);
   });
 
   test("with optional arguments", () => {
@@ -228,12 +228,12 @@ describe("function addMetaInfoFromArg", () => {
     expect(descr.nbrArgRepeating).toBe(0);
     expect(descr.nbrOptionalNonRepeatingArgs).toBe(1);
 
-    const getArgToFocusOnOneArg = argTargeting(descr, 1);
-    expect(getArgToFocusOnOneArg(0).index).toBe(0);
+    const argsToFocusOnOneArg = argTargeting(descr, 1);
+    expect(argsToFocusOnOneArg[0].index).toBe(0);
 
-    const getArgToFocusOnTwoArgs = argTargeting(descr, 2);
-    expect(getArgToFocusOnTwoArgs(0).index).toBe(0);
-    expect(getArgToFocusOnTwoArgs(1).index).toBe(1);
+    const argsToFocusOnTwoArgs = argTargeting(descr, 2);
+    expect(argsToFocusOnTwoArgs[0].index).toBe(0);
+    expect(argsToFocusOnTwoArgs[1].index).toBe(1);
   });
 
   test("with repeatable argument", () => {
@@ -254,17 +254,17 @@ describe("function addMetaInfoFromArg", () => {
     expect(descr.nbrArgRepeating).toBe(1);
     expect(descr.nbrOptionalNonRepeatingArgs).toBe(0);
 
-    const getArgToFocusOnOneArg = argTargeting(descr, 1);
-    expect(getArgToFocusOnOneArg(0).index).toBe(0);
+    const argsToFocusOnOneArg = argTargeting(descr, 1);
+    expect(argsToFocusOnOneArg[0].index).toBe(0);
 
-    const getArgToFocusOnSeveralArgs = argTargeting(descr, 42);
-    expect(getArgToFocusOnSeveralArgs(0).index).toBe(0);
-    expect(getArgToFocusOnSeveralArgs(1).index).toBe(1);
-    expect(getArgToFocusOnSeveralArgs(1).repeatingGroupIndex).toBe(0);
-    expect(getArgToFocusOnSeveralArgs(20).index).toBe(1);
-    expect(getArgToFocusOnSeveralArgs(20).repeatingGroupIndex).toBe(19);
-    expect(getArgToFocusOnSeveralArgs(41).index).toBe(1);
-    expect(getArgToFocusOnSeveralArgs(41).repeatingGroupIndex).toBe(40);
+    const argsToFocusOnSeveralArgs = argTargeting(descr, 42);
+    expect(argsToFocusOnSeveralArgs[0].index).toBe(0);
+    expect(argsToFocusOnSeveralArgs[1].index).toBe(1);
+    expect(argsToFocusOnSeveralArgs[1].repeatingGroupIndex).toBe(0);
+    expect(argsToFocusOnSeveralArgs[20].index).toBe(1);
+    expect(argsToFocusOnSeveralArgs[20].repeatingGroupIndex).toBe(19);
+    expect(argsToFocusOnSeveralArgs[41].index).toBe(1);
+    expect(argsToFocusOnSeveralArgs[41].repeatingGroupIndex).toBe(40);
   });
 
   test("with more than one repeatable argument", () => {
@@ -286,16 +286,16 @@ describe("function addMetaInfoFromArg", () => {
     expect(descr.nbrArgRepeating).toBe(2);
     expect(descr.nbrOptionalNonRepeatingArgs).toBe(0);
 
-    const getArgToFocus = argTargeting(descr, 42);
-    expect(getArgToFocus(0).index).toBe(0);
-    expect(getArgToFocus(1).index).toBe(1);
-    expect(getArgToFocus(1).repeatingGroupIndex).toBe(0);
-    expect(getArgToFocus(2).index).toBe(2);
-    expect(getArgToFocus(2).repeatingGroupIndex).toBe(0);
-    expect(getArgToFocus(4).index).toBe(2);
-    expect(getArgToFocus(4).repeatingGroupIndex).toBe(1);
-    expect(getArgToFocus(7).index).toBe(1);
-    expect(getArgToFocus(7).repeatingGroupIndex).toBe(3);
+    const argsToFocus = argTargeting(descr, 42);
+    expect(argsToFocus[0].index).toBe(0);
+    expect(argsToFocus[1].index).toBe(1);
+    expect(argsToFocus[1].repeatingGroupIndex).toBe(0);
+    expect(argsToFocus[2].index).toBe(2);
+    expect(argsToFocus[2].repeatingGroupIndex).toBe(0);
+    expect(argsToFocus[4].index).toBe(2);
+    expect(argsToFocus[4].repeatingGroupIndex).toBe(1);
+    expect(argsToFocus[7].index).toBe(1);
+    expect(argsToFocus[7].repeatingGroupIndex).toBe(3);
   });
 
   test("with optional arg after repeatable argument", () => {
@@ -319,31 +319,31 @@ describe("function addMetaInfoFromArg", () => {
     expect(descr.nbrArgRepeating).toBe(2);
     expect(descr.nbrOptionalNonRepeatingArgs).toBe(1);
 
-    const getArgToFocus_3 = argTargeting(descr, 3);
-    expect(getArgToFocus_3(0).index).toBe(0);
-    expect(getArgToFocus_3(1).index).toBe(1);
-    expect(getArgToFocus_3(1).repeatingGroupIndex).toBe(0);
-    expect(getArgToFocus_3(2).index).toBe(2);
-    expect(getArgToFocus_3(2).repeatingGroupIndex).toBe(0);
+    const argsToFocus_3 = argTargeting(descr, 3);
+    expect(argsToFocus_3[0].index).toBe(0);
+    expect(argsToFocus_3[1].index).toBe(1);
+    expect(argsToFocus_3[1].repeatingGroupIndex).toBe(0);
+    expect(argsToFocus_3[2].index).toBe(2);
+    expect(argsToFocus_3[2].repeatingGroupIndex).toBe(0);
 
-    const getArgToFocus_4 = argTargeting(descr, 4);
-    expect(getArgToFocus_4(0).index).toBe(0);
-    expect(getArgToFocus_4(1).index).toBe(1);
-    expect(getArgToFocus_4(1).repeatingGroupIndex).toBe(0);
-    expect(getArgToFocus_4(2).index).toBe(2);
-    expect(getArgToFocus_4(2).repeatingGroupIndex).toBe(0);
-    expect(getArgToFocus_4(3).index).toBe(3);
+    const argsToFocus_4 = argTargeting(descr, 4);
+    expect(argsToFocus_4[0].index).toBe(0);
+    expect(argsToFocus_4[1].index).toBe(1);
+    expect(argsToFocus_4[1].repeatingGroupIndex).toBe(0);
+    expect(argsToFocus_4[2].index).toBe(2);
+    expect(argsToFocus_4[2].repeatingGroupIndex).toBe(0);
+    expect(argsToFocus_4[3].index).toBe(3);
 
-    const getArgToFocus_5 = argTargeting(descr, 5);
-    expect(getArgToFocus_5(0).index).toBe(0);
-    expect(getArgToFocus_5(1).index).toBe(1);
-    expect(getArgToFocus_5(1).repeatingGroupIndex).toBe(0);
-    expect(getArgToFocus_5(2).index).toBe(2);
-    expect(getArgToFocus_5(2).repeatingGroupIndex).toBe(0);
-    expect(getArgToFocus_5(3).index).toBe(1);
-    expect(getArgToFocus_5(3).repeatingGroupIndex).toBe(1);
-    expect(getArgToFocus_5(4).index).toBe(2);
-    expect(getArgToFocus_5(4).repeatingGroupIndex).toBe(1);
+    const argsToFocus_5 = argTargeting(descr, 5);
+    expect(argsToFocus_5[0].index).toBe(0);
+    expect(argsToFocus_5[1].index).toBe(1);
+    expect(argsToFocus_5[1].repeatingGroupIndex).toBe(0);
+    expect(argsToFocus_5[2].index).toBe(2);
+    expect(argsToFocus_5[2].repeatingGroupIndex).toBe(0);
+    expect(argsToFocus_5[3].index).toBe(1);
+    expect(argsToFocus_5[3].repeatingGroupIndex).toBe(1);
+    expect(argsToFocus_5[4].index).toBe(2);
+    expect(argsToFocus_5[4].repeatingGroupIndex).toBe(1);
   });
 
   test("with 2 optionals arg after 3 repeatable arguments", () => {
@@ -369,31 +369,31 @@ describe("function addMetaInfoFromArg", () => {
     expect(descr.nbrArgRepeating).toBe(3);
     expect(descr.nbrOptionalNonRepeatingArgs).toBe(2);
 
-    const getArgToFocus_5 = argTargeting(descr, 5);
-    expect(getArgToFocus_5(0).index).toBe(0);
-    expect(getArgToFocus_5(1).index).toBe(1);
-    expect(getArgToFocus_5(1).repeatingGroupIndex).toBe(0);
-    expect(getArgToFocus_5(2).index).toBe(2);
-    expect(getArgToFocus_5(2).repeatingGroupIndex).toBe(0);
-    expect(getArgToFocus_5(3).index).toBe(3);
-    expect(getArgToFocus_5(3).repeatingGroupIndex).toBe(0);
-    expect(getArgToFocus_5(4).index).toBe(4);
+    const argsToFocus_5 = argTargeting(descr, 5);
+    expect(argsToFocus_5[0].index).toBe(0);
+    expect(argsToFocus_5[1].index).toBe(1);
+    expect(argsToFocus_5[1].repeatingGroupIndex).toBe(0);
+    expect(argsToFocus_5[2].index).toBe(2);
+    expect(argsToFocus_5[2].repeatingGroupIndex).toBe(0);
+    expect(argsToFocus_5[3].index).toBe(3);
+    expect(argsToFocus_5[3].repeatingGroupIndex).toBe(0);
+    expect(argsToFocus_5[4].index).toBe(4);
 
-    const getArgToFocus_8 = argTargeting(descr, 8);
-    expect(getArgToFocus_8(0).index).toBe(0);
-    expect(getArgToFocus_8(1).index).toBe(1);
-    expect(getArgToFocus_8(1).repeatingGroupIndex).toBe(0);
-    expect(getArgToFocus_8(2).index).toBe(2);
-    expect(getArgToFocus_8(2).repeatingGroupIndex).toBe(0);
-    expect(getArgToFocus_8(3).index).toBe(3);
-    expect(getArgToFocus_8(3).repeatingGroupIndex).toBe(0);
-    expect(getArgToFocus_8(4).index).toBe(1);
-    expect(getArgToFocus_8(4).repeatingGroupIndex).toBe(1);
-    expect(getArgToFocus_8(5).index).toBe(2);
-    expect(getArgToFocus_8(5).repeatingGroupIndex).toBe(1);
-    expect(getArgToFocus_8(6).index).toBe(3);
-    expect(getArgToFocus_8(6).repeatingGroupIndex).toBe(1);
-    expect(getArgToFocus_8(7).index).toBe(4);
+    const argsToFocus_8 = argTargeting(descr, 8);
+    expect(argsToFocus_8[0].index).toBe(0);
+    expect(argsToFocus_8[1].index).toBe(1);
+    expect(argsToFocus_8[1].repeatingGroupIndex).toBe(0);
+    expect(argsToFocus_8[2].index).toBe(2);
+    expect(argsToFocus_8[2].repeatingGroupIndex).toBe(0);
+    expect(argsToFocus_8[3].index).toBe(3);
+    expect(argsToFocus_8[3].repeatingGroupIndex).toBe(0);
+    expect(argsToFocus_8[4].index).toBe(1);
+    expect(argsToFocus_8[4].repeatingGroupIndex).toBe(1);
+    expect(argsToFocus_8[5].index).toBe(2);
+    expect(argsToFocus_8[5].repeatingGroupIndex).toBe(1);
+    expect(argsToFocus_8[6].index).toBe(3);
+    expect(argsToFocus_8[6].repeatingGroupIndex).toBe(1);
+    expect(argsToFocus_8[7].index).toBe(4);
   });
 
   test("with required arg after repeatable argument", () => {
@@ -417,29 +417,29 @@ describe("function addMetaInfoFromArg", () => {
     expect(descr.nbrArgRepeating).toBe(2);
     expect(descr.nbrOptionalNonRepeatingArgs).toBe(0);
 
-    const getArgToFocus_2 = argTargeting(descr, 2);
-    expect(getArgToFocus_2(0).index).toBe(0);
-    expect(getArgToFocus_2(1).index).toBe(3);
+    const argsToFocus_2 = argTargeting(descr, 2);
+    expect(argsToFocus_2[0].index).toBe(0);
+    expect(argsToFocus_2[1].index).toBe(3);
 
-    const getArgToFocus_4 = argTargeting(descr, 4);
-    expect(getArgToFocus_4(0).index).toBe(0);
-    expect(getArgToFocus_4(1).index).toBe(1);
-    expect(getArgToFocus_4(1).repeatingGroupIndex).toBe(0);
-    expect(getArgToFocus_4(2).index).toBe(2);
-    expect(getArgToFocus_4(2).repeatingGroupIndex).toBe(0);
-    expect(getArgToFocus_4(3).index).toBe(3);
+    const argsToFocus_4 = argTargeting(descr, 4);
+    expect(argsToFocus_4[0].index).toBe(0);
+    expect(argsToFocus_4[1].index).toBe(1);
+    expect(argsToFocus_4[1].repeatingGroupIndex).toBe(0);
+    expect(argsToFocus_4[2].index).toBe(2);
+    expect(argsToFocus_4[2].repeatingGroupIndex).toBe(0);
+    expect(argsToFocus_4[3].index).toBe(3);
 
-    const getArgToFocus_6 = argTargeting(descr, 6);
-    expect(getArgToFocus_6(0).index).toBe(0);
-    expect(getArgToFocus_6(1).index).toBe(1);
-    expect(getArgToFocus_6(1).repeatingGroupIndex).toBe(0);
-    expect(getArgToFocus_6(2).index).toBe(2);
-    expect(getArgToFocus_6(2).repeatingGroupIndex).toBe(0);
-    expect(getArgToFocus_6(3).index).toBe(1);
-    expect(getArgToFocus_6(3).repeatingGroupIndex).toBe(1);
-    expect(getArgToFocus_6(4).index).toBe(2);
-    expect(getArgToFocus_6(4).repeatingGroupIndex).toBe(1);
-    expect(getArgToFocus_6(5).index).toBe(3);
+    const argsToFocus_6 = argTargeting(descr, 6);
+    expect(argsToFocus_6[0].index).toBe(0);
+    expect(argsToFocus_6[1].index).toBe(1);
+    expect(argsToFocus_6[1].repeatingGroupIndex).toBe(0);
+    expect(argsToFocus_6[2].index).toBe(2);
+    expect(argsToFocus_6[2].repeatingGroupIndex).toBe(0);
+    expect(argsToFocus_6[3].index).toBe(1);
+    expect(argsToFocus_6[3].repeatingGroupIndex).toBe(1);
+    expect(argsToFocus_6[4].index).toBe(2);
+    expect(argsToFocus_6[4].repeatingGroupIndex).toBe(1);
+    expect(argsToFocus_6[5].index).toBe(3);
   });
 
   test("with required arg after optional argument", () => {
@@ -463,20 +463,20 @@ describe("function addMetaInfoFromArg", () => {
     expect(descr.nbrArgRepeating).toBe(0);
     expect(descr.nbrOptionalNonRepeatingArgs).toBe(2);
 
-    const getArgToFocus_2 = argTargeting(descr, 2);
-    expect(getArgToFocus_2(0).index).toBe(0);
-    expect(getArgToFocus_2(1).index).toBe(3);
+    const argsToFocus_2 = argTargeting(descr, 2);
+    expect(argsToFocus_2[0].index).toBe(0);
+    expect(argsToFocus_2[1].index).toBe(3);
 
-    const getArgToFocus_3 = argTargeting(descr, 3);
-    expect(getArgToFocus_3(0).index).toBe(0);
-    expect(getArgToFocus_3(1).index).toBe(1);
-    expect(getArgToFocus_3(2).index).toBe(3);
+    const argsToFocus_3 = argTargeting(descr, 3);
+    expect(argsToFocus_3[0].index).toBe(0);
+    expect(argsToFocus_3[1].index).toBe(1);
+    expect(argsToFocus_3[2].index).toBe(3);
 
-    const getArgToFocus_4 = argTargeting(descr, 4);
-    expect(getArgToFocus_4(0).index).toBe(0);
-    expect(getArgToFocus_4(1).index).toBe(1);
-    expect(getArgToFocus_4(2).index).toBe(2);
-    expect(getArgToFocus_4(3).index).toBe(3);
+    const argsToFocus_4 = argTargeting(descr, 4);
+    expect(argsToFocus_4[0].index).toBe(0);
+    expect(argsToFocus_4[1].index).toBe(1);
+    expect(argsToFocus_4[2].index).toBe(2);
+    expect(argsToFocus_4[3].index).toBe(3);
   });
 
   test("a random case", () => {
@@ -506,39 +506,39 @@ describe("function addMetaInfoFromArg", () => {
     expect(descr.nbrArgRepeating).toBe(4);
     expect(descr.nbrOptionalNonRepeatingArgs).toBe(3);
 
-    const getArgToFocus_3 = argTargeting(descr, 3);
-    expect(getArgToFocus_3(0).index).toBe(1);
-    expect(getArgToFocus_3(1).index).toBe(3);
-    expect(getArgToFocus_3(2).index).toBe(9);
+    const argsToFocus_3 = argTargeting(descr, 3);
+    expect(argsToFocus_3[0].index).toBe(1);
+    expect(argsToFocus_3[1].index).toBe(3);
+    expect(argsToFocus_3[2].index).toBe(9);
 
-    const getArgToFocus_4 = argTargeting(descr, 4);
-    expect(getArgToFocus_4(0).index).toBe(0);
-    expect(getArgToFocus_4(1).index).toBe(1);
-    expect(getArgToFocus_4(2).index).toBe(3);
-    expect(getArgToFocus_4(3).index).toBe(9);
+    const argsToFocus_4 = argTargeting(descr, 4);
+    expect(argsToFocus_4[0].index).toBe(0);
+    expect(argsToFocus_4[1].index).toBe(1);
+    expect(argsToFocus_4[2].index).toBe(3);
+    expect(argsToFocus_4[3].index).toBe(9);
 
-    const getArgToFocus_5 = argTargeting(descr, 5);
-    expect(getArgToFocus_5(0).index).toBe(0);
-    expect(getArgToFocus_5(1).index).toBe(1);
-    expect(getArgToFocus_5(2).index).toBe(2);
-    expect(getArgToFocus_5(3).index).toBe(3);
-    expect(getArgToFocus_5(4).index).toBe(9);
+    const argsToFocus_5 = argTargeting(descr, 5);
+    expect(argsToFocus_5[0].index).toBe(0);
+    expect(argsToFocus_5[1].index).toBe(1);
+    expect(argsToFocus_5[2].index).toBe(2);
+    expect(argsToFocus_5[3].index).toBe(3);
+    expect(argsToFocus_5[4].index).toBe(9);
 
-    const getArgToFocus_6 = argTargeting(descr, 6);
-    expect(getArgToFocus_6(0).index).toBe(0);
-    expect(getArgToFocus_6(1).index).toBe(1);
-    expect(getArgToFocus_6(2).index).toBe(2);
-    expect(getArgToFocus_6(3).index).toBe(3);
-    expect(getArgToFocus_6(4).index).toBe(8);
-    expect(getArgToFocus_6(5).index).toBe(9);
+    const argsToFocus_6 = argTargeting(descr, 6);
+    expect(argsToFocus_6[0].index).toBe(0);
+    expect(argsToFocus_6[1].index).toBe(1);
+    expect(argsToFocus_6[2].index).toBe(2);
+    expect(argsToFocus_6[3].index).toBe(3);
+    expect(argsToFocus_6[4].index).toBe(8);
+    expect(argsToFocus_6[5].index).toBe(9);
 
-    const getArgToFocus_7 = argTargeting(descr, 7);
-    expect(getArgToFocus_7(0).index).toBe(1);
-    expect(getArgToFocus_7(1).index).toBe(3);
-    expect(getArgToFocus_7(2).index).toBe(4);
-    expect(getArgToFocus_7(3).index).toBe(5);
-    expect(getArgToFocus_7(4).index).toBe(6);
-    expect(getArgToFocus_7(5).index).toBe(7);
-    expect(getArgToFocus_7(6).index).toBe(9);
+    const argsToFocus_7 = argTargeting(descr, 7);
+    expect(argsToFocus_7[0].index).toBe(1);
+    expect(argsToFocus_7[1].index).toBe(3);
+    expect(argsToFocus_7[2].index).toBe(4);
+    expect(argsToFocus_7[3].index).toBe(5);
+    expect(argsToFocus_7[4].index).toBe(6);
+    expect(argsToFocus_7[5].index).toBe(7);
+    expect(argsToFocus_7[6].index).toBe(9);
   });
 });


### PR DESCRIPTION
Move it outside of the loop.

It's not a big perf improvement because `argTargeting` has a cache, but it's free.

Task: 0

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo