### PR TITLE
[FIX] computed style: fix multi-user clear formatting

### DIFF
--- a/src/plugins/ui_feature/cell_computed_style.ts
+++ b/src/plugins/ui_feature/cell_computed_style.ts
@@ -21,6 +21,7 @@ export class CellComputedStylePlugin extends UIPlugin {
       invalidateEvaluationCommands.has(cmd.type) ||
       cmd.type === "UPDATE_CELL" ||
       cmd.type === "SET_FORMATTING" ||
+      cmd.type === "CLEAR_FORMATTING" ||
       cmd.type === "EVALUATE_CELLS"
     ) {
       this.styles = {};

--- a/tests/collaborative/collaborative.test.ts
+++ b/tests/collaborative/collaborative.test.ts
@@ -915,6 +915,22 @@ describe("Multi users synchronisation", () => {
     );
   });
 
+  test("delete the style of a cell is updated for each client", () => {
+    setStyle(alice, "A1", { fillColor: "#FF0000" });
+    expect([alice, bob, charlie]).toHaveSynchronizedValue(
+      (user) => getStyle(user, "A1").fillColor,
+      "#FF0000"
+    );
+    alice.dispatch("CLEAR_FORMATTING", {
+      sheetId: alice.getters.getActiveSheetId(),
+      target: [toZone("A1")],
+    });
+    expect([alice, bob, charlie]).toHaveSynchronizedValue(
+      (user) => getStyle(user, "A1")!.fillColor,
+      undefined
+    );
+  });
+
   test.each(["COL", "ROW"] as const)("Can group headers concurrently", (dimension) => {
     const sheetId = alice.getters.getActiveSheetId();
 


### PR DESCRIPTION
Before this commit:
When in multi-user, after one user uses clear formatting, other users still see the old format until they trigger a change on a cell.

After this commit:
CLEAR_FORMATTING command invalidate cell computed style cache.

UPDATE_CELL is not handled in the plugin UI because it's a sub-command of CLEAR_FORMATTING and sub-commands are not dispatched to UI plugins when they come from the network.

Task: [6086129](https://www.odoo.com/odoo/2328/tasks/6086129)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo