### PR TITLE
[FIX] chart: figure sometime still exist after chart deletion

### DIFF
--- a/src/plugins/core/chart.ts
+++ b/src/plugins/core/chart.ts
@@ -81,7 +81,7 @@ export class ChartPlugin extends CorePlugin<ChartState> implements ChartState {
           )
         );
       case "DELETE_CHART":
-        return this.checkChartExists(cmd);
+        return CommandResult.SubCommandOnly;
       default:
         return CommandResult.Success;
     }

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -1517,6 +1517,7 @@ export const enum CommandResult {
   InvalidCarouselItem = "InvalidCarouselItem",
   SheetLocked = "SheetLocked",
   InvalidZoomLevel = "InvalidZoomLevel",
+  SubCommandOnly = "SubCommandOnly",
 }
 
 export interface CommandHandler<T> {

--- a/tests/figures/chart/chart_plugin.test.ts
+++ b/tests/figures/chart/chart_plugin.test.ts
@@ -1288,6 +1288,16 @@ describe("datasource tests", function () {
   });
 });
 
+test("Top level command DELETE_CHART does not delete chart", () => {
+  const sheetId = model.getters.getActiveSheetId();
+  createChart(model, { type: "line" }, "chartId");
+  expect(model.dispatch("DELETE_CHART", { sheetId, chartId: "chartId" })).toBeCancelledBecause(
+    CommandResult.SubCommandOnly
+  );
+  expect(model.getters.getFigures(sheetId).length).toBe(1);
+  expect(model.getters.getChart("chartId")).toBeDefined();
+});
+
 describe("title", function () {
   test("change title manually", () => {
     createChart(


### PR DESCRIPTION
Task: 6107235

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo