### PR TITLE
[FIX] package: add missing types dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@swc/core": "1.6.7",
         "@swc/jest": "0.2.36",
         "@types/jest": "^30.0.0",
+        "@types/jest-image-snapshot": "^6.4.1",
         "@types/node": "^20.17.24",
         "@types/rbush": "^3.0.3",
         "@typescript-eslint/eslint-plugin": "^8.30.1",
@@ -2927,6 +2928,18 @@
         "pretty-format": "^30.0.0"
       }
     },
+    "node_modules/@types/jest-image-snapshot": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@types/jest-image-snapshot/-/jest-image-snapshot-6.4.1.tgz",
+      "integrity": "sha512-pj3Sdc7Cx5mMLUttPprazSDQCur2cr512Dm38e9aAHI55LDxEhqdyqzK9myC4EmEy7sPAF2nGJ8zifX4qso7sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/jest": "*",
+        "@types/pixelmatch": "*",
+        "ssim.js": "^3.1.1"
+      }
+    },
     "node_modules/@types/jsdom": {
       "version": "21.1.7",
       "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.7.tgz",
@@ -2955,6 +2968,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/pixelmatch": {
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/@types/pixelmatch/-/pixelmatch-5.2.6.tgz",
+      "integrity": "sha512-wC83uexE5KGuUODn6zkm9gMzTwdY5L0chiK+VrKcDfEjzxh1uadlWTvOmAbCpnM9zx/Ww3f8uKlYQVnO/TrqVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/rbush": {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@swc/jest": "0.2.36",
     "@swc/core": "1.6.7",
     "@types/jest": "^30.0.0",
+    "@types/jest-image-snapshot": "^6.4.1",
     "@types/node": "^20.17.24",
     "@types/rbush": "^3.0.3",
     "@typescript-eslint/eslint-plugin": "^8.30.1",


### PR DESCRIPTION
Commit 3070d45ea666a2a28336c441f075f98d2728796d introduced `@types/jest-image-snapshot` but it was not correctly forward ported.

This commit adds the missing dependency to the package.json.

Task: 6140820

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo