### PR TITLE
[IMP] color picker: add eye dropper support

### DIFF
--- a/src/components/color_picker/color_picker.css
+++ b/src/components/color_picker/color_picker.css
@@ -31,9 +31,12 @@
         }
       }
     }
+
+    --color-picker-item-size: calc(var(--os-item-edge-length) + (2 * var(--os-item-border-width)));
+
     .o-color-picker-line-item {
-      width: calc(var(--os-item-edge-length) + (2 * var(--os-item-border-width)));
-      height: calc(var(--os-item-edge-length) + (2 * var(--os-item-border-width)));
+      width: var(--color-picker-item-size);
+      height: var(--color-picker-item-size);
       margin: 0px;
       border-radius: 50px;
       border: var(--os-item-border-width) solid light-dark(var(--os-gray-600), #c0c0c0);
@@ -43,6 +46,18 @@
         background-color: var(--os-background-gray-color-hover);
         outline: 1px solid var(--os-gray-500);
         cursor: pointer;
+      }
+    }
+    .eyedropper {
+      width: var(--color-picker-item-size);
+      height: var(--color-picker-item-size);
+      &:hover {
+        background-color: var(--os-hovered-menu-item-color);
+        color: var(--os-button-active-text-color);
+        cursor: pointer;
+      }
+      .fa {
+        font-size: 13px;
       }
     }
     .o-buttons {

--- a/src/components/color_picker/color_picker.ts
+++ b/src/components/color_picker/color_picker.ts
@@ -209,4 +209,27 @@ export class ColorPicker extends Component<SpreadsheetChildEnv> {
   isSameColor(color1: Color, color2: Color): boolean {
     return isSameColor(color1, color2);
   }
+
+  get canUseEyeDropper(): boolean {
+    // In dark mode we'd have to do the opposite color inversion than then dark mode color inversion to get the correct color.
+    // But this mathematically cannot always be done, because our color inversion lose information with clipping and rounding.
+    return !!globalThis.EyeDropper && !this.env.model.getters.isDarkMode();
+  }
+
+  async activateEyedropper() {
+    if (!globalThis.EyeDropper) {
+      return;
+    }
+
+    try {
+      const result = await new globalThis.EyeDropper().open();
+      if (result && result.sRGBHex) {
+        this.props.onColorPicked(toHex(result.sRGBHex));
+      }
+    } catch (error) {
+      if (error.name !== "AbortError") {
+        throw error;
+      }
+    }
+  }
 }

--- a/src/components/color_picker/color_picker.xml
+++ b/src/components/color_picker/color_picker.xml
@@ -27,11 +27,6 @@
           <span>Custom</span>
         </div>
         <div class="colors-grid o-color-picker-toggler" t-on-click.stop="this.toggleColorPicker">
-          <div class="o-color-picker-line-item bg-white o-color-picker-toggler-button">
-            <div class="o-color-picker-toggler-sign">
-              <t t-call="o-spreadsheet-Icon.PLUS"/>
-            </div>
-          </div>
           <div
             t-foreach="this.env.model.getters.getCustomColors()"
             t-as="color"
@@ -46,6 +41,17 @@
               t-attf-style="color:{{this.checkmarkColor}}">
               ✓
             </div>
+          </div>
+          <div class="o-color-picker-line-item bg-white o-color-picker-toggler-button">
+            <div class="o-color-picker-toggler-sign">
+              <t t-call="o-spreadsheet-Icon.PLUS"/>
+            </div>
+          </div>
+          <div
+            class="eyedropper d-flex align-items-center justify-content-center rounded-circle"
+            t-if="this.canUseEyeDropper"
+            t-on-click.stop="this.activateEyedropper">
+            <i class="fa fa-eyedropper"/>
           </div>
         </div>
         <div t-if="this.state.showGradient" class="o-custom-selector">

--- a/src/global_augmentation.d.ts
+++ b/src/global_augmentation.d.ts
@@ -2,6 +2,4 @@
 // Provides global type augmentation for TypeScript type checking without being
 // included in the rollup-plugin-dts bundle (unreachable from module graph).
 declare var Chart: import("./types/chart/chartjs").GlobalChart | undefined;
-interface Window {
-  ChartGeo: typeof import("chartjs-chart-geo");
-}
+declare var ChartGeo: typeof import("chartjs-chart-geo") | undefined;

--- a/src/global_augmentation.d.ts
+++ b/src/global_augmentation.d.ts
@@ -3,3 +3,14 @@
 // included in the rollup-plugin-dts bundle (unreachable from module graph).
 declare var Chart: import("./types/chart/chartjs").GlobalChart | undefined;
 declare var ChartGeo: typeof import("chartjs-chart-geo") | undefined;
+
+// The eye dropper API is still experimental, and thus not yet included in ts's typing
+interface EyeDropper {
+  open(): Promise<{ sRGBHex: string }>;
+}
+
+interface EyeDropperConstructor {
+  new (): EyeDropper;
+}
+
+declare var EyeDropper: EyeDropperConstructor | undefined;

--- a/src/helpers/figures/charts/runtime/chartjs_scales.ts
+++ b/src/helpers/figures/charts/runtime/chartjs_scales.ts
@@ -471,7 +471,7 @@ export function getFunnelChartScales(
 }
 
 function getGeoChartProjection(projection: GeoChartProjection) {
-  if (projection === "conicConformal") {
+  if (globalThis.ChartGeo && projection === "conicConformal") {
     return globalThis.ChartGeo.geoConicConformal().rotate([100, 0]); // Centered on the US
   }
   return projection;

--- a/src/plugins/ui_feature/geo_features.ts
+++ b/src/plugins/ui_feature/geo_features.ts
@@ -132,10 +132,10 @@ export class GeoFeaturePlugin extends UIPlugin {
     }
     // TopoJSON
     if (json.type === "Topology") {
-      const features = (globalThis as any).ChartGeo.topojson.feature(
-        json,
-        Object.values(json.objects)[0]
-      );
+      if (!globalThis.ChartGeo) {
+        return null;
+      }
+      const features = globalThis.ChartGeo.topojson.feature(json, Object.values(json.objects)[0]);
       return features.type === "FeatureCollection" ? features.features : [features];
     }
     // GeoJSON

--- a/src/types/chart/chartjs_global_augmentation.d.ts
+++ b/src/types/chart/chartjs_global_augmentation.d.ts
@@ -1,4 +1,0 @@
-// This file is a script-mode ambient declaration (no imports/exports).
-// It augments the global scope for TypeScript type checking without being
-// included in the rollup-plugin-dts bundle (unreachable from module graph).
-declare var Chart: import("./chartjs").GlobalChart | undefined;

--- a/tests/colors/__snapshots__/color_picker_component.test.ts.snap
+++ b/tests/colors/__snapshots__/color_picker_component.test.ts.snap
@@ -434,6 +434,8 @@ exports[`Color Picker buttons Full component rendering 1`] = `
   <div
     class="colors-grid o-color-picker-toggler"
   >
+    
+    
     <div
       class="o-color-picker-line-item bg-white o-color-picker-toggler-button"
     >
@@ -452,7 +454,13 @@ exports[`Color Picker buttons Full component rendering 1`] = `
         </svg>
       </div>
     </div>
-    
+    <div
+      class="eyedropper d-flex align-items-center justify-content-center rounded-circle"
+    >
+      <i
+        class="fa fa-eyedropper"
+      />
+    </div>
     
   </div>
   <div

--- a/tests/colors/color_picker_component.test.ts
+++ b/tests/colors/color_picker_component.test.ts
@@ -2,15 +2,25 @@ import { Color, Model } from "../../src";
 import { ColorPicker } from "../../src/components/color_picker/color_picker";
 import { toHex } from "../../src/helpers/color";
 import { PropsOf } from "../../src/types/props_of";
+import { registerCleanup } from "../setup/jest.setup";
 import { setFormatting } from "../test_helpers/commands_helpers";
 import {
   getElComputedStyle,
   setInputValueAndTrigger,
   simulateClick,
 } from "../test_helpers/dom_helper";
-import { mountComponentWithPortalTarget } from "../test_helpers/helpers";
+import { mountComponentWithPortalTarget, nextTick } from "../test_helpers/helpers";
 
 let fixture: HTMLElement;
+
+function addMockEyeDropperSupport(mockColor: Color) {
+  globalThis.EyeDropper = class {
+    open() {
+      return Promise.resolve({ sRGBHex: mockColor });
+    }
+  };
+  registerCleanup(() => delete globalThis.EyeDropper);
+}
 
 async function mountColorPicker(
   partialProps: Partial<PropsOf<ColorPicker>> = {},
@@ -24,6 +34,7 @@ async function mountColorPicker(
     disableNoColor: partialProps.disableNoColor || false,
   };
   ({ fixture } = await mountComponentWithPortalTarget(ColorPicker, { model, props }));
+  return model;
 }
 
 test("Color picker is correctly positioned", async () => {
@@ -52,6 +63,7 @@ describe("Color Picker buttons", () => {
   });
 
   test("Full component rendering", async () => {
+    addMockEyeDropperSupport("#123456");
     await mountColorPicker();
     await simulateClick(".o-color-picker-toggler-sign");
     expect(fixture.querySelector(".o-color-picker")).toMatchSnapshot();
@@ -206,5 +218,30 @@ describe("Color Picker buttons", () => {
     expect((inputTarget as HTMLInputElement).value).toBe(hexCode.slice(0, 7));
     const addButton = fixture.querySelector(".o-add-button")!;
     expect(addButton.classList).toContain("o-disabled");
+  });
+
+  test("Eye dropper button is not there if the EyeDropper API is not present", async () => {
+    await mountColorPicker();
+    expect(".eyedropper").toHaveCount(0);
+  });
+
+  test("Eye dropper button is not there in dark mode", async () => {
+    // In dark mode we'd have to do the opposite color inversion than then dark mode color inversion to get the correct color.
+    // But this mathematically cannot always be done, because our color inversion lose information with clipping and rounding.
+    addMockEyeDropperSupport("#abc123");
+    const model = await mountColorPicker({});
+    expect(".eyedropper").toHaveCount(1);
+
+    model.dispatch("UPDATE_COLOR_SCHEME", { colorScheme: "dark" });
+    await nextTick();
+    expect(".eyedropper").toHaveCount(0);
+  });
+
+  test("Can pick a custom color with the eye dropper", async () => {
+    addMockEyeDropperSupport("#abc123");
+    const onColorPicked = jest.fn();
+    await mountColorPicker({ onColorPicked });
+    await simulateClick(".eyedropper");
+    expect(onColorPicked).toHaveBeenCalledWith("#ABC123");
   });
 });


### PR DESCRIPTION
## Description:

### [IMP] color picker: add eye dropper support

This commit adds a button to pick a color from anywhere on your
screen using the EyeDropper API.

The EyeDropper API is still experimental and not widely supported
(only on desktop chromium browser at the time of writing this),
so we make sure the button is only there when the API is avilable.

### [IMP] typing: improve `globalThis` typing

- `globalThis.Chart` was defined twice
- `ChartGeo` was defined in `window` instead of `globalThis`

Task: [6226285](https://www.odoo.com/odoo/2328/tasks/6226285)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo