### PR TITLE
[FIX] format: don't humanize scientific format

### DIFF
--- a/src/helpers/format/format.ts
+++ b/src/helpers/format/format.ts
@@ -800,7 +800,7 @@ function _createLargeNumberFormat<T extends InternalFormat>(
   magnitude: number,
   postFix: string
 ): T {
-  if (format.type !== "number") {
+  if (format.type !== "number" || format.scientific) {
     return format;
   }
 

--- a/tests/functions/module_custom.test.ts
+++ b/tests/functions/module_custom.test.ts
@@ -1,6 +1,6 @@
 import { Model } from "../../src";
 import { setCellContent, setCellFormat, setFormat } from "../test_helpers/commands_helpers";
-import { getCellContent, getCellError } from "../test_helpers/getters_helpers";
+import { getCellContent, getCellError, getEvaluatedCell } from "../test_helpers/getters_helpers";
 import { evaluateCellText } from "../test_helpers/helpers";
 
 describe("FORMAT.LARGE.NUMBER formula", () => {
@@ -169,6 +169,17 @@ describe("FORMAT.LARGE.NUMBER formula", () => {
     setCellContent(model, "A2", '=FORMAT.LARGE.NUMBER(A1, "m")');
     // should be "5,000mk" in a perfect world. But we cannot tell the difference between a custom currency and a unit in a format.
     expect(getCellContent(model, "A2")).toBe("5,000m");
+  });
+
+  test("FORMAT.LARGE.NUMBER does nothing on numbers with scientific format", () => {
+    const model = new Model();
+    setCellContent(model, "A1", "100000");
+    setFormat(model, "A1", "0e");
+    setCellContent(model, "A2", "=FORMAT.LARGE.NUMBER(A1)");
+    expect(getCellContent(model, "A2")).toBe("1e+05");
+
+    setFormat(model, "A1", "0;0e;-0e;@[$Hello]");
+    expect(getEvaluatedCell(model, "A2").format).toBe("0,[$k];0e;-0e;@[$Hello]");
   });
 
   test("Percentage in decimal part is preserved by FORMAT.LARGE.NUMBER", () => {


### PR DESCRIPTION
## Description

The methods trying to humanize a format (in charts, and in `FORMAT.LARGE.NUMBER`) were displaying strange results when used with scientific formats (eg. `0ke+4` instead of either `50k` or `5e+4`).

Task: [6068353](https://www.odoo.com/odoo/2328/tasks/6068353)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo