### PR TITLE
[REL] 19.4.0-alpha.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@odoo/o-spreadsheet",
-  "version": "19.4.0-alpha.3",
+  "version": "19.4.0-alpha.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@odoo/o-spreadsheet",
-      "version": "19.4.0-alpha.3",
+      "version": "19.4.0-alpha.4",
       "hasInstallScript": true,
       "license": "LGPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@odoo/o-spreadsheet",
-  "version": "19.4.0-alpha.3",
+  "version": "19.4.0-alpha.4",
   "description": "A spreadsheet component",
   "type": "module",
   "main": "dist/o_spreadsheet.cjs",


### PR DESCRIPTION
### Contains the following commits:

https://github.com/odoo/o-spreadsheet/commit/dd07fc7b0c [FIX] package: husky should run at post install [Task: 0](https://www.odoo.com/odoo/2328/tasks/0)
https://github.com/odoo/o-spreadsheet/commit/7d7e6ead84 [FIX] workflow: fix the tag definition [Task: 0](https://www.odoo.com/odoo/2328/tasks/0)
https://github.com/odoo/o-spreadsheet/commit/49c0890579 [FIX] Workflow: fix missing permission to use OpenID Connect [Task: 0](https://www.odoo.com/odoo/2328/tasks/0)
https://github.com/odoo/o-spreadsheet/commit/cd18e7a27a [FIX] workflow: Split the workflow in parallel jobs [Task: 0](https://www.odoo.com/odoo/2328/tasks/0)
https://github.com/odoo/o-spreadsheet/commit/5616fbe642 [IMP] named ranges: add support of xlsx import/export [Task: 5462359](https://www.odoo.com/odoo/2328/tasks/5462359)
https://github.com/odoo/o-spreadsheet/commit/857d43fc03 [FIX] composer: remove forced reflow in content editable [Task: 6199661](https://www.odoo.com/odoo/2328/tasks/6199661)
https://github.com/odoo/o-spreadsheet/commit/447b131d18 [FIX] evaluation: error handling on vectorize function [Task: 6009255](https://www.odoo.com/odoo/2328/tasks/6009255)
https://github.com/odoo/o-spreadsheet/commit/15165504ce [FIX] chart: remove masterChartConfig from ScatterChartRuntime [Task: 0](https://www.odoo.com/odoo/2328/tasks/0)
https://github.com/odoo/o-spreadsheet/commit/87aec758a2 [IMP] charts: add bubble chart [Task: 5262905](https://www.odoo.com/odoo/2328/tasks/5262905)
https://github.com/odoo/o-spreadsheet/commit/8389c44909 [IMP] link: change shortcut [Task: 6179942](https://www.odoo.com/odoo/2328/tasks/6179942)

Task: 0
