### PR TITLE
|IMP] node: remove useless dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
         "@types/rbush": "^3.0.3",
         "@typescript-eslint/eslint-plugin": "^8.30.1",
         "babel-eslint": "^10.1.0",
-        "body-parser": "^1.19.0",
         "canvas": "^3.0.0",
         "chart.js": "4.5.0",
         "chartjs-adapter-luxon": "^1.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,6 @@
         "live-server": "^1.2.1",
         "luxon": "^3.7.2",
         "minimist": "^1.2.8",
-        "mockdate": "^3.0.2",
         "node-watch": "^0.7.3",
         "npm-run-all": "^4.1.5",
         "prettier": "^2.8.0",
@@ -11459,11 +11458,6 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/mockdate": {
-      "version": "3.0.5",
       "dev": true,
       "license": "MIT"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,6 @@
         "chart.js": "4.5.0",
         "chartjs-adapter-luxon": "^1.3.1",
         "chartjs-chart-geo": "^4.3.2",
-        "cors": "^2.8.5",
         "express": "^4.17.1",
         "express-form-data": "^2.0.19",
         "express-ws": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "@types/rbush": "^3.0.3",
     "@typescript-eslint/eslint-plugin": "^8.30.1",
     "babel-eslint": "^10.1.0",
-    "body-parser": "^1.19.0",
     "canvas": "^3.0.0",
     "chart.js": "4.5.0",
     "chartjs-adapter-luxon": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
     "chart.js": "4.5.0",
     "chartjs-adapter-luxon": "^1.3.1",
     "chartjs-chart-geo": "^4.3.2",
-    "cors": "^2.8.5",
     "express": "^4.17.1",
     "express-form-data": "^2.0.19",
     "express-ws": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
     "live-server": "^1.2.1",
     "luxon": "^3.7.2",
     "minimist": "^1.2.8",
-    "mockdate": "^3.0.2",
     "node-watch": "^0.7.3",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.8.0",

--- a/tests/functions/module_date.test.ts
+++ b/tests/functions/module_date.test.ts
@@ -584,18 +584,18 @@ describe("NETWORKDAYS.INTL formula", () => {
 });
 
 describe("NOW formula", () => {
-  const MockDate = require("mockdate");
-
   test("functional tests on simple arguments", async () => {
-    MockDate.set(new Date(2042, 3, 2, 4, 7, 30, 999));
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date(2042, 3, 2, 4, 7, 30, 999).getTime());
     expect(evaluateCell("A1", { A1: "=NOW()" })).toBe(51958.171875);
-    MockDate.reset();
+    jest.useRealTimers();
   });
 
   test("return value with formatting", async () => {
-    MockDate.set(new Date(2042, 3, 2, 4, 7, 30, 999));
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date(2042, 3, 2, 4, 7, 30, 999).getTime());
     expect(evaluateCellFormat("A1", { A1: "=NOW()" })).toBe("m/d/yyyy hh:mm:ss a");
-    MockDate.reset();
+    jest.useRealTimers();
   });
 
   test("Return format is locale dependant", () => {
@@ -683,17 +683,18 @@ describe("TIMEVALUE formula", () => {
 });
 
 describe("TODAY formula", () => {
-  const MockDate = require("mockdate");
   test("functional tests on simple arguments", async () => {
-    MockDate.set(new Date(2042, 3, 2, 4, 7, 30, 999));
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date(2042, 3, 2, 4, 7, 30, 999).getTime());
     expect(evaluateCell("A1", { A1: "=TODAY()" })).toBe(51958);
-    MockDate.reset();
+    jest.useRealTimers();
   });
 
   test("return value with formatting", async () => {
-    MockDate.set(new Date(2042, 3, 2, 4, 7, 30, 999));
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date(2042, 3, 2, 4, 7, 30, 999).getTime());
     expect(evaluateCellFormat("A1", { A1: "=TODAY()" })).toBe("m/d/yyyy");
-    MockDate.reset();
+    jest.useRealTimers();
   });
 
   test("Return format is locale dependant", () => {

--- a/tools/server/main.cjs
+++ b/tools/server/main.cjs
@@ -4,14 +4,23 @@
  */
 const formData = require("express-form-data");
 const express = require("express");
-const cors = require("cors");
 const fs = require("fs");
 const path = require("path"); // magic
 const expressWS = require("express-ws")(express());
 const app = expressWS.app;
 
 //add middleware
-app.use(cors());
+app.use((req, res, next) => {
+  res.header("Access-Control-Allow-Origin", "*");
+  res.header("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS");
+  res.header("Access-Control-Allow-Headers", "Content-Type, Authorization");
+
+  if (req.method === "OPTIONS") {
+    return res.sendStatus(200);
+  }
+
+  next();
+});
 app.use(express.json());
 // parse data with connect-multiparty.
 app.use(formData.parse(/* options */));


### PR DESCRIPTION
## Description:

### [IMP] node: remove `mockdate` dependency

We used the `mockdate` package in the tests to mock the current date.
Mocking the date is something that can be done with jest, the extra
dependency is not needed.

### [IMP] node: remove `cors` dependency

We use the `cors` package to handle Cross-Origin Resource Sharing (CORS)
in our Node.js server. But we don't really care about fine-tuned
CORS configuration for our demo server, we can set the headers
manually and remove the `cors` dependency.

In practice, `cors` is still installed as it's a dependency of
`live-server`, but this will make it easier to get rid of `liver-server`
in the future.

### [IMP] node: remove explicit `body-parser` dependency

We have a dev dependency on `body-parser` that is not used directly
in the codebase. It will still be installed since it's a dependency of
`express`, but we can remove it from our `package.json`.

 Task: 0
Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo