### PR TITLE
[FIX] chart side panel: fix input title

### DIFF
--- a/src/components/side_panel/chart/building_blocks/title/title.ts
+++ b/src/components/side_panel/chart/building_blocks/title/title.ts
@@ -1,4 +1,4 @@
-import { Component, useExternalListener, useState } from "@odoo/owl";
+import { Component, onWillUpdateProps, useExternalListener, useState } from "@odoo/owl";
 import { GRAY_300 } from "../../../../../constants";
 import { Color, SpreadsheetChildEnv, TitleDesign } from "../../../../../types";
 import { ColorPickerWidget } from "../../../../color_picker/color_picker_widget";
@@ -73,14 +73,24 @@ export class ChartTitle extends Component<Props, SpreadsheetChildEnv> {
 
   setup() {
     useExternalListener(window, "click", this.onExternalClick);
+    onWillUpdateProps((nextProps: Props) => {
+      if (nextProps.title !== this.props.title) {
+        this.state.inputTitle = nextProps.title ?? "";
+      }
+    });
   }
 
   state = useState({
     activeTool: "",
+    inputTitle: this.props.title ?? "",
   });
 
-  updateTitle(ev: InputEvent) {
-    this.props.updateTitle((ev.target as HTMLInputElement).value);
+  onInputTitle(ev: InputEvent) {
+    this.state.inputTitle = (ev.target as HTMLInputElement).value;
+  }
+
+  updateTitle() {
+    this.props.updateTitle(this.state.inputTitle);
   }
 
   toggleDropdownTool(tool: string, ev: MouseEvent) {

--- a/src/components/side_panel/chart/building_blocks/title/title.xml
+++ b/src/components/side_panel/chart/building_blocks/title/title.xml
@@ -9,7 +9,8 @@
       <input
         type="text"
         class="o-input"
-        t-att-value="props.title"
+        t-att-value="state.inputTitle"
+        t-on-input="onInputTitle"
         t-on-change="updateTitle"
         t-att-placeholder="placeholder"
       />

--- a/tests/figures/chart/charts_component.test.ts
+++ b/tests/figures/chart/charts_component.test.ts
@@ -44,6 +44,7 @@ import {
   click,
   doubleClick,
   focusAndKeyDown,
+  getTarget,
   keyDown,
   setInputValueAndTrigger,
   simulateClick,
@@ -395,6 +396,27 @@ describe("charts", () => {
       bold: true,
       italic: true,
     });
+  });
+
+  test("can edit chart axis title and it does not disappear during the edition", async () => {
+    await mountSpreadsheet();
+    createChart(
+      model,
+      {
+        dataSets: [{ dataRange: "C1:C4" }],
+        labelRange: "A2:A4",
+        type: "line",
+      },
+      chartId
+    );
+    await mountChartSidePanel();
+    await openChartDesignSidePanel(model, env, fixture, chartId);
+    const input_title = getTarget(".o-chart-title input") as HTMLInputElement;
+    setInputValueAndTrigger(input_title, "new title", "onlyInput");
+    //dispatch a command to force a render
+    model.dispatch("EVALUATE_CELLS");
+    await nextTick();
+    expect(input_title.value).toBe("new title");
   });
 
   test("can edit chart axis title color", async () => {


### PR DESCRIPTION
Before this commit:
input values were lost on re-render (disappeared after a mouse move for example.

Task: [4821998](https://www.odoo.com/odoo/2328/tasks/4821998)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo