### PR TITLE
[FIX] package: package install is broken

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,5 +76,8 @@ jobs:
           name: dist
           path: ./dist
 
+      - name: Install
+        run: npm install
+
       - name: Publish
         run: npm publish --access public

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "@odoo/o-spreadsheet",
       "version": "19.3.2",
-      "hasInstallScript": true,
       "license": "LGPL-3.0-or-later",
       "dependencies": {
         "@odoo/owl": "2.8.3",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "node": ">=22.0.0"
   },
   "scripts": {
-    "postinstall": "husky install",
+    "prepare": "husky install",
     "prettier": "prettier . --write",
     "check-formatting": "prettier . --check && eslint",
     "lint": "eslint --fix",


### PR DESCRIPTION
We changed the step `prepare`to `postinstall` for local development but unfortunately, the postinstall step runs when the package is installed in other projects (not the case with prepare) and since our postinstall scrips depends on devDependencies, it could not work.

closes odoo/o-spreadsheet#8648

Task: 0
X-original-commit: 70a2b5fdb5a091a80a450df8deb051eaa3a1e887

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo