### PR TITLE
[IMP] scrollbar: take whole available size with frozen panes

### DIFF
--- a/src/components/scrollbar/scrollbar.css
+++ b/src/components/scrollbar/scrollbar.css
@@ -1,4 +1,7 @@
 .o-spreadsheet {
+  .o-scrollbar-container {
+    background-color: var(--os-background-gray-color);
+  }
   .o-scrollbar {
     position: absolute;
     overflow: auto;

--- a/src/components/scrollbar/scrollbar_horizontal.ts
+++ b/src/components/scrollbar/scrollbar_horizontal.ts
@@ -1,5 +1,6 @@
 import { Component, xml } from "@odoo/owl";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
+import { cssPropertiesToCss } from "../helpers";
 import { isBrowserFirefox } from "../helpers/dom_helpers";
 import { ScrollBar } from "./scrollbar";
 
@@ -13,6 +14,7 @@ export class HorizontalScrollBar extends Component<Props, SpreadsheetChildEnv> {
   };
   static components = { ScrollBar };
   static template = xml/*xml*/ `
+  <div class="o-scrollbar-container position-absolute" t-att-style="containerStyle">
       <ScrollBar
         t-if="isDisplayed"
         width="width"
@@ -20,7 +22,8 @@ export class HorizontalScrollBar extends Component<Props, SpreadsheetChildEnv> {
         offset="offset"
         direction="'horizontal'"
         onScroll.bind="onScroll"
-      />`;
+      />
+  </div>`;
   static defaultProps = {
     leftOffset: 0,
   };
@@ -40,12 +43,21 @@ export class HorizontalScrollBar extends Component<Props, SpreadsheetChildEnv> {
     return xRatio < 1;
   }
 
+  get containerStyle() {
+    const scrollbarWidth = this.env.model.getters.getScrollBarWidth();
+    return cssPropertiesToCss({
+      left: `${this.props.leftOffset}px`,
+      bottom: "0px",
+      height: `${scrollbarWidth}px`,
+      right: isBrowserFirefox() ? `${scrollbarWidth}px` : "0",
+    });
+  }
+
   get position() {
     const { x } = this.env.model.getters.getMainViewportRect();
     const scrollbarWidth = this.env.model.getters.getScrollBarWidth();
     return {
-      left: `${this.props.leftOffset + x}px`,
-      bottom: "0px",
+      left: `${x}px`,
       height: `${scrollbarWidth}px`,
       right: isBrowserFirefox() ? `${scrollbarWidth}px` : "0",
     };

--- a/src/components/scrollbar/scrollbar_vertical.ts
+++ b/src/components/scrollbar/scrollbar_vertical.ts
@@ -1,5 +1,6 @@
 import { Component, xml } from "@odoo/owl";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
+import { cssPropertiesToCss } from "../helpers";
 import { isBrowserFirefox } from "../helpers/dom_helpers";
 import { ScrollBar } from "./scrollbar";
 
@@ -13,14 +14,16 @@ export class VerticalScrollBar extends Component<Props, SpreadsheetChildEnv> {
   };
   static components = { ScrollBar };
   static template = xml/*xml*/ `
-    <ScrollBar
-      t-if="isDisplayed"
-      height="height"
-      position="position"
-      offset="offset"
-      direction="'vertical'"
-      onScroll.bind="onScroll"
-    />`;
+    <div class="o-scrollbar-container position-absolute" t-att-style="containerStyle">
+      <ScrollBar
+        t-if="isDisplayed"
+        height="height"
+        position="position"
+        offset="offset"
+        direction="'vertical'"
+        onScroll.bind="onScroll"
+      />
+    </div>`;
   static defaultProps = {
     topOffset: 0,
   };
@@ -40,12 +43,21 @@ export class VerticalScrollBar extends Component<Props, SpreadsheetChildEnv> {
     return yRatio < 1;
   }
 
+  get containerStyle() {
+    const scrollbarWidth = this.env.model.getters.getScrollBarWidth();
+    return cssPropertiesToCss({
+      top: `${this.props.topOffset}px`,
+      right: "0px",
+      width: `${scrollbarWidth}px`,
+      bottom: isBrowserFirefox() ? `${scrollbarWidth}px` : "0",
+    });
+  }
+
   get position() {
     const { y } = this.env.model.getters.getMainViewportRect();
     const scrollbarWidth = this.env.model.getters.getScrollBarWidth();
     return {
-      top: `${this.props.topOffset + y}px`,
-      right: "0px",
+      top: `${y}px`,
       width: `${scrollbarWidth}px`,
       bottom: isBrowserFirefox() ? `${scrollbarWidth}px` : "0",
     };

--- a/tests/grid/__snapshots__/dashboard_grid_component.test.ts.snap
+++ b/tests/grid/__snapshots__/dashboard_grid_component.test.ts.snap
@@ -41,21 +41,31 @@ exports[`Grid component in dashboard mode simple dashboard rendering snapshot 1`
     
   </div>
   <div
-    class="o-scrollbar vertical"
+    class="o-scrollbar-container position-absolute"
     style="top:0px; right:0px; width:15px; bottom:0; "
   >
     <div
-      style="width:1px; height:2300px; "
-    />
+      class="o-scrollbar vertical"
+      style="top:0px; width:15px; bottom:0; "
+    >
+      <div
+        style="width:1px; height:2300px; "
+      />
+    </div>
   </div>
   
   <div
-    class="o-scrollbar horizontal"
+    class="o-scrollbar-container position-absolute"
     style="left:0px; bottom:0px; height:15px; right:0; "
   >
     <div
-      style="width:2496px; height:1px; "
-    />
+      class="o-scrollbar horizontal"
+      style="left:0px; height:15px; right:0; "
+    >
+      <div
+        style="width:2496px; height:1px; "
+      />
+    </div>
   </div>
   
   <div

--- a/tests/grid/__snapshots__/grid_component.test.ts.snap
+++ b/tests/grid/__snapshots__/grid_component.test.ts.snap
@@ -127,21 +127,31 @@ exports[`Grid component simple rendering snapshot 1`] = `
   
   
   <div
-    class="o-scrollbar vertical"
+    class="o-scrollbar-container position-absolute"
     style="top:26px; right:0px; width:15px; bottom:0; "
   >
     <div
-      style="width:1px; height:2346px; "
-    />
+      class="o-scrollbar vertical"
+      style="top:0px; width:15px; bottom:0; "
+    >
+      <div
+        style="width:1px; height:2346px; "
+      />
+    </div>
   </div>
   
   <div
-    class="o-scrollbar horizontal"
+    class="o-scrollbar-container position-absolute"
     style="left:48px; bottom:0px; height:15px; right:0; "
   >
     <div
-      style="width:2496px; height:1px; "
-    />
+      class="o-scrollbar horizontal"
+      style="left:0px; height:15px; right:0; "
+    >
+      <div
+        style="width:2496px; height:1px; "
+      />
+    </div>
   </div>
   
   <div

--- a/tests/spreadsheet/__snapshots__/spreadsheet_component.test.ts.snap
+++ b/tests/spreadsheet/__snapshots__/spreadsheet_component.test.ts.snap
@@ -969,21 +969,31 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
         
         
         <div
-          class="o-scrollbar vertical"
+          class="o-scrollbar-container position-absolute"
           style="top:26px; right:0px; width:15px; bottom:0; "
         >
           <div
-            style="width:1px; height:2346px; "
-          />
+            class="o-scrollbar vertical"
+            style="top:0px; width:15px; bottom:0; "
+          >
+            <div
+              style="width:1px; height:2346px; "
+            />
+          </div>
         </div>
         
         <div
-          class="o-scrollbar horizontal"
+          class="o-scrollbar-container position-absolute"
           style="left:48px; bottom:0px; height:15px; right:0; "
         >
           <div
-            style="width:2496px; height:1px; "
-          />
+            class="o-scrollbar horizontal"
+            style="left:0px; height:15px; right:0; "
+          >
+            <div
+              style="width:2496px; height:1px; "
+            />
+          </div>
         </div>
         
         <div
@@ -2015,21 +2025,31 @@ exports[`components take the small screen into account 1`] = `
         
         
         <div
-          class="o-scrollbar vertical"
+          class="o-scrollbar-container position-absolute"
           style="top:26px; right:0px; width:15px; bottom:0; "
         >
           <div
-            style="width:1px; height:2346px; "
-          />
+            class="o-scrollbar vertical"
+            style="top:0px; width:15px; bottom:0; "
+          >
+            <div
+              style="width:1px; height:2346px; "
+            />
+          </div>
         </div>
         
         <div
-          class="o-scrollbar horizontal"
+          class="o-scrollbar-container position-absolute"
           style="left:48px; bottom:0px; height:15px; right:0; "
         >
           <div
-            style="width:2496px; height:1px; "
-          />
+            class="o-scrollbar horizontal"
+            style="left:0px; height:15px; right:0; "
+          >
+            <div
+              style="width:2496px; height:1px; "
+            />
+          </div>
         </div>
         
         <div


### PR DESCRIPTION
## Description

When there are frozen panes, the scrollbars are offset to start at the start of the main viewport. But there is no element on the side of the frozen panes, so components like Autofill and Table Resizer can overflow from the grid with nothing to cover them.

Task: [5891719](https://www.odoo.com/odoo/2328/tasks/5891719)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo