### PR TITLE
[PERF] charts: avoid useless evaluation

### DIFF
--- a/src/helpers/figures/chart.ts
+++ b/src/helpers/figures/chart.ts
@@ -18,6 +18,7 @@ import { Validator } from "../../types/validator";
 
 export class SpreadsheetChart {
   private readonly dataSource: ChartDataSource<Range> | undefined;
+  private _cachedRanges?: Set<Range>;
 
   private constructor(
     private readonly getters: CoreGetters,
@@ -172,6 +173,15 @@ export class SpreadsheetChart {
       return undefined;
     }
     return this.chartTypeBuilder.getDefinitionForExcel(getters, definition, excelDataSets);
+  }
+
+  getRanges(): Set<Range> {
+    if (!this._cachedRanges) {
+      this._cachedRanges = new Set(
+        this.chartTypeBuilder.getRanges(this.definition, this.getters, this.sheetId)
+      );
+    }
+    return this._cachedRanges;
   }
 
   getData(getters: Getters, chartId: UID): ChartData {

--- a/src/helpers/figures/charts/bar_chart.ts
+++ b/src/helpers/figures/charts/bar_chart.ts
@@ -4,7 +4,7 @@ import { BarChartRuntime } from "../../../types/chart/bar_chart";
 import { CommandResult } from "../../../types/commands";
 import { toXlsxHexColor } from "../../../xlsx/helpers/colors";
 import { AbstractChart } from "./abstract_chart";
-import { chartFontColor, getDefinedAxis } from "./chart_common";
+import { chartFontColor, getDataSourceRanges, getDefinedAxis } from "./chart_common";
 import { CHART_COMMON_OPTIONS } from "./chart_ui_common";
 import { getBarChartData } from "./runtime/chart_data_extractor";
 import { getBarChartDatasets } from "./runtime/chartjs_dataset";
@@ -77,6 +77,8 @@ export const BarChart: ChartTypeBuilder<"bar"> = {
       verticalAxis: getDefinedAxis(definition),
     };
   },
+
+  getRanges: (definition) => getDataSourceRanges(definition.dataSource),
 
   getRuntime(getters, definition, { extractData }, sheetId, eventHandlers): BarChartRuntime {
     const data = extractData();

--- a/src/helpers/figures/charts/bubble_chart.ts
+++ b/src/helpers/figures/charts/bubble_chart.ts
@@ -151,6 +151,15 @@ export const BubbleChart: ChartTypeBuilder<"bubble"> = {
 
   getDefinitionForExcel: () => undefined,
 
+  getRanges(definition) {
+    return [
+      ...definition.yRanges,
+      definition.xRange,
+      definition.labelRange,
+      definition.sizeRange,
+    ].filter((r): r is Range => r !== undefined && !r.invalidXc && !r.invalidSheetName);
+  },
+
   updateRanges(definition, adapterFunctions) {
     const adaptedYRanges = definition.yRanges
       .map((yRange) => adaptChartRange(yRange, adapterFunctions))

--- a/src/helpers/figures/charts/calendar_chart.ts
+++ b/src/helpers/figures/charts/calendar_chart.ts
@@ -9,6 +9,7 @@ import { LegendPosition } from "../../../types/chart/common_chart";
 import { CommandResult } from "../../../types/commands";
 import { Validator } from "../../../types/validator";
 import { AbstractChart } from "./abstract_chart";
+import { getDataSourceRanges } from "./chart_common";
 import { CHART_COMMON_OPTIONS } from "./chart_ui_common";
 import { getCalendarChartData } from "./runtime/chart_data_extractor";
 import { getCalendarChartDatasetAndLabels } from "./runtime/chartjs_dataset";
@@ -85,6 +86,8 @@ export const CalendarChart: ChartTypeBuilder<"calendar"> = {
   },
 
   getDefinitionForExcel: () => undefined,
+
+  getRanges: (definition) => getDataSourceRanges(definition.dataSource),
 
   getRuntime(getters, definition, { extractData }): CalendarChartRuntime {
     const data = extractData();

--- a/src/helpers/figures/charts/chart_common.ts
+++ b/src/helpers/figures/charts/chart_common.ts
@@ -2,6 +2,7 @@ import { DEFAULT_WINDOW_SIZE, MAX_CHAR_LABEL } from "../../../constants";
 import { _t } from "../../../translation";
 import {
   ChartAxisFormats,
+  ChartDataSource,
   ChartDefinition,
   ChartRangeDataSource,
   DataSet,
@@ -378,6 +379,26 @@ export function truncateLabel(label: string | undefined, maxLen: number = MAX_CH
 
 export function isTrendLineAxis(axisID: string) {
   return axisID === TREND_LINE_XAXIS_ID || axisID === MOVING_AVERAGE_TREND_LINE_XAXIS_ID;
+}
+
+export function getDataSourceRanges(dataSource: ChartDataSource<Range> | undefined): Range[] {
+  if (!dataSource || dataSource.type !== "range") {
+    return [];
+  }
+  const ranges: Range[] = [];
+  for (const { dataRange } of dataSource.dataSets) {
+    if (!dataRange.invalidXc && !dataRange.invalidSheetName) {
+      ranges.push(dataRange);
+    }
+  }
+  if (
+    dataSource.labelRange &&
+    !dataSource.labelRange.invalidXc &&
+    !dataSource.labelRange.invalidSheetName
+  ) {
+    ranges.push(dataSource.labelRange);
+  }
+  return ranges;
 }
 
 export function getChartBackgroundColor(

--- a/src/helpers/figures/charts/combo_chart.ts
+++ b/src/helpers/figures/charts/combo_chart.ts
@@ -4,7 +4,7 @@ import { ComboChartDataSetStyle, ComboChartRuntime } from "../../../types/chart/
 import { CommandResult } from "../../../types/commands";
 import { toXlsxHexColor } from "../../../xlsx/helpers/colors";
 import { AbstractChart } from "./abstract_chart";
-import { chartFontColor, getDefinedAxis } from "./chart_common";
+import { chartFontColor, getDataSourceRanges, getDefinedAxis } from "./chart_common";
 import { CHART_COMMON_OPTIONS } from "./chart_ui_common";
 import { getBarChartData } from "./runtime/chart_data_extractor";
 import { getComboChartDatasets } from "./runtime/chartjs_dataset";
@@ -82,6 +82,8 @@ export const ComboChart: ChartTypeBuilder<"combo"> = {
       humanize: context.humanize,
     };
   },
+
+  getRanges: (definition) => getDataSourceRanges(definition.dataSource),
 
   getRuntime(getters, definition, { extractData }, sheetId, eventHandlers): ComboChartRuntime {
     const data = extractData();

--- a/src/helpers/figures/charts/funnel_chart.ts
+++ b/src/helpers/figures/charts/funnel_chart.ts
@@ -3,6 +3,7 @@ import { ChartTypeBuilder } from "../../../registries/chart_registry";
 import { FunnelChartRuntime } from "../../../types/chart/funnel_chart";
 import { CommandResult } from "../../../types/commands";
 import { AbstractChart } from "./abstract_chart";
+import { getDataSourceRanges } from "./chart_common";
 import { CHART_COMMON_OPTIONS } from "./chart_ui_common";
 import { getFunnelChartData } from "./runtime/chart_data_extractor";
 import { getFunnelChartDatasets } from "./runtime/chartjs_dataset";
@@ -63,6 +64,8 @@ export const FunnelChart: ChartTypeBuilder<"funnel"> = {
   },
 
   getDefinitionForExcel: () => undefined,
+
+  getRanges: (definition) => getDataSourceRanges(definition.dataSource),
 
   getRuntime(getters, definition, { extractData }, sheetId, eventHandlers): FunnelChartRuntime {
     const data = extractData();

--- a/src/helpers/figures/charts/gauge_chart.ts
+++ b/src/helpers/figures/charts/gauge_chart.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_GAUGE_MIDDLE_COLOR,
   DEFAULT_GAUGE_UPPER_COLOR,
 } from "../../../constants";
+import { CompiledFormula } from "../../../formulas/compiler";
 import { isMultipleElementMatrix, toScalar } from "../../../functions/helper_matrices";
 import { tryToNumber } from "../../../functions/helpers";
 import { BasePlugin } from "../../../plugins/base_plugin";
@@ -228,6 +229,31 @@ export const GaugeChart: ChartTypeBuilder<"gauge"> = {
   },
 
   getDefinitionForExcel: () => undefined,
+
+  getRanges(definition, getters, sheetId) {
+    const ranges: Range[] = [definition.dataRange].filter(
+      (r): r is Range => r !== undefined && !r.invalidXc && !r.invalidSheetName
+    );
+    if (definition.sectionRule) {
+      const formulaValues = [
+        definition.sectionRule.rangeMin,
+        definition.sectionRule.rangeMax,
+        definition.sectionRule.lowerInflectionPoint.value,
+        definition.sectionRule.upperInflectionPoint.value,
+      ];
+      for (const formula of formulaValues) {
+        if (formula.startsWith("=")) {
+          for (const range of CompiledFormula.Compile(formula, sheetId, getters)
+            .rangeDependencies) {
+            if (!range.invalidXc && !range.invalidSheetName) {
+              ranges.push(range);
+            }
+          }
+        }
+      }
+    }
+    return ranges;
+  },
 
   getContextCreation(definition) {
     return {

--- a/src/helpers/figures/charts/geo_chart.ts
+++ b/src/helpers/figures/charts/geo_chart.ts
@@ -3,6 +3,7 @@ import { ChartTypeBuilder } from "../../../registries/chart_registry";
 import { GeoChartRuntime } from "../../../types/chart/geo_chart";
 import { CommandResult } from "../../../types/commands";
 import { AbstractChart } from "./abstract_chart";
+import { getDataSourceRanges } from "./chart_common";
 import { CHART_COMMON_OPTIONS } from "./chart_ui_common";
 import { getGeoChartData } from "./runtime/chart_data_extractor";
 import { getGeoChartDatasets } from "./runtime/chartjs_dataset";
@@ -54,6 +55,8 @@ export const GeoChart: ChartTypeBuilder<"geo"> = {
   },
 
   getDefinitionForExcel: () => undefined,
+
+  getRanges: (definition) => getDataSourceRanges(definition.dataSource),
 
   getRuntime(getters, definition, { extractData }, sheetId, eventHandlers): GeoChartRuntime {
     const data = extractData();

--- a/src/helpers/figures/charts/line_chart.ts
+++ b/src/helpers/figures/charts/line_chart.ts
@@ -4,7 +4,7 @@ import { LineChartRuntime } from "../../../types/chart/line_chart";
 import { CommandResult } from "../../../types/commands";
 import { toXlsxHexColor } from "../../../xlsx/helpers/colors";
 import { AbstractChart } from "./abstract_chart";
-import { chartFontColor, getDefinedAxis } from "./chart_common";
+import { chartFontColor, getDataSourceRanges, getDefinedAxis } from "./chart_common";
 import { CHART_COMMON_OPTIONS } from "./chart_ui_common";
 import { getLineChartData } from "./runtime/chart_data_extractor";
 import { getLineChartDatasets } from "./runtime/chartjs_dataset";
@@ -81,6 +81,8 @@ export const LineChart: ChartTypeBuilder<"line"> = {
       verticalAxis: getDefinedAxis(definition),
     };
   },
+
+  getRanges: (definition) => getDataSourceRanges(definition.dataSource),
 
   getRuntime(getters, definition, { extractData }, sheetId, eventHandlers): LineChartRuntime {
     const data = extractData();

--- a/src/helpers/figures/charts/pie_chart.ts
+++ b/src/helpers/figures/charts/pie_chart.ts
@@ -4,7 +4,7 @@ import { PieChartRuntime } from "../../../types/chart/pie_chart";
 import { CommandResult } from "../../../types/commands";
 import { toXlsxHexColor } from "../../../xlsx/helpers/colors";
 import { AbstractChart } from "./abstract_chart";
-import { chartFontColor } from "./chart_common";
+import { chartFontColor, getDataSourceRanges } from "./chart_common";
 import { CHART_COMMON_OPTIONS } from "./chart_ui_common";
 import { getPieChartData } from "./runtime/chart_data_extractor";
 import { getPieChartDatasets } from "./runtime/chartjs_dataset";
@@ -70,6 +70,8 @@ export const PieChart: ChartTypeBuilder<"pie"> = {
       labelRange,
     };
   },
+
+  getRanges: (definition) => getDataSourceRanges(definition.dataSource),
 
   getRuntime(getters, definition, { extractData }, sheetId, eventHandlers): PieChartRuntime {
     const data = extractData();

--- a/src/helpers/figures/charts/pyramid_chart.ts
+++ b/src/helpers/figures/charts/pyramid_chart.ts
@@ -5,7 +5,7 @@ import { CommandResult } from "../../../types/commands";
 import { toXlsxHexColor } from "../../../xlsx/helpers/colors";
 import { isNumberResult } from "../../cells/cell_evaluation";
 import { AbstractChart } from "./abstract_chart";
-import { chartFontColor, getDefinedAxis } from "./chart_common";
+import { chartFontColor, getDataSourceRanges, getDefinedAxis } from "./chart_common";
 import { getChartData } from "./chart_data_sources";
 import { CHART_COMMON_OPTIONS } from "./chart_ui_common";
 import { getPyramidChartData } from "./runtime/chart_data_extractor";
@@ -94,6 +94,8 @@ export const PyramidChart: ChartTypeBuilder<"pyramid"> = {
       maxValue,
     };
   },
+
+  getRanges: (definition) => getDataSourceRanges(definition.dataSource),
 
   getRuntime(getters, definition, { extractData }, sheetId, eventHandlers): PyramidChartRuntime {
     const data = extractData();

--- a/src/helpers/figures/charts/radar_chart.ts
+++ b/src/helpers/figures/charts/radar_chart.ts
@@ -4,7 +4,7 @@ import { RadarChartRuntime } from "../../../types/chart/radar_chart";
 import { CommandResult } from "../../../types/commands";
 import { toXlsxHexColor } from "../../../xlsx/helpers/colors";
 import { AbstractChart } from "./abstract_chart";
-import { chartFontColor } from "./chart_common";
+import { chartFontColor, getDataSourceRanges } from "./chart_common";
 import { CHART_COMMON_OPTIONS } from "./chart_ui_common";
 import { getRadarChartData } from "./runtime/chart_data_extractor";
 import { getRadarChartDatasets } from "./runtime/chartjs_dataset";
@@ -71,6 +71,8 @@ export const RadarChart: ChartTypeBuilder<"radar"> = {
       labelRange,
     };
   },
+
+  getRanges: (definition) => getDataSourceRanges(definition.dataSource),
 
   getRuntime(getters, definition, { extractData }, sheetId, eventHandlers): RadarChartRuntime {
     const data = extractData();

--- a/src/helpers/figures/charts/scatter_chart.ts
+++ b/src/helpers/figures/charts/scatter_chart.ts
@@ -4,7 +4,7 @@ import { ScatterChartRuntime } from "../../../types/chart/scatter_chart";
 import { CommandResult } from "../../../types/commands";
 import { toXlsxHexColor } from "../../../xlsx/helpers/colors";
 import { AbstractChart } from "./abstract_chart";
-import { chartFontColor, getDefinedAxis } from "./chart_common";
+import { chartFontColor, getDataSourceRanges, getDefinedAxis } from "./chart_common";
 import { CHART_COMMON_OPTIONS } from "./chart_ui_common";
 import { getLineChartData } from "./runtime/chart_data_extractor";
 import { getScatterChartDatasets } from "./runtime/chartjs_dataset";
@@ -70,6 +70,8 @@ export const ScatterChart: ChartTypeBuilder<"scatter"> = {
       verticalAxis: getDefinedAxis(definition),
     };
   },
+
+  getRanges: (definition) => getDataSourceRanges(definition.dataSource),
 
   getRuntime(getters, definition, { extractData }, sheetId, eventHandlers): ScatterChartRuntime {
     const data = extractData();

--- a/src/helpers/figures/charts/scorecard_chart.ts
+++ b/src/helpers/figures/charts/scorecard_chart.ts
@@ -265,6 +265,12 @@ export const ScorecardChart: ChartTypeBuilder<"scorecard"> = {
 
   getDefinitionForExcel: () => undefined,
 
+  getRanges(definition) {
+    return [definition.keyValue, definition.baseline].filter(
+      (r): r is Range => r !== undefined && !r.invalidXc && !r.invalidSheetName
+    );
+  },
+
   updateRanges(definition, adapterFunctions: RangeAdapterFunctions) {
     const baseline = adaptChartRange(definition.baseline, adapterFunctions);
     const keyValue = adaptChartRange(definition.keyValue, adapterFunctions);

--- a/src/helpers/figures/charts/sunburst_chart.ts
+++ b/src/helpers/figures/charts/sunburst_chart.ts
@@ -3,6 +3,7 @@ import { ChartTypeBuilder } from "../../../registries/chart_registry";
 import { SunburstChartRuntime } from "../../../types/chart/sunburst_chart";
 import { CommandResult } from "../../../types/commands";
 import { AbstractChart } from "./abstract_chart";
+import { getDataSourceRanges } from "./chart_common";
 import { CHART_COMMON_OPTIONS } from "./chart_ui_common";
 import { getHierarchalChartData } from "./runtime/chart_data_extractor";
 import { getSunburstChartDatasets } from "./runtime/chartjs_dataset";
@@ -65,6 +66,8 @@ export const SunburstChart: ChartTypeBuilder<"sunburst"> = {
   },
 
   getDefinitionForExcel: () => undefined,
+
+  getRanges: (definition) => getDataSourceRanges(definition.dataSource),
 
   getRuntime(
     getters,

--- a/src/helpers/figures/charts/tree_map_chart.ts
+++ b/src/helpers/figures/charts/tree_map_chart.ts
@@ -3,6 +3,7 @@ import { ChartTypeBuilder } from "../../../registries/chart_registry";
 import { TreeMapChartRuntime } from "../../../types/chart/tree_map_chart";
 import { CommandResult } from "../../../types/commands";
 import { AbstractChart } from "./abstract_chart";
+import { getDataSourceRanges } from "./chart_common";
 import { CHART_COMMON_OPTIONS } from "./chart_ui_common";
 import { getHierarchalChartData } from "./runtime/chart_data_extractor";
 import { getTreeMapChartDatasets } from "./runtime/chartjs_dataset";
@@ -66,6 +67,8 @@ export const TreeMapChart: ChartTypeBuilder<"treemap"> = {
   },
 
   getDefinitionForExcel: () => undefined,
+
+  getRanges: (definition) => getDataSourceRanges(definition.dataSource),
 
   getRuntime(
     getters,

--- a/src/helpers/figures/charts/waterfall_chart.ts
+++ b/src/helpers/figures/charts/waterfall_chart.ts
@@ -3,6 +3,7 @@ import { ChartTypeBuilder } from "../../../registries/chart_registry";
 import { WaterfallChartRuntime } from "../../../types/chart/waterfall_chart";
 import { CommandResult } from "../../../types/commands";
 import { AbstractChart } from "./abstract_chart";
+import { getDataSourceRanges } from "./chart_common";
 import { CHART_COMMON_OPTIONS } from "./chart_ui_common";
 import { getBarChartData } from "./runtime/chart_data_extractor";
 import { getWaterfallDatasetAndLabels } from "./runtime/chartjs_dataset";
@@ -70,6 +71,8 @@ export const WaterfallChart: ChartTypeBuilder<"waterfall"> = {
   },
 
   getDefinitionForExcel: () => undefined,
+
+  getRanges: (definition) => getDataSourceRanges(definition.dataSource),
 
   getRuntime(getters, definition, { extractData }, sheetId, eventHandlers): WaterfallChartRuntime {
     const data = extractData();

--- a/src/plugins/ui_core_views/cell_evaluation/evaluation_plugin.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluation_plugin.ts
@@ -22,7 +22,7 @@ import {
   UID,
   Zone,
 } from "../../../types/misc";
-import { Range } from "../../../types/range";
+import { BoundedRange, Range } from "../../../types/range";
 import { ExcelWorkbookData } from "../../../types/workbook_data";
 import { SquishedFormula } from "../../core/squisher";
 import { CoreViewPlugin, CoreViewPluginConfig } from "../../core_view_plugin";
@@ -159,6 +159,7 @@ export class EvaluationPlugin extends CoreViewPlugin {
     "isArrayFormulaSpillBlocked",
     "isEmpty",
     "getPerfProfile",
+    "getCellsDependingOn",
   ] as const;
 
   private shouldRebuildDependenciesGraph = true;
@@ -309,6 +310,19 @@ export class EvaluationPlugin extends CoreViewPlugin {
 
   getPerfProfile(): PerfProfile | undefined {
     return this.evaluator.getPerfProfile();
+  }
+
+  /**
+   * Returns ranges of formula cells that (transitively) depend on the given cell position.
+   */
+  getCellsDependingOn(position: CellPosition): Iterable<BoundedRange> {
+    const zone = {
+      left: position.col,
+      right: position.col,
+      top: position.row,
+      bottom: position.row,
+    };
+    return this.evaluator.getCellsDependingOn([{ sheetId: position.sheetId, zone }]);
   }
 
   /**

--- a/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
@@ -712,7 +712,7 @@ export class Evaluator {
     return cell.compiledFormula.rangeDependencies;
   }
 
-  private getCellsDependingOn(ranges: Iterable<BoundedRange>): RangeSet {
+  getCellsDependingOn(ranges: Iterable<BoundedRange>): RangeSet {
     return this.formulaDependencies().getCellsDependingOn(ranges, this.nextRangesToUpdate);
   }
 }

--- a/src/plugins/ui_core_views/evaluation_chart.ts
+++ b/src/plugins/ui_core_views/evaluation_chart.ts
@@ -3,6 +3,8 @@ import { SpreadsheetChart } from "../../helpers/figures/chart";
 import { chartFontColor } from "../../helpers/figures/charts/chart_common";
 import { chartToImageUrl } from "../../helpers/figures/charts/chart_ui_common";
 import { generateMasterChartConfig } from "../../helpers/figures/charts/runtime/chart_zoom";
+import { isDefined } from "../../helpers/misc";
+import { isInside, overlap } from "../../helpers/zones";
 import { ChartRuntime, ExcelChartDefinition } from "../../types/chart/chart";
 import {
   CoreViewCommand,
@@ -11,7 +13,7 @@ import {
   invalidateEvaluationCommands,
 } from "../../types/commands";
 import { Color, UID } from "../../types/misc";
-import { Range } from "../../types/range";
+import { BoundedRange, Range } from "../../types/range";
 import { ExcelWorkbookData, FigureData } from "../../types/workbook_data";
 import { CoreViewPlugin } from "../core_view_plugin";
 
@@ -33,7 +35,7 @@ export class EvaluationChartPlugin extends CoreViewPlugin<EvaluationChartState> 
     if (
       invalidateEvaluationCommands.has(cmd.type) ||
       invalidateCFEvaluationCommands.has(cmd.type) ||
-      invalidateChartEvaluationCommands.has(cmd.type)
+      (invalidateChartEvaluationCommands.has(cmd.type) && cmd.type !== "UPDATE_CELL")
     ) {
       for (const chartId in this.charts) {
         this.charts[chartId] = undefined;
@@ -41,6 +43,9 @@ export class EvaluationChartPlugin extends CoreViewPlugin<EvaluationChartState> 
     }
 
     switch (cmd.type) {
+      case "UPDATE_CELL":
+        this.invalidateChartsAffectedByCell(cmd.sheetId, cmd.col, cmd.row);
+        break;
       case "UPDATE_CHART":
       case "CREATE_CHART":
         this.charts[cmd.chartId] = undefined;
@@ -56,6 +61,46 @@ export class EvaluationChartPlugin extends CoreViewPlugin<EvaluationChartState> 
         }
         break;
     }
+  }
+
+  private invalidateChartsAffectedByCell(sheetId: UID, col: number, row: number): void {
+    if (!Object.values(this.charts).some(isDefined)) {
+      return;
+    }
+    const dependents = [...this.getters.getCellsDependingOn({ sheetId, col, row })];
+    for (const chartId in this.charts) {
+      if (this.charts[chartId] === undefined) {
+        continue;
+      }
+      if (this.chartIsAffectedByCell(chartId, sheetId, col, row, dependents)) {
+        this.charts[chartId] = undefined;
+      }
+    }
+  }
+
+  private chartIsAffectedByCell(
+    chartId: UID,
+    sheetId: UID,
+    col: number,
+    row: number,
+    dependents: BoundedRange[]
+  ): boolean {
+    const chart = this.getters.getChart(chartId);
+    if (!chart) {
+      return false;
+    }
+    const chartRanges = chart.getRanges();
+    for (const r of chartRanges) {
+      if (r.sheetId === sheetId && isInside(col, row, r.zone)) {
+        return true;
+      }
+      for (const dep of dependents) {
+        if (r.sheetId === dep.sheetId && overlap(dep.zone, r.zone)) {
+          return true;
+        }
+      }
+    }
+    return false;
   }
 
   getChartRuntime(chartId: UID): ChartRuntime {

--- a/src/registries/chart_registry.ts
+++ b/src/registries/chart_registry.ts
@@ -100,6 +100,7 @@ export interface ChartTypeBuilder<T extends ChartType> {
     sheetId: UID,
     eventHandlers: ChartJsEventHandlers
   ): ChartRuntime;
+  getRanges(definition: ChartTypeDefinition<T, Range>, getters: CoreGetters, sheetId: UID): Range[];
   allowedDefinitionKeys: readonly string[];
   sequence: number;
   dataSeriesLimit?: number;

--- a/tests/figures/chart/chart_animations.test.ts
+++ b/tests/figures/chart/chart_animations.test.ts
@@ -6,6 +6,7 @@ import {
   createChart,
   evaluateCells,
   setCellContent,
+  setCellFormat,
   setViewportOffset,
   updateChart,
 } from "../../test_helpers/commands_helpers";
@@ -72,10 +73,11 @@ describe("Chart animations in dashboard", () => {
 
     expect(mockedChart.config.options.animation).toEqual({ animateRotate: true });
 
-    // Dispatch a command that doesn't change the chart data
+    // Dispatch a command that doesn't change the chart data (cell outside chart range)
+    // The chart is not updated at all, so animation config is unchanged
     setCellContent(model, "A50", "6");
     await nextTick();
-    expect(mockedChart.config.options.animation).toBe(false);
+    expect(mockedChart.config.options.animation).toEqual({ animateRotate: true });
 
     // Change the chart data
     setCellContent(model, "A2", "6");
@@ -99,7 +101,8 @@ describe("Chart animations in dashboard", () => {
 
     expect(mockedChart.config.options.animation).toEqual({ animateRotate: true });
 
-    setCellContent(model, "B1", "6");
+    // Format change on a cell inside the range: the runtime is re-created but actual data is unchanged
+    setCellFormat(model, "A2", "0.00");
     await nextTick();
     expect(mockedChart.config.options.animation).toBe(false);
 

--- a/tests/figures/chart/chart_evaluation_invalidation.test.ts
+++ b/tests/figures/chart/chart_evaluation_invalidation.test.ts
@@ -1,0 +1,411 @@
+import { Model } from "../../../src";
+import { SpreadsheetChart } from "../../../src/helpers/figures/chart";
+import { toChartDataSource } from "../../test_helpers/chart_helpers";
+import {
+  createBubbleChart,
+  createChart,
+  createGaugeChart,
+  createGeoChart,
+  createScorecardChart,
+  setCellContent,
+} from "../../test_helpers/commands_helpers";
+import { mockGeoJsonService } from "../../test_helpers/helpers";
+
+function spyOnGetRuntime() {
+  return jest.spyOn(SpreadsheetChart.prototype, "getRuntime");
+}
+
+function createGaugeWithFormulaInSectionRule(
+  model: Model,
+  sectionRuleOverride: Record<string, unknown>,
+  chartId: string
+) {
+  createGaugeChart(
+    model,
+    {
+      sectionRule: {
+        rangeMin: "0",
+        rangeMax: "100",
+        colors: {
+          lowerColor: "#6aa84f",
+          middleColor: "#f1c232",
+          upperColor: "#cc0000",
+        },
+        lowerInflectionPoint: { type: "number", value: "33", operator: "<=" },
+        upperInflectionPoint: { type: "number", value: "66", operator: "<=" },
+        ...sectionRuleOverride,
+      },
+    },
+    chartId
+  );
+}
+
+describe("Chart runtime cache invalidation", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("updating a cell that a chart range formula depends on invalidates the chart runtime", () => {
+    const model = new Model();
+    setCellContent(model, "A1", "1");
+    setCellContent(model, "B1", "=A1*2"); // B1 is in chart range and depends on A1
+    const chartId = "chart1";
+    createChart(
+      model,
+      { type: "bar", ...toChartDataSource({ dataSets: [{ dataRange: "B1" }] }) },
+      chartId
+    );
+
+    model.getters.getChartRuntime(chartId);
+    const spy = spyOnGetRuntime();
+    setCellContent(model, "A1", "99"); // A1 is outside chart range but B1=A1*2
+    model.getters.getChartRuntime(chartId);
+
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  test("updating a cell whose dependents are outside chart range does NOT invalidate the chart runtime", () => {
+    const model = new Model();
+    setCellContent(model, "A1", "1");
+    setCellContent(model, "B1", "2");
+    setCellContent(model, "C1", "=B1*2"); // C1 depends on B1, but chart uses only A1
+    const chartId = "chart1";
+    createChart(
+      model,
+      { type: "bar", ...toChartDataSource({ dataSets: [{ dataRange: "A1" }] }) },
+      chartId
+    );
+
+    model.getters.getChartRuntime(chartId);
+    const spy = spyOnGetRuntime();
+    setCellContent(model, "B1", "99"); // B1 is outside chart range, C1 also outside
+    model.getters.getChartRuntime(chartId);
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  test("updating a cell only invalidates the affected chart, not all charts", () => {
+    const model = new Model();
+    setCellContent(model, "A1", "1");
+    setCellContent(model, "B1", "2");
+
+    createChart(
+      model,
+      { type: "bar", ...toChartDataSource({ dataSets: [{ dataRange: "A1" }] }) },
+      "chartA"
+    );
+    createChart(
+      model,
+      { type: "bar", ...toChartDataSource({ dataSets: [{ dataRange: "B1" }] }) },
+      "chartB"
+    );
+
+    model.getters.getChartRuntime("chartA");
+    model.getters.getChartRuntime("chartB");
+    const spy = spyOnGetRuntime();
+    setCellContent(model, "A1", "99"); // only affects chartA
+    model.getters.getChartRuntime("chartA");
+    model.getters.getChartRuntime("chartB");
+
+    expect(spy).toHaveBeenCalledTimes(1); // only chartA's getRuntime was called
+  });
+
+  describe("dataSource-based charts", () => {
+    const dataSourceChartTypes = [
+      "bar",
+      "line",
+      "pie",
+      "scatter",
+      "combo",
+      "radar",
+      "waterfall",
+      "funnel",
+      "pyramid",
+      "sunburst",
+      "treemap",
+      "calendar",
+    ] as const;
+
+    test.each(dataSourceChartTypes)(
+      "%s: updating a cell inside the data range invalidates the runtime",
+      (type) => {
+        const model = new Model();
+        setCellContent(model, "A1", "1");
+        const chartId = "chartId";
+        createChart(
+          model,
+          { type, ...toChartDataSource({ dataSets: [{ dataRange: "A1" }] }) },
+          chartId
+        );
+
+        model.getters.getChartRuntime(chartId);
+        const spy = spyOnGetRuntime();
+        setCellContent(model, "A1", "42");
+        model.getters.getChartRuntime(chartId);
+
+        expect(spy).toHaveBeenCalledTimes(1);
+      }
+    );
+
+    test.each(dataSourceChartTypes)(
+      "%s: updating a cell outside the data range does NOT invalidate the runtime",
+      (type) => {
+        const model = new Model();
+        setCellContent(model, "A1", "1");
+        const chartId = "chartId";
+        createChart(
+          model,
+          { type, ...toChartDataSource({ dataSets: [{ dataRange: "A1" }] }) },
+          chartId
+        );
+
+        model.getters.getChartRuntime(chartId);
+        const spy = spyOnGetRuntime();
+        setCellContent(model, "Z99", "irrelevant");
+        model.getters.getChartRuntime(chartId);
+
+        expect(spy).not.toHaveBeenCalled();
+      }
+    );
+
+    test("updating a cell inside the label range invalidates the runtime", () => {
+      const model = new Model();
+      setCellContent(model, "A1", "label");
+      setCellContent(model, "B1", "1");
+      const chartId = "chartId";
+      createChart(
+        model,
+        {
+          type: "bar",
+          ...toChartDataSource({ dataSets: [{ dataRange: "B1" }], labelRange: "A1" }),
+        },
+        chartId
+      );
+
+      model.getters.getChartRuntime(chartId);
+      const spy = spyOnGetRuntime();
+      setCellContent(model, "A1", "new label");
+      model.getters.getChartRuntime(chartId);
+
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("gauge chart", () => {
+    test("updating a cell inside the data range invalidates the runtime", () => {
+      const model = new Model();
+      setCellContent(model, "A1", "42");
+      const chartId = "chartId";
+      createGaugeChart(model, { dataRange: "A1" }, chartId);
+
+      model.getters.getChartRuntime(chartId);
+      const spy = spyOnGetRuntime();
+      setCellContent(model, "A1", "100");
+      model.getters.getChartRuntime(chartId);
+
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    test("updating a cell outside the data range does NOT invalidate the runtime", () => {
+      const model = new Model();
+      setCellContent(model, "A1", "42");
+      const chartId = "chartId";
+      createGaugeChart(model, { dataRange: "A1" }, chartId);
+
+      model.getters.getChartRuntime(chartId);
+      const spy = spyOnGetRuntime();
+      setCellContent(model, "Z99", "irrelevant");
+      model.getters.getChartRuntime(chartId);
+
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    test.each(["rangeMin", "rangeMax"])(
+      "updating a cell referenced in sectionRule.%s invalidates the runtime",
+      (key) => {
+        const model = new Model();
+        setCellContent(model, "B1", "0");
+        const chartId = "chartId";
+        createGaugeWithFormulaInSectionRule(model, { [key]: "=B1" }, chartId);
+        model.getters.getChartRuntime(chartId);
+        const spy = spyOnGetRuntime();
+        setCellContent(model, "B1", "50");
+        model.getters.getChartRuntime(chartId);
+
+        expect(spy).toHaveBeenCalledTimes(1);
+      }
+    );
+
+    test.each(["lowerInflectionPoint", "upperInflectionPoint"])(
+      "updating a cell referenced in sectionRule.%s.value invalidates the runtime",
+      (key) => {
+        const model = new Model();
+        setCellContent(model, "B1", "25");
+        const chartId = "chartId";
+        createGaugeWithFormulaInSectionRule(
+          model,
+          { [key]: { type: "number", value: "=B1", operator: "<=" } },
+          chartId
+        );
+
+        model.getters.getChartRuntime(chartId);
+        const spy = spyOnGetRuntime();
+        setCellContent(model, "B1", "40");
+        model.getters.getChartRuntime(chartId);
+
+        expect(spy).toHaveBeenCalledTimes(1);
+      }
+    );
+  });
+
+  describe("scorecard chart", () => {
+    test("updating a cell inside keyValue range invalidates the runtime", () => {
+      const model = new Model();
+      setCellContent(model, "A1", "42");
+      const chartId = "chartId";
+      createScorecardChart(model, { keyValue: "A1" }, chartId);
+
+      model.getters.getChartRuntime(chartId);
+      const spy = spyOnGetRuntime();
+      setCellContent(model, "A1", "100");
+      model.getters.getChartRuntime(chartId);
+
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    test("updating a cell inside baseline range invalidates the runtime", () => {
+      const model = new Model();
+      setCellContent(model, "A1", "42");
+      setCellContent(model, "B1", "10");
+      const chartId = "chartId";
+      createScorecardChart(model, { keyValue: "A1", baseline: "B1" }, chartId);
+
+      model.getters.getChartRuntime(chartId);
+      const spy = spyOnGetRuntime();
+      setCellContent(model, "B1", "20");
+      model.getters.getChartRuntime(chartId);
+
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    test("updating a cell outside scorecard ranges does NOT invalidate the runtime", () => {
+      const model = new Model();
+      setCellContent(model, "A1", "42");
+      setCellContent(model, "B1", "10");
+      const chartId = "chartId";
+      createScorecardChart(model, { keyValue: "A1", baseline: "B1" }, chartId);
+
+      model.getters.getChartRuntime(chartId);
+      const spy = spyOnGetRuntime();
+      setCellContent(model, "Z99", "irrelevant");
+      model.getters.getChartRuntime(chartId);
+
+      expect(spy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("bubble chart", () => {
+    test("updating a cell inside a yRange invalidates the runtime", () => {
+      const model = new Model();
+      setCellContent(model, "A1", "1");
+      const chartId = "chartId";
+      createBubbleChart(model, { yRanges: ["A1"] }, chartId);
+
+      model.getters.getChartRuntime(chartId);
+      const spy = spyOnGetRuntime();
+      setCellContent(model, "A1", "42");
+      model.getters.getChartRuntime(chartId);
+
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    test.each(["xRange", "labelRange", "sizeRange"])(
+      "updating a cell inside %s invalidates the runtime",
+      (key) => {
+        const model = new Model();
+        setCellContent(model, "A1", "1");
+        setCellContent(model, "B1", "2");
+        const chartId = "chartId";
+        createBubbleChart(model, { yRanges: ["A1"], [key]: "B1" }, chartId);
+
+        model.getters.getChartRuntime(chartId);
+        const spy = spyOnGetRuntime();
+        setCellContent(model, "B1", "99");
+        model.getters.getChartRuntime(chartId);
+
+        expect(spy).toHaveBeenCalledTimes(1);
+      }
+    );
+
+    test("updating a cell outside all bubble ranges does NOT invalidate the runtime", () => {
+      const model = new Model();
+      setCellContent(model, "A1", "1");
+      setCellContent(model, "B1", "2");
+      setCellContent(model, "C1", "label");
+      setCellContent(model, "D1", "5");
+      const chartId = "chartId";
+      createBubbleChart(
+        model,
+        { yRanges: ["A1"], xRange: "B1", labelRange: "C1", sizeRange: "D1" },
+        chartId
+      );
+
+      model.getters.getChartRuntime(chartId);
+      const spy = spyOnGetRuntime();
+      setCellContent(model, "Z99", "irrelevant");
+      model.getters.getChartRuntime(chartId);
+
+      expect(spy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("geo chart", () => {
+    test("updating a cell inside the data range invalidates the runtime", () => {
+      const model = new Model({}, { external: { geoJsonService: mockGeoJsonService } });
+      setCellContent(model, "A1", "France");
+      const chartId = "chartId";
+      createGeoChart(
+        model,
+        {
+          dataSource: {
+            type: "range",
+            dataSets: [{ dataRange: "A1", dataSetId: "0" }],
+            dataSetsHaveTitle: false,
+          },
+        },
+        chartId
+      );
+
+      model.getters.getChartRuntime(chartId);
+      const spy = spyOnGetRuntime();
+      setCellContent(model, "A1", "Germany");
+      model.getters.getChartRuntime(chartId);
+
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    test("updating a cell outside the data range does NOT invalidate the runtime", () => {
+      const model = new Model({}, { external: { geoJsonService: mockGeoJsonService } });
+      setCellContent(model, "A1", "France");
+      const chartId = "chartId";
+      createGeoChart(
+        model,
+        {
+          dataSource: {
+            type: "range",
+            dataSets: [{ dataRange: "A1", dataSetId: "0" }],
+            dataSetsHaveTitle: false,
+          },
+        },
+        chartId
+      );
+
+      model.getters.getChartRuntime(chartId);
+      const spy = spyOnGetRuntime();
+      setCellContent(model, "Z99", "irrelevant");
+      model.getters.getChartRuntime(chartId);
+
+      expect(spy).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Description

This task aims to avoid useless reevaluation of charts when a cell not related to the data of the chart is updated. Here, when a cell is updated (through UPDATE_CELL), we compute the list of the cells depending on this one, and then check for each chart if there is some updated cells in the dataranges of the chart.

## Related Task

- Task: [6226590](https://www.odoo.com/odoo/2328/tasks/6226590)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo