### PR TITLE
[FIX] composer: remove forced reflow in content editable

### DIFF
--- a/src/components/composer/content_editable_helper.ts
+++ b/src/components/composer/content_editable_helper.ts
@@ -1,5 +1,5 @@
 import { NEWLINE } from "../../constants";
-import { deepEquals } from "../../helpers";
+import { deepEquals, toHex } from "../../helpers";
 import {
   getBoundingRectAsPOJO,
   getCurrentSelection,
@@ -274,12 +274,12 @@ export class ContentEditableHelper {
 }
 
 function compareContentToSpanElement(content: HtmlContent, node: HTMLElement): boolean {
-  const contentColor = content.color || "";
-  const nodeColor = node.style?.color || "";
+  const contentColor = content.color ? toHex(content.color) : "";
+  const nodeColor = node.style?.color ? toHex(node.style?.color) : "";
 
   const sameColor = contentColor === nodeColor;
   const sameClass = deepEquals(content.classes, [...node.classList]);
-  const sameContent = node.innerText === content.value;
+  const sameContent = node.textContent === content.value;
   return sameColor && sameClass && sameContent;
 }
 

--- a/src/helpers/color.ts
+++ b/src/helpers/color.ts
@@ -47,6 +47,8 @@ export function colorToNumber(color: Color | number): number {
  * Converts any CSS color value to a standardized hex6 value.
  * Accepts: hex3, hex6, hex8, rgb[1] and rgba[1].
  *
+ * In the case of `light-dark(...)` colors, it will convert both light and dark colors to hex.
+ *
  * [1] under the form rgb(r, g, b, a?) or rgba(r, g, b, a?)
  * with r,g,b ∈ [0, 255] and a ∈ [0, 1]
  *
@@ -59,12 +61,21 @@ export function colorToNumber(color: Color | number): number {
  * toHex("rgb(30, 80, 16)")
  * >> "#1E5010"
  *
- *  * toHex("rgb(30, 80, 16, 0.5)")
+ * toHex("rgb(30, 80, 16, 0.5)")
  * >> "#1E501080"
  *
+ * toHex("light-dark(#aaa, #bbb)")
+ * >> "light-dark(#AAAAAA, #BBBBBB)"
  */
 export function toHex(color: Color): Color {
   let hexColor = color;
+  if (color.startsWith("light-dark")) {
+    const match = color.match(LIGHT_DARK_REGEX);
+    if (!match) {
+      throw new Error(`Invalid light-dark color: ${color}`);
+    }
+    return `light-dark(${toHex(match[1])}, ${toHex(match[2])})`;
+  }
   if (color.startsWith("rgb")) {
     hexColor = rgbaStringToHex(color);
   } else {

--- a/tests/colors/color_helpers.test.ts
+++ b/tests/colors/color_helpers.test.ts
@@ -79,6 +79,13 @@ describe("toHex", () => {
   test.each(testColors)("toHex() %s", ({ input, hex }) => {
     expect(toHex(input)).toBeSameColorAs(hex);
   });
+
+  test("toHex works with light-dark colors", () => {
+    expect(toHex("light-dark(#aaa, #bbb)")).toEqual("light-dark(#AAAAAA, #BBBBBB)");
+    expect(toHex("light-dark(rgb(0,0,0), rgba(0,255,255,0.5))")).toEqual(
+      "light-dark(#000000, #00FFFF80)"
+    );
+  });
 });
 
 describe("colorToRGBA", () => {


### PR DESCRIPTION
## Description

With the introduction of dark mode, we removed the `toHex` in the color comparison of `compareContentToSpanElement`, because it didn't handle `light-dark()` colors. But using simple color string comparison is wrong, because the browser will often change color formats (e.g. hex values will be converted to rgb strings).

The method `compareContentToSpanElement` would also use `innerText` to compare text, but `innerText` is style-awayre and might trigger a reflow. Which can be a performance bottleneck.

This commit:
- make `toHex` handle `light-dark()` colors, so we can use it in the content editable helper
- change `innerText` to `textContent` to avoid forced reflow when the content actually changed

Benchmark:
---------------

Performance in Odoo (that has an expansive style/layout computation) on a slow-ish CPU when hovering an autocomplete pivot item in the formula `=1+1+1+1+1+1+1+1+1+1+1+PIVOT()`:

Before:
- Animation frame: ~92ms
- compareContentToSpanElement: ~79 ms

After:
- Animation frame: ~4ms
- compareContentToSpanElement: ~0.35

Task: [6199661](https://www.odoo.com/odoo/2328/tasks/6199661)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo