### PR TITLE
[FIX] composer: add flex-grow-1 to value container

### DIFF
--- a/src/components/composer/autocomplete_dropdown/autocomplete_dropdown.xml
+++ b/src/components/composer/autocomplete_dropdown/autocomplete_dropdown.xml
@@ -13,7 +13,7 @@
           t-on-pointermove="() => this.props.onValueHovered(proposal_index)">
           <div class="d-flex align-items-center gap-2">
             <div t-if="proposal.icon" t-call="{{proposal.icon}}"/>
-            <div class="o-autocomplete-value text-truncate">
+            <div class="o-autocomplete-value text-truncate flex-grow-1">
               <t t-set="htmlContent" t-value="proposal.htmlContent || [{ value: proposal.text}]"/>
               <span
                 t-foreach="htmlContent"

--- a/tests/composer/__snapshots__/autocomplete_dropdown_component.test.ts.snap
+++ b/tests/composer/__snapshots__/autocomplete_dropdown_component.test.ts.snap
@@ -24,7 +24,7 @@ exports[`Functions autocomplete autocomplete simple snapshot with =S 1`] = `
       </div>
       
       <div
-        class="o-autocomplete-value text-truncate"
+        class="o-autocomplete-value text-truncate flex-grow-1"
       >
         <span
           class="o-semi-bold"
@@ -67,7 +67,7 @@ exports[`Functions autocomplete autocomplete simple snapshot with =S 1`] = `
       </div>
       
       <div
-        class="o-autocomplete-value text-truncate"
+        class="o-autocomplete-value text-truncate flex-grow-1"
       >
         <span
           class="o-semi-bold"
@@ -119,7 +119,7 @@ exports[`composer Assistant render above the cell when not enough place below 1`
         </div>
         
         <div
-          class="o-autocomplete-value text-truncate"
+          class="o-autocomplete-value text-truncate flex-grow-1"
         >
           <span
             class="o-semi-bold"
@@ -162,7 +162,7 @@ exports[`composer Assistant render above the cell when not enough place below 1`
         </div>
         
         <div
-          class="o-autocomplete-value text-truncate"
+          class="o-autocomplete-value text-truncate flex-grow-1"
         >
           <span
             class="o-semi-bold"
@@ -216,7 +216,7 @@ exports[`composer Assistant render below the cell by default 1`] = `
         </div>
         
         <div
-          class="o-autocomplete-value text-truncate"
+          class="o-autocomplete-value text-truncate flex-grow-1"
         >
           <span
             class="o-semi-bold"
@@ -259,7 +259,7 @@ exports[`composer Assistant render below the cell by default 1`] = `
         </div>
         
         <div
-          class="o-autocomplete-value text-truncate"
+          class="o-autocomplete-value text-truncate flex-grow-1"
         >
           <span
             class="o-semi-bold"


### PR DESCRIPTION
## Description:

Current behavior before PR:
- Commit 7fc45f8 added a flex wrapper for `proposal.icon`
- Due to this, `.o-autocomplete-value` became content-sized instead of using the full available width
- This breaks child element class that rely on full width (e.g. right-aligned content)

Desired behavior after PR is merged:
- Add `flex-grow-1` to `.o-autocomplete-value` so it expands and uses the available space.

Task: [6159426](https://www.odoo.com/odoo/2328/tasks/6159426)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo