### PR TITLE
[FIX] side_panel: stabilize list criterion color sync

### DIFF
--- a/src/components/side_panel/criterion_form/value_in_list_criterion/value_in_list_criterion.ts
+++ b/src/components/side_panel/criterion_form/value_in_list_criterion/value_in_list_criterion.ts
@@ -55,9 +55,8 @@ export class ListCriterionForm extends CriterionForm<IsValueInListCriterion> {
     const values = this.state.items.map((item) => item.value);
     const colors: Record<string, Color> = {};
     for (const { value, color } of this.state.items) {
-      const trimmed = value?.trim();
-      if (trimmed && color) {
-        colors[trimmed] = color;
+      if (value?.trim() !== "" && color) {
+        colors[value] = color;
       }
     }
     this.updateCriterion({ values, colors });

--- a/src/components/side_panel/criterion_form/value_in_list_criterion/value_in_list_criterion.ts
+++ b/src/components/side_panel/criterion_form/value_in_list_criterion/value_in_list_criterion.ts
@@ -12,8 +12,13 @@ css/* scss */ `
   }
 `;
 
+interface ListItem {
+  value: string;
+  color?: Color;
+}
+
 interface State {
-  numberOfValues: number;
+  items: ListItem[];
   focusedValueIndex?: number;
 }
 
@@ -22,11 +27,21 @@ export class ListCriterionForm extends CriterionForm<IsValueInListCriterion> {
   static components = { CriterionInput, RoundColorPicker };
 
   state = useState<State>({
-    numberOfValues: Math.max(this.props.criterion.values.length, 2),
+    items: [],
   });
 
   setup() {
     super.setup();
+    const values = this.props.criterion.values || [];
+    const colors = this.props.criterion.colors || {};
+    this.state.items = Array.from({ length: Math.max(values.length, 2) }, (_, i) => {
+      const value = values[i] ?? "";
+      return {
+        value,
+        color: value ? colors[value] : undefined,
+      };
+    });
+
     const setupDefault = (props: this["props"]) => {
       if (props.criterion.displayStyle === undefined) {
         this.updateCriterion({ displayStyle: "chip" });
@@ -36,27 +51,35 @@ export class ListCriterionForm extends CriterionForm<IsValueInListCriterion> {
     onWillStart(() => setupDefault(this.props));
   }
 
-  onValueChanged(value: string, index: number) {
-    const values = [...this.displayedValues];
-    values[index] = value;
-    this.updateCriterion({ values });
+  private syncCriterion() {
+    const values = this.state.items.map((item) => item.value);
+    const colors: Record<string, Color> = {};
+    for (const { value, color } of this.state.items) {
+      const trimmed = value?.trim();
+      if (trimmed && color) {
+        colors[trimmed] = color;
+      }
+    }
+    this.updateCriterion({ values, colors });
   }
 
-  onColorChanged(color: Color, value: string) {
-    const colors = { ...this.props.criterion.colors };
-    colors[value] = color || undefined;
-    this.updateCriterion({ colors });
+  onValueChanged(index: number, value: string) {
+    this.state.items[index].value = value;
+    this.syncCriterion();
+  }
+
+  onColorChanged(index: number, color: Color) {
+    this.state.items[index].color = color;
+    this.syncCriterion();
   }
 
   onAddAnotherValue() {
-    this.state.numberOfValues++;
+    this.state.items.push({ value: "" });
   }
 
   removeItem(index: number) {
-    const values = [...this.displayedValues];
-    values.splice(index, 1);
-    this.state.numberOfValues--;
-    this.updateCriterion({ values });
+    this.state.items.splice(index, 1);
+    this.syncCriterion();
   }
 
   onChangedDisplayStyle(ev: Event) {
@@ -65,7 +88,7 @@ export class ListCriterionForm extends CriterionForm<IsValueInListCriterion> {
   }
 
   onKeyDown(ev: KeyboardEvent, index: number) {
-    if ((ev.key === "Enter" || ev.key === "Tab") && index === this.state.numberOfValues - 1) {
+    if ((ev.key === "Enter" || ev.key === "Tab") && index === this.state.items.length - 1) {
       this.onAddAnotherValue();
       this.state.focusedValueIndex = index + 1;
       ev.preventDefault();
@@ -76,13 +99,5 @@ export class ListCriterionForm extends CriterionForm<IsValueInListCriterion> {
 
   onBlurInput() {
     this.state.focusedValueIndex = undefined;
-  }
-
-  get displayedValues(): string[] {
-    const values: string[] = [];
-    for (let i = 0; i < this.state.numberOfValues; i++) {
-      values.push(this.props.criterion.values[i] || "");
-    }
-    return values;
   }
 }

--- a/src/components/side_panel/criterion_form/value_in_list_criterion/value_in_list_criterion.xml
+++ b/src/components/side_panel/criterion_form/value_in_list_criterion/value_in_list_criterion.xml
@@ -1,25 +1,25 @@
 <templates>
   <t t-name="o-spreadsheet-ListCriterionForm">
-    <t t-foreach="displayedValues" t-as="value" t-key="value_index">
+    <t t-foreach="this.state.items" t-as="item" t-key="item_index">
       <div class="o-dv-list-values d-flex align-items-center">
         <div class="me-1">
           <RoundColorPicker
-            currentColor="props.criterion.colors?.[value] || '#E7E9ED'"
-            onColorPicked="(c) => this.onColorChanged(c, value)"
+            currentColor="item.color || '#E7E9ED'"
+            onColorPicked="(c) => this.onColorChanged(item_index, c)"
           />
         </div>
         <CriterionInput
-          value="props.criterion.values[value_index]"
-          onValueChanged="(v) => this.onValueChanged(v, value_index)"
+          value="item.value"
+          onValueChanged="(v) => this.onValueChanged(item_index, v)"
           criterionType="props.criterion.type"
-          onKeyDown="(ev) => this.onKeyDown(ev, value_index)"
-          focused="value_index === state.focusedValueIndex"
+          onKeyDown="(ev) => this.onKeyDown(ev, item_index)"
+          focused="item_index === this.state.focusedValueIndex"
           onBlur.bind="onBlurInput"
           disableFormulas="props.disableFormulas"
         />
         <div
           class="o-dv-list-item-delete ms-2 o-button-icon"
-          t-on-click="() => this.removeItem(value_index)">
+          t-on-click="() => this.removeItem(item_index)">
           <t t-call="o-spreadsheet-Icon.TRASH_FILLED"/>
         </div>
       </div>

--- a/src/components/side_panel/data_validation/dv_editor/dv_editor.ts
+++ b/src/components/side_panel/data_validation/dv_editor/dv_editor.ts
@@ -97,8 +97,7 @@ export class DataValidationEditor extends Component<Props, SpreadsheetChildEnv> 
 
     const values = criterion.values
       .slice(0, criterionEvaluator.numberOfValues(criterion))
-      .map((value) => value?.trim())
-      .filter((value) => value !== "" && value !== undefined)
+      .filter((value) => value && value.trim() !== "")
       .map((value) => canonicalizeContent(value, locale));
     rule.criterion = { ...criterion, values };
     return {

--- a/tests/data_validation/data_validation_list_component.test.ts
+++ b/tests/data_validation/data_validation_list_component.test.ts
@@ -169,6 +169,37 @@ describe("Edit criterion in side panel", () => {
         {}
       );
     });
+
+    test("changing color on empty value should not be saved", async () => {
+      await click(fixture, ".o-dv-list-add-value");
+
+      // select color for that empty input
+      const colorBtns = fixture.querySelectorAll(".o-round-color-picker-button");
+      await click(colorBtns[colorBtns.length - 1]);
+      await click(fixture, ".o-color-picker-line-item[data-color='#CFE2F3'");
+      await click(fixture, ".o-dv-save");
+
+      // no color should be stored because value is empty
+      expect((getDataValidationRules(model)[0].criterion as IsValueInListCriterion).colors).toEqual(
+        {}
+      );
+    });
+
+    test("color should follow updated value", async () => {
+      // set color for "ok"
+      await click(fixture.querySelectorAll(".o-round-color-picker-button")[0]);
+      await click(fixture, ".o-color-picker-line-item[data-color='#CFE2F3'");
+
+      // change "ok" to "bye"
+      const inputs = fixture.querySelectorAll<HTMLInputElement>(".o-dv-list-values .o-input");
+      setInputValueAndTrigger(inputs[0], "bye");
+
+      await click(fixture, ".o-dv-save");
+      const { values, colors } = getDataValidationRules(model)[0]
+        .criterion as IsValueInListCriterion;
+      expect(values[0]).toBe("bye");
+      expect(colors).toEqual({ bye: "#CFE2F3" });
+    });
   });
 
   describe("Value in range", () => {

--- a/tests/data_validation/data_validation_list_component.test.ts
+++ b/tests/data_validation/data_validation_list_component.test.ts
@@ -200,6 +200,19 @@ describe("Edit criterion in side panel", () => {
       expect(values[0]).toBe("bye");
       expect(colors).toEqual({ bye: "#CFE2F3" });
     });
+
+    test("Can store values and color with leading and trailing spaces", async () => {
+      const inputs = fixture.querySelectorAll<HTMLInputElement>(".o-dv-list-values .o-input");
+      setInputValueAndTrigger(inputs[0], "  hello  ");
+      await click(fixture.querySelector(".o-round-color-picker-button")!);
+      await click(fixture, ".o-color-picker-line-item[data-color='#CFE2F3'");
+      await click(fixture, ".o-dv-save");
+
+      const { values, colors } = getDataValidationRules(model)[0]
+        .criterion as IsValueInListCriterion;
+      expect(values[0]).toBe("  hello  ");
+      expect(colors).toEqual({ "  hello  ": "#CFE2F3" });
+    });
   });
 
   describe("Value in range", () => {


### PR DESCRIPTION
## Description:

The list criterion form did not handle colors correctly when values were edited.

Colors were mapped using the value as key, which caused:
- Changing a value kept the old key -> stale color entries
- Editing a value after assigning a color lost the color
- Empty values were synced -> inconsistent UI behavior

Example:
- Setting a color without value creates `{'': '#CFE2F3'}` -> all empty inputs show the same color
- Changing value 'ok' (with color) to 'bye' keeps color on 'ok' and loses it for 'bye'

We cannot change the schema as many spreadsheets already depend on it and it may break existing data.
The issue comes from directly syncing UI state with the schema.

This commit introduces an intermediate UI state:
- Initialize UI from schema
- Avoid direct sync while editing
- Clean and apply valid color mappings

This ensures stable behavior when editing values and assigning colors.

Task: [5418098](https://www.odoo.com/odoo/2328/tasks/5418098)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo