### PR TITLE
[FIX] LockedSheet: missing commands in the whitelist

### DIFF
--- a/src/plugins/ui_feature/lock_sheet.ts
+++ b/src/plugins/ui_feature/lock_sheet.ts
@@ -22,11 +22,6 @@ export class LockSheetPlugin extends UIPlugin {
       ("sheetId" in cmd && this.getters.isSheetLocked(cmd.sheetId)) ||
       (!isCoreCommand(cmd) && this.isCurrentSheetLocked())
     ) {
-      // this.ui.notifyUI({
-      //   type: "info",
-      //   text: _t("This sheet is locked and cannot be modified. Please unlock it first."),
-      //   sticky: false,
-      // });
       return CommandResult.SheetLocked;
     }
     return CommandResult.Success;

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -244,6 +244,11 @@ export const lockedSheetAllowedCommands = new Set<Command["type"]>([
   "UPDATE_CAROUSEL_ACTIVE_ITEM",
   "DUPLICATE_PIVOT_IN_NEW_SHEET",
   "UPDATE_FILTER",
+  "ACTIVATE_NEXT_SHEET",
+  "ACTIVATE_PREVIOUS_SHEET",
+  "SCROLL_TO_CELL",
+  "SHIFT_VIEWPORT_DOWN",
+  "SHIFT_VIEWPORT_UP",
 ]);
 
 export const coreTypes = new Set<CoreCommandTypes>([

--- a/tests/lock_sheet/lock_sheet_plugin.test.ts
+++ b/tests/lock_sheet/lock_sheet_plugin.test.ts
@@ -10,6 +10,7 @@ import {
 } from "../../src";
 import { createChart, createSheet, lockSheet } from "../test_helpers/commands_helpers";
 import { TEST_COMMANDS } from "../test_helpers/constants";
+import { toCellPosition } from "../test_helpers/helpers";
 import { addPivot } from "../test_helpers/pivot_helpers";
 
 const allowedCommands: Command["type"][] = [];
@@ -62,5 +63,28 @@ describe("Lock Sheet plugin", () => {
       const result = model.dispatch(cmdType, TEST_COMMANDS[cmdType]);
       expect(result).toBeSuccessfullyDispatched();
     }
+  });
+
+  test("sheet navigation commands are allowed on locked sheets", () => {
+    const model = new Model();
+    const firstSheetId = model.getters.getActiveSheetId();
+    const lockedSheetId = "locked";
+    createSheet(model, {
+      name: "Another sheet",
+      position: 0,
+      sheetId: lockedSheetId,
+      activate: true,
+    });
+    lockSheet(model);
+    expect(
+      model.dispatch("SCROLL_TO_CELL", toCellPosition(lockedSheetId, "Z100"))
+    ).toBeSuccessfullyDispatched();
+    expect(model.dispatch("SHIFT_VIEWPORT_UP")).toBeSuccessfullyDispatched();
+    expect(model.dispatch("SHIFT_VIEWPORT_DOWN")).toBeSuccessfullyDispatched();
+    model.dispatch("ACTIVATE_NEXT_SHEET");
+    expect(model.getters.getActiveSheetId()).toBe(firstSheetId);
+    lockSheet(model);
+    model.dispatch("ACTIVATE_PREVIOUS_SHEET");
+    expect(model.getters.getActiveSheetId()).toBe(lockedSheetId);
   });
 });


### PR DESCRIPTION
Some commands related to the "scrolling" inside a sheet and between sheets were not whitelisted and did not work on a locked sheet.

E.g. Use shift+pagedown to scroll between sheets, once you arrive on a locked sheet, you are stuck.

Task: 6240417

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo