### PR TITLE
[FIX] pivot: unused pivot detection 

### DIFF
--- a/src/helpers/pivot/pivot_composer_helpers.ts
+++ b/src/helpers/pivot/pivot_composer_helpers.ts
@@ -97,6 +97,10 @@ export function getFirstPivotFunction(tokens: Token[]) {
   return getFunctionsFromTokens(tokens, PIVOT_FUNCTIONS)[0];
 }
 
+export function getPivotFunctions(tokens: Token[]) {
+  return getFunctionsFromTokens(tokens, PIVOT_FUNCTIONS);
+}
+
 /**
  * Parse a spreadsheet formula and detect the number of PIVOT functions that are
  * present in the given formula.

--- a/src/helpers/pivot/pivot_highlight.ts
+++ b/src/helpers/pivot/pivot_highlight.ts
@@ -15,8 +15,8 @@ function getVisiblePivotCellPositions(getters: Getters, pivotId: UID) {
   for (const col of getters.getSheetViewVisibleCols()) {
     for (const row of getters.getSheetViewVisibleRows()) {
       const position = { sheetId, col, row };
-      const cellPivotId = getters.getPivotIdFromPosition(position);
-      if (pivotId === cellPivotId) {
+      const cellPivotIds = getters.getPivotIdsFromPosition(position);
+      if (cellPivotIds.includes(pivotId)) {
         positions.push(position);
       }
     }

--- a/src/plugins/ui_core_views/pivot_ui.ts
+++ b/src/plugins/ui_core_views/pivot_ui.ts
@@ -2,10 +2,10 @@ import { Token } from "../../formulas";
 import { astToFormula } from "../../formulas/parser";
 import { toScalar } from "../../functions/helper_matrices";
 import { toBoolean } from "../../functions/helpers";
-import { deepCopy } from "../../helpers";
+import { deepCopy, isDefined } from "../../helpers";
 import {
-  getFirstPivotFunction,
   getNumberOfPivotFunctions,
+  getPivotFunctions,
 } from "../../helpers/pivot/pivot_composer_helpers";
 import withPivotPresentationLayer from "../../helpers/pivot/pivot_presentation";
 import { pivotRegistry } from "../../helpers/pivot/pivot_registry";
@@ -15,9 +15,11 @@ import { _t } from "../../translation";
 import {
   AddPivotCommand,
   CellPosition,
+  CellValue,
   Command,
   CoreCommand,
   FunctionResultObject,
+  Matrix,
   PivotCoreMeasure,
   PivotTableCell,
   RangeCompiledFormula,
@@ -35,11 +37,17 @@ function isPivotCommand(cmd: CoreCommand): cmd is AddPivotCommand | UpdatePivotC
   return UNDO_REDO_PIVOT_COMMANDS.includes(cmd.type);
 }
 
+interface PivotEvaluatedArgs {
+  functionName: string;
+  args: (CellValue | Matrix<CellValue> | undefined)[];
+}
+
 export class PivotUIPlugin extends UIPlugin {
   static getters = [
     "getPivot",
     "getFirstPivotFunction",
     "getPivotIdFromPosition",
+    "getPivotIdsFromPosition",
     "getPivotCellFromPosition",
     "generateNewCalculatedMeasureName",
     "isPivotUnused",
@@ -121,24 +129,31 @@ export class PivotUIPlugin extends UIPlugin {
   // ---------------------------------------------------------------------
 
   /**
-   * Get the id of the pivot at the given position. Returns undefined if there
+   * Get the id of the first pivot in the formula at the given position. Returns undefined if there
    * is no pivot at this position
    */
-  getPivotIdFromPosition(position: CellPosition) {
-    const cell = this.getters.getCorrespondingFormulaCell(position);
-    if (cell && cell.isFormula) {
-      return this.getPivotIdFromFormula(position.sheetId, cell.compiledFormula);
-    }
-    return undefined;
+  getPivotIdFromPosition(position: CellPosition): UID | undefined {
+    return this.getPivotIdsFromPosition(position)[0];
   }
 
-  private getPivotIdFromFormula(sheetId: UID, formula: RangeCompiledFormula) {
-    const pivotFunction = this.getFirstPivotFunction(sheetId, formula.tokens);
-    if (pivotFunction) {
-      const pivotId = pivotFunction.args[0]?.toString();
-      return pivotId && this.getters.getPivotId(pivotId);
+  /**
+   * Get all of the ids of the pivot present in the formula at the given position.
+   */
+  getPivotIdsFromPosition(position: CellPosition): UID[] {
+    const cell = this.getters.getCorrespondingFormulaCell(position);
+    if (cell && cell.isFormula) {
+      return this.getPivotIdsFromFormula(position.sheetId, cell.compiledFormula);
     }
-    return undefined;
+    return [];
+  }
+
+  private getPivotIdsFromFormula(sheetId: UID, formula: RangeCompiledFormula): UID[] {
+    return this.getPivotFunctions(sheetId, formula.tokens)
+      .map((pivotFunction) => {
+        const pivotId = pivotFunction.args[0]?.toString();
+        return pivotId && this.getters.getPivotId(pivotId);
+      })
+      .filter(isDefined);
   }
 
   isSpillPivotFormula(position: CellPosition) {
@@ -153,26 +168,34 @@ export class PivotUIPlugin extends UIPlugin {
     return false;
   }
 
-  getFirstPivotFunction(sheetId: UID, tokens: Token[]) {
-    const pivotFunction = getFirstPivotFunction(tokens);
-    if (!pivotFunction) {
-      return undefined;
+  private getPivotFunctions(sheetId: UID, tokens: Token[]): PivotEvaluatedArgs[] {
+    const pivotFunctions = getPivotFunctions(tokens);
+    if (!pivotFunctions.length) {
+      return [];
     }
-    const { functionName, args } = pivotFunction;
-    const evaluatedArgs = args.map((argAst) => {
-      if (argAst.type === "EMPTY") {
-        return undefined;
-      } else if (
-        argAst.type === "STRING" ||
-        argAst.type === "BOOLEAN" ||
-        argAst.type === "NUMBER"
-      ) {
-        return argAst.value;
-      }
-      const argsString = astToFormula(argAst);
-      return this.getters.evaluateFormula(sheetId, argsString);
-    });
-    return { functionName, args: evaluatedArgs };
+    const evaluatedPivotFunctions: PivotEvaluatedArgs[] = [];
+    for (const pivotFunction of pivotFunctions) {
+      const { functionName, args } = pivotFunction;
+      const evaluatedArgs = args.map((argAst) => {
+        if (argAst.type === "EMPTY") {
+          return undefined;
+        } else if (
+          argAst.type === "STRING" ||
+          argAst.type === "BOOLEAN" ||
+          argAst.type === "NUMBER"
+        ) {
+          return argAst.value;
+        }
+        const argsString = astToFormula(argAst);
+        return this.getters.evaluateFormula(sheetId, argsString);
+      });
+      evaluatedPivotFunctions.push({ functionName, args: evaluatedArgs });
+    }
+    return evaluatedPivotFunctions;
+  }
+
+  getFirstPivotFunction(sheetId: UID, tokens: Token[]): PivotEvaluatedArgs | undefined {
+    return this.getPivotFunctions(sheetId, tokens)[0];
   }
 
   /**
@@ -321,8 +344,8 @@ export class PivotUIPlugin extends UIPlugin {
     for (const sheetId of this.getters.getSheetIds()) {
       for (const cellId in this.getters.getCells(sheetId)) {
         const position = this.getters.getCellPosition(cellId);
-        const pivotId = this.getPivotIdFromPosition(position);
-        if (pivotId) {
+        const pivotIds = this.getPivotIdsFromPosition(position);
+        for (const pivotId of pivotIds) {
           unusedPivots.delete(pivotId);
           if (!unusedPivots.size) {
             this.unusedPivots = [];
@@ -338,8 +361,8 @@ export class PivotUIPlugin extends UIPlugin {
         if (measure.computedBy) {
           const { sheetId } = measure.computedBy;
           const formula = this.getters.getMeasureCompiledFormula(pivotId, measure);
-          const relatedPivotId = this.getPivotIdFromFormula(sheetId, formula);
-          if (relatedPivotId) {
+          const relatedPivotIds = this.getPivotIdsFromFormula(sheetId, formula);
+          for (const relatedPivotId of relatedPivotIds) {
             unusedPivots.delete(relatedPivotId);
             if (!unusedPivots.size) {
               this.unusedPivots = [];

--- a/src/plugins/ui_core_views/pivot_ui.ts
+++ b/src/plugins/ui_core_views/pivot_ui.ts
@@ -20,6 +20,7 @@ import {
   FunctionResultObject,
   PivotCoreMeasure,
   PivotTableCell,
+  RangeCompiledFormula,
   UID,
   UpdatePivotCommand,
   invalidateEvaluationCommands,
@@ -126,14 +127,16 @@ export class PivotUIPlugin extends UIPlugin {
   getPivotIdFromPosition(position: CellPosition) {
     const cell = this.getters.getCorrespondingFormulaCell(position);
     if (cell && cell.isFormula) {
-      const pivotFunction = this.getFirstPivotFunction(
-        position.sheetId,
-        cell.compiledFormula.tokens
-      );
-      if (pivotFunction) {
-        const pivotId = pivotFunction.args[0]?.toString();
-        return pivotId && this.getters.getPivotId(pivotId);
-      }
+      return this.getPivotIdFromFormula(position.sheetId, cell.compiledFormula);
+    }
+    return undefined;
+  }
+
+  private getPivotIdFromFormula(sheetId: UID, formula: RangeCompiledFormula) {
+    const pivotFunction = this.getFirstPivotFunction(sheetId, formula.tokens);
+    if (pivotFunction) {
+      const pivotId = pivotFunction.args[0]?.toString();
+      return pivotId && this.getters.getPivotId(pivotId);
     }
     return undefined;
   }
@@ -328,6 +331,25 @@ export class PivotUIPlugin extends UIPlugin {
         }
       }
     }
+
+    for (const pivotId of this.getters.getPivotIds()) {
+      const pivot = this.getters.getPivot(pivotId);
+      for (const measure of pivot.definition.measures) {
+        if (measure.computedBy) {
+          const { sheetId } = measure.computedBy;
+          const formula = this.getters.getMeasureCompiledFormula(pivotId, measure);
+          const relatedPivotId = this.getPivotIdFromFormula(sheetId, formula);
+          if (relatedPivotId) {
+            unusedPivots.delete(relatedPivotId);
+            if (!unusedPivots.size) {
+              this.unusedPivots = [];
+              return [];
+            }
+          }
+        }
+      }
+    }
+
     this.unusedPivots = [...unusedPivots];
     return this.unusedPivots;
   }

--- a/tests/pivots/pivot_plugin.test.ts
+++ b/tests/pivots/pivot_plugin.test.ts
@@ -1,6 +1,7 @@
 import { CellErrorType, CommandResult, Model } from "../../src";
 import { FORBIDDEN_SHEETNAME_CHARS } from "../../src/constants";
 import { toZone } from "../../src/helpers";
+import { getPivotHighlights } from "../../src/helpers/pivot/pivot_highlight";
 import { EMPTY_PIVOT_CELL } from "../../src/helpers/pivot/table_spreadsheet_pivot";
 import { getEvaluatedCell } from "../test_helpers";
 import { renameSheet, selectCell, setCellContent } from "../test_helpers/commands_helpers";
@@ -417,5 +418,23 @@ describe("Pivot plugin", () => {
       expect(model.getters.isPivotUnused("1")).toBe(false);
       expect(model.getters.isPivotUnused("2")).toBe(false);
     });
+
+    test("Can detect unused pivots with multiple pivot formulas in the same cell", () => {
+      const model = createModelWithPivot("A1:I5");
+      addPivot(model, "A1:I5", { name: "Unused Pivot" }, "2");
+      setCellContent(model, "A40", "=PIVOT(1) + PIVOT(2)");
+
+      expect(model.getters.isPivotUnused("1")).toBe(false);
+      expect(model.getters.isPivotUnused("2")).toBe(false);
+    });
+  });
+
+  test("Pivot highlights works with multiple pivot formulas in the same cell", () => {
+    const model = createModelWithPivot("A1:I5");
+    addPivot(model, "A1:I5", { name: "Unused Pivot" }, "2");
+    setCellContent(model, "A40", "=SUM(PIVOT(1) + PIVOT(2))");
+
+    expect(getPivotHighlights(model.getters, "1")).toMatchObject([{ zone: toZone("A40") }]);
+    expect(getPivotHighlights(model.getters, "2")).toMatchObject([{ zone: toZone("A40") }]);
   });
 });

--- a/tests/pivots/pivot_plugin.test.ts
+++ b/tests/pivots/pivot_plugin.test.ts
@@ -386,4 +386,36 @@ describe("Pivot plugin", () => {
       EMPTY_PIVOT_CELL
     );
   });
+
+  describe("isPivotUnused getter", () => {
+    test("Can use getter to detect unused pivot", () => {
+      const model = createModelWithPivot("A1:I5");
+      setCellContent(model, "A40", "=PIVOT(1)");
+      addPivot(model, "A1:I5", { name: "Unused Pivot" }, "2");
+      expect(model.getters.isPivotUnused("1")).toBe(false);
+      expect(model.getters.isPivotUnused("2")).toBe(true);
+    });
+
+    test("Pivot used in another pivot calculated measure is marked as used", () => {
+      const model = createModelWithPivot("A1:I5");
+      setCellContent(model, "A40", "=PIVOT(1)");
+      addPivot(model, "A1:I5", { name: "Unused Pivot" }, "2");
+      updatePivot(model, "1", {
+        measures: [
+          {
+            id: "Calculated",
+            fieldName: "Calculated",
+            aggregator: "sum",
+            computedBy: {
+              formula: "=PIVOT(2)",
+              sheetId: model.getters.getActiveSheetId(),
+            },
+          },
+        ],
+      });
+
+      expect(model.getters.isPivotUnused("1")).toBe(false);
+      expect(model.getters.isPivotUnused("2")).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
## Description:

### [FIX] pivot: unused pivot detection with composed formula

If a formula has two pivots (eg. `=PIVOT(1) + PIVOT(2)`), the
second pivot will not be detected as used.

### [FIX] pivot: unused pivot detection with calculated measure

If a pivot has a calculated measure that refers to a second pivot,
the second pivot is not detected as used. This commit fixes that.

Note: the fix does not fix 100% of the issues. A pivot only referenced
in other places (eg. in a CF rule formula) will still not be
detected as used. But checking every other place the pivot can be
referenced is expensive and error-prone. That may be done in master.

Task: [6105894](https://www.odoo.com/odoo/2328/tasks/6105894)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo