### PR TITLE
[FIX] format: large number format with no digits

### DIFF
--- a/src/helpers/format/format.ts
+++ b/src/helpers/format/format.ts
@@ -813,7 +813,7 @@ function _createLargeNumberFormat<T extends InternalFormat>(
 
   const lastDigitIndex = newIntegerPart.findLastIndex((token) => token.type === "DIGIT");
   if (lastDigitIndex === -1) {
-    throw new Error("Cannot create a large number format from a format with no digit.");
+    return format;
   }
   while (newIntegerPart[lastDigitIndex + 1]?.type === "THOUSANDS_SEPARATOR") {
     newIntegerPart = removeIndexesFromArray(newIntegerPart, [lastDigitIndex + 1]);

--- a/tests/formats/format_helpers.test.ts
+++ b/tests/formats/format_helpers.test.ts
@@ -1091,6 +1091,7 @@ describe("rounding format", () => {
   test("Round multi part format", () => {
     expect(roundFormat("0.00\\€;$0.#; 0.00 ;@")).toBe("0\\€;$0; 0 ;@");
     expect(roundFormat("dd/mm/yyyy;0.#")).toBe("dd/mm/yyyy;0");
+    expect(roundFormat(" - ; - ; - ; - ")).toBe(" - ; - ; - ; - ");
   });
 });
 

--- a/tests/formats/formatting_plugin.test.ts
+++ b/tests/formats/formatting_plugin.test.ts
@@ -249,6 +249,10 @@ describe("formatting values (with formatters)", () => {
     setFormat(model, "A1", ";;;@");
     setDecimal(model, "A1", -1);
     expect(getCell(model, "A1")?.format).toBe(";;;@");
+
+    setFormat(model, "A1", " - ; - ; - ; - ");
+    setDecimal(model, "A1", -1);
+    expect(getCell(model, "A1")?.format).toBe(" - ; - ; - ; - ");
   });
 
   test("SET_DECIMAL on scientific format", () => {

--- a/tests/functions/module_custom.test.ts
+++ b/tests/functions/module_custom.test.ts
@@ -1,6 +1,6 @@
 import { Model } from "../../src";
 import { setCellContent, setCellFormat, setFormat } from "../test_helpers/commands_helpers";
-import { getCellContent, getCellError } from "../test_helpers/getters_helpers";
+import { getCellContent, getCellError, getEvaluatedCell } from "../test_helpers/getters_helpers";
 import { evaluateCellText } from "../test_helpers/helpers";
 
 describe("FORMAT.LARGE.NUMBER formula", () => {
@@ -177,5 +177,13 @@ describe("FORMAT.LARGE.NUMBER formula", () => {
     setFormat(model, "A1", "#,##0.0%");
     setCellContent(model, "A2", "=FORMAT.LARGE.NUMBER(A1)");
     expect(getCellContent(model, "A2")).toBe("10,000k%");
+  });
+
+  test("FORMAT.LARGE.NUMBER does not crash on format without digits", () => {
+    const model = new Model();
+    setCellContent(model, "A1", "100000");
+    setFormat(model, "A1", " - ; - ; - ; - ");
+    setCellContent(model, "A2", "=FORMAT.LARGE.NUMBER(A1)");
+    expect(getEvaluatedCell(model, "A2")?.format).toBe(" - ; - ; - ; - ");
   });
 });


### PR DESCRIPTION
## Description

Since e8b38a a format with no date part and no digit is (correctly) detected as a number format. But `_createLargeNumberFormat` would crash if there were no digits.

Task: [6010376](https://www.odoo.com/odoo/2328/tasks/6010376)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo