### PR TITLE
[FIX] cells: avoid string convertion on import for date.

### DIFF
--- a/src/plugins/core/cell.ts
+++ b/src/plugins/core/cell.ts
@@ -363,7 +363,9 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
 
   importCell(sheetId: UID, content?: string, style?: Style, format?: Format): Cell {
     const cellId = this.getNextUid();
-    return this.createCell(cellId, content || "", format, style, sheetId);
+    return this.createCell(cellId, content || "", format, style, sheetId, {
+      avoidAutomaticDateFormat: true,
+    });
   }
 
   exportForExcel(data: ExcelWorkbookData) {
@@ -656,10 +658,11 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
     content: string,
     format: Format | undefined,
     style: Style | undefined,
-    sheetId: UID
+    sheetId: UID,
+    options?: { avoidAutomaticDateFormat: boolean }
   ): Cell {
     if (!content.startsWith("=")) {
-      return this.createLiteralCell(id, content, format, style);
+      return this.createLiteralCell(id, content, format, style, options);
     }
     return this.createFormulaCell(id, content, format, style, sheetId);
   }
@@ -668,16 +671,29 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
     id: UID,
     content: string,
     format: Format | undefined,
-    style: Style | undefined
+    style: Style | undefined,
+    options?: { avoidAutomaticDateFormat: boolean }
   ): LiteralCell {
     const locale = this.getters.getLocale();
-    const parsedValue = parseLiteral(content, locale);
+    let parsedValue = parseLiteral(content, locale);
 
-    format =
-      format ||
-      (typeof parsedValue === "number"
-        ? detectDateFormat(content, locale) || detectNumberFormat(content)
-        : undefined);
+    if (!format && typeof parsedValue === "number") {
+      const dateFormat = detectDateFormat(content, locale);
+      if (options?.avoidAutomaticDateFormat && dateFormat) {
+        return {
+          id,
+          content,
+          style,
+          format,
+          isFormula: false,
+          parsedValue: content,
+        };
+      }
+      format = dateFormat || detectNumberFormat(content);
+    } else {
+      format ||= undefined;
+    }
+
     if (!isTextFormat(format) && !isEvaluationError(content)) {
       content = toString(parsedValue);
     }

--- a/tests/model/core.test.ts
+++ b/tests/model/core.test.ts
@@ -587,9 +587,14 @@ describe("history", () => {
             colNumber: 10,
             rowNumber: 10,
             cells: {
-              A1: { content: "1000", format: "#,##0" },
-              A3: { content: "2000", format: "#,##0" },
-              B2: { content: "TRUE", format: "#,##0" },
+              A1: { content: "1000" },
+              A3: { content: "2000" },
+              B2: { content: "TRUE" },
+            },
+            formats: {
+              A1: 1,
+              A3: 1,
+              B2: 1,
             },
           },
           {
@@ -597,12 +602,21 @@ describe("history", () => {
             colNumber: 10,
             rowNumber: 10,
             cells: {
-              A1: { content: "21000", format: "#,##0" },
-              A3: { content: "12-31-2020", format: "mm/dd/yyyy" },
-              B2: { content: "TRUE", format: "#,##0" },
+              A1: { content: "21000" },
+              A3: { content: "12-31-2020" },
+              B2: { content: "TRUE" },
+            },
+            formats: {
+              A1: 1,
+              A3: 2,
+              B2: 1,
             },
           },
         ],
+        formats: {
+          "1": "#,##0",
+          "2": "mm-dd-yyyy",
+        },
       });
       expect(getRangeValues(model, "A1:A3", sheet1Id)).toEqual([1000, null, 2000]);
       expect(getRangeValues(model, "$A$1:$A$3", sheet1Id)).toEqual([1000, null, 2000]);

--- a/tests/model/model_import_export.test.ts
+++ b/tests/model/model_import_export.test.ts
@@ -832,7 +832,7 @@ test("import then export (figures)", () => {
   expect(model).toExport(modelData);
 });
 
-test("import date as string and detect the format", () => {
+test("don't import string as date", () => {
   const model = new Model({
     sheets: [
       {
@@ -840,12 +840,12 @@ test("import date as string and detect the format", () => {
       },
     ],
   });
-  expect(getCell(model, "A1")?.format).toBe("m/d/yyyy");
-  expect(getCell(model, "A1")?.content).toBe("44196");
+  expect(getCell(model, "A1")?.format).toBeUndefined();
+  expect(getCell(model, "A1")?.content).toBe("12/31/2020");
   expect(getEvaluatedCell(model, "A1")?.formattedValue).toBe("12/31/2020");
 });
 
-test("import localized date as string and detect the format", () => {
+test("don't import string as localized date", () => {
   const model = new Model({
     sheets: [
       {
@@ -854,8 +854,8 @@ test("import localized date as string and detect the format", () => {
     ],
     settings: { locale: FR_LOCALE },
   });
-  expect(getCell(model, "A1")?.format).toBe("d/m/yyyy");
-  expect(getCell(model, "A1")?.content).toBe("44196");
+  expect(getCell(model, "A1")?.format).toBeUndefined();
+  expect(getCell(model, "A1")?.content).toBe("31/12/2020");
   expect(getEvaluatedCell(model, "A1")?.formattedValue).toBe("31/12/2020");
 });
 

--- a/tests/pivots/pivot_data.ts
+++ b/tests/pivots/pivot_data.ts
@@ -18,66 +18,87 @@ export const pivotModelData = function (xc: string) {
           },
           A2: {
             content: "04/03/2024",
+            format: 2,
           },
           A3: {
             content: "03/03/2024",
+            format: 2,
           },
           A4: {
             content: "02/02/2024",
+            format: 2,
           },
           A5: {
             content: "04/02/2024",
+            format: 2,
           },
           A6: {
             content: "03/28/2024",
+            format: 2,
           },
           A7: {
             content: "04/02/2024",
+            format: 2,
           },
           A8: {
             content: "04/02/2024",
+            format: 2,
           },
           A9: {
             content: "02/27/2024",
+            format: 2,
           },
           A10: {
             content: "04/01/2024",
+            format: 2,
           },
           A11: {
             content: "04/02/2024",
+            format: 2,
           },
           A12: {
             content: "04/03/2024",
+            format: 2,
           },
           A13: {
             content: "02/03/2024",
+            format: 2,
           },
           A14: {
             content: "03/03/2024",
+            format: 2,
           },
           A15: {
             content: "01/26/2024",
+            format: 2,
           },
           A16: {
             content: "03/27/2024",
+            format: 2,
           },
           A17: {
             content: "03/27/2024",
+            format: 2,
           },
           A18: {
             content: "03/31/2024",
+            format: 2,
           },
           A19: {
             content: "01/31/2024",
+            format: 2,
           },
           A20: {
             content: "04/02/2024",
+            format: 2,
           },
           A21: {
             content: "04/05/2024",
+            format: 2,
           },
           A22: {
             content: "19/05/2024",
+            format: 2,
           },
           B1: {
             content: "Opportunity",
@@ -553,6 +574,7 @@ export const pivotModelData = function (xc: string) {
     styles: {},
     formats: {
       "1": "[$$]#,##0.00",
+      "2": "m/d/yyyy",
     },
     borders: {},
     revisionId: "fbf5c369-70ff-4a05-929e-859e0608c53a",

--- a/tests/pivots/spreadsheet_pivot/spreadsheet_pivot.test.ts
+++ b/tests/pivots/spreadsheet_pivot/spreadsheet_pivot.test.ts
@@ -86,6 +86,12 @@ describe("Spreadsheet Pivot", () => {
     const model = new Model({
       sheets: [
         {
+          formats: {
+            "A2:A3": 1,
+            A4: 2,
+            E2: 1,
+            H4: 1,
+          },
           cells: {
             A1: { content: "Date" },
             A2: { content: "04/01/2024" },
@@ -125,6 +131,10 @@ describe("Spreadsheet Pivot", () => {
           },
         },
       ],
+      formats: {
+        "1": "mm/dd/yyyy",
+        "2": "mm/dd/yyyy hh:mm:ss a",
+      },
     });
     addPivot(model, "A1:I4", {});
     const fields = model.getters.getPivot("1").getFields();

--- a/tests/sort_plugin.test.ts
+++ b/tests/sort_plugin.test.ts
@@ -88,15 +88,21 @@ describe("Basic Sorting", () => {
           colNumber: 1,
           rowNumber: 6,
           cells: {
-            A1: { content: "11/24/1991", format: dateFormat },
-            A2: { content: "06/06/1944", format: dateFormat },
-            A3: { content: "11/08/2016", format: dateFormat },
-            A4: { content: "09/05/1946", format: dateFormat },
-            A5: { content: "08/18/1969", format: dateFormat },
-            A6: { content: "08/15/1969", format: dateFormat },
+            A1: { content: "11/24/1991" },
+            A2: { content: "06/06/1944" },
+            A3: { content: "11/08/2016" },
+            A4: { content: "09/05/1946" },
+            A5: { content: "08/18/1969" },
+            A6: { content: "08/15/1969" },
+          },
+          formats: {
+            "A1:A6": 1,
           },
         },
       ],
+      formats: {
+        "1": dateFormat,
+      },
     });
     sort(model, {
       zone: "A1:A6",
@@ -172,8 +178,14 @@ describe("Basic Sorting", () => {
             A10: { content: "2020/09/01" },
             A11: { content: "=B1/B2" },
           },
+          formats: {
+            A10: 1,
+          },
         },
       ],
+      formats: {
+        1: "yyyy/mm/dd",
+      },
     });
     sort(model, {
       zone: "A1:A11",
@@ -521,8 +533,10 @@ describe("Sort adjacent columns with headers", () => {
             C3: { content: "09/14/2020" },
             C4: { content: "09/15/2020" },
           },
+          formats: { "C2:C4": 1 },
         },
       ],
+      formats: { 1: "mm/dd/yyyy" },
     });
   });
   test("Presence of header", () => {
@@ -656,6 +670,7 @@ describe("Sort Merges", () => {
           D5: { content: "08/20/2020" },
           D8: { content: "07/20/2020" },
         },
+        formats: { D2: 1, D5: 1, D8: 1 },
         merges: [
           "B2:B4",
           "B5:B7",
@@ -669,6 +684,9 @@ describe("Sort Merges", () => {
         ],
       },
     ],
+    formats: {
+      1: "mm/dd/yyyy",
+    },
   };
   beforeEach(() => {
     model = new Model(modelData);


### PR DESCRIPTION
Do not convert strings that look like dates at import 

Task: 4918754

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [4918754](https://www.odoo.com/odoo/2328/tasks/4918754)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo