### PR TITLE
[FIX] pivot side panel: invalid computed measure

### DIFF
--- a/src/components/side_panel/pivot/pivot_layout_configurator/pivot_measure/pivot_measure.ts
+++ b/src/components/side_panel/pivot/pivot_layout_configurator/pivot_measure/pivot_measure.ts
@@ -1,8 +1,10 @@
 import { Component } from "@odoo/owl";
 import { compile } from "../../../../../formulas";
+import { InternalCompiledFormula } from "../../../../../formulas/compiler";
+import { functionRegistry } from "../../../../../functions";
 import { PivotRuntimeDefinition } from "../../../../../helpers/pivot/pivot_runtime_definition";
 import { createMeasureAutoComplete } from "../../../../../registries/auto_completes/pivot_dimension_auto_complete";
-import { PivotMeasure } from "../../../../../types";
+import { PivotMeasure, Range } from "../../../../../types";
 import { StandaloneComposer } from "../../../../composer/standalone_composer/standalone_composer";
 import { PivotDimension } from "../pivot_dimension/pivot_dimension";
 
@@ -84,6 +86,31 @@ export class PivotMeasureEditor extends Component<Props> {
   }
 
   get isCalculatedMeasureInvalid(): boolean {
-    return compile(this.props.measure.computedBy?.formula ?? "").isBadExpression;
+    const compiledFormula = compile(
+      this.props.measure.computedBy?.formula ?? ""
+    ) as InternalCompiledFormula;
+    if (compiledFormula.isBadExpression) {
+      return true;
+    }
+    const measures = new Set(this.props.definition.measures.map((m) => m.id));
+    const dimensions = new Set([
+      ...this.props.definition.columns.map((d) => d.nameWithGranularity),
+      ...this.props.definition.rows.map((d) => d.nameWithGranularity),
+    ]);
+    for (const symbol of compiledFormula.symbols) {
+      if (!measures.has(symbol) && !dimensions.has(symbol) && !functionRegistry.contains(symbol)) {
+        return true;
+      }
+    }
+    const sheetId = this.env.model.getters.getActiveSheetId();
+    const rangeDependencies: Range[] = compiledFormula.dependencies.map((xc) =>
+      this.env.model.getters.getRangeFromSheetXC(sheetId, xc)
+    );
+    for (const range of rangeDependencies) {
+      if (range.invalidSheetName) {
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/src/formulas/compiler.ts
+++ b/src/formulas/compiler.ts
@@ -38,7 +38,7 @@ interface LiteralValues {
   strings: { value: string }[];
 }
 
-type InternalCompiledFormula = CompiledFormula & {
+export type InternalCompiledFormula = CompiledFormula & {
   literalValues: LiteralValues;
   symbols: string[];
 };

--- a/tests/pivots/spreadsheet_pivot/spreadsheet_pivot_side_panel.test.ts
+++ b/tests/pivots/spreadsheet_pivot/spreadsheet_pivot_side_panel.test.ts
@@ -171,13 +171,16 @@ describe("Spreadsheet pivot side panel", () => {
     ]);
   });
 
-  test("Invalid calculated measure formula have an invalid class on the composer", async () => {
-    await click(fixture.querySelectorAll(".add-dimension")[2]);
-    expect(fixture.querySelector(".o-popover")).toBeDefined();
-    await click(fixture, ".add-calculated-measure");
-    await editStandaloneComposer(".pivot-dimension .o-composer", "=abcdefg()");
-    expect(fixture.querySelector(".o-standalone-composer")).toHaveClass("o-invalid");
-  });
+  test.each(["=abcdefg()", "=InvalidMeasureName", "=1/0a", "=NotAnExistingSheetName!a1"])(
+    "Invalid calculated measure formula have an invalid class on the composer",
+    async (formula) => {
+      await click(fixture.querySelectorAll(".add-dimension")[2]);
+      expect(fixture.querySelector(".o-popover")).toBeDefined();
+      await click(fixture, ".add-calculated-measure");
+      await editStandaloneComposer(".pivot-dimension .o-composer", formula);
+      expect(".o-standalone-composer.o-invalid").toHaveCount(1);
+    }
+  );
 
   test("can have a computed measure without aggregate", async () => {
     setCellContent(model, "A1", "amount");


### PR DESCRIPTION
Before this commit:
When creating a computed measure with  "=1/0a" or "=NotAnExistingSheetName!a1", the measure is not shown as invalid in the composer but it's shown as a BAD_EXPR in the grid

After this commit:
The measure is shown as invalid in the composer

Task: [5095901](https://www.odoo.com/odoo/2328/tasks/5095901)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo