### PR TITLE
[FIX] zoom: scorecard chart rendering with zoom

### DIFF
--- a/src/components/figures/chart/scorecard/chart_scorecard.ts
+++ b/src/components/figures/chart/scorecard/chart_scorecard.ts
@@ -43,6 +43,6 @@ export class ScorecardChart extends Component<Props, SpreadsheetChildEnv> {
       getZoomedRect(1 / zoom, canvas.getBoundingClientRect()),
       this.runtime
     );
-    drawScoreChart(config, canvas);
+    drawScoreChart(config, canvas, zoom);
   }
 }

--- a/src/helpers/figures/charts/scorecard_chart.ts
+++ b/src/helpers/figures/charts/scorecard_chart.ts
@@ -310,7 +310,8 @@ type Canvas2DContext = CanvasRenderingContext2D | OffscreenCanvasRenderingContex
 
 export function drawScoreChart(
   structure: ScorecardChartConfig,
-  canvas: HTMLCanvasElement | OffscreenCanvas
+  canvas: HTMLCanvasElement | OffscreenCanvas,
+  zoom: number = 1
 ) {
   const ctx = canvas.getContext("2d") as Canvas2DContext;
   if (!ctx) {
@@ -318,9 +319,9 @@ export function drawScoreChart(
   }
   const dpr = typeof globalThis.devicePixelRatio === "number" ? globalThis.devicePixelRatio : 1;
 
-  canvas.width = dpr * structure.canvas.width;
-  canvas.height = dpr * structure.canvas.height;
-  ctx.scale(dpr, dpr);
+  canvas.width = dpr * structure.canvas.width * zoom;
+  canvas.height = dpr * structure.canvas.height * zoom;
+  ctx.scale(dpr * zoom, dpr * zoom);
   const availableWidth = structure.canvas.width - CHART_PADDING;
 
   ctx.fillStyle = structure.canvas.backgroundColor;


### PR DESCRIPTION
## Description

The scorecards were blurry when zooming a sheet. We were not scaling their canvas properly according to the zoom level.

Task: [6072348](https://www.odoo.com/odoo/2328/tasks/6072348)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo