### PR TITLE
[FIX] side_panel: prevent chart picker layout shift on hover

### DIFF
--- a/src/components/side_panel/chart/chart_type_picker/chart_type_picker.ts
+++ b/src/components/side_panel/chart/chart_type_picker/chart_type_picker.ts
@@ -32,13 +32,13 @@ css/* scss */ `
     background: #fff;
     .o-chart-type-item {
       cursor: pointer;
-      padding: 3px 6px;
+      padding: 2px 5px;
       margin: 1px 2px;
+      border: 1px solid transparent;
       &.selected,
       &:hover {
-        border: 1px solid ${ACTION_COLOR};
+        border-color: ${ACTION_COLOR};
         background: ${BADGE_SELECTED_COLOR};
-        padding: 2px 5px;
       }
       .o-chart-preview {
         width: 48px;


### PR DESCRIPTION
## Description:

Current behavior before PR:
- Hovering or selecting a chart type was adding a border while reducing padding to compensate for the size change.
- At non-100% zoom levels, fractional pixel rounding caused inconsistent sizing, leading to layout shifts in the flex container.
- This resulted in chart icons 'dancing' when moving the cursor between them.

Desired behavior after PR is merged:
- A transparent border is applied in the default state to reserve space.
- On hover/selection, only the border color is updated without changing padding.
- This ensures consistent element dimensions and prevents layout shifts across all zoom levels.

Task: [6095239](https://www.odoo.com/odoo/2328/tasks/6095239)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo