### PR TITLE
[FIX] *: Fix auto-import issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@odoo/o-spreadsheet",
-  "version": "19.4.0-alpha.2",
+  "version": "19.3.0-alpha.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@odoo/o-spreadsheet",
-      "version": "19.4.0-alpha.2",
+      "version": "19.3.0-alpha.11",
       "license": "LGPL-3.0-or-later",
       "dependencies": {
         "@odoo/owl": "2.8.3",
@@ -19,7 +19,6 @@
         "@swc/core": "1.6.7",
         "@swc/jest": "0.2.36",
         "@types/jest": "^30.0.0",
-        "@types/jest-image-snapshot": "^6.4.1",
         "@types/node": "^20.17.24",
         "@types/rbush": "^3.0.3",
         "@typescript-eslint/eslint-plugin": "^8.30.1",
@@ -3413,18 +3412,6 @@
         "pretty-format": "^30.0.0"
       }
     },
-    "node_modules/@types/jest-image-snapshot": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/@types/jest-image-snapshot/-/jest-image-snapshot-6.4.1.tgz",
-      "integrity": "sha512-pj3Sdc7Cx5mMLUttPprazSDQCur2cr512Dm38e9aAHI55LDxEhqdyqzK9myC4EmEy7sPAF2nGJ8zifX4qso7sQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/jest": "*",
-        "@types/pixelmatch": "*",
-        "ssim.js": "^3.1.1"
-      }
-    },
     "node_modules/@types/jsdom": {
       "version": "21.1.7",
       "dev": true,
@@ -3451,16 +3438,6 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
-      }
-    },
-    "node_modules/@types/pixelmatch": {
-      "version": "5.2.6",
-      "resolved": "https://registry.npmjs.org/@types/pixelmatch/-/pixelmatch-5.2.6.tgz",
-      "integrity": "sha512-wC83uexE5KGuUODn6zkm9gMzTwdY5L0chiK+VrKcDfEjzxh1uadlWTvOmAbCpnM9zx/Ww3f8uKlYQVnO/TrqVg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/@types/rbush": {

--- a/src/components/figures/chart/chartJs/chartjs_colorscale_plugin.ts
+++ b/src/components/figures/chart/chartJs/chartjs_colorscale_plugin.ts
@@ -1,5 +1,4 @@
 import { ChartType, Plugin } from "chart.js";
-import { Color, Locale } from "../../../..";
 import {
   CHART_AXIS_TITLE_FONT_SIZE,
   CHART_COLORSCALE_WIDTH,
@@ -7,6 +6,8 @@ import {
 } from "../../../../constants";
 import { humanizeNumber } from "../../../../helpers/format/format";
 import { getDefaultContextFont } from "../../../../helpers/text_helper";
+import { Locale } from "../../../../types/locale";
+import { Color } from "../../../../types/misc";
 
 export interface ChartColorScalePluginOptions {
   position: "left" | "right" | "none";

--- a/src/components/figures/chart/chartJs/chartjs_minor_grid_plugin.ts
+++ b/src/components/figures/chart/chartJs/chartjs_minor_grid_plugin.ts
@@ -1,5 +1,5 @@
 import type { Chart } from "chart.js";
-import { Color } from "../../../..";
+import { Color } from "../../../../types/misc";
 
 interface MinorGridOptions {
   display?: boolean;

--- a/src/components/figures/chart/chartJs/zoomable_chart/zoomable_chart_store.ts
+++ b/src/components/figures/chart/chartJs/zoomable_chart/zoomable_chart_store.ts
@@ -1,9 +1,10 @@
-import { Command, UID } from "../../../../..";
 import {
   MOVING_AVERAGE_TREND_LINE_XAXIS_ID,
   TREND_LINE_XAXIS_ID,
 } from "../../../../../helpers/figures/charts/chart_common";
 import { SpreadsheetStore } from "../../../../../stores/spreadsheet_store";
+import { Command } from "../../../../../types/commands";
+import { UID } from "../../../../../types/misc";
 
 const TREND_LINE_AXES_IDS = [TREND_LINE_XAXIS_ID, MOVING_AVERAGE_TREND_LINE_XAXIS_ID] as const;
 const ZOOMABLE_AXIS_IDS = ["x", ...TREND_LINE_AXES_IDS] as const;

--- a/src/components/helpers/zoom.ts
+++ b/src/components/helpers/zoom.ts
@@ -1,4 +1,5 @@
-import { DOMCoordinates, Pixel, Rect } from "../..";
+import { Pixel } from "../../types/misc";
+import { DOMCoordinates, Rect } from "../../types/rendering";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 import { zoomCorrectedElementRect } from "./dom_helpers";
 

--- a/src/components/pivot_html_renderer/pivot_html_renderer.ts
+++ b/src/components/pivot_html_renderer/pivot_html_renderer.ts
@@ -1,8 +1,9 @@
 import { Component, useState } from "@odoo/owl";
-import { FunctionResultObject, Maybe, SpreadsheetPivotTable, UID } from "../..";
 import { toString } from "../../functions/helpers";
 import { formatValue } from "../../helpers/format/format";
 import { generatePivotArgs } from "../../helpers/pivot/pivot_helpers";
+import { SpreadsheetPivotTable } from "../../helpers/pivot/table_spreadsheet_pivot";
+import { FunctionResultObject, Maybe, UID } from "../../types/misc";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 import { Checkbox } from "../side_panel/components/checkbox/checkbox";
 

--- a/src/components/side_panel/chart/building_blocks/generic_side_panel/config_panel.ts
+++ b/src/components/side_panel/chart/building_blocks/generic_side_panel/config_panel.ts
@@ -1,5 +1,5 @@
 import { Component, useState } from "@odoo/owl";
-import { ChartDefinitionWithDataSource } from "../../../../..";
+import { ChartDefinitionWithDataSource } from "../../../../../types/chart/chart";
 import { SpreadsheetChildEnv } from "../../../../../types/spreadsheet_env";
 import { ChartTerms } from "../../../../translations_terms";
 import { Checkbox } from "../../../components/checkbox/checkbox";

--- a/src/components/side_panel/chart/calendar_chart/calendar_chart_config_panel.ts
+++ b/src/components/side_panel/chart/calendar_chart/calendar_chart_config_panel.ts
@@ -1,4 +1,3 @@
-import { ChartRangeDataSource } from "../../../..";
 import { toJsDate } from "../../../../functions/helpers";
 import { isDateTime } from "../../../../helpers/dates";
 import { SpreadsheetChart } from "../../../../helpers/figures/chart";
@@ -10,6 +9,7 @@ import {
   CalendarChartDefinition,
   CalendarChartGranularity,
 } from "../../../../types/chart/calendar_chart";
+import { ChartRangeDataSource } from "../../../../types/chart/chart";
 import { DEFAULT_LOCALE } from "../../../../types/locale";
 import { ValueAndLabel } from "../../../../types/misc";
 import { Select } from "../../../select/select";

--- a/src/components/side_panel/chart/combo_chart/combo_chart_design_panel.ts
+++ b/src/components/side_panel/chart/combo_chart/combo_chart_design_panel.ts
@@ -1,6 +1,7 @@
-import { CustomizableSeriesChartRuntime, UID } from "../../../..";
 import { _t } from "../../../../translation";
+import { CustomizableSeriesChartRuntime } from "../../../../types/chart/chart";
 import { ComboChartDefinition } from "../../../../types/chart/combo_chart";
+import { UID } from "../../../../types/misc";
 import { RadioSelection } from "../../components/radio_selection/radio_selection";
 import { ChartShowDataMarkers } from "../building_blocks/show_data_markers/show_data_markers";
 import { ChartSidePanelProps } from "../common";

--- a/src/components/side_panel/chart/common.ts
+++ b/src/components/side_panel/chart/common.ts
@@ -1,4 +1,6 @@
-import { ChartDefinition, DispatchResult, UID } from "../../..";
+import { ChartDefinition } from "../../../types/chart/chart";
+import { DispatchResult } from "../../../types/commands";
+import { UID } from "../../../types/misc";
 
 export interface ChartSidePanelProps<T extends ChartDefinition<string>> {
   chartId: UID;

--- a/src/components/side_panel/chart/treemap_chart/treemap_category_color/treemap_category_color.ts
+++ b/src/components/side_panel/chart/treemap_chart/treemap_category_color/treemap_category_color.ts
@@ -1,6 +1,5 @@
 import { Component } from "@odoo/owl";
 import { ChartConfiguration } from "chart.js";
-import { DeepPartial, DispatchResult, UID } from "../../../../..";
 import { deepCopy } from "../../../../../helpers/misc";
 import {
   TreeMapCategoryColorOptions,
@@ -9,6 +8,8 @@ import {
   TreeMapChartRuntime,
   TreeMapGroupColor,
 } from "../../../../../types/chart/tree_map_chart";
+import { DispatchResult } from "../../../../../types/commands";
+import { DeepPartial, UID } from "../../../../../types/misc";
 import { SpreadsheetChildEnv } from "../../../../../types/spreadsheet_env";
 import { Checkbox } from "../../../components/checkbox/checkbox";
 import { RoundColorPicker } from "../../../components/round_color_picker/round_color_picker";

--- a/src/components/side_panel/chart/treemap_chart/treemap_color_scale/treemap_color_scale.ts
+++ b/src/components/side_panel/chart/treemap_chart/treemap_color_scale/treemap_color_scale.ts
@@ -1,10 +1,11 @@
 import { Component } from "@odoo/owl";
-import { DispatchResult, UID } from "../../../../..";
 import {
   TreeMapChartDefaults,
   TreeMapChartDefinition,
   TreeMapColorScaleOptions,
 } from "../../../../../types/chart/tree_map_chart";
+import { DispatchResult } from "../../../../../types/commands";
+import { UID } from "../../../../../types/misc";
 import { SpreadsheetChildEnv } from "../../../../../types/spreadsheet_env";
 import { RoundColorPicker } from "../../../components/round_color_picker/round_color_picker";
 

--- a/src/components/side_panel/pivot/pivot_measure_display_panel/pivot_measure_display_panel.ts
+++ b/src/components/side_panel/pivot/pivot_measure_display_panel/pivot_measure_display_panel.ts
@@ -1,6 +1,7 @@
 import { Component } from "@odoo/owl";
-import { PivotCoreMeasure, UID, ValueAndLabel } from "../../../..";
 import { useLocalStore } from "../../../../store_engine/store_hooks";
+import { UID, ValueAndLabel } from "../../../../types/misc";
+import { PivotCoreMeasure } from "../../../../types/pivot";
 import { SpreadsheetChildEnv } from "../../../../types/spreadsheet_env";
 import { Store } from "../../../../types/store_engine";
 import { Select } from "../../../select/select";

--- a/src/components/tables/table_style_preview/table_canvas_helpers.ts
+++ b/src/components/tables/table_style_preview/table_canvas_helpers.ts
@@ -1,4 +1,4 @@
-import { Pixel } from "../../..";
+import { Pixel } from "../../../types/misc";
 import { ComputedTableStyle, TableMetaData } from "../../../types/table";
 
 interface DrawTableParams extends TableMetaData {

--- a/src/helpers/figures/chart.ts
+++ b/src/helpers/figures/chart.ts
@@ -1,4 +1,3 @@
-import { RangeAdapterFunctions, UID } from "../..";
 import {
   ChartDataSourceBuilder,
   chartDataSourceRegistry,
@@ -13,6 +12,7 @@ import {
 } from "../../types/chart/chart";
 import { CoreGetters } from "../../types/core_getters";
 import { Getters } from "../../types/getters";
+import { RangeAdapterFunctions, UID } from "../../types/misc";
 import { Range } from "../../types/range";
 import { Validator } from "../../types/validator";
 

--- a/src/helpers/figures/charts/chart_ui_common.ts
+++ b/src/helpers/figures/charts/chart_ui_common.ts
@@ -1,9 +1,9 @@
 import { ChartConfiguration, ChartOptions } from "chart.js";
-import { DOMDimension } from "../../..";
 import { ChartRuntime, ChartType } from "../../../types/chart/chart";
 import { GaugeChartRuntime } from "../../../types/chart/gauge_chart";
 import { ScorecardChartRuntime } from "../../../types/chart/scorecard_chart";
 import { Figure } from "../../../types/figure";
+import { DOMDimension } from "../../../types/rendering";
 import { deepCopy } from "../../misc";
 import {
   areChartJSExtensionsLoaded,

--- a/src/helpers/pivot/pivot_menu_items.ts
+++ b/src/helpers/pivot/pivot_menu_items.ts
@@ -1,7 +1,9 @@
+import { ActionSpec } from "../../actions/action";
+import { _t } from "../../translation";
+import { CellValue, CellValueType } from "../../types/cells";
+import { Getters } from "../../types/getters";
+import { CellPosition, SortDirection, UID } from "../../types/misc";
 import {
-  CellPosition,
-  CellValue,
-  Getters,
   PivotCoreDefinition,
   PivotCustomGroup,
   PivotCustomGroupedField,
@@ -9,12 +11,7 @@ import {
   PivotField,
   PivotFields,
   PivotHeaderCell,
-  SortDirection,
-  UID,
-} from "../..";
-import { ActionSpec } from "../../actions/action";
-import { _t } from "../../translation";
-import { CellValueType } from "../../types/cells";
+} from "../../types/pivot";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 import { deepCopy, deepEquals } from "../misc";
 import { cellPositions } from "../zones";

--- a/src/plugins/ui_core_views/cell_evaluation/evaluation_plugin.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluation_plugin.ts
@@ -1,4 +1,3 @@
-import { PerfProfile } from "../../..";
 import { CompiledFormula } from "../../../formulas/compiler";
 import { matrixMap } from "../../../functions/helpers";
 import { toXC } from "../../../helpers/coordinates";
@@ -13,6 +12,7 @@ import {
 } from "../../../types/commands";
 import { CellErrorType } from "../../../types/errors";
 import { Format } from "../../../types/format";
+import { PerfProfile } from "../../../types/functions";
 import {
   CellPosition,
   FunctionResultObject,

--- a/src/plugins/ui_core_views/cell_evaluation/formula_dependency_graph.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/formula_dependency_graph.ts
@@ -1,5 +1,5 @@
-import { CellPosition, HeaderIndex, UID } from "../../..";
 import { positionToZone } from "../../../helpers/zones";
+import { CellPosition, HeaderIndex, UID } from "../../../types/misc";
 import { BoundedRange, Range } from "../../../types/range";
 import { IntervalTree } from "./interval_tree";
 import { RangeSet } from "./range_set";

--- a/src/plugins/ui_core_views/cell_evaluation/range_set.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/range_set.ts
@@ -1,5 +1,5 @@
-import { CellPosition, UID } from "../../..";
 import { positionToBoundedRange } from "../../../helpers/range";
+import { CellPosition, UID } from "../../../types/misc";
 import { BoundedRange } from "../../../types/range";
 import { ZoneSet } from "./zone_set";
 

--- a/src/plugins/ui_core_views/cell_evaluation/zone_set.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/zone_set.ts
@@ -1,9 +1,9 @@
-import { UnboundedZone, Zone } from "../../..";
 import {
   constructZonesFromProfiles,
   modifyProfiles,
   profilesContainsZone,
 } from "../../../helpers/recompute_zones";
+import { UnboundedZone, Zone } from "../../../types/misc";
 
 export class ZoneSet {
   private profilesStartingPosition: number[] = [0];

--- a/src/plugins/ui_core_views/dynamic_tables.ts
+++ b/src/plugins/ui_core_views/dynamic_tables.ts
@@ -1,4 +1,3 @@
-import { CellPosition, FilterId, TableId, UID, Zone } from "../..";
 import { toXC } from "../../helpers/coordinates";
 import { getItemId } from "../../helpers/data_normalization";
 import { deepEquals, isObjectEmptyRecursive } from "../../helpers/misc";
@@ -15,6 +14,7 @@ import {
 } from "../../helpers/zones";
 import { Command, invalidateEvaluationCommands } from "../../types/commands";
 import { CellErrorType } from "../../types/errors";
+import { CellPosition, FilterId, TableId, UID, Zone } from "../../types/misc";
 import { PivotStyle } from "../../types/pivot";
 import { CoreTable, DynamicTable, Filter, Table, TableConfig } from "../../types/table";
 import { ExcelTableData, ExcelWorkbookData } from "../../types/workbook_data";

--- a/src/plugins/ui_core_views/fingerprint.ts
+++ b/src/plugins/ui_core_views/fingerprint.ts
@@ -1,7 +1,7 @@
-import { CellPosition } from "../..";
 import { isFullColRange, isFullRowRange } from "../../helpers/range";
 import { reorderZone } from "../../helpers/zones";
 import { Cell, CellValueType, FormulaCell } from "../../types/cells";
+import { CellPosition } from "../../types/misc";
 import { CoreViewPlugin } from "../core_view_plugin";
 
 /**

--- a/src/plugins/ui_feature/color_theme.ts
+++ b/src/plugins/ui_feature/color_theme.ts
@@ -1,6 +1,6 @@
-import { GridRenderingTheme } from "../..";
 import { adaptForDarkMode } from "../../helpers/color";
 import { Command } from "../../types/commands";
+import { GridRenderingTheme } from "../../types/rendering";
 import { UIPlugin, UIPluginConfig } from "../ui_plugin";
 
 const FROZEN_PANE_HEADER_BORDER_COLOR = "#BCBCBC";

--- a/src/types/chart/calendar_chart.ts
+++ b/src/types/chart/calendar_chart.ts
@@ -1,8 +1,8 @@
 import { ChartConfiguration } from "chart.js";
-import { ChartColorScale } from "../..";
 import { Color } from "../misc";
 import { Granularity } from "../pivot";
 import { Range } from "../range";
+import { ChartColorScale } from "./chart";
 import { CommonChartDefinition } from "./common_chart";
 
 export const CALENDAR_CHART_GRANULARITIES = [

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -20,5 +20,6 @@
     "noImplicitAny": false,
     "strict": false
   },
-  "include": ["src"]
+  "include": ["src"],
+  "autoImportFileExcludePatterns": ["src/index.ts"]
 }


### PR DESCRIPTION
With the removal of several index files, the typescript engine tends to suggest imports from the root file of the project "src/index.ts" which unfortunately increases the risks of circular dependencies.

This revision tweaks the TS server configuration to ignore that file from the autoImport tree. It also removes the current references to that file to prevent future potential circular dependencies issues.

Task: 0

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo