### PR TITLE
[IMP] charts: update gauge/scorecard on resize

### DIFF
--- a/src/components/figures/chart/gauge/gauge_chart_component.ts
+++ b/src/components/figures/chart/gauge/gauge_chart_component.ts
@@ -1,4 +1,4 @@
-import { Component, useEffect, useRef } from "@odoo/owl";
+import { Component, onMounted, onWillUnmount, useEffect, useRef } from "@odoo/owl";
 import { drawGaugeChart } from "../../../../helpers/figures/charts/gauge_chart_rendering";
 import { deepEquals } from "../../../../helpers/misc";
 import { EASING_FN } from "../../../../registries/cell_animation_registry";
@@ -67,6 +67,15 @@ export class GaugeChartComponent extends Component<Props, SpreadsheetChildEnv> {
         return [rect.width, rect.height, this.runtime, this.canvas.el, window.devicePixelRatio];
       }
     );
+    const resizeObserver = new ResizeObserver(() => {
+      if (animation) {
+        animation.stop();
+        animation = null;
+      }
+      drawGaugeChart(this.canvasEl, this.runtime, this.env.model.getters.getViewportZoomLevel());
+    });
+    onMounted(() => resizeObserver.observe(this.canvas.el as HTMLCanvasElement));
+    onWillUnmount(() => resizeObserver.disconnect());
   }
 
   drawGaugeWithAnimation() {

--- a/src/components/figures/chart/scorecard/chart_scorecard.ts
+++ b/src/components/figures/chart/scorecard/chart_scorecard.ts
@@ -1,4 +1,4 @@
-import { Component, useEffect, useRef } from "@odoo/owl";
+import { Component, onMounted, onWillUnmount, useEffect, useRef } from "@odoo/owl";
 import { drawScoreChart } from "../../../../helpers/figures/charts/scorecard_chart";
 import { getScorecardConfiguration } from "../../../../helpers/figures/charts/scorecard_chart_config_builder";
 import { ScorecardChartRuntime } from "../../../../types/chart/scorecard_chart";
@@ -34,6 +34,9 @@ export class ScorecardChart extends Component<Props, SpreadsheetChildEnv> {
       const rect = canvas.getBoundingClientRect();
       return [rect.width, rect.height, this.runtime, this.canvas.el, window.devicePixelRatio];
     });
+    const resizeObserver = new ResizeObserver(() => this.createChart());
+    onMounted(() => resizeObserver.observe(this.canvas.el as HTMLCanvasElement));
+    onWillUnmount(() => resizeObserver.disconnect());
   }
 
   private createChart() {

--- a/tests/figures/chart/gauge/gauge_rendering.test.ts
+++ b/tests/figures/chart/gauge/gauge_rendering.test.ts
@@ -293,3 +293,19 @@ describe("Gauge chart component animation", () => {
     readonlyAllowedCommands.delete("UPDATE_CELL");
   });
 });
+
+test("Gauge is re-render on element size change", async () => {
+  const model = new Model();
+  createGaugeChart(model, {});
+  const { fixture } = await mountSpreadsheet({ model });
+
+  const canvas = fixture.querySelector<HTMLCanvasElement>("canvas.o-gauge-chart")!;
+  const ctx = canvas.getContext("2d")!;
+
+  const spy = jest.spyOn(ctx, "scale"); // ctx.scale is the first thing the gauge rendering process calls
+  window.resizers.resize();
+  expect(spy).toHaveBeenCalledTimes(1);
+
+  window.resizers.resize();
+  expect(spy).toHaveBeenCalledTimes(2);
+});

--- a/tests/figures/chart/scorecard/scorecard_chart_component.test.ts
+++ b/tests/figures/chart/scorecard/scorecard_chart_component.test.ts
@@ -32,7 +32,11 @@ import {
 } from "../../../test_helpers/commands_helpers";
 import { FR_LOCALE } from "../../../test_helpers/constants";
 import { getCellContent } from "../../../test_helpers/getters_helpers";
-import { mountComponentWithPortalTarget, nextTick } from "../../../test_helpers/helpers";
+import {
+  mountComponentWithPortalTarget,
+  mountSpreadsheet,
+  nextTick,
+} from "../../../test_helpers/helpers";
 
 let model: Model;
 let chartId: string;
@@ -766,4 +770,20 @@ describe("Scorecard charts rendering", () => {
     renderScorecardChart(model, chartId, sheetId, canvas);
     expect(scorecardChartStyle.baseline.bold).not.toEqual(true);
   });
+});
+
+test("Scorecard is re-render on element size change", async () => {
+  const model = new Model();
+  createScorecardChart(model, {});
+  const { fixture } = await mountSpreadsheet({ model });
+
+  const canvas = fixture.querySelector<HTMLCanvasElement>("canvas.o-scorecard")!;
+  const ctx = canvas.getContext("2d")!;
+
+  const spy = jest.spyOn(ctx, "scale"); // ctx.scale is the first thing the scorecard rendering process calls
+  window.resizers.resize();
+  expect(spy).toHaveBeenCalledTimes(1);
+
+  window.resizers.resize();
+  expect(spy).toHaveBeenCalledTimes(2);
 });

--- a/tests/setup/canvas.mock.ts
+++ b/tests/setup/canvas.mock.ts
@@ -40,8 +40,12 @@ export class MockCanvasRenderingContext2D {
 }
 
 const patch = {
+  _mockContext: null as MockCanvasRenderingContext2D | null,
   getContext: function () {
-    return new MockCanvasRenderingContext2D() as any as CanvasRenderingContext2D;
+    if (!this._mockContext) {
+      this._mockContext = new MockCanvasRenderingContext2D();
+    }
+    return this._mockContext;
   },
   toDataURL: function () {
     return "data:image/png;base64,randomDataThatIsActuallyABase64Image";


### PR DESCRIPTION
## Description

Gauge/scorecard are not updated during the resizing drag & drop, making them look distorted and making it hard for the user to figure out the correct dimension the chart should have to look nice.

Task: [6215876](https://www.odoo.com/odoo/2328/tasks/6215876)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo