### PR TITLE
[FIX] grid: wrong z-index for grid elements

### DIFF
--- a/src/components/autofill/autofill.css
+++ b/src/components/autofill/autofill.css
@@ -11,6 +11,7 @@
     position: absolute;
     height: var(--os-autofill-edge-length);
     width: var(--os-autofill-edge-length);
+    z-index: var(--os-components-importance-grid-overlay);
     &:hover {
       cursor: crosshair;
     }

--- a/src/components/grid_add_rows_footer/grid_add_rows_footer.ts
+++ b/src/components/grid_add_rows_footer/grid_add_rows_footer.ts
@@ -36,7 +36,6 @@ export class GridAddRowsFooter extends Component<Props, SpreadsheetChildEnv> {
 
     return cssPropertiesToCss({
       top: `${top}px`,
-      ["z-index"]: "1",
     });
   }
 

--- a/src/components/highlight/highlight/highlight.css
+++ b/src/components/highlight/highlight/highlight.css
@@ -1,5 +1,5 @@
 .o-spreadsheet {
-  .o-highlight {
+  .o-highlight > * {
     z-index: var(--os-components-importance-highlight);
   }
 }

--- a/src/components/spreadsheet/spreadsheet.css
+++ b/src/components/spreadsheet/spreadsheet.css
@@ -207,7 +207,7 @@
     .o-grid-overlay {
       position: absolute;
       outline: none;
-      z-index: 1;
+      z-index: var(--os-components-importance-grid-overlay);
     }
   }
 

--- a/src/components/tables/table_resizer/table_resizer.css
+++ b/src/components/tables/table_resizer/table_resizer.css
@@ -5,5 +5,6 @@
     border-bottom: 3px solid var(--os-gray-500);
     border-right: 3px solid var(--os-gray-500);
     cursor: nwse-resize;
+    z-index: var(--os-components-importance-grid-overlay);
   }
 }

--- a/src/variables.css
+++ b/src/variables.css
@@ -113,6 +113,7 @@
   --os-menu-separator-padding: 5px;
 
   --os-components-importance-grid: 0;
+  --os-components-importance-grid-overlay: 1;
   --os-components-importance-highlight: 5;
   --os-components-importance-header-grouping-button: 6;
   --os-components-importance-figure: 10;

--- a/tests/grid/__snapshots__/grid_component.test.ts.snap
+++ b/tests/grid/__snapshots__/grid_component.test.ts.snap
@@ -25,7 +25,7 @@ exports[`Grid component simple rendering snapshot 1`] = `
     
     <div
       class="o-grid-add-rows mt-2 ms-2 w-100 d-flex position-relative align-items-center os-theme-dependant"
-      style="top:2300px; z-index:1; "
+      style="top:2300px; "
     >
       <button
         class="o-button flex-grow-0 me-2"

--- a/tests/spreadsheet/__snapshots__/spreadsheet_component.test.ts.snap
+++ b/tests/spreadsheet/__snapshots__/spreadsheet_component.test.ts.snap
@@ -891,7 +891,7 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
           
           <div
             class="o-grid-add-rows mt-2 ms-2 w-100 d-flex position-relative align-items-center os-theme-dependant"
-            style="top:2300px; z-index:1; "
+            style="top:2300px; "
           >
             <button
               class="o-button flex-grow-0 me-2"
@@ -1962,7 +1962,7 @@ exports[`components take the small screen into account 1`] = `
           
           <div
             class="o-grid-add-rows mt-2 ms-2 w-100 d-flex position-relative align-items-center os-theme-dependant"
-            style="top:2300px; z-index:1; "
+            style="top:2300px; "
           >
             <button
               class="o-button flex-grow-0 me-2"


### PR DESCRIPTION
## Description

With the new dark mode for the grid, the canvas is applied a css `filter` property. This creates a new stacking context for the canvas, so elements that were previously above it were now below it. Some `z-index` values were added, but they were missing for some elements.

- Added a css variable for the grid overlay `z-index`
- Added `z-index` to autofill and table resizer so they are at the same level as the grid overlay.
- `Add row footer` button `z-index` was useless since it's a child of the grid overlay
- Highlight had a custom `z-index` ... which was not applied since the highlight element had `position: static`. The `z-index` should be applied to its children.

Task: [0](https://www.odoo.com/odoo/2328/tasks/0)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo