### PR TITLE
[FIX] Table side panel: fix closing

### DIFF
--- a/src/actions/edit_actions.ts
+++ b/src/actions/edit_actions.ts
@@ -6,6 +6,7 @@ import { _t } from "../translation";
 import { SpreadsheetChildEnv } from "../types/spreadsheet_env";
 import { ActionSpec } from "./action";
 import * as ACTIONS from "./menu_items_actions";
+import { FIRST_TABLE_IN_SELECTION } from "./menu_items_actions";
 
 export const undo: ActionSpec = {
   name: _t("Undo"),
@@ -159,7 +160,12 @@ export const mergeCells: ActionSpec = {
 
 export const editTable: ActionSpec = {
   name: () => _t("Edit table"),
-  execute: (env) => env.openSidePanel("TableSidePanel", {}),
+  execute: (env) => {
+    const table = FIRST_TABLE_IN_SELECTION(env);
+    if (table) {
+      env.openSidePanel("TableSidePanel", { table });
+    }
+  },
   icon: "o-spreadsheet-Icon.EDIT_TABLE",
 };
 

--- a/src/actions/menu_items_actions.ts
+++ b/src/actions/menu_items_actions.ts
@@ -633,7 +633,10 @@ export const INSERT_TABLE = (env: SpreadsheetChildEnv) => {
 
   const result = interactiveCreateTable(env, sheetId);
   if (result.isSuccessful) {
-    env.openSidePanel("TableSidePanel", {});
+    const table = FIRST_TABLE_IN_SELECTION(env);
+    if (table) {
+      env.openSidePanel("TableSidePanel", { table });
+    }
   }
 };
 

--- a/src/components/side_panel/table_panel/table_panel.ts
+++ b/src/components/side_panel/table_panel/table_panel.ts
@@ -1,4 +1,4 @@
-import { proxy, useProps } from "@odoo/owl";
+import { onWillUpdateProps, proxy, useProps } from "@odoo/owl";
 import { getZoneArea, positionToZone } from "../../../helpers/zones";
 import { Component } from "../../../owl3_compatibility_layer";
 import { CommandResult, DispatchResult } from "../../../types/commands";
@@ -6,6 +6,7 @@ import { Zone } from "../../../types/misc";
 import { Range } from "../../../types/range";
 import { TableConfig } from "../../../types/table";
 
+import { deepEquals } from "../../../helpers/misc";
 import { getTableTopLeft } from "../../../helpers/table_helpers";
 import { useStore } from "../../../store_engine/store_hooks";
 import { TableResizeStore } from "../../../stores/table_resize_store";
@@ -52,6 +53,13 @@ export class TablePanel extends Component<SpreadsheetChildEnv> {
       filtersEnabledIfPossible: this.props.table.config.hasFilters,
     });
     useStore(TableResizeStore);
+    onWillUpdateProps((nextProps) => {
+      if (!deepEquals(nextProps.table.range, this.props.table.range)) {
+        this.state.tableXc = this.env.model.getters.getRangeString(nextProps.table.range, sheetId);
+        this.state.tableZoneErrors = [];
+        this.state.filtersEnabledIfPossible = nextProps.table.config.hasFilters;
+      }
+    });
   }
 
   updateHasFilters(hasFilters: boolean) {

--- a/src/components/side_panel/table_panel/table_panel.ts
+++ b/src/components/side_panel/table_panel/table_panel.ts
@@ -6,11 +6,13 @@ import { Zone } from "../../../types/misc";
 import { Range } from "../../../types/range";
 import { TableConfig } from "../../../types/table";
 
+import { HIGHLIGHT_COLOR } from "../../../constants";
 import { deepEquals } from "../../../helpers/misc";
 import { getTableTopLeft } from "../../../helpers/table_helpers";
 import { useStore } from "../../../store_engine/store_hooks";
 import { TableResizeStore } from "../../../stores/table_resize_store";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
+import { useHighlights } from "../../helpers/highlight_hook";
 import { NumberInput } from "../../number_input/number_input";
 import { types } from "../../props_validation";
 import { SelectionInput } from "../../selection_input/selection_input";
@@ -47,6 +49,7 @@ export class TablePanel extends Component<SpreadsheetChildEnv> {
 
   setup() {
     const sheetId = this.env.model.getters.getActiveSheetId();
+    useHighlights(this);
     this.state = proxy({
       tableZoneErrors: [],
       tableXc: this.env.model.getters.getRangeString(this.props.table.range, sheetId),
@@ -60,6 +63,10 @@ export class TablePanel extends Component<SpreadsheetChildEnv> {
         this.state.filtersEnabledIfPossible = nextProps.table.config.hasFilters;
       }
     });
+  }
+
+  get highlights() {
+    return [{ range: this.props.table.range, noFill: true, color: HIGHLIGHT_COLOR }];
   }
 
   updateHasFilters(hasFilters: boolean) {

--- a/src/components/tables/table_dropdown_button/table_dropdown_button.ts
+++ b/src/components/tables/table_dropdown_button/table_dropdown_button.ts
@@ -43,7 +43,10 @@ export class TableDropdownButton extends Component<SpreadsheetChildEnv> {
     const tableConfig = { ...this.tableConfig, styleId };
     const result = interactiveCreateTable(this.env, sheetId, tableConfig);
     if (result.isSuccessful) {
-      this.env.openSidePanel("TableSidePanel", {});
+      const table = FIRST_TABLE_IN_SELECTION(this.env);
+      if (table) {
+        this.env.openSidePanel("TableSidePanel", { table });
+      }
     }
     this.closePopover();
   }
@@ -58,9 +61,10 @@ export class TableDropdownButton extends Component<SpreadsheetChildEnv> {
       this.env.openSidePanel("PivotSidePanel", { pivotId, openTab: "design" });
       return;
     }
-    if (FIRST_TABLE_IN_SELECTION(this.env)) {
+    const table = FIRST_TABLE_IN_SELECTION(this.env);
+    if (table) {
       this.topBarToolStore.closeDropdowns();
-      this.env.toggleSidePanel("TableSidePanel", {});
+      this.env.toggleSidePanel("TableSidePanel", { table });
       return;
     }
 

--- a/src/plugins/core/tables.ts
+++ b/src/plugins/core/tables.ts
@@ -47,8 +47,12 @@ interface TableState {
 }
 
 export class TablePlugin extends CorePlugin<TableState> implements TableState {
-  static getters = ["getCoreTable", "getCoreTables", "getCoreTableMatchingTopLeft"] as const;
-
+  static getters = [
+    "getCoreTable",
+    "getCoreTables",
+    "getCoreTableMatchingTopLeft",
+    "getCoreTableById",
+  ] as const;
   readonly tables: Record<UID, Record<TableId, CoreTable | undefined>> = {};
   readonly nextTableId: number = 1;
 
@@ -194,6 +198,10 @@ export class TablePlugin extends CorePlugin<TableState> implements TableState {
 
   getCoreTable({ sheetId, col, row }: CellPosition): CoreTable | undefined {
     return this.getCoreTables(sheetId).find((table) => isInside(col, row, table.range.zone));
+  }
+
+  getCoreTableById(sheetId: UID, tableId: UID): CoreTable | undefined {
+    return this.tables[sheetId]?.[tableId];
   }
 
   private getTablesOverlappingZones(sheetId: UID, zones: Zone[]): CoreTable[] {

--- a/src/registries/side_panel_registry.ts
+++ b/src/registries/side_panel_registry.ts
@@ -19,7 +19,6 @@ import { SidePanelState } from "../components/side_panel/side_panel/side_panel_s
 import { SplitIntoColumnsPanel } from "../components/side_panel/split_to_columns_panel/split_to_columns_panel";
 import { TablePanel } from "../components/side_panel/table_panel/table_panel";
 import { TableStyleEditorPanel } from "../components/side_panel/table_style_editor_panel/table_style_editor_panel";
-import { getTableTopLeft } from "../helpers/table_helpers";
 import { _t } from "../translation";
 import { ConditionalFormat } from "../types/conditional_formatting";
 import { Getters } from "../types/getters";
@@ -141,16 +140,13 @@ sidePanelRegistry.add("DataAnalysisPanel", {
 sidePanelRegistry.add("TableSidePanel", {
   title: _t("Edit table"),
   Body: TablePanel,
-  computeState: (getters: Getters) => {
-    const sheetId = getters.getActiveSheetId();
-    const selection = getters.getSelectedZones();
-    const table = getters.getTablesOverlappingZones(sheetId, selection)[0];
-    if (!table || table.isPivotTable) {
+  computeState: (getters: Getters, props: PropsOf<TablePanel>) => {
+    const sheetId = props.table.range.sheetId;
+    const table = getters.getCoreTableById(sheetId, props.table.id);
+    if (sheetId !== getters.getActiveSheetId() || !table) {
       return { isOpen: false };
     }
-
-    const coreTable = getters.getCoreTable(getTableTopLeft(table));
-    return { isOpen: true, props: { table: coreTable }, key: table.id };
+    return { isOpen: true, props: { ...props, table }, key: props.table.id };
   },
 });
 

--- a/tests/menus/menu_items_registry.test.ts
+++ b/tests/menus/menu_items_registry.test.ts
@@ -49,6 +49,7 @@ import { createModelWithPivot } from "../test_helpers/pivot_helpers";
 import { Currency, Model } from "../../src";
 
 import { ActionSpec, createAction, createActions } from "../../src/actions/action";
+import { FIRST_TABLE_IN_SELECTION } from "../../src/actions/menu_items_actions";
 import { CellComposerStore } from "../../src/components/composer/composer/cell_composer_store";
 import { FONT_SIZES } from "../../src/constants";
 import { functionRegistry } from "../../src/functions/function_registry";
@@ -1747,9 +1748,10 @@ describe("Menu Item actions", () => {
       test("Edit -> Table (topbar)", async () => {
         const spyOpenSidePanel = jest.spyOn(env, "openSidePanel");
         createTable(model, "A1:A5");
+        const table = FIRST_TABLE_IN_SELECTION(env);
         expect(getName(editTablePath, env)).toBe("Edit table");
         await doAction(editTablePath, env);
-        expect(spyOpenSidePanel).toHaveBeenCalledWith("TableSidePanel", {});
+        expect(spyOpenSidePanel).toHaveBeenCalledWith("TableSidePanel", { table });
       });
 
       test("Edit -> Table (topbar) is not visible if there is no table in the selection", () => {
@@ -1761,9 +1763,10 @@ describe("Menu Item actions", () => {
       test("Edit table (cellRegistry)", async () => {
         const spyOpenSidePanel = jest.spyOn(env, "openSidePanel");
         createTable(model, "A1:A5");
+        const table = FIRST_TABLE_IN_SELECTION(env);
         expect(getName(["edit_table"], env, cellMenuRegistry)).toBe("Edit table");
         await doAction(["edit_table"], env, cellMenuRegistry);
-        expect(spyOpenSidePanel).toHaveBeenCalledWith("TableSidePanel", {});
+        expect(spyOpenSidePanel).toHaveBeenCalledWith("TableSidePanel", { table });
       });
 
       test("Delete table (cellRegistry)", async () => {

--- a/tests/table/table_panel_component.test.ts
+++ b/tests/table/table_panel_component.test.ts
@@ -10,9 +10,15 @@ import {
 } from "../test_helpers/commands_helpers";
 import { click, setInputValueAndTrigger, simulateClick } from "../test_helpers/dom_helper";
 import { getCellRawContent } from "../test_helpers/getters_helpers";
-import { mountComponentWithPortalTarget, nextTick, setGrid } from "../test_helpers/helpers";
+import {
+  mountComponentWithPortalTarget,
+  nextTick,
+  setGrid,
+  toRangeData,
+} from "../test_helpers/helpers";
 
 import { Model } from "../../src";
+import { FIRST_TABLE_IN_SELECTION } from "../../src/actions/menu_items_actions";
 import { AutofillStore } from "../../src/components/autofill/autofill_store";
 import { TableAutofillStore } from "../../src/components/autofill/table_autofill_store";
 import { SidePanels } from "../../src/components/side_panel/side_panels/side_panels";
@@ -40,9 +46,10 @@ describe("Table side panel", () => {
     sheetId = model.getters.getActiveSheetId();
     createTable(model, "A1:C3");
     ({ fixture, env } = await mountComponentWithPortalTarget(SidePanels, { model }));
+    const table = FIRST_TABLE_IN_SELECTION(env);
     env.getStore(AutofillStore);
     env.getStore(TableAutofillStore);
-    env.openSidePanel("TableSidePanel", {});
+    env.openSidePanel("TableSidePanel", { table });
     await nextTick();
   });
 
@@ -173,7 +180,20 @@ describe("Table side panel", () => {
     expect(getTable(model, sheetId).range.zone).toEqual(toZone("A1"));
   });
 
-  test("Changing the selection changes the edited table", async () => {
+  test("The table zone displayed in the side panel is updated when the user modifies the table range with the mouse", async () => {
+    const table = getTable(model, sheetId);
+    expect(fixture.querySelector<HTMLInputElement>(".o-selection input")!.value).toBe("A1:C3");
+    env.model.dispatch("UPDATE_TABLE", {
+      sheetId,
+      zone: table.range.zone,
+      newTableRange: toRangeData(sheetId, "D1:D2"),
+      config: { numberOfHeaders: 0 },
+    });
+    await nextTick();
+    expect(fixture.querySelector<HTMLInputElement>(".o-selection input")!.value).toBe("D1:D2");
+  });
+
+  test("Changing the selection does not change the edited table", async () => {
     createTable(model, "D1:D2");
     updateTableConfig(model, "D1:D2", { numberOfHeaders: 0 });
 
@@ -182,22 +202,22 @@ describe("Table side panel", () => {
 
     setSelection(model, ["D1"]);
     await nextTick();
-    expect(fixture.querySelector<HTMLInputElement>("input[name='headerRow']")!.checked).toBe(false);
-    expect(fixture.querySelector<HTMLInputElement>(".o-selection input")!.value).toBe("D1:D2");
+    expect(fixture.querySelector<HTMLInputElement>("input[name='headerRow']")!.checked).toBe(true);
+    expect(fixture.querySelector<HTMLInputElement>(".o-selection input")!.value).toBe("A1:C3");
   });
 
-  test("Selecting a cell without a table closes the side panel", async () => {
+  test("Selecting a cell without a table does not close the side panel", async () => {
     setSelection(model, ["D1"]);
     await nextTick();
-    expect(fixture.querySelector(".o-table-panel")).toBeNull();
+    expect(fixture.querySelector(".o-table-panel")).not.toBeNull();
   });
 
-  test("Selecting a cell with a pivot table closes the table panel", async () => {
+  test("Selecting a cell with a pivot table does not close the table panel", async () => {
     setGrid(model, { A1: "Header1", B1: "Header2", A2: "Data1", B2: "Data2", F1: "=PIVOT(1)" });
     addPivot(model, "A1:B2", { style: { tableStyleId: "PivotTableStyleMedium9" } });
     setSelection(model, ["F1"]);
     await nextTick();
-    expect(fixture.querySelector(".o-table-panel")).toBeNull();
+    expect(fixture.querySelector(".o-table-panel")).not.toBeNull();
   });
 
   test("Can edit the table style", async () => {

--- a/tests/table/table_panel_component.test.ts
+++ b/tests/table/table_panel_component.test.ts
@@ -11,6 +11,7 @@ import {
 import { click, setInputValueAndTrigger, simulateClick } from "../test_helpers/dom_helper";
 import { getCellRawContent } from "../test_helpers/getters_helpers";
 import {
+  getHighlightsFromStore,
   mountComponentWithPortalTarget,
   nextTick,
   setGrid,
@@ -180,6 +181,12 @@ describe("Table side panel", () => {
     expect(getTable(model, sheetId).range.zone).toEqual(toZone("A1"));
   });
 
+  test("the table range is highlighted when the side panel is open", async () => {
+    expect(getHighlightsFromStore(env).map((h) => zoneToXc(h.range.zone))).toEqual(["A1:C3"]);
+    await simulateClick(".o-sidePanelClose");
+    expect(getHighlightsFromStore(env).map((h) => zoneToXc(h.range.zone))).toEqual([]);
+  });
+
   test("The table zone displayed in the side panel is updated when the user modifies the table range with the mouse", async () => {
     const table = getTable(model, sheetId);
     expect(fixture.querySelector<HTMLInputElement>(".o-selection input")!.value).toBe("A1:C3");
@@ -191,6 +198,19 @@ describe("Table side panel", () => {
     });
     await nextTick();
     expect(fixture.querySelector<HTMLInputElement>(".o-selection input")!.value).toBe("D1:D2");
+  });
+
+  test("The highlighted zone is updated when the user modifies the table range with the mouse", async () => {
+    const table = getTable(model, sheetId);
+    expect(getHighlightsFromStore(env).map((h) => zoneToXc(h.range.zone))).toEqual(["A1:C3"]);
+    env.model.dispatch("UPDATE_TABLE", {
+      sheetId,
+      zone: table.range.zone,
+      newTableRange: toRangeData(sheetId, "D1:D2"),
+      config: { numberOfHeaders: 0 },
+    });
+    await nextTick();
+    expect(getHighlightsFromStore(env).map((h) => zoneToXc(h.range.zone))).toEqual(["D1:D2"]);
   });
 
   test("Changing the selection does not change the edited table", async () => {


### PR DESCRIPTION
The table side panel was closing when selecting a cell without a table, it now stays open until the user explicitly closes it, selects another table or deletes the table.

Task: [6008091](https://www.odoo.com/odoo/2328/tasks/6008091)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo