### PR TITLE
[IMP] action menu: replace Ctrl by Cmd for Mac users

### DIFF
--- a/src/actions/action.ts
+++ b/src/actions/action.ts
@@ -1,3 +1,4 @@
+import { isMacOS } from "../components/helpers/dom_helpers";
 import { Color } from "../types/misc";
 import { SpreadsheetChildEnv } from "../types/spreadsheet_env";
 
@@ -111,13 +112,17 @@ export function createActions(menuItems: ActionSpec[]): Action[] {
   return menuItems.map(createAction).sort((a, b) => a.sequence - b.sequence);
 }
 
+function adaptShortcutMacOs(shortcut: string) {
+  return shortcut.replace("Ctrl", "⌘").replace("Alt", "⌃");
+}
+
 let nextItemId = 1;
 
 export function createAction(item: ActionSpec): Action {
   const name = item.name;
   const children = item.children;
   const description = item.description;
-  const shortcut = item.shortcut;
+  const shortcut = item.shortcut && isMacOS() ? adaptShortcutMacOs(item.shortcut) : item.shortcut;
   const icon = item.icon;
   const secondaryIcon = item.secondaryIcon;
   const itemId = item.id || nextItemId++;

--- a/src/actions/insert_actions.ts
+++ b/src/actions/insert_actions.ts
@@ -212,7 +212,7 @@ export const insertImage: ActionSpec = {
 
 export const insertTable: ActionSpec = {
   name: () => _t("Table"),
-  description: "Alt+T",
+  shortcut: "Alt+T",
   execute: ACTIONS.INSERT_TABLE,
   isVisible: (env) =>
     ACTIONS.IS_SELECTION_CONTINUOUS(env) && !env.model.getters.getFirstTableInSelection(),
@@ -285,7 +285,7 @@ export const categoriesFunctionListMenuBuilder: ActionBuilder = () => {
 
 export const insertLink: ActionSpec = {
   name: _t("Link"),
-  description: "Ctrl+Shift+K",
+  shortcut: "Ctrl+Shift+K",
   execute: ACTIONS.INSERT_LINK,
   icon: "o-spreadsheet-Icon.INSERT_LINK",
 };
@@ -348,7 +348,7 @@ export const insertDropdown: ActionSpec = {
 
 export const insertSheet: ActionSpec = {
   name: _t("Insert sheet"),
-  description: "Shift+F11",
+  shortcut: "Shift+F11",
   execute: (env) => {
     const activeSheetId = env.model.getters.getActiveSheetId();
     const position = env.model.getters.getSheetIds().indexOf(activeSheetId) + 1;

--- a/tests/spreadsheet/spreadsheet_component.test.ts
+++ b/tests/spreadsheet/spreadsheet_component.test.ts
@@ -194,6 +194,19 @@ describe("Simple Spreadsheet Component", () => {
     mockUserAgent.mockReset();
   });
 
+  test("Mac user have ⌘ in menu instead of Ctrl", async () => {
+    const mockUserAgent = jest.spyOn(navigator, "userAgent", "get");
+    mockUserAgent.mockImplementation(
+      () => "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Firefox/119.0"
+    );
+    ({ model, parent, fixture } = await mountSpreadsheet({
+      model: new Model({ sheets: [{ id: "sh1" }] }),
+    }));
+    await click(fixture, ".o-topbar-menu[data-id='format']");
+    expect(document.querySelectorAll('span[title="Bold (⌘+B)"]').length).toBe(1);
+    mockUserAgent.mockReset();
+  });
+
   test("Insert a function properly sets the edition", async () => {
     ({ model, parent, fixture, env } = await mountSpreadsheet());
     const composerStore = env.getStore(CellComposerStore);


### PR DESCRIPTION
Task: 6200859

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [6200859](https://www.odoo.com/odoo/2328/tasks/6200859)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo