### PR TITLE
[PERF] vectorization: reduce overhead

### DIFF
--- a/src/functions/create_compute_function.ts
+++ b/src/functions/create_compute_function.ts
@@ -2,7 +2,12 @@ import { CellValue } from "../types/cells";
 import { BadExpressionError, EvaluationError, NotAvailableError } from "../types/errors";
 
 import { _t } from "../translation";
-import { ComputeFunction, EvalContext, FunctionDescription } from "../types/functions";
+import {
+  ArgDefinition,
+  ComputeFunction,
+  EvalContext,
+  FunctionDescription,
+} from "../types/functions";
 import { Arg, FunctionResultObject, isMatrix, Matrix } from "../types/misc";
 import { argTargeting } from "./arguments";
 import { generateMatrix, isEvaluationError, matrixForEach, matrixMap } from "./helpers";
@@ -87,9 +92,15 @@ export function applyVectorization(
     }
   }
 
+  const argsToFocus = argTargeting(descr, args.length);
+  const argDefinitions: ArgDefinition[] = new Array(args.length);
+  for (let k = 0; k < args.length; k++) {
+    argDefinitions[k] = descr.args[argsToFocus[k].index];
+  }
+
   if (countVectorizedCol === 1 && countVectorizedRow === 1) {
     // either this function is not vectorized or it ends up with a 1x1 dimension
-    return errorHandlingCompute(descr, context, args);
+    return errorHandlingCompute(descr, context, args, argDefinitions);
   }
 
   // Reused across every vectorized cell to avoid allocating a new args array per call.
@@ -128,7 +139,12 @@ export function applyVectorization(
     for (let k = 0; k < argGetters.length; k++) {
       argsBuffer[k] = argGetters[k](col, row);
     }
-    const singleCellComputeResult = errorHandlingCompute(descr, context, argsBuffer);
+    const singleCellComputeResult = errorHandlingCompute(
+      descr,
+      context,
+      argsBuffer,
+      argDefinitions
+    );
     // In the case where the user tries to vectorize arguments of an array formula, we will get an
     // array for every combination of the vectorized arguments, which will lead to a 3D matrix and
     // we won't be able to return the values.
@@ -170,17 +186,16 @@ function computeFunctionToObject(
 function errorHandlingCompute(
   descr: FunctionDescription,
   context: EvalContext,
-  args: Arg[]
+  args: Arg[],
+  argDefinitions: ArgDefinition[]
 ): Matrix<FunctionResultObject> | FunctionResultObject {
-  const argsToFocus = argTargeting(descr, args.length);
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
-    const argDefinition = descr.args[argsToFocus[i].index];
 
     // Early exit if the argument is an error and the function does not accept errors.
     // We only check scalar arguments, not matrix arguments for performance reasons.
     // Casting helpers are responsible for handling errors in matrix arguments.
-    if (!argDefinition.acceptErrors && !isMatrix(arg) && isEvaluationError(arg?.value)) {
+    if (!argDefinitions[i].acceptErrors && !isMatrix(arg) && isEvaluationError(arg?.value)) {
       return arg;
     }
   }

--- a/src/functions/create_compute_function.ts
+++ b/src/functions/create_compute_function.ts
@@ -10,7 +10,7 @@ import {
 } from "../types/functions";
 import { Arg, FunctionResultObject, isMatrix, Matrix } from "../types/misc";
 import { argTargeting } from "./arguments";
-import { generateMatrix, isEvaluationError, matrixForEach, matrixMap } from "./helpers";
+import { isEvaluationError, matrixForEach, matrixMap } from "./helpers";
 
 type VectorArgType = "horizontal" | "vertical" | "matrix";
 
@@ -135,34 +135,41 @@ export function applyVectorization(
   }
   const nbVectorized = vectorizedIndices.length;
 
-  return generateMatrix(countVectorizedCol, countVectorizedRow, (col, row) => {
-    if (col > vectorizedColLimit - 1 || row > vectorizedRowLimit - 1) {
-      return new NotAvailableError(
-        _t("Array arguments to [[FUNCTION_NAME]] are of different size.")
+  const result: Matrix<FunctionResultObject> = new Array(countVectorizedCol);
+  for (let col = 0; col < countVectorizedCol; col++) {
+    const column: FunctionResultObject[] = new Array(countVectorizedRow);
+    result[col] = column;
+    for (let row = 0; row < countVectorizedRow; row++) {
+      if (col > vectorizedColLimit - 1 || row > vectorizedRowLimit - 1) {
+        column[row] = new NotAvailableError(
+          _t("Array arguments to [[FUNCTION_NAME]] are of different size.")
+        );
+        continue;
+      }
+      for (let k = 0; k < nbVectorized; k++) {
+        argsBuffer[vectorizedIndices[k]] = argGetters[k](col, row);
+      }
+      const singleCellComputeResult = errorHandlingCompute(
+        descr,
+        context,
+        argsBuffer,
+        argDefinitions
       );
+      // In the case where the user tries to vectorize arguments of an array formula, we will get an
+      // array for every combination of the vectorized arguments, which will lead to a 3D matrix and
+      // we won't be able to return the values.
+      // In this case, we keep the first element of each spreading part, just as Excel does, and
+      // create an array with these parts.
+      // For exemple, we have MUNIT(x) that return an unitary matrix of x*x. If we use it with a
+      // range, like MUNIT(A1:A2), we will get two unitary matrices (one for the value in A1 and one
+      // for the value in A2). In this case, we will simply take the first value of each matrix and
+      // return the array [First value of MUNIT(A1), First value of MUNIT(A2)].
+      column[row] = isMatrix(singleCellComputeResult)
+        ? singleCellComputeResult[0][0]
+        : singleCellComputeResult;
     }
-    for (let k = 0; k < nbVectorized; k++) {
-      argsBuffer[vectorizedIndices[k]] = argGetters[k](col, row);
-    }
-    const singleCellComputeResult = errorHandlingCompute(
-      descr,
-      context,
-      argsBuffer,
-      argDefinitions
-    );
-    // In the case where the user tries to vectorize arguments of an array formula, we will get an
-    // array for every combination of the vectorized arguments, which will lead to a 3D matrix and
-    // we won't be able to return the values.
-    // In this case, we keep the first element of each spreading part, just as Excel does, and
-    // create an array with these parts.
-    // For exemple, we have MUNIT(x) that return an unitary matrix of x*x. If we use it with a
-    // range, like MUNIT(A1:A2), we will get two unitary matrices (one for the value in A1 and one
-    // for the value in A2). In this case, we will simply take the first value of each matrix and
-    // return the array [First value of MUNIT(A1), First value of MUNIT(A2)].
-    return isMatrix(singleCellComputeResult)
-      ? singleCellComputeResult[0][0]
-      : singleCellComputeResult;
-  });
+  }
+  return result;
 }
 
 function computeFunctionToObject(

--- a/src/functions/create_compute_function.ts
+++ b/src/functions/create_compute_function.ts
@@ -92,19 +92,28 @@ export function applyVectorization(
     return errorHandlingCompute(descr, context, args);
   }
 
-  const getArgOffset: (i: number, j: number) => Arg[] = (i, j) =>
-    args.map((arg, index) => {
-      switch (vectorArgsType?.[index]) {
+  // Reused across every vectorized cell to avoid allocating a new args array per call.
+  const argsBuffer: Arg[] = new Array(args.length);
+
+  const fillArgsBuffer = (i: number, j: number): void => {
+    for (let k = 0; k < args.length; k++) {
+      const arg = args[k];
+      switch (vectorArgsType?.[k]) {
         case "matrix":
-          return arg![i][j];
+          argsBuffer[k] = arg![i][j];
+          break;
         case "horizontal":
-          return arg![i][0];
+          argsBuffer[k] = arg![i][0];
+          break;
         case "vertical":
-          return arg![0][j];
+          argsBuffer[k] = arg![0][j];
+          break;
         case undefined:
-          return arg;
+          argsBuffer[k] = arg;
+          break;
       }
-    });
+    }
+  };
 
   return generateMatrix(countVectorizedCol, countVectorizedRow, (col, row) => {
     if (col > vectorizedColLimit - 1 || row > vectorizedRowLimit - 1) {
@@ -112,7 +121,8 @@ export function applyVectorization(
         _t("Array arguments to [[FUNCTION_NAME]] are of different size.")
       );
     }
-    const singleCellComputeResult = errorHandlingCompute(descr, context, getArgOffset(col, row));
+    fillArgsBuffer(col, row);
+    const singleCellComputeResult = errorHandlingCompute(descr, context, argsBuffer);
     // In the case where the user tries to vectorize arguments of an array formula, we will get an
     // array for every combination of the vectorized arguments, which will lead to a 3D matrix and
     // we won't be able to return the values.

--- a/src/functions/create_compute_function.ts
+++ b/src/functions/create_compute_function.ts
@@ -182,7 +182,23 @@ function computeFunctionToObject(
     debugger;
     context.debug = false;
   }
-  const result = descr.compute.apply(context, args);
+  // Specialize the call for common arities for performance reasons
+  const compute = descr.compute;
+  let result: FunctionResultObject | Matrix<FunctionResultObject> | CellValue | Matrix<CellValue>;
+  switch (args.length) {
+    case 1:
+      result = compute.call(context, args[0]);
+      break;
+    case 2:
+      result = compute.call(context, args[0], args[1]);
+      break;
+    case 3:
+      result = compute.call(context, args[0], args[1], args[2]);
+      break;
+    default:
+      // fallback to a generic apply for functions with more than 3 arguments
+      result = compute.apply(context, args);
+  }
 
   if (!isMatrix(result)) {
     return isFunctionResultObject(result) ? result : { value: result };

--- a/src/functions/create_compute_function.ts
+++ b/src/functions/create_compute_function.ts
@@ -95,25 +95,29 @@ export function applyVectorization(
   // Reused across every vectorized cell to avoid allocating a new args array per call.
   const argsBuffer: Arg[] = new Array(args.length);
 
-  const fillArgsBuffer = (i: number, j: number): void => {
-    for (let k = 0; k < args.length; k++) {
-      const arg = args[k];
-      switch (vectorArgsType?.[k]) {
-        case "matrix":
-          argsBuffer[k] = arg![i][j];
-          break;
-        case "horizontal":
-          argsBuffer[k] = arg![i][0];
-          break;
-        case "vertical":
-          argsBuffer[k] = arg![0][j];
-          break;
-        case undefined:
-          argsBuffer[k] = arg;
-          break;
+  // Resolve each arg's access pattern once, outside the inner loop.
+  type ArgGetter = (i: number, j: number) => Arg;
+  const argGetters: ArgGetter[] = new Array(args.length);
+  for (let k = 0; k < args.length; k++) {
+    const arg = args[k];
+    switch (vectorArgsType?.[k]) {
+      case "matrix": {
+        argGetters[k] = (i, j) => arg![i][j];
+        break;
       }
+      case "horizontal": {
+        argGetters[k] = (i) => arg![i][0];
+        break;
+      }
+      case "vertical": {
+        argGetters[k] = (_i, j) => arg![0][j];
+        break;
+      }
+      case undefined:
+        argGetters[k] = () => arg;
+        break;
     }
-  };
+  }
 
   return generateMatrix(countVectorizedCol, countVectorizedRow, (col, row) => {
     if (col > vectorizedColLimit - 1 || row > vectorizedRowLimit - 1) {
@@ -121,7 +125,9 @@ export function applyVectorization(
         _t("Array arguments to [[FUNCTION_NAME]] are of different size.")
       );
     }
-    fillArgsBuffer(col, row);
+    for (let k = 0; k < argGetters.length; k++) {
+      argsBuffer[k] = argGetters[k](col, row);
+    }
     const singleCellComputeResult = errorHandlingCompute(descr, context, argsBuffer);
     // In the case where the user tries to vectorize arguments of an array formula, we will get an
     // array for every combination of the vectorized arguments, which will lead to a 3D matrix and

--- a/src/functions/create_compute_function.ts
+++ b/src/functions/create_compute_function.ts
@@ -108,27 +108,32 @@ export function applyVectorization(
 
   // Resolve each arg's access pattern once, outside the inner loop.
   type ArgGetter = (i: number, j: number) => Arg;
-  const argGetters: ArgGetter[] = new Array(args.length);
+  const argGetters: ArgGetter[] = [];
+  const vectorizedIndices: number[] = []; // tracks which slots need updating each iteration.
   for (let k = 0; k < args.length; k++) {
     const arg = args[k];
     switch (vectorArgsType?.[k]) {
       case "matrix": {
-        argGetters[k] = (i, j) => arg![i][j];
+        argGetters.push((i, j) => arg![i][j]);
+        vectorizedIndices.push(k);
         break;
       }
       case "horizontal": {
-        argGetters[k] = (i) => arg![i][0];
+        argGetters.push((i) => arg![i][0]);
+        vectorizedIndices.push(k);
         break;
       }
       case "vertical": {
-        argGetters[k] = (_i, j) => arg![0][j];
+        argGetters.push((_i, j) => arg![0][j]);
+        vectorizedIndices.push(k);
         break;
       }
       case undefined:
-        argGetters[k] = () => arg;
+        argsBuffer[k] = arg;
         break;
     }
   }
+  const nbVectorized = vectorizedIndices.length;
 
   return generateMatrix(countVectorizedCol, countVectorizedRow, (col, row) => {
     if (col > vectorizedColLimit - 1 || row > vectorizedRowLimit - 1) {
@@ -136,8 +141,8 @@ export function applyVectorization(
         _t("Array arguments to [[FUNCTION_NAME]] are of different size.")
       );
     }
-    for (let k = 0; k < argGetters.length; k++) {
-      argsBuffer[k] = argGetters[k](col, row);
+    for (let k = 0; k < nbVectorized; k++) {
+      argsBuffer[vectorizedIndices[k]] = argGetters[k](col, row);
     }
     const singleCellComputeResult = errorHandlingCompute(
       descr,


### PR DESCRIPTION
## Description:

Benchmark scenario: 1500 cells of `=SUM($C:$C="132")` against a 10k-row `C:C` column.

```
  evaluate all cells
  master:     Mean: 2171.79 ms, StdErr: 12.84 ms, n=30
  8c3ee83d3:  Mean: 1983.47 ms, StdErr: 12.82 ms, n=30 (vs prev: -9%)
  43cf81dad:  Mean: 1919.10 ms, StdErr: 12.66 ms, n=30 (vs prev: -3%, vs baseline: -12%)
  f098d7dd1:  Mean: 1677.95 ms, StdErr: 21.29 ms, n=30 (vs prev: -13%, vs baseline: -23%)
  97c7eb2a0:  Mean: 1528.36 ms, StdErr: 11.75 ms, n=30 (vs prev: -9%, vs baseline: -30%)
  59e18c7b2:  Mean: 1458.47 ms, StdErr: 10.62 ms, n=30 (vs prev: -5%, vs baseline: -33%)
  6601e60dd:  Mean: 1378.92 ms, StdErr: 10.24 ms, n=30 (vs prev: -5%, vs baseline: -37%)
```

Task: [6222157](https://www.odoo.com/odoo/2328/tasks/6222157)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo