### PR TITLE
[FIX] clipboard: escape cell content

### DIFF
--- a/src/plugins/ui_stateful/clipboard.ts
+++ b/src/plugins/ui_stateful/clipboard.ts
@@ -593,7 +593,7 @@ export class ClipboardPlugin extends UIPlugin {
         innerHTML = "\t";
       }
     } else if (cells.length === 1 && cells[0].length === 1) {
-      innerHTML = `${this.getters.getCellText(cells[0][0].position)}`;
+      innerHTML = xmlEscape(`${this.getters.getCellText(cells[0][0].position)}`);
     } else if (!cells[0][0]) {
       return "";
     } else {

--- a/tests/clipboard/clipboard_plugin.test.ts
+++ b/tests/clipboard/clipboard_plugin.test.ts
@@ -663,6 +663,21 @@ describe("clipboard", () => {
         )}'>1</div>`
       );
     });
+
+    test("Copied cell content is html-escaped", async () => {
+      const model = new Model();
+      setCellContent(model, "A1", "<b>hello</b>");
+      copy(model, "A1");
+      const cbPlugin = getPlugin(model, ClipboardPlugin);
+      const clipboardId = model.getters.getClipboardId();
+      const clipboardData = JSON.stringify(cbPlugin["getSheetData"]());
+      const osClipboardContent = await model.getters.getClipboardTextAndImageContent();
+      expect(osClipboardContent[ClipboardMIMEType.Html]).toBe(
+        `<div data-osheet-clipboard-id='${clipboardId}' data-osheet-clipboard='${xmlEscape(
+          clipboardData
+        )}'>&lt;b&gt;hello&lt;/b&gt;</div>`
+      );
+    });
   });
 
   test("can copy a rectangular selection", () => {


### PR DESCRIPTION
Escape cell content to avoid rendering the cell content as html when copy-pasting 
Task: 6214316

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [6214316](https://www.odoo.com/odoo/2328/tasks/6214316)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo