### PR TITLE
[copy/paste cross spreadsheet] cross version paste should be prevented

### DIFF
--- a/src/helpers/ui/paste_interactive.ts
+++ b/src/helpers/ui/paste_interactive.ts
@@ -47,34 +47,19 @@ export function interactivePasteFromOS(
   clipboardContent: ParsedOSClipboardContent,
   pasteOption?: ClipboardPasteOptions
 ) {
-  let result: DispatchResult;
-  // We do not trust the clipboard content to be accurate and comprehensive.
-  // Therefore, to ensure reliability, we handle unexpected errors that may
-  // arise from content that would not be suitable for the current version.
-  try {
-    result = env.model.dispatch("PASTE_FROM_OS_CLIPBOARD", {
-      target,
-      clipboardContent,
-      pasteOption,
-    });
-  } catch (error) {
-    const parsedSpreadsheetContent = clipboardContent.data;
-
-    if (parsedSpreadsheetContent?.version !== CURRENT_VERSION) {
-      env.raiseError(
-        _t(
-          "An unexpected error occurred while pasting content.\
-          This is probably due to a spreadsheet version mismatch."
-        )
-      );
-    }
-    result = env.model.dispatch("PASTE_FROM_OS_CLIPBOARD", {
-      target,
-      clipboardContent: {
-        text: clipboardContent.text,
-      },
-      pasteOption,
+  if (clipboardContent.data && clipboardContent.data.version !== CURRENT_VERSION) {
+    env.notifyUser({
+      type: "warning",
+      text: _t(
+        "You copied content from a different version of the application. Only text content will be pasted."
+      ),
+      sticky: false,
     });
   }
+  const result = env.model.dispatch("PASTE_FROM_OS_CLIPBOARD", {
+    target,
+    clipboardContent,
+    pasteOption,
+  });
   handlePasteResult(env, result);
 }

--- a/src/plugins/ui_stateful/clipboard.ts
+++ b/src/plugins/ui_stateful/clipboard.ts
@@ -17,6 +17,7 @@ import {
   ClipboardOptions,
   MinimalClipboardData,
   OSClipboardContent,
+  ParsedOSClipboardContent,
 } from "../../types/clipboard";
 import {
   Command,
@@ -127,9 +128,16 @@ export class ClipboardPlugin extends UIPlugin {
       case "PASTE_FROM_OS_CLIPBOARD": {
         this._isCutOperation = false;
 
+        let contentToPaste: ParsedOSClipboardContent = cmd.clipboardContent;
+
+        // Only paste the spreadsheet data in the clipboard if the versions match
+        if (contentToPaste.data?.version !== CURRENT_VERSION) {
+          contentToPaste = { ...contentToPaste };
+          delete contentToPaste.data;
+        }
+
         this.copiedData =
-          cmd.clipboardContent.data ||
-          this.convertTextToClipboardData(cmd.clipboardContent.text ?? "");
+          contentToPaste.data || this.convertTextToClipboardData(contentToPaste.text ?? "");
 
         const pasteOption = cmd.pasteOption;
         this.paste(cmd.target, this.copiedData, {

--- a/tests/clipboard/clipboard_plugin.test.ts
+++ b/tests/clipboard/clipboard_plugin.test.ts
@@ -3023,6 +3023,23 @@ describe("cross spreadsheet copy/paste", () => {
     pasteFromOSClipboard(modelB, "D2", content);
     expect(getCellContent(modelB, "D2")).toBe("newContent");
   });
+
+  test("should only paste text content if there is a version mismatch", () => {
+    const modelA = new Model();
+    const modelB = new Model();
+
+    setCellContent(modelA, "B2", "Hello");
+    setStyle(modelA, "B2", { bold: true });
+
+    copy(modelA, "B2");
+    const clipboardContent = modelA.getters.getClipboardContent();
+    const parsedContent = parseOSClipboardContent(clipboardContent);
+    parsedContent.data!.version = 3; // Version mismatch
+    pasteFromOSClipboard(modelB, "D2", parsedContent);
+
+    expect(getCellContent(modelB, "D2")).toBe("Hello");
+    expect(getStyle(modelB, "D2")).toEqual({});
+  });
 });
 
 test("Can use clipboard handlers to paste in a sheet other than the active sheet", () => {


### PR DESCRIPTION
## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [6095101](https://www.odoo.com/odoo/2328/tasks/6095101)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo