### PR TITLE
[FIX] package: package install is broken

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,5 +76,8 @@ jobs:
           name: dist
           path: ./dist
 
+      - name: Install
+        run: npm install
+
       - name: Publish
         run: npm publish --access public

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "prettier": "prettier . --write",
     "check-formatting": "prettier . --check && eslint",
     "dist": "tsc --module es6 --declaration --declarationDir dist/types && rolldown -c && npm run build:bundleXml -- --outDir dist",
-    "postinstall": "husky install",
+    "prepare": "husky install",
     "watch:bundle": "npm run build:bundleJs -- --watch",
     "watch:ts": "npm run build:js -- --watch",
     "watch:xml": "node tools/bundle_xml/watch_xml_templates.cjs",


### PR DESCRIPTION
We changed the step `prepare`to `postinstall` for local development but unfortunately, the postinstall step runs when the package is installed in other projects (not the case with prepare) and since our postinstall scrips depends on devDependencies, it could not work.

Task: 0

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo