### PR TITLE
[FIX] color_picker: prevent gradient from opening when picking a cust…

### DIFF
--- a/src/components/color_picker/color_picker.xml
+++ b/src/components/color_picker/color_picker.xml
@@ -39,7 +39,7 @@
             class="o-color-picker-line-item"
             t-att-data-color="color"
             t-attf-style="background-color:{{color}};"
-            t-on-click="() => this.onColorClick(color)">
+            t-on-click.stop="() => this.onColorClick(color)">
             <div
               t-if="isSameColor(props.currentColor, color)"
               align="center"

--- a/tests/colors/color_picker_component.test.ts
+++ b/tests/colors/color_picker_component.test.ts
@@ -66,6 +66,16 @@ describe("Color Picker buttons", () => {
     expect(onColorPicked).toHaveBeenCalledWith("#FF9900");
   });
 
+  test("Clicking a custom color picks it without opening the gradient", async () => {
+    const model = new Model();
+    setStyle(model, "A1", { fillColor: "#123456" });
+    const onColorPicked = jest.fn();
+    await mountColorPicker({ onColorPicked }, model);
+    await simulateClick("div[data-color='#123456']");
+    expect(onColorPicked).toHaveBeenCalledWith("#123456");
+    expect(fixture.querySelector(".o-custom-selector")).toBeNull();
+  });
+
   test("Can pick a custom color in the gradient", async () => {
     const onColorPicked = jest.fn();
     await mountColorPicker({ onColorPicked });


### PR DESCRIPTION
…om color

Clicking a custom color swatch bubbled up to the parent toggler and opened the gradient picker instead of just selecting the color. Stop the click propagation on the custom color item so it only triggers the color pick.

Task: 6186050

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo