### PR TITLE
[FIX] named_range: disallow TRUE/FALSE as named ranges

### DIFF
--- a/src/helpers/ui/named_range_interactive.ts
+++ b/src/helpers/ui/named_range_interactive.ts
@@ -27,10 +27,10 @@ function handleResult(env: SpreadsheetChildEnv, result: DispatchResult) {
   if (!result.isSuccessful) {
     if (result.isCancelledBecause(CommandResult.NamedRangeNameAlreadyExists)) {
       env.raiseError(_t("A named range with this name already exists."));
-    } else if (result.isCancelledBecause(CommandResult.NamedRangeNameWithInvalidCharacter)) {
+    } else if (result.isCancelledBecause(CommandResult.NamedRangeInvalidName)) {
       env.raiseError(
         _t(
-          "The named range name contains invalid characters. Valid characters are letters, numbers, underscores, and periods."
+          "The named range name is invalid. Valid names can contain letters, digits, underscores, and periods. The name cannot be only a number, TRUE, or FALSE."
         )
       );
     } else if (result.isCancelledBecause(CommandResult.NamedRangeNameLooksLikeCellReference)) {

--- a/src/plugins/core/named_range.ts
+++ b/src/plugins/core/named_range.ts
@@ -136,8 +136,12 @@ export class NamedRangesPlugin extends CorePlugin<NamedRangeState> implements Na
       return CommandResult.NamedRangeNameAlreadyExists;
     }
 
-    if (!validNamedRangeNameRegex.test(name) || isNumber(name, DEFAULT_LOCALE)) {
-      return CommandResult.NamedRangeNameWithInvalidCharacter;
+    if (
+      !validNamedRangeNameRegex.test(name) ||
+      isNumber(name, DEFAULT_LOCALE) ||
+      ["TRUE", "FALSE"].includes(name.toUpperCase())
+    ) {
+      return CommandResult.NamedRangeInvalidName;
     }
 
     if (rangeReference.test(name)) {

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -1550,7 +1550,7 @@ export const enum CommandResult {
   SheetLocked = "SheetLocked",
   InvalidZoomLevel = "InvalidZoomLevel",
   NamedRangeNameAlreadyExists = "NamedRangeNameAlreadyExists",
-  NamedRangeNameWithInvalidCharacter = "NamedRangeNameWithInvalidCharacter",
+  NamedRangeInvalidName = "NamedRangeInvalidName",
   NamedRangeNameLooksLikeCellReference = "NamedRangeNameLooksLikeCellReference",
   NamedRangeNotFound = "NamedRangeNotFound",
 }

--- a/tests/named_ranges/named_ranges_panel_component.test.ts
+++ b/tests/named_ranges/named_ranges_panel_component.test.ts
@@ -71,7 +71,7 @@ describe("Named ranges side panel", () => {
 
     expect(raiseError).toHaveBeenCalledTimes(1);
     expect(raiseError).toHaveBeenCalledWith(
-      "The named range name contains invalid characters. Valid characters are letters, numbers, underscores, and periods."
+      "The named range name is invalid. Valid names can contain letters, digits, underscores, and periods. The name cannot be only a number, TRUE, or FALSE."
     );
     expect(model.getters.getNamedRanges()[0].name).toBe("MyRange");
     expect(".o-named-range-preview .os-input").toHaveValue("MyRange");

--- a/tests/named_ranges/named_ranges_plugin.test.ts
+++ b/tests/named_ranges/named_ranges_plugin.test.ts
@@ -53,6 +53,15 @@ describe("Named range plugin", () => {
       expect(result).not.toBeSuccessfullyDispatched();
     });
 
+    test.each(["TRUE", "false"])(
+      "Cannot create a named range with a boolean literal name %s",
+      (name) => {
+        expect(createNamedRange(model, name, "A1")).toBeCancelledBecause(
+          CommandResult.NamedRangeInvalidName
+        );
+      }
+    );
+
     test("Cannot update a named range that does not exist", () => {
       expect(updateNamedRange(model, "NonExistentRange", "NewName", "C3:D4")).toBeCancelledBecause(
         CommandResult.NamedRangeNotFound
@@ -67,9 +76,19 @@ describe("Named range plugin", () => {
         CommandResult.NamedRangeNameAlreadyExists
       );
       expect(updateNamedRange(model, "RangeTwo", "Invalid Name", "C3:D4")).toBeCancelledBecause(
-        CommandResult.NamedRangeNameWithInvalidCharacter
+        CommandResult.NamedRangeInvalidName
       );
     });
+
+    test.each(["TRUE", "FALSE"])(
+      "Cannot update a named range to a boolean literal name %s",
+      (newName) => {
+        createNamedRange(model, "RangeOne", "A1");
+        expect(updateNamedRange(model, "RangeOne", newName, "C3:D4")).toBeCancelledBecause(
+          CommandResult.NamedRangeInvalidName
+        );
+      }
+    );
 
     test("Cannot delete a named range that does not exist", () => {
       createNamedRange(model, "RangeOne", "A1");

--- a/tests/named_ranges/named_ranges_selector_component.test.ts
+++ b/tests/named_ranges/named_ranges_selector_component.test.ts
@@ -73,7 +73,7 @@ describe("Named ranges topbar selector", () => {
     await mountRangeSelector();
     await setInputValueAndTrigger(".o-named-range-selector input", "Wrong name !");
     expect(raiseError).toHaveBeenCalledWith(
-      "The named range name contains invalid characters. Valid characters are letters, numbers, underscores, and periods."
+      "The named range name is invalid. Valid names can contain letters, digits, underscores, and periods. The name cannot be only a number, TRUE, or FALSE."
     );
     expect(model.getters.getNamedRanges()).toHaveLength(0);
   });


### PR DESCRIPTION
## Description:

TRUE and FALSE are parsed as boolean literals in formulas, so named ranges with those names are not usable as named range references.

This commit renames the generic invalid-character result to NamedRangeInvalidName, rejects TRUE/FALSE in the named range validator, and updates the UI error message to match the effective validation rules.

Task: [6089940](https://www.odoo.com/odoo/2328/tasks/6089940)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo