### PR TITLE
[FIX] named range: keep dropdown open on hover

### DIFF
--- a/src/components/menu/menu.ts
+++ b/src/components/menu/menu.ts
@@ -21,6 +21,7 @@ export interface MenuProps {
   isHoveredMenuFocused?: boolean;
   width?: number;
   onKeyDown?: (ev: KeyboardEvent) => void;
+  disableKeyboardNavigation?: boolean;
 }
 
 export interface MenuState {
@@ -44,6 +45,7 @@ export class Menu extends Component<MenuProps, SpreadsheetChildEnv> {
     isHoveredMenuFocused: { type: Boolean, optional: true },
     onScroll: { type: Function, optional: true },
     onKeyDown: { type: Function, optional: true },
+    disableKeyboardNavigation: { type: Boolean, optional: true },
   };
 
   static components = {};
@@ -53,7 +55,12 @@ export class Menu extends Component<MenuProps, SpreadsheetChildEnv> {
 
   setup(): void {
     useEffect(() => {
-      if (this.props.hoveredMenuId && this.props.isHoveredMenuFocused && this.menuRef.el) {
+      if (
+        this.props.hoveredMenuId &&
+        this.props.isHoveredMenuFocused &&
+        this.menuRef.el &&
+        !this.props.disableKeyboardNavigation
+      ) {
         const selector = `[data-name='${this.props.hoveredMenuId}']`;
         const menuItemElement = this.menuRef.el.querySelector(selector) as HTMLElement;
         menuItemElement?.focus();

--- a/src/components/menu_popover/menu_popover.ts
+++ b/src/components/menu_popover/menu_popover.ts
@@ -143,6 +143,7 @@ export class MenuPopover extends Component<Props, SpreadsheetChildEnv> {
       onKeyDown: this.onKeydown.bind(this),
       hoveredMenuId,
       isHoveredMenuFocused: !this.subMenu.isOpen,
+      disableKeyboardNavigation: this.props.disableKeyboardNavigation,
     };
   }
 

--- a/src/components/menu_popover/menu_popover.xml
+++ b/src/components/menu_popover/menu_popover.xml
@@ -23,6 +23,7 @@
         width="props.width"
         autoSelectFirstItem="subMenu.autoSelectFirstItem"
         onKeyboardNavigation.bind="this.onKeydown"
+        disableKeyboardNavigation="this.props.disableKeyboardNavigation"
       />
     </Popover>
   </t>

--- a/tests/named_ranges/named_ranges_selector_component.test.ts
+++ b/tests/named_ranges/named_ranges_selector_component.test.ts
@@ -211,4 +211,17 @@ describe("Named ranges topbar selector", () => {
       { name: "MyRange", range: { zone: toZone("A1") } },
     ]);
   });
+
+  test("Hovering a menu item does not close the dropdown", async () => {
+    createNamedRange(model, "MyRange", "A1:B3");
+    await mountRangeSelector();
+    const input = fixture.querySelector<HTMLInputElement>(".o-named-range-selector input")!;
+    input.focus();
+    await nextTick();
+
+    expect(".o-menu-item").toHaveCount(2); // 1 named range + "Manage named ranges"
+    triggerMouseEvent(".o-menu-item", "mouseenter");
+    await nextTick();
+    expect(".o-menu-item").toHaveCount(2);
+  });
 });


### PR DESCRIPTION
## Description

When opening the named range dropdown by focusing the input, the dropdown would close when hovering the menu items.

This was because hovering a menu item would focus it (to enable for keyboard navigation), which would trigger the onBlur event of the input, closing the dropdown.

Task: [6167171](https://www.odoo.com/odoo/2328/tasks/6167171)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo