### PR TITLE
[REF] lint: enforce braces for all control statements

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -29,6 +29,7 @@ export default tseslint.config(
       "no-unsafe-optional-chaining": "error", // ban unsafe optional chaining
       eqeqeq: "error", // ban non-strict equal
       "@typescript-eslint/no-non-null-asserted-optional-chain": "error", // ban non-null assertion in optional chain
+      curly: ["error", "all"], // enforce curly braces for all control statements
       ...(!fastMode && { "@typescript-eslint/consistent-type-exports": "error" }), // enforce consistent type exports
     },
   }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test": "tsc --noEmit --project tests/tsconfig.json && jest",
     "test:watch": "jest --watch",
     "prettier": "prettier . --write",
-    "check-formatting": "prettier . --check",
+    "check-formatting": "prettier . --check && eslint",
     "dist": "tsc --module es6 --declaration --declarationDir dist/types && rolldown -c && npm run build:bundleXml -- --outDir dist",
     "prepare": "husky install",
     "watch:bundle": "npm run build:bundleJs -- --watch",
@@ -161,8 +161,8 @@
   },
   "lint-staged": {
     "*": [
-      "prettier --write",
-      "eslint --fix"
+      "eslint --fix",
+      "prettier --write"
     ]
   },
   "publishConfig": {

--- a/src/collaborative/session.ts
+++ b/src/collaborative/session.ts
@@ -82,7 +82,9 @@ export class Session extends EventBus<CollaborativeEvent> {
    * It will be transmitted to all other connected clients.
    */
   save(rootCommand: Command, commands: CoreCommand[], changes: HistoryChange[]) {
-    if (!commands.length || !changes.length || !this.canApplyOptimisticUpdate()) return;
+    if (!commands.length || !changes.length || !this.canApplyOptimisticUpdate()) {
+      return;
+    }
     const revision = new Revision(
       this.uuidGenerator.uuidv4(),
       this.clientId,
@@ -219,7 +221,9 @@ export class Session extends EventBus<CollaborativeEvent> {
   private _move(position: ClientPosition) {
     // this method is debounced and might be called after the client
     // left the session.
-    if (!this.clients[this.clientId]) return;
+    if (!this.clients[this.clientId]) {
+      return;
+    }
     const currentPosition = this.clients[this.clientId]?.position;
     if (
       currentPosition?.col === position.col &&
@@ -243,7 +247,9 @@ export class Session extends EventBus<CollaborativeEvent> {
    * session.
    */
   private onMessageReceived(message: CollaborationMessage) {
-    if (this.isAlreadyProcessed(message)) return;
+    if (this.isAlreadyProcessed(message)) {
+      return;
+    }
     if (this.isWrongServerRevisionId(message)) {
       this.trigger("unexpected-revision-id");
       return;
@@ -369,7 +375,9 @@ export class Session extends EventBus<CollaborativeEvent> {
    */
   private sendPendingMessage() {
     let message = this.pendingMessages[0];
-    if (!message) return;
+    if (!message) {
+      return;
+    }
     if (message.type === "REMOTE_REVISION") {
       let revision = this.revisions.get(message.nextRevisionId);
       if (revision.commands.length === 0) {

--- a/src/components/animation/ripple.ts
+++ b/src/components/animation/ripple.ts
@@ -66,7 +66,9 @@ class RippleEffect extends Component<RippleEffectProps, SpreadsheetChildEnv> {
     let animation: Animation | undefined = undefined;
     onMounted(() => {
       const rippleEl = this.rippleRef.el;
-      if (!rippleEl || !rippleEl.animate) return;
+      if (!rippleEl || !rippleEl.animate) {
+        return;
+      }
       animation = rippleEl.animate(RIPPLE_KEY_FRAMES, {
         duration: this.props.duration,
         easing: "ease-out",
@@ -131,9 +133,13 @@ export class Ripple extends Component<RippleProps, SpreadsheetChildEnv> {
   private currentId = 1;
 
   onClick(ev: MouseEvent) {
-    if (!this.props.enabled) return;
+    if (!this.props.enabled) {
+      return;
+    }
     const containerEl = this.childContainer.el;
-    if (!containerEl) return;
+    if (!containerEl) {
+      return;
+    }
 
     const rect = this.getRippleChildRectInfo();
     const { x, y, width, height } = rect;
@@ -166,7 +172,9 @@ export class Ripple extends Component<RippleProps, SpreadsheetChildEnv> {
 
   private getRippleChildRectInfo(): RectWithMargins {
     const el = this.childContainer.el;
-    if (!el) throw new Error("No child container element found");
+    if (!el) {
+      throw new Error("No child container element found");
+    }
 
     if (el.childElementCount !== 1 || !el.firstElementChild) {
       const boundingRect = getBoundingRectAsPOJO(el);
@@ -186,13 +194,17 @@ export class Ripple extends Component<RippleProps, SpreadsheetChildEnv> {
 
   private removeRipple(id: number) {
     const index = this.state.ripples.findIndex((r) => r.id === id);
-    if (index === -1) return;
+    if (index === -1) {
+      return;
+    }
     this.state.ripples.splice(index, 1);
   }
 
   getRippleEffectProps(id: number): RippleEffectProps {
     const rect = this.state.ripples.find((r) => r.id === id)?.rippleRect;
-    if (!rect) throw new Error("Cannot find a ripple with the id " + id);
+    if (!rect) {
+      throw new Error("Cannot find a ripple with the id " + id);
+    }
     return {
       color: this.props.color,
       opacity: this.props.opacity,

--- a/src/components/bottom_bar/bottom_bar.ts
+++ b/src/components/bottom_bar/bottom_bar.ts
@@ -206,15 +206,23 @@ export class BottomBar extends Component<Props, SpreadsheetChildEnv> {
   }
 
   onArrowLeft(ev: MouseEvent) {
-    if (!this.state.isSheetListScrollableLeft) return;
-    if (!this.targetScroll) this.targetScroll = this.sheetListCurrentScroll;
+    if (!this.state.isSheetListScrollableLeft) {
+      return;
+    }
+    if (!this.targetScroll) {
+      this.targetScroll = this.sheetListCurrentScroll;
+    }
     const newScroll = this.targetScroll - this.sheetListWidth;
     this.scrollSheetListTo(Math.max(0, newScroll));
   }
 
   onArrowRight(ev: MouseEvent) {
-    if (!this.state.isSheetListScrollableRight) return;
-    if (!this.targetScroll) this.targetScroll = this.sheetListCurrentScroll;
+    if (!this.state.isSheetListScrollableRight) {
+      return;
+    }
+    if (!this.targetScroll) {
+      this.targetScroll = this.sheetListCurrentScroll;
+    }
     const newScroll = this.targetScroll + this.sheetListWidth;
     this.scrollSheetListTo(Math.min(this.sheetListMaxScroll, newScroll));
   }
@@ -225,13 +233,17 @@ export class BottomBar extends Component<Props, SpreadsheetChildEnv> {
   }
 
   private scrollSheetListTo(scroll: number) {
-    if (!this.sheetListRef.el) return;
+    if (!this.sheetListRef.el) {
+      return;
+    }
     this.targetScroll = scroll;
     this.sheetListRef.el.scrollTo({ top: 0, left: scroll, behavior: "smooth" });
   }
 
   onSheetMouseDown(sheetId: UID, event: MouseEvent) {
-    if (event.button !== 0 || this.env.model.getters.isReadonly()) return;
+    if (event.button !== 0 || this.env.model.getters.isReadonly()) {
+      return;
+    }
     this.closeMenu();
 
     const visibleSheets = this.getVisibleSheets();
@@ -278,17 +290,23 @@ export class BottomBar extends Component<Props, SpreadsheetChildEnv> {
   }
 
   get sheetListCurrentScroll() {
-    if (!this.sheetListRef.el) return 0;
+    if (!this.sheetListRef.el) {
+      return 0;
+    }
     return this.sheetListRef.el.scrollLeft;
   }
 
   get sheetListWidth() {
-    if (!this.sheetListRef.el) return 0;
+    if (!this.sheetListRef.el) {
+      return 0;
+    }
     return this.sheetListRef.el.clientWidth;
   }
 
   get sheetListMaxScroll() {
-    if (!this.sheetListRef.el) return 0;
+    if (!this.sheetListRef.el) {
+      return 0;
+    }
     return this.sheetListRef.el.scrollWidth - this.sheetListRef.el.clientWidth;
   }
 }

--- a/src/components/bottom_bar_sheet/bottom_bar_sheet.ts
+++ b/src/components/bottom_bar_sheet/bottom_bar_sheet.ts
@@ -94,7 +94,9 @@ export class BottomBarSheet extends Component<Props, SpreadsheetChildEnv> {
   }
 
   private focusInputAndSelectContent() {
-    if (!this.state.isEditing || !this.sheetNameRef.el) return;
+    if (!this.state.isEditing || !this.sheetNameRef.el) {
+      return;
+    }
 
     this.sheetNameRef.el.focus();
     const selection = window.getSelection();
@@ -142,7 +144,9 @@ export class BottomBarSheet extends Component<Props, SpreadsheetChildEnv> {
   }
 
   onKeyDown(ev: KeyboardEvent) {
-    if (!this.state.isEditing) return;
+    if (!this.state.isEditing) {
+      return;
+    }
     if (ev.key === "Enter") {
       ev.preventDefault();
       this.stopEdition();
@@ -155,7 +159,9 @@ export class BottomBarSheet extends Component<Props, SpreadsheetChildEnv> {
   }
 
   onMouseEventSheetName(ev: MouseEvent) {
-    if (this.state.isEditing) ev.stopPropagation();
+    if (this.state.isEditing) {
+      ev.stopPropagation();
+    }
   }
 
   private startEdition() {
@@ -164,7 +170,9 @@ export class BottomBarSheet extends Component<Props, SpreadsheetChildEnv> {
   }
 
   private stopEdition() {
-    if (!this.state.isEditing || !this.sheetNameRef.el) return;
+    if (!this.state.isEditing || !this.sheetNameRef.el) {
+      return;
+    }
 
     this.state.isEditing = false;
     this.editionState = "initializing";
@@ -201,7 +209,9 @@ export class BottomBarSheet extends Component<Props, SpreadsheetChildEnv> {
   }
 
   private setInputContent(content: string) {
-    if (this.sheetNameRef.el) this.sheetNameRef.el.textContent = content;
+    if (this.sheetNameRef.el) {
+      this.sheetNameRef.el.textContent = content;
+    }
   }
 
   get contextMenuRegistry() {

--- a/src/components/composer/composer/composer.ts
+++ b/src/components/composer/composer/composer.ts
@@ -500,7 +500,9 @@ export class Composer extends Component<ComposerProps, SpreadsheetChildEnv> {
     if (isValidFormula) {
       const tokens = this.env.model.getters.getCurrentTokens();
       const currentSelection = this.contentHelper.getCurrentSelection();
-      if (currentSelection.start === currentSelection.end) return;
+      if (currentSelection.start === currentSelection.end) {
+        return;
+      }
 
       const currentSelectedText = composerContent.substring(
         currentSelection.start,
@@ -688,7 +690,9 @@ export class Composer extends Component<ComposerProps, SpreadsheetChildEnv> {
       : this.env.model.getters.getCurrentEditedCell()?.sheetId;
 
     const highlight = highlights.find((highlight) => {
-      if (highlight.sheetId !== refSheet) return false;
+      if (highlight.sheetId !== refSheet) {
+        return false;
+      }
 
       const range = this.env.model.getters.getRangeFromSheetXC(refSheet, xc);
       let zone = range.zone;

--- a/src/components/composer/content_editable_helper.ts
+++ b/src/components/composer/content_editable_helper.ts
@@ -42,9 +42,15 @@ export class ContentEditableHelper {
         console.warn(
           `wrong selection asked start ${start}, end ${end}, text content length ${textLength}`
         );
-        if (start < 0) start = 0;
-        if (end > textLength) end = textLength;
-        if (start > textLength) start = textLength;
+        if (start < 0) {
+          start = 0;
+        }
+        if (end > textLength) {
+          end = textLength;
+        }
+        if (start > textLength) {
+          start = textLength;
+        }
       }
       const startNode = this.findChildAtCharacterIndex(start);
       const endNode = this.findChildAtCharacterIndex(end);
@@ -141,7 +147,9 @@ export class ContentEditableHelper {
         }
         // this is an empty line in the content
         if (!content.value && !content.class) {
-          if (child) p.removeChild(child);
+          if (child) {
+            p.removeChild(child);
+          }
           continue;
         }
         const span = document.createElement("span");
@@ -188,7 +196,9 @@ export class ContentEditableHelper {
 
   scrollSelectionIntoView() {
     const focusedNode = document.getSelection()?.focusNode;
-    if (!focusedNode || !this.el.contains(focusedNode)) return;
+    if (!focusedNode || !this.el.contains(focusedNode)) {
+      return;
+    }
     const element = focusedNode instanceof HTMLElement ? focusedNode : focusedNode.parentElement;
     element?.scrollIntoView({ block: "nearest" });
   }

--- a/src/components/figures/figure/figure.ts
+++ b/src/components/figures/figure/figure.ts
@@ -146,7 +146,9 @@ export class FigureComponent extends Component<Props, SpreadsheetChildEnv> {
   }
 
   private getBorderWidth(): Pixel {
-    if (this.env.isDashboard()) return 0;
+    if (this.env.isDashboard()) {
+      return 0;
+    }
     return this.isSelected ? ACTIVE_BORDER_WIDTH : this.borderWidth;
   }
 
@@ -274,7 +276,9 @@ export class FigureComponent extends Component<Props, SpreadsheetChildEnv> {
   }
 
   onContextMenu(ev: MouseEvent) {
-    if (this.env.isDashboard()) return;
+    if (this.env.isDashboard()) {
+      return;
+    }
     const position = {
       x: ev.clientX,
       y: ev.clientY,

--- a/src/components/figures/figure_container/figure_container.ts
+++ b/src/components/figures/figure_container/figure_container.ts
@@ -404,7 +404,9 @@ export class FiguresContainer extends Component<Props, SpreadsheetChildEnv> {
 
   private getDndFigure(): Figure {
     const figure = this.getVisibleFigures().find((fig) => fig.id === this.dnd.draggedFigure?.id);
-    if (!figure) throw new Error("Dnd figure not found");
+    if (!figure) {
+      throw new Error("Dnd figure not found");
+    }
     return {
       ...figure,
       ...this.dnd.draggedFigure,
@@ -412,7 +414,9 @@ export class FiguresContainer extends Component<Props, SpreadsheetChildEnv> {
   }
 
   getFigureStyle(figure: Figure): string {
-    if (figure.id !== this.dnd.draggedFigure?.id) return "";
+    if (figure.id !== this.dnd.draggedFigure?.id) {
+      return "";
+    }
     return cssPropertiesToCss({
       opacity: "0.9",
       cursor: "grabbing",
@@ -422,7 +426,9 @@ export class FiguresContainer extends Component<Props, SpreadsheetChildEnv> {
   private getSnap<T extends HFigureAxisType | VFigureAxisType>(
     snapLine: SnapLine<T> | undefined
   ): Snap<T> | undefined {
-    if (!snapLine || !this.dnd.draggedFigure) return undefined;
+    if (!snapLine || !this.dnd.draggedFigure) {
+      return undefined;
+    }
 
     const figureVisibleRects = snapLine.matchedFigIds
       .map((id) => this.getVisibleFigures().find((fig) => fig.id === id))
@@ -447,7 +453,9 @@ export class FiguresContainer extends Component<Props, SpreadsheetChildEnv> {
     snapLine: SnapLine<HFigureAxisType | VFigureAxisType> | undefined,
     containerRect: Rect
   ): string {
-    if (!snapLine) return "";
+    if (!snapLine) {
+      return "";
+    }
     if (["top", "vCenter", "bottom"].includes(snapLine.snappedAxisType)) {
       return cssPropertiesToCss({
         top: `${snapLine.position - containerRect.y}px`,

--- a/src/components/filters/filter_menu/filter_menu.ts
+++ b/src/components/filters/filter_menu/filter_menu.ts
@@ -239,7 +239,9 @@ export class FilterMenu extends Component<Props, SpreadsheetChildEnv> {
   onKeyDown(ev: KeyboardEvent) {
     const displayedValues = this.displayedValues;
 
-    if (displayedValues.length === 0) return;
+    if (displayedValues.length === 0) {
+      return;
+    }
 
     let selectedIndex: number | undefined = undefined;
     if (this.state.selectedValue !== undefined) {

--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -523,9 +523,15 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
   onKeydown(ev: KeyboardEvent) {
     let keyDownString = "";
     if (!MODIFIER_KEYS.includes(ev.key)) {
-      if (isCtrlKey(ev)) keyDownString += "CTRL+";
-      if (ev.altKey) keyDownString += "ALT+";
-      if (ev.shiftKey) keyDownString += "SHIFT+";
+      if (isCtrlKey(ev)) {
+        keyDownString += "CTRL+";
+      }
+      if (ev.altKey) {
+        keyDownString += "ALT+";
+      }
+      if (ev.shiftKey) {
+        keyDownString += "SHIFT+";
+      }
     }
     keyDownString += ev.key.toUpperCase();
 

--- a/src/components/grid_overlay/grid_overlay.ts
+++ b/src/components/grid_overlay/grid_overlay.ts
@@ -125,7 +125,9 @@ function useTouchMove(
   let y = null as number | null;
 
   function onTouchStart(ev: TouchEvent) {
-    if (ev.touches.length !== 1) return;
+    if (ev.touches.length !== 1) {
+      return;
+    }
     x = ev.touches[0].clientX;
     y = ev.touches[0].clientY;
   }
@@ -136,7 +138,9 @@ function useTouchMove(
   }
 
   function onTouchMove(ev: TouchEvent) {
-    if (ev.touches.length !== 1) return;
+    if (ev.touches.length !== 1) {
+      return;
+    }
     // On mobile browsers, swiping down is often associated with "pull to refresh".
     // We only want this behavior if the grid is already at the top.
     // Otherwise we only want to move the canvas up, without triggering any refresh.

--- a/src/components/headers_overlay/headers_overlay.ts
+++ b/src/components/headers_overlay/headers_overlay.ts
@@ -298,7 +298,9 @@ abstract class AbstractResizer extends Component<ResizerProps, SpreadsheetChildE
   onContextMenu(ev: MouseEvent) {
     ev.preventDefault();
     const index = this._getElementIndex(this._getEvOffset(ev));
-    if (index < 0) return;
+    if (index < 0) {
+      return;
+    }
     if (!this._getActiveElements().has(index)) {
       this._selectElement(index, false);
     }

--- a/src/components/helpers/css.ts
+++ b/src/components/helpers/css.ts
@@ -102,7 +102,9 @@ export function getTextDecoration({
  */
 export function cellStyleToCss(style: Style | undefined): CSSProperties {
   const attributes = cellTextStyleToCss(style);
-  if (!style) return attributes;
+  if (!style) {
+    return attributes;
+  }
 
   if (style.fillColor) {
     attributes["background"] = style.fillColor;
@@ -116,7 +118,9 @@ export function cellStyleToCss(style: Style | undefined): CSSProperties {
  */
 export function cellTextStyleToCss(style: Style | undefined): CSSProperties {
   const attributes: Record<string, string> = {};
-  if (!style) return attributes;
+  if (!style) {
+    return attributes;
+  }
 
   if (style.bold) {
     attributes["font-weight"] = "bold";

--- a/src/components/helpers/dom_helpers.ts
+++ b/src/components/helpers/dom_helpers.ts
@@ -65,9 +65,15 @@ export function keyboardEventToShortcutString(
 ): string {
   let keyDownString = "";
   if (!MODIFIER_KEYS.includes(ev.key)) {
-    if (isCtrlKey(ev)) keyDownString += "Ctrl+";
-    if (ev.altKey) keyDownString += "Alt+";
-    if (ev.shiftKey) keyDownString += "Shift+";
+    if (isCtrlKey(ev)) {
+      keyDownString += "Ctrl+";
+    }
+    if (ev.altKey) {
+      keyDownString += "Alt+";
+    }
+    if (ev.shiftKey) {
+      keyDownString += "Shift+";
+    }
   }
   const key = mode === "key" ? ev.key : ev.code;
   keyDownString += letterRegex.test(key) ? key.toUpperCase() : key;

--- a/src/components/helpers/drag_and_drop_hook.ts
+++ b/src/components/helpers/drag_and_drop_hook.ts
@@ -50,7 +50,9 @@ export function useDragAndDropListItems() {
   const start = (direction: Direction, args: DndPartialArgs) => {
     const onChange = () => {
       document.body.style.cursor = "move";
-      if (!dndHelper) return;
+      if (!dndHelper) {
+        return;
+      }
       Object.assign(state.itemsStyle, dndHelper.getItemStyles());
       args.onChange?.();
     };
@@ -260,7 +262,9 @@ class DOMDndHelper {
   }
 
   private startEdgeScroll(direction: -1 | 1) {
-    if (this.edgeScrollIntervalId) return;
+    if (this.edgeScrollIntervalId) {
+      return;
+    }
     this.edgeScrollIntervalId = window.setInterval(() => {
       const offset = direction * 3;
       let newPosition = this.currentMousePosition + offset;
@@ -283,8 +287,12 @@ class DOMDndHelper {
    * If the mouse is outside the container, return the first or last item index.
    */
   private getHoveredItemIndex(mousePosition: Pixel, items: DragAndDropItems[]): number {
-    if (mousePosition <= this.minPosition) return 0;
-    if (mousePosition >= this.maxPosition) return items.length - 1;
+    if (mousePosition <= this.minPosition) {
+      return 0;
+    }
+    if (mousePosition >= this.maxPosition) {
+      return items.length - 1;
+    }
     return items.findIndex((item) => item.position + item.size >= mousePosition);
   }
 

--- a/src/components/helpers/figure_snap_helper.ts
+++ b/src/components/helpers/figure_snap_helper.ts
@@ -62,8 +62,11 @@ export function snapForMove(
     const isBaseFigFrozenY = figureToSnap.y < viewportY;
     const isSnappedFrozenY = snappedFigure.y < viewportY;
 
-    if (isBaseFigFrozenY && !isSnappedFrozenY) snappedFigure.y += scrollY;
-    else if (!isBaseFigFrozenY && isSnappedFrozenY) snappedFigure.y -= scrollY;
+    if (isBaseFigFrozenY && !isSnappedFrozenY) {
+      snappedFigure.y += scrollY;
+    } else if (!isBaseFigFrozenY && isSnappedFrozenY) {
+      snappedFigure.y -= scrollY;
+    }
   }
 
   if (verticalSnapLine) {
@@ -72,8 +75,11 @@ export function snapForMove(
     const isBaseFigFrozenX = figureToSnap.x < viewportX;
     const isSnappedFrozenX = snappedFigure.x < viewportX;
 
-    if (isBaseFigFrozenX && !isSnappedFrozenX) snappedFigure.x += scrollX;
-    else if (!isBaseFigFrozenX && isSnappedFrozenX) snappedFigure.x -= scrollX;
+    if (isBaseFigFrozenX && !isSnappedFrozenX) {
+      snappedFigure.x += scrollX;
+    } else if (!isBaseFigFrozenX && isSnappedFrozenX) {
+      snappedFigure.x -= scrollX;
+    }
   }
 
   return { snappedFigure, verticalSnapLine, horizontalSnapLine };
@@ -179,14 +185,18 @@ function isAxisVisible<T extends HFigureAxisType | VFigureAxisType>(
     case "top":
     case "bottom":
     case "vCenter":
-      if (figure.y < mainViewportY) return true;
+      if (figure.y < mainViewportY) {
+        return true;
+      }
       axisStartEndPositions.push({ x: figure.x, y: axis.position });
       axisStartEndPositions.push({ x: figure.x + figure.width, y: axis.position });
       break;
     case "left":
     case "right":
     case "hCenter":
-      if (figure.x < mainViewportX) return true;
+      if (figure.x < mainViewportX) {
+        return true;
+      }
       axisStartEndPositions.push({ x: axis.position, y: figure.y });
       axisStartEndPositions.push({ x: axis.position, y: figure.y + figure.height });
       break;
@@ -220,7 +230,9 @@ function getSnapLine<T extends HFigureAxisType[] | VFigureAxisType[]>(
 
     for (const axisOfFigure of axesOfFigure) {
       for (const axisOfOtherFig of axesOfOtherFig) {
-        if (!canSnap(axisOfFigure.position, axisOfOtherFig.position)) continue;
+        if (!canSnap(axisOfFigure.position, axisOfOtherFig.position)) {
+          continue;
+        }
 
         const snapOffset = axisOfFigure.position - axisOfOtherFig.position;
 

--- a/src/components/link/link_display/link_display.ts
+++ b/src/components/link/link_display/link_display.ts
@@ -120,7 +120,9 @@ export const LinkCellPopoverBuilder: PopoverBuilders = {
     const cell = getters.getEvaluatedCell(position);
     const shouldDisplayLink =
       !getters.isDashboard() && cell.link && getters.isVisibleInViewport(position);
-    if (!shouldDisplayLink) return { isOpen: false };
+    if (!shouldDisplayLink) {
+      return { isOpen: false };
+    }
     return {
       isOpen: true,
       Component: LinkDisplay,

--- a/src/components/menu/menu.ts
+++ b/src/components/menu/menu.ts
@@ -234,7 +234,9 @@ export class Menu extends Component<Props, SpreadsheetChildEnv> {
    */
   openSubMenu(menu: Action, menuIndex: number, ev: MouseEvent) {
     const parentMenuEl = ev.currentTarget as HTMLElement;
-    if (!parentMenuEl) return;
+    if (!parentMenuEl) {
+      return;
+    }
     const y = parentMenuEl.getBoundingClientRect().top;
 
     this.subMenu.position = {

--- a/src/components/popover/popover.ts
+++ b/src/components/popover/popover.ts
@@ -69,7 +69,9 @@ export class Popover extends Component<PopoverProps, SpreadsheetChildEnv> {
     // useEffect occurs after the DOM is created and the element width/height are computed, but before
     // the element in rendered, so we can still set its position
     useEffect(() => {
-      if (!this.containerRect) throw new Error("Popover container is not defined");
+      if (!this.containerRect) {
+        throw new Error("Popover container is not defined");
+      }
       const el = this.popoverRef.el!;
 
       const anchor = rectIntersection(this.props.anchorRect, this.containerRect);
@@ -80,7 +82,9 @@ export class Popover extends Component<PopoverProps, SpreadsheetChildEnv> {
       el.style.display = newDisplay;
       this.currentDisplayValue = newDisplay;
 
-      if (!anchor) return;
+      if (!anchor) {
+        return;
+      }
 
       const propsMaxSize = { width: this.props.maxWidth, height: this.props.maxHeight };
       let elDims = {
@@ -217,9 +221,15 @@ abstract class PopoverPositionContext {
     const shouldRenderAtBottom = this.shouldRenderAtBottom(elDims.height);
     const shouldRenderAtRight = this.shouldRenderAtRight(elDims.width);
 
-    if (shouldRenderAtBottom && shouldRenderAtRight) return "BottomRight";
-    if (shouldRenderAtBottom && !shouldRenderAtRight) return "BottomLeft";
-    if (!shouldRenderAtBottom && shouldRenderAtRight) return "TopRight";
+    if (shouldRenderAtBottom && shouldRenderAtRight) {
+      return "BottomRight";
+    }
+    if (shouldRenderAtBottom && !shouldRenderAtRight) {
+      return "BottomLeft";
+    }
+    if (!shouldRenderAtBottom && shouldRenderAtRight) {
+      return "TopRight";
+    }
     return "TopLeft";
   }
 }

--- a/src/components/side_panel/conditional_formatting/cf_preview_list/cf_preview_list.ts
+++ b/src/components/side_panel/conditional_formatting/cf_preview_list/cf_preview_list.ts
@@ -132,7 +132,9 @@ export class ConditionalFormatPreviewList extends Component<Props, SpreadsheetCh
   }
 
   onMouseDown(cf: ConditionalFormat, event: MouseEvent) {
-    if (event.button !== 0) return;
+    if (event.button !== 0) {
+      return;
+    }
 
     const previewRects = Array.from(this.cfListRef.el!.children).map((previewEl) =>
       getBoundingRectAsPOJO(previewEl)

--- a/src/components/side_panel/data_validation/data_validation_panel.ts
+++ b/src/components/side_panel/data_validation/data_validation_panel.ts
@@ -39,7 +39,9 @@ export class DataValidationPanel extends Component<Props, SpreadsheetChildEnv> {
   }
 
   localizeDVRule(rule?: DataValidationRule): DataValidationRule | undefined {
-    if (!rule) return rule;
+    if (!rule) {
+      return rule;
+    }
     const locale = this.env.model.getters.getLocale();
     return localizeDataValidationRule(rule, locale);
   }

--- a/src/components/side_panel/settings/settings_panel.ts
+++ b/src/components/side_panel/settings/settings_panel.ts
@@ -25,7 +25,9 @@ export class SettingsPanel extends Component<Props, SpreadsheetChildEnv> {
 
   onLocaleChange(code: LocaleCode) {
     const locale = this.loadedLocales.find((l) => l.code === code);
-    if (!locale) return;
+    if (!locale) {
+      return;
+    }
     this.env.model.dispatch("UPDATE_LOCALE", { locale });
   }
 

--- a/src/components/side_panel/split_to_columns_panel/split_to_columns_panel.ts
+++ b/src/components/side_panel/split_to_columns_panel/split_to_columns_panel.ts
@@ -58,12 +58,16 @@ export class SplitIntoColumnsPanel extends Component<Props, SpreadsheetChildEnv>
   }
 
   updateCustomSeparator(ev: InputEvent) {
-    if (!ev.target) return;
+    if (!ev.target) {
+      return;
+    }
     this.state.customSeparator = (ev.target as HTMLInputElement).value;
   }
 
   updateAddNewColumnsCheckbox(ev: Event) {
-    if (!ev.target) return;
+    if (!ev.target) {
+      return;
+    }
     this.state.addNewColumns = (ev.target as HTMLInputElement).checked;
   }
 

--- a/src/functions/helpers.ts
+++ b/src/functions/helpers.ts
@@ -404,12 +404,16 @@ function conditionalVisitArgs(
       const lenCol = arg[0].length;
       for (let y = 0; y < lenCol; y++) {
         for (let x = 0; x < lenRow; x++) {
-          if (!cellCb(arg[x][y] ?? undefined)) return;
+          if (!cellCb(arg[x][y] ?? undefined)) {
+            return;
+          }
         }
       }
     } else {
       // arg is set directly in the formula function
-      if (!dataCb(arg)) return;
+      if (!dataCb(arg)) {
+        return;
+      }
     }
   }
 }
@@ -768,7 +772,9 @@ export function linearSearch<T>(
   getValueInData: (data: T, index: number) => CellValue | undefined,
   reverseSearch = false
 ): number {
-  if (target === null || target === undefined) return -1;
+  if (target === null || target === undefined) {
+    return -1;
+  }
 
   const _target = normalizeValue(target);
   const getValue = reverseSearch

--- a/src/functions/module_date.ts
+++ b/src/functions/module_date.ts
@@ -756,8 +756,12 @@ export const WEEKDAY = {
       _t("The type (%s) must be 1, 2 or 3.", _type.toString())
     );
 
-    if (_type === 1) return m + 1;
-    if (_type === 2) return m === 0 ? 7 : m;
+    if (_type === 1) {
+      return m + 1;
+    }
+    if (_type === 2) {
+      return m === 0 ? 7 : m;
+    }
     return m === 0 ? 6 : m - 1;
   },
   isExported: true,

--- a/src/functions/module_filter.ts
+++ b/src/functions/module_filter.ts
@@ -339,7 +339,9 @@ export const UNIQUE = {
       result.push(row.data);
     }
 
-    if (!result.length) throw new Error(_t("No unique values found"));
+    if (!result.length) {
+      throw new Error(_t("No unique values found"));
+    }
 
     return _byColumn ? result : transposeMatrix(result);
   },

--- a/src/functions/module_financial.ts
+++ b/src/functions/module_financial.ts
@@ -751,7 +751,9 @@ export const DDB = {
     assertPeriodSmallerOrEqualToLife(_period, _life);
     assertDeprecationFactorStrictlyPositive(_factor);
 
-    if (_cost === 0 || _salvage >= _cost) return 0;
+    if (_cost === 0 || _salvage >= _cost) {
+      return 0;
+    }
 
     const deprecFactor = _factor / _life;
     if (deprecFactor > 1) {
@@ -1196,8 +1198,12 @@ export const IRR = {
     visitNumbers(
       [cashFlowAmounts],
       (amount) => {
-        if (amount > 0) positive = true;
-        if (amount < 0) negative = true;
+        if (amount > 0) {
+          positive = true;
+        }
+        if (amount < 0) {
+          negative = true;
+        }
         amounts.push(amount);
       },
       this.locale
@@ -1670,7 +1676,9 @@ export const PPMT = {
 
     const payment = PMT.compute.bind(this)(r, n, pv, fv, endOrBeginning);
 
-    if (type === 1 && period === 1) return payment;
+    if (type === 1 && period === 1) {
+      return payment;
+    }
     const eqPeriod = type === 0 ? period - 1 : period - 2;
     const eqPv = pv + payment * type;
 
@@ -2431,7 +2439,9 @@ export const VDB = {
     assertStartAndEndPeriodAreValid(_startPeriod, _endPeriod, _life);
     assertDeprecationFactorStrictlyPositive(_factor);
 
-    if (_cost === 0) return 0;
+    if (_cost === 0) {
+      return 0;
+    }
     if (_salvage >= _cost) {
       return _startPeriod < 1 ? _cost - _salvage : 0;
     }
@@ -2512,8 +2522,11 @@ export const XIRR = {
     const map = new Map<number, number>();
     for (const i of range(0, _dates.length)) {
       const date = _dates[i];
-      if (map.has(date)) map.set(date, map.get(date)! + _cashFlows[i]);
-      else map.set(date, _cashFlows[i]);
+      if (map.has(date)) {
+        map.set(date, map.get(date)! + _cashFlows[i]);
+      } else {
+        map.set(date, _cashFlows[i]);
+      }
     }
     const dates = Array.from(map.keys());
     const values = dates.map((date) => map.get(date)!);
@@ -2552,7 +2565,9 @@ export const XIRR = {
     };
     const nanFallback = (previousFallback: number | undefined) => {
       // -0.9 => -0.99 => -0.999 => ...
-      if (!previousFallback) return -0.9;
+      if (!previousFallback) {
+        return -0.9;
+      }
       return previousFallback / 10 - 0.9;
     };
 
@@ -2603,14 +2618,19 @@ export const XNPV = {
     assertEveryDateGreaterThanFirstDateOfCashFlowDates(_dates);
     assertRateStrictlyPositive(rate);
 
-    if (_cashFlows.length === 1) return _cashFlows[0];
+    if (_cashFlows.length === 1) {
+      return _cashFlows[0];
+    }
 
     // aggregate values of the same date
     const map = new Map<number, number>();
     for (const i of range(0, _dates.length)) {
       const date = _dates[i];
-      if (map.has(date)) map.set(date, map.get(date)! + _cashFlows[i]);
-      else map.set(date, _cashFlows[i]);
+      if (map.has(date)) {
+        map.set(date, map.get(date)! + _cashFlows[i]);
+      } else {
+        map.set(date, _cashFlows[i]);
+      }
     }
     const dates = Array.from(map.keys());
     const values = dates.map((date) => map.get(date)!);

--- a/src/functions/module_lookup.ts
+++ b/src/functions/module_lookup.ts
@@ -302,7 +302,9 @@ export const LOOKUP = {
       getElement
     );
 
-    if (index === -1) assertAvailable(undefined, searchKey?.value);
+    if (index === -1) {
+      assertAvailable(undefined, searchKey?.value);
+    }
 
     verticalSearch
       ? assertAvailable(_searchArray[0][index], searchKey?.value)

--- a/src/functions/module_web.ts
+++ b/src/functions/module_web.ts
@@ -20,7 +20,9 @@ export const HYPERLINK = {
   compute: function (url: Maybe<CellValue>, linkLabel: Maybe<CellValue>): string {
     const processedUrl = toString(url).trim();
     const processedLabel = toString(linkLabel) || processedUrl;
-    if (processedUrl === "") return processedLabel;
+    if (processedUrl === "") {
+      return processedLabel;
+    }
     return markdownLink(processedLabel, processedUrl);
   },
   isExported: true,

--- a/src/helpers/color.ts
+++ b/src/helpers/color.ts
@@ -153,11 +153,21 @@ export function rgbaToHex(rgba: RGBA): Color {
   let b = rgba.b.toString(16);
   let a = Math.round(rgba.a * 255).toString(16);
 
-  if (r.length === 1) r = "0" + r;
-  if (g.length === 1) g = "0" + g;
-  if (b.length === 1) b = "0" + b;
-  if (a.length === 1) a = "0" + a;
-  if (a === "ff") a = "";
+  if (r.length === 1) {
+    r = "0" + r;
+  }
+  if (g.length === 1) {
+    g = "0" + g;
+  }
+  if (b.length === 1) {
+    b = "0" + b;
+  }
+  if (a.length === 1) {
+    a = "0" + a;
+  }
+  if (a === "ff") {
+    a = "";
+  }
 
   return ("#" + r + g + b + a).toUpperCase();
 }
@@ -261,18 +271,28 @@ export function rgbaToHSLA(rgba: RGBA): HSLA {
 
   // Calculate hue
   // No difference
-  if (delta === 0) h = 0;
+  if (delta === 0) {
+    h = 0;
+  }
   // Red is max
-  else if (cMax === r) h = ((g - b) / delta) % 6;
+  else if (cMax === r) {
+    h = ((g - b) / delta) % 6;
+  }
   // Green is max
-  else if (cMax === g) h = (b - r) / delta + 2;
+  else if (cMax === g) {
+    h = (b - r) / delta + 2;
+  }
   // Blue is max
-  else h = (r - g) / delta + 4;
+  else {
+    h = (r - g) / delta + 4;
+  }
 
   h = Math.round(h * 60);
 
   // Make negative hues positive behind 360°
-  if (h < 0) h += 360;
+  if (h < 0) {
+    h += 360;
+  }
 
   l = (cMax + cMin) / 2;
 

--- a/src/helpers/dates.ts
+++ b/src/helpers/dates.ts
@@ -530,8 +530,12 @@ export function getYearFrac(startDate: number, endDate: number, _dayCountConvent
   switch (_dayCountConvention) {
     // 30/360 US convention --------------------------------------------------
     case 0:
-      if (dayStart === 31) dayStart = 30;
-      if (dayStart === 30 && dayEnd === 31) dayEnd = 30;
+      if (dayStart === 31) {
+        dayStart = 30;
+      }
+      if (dayStart === 30 && dayEnd === 31) {
+        dayEnd = 30;
+      }
       // If jsStartDate is the last day of February
       if (monthStart === 1 && dayStart === (isLeapYear(yearStart) ? 29 : 28)) {
         dayStart = 30;
@@ -617,8 +621,12 @@ export function getYearFrac(startDate: number, endDate: number, _dayCountConvent
 
     // 30/360 European convention --------------------------------------------
     case 4:
-      if (dayStart === 31) dayStart = 30;
-      if (dayEnd === 31) dayEnd = 30;
+      if (dayStart === 31) {
+        dayStart = 30;
+      }
+      if (dayEnd === 31) {
+        dayEnd = 30;
+      }
       yearsStart = yearStart + (monthStart * 30 + dayStart) / 360;
       yearsEnd = yearEnd + (monthEnd * 30 + dayEnd) / 360;
       break;

--- a/src/helpers/figures/charts/bar_chart.ts
+++ b/src/helpers/figures/charts/bar_chart.ts
@@ -229,7 +229,9 @@ function getBarConfiguration(
         color: fontColor,
         callback: (value) => {
           value = Number(value);
-          if (isNaN(value)) return value;
+          if (isNaN(value)) {
+            return value;
+          }
           const { locale, format } = localeFormat;
           return formatValue(value, {
             locale,

--- a/src/helpers/figures/charts/chart_common.ts
+++ b/src/helpers/figures/charts/chart_common.ts
@@ -261,7 +261,9 @@ export function toExcelLabelRange(
   labelRange: Range | undefined,
   shouldRemoveFirstLabel?: boolean
 ) {
-  if (!labelRange) return undefined;
+  if (!labelRange) {
+    return undefined;
+  }
   const zone = {
     ...labelRange.zone,
   };
@@ -373,9 +375,15 @@ export function shouldRemoveFirstLabel(
   dataset: DataSet | undefined,
   dataSetsHaveTitle: boolean
 ) {
-  if (!dataSetsHaveTitle) return false;
-  if (!labelRange) return false;
-  if (!dataset) return true;
+  if (!dataSetsHaveTitle) {
+    return false;
+  }
+  if (!labelRange) {
+    return false;
+  }
+  if (!dataset) {
+    return true;
+  }
   const datasetLength = getZoneArea(dataset.dataRange.zone);
   const labelLength = getZoneArea(labelRange.zone);
   if (labelLength < datasetLength) {

--- a/src/helpers/figures/charts/chart_ui_common.ts
+++ b/src/helpers/figures/charts/chart_ui_common.ts
@@ -160,7 +160,9 @@ export function getChartLabelFormat(
   range: Range | undefined,
   shouldRemoveFirstLabel: boolean
 ): Format | undefined {
-  if (!range) return undefined;
+  if (!range) {
+    return undefined;
+  }
 
   const { sheetId, zone } = range;
 
@@ -213,7 +215,9 @@ export function getChartDatasetFormat(getters: Getters, dataSets: DataSet[]): Fo
   for (const ds of dataSets) {
     const formatsInDataset = getters.getRangeFormats(ds.dataRange);
     const format = formatsInDataset.find((f) => f !== undefined && !isDateTimeFormat(f));
-    if (format) return format;
+    if (format) {
+      return format;
+    }
   }
   return undefined;
 }

--- a/src/helpers/figures/charts/line_chart.ts
+++ b/src/helpers/figures/charts/line_chart.ts
@@ -336,7 +336,9 @@ function getLineConfiguration(
         color: fontColor,
         callback: (value) => {
           value = Number(value);
-          if (isNaN(value)) return value;
+          if (isNaN(value)) {
+            return value;
+          }
           const { locale, format } = options;
           return formatValue(value, {
             locale,

--- a/src/helpers/format.ts
+++ b/src/helpers/format.ts
@@ -241,7 +241,9 @@ function splitNumber(
   maxDecimals: number = MAX_DECIMAL_PLACES
 ): { integerDigits: string; decimalDigits: string | undefined } {
   const asString = value.toString();
-  if (asString.includes("e")) return splitNumberIntl(value, maxDecimals);
+  if (asString.includes("e")) {
+    return splitNumberIntl(value, maxDecimals);
+  }
 
   if (Number.isInteger(value)) {
     return { integerDigits: asString, decimalDigits: undefined };
@@ -491,7 +493,9 @@ export const getDecimalNumberRegex = memoize(function getDecimalNumberRegex(loca
  */
 export function createDefaultFormat(value: number): Format {
   let { integerDigits, decimalDigits } = splitNumber(value);
-  if (!decimalDigits) return "0";
+  if (!decimalDigits) {
+    return "0";
+  }
 
   const digitsInIntegerPart = integerDigits.replace("-", "").length;
 

--- a/src/helpers/misc.ts
+++ b/src/helpers/misc.ts
@@ -246,7 +246,9 @@ export function isNotNull<T>(argument: T | null): argument is T {
  * Check if all the values of an object, and all the values of the objects inside of it, are undefined.
  */
 export function isObjectEmptyRecursive<T extends object>(argument: T | undefined): boolean {
-  if (argument === undefined) return true;
+  if (argument === undefined) {
+    return true;
+  }
   return Object.values(argument).every((value) =>
     typeof value === "object" ? isObjectEmptyRecursive(value) : !value
   );
@@ -356,10 +358,18 @@ export function getAddHeaderStartIndex(position: "before" | "after", base: numbe
  * Compares two objects.
  */
 export function deepEquals(o1: any, o2: any): boolean {
-  if (o1 === o2) return true;
-  if ((o1 && !o2) || (o2 && !o1)) return false;
-  if (typeof o1 !== typeof o2) return false;
-  if (typeof o1 !== "object") return false;
+  if (o1 === o2) {
+    return true;
+  }
+  if ((o1 && !o2) || (o2 && !o1)) {
+    return false;
+  }
+  if (typeof o1 !== typeof o2) {
+    return false;
+  }
+  if (typeof o1 !== "object") {
+    return false;
+  }
 
   // Objects can have different keys if the values are undefined
   for (const key in o2) {
@@ -369,11 +379,17 @@ export function deepEquals(o1: any, o2: any): boolean {
   }
 
   for (const key in o1) {
-    if (typeof o1[key] !== typeof o2[key]) return false;
+    if (typeof o1[key] !== typeof o2[key]) {
+      return false;
+    }
     if (typeof o1[key] === "object") {
-      if (!deepEquals(o1[key], o2[key])) return false;
+      if (!deepEquals(o1[key], o2[key])) {
+        return false;
+      }
     } else {
-      if (o1[key] !== o2[key]) return false;
+      if (o1[key] !== o2[key]) {
+        return false;
+      }
     }
   }
 
@@ -449,7 +465,9 @@ const newLineRegexp = /(\r\n|\r)/g;
  * Replace all different newlines characters by \n
  */
 export function replaceNewLines(text: string | undefined): string {
-  if (!text) return "";
+  if (!text) {
+    return "";
+  }
   return text.replace(newLineRegexp, NEWLINE);
 }
 
@@ -544,7 +562,9 @@ export function isNumberBetween(value: number, min: number, max: number): boolea
 export function largeMax(array: number[]) {
   let len = array.length;
 
-  if (len < 100_000) return Math.max(...array);
+  if (len < 100_000) {
+    return Math.max(...array);
+  }
 
   let max: number = -Infinity;
   while (len--) {
@@ -560,7 +580,9 @@ export function largeMax(array: number[]) {
 export function largeMin(array: number[]) {
   let len = array.length;
 
-  if (len < 100_000) return Math.min(...array);
+  if (len < 100_000) {
+    return Math.min(...array);
+  }
 
   let min: number = +Infinity;
   while (len--) {

--- a/src/helpers/numbers.ts
+++ b/src/helpers/numbers.ts
@@ -48,7 +48,9 @@ const getNumberRegex = memoize(function getNumberRegex(locale: Locale) {
  * Note that "" (empty string) does not count as a number string
  */
 export function isNumber(value: string | undefined, locale: Locale): boolean {
-  if (!value) return false;
+  if (!value) {
+    return false;
+  }
   // TO DO: add regexp for DATE string format (ex match: "28 02 2020")
   return getNumberRegex(locale).test(value.trim());
 }

--- a/src/helpers/range.ts
+++ b/src/helpers/range.ts
@@ -202,7 +202,9 @@ export function createValidRange(
   sheetId: UID,
   xc?: string
 ): Range | undefined {
-  if (!xc) return;
+  if (!xc) {
+    return;
+  }
   const range = getters.getRangeFromSheetXC(sheetId, xc);
   return !(range.invalidSheetName || range.invalidXc) ? range : undefined;
 }

--- a/src/helpers/rectangle.ts
+++ b/src/helpers/rectangle.ts
@@ -23,7 +23,9 @@ function rectToZone(rect: Rect): Zone {
 }
 
 function zoneToRect(zone: Zone | undefined): Rect | undefined {
-  if (!zone) return undefined;
+  if (!zone) {
+    return undefined;
+  }
   return {
     x: zone.left,
     y: zone.top,

--- a/src/helpers/reference_type.ts
+++ b/src/helpers/reference_type.ts
@@ -13,7 +13,9 @@ type FixedReferenceType = "col" | "row" | "colrow" | "none";
  *   A1:$B$1 => $A$1:B$1 => A$1:$B1 => $A1:B1 => A1:$B$1
  */
 export function loopThroughReferenceType(token: Readonly<Token>): Token {
-  if (token.type !== "REFERENCE") return token;
+  if (token.type !== "REFERENCE") {
+    return token;
+  }
   const { xc, sheetName } = splitReference(token.value);
   const [left, right] = xc.split(":") as [string, string | undefined];
 

--- a/src/helpers/text_helper.ts
+++ b/src/helpers/text_helper.ts
@@ -124,8 +124,12 @@ export function splitTextToWidth(
   style: Style | undefined,
   width: number | undefined
 ): string[] {
-  if (!style) style = {};
-  if (isMarkdownLink(text)) text = parseMarkdownLink(text).label;
+  if (!style) {
+    style = {};
+  }
+  if (isMarkdownLink(text)) {
+    text = parseMarkdownLink(text).label;
+  }
   const brokenText: string[] = [];
 
   // Checking if text contains NEWLINE before split makes it very slightly slower if text contains it,
@@ -200,8 +204,12 @@ export function getFontSizeMatchingWidth(
   precision = 0.25
 ) {
   let minFontSize = 1;
-  if (getTextWidth(minFontSize) > lineWidth) return minFontSize;
-  if (getTextWidth(maxFontSize) < lineWidth) return maxFontSize;
+  if (getTextWidth(minFontSize) > lineWidth) {
+    return minFontSize;
+  }
+  if (getTextWidth(maxFontSize) < lineWidth) {
+    return maxFontSize;
+  }
 
   // Dichotomic search
   let fontSize = (minFontSize + maxFontSize) / 2;

--- a/src/helpers/zones.ts
+++ b/src/helpers/zones.ts
@@ -291,7 +291,9 @@ export function reduceZoneOnDeletion<Z extends UnboundedZone | Zone>(
   for (const removedElement of elements.sort((a, b) => b - a)) {
     if (zone[start] > removedElement) {
       newStart--;
-      if (newEnd !== undefined) newEnd--;
+      if (newEnd !== undefined) {
+        newEnd--;
+      }
     }
     if (
       zoneEnd !== undefined &&
@@ -678,7 +680,9 @@ export function getZoneArea(zone: Zone): number {
  * including cells outside the zones
  * */
 export function areZonesContinuous(...zones: Zone[]): boolean {
-  if (zones.length < 2) return true;
+  if (zones.length < 2) {
+    return true;
+  }
   return recomputeZones(zones.map(zoneToXc), []).length === 1;
 }
 

--- a/src/history/branch.ts
+++ b/src/history/branch.ts
@@ -36,8 +36,12 @@ export class Branch<T> {
    */
   getFirstOperationAmong(op1: UID, op2: UID): UID {
     for (const operation of this.operations) {
-      if (operation.id === op1) return op1;
-      if (operation.id === op2) return op2;
+      if (operation.id === op1) {
+        return op1;
+      }
+      if (operation.id === op2) {
+        return op2;
+      }
     }
     throw new Error(`Operation ${op1} and ${op2} not found`);
   }

--- a/src/history/repeat_commands/repeat_commands_generic.ts
+++ b/src/history/repeat_commands/repeat_commands_generic.ts
@@ -8,13 +8,17 @@ export const genericRepeatsTransforms = [
 ];
 
 export function repeatSheetDependantCommand<T extends Command>(getters: Getters, command: T): T {
-  if (!("sheetId" in command)) return command;
+  if (!("sheetId" in command)) {
+    return command;
+  }
 
   return { ...deepCopy(command), sheetId: getters.getActiveSheetId() };
 }
 
 export function repeatTargetDependantCommand<T extends Command>(getters: Getters, command: T): T {
-  if (!("target" in command) || !Array.isArray(command.target)) return command;
+  if (!("target" in command) || !Array.isArray(command.target)) {
+    return command;
+  }
 
   return {
     ...deepCopy(command),
@@ -23,7 +27,9 @@ export function repeatTargetDependantCommand<T extends Command>(getters: Getters
 }
 
 export function repeatZoneDependantCommand<T extends Command>(getters: Getters, command: T): T {
-  if (!("zone" in command)) return command;
+  if (!("zone" in command)) {
+    return command;
+  }
 
   return {
     ...deepCopy(command),
@@ -32,7 +38,9 @@ export function repeatZoneDependantCommand<T extends Command>(getters: Getters, 
 }
 
 export function repeatPositionDependantCommand<T extends Command>(getters: Getters, command: T): T {
-  if (!("row" in command) || !("col" in command)) return command;
+  if (!("row" in command) || !("col" in command)) {
+    return command;
+  }
 
   const { col, row } = getters.getActivePosition();
   return { ...deepCopy(command), col, row };

--- a/src/history/tree.ts
+++ b/src/history/tree.ts
@@ -147,7 +147,9 @@ export class Tree<T = unknown> {
    */
   redo(branch: Branch<T>) {
     const removedBranch = this.nextBranch(branch);
-    if (!removedBranch) return;
+    if (!removedBranch) {
+      return;
+    }
     const nextBranch = this.nextBranch(removedBranch);
     this.removeBranchFromTree(removedBranch);
 
@@ -204,7 +206,9 @@ export class Tree<T = unknown> {
    */
   private rebaseUp(branch: Branch<T>) {
     const { previousBranch, branchingOperation } = this.findPreviousBranchingOperation(branch);
-    if (!previousBranch || !branchingOperation) return;
+    if (!previousBranch || !branchingOperation) {
+      return;
+    }
     const rebaseTransformation = this.buildTransformation.without(branchingOperation.data);
     const newBranch = previousBranch.fork(branchingOperation.id);
     this.branchingOperationIds.set(newBranch, this.branchingOperationIds.get(branch));
@@ -312,7 +316,9 @@ export class Tree<T = unknown> {
    */
   private insertPrevious(branch: Branch<T>, newOperation: Operation<T>, insertAfter: UID) {
     const { previousBranch, branchingOperation } = this.findPreviousBranchingOperation(branch);
-    if (!previousBranch || !branchingOperation) return;
+    if (!previousBranch || !branchingOperation) {
+      return;
+    }
     const transformation = this.buildTransformation.with(branchingOperation.data);
     const branchTail = branch.fork(insertAfter);
     branchTail.transform(transformation);
@@ -327,9 +333,13 @@ export class Tree<T = unknown> {
     branchingOperation?: Operation<T>;
   } {
     const previousBranch = this.previousBranch(branch);
-    if (!previousBranch) return { previousBranch: undefined, branchingOperation: undefined };
+    if (!previousBranch) {
+      return { previousBranch: undefined, branchingOperation: undefined };
+    }
     const previousBranchingId = this.branchingOperationIds.get(previousBranch);
-    if (!previousBranchingId) return { previousBranch: undefined, branchingOperation: undefined };
+    if (!previousBranchingId) {
+      return { previousBranch: undefined, branchingOperation: undefined };
+    }
     return {
       previousBranch,
       branchingOperation: previousBranch.getOperation(previousBranchingId),

--- a/src/plugins/core/borders.ts
+++ b/src/plugins/core/borders.ts
@@ -323,7 +323,9 @@ export class BordersPlugin extends CorePlugin<BordersPluginState> implements Bor
    */
   private getColumnsWithBorders(sheetId: UID): HeaderIndex[] {
     const sheetBorders = this.borders[sheetId];
-    if (!sheetBorders) return [];
+    if (!sheetBorders) {
+      return [];
+    }
     return Object.keys(sheetBorders).map((index) => parseInt(index, 10));
   }
 
@@ -332,7 +334,9 @@ export class BordersPlugin extends CorePlugin<BordersPluginState> implements Bor
    */
   private getRowsWithBorders(sheetId: UID): number[] {
     const sheetBorders = this.borders[sheetId]?.filter(isDefined);
-    if (!sheetBorders) return [];
+    if (!sheetBorders) {
+      return [];
+    }
     const rowsWithBorders = new Set<number>();
     for (const rowBorders of sheetBorders) {
       for (const rowBorder in rowBorders) {
@@ -347,7 +351,9 @@ export class BordersPlugin extends CorePlugin<BordersPluginState> implements Bor
    */
   private getRowsRange(sheetId: UID): HeaderIndex[] {
     const sheetBorders = this.borders[sheetId];
-    if (!sheetBorders) return [];
+    if (!sheetBorders) {
+      return [];
+    }
     return range(0, this.getters.getNumberRows(sheetId) + 1);
   }
 
@@ -364,7 +370,9 @@ export class BordersPlugin extends CorePlugin<BordersPluginState> implements Bor
     { moveFirstLeftBorder }: { moveFirstLeftBorder?: boolean } = {}
   ) {
     const borders = this.borders[sheetId];
-    if (!borders) return;
+    if (!borders) {
+      return;
+    }
     if (delta < 0) {
       this.moveBordersOfColumn(sheetId, start, delta, "vertical", {
         destructive: false,
@@ -394,7 +402,9 @@ export class BordersPlugin extends CorePlugin<BordersPluginState> implements Bor
     { moveFirstTopBorder }: { moveFirstTopBorder?: boolean } = {}
   ) {
     const borders = this.borders[sheetId];
-    if (!borders) return;
+    if (!borders) {
+      return;
+    }
     if (delta < 0) {
       this.moveBordersOfRow(sheetId, start, delta, "horizontal", {
         destructive: false,
@@ -430,7 +440,9 @@ export class BordersPlugin extends CorePlugin<BordersPluginState> implements Bor
     { destructive }: { destructive: boolean } = { destructive: true }
   ) {
     const borders = this.borders[sheetId];
-    if (!borders) return;
+    if (!borders) {
+      return;
+    }
     this.getColumnsWithBorders(sheetId).forEach((col) => {
       const targetBorder = borders[col]?.[row + delta]?.[borderDirection];
       const movedBorder = borders[col]?.[row]?.[borderDirection];
@@ -465,7 +477,9 @@ export class BordersPlugin extends CorePlugin<BordersPluginState> implements Bor
     { destructive }: { destructive: boolean } = { destructive: true }
   ) {
     const borders = this.borders[sheetId];
-    if (!borders) return;
+    if (!borders) {
+      return;
+    }
     this.getRowsRange(sheetId).forEach((row) => {
       const targetBorder = borders[col + delta]?.[row]?.[borderDirection];
       const movedBorder = borders[col]?.[row]?.[borderDirection];

--- a/src/plugins/core/cell.ts
+++ b/src/plugins/core/cell.ts
@@ -648,14 +648,18 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
   private checkCellOutOfSheet(cmd: PositionDependentCommand): CommandResult {
     const { sheetId, col, row } = cmd;
     const sheet = this.getters.tryGetSheet(sheetId);
-    if (!sheet) return CommandResult.InvalidSheetId;
+    if (!sheet) {
+      return CommandResult.InvalidSheetId;
+    }
     const sheetZone = this.getters.getSheetZone(sheetId);
     return isInside(col, row, sheetZone) ? CommandResult.Success : CommandResult.TargetOutOfSheet;
   }
 
   private checkUselessClearCell(cmd: ClearCellCommand): CommandResult {
     const cell = this.getters.getCell(cmd);
-    if (!cell) return CommandResult.NoChanges;
+    if (!cell) {
+      return CommandResult.NoChanges;
+    }
     if (!cell.content && !cell.style && !cell.format) {
       return CommandResult.NoChanges;
     }

--- a/src/plugins/core/conditional_format.ts
+++ b/src/plugins/core/conditional_format.ts
@@ -305,9 +305,13 @@ export class ConditionalFormatPlugin
   }
 
   private checkValidPriorityChange(cfId: string, delta: number, sheetId: string) {
-    if (!this.cfRules[sheetId]) return CommandResult.InvalidSheetId;
+    if (!this.cfRules[sheetId]) {
+      return CommandResult.InvalidSheetId;
+    }
     const ruleIndex = this.cfRules[sheetId].findIndex((cf) => cf.id === cfId);
-    if (ruleIndex === -1) return CommandResult.InvalidConditionalFormatId;
+    if (ruleIndex === -1) {
+      return CommandResult.InvalidConditionalFormatId;
+    }
 
     const cfIndex2 = ruleIndex - delta;
     if (cfIndex2 < 0 || cfIndex2 >= this.cfRules[sheetId].length) {
@@ -425,7 +429,9 @@ export class ConditionalFormatPlugin
     threshold: ColorScaleThreshold | ColorScaleMidPointThreshold | IconThreshold,
     thresholdName: string
   ) {
-    if (threshold.type !== "formula") return CommandResult.Success;
+    if (threshold.type !== "formula") {
+      return CommandResult.Success;
+    }
     try {
       compile(threshold.value || "");
     } catch (error) {

--- a/src/plugins/core/data_validation.ts
+++ b/src/plugins/core/data_validation.ts
@@ -155,7 +155,9 @@ export class DataValidationPlugin
 
   cellHasListDataValidationIcon(cellPosition: CellPosition): boolean {
     const rule = this.getValidationRuleForCell(cellPosition);
-    if (!rule) return false;
+    if (!rule) {
+      return false;
+    }
 
     return (
       (rule.criterion.type === "isValueInList" || rule.criterion.type === "isValueInRange") &&

--- a/src/plugins/core/merge.ts
+++ b/src/plugins/core/merge.ts
@@ -103,7 +103,9 @@ export class MergePlugin extends CorePlugin<MergeState> implements MergeState {
         break;
       case "DUPLICATE_SHEET":
         const merges = this.merges[cmd.sheetId];
-        if (!merges) break;
+        if (!merges) {
+          break;
+        }
         for (const range of Object.values(merges).filter(isDefined)) {
           this.addMerge(cmd.sheetIdTo, range.zone);
         }
@@ -146,7 +148,9 @@ export class MergePlugin extends CorePlugin<MergeState> implements MergeState {
 
   getMergesInZone(sheetId: UID, zone: Zone): Merge[] {
     const sheetMap = this.mergeCellMap[sheetId];
-    if (!sheetMap) return [];
+    if (!sheetMap) {
+      return [];
+    }
     const mergeIds = new Set<number>();
 
     for (const { col, row } of positions(zone)) {
@@ -341,7 +345,9 @@ export class MergePlugin extends CorePlugin<MergeState> implements MergeState {
 
   private checkDestructiveMerge({ sheetId, target }: AddMergeCommand): CommandResult {
     const sheet = this.getters.tryGetSheet(sheetId);
-    if (!sheet) return CommandResult.Success;
+    if (!sheet) {
+      return CommandResult.Success;
+    }
     const isDestructive = target.some((zone) => this.isMergeDestructive(sheetId, zone));
     return isDestructive ? CommandResult.MergeIsDestructive : CommandResult.Success;
   }
@@ -359,7 +365,9 @@ export class MergePlugin extends CorePlugin<MergeState> implements MergeState {
 
   private checkFrozenPanes({ sheetId, target }: AddMergeCommand): CommandResult {
     const sheet = this.getters.tryGetSheet(sheetId);
-    if (!sheet) return CommandResult.Success;
+    if (!sheet) {
+      return CommandResult.Success;
+    }
     const { xSplit, ySplit } = this.getters.getPaneDivisions(sheetId);
     for (const zone of target) {
       if (

--- a/src/plugins/core/sheet.ts
+++ b/src/plugins/core/sheet.ts
@@ -112,9 +112,12 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
         return this.checkValidations(cmd, this.checkSheetName, this.checkSheetPosition);
       }
       case "DUPLICATE_SHEET": {
-        if (this.sheets[cmd.sheetIdTo]) return CommandResult.DuplicatedSheetId;
-        if (this.orderedSheetIds.map(this.getSheetName.bind(this)).includes(cmd.sheetNameTo))
+        if (this.sheets[cmd.sheetIdTo]) {
+          return CommandResult.DuplicatedSheetId;
+        }
+        if (this.orderedSheetIds.map(this.getSheetName.bind(this)).includes(cmd.sheetNameTo)) {
           return CommandResult.DuplicatedSheetName;
+        }
         return CommandResult.Success;
       }
       case "MOVE_SHEET":
@@ -535,7 +538,9 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
    * not outside the sheet.
    */
   checkZonesExistInSheet(sheetId: UID, zones: Zone[]): CommandResult {
-    if (!zones.every(isZoneValid)) return CommandResult.InvalidRange;
+    if (!zones.every(isZoneValid)) {
+      return CommandResult.InvalidRange;
+    }
 
     if (zones.length) {
       const sheetZone = this.getSheetZone(sheetId);
@@ -1054,7 +1059,9 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
    * not outside the sheet.
    */
   private checkZonesAreInSheet(cmd: CoreCommand): CommandResult {
-    if (!("sheetId" in cmd)) return CommandResult.Success;
+    if (!("sheetId" in cmd)) {
+      return CommandResult.Success;
+    }
     if (
       "ranges" in cmd &&
       cmd.ranges.some((rangeData) => !this.getters.tryGetSheet(rangeData._sheetId))

--- a/src/plugins/ui_core_views/cell_evaluation/evaluation_plugin.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluation_plugin.ts
@@ -229,7 +229,9 @@ export class EvaluationPlugin extends UIPlugin {
    */
   getRangeFormattedValues(range: Range): FormattedValue[] {
     const sheet = this.getters.tryGetSheet(range.sheetId);
-    if (sheet === undefined) return [];
+    if (sheet === undefined) {
+      return [];
+    }
     return this.getters
       .getEvaluatedCellsInZone(sheet.id, range.zone)
       .map((cell) => cell.formattedValue);
@@ -240,7 +242,9 @@ export class EvaluationPlugin extends UIPlugin {
    */
   getRangeValues(range: Range): CellValue[] {
     const sheet = this.getters.tryGetSheet(range.sheetId);
-    if (sheet === undefined) return [];
+    if (sheet === undefined) {
+      return [];
+    }
     return this.getters.getEvaluatedCellsInZone(sheet.id, range.zone).map((cell) => cell.value);
   }
 
@@ -249,7 +253,9 @@ export class EvaluationPlugin extends UIPlugin {
    */
   getRangeFormats(range: Range): (Format | undefined)[] {
     const sheet = this.getters.tryGetSheet(range.sheetId);
-    if (sheet === undefined) return [];
+    if (sheet === undefined) {
+      return [];
+    }
     return this.getters.getEvaluatedCellsInZone(sheet.id, range.zone).map((cell) => cell.format);
   }
 

--- a/src/plugins/ui_core_views/evaluation_chart.ts
+++ b/src/plugins/ui_core_views/evaluation_chart.ts
@@ -71,8 +71,9 @@ export class EvaluationChartPlugin extends UIPlugin<EvaluationChartState> {
     chartBackground: Color | undefined,
     mainRange: Range | undefined
   ): EvaluationChartStyle {
-    if (chartBackground)
+    if (chartBackground) {
       return { background: chartBackground, fontColor: chartFontColor(chartBackground) };
+    }
     if (!mainRange) {
       return {
         background: BACKGROUND_CHART_COLOR,

--- a/src/plugins/ui_core_views/evaluation_conditional_format.ts
+++ b/src/plugins/ui_core_views/evaluation_conditional_format.ts
@@ -141,7 +141,9 @@ export class EvaluationConditionalFormatPlugin extends UIPlugin {
                     return value;
                   });
                   if (predicate && predicate(target, { ...cf.rule, values })) {
-                    if (!computedStyle[col]) computedStyle[col] = [];
+                    if (!computedStyle[col]) {
+                      computedStyle[col] = [];
+                    }
                     // we must combine all the properties of all the CF rules applied to the given cell
                     computedStyle[col][row] = Object.assign(
                       computedStyle[col]?.[row] || {},
@@ -163,7 +165,9 @@ export class EvaluationConditionalFormatPlugin extends UIPlugin {
   private getComputedIcons(sheetId: UID): ComputedIcons {
     const computedIcons = {};
     for (const cf of this.getters.getConditionalFormats(sheetId).reverse()) {
-      if (cf.rule.type !== "IconSetRule") continue;
+      if (cf.rule.type !== "IconSetRule") {
+        continue;
+      }
 
       for (const range of cf.ranges) {
         this.applyIcon(sheetId, range, cf.rule, computedIcons);
@@ -361,7 +365,9 @@ export class EvaluationConditionalFormatPlugin extends UIPlugin {
               colorCellArgs[0].colorDiffUnit
             );
           }
-          if (!computedStyle[col]) computedStyle[col] = [];
+          if (!computedStyle[col]) {
+            computedStyle[col] = [];
+          }
           computedStyle[col][row] = computedStyle[col]?.[row] || {};
           computedStyle[col][row]!.fillColor = colorNumberString(color);
         }

--- a/src/plugins/ui_feature/local_history.ts
+++ b/src/plugins/ui_feature/local_history.ts
@@ -101,7 +101,9 @@ export class HistoryPlugin extends UIPlugin {
   }
 
   canRedo(): boolean {
-    if (this.redoStack.length > 0) return true;
+    if (this.redoStack.length > 0) {
+      return true;
+    }
     const lastNonRedoRevision = this.getPossibleRevisionToRepeat();
     return canRepeatRevision(lastNonRedoRevision);
   }

--- a/src/plugins/ui_feature/sort.ts
+++ b/src/plugins/ui_feature/sort.ts
@@ -228,7 +228,9 @@ export class SortPlugin extends UIPlugin {
    *
    */
   private hasHeader(sheetId: UID, items: Position[][]): boolean {
-    if (items[0].length === 1) return false;
+    if (items[0].length === 1) {
+      return false;
+    }
     let cells: CellValueType[][] = items.map((col) =>
       col.map(({ col, row }) => this.getters.getEvaluatedCell({ sheetId, col, row }).type)
     );

--- a/src/plugins/ui_stateful/edition.ts
+++ b/src/plugins/ui_stateful/edition.ts
@@ -698,7 +698,9 @@ export class EditionPlugin extends UIPlugin {
     const usedIndexes = new Set(Object.values(colorsToKeep));
     let currentIndex = 0;
     const nextIndex = () => {
-      while (usedIndexes.has(currentIndex)) currentIndex++;
+      while (usedIndexes.has(currentIndex)) {
+        currentIndex++;
+      }
       usedIndexes.add(currentIndex);
       return currentIndex;
     };

--- a/src/plugins/ui_stateful/filter_evaluation.ts
+++ b/src/plugins/ui_stateful/filter_evaluation.ts
@@ -143,7 +143,9 @@ export class FilterEvaluationPlugin extends UIPlugin {
   getFilterValues(position: CellPosition): string[] {
     const id = this.getters.getFilterId(position);
     const sheetId = position.sheetId;
-    if (!id || !this.filterValues[sheetId]) return [];
+    if (!id || !this.filterValues[sheetId]) {
+      return [];
+    }
     return this.filterValues[sheetId][id] || [];
   }
 
@@ -164,8 +166,12 @@ export class FilterEvaluationPlugin extends UIPlugin {
 
   private updateFilter({ col, row, hiddenValues, sheetId }: UpdateFilterCommand) {
     const id = this.getters.getFilterId({ sheetId, col, row });
-    if (!id) return;
-    if (!this.filterValues[sheetId]) this.filterValues[sheetId] = {};
+    if (!id) {
+      return;
+    }
+    if (!this.filterValues[sheetId]) {
+      this.filterValues[sheetId] = {};
+    }
     this.filterValues[sheetId][id] = hiddenValues;
   }
 
@@ -184,7 +190,9 @@ export class FilterEvaluationPlugin extends UIPlugin {
         continue;
       }
       const filteredValues = this.filterValues[sheetId]?.[filter.id]?.map(toLowerCase);
-      if (!filteredValues || !filter.filteredZone) continue;
+      if (!filteredValues || !filter.filteredZone) {
+        continue;
+      }
       const filteredValuesSet = new Set(filteredValues);
       for (let row = filter.filteredZone.top; row <= filter.filteredZone.bottom; row++) {
         const value = this.getCellValueAsString(sheetId, filter.col, row);
@@ -217,7 +225,9 @@ export class FilterEvaluationPlugin extends UIPlugin {
           const filteredValues: string[] = this.getFilterValues(position);
 
           const filter = this.getters.getFilter(position);
-          if (!filter) continue;
+          if (!filter) {
+            continue;
+          }
 
           const valuesInFilterZone = filter.filteredZone
             ? positions(filter.filteredZone).map(

--- a/src/xlsx/conversion/cf_conversion.ts
+++ b/src/xlsx/conversion/cf_conversion.ts
@@ -27,7 +27,9 @@ export function convertConditionalFormats(
   const cfs: ConditionalFormat[] = [];
   let cfId = 1;
   for (const cf of xlsxCfs) {
-    if (cf.cfRules.length === 0) continue;
+    if (cf.cfRules.length === 0) {
+      continue;
+    }
 
     addCfConversionWarnings(cf, dxfs, warningManager);
 
@@ -35,8 +37,9 @@ export function convertConditionalFormats(
     let operator: ConditionalFormattingOperatorValues | undefined;
     const values: string[] = [];
 
-    if (rule.dxfId === undefined && !(rule.type === "colorScale" || rule.type === "iconSet"))
+    if (rule.dxfId === undefined && !(rule.type === "colorScale" || rule.type === "iconSet")) {
       continue;
+    }
     switch (rule.type) {
       case "aboveAverage":
       case "containsErrors":
@@ -65,7 +68,9 @@ export function convertConditionalFormats(
       case "notContainsText":
       case "beginsWith":
       case "endsWith":
-        if (!rule.text) continue;
+        if (!rule.text) {
+          continue;
+        }
         operator = CF_TYPE_CONVERSION_MAP[rule.type]!;
         values.push(rule.text);
         break;
@@ -74,7 +79,9 @@ export function convertConditionalFormats(
         operator = CF_TYPE_CONVERSION_MAP[rule.type]!;
         break;
       case "cellIs":
-        if (!rule.operator || !rule.formula || rule.formula.length === 0) continue;
+        if (!rule.operator || !rule.formula || rule.formula.length === 0) {
+          continue;
+        }
         operator = convertCFCellIsOperator(rule.operator);
         values.push(prefixFormula(rule.formula[0]));
         if (rule.formula.length === 2) {
@@ -154,7 +161,9 @@ function convertIconSet(
   warningManager: XLSXImportWarningManager
 ): ConditionalFormat | undefined {
   const xlsxIconSet = xlsxCf.cfRules[0].iconSet;
-  if (!xlsxIconSet) return undefined;
+  if (!xlsxIconSet) {
+    return undefined;
+  }
   let cfVos = xlsxIconSet.cfvos;
   let cfIcons = xlsxIconSet.cfIcons;
   if (cfVos.length < 3 || (cfIcons && cfIcons.length < 3)) {
@@ -235,7 +244,9 @@ function convertIconSet(
  */
 function convertIcons(xlsxIconSet: ExcelIconSet, index: number): string {
   const iconSet = ICON_SET_CONVERSION_MAP[xlsxIconSet];
-  if (!iconSet) return "";
+  if (!iconSet) {
+    return "";
+  }
 
   return index === 0
     ? ICON_SETS[iconSet].bad

--- a/src/xlsx/conversion/color_conversion.ts
+++ b/src/xlsx/conversion/color_conversion.ts
@@ -54,7 +54,9 @@ export function convertColor(xlsxColor: XLSXColor | undefined): Color | undefine
  * representation #RRGGBBAA
  */
 function xlsxColorToHEXA(color: Color): Color {
-  if (color.length === 6) return "#" + color + "FF";
+  if (color.length === 6) {
+    return "#" + color + "FF";
+  }
   return "#" + color.slice(2) + color.slice(0, 2);
 }
 

--- a/src/xlsx/conversion/sheet_conversion.ts
+++ b/src/xlsx/conversion/sheet_conversion.ts
@@ -59,9 +59,13 @@ function convertCols(sheet: XLSXWorksheet, numberOfCols: number): Record<number,
   for (let i = 1; i < numberOfCols + 1; i++) {
     const col = sheet.cols.find((col) => col.min <= i && i <= col.max);
     let colSize: number;
-    if (col && col.width) colSize = col.width;
-    else if (sheet.sheetFormat?.defaultColWidth) colSize = sheet.sheetFormat.defaultColWidth;
-    else colSize = EXCEL_DEFAULT_COL_WIDTH;
+    if (col && col.width) {
+      colSize = col.width;
+    } else if (sheet.sheetFormat?.defaultColWidth) {
+      colSize = sheet.sheetFormat.defaultColWidth;
+    } else {
+      colSize = EXCEL_DEFAULT_COL_WIDTH;
+    }
     cols[i - 1] = { size: convertWidthFromExcel(colSize), isHidden: col?.hidden };
   }
   return cols;
@@ -73,9 +77,13 @@ function convertRows(sheet: XLSXWorksheet, numberOfRows: number): Record<number,
   for (let i = 1; i < numberOfRows + 1; i++) {
     const row = sheet.rows.find((row) => row.index === i);
     let rowSize: number;
-    if (row && row.height) rowSize = row.height;
-    else if (sheet.sheetFormat?.defaultRowHeight) rowSize = sheet.sheetFormat.defaultRowHeight;
-    else rowSize = EXCEL_DEFAULT_ROW_HEIGHT;
+    if (row && row.height) {
+      rowSize = row.height;
+    } else if (sheet.sheetFormat?.defaultRowHeight) {
+      rowSize = sheet.sheetFormat.defaultRowHeight;
+    } else {
+      rowSize = EXCEL_DEFAULT_ROW_HEIGHT;
+    }
     rows[i - 1] = { size: convertHeightFromExcel(rowSize), isHidden: row?.hidden };
   }
   return rows;

--- a/src/xlsx/conversion/style_conversion.ts
+++ b/src/xlsx/conversion/style_conversion.ts
@@ -53,7 +53,9 @@ function convertBorderDescr(
   borderDescr: XLSXBorderDescr | undefined,
   warningManager: XLSXImportWarningManager
 ): BorderDescr | undefined {
-  if (!borderDescr) return undefined;
+  if (!borderDescr) {
+    return undefined;
+  }
 
   addBorderDescrWarnings(borderDescr, warningManager);
 

--- a/src/xlsx/conversion/table_conversion.ts
+++ b/src/xlsx/conversion/table_conversion.ts
@@ -31,8 +31,12 @@ export function convertTables(convertedData: WorkbookData, xlsxData: XLSXImportD
   for (const xlsxSheet of xlsxData.sheets) {
     for (const table of xlsxSheet.tables) {
       const sheet = convertedData.sheets.find((sheet) => sheet.name === xlsxSheet.sheetName);
-      if (!sheet || !table.autoFilter) continue;
-      if (!sheet.filterTables) sheet.filterTables = [];
+      if (!sheet || !table.autoFilter) {
+        continue;
+      }
+      if (!sheet.filterTables) {
+        sheet.filterTables = [];
+      }
       sheet.filterTables.push({ range: table.ref });
     }
   }
@@ -56,7 +60,9 @@ function applyTableStyle(convertedData: WorkbookData, xlsxData: XLSXImportData) 
   for (const xlsxSheet of xlsxData.sheets) {
     for (const table of xlsxSheet.tables) {
       const sheet = convertedData.sheets.find((sheet) => sheet.name === xlsxSheet.sheetName);
-      if (!sheet) continue;
+      if (!sheet) {
+        continue;
+      }
       const tableZone = toZone(table.ref);
 
       // Table style

--- a/src/xlsx/extraction/base_extractor.ts
+++ b/src/xlsx/extraction/base_extractor.ts
@@ -35,8 +35,12 @@ class AttributeValue {
   }
 
   asBool(): boolean {
-    if (this.value === "true") return true; // for files exported from Libre Office
-    if (this.value === "false") return false;
+    if (this.value === "true") {
+      return true;
+    } // for files exported from Libre Office
+    if (this.value === "false") {
+      return false;
+    }
     return Boolean(Number(this.value));
   }
 
@@ -179,7 +183,9 @@ export class XlsxBaseExtractor {
   ): ExtractAttrType<T> {
     const attribute = e.attributes[attName];
 
-    if (!attribute) this.handleMissingValue(e, `attribute "${attName}"`, optionalArgs);
+    if (!attribute) {
+      this.handleMissingValue(e, `attribute "${attName}"`, optionalArgs);
+    }
 
     const value = attribute?.value ? attribute.value : optionalArgs?.default;
     return (value === undefined ? undefined : new AttributeValue(value)) as ExtractAttrType<T>;
@@ -341,11 +347,15 @@ export class XlsxBaseExtractor {
    * Returns the xml file targeted by a relationship.
    */
   protected getTargetXmlFile(relationship: XLSXRel): XLSXImportFile {
-    if (!relationship) throw new Error("Undefined target file");
+    if (!relationship) {
+      throw new Error("Undefined target file");
+    }
     const target = this.processRelationshipTargetName(relationship.target);
     // Use "endsWith" because targets are relative paths, and we know the files by their absolute path.
     const f = this.getListOfXMLFiles().find((f) => f.file.fileName.endsWith(target));
-    if (!f || !f.file) throw new Error("Cannot find target file");
+    if (!f || !f.file) {
+      throw new Error("Cannot find target file");
+    }
     return f;
   }
 
@@ -353,11 +363,15 @@ export class XlsxBaseExtractor {
    * Returns the image parameters targeted by a relationship.
    */
   protected getTargetImageFile(relationship: XLSXRel): XLSXImageFile {
-    if (!relationship) throw new Error("Undefined target file");
+    if (!relationship) {
+      throw new Error("Undefined target file");
+    }
     const target = this.processRelationshipTargetName(relationship.target);
     // Use "endsWith" because targets are relative paths, and we know the files by their absolute path.
     const f = this.xlsxFileStructure.images.find((f) => f.fileName.endsWith(target));
-    if (!f) throw new Error("Cannot find target file");
+    if (!f) {
+      throw new Error("Cannot find target file");
+    }
     return f;
   }
 

--- a/src/xlsx/extraction/cf_extractor.ts
+++ b/src/xlsx/extraction/cf_extractor.ts
@@ -111,7 +111,9 @@ export class XlsxCfExtractor extends XlsxBaseExtractor {
     theme: XLSXTheme | undefined
   ): XLSXColorScale | undefined {
     const colorScaleElement = this.querySelector(cfRulesElement, "colorScale");
-    if (!colorScaleElement) return undefined;
+    if (!colorScaleElement) {
+      return undefined;
+    }
 
     return {
       colors: this.mapOnElements(
@@ -126,7 +128,9 @@ export class XlsxCfExtractor extends XlsxBaseExtractor {
 
   private extractCfIconSet(cfRulesElement: Element): XLSXIconSet | undefined {
     const iconSetElement = this.querySelector(cfRulesElement, "iconSet, x14:iconSet");
-    if (!iconSetElement) return undefined;
+    if (!iconSetElement) {
+      return undefined;
+    }
 
     return {
       iconSet: this.extractAttr(iconSetElement, "iconSet", {

--- a/src/xlsx/extraction/sheet_extractor.ts
+++ b/src/xlsx/extraction/sheet_extractor.ts
@@ -216,7 +216,9 @@ export class XlsxSheetExtractor extends XlsxBaseExtractor {
 
   private extractSheetFormat(worksheet: Element): XLSXSheetFormat | undefined {
     const formatElement = this.querySelector(worksheet, "sheetFormatPr");
-    if (!formatElement) return undefined;
+    if (!formatElement) {
+      return undefined;
+    }
 
     return {
       defaultColWidth: this.extractAttr(formatElement, "defaultColWidth", {
@@ -292,7 +294,9 @@ export class XlsxSheetExtractor extends XlsxBaseExtractor {
 
   private extractCellFormula(cellElement: Element): XLSXFormula | undefined {
     const formulaElement = this.querySelector(cellElement, "f");
-    if (!formulaElement) return undefined;
+    if (!formulaElement) {
+      return undefined;
+    }
     const content = this.extractTextContent(formulaElement);
     const sharedIndex = this.extractAttr(formulaElement, "si")?.asNum();
     const ref = this.extractAttr(formulaElement, "ref")?.asString();

--- a/src/xlsx/extraction/style_extractor.ts
+++ b/src/xlsx/extraction/style_extractor.ts
@@ -140,7 +140,9 @@ export class XlsxStyleExtractor extends XlsxBaseExtractor {
     theme: XLSXTheme | undefined
   ): XLSXBorderDescr | undefined {
     const directionElement = this.querySelector(borderElement, direction);
-    if (!directionElement || !directionElement.attributes["style"]) return undefined;
+    if (!directionElement || !directionElement.attributes["style"]) {
+      return undefined;
+    }
     return {
       style: this.extractAttr(directionElement, "style", {
         required: true,

--- a/src/xlsx/functions/worksheet.ts
+++ b/src/xlsx/functions/worksheet.ts
@@ -185,7 +185,9 @@ export function addMerges(merges: string[]): XMLString {
         ${joinXmlNodes(mergeNodes)}
       </mergeCells>
     `;
-  } else return escapeXml``;
+  } else {
+    return escapeXml``;
+  }
 }
 
 export function addSheetViews(sheet: ExcelSheetData) {

--- a/src/xlsx/helpers/content_helpers.ts
+++ b/src/xlsx/helpers/content_helpers.ts
@@ -75,12 +75,16 @@ export function convertWidthToExcel(width: number): number {
 }
 
 export function convertHeightFromExcel(height: number | undefined): number | undefined {
-  if (!height) return height;
+  if (!height) {
+    return height;
+  }
   return Math.round((height / HEIGHT_FACTOR) * 100) / 100;
 }
 
 export function convertWidthFromExcel(width: number | undefined): number | undefined {
-  if (!width) return width;
+  if (!width) {
+    return width;
+  }
   return Math.round((width / WIDTH_FACTOR) * 100) / 100;
 }
 

--- a/src/xlsx/xlsx_writer.ts
+++ b/src/xlsx/xlsx_writer.ts
@@ -149,10 +149,14 @@ function createWorksheets(data: ExcelWorkbookData, construct: XLSXStructure): XL
 
     for (const image of sheet.images) {
       const mimeType = image.data.mimetype;
-      if (mimeType === undefined) continue;
+      if (mimeType === undefined) {
+        continue;
+      }
       const extension = IMAGE_MIMETYPE_TO_EXTENSION_MAPPING[mimeType];
       // only support exporting images with mimetypes specified in the mapping
-      if (extension === undefined) continue;
+      if (extension === undefined) {
+        continue;
+      }
       const xlsxImageId = convertImageId(image.id);
       const imageFileName = `image${xlsxImageId}.${extension}`;
 
@@ -258,7 +262,9 @@ function createTablesForSheet(
   files: XLSXExportFile[]
 ): XMLString {
   let currentTableId = startingTableId;
-  if (!sheetData.filterTables.length) return new XMLString("");
+  if (!sheetData.filterTables.length) {
+    return new XMLString("");
+  }
 
   const sheetRelFile = `xl/worksheets/_rels/sheet${sheetId}.xml.rels`;
 

--- a/tests/__mocks__/content_editable_helper.ts
+++ b/tests/__mocks__/content_editable_helper.ts
@@ -30,7 +30,9 @@ export class ContentEditableHelper {
   selectRange(start: number, end: number) {
     this.manualRange = true;
     // We cannot set the cursor position beyond the text of the editor
-    if (!this.el || !this.el.textContent || start < 0 || end > this.el.textContent.length) return;
+    if (!this.el || !this.el.textContent || start < 0 || end > this.el.textContent.length) {
+      return;
+    }
     this.currentState.cursorStart = start;
     this.currentState.cursorEnd = end;
   }
@@ -104,7 +106,9 @@ export class ContentEditableHelper {
   }
 
   private attachEventHandlers() {
-    if (this.el === null) return;
+    if (this.el === null) {
+      return;
+    }
     this.el.addEventListener("keydown", (ev: KeyboardEvent) => this.onKeyDown(this.el!, ev));
     // @ts-ignore
     this.el.addEventListener("focus", (ev: FocusEvent) => (window.mockContentHelper = this));

--- a/tests/autofill/autofill_component.test.ts
+++ b/tests/autofill/autofill_component.test.ts
@@ -389,7 +389,9 @@ describe("Autofill edge scrolling", () => {
 });
 
 function isVisibleInViewport(element: HTMLElement | null, model: Model) {
-  if (element === null) return false;
+  if (element === null) {
+    return false;
+  }
   const activeSheetViewDimension = model.getters.getSheetViewDimensionWithHeaders();
   const top = getStylePropertyInPx(element, "top") || -Infinity;
   const left = getStylePropertyInPx(element, "left") || -Infinity;

--- a/tests/bottom_bar/bottom_bar_component.test.ts
+++ b/tests/bottom_bar/bottom_bar_component.test.ts
@@ -482,7 +482,9 @@ describe("BottomBar component", () => {
     jest
       .spyOn(Element.prototype, "clientWidth", "get")
       .mockImplementation(function (this: HTMLDivElement) {
-        if (this.classList.contains("o-sheet-list")) return 300;
+        if (this.classList.contains("o-sheet-list")) {
+          return 300;
+        }
         return 0;
       });
 
@@ -854,8 +856,11 @@ describe("BottomBar component", () => {
       mockGetBoundingClientRect({
         "o-sheet-list": () => ({ x: 0, width: 500 }),
         "o-sheet": (el: HTMLElement) => {
-          if (el.dataset.id === "Sheet1") return { x: 0, width: 100 };
-          else if (el.dataset.id === "Sheet2") return { x: 100, width: 300 };
+          if (el.dataset.id === "Sheet1") {
+            return { x: 0, width: 100 };
+          } else if (el.dataset.id === "Sheet2") {
+            return { x: 100, width: 300 };
+          }
           return { x: model.getters.getSheetIds().indexOf(el.dataset.id!) * 100 + 200, width: 100 };
         },
       });

--- a/tests/menus/context_menu_component.test.ts
+++ b/tests/menus/context_menu_component.test.ts
@@ -52,7 +52,9 @@ mockGetBoundingClientRect({
     const parentPosition = getElPosition(el.parentElement!);
     let offset = MENU_VERTICAL_PADDING;
     for (const e of el.parentElement!.children) {
-      if (e === el) break;
+      if (e === el) {
+        break;
+      }
 
       if (el.classList.contains("o-menu-item")) {
         offset += MENU_ITEM_HEIGHT;

--- a/tests/renderer_plugin.test.ts
+++ b/tests/renderer_plugin.test.ts
@@ -1630,7 +1630,9 @@ describe("renderer", () => {
     function getCellOverflowingBackgroundDims() {
       // first draw of white rectangle is the spreadsheet's background
       const instruction = fillWhiteRectInstructions[1];
-      if (!instruction) return undefined;
+      if (!instruction) {
+        return undefined;
+      }
       return {
         x: instruction[0],
         y: instruction[1],
@@ -1648,7 +1650,9 @@ describe("renderer", () => {
           drawingWhiteBackground = key === "fillStyle" && toHex(value) === "#FFFFFF";
         },
         onFunctionCall: (key, args) => {
-          if (key !== "fillRect" || !drawingWhiteBackground) return;
+          if (key !== "fillRect" || !drawingWhiteBackground) {
+            return;
+          }
           fillWhiteRectInstructions.push(args);
         },
       });

--- a/tests/test_helpers/dom_helper.ts
+++ b/tests/test_helpers/dom_helper.ts
@@ -191,7 +191,9 @@ export function triggerKeyboardEvent(
 function dispatchEvent(selector: string | EventTarget, ev: Event) {
   if (typeof selector === "string") {
     const el = document.querySelector(selector);
-    if (!el) throw new Error(`"${selector}" does not match any element.`);
+    if (!el) {
+      throw new Error(`"${selector}" does not match any element.`);
+    }
     el.dispatchEvent(ev);
   } else {
     selector.dispatchEvent(ev);
@@ -263,13 +265,17 @@ export async function focusAndKeyUp(
 
 export function getElComputedStyle(selector: string, style: string): string {
   const element = document.querySelector(selector);
-  if (!element) throw new Error(`No element matching selector "${selector}"`);
+  if (!element) {
+    throw new Error(`No element matching selector "${selector}"`);
+  }
   return window.getComputedStyle(element)[style];
 }
 
 export function getElStyle(selector: string, style: string): string {
   const element = document.querySelector<HTMLElement>(selector);
-  if (!element) throw new Error(`No element matching selector "${selector}"`);
+  if (!element) {
+    throw new Error(`No element matching selector "${selector}"`);
+  }
   return element.style[style];
 }
 
@@ -368,7 +374,9 @@ export function triggerTouchEvent(
   extra: Partial<Touch>
 ) {
   const target = typeof selector === "string" ? document.querySelector(selector) : selector;
-  if (!target) throw new Error(`"${selector}" does not match any element.`);
+  if (!target) {
+    throw new Error(`"${selector}" does not match any element.`);
+  }
 
   const ev = new TouchEvent(type, {
     cancelable: true,

--- a/tests/test_helpers/helpers.ts
+++ b/tests/test_helpers/helpers.ts
@@ -273,21 +273,27 @@ export function getGridStyle(model: Model): GridStyleDescr {
 
 export function setGrid(model: Model, grid: GridDescr) {
   for (const [xc, value] of Object.entries(grid)) {
-    if (value === undefined) continue;
+    if (value === undefined) {
+      continue;
+    }
     setCellContent(model, xc, value);
   }
 }
 
 export function setGridFormat(model: Model, grid: GridFormatDescr) {
   for (const [xc, format] of Object.entries(grid)) {
-    if (format === undefined) continue;
+    if (format === undefined) {
+      continue;
+    }
     setFormat(model, format, target(xc));
   }
 }
 
 export function setGridStyle(model: Model, grid: GridStyleDescr) {
   for (const [xc, style] of Object.entries(grid)) {
-    if (style === undefined) continue;
+    if (style === undefined) {
+      continue;
+    }
     setStyle(model, xc, style);
   }
 }
@@ -487,7 +493,9 @@ export function XCToMergeCellMap(
   for (const mergeXC of mergeXCList) {
     const { col, row } = toCartesian(mergeXC);
     const merge = model.getters.getMerge({ sheetId, col, row });
-    if (!mergeCellMap[col]) mergeCellMap[col] = [];
+    if (!mergeCellMap[col]) {
+      mergeCellMap[col] = [];
+    }
     mergeCellMap[col][row] = merge ? merge.id : undefined;
   }
   return mergeCellMap;
@@ -580,7 +588,9 @@ export async function startGridComposition(key?: string) {
  */
 export function textContentAll(cssSelector: string): string[] {
   const nodes = document.querySelectorAll(cssSelector);
-  if (!nodes) return [];
+  if (!nodes) {
+    return [];
+  }
   return [...nodes].map((node) => node.textContent).filter((text): text is string => text !== null);
 }
 
@@ -723,7 +733,9 @@ export function getFigureDefinition(
 /** Extract a property of the style of the given html element and return its size in pixel */
 export function getStylePropertyInPx(el: HTMLElement, property: string): number | undefined {
   const styleProperty = el.style[property] as string;
-  if (!styleProperty) return undefined;
+  if (!styleProperty) {
+    return undefined;
+  }
   return Number(styleProperty.replace("px", ""));
 }
 

--- a/tests/test_helpers/mock_helpers.ts
+++ b/tests/test_helpers/mock_helpers.ts
@@ -35,16 +35,24 @@ export function mockGetBoundingClientRect(
 function populateDOMRect(partialRect: Partial<DOMRect>): Partial<DOMRect> {
   const rect = { ...partialRect };
 
-  if (rect.x !== undefined && !rect.left) rect.left = rect.x;
-  if (rect.y !== undefined && !rect.top) rect.top = rect.y;
-  if (rect.width !== undefined && rect.x !== undefined && !rect.right)
+  if (rect.x !== undefined && !rect.left) {
+    rect.left = rect.x;
+  }
+  if (rect.y !== undefined && !rect.top) {
+    rect.top = rect.y;
+  }
+  if (rect.width !== undefined && rect.x !== undefined && !rect.right) {
     rect.right = rect.x + rect.width;
-  if (rect.height !== undefined && rect.y !== undefined && !rect.bottom)
+  }
+  if (rect.height !== undefined && rect.y !== undefined && !rect.bottom) {
     rect.bottom = rect.y + rect.height;
-  if (rect.left !== undefined && rect.right !== undefined && !rect.width)
+  }
+  if (rect.left !== undefined && rect.right !== undefined && !rect.width) {
     rect.width = rect.right - rect.left;
-  if (rect.top !== undefined && rect.bottom !== undefined && !rect.height)
+  }
+  if (rect.top !== undefined && rect.bottom !== undefined && !rect.height) {
     rect.height = rect.bottom - rect.top;
+  }
 
   return rect;
 }


### PR DESCRIPTION
This commit is a backport of 7c556a9166f35d8bf241949bcc7fed3a12d7a4e5

patterns like `if (foo) foo++;`, `if (foo) continue;` or `if (foo) return;` are less readable then the version with braces.

`continue` or `return` are easy to miss when it's too far right on the line after a long `if (...a long condition...)`

It also improves code style consistency across the codebase, which always improves readability.

I changed the order of eslint and prettier in the precommit hook. because eslint rewrites `if (foo) return;` to `if (foo) {return;}`, which then needs to be prettified.

I'm sorry FLDA and ADRM (but not really sorry)

Task: 0

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo