### PR TITLE
[FIX] spreadsheet_pivot: avoid crash on invalid dimension values

### DIFF
--- a/src/helpers/pivot/spreadsheet_pivot/spreadsheet_pivot.ts
+++ b/src/helpers/pivot/spreadsheet_pivot/spreadsheet_pivot.ts
@@ -404,10 +404,10 @@ export class SpreadsheetPivot implements Pivot<SpreadsheetPivotRuntimeDefinition
     if (nonEmptyCells.every((cell) => cell.type === CellValueType.boolean)) {
       return "boolean";
     }
-    if (nonEmptyCells.some((cell) => cell.type === CellValueType.text)) {
-      return "char";
+    if (nonEmptyCells.every((cell) => cell.type === CellValueType.number)) {
+      return "integer";
     }
-    return "integer";
+    return "char";
   }
 
   private assertCellIsValidField(col: number, row: number, cell: EvaluatedCell) {

--- a/tests/pivots/spreadsheet_pivot/spreadsheet_pivot.test.ts
+++ b/tests/pivots/spreadsheet_pivot/spreadsheet_pivot.test.ts
@@ -236,6 +236,50 @@ describe("Spreadsheet Pivot", () => {
     expect(getEvaluatedGrid(model, "B26:D26")).toEqual([["2024", "Total", ""]]);
   });
 
+  test("can group pivot columns with values in error", () => {
+    // prettier-ignore
+    const grid = {
+      A1: "Dates",        B1: "Revenue", C1: "=PIVOT(1)",
+      A2: "01/01/2026",   B2: "100",
+      A3: "01/02/2026",   B3: "200",
+      A4: "=NA()",        B4: "300",
+    };
+    const model = createModelFromGrid(grid);
+    addPivot(model, "A1:B4", {
+      columns: [{ fieldName: "Dates", order: "asc" }],
+      rows: [],
+      measures: [{ id: "Revenue:sum", fieldName: "Revenue", aggregator: "sum" }],
+    });
+
+    expect(getEvaluatedGrid(model, "C1:F3")).toEqual([
+      ["(#1) Pivot", "#N/A", "01/01/2026", "01/02/2026"],
+      ["", "Revenue", "Revenue", "Revenue"],
+      ["Total", "300", "100", "200"],
+    ]);
+  });
+
+  test("Mixed number and boolean dimension values are treated as char", () => {
+    // prettier-ignore
+    const grid = {
+      A1: "Amount", B1: "Revenue", C1: "=PIVOT(1)",
+      A2: "100",    B2: "200",
+      A3: "200",    B3: "300",
+      A4: "TRUE",   B4: "400",
+    };
+    const model = createModelFromGrid(grid);
+    addPivot(model, "A1:B4", {
+      columns: [{ fieldName: "Amount", order: "asc" }],
+      rows: [],
+      measures: [{ id: "Revenue:sum", fieldName: "Revenue", aggregator: "sum" }],
+    });
+
+    expect(getEvaluatedGrid(model, "C1:G3")).toEqual([
+      ["(#1) Pivot", "100", "200", "TRUE", "Total"],
+      ["", "Revenue", "Revenue", "Revenue", "Revenue"],
+      ["Total", "200", "300", "400", "900"],
+    ]);
+  });
+
   test("Pivot Rows are ordered", () => {
     const model = createModelWithPivot("A1:I5");
     setCellContent(model, "A26", `=pivot(1)`);


### PR DESCRIPTION
## Description:

A spreadsheet pivot could crash when a grouped dimension contained an evaluation error such as "#N/A", or mixed boolean values.

Steps to reproduce:
- create a table:

| Dates | Revenue |
| -------- | -------- |
| 01/01/2026 | 100 |
| =NA() | 200 |


- insert a Spreadsheet Pivot
- add "Dates" as a column

Adding a grouped or ordered dimension could break the whole spreadsheet when the source field contained values that could not be normalized as numbers.

In that case the pivot inferred the field as a numeric-like dimension and tried to sort its grouped keys as numbers. This worked for valid date or numeric values, but crashed as soon as one grouped key was "#N/A" or another non-normalizable value. Once the pivot recomputation failed, the spreadsheet became unusable and the pivot could no longer be removed or recovered through undo.

Infer a field as numeric only when all its non-empty values are numbers. Mixed or error values now fall back to char, so they are grouped as visible values instead of being converted as numbers during pivot recomputation.


Task: [6111913](https://www.odoo.com/odoo/2328/tasks/6111913)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo