### PR TITLE
[FIX] chart: cannot change chart type with gauge/scorecard

### DIFF
--- a/src/components/side_panel/chart/chart_type_picker/chart_type_picker.ts
+++ b/src/components/side_panel/chart/chart_type_picker/chart_type_picker.ts
@@ -1,10 +1,12 @@
 import { Component, useExternalListener, useRef, useState } from "@odoo/owl";
+import { chartDataSourceRegistry } from "../../../../registries/chart_data_source_registry";
 import { chartSubtypeRegistry } from "../../../../registries/chart_subtype_registry";
+import { CHART_TYPES, ChartDefinition, ChartType } from "../../../../types/chart/chart";
 import {
   chartCategories,
   ChartSubtypeProperties,
 } from "../../../../types/chart_subtype_properties";
-import { ChartDefinition, ChartType, UID } from "../../../../types/index";
+import { UID } from "../../../../types/index";
 import { SpreadsheetChildEnv } from "../../../../types/spreadsheet_env";
 import { cssPropertiesToCss } from "../../../helpers/css";
 import { isChildEvent } from "../../../helpers/dom_helpers";
@@ -37,8 +39,9 @@ export class ChartTypePicker extends Component<Props, SpreadsheetChildEnv> {
 
   setup(): void {
     useExternalListener(window, "pointerdown", this.onExternalClick, { capture: true });
-    const chart = this.env.model.getters.getChart(this.props.chartId);
-    const supportedTypes = chart?.getSupportedChartTypes() ?? new Set<ChartType>();
+
+    const definition = this.env.model.getters.getChartDefinition(this.props.chartId);
+    const supportedTypes = this.getSupportedChartTypes(definition);
 
     for (const subtypeProperties of chartSubtypeRegistry.getAll()) {
       if (!supportedTypes.has(subtypeProperties.chartType)) {
@@ -50,6 +53,24 @@ export class ChartTypePicker extends Component<Props, SpreadsheetChildEnv> {
         this.chartTypeByCategories[subtypeProperties.category] = [subtypeProperties];
       }
     }
+  }
+
+  private getSupportedChartTypes(definition: ChartDefinition): Set<ChartType> {
+    let supportedTypes: Set<ChartType>;
+
+    if (definition.dataSource) {
+      const dataSourceBuilder = chartDataSourceRegistry.get(definition.dataSource.type);
+      supportedTypes = new Set(dataSourceBuilder.supportedChartTypes);
+    } else if (
+      !definition.dataSource &&
+      (definition.type === "scorecard" || definition.type === "gauge")
+    ) {
+      // Scorecard and gauge don't have a data source but can still be converted to other types of charts
+      supportedTypes = new Set(CHART_TYPES);
+    } else {
+      throw new Error("Missing chart data source for a chart type that requires it");
+    }
+    return supportedTypes;
   }
 
   onExternalClick(ev: MouseEvent) {

--- a/src/helpers/figures/chart.ts
+++ b/src/helpers/figures/chart.ts
@@ -90,10 +90,6 @@ export class SpreadsheetChart {
     } as ChartDefinition<string>;
   }
 
-  getSupportedChartTypes(): Set<ChartType> {
-    return new Set(this.dataSourceBuilder.supportedChartTypes);
-  }
-
   getRangeDefinition(): ChartDefinition<Range> {
     return {
       ...this.definition,

--- a/tests/figures/chart/charts_component.test.ts
+++ b/tests/figures/chart/charts_component.test.ts
@@ -3312,4 +3312,12 @@ describe("Change chart type", () => {
     expect(model.getters.getChartDefinition(chartId)).toMatchObject({ fillArea: false });
     expect(select.textContent).toBe("Radar");
   });
+
+  test("Can change chart type from a gauge chart to a bar chart", async () => {
+    createGaugeChart(model, {}, chartId);
+    await mountChartSidePanel(chartId);
+
+    await changeChartType("bar");
+    expect(model.getters.getChartDefinition(chartId)).toMatchObject({ type: "bar" });
+  });
 });


### PR DESCRIPTION
## Description

The chart type picker was using `chart.getSupportedChartTypes()` to check which charts the current chart can switch to. But this didn't work for gauge/scorecards, as they don't have a dataSource and `getSupportedChartTypes` would return an empty set.

Note: In master we should improve the architecture so this type of issue do not happens again. Either the gauge/scorecards should not have a dataSource key, and calls to that should crash, or they should use a functional dataSource.

Task: [6179286](https://www.odoo.com/odoo/2328/tasks/6179286)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo