### PR TITLE
[IMP] pivots: clarify sorting option for rows

### DIFF
--- a/src/components/side_panel/pivot/pivot_layout_configurator/pivot_dimension_order/pivot_dimension_order.ts
+++ b/src/components/side_panel/pivot/pivot_layout_configurator/pivot_dimension_order/pivot_dimension_order.ts
@@ -15,6 +15,7 @@ export class PivotDimensionOrder extends Component<SpreadsheetChildEnv> {
       types.PivotDimension(),
       types.instanceOf(InputEvent),
     ]),
+    "isMeasureSorted?": types.boolean(),
   });
   static components = { Select };
 
@@ -23,9 +24,19 @@ export class PivotDimensionOrder extends Component<SpreadsheetChildEnv> {
       { value: "asc", label: _t("Ascending") },
       { value: "desc", label: _t("Descending") },
     ];
+    if (this.props.isMeasureSorted) {
+      options.unshift({ value: "measures", label: _t("Sorted by measure") });
+    }
     if (this.props.dimension.type === "date") {
       return options;
     }
     return [{ value: "", label: _t("Unsorted") }, ...options];
+  }
+
+  get selectedValue() {
+    if (this.props.isMeasureSorted) {
+      return "measures";
+    }
+    return this.props.dimension.order || "";
   }
 }

--- a/src/components/side_panel/pivot/pivot_layout_configurator/pivot_dimension_order/pivot_dimension_order.xml
+++ b/src/components/side_panel/pivot/pivot_layout_configurator/pivot_dimension_order/pivot_dimension_order.xml
@@ -6,7 +6,7 @@
         <Select
           class="'flex-grow-1'"
           values="this.orderSelectOptions"
-          selectedValue="this.props.dimension.order || ''"
+          selectedValue="this.selectedValue"
           onChange="(value) => this.props.onUpdated(this.props.dimension, value)"
         />
       </div>

--- a/src/components/side_panel/pivot/pivot_layout_configurator/pivot_layout_configurator.ts
+++ b/src/components/side_panel/pivot/pivot_layout_configurator/pivot_layout_configurator.ts
@@ -283,7 +283,10 @@ export class PivotLayoutConfigurator extends Component<SpreadsheetChildEnv> {
   }
 
   updateOrder(updateDimension: PivotDimensionType, order?: SortDirection) {
-    const { rows, columns } = this.props.definition;
+    const { rows, columns, sortedColumn } = this.props.definition;
+    const isRow = rows.some(
+      (row) => row.nameWithGranularity === updateDimension.nameWithGranularity
+    );
     this.props.onDimensionsUpdated({
       rows: rows.map((row) => {
         if (row.nameWithGranularity === updateDimension.nameWithGranularity) {
@@ -297,6 +300,7 @@ export class PivotLayoutConfigurator extends Component<SpreadsheetChildEnv> {
         }
         return col;
       }),
+      sortedColumn: isRow ? undefined : sortedColumn,
     });
   }
 
@@ -327,5 +331,9 @@ export class PivotLayoutConfigurator extends Component<SpreadsheetChildEnv> {
           possibleValues.length
         )
       : undefined;
+  }
+
+  get hasSortedColumn() {
+    return !!this.props.definition.sortedColumn;
   }
 }

--- a/src/components/side_panel/pivot/pivot_layout_configurator/pivot_layout_configurator.xml
+++ b/src/components/side_panel/pivot/pivot_layout_configurator/pivot_layout_configurator.xml
@@ -72,7 +72,11 @@
               availableGranularities="this.props.unusedGranularities[row.fieldName]"
               allGranularities="this.getGranularitiesFor(row)"
             />
-            <PivotDimensionOrder dimension="row" onUpdated.bind="this.updateOrder"/>
+            <PivotDimensionOrder
+              dimension="row"
+              onUpdated.bind="this.updateOrder"
+              isMeasureSorted="this.hasSortedColumn"
+            />
             <PivotCustomGroupsCollapsible
               t-if="row.isCustomField"
               pivotId="this.props.pivotId"

--- a/tests/pivots/spreadsheet_pivot/spreadsheet_pivot_side_panel.test.ts
+++ b/tests/pivots/spreadsheet_pivot/spreadsheet_pivot_side_panel.test.ts
@@ -957,6 +957,24 @@ describe("Spreadsheet pivot side panel", () => {
       await click(column, ".fa-trash");
       expect(model.getters.getPivotCoreDefinition("2").sortedColumn).toBeUndefined();
     });
+
+    test("Pivot sorted columns is removed when changing the sorting of a row in the panel", async () => {
+      updatePivot(model, "2", {
+        rows: [{ fieldName: "Product", order: "asc" }],
+      });
+      await nextTick();
+
+      const row = fixture.querySelectorAll(".pivot-dimension")[1];
+      const select = row.querySelector(".o-select")!;
+      expect(model.getters.getPivotCoreDefinition("2").sortedColumn).toEqual(sortedColumn);
+      expect(select).toHaveText("Sorted by measure");
+
+      await editSelectComponent(select, "desc");
+      expect(model.getters.getPivotCoreDefinition("2").rows).toEqual([
+        { fieldName: "Product", order: "desc" },
+      ]);
+      expect(model.getters.getPivotCoreDefinition("2").sortedColumn).toBeUndefined();
+    });
   });
 
   test("Trying to load a very big pivot will raise an error message", async () => {


### PR DESCRIPTION
## Description

If a pivot has a sortedColumn (sorted based on the values of this column), editing the sorting order of the rows in the side panel looks like it has no effect.

This commit clarifies it by setting the select to `Sorted by measure`, and if the user edit it we remove the sorted column.

Task: [6186102](https://www.odoo.com/odoo/2328/tasks/6186102)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo