### PR TITLE
[FIX] xlsx: preserve chart title font size on xlsx export

### DIFF
--- a/src/xlsx/functions/charts.ts
+++ b/src/xlsx/functions/charts.ts
@@ -170,6 +170,11 @@ function insertText(
   fontsize: number = CHART_TITLE_FONT_SIZE,
   style: { bold?: boolean; italic?: boolean } = {}
 ): XMLString {
+  const textProperties: XMLAttributes = [
+    ["b", style.bold ? "1" : "0"],
+    ["i", style.italic ? "1" : "0"],
+    ["sz", fontsize * 100],
+  ];
   return escapeXml/*xml*/ `
     <c:tx>
       <c:rich>
@@ -177,13 +182,13 @@ function insertText(
         <a:lstStyle />
         <a:p>
           <a:pPr lvl="0">
-            <a:defRPr b="${style?.bold ? 1 : 0}" i="${style?.italic ? 1 : 0}">
+            <a:defRPr ${formatAttributes(textProperties)}>
               ${solidFill(fontColor)}
               <a:latin typeface="+mn-lt"/>
             </a:defRPr>
           </a:pPr>
           <a:r> <!-- Runs -->
-            <a:rPr b="${style?.bold ? 1 : 0}" i="${style?.italic ? 1 : 0}" sz="${fontsize * 100}"/>
+            <a:rPr ${formatAttributes(textProperties)}/>
             <a:t>${text}</a:t>
           </a:r>
         </a:p>

--- a/tests/xlsx/__snapshots__/xlsx_export.test.ts.snap
+++ b/tests/xlsx/__snapshots__/xlsx_export.test.ts.snap
@@ -34,7 +34,7 @@ exports[`Test XLSX export Charts Chart legend is set to none position 1`] = `
                     <a:lstStyle/>
                     <a:p>
                         <a:pPr lvl="0">
-                            <a:defRPr b="0" i="0">
+                            <a:defRPr b="0" i="0" sz="1600">
                                 <a:solidFill>
                                     <a:srgbClr val="666666"/>
                                 </a:solidFill>
@@ -175,7 +175,7 @@ exports[`Test XLSX export Charts Chart legend is set to none position 1`] = `
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -240,7 +240,7 @@ exports[`Test XLSX export Charts Chart legend is set to none position 1`] = `
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -650,7 +650,7 @@ exports[`Test XLSX export Charts Export chart overflowing outside the sheet 1`] 
                     <a:lstStyle/>
                     <a:p>
                         <a:pPr lvl="0">
-                            <a:defRPr b="0" i="0">
+                            <a:defRPr b="0" i="0" sz="1600">
                                 <a:solidFill>
                                     <a:srgbClr val="666666"/>
                                 </a:solidFill>
@@ -777,7 +777,7 @@ exports[`Test XLSX export Charts Export chart overflowing outside the sheet 1`] 
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -842,7 +842,7 @@ exports[`Test XLSX export Charts Export chart overflowing outside the sheet 1`] 
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -1270,7 +1270,7 @@ exports[`Test XLSX export Charts chart dataset without title 1`] = `
                     <a:lstStyle/>
                     <a:p>
                         <a:pPr lvl="0">
-                            <a:defRPr b="0" i="0">
+                            <a:defRPr b="0" i="0" sz="1600">
                                 <a:solidFill>
                                     <a:srgbClr val="666666"/>
                                 </a:solidFill>
@@ -1397,7 +1397,7 @@ exports[`Test XLSX export Charts chart dataset without title 1`] = `
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -1462,7 +1462,7 @@ exports[`Test XLSX export Charts chart dataset without title 1`] = `
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -1891,7 +1891,7 @@ exports[`Test XLSX export Charts chart font color is white with a dark backgroun
                     <a:lstStyle/>
                     <a:p>
                         <a:pPr lvl="0">
-                            <a:defRPr b="0" i="0">
+                            <a:defRPr b="0" i="0" sz="1600">
                                 <a:solidFill>
                                     <a:srgbClr val="666666"/>
                                 </a:solidFill>
@@ -2032,7 +2032,7 @@ exports[`Test XLSX export Charts chart font color is white with a dark backgroun
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -2097,7 +2097,7 @@ exports[`Test XLSX export Charts chart font color is white with a dark backgroun
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -2180,7 +2180,7 @@ exports[`Test XLSX export Charts chart font color is white with a dark backgroun
                     <a:lstStyle/>
                     <a:p>
                         <a:pPr lvl="0">
-                            <a:defRPr b="0" i="0">
+                            <a:defRPr b="0" i="0" sz="1600">
                                 <a:solidFill>
                                     <a:srgbClr val="666666"/>
                                 </a:solidFill>
@@ -2389,7 +2389,7 @@ exports[`Test XLSX export Charts chart font color is white with a dark backgroun
                     <a:lstStyle/>
                     <a:p>
                         <a:pPr lvl="0">
-                            <a:defRPr b="0" i="0">
+                            <a:defRPr b="0" i="0" sz="1600">
                                 <a:solidFill>
                                     <a:srgbClr val="666666"/>
                                 </a:solidFill>
@@ -2553,7 +2553,7 @@ exports[`Test XLSX export Charts chart font color is white with a dark backgroun
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -2618,7 +2618,7 @@ exports[`Test XLSX export Charts chart font color is white with a dark backgroun
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -2701,7 +2701,7 @@ exports[`Test XLSX export Charts chart font color is white with a dark backgroun
                     <a:lstStyle/>
                     <a:p>
                         <a:pPr lvl="0">
-                            <a:defRPr b="0" i="0">
+                            <a:defRPr b="0" i="0" sz="1600">
                                 <a:solidFill>
                                     <a:srgbClr val="666666"/>
                                 </a:solidFill>
@@ -2788,7 +2788,7 @@ exports[`Test XLSX export Charts chart font color is white with a dark backgroun
                     <a:lstStyle/>
                     <a:p>
                         <a:pPr lvl="0">
-                            <a:defRPr b="0" i="0">
+                            <a:defRPr b="0" i="0" sz="1600">
                                 <a:solidFill>
                                     <a:srgbClr val="666666"/>
                                 </a:solidFill>
@@ -2953,7 +2953,7 @@ exports[`Test XLSX export Charts chart font color is white with a dark backgroun
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -3018,7 +3018,7 @@ exports[`Test XLSX export Charts chart font color is white with a dark backgroun
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -3101,7 +3101,7 @@ exports[`Test XLSX export Charts chart font color is white with a dark backgroun
                     <a:lstStyle/>
                     <a:p>
                         <a:pPr lvl="0">
-                            <a:defRPr b="0" i="0">
+                            <a:defRPr b="0" i="0" sz="1600">
                                 <a:solidFill>
                                     <a:srgbClr val="666666"/>
                                 </a:solidFill>
@@ -3264,7 +3264,7 @@ exports[`Test XLSX export Charts chart font color is white with a dark backgroun
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -3329,7 +3329,7 @@ exports[`Test XLSX export Charts chart font color is white with a dark backgroun
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -4041,7 +4041,7 @@ exports[`Test XLSX export Charts charts in different sheets 1`] = `
                     <a:lstStyle/>
                     <a:p>
                         <a:pPr lvl="0">
-                            <a:defRPr b="0" i="0">
+                            <a:defRPr b="0" i="0" sz="1600">
                                 <a:solidFill>
                                     <a:srgbClr val="666666"/>
                                 </a:solidFill>
@@ -4205,7 +4205,7 @@ exports[`Test XLSX export Charts charts in different sheets 1`] = `
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -4270,7 +4270,7 @@ exports[`Test XLSX export Charts charts in different sheets 1`] = `
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -4526,7 +4526,7 @@ exports[`Test XLSX export Charts charts in different sheets 1`] = `
                     <a:lstStyle/>
                     <a:p>
                         <a:pPr lvl="0">
-                            <a:defRPr b="0" i="0">
+                            <a:defRPr b="0" i="0" sz="1600">
                                 <a:solidFill>
                                     <a:srgbClr val="666666"/>
                                 </a:solidFill>
@@ -4667,7 +4667,7 @@ exports[`Test XLSX export Charts charts in different sheets 1`] = `
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -4732,7 +4732,7 @@ exports[`Test XLSX export Charts charts in different sheets 1`] = `
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -5099,7 +5099,7 @@ exports[`Test XLSX export Charts doughnut chart 1`] = `
                     <a:lstStyle/>
                     <a:p>
                         <a:pPr lvl="0">
-                            <a:defRPr b="0" i="0">
+                            <a:defRPr b="0" i="0" sz="1600">
                                 <a:solidFill>
                                     <a:srgbClr val="666666"/>
                                 </a:solidFill>
@@ -5679,7 +5679,7 @@ exports[`Test XLSX export Charts horizontal bar chart 1`] = `
                     <a:lstStyle/>
                     <a:p>
                         <a:pPr lvl="0">
-                            <a:defRPr b="0" i="0">
+                            <a:defRPr b="0" i="0" sz="1600">
                                 <a:solidFill>
                                     <a:srgbClr val="666666"/>
                                 </a:solidFill>
@@ -5820,7 +5820,7 @@ exports[`Test XLSX export Charts horizontal bar chart 1`] = `
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -5885,7 +5885,7 @@ exports[`Test XLSX export Charts horizontal bar chart 1`] = `
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -6313,7 +6313,7 @@ exports[`Test XLSX export Charts multiple charts in the same sheet 1`] = `
                     <a:lstStyle/>
                     <a:p>
                         <a:pPr lvl="0">
-                            <a:defRPr b="0" i="0">
+                            <a:defRPr b="0" i="0" sz="1600">
                                 <a:solidFill>
                                     <a:srgbClr val="666666"/>
                                 </a:solidFill>
@@ -6477,7 +6477,7 @@ exports[`Test XLSX export Charts multiple charts in the same sheet 1`] = `
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -6542,7 +6542,7 @@ exports[`Test XLSX export Charts multiple charts in the same sheet 1`] = `
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -6625,7 +6625,7 @@ exports[`Test XLSX export Charts multiple charts in the same sheet 1`] = `
                     <a:lstStyle/>
                     <a:p>
                         <a:pPr lvl="0">
-                            <a:defRPr b="0" i="0">
+                            <a:defRPr b="0" i="0" sz="1600">
                                 <a:solidFill>
                                     <a:srgbClr val="666666"/>
                                 </a:solidFill>
@@ -6766,7 +6766,7 @@ exports[`Test XLSX export Charts multiple charts in the same sheet 1`] = `
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -6831,7 +6831,7 @@ exports[`Test XLSX export Charts multiple charts in the same sheet 1`] = `
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -7307,7 +7307,7 @@ exports[`Test XLSX export Charts pie chart with only title dataset 1`] = `
                     <a:lstStyle/>
                     <a:p>
                         <a:pPr lvl="0">
-                            <a:defRPr b="0" i="0">
+                            <a:defRPr b="0" i="0" sz="1600">
                                 <a:solidFill>
                                     <a:srgbClr val="666666"/>
                                 </a:solidFill>
@@ -7630,7 +7630,7 @@ exports[`Test XLSX export Charts pyramid chart 1`] = `
                     <a:lstStyle/>
                     <a:p>
                         <a:pPr lvl="0">
-                            <a:defRPr b="0" i="0">
+                            <a:defRPr b="0" i="0" sz="1600">
                                 <a:solidFill>
                                     <a:srgbClr val="666666"/>
                                 </a:solidFill>
@@ -7777,7 +7777,7 @@ exports[`Test XLSX export Charts pyramid chart 1`] = `
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -7845,7 +7845,7 @@ exports[`Test XLSX export Charts pyramid chart 1`] = `
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -7910,7 +7910,7 @@ exports[`Test XLSX export Charts pyramid chart 1`] = `
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -7974,7 +7974,7 @@ exports[`Test XLSX export Charts pyramid chart 1`] = `
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -8402,7 +8402,7 @@ exports[`Test XLSX export Charts simple bar chart with customized axis 1`] = `
                     <a:lstStyle/>
                     <a:p>
                         <a:pPr lvl="0">
-                            <a:defRPr b="0" i="0">
+                            <a:defRPr b="0" i="0" sz="1600">
                                 <a:solidFill>
                                     <a:srgbClr val="666666"/>
                                 </a:solidFill>
@@ -8505,7 +8505,7 @@ exports[`Test XLSX export Charts simple bar chart with customized axis 1`] = `
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="1" i="1">
+                                    <a:defRPr b="1" i="1" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="FF0000"/>
                                         </a:solidFill>
@@ -8572,7 +8572,7 @@ exports[`Test XLSX export Charts simple bar chart with customized axis 1`] = `
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="1" i="1">
+                                    <a:defRPr b="1" i="1" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="0000FF"/>
                                         </a:solidFill>
@@ -9002,7 +9002,7 @@ exports[`Test XLSX export Charts simple bar chart with customized dataset 1`] = 
                     <a:lstStyle/>
                     <a:p>
                         <a:pPr lvl="0">
-                            <a:defRPr b="0" i="0">
+                            <a:defRPr b="0" i="0" sz="1600">
                                 <a:solidFill>
                                     <a:srgbClr val="666666"/>
                                 </a:solidFill>
@@ -9103,7 +9103,7 @@ exports[`Test XLSX export Charts simple bar chart with customized dataset 1`] = 
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -9168,7 +9168,7 @@ exports[`Test XLSX export Charts simple bar chart with customized dataset 1`] = 
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -9596,7 +9596,7 @@ exports[`Test XLSX export Charts simple bar chart with customized title 1`] = `
                     <a:lstStyle/>
                     <a:p>
                         <a:pPr lvl="0">
-                            <a:defRPr b="1" i="1">
+                            <a:defRPr b="1" i="1" sz="1600">
                                 <a:solidFill>
                                     <a:srgbClr val="666666"/>
                                 </a:solidFill>
@@ -9699,7 +9699,7 @@ exports[`Test XLSX export Charts simple bar chart with customized title 1`] = `
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -9764,7 +9764,7 @@ exports[`Test XLSX export Charts simple bar chart with customized title 1`] = `
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -10192,7 +10192,7 @@ exports[`Test XLSX export Charts simple bar chart with dataset [ [Object] ] 1`] 
                     <a:lstStyle/>
                     <a:p>
                         <a:pPr lvl="0">
-                            <a:defRPr b="0" i="0">
+                            <a:defRPr b="0" i="0" sz="1600">
                                 <a:solidFill>
                                     <a:srgbClr val="666666"/>
                                 </a:solidFill>
@@ -10295,7 +10295,7 @@ exports[`Test XLSX export Charts simple bar chart with dataset [ [Object] ] 1`] 
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -10360,7 +10360,7 @@ exports[`Test XLSX export Charts simple bar chart with dataset [ [Object] ] 1`] 
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -10788,7 +10788,7 @@ exports[`Test XLSX export Charts simple bar chart with dataset [ [Object], [Obje
                     <a:lstStyle/>
                     <a:p>
                         <a:pPr lvl="0">
-                            <a:defRPr b="0" i="0">
+                            <a:defRPr b="0" i="0" sz="1600">
                                 <a:solidFill>
                                     <a:srgbClr val="666666"/>
                                 </a:solidFill>
@@ -10929,7 +10929,7 @@ exports[`Test XLSX export Charts simple bar chart with dataset [ [Object], [Obje
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -10994,7 +10994,7 @@ exports[`Test XLSX export Charts simple bar chart with dataset [ [Object], [Obje
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -11422,7 +11422,7 @@ exports[`Test XLSX export Charts simple combo chart with customized axis 1`] = `
                     <a:lstStyle/>
                     <a:p>
                         <a:pPr lvl="0">
-                            <a:defRPr b="0" i="0">
+                            <a:defRPr b="0" i="0" sz="1600">
                                 <a:solidFill>
                                     <a:srgbClr val="666666"/>
                                 </a:solidFill>
@@ -11524,7 +11524,7 @@ exports[`Test XLSX export Charts simple combo chart with customized axis 1`] = `
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="1" i="1">
+                                    <a:defRPr b="1" i="1" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="FF0000"/>
                                         </a:solidFill>
@@ -11591,7 +11591,7 @@ exports[`Test XLSX export Charts simple combo chart with customized axis 1`] = `
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="1" i="1">
+                                    <a:defRPr b="1" i="1" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="0000FF"/>
                                         </a:solidFill>
@@ -12021,7 +12021,7 @@ exports[`Test XLSX export Charts simple combo chart with customized dataset 1`] 
                     <a:lstStyle/>
                     <a:p>
                         <a:pPr lvl="0">
-                            <a:defRPr b="0" i="0">
+                            <a:defRPr b="0" i="0" sz="1600">
                                 <a:solidFill>
                                     <a:srgbClr val="666666"/>
                                 </a:solidFill>
@@ -12121,7 +12121,7 @@ exports[`Test XLSX export Charts simple combo chart with customized dataset 1`] 
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -12186,7 +12186,7 @@ exports[`Test XLSX export Charts simple combo chart with customized dataset 1`] 
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -12614,7 +12614,7 @@ exports[`Test XLSX export Charts simple combo chart with customized title 1`] = 
                     <a:lstStyle/>
                     <a:p>
                         <a:pPr lvl="0">
-                            <a:defRPr b="1" i="1">
+                            <a:defRPr b="1" i="1" sz="1600">
                                 <a:solidFill>
                                     <a:srgbClr val="666666"/>
                                 </a:solidFill>
@@ -12716,7 +12716,7 @@ exports[`Test XLSX export Charts simple combo chart with customized title 1`] = 
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -12781,7 +12781,7 @@ exports[`Test XLSX export Charts simple combo chart with customized title 1`] = 
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -13209,7 +13209,7 @@ exports[`Test XLSX export Charts simple combo chart with dataset [ [Object] ] 1`
                     <a:lstStyle/>
                     <a:p>
                         <a:pPr lvl="0">
-                            <a:defRPr b="0" i="0">
+                            <a:defRPr b="0" i="0" sz="1600">
                                 <a:solidFill>
                                     <a:srgbClr val="666666"/>
                                 </a:solidFill>
@@ -13311,7 +13311,7 @@ exports[`Test XLSX export Charts simple combo chart with dataset [ [Object] ] 1`
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -13376,7 +13376,7 @@ exports[`Test XLSX export Charts simple combo chart with dataset [ [Object] ] 1`
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -13804,7 +13804,7 @@ exports[`Test XLSX export Charts simple combo chart with dataset [ [Object], [Ob
                     <a:lstStyle/>
                     <a:p>
                         <a:pPr lvl="0">
-                            <a:defRPr b="0" i="0">
+                            <a:defRPr b="0" i="0" sz="1600">
                                 <a:solidFill>
                                     <a:srgbClr val="666666"/>
                                 </a:solidFill>
@@ -13965,7 +13965,7 @@ exports[`Test XLSX export Charts simple combo chart with dataset [ [Object], [Ob
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -14030,7 +14030,7 @@ exports[`Test XLSX export Charts simple combo chart with dataset [ [Object], [Ob
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -14458,7 +14458,7 @@ exports[`Test XLSX export Charts simple line chart with customized axis 1`] = `
                     <a:lstStyle/>
                     <a:p>
                         <a:pPr lvl="0">
-                            <a:defRPr b="0" i="0">
+                            <a:defRPr b="0" i="0" sz="1600">
                                 <a:solidFill>
                                     <a:srgbClr val="666666"/>
                                 </a:solidFill>
@@ -14571,7 +14571,7 @@ exports[`Test XLSX export Charts simple line chart with customized axis 1`] = `
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="1" i="1">
+                                    <a:defRPr b="1" i="1" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="FF0000"/>
                                         </a:solidFill>
@@ -14638,7 +14638,7 @@ exports[`Test XLSX export Charts simple line chart with customized axis 1`] = `
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="1" i="1">
+                                    <a:defRPr b="1" i="1" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="0000FF"/>
                                         </a:solidFill>
@@ -15068,7 +15068,7 @@ exports[`Test XLSX export Charts simple line chart with customized dataset 1`] =
                     <a:lstStyle/>
                     <a:p>
                         <a:pPr lvl="0">
-                            <a:defRPr b="0" i="0">
+                            <a:defRPr b="0" i="0" sz="1600">
                                 <a:solidFill>
                                     <a:srgbClr val="666666"/>
                                 </a:solidFill>
@@ -15179,7 +15179,7 @@ exports[`Test XLSX export Charts simple line chart with customized dataset 1`] =
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -15244,7 +15244,7 @@ exports[`Test XLSX export Charts simple line chart with customized dataset 1`] =
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -15672,7 +15672,7 @@ exports[`Test XLSX export Charts simple line chart with customized title 1`] = `
                     <a:lstStyle/>
                     <a:p>
                         <a:pPr lvl="0">
-                            <a:defRPr b="1" i="1">
+                            <a:defRPr b="1" i="1" sz="1600">
                                 <a:solidFill>
                                     <a:srgbClr val="666666"/>
                                 </a:solidFill>
@@ -15785,7 +15785,7 @@ exports[`Test XLSX export Charts simple line chart with customized title 1`] = `
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -15850,7 +15850,7 @@ exports[`Test XLSX export Charts simple line chart with customized title 1`] = `
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -16278,7 +16278,7 @@ exports[`Test XLSX export Charts simple line chart with dataset [ [Object] ] 1`]
                     <a:lstStyle/>
                     <a:p>
                         <a:pPr lvl="0">
-                            <a:defRPr b="0" i="0">
+                            <a:defRPr b="0" i="0" sz="1600">
                                 <a:solidFill>
                                     <a:srgbClr val="666666"/>
                                 </a:solidFill>
@@ -16391,7 +16391,7 @@ exports[`Test XLSX export Charts simple line chart with dataset [ [Object] ] 1`]
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -16456,7 +16456,7 @@ exports[`Test XLSX export Charts simple line chart with dataset [ [Object] ] 1`]
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -16884,7 +16884,7 @@ exports[`Test XLSX export Charts simple line chart with dataset [ [Object], [Obj
                     <a:lstStyle/>
                     <a:p>
                         <a:pPr lvl="0">
-                            <a:defRPr b="0" i="0">
+                            <a:defRPr b="0" i="0" sz="1600">
                                 <a:solidFill>
                                     <a:srgbClr val="666666"/>
                                 </a:solidFill>
@@ -17048,7 +17048,7 @@ exports[`Test XLSX export Charts simple line chart with dataset [ [Object], [Obj
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -17113,7 +17113,7 @@ exports[`Test XLSX export Charts simple line chart with dataset [ [Object], [Obj
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -17541,7 +17541,7 @@ exports[`Test XLSX export Charts simple pie chart with dataset [ [Object] ] 1`] 
                     <a:lstStyle/>
                     <a:p>
                         <a:pPr lvl="0">
-                            <a:defRPr b="0" i="0">
+                            <a:defRPr b="0" i="0" sz="1600">
                                 <a:solidFill>
                                     <a:srgbClr val="666666"/>
                                 </a:solidFill>
@@ -18047,7 +18047,7 @@ exports[`Test XLSX export Charts simple pie chart with dataset [ [Object], [Obje
                     <a:lstStyle/>
                     <a:p>
                         <a:pPr lvl="0">
-                            <a:defRPr b="0" i="0">
+                            <a:defRPr b="0" i="0" sz="1600">
                                 <a:solidFill>
                                     <a:srgbClr val="666666"/>
                                 </a:solidFill>
@@ -18627,7 +18627,7 @@ exports[`Test XLSX export Charts simple radar chart with customized axis 1`] = `
                     <a:lstStyle/>
                     <a:p>
                         <a:pPr lvl="0">
-                            <a:defRPr b="0" i="0">
+                            <a:defRPr b="0" i="0" sz="1600">
                                 <a:solidFill>
                                     <a:srgbClr val="666666"/>
                                 </a:solidFill>
@@ -18739,7 +18739,7 @@ exports[`Test XLSX export Charts simple radar chart with customized axis 1`] = `
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -18804,7 +18804,7 @@ exports[`Test XLSX export Charts simple radar chart with customized axis 1`] = `
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -19232,7 +19232,7 @@ exports[`Test XLSX export Charts simple radar chart with customized dataset 1`] 
                     <a:lstStyle/>
                     <a:p>
                         <a:pPr lvl="0">
-                            <a:defRPr b="0" i="0">
+                            <a:defRPr b="0" i="0" sz="1600">
                                 <a:solidFill>
                                     <a:srgbClr val="666666"/>
                                 </a:solidFill>
@@ -19342,7 +19342,7 @@ exports[`Test XLSX export Charts simple radar chart with customized dataset 1`] 
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -19407,7 +19407,7 @@ exports[`Test XLSX export Charts simple radar chart with customized dataset 1`] 
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -19835,7 +19835,7 @@ exports[`Test XLSX export Charts simple radar chart with customized title 1`] = 
                     <a:lstStyle/>
                     <a:p>
                         <a:pPr lvl="0">
-                            <a:defRPr b="1" i="1">
+                            <a:defRPr b="1" i="1" sz="1600">
                                 <a:solidFill>
                                     <a:srgbClr val="666666"/>
                                 </a:solidFill>
@@ -19947,7 +19947,7 @@ exports[`Test XLSX export Charts simple radar chart with customized title 1`] = 
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -20012,7 +20012,7 @@ exports[`Test XLSX export Charts simple radar chart with customized title 1`] = 
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -20440,7 +20440,7 @@ exports[`Test XLSX export Charts simple radar chart with dataset [ [Object] ] 1`
                     <a:lstStyle/>
                     <a:p>
                         <a:pPr lvl="0">
-                            <a:defRPr b="0" i="0">
+                            <a:defRPr b="0" i="0" sz="1600">
                                 <a:solidFill>
                                     <a:srgbClr val="666666"/>
                                 </a:solidFill>
@@ -20552,7 +20552,7 @@ exports[`Test XLSX export Charts simple radar chart with dataset [ [Object] ] 1`
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -20617,7 +20617,7 @@ exports[`Test XLSX export Charts simple radar chart with dataset [ [Object] ] 1`
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -21045,7 +21045,7 @@ exports[`Test XLSX export Charts simple radar chart with dataset [ [Object], [Ob
                     <a:lstStyle/>
                     <a:p>
                         <a:pPr lvl="0">
-                            <a:defRPr b="0" i="0">
+                            <a:defRPr b="0" i="0" sz="1600">
                                 <a:solidFill>
                                     <a:srgbClr val="666666"/>
                                 </a:solidFill>
@@ -21208,7 +21208,7 @@ exports[`Test XLSX export Charts simple radar chart with dataset [ [Object], [Ob
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -21273,7 +21273,7 @@ exports[`Test XLSX export Charts simple radar chart with dataset [ [Object], [Ob
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -21701,7 +21701,7 @@ exports[`Test XLSX export Charts simple scatter chart with customized axis 1`] =
                     <a:lstStyle/>
                     <a:p>
                         <a:pPr lvl="0">
-                            <a:defRPr b="0" i="0">
+                            <a:defRPr b="0" i="0" sz="1600">
                                 <a:solidFill>
                                     <a:srgbClr val="666666"/>
                                 </a:solidFill>
@@ -21815,7 +21815,7 @@ exports[`Test XLSX export Charts simple scatter chart with customized axis 1`] =
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="1" i="1">
+                                    <a:defRPr b="1" i="1" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="FF0000"/>
                                         </a:solidFill>
@@ -21882,7 +21882,7 @@ exports[`Test XLSX export Charts simple scatter chart with customized axis 1`] =
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="1" i="1">
+                                    <a:defRPr b="1" i="1" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="0000FF"/>
                                         </a:solidFill>
@@ -22312,7 +22312,7 @@ exports[`Test XLSX export Charts simple scatter chart with customized dataset 1`
                     <a:lstStyle/>
                     <a:p>
                         <a:pPr lvl="0">
-                            <a:defRPr b="0" i="0">
+                            <a:defRPr b="0" i="0" sz="1600">
                                 <a:solidFill>
                                     <a:srgbClr val="666666"/>
                                 </a:solidFill>
@@ -22424,7 +22424,7 @@ exports[`Test XLSX export Charts simple scatter chart with customized dataset 1`
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -22489,7 +22489,7 @@ exports[`Test XLSX export Charts simple scatter chart with customized dataset 1`
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -22917,7 +22917,7 @@ exports[`Test XLSX export Charts simple scatter chart with customized title 1`] 
                     <a:lstStyle/>
                     <a:p>
                         <a:pPr lvl="0">
-                            <a:defRPr b="1" i="1">
+                            <a:defRPr b="1" i="1" sz="1600">
                                 <a:solidFill>
                                     <a:srgbClr val="666666"/>
                                 </a:solidFill>
@@ -23031,7 +23031,7 @@ exports[`Test XLSX export Charts simple scatter chart with customized title 1`] 
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -23096,7 +23096,7 @@ exports[`Test XLSX export Charts simple scatter chart with customized title 1`] 
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -23524,7 +23524,7 @@ exports[`Test XLSX export Charts simple scatter chart with dataset [ [Object] ] 
                     <a:lstStyle/>
                     <a:p>
                         <a:pPr lvl="0">
-                            <a:defRPr b="0" i="0">
+                            <a:defRPr b="0" i="0" sz="1600">
                                 <a:solidFill>
                                     <a:srgbClr val="666666"/>
                                 </a:solidFill>
@@ -23638,7 +23638,7 @@ exports[`Test XLSX export Charts simple scatter chart with dataset [ [Object] ] 
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -23703,7 +23703,7 @@ exports[`Test XLSX export Charts simple scatter chart with dataset [ [Object] ] 
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -24131,7 +24131,7 @@ exports[`Test XLSX export Charts simple scatter chart with dataset [ [Object], [
                     <a:lstStyle/>
                     <a:p>
                         <a:pPr lvl="0">
-                            <a:defRPr b="0" i="0">
+                            <a:defRPr b="0" i="0" sz="1600">
                                 <a:solidFill>
                                     <a:srgbClr val="666666"/>
                                 </a:solidFill>
@@ -24296,7 +24296,7 @@ exports[`Test XLSX export Charts simple scatter chart with dataset [ [Object], [
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -24361,7 +24361,7 @@ exports[`Test XLSX export Charts simple scatter chart with dataset [ [Object], [
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -24789,7 +24789,7 @@ exports[`Test XLSX export Charts stacked bar chart 1`] = `
                     <a:lstStyle/>
                     <a:p>
                         <a:pPr lvl="0">
-                            <a:defRPr b="0" i="0">
+                            <a:defRPr b="0" i="0" sz="1600">
                                 <a:solidFill>
                                     <a:srgbClr val="666666"/>
                                 </a:solidFill>
@@ -24930,7 +24930,7 @@ exports[`Test XLSX export Charts stacked bar chart 1`] = `
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -24995,7 +24995,7 @@ exports[`Test XLSX export Charts stacked bar chart 1`] = `
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -36946,7 +36946,7 @@ exports[`Test XLSX export multiple elements are exported in the correct order 1`
                     <a:lstStyle/>
                     <a:p>
                         <a:pPr lvl="0">
-                            <a:defRPr b="0" i="0">
+                            <a:defRPr b="0" i="0" sz="1600">
                                 <a:solidFill>
                                     <a:srgbClr val="666666"/>
                                 </a:solidFill>
@@ -37073,7 +37073,7 @@ exports[`Test XLSX export multiple elements are exported in the correct order 1`
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -37138,7 +37138,7 @@ exports[`Test XLSX export multiple elements are exported in the correct order 1`
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -37488,7 +37488,7 @@ exports[`Test XLSX export references with headers should be converted to referen
                     <a:lstStyle/>
                     <a:p>
                         <a:pPr lvl="0">
-                            <a:defRPr b="0" i="0">
+                            <a:defRPr b="0" i="0" sz="1600">
                                 <a:solidFill>
                                     <a:srgbClr val="666666"/>
                                 </a:solidFill>
@@ -37681,7 +37681,7 @@ exports[`Test XLSX export references with headers should be converted to referen
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -37746,7 +37746,7 @@ exports[`Test XLSX export references with headers should be converted to referen
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -37829,7 +37829,7 @@ exports[`Test XLSX export references with headers should be converted to referen
                     <a:lstStyle/>
                     <a:p>
                         <a:pPr lvl="0">
-                            <a:defRPr b="0" i="0">
+                            <a:defRPr b="0" i="0" sz="1600">
                                 <a:solidFill>
                                     <a:srgbClr val="666666"/>
                                 </a:solidFill>
@@ -37998,7 +37998,7 @@ exports[`Test XLSX export references with headers should be converted to referen
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -38063,7 +38063,7 @@ exports[`Test XLSX export references with headers should be converted to referen
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -38146,7 +38146,7 @@ exports[`Test XLSX export references with headers should be converted to referen
                     <a:lstStyle/>
                     <a:p>
                         <a:pPr lvl="0">
-                            <a:defRPr b="0" i="0">
+                            <a:defRPr b="0" i="0" sz="1600">
                                 <a:solidFill>
                                     <a:srgbClr val="666666"/>
                                 </a:solidFill>
@@ -39876,7 +39876,7 @@ exports[`Test XLSX export references with headers should be converted to referen
                     <a:lstStyle/>
                     <a:p>
                         <a:pPr lvl="0">
-                            <a:defRPr b="0" i="0">
+                            <a:defRPr b="0" i="0" sz="1600">
                                 <a:solidFill>
                                     <a:srgbClr val="666666"/>
                                 </a:solidFill>
@@ -40071,7 +40071,7 @@ exports[`Test XLSX export references with headers should be converted to referen
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -40136,7 +40136,7 @@ exports[`Test XLSX export references with headers should be converted to referen
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -40219,7 +40219,7 @@ exports[`Test XLSX export references with headers should be converted to referen
                     <a:lstStyle/>
                     <a:p>
                         <a:pPr lvl="0">
-                            <a:defRPr b="0" i="0">
+                            <a:defRPr b="0" i="0" sz="1600">
                                 <a:solidFill>
                                     <a:srgbClr val="666666"/>
                                 </a:solidFill>
@@ -40382,7 +40382,7 @@ exports[`Test XLSX export references with headers should be converted to referen
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>
@@ -40447,7 +40447,7 @@ exports[`Test XLSX export references with headers should be converted to referen
                             <a:lstStyle/>
                             <a:p>
                                 <a:pPr lvl="0">
-                                    <a:defRPr b="0" i="0">
+                                    <a:defRPr b="0" i="0" sz="1200">
                                         <a:solidFill>
                                             <a:srgbClr val="000000"/>
                                         </a:solidFill>


### PR DESCRIPTION
### Sorry the huge diff, it is because of snapshop :/

## Description:

When exporting a chart title to XLSX, the font size was only set on the
text run properties (`a:rPr`). However, some spreadsheet editors also rely
on the paragraph default run properties (`a:defRPr`) to determine the
selected title font size.

As a result, importing the exported file in Google Sheets could reset the
title size to automatic, and Excel Online could render the title with the
right visual size while still showing the default size in the font size
selector.

Set the font size on both `a:defRPr` and `a:rPr` so the exported title
style is explicit and consistently preserved across spreadsheet editors.

Task: [6170954](https://www.odoo.com/odoo/2328/tasks/6170954)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo