### PR TITLE
[IMP] Statistics: Add first format to bottombar

### DIFF
--- a/src/components/bottom_bar/bottom_bar_statistic/aggregate_statistics_store.ts
+++ b/src/components/bottom_bar/bottom_bar_statistic/aggregate_statistics_store.ts
@@ -1,5 +1,6 @@
 import { sum } from "../../../functions/helper_math";
 import { average, countAny, countNumbers, max, min } from "../../../functions/helper_statistical";
+import { isDateTimeFormat } from "../../../helpers/format/format";
 import { recomputeZones } from "../../../helpers/recompute_zones";
 import {
   SelectionStatisticFunction,
@@ -17,31 +18,44 @@ const selectionStatisticFunctions: SelectionStatisticFunction[] = [
     name: _t("Sum"),
     types: [CellValueType.number],
     compute: (values, locale) => sum([[values]], locale),
+    visible: (values, locale) =>
+      values.some((cell) => !cell.format || !isDateTimeFormat(cell.format)),
+    computeFormat: (values, locale) =>
+      values.find((cell) => !cell.format || !isDateTimeFormat(cell.format))?.format ?? "",
   },
   {
     name: _t("Avg"),
     types: [CellValueType.number],
     compute: (values, locale) => average([[values]], locale),
+    visible: (values, locale) =>
+      values.some((cell) => !cell.format || !isDateTimeFormat(cell.format)),
+    computeFormat: (values, locale) => values[0]?.format ?? "",
   },
   {
     name: _t("Min"),
     types: [CellValueType.number],
     compute: (values, locale) => min([[values]], locale).value,
+    visible: (values, locale) => values.length > 0,
+    computeFormat: (values, locale) => values[0]?.format ?? "",
   },
   {
     name: _t("Max"),
     types: [CellValueType.number],
     compute: (values, locale) => max([[values]], locale).value,
+    visible: (values, locale) => values.length > 0,
+    computeFormat: (values, locale) => values[0]?.format ?? "",
   },
   {
     name: _t("Count"),
     types: [CellValueType.number, CellValueType.text, CellValueType.boolean, CellValueType.error],
     compute: (values) => countAny([[values]]),
+    computeFormat: (values, locale) => "",
   },
   {
     name: _t("Count Numbers"),
     types: [CellValueType.number, CellValueType.text, CellValueType.boolean, CellValueType.error],
     compute: (values, locale) => countNumbers([[values]], locale),
+    computeFormat: (values, locale) => "",
   },
 ];
 

--- a/src/components/bottom_bar/bottom_bar_statistic/bottom_bar_statistic.ts
+++ b/src/components/bottom_bar/bottom_bar_statistic/bottom_bar_statistic.ts
@@ -46,8 +46,8 @@ export class BottomBarStatistic extends Component<Props, SpreadsheetChildEnv> {
     ) {
       return undefined;
     }
-    if (this.state.selectedStatisticFn === "") {
-      this.state.selectedStatisticFn = Object.keys(this.store.statisticFnResults)[0];
+    if (!this.store.statisticFnResults[this.state.selectedStatisticFn]) {
+      return this.getComposedFnName(Object.keys(this.store.statisticFnResults)[0]);
     }
     return this.getComposedFnName(this.state.selectedStatisticFn);
   }
@@ -74,10 +74,9 @@ export class BottomBarStatistic extends Component<Props, SpreadsheetChildEnv> {
   private getComposedFnName(fnName: string): string {
     const locale = this.env.model.getters.getLocale();
     const fnValue = this.store.statisticFnResults[fnName];
-    return (
-      fnName +
-      ": " +
-      (fnValue?.value !== undefined ? formatValue(fnValue.value(), { locale }) : "__")
-    );
+    if (!fnValue?.value) {
+      return "";
+    }
+    return fnName + ": " + formatValue(fnValue.value(), { locale, format: fnValue.format() });
   }
 }

--- a/src/components/side_panel/column_stats/column_stats_store.ts
+++ b/src/components/side_panel/column_stats/column_stats_store.ts
@@ -1,6 +1,6 @@
 import { sum } from "../../../functions/helper_math";
 import { average, max, median, min } from "../../../functions/helper_statistical";
-import { formatValue } from "../../../helpers/format/format";
+import { formatValue, isDateTimeFormat } from "../../../helpers/format/format";
 import { isDefined } from "../../../helpers/misc";
 import {
   computeStatisticFnResults,
@@ -20,7 +20,7 @@ const columnStatisticFunctions: SelectionStatisticFunction[] = [
     name: _t("Total rows"),
     types: Object.values(CellValueType),
     compute: (values, locale) => values.length,
-    format: "0",
+    computeFormat: (values, locale) => "0",
   },
   {
     name: _t("Unique values"),
@@ -32,32 +32,40 @@ const columnStatisticFunctions: SelectionStatisticFunction[] = [
       }
       return uniqueValues.size;
     },
-    format: "0",
+    computeFormat: (values, locale) => "0",
   },
   {
     name: _t("Sum"),
     types: [CellValueType.number],
     compute: (values, locale) => sum([[values]], locale),
+    visible: (values, locale) =>
+      values.some((cell) => !cell.format || !isDateTimeFormat(cell.format)),
+    computeFormat: (values, locale) =>
+      values.find((cell) => !cell.format || !isDateTimeFormat(cell.format))?.format ?? "0.00",
   },
   {
     name: _t("Average"),
     types: [CellValueType.number],
     compute: (values, locale) => average([[values]], locale),
+    computeFormat: (values, locale) => values[0]?.format ?? "0.00",
   },
   {
     name: _t("Median"),
     types: [CellValueType.number],
     compute: (values, locale) => median([[values]], locale) ?? "",
+    computeFormat: (values, locale) => values[0]?.format ?? "0.00",
   },
   {
     name: _t("Minimum value"),
     types: [CellValueType.number],
     compute: (values, locale) => min([[values]], locale).value,
+    computeFormat: (values, locale) => values[0]?.format ?? "0.00",
   },
   {
     name: _t("Maximum value"),
     types: [CellValueType.number],
     compute: (values, locale) => max([[values]], locale).value,
+    computeFormat: (values, locale) => values[0]?.format ?? "0.00",
   },
 ];
 
@@ -335,7 +343,7 @@ export class ColumnStatisticsStore extends SpreadsheetStore {
         name,
         value: formatValue(fnValue.value(), {
           locale: localeFormat.locale,
-          format: fnValue.format ?? localeFormat.format,
+          format: fnValue.format() ?? localeFormat.format,
         }),
       };
     });

--- a/src/helpers/selection_statistic_functions.ts
+++ b/src/helpers/selection_statistic_functions.ts
@@ -1,4 +1,5 @@
 import { CellValueType, EvaluatedCell } from "../types/cells";
+import { Format } from "../types/format";
 import { Locale } from "../types/locale";
 import { Lazy } from "../types/misc";
 import { lazy, memoize } from "./misc";
@@ -7,16 +8,17 @@ export interface StatisticFnResults {
   [name: string]:
     | {
         value: Lazy<number | string> | undefined;
-        format?: string;
+        format: Lazy<string>;
       }
     | undefined;
 }
 
 export interface SelectionStatisticFunction {
   name: string;
-  compute: (data: EvaluatedCell[], locale: Locale) => number | string;
+  compute: (cells: EvaluatedCell[], locale: Locale) => number | string;
   types: CellValueType[];
-  format?: string;
+  visible?: (cells: EvaluatedCell[], locale: Locale) => boolean;
+  computeFormat: (cells: EvaluatedCell[], locale: Locale) => Format;
 }
 
 export function computeStatisticFnResults(
@@ -33,12 +35,15 @@ export function computeStatisticFnResults(
   for (const fn of selectionStatisticFunctions) {
     let fnResult: Lazy<number | string> | undefined = undefined;
     const evaluatedCells = getCells(fn.types.sort().join(","));
+    if (fn.visible && !fn.visible(evaluatedCells, locale)) {
+      continue;
+    }
     if (evaluatedCells.length) {
       fnResult = lazy(() => fn.compute(evaluatedCells, locale));
     }
     statisticFnResults[fn.name] = {
       value: fnResult,
-      format: fn.format,
+      format: lazy(() => fn.computeFormat(evaluatedCells, locale) ?? ""),
     };
   }
   return statisticFnResults;

--- a/tests/bottom_bar/aggregate_statistics_store.test.ts
+++ b/tests/bottom_bar/aggregate_statistics_store.test.ts
@@ -37,6 +37,59 @@ describe("Aggregate statistic functions", () => {
     expect(statisticFnResults["Count"]?.value?.()).toBe(3);
   });
 
+  test.each(["Count", "Count Numbers"])("%s aggregate does not inherit format", (statName) => {
+    const { store, model } = makeStore(AggregateStatisticsStore);
+    setCellContent(model, "A1", "1");
+    setCellContent(model, "A2", "2");
+    setCellContent(model, "A3", "3");
+
+    setFormat(model, "A1:A3", "0.00%");
+
+    setSelection(model, ["A1:A3"]);
+    const statisticFnResults = store.statisticFnResults;
+    expect(statisticFnResults[statName]?.format()).toBe("");
+  });
+
+  test.each(["Avg", "Min", "Max"])("%s aggregate inherits first found format", (statName) => {
+    const { store, model } = makeStore(AggregateStatisticsStore);
+    setCellContent(model, "A1", "Hello");
+    setCellContent(model, "A2", "1");
+    setCellContent(model, "A3", "2");
+
+    setFormat(model, "A2", "0.00%");
+
+    setSelection(model, ["A1:A3"]);
+    const statisticFnResults = store.statisticFnResults;
+    expect(statisticFnResults[statName]?.format()).toBe("0.00%");
+  });
+
+  test("Sum inherits first found format that is not a date", () => {
+    const { store, model } = makeStore(AggregateStatisticsStore);
+    setCellContent(model, "A1", "Hello");
+    setCellContent(model, "A2", "1");
+    setCellContent(model, "A3", "2");
+
+    setFormat(model, "A2", "mm/dd/yyyy");
+    setFormat(model, "A3", "0.00%");
+
+    setSelection(model, ["A1:A3"]);
+    const statisticFnResults = store.statisticFnResults;
+    expect(statisticFnResults["Sum"]?.format()).toBe("0.00%");
+  });
+
+  test("Sum is not visible when only selecting numbers that are dates", () => {
+    const { store, model } = makeStore(AggregateStatisticsStore);
+    setCellContent(model, "A1", "Hello");
+    setCellContent(model, "A2", "1");
+    setCellContent(model, "A3", "2");
+
+    setFormat(model, "A2:A3", "mm/dd/yyyy");
+
+    setSelection(model, ["A1:A3"]);
+    const statisticFnResults = store.statisticFnResults;
+    expect(statisticFnResults["Sum"]).toBeUndefined();
+  });
+
   test("statistic function should not include hidden rows/columns in calculations", () => {
     const { store, model } = makeStore(AggregateStatisticsStore);
     setCellContent(model, "A1", "1");

--- a/tests/bottom_bar/bottom_bar_component.test.ts
+++ b/tests/bottom_bar/bottom_bar_component.test.ts
@@ -663,13 +663,13 @@ describe("BottomBar component", () => {
     expect(fixture.querySelector(".o-selection-statistic")?.textContent).toBe("Sum: 0");
   });
 
-  test("Display empty information if the statistic function doesn't handle the types of the selected cells", async () => {
+  test("Only the statistic function which handle the types of the selected cells", async () => {
     const { model } = await mountBottomBar();
     setCellContent(model, "A2", "I am not a number");
 
     selectCell(model, "A2");
     await nextTick();
-    expect(fixture.querySelector(".o-selection-statistic")?.textContent).toBe("Sum: __");
+    expect(fixture.querySelector(".o-selection-statistic")?.textContent).toBe("Count: 1");
   });
 
   test("Can open the list of statistics", async () => {


### PR DESCRIPTION
Task: 6186747

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [6189449](https://www.odoo.com/odoo/2328/tasks/6189449)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo