### PR TITLE
[FIX] pivot: `getPivotCellFromPosition` will throw on invalid formula

### DIFF
--- a/src/plugins/ui_core_views/pivot_ui.ts
+++ b/src/plugins/ui_core_views/pivot_ui.ts
@@ -217,20 +217,20 @@ export class PivotUIPlugin extends UIPlugin {
     ) {
       return EMPTY_PIVOT_CELL;
     }
-    if (functionName === "PIVOT") {
-      const includeTotal = toScalar(args[2]);
-      const shouldIncludeTotal = includeTotal === undefined ? true : toBoolean(includeTotal);
-      const includeColumnHeaders = toScalar(args[3]);
-      const shouldIncludeColumnHeaders =
-        includeColumnHeaders === undefined ? true : toBoolean(includeColumnHeaders);
-      const pivotCells = pivot
-        .getTableStructure()
-        .getPivotCells(shouldIncludeTotal, shouldIncludeColumnHeaders);
-      const pivotCol = position.col - mainPosition.col;
-      const pivotRow = position.row - mainPosition.row;
-      return pivotCells[pivotCol][pivotRow];
-    }
     try {
+      if (functionName === "PIVOT") {
+        const includeTotal = toScalar(args[2]);
+        const shouldIncludeTotal = includeTotal === undefined ? true : toBoolean(includeTotal);
+        const includeColumnHeaders = toScalar(args[3]);
+        const shouldIncludeColumnHeaders =
+          includeColumnHeaders === undefined ? true : toBoolean(includeColumnHeaders);
+        const pivotCells = pivot
+          .getTableStructure()
+          .getPivotCells(shouldIncludeTotal, shouldIncludeColumnHeaders);
+        const pivotCol = position.col - mainPosition.col;
+        const pivotRow = position.row - mainPosition.row;
+        return pivotCells[pivotCol][pivotRow];
+      }
       const offsetRow = position.row - mainPosition.row;
       const offsetCol = position.col - mainPosition.col;
       args = args.map((arg) => (isMatrix(arg) ? arg[offsetCol][offsetRow] : arg));

--- a/tests/pivots/pivot_plugin.test.ts
+++ b/tests/pivots/pivot_plugin.test.ts
@@ -1,10 +1,11 @@
-import { CommandResult, Model } from "../../src";
+import { CellErrorType, CommandResult, Model } from "../../src";
 import { FORBIDDEN_SHEETNAME_CHARS } from "../../src/constants";
 import { toZone } from "../../src/helpers";
 import { EMPTY_PIVOT_CELL } from "../../src/helpers/pivot/table_spreadsheet_pivot";
+import { getEvaluatedCell } from "../test_helpers";
 import { renameSheet, selectCell, setCellContent } from "../test_helpers/commands_helpers";
 import { createModelFromGrid, toCellPosition } from "../test_helpers/helpers";
-import { addPivot, updatePivot } from "../test_helpers/pivot_helpers";
+import { addPivot, createModelWithPivot, updatePivot } from "../test_helpers/pivot_helpers";
 
 describe("Pivot plugin", () => {
   test("isSpillPivotFormula", () => {
@@ -325,7 +326,7 @@ describe("Pivot plugin", () => {
     // prettier-ignore
     const grid = {
       A1: "Customer", B1: "Price",
-      A2: "Alice",    B2: "10",    
+      A2: "Alice",    B2: "10",
       A3: "Bob",      B3: "30",
     };
     const model = createModelFromGrid(grid);
@@ -373,5 +374,16 @@ describe("Pivot plugin", () => {
       pivotId: "pivot1",
     });
     expect(result).toBeCancelledBecause(CommandResult.PivotInError);
+  });
+
+  test("getPivotCellFromPosition shouldn't throw if the pivot formula is invalid", () => {
+    const model = createModelWithPivot("A1:I5");
+    setCellContent(model, "A40", "=PIVOT(1, 10, false.false)");
+    expect(getEvaluatedCell(model, "A40").value).toBe(CellErrorType.BadExpression);
+
+    const sheetId = model.getters.getActiveSheetId();
+    expect(model.getters.getPivotCellFromPosition(toCellPosition(sheetId, "A40"))).toEqual(
+      EMPTY_PIVOT_CELL
+    );
   });
 });


### PR DESCRIPTION
## Description

If the pivot formulas arguments are invalid, `getPivotCellFromPosition` would throw, which is not the expected behaviour.

Task: [6109696](https://www.odoo.com/odoo/2328/tasks/6109696)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo