### PR TITLE
[IMP] side panel collapsible : added a slot for additional buttons

### DIFF
--- a/src/components/side_panel/components/collapsible/side_panel_collapsible.css
+++ b/src/components/side_panel/components/collapsible/side_panel_collapsible.css
@@ -2,7 +2,7 @@
   .o_side_panel_collapsible_title {
     font-size: 16px;
     cursor: pointer;
-    padding: 6px 0px 6px 6px !important;
+    padding: 6px 6px 6px 6px !important;
     .collapsor-arrow {
       transform: rotate(-90deg);
       display: inline-block;

--- a/src/components/side_panel/components/collapsible/side_panel_collapsible.xml
+++ b/src/components/side_panel/components/collapsible/side_panel_collapsible.xml
@@ -1,17 +1,17 @@
 <templates>
   <t t-name="o-spreadsheet-SidePanelCollapsible">
     <div class="" t-att-class="this.props.class">
-      <div
-        class="o_side_panel_collapsible_title o-fw-bold d-flex align-items-center"
-        t-on-click="() => this.toggle()">
+      <div class="o_side_panel_collapsible_title o-fw-bold d-flex align-items-center">
         <div
           class="collapsor w-100 d-flex align-items-center ps-1"
-          t-att-class="this.state.isCollapsed ? 'collapsed' : ''">
+          t-att-class="this.state.isCollapsed ? 'collapsed' : ''"
+          t-on-click="() => this.toggle()">
           <span class="collapsor-arrow">
             <t t-call="o-spreadsheet-Icon.ANGLE_DOWN"/>
           </span>
           <div class="ps-2" t-out="this.props.title"/>
         </div>
+        <t t-call-slot="titleButton"/>
       </div>
       <Collapse isCollapsed="this.state.isCollapsed">
         <div class="pt-2">

--- a/tests/table/__snapshots__/filter_menu_component.test.ts.snap
+++ b/tests/table/__snapshots__/filter_menu_component.test.ts.snap
@@ -56,6 +56,8 @@ exports[`Filter menu component Filter Tests Filter menu is correctly rendered 1`
             Filter by criterion
           </div>
         </div>
+        
+        
       </div>
       <div
         class="os-collapse d-none"
@@ -110,6 +112,8 @@ exports[`Filter menu component Filter Tests Filter menu is correctly rendered 1`
             Filter by values
           </div>
         </div>
+        
+        
       </div>
       <div
         class="os-collapse"


### PR DESCRIPTION
In order to add a button in the collapsible title, we added a slot in the component o-spreadsheet-SidePanelCollapsible. This allows us to add a button to create a new global filter directly in the collapsible title of the matching filters section.

Task: [6079698](https://www.odoo.com/odoo/2328/tasks/6079698)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo