### PR TITLE
[FIX] Pivots: cache `getPivotIdFromPosition` for performance

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -136,6 +136,7 @@ import { PivotMeasureDisplayPanelStore } from "./components/side_panel/pivot/piv
 import { HoveredTableStore } from "./components/tables/hovered_table_store";
 import { TextInput } from "./components/text_input/text_input";
 import { ChartTerms } from "./components/translations_terms";
+import { PositionMap } from "./helpers/cells/position_map";
 import * as CHART_HELPERS from "./helpers/figures/charts";
 import * as CHART_RUNTIME_HELPERS from "./helpers/figures/charts/runtime";
 import {
@@ -372,6 +373,7 @@ export const helpers = {
   isNumber,
   isDateTime,
   createCustomFields,
+  PositionMap,
 };
 
 export const links = {

--- a/src/plugins/ui_core_views/pivot_ui.ts
+++ b/src/plugins/ui_core_views/pivot_ui.ts
@@ -3,6 +3,7 @@ import { astToFormula } from "../../formulas/formula_formatter";
 import { toScalar } from "../../functions/helper_matrices";
 import { toBoolean } from "../../functions/helpers";
 import { deepCopy, deepEquals, getUniqueText, isDefined } from "../../helpers";
+import { PositionMap } from "../../helpers/cells/position_map";
 import {
   getNumberOfPivotFunctions,
   getPivotFunctions,
@@ -62,6 +63,8 @@ export class PivotUIPlugin extends CoreViewPlugin {
   private pivots: Record<UID, Pivot> = {};
   private unusedPivots?: UID[];
   private custom: UIPluginConfig["custom"];
+  private pivotPositionCache: PositionMap<UID[]> = new PositionMap();
+  private shouldInvalidateCache: boolean = false;
 
   constructor(config: CoreViewPluginConfig) {
     super(config);
@@ -79,9 +82,13 @@ export class PivotUIPlugin extends CoreViewPlugin {
 
   handle(cmd: Command) {
     if (invalidateEvaluationCommands.has(cmd.type)) {
+      this.shouldInvalidateCache = true;
       for (const pivotId of this.getters.getPivotIds()) {
         this.setupPivot(pivotId, { recreate: true });
       }
+    }
+    if (cmd.type === "UPDATE_CELL") {
+      this.shouldInvalidateCache = true;
     }
     switch (cmd.type) {
       case "REFRESH_PIVOT":
@@ -131,6 +138,13 @@ export class PivotUIPlugin extends CoreViewPlugin {
     }
   }
 
+  finalize() {
+    if (this.shouldInvalidateCache) {
+      this.pivotPositionCache = new PositionMap();
+      this.shouldInvalidateCache = false;
+    }
+  }
+
   // ---------------------------------------------------------------------
   // Getters
   // ---------------------------------------------------------------------
@@ -147,11 +161,14 @@ export class PivotUIPlugin extends CoreViewPlugin {
    * Get all of the ids of the pivot present in the formula at the given position.
    */
   getPivotIdsFromPosition(position: CellPosition): UID[] {
-    const cell = this.getters.getCorrespondingFormulaCell(position);
-    if (cell && cell.isFormula) {
-      return this.getPivotIdsFromFormula(position.sheetId, cell.compiledFormula);
+    if (!this.pivotPositionCache.has(position)) {
+      const cell = this.getters.getCorrespondingFormulaCell(position);
+      if (cell && cell.isFormula) {
+        const pivotIds = this.getPivotIdsFromFormula(position.sheetId, cell.compiledFormula);
+        this.pivotPositionCache.set(position, pivotIds);
+      }
     }
-    return [];
+    return this.pivotPositionCache.get(position) || [];
   }
 
   private getPivotIdsFromFormula(sheetId: UID, formula: RangeCompiledFormula): UID[] {


### PR DESCRIPTION
the getter `getPivotIdFromPosition` can be heavily called, notably when a pivot sidepanel is open. This can become costy as we parse the tokens every time to find PIVOT functions.

This revision caches the values, which are only invalidated when a cell content is altered.

Task: 6159213

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo