### PR TITLE
[FIX] Find and replace : selection after an UPDATE_CELL

### DIFF
--- a/src/components/composer/composer/cell_composer_store.ts
+++ b/src/components/composer/composer/cell_composer_store.ts
@@ -39,8 +39,10 @@ export class CellComposerStore extends AbstractComposerStore {
   stopEdition(direction?: Direction) {
     const canStopEdition = this.canStopEdition();
     if (canStopEdition) {
+      const { col, row } = this.currentEditedCell;
       this._stopEdition();
       if (direction) {
+        this.model.selection.selectCell(col, row);
         this.model.selection.moveAnchorCell(direction, 1);
       }
       return;

--- a/src/components/side_panel/find_and_replace/find_and_replace_store.ts
+++ b/src/components/side_panel/find_and_replace/find_and_replace_store.ts
@@ -29,11 +29,11 @@ export class FindAndReplaceStore extends SpreadsheetStore implements HighlightPr
   private allSheetsMatches: CellPosition[] = [];
   private activeSheetMatches: CellPosition[] = [];
   private specificRangeMatches: CellPosition[] = [];
+  private selectedMatchPosition: CellPosition | null = null;
 
   private currentSearchRegex: RegExp | null = null;
   private isSearchDirty = false;
   private initialShowFormulaState: boolean;
-  private preserveSelectedMatchIndex: boolean = false;
   private irreplaceableMatchCount: number = 0;
 
   private notificationStore = this.get(NotificationStore);
@@ -173,6 +173,7 @@ export class FindAndReplaceStore extends SpreadsheetStore implements HighlightPr
     this.searchOptions = searchOptions;
     if (toSearch !== this.toSearch) {
       this.selectedMatchIndex = null;
+      this.selectedMatchPosition = null;
     }
     this.toSearch = toSearch;
     this.currentSearchRegex = getSearchRegex(this.toSearch, this.searchOptions);
@@ -183,10 +184,23 @@ export class FindAndReplaceStore extends SpreadsheetStore implements HighlightPr
    * refresh the matches according to the current search options
    */
   private refreshSearch(jumpToMatchSheet = true) {
-    if (!this.preserveSelectedMatchIndex) {
-      this.selectedMatchIndex = null;
-    }
     this.findMatches();
+    if (this.selectedMatchPosition) {
+      if (this.selectedMatchPosition.sheetId !== this.getters.getActiveSheetId()) {
+        this.selectedMatchIndex = null;
+        this.selectedMatchPosition = null;
+      } else {
+        const index = this.searchMatches.findIndex(
+          (match) =>
+            match.sheetId === this.selectedMatchPosition?.sheetId &&
+            match.col === this.selectedMatchPosition?.col &&
+            match.row === this.selectedMatchPosition?.row
+        );
+        if (index !== -1) {
+          this.selectedMatchIndex = index;
+        }
+      }
+    }
     this.selectNextCell(Direction.current, jumpToMatchSheet);
   }
 
@@ -272,6 +286,7 @@ export class FindAndReplaceStore extends SpreadsheetStore implements HighlightPr
     const matches = this.searchMatches;
     if (!matches.length) {
       this.selectedMatchIndex = null;
+      this.selectedMatchPosition = null;
       return;
     }
     let nextIndex: number;
@@ -291,20 +306,15 @@ export class FindAndReplaceStore extends SpreadsheetStore implements HighlightPr
     // loop index value inside the array (index -1 => last index)
     nextIndex = (nextIndex + matches.length) % matches.length;
     this.selectedMatchIndex = nextIndex;
+    this.selectedMatchPosition = matches[this.selectedMatchIndex];
     const selectedMatch = matches[nextIndex];
 
     // Switch to the sheet where the match is located
     if (jumpToMatchSheet && this.getters.getActiveSheetId() !== selectedMatch.sheetId) {
-      // We set `preserveSelectedMatchIndex` to true to avoid resetting the selected search
-      // index in the `refreshSearch` function when a new sheet is activated. The reason being
-      // that, when we automatically go back to previous sheet while performing a search, the
-      // search index is reset to the first occurrence each time.
-      this.preserveSelectedMatchIndex = true;
       this.model.dispatch("ACTIVATE_SHEET", {
         sheetIdFrom: this.getters.getActiveSheetId(),
         sheetIdTo: selectedMatch.sheetId,
       });
-      this.preserveSelectedMatchIndex = false;
       // We do not want to reset the selection at finalize in this case
       this.isSearchDirty = false;
     }
@@ -320,14 +330,12 @@ export class FindAndReplaceStore extends SpreadsheetStore implements HighlightPr
     if (this.selectedMatchIndex === null) {
       return;
     }
-    this.preserveSelectedMatchIndex = true;
     this.model.dispatch("REPLACE_SEARCH", {
       searchString: this.toSearch,
       replaceWith: this.toReplace,
       matches: [this.searchMatches[this.selectedMatchIndex]],
       searchOptions: this.searchOptions,
     });
-    this.preserveSelectedMatchIndex = false;
   }
   /**
    * Apply the replace function to all the matches one time.

--- a/tests/find_and_replace/find_and_replace_store.test.ts
+++ b/tests/find_and_replace/find_and_replace_store.test.ts
@@ -347,7 +347,7 @@ describe("basic search", () => {
     expect(store.selectedMatchIndex).toStrictEqual(0);
     unhideRows(model, [1]);
     expect(store.searchMatches).toHaveLength(2);
-    expect(store.selectedMatchIndex).toStrictEqual(0);
+    expect(store.selectedMatchIndex).toStrictEqual(1);
   });
 
   test("Need to update search if updating or removing the filter", () => {
@@ -362,7 +362,7 @@ describe("basic search", () => {
     expect(store.selectedMatchIndex).toStrictEqual(0);
     deleteTable(model, "A1:A6");
     expect(store.searchMatches).toHaveLength(2);
-    expect(store.selectedMatchIndex).toStrictEqual(0);
+    expect(store.selectedMatchIndex).toStrictEqual(1);
   });
 
   test("Switching sheet properly recomputes search results and shows them in the viewport", () => {
@@ -976,4 +976,16 @@ describe("replace warnings", () => {
       text: "Match(es) cannot be replaced as they are part of a formula.",
     });
   });
+});
+
+test("edit a cell update the search but keep the selected match", () => {
+  setCellContent(model, "A1", "test");
+  setCellContent(model, "A2", "test");
+  updateSearch(model, "test", { searchScope: "activeSheet" });
+  store.selectNextMatch();
+  expect(store.searchMatches).toHaveLength(2);
+  expect(store.selectedMatchIndex).toStrictEqual(1);
+  setCellContent(model, "B1", "test");
+  expect(store.searchMatches).toHaveLength(3);
+  expect(store.selectedMatchIndex).toStrictEqual(2);
 });

--- a/tests/find_and_replace/find_replace_side_panel_component.test.ts
+++ b/tests/find_and_replace/find_replace_side_panel_component.test.ts
@@ -1,7 +1,9 @@
 import { Model, Spreadsheet } from "../../src";
+import { CellComposerStore } from "../../src/components/composer/composer/cell_composer_store";
 import { DEFAULT_CELL_HEIGHT, DEFAULT_CELL_WIDTH } from "../../src/constants";
+import { toZone } from "../../src/helpers";
 import { SearchOptions } from "../../src/types/find_and_replace";
-import { createSheet, setCellContent } from "../test_helpers/commands_helpers";
+import { createSheet, selectCell, setCellContent } from "../test_helpers/commands_helpers";
 import {
   click,
   focusAndKeyDown,
@@ -418,5 +420,16 @@ describe("find and replace sidePanel component", () => {
         "5 matches in all sheets",
       ]);
     });
+  });
+
+  test("Edit a cell and press enter selects the cell below the one edited and not B2", async () => {
+    setCellContent(model, "B1", "hello");
+    inputSearchValue("hello");
+    expect(model.getters.getSelectedZones()).toMatchObject([toZone("B1")]);
+    const composerStore = parent.env.getStore(CellComposerStore);
+    selectCell(model, "C11");
+    composerStore.startEdition("hello");
+    composerStore.stopEdition("down");
+    expect(model.getters.getSelectedZones()).toMatchObject([toZone("C12")]);
   });
 });


### PR DESCRIPTION
Before this commit :
Reproduce the followning steps to see the issue
- write "tabouret" in cells A1 to A5
- open find & replace panel and look for tabouret
- with the sidepanel open, write "tabouret" in cell C11
- Hit Enter -> your selection should be on C12 (since you edited a cell) but instead it is in A2

Task: [4818132](https://www.odoo.com/odoo/2328/tasks/4818132)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo