### PR TITLE
[FIX] data_validation: preserve spaces in dv values

### DIFF
--- a/src/components/side_panel/data_validation/dv_editor/dv_editor.ts
+++ b/src/components/side_panel/data_validation/dv_editor/dv_editor.ts
@@ -95,8 +95,7 @@ export class DataValidationEditor extends Component<Props, SpreadsheetChildEnv> 
 
     const values = criterion.values
       .slice(0, criterionEvaluator.numberOfValues(criterion))
-      .map((value) => value?.trim())
-      .filter((value) => value !== "" && value !== undefined)
+      .filter((value) => value && value.trim() !== "")
       .map((value) => canonicalizeContent(value, locale));
     rule.criterion = { ...criterion, values };
     return {

--- a/tests/data_validation/data_validation_list_component.test.ts
+++ b/tests/data_validation/data_validation_list_component.test.ts
@@ -116,6 +116,14 @@ describe("Edit criterion in side panel", () => {
         (getDataValidationRules(model)[0].criterion as IsValueInListCriterion).displayStyle
       ).toEqual("plainText");
     });
+
+    test("Can store values with leading and trailing spaces", async () => {
+      await click(fixture, ".o-dv-list-add-value");
+      const inputs = fixture.querySelectorAll<HTMLInputElement>(".o-dv-list-values .o-input");
+      setInputValueAndTrigger(inputs[0], "  hello  ");
+      click(fixture, ".o-dv-save");
+      expect(getDataValidationRules(model)[0].criterion.values[0]).toEqual("  hello  ");
+    });
   });
 
   describe("Value in range", () => {


### PR DESCRIPTION
## Description:

Current behavior before PR:
- Values with leading/trailing spaces were trimmed in DV, unlike grid values, causing inconsistencies.

Desired behavior after PR is merged:
- DV values are stored with spaces like grid values.

Task: [5418098](https://www.odoo.com/odoo/2328/tasks/5418098)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo