### PR TITLE
[FIX] pivot: fix design panel layout

### DIFF
--- a/src/components/side_panel/pivot/pivot_side_panel/pivot_design_panel/pivot_design_panel.xml
+++ b/src/components/side_panel/pivot/pivot_side_panel/pivot_design_panel/pivot_design_panel.xml
@@ -1,103 +1,105 @@
 <templates>
   <t t-name="o-spreadsheet-PivotDesignPanel">
-    <Section class="'o-pivot-design h-100 overflow-y-auto'" title.translate="Display options">
-      <div>
-        <div class="container-fluid p-0 pt-2">
-          <div class="row mb-2 align-items-center">
-            <div class="col-6">Max rows:</div>
-            <div class="col-6 d-flex align-items-center">
-              <NumberInput
-                value="pivotStyle.numberOfRows ?? ''"
-                class="'o-pivot-n-of-rows'"
-                placeholder.translate="e.g. 10"
-                onChange="(value) => this.updatePivotStyleNumberProperty(value, 'numberOfRows')"
-              />
+    <div class="h-100 overflow-y-auto">
+      <Section class="'o-pivot-design'" title.translate="Display options">
+        <div>
+          <div class="container-fluid p-0 pt-2">
+            <div class="row mb-2 align-items-center">
+              <div class="col-6">Max rows:</div>
+              <div class="col-6 d-flex align-items-center">
+                <NumberInput
+                  value="pivotStyle.numberOfRows ?? ''"
+                  class="'o-pivot-n-of-rows'"
+                  placeholder.translate="e.g. 10"
+                  onChange="(value) => this.updatePivotStyleNumberProperty(value, 'numberOfRows')"
+                />
+              </div>
             </div>
-          </div>
-          <div class="row mb-2 align-items-center">
-            <div class="col-6">Max columns:</div>
-            <div class="col-6 d-flex align-items-center">
-              <NumberInput
-                value="pivotStyle.numberOfColumns ?? ''"
-                class="'o-pivot-n-of-columns'"
-                placeholder.translate="e.g. 5"
-                onChange="(value) => this.updatePivotStyleNumberProperty(value, 'numberOfColumns')"
-              />
+            <div class="row mb-2 align-items-center">
+              <div class="col-6">Max columns:</div>
+              <div class="col-6 d-flex align-items-center">
+                <NumberInput
+                  value="pivotStyle.numberOfColumns ?? ''"
+                  class="'o-pivot-n-of-columns'"
+                  placeholder.translate="e.g. 5"
+                  onChange="(value) => this.updatePivotStyleNumberProperty(value, 'numberOfColumns')"
+                />
+              </div>
             </div>
-          </div>
-          <div class="row mb-2 align-items-center">
-            <div class="col-6">Show totals:</div>
-            <div class="col-6 d-flex align-items-center">
-              <Checkbox
-                name="'displayTotals'"
-                value="pivotStyle.displayTotals ?? defaultStyle.displayTotals"
-                onChange="(val) => this.updatePivotStyleProperty('displayTotals', val)"
-              />
+            <div class="row mb-2 align-items-center">
+              <div class="col-6">Show totals:</div>
+              <div class="col-6 d-flex align-items-center">
+                <Checkbox
+                  name="'displayTotals'"
+                  value="pivotStyle.displayTotals ?? defaultStyle.displayTotals"
+                  onChange="(val) => this.updatePivotStyleProperty('displayTotals', val)"
+                />
+              </div>
             </div>
-          </div>
-          <div class="row mb-2 align-items-center">
-            <div class="col-6">Show column titles:</div>
-            <div class="col-6 d-flex align-items-center">
-              <Checkbox
-                name="'displayColumnHeaders'"
-                value="pivotStyle.displayColumnHeaders ?? defaultStyle.displayColumnHeaders"
-                onChange="(val) => this.updatePivotStyleProperty('displayColumnHeaders', val)"
-              />
+            <div class="row mb-2 align-items-center">
+              <div class="col-6">Show column titles:</div>
+              <div class="col-6 d-flex align-items-center">
+                <Checkbox
+                  name="'displayColumnHeaders'"
+                  value="pivotStyle.displayColumnHeaders ?? defaultStyle.displayColumnHeaders"
+                  onChange="(val) => this.updatePivotStyleProperty('displayColumnHeaders', val)"
+                />
+              </div>
             </div>
-          </div>
-          <div class="row mb-2 align-items-center">
-            <div class="col-6">Show measure titles:</div>
-            <div class="col-6 d-flex align-items-center">
-              <Checkbox
-                name="'displayMeasuresRow'"
-                value="pivotStyle.displayMeasuresRow ?? defaultStyle.displayMeasuresRow"
-                onChange="(val) => this.updatePivotStyleProperty('displayMeasuresRow', val)"
-              />
+            <div class="row mb-2 align-items-center">
+              <div class="col-6">Show measure titles:</div>
+              <div class="col-6 d-flex align-items-center">
+                <Checkbox
+                  name="'displayMeasuresRow'"
+                  value="pivotStyle.displayMeasuresRow ?? defaultStyle.displayMeasuresRow"
+                  onChange="(val) => this.updatePivotStyleProperty('displayMeasuresRow', val)"
+                />
+              </div>
             </div>
           </div>
         </div>
-      </div>
-    </Section>
+      </Section>
 
-    <Section class="'o-pivot-table-style'" title.translate="Pivot table style">
-      <div class="row mb-2 align-items-center pt-2">
-        <div class="col-6">Banded rows:</div>
-        <div class="col-6 d-flex align-items-center">
-          <Checkbox
-            name="'bandedRows'"
-            value="pivotStyle.bandedRows ?? defaultStyle.bandedRows"
-            onChange="(val) => this.updatePivotStyleProperty('bandedRows', val)"
+      <Section class="'o-pivot-table-style'" title.translate="Pivot table style">
+        <div class="row mb-2 align-items-center pt-2">
+          <div class="col-6">Banded rows:</div>
+          <div class="col-6 d-flex align-items-center">
+            <Checkbox
+              name="'bandedRows'"
+              value="pivotStyle.bandedRows ?? defaultStyle.bandedRows"
+              onChange="(val) => this.updatePivotStyleProperty('bandedRows', val)"
+            />
+          </div>
+        </div>
+        <div class="row mb-2 align-items-center">
+          <div class="col-6">Banded columns</div>
+          <div class="col-6 d-flex align-items-center">
+            <Checkbox
+              name="'bandedColumns'"
+              value="pivotStyle.bandedColumns ?? defaultStyle.bandedColumns"
+              onChange="(val) => this.updatePivotStyleProperty('bandedColumns', val)"
+            />
+          </div>
+        </div>
+        <div class="row mb-2 align-items-center">
+          <div class="col-6">Filter button</div>
+          <div class="col-6 d-flex align-items-center">
+            <Checkbox
+              name="'hasFilters'"
+              value="pivotStyle.hasFilters ?? defaultStyle.hasFilters"
+              onChange="(val) => this.updatePivotStyleProperty('hasFilters', val)"
+            />
+          </div>
+        </div>
+        <div class="mt-4">
+          <TableStylePicker
+            tableConfig="tableConfig"
+            onStylePicked.bind="onStylePicked"
+            tableStyles="tableStyles"
+            type="'pivot'"
           />
         </div>
-      </div>
-      <div class="row mb-2 align-items-center">
-        <div class="col-6">Banded columns</div>
-        <div class="col-6 d-flex align-items-center">
-          <Checkbox
-            name="'bandedColumns'"
-            value="pivotStyle.bandedColumns ?? defaultStyle.bandedColumns"
-            onChange="(val) => this.updatePivotStyleProperty('bandedColumns', val)"
-          />
-        </div>
-      </div>
-      <div class="row mb-2 align-items-center">
-        <div class="col-6">Filter button</div>
-        <div class="col-6 d-flex align-items-center">
-          <Checkbox
-            name="'hasFilters'"
-            value="pivotStyle.hasFilters ?? defaultStyle.hasFilters"
-            onChange="(val) => this.updatePivotStyleProperty('hasFilters', val)"
-          />
-        </div>
-      </div>
-      <div class="mt-4">
-        <TableStylePicker
-          tableConfig="tableConfig"
-          onStylePicked.bind="onStylePicked"
-          tableStyles="tableStyles"
-          type="'pivot'"
-        />
-      </div>
-    </Section>
+      </Section>
+    </div>
   </t>
 </templates>

--- a/tests/pivots/spreadsheet_pivot/__snapshots__/spreadsheet_pivot_side_panel.test.ts.snap
+++ b/tests/pivots/spreadsheet_pivot/__snapshots__/spreadsheet_pivot_side_panel.test.ts.snap
@@ -262,672 +262,678 @@ exports[`Spreadsheet pivot side panel It should correctly be displayed 1`] = `
             class="h-100 d-none"
           >
             <div
-              class="o-section o-pivot-design h-100 overflow-y-auto"
+              class="h-100 overflow-y-auto"
             >
               <div
-                class="o-section-title"
+                class="o-section o-pivot-design"
               >
-                Display options
+                <div
+                  class="o-section-title"
+                >
+                  Display options
+                  
+                  
+                </div>
                 
+                <div>
+                  <div
+                    class="container-fluid p-0 pt-2"
+                  >
+                    <div
+                      class="row mb-2 align-items-center"
+                    >
+                      <div
+                        class="col-6"
+                      >
+                        Max rows:
+                      </div>
+                      <div
+                        class="col-6 d-flex align-items-center"
+                      >
+                        <input
+                          class="o-pivot-n-of-rows o-input"
+                          placeholder="e.g. 10"
+                          type="number"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="row mb-2 align-items-center"
+                    >
+                      <div
+                        class="col-6"
+                      >
+                        Max columns:
+                      </div>
+                      <div
+                        class="col-6 d-flex align-items-center"
+                      >
+                        <input
+                          class="o-pivot-n-of-columns o-input"
+                          placeholder="e.g. 5"
+                          type="number"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="row mb-2 align-items-center"
+                    >
+                      <div
+                        class="col-6"
+                      >
+                        Show totals:
+                      </div>
+                      <div
+                        class="col-6 d-flex align-items-center"
+                      >
+                        <label
+                          class="o-checkbox d-flex align-items-center"
+                          role="button"
+                        >
+                          <input
+                            class="me-2 flex-shrink-0 border"
+                            name="displayTotals"
+                            type="checkbox"
+                          />
+                          
+                        </label>
+                      </div>
+                    </div>
+                    <div
+                      class="row mb-2 align-items-center"
+                    >
+                      <div
+                        class="col-6"
+                      >
+                        Show column titles:
+                      </div>
+                      <div
+                        class="col-6 d-flex align-items-center"
+                      >
+                        <label
+                          class="o-checkbox d-flex align-items-center"
+                          role="button"
+                        >
+                          <input
+                            class="me-2 flex-shrink-0 border"
+                            name="displayColumnHeaders"
+                            type="checkbox"
+                          />
+                          
+                        </label>
+                      </div>
+                    </div>
+                    <div
+                      class="row mb-2 align-items-center"
+                    >
+                      <div
+                        class="col-6"
+                      >
+                        Show measure titles:
+                      </div>
+                      <div
+                        class="col-6 d-flex align-items-center"
+                      >
+                        <label
+                          class="o-checkbox d-flex align-items-center"
+                          role="button"
+                        >
+                          <input
+                            class="me-2 flex-shrink-0 border"
+                            name="displayMeasuresRow"
+                            type="checkbox"
+                          />
+                          
+                        </label>
+                      </div>
+                    </div>
+                  </div>
+                </div>
                 
               </div>
               
-              <div>
+              <div
+                class="o-section o-pivot-table-style"
+              >
                 <div
-                  class="container-fluid p-0 pt-2"
+                  class="o-section-title"
+                >
+                  Pivot table style
+                  
+                  
+                </div>
+                
+                <div
+                  class="row mb-2 align-items-center pt-2"
                 >
                   <div
-                    class="row mb-2 align-items-center"
+                    class="col-6"
                   >
-                    <div
-                      class="col-6"
-                    >
-                      Max rows:
-                    </div>
-                    <div
-                      class="col-6 d-flex align-items-center"
+                    Banded rows:
+                  </div>
+                  <div
+                    class="col-6 d-flex align-items-center"
+                  >
+                    <label
+                      class="o-checkbox d-flex align-items-center"
+                      role="button"
                     >
                       <input
-                        class="o-pivot-n-of-rows o-input"
-                        placeholder="e.g. 10"
-                        type="number"
+                        class="me-2 flex-shrink-0 border"
+                        name="bandedRows"
+                        type="checkbox"
                       />
-                    </div>
+                      
+                    </label>
+                  </div>
+                </div>
+                <div
+                  class="row mb-2 align-items-center"
+                >
+                  <div
+                    class="col-6"
+                  >
+                    Banded columns
                   </div>
                   <div
-                    class="row mb-2 align-items-center"
+                    class="col-6 d-flex align-items-center"
                   >
-                    <div
-                      class="col-6"
-                    >
-                      Max columns:
-                    </div>
-                    <div
-                      class="col-6 d-flex align-items-center"
+                    <label
+                      class="o-checkbox d-flex align-items-center"
+                      role="button"
                     >
                       <input
-                        class="o-pivot-n-of-columns o-input"
-                        placeholder="e.g. 5"
-                        type="number"
+                        class="me-2 flex-shrink-0 border"
+                        name="bandedColumns"
+                        type="checkbox"
                       />
-                    </div>
-                  </div>
-                  <div
-                    class="row mb-2 align-items-center"
-                  >
-                    <div
-                      class="col-6"
-                    >
-                      Show totals:
-                    </div>
-                    <div
-                      class="col-6 d-flex align-items-center"
-                    >
-                      <label
-                        class="o-checkbox d-flex align-items-center"
-                        role="button"
-                      >
-                        <input
-                          class="me-2 flex-shrink-0 border"
-                          name="displayTotals"
-                          type="checkbox"
-                        />
-                        
-                      </label>
-                    </div>
-                  </div>
-                  <div
-                    class="row mb-2 align-items-center"
-                  >
-                    <div
-                      class="col-6"
-                    >
-                      Show column titles:
-                    </div>
-                    <div
-                      class="col-6 d-flex align-items-center"
-                    >
-                      <label
-                        class="o-checkbox d-flex align-items-center"
-                        role="button"
-                      >
-                        <input
-                          class="me-2 flex-shrink-0 border"
-                          name="displayColumnHeaders"
-                          type="checkbox"
-                        />
-                        
-                      </label>
-                    </div>
-                  </div>
-                  <div
-                    class="row mb-2 align-items-center"
-                  >
-                    <div
-                      class="col-6"
-                    >
-                      Show measure titles:
-                    </div>
-                    <div
-                      class="col-6 d-flex align-items-center"
-                    >
-                      <label
-                        class="o-checkbox d-flex align-items-center"
-                        role="button"
-                      >
-                        <input
-                          class="me-2 flex-shrink-0 border"
-                          name="displayMeasuresRow"
-                          type="checkbox"
-                        />
-                        
-                      </label>
-                    </div>
+                      
+                    </label>
                   </div>
                 </div>
-              </div>
-              
-            </div>
-            <div
-              class="o-section o-pivot-table-style"
-            >
-              <div
-                class="o-section-title"
-              >
-                Pivot table style
-                
-                
-              </div>
-              
-              <div
-                class="row mb-2 align-items-center pt-2"
-              >
                 <div
-                  class="col-6"
-                >
-                  Banded rows:
-                </div>
-                <div
-                  class="col-6 d-flex align-items-center"
-                >
-                  <label
-                    class="o-checkbox d-flex align-items-center"
-                    role="button"
-                  >
-                    <input
-                      class="me-2 flex-shrink-0 border"
-                      name="bandedRows"
-                      type="checkbox"
-                    />
-                    
-                  </label>
-                </div>
-              </div>
-              <div
-                class="row mb-2 align-items-center"
-              >
-                <div
-                  class="col-6"
-                >
-                  Banded columns
-                </div>
-                <div
-                  class="col-6 d-flex align-items-center"
-                >
-                  <label
-                    class="o-checkbox d-flex align-items-center"
-                    role="button"
-                  >
-                    <input
-                      class="me-2 flex-shrink-0 border"
-                      name="bandedColumns"
-                      type="checkbox"
-                    />
-                    
-                  </label>
-                </div>
-              </div>
-              <div
-                class="row mb-2 align-items-center"
-              >
-                <div
-                  class="col-6"
-                >
-                  Filter button
-                </div>
-                <div
-                  class="col-6 d-flex align-items-center"
-                >
-                  <label
-                    class="o-checkbox d-flex align-items-center"
-                    role="button"
-                  >
-                    <input
-                      class="me-2 flex-shrink-0 border"
-                      name="hasFilters"
-                      type="checkbox"
-                    />
-                    
-                  </label>
-                </div>
-              </div>
-              <div
-                class="mt-4"
-              >
-                <div
-                  class="o-table-style-picker d-flex flew-row justify-content-between ps-1 border rounded"
+                  class="row mb-2 align-items-center"
                 >
                   <div
-                    class="d-flex flex-row overflow-hidden o-pivot-previews"
+                    class="col-6"
                   >
-                    <div
-                      class="o-table-style-list-item position-relative selected"
-                      data-id="None"
-                      title="None"
-                    >
-                      <div
-                        class="o-table-preview"
-                      >
-                        <canvas
-                          class="w-100 h-100"
-                        />
-                      </div>
-                      
-                    </div>
-                    
-                    <div
-                      class="o-table-style-list-item position-relative"
-                      data-id="PivotTableStyleLight1"
-                      title="Light Black 1"
-                    >
-                      <div
-                        class="o-table-preview"
-                      >
-                        <canvas
-                          class="w-100 h-100"
-                        />
-                      </div>
-                      
-                    </div>
-                    
-                    <div
-                      class="o-table-style-list-item position-relative"
-                      data-id="PivotTableStyleLight2"
-                      title="Light Blue 2"
-                    >
-                      <div
-                        class="o-table-preview"
-                      >
-                        <canvas
-                          class="w-100 h-100"
-                        />
-                      </div>
-                      
-                    </div>
-                    
-                    <div
-                      class="o-table-style-list-item position-relative"
-                      data-id="PivotTableStyleLight3"
-                      title="Light Red 3"
-                    >
-                      <div
-                        class="o-table-preview"
-                      >
-                        <canvas
-                          class="w-100 h-100"
-                        />
-                      </div>
-                      
-                    </div>
-                    
-                    <div
-                      class="o-table-style-list-item position-relative"
-                      data-id="PivotTableStyleLight4"
-                      title="Light Green 4"
-                    >
-                      <div
-                        class="o-table-preview"
-                      >
-                        <canvas
-                          class="w-100 h-100"
-                        />
-                      </div>
-                      
-                    </div>
-                    
-                    <div
-                      class="o-table-style-list-item position-relative"
-                      data-id="PivotTableStyleLight5"
-                      title="Light Purple 5"
-                    >
-                      <div
-                        class="o-table-preview"
-                      >
-                        <canvas
-                          class="w-100 h-100"
-                        />
-                      </div>
-                      
-                    </div>
-                    
-                    <div
-                      class="o-table-style-list-item position-relative"
-                      data-id="PivotTableStyleLight6"
-                      title="Light Gray 6"
-                    >
-                      <div
-                        class="o-table-preview"
-                      >
-                        <canvas
-                          class="w-100 h-100"
-                        />
-                      </div>
-                      
-                    </div>
-                    
-                    <div
-                      class="o-table-style-list-item position-relative"
-                      data-id="PivotTableStyleLight7"
-                      title="Light Orange 7"
-                    >
-                      <div
-                        class="o-table-preview"
-                      >
-                        <canvas
-                          class="w-100 h-100"
-                        />
-                      </div>
-                      
-                    </div>
-                    
-                    <div
-                      class="o-table-style-list-item position-relative"
-                      data-id="PivotTableStyleLight8"
-                      title="Light Black 8"
-                    >
-                      <div
-                        class="o-table-preview"
-                      >
-                        <canvas
-                          class="w-100 h-100"
-                        />
-                      </div>
-                      
-                    </div>
-                    
-                    <div
-                      class="o-table-style-list-item position-relative"
-                      data-id="PivotTableStyleLight9"
-                      title="Light Blue 9"
-                    >
-                      <div
-                        class="o-table-preview"
-                      >
-                        <canvas
-                          class="w-100 h-100"
-                        />
-                      </div>
-                      
-                    </div>
-                    
-                    <div
-                      class="o-table-style-list-item position-relative"
-                      data-id="PivotTableStyleLight10"
-                      title="Light Red 10"
-                    >
-                      <div
-                        class="o-table-preview"
-                      >
-                        <canvas
-                          class="w-100 h-100"
-                        />
-                      </div>
-                      
-                    </div>
-                    
-                    <div
-                      class="o-table-style-list-item position-relative"
-                      data-id="PivotTableStyleLight11"
-                      title="Light Green 11"
-                    >
-                      <div
-                        class="o-table-preview"
-                      >
-                        <canvas
-                          class="w-100 h-100"
-                        />
-                      </div>
-                      
-                    </div>
-                    
-                    <div
-                      class="o-table-style-list-item position-relative"
-                      data-id="PivotTableStyleLight12"
-                      title="Light Purple 12"
-                    >
-                      <div
-                        class="o-table-preview"
-                      >
-                        <canvas
-                          class="w-100 h-100"
-                        />
-                      </div>
-                      
-                    </div>
-                    
-                    <div
-                      class="o-table-style-list-item position-relative"
-                      data-id="PivotTableStyleLight13"
-                      title="Light Gray 13"
-                    >
-                      <div
-                        class="o-table-preview"
-                      >
-                        <canvas
-                          class="w-100 h-100"
-                        />
-                      </div>
-                      
-                    </div>
-                    
-                    <div
-                      class="o-table-style-list-item position-relative"
-                      data-id="PivotTableStyleLight14"
-                      title="Light Orange 14"
-                    >
-                      <div
-                        class="o-table-preview"
-                      >
-                        <canvas
-                          class="w-100 h-100"
-                        />
-                      </div>
-                      
-                    </div>
-                    
-                    <div
-                      class="o-table-style-list-item position-relative"
-                      data-id="PivotTableStyleLight15"
-                      title="Light Black 15"
-                    >
-                      <div
-                        class="o-table-preview"
-                      >
-                        <canvas
-                          class="w-100 h-100"
-                        />
-                      </div>
-                      
-                    </div>
-                    
-                    <div
-                      class="o-table-style-list-item position-relative"
-                      data-id="PivotTableStyleLight16"
-                      title="Light Blue 16"
-                    >
-                      <div
-                        class="o-table-preview"
-                      >
-                        <canvas
-                          class="w-100 h-100"
-                        />
-                      </div>
-                      
-                    </div>
-                    
-                    <div
-                      class="o-table-style-list-item position-relative"
-                      data-id="PivotTableStyleLight17"
-                      title="Light Red 17"
-                    >
-                      <div
-                        class="o-table-preview"
-                      >
-                        <canvas
-                          class="w-100 h-100"
-                        />
-                      </div>
-                      
-                    </div>
-                    
-                    <div
-                      class="o-table-style-list-item position-relative"
-                      data-id="PivotTableStyleLight18"
-                      title="Light Green 18"
-                    >
-                      <div
-                        class="o-table-preview"
-                      >
-                        <canvas
-                          class="w-100 h-100"
-                        />
-                      </div>
-                      
-                    </div>
-                    
-                    <div
-                      class="o-table-style-list-item position-relative"
-                      data-id="PivotTableStyleLight19"
-                      title="Light Purple 19"
-                    >
-                      <div
-                        class="o-table-preview"
-                      >
-                        <canvas
-                          class="w-100 h-100"
-                        />
-                      </div>
-                      
-                    </div>
-                    
-                    <div
-                      class="o-table-style-list-item position-relative"
-                      data-id="PivotTableStyleLight20"
-                      title="Light Gray 20"
-                    >
-                      <div
-                        class="o-table-preview"
-                      >
-                        <canvas
-                          class="w-100 h-100"
-                        />
-                      </div>
-                      
-                    </div>
-                    
-                    <div
-                      class="o-table-style-list-item position-relative"
-                      data-id="PivotTableStyleLight21"
-                      title="Light Orange 21"
-                    >
-                      <div
-                        class="o-table-preview"
-                      >
-                        <canvas
-                          class="w-100 h-100"
-                        />
-                      </div>
-                      
-                    </div>
-                    
-                    <div
-                      class="o-table-style-list-item position-relative"
-                      data-id="PivotTableStyleLight22"
-                      title="Light Black 22"
-                    >
-                      <div
-                        class="o-table-preview"
-                      >
-                        <canvas
-                          class="w-100 h-100"
-                        />
-                      </div>
-                      
-                    </div>
-                    
-                    <div
-                      class="o-table-style-list-item position-relative"
-                      data-id="PivotTableStyleLight23"
-                      title="Light Blue 23"
-                    >
-                      <div
-                        class="o-table-preview"
-                      >
-                        <canvas
-                          class="w-100 h-100"
-                        />
-                      </div>
-                      
-                    </div>
-                    
-                    <div
-                      class="o-table-style-list-item position-relative"
-                      data-id="PivotTableStyleLight24"
-                      title="Light Red 24"
-                    >
-                      <div
-                        class="o-table-preview"
-                      >
-                        <canvas
-                          class="w-100 h-100"
-                        />
-                      </div>
-                      
-                    </div>
-                    
-                    <div
-                      class="o-table-style-list-item position-relative"
-                      data-id="PivotTableStyleLight25"
-                      title="Light Green 25"
-                    >
-                      <div
-                        class="o-table-preview"
-                      >
-                        <canvas
-                          class="w-100 h-100"
-                        />
-                      </div>
-                      
-                    </div>
-                    
-                    <div
-                      class="o-table-style-list-item position-relative"
-                      data-id="PivotTableStyleLight26"
-                      title="Light Purple 26"
-                    >
-                      <div
-                        class="o-table-preview"
-                      >
-                        <canvas
-                          class="w-100 h-100"
-                        />
-                      </div>
-                      
-                    </div>
-                    
-                    <div
-                      class="o-table-style-list-item position-relative"
-                      data-id="PivotTableStyleLight27"
-                      title="Light Gray 27"
-                    >
-                      <div
-                        class="o-table-preview"
-                      >
-                        <canvas
-                          class="w-100 h-100"
-                        />
-                      </div>
-                      
-                    </div>
-                    
-                    <div
-                      class="o-table-style-list-item position-relative"
-                      data-id="PivotTableStyleLight28"
-                      title="Light Orange 28"
-                    >
-                      <div
-                        class="o-table-preview"
-                      >
-                        <canvas
-                          class="w-100 h-100"
-                        />
-                      </div>
-                      
-                    </div>
-                    
-                    
+                    Filter button
                   </div>
                   <div
-                    class="o-table-style-picker-arrow d-flex align-items-center px-1 border-start"
+                    class="col-6 d-flex align-items-center"
                   >
-                    <div
-                      class="o-icon fa-small"
+                    <label
+                      class="o-checkbox d-flex align-items-center"
+                      role="button"
                     >
-                      <i
-                        class="fa fa-caret-down"
+                      <input
+                        class="me-2 flex-shrink-0 border"
+                        name="hasFilters"
+                        type="checkbox"
                       />
+                      
+                    </label>
+                  </div>
+                </div>
+                <div
+                  class="mt-4"
+                >
+                  <div
+                    class="o-table-style-picker d-flex flew-row justify-content-between ps-1 border rounded"
+                  >
+                    <div
+                      class="d-flex flex-row overflow-hidden o-pivot-previews"
+                    >
+                      <div
+                        class="o-table-style-list-item position-relative selected"
+                        data-id="None"
+                        title="None"
+                      >
+                        <div
+                          class="o-table-preview"
+                        >
+                          <canvas
+                            class="w-100 h-100"
+                          />
+                        </div>
+                        
+                      </div>
+                      
+                      <div
+                        class="o-table-style-list-item position-relative"
+                        data-id="PivotTableStyleLight1"
+                        title="Light Black 1"
+                      >
+                        <div
+                          class="o-table-preview"
+                        >
+                          <canvas
+                            class="w-100 h-100"
+                          />
+                        </div>
+                        
+                      </div>
+                      
+                      <div
+                        class="o-table-style-list-item position-relative"
+                        data-id="PivotTableStyleLight2"
+                        title="Light Blue 2"
+                      >
+                        <div
+                          class="o-table-preview"
+                        >
+                          <canvas
+                            class="w-100 h-100"
+                          />
+                        </div>
+                        
+                      </div>
+                      
+                      <div
+                        class="o-table-style-list-item position-relative"
+                        data-id="PivotTableStyleLight3"
+                        title="Light Red 3"
+                      >
+                        <div
+                          class="o-table-preview"
+                        >
+                          <canvas
+                            class="w-100 h-100"
+                          />
+                        </div>
+                        
+                      </div>
+                      
+                      <div
+                        class="o-table-style-list-item position-relative"
+                        data-id="PivotTableStyleLight4"
+                        title="Light Green 4"
+                      >
+                        <div
+                          class="o-table-preview"
+                        >
+                          <canvas
+                            class="w-100 h-100"
+                          />
+                        </div>
+                        
+                      </div>
+                      
+                      <div
+                        class="o-table-style-list-item position-relative"
+                        data-id="PivotTableStyleLight5"
+                        title="Light Purple 5"
+                      >
+                        <div
+                          class="o-table-preview"
+                        >
+                          <canvas
+                            class="w-100 h-100"
+                          />
+                        </div>
+                        
+                      </div>
+                      
+                      <div
+                        class="o-table-style-list-item position-relative"
+                        data-id="PivotTableStyleLight6"
+                        title="Light Gray 6"
+                      >
+                        <div
+                          class="o-table-preview"
+                        >
+                          <canvas
+                            class="w-100 h-100"
+                          />
+                        </div>
+                        
+                      </div>
+                      
+                      <div
+                        class="o-table-style-list-item position-relative"
+                        data-id="PivotTableStyleLight7"
+                        title="Light Orange 7"
+                      >
+                        <div
+                          class="o-table-preview"
+                        >
+                          <canvas
+                            class="w-100 h-100"
+                          />
+                        </div>
+                        
+                      </div>
+                      
+                      <div
+                        class="o-table-style-list-item position-relative"
+                        data-id="PivotTableStyleLight8"
+                        title="Light Black 8"
+                      >
+                        <div
+                          class="o-table-preview"
+                        >
+                          <canvas
+                            class="w-100 h-100"
+                          />
+                        </div>
+                        
+                      </div>
+                      
+                      <div
+                        class="o-table-style-list-item position-relative"
+                        data-id="PivotTableStyleLight9"
+                        title="Light Blue 9"
+                      >
+                        <div
+                          class="o-table-preview"
+                        >
+                          <canvas
+                            class="w-100 h-100"
+                          />
+                        </div>
+                        
+                      </div>
+                      
+                      <div
+                        class="o-table-style-list-item position-relative"
+                        data-id="PivotTableStyleLight10"
+                        title="Light Red 10"
+                      >
+                        <div
+                          class="o-table-preview"
+                        >
+                          <canvas
+                            class="w-100 h-100"
+                          />
+                        </div>
+                        
+                      </div>
+                      
+                      <div
+                        class="o-table-style-list-item position-relative"
+                        data-id="PivotTableStyleLight11"
+                        title="Light Green 11"
+                      >
+                        <div
+                          class="o-table-preview"
+                        >
+                          <canvas
+                            class="w-100 h-100"
+                          />
+                        </div>
+                        
+                      </div>
+                      
+                      <div
+                        class="o-table-style-list-item position-relative"
+                        data-id="PivotTableStyleLight12"
+                        title="Light Purple 12"
+                      >
+                        <div
+                          class="o-table-preview"
+                        >
+                          <canvas
+                            class="w-100 h-100"
+                          />
+                        </div>
+                        
+                      </div>
+                      
+                      <div
+                        class="o-table-style-list-item position-relative"
+                        data-id="PivotTableStyleLight13"
+                        title="Light Gray 13"
+                      >
+                        <div
+                          class="o-table-preview"
+                        >
+                          <canvas
+                            class="w-100 h-100"
+                          />
+                        </div>
+                        
+                      </div>
+                      
+                      <div
+                        class="o-table-style-list-item position-relative"
+                        data-id="PivotTableStyleLight14"
+                        title="Light Orange 14"
+                      >
+                        <div
+                          class="o-table-preview"
+                        >
+                          <canvas
+                            class="w-100 h-100"
+                          />
+                        </div>
+                        
+                      </div>
+                      
+                      <div
+                        class="o-table-style-list-item position-relative"
+                        data-id="PivotTableStyleLight15"
+                        title="Light Black 15"
+                      >
+                        <div
+                          class="o-table-preview"
+                        >
+                          <canvas
+                            class="w-100 h-100"
+                          />
+                        </div>
+                        
+                      </div>
+                      
+                      <div
+                        class="o-table-style-list-item position-relative"
+                        data-id="PivotTableStyleLight16"
+                        title="Light Blue 16"
+                      >
+                        <div
+                          class="o-table-preview"
+                        >
+                          <canvas
+                            class="w-100 h-100"
+                          />
+                        </div>
+                        
+                      </div>
+                      
+                      <div
+                        class="o-table-style-list-item position-relative"
+                        data-id="PivotTableStyleLight17"
+                        title="Light Red 17"
+                      >
+                        <div
+                          class="o-table-preview"
+                        >
+                          <canvas
+                            class="w-100 h-100"
+                          />
+                        </div>
+                        
+                      </div>
+                      
+                      <div
+                        class="o-table-style-list-item position-relative"
+                        data-id="PivotTableStyleLight18"
+                        title="Light Green 18"
+                      >
+                        <div
+                          class="o-table-preview"
+                        >
+                          <canvas
+                            class="w-100 h-100"
+                          />
+                        </div>
+                        
+                      </div>
+                      
+                      <div
+                        class="o-table-style-list-item position-relative"
+                        data-id="PivotTableStyleLight19"
+                        title="Light Purple 19"
+                      >
+                        <div
+                          class="o-table-preview"
+                        >
+                          <canvas
+                            class="w-100 h-100"
+                          />
+                        </div>
+                        
+                      </div>
+                      
+                      <div
+                        class="o-table-style-list-item position-relative"
+                        data-id="PivotTableStyleLight20"
+                        title="Light Gray 20"
+                      >
+                        <div
+                          class="o-table-preview"
+                        >
+                          <canvas
+                            class="w-100 h-100"
+                          />
+                        </div>
+                        
+                      </div>
+                      
+                      <div
+                        class="o-table-style-list-item position-relative"
+                        data-id="PivotTableStyleLight21"
+                        title="Light Orange 21"
+                      >
+                        <div
+                          class="o-table-preview"
+                        >
+                          <canvas
+                            class="w-100 h-100"
+                          />
+                        </div>
+                        
+                      </div>
+                      
+                      <div
+                        class="o-table-style-list-item position-relative"
+                        data-id="PivotTableStyleLight22"
+                        title="Light Black 22"
+                      >
+                        <div
+                          class="o-table-preview"
+                        >
+                          <canvas
+                            class="w-100 h-100"
+                          />
+                        </div>
+                        
+                      </div>
+                      
+                      <div
+                        class="o-table-style-list-item position-relative"
+                        data-id="PivotTableStyleLight23"
+                        title="Light Blue 23"
+                      >
+                        <div
+                          class="o-table-preview"
+                        >
+                          <canvas
+                            class="w-100 h-100"
+                          />
+                        </div>
+                        
+                      </div>
+                      
+                      <div
+                        class="o-table-style-list-item position-relative"
+                        data-id="PivotTableStyleLight24"
+                        title="Light Red 24"
+                      >
+                        <div
+                          class="o-table-preview"
+                        >
+                          <canvas
+                            class="w-100 h-100"
+                          />
+                        </div>
+                        
+                      </div>
+                      
+                      <div
+                        class="o-table-style-list-item position-relative"
+                        data-id="PivotTableStyleLight25"
+                        title="Light Green 25"
+                      >
+                        <div
+                          class="o-table-preview"
+                        >
+                          <canvas
+                            class="w-100 h-100"
+                          />
+                        </div>
+                        
+                      </div>
+                      
+                      <div
+                        class="o-table-style-list-item position-relative"
+                        data-id="PivotTableStyleLight26"
+                        title="Light Purple 26"
+                      >
+                        <div
+                          class="o-table-preview"
+                        >
+                          <canvas
+                            class="w-100 h-100"
+                          />
+                        </div>
+                        
+                      </div>
+                      
+                      <div
+                        class="o-table-style-list-item position-relative"
+                        data-id="PivotTableStyleLight27"
+                        title="Light Gray 27"
+                      >
+                        <div
+                          class="o-table-preview"
+                        >
+                          <canvas
+                            class="w-100 h-100"
+                          />
+                        </div>
+                        
+                      </div>
+                      
+                      <div
+                        class="o-table-style-list-item position-relative"
+                        data-id="PivotTableStyleLight28"
+                        title="Light Orange 28"
+                      >
+                        <div
+                          class="o-table-preview"
+                        >
+                          <canvas
+                            class="w-100 h-100"
+                          />
+                        </div>
+                        
+                      </div>
+                      
+                      
+                    </div>
+                    <div
+                      class="o-table-style-picker-arrow d-flex align-items-center px-1 border-start"
+                    >
+                      <div
+                        class="o-icon fa-small"
+                      >
+                        <i
+                          class="fa fa-caret-down"
+                        />
+                      </div>
                     </div>
                   </div>
+                  
                 </div>
                 
               </div>
@@ -1188,672 +1194,678 @@ exports[`Spreadsheet pivot side panel It should display only the selection input
             class="h-100 d-none"
           >
             <div
-              class="o-section o-pivot-design h-100 overflow-y-auto"
+              class="h-100 overflow-y-auto"
             >
               <div
-                class="o-section-title"
+                class="o-section o-pivot-design"
               >
-                Display options
+                <div
+                  class="o-section-title"
+                >
+                  Display options
+                  
+                  
+                </div>
                 
+                <div>
+                  <div
+                    class="container-fluid p-0 pt-2"
+                  >
+                    <div
+                      class="row mb-2 align-items-center"
+                    >
+                      <div
+                        class="col-6"
+                      >
+                        Max rows:
+                      </div>
+                      <div
+                        class="col-6 d-flex align-items-center"
+                      >
+                        <input
+                          class="o-pivot-n-of-rows o-input"
+                          placeholder="e.g. 10"
+                          type="number"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="row mb-2 align-items-center"
+                    >
+                      <div
+                        class="col-6"
+                      >
+                        Max columns:
+                      </div>
+                      <div
+                        class="col-6 d-flex align-items-center"
+                      >
+                        <input
+                          class="o-pivot-n-of-columns o-input"
+                          placeholder="e.g. 5"
+                          type="number"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="row mb-2 align-items-center"
+                    >
+                      <div
+                        class="col-6"
+                      >
+                        Show totals:
+                      </div>
+                      <div
+                        class="col-6 d-flex align-items-center"
+                      >
+                        <label
+                          class="o-checkbox d-flex align-items-center"
+                          role="button"
+                        >
+                          <input
+                            class="me-2 flex-shrink-0 border"
+                            name="displayTotals"
+                            type="checkbox"
+                          />
+                          
+                        </label>
+                      </div>
+                    </div>
+                    <div
+                      class="row mb-2 align-items-center"
+                    >
+                      <div
+                        class="col-6"
+                      >
+                        Show column titles:
+                      </div>
+                      <div
+                        class="col-6 d-flex align-items-center"
+                      >
+                        <label
+                          class="o-checkbox d-flex align-items-center"
+                          role="button"
+                        >
+                          <input
+                            class="me-2 flex-shrink-0 border"
+                            name="displayColumnHeaders"
+                            type="checkbox"
+                          />
+                          
+                        </label>
+                      </div>
+                    </div>
+                    <div
+                      class="row mb-2 align-items-center"
+                    >
+                      <div
+                        class="col-6"
+                      >
+                        Show measure titles:
+                      </div>
+                      <div
+                        class="col-6 d-flex align-items-center"
+                      >
+                        <label
+                          class="o-checkbox d-flex align-items-center"
+                          role="button"
+                        >
+                          <input
+                            class="me-2 flex-shrink-0 border"
+                            name="displayMeasuresRow"
+                            type="checkbox"
+                          />
+                          
+                        </label>
+                      </div>
+                    </div>
+                  </div>
+                </div>
                 
               </div>
               
-              <div>
+              <div
+                class="o-section o-pivot-table-style"
+              >
                 <div
-                  class="container-fluid p-0 pt-2"
+                  class="o-section-title"
+                >
+                  Pivot table style
+                  
+                  
+                </div>
+                
+                <div
+                  class="row mb-2 align-items-center pt-2"
                 >
                   <div
-                    class="row mb-2 align-items-center"
+                    class="col-6"
                   >
-                    <div
-                      class="col-6"
-                    >
-                      Max rows:
-                    </div>
-                    <div
-                      class="col-6 d-flex align-items-center"
+                    Banded rows:
+                  </div>
+                  <div
+                    class="col-6 d-flex align-items-center"
+                  >
+                    <label
+                      class="o-checkbox d-flex align-items-center"
+                      role="button"
                     >
                       <input
-                        class="o-pivot-n-of-rows o-input"
-                        placeholder="e.g. 10"
-                        type="number"
+                        class="me-2 flex-shrink-0 border"
+                        name="bandedRows"
+                        type="checkbox"
                       />
-                    </div>
+                      
+                    </label>
+                  </div>
+                </div>
+                <div
+                  class="row mb-2 align-items-center"
+                >
+                  <div
+                    class="col-6"
+                  >
+                    Banded columns
                   </div>
                   <div
-                    class="row mb-2 align-items-center"
+                    class="col-6 d-flex align-items-center"
                   >
-                    <div
-                      class="col-6"
-                    >
-                      Max columns:
-                    </div>
-                    <div
-                      class="col-6 d-flex align-items-center"
+                    <label
+                      class="o-checkbox d-flex align-items-center"
+                      role="button"
                     >
                       <input
-                        class="o-pivot-n-of-columns o-input"
-                        placeholder="e.g. 5"
-                        type="number"
+                        class="me-2 flex-shrink-0 border"
+                        name="bandedColumns"
+                        type="checkbox"
                       />
-                    </div>
-                  </div>
-                  <div
-                    class="row mb-2 align-items-center"
-                  >
-                    <div
-                      class="col-6"
-                    >
-                      Show totals:
-                    </div>
-                    <div
-                      class="col-6 d-flex align-items-center"
-                    >
-                      <label
-                        class="o-checkbox d-flex align-items-center"
-                        role="button"
-                      >
-                        <input
-                          class="me-2 flex-shrink-0 border"
-                          name="displayTotals"
-                          type="checkbox"
-                        />
-                        
-                      </label>
-                    </div>
-                  </div>
-                  <div
-                    class="row mb-2 align-items-center"
-                  >
-                    <div
-                      class="col-6"
-                    >
-                      Show column titles:
-                    </div>
-                    <div
-                      class="col-6 d-flex align-items-center"
-                    >
-                      <label
-                        class="o-checkbox d-flex align-items-center"
-                        role="button"
-                      >
-                        <input
-                          class="me-2 flex-shrink-0 border"
-                          name="displayColumnHeaders"
-                          type="checkbox"
-                        />
-                        
-                      </label>
-                    </div>
-                  </div>
-                  <div
-                    class="row mb-2 align-items-center"
-                  >
-                    <div
-                      class="col-6"
-                    >
-                      Show measure titles:
-                    </div>
-                    <div
-                      class="col-6 d-flex align-items-center"
-                    >
-                      <label
-                        class="o-checkbox d-flex align-items-center"
-                        role="button"
-                      >
-                        <input
-                          class="me-2 flex-shrink-0 border"
-                          name="displayMeasuresRow"
-                          type="checkbox"
-                        />
-                        
-                      </label>
-                    </div>
+                      
+                    </label>
                   </div>
                 </div>
-              </div>
-              
-            </div>
-            <div
-              class="o-section o-pivot-table-style"
-            >
-              <div
-                class="o-section-title"
-              >
-                Pivot table style
-                
-                
-              </div>
-              
-              <div
-                class="row mb-2 align-items-center pt-2"
-              >
                 <div
-                  class="col-6"
-                >
-                  Banded rows:
-                </div>
-                <div
-                  class="col-6 d-flex align-items-center"
-                >
-                  <label
-                    class="o-checkbox d-flex align-items-center"
-                    role="button"
-                  >
-                    <input
-                      class="me-2 flex-shrink-0 border"
-                      name="bandedRows"
-                      type="checkbox"
-                    />
-                    
-                  </label>
-                </div>
-              </div>
-              <div
-                class="row mb-2 align-items-center"
-              >
-                <div
-                  class="col-6"
-                >
-                  Banded columns
-                </div>
-                <div
-                  class="col-6 d-flex align-items-center"
-                >
-                  <label
-                    class="o-checkbox d-flex align-items-center"
-                    role="button"
-                  >
-                    <input
-                      class="me-2 flex-shrink-0 border"
-                      name="bandedColumns"
-                      type="checkbox"
-                    />
-                    
-                  </label>
-                </div>
-              </div>
-              <div
-                class="row mb-2 align-items-center"
-              >
-                <div
-                  class="col-6"
-                >
-                  Filter button
-                </div>
-                <div
-                  class="col-6 d-flex align-items-center"
-                >
-                  <label
-                    class="o-checkbox d-flex align-items-center"
-                    role="button"
-                  >
-                    <input
-                      class="me-2 flex-shrink-0 border"
-                      name="hasFilters"
-                      type="checkbox"
-                    />
-                    
-                  </label>
-                </div>
-              </div>
-              <div
-                class="mt-4"
-              >
-                <div
-                  class="o-table-style-picker d-flex flew-row justify-content-between ps-1 border rounded"
+                  class="row mb-2 align-items-center"
                 >
                   <div
-                    class="d-flex flex-row overflow-hidden o-pivot-previews"
+                    class="col-6"
                   >
-                    <div
-                      class="o-table-style-list-item position-relative selected"
-                      data-id="None"
-                      title="None"
-                    >
-                      <div
-                        class="o-table-preview"
-                      >
-                        <canvas
-                          class="w-100 h-100"
-                        />
-                      </div>
-                      
-                    </div>
-                    
-                    <div
-                      class="o-table-style-list-item position-relative"
-                      data-id="PivotTableStyleLight1"
-                      title="Light Black 1"
-                    >
-                      <div
-                        class="o-table-preview"
-                      >
-                        <canvas
-                          class="w-100 h-100"
-                        />
-                      </div>
-                      
-                    </div>
-                    
-                    <div
-                      class="o-table-style-list-item position-relative"
-                      data-id="PivotTableStyleLight2"
-                      title="Light Blue 2"
-                    >
-                      <div
-                        class="o-table-preview"
-                      >
-                        <canvas
-                          class="w-100 h-100"
-                        />
-                      </div>
-                      
-                    </div>
-                    
-                    <div
-                      class="o-table-style-list-item position-relative"
-                      data-id="PivotTableStyleLight3"
-                      title="Light Red 3"
-                    >
-                      <div
-                        class="o-table-preview"
-                      >
-                        <canvas
-                          class="w-100 h-100"
-                        />
-                      </div>
-                      
-                    </div>
-                    
-                    <div
-                      class="o-table-style-list-item position-relative"
-                      data-id="PivotTableStyleLight4"
-                      title="Light Green 4"
-                    >
-                      <div
-                        class="o-table-preview"
-                      >
-                        <canvas
-                          class="w-100 h-100"
-                        />
-                      </div>
-                      
-                    </div>
-                    
-                    <div
-                      class="o-table-style-list-item position-relative"
-                      data-id="PivotTableStyleLight5"
-                      title="Light Purple 5"
-                    >
-                      <div
-                        class="o-table-preview"
-                      >
-                        <canvas
-                          class="w-100 h-100"
-                        />
-                      </div>
-                      
-                    </div>
-                    
-                    <div
-                      class="o-table-style-list-item position-relative"
-                      data-id="PivotTableStyleLight6"
-                      title="Light Gray 6"
-                    >
-                      <div
-                        class="o-table-preview"
-                      >
-                        <canvas
-                          class="w-100 h-100"
-                        />
-                      </div>
-                      
-                    </div>
-                    
-                    <div
-                      class="o-table-style-list-item position-relative"
-                      data-id="PivotTableStyleLight7"
-                      title="Light Orange 7"
-                    >
-                      <div
-                        class="o-table-preview"
-                      >
-                        <canvas
-                          class="w-100 h-100"
-                        />
-                      </div>
-                      
-                    </div>
-                    
-                    <div
-                      class="o-table-style-list-item position-relative"
-                      data-id="PivotTableStyleLight8"
-                      title="Light Black 8"
-                    >
-                      <div
-                        class="o-table-preview"
-                      >
-                        <canvas
-                          class="w-100 h-100"
-                        />
-                      </div>
-                      
-                    </div>
-                    
-                    <div
-                      class="o-table-style-list-item position-relative"
-                      data-id="PivotTableStyleLight9"
-                      title="Light Blue 9"
-                    >
-                      <div
-                        class="o-table-preview"
-                      >
-                        <canvas
-                          class="w-100 h-100"
-                        />
-                      </div>
-                      
-                    </div>
-                    
-                    <div
-                      class="o-table-style-list-item position-relative"
-                      data-id="PivotTableStyleLight10"
-                      title="Light Red 10"
-                    >
-                      <div
-                        class="o-table-preview"
-                      >
-                        <canvas
-                          class="w-100 h-100"
-                        />
-                      </div>
-                      
-                    </div>
-                    
-                    <div
-                      class="o-table-style-list-item position-relative"
-                      data-id="PivotTableStyleLight11"
-                      title="Light Green 11"
-                    >
-                      <div
-                        class="o-table-preview"
-                      >
-                        <canvas
-                          class="w-100 h-100"
-                        />
-                      </div>
-                      
-                    </div>
-                    
-                    <div
-                      class="o-table-style-list-item position-relative"
-                      data-id="PivotTableStyleLight12"
-                      title="Light Purple 12"
-                    >
-                      <div
-                        class="o-table-preview"
-                      >
-                        <canvas
-                          class="w-100 h-100"
-                        />
-                      </div>
-                      
-                    </div>
-                    
-                    <div
-                      class="o-table-style-list-item position-relative"
-                      data-id="PivotTableStyleLight13"
-                      title="Light Gray 13"
-                    >
-                      <div
-                        class="o-table-preview"
-                      >
-                        <canvas
-                          class="w-100 h-100"
-                        />
-                      </div>
-                      
-                    </div>
-                    
-                    <div
-                      class="o-table-style-list-item position-relative"
-                      data-id="PivotTableStyleLight14"
-                      title="Light Orange 14"
-                    >
-                      <div
-                        class="o-table-preview"
-                      >
-                        <canvas
-                          class="w-100 h-100"
-                        />
-                      </div>
-                      
-                    </div>
-                    
-                    <div
-                      class="o-table-style-list-item position-relative"
-                      data-id="PivotTableStyleLight15"
-                      title="Light Black 15"
-                    >
-                      <div
-                        class="o-table-preview"
-                      >
-                        <canvas
-                          class="w-100 h-100"
-                        />
-                      </div>
-                      
-                    </div>
-                    
-                    <div
-                      class="o-table-style-list-item position-relative"
-                      data-id="PivotTableStyleLight16"
-                      title="Light Blue 16"
-                    >
-                      <div
-                        class="o-table-preview"
-                      >
-                        <canvas
-                          class="w-100 h-100"
-                        />
-                      </div>
-                      
-                    </div>
-                    
-                    <div
-                      class="o-table-style-list-item position-relative"
-                      data-id="PivotTableStyleLight17"
-                      title="Light Red 17"
-                    >
-                      <div
-                        class="o-table-preview"
-                      >
-                        <canvas
-                          class="w-100 h-100"
-                        />
-                      </div>
-                      
-                    </div>
-                    
-                    <div
-                      class="o-table-style-list-item position-relative"
-                      data-id="PivotTableStyleLight18"
-                      title="Light Green 18"
-                    >
-                      <div
-                        class="o-table-preview"
-                      >
-                        <canvas
-                          class="w-100 h-100"
-                        />
-                      </div>
-                      
-                    </div>
-                    
-                    <div
-                      class="o-table-style-list-item position-relative"
-                      data-id="PivotTableStyleLight19"
-                      title="Light Purple 19"
-                    >
-                      <div
-                        class="o-table-preview"
-                      >
-                        <canvas
-                          class="w-100 h-100"
-                        />
-                      </div>
-                      
-                    </div>
-                    
-                    <div
-                      class="o-table-style-list-item position-relative"
-                      data-id="PivotTableStyleLight20"
-                      title="Light Gray 20"
-                    >
-                      <div
-                        class="o-table-preview"
-                      >
-                        <canvas
-                          class="w-100 h-100"
-                        />
-                      </div>
-                      
-                    </div>
-                    
-                    <div
-                      class="o-table-style-list-item position-relative"
-                      data-id="PivotTableStyleLight21"
-                      title="Light Orange 21"
-                    >
-                      <div
-                        class="o-table-preview"
-                      >
-                        <canvas
-                          class="w-100 h-100"
-                        />
-                      </div>
-                      
-                    </div>
-                    
-                    <div
-                      class="o-table-style-list-item position-relative"
-                      data-id="PivotTableStyleLight22"
-                      title="Light Black 22"
-                    >
-                      <div
-                        class="o-table-preview"
-                      >
-                        <canvas
-                          class="w-100 h-100"
-                        />
-                      </div>
-                      
-                    </div>
-                    
-                    <div
-                      class="o-table-style-list-item position-relative"
-                      data-id="PivotTableStyleLight23"
-                      title="Light Blue 23"
-                    >
-                      <div
-                        class="o-table-preview"
-                      >
-                        <canvas
-                          class="w-100 h-100"
-                        />
-                      </div>
-                      
-                    </div>
-                    
-                    <div
-                      class="o-table-style-list-item position-relative"
-                      data-id="PivotTableStyleLight24"
-                      title="Light Red 24"
-                    >
-                      <div
-                        class="o-table-preview"
-                      >
-                        <canvas
-                          class="w-100 h-100"
-                        />
-                      </div>
-                      
-                    </div>
-                    
-                    <div
-                      class="o-table-style-list-item position-relative"
-                      data-id="PivotTableStyleLight25"
-                      title="Light Green 25"
-                    >
-                      <div
-                        class="o-table-preview"
-                      >
-                        <canvas
-                          class="w-100 h-100"
-                        />
-                      </div>
-                      
-                    </div>
-                    
-                    <div
-                      class="o-table-style-list-item position-relative"
-                      data-id="PivotTableStyleLight26"
-                      title="Light Purple 26"
-                    >
-                      <div
-                        class="o-table-preview"
-                      >
-                        <canvas
-                          class="w-100 h-100"
-                        />
-                      </div>
-                      
-                    </div>
-                    
-                    <div
-                      class="o-table-style-list-item position-relative"
-                      data-id="PivotTableStyleLight27"
-                      title="Light Gray 27"
-                    >
-                      <div
-                        class="o-table-preview"
-                      >
-                        <canvas
-                          class="w-100 h-100"
-                        />
-                      </div>
-                      
-                    </div>
-                    
-                    <div
-                      class="o-table-style-list-item position-relative"
-                      data-id="PivotTableStyleLight28"
-                      title="Light Orange 28"
-                    >
-                      <div
-                        class="o-table-preview"
-                      >
-                        <canvas
-                          class="w-100 h-100"
-                        />
-                      </div>
-                      
-                    </div>
-                    
-                    
+                    Filter button
                   </div>
                   <div
-                    class="o-table-style-picker-arrow d-flex align-items-center px-1 border-start"
+                    class="col-6 d-flex align-items-center"
                   >
-                    <div
-                      class="o-icon fa-small"
+                    <label
+                      class="o-checkbox d-flex align-items-center"
+                      role="button"
                     >
-                      <i
-                        class="fa fa-caret-down"
+                      <input
+                        class="me-2 flex-shrink-0 border"
+                        name="hasFilters"
+                        type="checkbox"
                       />
+                      
+                    </label>
+                  </div>
+                </div>
+                <div
+                  class="mt-4"
+                >
+                  <div
+                    class="o-table-style-picker d-flex flew-row justify-content-between ps-1 border rounded"
+                  >
+                    <div
+                      class="d-flex flex-row overflow-hidden o-pivot-previews"
+                    >
+                      <div
+                        class="o-table-style-list-item position-relative selected"
+                        data-id="None"
+                        title="None"
+                      >
+                        <div
+                          class="o-table-preview"
+                        >
+                          <canvas
+                            class="w-100 h-100"
+                          />
+                        </div>
+                        
+                      </div>
+                      
+                      <div
+                        class="o-table-style-list-item position-relative"
+                        data-id="PivotTableStyleLight1"
+                        title="Light Black 1"
+                      >
+                        <div
+                          class="o-table-preview"
+                        >
+                          <canvas
+                            class="w-100 h-100"
+                          />
+                        </div>
+                        
+                      </div>
+                      
+                      <div
+                        class="o-table-style-list-item position-relative"
+                        data-id="PivotTableStyleLight2"
+                        title="Light Blue 2"
+                      >
+                        <div
+                          class="o-table-preview"
+                        >
+                          <canvas
+                            class="w-100 h-100"
+                          />
+                        </div>
+                        
+                      </div>
+                      
+                      <div
+                        class="o-table-style-list-item position-relative"
+                        data-id="PivotTableStyleLight3"
+                        title="Light Red 3"
+                      >
+                        <div
+                          class="o-table-preview"
+                        >
+                          <canvas
+                            class="w-100 h-100"
+                          />
+                        </div>
+                        
+                      </div>
+                      
+                      <div
+                        class="o-table-style-list-item position-relative"
+                        data-id="PivotTableStyleLight4"
+                        title="Light Green 4"
+                      >
+                        <div
+                          class="o-table-preview"
+                        >
+                          <canvas
+                            class="w-100 h-100"
+                          />
+                        </div>
+                        
+                      </div>
+                      
+                      <div
+                        class="o-table-style-list-item position-relative"
+                        data-id="PivotTableStyleLight5"
+                        title="Light Purple 5"
+                      >
+                        <div
+                          class="o-table-preview"
+                        >
+                          <canvas
+                            class="w-100 h-100"
+                          />
+                        </div>
+                        
+                      </div>
+                      
+                      <div
+                        class="o-table-style-list-item position-relative"
+                        data-id="PivotTableStyleLight6"
+                        title="Light Gray 6"
+                      >
+                        <div
+                          class="o-table-preview"
+                        >
+                          <canvas
+                            class="w-100 h-100"
+                          />
+                        </div>
+                        
+                      </div>
+                      
+                      <div
+                        class="o-table-style-list-item position-relative"
+                        data-id="PivotTableStyleLight7"
+                        title="Light Orange 7"
+                      >
+                        <div
+                          class="o-table-preview"
+                        >
+                          <canvas
+                            class="w-100 h-100"
+                          />
+                        </div>
+                        
+                      </div>
+                      
+                      <div
+                        class="o-table-style-list-item position-relative"
+                        data-id="PivotTableStyleLight8"
+                        title="Light Black 8"
+                      >
+                        <div
+                          class="o-table-preview"
+                        >
+                          <canvas
+                            class="w-100 h-100"
+                          />
+                        </div>
+                        
+                      </div>
+                      
+                      <div
+                        class="o-table-style-list-item position-relative"
+                        data-id="PivotTableStyleLight9"
+                        title="Light Blue 9"
+                      >
+                        <div
+                          class="o-table-preview"
+                        >
+                          <canvas
+                            class="w-100 h-100"
+                          />
+                        </div>
+                        
+                      </div>
+                      
+                      <div
+                        class="o-table-style-list-item position-relative"
+                        data-id="PivotTableStyleLight10"
+                        title="Light Red 10"
+                      >
+                        <div
+                          class="o-table-preview"
+                        >
+                          <canvas
+                            class="w-100 h-100"
+                          />
+                        </div>
+                        
+                      </div>
+                      
+                      <div
+                        class="o-table-style-list-item position-relative"
+                        data-id="PivotTableStyleLight11"
+                        title="Light Green 11"
+                      >
+                        <div
+                          class="o-table-preview"
+                        >
+                          <canvas
+                            class="w-100 h-100"
+                          />
+                        </div>
+                        
+                      </div>
+                      
+                      <div
+                        class="o-table-style-list-item position-relative"
+                        data-id="PivotTableStyleLight12"
+                        title="Light Purple 12"
+                      >
+                        <div
+                          class="o-table-preview"
+                        >
+                          <canvas
+                            class="w-100 h-100"
+                          />
+                        </div>
+                        
+                      </div>
+                      
+                      <div
+                        class="o-table-style-list-item position-relative"
+                        data-id="PivotTableStyleLight13"
+                        title="Light Gray 13"
+                      >
+                        <div
+                          class="o-table-preview"
+                        >
+                          <canvas
+                            class="w-100 h-100"
+                          />
+                        </div>
+                        
+                      </div>
+                      
+                      <div
+                        class="o-table-style-list-item position-relative"
+                        data-id="PivotTableStyleLight14"
+                        title="Light Orange 14"
+                      >
+                        <div
+                          class="o-table-preview"
+                        >
+                          <canvas
+                            class="w-100 h-100"
+                          />
+                        </div>
+                        
+                      </div>
+                      
+                      <div
+                        class="o-table-style-list-item position-relative"
+                        data-id="PivotTableStyleLight15"
+                        title="Light Black 15"
+                      >
+                        <div
+                          class="o-table-preview"
+                        >
+                          <canvas
+                            class="w-100 h-100"
+                          />
+                        </div>
+                        
+                      </div>
+                      
+                      <div
+                        class="o-table-style-list-item position-relative"
+                        data-id="PivotTableStyleLight16"
+                        title="Light Blue 16"
+                      >
+                        <div
+                          class="o-table-preview"
+                        >
+                          <canvas
+                            class="w-100 h-100"
+                          />
+                        </div>
+                        
+                      </div>
+                      
+                      <div
+                        class="o-table-style-list-item position-relative"
+                        data-id="PivotTableStyleLight17"
+                        title="Light Red 17"
+                      >
+                        <div
+                          class="o-table-preview"
+                        >
+                          <canvas
+                            class="w-100 h-100"
+                          />
+                        </div>
+                        
+                      </div>
+                      
+                      <div
+                        class="o-table-style-list-item position-relative"
+                        data-id="PivotTableStyleLight18"
+                        title="Light Green 18"
+                      >
+                        <div
+                          class="o-table-preview"
+                        >
+                          <canvas
+                            class="w-100 h-100"
+                          />
+                        </div>
+                        
+                      </div>
+                      
+                      <div
+                        class="o-table-style-list-item position-relative"
+                        data-id="PivotTableStyleLight19"
+                        title="Light Purple 19"
+                      >
+                        <div
+                          class="o-table-preview"
+                        >
+                          <canvas
+                            class="w-100 h-100"
+                          />
+                        </div>
+                        
+                      </div>
+                      
+                      <div
+                        class="o-table-style-list-item position-relative"
+                        data-id="PivotTableStyleLight20"
+                        title="Light Gray 20"
+                      >
+                        <div
+                          class="o-table-preview"
+                        >
+                          <canvas
+                            class="w-100 h-100"
+                          />
+                        </div>
+                        
+                      </div>
+                      
+                      <div
+                        class="o-table-style-list-item position-relative"
+                        data-id="PivotTableStyleLight21"
+                        title="Light Orange 21"
+                      >
+                        <div
+                          class="o-table-preview"
+                        >
+                          <canvas
+                            class="w-100 h-100"
+                          />
+                        </div>
+                        
+                      </div>
+                      
+                      <div
+                        class="o-table-style-list-item position-relative"
+                        data-id="PivotTableStyleLight22"
+                        title="Light Black 22"
+                      >
+                        <div
+                          class="o-table-preview"
+                        >
+                          <canvas
+                            class="w-100 h-100"
+                          />
+                        </div>
+                        
+                      </div>
+                      
+                      <div
+                        class="o-table-style-list-item position-relative"
+                        data-id="PivotTableStyleLight23"
+                        title="Light Blue 23"
+                      >
+                        <div
+                          class="o-table-preview"
+                        >
+                          <canvas
+                            class="w-100 h-100"
+                          />
+                        </div>
+                        
+                      </div>
+                      
+                      <div
+                        class="o-table-style-list-item position-relative"
+                        data-id="PivotTableStyleLight24"
+                        title="Light Red 24"
+                      >
+                        <div
+                          class="o-table-preview"
+                        >
+                          <canvas
+                            class="w-100 h-100"
+                          />
+                        </div>
+                        
+                      </div>
+                      
+                      <div
+                        class="o-table-style-list-item position-relative"
+                        data-id="PivotTableStyleLight25"
+                        title="Light Green 25"
+                      >
+                        <div
+                          class="o-table-preview"
+                        >
+                          <canvas
+                            class="w-100 h-100"
+                          />
+                        </div>
+                        
+                      </div>
+                      
+                      <div
+                        class="o-table-style-list-item position-relative"
+                        data-id="PivotTableStyleLight26"
+                        title="Light Purple 26"
+                      >
+                        <div
+                          class="o-table-preview"
+                        >
+                          <canvas
+                            class="w-100 h-100"
+                          />
+                        </div>
+                        
+                      </div>
+                      
+                      <div
+                        class="o-table-style-list-item position-relative"
+                        data-id="PivotTableStyleLight27"
+                        title="Light Gray 27"
+                      >
+                        <div
+                          class="o-table-preview"
+                        >
+                          <canvas
+                            class="w-100 h-100"
+                          />
+                        </div>
+                        
+                      </div>
+                      
+                      <div
+                        class="o-table-style-list-item position-relative"
+                        data-id="PivotTableStyleLight28"
+                        title="Light Orange 28"
+                      >
+                        <div
+                          class="o-table-preview"
+                        >
+                          <canvas
+                            class="w-100 h-100"
+                          />
+                        </div>
+                        
+                      </div>
+                      
+                      
+                    </div>
+                    <div
+                      class="o-table-style-picker-arrow d-flex align-items-center px-1 border-start"
+                    >
+                      <div
+                        class="o-icon fa-small"
+                      >
+                        <i
+                          class="fa fa-caret-down"
+                        />
+                      </div>
                     </div>
                   </div>
+                  
                 </div>
                 
               </div>


### PR DESCRIPTION
## Description

Since af097c3, the pivot design panel needs to have a `height: 100%` style. But the style was applied to the first section instead of the whole panel, making the second session invisible.

Task: [6148708](https://www.odoo.com/odoo/2328/tasks/6148708)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo