### PR TITLE
[IMP] pivot: add side panel for unused pivots

### DIFF
--- a/src/actions/action.ts
+++ b/src/actions/action.ts
@@ -43,10 +43,6 @@ export interface ActionSpec {
   icon?: string | ((env: SpreadsheetChildEnv) => string);
   iconColor?: Color;
   /**
-   * Can be defined to display another icon on the right of the item.
-   */
-  secondaryIcon?: string | ((env: SpreadsheetChildEnv) => string);
-  /**
    * is the action allowed when running spreadsheet in readonly mode
    */
   isReadonlyAllowed?: boolean;
@@ -86,7 +82,6 @@ export interface Action {
   isActive?: (env: SpreadsheetChildEnv) => boolean;
   icon: (env: SpreadsheetChildEnv) => string;
   iconColor?: Color;
-  secondaryIcon: (env: SpreadsheetChildEnv) => string;
   isReadonlyAllowed: boolean;
   isEnabledOnLockedSheet: boolean;
   execute?: (env: SpreadsheetChildEnv, isMiddleClick?: boolean) => unknown;
@@ -97,12 +92,10 @@ export interface Action {
   onStopHover?: (env: SpreadsheetChildEnv) => void;
 }
 
-export interface ComputedAction
-  extends Omit<Action, "name" | "description" | "icon" | "secondaryIcon" | "children"> {
+export interface ComputedAction extends Omit<Action, "name" | "description" | "icon" | "children"> {
   name: string;
   description: string;
   icon: string;
-  secondaryIcon: string;
 }
 
 export type ActionBuilder = (env: SpreadsheetChildEnv) => ActionSpec[];
@@ -129,7 +122,6 @@ export function createAction(item: ActionSpec): Action {
   const description = item.description;
   const shortcut = filterActionShortcutForMacOs(item.shortcut);
   const icon = item.icon;
-  const secondaryIcon = item.secondaryIcon;
   const itemId = item.id || nextItemId++;
   const isEnabled = item.isEnabled ? item.isEnabled : () => true;
   return {
@@ -160,7 +152,6 @@ export function createAction(item: ActionSpec): Action {
     separator: item.separator || false,
     icon: typeof icon === "function" ? icon : () => icon || "",
     iconColor: item.iconColor,
-    secondaryIcon: typeof secondaryIcon === "function" ? secondaryIcon : () => secondaryIcon || "",
     description: typeof description === "function" ? description : () => description || "",
     shortcut: shortcut || "",
     textColor: item.textColor,

--- a/src/actions/data_actions.ts
+++ b/src/actions/data_actions.ts
@@ -44,6 +44,12 @@ export const trimWhitespace: ActionSpec = {
   },
 };
 
+export const cleanupDataSources: ActionSpec = {
+  name: _t("Remove unused data sources"),
+  execute: (env) => env.openSidePanel("DataSourceCleanup", {}),
+  isEnabled: (env) => !env.isSmall,
+};
+
 export const sortDescending: ActionSpec = {
   name: _t("Descending (Z ⟶ A)"),
   execute: (env) => {

--- a/src/components/icons/icons.xml
+++ b/src/components/icons/icons.xml
@@ -961,11 +961,6 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.UNUSED_PIVOT_WARNING">
-    <div class="o-unused-pivot-icon text-warning" title="This pivot is not used">
-      <t t-call="o-spreadsheet-Icon.TRIANGLE_EXCLAMATION"/>
-    </div>
-  </t>
   <t t-name="o-spreadsheet-Icon.ANGLE_DOWN">
     <div class="o-icon">
       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 224 256">

--- a/src/components/menu/menu.xml
+++ b/src/components/menu/menu.xml
@@ -46,11 +46,9 @@
                 class="o-menu-item-description ms-auto text-truncate"
                 t-out="description"
               />
-              <t t-set="secondaryIcon" t-value="menuItem.secondaryIcon(this.env)"/>
               <div
-                t-if="isMenuRoot || secondaryIcon"
+                t-if="isMenuRoot"
                 class="o-menu-item-root ms-auto align-items-center d-flex gap-1">
-                <t t-if="secondaryIcon" t-call="{{secondaryIcon}}"/>
                 <t t-if="isMenuRoot" t-call="o-spreadsheet-Icon.CARET_RIGHT"/>
               </div>
             </div>

--- a/src/components/side_panel/data_sources_cleanup/data_sources_cleanup.ts
+++ b/src/components/side_panel/data_sources_cleanup/data_sources_cleanup.ts
@@ -1,0 +1,53 @@
+import { proxy } from "@odoo/owl";
+import { Component } from "../../../owl3_compatibility_layer";
+import { useLocalStore } from "../../../store_engine/store_hooks";
+import { UID } from "../../../types/misc";
+import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
+import { Store } from "../../../types/store_engine";
+import { Checkbox } from "../components/checkbox/checkbox";
+import { Section } from "../components/section/section";
+import { DataSourcesCleanupStore } from "./data_sources_cleanup_store";
+
+interface State {
+  uncheckedDataSources: Record<UID, boolean>;
+}
+
+export class DataSourcesCleanup extends Component<SpreadsheetChildEnv> {
+  static template = "o-spreadsheet-DataSourcesCleanup";
+  static components = { Section, Checkbox };
+
+  state = proxy<State>({
+    uncheckedDataSources: {},
+  });
+
+  store!: Store<DataSourcesCleanupStore>;
+
+  setup() {
+    this.store = useLocalStore(DataSourcesCleanupStore);
+  }
+
+  onToggleDataSource(type: string, id: UID, checked: boolean) {
+    this.state.uncheckedDataSources[`${type}-${id}`] = !checked;
+  }
+
+  isDataSourceChecked(type: string, id: UID) {
+    return !this.state.uncheckedDataSources[`${type}-${id}`];
+  }
+
+  get dataSourcesToDelete() {
+    const dataSourcesToDelete: { type: string; id: UID }[] = [];
+    for (const category of this.store.unusedDataSourcesCategories) {
+      for (const dataSource of category.dataSources) {
+        const stateKey = `${category.type}-${dataSource.id}`;
+        if (!this.state.uncheckedDataSources[stateKey]) {
+          dataSourcesToDelete.push({ type: category.type, id: dataSource.id });
+        }
+      }
+    }
+    return dataSourcesToDelete;
+  }
+
+  onRemoveUnusedDataSources() {
+    this.env.model.dispatch("DELETE_DATA_SOURCES", { dataSources: this.dataSourcesToDelete });
+  }
+}

--- a/src/components/side_panel/data_sources_cleanup/data_sources_cleanup.xml
+++ b/src/components/side_panel/data_sources_cleanup/data_sources_cleanup.xml
@@ -1,0 +1,29 @@
+<templates>
+  <t t-name="o-spreadsheet-DataSourcesCleanup">
+    <div class="o-data-source-cleanup">
+      <Section
+        t-foreach="this.store.unusedDataSourcesCategories"
+        t-as="category"
+        t-key="category.type"
+        title="category.label">
+        <t t-foreach="category.dataSources" t-as="dataSource" t-key="dataSource_index">
+          <Checkbox
+            name="dataSource.id"
+            label="dataSource.label"
+            value="this.isDataSourceChecked(category.type, dataSource.id)"
+            onChange="(checked) => this.onToggleDataSource(category.type, dataSource.id, checked)"
+            className="'mb-2'"
+          />
+        </t>
+        <div t-if="!category.dataSources.length" class="w-100 d-flex fst-italic text-muted">
+          No unused data source in this category.
+        </div>
+      </Section>
+      <Section t-if="this.dataSourcesToDelete.length" class="'pt-0'">
+        <button class="o-button o-button-danger" t-on-click="this.onRemoveUnusedDataSources">
+          Delete selected items
+        </button>
+      </Section>
+    </div>
+  </t>
+</templates>

--- a/src/components/side_panel/data_sources_cleanup/data_sources_cleanup_store.ts
+++ b/src/components/side_panel/data_sources_cleanup/data_sources_cleanup_store.ts
@@ -1,0 +1,37 @@
+import {
+  UnusedDataSource,
+  unusedDataSourceRegistry,
+} from "../../../registries/data_source_registry";
+import { SpreadsheetStore } from "../../../stores/spreadsheet_store";
+import { Command } from "../../../types/commands";
+
+interface UnusedDataSourceCategory {
+  type: string;
+  label: string;
+  dataSources: UnusedDataSource[];
+}
+
+export class DataSourcesCleanupStore extends SpreadsheetStore {
+  protected handle(cmd: Command): void {
+    switch (cmd.type) {
+      case "DELETE_DATA_SOURCES":
+        for (const item of cmd.dataSources) {
+          const dataSourceType = unusedDataSourceRegistry.get(item.type);
+          dataSourceType.deleteDataSource(this.model.dispatch, item.id);
+        }
+    }
+  }
+
+  get unusedDataSourcesCategories(): UnusedDataSourceCategory[] {
+    const unusedDataSourcesCategories: UnusedDataSourceCategory[] = [];
+    for (const dataSourceType of unusedDataSourceRegistry.getAll()) {
+      unusedDataSourcesCategories.push({
+        type: dataSourceType.type,
+        label: dataSourceType.unusedLabel,
+        dataSources: dataSourceType.getUnusedInstances(this.getters),
+      });
+    }
+
+    return unusedDataSourcesCategories;
+  }
+}

--- a/src/helpers/figures/chart.ts
+++ b/src/helpers/figures/chart.ts
@@ -1,3 +1,4 @@
+import { CompiledFormula } from "../../formulas/compiler";
 import {
   ChartDataSourceBuilder,
   chartDataSourceRegistry,
@@ -183,6 +184,10 @@ export class SpreadsheetChart {
     return dataSource
       ? this.dataSourceBuilder.extractData(dataSource, chartId, getters)
       : { dataSetsValues: [], labelValues: [] };
+  }
+
+  getFormulas(getters: CoreGetters): CompiledFormula[] {
+    return this.chartTypeBuilder.getFormulas(getters, this.sheetId, this.definition);
   }
 
   getRuntime(getters: Getters, chartId: UID) {

--- a/src/helpers/figures/charts/bar_chart.ts
+++ b/src/helpers/figures/charts/bar_chart.ts
@@ -50,6 +50,8 @@ export const BarChart: ChartTypeBuilder<"bar"> = {
 
   getContextCreation: (definition) => definition,
 
+  getFormulas: () => [],
+
   getDefinitionFromContextCreation(context, dataSourceBuilder) {
     return {
       background: context.background,

--- a/src/helpers/figures/charts/bubble_chart.ts
+++ b/src/helpers/figures/charts/bubble_chart.ts
@@ -109,6 +109,8 @@ export const BubbleChart: ChartTypeBuilder<"bubble"> = {
     };
   },
 
+  getFormulas: () => [],
+
   getDefinitionFromContextCreation(context, dataSourceBuilder): BubbleChartDefinition {
     const isDataSourceRange = context.dataSource?.type === "range";
     return {

--- a/src/helpers/figures/charts/calendar_chart.ts
+++ b/src/helpers/figures/charts/calendar_chart.ts
@@ -65,6 +65,8 @@ export const CalendarChart: ChartTypeBuilder<"calendar"> = {
 
   getContextCreation: (definition) => definition,
 
+  getFormulas: () => [],
+
   getDefinitionFromContextCreation(context, dataSourceBuilder) {
     let legendPosition: LegendPosition = "left";
     if (context.legendPosition === "right") {

--- a/src/helpers/figures/charts/combo_chart.ts
+++ b/src/helpers/figures/charts/combo_chart.ts
@@ -45,6 +45,8 @@ export const ComboChart: ChartTypeBuilder<"combo"> = {
 
   getContextCreation: (definition) => definition,
 
+  getFormulas: () => [],
+
   getDefinitionForExcel(getters, definition, { dataSets, labelRange }) {
     return {
       ...definition,

--- a/src/helpers/figures/charts/funnel_chart.ts
+++ b/src/helpers/figures/charts/funnel_chart.ts
@@ -44,6 +44,8 @@ export const FunnelChart: ChartTypeBuilder<"funnel"> = {
 
   getContextCreation: (definition) => definition,
 
+  getFormulas: () => [],
+
   getDefinitionFromContextCreation(context, dataSourceBuilder) {
     return {
       background: context.background,

--- a/src/helpers/figures/charts/gauge_chart.ts
+++ b/src/helpers/figures/charts/gauge_chart.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_GAUGE_MIDDLE_COLOR,
   DEFAULT_GAUGE_UPPER_COLOR,
 } from "../../../constants";
+import { CompiledFormula } from "../../../formulas/compiler";
 import { isMultipleElementMatrix, toScalar } from "../../../functions/helper_matrices";
 import { tryToNumber } from "../../../functions/helpers";
 import { BasePlugin } from "../../../plugins/base_plugin";
@@ -248,6 +249,17 @@ export const GaugeChart: ChartTypeBuilder<"gauge"> = {
     const adaptFormula = (formula: string) => adaptFormulaString(sheetId, formula);
     const sectionRule = adaptSectionRuleFormulas(definition.sectionRule, adaptFormula);
     return { ...definition, dataRange, sectionRule };
+  },
+
+  getFormulas(getters, sheetId, definition): CompiledFormula[] {
+    return [
+      definition.sectionRule.rangeMin,
+      definition.sectionRule.rangeMax,
+      definition.sectionRule.lowerInflectionPoint.value,
+      definition.sectionRule.upperInflectionPoint.value,
+    ]
+      .filter((value) => value.startsWith("="))
+      .map((formula) => CompiledFormula.Compile(formula, sheetId, getters));
   },
 
   getRuntime(getters: Getters, definition, dataSource, sheetId): GaugeChartRuntime {

--- a/src/helpers/figures/charts/geo_chart.ts
+++ b/src/helpers/figures/charts/geo_chart.ts
@@ -41,6 +41,8 @@ export const GeoChart: ChartTypeBuilder<"geo"> = {
 
   getContextCreation: (definition) => definition,
 
+  getFormulas: () => [],
+
   getDefinitionFromContextCreation(context, dataSourceBuilder) {
     return {
       background: context.background,

--- a/src/helpers/figures/charts/line_chart.ts
+++ b/src/helpers/figures/charts/line_chart.ts
@@ -50,6 +50,8 @@ export const LineChart: ChartTypeBuilder<"line"> = {
 
   getContextCreation: (definition) => definition,
 
+  getFormulas: () => [],
+
   getDefinitionFromContextCreation(context, dataSourceBuilder) {
     return {
       background: context.background,

--- a/src/helpers/figures/charts/pie_chart.ts
+++ b/src/helpers/figures/charts/pie_chart.ts
@@ -44,6 +44,8 @@ export const PieChart: ChartTypeBuilder<"pie"> = {
 
   getContextCreation: (definition) => definition,
 
+  getFormulas: () => [],
+
   getDefinitionFromContextCreation(context, dataSourceBuilder) {
     return {
       background: context.background,

--- a/src/helpers/figures/charts/pyramid_chart.ts
+++ b/src/helpers/figures/charts/pyramid_chart.ts
@@ -52,6 +52,8 @@ export const PyramidChart: ChartTypeBuilder<"pyramid"> = {
 
   getContextCreation: (definition) => definition,
 
+  getFormulas: () => [],
+
   getDefinitionFromContextCreation(context, dataSourceBuilder) {
     return {
       background: context.background,

--- a/src/helpers/figures/charts/radar_chart.ts
+++ b/src/helpers/figures/charts/radar_chart.ts
@@ -45,6 +45,8 @@ export const RadarChart: ChartTypeBuilder<"radar"> = {
 
   getContextCreation: (definition) => definition,
 
+  getFormulas: () => [],
+
   getDefinitionFromContextCreation(context, dataSourceBuilder) {
     return {
       background: context.background,

--- a/src/helpers/figures/charts/scatter_chart.ts
+++ b/src/helpers/figures/charts/scatter_chart.ts
@@ -44,6 +44,8 @@ export const ScatterChart: ChartTypeBuilder<"scatter"> = {
 
   getContextCreation: (definition) => definition,
 
+  getFormulas: () => [],
+
   getDefinitionFromContextCreation(context, dataSourceBuilder) {
     return {
       background: context.background,

--- a/src/helpers/figures/charts/scorecard_chart.ts
+++ b/src/helpers/figures/charts/scorecard_chart.ts
@@ -278,6 +278,8 @@ export const ScorecardChart: ChartTypeBuilder<"scorecard"> = {
     return { ...definition, baseline, keyValue };
   },
 
+  getFormulas: () => [],
+
   getRuntime(getters, definition): ScorecardChartRuntime {
     let formattedKeyValue = "";
     let keyValueCell: EvaluatedCell | undefined;

--- a/src/helpers/figures/charts/sunburst_chart.ts
+++ b/src/helpers/figures/charts/sunburst_chart.ts
@@ -40,6 +40,8 @@ export const SunburstChart: ChartTypeBuilder<"sunburst"> = {
 
   updateRanges: (definition) => definition,
 
+  getFormulas: () => [],
+
   getDefinitionFromContextCreation(context, dataSourceBuilder) {
     return {
       background: context.background,

--- a/src/helpers/figures/charts/tree_map_chart.ts
+++ b/src/helpers/figures/charts/tree_map_chart.ts
@@ -39,6 +39,8 @@ export const TreeMapChart: ChartTypeBuilder<"treemap"> = {
 
   updateRanges: (definition) => definition,
 
+  getFormulas: () => [],
+
   getDefinitionFromContextCreation(context, dataSourceBuilder) {
     return {
       background: context.background,

--- a/src/helpers/figures/charts/waterfall_chart.ts
+++ b/src/helpers/figures/charts/waterfall_chart.ts
@@ -49,6 +49,8 @@ export const WaterfallChart: ChartTypeBuilder<"waterfall"> = {
 
   getContextCreation: (definition) => definition,
 
+  getFormulas: () => [],
+
   getDefinitionFromContextCreation(context, dataSourceBuilder) {
     return {
       background: context.background,

--- a/src/helpers/pivot/pivot_composer_helpers.ts
+++ b/src/helpers/pivot/pivot_composer_helpers.ts
@@ -12,7 +12,7 @@ const PIVOT_FUNCTIONS = ["PIVOT.VALUE", "PIVOT.HEADER", "PIVOT"];
  * Get the first Pivot function description of the given formula.
  */
 export function getFirstPivotFunction(compiledFormula: CompiledFormula, getters: CoreGetters) {
-  return compiledFormula.getFunctionsFromTokens(PIVOT_FUNCTIONS, getters)[0];
+  return getPivotFunctions(compiledFormula, getters)[0];
 }
 
 export function getPivotFunctions(compiledFormula: CompiledFormula, getters: CoreGetters) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -323,6 +323,7 @@ export const registries = {
   chartJsExtensionRegistry,
   onIterationEndEvaluationRegistry,
   specificRangeTransformRegistry,
+  unusedDataSourceRegistry,
 };
 
 /** Registries Population */
@@ -356,6 +357,7 @@ import { chartDataSourceSidePanelComponentRegistry } from "./registries/chart_da
 import { chartDataSourceRegistry } from "./registries/chart_data_source_registry";
 import { chartSubtypeRegistry } from "./registries/chart_subtype_registry";
 import { clipboardHandlersRegistries } from "./registries/clipboardHandlersRegistries";
+import { unusedDataSourceRegistry } from "./registries/data_source_registry";
 import { onIterationEndEvaluationRegistry } from "./registries/evaluation_registry";
 import { specificRangeTransformRegistry } from "./registries/srt_registry";
 import { globalStores } from "./store_engine/store_registries";

--- a/src/model.ts
+++ b/src/model.ts
@@ -14,6 +14,7 @@ import {
   repairInitialMessages,
 } from "./migrations/data";
 import { BasePlugin } from "./plugins/base_plugin";
+import { FormulaProviderAggregator } from "./plugins/core/formulas_provider";
 import { RangeAdapterPlugin } from "./plugins/core/range";
 import { CorePlugin, CorePluginConfig, CorePluginConstructor } from "./plugins/core_plugin";
 import { CoreViewPluginConfig, CoreViewPluginConstructor } from "./plugins/core_view_plugin";
@@ -87,6 +88,7 @@ export class Model extends EventBus<any> implements CommandDispatcher {
   private statefulUIPlugins: UIPlugin[] = [];
 
   private range: RangeAdapterPlugin;
+  private formulasPlugin: FormulaProviderAggregator;
 
   private session: Session;
 
@@ -184,6 +186,8 @@ export class Model extends EventBus<any> implements CommandDispatcher {
     this.coreGetters.copyFormulaStringForSheet = this.range.copyFormulaStringForSheet.bind(
       this.range
     );
+    this.formulasPlugin = new FormulaProviderAggregator();
+    this.coreGetters.getAllFormulas = this.formulasPlugin.getAllFormulas.bind(this.formulasPlugin);
 
     // Initiate stream processor
     this.selection = new SelectionStreamProcessorImpl(this.getters);
@@ -408,6 +412,7 @@ export class Model extends EventBus<any> implements CommandDispatcher {
       getters: this.coreGetters,
       stateObserver: this.state,
       range: this.range,
+      formulasPlugin: this.formulasPlugin,
       dispatch: this.dispatchFromCorePlugin,
       canDispatch: this.canDispatch,
       custom: this.config.custom,

--- a/src/plugins/core/cell.ts
+++ b/src/plugins/core/cell.ts
@@ -611,4 +611,17 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
     }
     return CommandResult.Success;
   }
+
+  getFormulas(): CompiledFormula[] {
+    const formulas: CompiledFormula[] = [];
+    for (const sheetId in this.cells) {
+      for (const cellId in this.cells[sheetId]) {
+        const cell = this.cells[sheetId]?.[cellId];
+        if (cell?.isFormula) {
+          formulas.push(cell.compiledFormula);
+        }
+      }
+    }
+    return formulas;
+  }
 }

--- a/src/plugins/core/chart.ts
+++ b/src/plugins/core/chart.ts
@@ -1,6 +1,7 @@
 import { DEFAULT_FIGURE_HEIGHT, DEFAULT_FIGURE_WIDTH, FIGURE_ID_SPLITTER } from "../../constants";
+import { CompiledFormula } from "../../formulas/compiler";
 import { SpreadsheetChart } from "../../helpers/figures/chart";
-import { deepEquals } from "../../helpers/misc";
+import { deepEquals, isDefined } from "../../helpers/misc";
 import { ChartCreationContext, ChartDefinition, ChartType } from "../../types/chart/chart";
 import {
   Command,
@@ -344,5 +345,11 @@ export class ChartPlugin extends CorePlugin<ChartState> implements ChartState {
     return cmd.offset !== undefined && cmd.col !== undefined && cmd.row !== undefined
       ? CommandResult.Success
       : CommandResult.MissingFigureArguments;
+  }
+
+  getFormulas(): CompiledFormula[] {
+    return Object.values(this.charts)
+      .filter(isDefined)
+      .flatMap(({ chart }) => chart.getFormulas(this.getters));
   }
 }

--- a/src/plugins/core/conditional_format.ts
+++ b/src/plugins/core/conditional_format.ts
@@ -1,5 +1,5 @@
 import { CompiledFormula } from "../../formulas/compiler";
-import { deepEquals } from "../../helpers/misc";
+import { deepEquals, isDefined } from "../../helpers/misc";
 import { recomputeZones } from "../../helpers/recompute_zones";
 import { isInside, toUnboundedZone } from "../../helpers/zones";
 import { criterionEvaluatorRegistry } from "../../registries/criterion_registry";
@@ -664,5 +664,27 @@ export class ConditionalFormatPlugin
     cfRules.splice(currentIndex, 1);
     cfRules.splice(targetIndex, 0, cf);
     this.history.update("cfRules", sheetId, cfRules);
+  }
+
+  getFormulas(): CompiledFormula[] {
+    const getFormula = (threshold: ColorScaleThreshold | IconThreshold | undefined) =>
+      threshold?.type === "formula" ? threshold.value : undefined;
+
+    return Object.keys(this.cfRules).flatMap((sheetId) =>
+      this.cfRules[sheetId]
+        .flatMap((cf) => {
+          const rule = cf.rule;
+          if (rule.type === "CellIsRule") {
+            return rule.values.filter((v) => v.startsWith("="));
+          } else if (rule.type === "ColorScaleRule") {
+            return [getFormula(rule.minimum), getFormula(rule.maximum), getFormula(rule.midpoint)];
+          } else if (rule.type === "IconSetRule") {
+            return [getFormula(rule.lowerInflectionPoint), getFormula(rule.upperInflectionPoint)];
+          }
+          return [];
+        })
+        .filter(isDefined)
+        .map((formulaString) => CompiledFormula.Compile(formulaString, sheetId, this.getters))
+    );
   }
 }

--- a/src/plugins/core/data_validation.ts
+++ b/src/plugins/core/data_validation.ts
@@ -373,4 +373,14 @@ export class DataValidationPlugin
     }
     return CommandResult.Success;
   }
+
+  getFormulas(): CompiledFormula[] {
+    return Object.keys(this.rules).flatMap((sheetId) =>
+      this.rules[sheetId].flatMap((rule) =>
+        rule.criterion.values
+          .filter((value) => value.startsWith("="))
+          .map((formulaString) => CompiledFormula.Compile(formulaString, sheetId, this.getters))
+      )
+    );
+  }
 }

--- a/src/plugins/core/formulas_provider.ts
+++ b/src/plugins/core/formulas_provider.ts
@@ -1,0 +1,15 @@
+import { CompiledFormula } from "../../formulas/compiler";
+import { FormulaProvider } from "../../types/misc";
+
+export class FormulaProviderAggregator {
+  private providers: Array<FormulaProvider["getFormulas"]> = [];
+  static getters = ["getAllFormulas"] as const;
+
+  addFormulaProvider(provider: FormulaProvider["getFormulas"]) {
+    this.providers.push(provider);
+  }
+
+  getAllFormulas(): CompiledFormula[] {
+    return this.providers.flatMap((provider) => provider());
+  }
+}

--- a/src/plugins/core/pivot.ts
+++ b/src/plugins/core/pivot.ts
@@ -449,6 +449,18 @@ export class PivotCorePlugin extends CorePlugin<CoreState> implements CoreState 
     return CommandResult.Success;
   }
 
+  getFormulas(): CompiledFormula[] {
+    return Object.keys(this.pivots).flatMap((pivotId) => {
+      const pivot = this.pivots[pivotId];
+      if (!pivot) {
+        return [];
+      }
+      return pivot.definition.measures
+        .filter((measure) => measure.computedBy)
+        .map((measure) => this.getMeasureCompiledFormula(pivotId, measure));
+    });
+  }
+
   // ---------------------------------------------------------------------
   // Import/Export
   // ---------------------------------------------------------------------

--- a/src/plugins/core_plugin.ts
+++ b/src/plugins/core_plugin.ts
@@ -1,16 +1,19 @@
+import { CompiledFormula } from "../formulas/compiler";
 import { StateObserver } from "../state_observer";
 import { CoreCommand, CoreCommandDispatcher } from "../types/commands";
 import { CoreGetters } from "../types/core_getters";
-import { RangeAdapterFunctions, RangeProvider } from "../types/misc";
+import { FormulaProvider, RangeAdapterFunctions, RangeProvider } from "../types/misc";
 import { ModelConfig } from "../types/model";
 import { WorkbookData } from "../types/workbook_data";
 import { BasePlugin } from "./base_plugin";
+import { FormulaProviderAggregator } from "./core/formulas_provider";
 import { RangeAdapterPlugin } from "./core/range";
 
 export interface CorePluginConfig {
   readonly getters: CoreGetters;
   readonly stateObserver: StateObserver;
   readonly range: RangeAdapterPlugin;
+  readonly formulasPlugin: FormulaProviderAggregator;
   readonly dispatch: CoreCommandDispatcher["dispatch"];
   readonly canDispatch: CoreCommandDispatcher["dispatch"];
   readonly custom: ModelConfig["custom"];
@@ -30,15 +33,23 @@ export interface CorePluginConstructor {
  */
 export class CorePlugin<State = any>
   extends BasePlugin<State, CoreCommand>
-  implements RangeProvider
+  implements RangeProvider, FormulaProvider
 {
   protected getters: CoreGetters;
   protected dispatch: CoreCommandDispatcher["dispatch"];
   protected canDispatch: CoreCommandDispatcher["dispatch"];
 
-  constructor({ getters, stateObserver, range, dispatch, canDispatch }: CorePluginConfig) {
+  constructor({
+    getters,
+    stateObserver,
+    range,
+    dispatch,
+    canDispatch,
+    formulasPlugin,
+  }: CorePluginConfig) {
     super(stateObserver);
     range.addRangeProvider(this.adaptRanges.bind(this));
+    formulasPlugin.addFormulaProvider(this.getFormulas.bind(this));
     this.getters = getters;
     this.dispatch = dispatch;
     this.canDispatch = canDispatch;
@@ -63,4 +74,8 @@ export class CorePlugin<State = any>
    * @param sheetName couple of old and new sheet names to adapt ranges pointing to that sheet
    */
   adaptRanges(rangeAdapterFunctions: RangeAdapterFunctions): void {}
+
+  getFormulas(): CompiledFormula[] {
+    return [];
+  }
 }

--- a/src/plugins/ui_core_views/pivot_ui.ts
+++ b/src/plugins/ui_core_views/pivot_ui.ts
@@ -21,6 +21,7 @@ import {
   CoreCommand,
   UpdatePivotCommand,
   invalidateEvaluationCommands,
+  isCoreCommand,
 } from "../../types/commands";
 import {
   CellPosition,
@@ -82,6 +83,10 @@ export class PivotUIPlugin extends CoreViewPlugin {
   }
 
   handle(cmd: Command) {
+    if (isCoreCommand(cmd) || cmd.type === "UNDO" || cmd.type === "REDO") {
+      this.unusedPivotsInFormulas = undefined;
+    }
+
     if (invalidateEvaluationCommands.has(cmd.type)) {
       this.shouldInvalidateCache = true;
       for (const pivotId of this.getters.getPivotIds()) {
@@ -109,15 +114,8 @@ export class PivotUIPlugin extends CoreViewPlugin {
         this.setupPivot(cmd.pivotId, { recreate: true });
         break;
       }
-      case "DELETE_SHEET":
-      case "UPDATE_CELL": {
-        this.unusedPivotsInFormulas = undefined;
-        break;
-      }
       case "UNDO":
       case "REDO": {
-        this.unusedPivotsInFormulas = undefined;
-
         const pivotCommands = cmd.commands.filter(isPivotCommand);
 
         for (const cmd of pivotCommands) {
@@ -165,15 +163,15 @@ export class PivotUIPlugin extends CoreViewPlugin {
     if (!this.pivotPositionCache.has(position)) {
       const cell = this.getters.getCorrespondingFormulaCell(position);
       if (cell && cell.isFormula) {
-        const pivotIds = this.getPivotIdsFromFormula(position.sheetId, cell.compiledFormula);
+        const pivotIds = this.getPivotIdsFromFormula(cell.compiledFormula);
         this.pivotPositionCache.set(position, pivotIds);
       }
     }
     return this.pivotPositionCache.get(position) || [];
   }
 
-  private getPivotIdsFromFormula(sheetId: UID, formula: CompiledFormula): UID[] {
-    return this.getPivotFunctions(sheetId, formula)
+  private getPivotIdsFromFormula(formula: CompiledFormula): UID[] {
+    return this.getPivotFunctions(formula.sheetId, formula)
       .map((pivotFunction) => {
         const pivotId = pivotFunction.args[0]?.toString();
         return pivotId && this.getters.getPivotId(pivotId);
@@ -384,34 +382,13 @@ export class PivotUIPlugin extends CoreViewPlugin {
       return this.unusedPivotsInFormulas;
     }
     const unusedPivots = new Set(this.getters.getPivotIds());
-    for (const sheetId of this.getters.getSheetIds()) {
-      for (const cell of this.getters.getCells(sheetId)) {
-        const position = this.getters.getCellPosition(cell.id);
-        const pivotIds = this.getPivotIdsFromPosition(position);
-        for (const pivotId of pivotIds) {
-          unusedPivots.delete(pivotId);
-          if (!unusedPivots.size) {
-            this.unusedPivotsInFormulas = [];
-            return [];
-          }
-        }
-      }
-    }
-
-    for (const pivotId of this.getters.getPivotIds()) {
-      const pivot = this.getters.getPivotCoreDefinition(pivotId);
-      for (const measure of pivot.measures) {
-        if (measure.computedBy) {
-          const { sheetId } = measure.computedBy;
-          const formula = this.getters.getMeasureCompiledFormula(pivotId, measure);
-          const relatedPivotIds = this.getPivotIdsFromFormula(sheetId, formula);
-          for (const relatedPivotId of relatedPivotIds) {
-            unusedPivots.delete(relatedPivotId);
-            if (!unusedPivots.size) {
-              this.unusedPivotsInFormulas = [];
-              return [];
-            }
-          }
+    for (const formula of this.getters.getAllFormulas()) {
+      const pivotIds = this.getPivotIdsFromFormula(formula);
+      for (const pivotId of pivotIds) {
+        unusedPivots.delete(pivotId);
+        if (!unusedPivots.size) {
+          this.unusedPivotsInFormulas = [];
+          return [];
         }
       }
     }

--- a/src/registries/chart_registry.ts
+++ b/src/registries/chart_registry.ts
@@ -1,4 +1,5 @@
 import { CoreChartOptions } from "chart.js";
+import { CompiledFormula } from "..";
 import {
   ChartCreationContext,
   ChartData,
@@ -101,6 +102,12 @@ export interface ChartTypeBuilder<T extends ChartType> {
     sheetId: UID,
     eventHandlers: ChartJsEventHandlers
   ): ChartRuntime;
+  /** Get all the formulas used in the chart */
+  getFormulas(
+    getters: CoreGetters,
+    sheetId: UID,
+    definition: ChartTypeDefinition<T, Range>
+  ): CompiledFormula[];
   allowedDefinitionKeys: readonly string[];
   sequence: number;
   dataSeriesLimit?: number;

--- a/src/registries/data_source_registry.ts
+++ b/src/registries/data_source_registry.ts
@@ -1,0 +1,34 @@
+import { Model } from "../model";
+import { _t } from "../translation";
+import { Getters } from "../types/getters";
+import { UID } from "../types/misc";
+import { Registry } from "./registry";
+
+export interface UnusedDataSource {
+  label: string;
+  id: UID;
+}
+
+export interface DataSourceType {
+  type: string;
+  unusedLabel: string;
+  getUnusedInstances: (getters: Getters) => UnusedDataSource[];
+  deleteDataSource: (dispatch: Model["dispatch"], id: UID) => void;
+}
+
+export const unusedDataSourceRegistry = new Registry<DataSourceType>();
+
+unusedDataSourceRegistry.add("pivot", {
+  type: "pivot",
+  unusedLabel: _t("Unused pivots"),
+  deleteDataSource: (dispatch, id) => dispatch("REMOVE_PIVOT", { pivotId: id }),
+  getUnusedInstances: (getters) => {
+    const unusedPivots: UnusedDataSource[] = [];
+    for (const id of getters.getPivotIds()) {
+      if (getters.isPivotUnused(id)) {
+        unusedPivots.push({ id, label: getters.getPivotDisplayName(id) });
+      }
+    }
+    return unusedPivots;
+  },
+});

--- a/src/registries/menus/topbar_menu_registry.ts
+++ b/src/registries/menus/topbar_menu_registry.ts
@@ -482,6 +482,10 @@ topbarMenuRegistry
     ...ACTION_DATA.trimWhitespace,
     sequence: 20,
   })
+  .addChild("data_sources_cleanup", ["data", "data_cleanup"], {
+    ...ACTION_DATA.cleanupDataSources,
+    sequence: 30,
+  })
   .addChild("split_to_columns", ["data"], {
     ...ACTION_DATA.splitToColumns,
     sequence: 20,
@@ -532,10 +536,6 @@ topbarMenuRegistry
     name: _t("Pivot"),
     sequence: 50,
     icon: "o-spreadsheet-Icon.PIVOT",
-    secondaryIcon: (env) =>
-      env.model.getters.getPivotIds().some((pivotId) => env.model.getters.isPivotUnused(pivotId))
-        ? "o-spreadsheet-Icon.UNUSED_PIVOT_WARNING"
-        : "",
     children: [
       (env) => {
         const { getters } = env.model;
@@ -555,10 +555,6 @@ topbarMenuRegistry
             isEnabled: () => !env.isSmall,
             onStartHover: () => env.getStore(HighlightStore).register(highlightProvider),
             onStopHover: () => env.getStore(HighlightStore).unRegister(highlightProvider),
-            secondaryIcon: () =>
-              getters.isPivotUnused(pivotId)
-                ? "o-spreadsheet-Icon.UNUSED_PIVOT_WARNING"
-                : undefined,
           };
         });
       },

--- a/src/registries/side_panel_registry.ts
+++ b/src/registries/side_panel_registry.ts
@@ -3,6 +3,7 @@ import { ChartPanel } from "../components/side_panel/chart/main_chart_panel/main
 import { ColumnStatsPanel } from "../components/side_panel/column_stats/column_stats_panel";
 import { ConditionalFormattingEditor } from "../components/side_panel/conditional_formatting/cf_editor/cf_editor";
 import { ConditionalFormatPreviewList } from "../components/side_panel/conditional_formatting/cf_preview_list/cf_preview_list";
+import { DataSourcesCleanup } from "../components/side_panel/data_sources_cleanup/data_sources_cleanup";
 import { DataValidationPanel } from "../components/side_panel/data_validation/data_validation_panel";
 import { DataValidationEditor } from "../components/side_panel/data_validation/dv_editor/dv_editor";
 import { FindAndReplacePanel } from "../components/side_panel/find_and_replace/find_and_replace";
@@ -97,6 +98,11 @@ sidePanelRegistry.add("Settings", {
 sidePanelRegistry.add("RemoveDuplicates", {
   title: _t("Remove duplicates"),
   Body: RemoveDuplicatesPanel,
+});
+
+sidePanelRegistry.add("DataSourceCleanup", {
+  title: _t("Unused data sources"),
+  Body: DataSourcesCleanup,
 });
 
 sidePanelRegistry.add("DataValidation", {

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -1195,6 +1195,11 @@ export interface PivotStopPresenceTracking {
   type: "PIVOT_STOP_PRESENCE_TRACKING";
 }
 
+export interface DeleteDataSourcesCommand {
+  type: "DELETE_DATA_SOURCES";
+  dataSources: { type: string; id: UID }[];
+}
+
 export interface ToggleCheckboxCommand extends TargetDependentCommand {
   type: "TOGGLE_CHECKBOX";
 }
@@ -1371,6 +1376,7 @@ export type LocalCommand =
   | DuplicateCarouselChartCommand
   | UpdateCarouselActiveItemCommand
   | PopOutChartFromCarouselCommand
+  | DeleteDataSourcesCommand
   | UpdateChartRegionCommand
   | UpdateColorSchemeCommand
   | MoveFiguresCommand

--- a/src/types/core_getters.ts
+++ b/src/types/core_getters.ts
@@ -6,6 +6,7 @@ import { ConditionalFormatPlugin } from "../plugins/core/conditional_format";
 import { DataValidationPlugin } from "../plugins/core/data_validation";
 import { DefaultPlugin } from "../plugins/core/default";
 import { FigurePlugin } from "../plugins/core/figures";
+import { FormulaProviderAggregator } from "../plugins/core/formulas_provider";
 import { HeaderGroupingPlugin } from "../plugins/core/header_grouping";
 import { HeaderSizePlugin } from "../plugins/core/header_size";
 import { HeaderVisibilityPlugin } from "../plugins/core/header_visibility";
@@ -69,6 +70,11 @@ export type PluginGetters<
   Plugin extends { new (...args: unknown[]): any; getters: readonly string[] }
 > = Pick<InstanceType<Plugin>, GetterNames<Plugin>>;
 type RangeAdapterGetters = Pick<RangeAdapterPlugin, GetterNames<typeof RangeAdapterPlugin>>;
+type FormulasGetters = Pick<
+  FormulaProviderAggregator,
+  GetterNames<typeof FormulaProviderAggregator>
+>;
+
 export type CoreGetters = PluginGetters<typeof SheetPlugin> &
   PluginGetters<typeof HeaderSizePlugin> &
   PluginGetters<typeof HeaderVisibilityPlugin> &
@@ -81,6 +87,7 @@ export type CoreGetters = PluginGetters<typeof SheetPlugin> &
   PluginGetters<typeof CarouselPlugin> &
   PluginGetters<typeof FigurePlugin> &
   RangeAdapterGetters &
+  FormulasGetters &
   PluginGetters<typeof ConditionalFormatPlugin> &
   PluginGetters<typeof TablePlugin> &
   PluginGetters<typeof SettingsPlugin> &

--- a/src/types/misc.ts
+++ b/src/types/misc.ts
@@ -327,6 +327,10 @@ export interface RangeProvider {
   adaptRanges: (adapterFunctions: RangeAdapterFunctions) => void;
 }
 
+export interface FormulaProvider {
+  getFormulas: () => CompiledFormula[];
+}
+
 export type Validation<T> = (toValidate: T) => CommandResult | CommandResult[];
 
 export type Increment = 1 | -1 | 0;

--- a/tests/menus/__snapshots__/context_menu_component.test.ts.snap
+++ b/tests/menus/__snapshots__/context_menu_component.test.ts.snap
@@ -153,7 +153,6 @@ exports[`Context MenuPopover integration tests context menu simple rendering 1`]
       <div
         class="o-menu-item-root ms-auto align-items-center d-flex gap-1"
       >
-        
         <div
           class="o-icon fa-small"
         >
@@ -161,7 +160,6 @@ exports[`Context MenuPopover integration tests context menu simple rendering 1`]
             class="fa fa-caret-right"
           />
         </div>
-        
       </div>
       
     </div>
@@ -272,7 +270,6 @@ exports[`Context MenuPopover integration tests context menu simple rendering 1`]
       <div
         class="o-menu-item-root ms-auto align-items-center d-flex gap-1"
       >
-        
         <div
           class="o-icon fa-small"
         >
@@ -280,7 +277,6 @@ exports[`Context MenuPopover integration tests context menu simple rendering 1`]
             class="fa fa-caret-right"
           />
         </div>
-        
       </div>
       
     </div>
@@ -382,7 +378,6 @@ exports[`Context MenuPopover integration tests context menu simple rendering 1`]
       <div
         class="o-menu-item-root ms-auto align-items-center d-flex gap-1"
       >
-        
         <div
           class="o-icon fa-small"
         >
@@ -390,7 +385,6 @@ exports[`Context MenuPopover integration tests context menu simple rendering 1`]
             class="fa fa-caret-right"
           />
         </div>
-        
       </div>
       
     </div>

--- a/tests/menus/context_menu_component.test.ts
+++ b/tests/menus/context_menu_component.test.ts
@@ -700,23 +700,6 @@ describe("Context MenuPopover internal tests", () => {
     expect(fixture.querySelectorAll(".o-menu-item-icon").length).toBe(2);
   });
 
-  test("Can display a secondary icon", async () => {
-    let visible = true;
-    const menuItems = createActions([
-      {
-        name: "child1",
-        secondaryIcon: () => (visible ? "o-spreadsheet-Icon.SEARCH" : ""),
-        execute: () => {},
-      },
-    ]);
-    await renderContextMenu(300, 300, { menuItems });
-    expect(fixture.querySelector(".fa-search")).not.toBeNull();
-    visible = false;
-    parent.render(true);
-    await nextTick();
-    expect(fixture.querySelector(".fa-search")).toBeNull();
-  });
-
   test("Can change icon color", async () => {
     const menuItems = createActions([
       { name: "child1", icon: "o-spreadsheet-Icon.BOLD", iconColor: "#FFF000", execute: () => {} },

--- a/tests/menus/menu_component.test.ts
+++ b/tests/menus/menu_component.test.ts
@@ -68,23 +68,4 @@ describe("Menu component", () => {
 
     expect(".o-popover").toHaveCount(0);
   });
-
-  test("A root menu item can display both secondary icon and caret", async () => {
-    const menuItems = createActions([
-      {
-        id: "root",
-        name: "Root",
-        secondaryIcon: "o-spreadsheet-Icon.SEARCH",
-        children: [{ id: "child", name: "Child", execute: () => {} }],
-      },
-    ]);
-
-    const { fixture } = await mountComponent(Menu, {
-      props: { menuItems, onClose: () => {} },
-    });
-
-    const rootItem = fixture.querySelector(".o-menu div[data-name='root']")!;
-    expect(rootItem.querySelector(".fa-search")).not.toBeNull();
-    expect(rootItem.querySelector(".fa-caret-right")).not.toBeNull();
-  });
 });

--- a/tests/menus/menu_items_registry.test.ts
+++ b/tests/menus/menu_items_registry.test.ts
@@ -44,11 +44,7 @@ import {
   spyModelDispatch,
   target,
 } from "../test_helpers/helpers";
-import {
-  addPivot,
-  createModelWithPivot,
-  createModelWithTestPivotDataset,
-} from "../test_helpers/pivot_helpers";
+import { createModelWithPivot } from "../test_helpers/pivot_helpers";
 
 import { Currency, Model } from "../../src";
 
@@ -284,15 +280,6 @@ describe("Menu Item actions", () => {
     expect(pivotSubmenu.isVisible(pivotEnv)).toBeTruthy();
     expect(pivotSubmenu.children(pivotEnv)).toHaveLength(pivotIds.length);
     expect(pivotItem.name(pivotEnv)).toBe(pivotModel.getters.getPivotDisplayName(firstPivotId));
-  });
-
-  test("Data -> Pivot submenu shows a warning icon when at least one pivot is unused", () => {
-    const pivotModel = createModelWithTestPivotDataset();
-    addPivot(pivotModel, "A1:E18", { name: "Unused pivot" }, "2");
-    const pivotEnv = makeTestEnv({ model: pivotModel });
-
-    const pivotSubmenu = getNode(["data", "pivot_data_sources"], pivotEnv);
-    expect(pivotSubmenu.secondaryIcon(pivotEnv)).toBe("o-spreadsheet-Icon.UNUSED_PIVOT_WARNING");
   });
 
   test("Edit -> paste_special should not be hidden after a COPY ", () => {

--- a/tests/pivots/data_source_cleanup_panel.test.ts
+++ b/tests/pivots/data_source_cleanup_panel.test.ts
@@ -1,0 +1,173 @@
+import { Model } from "../../src";
+import { DataSourcesCleanup } from "../../src/components/side_panel/data_sources_cleanup/data_sources_cleanup";
+import { DataSourcesCleanupStore } from "../../src/components/side_panel/data_sources_cleanup/data_sources_cleanup_store";
+import {
+  addCfRule,
+  addDataValidation,
+  createGaugeChart,
+  setCellContent,
+  simulateClick,
+  undo,
+} from "../test_helpers";
+import { createModelFromGrid, mountComponent, nextTick } from "../test_helpers/helpers";
+import { addPivot } from "../test_helpers/pivot_helpers";
+import { makeStoreWithModel } from "../test_helpers/stores";
+
+let model: Model;
+
+beforeEach(() => {
+  model = createModelFromGrid({ A1: "Field", A2: "25" });
+});
+
+describe("Data source cleanup panel", () => {
+  async function mountPanel(model: Model) {
+    await mountComponent(DataSourcesCleanup, {
+      model,
+      props: { onCloseSidePanel: () => {} },
+    });
+  }
+
+  test("Can remove unused pivots", async () => {
+    addPivot(model, "A1:A2", {}, "pivot1");
+    addPivot(model, "A1:A2", {}, "pivot2");
+    await mountPanel(model);
+
+    expect(model.getters.getPivotIds()).toEqual(["pivot1", "pivot2"]);
+    expect("input[name='pivot2']").toHaveCount(1);
+    expect("input[name='pivot1']").toHaveCount(1);
+
+    await simulateClick("button.o-button");
+
+    expect("input[name='pivot2']").toHaveCount(0);
+    expect("input[name='pivot1']").toHaveCount(0);
+    expect(model.getters.getPivotIds()).toEqual([]);
+
+    undo(model);
+    await nextTick();
+
+    expect(model.getters.getPivotIds()).toEqual(["pivot1", "pivot2"]);
+    expect("input[name='pivot2']").toHaveCount(1);
+    expect("input[name='pivot1']").toHaveCount(1);
+  });
+
+  test("Can pick which pivots to remove", async () => {
+    addPivot(model, "A1:A2", {}, "pivot1");
+    addPivot(model, "A1:A2", {}, "pivot2");
+    await mountPanel(model);
+
+    await simulateClick("input[name='pivot2']");
+    expect("input[name='pivot1']").toHaveValue(true);
+    expect("input[name='pivot2']").toHaveValue(false);
+
+    await simulateClick("button.o-button");
+
+    expect("input[name='pivot1']").toHaveCount(0);
+    expect("input[name='pivot2']").toHaveCount(1);
+    expect(model.getters.getPivotIds()).toEqual(["pivot2"]);
+  });
+
+  test("Delete button is not there if there is nothing to remove", async () => {
+    addPivot(model, "A1:A2", {}, "pivot1");
+    await mountPanel(model);
+
+    await simulateClick("input[name='pivot1']");
+    expect("input[name='pivot1']").toHaveValue(false);
+    expect("button.o-button").toHaveCount(0);
+
+    await simulateClick("input[name='pivot1']");
+    expect("input[name='pivot1']").toHaveValue(true);
+    expect("button.o-button").toHaveCount(1);
+
+    await simulateClick("button.o-button");
+    expect("input[name='pivot1']").toHaveCount(0);
+    expect("button.o-button").toHaveCount(0);
+  });
+});
+
+describe("Data source cleanup store", () => {
+  let store: DataSourcesCleanupStore;
+  let sheetId: string;
+
+  beforeEach(() => {
+    store = makeStoreWithModel(model, DataSourcesCleanupStore).store;
+    sheetId = model.getters.getActiveSheetId();
+  });
+
+  function getUnusedPivots() {
+    const pivotCategory = store.unusedDataSourcesCategories.find(
+      (category) => category.type === "pivot"
+    );
+    return pivotCategory ? pivotCategory.dataSources.map((pivot) => pivot.id) : [];
+  }
+
+  test("Pivots are not detected as unused if they are in a formula", () => {
+    addPivot(model, "A1:A2", {}, "pivot1");
+    expect(getUnusedPivots()).toEqual(["pivot1"]);
+
+    setCellContent(model, "B1", "=PIVOT(1)");
+    expect(getUnusedPivots()).toEqual([]);
+  });
+
+  test("Pivots are not detected as unused if used in calculated measures", () => {
+    addPivot(model, "A1:A2", {}, "pivot1");
+    expect(getUnusedPivots()).toEqual(["pivot1"]);
+
+    addPivot(
+      model,
+      "A1:A2",
+      {
+        measures: [
+          {
+            id: "measure1",
+            fieldName: "measure1",
+            aggregator: "sum",
+            computedBy: { formula: "=SUM(PIVOT(1))", sheetId },
+          },
+        ],
+      },
+      "pivot2"
+    );
+    expect(getUnusedPivots()).toEqual(["pivot2"]);
+  });
+
+  test("Pivots are not detected as unused if used in computed formats", () => {
+    addPivot(model, "A1:A2", {}, "pivot1");
+    expect(getUnusedPivots()).toEqual(["pivot1"]);
+
+    addCfRule(model, "A1", {
+      type: "CellIsRule",
+      operator: "isEqual",
+      values: ["=SUM(PIVOT(1))"],
+      style: { fillColor: "#ff0f0f" },
+    });
+    expect(getUnusedPivots()).toEqual([]);
+  });
+
+  test("Pivots are not detected as unused if used in data validation", () => {
+    addPivot(model, "A1:A2", {}, "pivot1");
+    expect(getUnusedPivots()).toEqual(["pivot1"]);
+
+    addDataValidation(model, "A1", "id", { type: "isEqual", values: ["=SUM(PIVOT(1))"] });
+    expect(getUnusedPivots()).toEqual([]);
+  });
+
+  test("Pivots are not detected as unused if used in gauge chart", () => {
+    addPivot(model, "A1:A2", {}, "pivot1");
+    expect(getUnusedPivots()).toEqual(["pivot1"]);
+
+    createGaugeChart(model, {
+      sectionRule: {
+        rangeMin: "0",
+        rangeMax: "100",
+        colors: { lowerColor: "#ff0f0f", middleColor: "#ff9900", upperColor: "#00ff00" },
+        lowerInflectionPoint: {
+          type: "number",
+          value: "=SUM(PIVOT(1))",
+          operator: "<=",
+        },
+        upperInflectionPoint: { type: "number", value: "66", operator: "<=" },
+      },
+    });
+    expect(getUnusedPivots()).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Description

This commit replace the `Unused pivot` warning in the `Data` topbar menu by a dedicated side panel. Checking which pivot is unused is an expansive operation, and is not frankly important, removing the pivots only cleans up the JSON. Doing it every time we open the menu can make the menu very slow on big spreadsheets.

There was also a problem on how we were checking which pivot was unused. Only the formulas in the cells were checked, not the formulas of cfs/charts/... This commit introduce a new `FormulaProvider` to the core plugins, so they can register their formulas.

Task: [6185119](https://www.odoo.com/odoo/2328/tasks/6185119)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo