### PR TITLE
[IMP] locale: add digit grouping for thousands separators

### DIFF
--- a/src/helpers/format/format.ts
+++ b/src/helpers/format/format.ts
@@ -4,7 +4,7 @@ import { CellValue } from "../../types/cells";
 import { Currency } from "../../types/currency";
 import { EvaluationError } from "../../types/errors";
 import { Format, FormattedValue, LocaleFormat } from "../../types/format";
-import { DEFAULT_LOCALE, Locale } from "../../types/locale";
+import { DEFAULT_LOCALE, DEFAULT_LOCALE_DIGIT_GROUPING, Locale } from "../../types/locale";
 import { FunctionResultObject, Maybe } from "../../types/misc";
 import { DateTime, INITIAL_1900_DAY, isDateTime, numberToJsDate, parseDateTime } from "../dates";
 import {
@@ -256,7 +256,8 @@ function applyInternalNumberFormat(value: number, format: NumberInternalFormat, 
     integerDigits,
     format,
     format.thousandsSeparator ? locale.thousandsSeparator : undefined,
-    hasDigitInDecimalPart
+    hasDigitInDecimalPart,
+    locale
   );
 
   if (format.decimalPart !== undefined) {
@@ -276,7 +277,8 @@ function applyIntegerFormat(
   integerDigits: string,
   internalFormat: NumberInternalFormat,
   thousandsSeparator: string | undefined,
-  hasDigitInDecimalPart: boolean
+  hasDigitInDecimalPart: boolean,
+  locale: Locale
 ): string {
   let tokens = internalFormat.integerPart;
   // If the format has a decimal part with digits, we always want to display the integer digits
@@ -300,7 +302,10 @@ function applyIntegerFormat(
     }
 
     const digitIndex = integerDigits.length - 1 - indexInIntegerString;
-    if (thousandsSeparator && digitIndex > 0 && digitIndex % 3 === 0) {
+    const groups = getIndexesOfDigitsWithThousandSeparator(
+      locale.digitGrouping || DEFAULT_LOCALE_DIGIT_GROUPING
+    );
+    if (thousandsSeparator && groups.has(digitIndex - 1)) {
       formattedInteger = digit + thousandsSeparator + formattedInteger;
     } else {
       formattedInteger = digit + formattedInteger;
@@ -994,3 +999,42 @@ export function isFormatValid(format: Format): boolean {
 export function getNumberOfFormatParts(format: Format): number {
   return tokenizeFormat(format).length;
 }
+
+/**
+ * Return a set with the indexes of all the digits that should have a thousand separator based on the given grouping.
+ *
+ * The grouping is a string of the form `[3,2,0]`. It means that:
+ * - the first 3 digits are grouped together, then a thousand separator is added
+ * - then the next 2 digits are grouped together, then a thousand separator is added
+ * - 0 means that the previous grouping (in this case 2) is repeated
+ *
+ * The standard international grouping is [3,0] (grouping together the thousands). But some locales (eg. India) use
+ * different grouping methods.
+ */
+const getIndexesOfDigitsWithThousandSeparator = memoize(
+  function _getIndexesOfDigitsWithThousandSeparator(grouping: string): Set<number> {
+    const trimmedGrouping = grouping.trim();
+    if (!trimmedGrouping.startsWith("[") || !trimmedGrouping.endsWith("]")) {
+      throw new Error(`Invalid digit grouping: "${grouping}"`);
+    }
+    const groups = trimmedGrouping
+      .slice(1, -1)
+      .split(",")
+      .map((g) => Number(g));
+    if (groups.length === 0 || groups.some((g) => isNaN(g) || g < 0) || groups[0] === 0) {
+      throw new Error(`Invalid digit grouping: "${grouping}"`);
+    }
+    const maxNumberOfDigits = 30;
+    const groupIndexes = new Set<number>();
+    let currentGroupIndex = 0;
+    let currentDigit = -1;
+    do {
+      currentDigit += groups[currentGroupIndex];
+      groupIndexes.add(currentDigit);
+      currentGroupIndex =
+        groups[currentGroupIndex + 1] === 0 ? currentGroupIndex : currentGroupIndex + 1;
+    } while (currentDigit <= maxNumberOfDigits && groups[currentGroupIndex] !== undefined);
+
+    return groupIndexes;
+  }
+);

--- a/src/types/locale.ts
+++ b/src/types/locale.ts
@@ -11,6 +11,8 @@ export interface Locale {
   dateFormat: string;
   timeFormat: string;
   formulaArgSeparator: string;
+  /** Describes how to split the digits with the thousand separator. See `getIndexesOfDigitsWithThousandSeparator` for details. */
+  digitGrouping?: string;
 }
 
 export const DEFAULT_LOCALES: Locale[] = [
@@ -34,5 +36,18 @@ export const DEFAULT_LOCALES: Locale[] = [
     timeFormat: "hh:mm:ss",
     formulaArgSeparator: ";",
   },
+  {
+    name: "English (India)",
+    code: "en_IN" as LocaleCode,
+    thousandsSeparator: ",",
+    decimalSeparator: ".",
+    weekStart: 7, // Sunday
+    dateFormat: "dd/mm/yyyy",
+    timeFormat: "hh:mm:ss a",
+    formulaArgSeparator: ",",
+    digitGrouping: "[3,2,0]", // 12,34,56,789.00
+  },
 ];
 export const DEFAULT_LOCALE: Locale = DEFAULT_LOCALES[0];
+
+export const DEFAULT_LOCALE_DIGIT_GROUPING = "[3,0]"; // Group digits 3 by 3

--- a/tests/formats/format_helpers.test.ts
+++ b/tests/formats/format_helpers.test.ts
@@ -6,7 +6,7 @@ import {
   parseDateTime,
   roundFormat,
 } from "../../src/helpers";
-import { Currency, DEFAULT_LOCALE } from "../../src/types";
+import { Currency, DEFAULT_LOCALE, LocaleFormat } from "../../src/types";
 import { FR_LOCALE } from "../test_helpers/constants";
 
 const locale = DEFAULT_LOCALE;
@@ -416,6 +416,44 @@ describe("formatValue on number", () => {
     expect(formatValue(0, { format: '0;0;"Zero"', locale })).toBe("Zero");
     expect(formatValue("test", { format: '"Smile"', locale })).toBe("test");
     expect(formatValue("test", { format: '@"Smile"', locale })).toBe("testSmile");
+  });
+
+  test("Can format values using different digit groupings", () => {
+    const localeFormat: LocaleFormat = { format: "#,##0", locale: { ...DEFAULT_LOCALE } };
+    expect(formatValue(123456789, localeFormat)).toBe("123,456,789");
+
+    localeFormat.locale.digitGrouping = "[2, 0]"; // Group digits 2 by 2
+    expect(formatValue(123456789, localeFormat)).toBe("1,23,45,67,89");
+
+    localeFormat.locale.digitGrouping = "[3, 2, 0]"; // Group first 3 digits, then group digits 2 by 2
+    expect(formatValue(123456789, localeFormat)).toBe("12,34,56,789");
+
+    localeFormat.locale.digitGrouping = "[2, 3]"; // Group first 2 digits, then 3 next digits, then no group
+    expect(formatValue(123456789, localeFormat)).toBe("1234,567,89");
+
+    localeFormat.locale.digitGrouping = "[4]"; // Single group of 4 digits
+    expect(formatValue(123456789, localeFormat)).toBe("12345,6789");
+
+    localeFormat.locale.digitGrouping = "[2, 0, 5]"; // Part after 0 (repeated grouping) is ignored
+    expect(formatValue(123456789, localeFormat)).toBe("1,23,45,67,89");
+
+    localeFormat.locale.digitGrouping = "   [      3      ,2,0    ]  "; // Spaces are ignored
+    expect(formatValue(123456789, localeFormat)).toBe("12,34,56,789");
+  });
+
+  test("Invalid groupings", () => {
+    const localeFormat: LocaleFormat = { format: "#,##0", locale: { ...DEFAULT_LOCALE } };
+    localeFormat.locale.digitGrouping = "[0]"; // Nothing to repeat
+    expect(() => formatValue(123456789, localeFormat)).toThrow('Invalid digit grouping: "[0]"');
+
+    localeFormat.locale.digitGrouping = "[]"; // No grouping
+    expect(() => formatValue(123456789, localeFormat)).toThrow('Invalid digit grouping: "[]"');
+
+    localeFormat.locale.digitGrouping = "ok"; // Invalid grouping
+    expect(() => formatValue(123456789, localeFormat)).toThrow('Invalid digit grouping: "ok"');
+
+    localeFormat.locale.digitGrouping = "{3,0}"; // Invalid grouping
+    expect(() => formatValue(123456789, localeFormat)).toThrow('Invalid digit grouping: "{3,0}"');
   });
 });
 


### PR DESCRIPTION
## Description

Some locales (eg. India) do not use standard international thousand grouping for large numbers, but group the first 3 numbers, then group the next numbers by 2.

This commit adds the `digitGrouping` parameter to the locale to handle that behaviour.

Task: [4829185](https://www.odoo.com/odoo/2328/tasks/4829185)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo