### PR TITLE
[FIX] format: number format with no digit

### DIFF
--- a/src/helpers/format/format.ts
+++ b/src/helpers/format/format.ts
@@ -251,10 +251,12 @@ function applyInternalNumberFormat(value: number, format: NumberInternalFormat, 
   }
   const { integerDigits, decimalDigits } = splitNumber(Math.abs(value), maxDecimals);
 
+  const hasDigitInDecimalPart = !!format.decimalPart?.some((token) => token.type === "DIGIT");
   let formattedValue = applyIntegerFormat(
     integerDigits,
     format,
-    format.thousandsSeparator ? locale.thousandsSeparator : undefined
+    format.thousandsSeparator ? locale.thousandsSeparator : undefined,
+    hasDigitInDecimalPart
   );
 
   if (format.decimalPart !== undefined) {
@@ -273,10 +275,12 @@ function applyInternalNumberFormat(value: number, format: NumberInternalFormat, 
 function applyIntegerFormat(
   integerDigits: string,
   internalFormat: NumberInternalFormat,
-  thousandsSeparator: string | undefined
+  thousandsSeparator: string | undefined,
+  hasDigitInDecimalPart: boolean
 ): string {
   let tokens = internalFormat.integerPart;
-  if (!tokens.some((token) => token.type === "DIGIT")) {
+  // If the format has a decimal part with digits, we always want to display the integer digits
+  if (hasDigitInDecimalPart && !tokens.some((token) => token.type === "DIGIT")) {
     tokens = [...tokens, { type: "DIGIT", value: "#" }];
   }
   if (integerDigits === "0") {

--- a/tests/formats/format_helpers.test.ts
+++ b/tests/formats/format_helpers.test.ts
@@ -409,6 +409,14 @@ describe("formatValue on number", () => {
     expect(() => formatValue(1234, { format: "# @", locale })).toThrow();
     expect(() => formatValue(1234, { format: "@0", locale })).toThrow();
   });
+
+  test("Format with no digit in them", () => {
+    expect(formatValue(200, { format: "[$Positive]", locale })).toBe("Positive");
+    expect(formatValue(-123, { format: '0;,"Negative"', locale })).toBe("Negative");
+    expect(formatValue(0, { format: '0;0;"Zero"', locale })).toBe("Zero");
+    expect(formatValue("test", { format: '"Smile"', locale })).toBe("test");
+    expect(formatValue("test", { format: '@"Smile"', locale })).toBe("testSmile");
+  });
 });
 
 describe("formatValue on large numbers", () => {


### PR DESCRIPTION
## Description

Since e8b38a a format with no date part and no digit is (correctly) detected as a number format. But the implementation of a format with no digit applied to a non-zero number was not correct. `123` formatted with `[$str]` was formatted as `str123` instead of `str`.

Task: [6068824](https://www.odoo.com/odoo/2328/tasks/6068824)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo