### PR TITLE
[IMP] carousel: activate new carousel item on chart drag & drop

### DIFF
--- a/src/plugins/ui_stateful/carousel_ui.ts
+++ b/src/plugins/ui_stateful/carousel_ui.ts
@@ -219,9 +219,10 @@ export class CarouselUIPlugin extends UIPlugin {
     }
     const carousel = this.getters.getCarousel(figureId);
 
+    const newItem: CarouselItem = { type: "chart", chartId };
     const definition: Carousel = {
       ...carousel,
-      items: [...carousel.items, { type: "chart", chartId }],
+      items: [...carousel.items, newItem],
     };
     this.dispatch("UPDATE_CAROUSEL", { sheetId, figureId, definition });
     this.dispatch("UPDATE_CHART", {
@@ -231,6 +232,7 @@ export class CarouselUIPlugin extends UIPlugin {
       definition: this.getters.getChartDefinition(chartId),
     });
     this.dispatch("DELETE_FIGURE", { sheetId, figureId: chartFigureId });
+    this.dispatch("UPDATE_CAROUSEL_ACTIVE_ITEM", { figureId, sheetId, item: newItem });
   }
 
   private duplicateCarouselChart({

--- a/tests/figures/carousel/carousel_figure_component.test.ts
+++ b/tests/figures/carousel/carousel_figure_component.test.ts
@@ -85,7 +85,7 @@ describe("Carousel figure component", () => {
   });
 
   test("Can drag & drop a chart on a carousel to combine them", async () => {
-    createCarousel(model, { items: [] }, "carouselId", undefined, {
+    createCarousel(model, { items: [{ type: "carouselDataView" }] }, "carouselId", undefined, {
       col: 0,
       row: 0,
       size: { width: 200, height: 200 },
@@ -107,10 +107,17 @@ describe("Carousel figure component", () => {
       false
     );
     expect(".o-figure[data-id=carouselId]").toHaveClass("o-add-to-carousel");
+    expect(model.getters.getSelectedCarouselItem("carouselId")).toMatchObject({
+      type: "carouselDataView",
+    });
 
     triggerMouseEvent(".o-figure[data-id=chartFigureId]", "pointerup");
     expect(model.getters.getCarousel("carouselId")).toMatchObject({
-      items: [{ type: "chart", chartId: "chartId" }],
+      items: [{ type: "carouselDataView" }, { type: "chart", chartId: "chartId" }],
+    });
+    expect(model.getters.getSelectedCarouselItem("carouselId")).toMatchObject({
+      type: "chart",
+      chartId: "chartId",
     });
     expect(model.getters.getFigures(sheetId)).toHaveLength(1);
   });


### PR DESCRIPTION
## Description

When drag & dropping a chart on a carousel, there is no user feedback so the chart might look like it disappeared.

With this commit, when a chart is added to a carousel, the carousel item is automatically selected.

Task: [6217405](https://www.odoo.com/odoo/2328/tasks/6217405)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo