### PR TITLE
[IMP] node: add script to run the model in node

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "postdist": " npm run bundle:xml -- --outDir dist && npm run bundle:css -- --out dist",
     "test": "tsc --noEmit --project tsconfig.jest.json && jest",
     "monkey": "SPREADSHEET_MONKEY_COUNT=$npm_config_monkey_count jest 'tests/collaborative/collaborative_monkey_party.test.ts'",
+    "model-in-node": "npm run dist && node tools/run_in_node.cjs",
     "zipXlsx": "node tools/bundle_xlsx/zip_xlsx_demo.cjs",
     "unzipXlsx": "node tools/bundle_xlsx/unzip_xlsx_demo.cjs"
   },

--- a/tools/run_in_node.cjs
+++ b/tools/run_in_node.cjs
@@ -1,0 +1,3 @@
+const spreadsheet = require("../dist/o_spreadsheet.cjs");
+
+new spreadsheet.Model();


### PR DESCRIPTION
## Description:

This commit adds the `model-in-node` node script that runs the
spreadsheet model in a node environment.

Task: [6088515](https://www.odoo.com/odoo/2328/tasks/6088515)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo