### PR TITLE
[FIX] range: correctly handle unbounded ranges on row/col changes

### DIFF
--- a/src/helpers/range.ts
+++ b/src/helpers/range.ts
@@ -437,8 +437,20 @@ function getApplyRangeChangeAddColRow(cmd: AddColumnsRowsCommand): ApplyRangeCha
     if (range.sheetId !== cmd.sheetId) {
       return { changeType: "NONE", range };
     }
+
+    const isUnboundedAtEnd = range.unboundedZone[end] === undefined;
+
+    // Full column/row ranges (e.g. A:A) are anchored at the sheet origin,
+    // so any insertion only expands them (RESIZE), never moves them.
+    if (isUnboundedAtEnd && !range.unboundedZone.hasHeader) {
+      return {
+        changeType: "RESIZE",
+        range: createAdaptedRange(range, dimension, "RESIZE", cmd.quantity),
+      };
+    }
+
     if (cmd.position === "after") {
-      if (range.zone[start] <= cmd.base && cmd.base < range.zone[end]) {
+      if (range.zone[start] <= cmd.base && (cmd.base < range.zone[end] || isUnboundedAtEnd)) {
         return {
           changeType: "RESIZE",
           range: createAdaptedRange(range, dimension, "RESIZE", cmd.quantity),

--- a/tests/range_plugin.test.ts
+++ b/tests/range_plugin.test.ts
@@ -1,5 +1,5 @@
 import { CorePlugin, coreTypes, Model } from "../src";
-import { duplicateRangeInDuplicatedSheet } from "../src/helpers";
+import { duplicateRangeInDuplicatedSheet, numberToLetters } from "../src/helpers";
 import { corePluginRegistry } from "../src/plugins";
 import { Command, Range, RangeAdapterFunctions } from "../src/types";
 import { CellErrorType } from "../src/types/errors";
@@ -35,7 +35,7 @@ coreTypes.add("USE_RANGE");
 coreTypes.add("USE_TRANSIENT_RANGE");
 
 class PluginTestRange extends CorePlugin {
-  static getters = ["getUsedRanges", "getRanges"];
+  static getters = ["getUsedRanges", "getRanges", "getRangeZoneEdge"];
 
   ranges: Range[] = [];
 
@@ -77,6 +77,10 @@ class PluginTestRange extends CorePlugin {
 
   getRanges() {
     return this.ranges;
+  }
+
+  getRangeZoneEdge(edge, index = 0) {
+    return this.ranges[index].zone[edge];
   }
 }
 
@@ -661,11 +665,25 @@ describe("full column range", () => {
   test("insert row before'", () => {
     addRows(m, "before", 0, 1);
     expect(m.getters.getUsedRanges()).toEqual(["B:C"]);
+    expect(m.getters.getRangeZoneEdge("top")).toBe(0);
   });
-  test("insert row before (2)", () => {
+  test("insert row at bottom expands range", () => {
+    const bottom = m.getters.getRangeZoneEdge("bottom");
+    addRows(m, "after", bottom, 1);
+    expect(m.getters.getRangeZoneEdge("bottom")).toBe(bottom + 1);
+  });
+  test("insert row before moves B1:C range (has header)", () => {
     m.dispatch("USE_RANGE", { sheetId: m.getters.getActiveSheetId(), rangesXC: ["B1:C"] });
     addRows(m, "before", 0, 1);
     expect(m.getters.getUsedRanges()[1]).toEqual("B2:C");
+    expect(m.getters.getRangeZoneEdge("top", 1)).toBe(1);
+  });
+  test("insert row at bottom expands B1:C range (has header)", () => {
+    m.dispatch("USE_RANGE", { sheetId: m.getters.getActiveSheetId(), rangesXC: ["B1:C"] });
+    const bottom = m.getters.getRangeZoneEdge("bottom");
+    addRows(m, "after", bottom, 1);
+    expect(m.getters.getUsedRanges()[1]).toEqual("B1:C");
+    expect(m.getters.getRangeZoneEdge("bottom", 1)).toBe(bottom + 1);
   });
 });
 
@@ -712,11 +730,26 @@ describe("full row range", () => {
   test("insert col before range", () => {
     addColumns(m, "before", "A", 1);
     expect(m.getters.getUsedRanges()).toEqual(["2:3"]);
+    expect(m.getters.getRangeZoneEdge("left")).toBe(0);
   });
-  test("insert col before range (1)", () => {
+  test("insert col at right expands range", () => {
+    const right = m.getters.getRangeZoneEdge("right");
+    addColumns(m, "after", numberToLetters(right), 1);
+    expect(m.getters.getUsedRanges()).toEqual(["2:3"]);
+    expect(m.getters.getRangeZoneEdge("right")).toBe(right + 1);
+  });
+  test("insert col before moves A2:3 range (has header)", () => {
     m.dispatch("USE_RANGE", { sheetId: m.getters.getActiveSheetId(), rangesXC: ["A2:3"] });
     addColumns(m, "before", "A", 1);
     expect(m.getters.getUsedRanges()[1]).toEqual("B2:3");
+    expect(m.getters.getRangeZoneEdge("left", 1)).toBe(1);
+  });
+  test("insert col at right expands A2:3 range (has header)", () => {
+    m.dispatch("USE_RANGE", { sheetId: m.getters.getActiveSheetId(), rangesXC: ["A2:3"] });
+    const right = m.getters.getRangeZoneEdge("right");
+    addColumns(m, "after", numberToLetters(right), 1);
+    expect(m.getters.getUsedRanges()[1]).toEqual("A2:3");
+    expect(m.getters.getRangeZoneEdge("right", 1)).toBe(right + 1);
   });
 });
 


### PR DESCRIPTION
## Description:

Steps to reproduce:
- Create a sheet with 3 rows
- Set `A1 = 1`, `A2 = 2`, and `C1 = SUM(A:A)`
- Delete row 3
- Add a new row at the bottom
- Set `A3 = 6`

Issue:
- Unbounded ranges (e.g. `A:A`) are not properly updated on row/col changes.
  The changeType can be incorrectly computed as `NONE` or `MOVE` instead
  of `RESIZE`, causing formulas to miss newly added cells (e.g. `A3` in `SUM`).

Cause:
- Incomplete condition handling for unbounded ranges caused inconsistent
  changeType detection across different scenarios.

Fix:
- Refine changeType computation for unbounded ranges by covering all edge
  cases and ensuring correct `RESIZE` behavior when the range should expand.

Task: [6167358](https://www.odoo.com/odoo/2328/tasks/6167358)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo