### PR TITLE
[FIX] gauge error message displayed twice

### DIFF
--- a/src/components/side_panel/chart/gauge_chart_panel/gauge_chart_design_panel.ts
+++ b/src/components/side_panel/chart/gauge_chart_panel/gauge_chart_design_panel.ts
@@ -61,7 +61,7 @@ css/* scss */ `
 `;
 
 interface PanelState {
-  sectionRuleCancelledReasons?: CommandResult[];
+  sectionRuleCancelledReasons?: Set<CommandResult>;
   sectionRule: SectionRule;
 }
 
@@ -93,8 +93,8 @@ export class GaugeChartDesignPanel extends Component<Props, SpreadsheetChildEnv>
 
   setup() {
     this.state = useState<PanelState>({
-      sectionRuleCancelledReasons: this.checkSectionRuleFormulasAreValid(
-        this.props.definition.sectionRule
+      sectionRuleCancelledReasons: new Set(
+        this.checkSectionRuleFormulasAreValid(this.props.definition.sectionRule)
       ),
       sectionRule: deepCopy(this.props.definition.sectionRule),
     });
@@ -111,15 +111,15 @@ export class GaugeChartDesignPanel extends Component<Props, SpreadsheetChildEnv>
 
   get isRangeMinInvalid() {
     return !!(
-      this.state.sectionRuleCancelledReasons?.includes(CommandResult.EmptyGaugeRangeMin) ||
-      this.state.sectionRuleCancelledReasons?.includes(CommandResult.GaugeRangeMinNaN)
+      this.state.sectionRuleCancelledReasons?.has(CommandResult.EmptyGaugeRangeMin) ||
+      this.state.sectionRuleCancelledReasons?.has(CommandResult.GaugeRangeMinNaN)
     );
   }
 
   get isRangeMaxInvalid() {
     return !!(
-      this.state.sectionRuleCancelledReasons?.includes(CommandResult.EmptyGaugeRangeMax) ||
-      this.state.sectionRuleCancelledReasons?.includes(CommandResult.GaugeRangeMaxNaN)
+      this.state.sectionRuleCancelledReasons?.has(CommandResult.EmptyGaugeRangeMax) ||
+      this.state.sectionRuleCancelledReasons?.has(CommandResult.GaugeRangeMaxNaN)
     );
   }
 
@@ -128,13 +128,13 @@ export class GaugeChartDesignPanel extends Component<Props, SpreadsheetChildEnv>
   // ---------------------------------------------------------------------------
 
   get isLowerInflectionPointInvalid() {
-    return !!this.state.sectionRuleCancelledReasons?.includes(
+    return !!this.state.sectionRuleCancelledReasons?.has(
       CommandResult.GaugeLowerInflectionPointNaN
     );
   }
 
   get isUpperInflectionPointInvalid() {
-    return !!this.state.sectionRuleCancelledReasons?.includes(
+    return !!this.state.sectionRuleCancelledReasons?.has(
       CommandResult.GaugeUpperInflectionPointNaN
     );
   }
@@ -146,9 +146,8 @@ export class GaugeChartDesignPanel extends Component<Props, SpreadsheetChildEnv>
   }
 
   updateSectionRule(sectionRule: SectionRule) {
-    this.state.sectionRuleCancelledReasons = [];
-    this.state.sectionRuleCancelledReasons.push(
-      ...this.checkSectionRuleFormulasAreValid(this.state.sectionRule)
+    this.state.sectionRuleCancelledReasons = new Set(
+      this.checkSectionRuleFormulasAreValid(this.state.sectionRule)
     );
 
     const dispatchResult = this.props.updateChart(this.props.figureId, {
@@ -157,7 +156,9 @@ export class GaugeChartDesignPanel extends Component<Props, SpreadsheetChildEnv>
     if (dispatchResult.isSuccessful) {
       this.state.sectionRule = deepCopy(sectionRule);
     } else {
-      this.state.sectionRuleCancelledReasons.push(...dispatchResult.reasons);
+      for (const reason of dispatchResult.reasons) {
+        this.state.sectionRuleCancelledReasons.add(reason);
+      }
     }
   }
 
@@ -192,19 +193,19 @@ export class GaugeChartDesignPanel extends Component<Props, SpreadsheetChildEnv>
     };
   }
 
-  private checkSectionRuleFormulasAreValid(sectionRule: SectionRule): CommandResult[] {
-    const reasons: CommandResult[] = [];
+  private checkSectionRuleFormulasAreValid(sectionRule: SectionRule): Set<CommandResult> {
+    const reasons = new Set<CommandResult>();
     if (!this.valueIsValidNumber(sectionRule.rangeMin)) {
-      reasons.push(CommandResult.GaugeRangeMinNaN);
+      reasons.add(CommandResult.GaugeRangeMinNaN);
     }
     if (!this.valueIsValidNumber(sectionRule.rangeMax)) {
-      reasons.push(CommandResult.GaugeRangeMaxNaN);
+      reasons.add(CommandResult.GaugeRangeMaxNaN);
     }
     if (!this.valueIsValidNumber(sectionRule.lowerInflectionPoint.value)) {
-      reasons.push(CommandResult.GaugeLowerInflectionPointNaN);
+      reasons.add(CommandResult.GaugeLowerInflectionPointNaN);
     }
     if (!this.valueIsValidNumber(sectionRule.upperInflectionPoint.value)) {
-      reasons.push(CommandResult.GaugeUpperInflectionPointNaN);
+      reasons.add(CommandResult.GaugeUpperInflectionPointNaN);
     }
     return reasons;
   }

--- a/tests/figures/chart/gauge/gauge_panel_component.test.ts
+++ b/tests/figures/chart/gauge/gauge_panel_component.test.ts
@@ -158,6 +158,12 @@ describe("update chart with invalid section rule", () => {
     );
   });
 
+  test("error message is only displayed once", async () => {
+    await openChartDesignSidePanel(model, env, fixture, chartId);
+    await editStandaloneComposer(".lowerInflectionPoint .o-composer", "bla bla bla");
+    expect(".o-validation-error").toHaveCount(1);
+  });
+
   test.each(["bla bla bla", "=#ERROR"])("NaN rangeMin %s", async (content) => {
     await openChartDesignSidePanel(model, env, fixture, chartId);
     await editStandaloneComposer(".upperInflectionPoint .o-composer", "bla bla bla");


### PR DESCRIPTION
Before this commit:
The same error message is displayed twice.

How to reproduce:
- open the design side panel of a gauge chart
- write a wrong expression in the range

Task: [6179300](https://www.odoo.com/odoo/2328/tasks/6179300)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo