### PR TITLE
[FIX] formulas: add IFERROR second argument when exporting data

### DIFF
--- a/src/xlsx/constants.ts
+++ b/src/xlsx/constants.ts
@@ -89,10 +89,10 @@ export const FIRST_NUMFMT_ID = 164;
 
 export const DEFAULT_DOUGHNUT_CHART_HOLE_SIZE = 50;
 
-interface functionDefaultArg {
+type functionDefaultArg = {
   type: "NUMBER";
   value: number;
-}
+};
 
 export const FORCE_DEFAULT_ARGS_FUNCTIONS: Record<string, functionDefaultArg[]> = {
   FLOOR: [{ type: "NUMBER", value: 1 }],
@@ -100,6 +100,7 @@ export const FORCE_DEFAULT_ARGS_FUNCTIONS: Record<string, functionDefaultArg[]> 
   ROUND: [{ type: "NUMBER", value: 0 }],
   ROUNDUP: [{ type: "NUMBER", value: 0 }],
   ROUNDDOWN: [{ type: "NUMBER", value: 0 }],
+  IFERROR: [{ type: "NUMBER", value: 0 }],
 };
 
 /**

--- a/tests/xlsx/xlsx_export.test.ts
+++ b/tests/xlsx/xlsx_export.test.ts
@@ -454,7 +454,12 @@ describe("Test XLSX export", () => {
     test("formula with dependencies", () => {
       expect(adaptFormulaToExcel("=SUM(A1, A2)")).toEqual("SUM(A1,A2)");
     });
+
+    test("formula with default arguments required by Excel", () => {
+      expect(adaptFormulaToExcel("=IFERROR(1/0)")).toEqual("IFERROR(1/0,0)");
+    });
   });
+
   describe("Generic sheets (style, hidden, size, cf)", () => {
     test("Simple model data with default style", async () => {
       const model = new Model(simpleData);


### PR DESCRIPTION
## Task Description

In our implementation of the IFERROR formula, the second argument (value if error) is optionnal, defaulting to an empty string, which results to a 0 value in the cell when evaluated. In the excel documentation, the second argument of IFERROR is required leading to issue when exporting from spreadsheet a formula with IFERROR and
then importing it to excel or Gsheet.

This PR fixes this issue by adding a second argument when needed in the exporting process.

## Related Task
- Task: [5993405](https://www.odoo.com/odoo/2328/tasks/5993405)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo