### PR TITLE
[IMP] icons: add scalability

### DIFF
--- a/src/components/icons/icons.xml
+++ b/src/components/icons/icons.xml
@@ -1,6 +1,6 @@
 <templates>
   <t t-name="o-spreadsheet-Icon.CLEAR_AND_RELOAD">
-    <svg class="o-icon">
+    <svg class="o-icon" viewBox="0 0 18 18">
       <path
         fill="currentColor"
         d="M14 15H4V3h6v3h4M4 1.5A1.5 1.5 0 0 0 2.5 3v12a1.5 1.5 0 0 0 1.4 1.5h10a1.5 1.5 0 0 0 1.5-1.5V5l-3.5-3.5
@@ -9,7 +9,7 @@
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.EXPORT_XLSX">
-    <svg class="o-icon">
+    <svg class="o-icon" viewBox="0 0 18 18">
       <path
         fill="currentColor"
         d="M0 1a1 1 0 0 1 1-1h7a1 1 0 0 1 1 1v7a1 1 0 0 1-1 1H1a1 1 0 0 1-1-1m4-4V1H1v3m7 0V1H5v3M4 8V5H1v3m7 0V5H5v3m-3.5 2h2v4h3v-1.5l3 2.5-3 2.5V16h-5m9.5-6h6a1 1 0 0 1 1 1v6a1 1 0 0 1-1 1h-6a1 1 0 0 1-1-1v-6a1 1 0 0 1 1-1m1.7 7 1.3-2 1.3 2h2l-2-3 2-3h-2L14 13l-1.3-2h-2l2 3-2 3"
@@ -17,7 +17,7 @@
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.OPEN_READ_ONLY">
-    <svg class="o-icon">
+    <svg class="o-icon" viewBox="0 0 18 18">
       <path
         fill="currentColor"
         d="M13 7V5c0-2.5-2-4-4-4S5 2.5 5 5v2h-.5C3.5 7 3 7.5 3 8.5v7c0 1 .5 1.5 1.5 1.5h9c1 0 1.5-.5 1.5-1.5v-7c0-1-.5-1.5-1.5-1.5m-7-2c0-1.5 1-2.5 2.5-2.5s2.5 1 2.5 2.5v2h-5V5m1 7a1.5 1.5 0 0 1 3 0 1.5 1.5 0 0 1-3 0"
@@ -25,7 +25,7 @@
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.OPEN_DASHBOARD">
-    <svg class="o-icon">
+    <svg class="o-icon" viewBox="0 0 18 18">
       <path
         fill="currentColor"
         d="M13 2.07A8 8 0 1 0 15.93 5L14.2 6A6 6 0 1 1 12 3.8m-2 3.47a2 2 0 1 0 .73.73l5.5-5.5-.6-.6M9.3 3.8a.6.6 0 1 1-.01-.01m1.81.51a.6.6 0 1 1-.01-.01M7.5 4.3a.6.6 0 1 1-.01-.01M5.9 5.4a.6.6 0 1 1-.01-.01M4.8 6.9a.6.6 0 1 1-.01-.01m8.71.61a.6.6 0 1 0-.01 0"
@@ -33,7 +33,7 @@
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.OPEN_READ_WRITE">
-    <svg class="o-icon">
+    <svg class="o-icon" viewBox="0 0 18 18">
       <path
         fill="currentColor"
         d="M13 7V5a4 4 0 0 0-8 0v2h-.5C3.5 7 3 7.5 3 8.5v7c0 1 .5 1.5 1.5 1.5h9c1 0 1.5-.5 1.5-1.5v-7c0-1-.5-1.5-1.5-1.5m-7-2a2 2 0 0 1 5 0v2h-5m1 5a1.5 1.5 0 0 1 3 0 1.5 1.5 0 0 1-3 0m6 3.5h-9v-7h9"
@@ -41,7 +41,7 @@
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.IMPORT_XLSX">
-    <svg class="o-icon">
+    <svg class="o-icon" viewBox="0 0 18 18">
       <path
         fill="currentColor"
         d="M9 10a1 1 0 0 1 1-1h7a1 1 0 0 1 1 1v7a1 1 0 0 1-1 1h-7a1 1 0 0 1-1-1m4-4v-3h-3v3m7 0v-3h-3v3m-1 4v-3h-3v3m7 0v-3h-3v3M.5 9h2v4h3v-1.5l3 2.5-3 2.5V15h-5M1 0h6a1 1 0 0 1 1 1v6a1 1 0 0 1-1 1H1a1 1 0 0 1-1-1V1a1 1 0 0 1 1-1m1.7 7L4 5l1.3 2h2l-2-3 2-3h-2L4 3 2.7 1h-2l2 3-2 3"
@@ -49,7 +49,7 @@
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.UNDO">
-    <svg class="o-icon">
+    <svg class="o-icon" viewBox="0 0 18 18">
       <path
         fill="currentColor"
         d="M5.43 9.43 8 12H1V5l2.96 2.958A8.29 8.29 0 0 1 9.32 6c3.46 0 6.42 2.11 7.68 5l-2 1c-.94-2.39-3.13-3.92-5.68-4a6.57 6.57 0 0 0-3.89 1.43"
@@ -57,7 +57,7 @@
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.REDO">
-    <svg class="o-icon">
+    <svg class="o-icon" viewBox="0 0 18 18">
       <path
         fill="currentColor"
         d="M12.57 9.43 10 12h7V5l-2.96 2.96A8.29 8.29 0 0 0 8.68 6C5.22 6 2.26 8.11 1 11l2 1c.94-2.39 3.13-3.92 5.68-4a6.58 6.58 0 0 1 3.89 1.43"
@@ -75,7 +75,7 @@
     </div>
   </t>
   <t t-name="o-spreadsheet-Icon.CUT">
-    <svg class="o-icon">
+    <svg class="o-icon" viewBox="0 0 18 18">
       <path
         fill="currentColor"
         d="M3 2v2l4.5 5-1.2 1.3c-.4-.2-.8-.3-1.3-.3-1.7 0-3 1.3-3 3s1.3 3 3 3 3-1.3 3-3c0-.5-.1-.9-.3-1.3L9 10.4l1.3 1.3c-.2.4-.3.8-.3 1.3 0 1.7 1.3 3 3 3s3-1.3 3-3-1.3-3-3-3c-.5 0-.9.1-1.3.3L10.4 9 15 4.4V2h-.4L9 7.6 3.4 2H3Zm2 12.5c-.8 0-1.5-.7-1.5-1.5s.7-1.5 1.5-1.5 1.5.7 1.5 1.5-.7 1.5-1.5 1.5Zm9.5-1.5c0 .8-.7 1.5-1.5 1.5s-1.5-.7-1.5-1.5.7-1.5 1.5-1.5 1.5.7 1.5 1.5ZM9 8.5c.3 0 .5.2.5.5s-.2.5-.5.5-.5-.2-.5-.5.2-.5.5-.5"
@@ -83,7 +83,7 @@
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.COPY_AS_IMAGE">
-    <svg class="o-icon">
+    <svg class="o-icon" viewBox="0 0 18 18">
       <path
         fill="currentColor"
         d="m 14,15 v 1.5 H 2.5147386 c -0.5522847,0 -1,-0.447715 -1,-1 V 3 H 3 V 14 c 0,0.552285 0.4477153,1 1,1 h 10"
@@ -96,7 +96,7 @@
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.PASTE">
-    <svg class="o-icon">
+    <svg class="o-icon" viewBox="0 0 18 18">
       <path
         fill="currentColor"
         d="M14.5 2.5H11C10.7 1.6 10 1 9 1s-1.5.5-2 1.5H3.5C2.5 2.5 2 3 2 4v11c0 1 .5 1.5 1.5 1.5h11c1 0 1.5-.5 1.5-1.5V4c0-1-.5-1.5-1.5-1.5Zm-4.75.75c0 .5-.34.75-.75.75s-.75-.34-.75-.75.34-.75.75-.75.75.34.75.75ZM14.5 15h-11V4H5v2.5h8V4h1.5v11"
@@ -104,7 +104,7 @@
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.CLEAR">
-    <svg class="o-icon">
+    <svg class="o-icon" viewBox="0 0 18 18">
       <path
         fill="currentColor"
         d="M1.5 15a.75.75 0 0 0 0 1.5h15a.75.75 0 0 0 0-1.5M5.3 12.75c.1.1.3.2.5.2h4c.2 0 .4-.1.5-.2l5.5-5.5c.2-.3.2-.6 0-.8l-4.4-4.4c-.3-.2-.6-.2-.8 0l-4.8 4.8c-2.7 2.9-3.1 2.8-2.4 4M7 7.25l3.6 3.6-1 1-3.6.1-1.8-1.9"
@@ -112,7 +112,7 @@
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.FREEZE">
-    <svg class="o-icon">
+    <svg class="o-icon" viewBox="0 0 18 18">
       <path
         fill="currentColor"
         d="M.5 17.5h16a1 1 0 0 0 1-1v-15a1 1 0 0 0-1-1h-15a1 1 0 0 0-1 1v15a1 1 0 0 0 1 1m9-10.5v4.5H6V7m0 9v-3.5h4.5V16M5 16H3.5L5 14.5M5 13l-3 3v-1.5l3-3M2 13v-2l3-3v2m-3-.5v-2l3-3v2M2 6V4l2-2h1v1m11 13h-4.5v-3.5H16m0-1h-4.5V7H16m0-5v4h-4.5V2m-1 4H6V2h4.5"
@@ -120,7 +120,7 @@
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.UNFREEZE">
-    <svg class="o-icon">
+    <svg class="o-icon" viewBox="0 0 18 18">
       <path
         fill="currentColor"
         d="M.5 17.5h16a1 1 0 0 0 1-1v-15a1 1 0 0 0-1-1h-15a1 1 0 0 0-1 1v15a1 1 0 0 0 1 1M5 6H2V2h3m0 9.5H2V7h3m0 9H2v-3.5h3M10.5 7v4.5H6V7m0 9v-3.5h4.5V16m5.5 0h-4.5v-3.5H16m0-1h-4.5V7H16m0-5v4h-4.5V2m-1 4H6V2h4.5"
@@ -133,7 +133,7 @@
     </div>
   </t>
   <t t-name="o-spreadsheet-Icon.FORMULA">
-    <svg class="o-icon">
+    <svg class="o-icon" viewBox="0 0 18 18">
       <path
         fill="currentColor"
         d="M7 14.25q-.25.75-.75 1.25T5 16q-.75 0-1.5-.5Q3 15 3 14.25q0-.5.25-.75t.75-.25q.25 0 .25.75v.5H5q.5 0 .5-.5l1.25-6.5H5V6h2l.5-2.25q.25-.75.75-1.25T9.5 2q1 0 1.5.5t.5 1q0 .5-.25.75t-.5.25q-.5 0-.75-.25t-.25-.5V3H9.5q-.25 0-.5.5L8.5 6H10v1.5H8.25m1.25 1H15v1h-4l2 2-2 2h4v1H9V14l2.5-2.5L9 9"
@@ -141,7 +141,7 @@
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.HIDE_ROW">
-    <svg class="o-icon">
+    <svg class="o-icon" viewBox="0 0 18 18">
       <path
         fill="currentColor"
         d="M.5 2A1.5 1.5 0 0 1 2 .5h14A1.5 1.5 0 0 1 17.5 2v14a1.5 1.5 0 0 1-1.5 1.5H2A1.5 1.5 0 0 1 .5 16V2H2v3.5h14V2H2v9h14V7H2v9h14v-3.5H2M1 12l4-5h2l-4 5m2 0 4-5h2l-4 5m2 0 4-5h2l-4 5m2 0 4-5v4"
@@ -149,7 +149,7 @@
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.UNHIDE_ROW">
-    <svg class="o-icon">
+    <svg class="o-icon" viewBox="0 0 18 18">
       <path
         fill="currentColor"
         d="M17.5 16a1.5 1.5 0 0 1-1.5 1.5H2A1.5 1.5 0 0 1 .5 16V2A1.5 1.5 0 0 1 2 .5h14A1.5 1.5 0 0 1 17.5 2zH16v-3.5H2V16h14V2H2v3.5h14"
@@ -157,7 +157,7 @@
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.HIDE_COL">
-    <svg class="o-icon">
+    <svg class="o-icon" viewBox="0 0 18 18">
       <path
         fill="currentColor"
         d="M16 .5A1.5 1.5 0 0 1 17.5 2v14a1.5 1.5 0 0 1-1.5 1.5H2A1.5 1.5 0 0 1 .5 16V2A1.5 1.5 0 0 1 2 .5h14V2h-3.5v14H16V2H7v14h4V2H2v14h3.5V2M6 1l5 4v2L6 3m0 2 5 4v2L6 7m0 2 5 4v2l-5-4"
@@ -165,7 +165,7 @@
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.UNHIDE_COL">
-    <svg class="o-icon">
+    <svg class="o-icon" viewBox="0 0 18 18">
       <path
         fill="currentColor"
         d="M16 .5A1.5 1.5 0 0 1 17.5 2v14a1.5 1.5 0 0 1-1.5 1.5H2A1.5 1.5 0 0 1 .5 16V2A1.5 1.5 0 0 1 2 .5h14V2h-3.5v14H16V2H2V16h3.5V2"
@@ -173,7 +173,7 @@
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.INSERT_ROW">
-    <svg class="o-icon">
+    <svg class="o-icon" viewBox="0 0 18 18">
       <path
         fill="currentColor"
         d="M.5 2A1.5 1.5 0 0 1 2 .5h14A1.5 1.5 0 0 1 17.5 2v14a1.5 1.5 0 0 1-1.5 1.5H2A1.5 1.5 0 0 1 .5 16V2H2v3.5h14V2H2v9h14V7H2v9h14v-3.5H2"
@@ -181,7 +181,7 @@
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.INSERT_ROW_BEFORE">
-    <svg class="o-icon">
+    <svg class="o-icon" viewBox="0 0 18 18">
       <path
         fill="currentColor"
         d="M3.5 14.5A1.5 1.5 0 0 0 5 16h10a1.5 1.5 0 0 0 1.5-1.5v-7h-3V5h3V1.5A1.5 1.5 0 0 0 15 0H5a1.5 1.5 0 0 0-1.5 1.5v2h-3V9h3M15 12.5v2H5v-2M15 9v2H5V9m10-7.5v2H5v-2M12 5v2.5H2V5"
@@ -189,7 +189,7 @@
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.INSERT_ROW_AFTER">
-    <svg class="o-icon">
+    <svg class="o-icon" viewBox="0 0 18 18">
       <path
         fill="currentColor"
         d="M3.5 1.5A1.5 1.5 0 0 1 5 0h10a1.5 1.5 0 0 1 1.5 1.5v7h-3V11h3v3.5A1.5 1.5 0 0 1 15 16H5a1.5 1.5 0 0 1-1.5-1.5v-2h-3V7h3M15 3.5v-2H5v2M15 7V5H5v2m10 7.5v-2H5v2m7-3.5V8.5H2V11"
@@ -197,7 +197,7 @@
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.INSERT_COL">
-    <svg class="o-icon">
+    <svg class="o-icon" viewBox="0 0 18 18">
       <path
         fill="currentColor"
         d="M.5 2A1.5 1.5 0 0 1 2 .5h14A1.5 1.5 0 0 1 17.5 2v14a1.5 1.5 0 0 1-1.5 1.5H2A1.5 1.5 0 0 1 .5 16V2H2v14h3.5V2H2h5v14h4V2H2h10.5v14H16V2H2"
@@ -205,7 +205,7 @@
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.INSERT_COL_AFTER">
-    <svg class="o-icon">
+    <svg class="o-icon" viewBox="0 0 18 18">
       <path
         fill="currentColor"
         d="M2.5 3A1.5 1.5 0 0 0 1 4.5v10A1.5 1.5 0 0 0 2.5 16h7v-3H12v3h3.5a1.5 1.5 0 0 0 1.5-1.5v-10A1.5 1.5 0 0 0 15.5 3h-2V0H8v3M4.5 14.5h-2v-10h2m3.5 10H6v-10h2m7.5 10h-2v-10h2m-3.5 7H9.5v-10H12"
@@ -213,7 +213,7 @@
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.INSERT_COL_BEFORE">
-    <svg class="o-icon">
+    <svg class="o-icon" viewBox="0 0 18 18">
       <path
         fill="currentColor"
         d="M15.5 3A1.5 1.5 0 0 1 17 4.5v10a1.5 1.5 0 0 1-1.5 1.5h-7v-3H6v3H2.5A1.5 1.5 0 0 1 1 14.5v-10A1.5 1.5 0 0 1 2.5 3h2V0H10v3m3.5 11.5h2v-10h-2m-3.5 10h2v-10h-2m-7.5 10h2v-10h-2m3.5 7h2.5v-10H6"
@@ -221,7 +221,7 @@
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.INSERT_CELL">
-    <svg class="o-icon">
+    <svg class="o-icon" viewBox="0 0 18 18">
       <path
         fill="currentColor"
         d="M.5 2A1.5 1.5 0 0 1 2 .5h14A1.5 1.5 0 0 1 17.5 2v14a1.5 1.5 0 0 1-1.5 1.5H2A1.5 1.5 0 0 1 .5 16V2H2v14h14V2H2"
@@ -229,7 +229,7 @@
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.INSERT_CELL_SHIFT_DOWN">
-    <svg class="o-icon">
+    <svg class="o-icon" viewBox="0 0 18 18">
       <path
         fill="currentColor"
         d="M5 2.5A1.5 1.5 0 0 1 6.5 1h10A1.5 1.5 0 0 1 18 2.5v13a1.5 1.5 0 0 1-1.5 1.5h-10A1.5 1.5 0 0 1 5 15.5v-5h5.25v-3H5m11.5-2v-3h-4.75v3m-1.5 0v-3H6.5v3m10 5v-3h-4.75v3m-1.5 5v-3H6.5v3m10 0v-3h-4.75v3M0 12.5l2.5 4 2.5-4H3.25v-6h-1.5v6"
@@ -237,7 +237,7 @@
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.INSERT_CELL_SHIFT_RIGHT">
-    <svg class="o-icon">
+    <svg class="o-icon" viewBox="0 0 18 18">
       <path
         fill="currentColor"
         d="M2.5 5A1.5 1.5 0 0 0 1 6.5v10A1.5 1.5 0 0 0 2.5 18h13a1.5 1.5 0 0 0 1.5-1.5v-10A1.5 1.5 0 0 0 15.5 5h-5v5.25h-3V5m-2 11.5h-3v-4.75h3m0-1.5h-3V6.5h3m5 10h-3v-4.75h3m5-1.5h-3V6.5h3m0 10h-3v-4.75h3M12.5 0l4 2.5-4 2.5V3.25h-6v-1.5h6"
@@ -245,7 +245,7 @@
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.DELETE_CELL_SHIFT_UP">
-    <svg class="o-icon">
+    <svg class="o-icon" viewBox="0 0 18 18">
       <path
         fill="currentColor"
         d="M5 2.5A1.5 1.5 0 0 1 6.5 1h10A1.5 1.5 0 0 1 18 2.5v13a1.5 1.5 0 0 1-1.5 1.5h-10A1.5 1.5 0 0 1 5 15.5v-5h5.25v-3H5m11.5-2v-3h-4.75v3m-1.5 0v-3H6.5v3m10 5v-3h-4.75v3m-1.5 5v-3H6.5v3m10 0v-3h-4.75v3M0 10l2.5-4L5 10H3.25v6h-1.5v-6"
@@ -253,7 +253,7 @@
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.DELETE_CELL_SHIFT_LEFT">
-    <svg class="o-icon">
+    <svg class="o-icon" viewBox="0 0 18 18">
       <path
         fill="currentColor"
         d="M2.5 5A1.5 1.5 0 0 0 1 6.5v10A1.5 1.5 0 0 0 2.5 18h13a1.5 1.5 0 0 0 1.5-1.5v-10A1.5 1.5 0 0 0 15.5 5h-5v5.25h-3V5m-2 11.5h-3v-4.75h3m0-1.5h-3V6.5h3m5 10h-3v-4.75h3m5-1.5h-3V6.5h3m0 10h-3v-4.75h3M10 0 6 2.5 10 5V3.25h6v-1.5h-6"
@@ -281,7 +281,7 @@
     </div>
   </t>
   <t t-name="o-spreadsheet-Icon.INSERT_DROPDOWN">
-    <svg class="o-icon">
+    <svg class="o-icon" viewBox="0 0 18 18">
       <path
         fill="currentColor"
         d="M6 3.5a5 5.5 0 0 0 0 11h6a5 5.5 0 0 0 0-11H6V5h6a3.5 4 0 0 1 0 8H6a3.5 4 0 0 1 0-8m5 6 3-3H8"
@@ -296,7 +296,7 @@
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.PAINT_FORMAT">
-    <svg class="o-icon">
+    <svg class="o-icon" viewBox="0 0 18 18">
       <path
         fill="currentColor"
         d="M9,0 L1,0 C0.45,0 0,0.45 0,1 L0,4 C0,4.55 0.45,5 1,5 L9,5 C9.55,5 10,4.55 10,4 L10,3 L11,3 L11,6 L4,6 L4,14 L6,14 L6,8 L13,8 L13,2 L10,2 L10,1 C10,0.45 9.55,0 9,0 Z"
@@ -305,7 +305,7 @@
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.CONDITIONAL_FORMAT">
-    <svg class="o-icon">
+    <svg class="o-icon" viewBox="0 0 18 18">
       <path
         fill="currentColor"
         d="M12.25.5c2 0 3.5 1.5 3.5 3.5v6.5c0 .5 0 2-2 2h-2.5v4c0 .5-.5 1-1 1h-2.5c-.5 0-1-.5-1-1v-4h-2.5c-1 0-2-1-2-2V.5m12 3a1.5 1.5 0 0 0-1.5-1.5h-3v2h-1.5V2h-1v4h-2V2h-1.5v8.5h10.5m-12-3h12.5V9H2.25"
@@ -313,7 +313,7 @@
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.CLEAR_FORMAT">
-    <svg class="o-icon">
+    <svg class="o-icon" viewBox="0 0 18 18">
       <path
         fill="currentColor"
         d="M2.12 4.05 7.28 9.2l-2.43 5.3h2.5l1.64-3.58 4.59 4.58 1.27-1.27L3.4 2.77 2.12 4.05ZM5.67 2.5l2 2h1.76l-.55 1.21 1.71 1.71 1.34-2.92h3.92v-2H5.67"
@@ -321,7 +321,7 @@
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.BOLD">
-    <svg class="o-icon">
+    <svg class="o-icon" viewBox="0 0 18 18">
       <path
         fill="currentColor"
         d="M13.5 6.5C13.5 4.57 11.93 3 10 3H4.5v12h6.25c1.79 0 3.25-1.46 3.25-3.25 0-1.3-.77-2.41-1.87-2.93.83-.58 1.37-1.44 1.37-2.32M9.5 5c.83 0 1.5.67 1.5 1.5S10.33 8 9.5 8h-2V5h2m-2 8v-3H10c.83 0 1.5.67 1.5 1.5S10.83 13 10 13H7.5"
@@ -329,12 +329,12 @@
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.ITALIC">
-    <svg class="o-icon">
+    <svg class="o-icon" viewBox="0 0 18 18">
       <path fill="currentColor" d="M7 3v2h2.58l-3.66 8H3v2h8v-2H8.42l3.66-8H15V3"/>
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.UNDERLINE">
-    <svg class="o-icon">
+    <svg class="o-icon" viewBox="0 0 18 18">
       <path
         fill="currentColor"
         d="M9 15c2.76 0 5-2.24 5-5V3h-2v7c0 1.75-1.5 3-3 3s-3-1.242-3-3V3H4v7c0 2.76 2.24 5 5 5Zm-6 1v2h12v-2H3"
@@ -342,7 +342,7 @@
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.STRIKE">
-    <svg class="o-icon">
+    <svg class="o-icon" viewBox="0 0 18 18">
       <path
         fill="currentColor"
         d="M4.89 6.06c0-.46.1-.87.3-1.25.2-.38.46-.7.84-.97s.78-.47 1.28-.62A5.71 5.71 0 0 1 8.93 3c.61 0 1.16.08 1.65.25.5.17.92.4 1.27.7.35.3.62.66.81 1.07.19.41.28.87.28 1.36h-2.26a1.85 1.85 0 0 0-.11-.64 1.26 1.26 0 0 0-.33-.51 1.53 1.53 0 0 0-.56-.33A2.42 2.42 0 0 0 8.89 4.8c-.3 0-.55.03-.77.1a1.52 1.52 0 0 0-.54.27 1.14 1.14 0 0 0-.43.9c0 .36.18.66.55.91l.06.04C8.02 7.19 8.5 7.5 9 8H6s-.79-.62-.82-.69c-.19-.36-.29-.77-.29-1.25M16 9H2v2h7.22c.14.05.3.1.41.15.28.12.5.26.65.38.16.13.26.27.32.42.06.15.08.33.08.51 0 .18-.03.34-.1.49a1.02 1.02 0 0 1-.31.39 1.6 1.6 0 0 1-.53.26 2.71 2.71 0 0 1-.76.09c-.33 0-.62-.03-.89-.1a1.8 1.8 0 0 1-.68-.31 1.45 1.45 0 0 1-.44-.56c-.11-.23-.19-.57-.19-.74H4.55c0 .25.06.69.18 1.02a3.15 3.15 0 0 0 1.22 1.6c.28.2.58.36.92.49.33.13.67.23 1.04.29.36.06.72.09 1.08.09.6 0 1.15-.07 1.64-.21a3.88 3.88 0 0 0 1.25-.59 2.69 2.69 0 0 0 .8-.95c.19-.38.28-.81.28-1.29 0-.45-.08-.86-.23-1.211a2.26 2.26 0 0 0-.13-.25L16 11V9"
@@ -350,7 +350,7 @@
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.TEXT_COLOR">
-    <svg class="o-icon">
+    <svg class="o-icon" viewBox="0 0 18 18">
       <path
         fill="currentColor"
         d="M10 1H8L3.5 13h2l1.12-3h4.75l1.12 3h2L10 1ZM7.38 8 9 3.67 10.62 8H7.38"
@@ -358,7 +358,7 @@
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.FILL_COLOR">
-    <svg class="o-icon">
+    <svg class="o-icon" viewBox="0 0 18 18">
       <path
         fill="currentColor"
         d="M14.5 8.87S13 10.49 13 11.49c0 .83.67 1.5 1.5 1.5s1.5-.67 1.5-1.5c0-.99-1.5-2.62-1.5-2.62m-1.79-2.08L5.91 0 4.85 1.06l1.59 1.59-4.15 4.14a.996.996 0 0 0 0 1.41l4.5 4.5c.2.2.45.3.71.3.26 0 .51-.1.71-.29l4.5-4.5c.39-.39.39-1.03 0-1.42M4.21 7 7.5 3.71 10.79 7H4.21"
@@ -366,7 +366,7 @@
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.MERGE_CELL">
-    <svg class="o-icon">
+    <svg class="o-icon" viewBox="0 0 18 18">
       <path
         fill="currentColor"
         d="M3 6H1V2h7v2H3v2m7-2V2h7v4h-2V4h-5m0 10h5v-2h2v4h-7v-2m-9-2h2v2h5v2H1v-4m0-4h4V6l3 3-3 3v-2H1V8m9 1 3-3v2h4v2h-4v2l-3-3"
@@ -374,12 +374,12 @@
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.ALIGN_LEFT">
-    <svg class="o-icon align-left">
+    <svg class="o-icon align-left" viewBox="0 0 18 18">
       <path fill="currentColor" d="M2 16h10v-2H2v2M12 6H2v2h10V6M2 2v2h14V2H2m0 10h14v-2H2v2"/>
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.ALIGN_CENTER">
-    <svg class="o-icon align-center">
+    <svg class="o-icon align-center" viewBox="0 0 18 18">
       <path fill="currentColor" d="M4 14v2h10v-2H4m0-8v2h10V6H4m-2 6h14v-2H2v2M2 2v2h14V2H2"/>
     </svg>
   </t>
@@ -389,17 +389,17 @@
     </div>
   </t>
   <t t-name="o-spreadsheet-Icon.ALIGN_RIGHT">
-    <svg class="o-icon align-right">
+    <svg class="o-icon align-right" viewBox="0 0 18 18">
       <path fill="currentColor" d="M6 16h10v-2H6v2m-4-4h14v-2H2v2M2 2v2h14V2H2m4 6h10V6H6v2"/>
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.ALIGN_TOP">
-    <svg class="o-icon align-top">
+    <svg class="o-icon align-top" viewBox="0 0 18 18">
       <path d="M3 2h12v2H3m2.5 5H8v7h2V9h2.5L9 5.5" fill="currentColor"/>
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.ALIGN_MIDDLE">
-    <svg class="o-icon align-middle">
+    <svg class="o-icon align-middle" viewBox="0 0 18 18">
       <path
         d="M12.5 3H10V0H8v3H5.5L9 6.5M5.5 15H8v3h2v-3h2.5L9 11.5M3 8v2h12V8"
         fill="currentColor"
@@ -407,17 +407,17 @@
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.ALIGN_BOTTOM">
-    <svg class="o-icon align-bottom">
+    <svg class="o-icon align-bottom" viewBox="0 0 18 18">
       <path d="M5.5 9H8V2h2v7h2.5L9 12.5M3 14v2h12v-2" fill="currentColor"/>
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.WRAPPING_OVERFLOW">
-    <svg class="o-icon wrapping-overflow">
+    <svg class="o-icon wrapping-overflow" viewBox="0 0 18 18">
       <path d="M13 8H6v2h7v2l3-3-3-3M2 2h2v14H2M9 2h2v4H9m0 6h2v4H9" fill="currentColor"/>
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.WRAPPING_WRAP">
-    <svg class="o-icon wrapping-wrap">
+    <svg class="o-icon wrapping-wrap" viewBox="0 0 18 18">
       <path
         fill="currentColor"
         d="M6 5v2h3.75c.75 0 1.5.67 1.5 1.5 0 .75-.75 1.5-1.5 1.5H8V8l-3 3 3 3v-2h1.5c2 0 3.5-1.5 3.5-3.5S11.5 5 9.5 5M2 2h2v14H2M14 2M14,2,h2v14h-2"
@@ -425,12 +425,12 @@
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.WRAPPING_CLIP">
-    <svg class="o-icon wrapping-clip">
+    <svg class="o-icon wrapping-clip" viewBox="0 0 18 18">
       <path fill="currentColor" d="M2 2h2v14H2M14 2h2v14h-2v-6H6V8h8"/>
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.BORDERS">
-    <svg class="o-icon">
+    <svg class="o-icon" viewBox="0 0 18 18">
       <path
         fill="currentColor"
         d="M2 2v14h14V2H2m6 12H4v-4h4v4m0-6H4V4h4v4m6 6h-4v-4h4v4m0-6h-4V4h4v4"
@@ -438,7 +438,7 @@
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.BORDER_HV">
-    <svg class="o-icon" fill="currentColor">
+    <svg class="o-icon" fill="currentColor" viewBox="0 0 18 18">
       <path
         d="M2 16h2v-2H2v2M4 5H2v2h2V5m1 11h2v-2H5v2m8-14h-2v2h2V2M4 2H2v2h2V2m3 0H5v2h2V2M2 13h2v-2H2v2m9 3h2v-2h-2v2m3-14v2h2V2h-2m0 5h2V5h-2v2m0 9h2v-2h-2v2m0-3h2v-2h-2v2"
         opacity=".54"
@@ -447,7 +447,7 @@
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.BORDER_H">
-    <svg class="o-icon" fill="currentColor">
+    <svg class="o-icon" fill="currentColor" viewBox="0 0 18 18">
       <path
         d="M8 16h2v-2H8v2M5 4h2V2H5v2m3 9h2v-2H8v2m-3 3h2v-2H5v2M2 7h2V5H2v2m0 9h2v-2H2v2M2 4h2V2H2v2m0 9h2v-2H2v2m12 0h2v-2h-2v2m0 3h2v-2h-2v2m0-9h2V5h-2v2m0-5v2h2V2h-2M8 4h2V2H8v2m3 0h2V2h-2v2M8 7h2V5H8v2m3 9h2v-2h-2v2"
         opacity=".54"
@@ -456,7 +456,7 @@
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.BORDER_V">
-    <svg class="o-icon" fill="currentColor">
+    <svg class="o-icon" fill="currentColor" viewBox="0 0 18 18">
       <path
         d="M5 16h2v-2H5v2M2 7h2V5H2v2m0-3h2V2H2v2m3 6h2V8H5v2m0-6h2V2H5v2M2 16h2v-2H2v2m0-6h2V8H2v2m0 3h2v-2H2v2M14 2v2h2V2h-2m0 8h2V8h-2v2m0 6h2v-2h-2v2m0-9h2V5h-2v2m0 6h2v-2h-2v2m-3 3h2v-2h-2v2m0-6h2V8h-2v2m0-6h2V2h-2v2"
         opacity=".54"
@@ -465,13 +465,13 @@
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.BORDER_EXTERNAL">
-    <svg class="o-icon" fill="currentColor">
+    <svg class="o-icon" fill="currentColor" viewBox="0 0 18 18">
       <path d="M10 5H8v2h2V5m3 3h-2v2h2V8m-3 0H8v2h2V8m0 3H8v2h2v-2M7 8H5v2h2V8" opacity=".54"/>
       <path d="M2 2h14v14H2V2m12 12V4H4v10h10"/>
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.BORDER_LEFT">
-    <svg class="o-icon" fill="currentColor">
+    <svg class="o-icon" fill="currentColor" viewBox="0 0 18 18">
       <path
         d="M8 10h2V8H8v2m0-3h2V5H8v2m0 6h2v-2H8v2m0 3h2v-2H8v2m-3 0h2v-2H5v2M5 4h2V2H5v2m0 6h2V8H5v2m9 6h2v-2h-2v2m0-6h2V8h-2v2m0 3h2v-2h-2v2m0-6h2V5h-2v2M8 4h2V2H8v2m6-2v2h2V2h-2m-3 14h2v-2h-2v2m0-6h2V8h-2v2m0-6h2V2h-2v2"
         opacity=".54"
@@ -480,7 +480,7 @@
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.BORDER_TOP">
-    <svg class="o-icon" fill="currentColor">
+    <svg class="o-icon" fill="currentColor" viewBox="0 0 18 18">
       <path
         d="M5 10h2V8H5v2m-3 6h2v-2H2v2m6 0h2v-2H8v2m0-3h2v-2H8v2m-3 3h2v-2H5v2m-3-3h2v-2H2v2m6-3h2V8H8v2M2 7h2V5H2v2m0 3h2V8H2v2m12 0h2V8h-2v2m0 3h2v-2h-2v2m0-6h2V5h-2v2M8 7h2V5H8v2m3 9h2v-2h-2v2m0-6h2V8h-2v2m3 6h2v-2h-2v2"
         opacity=".54"
@@ -489,7 +489,7 @@
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.BORDER_RIGHT">
-    <svg class="o-icon" fill="currentColor">
+    <svg class="o-icon" fill="currentColor" viewBox="0 0 18 18">
       <path
         d="M2 4h2V2H2v2m3 0h2V2H5v2m0 6h2V8H5v2m0 6h2v-2H5v2M2 7h2V5H2v2m0 3h2V8H2v2m0 6h2v-2H2v2m0-3h2v-2H2v2m9-3h2V8h-2v2m-3 6h2v-2H8v2m3 0h2v-2h-2v2M8 4h2V2H8v2m3 0h2V2h-2v2m-3 9h2v-2H8v2m0-6h2V5H8v2m0 3h2V8H8v2"
         opacity=".54"
@@ -498,7 +498,7 @@
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.BORDER_BOTTOM">
-    <svg class="o-icon" fill="currentColor">
+    <svg class="o-icon" fill="currentColor" viewBox="0 0 18 18">
       <path
         d="M7 2H5v2h2V2m3 6H8v2h2V8m0 3H8v2h2v-2m3-3h-2v2h2V8M7 8H5v2h2V8m6-6h-2v2h2V2m-3 3H8v2h2V5m0-3H8v2h2V2m-6 9H2v2h2v-2m10 2h2v-2h-2v2m0-6h2V5h-2v2m0 3h2V8h-2v2m0-8v2h2V2h-2M4 2H2v2h2V2m0 3H2v2h2V5m0 3H2v2h2V8"
         opacity=".54"
@@ -507,7 +507,7 @@
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.BORDER_CLEAR">
-    <svg class="o-icon">
+    <svg class="o-icon" viewBox="0 0 18 18">
       <path
         fill="currentColor"
         d="M8 16h2v-2H8v2m-3-6h2V8H5v2m0-6h2V2H5v2m3 9h2v-2H8v2m-3 3h2v-2H5v2M2 7h2V5H2v2m0 9h2v-2H2v2M2 4h2V2H2v2m0 6h2V8H2v2m6 0h2V8H8v2m-6 3h2v-2H2v2m12 0h2v-2h-2v2m0 3h2v-2h-2v2m0-6h2V8h-2v2m0-3h2V5h-2v2m0-5v2h2V2h-2M8 4h2V2H8v2m3 0h2V2h-2v2M8 7h2V5H8v2m3 9h2v-2h-2v2m0-6h2V8h-2v2"
@@ -516,7 +516,7 @@
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.BORDER_TYPE">
-    <svg class="o-icon">
+    <svg class="o-icon" viewBox="0 0 18 18">
       <g fill="currentColor" transform="translate(2 2)">
         <polygon points="0 0 0 2 14 2 14 0"/>
         <polygon points="0 6 0 8 5 8 5 6"/>
@@ -529,7 +529,7 @@
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.BORDER_COLOR">
-    <svg class="o-icon">
+    <svg class="o-icon" viewBox="0 0 18 18">
       <g fill="currentColor" transform="translate(4 2)">
         <polygon points="0 12 0 9 7 2 10 5 3 12"/>
         <polygon points="8 1 9 0 12 3 11 4"/>
@@ -537,7 +537,7 @@
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.BORDER_NO_COLOR">
-    <svg class="o-icon">
+    <svg class="o-icon" viewBox="0 0 18 18">
       <g fill="currentColor">
         <polygon points="4 12 4 9 11 2 14 5 7 12"/>
         <polygon points="12 1 13 0 16 3 15 4"/>
@@ -712,7 +712,7 @@
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.SORT_RANGE">
-    <svg class="o-icon">
+    <svg class="o-icon" viewBox="0 0 18 18">
       <path
         fill="currentColor"
         d="M9 3.5h8v2H9M9 8h6v2H9m0 2.5h3v2H9M6 6l1-1-3-3-3 3 1 1 1-1v8l-1-1-1 1 3 3 3-3-1-1-1 1V5"
@@ -775,14 +775,14 @@
     <span class="o-text-icon">.00</span>
   </t>
   <t t-name="o-spreadsheet-Icon.NUMBER_FORMATS">
-    <svg class="o-icon" fill="currentColor">
+    <svg class="o-icon" fill="currentColor" viewBox="0 0 18 18">
       <path
         d="M0 6h2v8h2V4H0m9 0H5v2h4v2H6.5A1.5 1.5 0 0 0 5 9.5V14h6v-2H7v-2h2.5A1.5 1.5 0 0 0 11 8.5v-3A1.5 1.5 0 0 0 9.5 4M12 4v2h4v2h-2v2h2v2h-4v2h4.5a1.5 1.5 0 0 0 1.5-1.5v-2A1.5 1.5 0 0 0 16.5 9 1.5 1.5 0 0 0 18 7.5v-2A1.5 1.5 0 0 0 16.5 4"
       />
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.FONT_SIZE">
-    <svg class="o-icon" fill="currentColor">
+    <svg class="o-icon" fill="currentColor" viewBox="0 0 18 18">
       <text x="2" y="15" class="small-text">A</text>
       <text x="6" y="15" class="heavy-text">A</text>
     </svg>
@@ -793,7 +793,7 @@
     </div>
   </t>
   <t t-name="o-spreadsheet-Icon.SPLIT_TEXT">
-    <svg class="o-icon">
+    <svg class="o-icon" viewBox="0 0 18 18">
       <path
         fill="currentColor"
         d="M14 6v2h-4v2h4v2l3-3m-9 1V8H4V6L1 9l3 3v-2m3.5-6.5h3V7H12V3.5h3V2H3v1.5h3V7h1.5m3 7.5h-3V11H6v3.5H3V16h12v-1.5h-3V11h-1.5"
@@ -806,7 +806,7 @@
     </div>
   </t>
   <t t-name="o-spreadsheet-Icon.DISPLAY_HEADER">
-    <svg class="o-icon" width="18" height="18">
+    <svg class="o-icon" viewBox="0 0 18 18">
       <path
         fill="currentColor"
         d="M.75.5h16.5v17H.75m1.5-12H.75V7h1.5v1.5H.75V10h1.5v1.5H.75V13h1.5v1.5H.75V16h1.5v1.5h1.5V16h1.5v1.5h1.5V16h1.5v1.5h1.5V16h1.5v1.5h1.5V16h1.5v1.5h1.5V16h1.5v-1.5h-1.5V13h1.5v-1.5h-1.5V10h1.5V8.5h-1.5V7h1.5V5.5M2.75 2.25v1.5h2v-1.5m2.5 0v1.5h7v-1.5"
@@ -824,7 +824,7 @@
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.PLUS_IN_BOX">
-    <svg class="o-icon" width="18" height="18" style="">
+    <svg class="o-icon" viewBox="0 0 18 18">
       <path
         fill="currentColor"
         d="
@@ -836,7 +836,7 @@
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.MINUS_IN_BOX">
-    <svg class="o-icon" width="18" height="18" style="">
+    <svg class="o-icon" viewBox="0 0 18 18">
       <path
         fill="currentColor"
         d="
@@ -847,7 +847,7 @@
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.GROUP_ROWS">
-    <svg class="o-icon" width="18" height="18">
+    <svg class="o-icon" viewBox="0 0 18 18">
       <path
         fill="currentColor"
         d="M6 2.5A1.5 1.5 0 0 1 7.5 1H16a1.5 1.5 0 0 1 1.5 1.5V15a1.5 1.5 0 0 1-1.5 1.5H7.5A1.5 1.5 0 0 1 6 15M7.5 2.5v2H16v-2M7.5 6v2H16V6M7.5 9.5v2H16v-2M7.5 13v2H16v-2M2 5.75V13h3v-1.5H3.5V5.75h1.25V3l-1 1v.75H3M.25 1.25v4.5h4.5v-4.5m-3.5 1h2.5v2.5h-2.5"
@@ -855,7 +855,7 @@
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.UNGROUP_ROWS">
-    <svg class="o-icon" width="18" height="18">
+    <svg class="o-icon" viewBox="0 0 18 18">
       <path
         fill="currentColor"
         d="M6 2.5A1.5 1.5 0 0 1 7.5 1H16a1.5 1.5 0 0 1 1.5 1.5V15a1.5 1.5 0 0 1-1.5 1.5H7.5A1.5 1.5 0 0 1 6 15M7.5 2.5v2H16v-2M7.5 6v2H16V6M7.5 9.5v2H16v-2M7.5 13v2H16v-2M2 5.75V13h3v-1.5H3.5V5.75M0 5.25.75 6l2-2 2 2 .75-.75-2-2 2-2L4.75.5l-2 2-2-2-.75.75 2 2"
@@ -863,7 +863,7 @@
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.GROUP_COLUMNS">
-    <svg class="o-icon" width="18" height="18">
+    <svg class="o-icon" viewBox="0 0 18 18">
       <path
         fill="currentColor"
         d="M2.75 6a1.5 1.5 0 0 0-1.5 1.5V16a1.5 1.5 0 0 0 1.5 1.5h12.5a1.5 1.5 0 0 0 1.5-1.5V7.5a1.5 1.5 0 0 0-1.5-1.5M2.75 7.5h2V16h-2m3.5-8.5h2V16h-2m3.5-8.5h2V16h-2m3.5-8.5h2V16h-2M6 2h7.25v3h-1.5V3.5H6v1.25H3.25l1-1H5V3M1.5.25H6v4.5H1.5m1-3.5v2.5H5v-2.5"
@@ -871,7 +871,7 @@
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.UNGROUP_COLUMNS">
-    <svg class="o-icon" width="18" height="18">
+    <svg class="o-icon" viewBox="0 0 18 18">
       <path
         fill="currentColor"
         d="M2.75 6a1.5 1.5 0 0 0-1.5 1.5V16a1.5 1.5 0 0 0 1.5 1.5h12.5a1.5 1.5 0 0 0 1.5-1.5V7.5a1.5 1.5 0 0 0-1.5-1.5M2.75 7.5h2V16h-2m3.5-8.5h2V16h-2m3.5-8.5h2V16h-2m3.5-8.5h2V16h-2M6 2h7.25v3h-1.5V3.5H6M5.5 0l.75.75-2 2 2 2-.75.75-2-2-2 2-.75-.75 2-2-2-2L1.5 0l2 2"
@@ -879,7 +879,7 @@
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.DATA_VALIDATION">
-    <svg class="o-icon">
+    <svg class="o-icon" viewBox="0 0 18 18">
       <path
         fill="currentColor"
         d="M.5 2A1.5 1.5 0 0 1 2 .5h14A1.5 1.5 0 0 1 17.5 2v7H11V7H7v4s-.5 0-1.5 1h-1v5h-3a1.5 1.5 0 0 1-1-1M6 6V2H2v4m9 0V2H7v4m9 0V2h-4v4m-6 5V7H2v4m14-2V7h-4v2m-7.5 6.5V12H2v3.5"
@@ -907,7 +907,7 @@
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.EDIT_TABLE">
-    <svg class="o-icon" xmlns="http://www.w3.org/2000/svg" width="18" height="18">
+    <svg class="o-icon" viewBox="0 0 18 18">
       <path
         fill="currentColor"
         d="M2.5 1A1.5 1.5 0 0 0 1 2.5v11A1.5 1.5 0 0 0 2.5 15H7l1.5-1.5H7v-2.75h3.5v.75l2.25-2.25H12v-2.5h3.5v.75c.1-.2.45-.05.5.02l1 1V2.5A1.5 1.5 0 0 0 15.5 1m-13 1.5h13v2.75h-13m0 1.5h3v2.5h-3M7 6.75h3.5v2.5H7m-4.5 1.5h3v2.75h-3 M8.2 15.7v1.8h1.8l5.4-5.4-1.8-1.8-5.4 5.4Zm8.8-5.2a.5.5 0 0 0 0-.7l-1.1-1.1a.5.5 0 0 0-.7 0l-.9.9 1.8 1.8.9-.9Z"
@@ -915,7 +915,7 @@
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.DELETE_TABLE">
-    <svg class="o-icon" xmlns="http://www.w3.org/2000/svg" width="18" height="18">
+    <svg class="o-icon" viewBox="0 0 18 18">
       <path
         fill="currentColor"
         d="M2.5 1A1.5 1.5 0 0 0 1 2.5v11A1.5 1.5 0 0 0 2.5 15H7l1.5-1.5H7V6.75h3.5v.75L12 9V6.75h3.5l1.5 1.5V2.5A1.5 1.5 0 0 0 15.5 1m-13 1.5h13v2.75h-13m0 1.5h3v2.5h-3m0 1.5h3v2.75h-3m10-2.25 3-3 1.5 1.5-3 3 3 3-1.5 1.5-3-3-3 3-1.5-1.5 3-3-3-3 1.5-1.5"
@@ -923,7 +923,7 @@
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.PAINT_TABLE">
-    <svg class="o-icon" xmlns="http://www.w3.org/2000/svg" width="18" height="18">
+    <svg class="o-icon" viewBox="0 0 18 18">
       <path
         fill="currentColor"
         d="M2.5 1A1.5 1.5 0 0 0 1 2.5v11A1.5 1.5 0 0 0 2.5 15h5c0-.5 0-1 .5-1.5H7v-2.75h3.5v.75l2.25-2.25H12v-2.5h3.5v.75c1-.7 1.5-.4 1.5-.4V2.5A1.5 1.5 0 0 0 15.5 1m-13 1.5h13v2.75h-13m0 1.5h3v2.5h-3M7 6.75h3.5v2.5H7m-4.5 1.5h3v2.75h-3m7.5-.3c.7-.3 1.5-.1 2.1.6.6.7.8 1.4.5 1.9-.6 1.4-3.7 1.6-4 1.7l-.6.1.3-.5s.5-.8.5-2.1c0-.7.5-1.4 1.1-1.7Zm6.7-5.1a.9.9 0 0 1 1 1c-.1 1.3-2.5 3.7-4.3 5.3a3.9 3.9 0 0 0-.6-1.1c-.4-.4-.8-.7-1.3-.8 1.5-1.7 4-4.3 5.4-4.4"
@@ -939,7 +939,7 @@
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.PIVOT">
-    <svg class="o-icon" width="100%" height="100%" viewBox="0 0 18 18">
+    <svg class="o-icon" viewBox="0 0 18 18">
       <path
         fill="currentColor"
         d="M15.5 2A1.5 1.5 0 0 1 17 3.5V14a1.5 1.5 0 0 1-1.5 1.5h-13A1.5 1.5 0 0 1 1 14V7.5A1.5 1.5 0 0 1 2.5 6H5V3.5A1.5 1.5 0 0 1 6.5 2H17m-1.5 1.5h-9V6h9m-13 1.5V10H5V7.5m-2.5 4V14H5v-2.5m1.5-4V10h9V7.5m-9 4V14h9v-2.5"

--- a/tests/__snapshots__/top_bar_component.test.ts.snap
+++ b/tests/__snapshots__/top_bar_component.test.ts.snap
@@ -115,6 +115,7 @@ exports[`TopBar component simple rendering 1`] = `
             >
               <svg
                 class="o-icon"
+                viewBox="0 0 18 18"
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
@@ -135,6 +136,7 @@ exports[`TopBar component simple rendering 1`] = `
             >
               <svg
                 class="o-icon"
+                viewBox="0 0 18 18"
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
@@ -153,6 +155,7 @@ exports[`TopBar component simple rendering 1`] = `
             <span>
               <svg
                 class="o-icon"
+                viewBox="0 0 18 18"
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
@@ -172,6 +175,7 @@ exports[`TopBar component simple rendering 1`] = `
             >
               <svg
                 class="o-icon"
+                viewBox="0 0 18 18"
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
@@ -282,6 +286,7 @@ exports[`TopBar component simple rendering 1`] = `
                 <svg
                   class="o-icon"
                   fill="currentColor"
+                  viewBox="0 0 18 18"
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <path
@@ -360,6 +365,7 @@ exports[`TopBar component simple rendering 1`] = `
             >
               <svg
                 class="o-icon"
+                viewBox="0 0 18 18"
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
@@ -380,6 +386,7 @@ exports[`TopBar component simple rendering 1`] = `
             >
               <svg
                 class="o-icon"
+                viewBox="0 0 18 18"
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
@@ -400,6 +407,7 @@ exports[`TopBar component simple rendering 1`] = `
             >
               <svg
                 class="o-icon"
+                viewBox="0 0 18 18"
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
@@ -426,6 +434,7 @@ exports[`TopBar component simple rendering 1`] = `
                 >
                   <svg
                     class="o-icon"
+                    viewBox="0 0 18 18"
                     xmlns="http://www.w3.org/2000/svg"
                   >
                     <path
@@ -464,6 +473,7 @@ exports[`TopBar component simple rendering 1`] = `
                 >
                   <svg
                     class="o-icon"
+                    viewBox="0 0 18 18"
                     xmlns="http://www.w3.org/2000/svg"
                   >
                     <path
@@ -486,6 +496,7 @@ exports[`TopBar component simple rendering 1`] = `
               <span>
                 <svg
                   class="o-icon"
+                  viewBox="0 0 18 18"
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <path
@@ -506,6 +517,7 @@ exports[`TopBar component simple rendering 1`] = `
             >
               <svg
                 class="o-icon"
+                viewBox="0 0 18 18"
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
@@ -540,6 +552,7 @@ exports[`TopBar component simple rendering 1`] = `
               >
                 <svg
                   class="o-icon align-left"
+                  viewBox="0 0 18 18"
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <path
@@ -573,6 +586,7 @@ exports[`TopBar component simple rendering 1`] = `
               >
                 <svg
                   class="o-icon align-bottom"
+                  viewBox="0 0 18 18"
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <path
@@ -606,6 +620,7 @@ exports[`TopBar component simple rendering 1`] = `
               >
                 <svg
                   class="o-icon wrapping-overflow"
+                  viewBox="0 0 18 18"
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <path
@@ -684,8 +699,7 @@ exports[`TopBar component simple rendering 1`] = `
               >
                 <svg
                   class="o-icon"
-                  height="18"
-                  width="18"
+                  viewBox="0 0 18 18"
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <path

--- a/tests/menus/__snapshots__/context_menu_component.test.ts.snap
+++ b/tests/menus/__snapshots__/context_menu_component.test.ts.snap
@@ -21,6 +21,7 @@ exports[`Context MenuPopover integration tests context menu simple rendering 1`]
       >
         <svg
           class="o-icon"
+          viewBox="0 0 18 18"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path
@@ -97,6 +98,7 @@ exports[`Context MenuPopover integration tests context menu simple rendering 1`]
       >
         <svg
           class="o-icon"
+          viewBox="0 0 18 18"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path
@@ -136,6 +138,7 @@ exports[`Context MenuPopover integration tests context menu simple rendering 1`]
       >
         <svg
           class="o-icon"
+          viewBox="0 0 18 18"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path
@@ -187,6 +190,7 @@ exports[`Context MenuPopover integration tests context menu simple rendering 1`]
       >
         <svg
           class="o-icon"
+          viewBox="0 0 18 18"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path
@@ -221,6 +225,7 @@ exports[`Context MenuPopover integration tests context menu simple rendering 1`]
       >
         <svg
           class="o-icon"
+          viewBox="0 0 18 18"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path
@@ -255,6 +260,7 @@ exports[`Context MenuPopover integration tests context menu simple rendering 1`]
       >
         <svg
           class="o-icon"
+          viewBox="0 0 18 18"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path

--- a/tests/side_panels/building_blocks/__snapshots__/chart_title.test.ts.snap
+++ b/tests/side_panels/building_blocks/__snapshots__/chart_title.test.ts.snap
@@ -39,6 +39,7 @@ exports[`Chart title Can render a chart title component 1`] = `
           >
             <svg
               class="o-icon"
+              viewBox="0 0 18 18"
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
@@ -60,6 +61,7 @@ exports[`Chart title Can render a chart title component 1`] = `
           >
             <svg
               class="o-icon"
+              viewBox="0 0 18 18"
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
@@ -88,6 +90,7 @@ exports[`Chart title Can render a chart title component 1`] = `
             >
               <svg
                 class="o-icon align-left"
+                viewBox="0 0 18 18"
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
@@ -158,6 +161,7 @@ exports[`Chart title Can render a chart title component 1`] = `
             >
               <svg
                 class="o-icon"
+                viewBox="0 0 18 18"
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path

--- a/tests/spreadsheet/__snapshots__/spreadsheet_component.test.ts.snap
+++ b/tests/spreadsheet/__snapshots__/spreadsheet_component.test.ts.snap
@@ -124,6 +124,7 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
                 >
                   <svg
                     class="o-icon"
+                    viewBox="0 0 18 18"
                     xmlns="http://www.w3.org/2000/svg"
                   >
                     <path
@@ -144,6 +145,7 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
                 >
                   <svg
                     class="o-icon"
+                    viewBox="0 0 18 18"
                     xmlns="http://www.w3.org/2000/svg"
                   >
                     <path
@@ -162,6 +164,7 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
                 <span>
                   <svg
                     class="o-icon"
+                    viewBox="0 0 18 18"
                     xmlns="http://www.w3.org/2000/svg"
                   >
                     <path
@@ -181,6 +184,7 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
                 >
                   <svg
                     class="o-icon"
+                    viewBox="0 0 18 18"
                     xmlns="http://www.w3.org/2000/svg"
                   >
                     <path
@@ -291,6 +295,7 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
                     <svg
                       class="o-icon"
                       fill="currentColor"
+                      viewBox="0 0 18 18"
                       xmlns="http://www.w3.org/2000/svg"
                     >
                       <path
@@ -369,6 +374,7 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
                 >
                   <svg
                     class="o-icon"
+                    viewBox="0 0 18 18"
                     xmlns="http://www.w3.org/2000/svg"
                   >
                     <path
@@ -389,6 +395,7 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
                 >
                   <svg
                     class="o-icon"
+                    viewBox="0 0 18 18"
                     xmlns="http://www.w3.org/2000/svg"
                   >
                     <path
@@ -409,6 +416,7 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
                 >
                   <svg
                     class="o-icon"
+                    viewBox="0 0 18 18"
                     xmlns="http://www.w3.org/2000/svg"
                   >
                     <path
@@ -435,6 +443,7 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
                     >
                       <svg
                         class="o-icon"
+                        viewBox="0 0 18 18"
                         xmlns="http://www.w3.org/2000/svg"
                       >
                         <path
@@ -473,6 +482,7 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
                     >
                       <svg
                         class="o-icon"
+                        viewBox="0 0 18 18"
                         xmlns="http://www.w3.org/2000/svg"
                       >
                         <path
@@ -495,6 +505,7 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
                   <span>
                     <svg
                       class="o-icon"
+                      viewBox="0 0 18 18"
                       xmlns="http://www.w3.org/2000/svg"
                     >
                       <path
@@ -515,6 +526,7 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
                 >
                   <svg
                     class="o-icon"
+                    viewBox="0 0 18 18"
                     xmlns="http://www.w3.org/2000/svg"
                   >
                     <path
@@ -549,6 +561,7 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
                   >
                     <svg
                       class="o-icon align-left"
+                      viewBox="0 0 18 18"
                       xmlns="http://www.w3.org/2000/svg"
                     >
                       <path
@@ -582,6 +595,7 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
                   >
                     <svg
                       class="o-icon align-bottom"
+                      viewBox="0 0 18 18"
                       xmlns="http://www.w3.org/2000/svg"
                     >
                       <path
@@ -615,6 +629,7 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
                   >
                     <svg
                       class="o-icon wrapping-overflow"
+                      viewBox="0 0 18 18"
                       xmlns="http://www.w3.org/2000/svg"
                     >
                       <path
@@ -693,8 +708,7 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
                   >
                     <svg
                       class="o-icon"
-                      height="18"
-                      width="18"
+                      viewBox="0 0 18 18"
                       xmlns="http://www.w3.org/2000/svg"
                     >
                       <path
@@ -1213,6 +1227,7 @@ exports[`components take the small screen into account 1`] = `
                 >
                   <svg
                     class="o-icon"
+                    viewBox="0 0 18 18"
                     xmlns="http://www.w3.org/2000/svg"
                   >
                     <path
@@ -1233,6 +1248,7 @@ exports[`components take the small screen into account 1`] = `
                 >
                   <svg
                     class="o-icon"
+                    viewBox="0 0 18 18"
                     xmlns="http://www.w3.org/2000/svg"
                   >
                     <path
@@ -1251,6 +1267,7 @@ exports[`components take the small screen into account 1`] = `
                 <span>
                   <svg
                     class="o-icon"
+                    viewBox="0 0 18 18"
                     xmlns="http://www.w3.org/2000/svg"
                   >
                     <path
@@ -1270,6 +1287,7 @@ exports[`components take the small screen into account 1`] = `
                 >
                   <svg
                     class="o-icon"
+                    viewBox="0 0 18 18"
                     xmlns="http://www.w3.org/2000/svg"
                   >
                     <path
@@ -1380,6 +1398,7 @@ exports[`components take the small screen into account 1`] = `
                     <svg
                       class="o-icon"
                       fill="currentColor"
+                      viewBox="0 0 18 18"
                       xmlns="http://www.w3.org/2000/svg"
                     >
                       <path
@@ -1458,6 +1477,7 @@ exports[`components take the small screen into account 1`] = `
                 >
                   <svg
                     class="o-icon"
+                    viewBox="0 0 18 18"
                     xmlns="http://www.w3.org/2000/svg"
                   >
                     <path
@@ -1478,6 +1498,7 @@ exports[`components take the small screen into account 1`] = `
                 >
                   <svg
                     class="o-icon"
+                    viewBox="0 0 18 18"
                     xmlns="http://www.w3.org/2000/svg"
                   >
                     <path
@@ -1498,6 +1519,7 @@ exports[`components take the small screen into account 1`] = `
                 >
                   <svg
                     class="o-icon"
+                    viewBox="0 0 18 18"
                     xmlns="http://www.w3.org/2000/svg"
                   >
                     <path
@@ -1524,6 +1546,7 @@ exports[`components take the small screen into account 1`] = `
                     >
                       <svg
                         class="o-icon"
+                        viewBox="0 0 18 18"
                         xmlns="http://www.w3.org/2000/svg"
                       >
                         <path
@@ -1562,6 +1585,7 @@ exports[`components take the small screen into account 1`] = `
                     >
                       <svg
                         class="o-icon"
+                        viewBox="0 0 18 18"
                         xmlns="http://www.w3.org/2000/svg"
                       >
                         <path
@@ -1584,6 +1608,7 @@ exports[`components take the small screen into account 1`] = `
                   <span>
                     <svg
                       class="o-icon"
+                      viewBox="0 0 18 18"
                       xmlns="http://www.w3.org/2000/svg"
                     >
                       <path
@@ -1604,6 +1629,7 @@ exports[`components take the small screen into account 1`] = `
                 >
                   <svg
                     class="o-icon"
+                    viewBox="0 0 18 18"
                     xmlns="http://www.w3.org/2000/svg"
                   >
                     <path
@@ -1638,6 +1664,7 @@ exports[`components take the small screen into account 1`] = `
                   >
                     <svg
                       class="o-icon align-left"
+                      viewBox="0 0 18 18"
                       xmlns="http://www.w3.org/2000/svg"
                     >
                       <path
@@ -1671,6 +1698,7 @@ exports[`components take the small screen into account 1`] = `
                   >
                     <svg
                       class="o-icon align-bottom"
+                      viewBox="0 0 18 18"
                       xmlns="http://www.w3.org/2000/svg"
                     >
                       <path
@@ -1704,6 +1732,7 @@ exports[`components take the small screen into account 1`] = `
                   >
                     <svg
                       class="o-icon wrapping-overflow"
+                      viewBox="0 0 18 18"
                       xmlns="http://www.w3.org/2000/svg"
                     >
                       <path
@@ -1782,8 +1811,7 @@ exports[`components take the small screen into account 1`] = `
                   >
                     <svg
                       class="o-icon"
-                      height="18"
-                      width="18"
+                      viewBox="0 0 18 18"
                       xmlns="http://www.w3.org/2000/svg"
                     >
                       <path


### PR DESCRIPTION
## Description

Most of the current icons won't scale with their container, as they has been made for a 18x18 area. If we change this (e.g. change --os-icon-edge-length to something else), the result will be ugly. This can be fixed by adding a viewbox to all the svg, ensuring they will be resized to fill the container.

## Related Task:
- Task: 6047628