### PR TITLE
[FIX] Shortcuts: fix Macos Alt shortcuts

### DIFF
--- a/src/components/helpers/dom_helpers.ts
+++ b/src/components/helpers/dom_helpers.ts
@@ -215,7 +215,7 @@ export function keyboardEventToShortcutString(
     if (isCtrlKey(ev)) {
       keyDownString += "Ctrl+";
     }
-    if (ev.altKey) {
+    if (isAltKey(ev)) {
       keyDownString += "Alt+";
     }
     if (ev.shiftKey) {
@@ -238,6 +238,10 @@ export function isMacOS(): boolean {
  */
 export function isCtrlKey(ev: KeyboardEvent | MouseEvent): boolean {
   return isMacOS() || isIOS() ? ev.metaKey : ev.ctrlKey;
+}
+
+function isAltKey(ev: KeyboardEvent | MouseEvent): boolean {
+  return isMacOS() || isIOS() ? ev.ctrlKey : ev.altKey;
 }
 
 /**

--- a/tests/spreadsheet/spreadsheet_component.test.ts
+++ b/tests/spreadsheet/spreadsheet_component.test.ts
@@ -23,6 +23,7 @@ import {
   lockSheet,
   selectCell,
   setCellContent,
+  setSelection,
 } from "../test_helpers/commands_helpers";
 import {
   click,
@@ -33,7 +34,7 @@ import {
   keyDown,
   simulateClick,
 } from "../test_helpers/dom_helper";
-import { getCellContent } from "../test_helpers/getters_helpers";
+import { getCellContent, getEvaluatedCell } from "../test_helpers/getters_helpers";
 import {
   addToRegistry,
   doAction,
@@ -196,6 +197,37 @@ describe("Simple Spreadsheet Component", () => {
     mockUserAgent.mockReset();
   });
 
+  test("Mac user use CtrlKey, not AltKey", async () => {
+    let model = new Model({ sheets: [{ id: "sh1" }] });
+    setCellContent(model, "A1", "2");
+    setCellContent(model, "A2", "3");
+    setSelection(model, ["A1:A2"]);
+    ({ model, parent, fixture } = await mountSpreadsheet({ model }));
+    const mockUserAgent = jest.spyOn(navigator, "userAgent", "get");
+    mockUserAgent.mockImplementation(
+      () => "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Firefox/119.0"
+    );
+    await keyDown({ key: "=", altKey: true, bubbles: true });
+    expect(getEvaluatedCell(model, "A3").value).toBeNull();
+    await nextTick();
+    await keyDown({ key: "=", ctrlKey: true, bubbles: true });
+    expect(getEvaluatedCell(model, "A3").value).toBe(5);
+    jest.restoreAllMocks();
+  });
+
+  test("Mac user have ⌃ in menu instead of Alt", async () => {
+    const mockUserAgent = jest.spyOn(navigator, "userAgent", "get");
+    mockUserAgent.mockImplementation(
+      () => "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Firefox/119.0"
+    );
+    ({ model, parent, fixture } = await mountSpreadsheet({
+      model: new Model({ sheets: [{ id: "sh1" }] }),
+    }));
+    await click(fixture, ".o-topbar-menu[data-id='insert']");
+    expect('[data-name="insert_table"]').toHaveText("Table⌃+T");
+    mockUserAgent.mockReset();
+  });
+
   test("Mac user have ⌘ in menu instead of Ctrl", async () => {
     const mockUserAgent = jest.spyOn(navigator, "userAgent", "get");
     mockUserAgent.mockImplementation(
@@ -205,6 +237,8 @@ describe("Simple Spreadsheet Component", () => {
       model: new Model({ sheets: [{ id: "sh1" }] }),
     }));
     await click(fixture, ".o-topbar-menu[data-id='format']");
+    expect('[data-name="format_bold"]').toHaveText("Bold⌘+B");
+    // topbar shortcut
     expect(document.querySelectorAll('span[title="Bold (⌘+B)"]').length).toBe(1);
     mockUserAgent.mockReset();
   });


### PR DESCRIPTION
keyboard shortcuts involving the "Alt" (names Options) key do not work properly in macos because the options key alters the output of other alphanumeric keys (e.g. Options + T outputs the character †, an the browser then detects a keyboard event for which the key is `†`.

this revision replaces the shortcut modifier from Alt to Ctrl for mac os and iOs.

Task: 6240362

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [6240362](https://www.odoo.com/odoo/2328/tasks/6240362)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo