### PR TITLE
[FIX] table: correctly insert table on static pivots

### DIFF
--- a/src/components/tables/table_dropdown_button/table_dropdown_button.ts
+++ b/src/components/tables/table_dropdown_button/table_dropdown_button.ts
@@ -2,7 +2,7 @@ import { Component, useState } from "@odoo/owl";
 import { ActionSpec } from "../../../actions/action";
 import { DEFAULT_TABLE_CONFIG } from "../../../helpers/table_presets";
 import { interactiveCreateTable } from "../../../helpers/ui/table_interactive";
-import { positions } from "../../../helpers/zones";
+import { cellPositions } from "../../../helpers/zones";
 import { _t } from "../../../translation";
 import { UID } from "../../../types";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
@@ -52,7 +52,7 @@ export class TableDropdownButton extends Component<Props, SpreadsheetChildEnv> {
       this.closePopover();
       return;
     }
-    const pivotId = this.pivotIdInSelection;
+    const pivotId = this.dynamicPivotIdInSelection;
     if (pivotId) {
       this.env.openSidePanel("PivotSidePanel", { pivotId, openTab: "design" });
       return;
@@ -78,7 +78,7 @@ export class TableDropdownButton extends Component<Props, SpreadsheetChildEnv> {
   }
 
   get action(): ActionSpec {
-    const pivotId = this.pivotIdInSelection;
+    const pivotId = this.dynamicPivotIdInSelection;
     if (pivotId) {
       return {
         name: _t("Edit pivot style"),
@@ -104,17 +104,30 @@ export class TableDropdownButton extends Component<Props, SpreadsheetChildEnv> {
     return this.env.model.getters.getTableStyles();
   }
 
-  get pivotIdInSelection(): UID | undefined {
+  get dynamicPivotIdInSelection(): UID | undefined {
     const selection = this.env.model.getters.getSelectedZones();
+    const pivotCellIds = new Set(this.env.model.getters.getCellsWithTrackedFormula("PIVOT"));
+    if (pivotCellIds.size === 0) {
+      return undefined;
+    }
+
+    const activeSheetId = this.env.model.getters.getActiveSheetId();
     for (const zone of selection) {
-      for (const position of positions(zone)) {
-        const sheetId = this.env.model.getters.getActiveSheetId();
-        const pivotId = this.env.model.getters.getPivotIdFromPosition({ sheetId, ...position });
-        if (pivotId) {
-          return pivotId;
+      for (const position of cellPositions(activeSheetId, zone)) {
+        const mainPosition = this.env.model.getters.getArrayFormulaSpreadingOn(position);
+        if (!mainPosition) {
+          continue;
+        }
+        const cellId = this.env.model.getters.getCell(mainPosition)?.id;
+        if (cellId && pivotCellIds.has(cellId)) {
+          const pivotId = this.env.model.getters.getPivotIdFromPosition(mainPosition);
+          if (pivotId) {
+            return pivotId;
+          }
         }
       }
     }
+
     return undefined;
   }
 

--- a/tests/table/table_dropdown_button_component.test.ts
+++ b/tests/table/table_dropdown_button_component.test.ts
@@ -80,7 +80,7 @@ describe("Table dropdown button", () => {
     );
   });
 
-  test("Clicking on the widget open the pivot side panel if there is a pivot in the selection", async () => {
+  test("Clicking on the widget open the pivot side panel if there is a dynamic pivot in the selection", async () => {
     setGrid(model, { A1: "Price", A2: "10", A3: "=PIVOT(1)" });
     addPivot(model, "A1:A2", {});
     setSelection(model, ["A3"]);
@@ -88,8 +88,23 @@ describe("Table dropdown button", () => {
 
     expect(".o-table-widget .o-menu-item-button").toHaveAttribute("title", "Edit pivot style");
 
+    setSelection(model, ["A5"]); // Spread result
+    await nextTick();
+    expect(".o-table-widget .o-menu-item-button").toHaveAttribute("title", "Edit pivot style");
+
     await click(fixture, ".o-table-widget .o-menu-item-button");
     expect(".o-pivot-panel").toHaveCount(1);
     expect(".o-sidePanel-tab.o-panel-design").not.toHaveClass("inactive");
+  });
+
+  test("Clicking on the widget create a new table if there is a static pivot in the selection", async () => {
+    setGrid(model, { A1: "Price", A2: "10", A3: "=PIVOT.HEADER(1)" });
+    addPivot(model, "A1:A2", {});
+    setSelection(model, ["A3"]);
+    await nextTick();
+
+    expect(".o-table-widget .o-menu-item-button").toHaveAttribute("title", "Insert table");
+    await click(fixture, ".o-table-widget .o-menu-item-button");
+    expect(".o-table-style-popover").toHaveCount(1);
   });
 });


### PR DESCRIPTION
## Description

On a dynamic pivot, the topbar button to create/edit a table opens the pivot design side panel.

But on static pivot formulas, it should create/edit a normal table, as static pivots formulas are not affected by pivot table style.

Task: [6204984](https://www.odoo.com/odoo/2328/tasks/6204984)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo