### PR TITLE
[FIX] cells: avoid string convertion on import for date.

### DIFF
--- a/src/helpers/cells/cell_evaluation.ts
+++ b/src/helpers/cells/cell_evaluation.ts
@@ -47,10 +47,11 @@ export function createCell(
   content: string,
   format: Format | undefined,
   style: Style | undefined,
-  sheetId: UID
+  sheetId: UID,
+  options?: { avoidAutomaticDateFormat: boolean }
 ): Cell {
   if (!content.startsWith("=")) {
-    return createLiteralCell(getters, id, content, format, style);
+    return createLiteralCell(getters, id, content, format, style, options);
   }
   return createFormulaCell(getters, id, content, format, style, sheetId);
 }
@@ -60,16 +61,29 @@ export function createLiteralCell(
   id: number,
   content: string,
   format: Format | undefined,
-  style: Style | undefined
+  style: Style | undefined,
+  options?: { avoidAutomaticDateFormat: boolean }
 ): LiteralCell {
   const locale = getters.getLocale();
   const parsedValue = parseLiteral(content, locale);
 
-  format =
-    format ||
-    (typeof parsedValue === "number"
-      ? detectDateFormat(content, locale) || detectNumberFormat(content)
-      : undefined);
+  if (!format && typeof parsedValue === "number") {
+    const dateFormat = detectDateFormat(content, locale);
+    if (options?.avoidAutomaticDateFormat && dateFormat) {
+      return {
+        id,
+        content,
+        style,
+        format,
+        isFormula: false,
+        parsedValue: content,
+      };
+    }
+    format = dateFormat || detectNumberFormat(content);
+  } else {
+    format ||= undefined;
+  }
+
   if (!isTextFormat(format) && !content.startsWith("'") && !isEvaluationError(content)) {
     content = toString(parsedValue);
   }

--- a/src/plugins/core/cell.ts
+++ b/src/plugins/core/cell.ts
@@ -341,7 +341,9 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
     if (compiledFormula) {
       return createFormulaCellFromCompiledFormula(cellId, compiledFormula, format, style);
     }
-    return createCell(this.getters, cellId, content || "", format, style, sheetId);
+    return createCell(this.getters, cellId, content || "", format, style, sheetId, {
+      avoidAutomaticDateFormat: true,
+    });
   }
 
   exportForExcel(data: ExcelWorkbookData) {

--- a/tests/model/core.test.ts
+++ b/tests/model/core.test.ts
@@ -580,6 +580,11 @@ describe("history", () => {
               A3: "2000",
               B2: "TRUE",
             },
+            formats: {
+              A1: 1,
+              A3: 1,
+              B2: 1,
+            },
           },
           {
             id: sheet2Id,
@@ -590,8 +595,17 @@ describe("history", () => {
               A3: "12-31-2020",
               B2: "TRUE",
             },
+            formats: {
+              A1: 1,
+              A3: 2,
+              B2: 1,
+            },
           },
         ],
+        formats: {
+          "1": "#,##0",
+          "2": "mm-dd-yyyy",
+        },
       });
       expect(getRangeValues(model, "A1:A3", sheet1Id)).toEqual([1000, null, 2000]);
       expect(getRangeValues(model, "$A$1:$A$3", sheet1Id)).toEqual([1000, null, 2000]);

--- a/tests/model/model_import_export.test.ts
+++ b/tests/model/model_import_export.test.ts
@@ -1140,7 +1140,7 @@ test("import then export (figures)", () => {
   expect(model).toExport(modelData);
 });
 
-test("import date as string and detect the format", () => {
+test("don't import string as date", () => {
   const model = new Model({
     sheets: [
       {
@@ -1148,12 +1148,12 @@ test("import date as string and detect the format", () => {
       },
     ],
   });
-  expect(getCell(model, "A1")?.format).toBe("m/d/yyyy");
-  expect(getCellRawContent(model, "A1")).toBe("44196");
+  expect(getCell(model, "A1")?.format).toBeUndefined();
+  expect(getCellRawContent(model, "A1")).toBe("12/31/2020");
   expect(getEvaluatedCell(model, "A1")?.formattedValue).toBe("12/31/2020");
 });
 
-test("import localized date as string and detect the format", () => {
+test("don't import string as localized date", () => {
   const model = new Model({
     sheets: [
       {
@@ -1162,8 +1162,8 @@ test("import localized date as string and detect the format", () => {
     ],
     settings: { locale: FR_LOCALE },
   });
-  expect(getCell(model, "A1")?.format).toBe("d/m/yyyy");
-  expect(getCellRawContent(model, "A1")).toBe("44196");
+  expect(getCell(model, "A1")?.format).toBeUndefined();
+  expect(getCellRawContent(model, "A1")).toBe("31/12/2020");
   expect(getEvaluatedCell(model, "A1")?.formattedValue).toBe("31/12/2020");
 });
 

--- a/tests/pivots/pivot_data.ts
+++ b/tests/pivots/pivot_data.ts
@@ -179,6 +179,7 @@ export const pivotModelData = function (xc: string) {
         styles: {},
         formats: {
           "F2:F22": 1,
+          "A2:A22": 2,
         },
         isVisible: true,
         areGridLinesVisible: true,
@@ -186,6 +187,7 @@ export const pivotModelData = function (xc: string) {
     ],
     formats: {
       "1": "[$$]#,##0.00",
+      "2": "m/d/yyyy",
     },
     borders: {},
     revisionId: "fbf5c369-70ff-4a05-929e-859e0608c53a",

--- a/tests/pivots/spreadsheet_pivot/spreadsheet_pivot.test.ts
+++ b/tests/pivots/spreadsheet_pivot/spreadsheet_pivot.test.ts
@@ -97,6 +97,12 @@ describe("Spreadsheet Pivot", () => {
     const model = new Model({
       sheets: [
         {
+          formats: {
+            "A2:A3": 1,
+            A4: 2,
+            E2: 1,
+            H4: 1,
+          },
           cells: {
             A1: "Date",
             A2: "04/01/2024",
@@ -136,6 +142,10 @@ describe("Spreadsheet Pivot", () => {
           },
         },
       ],
+      formats: {
+        "1": "mm/dd/yyyy",
+        "2": "mm/dd/yyyy hh:mm:ss a",
+      },
     });
     addPivot(model, "A1:I4", {});
     const fields = model.getters.getPivot("1").getFields();

--- a/tests/sort_plugin.test.ts
+++ b/tests/sort_plugin.test.ts
@@ -180,8 +180,14 @@ describe("Basic Sorting", () => {
             A10: "2020/09/01",
             A11: "=B1/B2",
           },
+          formats: {
+            A10: 1,
+          },
         },
       ],
+      formats: {
+        1: "yyyy/mm/dd",
+      },
     });
     sort(model, {
       zone: "A1:A11",
@@ -550,8 +556,10 @@ describe("Sort adjacent columns with headers", () => {
             C3: "09/14/2020",
             C4: "09/15/2020",
           },
+          formats: { "C2:C4": 1 },
         },
       ],
+      formats: { 1: "mm/dd/yyyy" },
     });
   });
   test("Presence of header", () => {
@@ -685,6 +693,7 @@ describe("Sort Merges", () => {
           D5: "08/20/2020",
           D8: "07/20/2020",
         },
+        formats: { D2: 1, D5: 1, D8: 1 },
         merges: [
           "B2:B4",
           "B5:B7",
@@ -698,6 +707,9 @@ describe("Sort Merges", () => {
         ],
       },
     ],
+    formats: {
+      1: "mm/dd/yyyy",
+    },
   };
   beforeEach(() => {
     model = new Model(modelData);

--- a/tests/test_helpers/helpers.ts
+++ b/tests/test_helpers/helpers.ts
@@ -16,6 +16,8 @@ import { ImageProvider } from "../../src/helpers/figures/images/image_provider";
 import {
   batched,
   createRangeFromXc,
+  detectDateFormat,
+  getItemId,
   positions,
   range,
   toCartesian,
@@ -89,6 +91,7 @@ import {
   setFormatting,
   undo,
 } from "./commands_helpers";
+import { EN_LOCALE } from "./constants";
 import { DOMTarget, click, getTarget, getTextNodes, keyDown, keyUp } from "./dom_helper";
 import { getCellContent, getEvaluatedCell } from "./getters_helpers";
 
@@ -471,7 +474,18 @@ export function setGridStyle(model: Model, grid: GridStyleDescr) {
  *   {B5: "5", D8: "2.6", W4: "=round(A2)"} => {B5: 5, D8: 2.6, W4: 3}
  */
 export function evaluateGrid(grid: GridDescr): GridResult {
-  const model = new Model({ sheets: [{ cells: grid }] });
+  const sheetFormats = {};
+  const modelFormats = {};
+  for (const xc in grid) {
+    const format = detectDateFormat(grid[xc] ?? "", EN_LOCALE);
+    if (format) {
+      sheetFormats[xc] = getItemId(format, modelFormats);
+    }
+  }
+  const model = new Model({
+    sheets: [{ cells: grid, formats: sheetFormats }],
+    formats: modelFormats,
+  });
   const result = {};
   for (const xc in grid) {
     result[xc] = getEvaluatedCell(model, xc).value;


### PR DESCRIPTION
Do not convert strings that look like dates at import

Task: 4918754

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo