### PR TITLE
[FIX] grid overlay: unhide buttons visibility

### DIFF
--- a/src/components/headers_overlay/headers_overlay.ts
+++ b/src/components/headers_overlay/headers_overlay.ts
@@ -516,7 +516,7 @@ export class ColResizer extends AbstractResizer {
     const hiddenGroups = this.env.model.getters.getHiddenColsGroups(this.sheetId);
     const index = hiddenGroups.findIndex((group) => group[0] >= xSplit - 1);
     return {
-      headersGroups: hiddenGroups.slice(index),
+      headersGroups: index === -1 ? [] : hiddenGroups.slice(index),
       offset: this.env.model.getters.getMainViewportCoordinates().x,
       headerRange: { start: left, end: right },
     };
@@ -528,7 +528,7 @@ export class ColResizer extends AbstractResizer {
     const index = hiddenGroups.findIndex((group) => group[0] >= xSplit - 1);
 
     return {
-      headersGroups: hiddenGroups.slice(0, index + 1),
+      headersGroups: index === -1 ? hiddenGroups : hiddenGroups.slice(0, index + 1),
       headerRange: { start: 0, end: xSplit - 1 },
     };
   }
@@ -737,7 +737,7 @@ export class RowResizer extends AbstractResizer {
     const hiddenGroups = this.env.model.getters.getHiddenRowsGroups(this.sheetId);
     const index = hiddenGroups.findIndex((group) => group[0] >= ySplit - 1);
     return {
-      headersGroups: hiddenGroups.slice(index),
+      headersGroups: index === -1 ? [] : hiddenGroups.slice(index),
       offset: this.env.model.getters.getMainViewportCoordinates().y,
       headerRange: { start: top, end: bottom },
     };
@@ -749,7 +749,7 @@ export class RowResizer extends AbstractResizer {
     const index = hiddenGroups.findIndex((group) => group[0] >= ySplit - 1);
 
     return {
-      headersGroups: hiddenGroups.slice(0, index + 1),
+      headersGroups: index === -1 ? hiddenGroups : hiddenGroups.slice(0, index + 1),
       headerRange: { start: 0, end: ySplit - 1 },
     };
   }

--- a/tests/grid/grid_overlay_component.test.ts
+++ b/tests/grid/grid_overlay_component.test.ts
@@ -742,6 +742,15 @@ describe("Hide/show columns", () => {
       expect(getUnhideColumnButtons()).toHaveLength(0);
     });
 
+    test("buttons are visible if hidden columns are freezed", async () => {
+      freezeColumns(model, 5);
+      hideColumns(model, ["B", "C"]);
+      await nextTick();
+      const unhideButtons = getUnhideColumnButtons();
+      expect(unhideButtons).toHaveLength(2);
+      expect(unhideButtons.some((el) => el.classList.contains("invisible"))).toBeFalsy();
+    });
+
     test("left button is hidden if the column before the hidden group is not in the viewport", async () => {
       freezeColumns(model, 1);
       hideColumns(model, ["D"]);
@@ -862,6 +871,15 @@ describe("Hide/show rows", () => {
       setViewportOffset(model, 0, 5 * DEFAULT_CELL_HEIGHT);
       await nextTick();
       expect(getUnhideRowButtons()).toHaveLength(0);
+    });
+
+    test("buttons are visible if hidden rows are freezed", async () => {
+      freezeRows(model, 5);
+      hideRows(model, [1, 2]);
+      await nextTick();
+      const unhideButtons = getUnhideRowButtons();
+      expect(unhideButtons).toHaveLength(2);
+      expect(unhideButtons.some((el) => el.classList.contains("invisible"))).toBeFalsy();
     });
 
     test("top button is hidden if the row before the hidden group is not in the viewport", async () => {


### PR DESCRIPTION
Before this commit:
When a row/column is frozen and hidden, the unhide buttons were not visible in the header overlay. There is no way for the user to unhide these rows/columns.

After this commit:
The unhide buttons are now visible in the header overlay when a frozen row/column is hidden.

Task: [6127335](https://www.odoo.com/odoo/2328/tasks/6127335)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo