### PR TITLE
[IMP] link: change shortcut

### DIFF
--- a/src/actions/insert_actions.ts
+++ b/src/actions/insert_actions.ts
@@ -285,7 +285,7 @@ export const categoriesFunctionListMenuBuilder: ActionBuilder = () => {
 
 export const insertLink: ActionSpec = {
   name: _t("Link"),
-  description: "Ctrl+K",
+  description: "Ctrl+Shift+K",
   execute: ACTIONS.INSERT_LINK,
   icon: "o-spreadsheet-Icon.INSERT_LINK",
 };

--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -436,7 +436,7 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
     },
     PageDown: () => this.env.model.dispatch("SHIFT_VIEWPORT_DOWN"),
     PageUp: () => this.env.model.dispatch("SHIFT_VIEWPORT_UP"),
-    "Ctrl+K": () => {
+    "Ctrl+Shift+K": () => {
       this.closeMenu();
       INSERT_LINK(this.env);
     },

--- a/tests/grid/grid_component.test.ts
+++ b/tests/grid/grid_component.test.ts
@@ -1028,7 +1028,7 @@ describe("Grid component", () => {
     });
 
     test("pressing Ctrl+K opens the link editor", async () => {
-      await keyDown({ key: "k", ctrlKey: true });
+      await keyDown({ key: "k", shiftKey: true, ctrlKey: true });
       expect(fixture.querySelector(".o-link-editor")).not.toBeNull();
     });
 

--- a/tests/menus/__snapshots__/context_menu_component.test.ts.snap
+++ b/tests/menus/__snapshots__/context_menu_component.test.ts.snap
@@ -451,7 +451,7 @@ exports[`Context MenuPopover integration tests context menu simple rendering 1`]
       <div
         class="o-menu-item-description ms-auto text-truncate"
       >
-        Ctrl+K
+        Ctrl+Shift+K
       </div>
       
       


### PR DESCRIPTION
In odoo Ctrl+K is already used for the command palette in spreadsheet

Task: 6179942

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [6179942](https://www.odoo.com/odoo/2328/tasks/6179942)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo