### PR TITLE
[IMP] data validation : fix the case of a rule with ranges on multiple sheets

### DIFF
--- a/src/components/selection_input/selection_input.ts
+++ b/src/components/selection_input/selection_input.ts
@@ -25,6 +25,7 @@ interface Props {
   colors?: Color[];
   disabledRanges?: boolean[];
   disabledRangeTitle?: string;
+  prefixSheet?: boolean;
 }
 
 interface State {
@@ -62,6 +63,7 @@ export class SelectionInput extends Component<Props, SpreadsheetChildEnv> {
     colors: { type: Array, optional: true, default: [] },
     disabledRanges: { type: Array, optional: true, default: [] },
     disabledRangeTitle: { type: String, optional: true },
+    prefixSheet: { type: Boolean, optional: true },
   };
   private state: State = useState({
     isMissing: false,
@@ -117,7 +119,8 @@ export class SelectionInput extends Component<Props, SpreadsheetChildEnv> {
       this.props.ranges,
       this.props.hasSingleRange || false,
       this.props.colors,
-      this.props.disabledRanges
+      this.props.disabledRanges,
+      this.props.prefixSheet || false
     );
     if (this.props.autofocus) {
       this.store.focusById(this.store.selectionInputs[0]?.id);

--- a/src/components/selection_input/selection_input_store.ts
+++ b/src/components/selection_input/selection_input_store.ts
@@ -1,5 +1,5 @@
 import { ColorGenerator } from "../../helpers/color";
-import { splitReference } from "../../helpers/references";
+import { getFullReference, splitReference } from "../../helpers/references";
 import { isEqual, positionToZone } from "../../helpers/zones";
 import { HighlightStore } from "../../stores/highlight_store";
 import { SpreadsheetStore } from "../../stores/spreadsheet_store";
@@ -50,7 +50,8 @@ export class SelectionInputStore extends SpreadsheetStore {
     private initialRanges: string[] = [],
     private readonly inputHasSingleRange: boolean = false,
     public colors: Color[] = [],
-    public disabledRanges: boolean[] = []
+    public disabledRanges: boolean[] = [],
+    private readonly prefixSheet: boolean = false
   ) {
     super(get);
     if (inputHasSingleRange && initialRanges.length > 1) {
@@ -77,7 +78,7 @@ export class SelectionInputStore extends SpreadsheetStore {
     const zone = event.options.unbounded
       ? this.getters.getUnboundedZone(activeSheetId, event.anchor.zone)
       : event.anchor.zone;
-    const range = this.getters.getRangeFromZone(activeSheetId, zone);
+    const range = this.getters.getRangeFromZone(activeSheetId, zone, this.prefixSheet);
 
     const willAddNewRange =
       event.mode === "newAnchor" &&
@@ -188,6 +189,15 @@ export class SelectionInputStore extends SpreadsheetStore {
   }
 
   confirm() {
+    if (this.prefixSheet) {
+      const activesheetName = this.getters.getActiveSheetName();
+      this.ranges = this.ranges.map((range) => {
+        return {
+          ...range,
+          xc: getFullReference(activesheetName, range.xc),
+        };
+      });
+    }
     for (const range of this.selectionInputs) {
       if (range.xc === "") {
         this.removeRange(range.id);
@@ -249,7 +259,10 @@ export class SelectionInputStore extends SpreadsheetStore {
   }
 
   get isConfirmable(): boolean {
-    return this.selectionInputs.every((range) => range.isValidRange);
+    return (
+      this.selectionInputs.some((range) => range.xc) &&
+      this.selectionInputs.every((range) => range.isValidRange)
+    );
   }
 
   get hasFocus(): boolean {

--- a/src/components/side_panel/conditional_formatting/cf_editor/cf_editor_store.ts
+++ b/src/components/side_panel/conditional_formatting/cf_editor/cf_editor_store.ts
@@ -93,7 +93,7 @@ export class ConditionalFormattingEditorStore extends SpreadsheetStore {
   }
 
   updateConditionalFormat(newCf: Partial<ConditionalFormat> & { suppressErrors?: boolean }) {
-    const ranges = newCf.ranges || this.state.ranges;
+    const strRanges = newCf.ranges || this.state.ranges;
     const invalidRanges = this.state.ranges.some((xc) => !xc.match(rangeReference));
     if (invalidRanges) {
       if (!newCf.suppressErrors) {
@@ -104,20 +104,30 @@ export class ConditionalFormattingEditorStore extends SpreadsheetStore {
     const sheetId = this.model.getters.getActiveSheetId();
     const locale = this.model.getters.getLocale();
     const rule = newCf.rule || this.getEditedRule(this.state.currentCFType);
-    const result = this.model.dispatch("ADD_CONDITIONAL_FORMAT", {
-      cf: {
-        id: this.cfId,
-        rule: canonicalizeCFRule(rule, locale),
-      },
-      ranges: ranges.map((xc) => this.model.getters.getRangeDataFromXc(sheetId, xc)),
-      sheetId,
-    });
-    if (result.isSuccessful) {
-      this.state.hasEditedCf = true;
+    const ranges = strRanges.map((xc) => this.model.getters.getRangeDataFromXc(sheetId, xc));
+    if (!ranges.length) {
+      if (!newCf.suppressErrors) {
+        this.state.errors = [CommandResult.EmptyRange];
+      }
+      return;
     }
-    const reasons = result.reasons.filter((r) => r !== CommandResult.NoChanges);
-    if (!newCf.suppressErrors) {
-      this.state.errors = reasons;
+    const rangesBySheet = Object.groupBy(ranges, (range) => range._sheetId);
+    for (const sheetId in rangesBySheet) {
+      const result = this.model.dispatch("ADD_CONDITIONAL_FORMAT", {
+        cf: {
+          id: this.cfId,
+          rule: canonicalizeCFRule(rule, locale),
+        },
+        ranges: rangesBySheet[sheetId]!,
+        sheetId,
+      });
+      if (result.isSuccessful) {
+        this.state.hasEditedCf = true;
+      }
+      const reasons = result.reasons.filter((r) => r !== CommandResult.NoChanges);
+      if (!newCf.suppressErrors) {
+        this.state.errors = reasons;
+      }
     }
   }
 

--- a/src/components/side_panel/data_validation/dv_editor/dv_editor.ts
+++ b/src/components/side_panel/data_validation/dv_editor/dv_editor.ts
@@ -89,16 +89,26 @@ export class DataValidationEditor extends Component<Props, SpreadsheetChildEnv> 
   }
 
   onSave() {
-    const result = this.env.model.dispatch("ADD_DATA_VALIDATION_RULE", this.dispatchPayload);
-    if (!result.isSuccessful) {
-      this.state.errors = result.reasons;
-      return;
+    for (const payload of this.dispatchPayload) {
+      const result = this.env.model.dispatch("ADD_DATA_VALIDATION_RULE", payload);
+      if (!result.isSuccessful) {
+        this.state.errors = result.reasons;
+        return;
+      }
     }
     this.env.replaceSidePanel("DataValidation", `DataValidationEditor_${this.props.ruleId}`);
   }
 
-  get dispatchPayload(): Omit<AddDataValidationCommand, "type"> {
+  get dispatchPayload(): Omit<AddDataValidationCommand, "type">[] {
     const rule = { ...this.state.rule, ranges: undefined };
+    const ranges = this.state.rule.ranges.map((xc) =>
+      this.env.model.getters.getRangeDataFromXc(this.editingSheetId, xc)
+    );
+    if (!ranges.length) {
+      return [{ sheetId: this.editingSheetId, ranges: [], rule }];
+    }
+    const rangesBySheet = Object.groupBy(ranges, (range) => range._sheetId);
+
     const locale = this.env.model.getters.getLocale();
 
     const criterion = rule.criterion;
@@ -109,13 +119,12 @@ export class DataValidationEditor extends Component<Props, SpreadsheetChildEnv> 
       .filter((value) => value && value.trim() !== "")
       .map((value) => canonicalizeContent(value, locale));
     rule.criterion = { ...criterion, values };
-    return {
-      sheetId: this.editingSheetId,
-      ranges: this.state.rule.ranges.map((xc) =>
-        this.env.model.getters.getRangeDataFromXc(this.editingSheetId, xc)
-      ),
+
+    return Object.entries(rangesBySheet).map(([sheetId, sheetRanges]) => ({
+      sheetId,
+      ranges: sheetRanges!,
       rule,
-    };
+    }));
   }
 
   get dvCriterionOptions(): ValueAndLabel[] {

--- a/src/components/side_panel/data_validation/dv_editor/dv_editor.ts
+++ b/src/components/side_panel/data_validation/dv_editor/dv_editor.ts
@@ -1,5 +1,6 @@
 import { Component, ComponentConstructor, useState } from "@odoo/owl";
 import { canonicalizeContent, localizeDataValidationRule } from "../../../../helpers/locale";
+import { getFullReference } from "../../../../helpers/references";
 import { zoneToXc } from "../../../../helpers/zones";
 import {
   criterionComponentRegistry,
@@ -60,9 +61,7 @@ export class DataValidationEditor extends Component<Props, SpreadsheetChildEnv> 
       const locale = this.env.model.getters.getLocale();
       this.state.rule = {
         ...localizeDataValidationRule(rule, locale),
-        ranges: rule.ranges.map((range) =>
-          this.env.model.getters.getRangeString(range, this.editingSheetId)
-        ),
+        ranges: rule.ranges.map((range) => this.env.model.getters.getRangeString(range)),
       };
     }
   }
@@ -124,10 +123,9 @@ export class DataValidationEditor extends Component<Props, SpreadsheetChildEnv> 
   }
 
   get defaultDataValidationRule(): DataValidationRuleData {
-    const sheetId = this.env.model.getters.getActiveSheetId();
-    const ranges = this.env.model.getters
-      .getSelectedZones()
-      .map((zone) => zoneToXc(this.env.model.getters.getUnboundedZone(sheetId, zone)));
+    const sheetName = this.env.model.getters.getActiveSheetName();
+    const zones = this.env.model.getters.getSelectedZones();
+    const ranges = zones.map((zone) => getFullReference(sheetName, zoneToXc(zone)));
     return {
       id: this.props.ruleId,
       criterion: { type: "containsText", values: [""] },

--- a/src/components/side_panel/data_validation/dv_editor/dv_editor.xml
+++ b/src/components/side_panel/data_validation/dv_editor/dv_editor.xml
@@ -6,6 +6,7 @@
           ranges="state.rule.ranges"
           onSelectionChanged="(ranges) => this.onRangesChanged(ranges)"
           required="true"
+          prefixSheet="true"
         />
       </Section>
       <Section class="'pt-0'">

--- a/src/components/translations_terms.ts
+++ b/src/components/translations_terms.ts
@@ -154,6 +154,7 @@ export const DVTerms = {
   Errors: {
     [CommandResult.InvalidRange]: _t("The range is invalid."),
     [CommandResult.InvalidSheetId]: _t("The range is invalid."),
+    [CommandResult.EmptyRange]: _t("The range is empty."),
     [CommandResult.InvalidDataValidationCriterionValue]: _t(
       "One or more of the provided criteria values are invalid. Please review and correct them."
     ),

--- a/src/components/translations_terms.ts
+++ b/src/components/translations_terms.ts
@@ -153,6 +153,7 @@ export const DVTerms = {
   },
   Errors: {
     [CommandResult.InvalidRange]: _t("The range is invalid."),
+    [CommandResult.InvalidSheetId]: _t("The range is invalid."),
     [CommandResult.InvalidDataValidationCriterionValue]: _t(
       "One or more of the provided criteria values are invalid. Please review and correct them."
     ),

--- a/src/helpers/references.ts
+++ b/src/helpers/references.ts
@@ -50,6 +50,10 @@ export function splitReference(ref: string): { sheetName?: string; xc: string } 
 }
 
 export function getFullReference(sheetName: string | undefined, xc: string): string {
+  const { sheetName: currentSheetName } = splitReference(xc);
+  if (currentSheetName) {
+    return xc;
+  }
   return sheetName !== undefined ? `${getCanonicalSymbolName(sheetName)}!${xc}` : xc;
 }
 type FixedReferenceType = "col" | "row" | "colrow" | "none";

--- a/src/plugins/core/data_validation.ts
+++ b/src/plugins/core/data_validation.ts
@@ -1,6 +1,6 @@
 import { CompiledFormula } from "../../formulas/compiler";
 import { toXC } from "../../helpers/coordinates";
-import { deepCopy } from "../../helpers/misc";
+import { deepCopy, deepEquals } from "../../helpers/misc";
 import { duplicateRangeInDuplicatedSheet, getCellPositionsInRanges } from "../../helpers/range";
 import { recomputeZones } from "../../helpers/recompute_zones";
 import { isInside } from "../../helpers/zones";
@@ -229,7 +229,17 @@ export class DataValidationPlugin
       adaptedRules[ruleIndex] = newRule;
       this.history.update("rules", sheetId, adaptedRules);
     } else {
-      this.history.update("rules", sheetId, [...adaptedRules, newRule]);
+      const similarRuleIndex = adaptedRules.findIndex(
+        (rule) =>
+          deepEquals(rule.criterion, newRule.criterion) && rule.isBlocking === newRule.isBlocking
+      );
+      if (similarRuleIndex !== -1) {
+        const newRanges = [...adaptedRules[similarRuleIndex].ranges, ...newRule.ranges];
+        adaptedRules[similarRuleIndex].ranges = newRanges;
+        this.history.update("rules", sheetId, adaptedRules);
+      } else {
+        this.history.update("rules", sheetId, [...adaptedRules, newRule]);
+      }
     }
   }
 

--- a/src/plugins/core/range.ts
+++ b/src/plugins/core/range.ts
@@ -227,7 +227,7 @@ export class RangeAdapterPlugin implements CommandHandler<CoreCommand> {
     return this.getRangeDataFromZone(range.sheetId, range.unboundedZone);
   }
 
-  getRangeFromZone(sheetId: UID, zone: Zone | UnboundedZone): Range {
+  getRangeFromZone(sheetId: UID, zone: Zone | UnboundedZone, prefixSheet: boolean = false): Range {
     return createRange(
       {
         sheetId,
@@ -236,7 +236,7 @@ export class RangeAdapterPlugin implements CommandHandler<CoreCommand> {
           { colFixed: false, rowFixed: false },
           { colFixed: false, rowFixed: false },
         ],
-        prefixSheet: false,
+        prefixSheet,
       },
       this.getters.getSheetSize
     );
@@ -280,6 +280,8 @@ export class RangeAdapterPlugin implements CommandHandler<CoreCommand> {
       (!sheetName || this.getters.getSheetIdByName(sheetName) !== undefined)
     );
   }
+
+  //ici
 
   getRangesUnion(ranges: Range[]): Range {
     const zones = ranges.map((range) => range.unboundedZone);

--- a/tests/collaborative/collaborative.test.ts
+++ b/tests/collaborative/collaborative.test.ts
@@ -966,10 +966,7 @@ describe("Multi users synchronisation", () => {
     });
     expect([alice, bob, charlie]).toHaveSynchronizedValue(
       (user) => getDataValidationRules(user),
-      [
-        { id: "id", ranges: ["A1:A2"], criterion, isBlocking: false },
-        { id: "id2", ranges: ["A3:A7"], criterion, isBlocking: false },
-      ]
+      [{ id: "id", ranges: ["A1:A2", "A3:A7"], criterion, isBlocking: false }]
     );
   });
 

--- a/tests/data_validation/data_validation_core_plugin.test.ts
+++ b/tests/data_validation/data_validation_core_plugin.test.ts
@@ -563,71 +563,75 @@ describe("Data validation", () => {
   });
 
   describe("Grid manipulation", () => {
-    const criterion: DataValidationCriterion = { type: "containsText", values: ["1"] };
+    const criterion1: DataValidationCriterion = { type: "containsText", values: ["1"] };
+    const criterion2: DataValidationCriterion = { type: "containsText", values: ["2"] };
+    const criterion3: DataValidationCriterion = { type: "containsText", values: ["3"] };
+    const criterion4: DataValidationCriterion = { type: "containsText", values: ["4"] };
+    const criterion5: DataValidationCriterion = { type: "containsText", values: ["5"] };
 
     test("On row addition", () => {
-      addDataValidation(model, "A1", "id1", criterion);
-      addDataValidation(model, "B1:B2", "id2", criterion);
-      addDataValidation(model, "C4:D4", "id3", criterion);
-      addDataValidation(model, "F1, F7", "id4", criterion);
+      addDataValidation(model, "A1", "id1", criterion1);
+      addDataValidation(model, "B1:B2", "id2", criterion2);
+      addDataValidation(model, "C4:D4", "id3", criterion3);
+      addDataValidation(model, "F1, F7", "id4", criterion4);
 
       addRows(model, "after", 0, 2);
 
       expect(getDataValidationRules(model, sheetId)).toMatchObject([
-        { id: "id1", ranges: ["A1"], criterion, isBlocking: false },
-        { id: "id2", ranges: ["B1:B4"], criterion, isBlocking: false },
-        { id: "id3", ranges: ["C6:D6"], criterion, isBlocking: false },
-        { id: "id4", ranges: ["F1", "F9"], criterion, isBlocking: false },
+        { id: "id1", ranges: ["A1"], criterion: criterion1, isBlocking: false },
+        { id: "id2", ranges: ["B1:B4"], criterion: criterion2, isBlocking: false },
+        { id: "id3", ranges: ["C6:D6"], criterion: criterion3, isBlocking: false },
+        { id: "id4", ranges: ["F1", "F9"], criterion: criterion4, isBlocking: false },
       ]);
     });
 
     test("On column addition", () => {
-      addDataValidation(model, "A1", "id1", criterion);
-      addDataValidation(model, "A2:B2", "id2", criterion);
-      addDataValidation(model, "C4:D5", "id3", criterion);
-      addDataValidation(model, "A7, F7", "id4", criterion);
+      addDataValidation(model, "A1", "id1", criterion1);
+      addDataValidation(model, "A2:B2", "id2", criterion2);
+      addDataValidation(model, "C4:D5", "id3", criterion3);
+      addDataValidation(model, "A7, F7", "id4", criterion4);
 
       addColumns(model, "after", "A", 2);
 
       expect(getDataValidationRules(model, sheetId)).toMatchObject([
-        { id: "id1", ranges: ["A1"], criterion, isBlocking: false },
-        { id: "id2", ranges: ["A2:D2"], criterion, isBlocking: false },
-        { id: "id3", ranges: ["E4:F5"], criterion, isBlocking: false },
-        { id: "id4", ranges: ["A7", "H7"], criterion, isBlocking: false },
+        { id: "id1", ranges: ["A1"], criterion: criterion1, isBlocking: false },
+        { id: "id2", ranges: ["A2:D2"], criterion: criterion2, isBlocking: false },
+        { id: "id3", ranges: ["E4:F5"], criterion: criterion3, isBlocking: false },
+        { id: "id4", ranges: ["A7", "H7"], criterion: criterion4, isBlocking: false },
       ]);
     });
 
     test("On row deletion", () => {
-      addDataValidation(model, "A1", "id1", criterion);
-      addDataValidation(model, "B1:B2", "id2", criterion);
-      addDataValidation(model, "E2:E3", "id3", criterion);
-      addDataValidation(model, "C4:D4", "id4", criterion);
-      addDataValidation(model, "F2, F7", "id5", criterion);
+      addDataValidation(model, "A1", "id1", criterion1);
+      addDataValidation(model, "B1:B2", "id2", criterion2);
+      addDataValidation(model, "E2:E3", "id3", criterion3);
+      addDataValidation(model, "C4:D4", "id4", criterion4);
+      addDataValidation(model, "F2, F7", "id5", criterion5);
 
       deleteRows(model, [1, 2]);
 
       expect(getDataValidationRules(model, sheetId)).toMatchObject([
-        { id: "id1", ranges: ["A1"], criterion, isBlocking: false },
-        { id: "id2", ranges: ["B1"], criterion, isBlocking: false },
-        { id: "id4", ranges: ["C2:D2"], criterion, isBlocking: false },
-        { id: "id5", ranges: ["F5"], criterion, isBlocking: false },
+        { id: "id1", ranges: ["A1"], criterion: criterion1, isBlocking: false },
+        { id: "id2", ranges: ["B1"], criterion: criterion2, isBlocking: false },
+        { id: "id4", ranges: ["C2:D2"], criterion: criterion4, isBlocking: false },
+        { id: "id5", ranges: ["F5"], criterion: criterion5, isBlocking: false },
       ]);
     });
 
     test("On column deletion", () => {
-      addDataValidation(model, "A1", "id1", criterion);
-      addDataValidation(model, "A2:B2", "id2", criterion);
-      addDataValidation(model, "B3:C3", "id3", criterion);
-      addDataValidation(model, "D4:E5", "id4", criterion);
-      addDataValidation(model, "B7, F7", "id5", criterion);
+      addDataValidation(model, "A1", "id1", criterion1);
+      addDataValidation(model, "A2:B2", "id2", criterion2);
+      addDataValidation(model, "B3:C3", "id3", criterion3);
+      addDataValidation(model, "D4:E5", "id4", criterion4);
+      addDataValidation(model, "B7, F7", "id5", criterion5);
 
       deleteColumns(model, ["B", "C"]);
 
       expect(getDataValidationRules(model, sheetId)).toMatchObject([
-        { id: "id1", ranges: ["A1"], criterion, isBlocking: false },
-        { id: "id2", ranges: ["A2"], criterion, isBlocking: false },
-        { id: "id4", ranges: ["B4:C5"], criterion, isBlocking: false },
-        { id: "id5", ranges: ["D7"], criterion, isBlocking: false },
+        { id: "id1", ranges: ["A1"], criterion: criterion1, isBlocking: false },
+        { id: "id2", ranges: ["A2"], criterion: criterion2, isBlocking: false },
+        { id: "id4", ranges: ["B4:C5"], criterion: criterion4, isBlocking: false },
+        { id: "id5", ranges: ["D7"], criterion: criterion5, isBlocking: false },
       ]);
     });
   });
@@ -649,6 +653,16 @@ describe("Data validation", () => {
     expect(model.getters.isDataValidationInvalid(toCellPosition(sheetId, "A1"))).toBe(false);
     expect(model.getters.getDataValidationRules(sheetId)[0].criterion.values).toEqual([
       "=newRangeName",
+    ]);
+  });
+
+  test("Create a new rule with an existing criterion", () => {
+    const criterion: DataValidationCriterion = { type: "containsText", values: ["1"] };
+    addDataValidation(model, "A1", "id1", criterion);
+    addDataValidation(model, "B1:B2", "id2", criterion);
+
+    expect(getDataValidationRules(model, sheetId)).toMatchObject([
+      { id: "id1", ranges: ["A1", "B1:B2"], criterion: criterion, isBlocking: false },
     ]);
   });
 });

--- a/tests/data_validation/data_validation_generics_side_panel_component.test.ts
+++ b/tests/data_validation/data_validation_generics_side_panel_component.test.ts
@@ -337,6 +337,21 @@ describe("data validation sidePanel component", () => {
     expect(getDataValidationRules(model, "sh2")).toHaveLength(0);
   });
 
+  test("A rule with ranges on multiple sheets create duplicate rules for each sheet", async () => {
+    createSheet(model, { sheetId: "sh2", name: "Sheet2" });
+    await simulateClick(".o-dv-add");
+    await nextTick();
+    await setInputValueAndTrigger(".o-selection-input input", "Sheet1!A1");
+    await simulateClick(".o-add-selection");
+    const range2 = document.querySelectorAll(".o-selection-input input")[1];
+    await setInputValueAndTrigger(range2, "Sheet2!B1");
+    await editStandaloneComposer(".o-dv-settings .o-composer", "Random text");
+    await simulateClick(".o-dv-save");
+
+    expect(getDataValidationRules(model, sheetId)).toMatchObject([{ ranges: ["A1"] }]);
+    expect(getDataValidationRules(model, "sh2")).toMatchObject([{ ranges: ["B1"] }]);
+  });
+
   describe("Locale", () => {
     test("Number preview is localized", async () => {
       updateLocale(model, FR_LOCALE);

--- a/tests/figures/chart/sunburst/sunburst_panel_component.test.ts
+++ b/tests/figures/chart/sunburst/sunburst_panel_component.test.ts
@@ -54,6 +54,7 @@ describe("Sunburst chart side panel", () => {
     });
 
     test("Can change chart values in config side panel", async () => {
+      //ici
       const chartId = createSunburstChart(model, {
         ...toChartDataSource({
           dataSets: [{ dataRange: "A1:A3" }],

--- a/tests/pivots/spreadsheet_pivot/__snapshots__/spreadsheet_pivot_side_panel.test.ts.snap
+++ b/tests/pivots/spreadsheet_pivot/__snapshots__/spreadsheet_pivot_side_panel.test.ts.snap
@@ -1176,6 +1176,7 @@ exports[`Spreadsheet pivot side panel It should display only the selection input
                           
                           <button
                             class="o-button primary ms-2 o-selection-ok"
+                            disabled=""
                           >
                              Confirm 
                           </button>

--- a/tests/selection_input/selection_input_component.test.ts
+++ b/tests/selection_input/selection_input_component.test.ts
@@ -212,12 +212,13 @@ describe("Selection Input", () => {
     expect(fixture.querySelectorAll(".o-selection-ko").length).toBe(1);
   });
 
-  test("hitting enter key acts the same as clicking confirm button for valid dataset", async () => {
+  test("hitting enter key acts the same as clicking confirm button for valid selection", async () => {
     let isConfirmed = false;
     const onConfirmed = jest.fn(() => {
       isConfirmed = true;
     });
     await createSelectionInput({ onConfirmed });
+    await writeInput(0, "A1");
     expect(fixture.querySelector(".o-focused")).toBeTruthy();
     expect(isConfirmed).toBeFalsy();
     await keyDown({ key: "Enter" });
@@ -226,7 +227,7 @@ describe("Selection Input", () => {
     expect(isConfirmed).toBeTruthy();
   });
 
-  test("hitting enter key does nothing for an invalid dataset", async () => {
+  test("hitting enter key does nothing for an invalid selection", async () => {
     const onConfirmed = jest.fn();
     await createSelectionInput({ onConfirmed });
     await writeInput(0, "Kaboom");

--- a/tests/spreadsheet/spreadsheet_component.test.ts
+++ b/tests/spreadsheet/spreadsheet_component.test.ts
@@ -439,10 +439,10 @@ test("cell icon takes over a focused selection input", async () => {
   await simulateClick(fixture.querySelector(".o-selection-input input"));
   await nextTick();
   expect(".o-selection-input input.o-focused").toHaveCount(1);
-  expect(".o-selection-input input.o-focused").toHaveValue("B1:B3");
+  expect(".o-selection-input input.o-focused").toHaveValue("Sheet1!B1:B3");
   await clickGridIcon(model, "B1");
   expect(".o-selection-input input.o-focused").toHaveCount(0);
-  expect(".o-selection-input input").toHaveValue("B1:B3");
+  expect(".o-selection-input input").toHaveValue("Sheet1!B1:B3");
 });
 
 test("cell popovers to be closed on clicking outside grid", async () => {


### PR DESCRIPTION
Before this commit:
The user is allowed to witch sheet and select a range in a different sheet but then the DV is applied to this range in the active sheet while naming the other sheet in the description

After this commit:
If the user selects ranges on different sheets, we create one DV rule per sheet with the same criterion and values but with the correct ranges for each sheet.

Task: [6196116](https://www.odoo.com/odoo/2328/tasks/6196116)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo