### PR TITLE
[FIX] named range selector: select hidden named range

### DIFF
--- a/src/components/named_range_selector/named_range_selector.ts
+++ b/src/components/named_range_selector/named_range_selector.ts
@@ -163,15 +163,28 @@ export class NamedRangeSelector extends Component<Props, SpreadsheetChildEnv> {
     }
     const activeSheetId = this.env.model.getters.getActiveSheetId();
     if (activeSheetId !== sheetId) {
+      if (!this.env.model.getters.getSheet(sheetId).isVisible) {
+        this.env.notifyUser({
+          text: _t("The sheet on which the range is defined is hidden."),
+          type: "info",
+          sticky: false,
+        });
+        return;
+      }
       this.env.model.dispatch("ACTIVATE_SHEET", { sheetIdFrom: activeSheetId, sheetIdTo: sheetId });
     }
 
     // First select the bottom-right cell to try to scroll the sheet so that the whole range is visible
-    this.env.model.selection.selectCell(zone.right, zone.bottom);
-    this.env.model.selection.selectZone({
-      cell: { col: zone.left, row: zone.top },
-      zone,
+    this.env.model.selection.selectCell(zone.right, zone.bottom, {
+      allowsHiddenSelection: true,
     });
+    this.env.model.selection.selectZone(
+      {
+        cell: { col: zone.left, row: zone.top },
+        zone,
+      },
+      { allowsHiddenSelection: true }
+    );
   }
 
   get selectionKey(): string {

--- a/src/helpers/internal_viewport.ts
+++ b/src/helpers/internal_viewport.ts
@@ -177,6 +177,10 @@ export class InternalViewport {
     this.adjustViewportZoneY();
   }
 
+  isZoneVisible(zone: Zone): boolean {
+    return intersection(zone, this) !== undefined;
+  }
+
   /**
    *
    * Computes the visible coordinates & dimensions of a given zone inside the viewport

--- a/src/helpers/viewport_collection.ts
+++ b/src/helpers/viewport_collection.ts
@@ -231,6 +231,10 @@ export class ViewportCollection {
     return this.getSubViewports(sheetId).some((pane) => pane.isVisible(col, row));
   }
 
+  isZoneVisibleInViewport(sheetId: UID, zone: Zone): boolean {
+    return this.getSubViewports(sheetId).some((pane) => pane.isZoneVisible(zone));
+  }
+
   getScrollBarWidth(): Pixel {
     return SCROLLBAR_WIDTH / this.zoomLevel;
   }

--- a/src/plugins/ui_stateful/selection.ts
+++ b/src/plugins/ui_stateful/selection.ts
@@ -894,11 +894,27 @@ export class GridSelectionPlugin extends UIPlugin {
     ctx.strokeStyle = SELECTION_BORDER_COLOR;
     ctx.lineWidth = 1.5 * thinLineWidth;
     for (const zone of zones) {
+      if (!viewports.isZoneVisibleInViewport(sheetId, zone)) {
+        continue;
+      }
       const { x, y, width, height } = viewports.getVisibleRect(sheetId, zone);
       ctx.globalCompositeOperation = "multiply";
-      ctx.fillRect(x, y, width, height);
-      ctx.globalCompositeOperation = "source-over";
-      ctx.strokeRect(x, y, width, height);
+      const currentLineWidth = ctx.lineWidth;
+      if (height === 0 || width === 0) {
+        ctx.lineWidth = 3 * thinLineWidth;
+      }
+      if (height === 0 && width === 0) {
+        ctx.beginPath();
+        ctx.arc(x, y, 3, 0, 2 * Math.PI);
+        ctx.fill();
+        ctx.globalCompositeOperation = "source-over";
+        ctx.stroke();
+      } else {
+        ctx.fillRect(x, y, width, height);
+        ctx.globalCompositeOperation = "source-over";
+        ctx.strokeRect(x, y, width, height);
+      }
+      ctx.lineWidth = currentLineWidth;
     }
 
     ctx.globalCompositeOperation = "source-over";

--- a/src/selection_stream/selection_stream_processor.ts
+++ b/src/selection_stream/selection_stream_processor.ts
@@ -122,9 +122,9 @@ export class SelectionStreamProcessorImpl implements SelectionStreamProcessor {
   /**
    * Select a single cell as the new anchor.
    */
-  selectCell(col: HeaderIndex, row: HeaderIndex): DispatchResult {
+  selectCell(col: HeaderIndex, row: HeaderIndex, options?: SelectionEventOptions): DispatchResult {
     const zone = positionToZone({ col, row });
-    return this.selectZone({ zone, cell: { col, row } }, { scrollIntoView: true });
+    return this.selectZone({ zone, cell: { col, row } }, { scrollIntoView: true, ...options });
   }
 
   /**
@@ -429,20 +429,28 @@ export class SelectionStreamProcessorImpl implements SelectionStreamProcessor {
   }
 
   private checkEventAnchorZone(event: SelectionEvent): CommandResult {
-    return this.checkAnchorZone(event.anchor);
+    return this.checkAnchorZone(event.anchor, event.options);
   }
 
-  private checkAnchorZone(anchor: AnchorZone): CommandResult {
+  private checkAnchorZone(anchor: AnchorZone, options?: SelectionEventOptions): CommandResult {
     const { cell, zone } = anchor;
     if (!isInside(cell.col, cell.row, zone)) {
       return CommandResult.InvalidAnchorZone;
     }
     const { left, right, top, bottom } = zone;
     const sheetId = this.getters.getActiveSheetId();
-    const refCol = this.getters.findVisibleHeader(sheetId, "COL", left, right);
-    const refRow = this.getters.findVisibleHeader(sheetId, "ROW", top, bottom);
-    if (refRow === undefined || refCol === undefined) {
-      return CommandResult.SelectionOutOfBound;
+    if (!options?.allowsHiddenSelection) {
+      const refCol = this.getters.findVisibleHeader(sheetId, "COL", left, right);
+      const refRow = this.getters.findVisibleHeader(sheetId, "ROW", top, bottom);
+      if (refRow === undefined || refCol === undefined) {
+        return CommandResult.SelectionOutOfBound;
+      }
+    } else {
+      const numberCols = this.getters.getNumberCols(sheetId);
+      const numberRows = this.getters.getNumberRows(sheetId);
+      if (left < 0 || right > numberCols - 1 || top < 0 || bottom > numberRows - 1) {
+        return CommandResult.SelectionOutOfBound;
+      }
     }
     return CommandResult.Success;
   }

--- a/src/types/event_stream/selection_events.ts
+++ b/src/types/event_stream/selection_events.ts
@@ -3,6 +3,7 @@ import { AnchorZone } from "../misc";
 export type SelectionEventOptions = {
   scrollIntoView?: boolean;
   unbounded?: boolean;
+  allowsHiddenSelection?: boolean;
 };
 
 export interface SelectionEvent {

--- a/src/types/selection_stream_processor.ts
+++ b/src/types/selection_stream_processor.ts
@@ -20,7 +20,7 @@ type StatefulStream<Event, State> = {
 interface SelectionProcessor {
   selectZone(anchor: AnchorZone, options?: SelectionEventOptions): DispatchResult;
 
-  selectCell(col: number, row: number): DispatchResult;
+  selectCell(col: number, row: number, options?: SelectionEventOptions): DispatchResult;
 
   moveAnchorCell(direction: Direction, step: SelectionStep): DispatchResult;
 

--- a/tests/named_ranges/named_ranges_selector_component.test.ts
+++ b/tests/named_ranges/named_ranges_selector_component.test.ts
@@ -3,10 +3,13 @@ import { NamedRangeSelector } from "../../src/components/named_range_selector/na
 import { HIGHLIGHT_COLOR } from "../../src/constants";
 import { toZone } from "../../src/helpers/zones";
 import { HighlightStore } from "../../src/stores/highlight_store";
+import { NotificationStore } from "../../src/stores/notification_store";
 import { SpreadsheetChildEnv } from "../../src/types/spreadsheet_env";
 import {
   createNamedRange,
   createSheet,
+  hideColumns,
+  hideSheet,
   setInputValueAndTrigger,
   setSelection,
   simulateClick,
@@ -223,5 +226,42 @@ describe("Named ranges topbar selector", () => {
     triggerMouseEvent(".o-menu-item", "mouseenter");
     await nextTick();
     expect(".o-menu-item").toHaveCount(2);
+  });
+
+  test("select a named range from the dropdown select the zone even if it's hidden", async () => {
+    createSheet(model, { name: "Sheet1", sheetId: "Sheet1" });
+    createNamedRange(model, "MyRange", "B1:B2");
+    await mountRangeSelector();
+
+    hideColumns(model, ["B"]);
+
+    await simulateClick(".o-named-range-selector .fa-caret-down");
+    const menuItems = [...document.querySelectorAll<HTMLElement>(".o-menu-item")];
+
+    await simulateClick(menuItems[0]);
+    expect(model.getters.getActiveSheetId()).toEqual("Sheet1");
+    expect(model.getters.getSelectedZone()).toEqual(toZone("B1:B2"));
+  });
+
+  test("select a named range from the dropdown notify the user if the sheet is hidden", async () => {
+    createSheet(model, { name: "Sheet1", sheetId: "Sheet1" });
+    createSheet(model, { name: "Sheet2", sheetId: "Sheet2" });
+    createNamedRange(model, "MyRange", "B1:B2");
+    await mountRangeSelector();
+    const notificationStore = env.getStore(NotificationStore);
+    const spyNotify = jest.spyOn(notificationStore, "notifyUser");
+    hideSheet(model, "Sheet1");
+
+    await simulateClick(".o-named-range-selector .fa-caret-down");
+    const menuItems = [...document.querySelectorAll<HTMLElement>(".o-menu-item")];
+
+    await simulateClick(menuItems[0]);
+    expect(model.getters.getActiveSheetId()).toEqual("Sheet2");
+    expect(model.getters.getSelectedZone()).toEqual(toZone("A1"));
+    expect(spyNotify).toHaveBeenCalledWith({
+      type: "info",
+      sticky: false,
+      text: "The sheet on which the range is defined is hidden.",
+    });
   });
 });


### PR DESCRIPTION
Before this commit:
If the zone is hidden, nothing happens when selecting a named range from the dropdown. And if the sheet is hidden, the zone is selected in the active sheet, which is not the expected behavior.

After this commit:
When selecting a named range from the dropdown, the zone is selected even if it's hidden. And if the sheet is hidden, nothing is selected and the user is notified that the sheet is hidden.

Task: [6171849](https://www.odoo.com/odoo/2328/tasks/6171849)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo