### PR TITLE
[FIX] pivot side panel: invalid computed measure

### DIFF
--- a/src/components/side_panel/pivot/pivot_layout_configurator/pivot_measure/pivot_measure.ts
+++ b/src/components/side_panel/pivot/pivot_layout_configurator/pivot_measure/pivot_measure.ts
@@ -2,6 +2,7 @@ import { Component } from "@odoo/owl";
 import { PIVOT_TOKEN_COLOR } from "../../../../../constants";
 import { CompiledFormula } from "../../../../../formulas/compiler";
 import { Token } from "../../../../../formulas/tokenizer";
+import { functionRegistry } from "../../../../../functions/function_registry";
 import { unquote } from "../../../../../helpers";
 import { getFieldDisplayName } from "../../../../../helpers/pivot/pivot_helpers";
 import { PivotRuntimeDefinition } from "../../../../../helpers/pivot/pivot_runtime_definition";
@@ -110,7 +111,37 @@ export class PivotMeasureEditor extends Component<Props> {
   }
 
   get isCalculatedMeasureInvalid(): boolean {
-    return CompiledFormula.IsBadExpression(this.props.measure.computedBy?.formula ?? "");
+    const sheetId = this.env.model.getters.getActiveSheetId();
+    const compiledFormula = CompiledFormula.Compile(
+      this.props.measure.computedBy?.formula ?? "",
+      sheetId,
+      this.env.model.getters
+    );
+    if (compiledFormula.isBadExpression) {
+      return true;
+    }
+    const measures = new Set(this.props.definition.measures.map((m) => m.id));
+    const dimensions = new Set([
+      ...this.props.definition.columns.map((d) => d.nameWithGranularity),
+      ...this.props.definition.rows.map((d) => d.nameWithGranularity),
+    ]);
+    const namedRanges = new Set(this.env.model.getters.getNamedRanges().map((nr) => nr.name));
+    for (const symbol of compiledFormula.symbols) {
+      if (
+        !measures.has(symbol) &&
+        !dimensions.has(symbol) &&
+        !namedRanges.has(symbol) &&
+        !functionRegistry.contains(symbol)
+      ) {
+        return true;
+      }
+    }
+    for (const range of compiledFormula.rangeDependencies) {
+      if (range.invalidSheetName) {
+        return true;
+      }
+    }
+    return false;
   }
 
   get aggregatorOptions(): ValueAndLabel[] {

--- a/tests/pivots/spreadsheet_pivot/spreadsheet_pivot_side_panel.test.ts
+++ b/tests/pivots/spreadsheet_pivot/spreadsheet_pivot_side_panel.test.ts
@@ -14,6 +14,7 @@ import { NotificationStore } from "../../../src/stores/notification_store";
 import { SpreadsheetChildEnv } from "../../../src/types/spreadsheet_env";
 import {
   activateSheet,
+  createNamedRange,
   createSheet,
   selectCell,
   setCellContent,
@@ -178,12 +179,24 @@ describe("Spreadsheet pivot side panel", () => {
     ]);
   });
 
-  test("Invalid calculated measure formula have an invalid class on the composer", async () => {
+  test.each(["=abcdefg()", "=InvalidMeasureName", "=1/0a", "=NotAnExistingSheetName!a1"])(
+    "Invalid calculated measure formula have an invalid class on the composer",
+    async (formula) => {
+      await click(fixture.querySelectorAll(".add-dimension")[2]);
+      expect(fixture.querySelector(".o-popover")).toBeDefined();
+      await click(fixture, ".add-calculated-measure");
+      await editStandaloneComposer(".pivot-dimension .o-composer", formula);
+      expect(".o-standalone-composer.o-invalid").toHaveCount(1);
+    }
+  );
+
+  test("Calculated measure formula with a named range does not have an invalid class on the composer", async () => {
+    createNamedRange(model, "MyRange", "A1");
     await click(fixture.querySelectorAll(".add-dimension")[2]);
     expect(fixture.querySelector(".o-popover")).toBeDefined();
     await click(fixture, ".add-calculated-measure");
-    await editStandaloneComposer(".pivot-dimension .o-composer", "=abcdefg()");
-    expect(fixture.querySelector(".o-standalone-composer")).toHaveClass("o-invalid");
+    await editStandaloneComposer(".pivot-dimension .o-composer", "=MyRange");
+    expect(".o-standalone-composer.o-invalid").toHaveCount(0);
   });
 
   test("can have a computed measure without aggregate", async () => {


### PR DESCRIPTION
Before this commit:
When creating a computed measure with  "=1/0a" or "=NotAnExistingSheetName!a1", the measure is not shown as invalid in the composer but it's shown as a BAD_EXPR in the grid

After this commit:
The measure is shown as invalid in the composer

Task: [5095901](https://www.odoo.com/odoo/2328/tasks/5095901)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo