### PR TITLE
[FIX] Chart type: first chart type change resulted in empty chart

### DIFF
--- a/src/helpers/figures/charts/chart_data_sources.ts
+++ b/src/helpers/figures/charts/chart_data_sources.ts
@@ -57,7 +57,11 @@ export const ChartRangeDataSourceHandler: ChartDataSourceBuilder<
   },
 
   fromHierarchicalContextCreation(context) {
-    if (context.dataSource?.type !== "range" || context.hierarchicalDataSource?.type !== "range") {
+    if (
+      context.dataSource?.type !== "range" ||
+      (context.hierarchicalDataSource !== undefined &&
+        context.hierarchicalDataSource.type !== "range")
+    ) {
       return {
         type: "range",
         dataSets: [],

--- a/src/helpers/figures/charts/chart_data_sources.ts
+++ b/src/helpers/figures/charts/chart_data_sources.ts
@@ -52,6 +52,7 @@ export const ChartRangeDataSourceHandler: ChartDataSourceBuilder<
       type: "range",
       dataSets: [],
       dataSetsHaveTitle: false,
+      labelRange: context.auxiliaryRange,
       ...context.dataSource,
     };
   },

--- a/tests/figures/chart/charts_component.test.ts
+++ b/tests/figures/chart/charts_component.test.ts
@@ -3205,6 +3205,23 @@ describe("Change chart type", () => {
     });
   });
 
+  test("When changing chart type from hierarchical to bar, the label range is not lost", async () => {
+    createChart(
+      model,
+      { type: "sunburst", ...toChartDataSource({ dataSets: [{ dataRange: "A1:A4" }] }) },
+      chartId
+    );
+    await mountChartSidePanel(chartId);
+
+    await changeChartType("bar");
+    await nextTick();
+
+    const definition = model.getters.getChartDefinition(chartId);
+    expect(definition.dataSource).toMatchObject({
+      labelRange: "A1:A4",
+    });
+  });
+
   test("Can change chart type between bar and horizontal bar chart", async () => {
     createChart(model, { type: "bar", horizontal: false }, chartId);
     await mountChartSidePanel(chartId);

--- a/tests/figures/chart/charts_component.test.ts
+++ b/tests/figures/chart/charts_component.test.ts
@@ -3188,6 +3188,23 @@ describe("Change chart type", () => {
     }
   );
 
+  test("Change chart type to sunburst for the first time does not result in empty chart", async () => {
+    createChart(
+      model,
+      { type: "bar", ...toChartDataSource({ dataSets: [{ dataRange: "A1:A4" }] }) },
+      chartId
+    );
+    await mountChartSidePanel(chartId);
+
+    await changeChartType("sunburst");
+    await nextTick();
+
+    const definition = model.getters.getChartDefinition(chartId);
+    expect(definition.dataSource).toMatchObject({
+      labelRange: "A1:A4",
+    });
+  });
+
   test("Can change chart type between bar and horizontal bar chart", async () => {
     createChart(model, { type: "bar", horizontal: false }, chartId);
     await mountChartSidePanel(chartId);


### PR DESCRIPTION
Before this commit:
When changing the chart type for the first time, the dataSource in the chart definition was empty, which caused the chart to be empty.

How to reproduce:
1. Create a chart
2. Change the chart type in the side panel from bar to sunburst
3. The chart becomes empty
4. Change again the chart type to bar, the chart is not empty
5. Change again the chart type to sunburst, the chart is not empty

Task: [6197123](https://www.odoo.com/odoo/2328/tasks/6197123)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo