### PR TITLE
[FIX] sheetview: undo/redo should update frozen panes

### DIFF
--- a/src/plugins/ui_stateful/sheetview.ts
+++ b/src/plugins/ui_stateful/sheetview.ts
@@ -155,6 +155,7 @@ export class SheetViewPlugin extends UIPlugin {
         this.viewports.cleanViewports();
         for (const sheetId of this.getters.getSheetIds()) {
           this.sheetsWithDirtyViewports.add(sheetId);
+          this.syncPaneDivision(sheetId);
         }
         this.shouldAdjustViewports = true;
         break;
@@ -191,16 +192,20 @@ export class SheetViewPlugin extends UIPlugin {
       case "FREEZE_COLUMNS":
       case "FREEZE_ROWS":
       case "UNFREEZE_COLUMNS_ROWS":
+      case "REMOVE_COLUMNS_ROWS":
+      case "ADD_COLUMNS_ROWS":
         this.sheetsWithDirtyViewports.add(cmd.sheetId);
-        this.viewports.setPaneDivision(cmd.sheetId, this.getters.getPaneDivisions(cmd.sheetId));
+        this.syncPaneDivision(cmd.sheetId);
+        break;
+      case "DUPLICATE_SHEET":
+        this.sheetsWithDirtyViewports.add(cmd.sheetIdTo);
+        this.syncPaneDivision(cmd.sheetIdTo);
         break;
       case "REMOVE_TABLE":
       case "UPDATE_TABLE":
       case "UPDATE_FILTER":
-      case "REMOVE_COLUMNS_ROWS":
       case "RESIZE_COLUMNS_ROWS":
       case "HIDE_COLUMNS_ROWS":
-      case "ADD_COLUMNS_ROWS":
       case "UNHIDE_COLUMNS_ROWS":
       case "UNGROUP_HEADERS":
       case "GROUP_HEADERS":
@@ -258,6 +263,10 @@ export class SheetViewPlugin extends UIPlugin {
         this.viewports.resetViewports(sheetId);
       }
     }
+  }
+
+  private syncPaneDivision(sheetId: UID) {
+    this.viewports.setPaneDivision(sheetId, this.getters.getPaneDivisions(sheetId));
   }
 
   // ---------------------------------------------------------------------------

--- a/tests/sheet/sheetview_plugin.test.ts
+++ b/tests/sheet/sheetview_plugin.test.ts
@@ -20,6 +20,7 @@ import {
   createTableWithFilter,
   deleteColumns,
   deleteRows,
+  duplicateSheet,
   foldHeaderGroup,
   freezeColumns,
   freezeRows,
@@ -1092,6 +1093,62 @@ describe("Multi Panes viewport", () => {
     freezeColumns(model, 4);
     freezeRows(model, 5);
     expect(getPanesEntries()).toEqual(["topLeft", "topRight", "bottomLeft", "bottomRight"]);
+  });
+
+  test("Undo and redo keep frozen panes in sync with history", () => {
+    const sheetId = model.getters.getActiveSheetId();
+    const getPanesEntries = () => Object.keys(getPanes());
+
+    freezeColumns(model, 4);
+    freezeRows(model, 5);
+    expect(model.getters.getPaneDivisions(sheetId)).toEqual({ xSplit: 4, ySplit: 5 });
+    expect(getPanesEntries()).toEqual(["topLeft", "topRight", "bottomLeft", "bottomRight"]);
+
+    undo(model);
+    expect(model.getters.getPaneDivisions(sheetId)).toEqual({ xSplit: 4, ySplit: 0 });
+    expect(getPanesEntries()).toEqual(["bottomLeft", "bottomRight"]);
+
+    undo(model);
+    expect(model.getters.getPaneDivisions(sheetId)).toEqual({ xSplit: 0, ySplit: 0 });
+    expect(getPanesEntries()).toEqual(["bottomRight"]);
+
+    redo(model);
+    expect(model.getters.getPaneDivisions(sheetId)).toEqual({ xSplit: 4, ySplit: 0 });
+    expect(getPanesEntries()).toEqual(["bottomLeft", "bottomRight"]);
+
+    redo(model);
+    expect(model.getters.getPaneDivisions(sheetId)).toEqual({ xSplit: 4, ySplit: 5 });
+    expect(getPanesEntries()).toEqual(["topLeft", "topRight", "bottomLeft", "bottomRight"]);
+  });
+
+  test("Adding and removing headers before frozen panes keeps viewports in sync", () => {
+    const sheetId = model.getters.getActiveSheetId();
+
+    freezeColumns(model, 4);
+    freezeRows(model, 5);
+
+    addColumns(model, "before", "A", 1);
+    addRows(model, "before", 0, 1);
+    expect(model.getters.getPaneDivisions(sheetId)).toEqual({ xSplit: 5, ySplit: 6 });
+    expect(getPanes().topLeft).toMatchObject({ right: 4, bottom: 5 });
+
+    deleteColumns(model, ["A"]);
+    deleteRows(model, [0]);
+    expect(model.getters.getPaneDivisions(sheetId)).toEqual({ xSplit: 4, ySplit: 5 });
+    expect(getPanes().topLeft).toMatchObject({ right: 3, bottom: 4 });
+  });
+
+  test("Duplicated sheets keep frozen pane viewports", () => {
+    const sheetId = model.getters.getActiveSheetId();
+    const duplicatedSheetId = "duplicateSheetId";
+
+    freezeColumns(model, 4);
+    freezeRows(model, 5);
+    duplicateSheet(model, sheetId, duplicatedSheetId, "Duplicate");
+    activateSheet(model, duplicatedSheetId);
+
+    expect(model.getters.getPaneDivisions(duplicatedSheetId)).toEqual({ xSplit: 4, ySplit: 5 });
+    expect(Object.keys(getPanes())).toEqual(["topLeft", "topRight", "bottomLeft", "bottomRight"]);
   });
 
   test("vertical scrolling only impacts 'bottomLeft' and 'bottomRight'", () => {


### PR DESCRIPTION
## Description:

Undo and redo restore pane divisions in the sheet state, but sheetview kept
using cached pane divisions until a direct freeze command updated them.
This could leave frozen panes visually stuck after history replay.

Resync pane divisions from the core state before rebuilding dirty viewports.

Task: [6103593](https://www.odoo.com/odoo/2328/tasks/6103593)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo