### PR TITLE
[IMP] compiler: force validated strings

### DIFF
--- a/src/formulas/code_builder.ts
+++ b/src/formulas/code_builder.ts
@@ -2,40 +2,90 @@
  * Block of code that produces a value.
  */
 export interface FunctionCode {
-  readonly returnExpression: string;
+  readonly returnExpression: JsString;
   /**
    * Return the same function code but with the return expression assigned to a variable.
    */
   assignResultToVariable(): FunctionCode;
 }
 
+class JsString extends String {
+  // `brand` makes a plain `string` not assignable to `JsString`.
+  //   code.append("return 1;")        // type error
+  //   code.append(jsStr`return 1;`)   // ok
+  private declare brand: never;
+}
+
+type SafeJsValue = JsString | number | boolean | (JsString | number | boolean)[];
+
+/**
+ * Creates a JsString from a raw string, bypassing the template string interpolation checks.
+ * This can lead to security vulnerabilities if the string is not trusted!
+ */
+export function dangerouslyCreateJsStr(trustedStr: string): JsString {
+  return new JsString(trustedStr);
+}
+
+/**
+ * Creates a JsString from a template string, ensuring that all interpolated values are safe.
+ */
+export function jsStr(strings: TemplateStringsArray, ...values: SafeJsValue[]): JsString {
+  let str = "";
+  for (let i = 0; i < strings.length; i++) {
+    const value = values[i];
+    if (i >= values.length) {
+      str += strings[i];
+    } else if (isSafeJsValue(value)) {
+      str += strings[i] + value;
+    } else if (Array.isArray(value) && value.every(isSafeJsValue)) {
+      // same behavior as array interpolation in template strings
+      str += strings[i] + value.map((v) => v.toString()).join(",");
+    } else {
+      throw new Error(`Invalid interpolated value at index ${i}: ${value}`);
+    }
+  }
+  return dangerouslyCreateJsStr(str);
+}
+
+function isSafeJsValue(value: unknown): boolean {
+  return value instanceof JsString || typeof value === "number" || typeof value === "boolean";
+}
+
 export class FunctionCodeBuilder {
-  private code: string = "";
+  private code: JsString[] = [];
 
   constructor(private scope: Scope = new Scope()) {}
 
-  append(...lines: (string | FunctionCode)[]) {
-    this.code += lines.map((line) => line.toString()).join("\n") + "\n";
+  append(...lines: (JsString | FunctionCode)[]) {
+    for (const line of lines) {
+      if (line instanceof FunctionCodeImpl) {
+        this.code.push(...line.code);
+      } else if (line instanceof JsString) {
+        this.code.push(line);
+      } else {
+        throw new Error(`Invalid line: ${line}`);
+      }
+    }
   }
 
-  return(expression: string): FunctionCode {
+  return(expression: JsString): FunctionCode {
+    if (!isSafeJsValue(expression)) {
+      throw new Error(`Expected JsString, got ${expression}`);
+    }
     return new FunctionCodeImpl(this.scope, this.code, expression);
   }
 
   toString(): string {
-    return indentCode(this.code);
+    return indentCode(this.code.join("\n"));
   }
 }
 
 class FunctionCodeImpl implements FunctionCode {
-  private readonly code: string;
-  constructor(private readonly scope: Scope, code: string, readonly returnExpression: string) {
-    this.code = indentCode(code);
-  }
-
-  toString(): string {
-    return this.code;
-  }
+  constructor(
+    private readonly scope: Scope,
+    readonly code: JsString[],
+    readonly returnExpression: JsString
+  ) {}
 
   assignResultToVariable(): FunctionCode {
     if (this.scope.isAlreadyDeclared(this.returnExpression)) {
@@ -43,24 +93,26 @@ class FunctionCodeImpl implements FunctionCode {
     }
     const variableName = this.scope.nextVariableName();
     const code = new FunctionCodeBuilder(this.scope);
-    code.append(this.code);
-    code.append(`const ${variableName} = ${this.returnExpression};`);
+    code.append(...this.code);
+    code.append(jsStr`const ${variableName} = ${this.returnExpression};`);
     return code.return(variableName);
   }
 }
 
 export class Scope {
   private nextId = 1;
+  // use string instead of JsString because Set uses reference equality and
+  // we want to consider two JsString with the same content as the same variable
   private declaredVariables: Set<string> = new Set();
 
-  nextVariableName(): string {
-    const name = `_${this.nextId++}`;
-    this.declaredVariables.add(name);
+  nextVariableName(): JsString {
+    const name = jsStr`_${this.nextId++}`;
+    this.declaredVariables.add(name.toString());
     return name;
   }
 
-  isAlreadyDeclared(name: string): boolean {
-    return this.declaredVariables.has(name);
+  isAlreadyDeclared(name: JsString): boolean {
+    return this.declaredVariables.has(name.toString());
   }
 }
 

--- a/src/formulas/compiler.ts
+++ b/src/formulas/compiler.ts
@@ -5,7 +5,7 @@ import { concat, unquote } from "../helpers/misc";
 import { parseNumber } from "../helpers/numbers";
 import { _t } from "../translation";
 import { CoreGetters } from "../types/core_getters";
-import { BadExpressionError, UnknownFunctionError } from "../types/errors";
+import { BadExpressionError, EvaluationError, UnknownFunctionError } from "../types/errors";
 import { DEFAULT_LOCALE } from "../types/locale";
 import {
   ApplyRangeChange,
@@ -16,7 +16,13 @@ import {
   UID,
 } from "../types/misc";
 import { Range, RangeStringOptions } from "../types/range";
-import { FunctionCode, FunctionCodeBuilder, Scope } from "./code_builder";
+import {
+  dangerouslyCreateJsStr,
+  FunctionCode,
+  FunctionCodeBuilder,
+  jsStr,
+  Scope,
+} from "./code_builder";
 import { AST, ASTFuncall, iterateAstNodes, parseTokens } from "./parser";
 import { rangeTokenize } from "./range_tokenizer";
 import { Token } from "./tokenizer";
@@ -364,6 +370,9 @@ function compileTokens(tokens: Token[]): ICompiledFormula {
   try {
     return compileTokensOrThrow(tokens);
   } catch (error) {
+    if (!(error instanceof EvaluationError)) {
+      throw error;
+    }
     return {
       tokens,
       literalValues: { numbers: [], strings: [] },
@@ -398,7 +407,7 @@ function compileTokensOrThrow(tokens: Token[]): ICompiledFormula {
     const compiledAST = compileAST(ast);
     const code = new FunctionCodeBuilder();
     code.append(compiledAST);
-    code.append(`return ${compiledAST.returnExpression};`);
+    code.append(jsStr`return ${compiledAST.returnExpression};`);
     const baseFunction = new Function(
       "deps", // the dependencies in the current formula
       "ref", // a function to access a certain dependency at a given index
@@ -455,25 +464,31 @@ function compileTokensOrThrow(tokens: Token[]): ICompiledFormula {
     function compileAST(ast: AST, hasRange = false): FunctionCode {
       const code = new FunctionCodeBuilder(scope);
       if (ast.debug) {
-        code.append("debugger;");
-        code.append(`ctx["debug"] = true;`);
+        code.append(jsStr`debugger;`);
+        code.append(jsStr`ctx["debug"] = true;`);
       }
       switch (ast.type) {
         case "BOOLEAN":
-          return code.return(`{ value: ${ast.value} }`);
+          return code.return(jsStr`{ value: ${ast.value} }`);
         case "NUMBER":
-          return code.return(`this.literalValues.numbers[${numberCount++}]`);
+          return code.return(jsStr`this.literalValues.numbers[${numberCount++}]`);
         case "STRING":
-          return code.return(`this.literalValues.strings[${stringCount++}]`);
+          return code.return(jsStr`this.literalValues.strings[${stringCount++}]`);
         case "REFERENCE":
           return code.return(
-            `${ast.value.includes(":") || hasRange ? `range` : `ref`}(deps[${dependencyCount++}])`
+            jsStr`${
+              ast.value.includes(":") || hasRange ? jsStr`range` : jsStr`ref`
+            }(deps[${dependencyCount++}])`
           );
         case "FUNCALL":
           const args = compileFunctionArgs(ast).map((arg) => arg.assignResultToVariable());
           code.append(...args);
           const fnName = ast.value.toUpperCase();
-          return code.return(`ctx['${fnName}'](${args.map((arg) => arg.returnExpression)})`);
+          if (!Object.hasOwn(functions, fnName)) {
+            throw new Error(`Unknown function: "${fnName}"`);
+          }
+          const jsFnName = dangerouslyCreateJsStr(fnName); // validated with known functions
+          return code.return(jsStr`ctx['${jsFnName}'](${args.map((arg) => arg.returnExpression)})`);
         case "ARRAY": {
           // a literal array is compiled into function calls
           const arrayFunctionCall: ASTFuncall = {
@@ -492,26 +507,32 @@ function compileTokensOrThrow(tokens: Token[]): ICompiledFormula {
           return compileAST(arrayFunctionCall);
         }
         case "UNARY_OPERATION": {
-          const fnName = UNARY_OPERATOR_MAP[ast.value];
+          if (!Object.hasOwn(UNARY_OPERATOR_MAP, ast.value)) {
+            throw new Error(`Unknown operator: "${ast.value}"`);
+          }
+          const fnName = dangerouslyCreateJsStr(UNARY_OPERATOR_MAP[ast.value]); // validated with known operators
           const operand = compileAST(ast.operand, ast.value === "#").assignResultToVariable(); // hasRange is true to avoid vectorization of SPILLED.RANGE
           code.append(operand);
-          return code.return(`ctx['${fnName}'](${operand.returnExpression})`);
+          return code.return(jsStr`ctx['${fnName}'](${operand.returnExpression})`);
         }
         case "BIN_OPERATION": {
-          const fnName = OPERATOR_MAP[ast.value];
+          if (!Object.hasOwn(OPERATOR_MAP, ast.value)) {
+            throw new Error(`Unknown operator: "${ast.value}"`);
+          }
+          const fnName = dangerouslyCreateJsStr(OPERATOR_MAP[ast.value]); // validated with known operators
           const left = compileAST(ast.left, false).assignResultToVariable();
           const right = compileAST(ast.right, false).assignResultToVariable();
           code.append(left);
           code.append(right);
           return code.return(
-            `ctx['${fnName}'](${left.returnExpression}, ${right.returnExpression})`
+            jsStr`ctx['${fnName}'](${left.returnExpression}, ${right.returnExpression})`
           );
         }
         case "SYMBOL":
           const symbolIndex = symbols.indexOf(ast.value);
-          return code.return(`getSymbolValue(this.symbols[${symbolIndex}], ${hasRange})`);
+          return code.return(jsStr`getSymbolValue(this.symbols[${symbolIndex}], ${hasRange})`);
         case "EMPTY":
-          return code.return("undefined");
+          return code.return(jsStr`undefined`);
       }
     }
   }

--- a/tests/collaborative/collaborative_monkey_party.test.ts
+++ b/tests/collaborative/collaborative_monkey_party.test.ts
@@ -2,14 +2,14 @@ import seedrandom from "seedrandom";
 import {
   Command,
   CoreCommand,
-  Model,
-  UnboundedZone,
   isPositionDependent,
   isRangeDependant,
   isSheetDependent,
   isTargetDependent,
+  Model,
+  UnboundedZone,
 } from "../../src";
-import { FunctionCodeBuilder } from "../../src/formulas/code_builder";
+import { dangerouslyCreateJsStr, FunctionCodeBuilder } from "../../src/formulas/code_builder";
 import { deepCopy, deepEquals, range } from "../../src/helpers/misc";
 import { reorderZone } from "../../src/helpers/zones";
 import { MockTransportService } from "../__mocks__/transport_service";
@@ -111,37 +111,40 @@ function assignUser(commands: CoreCommand[], users: Model[]): UserAction[] {
 }
 
 function actionsToTestCode(testTitle: string, actions: UserAction[][]) {
-  const code = new FunctionCodeBuilder();
-  code.append(`test("${testTitle}", () => {`);
-  code.append("const { network, alice, bob, charlie } = setupCollaborativeEnv();");
+  const code: string[] = [];
+  code.push(`test("${testTitle}", () => {`);
+  code.push("const { network, alice, bob, charlie } = setupCollaborativeEnv();");
   for (const commandGroup of actions) {
     if (commandGroup.length === 1) {
       appendCommand(code, commandGroup[0]);
     } else {
-      code.append("network.concurrent(() => {");
+      code.push("network.concurrent(() => {");
       for (const action of commandGroup) {
         appendCommand(code, action);
       }
-      code.append("});");
+      code.push("});");
     }
   }
-  code.append(
+  code.push(
     "expect([alice, bob, charlie]).toHaveSynchronizedEvaluation();",
     "expect([alice, bob, charlie]).toHaveSynchronizedExportedData();",
     "});"
   );
-  return code.toString();
+  // format the code with the code builder
+  const builder = new FunctionCodeBuilder();
+  builder.append(...code.map(dangerouslyCreateJsStr));
+  return builder.toString();
 }
 
-function appendCommand(code: FunctionCodeBuilder, { user, command }: UserAction) {
+function appendCommand(code: string[], { user, command }: UserAction) {
   const userName = user.getters.getCurrentClient().name.toLowerCase();
   if (command.type === "REQUEST_UNDO") {
-    code.append(`undo(${userName});`);
+    code.push(`undo(${userName});`);
   } else if (command.type === "REQUEST_REDO") {
-    code.append(`redo(${userName});`);
+    code.push(`redo(${userName});`);
   } else {
     const cmdPayload = JSON.stringify({ ...command, type: undefined });
-    code.append(`${userName}.dispatch("${command.type}", ${cmdPayload});`);
+    code.push(`${userName}.dispatch("${command.type}", ${cmdPayload});`);
   }
 }
 

--- a/tests/helpers/code_builder.test.ts
+++ b/tests/helpers/code_builder.test.ts
@@ -1,0 +1,51 @@
+import { FunctionCodeBuilder, jsStr } from "../../src/formulas/code_builder";
+
+describe("code builder", () => {
+  test("can inject safe values", () => {
+    expect(jsStr`const a = ${jsStr`'hello'`};`.toString()).toBe(`const a = 'hello';`);
+    expect(jsStr`const a = ${jsStr`123`};`.toString()).toBe(`const a = 123;`);
+    expect(jsStr`const a = ${123};`.toString()).toBe(`const a = 123;`);
+    expect(jsStr`const a = ${true};`.toString()).toBe(`const a = true;`);
+    expect(jsStr`const a = ${false};`.toString()).toBe(`const a = false;`);
+  });
+
+  test("can inject array of safe values", () => {
+    expect(jsStr`const a = [${[jsStr`'hello'`, jsStr`123`, 123, true, false]}];`.toString()).toBe(
+      `const a = ['hello',123,123,true,false];`
+    );
+  });
+
+  test("cannot inject unsafe values", () => {
+    // @ts-expect-error
+    expect(() => jsStr`const a = ${"primitive string"};`).toThrow();
+    // @ts-expect-error
+    expect(() => jsStr`const a = ${{ a: 1 }};`).toThrow();
+    // @ts-expect-error
+    expect(() => jsStr`const a = ${new String("string")};`).toThrow();
+  });
+
+  test("can inject safe values", () => {
+    const code = new FunctionCodeBuilder();
+    code.append(jsStr`const a = 123;`);
+    expect(code.toString()).toBe("const a = 123;");
+    expect(code.return(jsStr`a`).returnExpression.toString()).toBe("a");
+    expect(
+      code
+        .return(jsStr`a`)
+        .assignResultToVariable()
+        .returnExpression.toString()
+    ).toBe("_1");
+  });
+
+  test("cannot add unsafe values", () => {
+    const code = new FunctionCodeBuilder();
+    // @ts-expect-error
+    expect(() => code.append("const a = 1;")).toThrow();
+    // @ts-expect-error
+    expect(() => code.append({ a: 1 })).toThrow();
+    // @ts-expect-error
+    expect(() => code.append(new String("string"))).toThrow();
+    // @ts-expect-error
+    expect(() => code.return(new String("string"))).toThrow();
+  });
+});


### PR DESCRIPTION
The formula compiler builds JS source by string concatenation and feeds it to `new Function(...)`. Several of those strings came from user input (function names, operator symbols), so any value that slipped past the parser's validation could end up executed as code.

This commit introduces a `JsString` branded type plus a `jsStr` tagged-template helper:
generated code can only be assembled from values explicitly marked trusted, and untrusted strings must go through `dangerouslyCreateJsStr`, which makes the trust decision auditable.

Task: 6185314

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo