### PR TITLE
[IMP] model: allow to leave session without snapshot

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -256,8 +256,9 @@ export class Model extends EventBus<any> implements CommandDispatcher {
     this.session.join(this.config.client);
   }
 
-  async leaveSession() {
-    const snapshot = this.getters.isReadonly() ? undefined : lazy(() => this.exportData());
+  async leaveSession({ shouldSnapshot }: { shouldSnapshot?: boolean } = { shouldSnapshot: true }) {
+    const snapshot =
+      shouldSnapshot && !this.getters.isReadonly() ? lazy(() => this.exportData()) : undefined;
     await this.session.leave(snapshot);
   }
 

--- a/tests/model/model.test.ts
+++ b/tests/model/model.test.ts
@@ -398,4 +398,18 @@ describe("Model", () => {
     });
     expect(messages.map((m) => m.type)).not.toContain("SNAPSHOT_CREATED");
   });
+
+  test("it should not snapshot when the session is left is shouldSnapshot false", async () => {
+    const transport = new MockTransportService();
+    const spy = jest.spyOn(transport, "sendMessage");
+    const xlsxData = await getTextXlsxFiles();
+    const model = new Model(xlsxData, {
+      transportService: transport,
+      client: { id: "test", name: "Test" },
+    });
+    await model.leaveSession({ shouldSnapshot: false });
+    expect(spy).not.toHaveBeenCalledWith({
+      type: "SNAPSHOT",
+    });
+  });
 });


### PR DESCRIPTION
Task: 6121503

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo