### PR TITLE
[FIX] css: remove unused variables

### DIFF
--- a/src/components/menu/menu.css
+++ b/src/components/menu/menu.css
@@ -18,11 +18,6 @@
           background-color: var(--os-button-active-bg);
           color: var(--os-button-active-text-color);
         }
-        .o-menu-item-icon {
-          .o-icon {
-            color: var(--os-icons-color);
-          }
-        }
         .o-menu-item-description {
           color: grey;
         }

--- a/src/components/spreadsheet/spreadsheet.css
+++ b/src/components/spreadsheet/spreadsheet.css
@@ -92,7 +92,6 @@
 
   .o-grid-container {
     display: grid;
-    background-color: var(--os-header-grouping-background-color);
 
     .o-top-left {
       border: 1px solid var(--os-grid-border-color);

--- a/src/variables.css
+++ b/src/variables.css
@@ -47,7 +47,6 @@
   --os-background-gray-color-hover: light-dark(rgba(0, 0, 0, 0.08), #ffffff40);
   --os-frozen-pane-header-border-color: #bcbcbc; /* FROZEN_PANE_HEADER_BORDER_COLOR */
   --os-grid-border-color: light-dark(#e2e3e3, var(--os-gray-200));
-  --os-separator-color: var(--os-gray-300);
   --os-green-arrow-color: #6aa84f; /* Same color as CF arrow icon */
   --os-red-arrow-color: #e06666; /* Same color as CF arrow icon */
   --os-active-sheet-bg: light-dark(#ffffff, var(--os-gray-300));


### PR DESCRIPTION
## Description

Commit d8db270 cleaned up the css, removing a bunch of variables to have a more consistent color palette. But some variables were forgotten, and not used anymore/not defined.

Task: [6119435](https://www.odoo.com/odoo/2328/tasks/6119435)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo