### PR TITLE
[REF] components: use owl3 props function

### DIFF
--- a/src/components/action_button/action_button.ts
+++ b/src/components/action_button/action_button.ts
@@ -1,31 +1,26 @@
-import { onWillUpdateProps } from "@odoo/owl";
-import { ActionSpec, createAction } from "../../actions/action";
+import { onWillUpdateProps, props } from "@odoo/owl";
+import { createAction } from "../../actions/action";
 import { Component } from "../../owl3_compatibility_layer";
+import { PropsOf } from "../../types/props_of";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 import { cssPropertiesToCss } from "../helpers/css";
+import { types } from "../props_validation";
 
-interface Props {
-  action: ActionSpec;
-  hasTriangleDownIcon?: boolean;
-  selectedColor?: string;
-  class?: string;
-  onClick?: (ev: MouseEvent) => void;
-}
-
-export class ActionButton extends Component<Props, SpreadsheetChildEnv> {
+export class ActionButton extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ActionButton";
-  static props = {
-    action: Object,
-    hasTriangleDownIcon: { type: Boolean, optional: true },
-    selectedColor: { type: String, optional: true },
-    class: { type: String, optional: true },
-    onClick: { type: Function, optional: true },
-  };
+
+  protected props = props({
+    action: types.ActionSpec(),
+    "hasTriangleDownIcon?": types.boolean(),
+    "selectedColor?": types.string(),
+    "class?": types.string(),
+    "onClick?": types.function(),
+  });
 
   private actionButton = createAction(this.props.action);
 
   setup() {
-    onWillUpdateProps((nextProps: Props) => {
+    onWillUpdateProps((nextProps: PropsOf<ActionButton>) => {
       if (nextProps.action !== this.props.action) {
         this.actionButton = createAction(nextProps.action);
       }

--- a/src/components/animation/ripple.ts
+++ b/src/components/animation/ripple.ts
@@ -1,5 +1,6 @@
-import { onMounted, onWillUnmount, proxy, signal } from "@odoo/owl";
+import { onMounted, onWillUnmount, props, proxy, signal, types } from "@odoo/owl";
 import { Component } from "../../owl3_compatibility_layer";
+import { PropsOf } from "../../types/props_of";
 import { Rect } from "../../types/rendering";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 import { cssPropertiesToCss, getElementMargins } from "../helpers/css";
@@ -10,35 +11,6 @@ const RIPPLE_KEY_FRAMES = [
   { transform: "scale(0.8)", offset: 0.33 },
   { opacity: "0", transform: "scale(1)", offset: 1 },
 ];
-
-interface RippleProps {
-  color: string;
-  opacity: number;
-  duration: number;
-
-  /** If true, the ripple will play from the element center instead of the position of the click */
-  ignoreClickPosition?: boolean;
-
-  /** Width of the ripple. Defaults to the width of the element the ripple is on (without margins). */
-  width?: number;
-  /** Height of the ripple. Defaults to the height of the element the ripple is on (without margins). */
-  height?: number;
-
-  offsetY?: number;
-  offsetX?: number;
-
-  allowOverflow?: boolean;
-  enabled: boolean;
-  onAnimationEnd: () => void;
-  class?: string;
-}
-
-interface RippleEffectProps
-  extends Omit<Required<RippleProps>, "ignoreClickPosition" | "enabled" | "class"> {
-  x: string;
-  y: string;
-  style: string;
-}
 
 interface RippleDef {
   rippleRect: Rect | undefined;
@@ -54,22 +26,25 @@ interface RectWithMargins extends Rect {
   marginLeft: number;
 }
 
-class RippleEffect extends Component<RippleEffectProps, SpreadsheetChildEnv> {
+class RippleEffect extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-RippleEffect";
-  static props = {
-    x: String,
-    y: String,
-    color: String,
-    opacity: Number,
-    duration: Number,
-    width: Number,
-    height: Number,
-    offsetY: Number,
-    offsetX: Number,
-    allowOverflow: Boolean,
-    onAnimationEnd: Function,
-    style: String,
-  };
+
+  protected props = props({
+    x: types.string(),
+    y: types.string(),
+    color: types.string(),
+    opacity: types.number(),
+    duration: types.number(),
+    /** Width of the ripple. Defaults to the width of the element the ripple is on (without margins). */
+    width: types.number(),
+    /** Height of the ripple. Defaults to the height of the element the ripple is on (without margins). */
+    height: types.number(),
+    offsetY: types.number(),
+    offsetX: types.number(),
+    allowOverflow: types.boolean(),
+    onAnimationEnd: types.function(),
+    style: types.string(),
+  });
 
   private rippleRef = signal<HTMLElement | null>(null);
 
@@ -110,32 +85,38 @@ class RippleEffect extends Component<RippleEffectProps, SpreadsheetChildEnv> {
   }
 }
 
-export class Ripple extends Component<RippleProps, SpreadsheetChildEnv> {
+export class Ripple extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-Ripple";
-  static props = {
-    color: { type: String, optional: true },
-    opacity: { type: Number, optional: true },
-    duration: { type: Number, optional: true },
-    ignoreClickPosition: { type: Boolean, optional: true },
-    width: { type: Number, optional: true },
-    height: { type: Number, optional: true },
-    offsetY: { type: Number, optional: true },
-    offsetX: { type: Number, optional: true },
-    allowOverflow: { type: Boolean, optional: true },
-    enabled: { type: Boolean, optional: true },
-    onAnimationEnd: { type: Function, optional: true },
-    slots: Object,
-    class: { type: String, optional: true },
-  };
   static components = { RippleEffect };
-  static defaultProps = {
-    color: "#aaaaaa",
-    opacity: 0.4,
-    duration: 800,
-    enabled: true,
-    onAnimationEnd: () => {},
-    class: "",
-  };
+
+  protected props = props(
+    {
+      "color?": types.string(),
+      "opacity?": types.number(),
+      "duration?": types.number(),
+
+      /** If true, the ripple will play from the element center instead of the position of the click */
+      "ignoreClickPosition?": types.boolean(),
+      /** Width of the ripple. Defaults to the width of the element the ripple is on (without margins). */
+      "width?": types.number(),
+      /** Height of the ripple. Defaults to the height of the element the ripple is on (without margins). */
+      "height?": types.number(),
+      "offsetY?": types.number(),
+      "offsetX?": types.number(),
+      "allowOverflow?": types.boolean(),
+      "enabled?": types.boolean(),
+      "onAnimationEnd?": types.function(),
+      "class?": types.string(),
+    },
+    {
+      color: "#aaaaaa",
+      opacity: 0.4,
+      duration: 800,
+      enabled: true,
+      onAnimationEnd: () => {},
+      class: "",
+    }
+  );
 
   private childContainerRef = signal<HTMLElement | null>(null);
 
@@ -211,7 +192,7 @@ export class Ripple extends Component<RippleProps, SpreadsheetChildEnv> {
     this.state.ripples.splice(index, 1);
   }
 
-  getRippleEffectProps(id: number): RippleEffectProps {
+  getRippleEffectProps(id: number): PropsOf<RippleEffect> {
     const rect = this.state.ripples.find((r) => r.id === id)?.rippleRect;
     if (!rect) {
       throw new Error("Cannot find a ripple with the id " + id);

--- a/src/components/autofill/autofill.ts
+++ b/src/components/autofill/autofill.ts
@@ -1,4 +1,4 @@
-import { proxy, xml } from "@odoo/owl";
+import { props, proxy, xml } from "@odoo/owl";
 import { clip } from "../../helpers/misc";
 import { Component } from "../../owl3_compatibility_layer";
 import { HeaderIndex } from "../../types/misc";
@@ -7,27 +7,24 @@ import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 import { cssPropertiesToCss } from "../helpers/css";
 import { useDragAndDropBeyondTheViewport } from "../helpers/drag_and_drop_grid_hook";
 import { withZoom } from "../helpers/zoom";
+import { types } from "../props_validation";
 
 // -----------------------------------------------------------------------------
 // Autofill
 // -----------------------------------------------------------------------------
-
-interface Props {
-  isVisible: boolean;
-  position: DOMCoordinates;
-}
 
 interface State {
   position: DOMCoordinates;
   handler: boolean;
 }
 
-export class Autofill extends Component<Props, SpreadsheetChildEnv> {
+export class Autofill extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-Autofill";
-  static props = {
-    position: Object,
-    isVisible: Boolean,
-  };
+
+  protected props = props({
+    position: types.DOMCoordinates(),
+    isVisible: types.boolean(),
+  });
   state: State = proxy({
     position: { x: 0, y: 0 },
     handler: false,
@@ -107,10 +104,10 @@ export class Autofill extends Component<Props, SpreadsheetChildEnv> {
   }
 }
 
-class TooltipComponent extends Component<Props> {
-  static props = {
-    content: String,
-  };
+class TooltipComponent extends Component<any> {
+  protected props: { content: string } = props({
+    content: types.string(),
+  });
   static template = xml/* xml */ `
     <div t-out="this.props.content"/>
   `;

--- a/src/components/border_editor/border_editor.ts
+++ b/src/components/border_editor/border_editor.ts
@@ -1,10 +1,12 @@
-import { proxy, signal } from "@odoo/owl";
+import { props, proxy, signal } from "@odoo/owl";
 import { Component } from "../../owl3_compatibility_layer";
-import { BorderPosition, BorderStyle, Color, Pixel, borderStyles } from "../../types/misc";
+import { BorderPosition, BorderStyle, Color, borderStyles } from "../../types/misc";
+import { PropsOf } from "../../types/props_of";
 import { Rect } from "../../types/rendering";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 import { ColorPickerWidget } from "../color_picker/color_picker_widget";
-import { Popover, PopoverProps } from "../popover/popover";
+import { Popover } from "../popover/popover";
+import { types } from "../props_validation";
 
 type Tool = "borderColorTool" | "borderTypeTool";
 
@@ -34,36 +36,21 @@ const BORDER_POSITIONS: [BorderPosition, string][][] = [
   ],
 ];
 
-export interface BorderEditorProps {
-  class?: string;
-  currentBorderColor: Color;
-  currentBorderStyle: BorderStyle;
-  currentBorderPosition: BorderPosition | undefined;
-  onBorderColorPicked: (color: Color) => void;
-  onBorderStylePicked: (style: BorderStyle) => void;
-  onBorderPositionPicked: (position: BorderPosition) => void;
-  maxHeight?: Pixel;
-  anchorRect: Rect;
-}
-
-// -----------------------------------------------------------------------------
-// Border Editor
-// -----------------------------------------------------------------------------
-
-export class BorderEditor extends Component<BorderEditorProps, SpreadsheetChildEnv> {
+export class BorderEditor extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-BorderEditor";
-  static props = {
-    class: { type: String, optional: true },
-    currentBorderColor: { type: String, optional: false },
-    currentBorderStyle: { type: String, optional: false },
-    currentBorderPosition: { type: String, optional: true },
-    onBorderColorPicked: Function,
-    onBorderStylePicked: Function,
-    onBorderPositionPicked: Function,
-    maxHeight: { type: Number, optional: true },
-    anchorRect: Object,
-  };
   static components = { ColorPickerWidget, Popover };
+
+  protected props = props({
+    "class?": types.string(),
+    currentBorderColor: types.Color(),
+    currentBorderStyle: types.BorderStyle(),
+    "currentBorderPosition?": types.BorderPosition(),
+    onBorderColorPicked: types.function<[color: Color]>([types.Color()]),
+    onBorderStylePicked: types.function<[style: BorderStyle]>([types.BorderStyle()]),
+    onBorderPositionPicked: types.function<[position: BorderPosition]>([types.BorderPosition()]),
+    "maxHeight?": types.Pixel(),
+    anchorRect: types.Rect(),
+  });
   BORDER_POSITIONS = BORDER_POSITIONS;
 
   lineStyleButtonRef = signal<HTMLElement | null>(null);
@@ -96,7 +83,7 @@ export class BorderEditor extends Component<BorderEditorProps, SpreadsheetChildE
     this.closeDropdown();
   }
 
-  get lineStylePickerPopoverProps(): PopoverProps {
+  get lineStylePickerPopoverProps(): PropsOf<Popover> {
     return {
       anchorRect: this.lineStylePickerAnchorRect,
       positioning: "bottom-left",
@@ -104,7 +91,7 @@ export class BorderEditor extends Component<BorderEditorProps, SpreadsheetChildE
     };
   }
 
-  get popoverProps(): PopoverProps {
+  get popoverProps(): PropsOf<Popover> {
     return {
       anchorRect: this.props.anchorRect,
       maxHeight: this.props.maxHeight,

--- a/src/components/border_editor/border_editor_widget.ts
+++ b/src/components/border_editor/border_editor_widget.ts
@@ -1,4 +1,4 @@
-import { onWillUpdateProps, proxy, signal } from "@odoo/owl";
+import { onWillUpdateProps, props, proxy, signal } from "@odoo/owl";
 import { DEFAULT_BORDER_DESC } from "../../constants";
 import { Component } from "../../owl3_compatibility_layer";
 import { BorderPosition, BorderStyle, Color, Pixel } from "../../types/misc";
@@ -6,13 +6,8 @@ import { Rect } from "../../types/rendering";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 import { getElBoundingRect } from "../helpers/dom_helpers";
 import { ToolBarDropdownStore, useToolBarDropdownStore } from "../helpers/top_bar_tool_hook";
+import { types } from "../props_validation";
 import { BorderEditor } from "./border_editor";
-
-interface Props {
-  disabled?: boolean;
-  dropdownMaxHeight?: Pixel;
-  class?: string;
-}
 
 interface State {
   currentColor: Color;
@@ -20,14 +15,15 @@ interface State {
   currentPosition: BorderPosition | undefined;
 }
 
-export class BorderEditorWidget extends Component<Props, SpreadsheetChildEnv> {
+export class BorderEditorWidget extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-BorderEditorWidget";
-  static props = {
-    disabled: { type: Boolean, optional: true },
-    dropdownMaxHeight: { type: Number, optional: true },
-    class: { type: String, optional: true },
-  };
   static components = { BorderEditor };
+
+  protected props = props({
+    "disabled?": types.boolean(),
+    "dropdownMaxHeight?": types.Pixel(),
+    "class?": types.string(),
+  });
   topBarToolStore!: ToolBarDropdownStore;
 
   borderEditorButtonRef = signal<HTMLElement | null>(null);

--- a/src/components/bottom_bar/bottom_bar.ts
+++ b/src/components/bottom_bar/bottom_bar.ts
@@ -1,4 +1,4 @@
-import { onWillUpdateProps, proxy, signal } from "@odoo/owl";
+import { onWillUpdateProps, props, proxy, signal, types } from "@odoo/owl";
 import { deepEquals } from "../../helpers/misc";
 import { UuidGenerator } from "../../helpers/uuid";
 import { Component } from "../../owl3_compatibility_layer";
@@ -24,17 +24,14 @@ interface BottomBarSheetItem {
   name: string;
 }
 
-interface Props {
-  onClick: () => void;
-}
-
 interface BottomBarMenuState extends MenuState {
   menuId: UID | undefined;
 }
 
-export class BottomBar extends Component<Props, SpreadsheetChildEnv> {
+export class BottomBar extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-BottomBar";
-  static props = { onClick: Function };
+
+  protected props = props({ onClick: types.function([]) });
 
   static components = { MenuPopover, Ripple, BottomBarSheet, BottomBarStatistic };
 

--- a/src/components/bottom_bar/bottom_bar_sheet/bottom_bar_sheet.ts
+++ b/src/components/bottom_bar/bottom_bar_sheet/bottom_bar_sheet.ts
@@ -1,4 +1,4 @@
-import { onMounted, onPatched, onWillUnmount, proxy, signal } from "@odoo/owl";
+import { onMounted, onPatched, onWillUnmount, props, proxy, signal, types } from "@odoo/owl";
 import { throttle } from "../../../helpers/misc";
 import { interactiveRenameSheet } from "../../../helpers/ui/sheet_interactive";
 import { Component, useExternalListener, useLayoutEffect } from "../../../owl3_compatibility_layer";
@@ -15,13 +15,6 @@ import { Ripple } from "../../animation/ripple";
 import { ColorPicker } from "../../color_picker/color_picker";
 import { cssPropertiesToCss } from "../../helpers/css";
 import { getElBoundingRect } from "../../helpers/dom_helpers";
-
-interface Props {
-  sheetId: string;
-  openContextMenu: (registry: MenuItemRegistry, ev: MouseEvent) => void;
-  style?: string;
-  onMouseDown: (ev: PointerEvent) => void;
-}
 
 interface State {
   isEditing: boolean;
@@ -42,19 +35,24 @@ const getSheetLockAnimation = (
   ];
 };
 
-export class BottomBarSheet extends Component<Props, SpreadsheetChildEnv> {
+export class BottomBarSheet extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-BottomBarSheet";
-  static props = {
-    sheetId: String,
-    openContextMenu: Function,
-    style: { type: String, optional: true },
-    onMouseDown: { type: Function, optional: true },
-  };
   static components = { Ripple, ColorPicker };
-  static defaultProps = {
-    onMouseDown: () => {},
-    style: "",
-  };
+  protected props = props(
+    {
+      sheetId: types.string(),
+      openContextMenu: types.function<[registry: MenuItemRegistry, ev: MouseEvent]>([
+        types.instanceOf(MenuItemRegistry),
+        types.instanceOf(MouseEvent),
+      ]),
+      "style?": types.string(),
+      "onMouseDown?": types.function<[ev: PointerEvent]>([types.instanceOf(PointerEvent)]),
+    },
+    {
+      onMouseDown: () => {},
+      style: "",
+    }
+  );
 
   private state = proxy<State>({ isEditing: false, pickerOpened: false });
 

--- a/src/components/bottom_bar/bottom_bar_statistic/bottom_bar_statistic.ts
+++ b/src/components/bottom_bar/bottom_bar_statistic/bottom_bar_statistic.ts
@@ -1,4 +1,4 @@
-import { onWillUpdateProps, proxy } from "@odoo/owl";
+import { onWillUpdateProps, props, proxy, types } from "@odoo/owl";
 import { formatValue } from "../../../helpers/format/format";
 import { Component } from "../../../owl3_compatibility_layer";
 import { MenuItemRegistry } from "../../../registries/menu_items_registry";
@@ -12,18 +12,18 @@ import { AggregateStatisticsStore } from "./aggregate_statistics_store";
 // SpreadSheet
 // -----------------------------------------------------------------------------
 
-interface Props {
-  openContextMenu: (x: number, y: number, registry: MenuItemRegistry) => void;
-  closeContextMenu: () => void;
-}
-
-export class BottomBarStatistic extends Component<Props, SpreadsheetChildEnv> {
+export class BottomBarStatistic extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-BottomBarStatistic";
-  static props = {
-    openContextMenu: Function,
-    closeContextMenu: Function,
-  };
   static components = { Ripple };
+
+  protected props = props({
+    openContextMenu: types.function<[x: number, y: number, registry: MenuItemRegistry]>([
+      types.number(),
+      types.number(),
+      types.instanceOf(MenuItemRegistry),
+    ]),
+    closeContextMenu: types.function([]),
+  });
 
   private state = proxy({ selectedStatisticFn: "" });
   private store!: Store<AggregateStatisticsStore>;

--- a/src/components/collaborative_client_tag/collaborative_client_tag.ts
+++ b/src/components/collaborative_client_tag/collaborative_client_tag.ts
@@ -1,25 +1,20 @@
-import { Color, HeaderIndex } from "../../types/misc";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 import { cssPropertiesToCss } from "../helpers/css";
 
+import { props } from "@odoo/owl";
 import { Component } from "../../owl3_compatibility_layer";
-interface ClientTagProps {
-  active: boolean;
-  name: string;
-  color: Color;
-  col: HeaderIndex;
-  row: HeaderIndex;
-}
+import { types } from "../props_validation";
 
-export class ClientTag extends Component<ClientTagProps, SpreadsheetChildEnv> {
+export class ClientTag extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ClientTag";
-  static props = {
-    active: Boolean,
-    name: String,
-    color: String,
-    col: Number,
-    row: Number,
-  };
+
+  protected props = props({
+    active: types.boolean(),
+    name: types.string(),
+    color: types.Color(),
+    col: types.HeaderIndex(),
+    row: types.HeaderIndex(),
+  });
   get tagStyle(): string {
     const { col, row, color } = this.props;
     const { height } = this.env.model.getters.getSheetViewDimensionWithHeaders();

--- a/src/components/color_picker/color_picker.ts
+++ b/src/components/color_picker/color_picker.ts
@@ -1,4 +1,4 @@
-import { proxy } from "@odoo/owl";
+import { props, proxy } from "@odoo/owl";
 import { COLOR_PICKER_DEFAULTS, ICON_EDGE_LENGTH } from "../../constants";
 import {
   hexToHSLA,
@@ -12,11 +12,12 @@ import { chartFontColor } from "../../helpers/figures/charts/chart_common";
 import { clip } from "../../helpers/misc";
 import { Component } from "../../owl3_compatibility_layer";
 import { Color, HSLA, Pixel, PixelPosition } from "../../types/misc";
-import { Rect } from "../../types/rendering";
+import { PropsOf } from "../../types/props_of";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 import { cssPropertiesToCss } from "../helpers/css";
 import { startDnd } from "../helpers/drag_and_drop";
-import { Popover, PopoverProps } from "../popover/popover";
+import { Popover } from "../popover/popover";
+import { types } from "../props_validation";
 
 const ITEM_BORDER_WIDTH = 1;
 const ITEM_EDGE_LENGTH = 18;
@@ -30,31 +31,26 @@ const CONTENT_WIDTH =
 const INNER_GRADIENT_WIDTH = CONTENT_WIDTH - 2 * ITEM_BORDER_WIDTH;
 const INNER_GRADIENT_HEIGHT = CONTENT_WIDTH - 30 - 2 * ITEM_BORDER_WIDTH;
 
-export interface ColorPickerProps {
-  anchorRect: Rect;
-  maxHeight?: Pixel;
-  onColorPicked: (color: Color) => void;
-  currentColor: Color;
-  disableNoColor?: boolean;
-}
-
 interface State {
   showGradient: boolean;
   currentHslaColor: HSLA;
   customHexColor: Color;
 }
 
-export class ColorPicker extends Component<ColorPickerProps, SpreadsheetChildEnv> {
+export class ColorPicker extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ColorPicker";
-  static props = {
-    onColorPicked: Function,
-    currentColor: { type: String, optional: true },
-    maxHeight: { type: Number, optional: true },
-    anchorRect: Object,
-    disableNoColor: { type: Boolean, optional: true },
-  };
-  static defaultProps = { currentColor: "" };
   static components = { Popover };
+
+  protected props = props(
+    {
+      onColorPicked: types.function<[color: string]>([types.string()]),
+      "currentColor?": types.string(),
+      "maxHeight?": types.Pixel(),
+      anchorRect: types.Rect(),
+      "disableNoColor?": types.boolean(),
+    },
+    { currentColor: "" }
+  );
 
   COLORS = COLOR_PICKER_DEFAULTS;
 
@@ -73,7 +69,7 @@ export class ColorPicker extends Component<ColorPickerProps, SpreadsheetChildEnv
     return "";
   }
 
-  get popoverProps(): PopoverProps {
+  get popoverProps(): PropsOf<Popover> {
     return {
       anchorRect: this.props.anchorRect,
       maxHeight: this.props.maxHeight,

--- a/src/components/color_picker/color_picker_widget.ts
+++ b/src/components/color_picker/color_picker_widget.ts
@@ -1,37 +1,26 @@
-import { signal } from "@odoo/owl";
+import { props, signal } from "@odoo/owl";
 import { Component } from "../../owl3_compatibility_layer";
-import { Pixel } from "../../types/misc";
 import { Rect } from "../../types/rendering";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 import { getElBoundingRect } from "../helpers/dom_helpers";
+import { types } from "../props_validation";
 import { ColorPicker } from "./color_picker";
 
-interface Props {
-  currentColor: string | undefined;
-  toggleColorPicker: () => void;
-  showColorPicker: boolean;
-  onColorPicked: (color: string) => void;
-  icon: string;
-  title?: string;
-  disabled?: boolean;
-  dropdownMaxHeight?: Pixel;
-  class?: string;
-}
-
-export class ColorPickerWidget extends Component<Props, SpreadsheetChildEnv> {
+export class ColorPickerWidget extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ColorPickerWidget";
-  static props = {
-    currentColor: { type: String, optional: true },
-    toggleColorPicker: Function,
-    showColorPicker: Boolean,
-    onColorPicked: Function,
-    icon: String,
-    title: { type: String, optional: true },
-    disabled: { type: Boolean, optional: true },
-    dropdownMaxHeight: { type: Number, optional: true },
-    class: { type: String, optional: true },
-  };
   static components = { ColorPicker };
+
+  protected props = props({
+    "currentColor?": types.string(),
+    toggleColorPicker: types.function([]),
+    showColorPicker: types.boolean(),
+    onColorPicked: types.function<[color: string]>([types.string()]),
+    icon: types.string(),
+    "title?": types.string(),
+    "disabled?": types.boolean(),
+    "dropdownMaxHeight?": types.Pixel(),
+    "class?": types.string(),
+  });
 
   colorPickerButtonRef = signal<HTMLElement | null>(null);
 

--- a/src/components/composer/autocomplete_dropdown/autocomplete_dropdown.ts
+++ b/src/components/composer/autocomplete_dropdown/autocomplete_dropdown.ts
@@ -1,24 +1,21 @@
-import { signal, useEffect } from "@odoo/owl";
+import { props, signal, useEffect } from "@odoo/owl";
 import { Component } from "../../../owl3_compatibility_layer";
 import { AutoCompleteProposal } from "../../../registries/auto_completes/auto_complete_registry";
 import { cssPropertiesToCss } from "../../helpers/css";
+import { types } from "../../props_validation";
 import { HtmlContent } from "../composer/composer";
 
-interface Props {
-  proposals: AutoCompleteProposal[];
-  selectedIndex: number | undefined;
-  onValueSelected: (proposal: AutoCompleteProposal) => void;
-  onValueHovered: (index: string) => void;
-}
-
-export class TextValueProvider extends Component<Props> {
+export class TextValueProvider extends Component<any> {
   static template = "o-spreadsheet-TextValueProvider";
-  static props = {
-    proposals: Array,
-    selectedIndex: { type: Number, optional: true },
-    onValueSelected: Function,
-    onValueHovered: Function,
-  };
+
+  protected props = props({
+    proposals: types.array(types.AutoCompleteProposal()),
+    "selectedIndex?": types.number(),
+    onValueSelected: types.function<[proposal: AutoCompleteProposal]>([
+      types.AutoCompleteProposal(),
+    ]),
+    onValueHovered: types.function<[index: string]>([types.string()]),
+  });
   autoCompleteListRef = signal<HTMLElement | null>(null);
 
   setup() {

--- a/src/components/composer/composer/composer.ts
+++ b/src/components/composer/composer/composer.ts
@@ -1,4 +1,4 @@
-import { onMounted, onWillUnmount, proxy, signal } from "@odoo/owl";
+import { onMounted, onWillUnmount, props, proxy, signal } from "@odoo/owl";
 import { NEWLINE, SCROLLBAR_WIDTH } from "../../../constants";
 import { setColorAlpha } from "../../../helpers/color";
 import { debounce, deepEquals, isFormula } from "../../../helpers/misc";
@@ -12,14 +12,15 @@ import { AutoCompleteProposal } from "../../../registries/auto_completes/auto_co
 import { useStore } from "../../../store_engine/store_hooks";
 import { DOMFocusableElementStore } from "../../../stores/DOM_focus_store";
 import { FunctionDescription } from "../../../types/functions";
-import { CSSProperties, Color, ComposerFocusType, Direction } from "../../../types/misc";
-import { DOMDimension, Rect } from "../../../types/rendering";
+import { CSSProperties, Color, Direction } from "../../../types/misc";
+import { Rect } from "../../../types/rendering";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
 import { Store } from "../../../types/store_engine";
 import { cssPropertiesToCss } from "../../helpers/css";
 import { isIOS, keyboardEventToShortcutString } from "../../helpers/dom_helpers";
 import { useSpreadsheetRect } from "../../helpers/position_hook";
 import { updateSelectionWithArrowKeys } from "../../helpers/selection_helpers";
+import { types } from "../../props_validation";
 import { TextValueProvider } from "../autocomplete_dropdown/autocomplete_dropdown";
 import { ContentEditableHelper } from "../content_editable_helper";
 import { FunctionDescriptionProvider } from "../formula_assistant/formula_assistant";
@@ -44,21 +45,6 @@ export type HtmlContent = {
   classes?: string[];
 };
 
-export interface CellComposerProps {
-  focus: ComposerFocusType;
-  inputStyle?: string;
-  rect?: Rect;
-  delimitation?: DOMDimension;
-  onComposerContentFocused: (selection: ComposerSelection) => void;
-  onComposerCellFocused?: (content: string) => void;
-  onInputContextMenu?: (event: MouseEvent) => void;
-  isDefaultFocus?: boolean;
-  composerStore: Store<AbstractComposerStore>;
-  placeholder?: string;
-  inputMode?: ElementContentEditable["inputMode"];
-  showAssistant?: boolean;
-}
-
 interface ComposerState {
   positionStart: number;
   positionEnd: number;
@@ -72,31 +58,34 @@ interface FunctionDescriptionState {
   repeatingArgGroupIndex: number | undefined;
 }
 
-export class Composer extends Component<CellComposerProps, SpreadsheetChildEnv> {
+export class Composer extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-Composer";
-  static props = {
-    focus: {
-      validate: (value: string) => ["inactive", "cellFocus", "contentFocus"].includes(value),
-    },
-    inputStyle: { type: String, optional: true },
-    rect: { type: Object, optional: true },
-    delimitation: { type: Object, optional: true },
-    onComposerCellFocused: { type: Function, optional: true },
-    onComposerContentFocused: Function,
-    isDefaultFocus: { type: Boolean, optional: true },
-    onInputContextMenu: { type: Function, optional: true },
-    composerStore: Object,
-    placeholder: { type: String, optional: true },
-    inputMode: { type: String, optional: true },
-    showAssistant: { type: Boolean, optional: true },
-  };
   static components = { TextValueProvider, FunctionDescriptionProvider, SpeechBubble };
-  static defaultProps = {
-    inputStyle: "",
-    isDefaultFocus: false,
-    inputMode: "text",
-    showAssistant: true,
-  };
+
+  protected props = props(
+    {
+      focus: types.ComposerFocusType(),
+      "inputStyle?": types.string(),
+      "rect?": types.Rect(),
+      "delimitation?": types.DOMDimension(),
+      "onComposerCellFocused?": types.function<[content: string]>([types.string()]),
+      onComposerContentFocused: types.function<[selection: ComposerSelection]>([
+        types.ComposerSelection(),
+      ]),
+      "isDefaultFocus?": types.boolean(),
+      "onInputContextMenu?": types.function<[event: MouseEvent]>([types.instanceOf(MouseEvent)]),
+      composerStore: types.Store<AbstractComposerStore>(),
+      "placeholder?": types.string(),
+      "inputMode?": types.string(),
+      "showAssistant?": types.boolean(),
+    },
+    {
+      inputStyle: "",
+      isDefaultFocus: false,
+      inputMode: "text",
+      showAssistant: true,
+    }
+  );
 
   private DOMFocusableElementStore!: Store<DOMFocusableElementStore>;
 

--- a/src/components/composer/formula_assistant/formula_assistant.ts
+++ b/src/components/composer/formula_assistant/formula_assistant.ts
@@ -1,23 +1,19 @@
-import { proxy } from "@odoo/owl";
+import { props, proxy } from "@odoo/owl";
 import { Component } from "../../../owl3_compatibility_layer";
-import { FunctionDescription } from "../../../types/functions";
+import { PropsOf } from "../../../types/props_of";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
+import { types } from "../../props_validation";
 import { Collapse } from "../../side_panel/components/collapse/collapse";
 
-interface Props {
-  functionDescription: FunctionDescription;
-  argsToFocus: number[];
-  repeatingArgGroupIndex: number | undefined;
-}
-
-export class FunctionDescriptionProvider extends Component<Props, SpreadsheetChildEnv> {
+export class FunctionDescriptionProvider extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-FunctionDescriptionProvider";
-  static props = {
-    functionDescription: Object,
-    argsToFocus: Array,
-    repeatingArgGroupIndex: { type: Number, optional: true },
-  };
   static components = { Collapse };
+
+  protected props = props({
+    functionDescription: types.FunctionDescription(),
+    argsToFocus: types.array(types.number()),
+    "repeatingArgGroupIndex?": types.number(),
+  });
 
   private state: { isCollapsed: boolean } = proxy({
     isCollapsed: true,
@@ -27,7 +23,7 @@ export class FunctionDescriptionProvider extends Component<Props, SpreadsheetChi
     this.state.isCollapsed = !this.state.isCollapsed;
   }
 
-  getContext(): Props {
+  getContext(): PropsOf<FunctionDescriptionProvider> {
     return this.props;
   }
 

--- a/src/components/composer/grid_composer/grid_composer.ts
+++ b/src/components/composer/grid_composer/grid_composer.ts
@@ -1,4 +1,4 @@
-import { onWillUpdateProps } from "@odoo/owl";
+import { onWillUpdateProps, props } from "@odoo/owl";
 import { SELECTION_BORDER_COLOR } from "../../../constants";
 import { toXC } from "../../../helpers/coordinates";
 import { deepEquals, isFormula } from "../../../helpers/misc";
@@ -8,33 +8,31 @@ import { positionToZone } from "../../../helpers/zones";
 import { Component } from "../../../owl3_compatibility_layer";
 import { useStore } from "../../../store_engine/store_hooks";
 import { CellPosition, ComposerFocusType } from "../../../types/misc";
-import { DOMDimension, Rect } from "../../../types/rendering";
+import { PropsOf } from "../../../types/props_of";
+import { Rect } from "../../../types/rendering";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
 import { Store } from "../../../types/store_engine";
 import { cssPropertiesToCss, getTextDecoration } from "../../helpers/css";
+import { types } from "../../props_validation";
 import { CellComposerStore } from "../composer/cell_composer_store";
-import { CellComposerProps, Composer } from "../composer/composer";
+import { Composer } from "../composer/composer";
 import { ComposerFocusStore, ComposerInterface } from "../composer_focus_store";
 
 const COMPOSER_BORDER_WIDTH = 3 * 0.4 * globalThis.devicePixelRatio || 1;
 const GRID_CELL_REFERENCE_TOP_OFFSET = 28;
 
-interface Props {
-  gridDims: DOMDimension;
-  onInputContextMenu: (event: MouseEvent) => void;
-}
-
 /**
  * This component is a composer which positions itself on the grid at the anchor cell.
  * It also applies the style of the cell to the composer input.
  */
-export class GridComposer extends Component<Props, SpreadsheetChildEnv> {
+export class GridComposer extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-GridComposer";
-  static props = {
-    gridDims: Object,
-    onInputContextMenu: Function,
-  };
   static components = { Composer };
+
+  protected props = props({
+    gridDims: types.DOMDimension(),
+    onInputContextMenu: types.function<[event: MouseEvent]>([types.instanceOf(MouseEvent)]),
+  });
 
   private rect: Rect = this.defaultRect;
   private isEditing: boolean = false;
@@ -101,7 +99,7 @@ export class GridComposer extends Component<Props, SpreadsheetChildEnv> {
       : "inactive";
   }
 
-  get composerProps(): CellComposerProps {
+  get composerProps(): PropsOf<Composer> {
     const { width, height } = this.env.model.getters.getSheetViewDimensionWithHeaders();
     // Remove the wrapper border width
     const maxHeight = this.props.gridDims.height - this.rect.y - 2 * COMPOSER_BORDER_WIDTH;

--- a/src/components/composer/speech_bubble/speech_bubble.ts
+++ b/src/components/composer/speech_bubble/speech_bubble.ts
@@ -1,21 +1,20 @@
-import { signal, useEffect } from "@odoo/owl";
+import { props, signal, useEffect } from "@odoo/owl";
 import { Component } from "../../../owl3_compatibility_layer";
-import { Rect } from "../../../types/rendering";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
 import { getBoundingRectAsPOJO } from "../../helpers/dom_helpers";
 import { useSpreadsheetRect } from "../../helpers/position_hook";
+import { types } from "../../props_validation";
 
 const BUBBLE_ARROW_SIZE = 7;
 
-export interface Props {
-  anchorRect: Rect;
-  content: string;
-}
-
-export class SpeechBubble extends Component<Props, SpreadsheetChildEnv> {
+export class SpeechBubble extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-SpeechBubble";
-  static props = { content: String, anchorRect: Object };
   static components = {};
+
+  protected props = props({
+    content: types.string(),
+    anchorRect: types.Rect(),
+  });
 
   private spreadsheetRect = useSpreadsheetRect();
   private bubbleRef = signal<HTMLElement | null>(null);

--- a/src/components/composer/standalone_composer/standalone_composer.ts
+++ b/src/components/composer/standalone_composer/standalone_composer.ts
@@ -1,52 +1,44 @@
-import { onMounted } from "@odoo/owl";
+import { onMounted, props } from "@odoo/owl";
 import { Token } from "../../../formulas/tokenizer";
 import { Component } from "../../../owl3_compatibility_layer";
-import { AutoCompleteProviderDefinition } from "../../../registries/auto_completes/auto_complete_registry";
 import { useLocalStore, useStore } from "../../../store_engine/store_hooks";
-import { Color, ComposerFocusType, UID } from "../../../types/misc";
+import { Color, ComposerFocusType } from "../../../types/misc";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
 import { Store } from "../../../types/store_engine";
 import { cssPropertiesToCss } from "../../helpers/css";
 import { useSpreadsheetRect } from "../../helpers/position_hook";
+import { types } from "../../props_validation";
 import { ComposerSelection } from "../composer/abstract_composer_store";
 import { Composer } from "../composer/composer";
 import { ComposerFocusStore, ComposerInterface } from "../composer_focus_store";
 import { StandaloneComposerStore } from "./standalone_composer_store";
 
-interface Props {
-  onConfirm: (content: string) => void;
-  composerContent: string;
-  defaultRangeSheetId: UID;
-  defaultStatic?: boolean;
-  contextualAutocomplete?: AutoCompleteProviderDefinition;
-  placeholder?: string;
-  title?: string;
-  class?: string;
-  invalid?: boolean;
-  autofocus?: boolean;
-  getContextualColoredSymbolToken?: (token: Token) => Color;
-}
-
-export class StandaloneComposer extends Component<Props, SpreadsheetChildEnv> {
+export class StandaloneComposer extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-StandaloneComposer";
-  static props = {
-    composerContent: { type: String, optional: true },
-    defaultRangeSheetId: { type: String, optional: true },
-    defaultStatic: { type: Boolean, optional: true },
-    onConfirm: Function,
-    contextualAutocomplete: { type: Object, optional: true },
-    placeholder: { type: String, optional: true },
-    title: { type: String, optional: true },
-    class: { type: String, optional: true },
-    invalid: { type: Boolean, optional: true },
-    autofocus: { type: Boolean, optional: true },
-    getContextualColoredSymbolToken: { type: Function, optional: true },
-  };
   static components = { Composer };
-  static defaultProps = {
-    composerContent: "",
-    defaultStatic: false,
-  };
+
+  protected props = props(
+    {
+      onConfirm: types.function<[content: string]>([types.string()]),
+      "composerContent?": types.string(),
+      defaultRangeSheetId: types.UID(),
+      "defaultStatic?": types.boolean(),
+      "contextualAutocomplete?": types.AutoCompleteProviderDefinition(),
+      "placeholder?": types.string(),
+      "title?": types.string(),
+      "class?": types.string(),
+      "invalid?": types.boolean(),
+      "autofocus?": types.boolean(),
+      "getContextualColoredSymbolToken?": types.function<[token: Token], Color>(
+        [types.Token()],
+        types.Color()
+      ),
+    },
+    {
+      composerContent: "",
+      defaultStatic: false,
+    }
+  );
 
   private composerFocusStore!: Store<ComposerFocusStore>;
   private standaloneComposerStore!: Store<StandaloneComposerStore>;

--- a/src/components/composer/top_bar_composer/top_bar_composer.ts
+++ b/src/components/composer/top_bar_composer/top_bar_composer.ts
@@ -12,9 +12,8 @@ import { ComposerFocusStore, ComposerInterface } from "../composer_focus_store";
 import { Component } from "../../../owl3_compatibility_layer";
 const COMPOSER_MAX_HEIGHT = 300;
 
-export class TopBarComposer extends Component<any, SpreadsheetChildEnv> {
+export class TopBarComposer extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-TopBarComposer";
-  static props = {};
   static components = { Composer };
 
   private composerFocusStore!: Store<ComposerFocusStore>;

--- a/src/components/dashboard/clickable_cell_sort_icon/clickable_cell_sort_icon.ts
+++ b/src/components/dashboard/clickable_cell_sort_icon/clickable_cell_sort_icon.ts
@@ -2,24 +2,23 @@ import { TEXT_BODY_MUTED } from "../../../constants";
 import { blendColors } from "../../../helpers/color";
 import { computeTextFontSizeInPixels } from "../../../helpers/text_helper";
 import { useStore } from "../../../store_engine/store_hooks";
-import { CellPosition, Color, SortDirection, Style } from "../../../types/misc";
+import { Color, Style } from "../../../types/misc";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
 import { Store } from "../../../types/store_engine";
 import { cssPropertiesToCss } from "../../helpers/css";
 import { HoveredTableStore } from "../../tables/hovered_table_store";
 
+import { props } from "@odoo/owl";
 import { Component } from "../../../owl3_compatibility_layer";
-interface Props {
-  position: CellPosition;
-  sortDirection: SortDirection | "none";
-}
+import { types } from "../../props_validation";
 
-export class ClickableCellSortIcon extends Component<Props, SpreadsheetChildEnv> {
+export class ClickableCellSortIcon extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ClickableCellSortIcon";
-  static props = {
-    position: Object,
-    sortDirection: String,
-  };
+
+  protected props = props({
+    position: types.CellPosition(),
+    sortDirection: types.or([types.SortDirection, types.literal("none")]),
+  });
   private hoveredTableStore!: Store<HoveredTableStore>;
 
   setup(): void {

--- a/src/components/dashboard/dashboard.ts
+++ b/src/components/dashboard/dashboard.ts
@@ -1,4 +1,4 @@
-import { signal, toRaw } from "@odoo/owl";
+import { props, signal, toRaw } from "@odoo/owl";
 import { Component, useChildSubEnv } from "../../owl3_compatibility_layer";
 import { useLocalStore, useStore } from "../../store_engine/store_hooks";
 import { RendererStore } from "../../stores/renderer_store";
@@ -17,17 +17,13 @@ import { useWheelHandler } from "../helpers/wheel_hook";
 import { getZoomedRect } from "../helpers/zoom";
 import { CellPopoverStore } from "../popover/cell_popover_store";
 import { Popover } from "../popover/popover";
+import { types } from "../props_validation";
 import { HorizontalScrollBar } from "../scrollbar/scrollbar_horizontal";
 import { VerticalScrollBar } from "../scrollbar/scrollbar_vertical";
 import { ClickableCell, ClickableCellsStore } from "./clickable_cell_store";
 
-interface Props {
-  getGridSize: () => DOMDimension;
-}
-
-export class SpreadsheetDashboard extends Component<Props, SpreadsheetChildEnv> {
+export class SpreadsheetDashboard extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-SpreadsheetDashboard";
-  static props = { getGridSize: Function };
   static components = {
     GridOverlay,
     GridPopover,
@@ -35,6 +31,10 @@ export class SpreadsheetDashboard extends Component<Props, SpreadsheetChildEnv> 
     VerticalScrollBar,
     HorizontalScrollBar,
   };
+
+  protected props = props({
+    getGridSize: types.function<[], DOMDimension>([], types.DOMDimension()),
+  });
 
   protected cellPopovers!: Store<CellPopoverStore>;
 

--- a/src/components/error_tooltip/error_tooltip.ts
+++ b/src/components/error_tooltip/error_tooltip.ts
@@ -4,24 +4,21 @@ import { _t } from "../../translation";
 import { CellPopoverComponent, PopoverBuilders } from "../../types/cell_popovers";
 import { CellValueType } from "../../types/cells";
 import { CellErrorType } from "../../types/errors";
-import { CellPosition } from "../../types/misc";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 
+import { props } from "@odoo/owl";
 import { Component } from "../../owl3_compatibility_layer";
+import { types } from "../props_validation";
 const ERROR_TOOLTIP_MAX_HEIGHT = 80;
 
-interface ErrorToolTipProps {
-  cellPosition: CellPosition;
-  onClosed?: () => void;
-}
-
-export class ErrorToolTip extends Component<ErrorToolTipProps, SpreadsheetChildEnv> {
+export class ErrorToolTip extends Component<SpreadsheetChildEnv> {
   static maxSize = { maxHeight: ERROR_TOOLTIP_MAX_HEIGHT };
   static template = "o-spreadsheet-ErrorToolTip";
-  static props = {
-    cellPosition: Object,
-    onClosed: { type: Function, optional: true },
-  };
+
+  protected props = props({
+    cellPosition: types.CellPosition(),
+    "onClosed?": types.function([]),
+  });
 
   get dataValidationErrorMessage() {
     return this.env.model.getters.getInvalidDataValidationMessage(this.props.cellPosition);

--- a/src/components/figures/chart/chartJs/chartjs.ts
+++ b/src/components/figures/chart/chartJs/chartjs.ts
@@ -1,4 +1,4 @@
-import { onMounted, onWillUnmount, signal } from "@odoo/owl";
+import { onMounted, onWillUnmount, props, signal, types } from "@odoo/owl";
 import { Chart, ChartConfiguration } from "chart.js/auto";
 import {
   chartJsExtensionRegistry,
@@ -8,7 +8,6 @@ import { deepCopy, deepEquals } from "../../../../helpers/misc";
 import { Component, useLayoutEffect } from "../../../../owl3_compatibility_layer";
 import { useStore } from "../../../../store_engine/store_hooks";
 import { ChartJSRuntime } from "../../../../types/chart/chart";
-import { UID } from "../../../../types/misc";
 import { SpreadsheetChildEnv } from "../../../../types/spreadsheet_env";
 import { Store } from "../../../../types/store_engine";
 import { ChartAnimationStore } from "./chartjs_animation_store";
@@ -26,11 +25,6 @@ import { sunburstHoverPlugin } from "./chartjs_sunburst_hover_plugin";
 import { sunburstLabelsPlugin } from "./chartjs_sunburst_labels_plugin";
 import { waterfallLinesPlugin } from "./chartjs_waterfall_plugin";
 import { zoomWindowPlugin } from "./zoomable_chart/zoomable_chartjs_plugins";
-
-interface Props {
-  chartId: UID;
-  isFullScreen?: boolean;
-}
 
 chartJsExtensionRegistry.add("chartShowValuesPlugin", {
   register: (Chart) => Chart.register(chartShowValuesPlugin),
@@ -82,12 +76,13 @@ chartJsExtensionRegistry.add("chartBackgroundPlugin", {
   unregister: (Chart) => Chart.unregister(chartBackgroundPlugin),
 });
 
-export class ChartJsComponent extends Component<Props, SpreadsheetChildEnv> {
+export class ChartJsComponent extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ChartJsComponent";
-  static props = {
-    chartId: String,
-    isFullScreen: { type: Boolean, optional: true },
-  };
+
+  protected props = props({
+    chartId: types.string(),
+    "isFullScreen?": types.boolean(),
+  });
 
   protected canvas = signal<HTMLCanvasElement | null>(null);
   protected chart?: Chart;

--- a/src/components/figures/chart/chart_dashboard_menu/chart_dashboard_menu.ts
+++ b/src/components/figures/chart/chart_dashboard_menu/chart_dashboard_menu.ts
@@ -1,22 +1,18 @@
-import { proxy } from "@odoo/owl";
+import { props, proxy } from "@odoo/owl";
 import { getChartMenuActions } from "../../../../actions/figure_menu_actions";
 import { isDefined } from "../../../../helpers/misc";
 import { Component } from "../../../../owl3_compatibility_layer";
 import { useStore } from "../../../../store_engine/store_hooks";
 import { _t } from "../../../../translation";
 import { GeoChartDefinition } from "../../../../types/chart/geo_chart";
-import { UID, ValueAndLabel } from "../../../../types/misc";
+import { ValueAndLabel } from "../../../../types/misc";
 import { SpreadsheetChildEnv } from "../../../../types/spreadsheet_env";
 import { Store } from "../../../../types/store_engine";
 import { FullScreenFigureStore } from "../../../full_screen_figure/full_screen_figure_store";
 import { getBoundingRectAsPOJO } from "../../../helpers/dom_helpers";
 import { MenuPopover, MenuState } from "../../../menu_popover/menu_popover";
+import { types } from "../../../props_validation";
 import { Select } from "../../../select/select";
-
-interface Props {
-  chartId: UID;
-  hasFullScreenButton: boolean;
-}
 
 interface MenuItem {
   id: string;
@@ -26,11 +22,19 @@ interface MenuItem {
   preview?: string;
 }
 
-export class ChartDashboardMenu extends Component<Props, SpreadsheetChildEnv> {
+export class ChartDashboardMenu extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ChartDashboardMenu";
   static components = { MenuPopover, Select };
-  static props = { chartId: String, hasFullScreenButton: { type: Boolean, optional: true } };
-  static defaultProps = { hasFullScreenButton: true };
+
+  protected props = props(
+    {
+      chartId: types.UID(),
+      "hasFullScreenButton?": types.boolean(),
+    },
+    {
+      hasFullScreenButton: true,
+    }
+  );
 
   private fullScreenFigureStore!: Store<FullScreenFigureStore>;
 

--- a/src/components/figures/chart/gauge/gauge_chart_component.ts
+++ b/src/components/figures/chart/gauge/gauge_chart_component.ts
@@ -1,28 +1,23 @@
-import { onMounted, onWillUnmount, signal } from "@odoo/owl";
+import { onMounted, onWillUnmount, props, signal, types } from "@odoo/owl";
 import { drawGaugeChart } from "../../../../helpers/figures/charts/gauge_chart_rendering";
 import { deepEquals } from "../../../../helpers/misc";
 import { Component, useLayoutEffect } from "../../../../owl3_compatibility_layer";
 import { EASING_FN } from "../../../../registries/cell_animation_registry";
 import { useStore } from "../../../../store_engine/store_hooks";
 import { GaugeChartRuntime } from "../../../../types/chart/gauge_chart";
-import { UID } from "../../../../types/misc";
 import { SpreadsheetChildEnv } from "../../../../types/spreadsheet_env";
 import { Store } from "../../../../types/store_engine";
 import { ChartAnimationStore } from "../chartJs/chartjs_animation_store";
 
 const ANIMATION_DURATION = 1000;
 
-interface Props {
-  chartId: UID;
-  isFullScreen?: boolean;
-}
-
-export class GaugeChartComponent extends Component<Props, SpreadsheetChildEnv> {
+export class GaugeChartComponent extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-GaugeChartComponent";
-  static props = {
-    chartId: String,
-    isFullScreen: { type: Boolean, optional: true },
-  };
+
+  protected props = props({
+    chartId: types.string(),
+    "isFullScreen?": types.boolean(),
+  });
 
   private canvas = signal<HTMLCanvasElement | null>(null);
 

--- a/src/components/figures/chart/scorecard/chart_scorecard.ts
+++ b/src/components/figures/chart/scorecard/chart_scorecard.ts
@@ -1,23 +1,18 @@
-import { onMounted, onWillUnmount, signal } from "@odoo/owl";
+import { onMounted, onWillUnmount, props, signal, types } from "@odoo/owl";
 import { drawScoreChart } from "../../../../helpers/figures/charts/scorecard_chart";
 import { getScorecardConfiguration } from "../../../../helpers/figures/charts/scorecard_chart_config_builder";
 import { Component, useLayoutEffect } from "../../../../owl3_compatibility_layer";
 import { ScorecardChartRuntime } from "../../../../types/chart/scorecard_chart";
-import { UID } from "../../../../types/misc";
 import { SpreadsheetChildEnv } from "../../../../types/spreadsheet_env";
 import { getZoomedRect } from "../../../helpers/zoom";
 
-interface Props {
-  chartId: UID;
-  isFullScreen?: Boolean;
-}
-
-export class ScorecardChart extends Component<Props, SpreadsheetChildEnv> {
+export class ScorecardChart extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ScorecardChart";
-  static props = {
-    chartId: String,
-    isFullScreen: { type: Boolean, optional: true },
-  };
+
+  protected props = props({
+    chartId: types.string(),
+    "isFullScreen?": types.boolean(),
+  });
   private canvas = signal<HTMLCanvasElement | null>(null);
 
   get runtime(): ScorecardChartRuntime {

--- a/src/components/figures/figure/figure.ts
+++ b/src/components/figures/figure/figure.ts
@@ -1,8 +1,8 @@
-import { proxy, signal } from "@odoo/owl";
+import { props, proxy, signal } from "@odoo/owl";
 import { Component, useLayoutEffect } from "../../../owl3_compatibility_layer";
 import { figureRegistry } from "../../../registries/figures_registry";
 import { MoveFiguresPayload } from "../../../types/commands";
-import { AnchorOffset, FigureUI, ResizeDirection } from "../../../types/figure";
+import { AnchorOffset, ResizeDirection } from "../../../types/figure";
 import { CSSProperties, Pixel } from "../../../types/misc";
 import { Rect } from "../../../types/rendering";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
@@ -14,6 +14,7 @@ import {
 } from "../../helpers/dom_helpers";
 import { withZoom } from "../../helpers/zoom";
 import { MenuPopover, MenuState } from "../../menu_popover/menu_popover";
+import { types } from "../../props_validation";
 
 type ResizeAnchor =
   | "top left"
@@ -32,28 +33,25 @@ const ANCHOR_SIZE = 8;
 const BORDER_WIDTH = 1;
 const ACTIVE_BORDER_WIDTH = 2;
 
-interface Props {
-  figureUI: FigureUI;
-  style: string;
-  class: string;
-  onMouseDown: (ev: MouseEvent) => void;
-  onClickAnchor(dirX: ResizeDirection, dirY: ResizeDirection, ev: MouseEvent): void;
-}
-
-export class FigureComponent extends Component<Props, SpreadsheetChildEnv> {
+export class FigureComponent extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-FigureComponent";
-  static props = {
-    figureUI: Object,
-    style: { type: String, optional: true },
-    class: { type: String, optional: true },
-    onMouseDown: { type: Function, optional: true },
-    onClickAnchor: { type: Function, optional: true },
-  };
   static components = { MenuPopover };
-  static defaultProps = {
-    onMouseDown: () => {},
-    onClickAnchor: () => {},
-  };
+
+  protected props = props(
+    {
+      figureUI: types.FigureUI(),
+      style: types.string(),
+      class: types.string(),
+      "onMouseDown?": types.function<[ev: MouseEvent]>([types.instanceOf(MouseEvent)]),
+      "onClickAnchor?": types.function<
+        [dirX: ResizeDirection, dirY: ResizeDirection, ev: MouseEvent]
+      >([types.ResizeDirection(), types.ResizeDirection(), types.instanceOf(MouseEvent)]),
+    },
+    {
+      onMouseDown: () => {},
+      onClickAnchor: () => {},
+    }
+  );
 
   private menuState: MenuState = proxy({ isOpen: false, anchorRect: null, menuItems: [] });
 

--- a/src/components/figures/figure_carousel/figure_carousel.ts
+++ b/src/components/figures/figure_carousel/figure_carousel.ts
@@ -1,4 +1,4 @@
-import { proxy, signal } from "@odoo/owl";
+import { props, proxy, signal } from "@odoo/owl";
 import { ActionSpec, createActions } from "../../../actions/action";
 import { DEFAULT_CAROUSEL_TITLE_STYLE } from "../../../constants";
 import { getCarouselItemTitle } from "../../../helpers/carousel_helpers";
@@ -7,7 +7,7 @@ import { Component, useLayoutEffect } from "../../../owl3_compatibility_layer";
 import { chartComponentRegistry } from "../../../registries/chart_component_registry";
 import { useStore } from "../../../store_engine/store_hooks";
 import { _t } from "../../../translation";
-import { Carousel, CarouselItem, FigureUI } from "../../../types/figure";
+import { Carousel, CarouselItem } from "../../../types/figure";
 import { CSSProperties, MenuMouseEvent } from "../../../types/misc";
 import { Rect } from "../../../types/rendering";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
@@ -16,25 +16,23 @@ import { FullScreenFigureStore } from "../../full_screen_figure/full_screen_figu
 import { cellTextStyleToCss, cssPropertiesToCss } from "../../helpers/css";
 import { getBoundingRectAsPOJO, getElBoundingRect } from "../../helpers/dom_helpers";
 import { MenuPopover, MenuState } from "../../menu_popover/menu_popover";
+import { types } from "../../props_validation";
 import { ChartAnimationStore } from "../chart/chartJs/chartjs_animation_store";
 import { ChartDashboardMenu } from "../chart/chart_dashboard_menu/chart_dashboard_menu";
 
-interface Props {
-  figureUI: FigureUI;
-  editFigureStyle?: (properties: CSSProperties) => void;
-  isFullScreen?: boolean;
-  openContextMenu?: (anchorRect: Rect, onClose?: () => void) => void;
-}
-
-export class CarouselFigure extends Component<Props, SpreadsheetChildEnv> {
+export class CarouselFigure extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-CarouselFigure";
-  static props = {
-    figureUI: Object,
-    editFigureStyle: { type: Function, optional: true },
-    isFullScreen: { type: Boolean, optional: true },
-    openContextMenu: { type: Function, optional: true },
-  };
   static components = { ChartDashboardMenu, MenuPopover };
+
+  protected props = props({
+    figureUI: types.FigureUI(),
+    "editFigureStyle?": types.function<[properties: CSSProperties]>([types.CSSProperties()]),
+    "isFullScreen?": types.boolean(),
+    "openContextMenu?": types.function<[anchorRect: Rect, onClose?: () => void]>([
+      types.Rect(),
+      types.function([]),
+    ]),
+  });
 
   private carouselTabsRef = signal<HTMLElement | null>(null);
   private carouselTabsDropdownRef = signal<HTMLElement | null>(null);

--- a/src/components/figures/figure_chart/figure_chart.ts
+++ b/src/components/figures/figure_chart/figure_chart.ts
@@ -1,30 +1,27 @@
 import { chartComponentRegistry } from "../../../registries/chart_component_registry";
 import { ChartType } from "../../../types/chart/chart";
-import { FigureUI } from "../../../types/figure";
 import { CSSProperties, UID } from "../../../types/misc";
 import { Rect } from "../../../types/rendering";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
 import { ChartDashboardMenu } from "../chart/chart_dashboard_menu/chart_dashboard_menu";
 
+import { props } from "@odoo/owl";
 import { Component } from "../../../owl3_compatibility_layer";
-interface Props {
-  // props figure is currently necessary scorecards, we need the chart dimension at render to avoid having to force the
-  // style by hand in the useLayoutEffect()
-  figureUI: FigureUI;
-  editFigureStyle?: (properties: CSSProperties) => void;
-  isFullScreen?: boolean;
-  openContextMenu?: (anchorRect: Rect, onClose?: () => void) => void;
-}
+import { types } from "../../props_validation";
 
-export class ChartFigure extends Component<Props, SpreadsheetChildEnv> {
+export class ChartFigure extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ChartFigure";
-  static props = {
-    figureUI: Object,
-    editFigureStyle: { type: Function, optional: true },
-    isFullScreen: { type: Boolean, optional: true },
-    openContextMenu: { type: Function, optional: true },
-  };
   static components = { ChartDashboardMenu };
+
+  protected props = props({
+    figureUI: types.FigureUI(),
+    "editFigureStyle?": types.function<[properties: CSSProperties]>([types.CSSProperties()]),
+    "isFullScreen?": types.boolean(),
+    "openContextMenu?": types.function<[anchorRect: Rect, onClose?: () => void]>([
+      types.Rect(),
+      types.function([]),
+    ]),
+  });
 
   onDoubleClick() {
     this.env.model.dispatch("SELECT_FIGURE", { figureId: this.props.figureUI.id });

--- a/src/components/figures/figure_container/figure_container.ts
+++ b/src/components/figures/figure_container/figure_container.ts
@@ -23,8 +23,6 @@ import { FigureComponent } from "../figure/figure";
 
 type ContainerType = "topLeft" | "topRight" | "bottomLeft" | "bottomRight" | "dnd";
 
-interface Props {}
-
 interface Container {
   type: ContainerType;
   figures: FigureUI[];
@@ -108,9 +106,8 @@ interface DndState {
  * that occurred during the drag & drop, and to position the figure on the correct pane.
  *
  */
-export class FiguresContainer extends Component<Props, SpreadsheetChildEnv> {
+export class FiguresContainer extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-FiguresContainer";
-  static props = {};
   static components = { FigureComponent };
 
   dnd = proxy<DndState>({

--- a/src/components/figures/figure_image/figure_image.ts
+++ b/src/components/figures/figure_image/figure_image.ts
@@ -1,23 +1,23 @@
-import { FigureUI } from "../../../types/figure";
 import { CSSProperties, UID } from "../../../types/misc";
 import { Rect } from "../../../types/rendering";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
 
+import { props } from "@odoo/owl";
 import { Component } from "../../../owl3_compatibility_layer";
-interface Props {
-  figureUI: FigureUI;
-  editFigureStyle?: (properties: CSSProperties) => void;
-  openContextMenu?: (anchorRect: Rect, onClose?: () => void) => void;
-}
+import { types } from "../../props_validation";
 
-export class ImageFigure extends Component<Props, SpreadsheetChildEnv> {
+export class ImageFigure extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ImageFigure";
-  static props = {
-    figureUI: Object,
-    editFigureStyle: { type: Function, optional: true },
-    openContextMenu: { type: Function, optional: true },
-  };
   static components = {};
+
+  protected props = props({
+    figureUI: types.FigureUI(),
+    "editFigureStyle?": types.function<[properties: CSSProperties]>([types.CSSProperties()]),
+    "openContextMenu?": types.function<[anchorRect: Rect, onClose?: () => void]>([
+      types.Rect(),
+      types.function([]),
+    ]),
+  });
 
   // ---------------------------------------------------------------------------
   // Getters

--- a/src/components/filters/filter_menu/filter_menu.ts
+++ b/src/components/filters/filter_menu/filter_menu.ts
@@ -1,4 +1,4 @@
-import { onWillUpdateProps, proxy } from "@odoo/owl";
+import { onWillUpdateProps, props, proxy } from "@odoo/owl";
 import { isDateTimeFormat } from "../../../helpers/format/format";
 import { deepCopy, deepEquals } from "../../../helpers/misc";
 import { interactiveSort } from "../../../helpers/sort_interactive";
@@ -8,6 +8,7 @@ import { Component } from "../../../owl3_compatibility_layer";
 import { CellPopoverComponent, PopoverBuilders } from "../../../types/cell_popovers";
 import { CellValueType } from "../../../types/cells";
 import { Position, SortDirection } from "../../../types/misc";
+import { PropsOf } from "../../../types/props_of";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
 import {
   CriterionFilter,
@@ -16,14 +17,10 @@ import {
   filterNumberCriterionOperators,
   filterTextCriterionOperators,
 } from "../../../types/table";
+import { types } from "../../props_validation";
 import { SidePanelCollapsible } from "../../side_panel/components/collapsible/side_panel_collapsible";
 import { FilterMenuCriterion } from "../filter_menu_criterion/filter_menu_criterion";
 import { FilterMenuValueList } from "../filter_menu_value_list/filter_menu_value_list";
-
-interface Props {
-  filterPosition: Position;
-  onClosed?: () => void;
-}
 
 interface State {
   values: Value[];
@@ -37,19 +34,21 @@ interface Value {
 
 type CriterionCategory = "text" | "number" | "date";
 
-export class FilterMenu extends Component<Props, SpreadsheetChildEnv> {
+export class FilterMenu extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-FilterMenu";
-  static props = {
-    filterPosition: Object,
-    onClosed: { type: Function, optional: true },
-  };
   static components = { FilterMenuValueList, SidePanelCollapsible, FilterMenuCriterion };
+
+  private props = props({
+    filterPosition: types.Position(),
+    "onClosed?": types.function([]),
+  });
+
   private state!: State;
   private criterionCategory: CriterionCategory = "text";
   private updatedCriterionValue: DataFilterValue | undefined;
 
   setup() {
-    onWillUpdateProps((nextProps: Props) => {
+    onWillUpdateProps((nextProps: PropsOf<FilterMenu>) => {
       if (!deepEquals(nextProps.filterPosition, this.props.filterPosition)) {
         this.updatedCriterionValue = undefined;
         this.criterionCategory = this.getCriterionCategory(nextProps.filterPosition);

--- a/src/components/filters/filter_menu_criterion/filter_menu_criterion.ts
+++ b/src/components/filters/filter_menu_criterion/filter_menu_criterion.ts
@@ -1,4 +1,4 @@
-import { onWillUpdateProps, proxy } from "@odoo/owl";
+import { onWillUpdateProps, props, proxy } from "@odoo/owl";
 import { deepEquals } from "../../../helpers/misc";
 import { Component, ComponentConstructor } from "../../../owl3_compatibility_layer";
 import {
@@ -6,35 +6,31 @@ import {
   getCriterionValueAndLabels,
 } from "../../../registries/criterion_component_registry";
 import { _t } from "../../../translation";
-import { GenericCriterionType } from "../../../types/generic_criterion";
 import { ValueAndLabel } from "../../../types/misc";
+import { PropsOf } from "../../../types/props_of";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
 import { CriterionFilter } from "../../../types/table";
+import { types } from "../../props_validation";
 import { Select } from "../../select/select";
-
-interface Props {
-  criterion: CriterionFilter;
-  criterionOperators: GenericCriterionType[];
-  onCriterionChanged: (criterion: CriterionFilter) => void;
-}
 
 interface State {
   criterion: CriterionFilter;
 }
 
-export class FilterMenuCriterion extends Component<Props, SpreadsheetChildEnv> {
+export class FilterMenuCriterion extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-FilterMenuCriterion";
-  static props = {
-    criterion: Object,
-    onCriterionChanged: Function,
-    criterionOperators: Array,
-  };
   static components = { Select };
+
+  protected props = props({
+    criterion: types.CriterionFilter(),
+    criterionOperators: types.array(types.GenericCriterionType()),
+    onCriterionChanged: types.function<[criterion: CriterionFilter]>([types.CriterionFilter()]),
+  });
 
   private state!: State;
 
   setup() {
-    onWillUpdateProps((nextProps: Props) => {
+    onWillUpdateProps((nextProps: PropsOf<FilterMenuCriterion>) => {
       if (!deepEquals(nextProps.criterion, this.props.criterion)) {
         this.state.criterion = nextProps.criterion;
       }

--- a/src/components/filters/filter_menu_item/filter_menu_value_item.ts
+++ b/src/components/filters/filter_menu_item/filter_menu_value_item.ts
@@ -1,28 +1,20 @@
-import { onWillPatch, signal } from "@odoo/owl";
+import { onWillPatch, props, signal, types } from "@odoo/owl";
 import { Component } from "../../../owl3_compatibility_layer";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
 import { Checkbox } from "../../side_panel/components/checkbox/checkbox";
 
-interface Props {
-  value: string;
-  isChecked: boolean;
-  isSelected: boolean;
-  onClick: () => void;
-  onMouseMove: () => void;
-  scrolledTo: "top" | "bottom" | undefined;
-}
-
-export class FilterMenuValueItem extends Component<Props, SpreadsheetChildEnv> {
+export class FilterMenuValueItem extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-FilterMenuValueItem";
   static components = { Checkbox };
-  static props = {
-    value: String,
-    isChecked: Boolean,
-    isSelected: Boolean,
-    onMouseMove: Function,
-    onClick: Function,
-    scrolledTo: { type: String, optional: true },
-  };
+
+  protected props = props({
+    value: types.string(),
+    isChecked: types.boolean(),
+    isSelected: types.boolean(),
+    onMouseMove: types.function([]),
+    onClick: types.function([]),
+    "scrolledTo?": types.or([types.literal("top"), types.literal("bottom")]),
+  });
 
   itemRef = signal<HTMLElement | null>(null);
 

--- a/src/components/filters/filter_menu_value_list/filter_menu_value_list.ts
+++ b/src/components/filters/filter_menu_value_list/filter_menu_value_list.ts
@@ -1,19 +1,16 @@
-import { onWillUpdateProps, proxy, signal } from "@odoo/owl";
+import { onWillUpdateProps, props, proxy, signal } from "@odoo/owl";
 import { deepEquals } from "../../../helpers/misc";
 import { fuzzyLookup } from "../../../helpers/search";
 import { Component } from "../../../owl3_compatibility_layer";
+import { PropsOf } from "../../../types/props_of";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
+import { types } from "../../props_validation";
 import { FilterMenuValueItem } from "../filter_menu_item/filter_menu_value_item";
-
-interface Props {
-  values: Value[];
-  onUpdateHiddenValues: (values: string[]) => void;
-}
 
 interface Value {
   checked: boolean;
   string: string;
-  scrolledTo?: "top" | "bottom" | undefined;
+  scrolledTo?: "top" | "bottom";
 }
 
 interface State {
@@ -24,13 +21,20 @@ interface State {
   hasMoreValues: boolean;
 }
 
-export class FilterMenuValueList extends Component<Props, SpreadsheetChildEnv> {
+export class FilterMenuValueList extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-FilterMenuValueList";
-  static props = {
-    values: Object,
-    onUpdateHiddenValues: Function,
-  };
   static components = { FilterMenuValueItem };
+
+  protected props = props({
+    values: types.array(
+      types.object({
+        checked: types.boolean(),
+        string: types.string(),
+        "scrolledTo?": types.or([types.literal("top"), types.literal("bottom")]),
+      })
+    ),
+    onUpdateHiddenValues: types.function<[values: string[]]>([types.array(types.string())]),
+  });
 
   private state: State = proxy({
     displayedValues: [],
@@ -43,7 +47,7 @@ export class FilterMenuValueList extends Component<Props, SpreadsheetChildEnv> {
   private searchBarRef = signal<HTMLInputElement | null>(null);
 
   setup() {
-    onWillUpdateProps((nextProps: Props) => {
+    onWillUpdateProps((nextProps: PropsOf<FilterMenuValueList>) => {
       if (!deepEquals(nextProps.values, this.props.values)) {
         this.computeDisplayedValues(nextProps);
       }
@@ -62,7 +66,7 @@ export class FilterMenuValueList extends Component<Props, SpreadsheetChildEnv> {
     this.state.selectedValue = value.string;
   }
 
-  private getSearchedValues(props: Props): Value[] {
+  private getSearchedValues(props: PropsOf<FilterMenuValueList>): Value[] {
     return !this.state.textFilter
       ? props.values
       : fuzzyLookup(this.state.textFilter, props.values, (val) => val.string);
@@ -98,7 +102,7 @@ export class FilterMenuValueList extends Component<Props, SpreadsheetChildEnv> {
     this.computeDisplayedValues(this.props);
   }
 
-  computeDisplayedValues(props: Props) {
+  computeDisplayedValues(props: PropsOf<FilterMenuValueList>) {
     const searchedValues = this.getSearchedValues(props);
     this.state.displayedValues = searchedValues.slice(0, this.state.numberOfDisplayedValues);
     this.state.hasMoreValues = searchedValues.length > this.state.numberOfDisplayedValues;

--- a/src/components/filters/pivot_filter_menu/pivot_filter_menu.ts
+++ b/src/components/filters/pivot_filter_menu/pivot_filter_menu.ts
@@ -1,9 +1,8 @@
-import { onWillUpdateProps } from "@odoo/owl";
+import { onWillUpdateProps, props } from "@odoo/owl";
 import { deepCopy, deepEquals } from "../../../helpers/misc";
 import { SpreadsheetPivotRuntimeDefinition } from "../../../helpers/pivot/spreadsheet_pivot/runtime_definition_spreadsheet_pivot";
 import { Component } from "../../../owl3_compatibility_layer";
-import { UID } from "../../../types/misc";
-import { PivotFilter } from "../../../types/pivot";
+import { PropsOf } from "../../../types/props_of";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
 import {
   CriterionFilter,
@@ -12,45 +11,40 @@ import {
   filterNumberCriterionOperators,
   filterTextCriterionOperators,
 } from "../../../types/table";
+import { types } from "../../props_validation";
 import { SidePanelCollapsible } from "../../side_panel/components/collapsible/side_panel_collapsible";
 import { FilterMenuCriterion } from "../filter_menu_criterion/filter_menu_criterion";
 import { FilterMenuValueList } from "../filter_menu_value_list/filter_menu_value_list";
 
-interface Props {
-  pivotId: UID;
-  definition: SpreadsheetPivotRuntimeDefinition;
-  filter: PivotFilter;
-  values: Value[];
-  onClosed?: () => void;
-  onConfirmed: (updatedCriterionValue: DataFilterValue) => void;
-}
-
-interface Value {
-  checked: boolean;
-  string: string;
-  scrolledTo?: "top" | "bottom" | undefined;
-}
-
 type CriterionCategory = "char" | "boolean" | "integer" | "datetime";
 
-export class PivotFilterMenu extends Component<Props, SpreadsheetChildEnv> {
+export class PivotFilterMenu extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-PivotFilterMenu";
-  static props = {
-    pivotId: String,
-    definition: Object,
-    filter: Object,
-    values: Object,
-    onClosed: { type: Function, optional: true },
-    onConfirmed: Function,
-  };
 
   static components = { FilterMenuValueList, SidePanelCollapsible, FilterMenuCriterion };
 
   private criterionCategory: CriterionCategory = "char";
   private updatedCriterionValue: DataFilterValue | undefined;
 
+  protected props = props({
+    pivotId: types.UID(),
+    definition: types.instanceOf(SpreadsheetPivotRuntimeDefinition),
+    filter: types.PivotFilter(),
+    values: types.array(
+      types.object({
+        checked: types.boolean(),
+        string: types.string(),
+        "scrolledTo?": types.or([types.literal("top"), types.literal("bottom")]),
+      })
+    ),
+    "onClosed?": types.function([]),
+    onConfirmed: types.function<[updatedCriterionValue: DataFilterValue]>([
+      types.DataFilterValue(),
+    ]),
+  });
+
   setup() {
-    onWillUpdateProps((nextProps: Props) => {
+    onWillUpdateProps((nextProps: PropsOf<PivotFilterMenu>) => {
       if (!deepEquals(nextProps.definition, this.props.definition)) {
         this.updatedCriterionValue = undefined;
         this.criterionCategory = this.getCriterionCategory();

--- a/src/components/font_size_editor/font_size_editor.ts
+++ b/src/components/font_size_editor/font_size_editor.ts
@@ -1,30 +1,26 @@
+import { props } from "@odoo/owl";
 import { FONT_SIZES } from "../../constants";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 import { NumberEditor } from "../number_editor/number_editor";
 
 import { Component } from "../../owl3_compatibility_layer";
-interface Props {
-  currentFontSize: number;
-  class: string;
-  onFontSizeChanged: (fontSize: number) => void;
-  onToggle?: () => void;
-  onFocusInput?: () => void;
-}
-
-export class FontSizeEditor extends Component<Props, SpreadsheetChildEnv> {
+import { types } from "../props_validation";
+export class FontSizeEditor extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-FontSizeEditor";
   static components = { NumberEditor };
-  static props = {
-    currentFontSize: Number,
-    onFontSizeChanged: Function,
-    onToggle: { type: Function, optional: true },
-    onFocusInput: { type: Function, optional: true },
-    class: String,
-  };
 
-  static defaultProps = {
-    onFocusInput: () => {},
-  };
+  protected props = props(
+    {
+      currentFontSize: types.number(),
+      onFontSizeChanged: types.function<[fontSize: number]>([types.number()]),
+      "onToggle?": types.function([]),
+      "onFocusInput?": types.function([]),
+      class: types.string(),
+    },
+    {
+      onFocusInput: () => {},
+    }
+  );
 
   fontSizes: number[] = FONT_SIZES;
 }

--- a/src/components/full_screen_figure/full_screen_figure.ts
+++ b/src/components/full_screen_figure/full_screen_figure.ts
@@ -9,9 +9,8 @@ import { ChartFigure } from "../figures/figure_chart/figure_chart";
 import { useSpreadsheetRect } from "../helpers/position_hook";
 import { FullScreenFigureStore } from "./full_screen_figure_store";
 
-export class FullScreenFigure extends Component<{}, SpreadsheetChildEnv> {
+export class FullScreenFigure extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-FullScreenFigure";
-  static props = {};
   static components = { ChartFigure };
 
   private fullScreenFigureStore!: Store<FullScreenFigureStore>;

--- a/src/components/generic_input/generic_input.ts
+++ b/src/components/generic_input/generic_input.ts
@@ -1,7 +1,8 @@
-import { onMounted, onWillUpdateProps, signal, useListener } from "@odoo/owl";
+import { onMounted, onWillUpdateProps, props, signal, useListener } from "@odoo/owl";
 import { Component } from "../../owl3_compatibility_layer";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 import { useAutofocus } from "../helpers/autofocus_hook";
+import { types } from "../props_validation";
 
 export interface GenericInputProps {
   value: string | number;
@@ -17,21 +18,23 @@ export interface GenericInputProps {
   resetOnBlur?: boolean;
 }
 
-export class GenericInput<T extends GenericInputProps> extends Component<T, SpreadsheetChildEnv> {
-  static props = {
-    value: [Number, String],
-    onChange: Function,
-    onFocused: { type: Function, optional: true },
-    onBlur: { type: Function, optional: true },
-    onInput: { type: Function, optional: true },
-    class: { type: String, optional: true },
-    id: { type: String, optional: true },
-    placeholder: { type: String, optional: true },
-    autofocus: { type: Boolean, optional: true },
-    alwaysShowBorder: { type: Boolean, optional: true },
-    selectContentOnFocus: { type: Boolean, optional: true },
-    resetOnBlur: { type: Boolean, optional: true },
-  };
+export const genericInputPropsDefinition = {
+  value: types.or([types.number(), types.string()]),
+  onChange: types.function<[value: string]>([types.string()]),
+  "onFocused?": types.function([]),
+  "onBlur?": types.function([]),
+  "onInput?": types.function<[value: string]>([types.string()]),
+  "class?": types.string(),
+  "id?": types.string(),
+  "placeholder?": types.string(),
+  "autofocus?": types.boolean(),
+  "alwaysShowBorder?": types.boolean(),
+  "selectContentOnFocus?": types.boolean(),
+  "resetOnBlur?": types.boolean(),
+};
+
+export class GenericInput<T extends GenericInputProps> extends Component<SpreadsheetChildEnv> {
+  protected props: T = props(genericInputPropsDefinition) as unknown as T;
 
   protected genericInputRef = signal<HTMLInputElement | null>(null);
 

--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -1,4 +1,4 @@
-import { onMounted, proxy, signal } from "@odoo/owl";
+import { onMounted, props, proxy, signal } from "@odoo/owl";
 import { insertSheet, insertTable } from "../../actions/insert_actions";
 import {
   CREATE_IMAGE,
@@ -80,6 +80,7 @@ import { MenuPopover, MenuState } from "../menu_popover/menu_popover";
 import { PaintFormatStore } from "../paint_format_button/paint_format_store";
 import { CellPopoverStore } from "../popover/cell_popover_store";
 import { Popover } from "../popover/popover";
+import { types } from "../props_validation";
 import { HorizontalScrollBar } from "../scrollbar/scrollbar_horizontal";
 import { VerticalScrollBar } from "../scrollbar/scrollbar_vertical";
 import { Selection } from "../selection/selection";
@@ -114,20 +115,11 @@ const registries = {
   UNGROUP_HEADERS: unGroupHeadersMenuRegistry,
 };
 
-interface Props {
-  exposeFocus: (focus: () => void) => void;
-  getGridSize: () => DOMDimension;
-}
-
 // -----------------------------------------------------------------------------
 // JS
 // -----------------------------------------------------------------------------
-export class Grid extends Component<Props, SpreadsheetChildEnv> {
+export class Grid extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-Grid";
-  static props = {
-    exposeFocus: Function,
-    getGridSize: Function,
-  };
   static components = {
     GridComposer,
     GridOverlay,
@@ -143,6 +135,12 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
     TableResizer,
     Selection,
   };
+
+  protected props = props({
+    exposeFocus: types.function<[focus: () => void]>([types.function([])]),
+    getGridSize: types.function<[], DOMDimension>([], types.DOMDimension()),
+  });
+
   readonly HEADER_HEIGHT = HEADER_HEIGHT;
   readonly HEADER_WIDTH = HEADER_WIDTH;
   private menuState!: MenuState;

--- a/src/components/grid_add_rows_footer/grid_add_rows_footer.ts
+++ b/src/components/grid_add_rows_footer/grid_add_rows_footer.ts
@@ -8,11 +8,8 @@ import { Store } from "../../types/store_engine";
 import { cssPropertiesToCss } from "../helpers/css";
 import { ValidationMessages } from "../validation_messages/validation_messages";
 
-interface Props {}
-
-export class GridAddRowsFooter extends Component<Props, SpreadsheetChildEnv> {
+export class GridAddRowsFooter extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-GridAddRowsFooter";
-  static props = {};
   static components = { ValidationMessages };
 
   private DOMFocusableElementStore!: Store<DOMFocusableElementStore>;

--- a/src/components/grid_overlay/grid_overlay.ts
+++ b/src/components/grid_overlay/grid_overlay.ts
@@ -1,4 +1,4 @@
-import { onMounted, onWillUnmount, Signal, signal, useListener } from "@odoo/owl";
+import { onMounted, onWillUnmount, props, Signal, signal, useListener } from "@odoo/owl";
 import { deepEquals } from "../../helpers/misc";
 import { isPointInsideRect } from "../../helpers/rectangle";
 import { positionToZone } from "../../helpers/zones";
@@ -17,6 +17,7 @@ import { useInterval } from "../helpers/time_hooks";
 import { withZoom, ZoomedMouseEvent } from "../helpers/zoom";
 import { PaintFormatStore } from "../paint_format_button/paint_format_store";
 import { CellPopoverStore } from "../popover/cell_popover_store";
+import { types } from "../props_validation";
 import { HoveredTableStore } from "../tables/hovered_table_store";
 import { HoveredIconStore } from "./hovered_icon_store";
 
@@ -129,41 +130,46 @@ function useCellHovered(
   return hoveredPosition;
 }
 
-interface Props {
-  onCellDoubleClicked: (col: HeaderIndex, row: HeaderIndex) => void;
-  onCellClicked: (
-    col: HeaderIndex,
-    row: HeaderIndex,
-    modifiers: GridClickModifiers,
-    zoomedMouseEvent: ZoomedMouseEvent<MouseEvent | PointerEvent>
-  ) => void;
-  onCellRightClicked: (col: HeaderIndex, row: HeaderIndex, coordinates: DOMCoordinates) => void;
-  onGridResized: () => void;
-  onGridMoved: (deltaX: Pixel, deltaY: Pixel) => void;
-  gridOverlayDimensions: string;
-}
-
-export class GridOverlay extends Component<Props, SpreadsheetChildEnv> {
+export class GridOverlay extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-GridOverlay";
-  static props = {
-    onCellDoubleClicked: { type: Function, optional: true },
-    onCellClicked: { type: Function, optional: true },
-    onCellRightClicked: { type: Function, optional: true },
-    onGridResized: { type: Function, optional: true },
-    onGridMoved: Function,
-    gridOverlayDimensions: String,
-    slots: { type: Object, optional: true },
-  };
   static components = {
     FiguresContainer,
     GridAddRowsFooter,
   };
-  static defaultProps = {
-    onCellDoubleClicked: () => {},
-    onCellClicked: () => {},
-    onCellRightClicked: () => {},
-    onGridResized: () => {},
-  };
+
+  protected props = props(
+    {
+      "onCellDoubleClicked?": types.function<[col: HeaderIndex, row: HeaderIndex]>([
+        types.HeaderIndex(),
+        types.HeaderIndex(),
+      ]),
+      "onCellClicked?": types.function<
+        [
+          col: HeaderIndex,
+          row: HeaderIndex,
+          modifiers: GridClickModifiers,
+          zoomedMouseEvent: ZoomedMouseEvent<MouseEvent | PointerEvent>
+        ]
+      >([
+        types.HeaderIndex(),
+        types.HeaderIndex(),
+        types.GridClickModifiers(),
+        types.ZoomedMouseEvent(),
+      ]),
+      "onCellRightClicked?": types.function<
+        [col: HeaderIndex, row: HeaderIndex, coordinates: DOMCoordinates]
+      >([types.HeaderIndex(), types.HeaderIndex(), types.DOMCoordinates()]),
+      "onGridResized?": types.function([]),
+      onGridMoved: types.function<[deltaX: Pixel, deltaY: Pixel]>([types.Pixel(), types.Pixel()]),
+      gridOverlayDimensions: types.string(),
+    },
+    {
+      onCellDoubleClicked: () => {},
+      onCellClicked: () => {},
+      onCellRightClicked: () => {},
+      onGridResized: () => {},
+    }
+  );
   private gridOverlayRef: Signal<HTMLElement | null> = signal(null);
   private cellPopovers!: Store<CellPopoverStore>;
   private paintFormatStore!: Store<PaintFormatStore>;

--- a/src/components/grid_popover/grid_popover.ts
+++ b/src/components/grid_popover/grid_popover.ts
@@ -1,26 +1,24 @@
 import { useStore } from "../../store_engine/store_hooks";
 import { ClosedCellPopover, PositionedCellPopoverComponent } from "../../types/cell_popovers";
-import { Rect } from "../../types/rendering";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 import { Store } from "../../types/store_engine";
 import { getZoomedRect } from "../helpers/zoom";
 import { CellPopoverStore } from "../popover/cell_popover_store";
 import { Popover } from "../popover/popover";
+import { types } from "../props_validation";
 
+import { props } from "@odoo/owl";
 import { Component } from "../../owl3_compatibility_layer";
-interface Props {
-  gridRect: Rect;
-  onClosePopover: () => void;
-  onMouseWheel: (ev: WheelEvent) => void;
-}
-export class GridPopover extends Component<Props, SpreadsheetChildEnv> {
+
+export class GridPopover extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-GridPopover";
-  static props = {
-    onClosePopover: Function,
-    onMouseWheel: Function,
-    gridRect: Object,
-  };
   static components = { Popover };
+
+  protected props = props({
+    onClosePopover: types.function([]),
+    onMouseWheel: types.function<[ev: WheelEvent]>([types.instanceOf(WheelEvent)]),
+    gridRect: types.Rect(),
+  });
   protected cellPopovers!: Store<CellPopoverStore>;
 
   setup() {

--- a/src/components/header_group/header_group.ts
+++ b/src/components/header_group/header_group.ts
@@ -1,18 +1,15 @@
+import { props } from "@odoo/owl";
 import { Action } from "../../actions/action";
 import { GROUP_LAYER_WIDTH, HEADER_HEIGHT, HEADER_WIDTH } from "../../constants";
 import { interactiveToggleGroup } from "../../helpers/ui/toggle_group_interactive";
 import { getHeaderGroupContextMenu } from "../../registries/menus/header_group_registry";
-import { Dimension, HeaderGroup } from "../../types/misc";
+import { Dimension } from "../../types/misc";
 import { DOMCoordinates, Rect } from "../../types/rendering";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 import { cssPropertiesToCss } from "../helpers/css";
+import { types } from "../props_validation";
 
 import { Component } from "../../owl3_compatibility_layer";
-interface Props {
-  group: HeaderGroup;
-  layerOffset: number;
-  openContextMenu(position: DOMCoordinates, menuItems: Action[]): void;
-}
 
 interface GroupBox {
   groupRect: Rect;
@@ -20,13 +17,17 @@ interface GroupBox {
   isEndHidden: boolean;
 }
 
-abstract class AbstractHeaderGroup extends Component<Props, SpreadsheetChildEnv> {
+abstract class AbstractHeaderGroup extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-HeaderGroup";
-  static props = {
-    group: Object,
-    layerOffset: Number,
-    openContextMenu: Function,
-  };
+
+  protected props = props({
+    group: types.HeaderGroup(),
+    layerOffset: types.number(),
+    openContextMenu: types.function<[position: DOMCoordinates, menuItems: Action[]]>([
+      types.DOMCoordinates(),
+      types.ArrayOf<Action>(),
+    ]),
+  });
 
   abstract dimension: Dimension;
 

--- a/src/components/header_group/header_group_container.ts
+++ b/src/components/header_group/header_group_container.ts
@@ -1,27 +1,24 @@
-import { proxy } from "@odoo/owl";
+import { props, proxy } from "@odoo/owl";
 import { Action } from "../../actions/action";
 import { GROUP_LAYER_WIDTH, HEADER_HEIGHT, HEADER_WIDTH } from "../../constants";
 import { Component } from "../../owl3_compatibility_layer";
 import { createHeaderGroupContainerContextMenu } from "../../registries/menus/header_group_registry";
-import { CSSProperties, Dimension, HeaderGroup, Pixel } from "../../types/misc";
+import { CSSProperties, Pixel } from "../../types/misc";
 import { DOMCoordinates } from "../../types/rendering";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 import { cssPropertiesToCss } from "../helpers/css";
 import { MenuPopover, MenuState } from "../menu_popover/menu_popover";
+import { types } from "../props_validation";
 import { ColGroup, RowGroup } from "./header_group";
 
-interface Props {
-  dimension: Dimension;
-  layers: HeaderGroup[][];
-}
-
-export class HeaderGroupContainer extends Component<Props, SpreadsheetChildEnv> {
+export class HeaderGroupContainer extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-HeaderGroupContainer";
-  static props = {
-    dimension: String,
-    layers: Array,
-  };
   static components = { RowGroup, ColGroup, MenuPopover };
+
+  protected props = props({
+    dimension: types.Dimension(),
+    layers: types.array(),
+  });
 
   menu: MenuState = proxy({ isOpen: false, anchorRect: null, menuItems: [] });
 

--- a/src/components/headers_overlay/headers_overlay.ts
+++ b/src/components/headers_overlay/headers_overlay.ts
@@ -1,4 +1,4 @@
-import { proxy, signal } from "@odoo/owl";
+import { props, proxy, signal } from "@odoo/owl";
 import { MIN_COL_WIDTH, MIN_ROW_HEIGHT } from "../../constants";
 import { Component } from "../../owl3_compatibility_layer";
 import { useStore } from "../../store_engine/store_hooks";
@@ -13,6 +13,7 @@ import { isCtrlKey } from "../helpers/dom_helpers";
 import { startDnd } from "../helpers/drag_and_drop";
 import { useDragAndDropBeyondTheViewport } from "../helpers/drag_and_drop_grid_hook";
 import { withZoom, ZoomedMouseEvent } from "../helpers/zoom";
+import { types } from "../props_validation";
 import { MergeErrorMessage, TableHeaderMoveErrorMessage } from "../translations_terms";
 import { ComposerFocusStore } from "./../composer/composer_focus_store";
 import { UnhideColumnHeaders, UnhideRowHeaders } from "./unhide_headers";
@@ -36,14 +37,16 @@ interface ResizerState {
   position: "before" | "after";
 }
 
-interface ResizerProps {
-  onOpenContextMenu: (type: ContextMenuType, x: Pixel, y: Pixel) => void;
-}
+export const resizerPropsDefinition = {
+  onOpenContextMenu: types.function<[type: ContextMenuType, x: Pixel, y: Pixel]>([
+    types.ContextMenuType(),
+    types.Pixel(),
+    types.Pixel(),
+  ]),
+};
 
-abstract class AbstractResizer extends Component<ResizerProps, SpreadsheetChildEnv> {
-  static props = {
-    onOpenContextMenu: Function,
-  };
+abstract class AbstractResizer extends Component<SpreadsheetChildEnv> {
+  protected props = props(resizerPropsDefinition);
   private composerFocusStore!: Store<ComposerFocusStore>;
 
   PADDING: number = 0;
@@ -344,10 +347,6 @@ abstract class AbstractResizer extends Component<ResizerProps, SpreadsheetChildE
 }
 
 export class ColResizer extends AbstractResizer {
-  static props = {
-    onOpenContextMenu: Function,
-  };
-
   static template = "o-spreadsheet-ColResizer";
   static components = { UnhideColumnHeaders };
 
@@ -517,9 +516,6 @@ export class ColResizer extends AbstractResizer {
 }
 
 export class RowResizer extends AbstractResizer {
-  static props = {
-    onOpenContextMenu: Function,
-  };
   static template = "o-spreadsheet-RowResizer";
   static components = { UnhideRowHeaders };
 
@@ -685,11 +681,10 @@ export class RowResizer extends AbstractResizer {
   }
 }
 
-export class HeadersOverlay extends Component<any, SpreadsheetChildEnv> {
-  static props = {
-    onOpenContextMenu: Function,
-  };
+export class HeadersOverlay extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-HeadersOverlay";
+
+  protected props = props(resizerPropsDefinition);
   static components = { ColResizer, RowResizer };
 
   selectAll() {

--- a/src/components/headers_overlay/unhide_headers.ts
+++ b/src/components/headers_overlay/unhide_headers.ts
@@ -1,24 +1,27 @@
+import { props } from "@odoo/owl";
 import { HEADER_HEIGHT, HEADER_WIDTH } from "../../constants";
 import { positionToZone } from "../../helpers/zones";
-import { ConsecutiveIndexes, HeaderIndex } from "../../types/misc";
+import { HeaderIndex } from "../../types/misc";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 import { cssPropertiesToCss } from "../helpers/css";
+import { types } from "../props_validation";
 
 import { Component } from "../../owl3_compatibility_layer";
-interface Props {
-  headersGroups: ConsecutiveIndexes[];
-  offset: number;
-  headerRange: { start: HeaderIndex; end: HeaderIndex };
-}
 
-export class UnhideRowHeaders extends Component<Props, SpreadsheetChildEnv> {
+export class UnhideRowHeaders extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-UnhideRowHeaders";
-  static props = {
-    headersGroups: Array,
-    headerRange: Object,
-    offset: { type: Number, optional: true },
-  };
-  static defaultProps = { offset: 0 };
+
+  protected props = props(
+    {
+      headersGroups: types.array(),
+      headerRange: types.object({
+        start: types.HeaderIndex(),
+        end: types.HeaderIndex(),
+      }),
+      "offset?": types.number(),
+    },
+    { offset: 0 }
+  );
 
   get sheetId() {
     return this.env.model.getters.getActiveSheetId();
@@ -49,14 +52,20 @@ export class UnhideRowHeaders extends Component<Props, SpreadsheetChildEnv> {
   }
 }
 
-export class UnhideColumnHeaders extends Component<Props, SpreadsheetChildEnv> {
+export class UnhideColumnHeaders extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-UnhideColumnHeaders";
-  static props = {
-    headersGroups: Array,
-    headerRange: Object,
-    offset: { type: Number, optional: true },
-  };
-  static defaultProps = { offset: 0 };
+
+  protected props = props(
+    {
+      headersGroups: types.array(),
+      headerRange: types.object({
+        start: types.HeaderIndex(),
+        end: types.HeaderIndex(),
+      }),
+      "offset?": types.number(),
+    },
+    { offset: 0 }
+  );
 
   get sheetId() {
     return this.env.model.getters.getActiveSheetId();

--- a/src/components/highlight/border/border.ts
+++ b/src/components/highlight/border/border.ts
@@ -1,25 +1,24 @@
-import { Zone } from "../../../types/misc";
+import { props } from "@odoo/owl";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
 import { cssPropertiesToCss } from "../../helpers/css";
+import { types } from "../../props_validation";
 
 import { Component } from "../../../owl3_compatibility_layer";
-type Orientation = "n" | "s" | "w" | "e";
 
-interface Props {
-  zone: Zone;
-  orientation: Orientation;
-  isMoving: boolean;
-  onMoveHighlight: (ev: PointerEvent) => void;
-}
-
-export class Border extends Component<Props, SpreadsheetChildEnv> {
+export class Border extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-Border";
-  static props = {
-    zone: Object,
-    orientation: String,
-    isMoving: Boolean,
-    onMoveHighlight: Function,
-  };
+
+  protected props = props({
+    zone: types.Zone(),
+    orientation: types.or([
+      types.literal("n"),
+      types.literal("s"),
+      types.literal("w"),
+      types.literal("e"),
+    ]),
+    isMoving: types.boolean(),
+    onMoveHighlight: types.function<[ev: PointerEvent]>([types.instanceOf(PointerEvent)]),
+  });
   get style() {
     const isTop = ["n", "w", "e"].includes(this.props.orientation);
     const isLeft = ["n", "w", "s"].includes(this.props.orientation);

--- a/src/components/highlight/corner/corner.ts
+++ b/src/components/highlight/corner/corner.ts
@@ -1,31 +1,36 @@
+import { props } from "@odoo/owl";
 import { AUTOFILL_EDGE_LENGTH } from "../../../constants";
 import { ResizeDirection } from "../../../types/figure";
-import { Color, Zone } from "../../../types/misc";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
 import { cssPropertiesToCss } from "../../helpers/css";
+import { types } from "../../props_validation";
 
 import { Component } from "../../../owl3_compatibility_layer";
 const MOBILE_HANDLER_WIDTH = 40;
 
 type Orientation = "nw" | "ne" | "sw" | "se" | "n" | "s" | "e" | "w";
 
-interface Props {
-  zone: Zone;
-  color: Color;
-  orientation: Orientation;
-  isResizing: boolean;
-  onResizeHighlight: (ev: PointerEvent, dirX: ResizeDirection, dirY: ResizeDirection) => void;
-}
-
-export class Corner extends Component<Props, SpreadsheetChildEnv> {
+export class Corner extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-Corner";
-  static props = {
-    zone: Object,
-    color: String,
-    orientation: String,
-    isResizing: Boolean,
-    onResizeHighlight: Function,
-  };
+
+  protected props = props({
+    zone: types.Zone(),
+    color: types.Color(),
+    orientation: types.or([
+      types.literal("nw"),
+      types.literal("ne"),
+      types.literal("sw"),
+      types.literal("se"),
+      types.literal("n"),
+      types.literal("s"),
+      types.literal("e"),
+      types.literal("w"),
+    ]),
+    isResizing: types.boolean(),
+    onResizeHighlight: types.function<
+      [ev: PointerEvent, dirX: ResizeDirection, dirY: ResizeDirection]
+    >([types.instanceOf(PointerEvent), types.ResizeDirection(), types.ResizeDirection()]),
+  });
   private dirX!: ResizeDirection;
   private dirY!: ResizeDirection;
 

--- a/src/components/highlight/highlight/highlight.ts
+++ b/src/components/highlight/highlight/highlight.ts
@@ -1,10 +1,9 @@
-import { proxy } from "@odoo/owl";
+import { props, proxy } from "@odoo/owl";
 import { clip } from "../../../helpers/misc";
 import { isEqual } from "../../../helpers/zones";
 import { Component } from "../../../owl3_compatibility_layer";
 import { ResizeDirection } from "../../../types/figure";
-import { Color, HeaderIndex, Zone } from "../../../types/misc";
-import { Range } from "../../../types/range";
+import { HeaderIndex, Zone } from "../../../types/misc";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
 import { gridOverlayPosition } from "../../helpers/dom_helpers";
 import {
@@ -12,27 +11,24 @@ import {
   useDragAndDropBeyondTheViewport,
 } from "../../helpers/drag_and_drop_grid_hook";
 import { withZoom } from "../../helpers/zoom";
+import { types } from "../../props_validation";
 import { Border } from "../border/border";
 import { Corner } from "../corner/corner";
-
-export interface HighlightProps {
-  range: Range;
-  color: Color;
-}
 
 interface HighlightState {
   shiftingMode: "isMoving" | "isResizing" | "none";
 }
-export class Highlight extends Component<HighlightProps, SpreadsheetChildEnv> {
+export class Highlight extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-Highlight";
-  static props = {
-    range: Object,
-    color: String,
-  };
   static components = {
     Corner,
     Border,
   };
+
+  protected props = props({
+    range: types.Range(),
+    color: types.Color(),
+  });
 
   highlightState: HighlightState = proxy({
     shiftingMode: "none",

--- a/src/components/icon_picker/icon_picker.ts
+++ b/src/components/icon_picker/icon_picker.ts
@@ -1,16 +1,16 @@
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 import { ICONS, ICON_SETS } from "../icons/icons";
 
+import { props } from "@odoo/owl";
 import { Component } from "../../owl3_compatibility_layer";
-interface Props {
-  onIconPicked: (icon: string) => void;
-}
+import { types } from "../props_validation";
 
-export class IconPicker extends Component<Props, SpreadsheetChildEnv> {
+export class IconPicker extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-IconPicker";
-  static props = {
-    onIconPicked: Function,
-  };
+
+  protected props = props({
+    onIconPicked: types.function<[icon: string]>([types.string()]),
+  });
 
   onIconClick(icon: string) {
     if (icon) {

--- a/src/components/link/link_display/link_display.ts
+++ b/src/components/link/link_display/link_display.ts
@@ -4,23 +4,23 @@ import { openLink, urlRepresentation } from "../../../helpers/links";
 import { useStore } from "../../../store_engine/store_hooks";
 import type { CellPopoverComponent, PopoverBuilders } from "../../../types/cell_popovers";
 import { EvaluatedCell } from "../../../types/cells";
-import { Link, Position } from "../../../types/misc";
+import { Link } from "../../../types/misc";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
 import { Store } from "../../../types/store_engine";
 import { isMiddleClickOrCtrlClick } from "../../helpers/dom_helpers";
 import { CellPopoverStore } from "../../popover/cell_popover_store";
 
+import { props } from "@odoo/owl";
 import { Component } from "../../../owl3_compatibility_layer";
-interface LinkDisplayProps {
-  cellPosition: Position;
-}
+import { types } from "../../props_validation";
 
-export class LinkDisplay extends Component<LinkDisplayProps, SpreadsheetChildEnv> {
+export class LinkDisplay extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-LinkDisplay";
-  static props = {
-    cellPosition: Object,
-    onClosed: { type: Function, optional: true },
-  };
+
+  protected props = props({
+    cellPosition: types.CellPosition(),
+    "onClosed?": types.function([]),
+  });
 
   protected cellPopovers!: Store<CellPopoverStore>;
 

--- a/src/components/link/link_editor/link_editor.ts
+++ b/src/components/link/link_editor/link_editor.ts
@@ -1,18 +1,14 @@
-import { onMounted, proxy, signal } from "@odoo/owl";
+import { onMounted, props, proxy, signal } from "@odoo/owl";
 import { urlRegistry, urlRepresentation } from "../../../helpers/links";
 import { canonicalizeNumberContent } from "../../../helpers/locale";
 import { markdownLink } from "../../../helpers/misc";
 import { fuzzyLookup } from "../../../helpers/search";
 import { Component } from "../../../owl3_compatibility_layer";
 import { CellPopoverComponent, PopoverBuilders } from "../../../types/cell_popovers";
-import { Link, Position } from "../../../types/misc";
+import { Link } from "../../../types/misc";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
 import { MenuPopover } from "../../menu_popover/menu_popover";
-
-interface LinkEditorProps {
-  cellPosition: Position;
-  onClosed?: () => void;
-}
+import { types } from "../../props_validation";
 
 interface LinkProposal {
   text: string;
@@ -30,13 +26,14 @@ interface LinkState {
   linksList: LinkProposal[];
 }
 
-export class LinkEditor extends Component<LinkEditorProps, SpreadsheetChildEnv> {
+export class LinkEditor extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-LinkEditor";
-  static props = {
-    cellPosition: Object,
-    onClosed: { type: Function, optional: true },
-  };
   static components = { MenuPopover };
+
+  protected props = props({
+    cellPosition: types.CellPosition(),
+    "onClosed?": types.function([]),
+  });
   static size = { maxHeight: 500 };
 
   urlInput = signal<HTMLElement | null>(null);

--- a/src/components/menu/menu.ts
+++ b/src/components/menu/menu.ts
@@ -1,30 +1,17 @@
-import { signal } from "@odoo/owl";
+import { props, signal } from "@odoo/owl";
 import { Action, isMenuItemEnabled, isRootMenu, MenuItemOrSeparator } from "../../actions/action";
 import { Component, useLayoutEffect } from "../../owl3_compatibility_layer";
 import { Pixel } from "../../types/misc";
 import { Rect } from "../../types/rendering";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 import { cssPropertiesToCss } from "../helpers/css";
+import { types } from "../props_validation";
 
 //------------------------------------------------------------------------------
 // Context Menu Component
 //------------------------------------------------------------------------------
 
 export type MenuItemRects = { [menuItemId: string]: Rect };
-
-export interface MenuProps {
-  menuItems: MenuItemOrSeparator[];
-  onClose: () => void;
-  onScroll?: (ev: CustomEvent) => void;
-  onClickMenu?: (menu: Action, ev: PointerEvent) => void;
-  onMouseEnter?: (menu: Action, ev: PointerEvent) => void;
-  onMouseLeave?: (menu: Action, ev: PointerEvent) => void;
-  hoveredMenuId?: string;
-  isHoveredMenuFocused?: boolean;
-  width?: number;
-  onKeyDown?: (ev: KeyboardEvent) => void;
-  disableKeyboardNavigation?: boolean;
-}
 
 export interface MenuState {
   isOpen: boolean;
@@ -34,24 +21,32 @@ export interface MenuState {
   isHoveringChild?: boolean;
 }
 
-export class Menu extends Component<MenuProps, SpreadsheetChildEnv> {
+export class Menu extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-Menu";
-  static props = {
-    menuItems: Array,
-    onClose: Function,
-    onClickMenu: { type: Function, optional: true },
-    onMouseEnter: { type: Function, optional: true },
-    onMouseLeave: { type: Function, optional: true },
-    width: { type: Number, optional: true },
-    hoveredMenuId: { type: String, optional: true },
-    isHoveredMenuFocused: { type: Boolean, optional: true },
-    onScroll: { type: Function, optional: true },
-    onKeyDown: { type: Function, optional: true },
-    disableKeyboardNavigation: { type: Boolean, optional: true },
-  };
-
   static components = {};
-  static defaultProps = {};
+
+  protected props = props({
+    menuItems: types.ArrayOf<MenuItemOrSeparator>(),
+    onClose: types.function([]),
+    "onClickMenu?": types.function<[menu: Action, ev: PointerEvent]>([
+      types.Action(),
+      types.instanceOf(PointerEvent),
+    ]),
+    "onMouseEnter?": types.function<[menu: Action, ev: PointerEvent]>([
+      types.Action(),
+      types.instanceOf(PointerEvent),
+    ]),
+    "onMouseLeave?": types.function<[menu: Action, ev: PointerEvent]>([
+      types.Action(),
+      types.instanceOf(PointerEvent),
+    ]),
+    "width?": types.number(),
+    "hoveredMenuId?": types.string(),
+    "isHoveredMenuFocused?": types.boolean(),
+    "onScroll?": types.function<[ev: CustomEvent]>([types.instanceOf(CustomEvent)]),
+    "onKeyDown?": types.function<[ev: KeyboardEvent]>([types.instanceOf(KeyboardEvent)]),
+    "disableKeyboardNavigation?": types.boolean(),
+  });
 
   private menuRef = signal<HTMLElement | null>(null);
 

--- a/src/components/menu_popover/menu_popover.ts
+++ b/src/components/menu_popover/menu_popover.ts
@@ -1,11 +1,11 @@
-import { onWillUnmount, onWillUpdateProps, proxy, signal } from "@odoo/owl";
+import { onWillUnmount, onWillUpdateProps, props, proxy, signal } from "@odoo/owl";
 import { Action, getMenuItemsAndSeparators, isMenuItemEnabled } from "../../actions/action";
 import { DESKTOP_MENU_ITEM_HEIGHT, MENU_VERTICAL_PADDING, MENU_WIDTH } from "../../constants";
 import { Component, useExternalListener, useLayoutEffect } from "../../owl3_compatibility_layer";
 import { useStore } from "../../store_engine/store_hooks";
 import { DOMFocusableElementStore } from "../../stores/DOM_focus_store";
-import { PopoverPropsPosition } from "../../types/cell_popovers";
 import { MenuMouseEvent, Pixel, UID } from "../../types/misc";
+import { PropsOf } from "../../types/props_of";
 import { Rect } from "../../types/rendering";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 import { cssPropertiesToCss } from "../helpers/css";
@@ -17,30 +17,15 @@ import {
   isMiddleClickOrCtrlClick,
 } from "../helpers/dom_helpers";
 import { useTimeOut } from "../helpers/time_hooks";
-import { Menu, MenuProps } from "../menu/menu";
-import { Popover, PopoverProps } from "../popover/popover";
+import { Menu } from "../menu/menu";
+import { Popover } from "../popover/popover";
+import { types } from "../props_validation";
 
 //------------------------------------------------------------------------------
 // Context MenuPopover Component
 //------------------------------------------------------------------------------
 
 const TIMEOUT_DELAY = 250;
-
-interface Props {
-  anchorRect: Rect;
-  popoverPositioning: PopoverPropsPosition;
-  menuItems: Action[];
-  depth: number;
-  maxHeight?: Pixel;
-  onClose: () => void;
-  onMenuClicked?: (ev: CustomEvent) => void;
-  menuId?: UID;
-  onMouseOver?: () => void;
-  width?: number;
-  autoSelectFirstItem?: boolean;
-  disableKeyboardNavigation?: boolean;
-  onKeyboardNavigation?: (ev: KeyboardEvent) => void;
-}
 
 export interface MenuState {
   isOpen: boolean;
@@ -56,29 +41,33 @@ interface State {
   hoveredMenu?: Action;
 }
 
-export class MenuPopover extends Component<Props, SpreadsheetChildEnv> {
+export class MenuPopover extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-Menu-Popover";
-  static props = {
-    anchorRect: Object,
-    popoverPositioning: { type: String, optional: true },
-    menuItems: Array,
-    depth: { type: Number, optional: true },
-    maxHeight: { type: Number, optional: true },
-    onClose: Function,
-    onMenuClicked: { type: Function, optional: true },
-    menuId: { type: String, optional: true },
-    onMouseOver: { type: Function, optional: true },
-    width: { type: Number, optional: true },
-    autoSelectFirstItem: { type: Boolean, optional: true },
-    disableKeyboardNavigation: { type: Boolean, optional: true },
-    onKeyboardNavigation: { type: Function, optional: true },
-  };
-
   static components = { MenuPopover, Menu, Popover };
-  static defaultProps = {
-    depth: 0,
-    popoverPositioning: "top-right",
-  };
+
+  protected props = props(
+    {
+      anchorRect: types.Rect(),
+      "popoverPositioning?": types.or([types.literal("top-right"), types.literal("bottom-left")]),
+      menuItems: types.ArrayOf<Action>(),
+      "depth?": types.number(),
+      "maxHeight?": types.Pixel(),
+      onClose: types.function([]),
+      "onMenuClicked?": types.function<[ev: CustomEvent]>([types.instanceOf(CustomEvent)]),
+      "menuId?": types.UID(),
+      "onMouseOver?": types.function([]),
+      "width?": types.number(),
+      "autoSelectFirstItem?": types.boolean(),
+      "disableKeyboardNavigation?": types.boolean(),
+      "onKeyboardNavigation?": types.function<[ev: KeyboardEvent]>([
+        types.instanceOf(KeyboardEvent),
+      ]),
+    },
+    {
+      depth: 0,
+      popoverPositioning: "top-right",
+    }
+  );
   private subMenu: MenuState = proxy({
     isOpen: false,
     anchorRect: null,
@@ -108,7 +97,7 @@ export class MenuPopover extends Component<Props, SpreadsheetChildEnv> {
 
     useExternalListener(window, "click", this.onExternalClick, { capture: true });
     useExternalListener(window, "contextmenu", this.onExternalClick, { capture: true });
-    onWillUpdateProps((nextProps: Props) => {
+    onWillUpdateProps((nextProps: PropsOf<MenuPopover>) => {
       if (nextProps.menuItems !== this.props.menuItems) {
         this.closeSubMenu();
       }
@@ -121,7 +110,7 @@ export class MenuPopover extends Component<Props, SpreadsheetChildEnv> {
     });
   }
 
-  get menuProps(): MenuProps {
+  get menuProps(): PropsOf<Menu> {
     const menItems = this.menuItems;
     const hoveredMenuId = menItems
       .filter((menuItem) => menuItem !== "separator")
@@ -147,7 +136,7 @@ export class MenuPopover extends Component<Props, SpreadsheetChildEnv> {
     return anchorRect;
   }
 
-  get popoverProps(): PopoverProps {
+  get popoverProps(): PropsOf<Popover> {
     const isRoot = this.props.depth === 0;
     return {
       anchorRect: {

--- a/src/components/named_range_selector/named_range_selector.ts
+++ b/src/components/named_range_selector/named_range_selector.ts
@@ -23,15 +23,12 @@ import { ToolBarDropdownStore, useToolBarDropdownStore } from "../helpers/top_ba
 import { MenuPopover, MenuState } from "../menu_popover/menu_popover";
 import { TextInput } from "../text_input/text_input";
 
-interface Props {}
-
 interface State extends Omit<MenuState, "isOpen"> {
   searchedText?: string;
 }
 
-export class NamedRangeSelector extends Component<Props, SpreadsheetChildEnv> {
+export class NamedRangeSelector extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-NamedRangeSelector";
-  static props = {};
   static components = { TextInput, MenuPopover };
 
   private DOMFocusableElementStore!: Store<DOMFocusableElementStore>;

--- a/src/components/number_editor/number_editor.ts
+++ b/src/components/number_editor/number_editor.ts
@@ -1,50 +1,40 @@
-import { onMounted, onWillUpdateProps, proxy, signal } from "@odoo/owl";
+import { onMounted, onWillUpdateProps, props, proxy, signal } from "@odoo/owl";
 import { clip } from "../../helpers/misc";
 import { Component, useExternalListener } from "../../owl3_compatibility_layer";
 import { useStore } from "../../store_engine/store_hooks";
 import { DOMFocusableElementStore } from "../../stores/DOM_focus_store";
+import { PropsOf } from "../../types/props_of";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 import { Store } from "../../types/store_engine";
 import { getElBoundingRect, isChildEvent } from "../helpers/dom_helpers";
-import { Popover, PopoverProps } from "../popover/popover";
+import { Popover } from "../popover/popover";
+import { types } from "../props_validation";
 
 interface State {
   isOpen: boolean;
 }
 
-interface Props {
-  currentValue: number;
-  class: string;
-  onValueChange: (fontSize: number) => void;
-  onToggle?: () => void;
-  onFocusInput?: () => void;
-  valueIcon?: String;
-  min: number;
-  max: number;
-  title: String;
-  valueList: number[];
-}
-
-export class NumberEditor extends Component<Props, SpreadsheetChildEnv> {
+export class NumberEditor extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-NumberEditor";
-  static props = {
-    currentValue: Number,
-    onValueChange: Function,
-    onToggle: { type: Function, optional: true },
-    onFocusInput: { type: Function, optional: true },
-    class: String,
-    valueIcon: { type: String, optional: true },
-    min: Number,
-    max: Number,
-    title: String,
-    valueList: Array<Number>,
-  };
-
-  static defaultProps = {
-    onFocusInput: () => {},
-  };
-
   static components = { Popover };
+
+  protected props = props(
+    {
+      currentValue: types.number(),
+      onValueChange: types.function<[fontSize: number]>([types.number()]),
+      "onToggle?": types.function([]),
+      "onFocusInput?": types.function([]),
+      class: types.string(),
+      "valueIcon?": types.string(),
+      min: types.number(),
+      max: types.number(),
+      title: types.string(),
+      valueList: types.array(types.number()),
+    },
+    {
+      onFocusInput: () => {},
+    }
+  );
 
   dropdown: State = proxy({ isOpen: false });
 
@@ -73,7 +63,7 @@ export class NumberEditor extends Component<Props, SpreadsheetChildEnv> {
     });
   }
 
-  get popoverProps(): PopoverProps {
+  get popoverProps(): PropsOf<Popover> {
     return {
       anchorRect: getElBoundingRect(this.rootEditorRef()),
       positioning: "bottom-left",

--- a/src/components/number_input/number_input.ts
+++ b/src/components/number_input/number_input.ts
@@ -1,5 +1,11 @@
+import { props } from "@odoo/owl";
 import { debounce } from "../../helpers/misc";
-import { GenericInput, GenericInputProps } from "../generic_input/generic_input";
+import {
+  GenericInput,
+  GenericInputProps,
+  genericInputPropsDefinition,
+} from "../generic_input/generic_input";
+import { types } from "../props_validation";
 
 interface Props extends GenericInputProps {
   alwaysShowBorder?: boolean;
@@ -11,11 +17,12 @@ interface Props extends GenericInputProps {
 export class NumberInput extends GenericInput<Props> {
   static template = "o-spreadsheet-NumberInput";
   static components = {};
-  static props = {
-    ...GenericInput.props,
-    min: { type: Number, optional: true },
-    max: { type: Number, optional: true },
-  };
+
+  protected props: Props = props({
+    ...genericInputPropsDefinition,
+    "min?": types.number(),
+    "max?": types.number(),
+  }) as unknown as Props;
 
   // Very short debounce to prevent up/down arrow on number input to spam the onChange
   debouncedOnChange = debounce(this.props.onChange.bind(this), 100, true);

--- a/src/components/paint_format_button/paint_format_button.ts
+++ b/src/components/paint_format_button/paint_format_button.ts
@@ -3,16 +3,15 @@ import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 import { Store } from "../../types/store_engine";
 import { PaintFormatStore } from "./paint_format_store";
 
+import { props } from "@odoo/owl";
 import { Component } from "../../owl3_compatibility_layer";
-interface Props {
-  class?: string;
-}
-
-export class PaintFormatButton extends Component<Props, SpreadsheetChildEnv> {
+import { types } from "../props_validation";
+export class PaintFormatButton extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-PaintFormatButton";
-  static props = {
-    class: { type: String, optional: true },
-  };
+
+  protected props = props({
+    "class?": types.string(),
+  });
 
   private paintFormatStore!: Store<PaintFormatStore>;
 

--- a/src/components/pivot_html_renderer/pivot_html_renderer.ts
+++ b/src/components/pivot_html_renderer/pivot_html_renderer.ts
@@ -1,10 +1,11 @@
-import { proxy } from "@odoo/owl";
+import { props, proxy } from "@odoo/owl";
 import { FunctionResultObject, Maybe, SpreadsheetPivotTable, UID } from "../..";
 import { toString } from "../../functions/helpers";
 import { formatValue } from "../../helpers/format/format";
 import { generatePivotArgs } from "../../helpers/pivot/pivot_helpers";
 import { Component } from "../../owl3_compatibility_layer";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
+import { types } from "../props_validation";
 import { Checkbox } from "../side_panel/components/checkbox/checkbox";
 
 interface PivotDialogColumn {
@@ -28,11 +29,6 @@ interface PivotDialogValue {
   isMissing: boolean;
 }
 
-interface Props {
-  pivotId: UID;
-  onCellClicked: (formula: string) => void;
-}
-
 interface State {
   showMissingValuesOnly: boolean;
 }
@@ -43,13 +39,13 @@ interface TableData {
   values: PivotDialogValue[][];
 }
 
-export class PivotHTMLRenderer extends Component<Props, SpreadsheetChildEnv> {
+export class PivotHTMLRenderer extends Component<SpreadsheetChildEnv> {
   static template = "o_spreadsheet.PivotHTMLRenderer";
   static components = { Checkbox };
-  static props = {
-    pivotId: String,
-    onCellClicked: Function,
-  };
+  protected props = props({
+    pivotId: types.UID(),
+    onCellClicked: types.function<[formula: string]>([types.string()]),
+  });
 
   private pivot = this.env.model.getters.getPivot(this.props.pivotId);
   data: TableData = {

--- a/src/components/popover/popover.ts
+++ b/src/components/popover/popover.ts
@@ -1,61 +1,40 @@
-import { onMounted, onWillUnmount, signal } from "@odoo/owl";
+import { onMounted, onWillUnmount, props, signal } from "@odoo/owl";
 import { rectIntersection } from "../../helpers/rectangle";
 import { Component, useLayoutEffect } from "../../owl3_compatibility_layer";
-import { PopoverPropsPosition } from "../../types/cell_popovers";
-import { CSSProperties, Pixel } from "../../types/misc";
+import { CSSProperties } from "../../types/misc";
 import { DOMCoordinates, DOMDimension, Rect } from "../../types/rendering";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 import { usePopoverContainer, useSpreadsheetRect } from "../helpers/position_hook";
+import { types } from "../props_validation";
 
 type PopoverPosition = "top-left" | "top-right" | "bottom-left" | "bottom-right";
 type DisplayValue = "none" | "block";
 
-export interface PopoverProps {
-  /**
-   * Rectangle around which the popover is displayed.
-   * Coordinates are expressed as absolute DOM position.
-   */
-  anchorRect: Rect;
-
-  /** The popover can be positioned below the anchor Rectangle, or to the right of the rectangle */
-  positioning: PopoverPropsPosition;
-
-  maxWidth?: Pixel;
-  maxHeight?: Pixel;
-
-  /** Offset to apply to the vertical position of the popover.*/
-  verticalOffset: number;
-
-  onMouseWheel?: () => void;
-  onPopoverMoved?: () => void;
-  onPopoverHidden?: () => void;
-
-  class?: string;
-}
-
-export class Popover extends Component<PopoverProps, SpreadsheetChildEnv> {
+export class Popover extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-Popover";
-  static props = {
-    anchorRect: Object,
-    containerRect: { type: Object, optional: true },
-    positioning: { type: String, optional: true },
-    maxWidth: { type: Number, optional: true },
-    maxHeight: { type: Number, optional: true },
-    verticalOffset: { type: Number, optional: true },
-    onMouseWheel: { type: Function, optional: true },
-    onPopoverHidden: { type: Function, optional: true },
-    onPopoverMoved: { type: Function, optional: true },
-    zIndex: { type: Number, optional: true },
-    class: { type: String, optional: true },
-    slots: Object,
-  };
-  static defaultProps = {
-    positioning: "bottom-left",
-    verticalOffset: 0,
-    onMouseWheel: () => {},
-    onPopoverMoved: () => {},
-    onPopoverHidden: () => {},
-  };
+
+  protected props = props(
+    {
+      anchorRect: types.Rect(),
+      "containerRect?": types.object({}),
+      "positioning?": types.or([types.literal("top-right"), types.literal("bottom-left")]),
+      "maxWidth?": types.Pixel(),
+      "maxHeight?": types.Pixel(),
+      "verticalOffset?": types.number(),
+      "onMouseWheel?": types.function([]),
+      "onPopoverHidden?": types.function([]),
+      "onPopoverMoved?": types.function([]),
+      "zIndex?": types.number(),
+      "class?": types.string(),
+    },
+    {
+      positioning: "bottom-left",
+      verticalOffset: 0,
+      onMouseWheel: () => {},
+      onPopoverMoved: () => {},
+      onPopoverHidden: () => {},
+    }
+  );
 
   private popoverRef = signal<HTMLElement | null>(null);
   private popoverContentRef = signal<HTMLElement | null>(null);

--- a/src/components/props_validation.ts
+++ b/src/components/props_validation.ts
@@ -1,0 +1,287 @@
+import { types as owlTypes } from "@odoo/owl";
+import { Action, ActionSpec, MenuItemOrSeparator } from "../actions/action";
+import { Token } from "../formulas/tokenizer";
+import { PivotRuntimeDefinition } from "../helpers/pivot/pivot_runtime_definition";
+import { Model } from "../model";
+import {
+  AutoCompleteProposal,
+  AutoCompleteProviderDefinition,
+} from "../registries/auto_completes/auto_complete_registry";
+import { SidePanelContent } from "../registries/side_panel_registry";
+import {
+  ChartColorScale,
+  ChartDefinition,
+  ChartDefinitionWithDataSource,
+  ChartRangeDataSource,
+  ChartStyle,
+  ChartWithAxisDefinition,
+  DataSetStyle,
+  TitleDesign,
+} from "../types/chart/chart";
+import { FunnelChartDefinition } from "../types/chart/funnel_chart";
+import { GeoChartDefinition } from "../types/chart/geo_chart";
+import {
+  TreeMapCategoryColorOptions,
+  TreeMapChartDefinition,
+  TreeMapColorScaleOptions,
+} from "../types/chart/tree_map_chart";
+import { DispatchResult } from "../types/commands";
+import { ColorScaleThreshold, ConditionalFormat } from "../types/conditional_formatting";
+import { DataValidationCriterionType, DataValidationRule } from "../types/data_validation";
+import { InformationNotification } from "../types/env";
+import { FigureUI, ResizeDirection } from "../types/figure";
+import { FunctionDescription } from "../types/functions";
+import { GenericCriterionType } from "../types/generic_criterion";
+import {
+  BorderPosition,
+  borderPositions,
+  BorderStyle,
+  borderStyles,
+  CellPosition,
+  Color,
+  ComposerFocusType,
+  composerFocusTypes,
+  CSSProperties,
+  Dimension,
+  GridClickModifiers,
+  HeaderGroup,
+  HeaderIndex,
+  NamedRange,
+  Pixel,
+  Position,
+  SortDirection,
+  UID,
+  Zone,
+} from "../types/misc";
+import {
+  PivotCoreDefinition,
+  PivotCoreMeasure,
+  PivotCustomGroupedField,
+  PivotDimension,
+  PivotField,
+  PivotFilter,
+  PivotMeasure,
+  SpreadsheetPivotCoreDefinition,
+} from "../types/pivot";
+import { Range } from "../types/range";
+import { DOMCoordinates, DOMDimension, Rect } from "../types/rendering";
+import { Store } from "../types/store_engine";
+import { NotificationStoreMethods } from "../types/stores/notification_store_methods";
+import {
+  CoreTable,
+  CriterionFilter,
+  DataFilterValue,
+  Table,
+  TableConfig,
+  TableStyle,
+} from "../types/table";
+import type { ComposerSelection } from "./composer/composer/abstract_composer_store";
+import type { ContextMenuType } from "./grid/grid";
+import type { ZoomedMouseEvent } from "./helpers/zoom";
+import type { SidePanelComponentProps } from "./side_panel/side_panel/side_panel_store";
+
+/*
+ * This file defines custom prop validators for our components, using the basic
+ * validators provided by Owl (e.g. `owlTypes.string()`) and adding extra checks
+ * when necessary. It also re-exports the basic validators from Owl so that they
+ * can be used in our components without having to import Owl directly in each of
+ * them.
+ * We also improve the type inference of the basic validators by creating wrapper
+ * functions (e.g. `validateString`) that allow us to specify a more specific
+ * type for the prop.
+ */
+
+/**
+ * Validate that a prop is a number, but with a more specific type than just `number` (e.g. `Pixel`).
+ */
+function validateNumber<T extends number>(): T {
+  return owlTypes.number() as any;
+}
+
+/**
+ * Validate that a prop is a string, but with a more specific type than just `string` (e.g. `Color`).
+ */
+function validateString<T extends string>(): T {
+  return owlTypes.string() as any;
+}
+
+/**
+ * Validate that a prop is an object, but with a more specific type than just `object` (e.g. `ActionSpec`).
+ */
+function validateObject<T>(): T {
+  return owlTypes.object() as any;
+}
+
+/**
+ * Validate that a prop is an array, but with a more specific element type than `any[]`.
+ */
+function validateArrayOf<T>(): T[] {
+  return owlTypes.array() as any;
+}
+
+/**
+ * Validate that a prop is a record (string-keyed dictionary), but with a more
+ * specific value type than `any`.
+ */
+function validateRecordOf<T>(): Record<string, T> {
+  return owlTypes.record() as any;
+}
+
+/**
+ * Validate that a prop is a `Set`, typed with a specific element type.
+ */
+function validateSetOf<T>(): Set<T> {
+  return owlTypes.instanceOf(Set) as any;
+}
+
+function validateRect(): Rect {
+  return owlTypes.object({
+    x: owlTypes.number(),
+    y: owlTypes.number(),
+    width: owlTypes.number(),
+    height: owlTypes.number(),
+  }) as any;
+}
+
+function validateBorderPosition(): BorderPosition {
+  return owlTypes.customValidator(validateString<BorderPosition>(), (position) =>
+    borderPositions.includes(position)
+  ) as any;
+}
+
+function validateBorderStyle(): BorderStyle {
+  return owlTypes.customValidator(validateString<BorderStyle>(), (style) =>
+    borderStyles.includes(style)
+  ) as any;
+}
+
+function validateDOMCoordinates(): DOMCoordinates {
+  return owlTypes.object({
+    x: owlTypes.number(),
+    y: owlTypes.number(),
+  }) as any;
+}
+
+function validateDOMDimension(): DOMDimension {
+  return owlTypes.object({
+    width: owlTypes.number(),
+    height: owlTypes.number(),
+  }) as any;
+}
+
+function validateSortDirection(): SortDirection {
+  return owlTypes.customValidator(validateString<SortDirection>(), (direction) =>
+    ["asc", "desc"].includes(direction)
+  ) as any;
+}
+
+function validateResizeDirection(): ResizeDirection {
+  return owlTypes.customValidator(validateNumber<ResizeDirection>(), (direction) =>
+    [-1, 0, 1].includes(direction)
+  ) as any;
+}
+
+function validateComposerFocusType(): ComposerFocusType {
+  return owlTypes.customValidator(validateString<ComposerFocusType>(), (value) =>
+    composerFocusTypes.includes(value)
+  ) as any;
+}
+
+function validateDimension(): Dimension {
+  return owlTypes.customValidator(validateString<Dimension>(), (value) =>
+    ["COL", "ROW"].includes(value)
+  ) as any;
+}
+
+function validateContextMenuType(): ContextMenuType {
+  return owlTypes.customValidator(validateString<ContextMenuType>(), (value) =>
+    ["ROW", "COL", "CELL", "FILTER", "GROUP_HEADERS", "UNGROUP_HEADERS"].includes(value)
+  ) as any;
+}
+
+/**
+ * Validate that a prop is a store. Typed as the CQS-wrapped `Store<T>` to
+ * match what `useStore(...)` returns at the call site.
+ */
+function validateStore<T>(): Store<T> {
+  return owlTypes.object() as any;
+}
+
+export const types = {
+  ...owlTypes,
+  ArrayOf: validateArrayOf,
+  RecordOf: validateRecordOf,
+  SetOf: validateSetOf,
+  GenericCriterionType: validateString<GenericCriterionType>,
+  UID: validateString<UID>,
+  CriterionFilter: validateObject<CriterionFilter>,
+  CSSProperties: validateObject<CSSProperties>,
+  ResizeDirection: validateResizeDirection,
+  FigureUI: validateObject<FigureUI>,
+  Token: validateObject<Token>,
+  CellPosition: validateObject<CellPosition>,
+  AutoCompleteProviderDefinition: validateObject<AutoCompleteProviderDefinition>,
+  AutoCompleteProposal: validateObject<AutoCompleteProposal>,
+  FunctionDescription: validateObject<FunctionDescription>,
+  Rect: validateRect,
+  Pixel: validateNumber<Pixel>,
+  HeaderIndex: validateNumber<HeaderIndex>,
+  BorderPosition: validateBorderPosition,
+  BorderStyle: validateBorderStyle,
+  Color: validateString<Color>,
+  ActionSpec: validateObject<ActionSpec>,
+  DOMCoordinates: validateDOMCoordinates,
+  DOMDimension: validateDOMDimension,
+  ComposerFocusType: validateComposerFocusType,
+  SortDirection: validateSortDirection,
+  Store: validateStore,
+  Position: validateObject<Position>,
+  PivotCoreDefinition: validateObject<PivotCoreDefinition>,
+  PivotField: validateObject<PivotField>,
+  PivotDimension: validateObject<PivotDimension>,
+  PivotMeasure: validateObject<PivotMeasure>,
+  PivotCoreMeasure: validateObject<PivotCoreMeasure>,
+  PivotCustomGroupedField: validateObject<PivotCustomGroupedField>,
+  PivotRuntimeDefinition: validateObject<PivotRuntimeDefinition>,
+  PivotFilter: validateObject<PivotFilter>,
+  DataFilterValue: validateObject<DataFilterValue>,
+  SpreadsheetPivotCoreDefinition: validateObject<SpreadsheetPivotCoreDefinition>,
+  ComposerSelection: validateObject<ComposerSelection>,
+  Action: validateObject<Action>,
+  MenuItemOrSeparator: validateObject<MenuItemOrSeparator>,
+  Model: validateObject<Model>,
+  DispatchResult: validateObject<DispatchResult>,
+  Zone: validateObject<Zone>,
+  Range: validateObject<Range>,
+  HeaderGroup: validateObject<HeaderGroup>,
+  GridClickModifiers: validateObject<GridClickModifiers>,
+  ZoomedMouseEvent: validateObject<ZoomedMouseEvent<MouseEvent | PointerEvent>>,
+  ConditionalFormat: validateObject<ConditionalFormat>,
+  ColorScaleThreshold: validateObject<ColorScaleThreshold>,
+  Table: validateObject<Table>,
+  CoreTable: validateObject<CoreTable>,
+  TableConfig: validateObject<TableConfig>,
+  TableStyle: validateObject<TableStyle>,
+  TitleDesign: validateObject<TitleDesign>,
+  ChartDefinition: validateObject<ChartDefinition<string>>,
+  ChartDefinitionWithDataSource: validateObject<ChartDefinitionWithDataSource<string>>,
+  ChartWithAxisDefinition: validateObject<ChartWithAxisDefinition>,
+  ChartStyle: validateObject<ChartStyle>,
+  ChartColorScale: validateObject<ChartColorScale>,
+  ChartRangeDataSource: validateObject<ChartRangeDataSource<string>>,
+  DataSetStyle: validateObject<DataSetStyle>,
+  GeoChartDefinition: validateObject<GeoChartDefinition<string>>,
+  FunnelChartDefinition: validateObject<FunnelChartDefinition<string>>,
+  TreeMapChartDefinition: validateObject<TreeMapChartDefinition>,
+  TreeMapCategoryColorOptions: validateObject<TreeMapCategoryColorOptions>,
+  TreeMapColorScaleOptions: validateObject<TreeMapColorScaleOptions>,
+  NamedRange: validateObject<NamedRange>,
+  DataValidationRule: validateObject<DataValidationRule>,
+  InformationNotification: validateObject<InformationNotification>,
+  NotificationStoreMethods: validateObject<NotificationStoreMethods>,
+  SidePanelContent: validateObject<SidePanelContent>,
+  SidePanelComponentProps: validateObject<SidePanelComponentProps>,
+  DataValidationCriterionType: validateString<DataValidationCriterionType>,
+  Dimension: validateDimension,
+  ContextMenuType: validateContextMenuType,
+};

--- a/src/components/scrollbar/scrollbar.ts
+++ b/src/components/scrollbar/scrollbar.ts
@@ -1,20 +1,12 @@
-import { onMounted, props, signal, types, xml } from "@odoo/owl";
+import { onMounted, props, signal, xml } from "@odoo/owl";
 import { Component, useLayoutEffect } from "../../owl3_compatibility_layer";
-import { CSSProperties, Pixel } from "../../types/misc";
+import { Pixel } from "../../types/misc";
 import { ScrollDirection } from "../../types/scroll_direction";
 import { cssPropertiesToCss } from "../helpers/css";
+import { types } from "../props_validation";
 import { ScrollBar as ScrollBarElement } from "../scrollbar";
 
-interface Props {
-  width: Pixel;
-  height: Pixel;
-  direction: ScrollDirection;
-  position: CSSProperties;
-  offset: Pixel;
-  onScroll: (offset: Pixel) => void;
-}
-
-export class ScrollBar extends Component<Props> {
+export class ScrollBar extends Component<any> {
   static template = xml/*xml*/ `
     <div
         t-attf-class="o-scrollbar {{this.props.direction}}"
@@ -25,26 +17,27 @@ export class ScrollBar extends Component<Props> {
     </div>
   `;
 
+  protected props = props(
+    {
+      "width?": types.Pixel(),
+      "height?": types.Pixel(),
+      direction: types.customValidator(types.string() as ScrollDirection, (direction) =>
+        ["horizontal", "vertical"].includes(direction)
+      ),
+      position: types.CSSProperties(),
+      offset: types.Pixel(),
+      onScroll: types.function<[offset: Pixel]>([types.Pixel()]),
+    },
+    {
+      width: 1,
+      height: 1,
+    }
+  );
+
   private scrollbarRef = signal<HTMLElement | null>(null);
   private scrollbar!: ScrollBarElement;
 
   setup() {
-    this.props = props(
-      {
-        "width?": types.number(),
-        "height?": types.number(),
-        direction: types.customValidator(types.string() as ScrollDirection, (direction) =>
-          ["horizontal", "vertical"].includes(direction)
-        ),
-        position: types.object({}),
-        offset: types.number(),
-        onScroll: types.function(),
-      },
-      {
-        width: 1,
-        height: 1,
-      }
-    );
     this.scrollbar = new ScrollBarElement(this.scrollbarRef(), this.props.direction);
     onMounted(() => {
       this.scrollbar.el = this.scrollbarRef()!;

--- a/src/components/scrollbar/scrollbar_horizontal.ts
+++ b/src/components/scrollbar/scrollbar_horizontal.ts
@@ -1,17 +1,11 @@
-import { xml } from "@odoo/owl";
+import { props, xml } from "@odoo/owl";
 import { Component } from "../../owl3_compatibility_layer";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 import { isBrowserFirefox } from "../helpers/dom_helpers";
+import { types } from "../props_validation";
 import { ScrollBar } from "./scrollbar";
 
-interface Props {
-  leftOffset: number;
-}
-
-export class HorizontalScrollBar extends Component<Props, SpreadsheetChildEnv> {
-  static props = {
-    leftOffset: { type: Number, optional: true },
-  };
+export class HorizontalScrollBar extends Component<SpreadsheetChildEnv> {
   static components = { ScrollBar };
   static template = xml/*xml*/ `
       <ScrollBar
@@ -22,9 +16,15 @@ export class HorizontalScrollBar extends Component<Props, SpreadsheetChildEnv> {
         direction="'horizontal'"
         onScroll.bind="this.onScroll"
       />`;
-  static defaultProps = {
-    leftOffset: 0,
-  };
+
+  protected props = props(
+    {
+      "leftOffset?": types.number(),
+    },
+    {
+      leftOffset: 0,
+    }
+  );
 
   get offset() {
     return this.env.model.getters.getActiveSheetScrollInfo().scrollX;

--- a/src/components/scrollbar/scrollbar_vertical.ts
+++ b/src/components/scrollbar/scrollbar_vertical.ts
@@ -1,17 +1,11 @@
-import { xml } from "@odoo/owl";
+import { props, xml } from "@odoo/owl";
 import { Component } from "../../owl3_compatibility_layer";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 import { isBrowserFirefox } from "../helpers/dom_helpers";
+import { types } from "../props_validation";
 import { ScrollBar } from "./scrollbar";
 
-interface Props {
-  topOffset: number;
-}
-
-export class VerticalScrollBar extends Component<Props, SpreadsheetChildEnv> {
-  static props = {
-    topOffset: { type: Number, optional: true },
-  };
+export class VerticalScrollBar extends Component<SpreadsheetChildEnv> {
   static components = { ScrollBar };
   static template = xml/*xml*/ `
     <ScrollBar
@@ -22,9 +16,15 @@ export class VerticalScrollBar extends Component<Props, SpreadsheetChildEnv> {
       direction="'vertical'"
       onScroll.bind="(offset) => this.onScroll(offset)"
     />`;
-  static defaultProps = {
-    topOffset: 0,
-  };
+
+  protected props = props(
+    {
+      "topOffset?": types.number(),
+    },
+    {
+      topOffset: 0,
+    }
+  );
 
   get offset() {
     return this.env.model.getters.getActiveSheetScrollInfo().scrollY;

--- a/src/components/select/select.ts
+++ b/src/components/select/select.ts
@@ -1,37 +1,30 @@
-import { proxy, signal } from "@odoo/owl";
+import { props, proxy, signal } from "@odoo/owl";
 import { Component, useExternalListener, useLayoutEffect } from "../../owl3_compatibility_layer";
 import { ValueAndLabel } from "../../types/misc";
+import { PropsOf } from "../../types/props_of";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 import { getElBoundingRect, isChildEvent } from "../helpers/dom_helpers";
-import { Popover, PopoverProps } from "../popover/popover";
-
-export interface SelectProps {
-  onChange: (value: string) => void;
-  values: ValueAndLabel[];
-  selectedValue?: string;
-  class?: string;
-  popoverClass?: string;
-  name?: string;
-  title?: string;
-}
+import { Popover } from "../popover/popover";
+import { types } from "../props_validation";
 
 interface State {
   isPopoverOpen: boolean;
   hoveredValue: string | undefined;
 }
 
-export class Select extends Component<SelectProps, SpreadsheetChildEnv> {
+export class Select extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-Select";
-  static props = {
-    onChange: Function,
-    values: Array,
-    selectedValue: { type: String, optional: true },
-    class: { type: String, optional: true },
-    popoverClass: { type: String, optional: true },
-    name: { type: String, optional: true },
-    title: { type: String, optional: true },
-  };
   static components = { Popover };
+
+  protected props = props({
+    onChange: types.function<[value: string]>([types.string()]),
+    values: types.array() as ValueAndLabel[],
+    "selectedValue?": types.string(),
+    "class?": types.string(),
+    "popoverClass?": types.string(),
+    "name?": types.string(),
+    "title?": types.string(),
+  });
 
   private selectRef = signal<HTMLElement | null>(null);
   private dropdownRef = signal<HTMLElement | null>(null);
@@ -119,7 +112,7 @@ export class Select extends Component<SelectProps, SpreadsheetChildEnv> {
     this.state.hoveredValue = undefined;
   }
 
-  get popoverProps(): PopoverProps {
+  get popoverProps(): PropsOf<Popover> {
     return {
       anchorRect: getElBoundingRect(this.selectRef()),
       positioning: "bottom-left",

--- a/src/components/selection/selection.ts
+++ b/src/components/selection/selection.ts
@@ -1,14 +1,14 @@
 import { SELECTION_BORDER_COLOR } from "../../constants";
+import { PropsOf } from "../../types/props_of";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
-import { Highlight, HighlightProps } from "../highlight/highlight/highlight";
+import { Highlight } from "../highlight/highlight/highlight";
 
 import { Component } from "../../owl3_compatibility_layer";
-export class Selection extends Component<{}, SpreadsheetChildEnv> {
+export class Selection extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-Selection";
-  static props = {};
   static components = { Highlight };
 
-  get highlightProps(): HighlightProps {
+  get highlightProps(): PropsOf<Highlight> {
     const sheetId = this.env.model.getters.getActiveSheetId();
     const zone = this.env.model.getters.getUnboundedZone(
       sheetId,

--- a/src/components/selection_input/selection_input.ts
+++ b/src/components/selection_input/selection_input.ts
@@ -1,32 +1,17 @@
-import { onWillStart, onWillUpdateProps, proxy, signal, useEffect } from "@odoo/owl";
+import { onWillStart, onWillUpdateProps, props, proxy, signal, useEffect } from "@odoo/owl";
 import { deepEquals, range } from "../../helpers/misc";
 import { Component, useLayoutEffect } from "../../owl3_compatibility_layer";
 import { useLocalStore, useStore } from "../../store_engine/store_hooks";
 import { DOMFocusableElementStore } from "../../stores/DOM_focus_store";
 import { Color } from "../../types/misc";
+import { PropsOf } from "../../types/props_of";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 import { Store } from "../../types/store_engine";
 import { cssPropertiesToCss } from "../helpers/css";
 import { useDragAndDropListItems } from "../helpers/drag_and_drop_dom_items_hook";
 import { updateSelectionWithArrowKeys } from "../helpers/selection_helpers";
+import { types } from "../props_validation";
 import { RangeInputValue, SelectionInputStore } from "./selection_input_store";
-
-interface Props {
-  ranges: string[];
-  hasSingleRange?: boolean;
-  required?: boolean;
-  autofocus?: boolean;
-  isInvalid?: boolean;
-  class?: string;
-  onSelectionChanged?: (ranges: string[]) => void;
-  onSelectionReordered?: (indexes: number[]) => void;
-  onSelectionRemoved?: (index: number) => void;
-  onSelectionConfirmed?: () => void;
-  onInputFocused?: () => void;
-  colors?: Color[];
-  disabledRanges?: boolean[];
-  disabledRangeTitle?: string;
-}
 
 interface State {
   isMissing: boolean;
@@ -46,24 +31,31 @@ interface SelectionRange extends Omit<RangeInputValue, "color"> {
  * onSelectionChanged is called every time the input value
  * changes.
  */
-export class SelectionInput extends Component<Props, SpreadsheetChildEnv> {
+export class SelectionInput extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-SelectionInput";
-  static props = {
-    ranges: Array,
-    hasSingleRange: { type: Boolean, optional: true },
-    required: { type: Boolean, optional: true },
-    autofocus: { type: Boolean, optional: true },
-    isInvalid: { type: Boolean, optional: true },
-    class: { type: String, optional: true },
-    onSelectionChanged: { type: Function, optional: true },
-    onSelectionConfirmed: { type: Function, optional: true },
-    onSelectionReordered: { type: Function, optional: true },
-    onSelectionRemoved: { type: Function, optional: true },
-    onInputFocused: { type: Function, optional: true },
-    colors: { type: Array, optional: true, default: [] },
-    disabledRanges: { type: Array, optional: true, default: [] },
-    disabledRangeTitle: { type: String, optional: true },
-  };
+
+  protected props = props(
+    {
+      ranges: types.array(types.string()),
+      "hasSingleRange?": types.boolean(),
+      "required?": types.boolean(),
+      "autofocus?": types.boolean(),
+      "isInvalid?": types.boolean(),
+      "class?": types.string(),
+      "onSelectionChanged?": types.function<[ranges: string[]]>([types.array(types.string())]),
+      "onSelectionConfirmed?": types.function([]),
+      "onSelectionReordered?": types.function<[indexes: number[]]>([types.array(types.number())]),
+      "onSelectionRemoved?": types.function<[index: number]>([types.number()]),
+      "onInputFocused?": types.function([]),
+      "colors?": types.ArrayOf<Color>(),
+      "disabledRanges?": types.array(types.boolean()),
+      "disabledRangeTitle?": types.string(),
+    },
+    {
+      colors: [],
+      disabledRanges: [],
+    }
+  );
   private state: State = proxy({
     isMissing: false,
   });
@@ -135,7 +127,7 @@ export class SelectionInput extends Component<Props, SpreadsheetChildEnv> {
       }
     };
     useLayoutEffect(checkVisibility);
-    onWillUpdateProps((nextProps) => {
+    onWillUpdateProps((nextProps: PropsOf<SelectionInput>) => {
       if (nextProps.ranges.join() !== this.store.selectionInputValues.join()) {
         this.triggerChange();
       }

--- a/src/components/side_panel/carousel_panel/carousel_panel.ts
+++ b/src/components/side_panel/carousel_panel/carousel_panel.ts
@@ -1,4 +1,4 @@
-import { onWillUpdateProps, signal } from "@odoo/owl";
+import { onWillUpdateProps, props, signal } from "@odoo/owl";
 import { ActionSpec } from "../../../actions/action";
 import { DEFAULT_CAROUSEL_TITLE_STYLE } from "../../../constants";
 import { getCarouselItemPreview, getCarouselItemTitle } from "../../../helpers/carousel_helpers";
@@ -12,20 +12,20 @@ import { UID } from "../../../types/misc";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
 import { getBoundingRectAsPOJO } from "../../helpers/dom_helpers";
 import { useDragAndDropListItems } from "../../helpers/drag_and_drop_dom_items_hook";
+import { types } from "../../props_validation";
 import { TextInput } from "../../text_input/text_input";
 import { TextStyler } from "../chart/building_blocks/text_styler/text_styler";
 import { CogWheelMenu } from "../components/cog_wheel_menu/cog_wheel_menu";
 import { Section } from "../components/section/section";
 
-interface Props {
-  onCloseSidePanel: () => void;
-  figureId: UID;
-}
-
-export class CarouselPanel extends Component<Props, SpreadsheetChildEnv> {
+export class CarouselPanel extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-CarouselPanel";
-  static props = { onCloseSidePanel: Function, figureId: String };
   static components = { Section, TextInput, TextStyler, CogWheelMenu };
+
+  protected props = props({
+    onCloseSidePanel: types.function([]),
+    figureId: types.UID(),
+  });
 
   DEFAULT_CAROUSEL_TITLE_STYLE = DEFAULT_CAROUSEL_TITLE_STYLE;
 

--- a/src/components/side_panel/chart/bar_chart/bar_chart_design_panel.ts
+++ b/src/components/side_panel/chart/bar_chart/bar_chart_design_panel.ts
@@ -1,16 +1,10 @@
 import { BarChartDefinition } from "../../../../types/chart/bar_chart";
-import { DispatchResult } from "../../../../types/commands";
-import { UID } from "../../../../types/misc";
+import { ChartSidePanelProps } from "../common";
 import { GenericZoomableChartDesignPanel } from "../zoomable_chart/design_panel";
 
-interface Props {
-  chartId: UID;
-  definition: BarChartDefinition<string>;
-  canUpdateChart: (chartId: UID, definition: BarChartDefinition<string>) => DispatchResult;
-  updateChart: (chartId: UID, definition: BarChartDefinition<string>) => DispatchResult;
-}
-
-export class BarChartDesignPanel extends GenericZoomableChartDesignPanel<Props> {
+export class BarChartDesignPanel extends GenericZoomableChartDesignPanel<
+  ChartSidePanelProps<BarChartDefinition<string>>
+> {
   static template = "o-spreadsheet-BarChartDesignPanel";
   get isZoomable() {
     return !this.props.definition.horizontal;

--- a/src/components/side_panel/chart/bubble_chart/bubble_chart_config_panel.ts
+++ b/src/components/side_panel/chart/bubble_chart/bubble_chart_config_panel.ts
@@ -1,4 +1,4 @@
-import { proxy } from "@odoo/owl";
+import { props, proxy } from "@odoo/owl";
 import { numberToLetters } from "../../../../helpers/coordinates";
 import { createValidRange } from "../../../../helpers/range";
 import { Component } from "../../../../owl3_compatibility_layer";
@@ -10,7 +10,7 @@ import { ChartTerms } from "../../../translations_terms";
 import { ChartDataSeries } from "../building_blocks/data_series/data_series";
 import { ChartErrorSection } from "../building_blocks/error_section/error_section";
 import { ChartLabelRange } from "../building_blocks/label_range/label_range";
-import { ChartSidePanelProps, ChartSidePanelPropsObject } from "../common";
+import { ChartSidePanelProps, chartSidePanelPropsDefinition } from "../common";
 
 interface BubbleChartPanelState {
   datasetDispatchResult?: DispatchResult;
@@ -21,14 +21,14 @@ interface BubbleChartPanelState {
 
 type Props = ChartSidePanelProps<BubbleChartDefinition>;
 
-export class BubbleChartConfigPanel extends Component<Props, SpreadsheetChildEnv> {
+export class BubbleChartConfigPanel extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-BubbleChartConfigPanel";
   static components = {
     ChartDataSeries,
     ChartLabelRange,
     ChartErrorSection,
   };
-  static props = ChartSidePanelPropsObject;
+  protected props = props(chartSidePanelPropsDefinition) as unknown as Props;
 
   protected state: BubbleChartPanelState = proxy({
     datasetDispatchResult: undefined,

--- a/src/components/side_panel/chart/bubble_chart/bubble_chart_design_panel.ts
+++ b/src/components/side_panel/chart/bubble_chart/bubble_chart_design_panel.ts
@@ -1,11 +1,11 @@
+import { props } from "@odoo/owl";
 import { FIRST_CHART_COLOR } from "../../../../helpers/color";
 import { CHART_AXIS_CHOICES } from "../../../../helpers/figures/charts/chart_common";
 import { Component } from "../../../../owl3_compatibility_layer";
 import { _t } from "../../../../translation";
 import { BubbleChartDefinition } from "../../../../types/chart/bubble_chart";
 import { VerticalAxisPosition } from "../../../../types/chart/common_chart";
-import { DispatchResult } from "../../../../types/commands";
-import { Color, UID } from "../../../../types/misc";
+import { Color } from "../../../../types/misc";
 import { SpreadsheetChildEnv } from "../../../../types/spreadsheet_env";
 import { Checkbox } from "../../components/checkbox/checkbox";
 import { SidePanelCollapsible } from "../../components/collapsible/side_panel_collapsible";
@@ -20,16 +20,9 @@ import { GeneralDesignEditor } from "../building_blocks/general_design/general_d
 import { ChartHumanizeNumbers } from "../building_blocks/humanize_numbers/humanize_numbers";
 import { ChartLegend } from "../building_blocks/legend/legend";
 import { ChartShowValues } from "../building_blocks/show_values/show_values";
-import { ChartSidePanelPropsObject } from "../common";
+import { ChartSidePanelProps, chartSidePanelPropsDefinition } from "../common";
 
-interface Props {
-  chartId: UID;
-  definition: BubbleChartDefinition;
-  canUpdateChart: (chartId: UID, definition: Partial<BubbleChartDefinition>) => DispatchResult;
-  updateChart: (chartId: UID, definition: Partial<BubbleChartDefinition>) => DispatchResult;
-}
-
-export class BubbleChartDesignPanel extends Component<Props, SpreadsheetChildEnv> {
+export class BubbleChartDesignPanel extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-BubbleChartDesignPanel";
   static components = {
     GeneralDesignEditor,
@@ -43,7 +36,9 @@ export class BubbleChartDesignPanel extends Component<Props, SpreadsheetChildEnv
     RoundColorPicker,
     Checkbox,
   };
-  static props = ChartSidePanelPropsObject;
+  protected props = props(
+    chartSidePanelPropsDefinition
+  ) as unknown as ChartSidePanelProps<BubbleChartDefinition>;
 
   get axesList(): AxisDefinition[] {
     return [

--- a/src/components/side_panel/chart/building_blocks/axis_design/axis_design_editor.ts
+++ b/src/components/side_panel/chart/building_blocks/axis_design/axis_design_editor.ts
@@ -1,4 +1,4 @@
-import { proxy } from "@odoo/owl";
+import { props, proxy } from "@odoo/owl";
 import { CHART_AXIS_TITLE_FONT_SIZE } from "../../../../../constants";
 import { toNumber } from "../../../../../functions/helpers";
 import { getDefinedAxis } from "../../../../../helpers/figures/charts/chart_common";
@@ -20,6 +20,7 @@ import { UID } from "../../../../../types/misc";
 import { SpreadsheetChildEnv } from "../../../../../types/spreadsheet_env";
 import { DateInput } from "../../../../date_input/date_input";
 import { NumberInput } from "../../../../number_input/number_input";
+import { types } from "../../../../props_validation";
 import { BadgeSelection } from "../../../components/badge_selection/badge_selection";
 import { Checkbox } from "../../../components/checkbox/checkbox";
 import { Section } from "../../../components/section/section";
@@ -30,17 +31,19 @@ export interface AxisDefinition {
   name: string;
 }
 
-interface Props {
-  chartId: UID;
-  definition: ChartWithAxisDefinition;
-  updateChart: (chartId: UID, definition: Partial<ChartWithAxisDefinition>) => DispatchResult;
-  axesList: AxisDefinition[];
-}
-
-export class AxisDesignEditor extends Component<Props, SpreadsheetChildEnv> {
+export class AxisDesignEditor extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-AxisDesignEditor";
   static components = { Section, ChartTitle, BadgeSelection, Checkbox, NumberInput, DateInput };
-  static props = { chartId: String, definition: Object, updateChart: Function, axesList: Array };
+
+  protected props = props({
+    chartId: types.UID(),
+    definition: types.ChartWithAxisDefinition(),
+    updateChart: types.function<
+      [chartId: UID, definition: Partial<ChartWithAxisDefinition>],
+      DispatchResult
+    >([types.UID(), types.object({})], types.DispatchResult()),
+    axesList: types.ArrayOf<AxisDefinition>(),
+  });
 
   state: { currentAxis: AxisId } = proxy({ currentAxis: "x" });
 

--- a/src/components/side_panel/chart/building_blocks/chart_title/chart_title.ts
+++ b/src/components/side_panel/chart/building_blocks/chart_title/chart_title.ts
@@ -1,3 +1,4 @@
+import { props } from "@odoo/owl";
 import { TitleDesign } from "../../../../../types/chart/chart";
 import { SpreadsheetChildEnv } from "../../../../../types/spreadsheet_env";
 import { TextInput } from "../../../../text_input/text_input";
@@ -5,32 +6,26 @@ import { Section } from "../../../components/section/section";
 import { TextStyler } from "../text_styler/text_styler";
 
 import { Component } from "../../../../../owl3_compatibility_layer";
-interface Props {
-  title?: string;
-  placeholder?: string;
-  updateTitle: (title: string) => void;
-  name?: string;
-  style: TitleDesign;
-  defaultStyle?: Partial<TitleDesign>;
-  updateStyle: (style: TitleDesign) => void;
-}
-
-export class ChartTitle extends Component<Props, SpreadsheetChildEnv> {
+import { types } from "../../../../props_validation";
+export class ChartTitle extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet.ChartTitle";
   static components = { Section, TextStyler, TextInput };
-  static props = {
-    title: { type: String, optional: true },
-    placeholder: { type: String, optional: true },
-    updateTitle: Function,
-    name: { type: String },
-    style: Object,
-    defaultStyle: { type: Object, optional: true },
-    updateStyle: Function,
-  };
-  static defaultProps = {
-    title: "",
-    placeholder: "",
-  };
+
+  protected props = props(
+    {
+      "title?": types.string(),
+      "placeholder?": types.string(),
+      updateTitle: types.function<[title: string]>([types.string()]),
+      "name?": types.string(),
+      style: types.TitleDesign(),
+      "defaultStyle?": types.object({}) as Partial<TitleDesign>,
+      updateStyle: types.function<[style: TitleDesign]>([types.object({})]),
+    },
+    {
+      title: "",
+      placeholder: "",
+    }
+  );
 
   updateTitle(value: string) {
     this.props.updateTitle(value);

--- a/src/components/side_panel/chart/building_blocks/color_scale/color_scale_picker.ts
+++ b/src/components/side_panel/chart/building_blocks/color_scale/color_scale_picker.ts
@@ -1,37 +1,35 @@
-import { proxy, signal } from "@odoo/owl";
+import { props, proxy, signal } from "@odoo/owl";
 import { DEFAULT_CHART_COLOR_SCALE } from "../../../../../constants";
 import { ColorScale, COLORSCALES, COLORSCHEMES } from "../../../../../helpers/color";
 import { Component, useExternalListener } from "../../../../../owl3_compatibility_layer";
 import { ChartColorScale, schemeToColorScale } from "../../../../../types/chart/chart";
 import { Color } from "../../../../../types/misc";
+import { PropsOf } from "../../../../../types/props_of";
 import { SpreadsheetChildEnv } from "../../../../../types/spreadsheet_env";
 import { cssPropertiesToCss } from "../../../../helpers/css";
-import { Popover, PopoverProps } from "../../../../popover/popover";
+import { Popover } from "../../../../popover/popover";
+import { types } from "../../../../props_validation";
 import { ChartTerms } from "../../../../translations_terms";
 import { RoundColorPicker } from "../../../components/round_color_picker/round_color_picker";
 import { Section } from "../../../components/section/section";
 
-interface Props {
-  definition: { colorScale: ChartColorScale };
-  onUpdateColorScale: (colorscale: ChartColorScale) => void;
-}
-
 interface ColorScalePickerState {
-  popoverProps: PopoverProps | undefined;
+  popoverProps: PropsOf<Popover> | undefined;
   popoverStyle: string;
 }
 
-export class ColorScalePicker extends Component<Props, SpreadsheetChildEnv> {
+export class ColorScalePicker extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ColorScalePicker";
   static components = {
     Section,
     RoundColorPicker,
     Popover,
   };
-  static props = {
-    definition: Object,
-    onUpdateColorScale: Function,
-  };
+
+  protected props = props({
+    definition: types.object({ "colorScale?": types.ChartColorScale() }),
+    onUpdateColorScale: types.function<[colorscale: ChartColorScale]>([types.ChartColorScale()]),
+  });
 
   colorScales = COLORSCALES.map((colorScale) => ({
     value: colorScale,
@@ -47,7 +45,7 @@ export class ColorScalePicker extends Component<Props, SpreadsheetChildEnv> {
   }
 
   get currentColorScale(): ChartColorScale {
-    return this.props.definition.colorScale || schemeToColorScale("oranges");
+    return this.props.definition.colorScale || (schemeToColorScale("oranges") as ChartColorScale);
   }
 
   get currentColorScaleStyle(): string | undefined {

--- a/src/components/side_panel/chart/building_blocks/data_series/data_series.ts
+++ b/src/components/side_panel/chart/building_blocks/data_series/data_series.ts
@@ -1,5 +1,5 @@
+import { props } from "@odoo/owl";
 import { _t } from "../../../../../translation";
-import { ChartDatasetOrientation, DataSetStyle } from "../../../../../types/chart/chart";
 import { Color, UID } from "../../../../../types/misc";
 import { SpreadsheetChildEnv } from "../../../../../types/spreadsheet_env";
 import { SelectionInput } from "../../../../selection_input/selection_input";
@@ -7,39 +7,26 @@ import { Section } from "../../../components/section/section";
 
 import { onWillUpdateProps } from "@odoo/owl";
 import { Component } from "../../../../../owl3_compatibility_layer";
+import { types } from "../../../../props_validation";
 
-interface Props {
-  ranges: { dataRange: string; dataSetId: UID }[];
-  dataSetStyles?: DataSetStyle;
-  hasSingleRange?: boolean;
-  onSelectionChanged: (ranges: string[]) => void;
-  onSelectionReordered?: (indexes: number[]) => void;
-  onSelectionRemoved?: (index: number) => void;
-  onSelectionConfirmed: () => void;
-  maxNumberOfUsedRanges?: number;
-  title?: string;
-  datasetOrientation?: ChartDatasetOrientation;
-  canChangeDatasetOrientation?: boolean;
-  onFlipAxis?: (structure: string) => void;
-}
-
-export class ChartDataSeries extends Component<Props, SpreadsheetChildEnv> {
+export class ChartDataSeries extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet.ChartDataSeries";
   static components = { SelectionInput, Section };
-  static props = {
-    ranges: Array,
-    dataSetStyles: { type: Object, optional: true },
-    hasSingleRange: { type: Boolean, optional: true },
-    onSelectionChanged: Function,
-    onSelectionReordered: { type: Function, optional: true },
-    onSelectionRemoved: { type: Function, optional: true },
-    onSelectionConfirmed: Function,
-    title: { type: String, optional: true },
-    maxNumberOfUsedRanges: { type: Number, optional: true },
-    datasetOrientation: { type: String, optional: true },
-    canChangeDatasetOrientation: { type: Boolean, optional: true },
-    onFlipAxis: { type: Function, optional: true },
-  };
+
+  protected props = props({
+    ranges: types.ArrayOf<{ dataRange: string; dataSetId: UID }>(),
+    "dataSetStyles?": types.DataSetStyle(),
+    "hasSingleRange?": types.boolean(),
+    onSelectionChanged: types.function<[ranges: string[]]>([types.array(types.string())]),
+    "onSelectionReordered?": types.function<[indexes: number[]]>([types.array(types.number())]),
+    "onSelectionRemoved?": types.function<[index: number]>([types.number()]),
+    onSelectionConfirmed: types.function([]),
+    "maxNumberOfUsedRanges?": types.number(),
+    "title?": types.string(),
+    "datasetOrientation?": types.or([types.literal("rows"), types.literal("columns")]),
+    "canChangeDatasetOrientation?": types.boolean(),
+    "onFlipAxis?": types.function<[structure: string]>([types.string()]),
+  });
 
   get ranges(): string[] {
     return this.props.ranges.map((r) => r.dataRange);

--- a/src/components/side_panel/chart/building_blocks/data_source/data_source.ts
+++ b/src/components/side_panel/chart/building_blocks/data_source/data_source.ts
@@ -1,44 +1,35 @@
+import { props } from "@odoo/owl";
 import { Component } from "../../../../../owl3_compatibility_layer";
 import { chartDataSourceSidePanelComponentRegistry } from "../../../../../registries/chart_data_source_component_registry";
-import { ChartDefinitionWithDataSource } from "../../../../../types/chart/chart";
-import { UID } from "../../../../../types/misc";
 import { SpreadsheetChildEnv } from "../../../../../types/spreadsheet_env";
-import { ChartSidePanelProps } from "../../common";
+import { types } from "../../../../props_validation";
 import { ChartDataSeries } from "../data_series/data_series";
 import { ChartLabelRange } from "../label_range/label_range";
 
-interface Props {
-  chartId: UID;
-  definition: ChartDefinitionWithDataSource<string>;
-  updateChart: ChartSidePanelProps<ChartDefinitionWithDataSource<string>>["updateChart"];
-  canUpdateChart: ChartSidePanelProps<ChartDefinitionWithDataSource<string>>["canUpdateChart"];
-  onErrorMessagesChanged?: (errorMessages: string[]) => void;
-  dataSeriesTitle?: string;
-  labelRangeTitle?: string;
-  getLabelRangeOptions?: () => Array<{
-    name: string;
-    label: string;
-    value: boolean;
-    onChange: (value: boolean) => void;
-  }>;
-}
-
-export class ChartDataSourceComponent extends Component<Props, SpreadsheetChildEnv> {
+export class ChartDataSourceComponent extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ChartDataSourceComponent";
   static components = {
     ChartDataSeries,
     ChartLabelRange,
   };
-  static props = {
-    chartId: String,
-    definition: Object,
-    updateChart: Function,
-    canUpdateChart: Function,
-    onErrorMessagesChanged: { type: Function, optional: true },
-    dataSeriesTitle: { type: String, optional: true },
-    labelRangeTitle: { type: String, optional: true },
-    getLabelRangeOptions: { type: Function, optional: true },
-  };
+
+  protected props = props({
+    chartId: types.UID(),
+    definition: types.ChartDefinitionWithDataSource(),
+    updateChart: types.function([]),
+    canUpdateChart: types.function([]),
+    "onErrorMessagesChanged?": types.function<[errorMessages: string[]]>([
+      types.array(types.string()),
+    ]),
+    "dataSeriesTitle?": types.string(),
+    "labelRangeTitle?": types.string(),
+    "getLabelRangeOptions?": types.function([]) as unknown as () => Array<{
+      name: string;
+      label: string;
+      value: boolean;
+      onChange: (value: boolean) => void;
+    }>,
+  });
 
   get DataSourceComponent() {
     const dataSourceType = this.props.definition.dataSource.type;

--- a/src/components/side_panel/chart/building_blocks/error_section/error_section.ts
+++ b/src/components/side_panel/chart/building_blocks/error_section/error_section.ts
@@ -1,14 +1,15 @@
+import { props } from "@odoo/owl";
 import { SpreadsheetChildEnv } from "../../../../../types/spreadsheet_env";
 import { Section } from "../../../components/section/section";
 
 import { Component } from "../../../../../owl3_compatibility_layer";
+import { types } from "../../../../props_validation";
 import { ValidationMessages } from "../../../../validation_messages/validation_messages";
-interface Props {
-  messages: string[];
-}
-
-export class ChartErrorSection extends Component<Props, SpreadsheetChildEnv> {
+export class ChartErrorSection extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet.ChartErrorSection";
   static components = { Section, ValidationMessages };
-  static props = { messages: { type: Array, element: String } };
+
+  protected props = props({
+    messages: types.array(types.string()),
+  });
 }

--- a/src/components/side_panel/chart/building_blocks/general_design/general_design_editor.ts
+++ b/src/components/side_panel/chart/building_blocks/general_design/general_design_editor.ts
@@ -1,26 +1,22 @@
-import { proxy } from "@odoo/owl";
+import { props, proxy } from "@odoo/owl";
 import { CHART_TITLE_FONT_SIZE } from "../../../../../constants";
 import { Component } from "../../../../../owl3_compatibility_layer";
 import { ChartDefinition, TitleDesign } from "../../../../../types/chart/chart";
-import { Color } from "../../../../../types/misc";
+import { DispatchResult } from "../../../../../types/commands";
+import { Color, UID } from "../../../../../types/misc";
 import { SpreadsheetChildEnv } from "../../../../../types/spreadsheet_env";
+import { types } from "../../../../props_validation";
 import { SidePanelCollapsible } from "../../../components/collapsible/side_panel_collapsible";
 import { RadioSelection } from "../../../components/radio_selection/radio_selection";
 import { RoundColorPicker } from "../../../components/round_color_picker/round_color_picker";
 import { Section } from "../../../components/section/section";
-import { ChartSidePanelProps, ChartSidePanelPropsObject } from "../../common";
 import { ChartTitle } from "../chart_title/chart_title";
 
 interface GeneralDesignEditorState {
   activeTool: string;
 }
 
-interface Props extends ChartSidePanelProps<ChartDefinition<string>> {
-  defaultChartTitleFontSize?: number;
-  slots?: object;
-}
-
-export class GeneralDesignEditor extends Component<Props, SpreadsheetChildEnv> {
+export class GeneralDesignEditor extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-GeneralDesignEditor";
   static components = {
     RoundColorPicker,
@@ -29,14 +25,25 @@ export class GeneralDesignEditor extends Component<Props, SpreadsheetChildEnv> {
     SidePanelCollapsible,
     RadioSelection,
   };
-  static props = {
-    ...ChartSidePanelPropsObject,
-    defaultChartTitleFontSize: { type: Number, optional: true },
-    slots: { type: Object, optional: true },
-  };
-  static defaultProps = {
-    defaultChartTitleFontSize: CHART_TITLE_FONT_SIZE,
-  };
+
+  protected props = props(
+    {
+      chartId: types.UID(),
+      definition: types.ChartDefinition(),
+      canUpdateChart: types.function<
+        [chartId: UID, definition: Partial<ChartDefinition<string>>],
+        DispatchResult
+      >([types.UID(), types.object({})], types.DispatchResult()),
+      updateChart: types.function<
+        [chartId: UID, definition: Partial<ChartDefinition<string>>],
+        DispatchResult
+      >([types.UID(), types.object({})], types.DispatchResult()),
+      "defaultChartTitleFontSize?": types.number(),
+    },
+    {
+      defaultChartTitleFontSize: CHART_TITLE_FONT_SIZE,
+    }
+  );
   private state!: GeneralDesignEditorState;
 
   setup() {

--- a/src/components/side_panel/chart/building_blocks/generic_side_panel/config_panel.ts
+++ b/src/components/side_panel/chart/building_blocks/generic_side_panel/config_panel.ts
@@ -1,11 +1,11 @@
-import { proxy } from "@odoo/owl";
+import { props, proxy } from "@odoo/owl";
 import { Component } from "../../../../../owl3_compatibility_layer";
 import { ChartDefinitionWithDataSource } from "../../../../../types/chart/chart";
 import { SpreadsheetChildEnv } from "../../../../../types/spreadsheet_env";
 import { ChartTerms } from "../../../../translations_terms";
 import { Checkbox } from "../../../components/checkbox/checkbox";
 import { Section } from "../../../components/section/section";
-import { ChartSidePanelProps, ChartSidePanelPropsObject } from "../../common";
+import { ChartSidePanelProps, chartSidePanelPropsDefinition } from "../../common";
 import { ChartDataSourceComponent } from "../data_source/data_source";
 import { ChartErrorSection } from "../error_section/error_section";
 
@@ -17,7 +17,7 @@ export class GenericChartConfigPanel<
   P extends ChartSidePanelProps<ChartDefinitionWithDataSource<string>> = ChartSidePanelProps<
     ChartDefinitionWithDataSource<string>
   >
-> extends Component<P, SpreadsheetChildEnv> {
+> extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-GenericChartConfigPanel";
   static components = {
     ChartDataSourceComponent,
@@ -25,7 +25,7 @@ export class GenericChartConfigPanel<
     Checkbox,
     ChartErrorSection,
   };
-  static props = ChartSidePanelPropsObject;
+  protected props = props(chartSidePanelPropsDefinition) as unknown as P;
 
   protected chartTerms = ChartTerms;
   protected state: GenericChartPanelState = proxy({

--- a/src/components/side_panel/chart/building_blocks/humanize_numbers/humanize_numbers.ts
+++ b/src/components/side_panel/chart/building_blocks/humanize_numbers/humanize_numbers.ts
@@ -3,18 +3,18 @@ import { _t } from "../../../../../translation";
 import { ChartDefinitionWithDataSource } from "../../../../../types/chart/chart";
 import { SpreadsheetChildEnv } from "../../../../../types/spreadsheet_env";
 import { Checkbox } from "../../../components/checkbox/checkbox";
-import { ChartSidePanelProps, ChartSidePanelPropsObject } from "../../common";
+import { ChartSidePanelProps, chartSidePanelPropsDefinition } from "../../common";
 
+import { props } from "@odoo/owl";
 import { Component } from "../../../../../owl3_compatibility_layer";
-export class ChartHumanizeNumbers extends Component<
-  ChartSidePanelProps<ChartDefinitionWithDataSource<string>>,
-  SpreadsheetChildEnv
-> {
+export class ChartHumanizeNumbers extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ChartHumanizeNumbers";
   static components = {
     Checkbox,
   };
-  static props = ChartSidePanelPropsObject;
+  protected props = props(chartSidePanelPropsDefinition) as unknown as ChartSidePanelProps<
+    ChartDefinitionWithDataSource<string>
+  >;
 
   get title() {
     const locale = this.env.model.getters.getLocale();

--- a/src/components/side_panel/chart/building_blocks/label_range/label_range.ts
+++ b/src/components/side_panel/chart/building_blocks/label_range/label_range.ts
@@ -1,3 +1,4 @@
+import { props } from "@odoo/owl";
 import { _t } from "../../../../../translation";
 import { SpreadsheetChildEnv } from "../../../../../types/spreadsheet_env";
 import { SelectionInput } from "../../../../selection_input/selection_input";
@@ -5,38 +6,31 @@ import { Checkbox } from "../../../components/checkbox/checkbox";
 import { Section } from "../../../components/section/section";
 
 import { Component } from "../../../../../owl3_compatibility_layer";
-interface Props {
-  title?: string;
-  range: string;
-  isInvalid: boolean;
-  onSelectionChanged: (range: string) => void;
-  onSelectionConfirmed: () => void;
-  class?: string;
-  options?: Array<{
-    name: string;
-    label: string;
-    value: boolean;
-    onChange: (value: boolean) => void;
-  }>;
-}
-
-export class ChartLabelRange extends Component<Props, SpreadsheetChildEnv> {
+import { types } from "../../../../props_validation";
+export class ChartLabelRange extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet.ChartLabelRange";
   static components = { SelectionInput, Checkbox, Section };
-  static props = {
-    title: { type: String, optional: true },
-    range: String,
-    class: { type: String, optional: true },
-    isInvalid: Boolean,
-    onSelectionChanged: Function,
-    onSelectionConfirmed: Function,
-    options: { type: Array, optional: true },
-  };
 
-  static defaultProps: Partial<Props> = {
-    title: _t("Categories / Labels"),
-    options: [],
-  };
+  protected props = props(
+    {
+      "title?": types.string(),
+      range: types.string(),
+      "class?": types.string(),
+      isInvalid: types.boolean(),
+      onSelectionChanged: types.function<[range: string]>([types.string()]),
+      onSelectionConfirmed: types.function([]),
+      "options?": types.ArrayOf<{
+        name: string;
+        label: string;
+        value: boolean;
+        onChange: (value: boolean) => void;
+      }>(),
+    },
+    {
+      title: _t("Categories / Labels"),
+      options: [],
+    }
+  );
 
   get sectionClass() {
     return "o-data-labels" + (this.props.class ? ` ${this.props.class}` : "");

--- a/src/components/side_panel/chart/building_blocks/legend/legend.ts
+++ b/src/components/side_panel/chart/building_blocks/legend/legend.ts
@@ -1,30 +1,33 @@
+import { props } from "@odoo/owl";
 import { _t } from "../../../../../translation";
-import { ChartDefinitionWithDataSource } from "../../../../../types/chart/chart";
 import { LegendPosition } from "../../../../../types/chart/common_chart";
 import { ValueAndLabel } from "../../../../../types/misc";
 import { SpreadsheetChildEnv } from "../../../../../types/spreadsheet_env";
 import { Select } from "../../../../select/select";
 import { Section } from "../../../components/section/section";
-import { ChartSidePanelProps, ChartSidePanelPropsObject } from "../../common";
 
 import { Component } from "../../../../../owl3_compatibility_layer";
-export class ChartLegend extends Component<
-  ChartSidePanelProps<ChartDefinitionWithDataSource<string>> & { isDisabled?: boolean },
-  SpreadsheetChildEnv
-> {
+import { types } from "../../../../props_validation";
+
+export class ChartLegend extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ChartLegend";
   static components = {
     Section,
     Select,
   };
-  static props = {
-    ...ChartSidePanelPropsObject,
-    isDisabled: { type: Boolean, optional: true },
-  };
 
-  static defaultProps = {
-    isDisabled: false,
-  };
+  protected props = props(
+    {
+      chartId: types.string(),
+      definition: types.ChartDefinitionWithDataSource(),
+      canUpdateChart: types.function(),
+      updateChart: types.function(),
+      "isDisabled?": types.boolean(),
+    },
+    {
+      isDisabled: false,
+    }
+  );
 
   updateLegendPosition(value: LegendPosition) {
     this.props.updateChart(this.props.chartId, {

--- a/src/components/side_panel/chart/building_blocks/pie_hole_size/pie_hole_size.ts
+++ b/src/components/side_panel/chart/building_blocks/pie_hole_size/pie_hole_size.ts
@@ -1,18 +1,19 @@
+import { props } from "@odoo/owl";
 import { clip } from "../../../../../helpers/misc";
 import { SpreadsheetChildEnv } from "../../../../../types/spreadsheet_env";
 import { NumberInput } from "../../../../number_input/number_input";
 import { Section } from "../../../components/section/section";
 
 import { Component } from "../../../../../owl3_compatibility_layer";
-interface Props {
-  onValueChange: (value: number) => void;
-  value: number;
-}
-
-export class PieHoleSize extends Component<Props, SpreadsheetChildEnv> {
+import { types } from "../../../../props_validation";
+export class PieHoleSize extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet.PieHoleSize";
   static components = { Section, NumberInput };
-  static props = { onValueChange: Function, value: Number };
+
+  protected props = props({
+    onValueChange: types.function<[value: number]>([types.number()]),
+    value: types.number(),
+  });
 
   onChange(value: string) {
     if (!isNaN(Number(value))) {

--- a/src/components/side_panel/chart/building_blocks/range_data_source/range_data_source.ts
+++ b/src/components/side_panel/chart/building_blocks/range_data_source/range_data_source.ts
@@ -1,4 +1,4 @@
-import { proxy } from "@odoo/owl";
+import { props, proxy } from "@odoo/owl";
 import { numberToLetters } from "../../../../../helpers/coordinates";
 import { createDataSets } from "../../../../../helpers/figures/charts/helpers_index";
 import { getChartColorsGenerator } from "../../../../../helpers/figures/charts/runtime/chartjs_dataset";
@@ -25,8 +25,8 @@ import {
 import { CommandResult, DispatchResult } from "../../../../../types/commands";
 import { UID, Zone } from "../../../../../types/misc";
 import { SpreadsheetChildEnv } from "../../../../../types/spreadsheet_env";
+import { types } from "../../../../props_validation";
 import { ChartTerms } from "../../../../translations_terms";
-import { ChartSidePanelProps } from "../../common";
 import { ChartDataSeries } from "../data_series/data_series";
 import { ChartLabelRange } from "../label_range/label_range";
 
@@ -35,40 +35,37 @@ interface ChartRangeDataSourceState {
   labelsDispatchResult?: DispatchResult;
 }
 
-interface Props {
-  chartId: UID;
-  definition: ChartDefinitionWithDataSource<string>;
-  dataSource: ChartRangeDataSourceType<string>;
-  updateChart: ChartSidePanelProps<ChartDefinitionWithDataSource<string>>["updateChart"];
-  canUpdateChart: ChartSidePanelProps<ChartDefinitionWithDataSource<string>>["canUpdateChart"];
-  onErrorMessagesChanged?: (errorMessages: string[]) => void;
-  dataSeriesTitle?: string;
-  labelRangeTitle?: string;
-  getLabelRangeOptions?: () => Array<{
-    name: string;
-    label: string;
-    value: boolean;
-    onChange: (value: boolean) => void;
-  }>;
-}
-
-export class ChartRangeDataSourceComponent extends Component<Props, SpreadsheetChildEnv> {
+export class ChartRangeDataSourceComponent extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ChartRangeDataSource";
   static components = {
     ChartDataSeries,
     ChartLabelRange,
   };
-  static props = {
-    chartId: String,
-    definition: Object,
-    dataSource: Object,
-    updateChart: Function,
-    canUpdateChart: Function,
-    onErrorMessagesChanged: { type: Function, optional: true },
-    dataSeriesTitle: { type: String, optional: true },
-    labelRangeTitle: { type: String, optional: true },
-    getLabelRangeOptions: { type: Function, optional: true },
-  };
+
+  protected props = props({
+    chartId: types.UID(),
+    definition: types.ChartDefinitionWithDataSource(),
+    dataSource: types.ChartRangeDataSource(),
+    updateChart: types.function<
+      [chartId: UID, definition: Partial<ChartDefinitionWithDataSource<string>>],
+      DispatchResult
+    >([types.UID(), types.object({})], types.DispatchResult()),
+    canUpdateChart: types.function<
+      [chartId: UID, definition: Partial<ChartDefinitionWithDataSource<string>>],
+      DispatchResult
+    >([types.UID(), types.object({})], types.DispatchResult()),
+    "onErrorMessagesChanged?": types.function<[errorMessages: string[]]>([
+      types.array(types.string()),
+    ]),
+    "dataSeriesTitle?": types.string(),
+    "labelRangeTitle?": types.string(),
+    "getLabelRangeOptions?": types.function([]) as unknown as () => Array<{
+      name: string;
+      label: string;
+      value: boolean;
+      onChange: (value: boolean) => void;
+    }>,
+  });
 
   protected state: ChartRangeDataSourceState = proxy({
     datasetDispatchResult: undefined,

--- a/src/components/side_panel/chart/building_blocks/series_design/series_design_editor.ts
+++ b/src/components/side_panel/chart/building_blocks/series_design/series_design_editor.ts
@@ -1,23 +1,20 @@
-import { proxy } from "@odoo/owl";
+import { props, proxy } from "@odoo/owl";
 import { getColorsPalette, getNthColor, toHex } from "../../../../../helpers/color";
 import { Component } from "../../../../../owl3_compatibility_layer";
 import {
   ChartDefinitionWithDataSource,
   CustomizableSeriesChartRuntime,
 } from "../../../../../types/chart/chart";
-import { ValueAndLabel } from "../../../../../types/misc";
+import { DispatchResult } from "../../../../../types/commands";
+import { UID, ValueAndLabel } from "../../../../../types/misc";
 import { SpreadsheetChildEnv } from "../../../../../types/spreadsheet_env";
+import { types } from "../../../../props_validation";
 import { Select } from "../../../../select/select";
 import { SidePanelCollapsible } from "../../../components/collapsible/side_panel_collapsible";
 import { RoundColorPicker } from "../../../components/round_color_picker/round_color_picker";
 import { Section } from "../../../components/section/section";
-import { ChartSidePanelProps, ChartSidePanelPropsObject } from "../../common";
 
-interface Props extends ChartSidePanelProps<ChartDefinitionWithDataSource<string>> {
-  slots?: object;
-}
-
-export class SeriesDesignEditor extends Component<Props, SpreadsheetChildEnv> {
+export class SeriesDesignEditor extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-SeriesDesignEditor";
   static components = {
     SidePanelCollapsible,
@@ -25,10 +22,19 @@ export class SeriesDesignEditor extends Component<Props, SpreadsheetChildEnv> {
     RoundColorPicker,
     Select,
   };
-  static props = {
-    ...ChartSidePanelPropsObject,
-    slots: { type: Object, optional: true },
-  };
+
+  protected props = props({
+    chartId: types.UID(),
+    definition: types.ChartDefinitionWithDataSource(),
+    canUpdateChart: types.function<
+      [chartId: UID, definition: Partial<ChartDefinitionWithDataSource<string>>],
+      DispatchResult
+    >([types.UID(), types.object({})], types.DispatchResult()),
+    updateChart: types.function<
+      [chartId: UID, definition: Partial<ChartDefinitionWithDataSource<string>>],
+      DispatchResult
+    >([types.UID(), types.object({})], types.DispatchResult()),
+  });
 
   protected state = proxy({ dataSetId: this.getDataSeries()[0]?.dataSetId || "" });
 

--- a/src/components/side_panel/chart/building_blocks/series_design/series_with_axis_design_editor.ts
+++ b/src/components/side_panel/chart/building_blocks/series_design/series_with_axis_design_editor.ts
@@ -1,3 +1,4 @@
+import { props } from "@odoo/owl";
 import { DEFAULT_WINDOW_SIZE } from "../../../../../constants";
 import { getColorsPalette, getNthColor, setColorAlpha, toHex } from "../../../../../helpers/color";
 import { CHART_AXIS_CHOICES } from "../../../../../helpers/figures/charts/chart_common";
@@ -9,22 +10,19 @@ import {
   CustomizableSeriesChartRuntime,
   TrendConfiguration,
 } from "../../../../../types/chart/chart";
+import { DispatchResult } from "../../../../../types/commands";
 import { Color, UID, ValueAndLabel } from "../../../../../types/misc";
 import { SpreadsheetChildEnv } from "../../../../../types/spreadsheet_env";
 import { NumberInput } from "../../../../number_input/number_input";
+import { types } from "../../../../props_validation";
 import { Select } from "../../../../select/select";
 import { Checkbox } from "../../../components/checkbox/checkbox";
 import { RadioSelection } from "../../../components/radio_selection/radio_selection";
 import { RoundColorPicker } from "../../../components/round_color_picker/round_color_picker";
 import { Section } from "../../../components/section/section";
-import { ChartSidePanelProps, ChartSidePanelPropsObject } from "../../common";
 import { SeriesDesignEditor } from "./series_design_editor";
 
-interface Props extends ChartSidePanelProps<ChartDefinitionWithDataSource<string>> {
-  slots?: object;
-}
-
-export class SeriesWithAxisDesignEditor extends Component<Props, SpreadsheetChildEnv> {
+export class SeriesWithAxisDesignEditor extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-SeriesWithAxisDesignEditor";
   static components = {
     SeriesDesignEditor,
@@ -35,10 +33,19 @@ export class SeriesWithAxisDesignEditor extends Component<Props, SpreadsheetChil
     NumberInput,
     Select,
   };
-  static props = {
-    ...ChartSidePanelPropsObject,
-    slots: { type: Object, optional: true },
-  };
+
+  protected props = props({
+    chartId: types.UID(),
+    definition: types.ChartDefinitionWithDataSource(),
+    canUpdateChart: types.function<
+      [chartId: UID, definition: Partial<ChartDefinitionWithDataSource<string>>],
+      DispatchResult
+    >([types.UID(), types.object({})], types.DispatchResult()),
+    updateChart: types.function<
+      [chartId: UID, definition: Partial<ChartDefinitionWithDataSource<string>>],
+      DispatchResult
+    >([types.UID(), types.object({})], types.DispatchResult()),
+  });
 
   axisChoices = CHART_AXIS_CHOICES;
 

--- a/src/components/side_panel/chart/building_blocks/show_data_markers/show_data_markers.ts
+++ b/src/components/side_panel/chart/building_blocks/show_data_markers/show_data_markers.ts
@@ -1,16 +1,16 @@
 import { ChartDefinitionWithDataSource } from "../../../../../types/chart/chart";
 import { SpreadsheetChildEnv } from "../../../../../types/spreadsheet_env";
 import { Checkbox } from "../../../components/checkbox/checkbox";
-import { ChartSidePanelProps, ChartSidePanelPropsObject } from "../../common";
+import { ChartSidePanelProps, chartSidePanelPropsDefinition } from "../../common";
 
+import { props } from "@odoo/owl";
 import { Component } from "../../../../../owl3_compatibility_layer";
-export class ChartShowDataMarkers extends Component<
-  ChartSidePanelProps<ChartDefinitionWithDataSource<string>>,
-  SpreadsheetChildEnv
-> {
+export class ChartShowDataMarkers extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ChartShowDataMarkers";
   static components = {
     Checkbox,
   };
-  static props = ChartSidePanelPropsObject;
+  protected props = props(chartSidePanelPropsDefinition) as unknown as ChartSidePanelProps<
+    ChartDefinitionWithDataSource<string>
+  >;
 }

--- a/src/components/side_panel/chart/building_blocks/show_values/show_values.ts
+++ b/src/components/side_panel/chart/building_blocks/show_values/show_values.ts
@@ -1,20 +1,20 @@
+import { props } from "@odoo/owl";
 import { Component } from "../../../../../owl3_compatibility_layer";
-import { ChartDefinitionWithDataSource } from "../../../../../types/chart/chart";
 import { SpreadsheetChildEnv } from "../../../../../types/spreadsheet_env";
+import { types } from "../../../../props_validation";
 import { Checkbox } from "../../../components/checkbox/checkbox";
-import { ChartSidePanelProps, ChartSidePanelPropsObject } from "../../common";
 
-interface Props extends ChartSidePanelProps<ChartDefinitionWithDataSource<string>> {
-  defaultValue?: boolean;
-}
-
-export class ChartShowValues extends Component<Props, SpreadsheetChildEnv> {
+export class ChartShowValues extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ChartShowValues";
   static components = {
     Checkbox,
   };
-  static props = {
-    ...ChartSidePanelPropsObject,
-    defaultValue: { type: Boolean, optional: true },
-  };
+
+  protected props = props({
+    chartId: types.UID(),
+    definition: types.ChartDefinitionWithDataSource(),
+    canUpdateChart: types.function([]),
+    updateChart: types.function([]),
+    "defaultValue?": types.boolean(),
+  });
 }

--- a/src/components/side_panel/chart/building_blocks/text_styler/text_styler.ts
+++ b/src/components/side_panel/chart/building_blocks/text_styler/text_styler.ts
@@ -1,4 +1,4 @@
-import { proxy } from "@odoo/owl";
+import { props, proxy } from "@odoo/owl";
 import { ActionSpec } from "../../../../../actions/action";
 import { DEFAULT_STYLE } from "../../../../../constants";
 import { Component, useExternalListener } from "../../../../../owl3_compatibility_layer";
@@ -9,33 +9,25 @@ import { SpreadsheetChildEnv } from "../../../../../types/spreadsheet_env";
 import { ActionButton } from "../../../../action_button/action_button";
 import { ColorPickerWidget } from "../../../../color_picker/color_picker_widget";
 import { FontSizeEditor } from "../../../../font_size_editor/font_size_editor";
-
-interface Props {
-  class?: string;
-  style: ChartStyle;
-  updateStyle: (style: ChartStyle) => void;
-  defaultStyle?: Partial<ChartStyle>;
-  hasVerticalAlign?: boolean;
-  hasHorizontalAlign?: boolean;
-  hasBackgroundColor?: boolean;
-}
+import { types } from "../../../../props_validation";
 
 export interface TextStylerState {
   activeTool: string;
 }
 
-export class TextStyler extends Component<Props, SpreadsheetChildEnv> {
+export class TextStyler extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet.TextStyler";
   static components = { ColorPickerWidget, ActionButton, FontSizeEditor };
-  static props = {
-    style: Object,
-    updateStyle: { type: Function, optional: true },
-    defaultStyle: { type: Object, optional: true },
-    hasVerticalAlign: { type: Boolean, optional: true },
-    hasHorizontalAlign: { type: Boolean, optional: true },
-    hasBackgroundColor: { type: Boolean, optional: true },
-    class: { type: String, optional: true },
-  };
+
+  protected props = props({
+    style: types.ChartStyle(),
+    updateStyle: types.function<[style: ChartStyle]>([types.ChartStyle()]),
+    "defaultStyle?": types.object({}) as Partial<ChartStyle>,
+    "hasVerticalAlign?": types.boolean(),
+    "hasHorizontalAlign?": types.boolean(),
+    "hasBackgroundColor?": types.boolean(),
+    "class?": types.string(),
+  });
   openedEl: HTMLElement | null = null;
 
   setup() {

--- a/src/components/side_panel/chart/calendar_chart/calendar_chart_design_panel.ts
+++ b/src/components/side_panel/chart/calendar_chart/calendar_chart_design_panel.ts
@@ -14,13 +14,11 @@ import {
 import { ColorScalePicker } from "../building_blocks/color_scale/color_scale_picker";
 import { GeneralDesignEditor } from "../building_blocks/general_design/general_design_editor";
 import { ChartShowValues } from "../building_blocks/show_values/show_values";
-import { ChartSidePanelProps, ChartSidePanelPropsObject } from "../common";
+import { ChartSidePanelProps, chartSidePanelPropsDefinition } from "../common";
 
+import { props } from "@odoo/owl";
 import { Component } from "../../../../owl3_compatibility_layer";
-export class CalendarChartDesignPanel extends Component<
-  ChartSidePanelProps<CalendarChartDefinition<string>>,
-  SpreadsheetChildEnv
-> {
+export class CalendarChartDesignPanel extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-CalendarChartDesignPanel";
   static components = {
     GeneralDesignEditor,
@@ -32,7 +30,9 @@ export class CalendarChartDesignPanel extends Component<
     RoundColorPicker,
     Select,
   };
-  static props = ChartSidePanelPropsObject;
+  protected props = props(chartSidePanelPropsDefinition) as unknown as ChartSidePanelProps<
+    CalendarChartDefinition<string>
+  >;
 
   get axesList(): AxisDefinition[] {
     return [

--- a/src/components/side_panel/chart/chart_type_picker/chart_type_picker.ts
+++ b/src/components/side_panel/chart/chart_type_picker/chart_type_picker.ts
@@ -1,4 +1,4 @@
-import { proxy, signal } from "@odoo/owl";
+import { props, proxy, signal } from "@odoo/owl";
 import { Component, useExternalListener } from "../../../../owl3_compatibility_layer";
 import { chartDataSourceRegistry } from "../../../../registries/chart_data_source_registry";
 import { chartSubtypeRegistry } from "../../../../registries/chart_subtype_registry";
@@ -8,27 +8,28 @@ import {
   ChartSubtypeProperties,
 } from "../../../../types/chart_subtype_properties";
 import { UID } from "../../../../types/misc";
+import { PropsOf } from "../../../../types/props_of";
 import { SpreadsheetChildEnv } from "../../../../types/spreadsheet_env";
 import { cssPropertiesToCss } from "../../../helpers/css";
 import { isChildEvent } from "../../../helpers/dom_helpers";
-import { Popover, PopoverProps } from "../../../popover/popover";
+import { Popover } from "../../../popover/popover";
+import { types } from "../../../props_validation";
 import { Section } from "../../components/section/section";
 import { MainChartPanelStore } from "../main_chart_panel/main_chart_panel_store";
 
-interface Props {
-  chartId: UID;
-  chartPanelStore: MainChartPanelStore;
-}
-
 interface ChartTypePickerState {
-  popoverProps: PopoverProps | undefined;
+  popoverProps: PropsOf<Popover> | undefined;
   popoverStyle: string;
 }
 
-export class ChartTypePicker extends Component<Props, SpreadsheetChildEnv> {
+export class ChartTypePicker extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ChartTypePicker";
   static components = { Section, Popover };
-  static props = { chartId: String, chartPanelStore: Object };
+
+  protected props = props({
+    chartId: types.UID(),
+    chartPanelStore: types.Store<MainChartPanelStore>(),
+  });
 
   categories = chartCategories;
   chartTypeByCategories: Record<string, ChartSubtypeProperties[]> = {};

--- a/src/components/side_panel/chart/chart_with_axis/design_panel.ts
+++ b/src/components/side_panel/chart/chart_with_axis/design_panel.ts
@@ -13,12 +13,13 @@ import { ChartHumanizeNumbers } from "../building_blocks/humanize_numbers/humani
 import { ChartLegend } from "../building_blocks/legend/legend";
 import { SeriesWithAxisDesignEditor } from "../building_blocks/series_design/series_with_axis_design_editor";
 import { ChartShowValues } from "../building_blocks/show_values/show_values";
-import { ChartSidePanelProps, ChartSidePanelPropsObject } from "../common";
+import { ChartSidePanelProps, chartSidePanelPropsDefinition } from "../common";
 
+import { props } from "@odoo/owl";
 import { Component } from "../../../../owl3_compatibility_layer";
 export class ChartWithAxisDesignPanel<
   P extends ChartSidePanelProps<ChartDefinitionWithDataSource<string>>
-> extends Component<P, SpreadsheetChildEnv> {
+> extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ChartWithAxisDesignPanel";
   static components = {
     GeneralDesignEditor,
@@ -30,7 +31,7 @@ export class ChartWithAxisDesignPanel<
     ChartShowValues,
     ChartHumanizeNumbers,
   };
-  static props = ChartSidePanelPropsObject;
+  protected props = props(chartSidePanelPropsDefinition) as unknown as P;
 
   get axesList(): AxisDefinition[] {
     const { useLeftAxis, useRightAxis } = getDefinedAxis(this.props.definition);

--- a/src/components/side_panel/chart/common.ts
+++ b/src/components/side_panel/chart/common.ts
@@ -1,6 +1,7 @@
 import { ChartDefinition } from "../../../types/chart/chart";
 import { DispatchResult } from "../../../types/commands";
 import { UID } from "../../../types/misc";
+import { types } from "../../props_validation";
 
 export interface ChartSidePanelProps<T extends ChartDefinition<string>> {
   chartId: UID;
@@ -9,9 +10,15 @@ export interface ChartSidePanelProps<T extends ChartDefinition<string>> {
   updateChart: (chartId: UID, definition: Partial<T>) => DispatchResult;
 }
 
-export const ChartSidePanelPropsObject = {
-  chartId: String,
-  definition: Object,
-  canUpdateChart: Function,
-  updateChart: Function,
+export const chartSidePanelPropsDefinition = {
+  chartId: types.UID(),
+  definition: types.object({}),
+  canUpdateChart: types.function<
+    [chartId: UID, definition: Partial<ChartDefinition<string>>],
+    DispatchResult
+  >([types.UID(), types.object({})], types.DispatchResult()),
+  updateChart: types.function<
+    [chartId: UID, definition: Partial<ChartDefinition<string>>],
+    DispatchResult
+  >([types.UID(), types.object({})], types.DispatchResult()),
 };

--- a/src/components/side_panel/chart/funnel_chart_panel/funnel_chart_design_panel.ts
+++ b/src/components/side_panel/chart/funnel_chart_panel/funnel_chart_design_panel.ts
@@ -1,21 +1,23 @@
+import { props } from "@odoo/owl";
 import { getFunnelLabelColors } from "../../../../helpers/figures/charts/runtime/chartjs_dataset";
 import { replaceItemAtIndex } from "../../../../helpers/misc";
 import { _t } from "../../../../translation";
 import { FunnelChartDefinition, FunnelChartRuntime } from "../../../../types/chart/funnel_chart";
 import { SpreadsheetChildEnv } from "../../../../types/spreadsheet_env";
+import { types } from "../../../props_validation";
 import { SidePanelCollapsible } from "../../components/collapsible/side_panel_collapsible";
 import { RoundColorPicker } from "../../components/round_color_picker/round_color_picker";
 import { Section } from "../../components/section/section";
 import { GeneralDesignEditor } from "../building_blocks/general_design/general_design_editor";
 import { ChartHumanizeNumbers } from "../building_blocks/humanize_numbers/humanize_numbers";
 import { ChartShowValues } from "../building_blocks/show_values/show_values";
-import { ChartSidePanelProps } from "../common";
+import { ChartSidePanelProps, chartSidePanelPropsDefinition } from "../common";
 
 import { Component } from "../../../../owl3_compatibility_layer";
-export class FunnelChartDesignPanel extends Component<
-  ChartSidePanelProps<FunnelChartDefinition<string>>,
-  SpreadsheetChildEnv
-> {
+
+type Props = ChartSidePanelProps<FunnelChartDefinition<string>>;
+
+export class FunnelChartDesignPanel extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-FunnelChartDesignPanel";
   static components = {
     ChartShowValues,
@@ -25,12 +27,11 @@ export class FunnelChartDesignPanel extends Component<
     Section,
     ChartHumanizeNumbers,
   };
-  static props = {
-    chartId: String,
-    definition: Object,
-    updateChart: Function,
-    canUpdateChart: Function,
-  };
+
+  protected props: Props = props({
+    ...chartSidePanelPropsDefinition,
+    definition: types.FunnelChartDefinition(),
+  }) as unknown as Props;
 
   getFunnelColorItems() {
     const runtime = this.env.model.getters.getChartRuntime(

--- a/src/components/side_panel/chart/gauge_chart_panel/gauge_chart_config_panel.ts
+++ b/src/components/side_panel/chart/gauge_chart_panel/gauge_chart_config_panel.ts
@@ -1,4 +1,4 @@
-import { proxy } from "@odoo/owl";
+import { props, proxy } from "@odoo/owl";
 import { Component } from "../../../../owl3_compatibility_layer";
 import { GaugeChartDefinition } from "../../../../types/chart/gauge_chart";
 import { CommandResult, DispatchResult } from "../../../../types/commands";
@@ -6,19 +6,18 @@ import { SpreadsheetChildEnv } from "../../../../types/spreadsheet_env";
 import { ChartTerms } from "../../../translations_terms";
 import { ChartDataSeries } from "../building_blocks/data_series/data_series";
 import { ChartErrorSection } from "../building_blocks/error_section/error_section";
-import { ChartSidePanelProps, ChartSidePanelPropsObject } from "../common";
+import { ChartSidePanelProps, chartSidePanelPropsDefinition } from "../common";
 
 interface PanelState {
   dataRangeDispatchResult?: DispatchResult;
 }
 
-export class GaugeChartConfigPanel extends Component<
-  ChartSidePanelProps<GaugeChartDefinition>,
-  SpreadsheetChildEnv
-> {
+export class GaugeChartConfigPanel extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-GaugeChartConfigPanel";
   static components = { ChartErrorSection, ChartDataSeries };
-  static props = ChartSidePanelPropsObject;
+  protected props = props(
+    chartSidePanelPropsDefinition
+  ) as unknown as ChartSidePanelProps<GaugeChartDefinition>;
 
   private state: PanelState = proxy({
     dataRangeDispatchResult: undefined,

--- a/src/components/side_panel/chart/gauge_chart_panel/gauge_chart_design_panel.ts
+++ b/src/components/side_panel/chart/gauge_chart_panel/gauge_chart_design_panel.ts
@@ -1,4 +1,4 @@
-import { proxy } from "@odoo/owl";
+import { props, proxy } from "@odoo/owl";
 import { isMultipleElementMatrix, toScalar } from "../../../../functions/helper_matrices";
 import { tryToNumber } from "../../../../functions/helpers";
 import { deepCopy } from "../../../../helpers/misc";
@@ -7,6 +7,7 @@ import { _t } from "../../../../translation";
 import { GaugeChartDefinition, SectionRule } from "../../../../types/chart/gauge_chart";
 import { CommandResult } from "../../../../types/commands";
 import { Color, ValueAndLabel } from "../../../../types/misc";
+import { PropsOf } from "../../../../types/props_of";
 import { SpreadsheetChildEnv } from "../../../../types/spreadsheet_env";
 import { StandaloneComposer } from "../../../composer/standalone_composer/standalone_composer";
 import { Select } from "../../../select/select";
@@ -17,17 +18,14 @@ import { Section } from "../../components/section/section";
 import { ChartErrorSection } from "../building_blocks/error_section/error_section";
 import { GeneralDesignEditor } from "../building_blocks/general_design/general_design_editor";
 import { ChartHumanizeNumbers } from "../building_blocks/humanize_numbers/humanize_numbers";
-import { ChartSidePanelProps, ChartSidePanelPropsObject } from "../common";
+import { ChartSidePanelProps, chartSidePanelPropsDefinition } from "../common";
 
 interface PanelState {
   sectionRuleCancelledReasons?: Set<CommandResult>;
   sectionRule: SectionRule;
 }
 
-export class GaugeChartDesignPanel extends Component<
-  ChartSidePanelProps<GaugeChartDefinition>,
-  SpreadsheetChildEnv
-> {
+export class GaugeChartDesignPanel extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-GaugeChartDesignPanel";
   static components = {
     SidePanelCollapsible,
@@ -39,7 +37,9 @@ export class GaugeChartDesignPanel extends Component<
     ChartHumanizeNumbers,
     Select,
   };
-  static props = ChartSidePanelPropsObject;
+  protected props = props(
+    chartSidePanelPropsDefinition
+  ) as unknown as ChartSidePanelProps<GaugeChartDefinition>;
 
   protected state!: PanelState;
 
@@ -143,7 +143,7 @@ export class GaugeChartDesignPanel extends Component<
 
   getGaugeInflectionComposerProps(
     sectionType: "lowerColor" | "middleColor"
-  ): StandaloneComposer["props"] {
+  ): PropsOf<StandaloneComposer> {
     const inflectionPointName =
       sectionType === "lowerColor" ? "lowerInflectionPoint" : "upperInflectionPoint";
     const inflectionPoint = this.state.sectionRule[inflectionPointName];

--- a/src/components/side_panel/chart/geo_chart_panel/geo_chart_region_select_section.ts
+++ b/src/components/side_panel/chart/geo_chart_panel/geo_chart_region_select_section.ts
@@ -1,3 +1,4 @@
+import { props } from "@odoo/owl";
 import { GeoChartDefinition } from "../../../../types/chart/geo_chart";
 import { DispatchResult } from "../../../../types/commands";
 import { UID, ValueAndLabel } from "../../../../types/misc";
@@ -6,20 +7,19 @@ import { Select } from "../../../select/select";
 import { Section } from "../../components/section/section";
 
 import { Component } from "../../../../owl3_compatibility_layer";
-interface Props {
-  chartId: UID;
-  definition: GeoChartDefinition;
-  updateChart: (chartId: UID, definition: Partial<GeoChartDefinition>) => DispatchResult;
-}
-
-export class GeoChartRegionSelectSection extends Component<Props, SpreadsheetChildEnv> {
+import { types } from "../../../props_validation";
+export class GeoChartRegionSelectSection extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-GeoChartRegionSelectSection";
   static components = { Section, Select };
-  static props = {
-    chartId: String,
-    definition: Object,
-    updateChart: Function,
-  };
+
+  protected props = props({
+    chartId: types.UID(),
+    definition: types.GeoChartDefinition(),
+    updateChart: types.function<
+      [chartId: UID, definition: Partial<GeoChartDefinition>],
+      DispatchResult
+    >([types.UID(), types.object({})], types.DispatchResult()),
+  });
 
   updateSelectedRegion(value: string) {
     this.props.updateChart(this.props.chartId, { region: value });

--- a/src/components/side_panel/chart/main_chart_panel/main_chart_panel.ts
+++ b/src/components/side_panel/chart/main_chart_panel/main_chart_panel.ts
@@ -1,23 +1,24 @@
+import { props } from "@odoo/owl";
 import { Component } from "../../../../owl3_compatibility_layer";
 import { useLocalStore } from "../../../../store_engine/store_hooks";
 import { ChartDefinition, ChartType } from "../../../../types/chart/chart";
 import { UID } from "../../../../types/misc";
 import { SpreadsheetChildEnv } from "../../../../types/spreadsheet_env";
 import { Store } from "../../../../types/store_engine";
+import { types } from "../../../props_validation";
 import { Section } from "../../components/section/section";
 import { ChartSidePanel, chartSidePanelComponentRegistry } from "../chart_side_panel_registry";
 import { ChartTypePicker } from "../chart_type_picker/chart_type_picker";
 import { MainChartPanelStore } from "./main_chart_panel_store";
 
-interface Props {
-  onCloseSidePanel: () => void;
-  chartId: UID;
-}
-
-export class ChartPanel extends Component<Props, SpreadsheetChildEnv> {
+export class ChartPanel extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ChartPanel";
   static components = { Section, ChartTypePicker };
-  static props = { onCloseSidePanel: Function, chartId: String };
+
+  protected props = props({
+    onCloseSidePanel: types.function([]),
+    chartId: types.UID(),
+  });
 
   store!: Store<MainChartPanelStore>;
 

--- a/src/components/side_panel/chart/pie_chart/pie_chart_design_panel.ts
+++ b/src/components/side_panel/chart/pie_chart/pie_chart_design_panel.ts
@@ -1,4 +1,4 @@
-import { proxy } from "@odoo/owl";
+import { props, proxy } from "@odoo/owl";
 import { deepCopy } from "../../../../helpers/misc";
 import { Component } from "../../../../owl3_compatibility_layer";
 import { PieChartDefinition, PieChartRuntime } from "../../../../types/chart/pie_chart";
@@ -15,12 +15,9 @@ import { ChartHumanizeNumbers } from "../building_blocks/humanize_numbers/humani
 import { ChartLegend } from "../building_blocks/legend/legend";
 import { PieHoleSize } from "../building_blocks/pie_hole_size/pie_hole_size";
 import { ChartShowValues } from "../building_blocks/show_values/show_values";
-import { ChartSidePanelProps, ChartSidePanelPropsObject } from "../common";
+import { ChartSidePanelProps, chartSidePanelPropsDefinition } from "../common";
 
-export class PieChartDesignPanel extends Component<
-  ChartSidePanelProps<PieChartDefinition<string>>,
-  SpreadsheetChildEnv
-> {
+export class PieChartDesignPanel extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-PieChartDesignPanel";
   static components = {
     GeneralDesignEditor,
@@ -34,7 +31,9 @@ export class PieChartDesignPanel extends Component<
     RoundColorPicker,
     Select,
   };
-  static props = ChartSidePanelPropsObject;
+  protected props = props(chartSidePanelPropsDefinition) as unknown as ChartSidePanelProps<
+    PieChartDefinition<string>
+  >;
 
   protected state = proxy({ index: 0 });
 

--- a/src/components/side_panel/chart/radar_chart/radar_chart_design_panel.ts
+++ b/src/components/side_panel/chart/radar_chart/radar_chart_design_panel.ts
@@ -8,13 +8,11 @@ import { ChartLegend } from "../building_blocks/legend/legend";
 import { SeriesDesignEditor } from "../building_blocks/series_design/series_design_editor";
 import { ChartShowDataMarkers } from "../building_blocks/show_data_markers/show_data_markers";
 import { ChartShowValues } from "../building_blocks/show_values/show_values";
-import { ChartSidePanelProps, ChartSidePanelPropsObject } from "../common";
+import { ChartSidePanelProps, chartSidePanelPropsDefinition } from "../common";
 
+import { props } from "@odoo/owl";
 import { Component } from "../../../../owl3_compatibility_layer";
-export class RadarChartDesignPanel extends Component<
-  ChartSidePanelProps<RadarChartDefinition<string>>,
-  SpreadsheetChildEnv
-> {
+export class RadarChartDesignPanel extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-RadarChartDesignPanel";
   static components = {
     GeneralDesignEditor,
@@ -26,5 +24,7 @@ export class RadarChartDesignPanel extends Component<
     Checkbox,
     ChartHumanizeNumbers,
   };
-  static props = ChartSidePanelPropsObject;
+  protected props = props(chartSidePanelPropsDefinition) as unknown as ChartSidePanelProps<
+    RadarChartDefinition<string>
+  >;
 }

--- a/src/components/side_panel/chart/scorecard_chart_panel/scorecard_chart_config_panel.ts
+++ b/src/components/side_panel/chart/scorecard_chart_panel/scorecard_chart_config_panel.ts
@@ -1,4 +1,4 @@
-import { proxy } from "@odoo/owl";
+import { props, proxy } from "@odoo/owl";
 import { Component } from "../../../../owl3_compatibility_layer";
 import { _t } from "../../../../translation";
 import { BaselineMode, ScorecardChartDefinition } from "../../../../types/chart/scorecard_chart";
@@ -10,20 +10,19 @@ import { SelectionInput } from "../../../selection_input/selection_input";
 import { ChartTerms } from "../../../translations_terms";
 import { Section } from "../../components/section/section";
 import { ChartErrorSection } from "../building_blocks/error_section/error_section";
-import { ChartSidePanelProps, ChartSidePanelPropsObject } from "../common";
+import { ChartSidePanelProps, chartSidePanelPropsDefinition } from "../common";
 
 interface PanelState {
   keyValueDispatchResult?: DispatchResult;
   baselineDispatchResult?: DispatchResult;
 }
 
-export class ScorecardChartConfigPanel extends Component<
-  ChartSidePanelProps<ScorecardChartDefinition>,
-  SpreadsheetChildEnv
-> {
+export class ScorecardChartConfigPanel extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ScorecardChartConfigPanel";
   static components = { SelectionInput, ChartErrorSection, Section, Select };
-  static props = ChartSidePanelPropsObject;
+  protected props = props(
+    chartSidePanelPropsDefinition
+  ) as unknown as ChartSidePanelProps<ScorecardChartDefinition>;
 
   private state: PanelState = proxy({
     keyValueDispatchResult: undefined,

--- a/src/components/side_panel/chart/scorecard_chart_panel/scorecard_chart_design_panel.ts
+++ b/src/components/side_panel/chart/scorecard_chart_panel/scorecard_chart_design_panel.ts
@@ -15,15 +15,13 @@ import { Section } from "../../components/section/section";
 import { ChartTitle } from "../building_blocks/chart_title/chart_title";
 import { GeneralDesignEditor } from "../building_blocks/general_design/general_design_editor";
 import { ChartHumanizeNumbers } from "../building_blocks/humanize_numbers/humanize_numbers";
-import { ChartSidePanelProps, ChartSidePanelPropsObject } from "../common";
+import { ChartSidePanelProps, chartSidePanelPropsDefinition } from "../common";
 
+import { props } from "@odoo/owl";
 import { Component } from "../../../../owl3_compatibility_layer";
 type ColorPickerId = undefined | "backgroundColor" | "baselineColorUp" | "baselineColorDown";
 
-export class ScorecardChartDesignPanel extends Component<
-  ChartSidePanelProps<ScorecardChartDefinition>,
-  SpreadsheetChildEnv
-> {
+export class ScorecardChartDesignPanel extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ScorecardChartDesignPanel";
   static components = {
     GeneralDesignEditor,
@@ -34,7 +32,9 @@ export class ScorecardChartDesignPanel extends Component<
     ChartTitle,
     ChartHumanizeNumbers,
   };
-  static props = ChartSidePanelPropsObject;
+  protected props = props(
+    chartSidePanelPropsDefinition
+  ) as unknown as ChartSidePanelProps<ScorecardChartDefinition>;
 
   get colorsSectionTitle(): string {
     return this.props.definition.baselineMode === "progress"

--- a/src/components/side_panel/chart/sunburst_chart/sunburst_chart_design_panel.ts
+++ b/src/components/side_panel/chart/sunburst_chart/sunburst_chart_design_panel.ts
@@ -16,13 +16,11 @@ import { ChartLegend } from "../building_blocks/legend/legend";
 import { PieHoleSize } from "../building_blocks/pie_hole_size/pie_hole_size";
 import { ChartShowValues } from "../building_blocks/show_values/show_values";
 import { TextStyler } from "../building_blocks/text_styler/text_styler";
-import { ChartSidePanelProps, ChartSidePanelPropsObject } from "../common";
+import { ChartSidePanelProps, chartSidePanelPropsDefinition } from "../common";
 
+import { props } from "@odoo/owl";
 import { Component } from "../../../../owl3_compatibility_layer";
-export class SunburstChartDesignPanel extends Component<
-  ChartSidePanelProps<SunburstChartDefinition<string>>,
-  SpreadsheetChildEnv
-> {
+export class SunburstChartDesignPanel extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-SunburstChartDesignPanel";
   static components = {
     GeneralDesignEditor,
@@ -36,7 +34,9 @@ export class SunburstChartDesignPanel extends Component<
     PieHoleSize,
     ChartHumanizeNumbers,
   };
-  static props = ChartSidePanelPropsObject;
+  protected props = props(chartSidePanelPropsDefinition) as unknown as ChartSidePanelProps<
+    SunburstChartDefinition<string>
+  >;
 
   defaults = SunburstChartDefaults;
 

--- a/src/components/side_panel/chart/treemap_chart/treemap_category_color/treemap_category_color.ts
+++ b/src/components/side_panel/chart/treemap_chart/treemap_category_color/treemap_category_color.ts
@@ -1,36 +1,36 @@
+import { props } from "@odoo/owl";
 import { ChartConfiguration } from "chart.js";
 import { deepCopy } from "../../../../../helpers/misc";
 import {
   TreeMapCategoryColorOptions,
   TreeMapChartDefaults,
-  TreeMapChartDefinition,
   TreeMapChartRuntime,
   TreeMapGroupColor,
 } from "../../../../../types/chart/tree_map_chart";
 import { DispatchResult } from "../../../../../types/commands";
-import { DeepPartial, UID } from "../../../../../types/misc";
+import { DeepPartial } from "../../../../../types/misc";
 import { SpreadsheetChildEnv } from "../../../../../types/spreadsheet_env";
+import { types } from "../../../../props_validation";
 import { Checkbox } from "../../../components/checkbox/checkbox";
 import { RoundColorPicker } from "../../../components/round_color_picker/round_color_picker";
 
 import { Component } from "../../../../../owl3_compatibility_layer";
-interface Props {
-  chartId: UID;
-  definition: TreeMapChartDefinition;
-  onColorChanged: (colors: TreeMapCategoryColorOptions) => DispatchResult;
-}
 
-export class TreeMapCategoryColors extends Component<Props, SpreadsheetChildEnv> {
+export class TreeMapCategoryColors extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-TreeMapCategoryColors";
   static components = {
     Checkbox,
     RoundColorPicker,
   };
-  static props = {
-    chartId: String,
-    definition: Object,
-    onColorChanged: Function,
-  };
+
+  protected props = props({
+    chartId: types.UID(),
+    definition: types.TreeMapChartDefinition(),
+    onColorChanged: types.function<[colors: TreeMapCategoryColorOptions], DispatchResult>(
+      [types.TreeMapCategoryColorOptions()],
+      types.DispatchResult()
+    ),
+  });
 
   get coloringOptions() {
     const coloringOptions =

--- a/src/components/side_panel/chart/treemap_chart/treemap_chart_design_panel.ts
+++ b/src/components/side_panel/chart/treemap_chart/treemap_chart_design_panel.ts
@@ -15,10 +15,11 @@ import { GeneralDesignEditor } from "../building_blocks/general_design/general_d
 import { ChartHumanizeNumbers } from "../building_blocks/humanize_numbers/humanize_numbers";
 import { ChartShowValues } from "../building_blocks/show_values/show_values";
 import { TextStyler } from "../building_blocks/text_styler/text_styler";
-import { ChartSidePanelProps, ChartSidePanelPropsObject } from "../common";
+import { ChartSidePanelProps, chartSidePanelPropsDefinition } from "../common";
 import { TreeMapCategoryColors } from "./treemap_category_color/treemap_category_color";
 import { TreeMapColorScale } from "./treemap_color_scale/treemap_color_scale";
 
+import { props } from "@odoo/owl";
 import { Component } from "../../../../owl3_compatibility_layer";
 const DEFAULT_COLOR_SCALE: TreeMapColorScaleOptions = {
   type: "colorScale",
@@ -33,10 +34,7 @@ const DEFAULT_SOLID_COLOR: TreeMapCategoryColorOptions = {
   useValueBasedGradient: true,
 };
 
-export class TreeMapChartDesignPanel extends Component<
-  ChartSidePanelProps<TreeMapChartDefinition<string>>,
-  SpreadsheetChildEnv
-> {
+export class TreeMapChartDesignPanel extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-TreeMapChartDesignPanel";
   static components = {
     GeneralDesignEditor,
@@ -51,7 +49,9 @@ export class TreeMapChartDesignPanel extends Component<
     TreeMapColorScale,
     ChartHumanizeNumbers,
   };
-  static props = ChartSidePanelPropsObject;
+  protected props = props(chartSidePanelPropsDefinition) as unknown as ChartSidePanelProps<
+    TreeMapChartDefinition<string>
+  >;
 
   private savedColors = {
     categoryColors: DEFAULT_SOLID_COLOR,

--- a/src/components/side_panel/chart/treemap_chart/treemap_color_scale/treemap_color_scale.ts
+++ b/src/components/side_panel/chart/treemap_chart/treemap_color_scale/treemap_color_scale.ts
@@ -1,28 +1,26 @@
+import { props } from "@odoo/owl";
 import {
   TreeMapChartDefaults,
-  TreeMapChartDefinition,
   TreeMapColorScaleOptions,
 } from "../../../../../types/chart/tree_map_chart";
 import { DispatchResult } from "../../../../../types/commands";
-import { UID } from "../../../../../types/misc";
 import { SpreadsheetChildEnv } from "../../../../../types/spreadsheet_env";
 import { RoundColorPicker } from "../../../components/round_color_picker/round_color_picker";
 
 import { Component } from "../../../../../owl3_compatibility_layer";
-interface Props {
-  chartId: UID;
-  definition: TreeMapChartDefinition;
-  onColorChanged: (colors: TreeMapColorScaleOptions) => DispatchResult;
-}
-
-export class TreeMapColorScale extends Component<Props, SpreadsheetChildEnv> {
+import { types } from "../../../../props_validation";
+export class TreeMapColorScale extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-TreeMapColorScale";
   static components = { RoundColorPicker };
-  static props = {
-    chartId: String,
-    definition: Object,
-    onColorChanged: Function,
-  };
+
+  protected props = props({
+    chartId: types.UID(),
+    definition: types.TreeMapChartDefinition(),
+    onColorChanged: types.function<[colors: TreeMapColorScaleOptions], DispatchResult>(
+      [types.TreeMapColorScaleOptions()],
+      types.DispatchResult()
+    ),
+  });
 
   get coloringOptions() {
     const coloringOptions =

--- a/src/components/side_panel/chart/waterfall_chart/waterfall_chart_design_panel.ts
+++ b/src/components/side_panel/chart/waterfall_chart/waterfall_chart_design_panel.ts
@@ -21,14 +21,12 @@ import { GeneralDesignEditor } from "../building_blocks/general_design/general_d
 import { ChartHumanizeNumbers } from "../building_blocks/humanize_numbers/humanize_numbers";
 import { ChartLegend } from "../building_blocks/legend/legend";
 import { ChartShowValues } from "../building_blocks/show_values/show_values";
-import { ChartSidePanelProps, ChartSidePanelPropsObject } from "../common";
+import { ChartSidePanelProps, chartSidePanelPropsDefinition } from "../common";
 import { Checkbox } from "./../../components/checkbox/checkbox";
 
+import { props } from "@odoo/owl";
 import { Component } from "../../../../owl3_compatibility_layer";
-export class WaterfallChartDesignPanel extends Component<
-  ChartSidePanelProps<WaterfallChartDefinition<string>>,
-  SpreadsheetChildEnv
-> {
+export class WaterfallChartDesignPanel extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-WaterfallChartDesignPanel";
   static components = {
     GeneralDesignEditor,
@@ -42,7 +40,9 @@ export class WaterfallChartDesignPanel extends Component<
     ChartLegend,
     ChartHumanizeNumbers,
   };
-  static props = ChartSidePanelPropsObject;
+  protected props = props(chartSidePanelPropsDefinition) as unknown as ChartSidePanelProps<
+    WaterfallChartDefinition<string>
+  >;
 
   axisChoices = CHART_AXIS_CHOICES;
 

--- a/src/components/side_panel/chart/zoomable_chart/design_panel.ts
+++ b/src/components/side_panel/chart/zoomable_chart/design_panel.ts
@@ -5,9 +5,9 @@ import { ChartSidePanelProps } from "../common";
 
 type ZoomableChartDefinition = Extract<ChartDefinition<string>, { zoomable?: boolean }>;
 
-interface Props extends ChartSidePanelProps<ZoomableChartDefinition> {}
-
-export class GenericZoomableChartDesignPanel<P extends Props> extends ChartWithAxisDesignPanel<P> {
+export class GenericZoomableChartDesignPanel<
+  P extends ChartSidePanelProps<ZoomableChartDefinition>
+> extends ChartWithAxisDesignPanel<P> {
   static template = "o-spreadsheet-GenericZoomableChartDesignPanel";
   static components = {
     ...ChartWithAxisDesignPanel.components,

--- a/src/components/side_panel/column_stats/column_stats_panel.ts
+++ b/src/components/side_panel/column_stats/column_stats_panel.ts
@@ -1,4 +1,4 @@
-import { onWillUnmount, proxy, signal } from "@odoo/owl";
+import { onWillUnmount, props, proxy, signal } from "@odoo/owl";
 import { Chart, ChartConfiguration } from "chart.js/auto";
 import { FIRST_CHART_COLOR } from "../../../helpers/color";
 import { numberToLetters } from "../../../helpers/coordinates";
@@ -12,19 +12,19 @@ import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
 import { Store } from "../../../types/store_engine";
 import { useHighlights } from "../../helpers/highlight_hook";
 import { NumberInput } from "../../number_input/number_input";
+import { types } from "../../props_validation";
 import { BadgeSelection } from "../components/badge_selection/badge_selection";
 import { SidePanelCollapsible } from "../components/collapsible/side_panel_collapsible";
 import { Section } from "../components/section/section";
 import { ColumnStatisticsStore } from "./column_stats_store";
 
-interface Props {
-  onCloseSidePanel: () => void;
-}
-
-export class ColumnStatsPanel extends Component<Props, SpreadsheetChildEnv> {
+export class ColumnStatsPanel extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ColumnStatsPanel";
-  static props = { onCloseSidePanel: Function };
   static components = { NumberInput, SidePanelCollapsible, BadgeSelection, Section };
+
+  protected props = props({
+    onCloseSidePanel: types.function([]),
+  });
 
   state = proxy({
     currentChart: "count",

--- a/src/components/side_panel/components/badge_selection/badge_selection.ts
+++ b/src/components/side_panel/components/badge_selection/badge_selection.ts
@@ -1,23 +1,20 @@
+import { props } from "@odoo/owl";
 import { SpreadsheetChildEnv } from "../../../../types/spreadsheet_env";
 
 import { Component } from "../../../../owl3_compatibility_layer";
+import { types } from "../../../props_validation";
 interface Choice {
   value: string;
   label: string;
   icon?: string;
 }
 
-interface Props {
-  choices: Choice[];
-  onChange: (value: string) => void;
-  selectedValue: string;
-}
-
-export class BadgeSelection extends Component<Props, SpreadsheetChildEnv> {
+export class BadgeSelection extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet.BadgeSelection";
-  static props = {
-    choices: Array,
-    onChange: Function,
-    selectedValue: String,
-  };
+
+  protected props = props({
+    choices: types.ArrayOf<Choice>(),
+    onChange: types.function<[value: string]>([types.string()]),
+    selectedValue: types.string(),
+  });
 }

--- a/src/components/side_panel/components/checkbox/checkbox.ts
+++ b/src/components/side_panel/components/checkbox/checkbox.ts
@@ -1,6 +1,8 @@
+import { props } from "@odoo/owl";
 import { SpreadsheetChildEnv } from "../../../../types/spreadsheet_env";
 
 import { Component } from "../../../../owl3_compatibility_layer";
+import { types } from "../../../props_validation";
 // FIXME Encoding version used in css
 // const CHECK_SVG = /*xml*/ `
 // <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'>
@@ -8,28 +10,23 @@ import { Component } from "../../../../owl3_compatibility_layer";
 // </svg>
 // `;
 
-interface Props {
-  label?: string;
-  value: boolean;
-  className?: string;
-  name?: string;
-  title?: string;
-  disabled?: boolean;
-  onChange: (value: boolean) => void;
-}
-
-export class Checkbox extends Component<Props, SpreadsheetChildEnv> {
+export class Checkbox extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet.Checkbox";
-  static props = {
-    label: { type: String, optional: true },
-    value: { type: Boolean, optional: true },
-    className: { type: String, optional: true },
-    name: { type: String, optional: true },
-    title: { type: String, optional: true },
-    disabled: { type: Boolean, optional: true },
-    onChange: Function,
-  };
-  static defaultProps = { value: false };
+
+  protected props = props(
+    {
+      "label?": types.string(),
+      "value?": types.boolean(),
+      "className?": types.string(),
+      "name?": types.string(),
+      "title?": types.string(),
+      "disabled?": types.boolean(),
+      onChange: types.function<[value: boolean]>([types.boolean()]),
+    },
+    {
+      value: false,
+    }
+  );
 
   onChange(ev: InputEvent) {
     const value = (ev.target as HTMLInputElement).checked;

--- a/src/components/side_panel/components/cog_wheel_menu/cog_wheel_menu.ts
+++ b/src/components/side_panel/components/cog_wheel_menu/cog_wheel_menu.ts
@@ -1,22 +1,19 @@
-import { proxy, signal } from "@odoo/owl";
-import { ActionSpec, createActions } from "../../../../actions/action";
+import { props, proxy, signal } from "@odoo/owl";
+import { createActions } from "../../../../actions/action";
 import { UuidGenerator } from "../../../../helpers/uuid";
 import { Component } from "../../../../owl3_compatibility_layer";
 import { MenuMouseEvent } from "../../../../types/misc";
 import { SpreadsheetChildEnv } from "../../../../types/spreadsheet_env";
 import { getBoundingRectAsPOJO } from "../../../helpers/dom_helpers";
 import { MenuPopover, MenuState } from "../../../menu_popover/menu_popover";
+import { types } from "../../../props_validation";
 
-interface Props {
-  items: ActionSpec[];
-}
-
-export class CogWheelMenu extends Component<Props, SpreadsheetChildEnv> {
+export class CogWheelMenu extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-CogWheelMenu";
   static components = { MenuPopover };
-  static props = {
-    items: Array,
-  };
+  protected props = props({
+    items: types.array(types.ActionSpec()),
+  });
 
   private buttonRef = signal<HTMLElement | null>(null);
   private menuState: MenuState = proxy({ isOpen: false, anchorRect: null, menuItems: [] });

--- a/src/components/side_panel/components/collapse/collapse.ts
+++ b/src/components/side_panel/components/collapse/collapse.ts
@@ -1,19 +1,14 @@
-import { onMounted, onWillUpdateProps, signal } from "@odoo/owl";
+import { onMounted, onWillUpdateProps, props, signal } from "@odoo/owl";
 import { Component } from "../../../../owl3_compatibility_layer";
 
 import { SpreadsheetChildEnv } from "../../../../types/spreadsheet_env";
+import { types } from "../../../props_validation";
 
-interface Props {
-  isCollapsed: boolean;
-  slots: any;
-}
-
-export class Collapse extends Component<Props, SpreadsheetChildEnv> {
+export class Collapse extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-Collapse";
-  static props = {
-    isCollapsed: Boolean,
-    slots: Object,
-  };
+  protected props = props({
+    isCollapsed: types.boolean(),
+  });
 
   private contentRef = signal<HTMLElement | null>(null);
 

--- a/src/components/side_panel/components/collapsible/side_panel_collapsible.ts
+++ b/src/components/side_panel/components/collapsible/side_panel_collapsible.ts
@@ -1,19 +1,20 @@
-import { proxy } from "@odoo/owl";
+import { props, proxy } from "@odoo/owl";
 import { Component } from "../../../../owl3_compatibility_layer";
+import { types } from "../../../props_validation";
 import { Collapse } from "../collapse/collapse";
 
-export class SidePanelCollapsible extends Component {
+export class SidePanelCollapsible extends Component<any> {
   static template = "o-spreadsheet-SidePanelCollapsible";
-  static props = {
-    slots: Object,
-    title: { type: String, optional: true },
-    isInitiallyCollapsed: { type: Boolean, optional: true },
-    class: { type: String, optional: true },
-  };
   static components = { Collapse };
 
+  protected props = props({
+    "title?": types.string(),
+    "isInitiallyCollapsed?": types.boolean(),
+    "class?": types.string(),
+  });
+
   private state: { isCollapsed: boolean } = proxy({
-    isCollapsed: this.props.isInitiallyCollapsed,
+    isCollapsed: !!this.props.isInitiallyCollapsed,
   });
 
   toggle() {

--- a/src/components/side_panel/components/radio_selection/radio_selection.ts
+++ b/src/components/side_panel/components/radio_selection/radio_selection.ts
@@ -1,17 +1,11 @@
+import { props } from "@odoo/owl";
 import { SpreadsheetChildEnv } from "../../../../types/spreadsheet_env";
 
 import { Component } from "../../../../owl3_compatibility_layer";
+import { types } from "../../../props_validation";
 interface Choice {
   value: unknown;
   label: string;
-}
-
-interface Props {
-  choices: Choice[];
-  onChange: (value: unknown) => void;
-  selectedValue: string;
-  name: string;
-  direction: "horizontal" | "vertical";
 }
 
 // FIXME Encoding version used in css
@@ -21,16 +15,19 @@ interface Props {
 // </svg>
 // `;
 
-export class RadioSelection extends Component<Props, SpreadsheetChildEnv> {
+export class RadioSelection extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet.RadioSelection";
-  static props = {
-    choices: Array,
-    onChange: Function,
-    selectedValue: { optional: false },
-    name: String,
-    direction: { type: String, optional: true },
-  };
-  static defaultProps = {
-    direction: "horizontal",
-  };
+
+  protected props = props(
+    {
+      choices: types.ArrayOf<Choice>(),
+      onChange: types.function<[value: unknown]>([types.any()]),
+      selectedValue: types.string(),
+      name: types.string(),
+      "direction?": types.or([types.literal("horizontal"), types.literal("vertical")]),
+    },
+    {
+      direction: "horizontal",
+    }
+  );
 }

--- a/src/components/side_panel/components/round_color_picker/round_color_picker.ts
+++ b/src/components/side_panel/components/round_color_picker/round_color_picker.ts
@@ -1,21 +1,15 @@
-import { proxy, signal } from "@odoo/owl";
+import { props, proxy, signal } from "@odoo/owl";
 import { Component, useExternalListener } from "../../../../owl3_compatibility_layer";
 import { Rect } from "../../../../types/rendering";
 import { SpreadsheetChildEnv } from "../../../../types/spreadsheet_env";
 import { ColorPicker } from "../../../color_picker/color_picker";
 import { cssPropertiesToCss } from "../../../helpers/css";
 import { getElBoundingRect } from "../../../helpers/dom_helpers";
+import { types } from "../../../props_validation";
 import { Section } from "../section/section";
 
 interface State {
   pickerOpened: boolean;
-}
-
-interface Props {
-  currentColor?: string;
-  onColorPicked: (color: string) => void;
-  title?: string;
-  disableNoColor?: boolean;
 }
 
 // FIXME Encoding version used in css
@@ -25,15 +19,15 @@ interface Props {
 // </svg>
 // `;
 
-export class RoundColorPicker extends Component<Props, SpreadsheetChildEnv> {
+export class RoundColorPicker extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet.RoundColorPicker";
   static components = { Section, ColorPicker };
-  static props = {
-    currentColor: { type: String, optional: true },
-    title: { type: String, optional: true },
-    onColorPicked: Function,
-    disableNoColor: { type: Boolean, optional: true },
-  };
+  protected props = props({
+    "currentColor?": types.string(),
+    "title?": types.string(),
+    onColorPicked: types.function<[color: string]>([types.string()]),
+    "disableNoColor?": types.boolean(),
+  });
 
   colorPickerButtonRef = signal<HTMLElement | null>(null);
 

--- a/src/components/side_panel/components/section/section.ts
+++ b/src/components/side_panel/components/section/section.ts
@@ -1,15 +1,15 @@
+import { props } from "@odoo/owl";
 import { SpreadsheetChildEnv } from "../../../../types/spreadsheet_env";
 
 import { Component } from "../../../../owl3_compatibility_layer";
-interface Props {
-  class?: string;
-}
+import { types } from "../../../props_validation";
 
-export class Section extends Component<Props, SpreadsheetChildEnv> {
+export class Section extends Component<SpreadsheetChildEnv> {
   static template = "o_spreadsheet.Section";
-  static props = {
-    class: { type: String, optional: true },
-    title: { type: String, optional: true },
-    slots: Object,
-  };
+
+  protected props = props({
+    "class?": types.string(),
+    "title?": types.string(),
+    slots: types.object(),
+  });
 }

--- a/src/components/side_panel/conditional_formatting/cf_editor/cell_is_rule_editor.ts
+++ b/src/components/side_panel/conditional_formatting/cf_editor/cell_is_rule_editor.ts
@@ -1,22 +1,21 @@
+import { props } from "@odoo/owl";
 import { Component } from "../../../../owl3_compatibility_layer";
 import { SpreadsheetChildEnv } from "../../../../types/spreadsheet_env";
-import { Store } from "../../../../types/store_engine";
 import { ColorPickerWidget } from "../../../color_picker/color_picker_widget";
 import { getTextDecoration } from "../../../helpers/css";
+import { types } from "../../../props_validation";
 import { Select } from "../../../select/select";
 import { ConditionalFormattingEditorStore } from "./cf_editor_store";
 
-interface Props {
-  store: Store<ConditionalFormattingEditorStore>;
-}
-
-export class CellIsRuleEditor extends Component<Props, SpreadsheetChildEnv> {
+export class CellIsRuleEditor extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-CellIsRuleEditor";
   static components = {
     ColorPickerWidget,
     Select,
   };
-  static props = { store: Object };
+  protected props = props({
+    store: types.Store<ConditionalFormattingEditorStore>(),
+  });
 
   getTextDecoration = getTextDecoration;
 

--- a/src/components/side_panel/conditional_formatting/cf_editor/cf_editor.ts
+++ b/src/components/side_panel/conditional_formatting/cf_editor/cf_editor.ts
@@ -1,3 +1,4 @@
+import { props } from "@odoo/owl";
 import { deepCopy } from "../../../../helpers/misc";
 import {
   Component,
@@ -6,10 +7,10 @@ import {
 } from "../../../../owl3_compatibility_layer";
 import { useLocalStore } from "../../../../store_engine/store_hooks";
 import { _t } from "../../../../translation";
-import { ConditionalFormat } from "../../../../types/conditional_formatting";
 import { UID } from "../../../../types/misc";
 import { SpreadsheetChildEnv } from "../../../../types/spreadsheet_env";
 import { Store } from "../../../../types/store_engine";
+import { types } from "../../../props_validation";
 import { SelectionInput } from "../../../selection_input/selection_input";
 import { ValidationMessages } from "../../../validation_messages/validation_messages";
 import { BadgeSelection } from "../../components/badge_selection/badge_selection";
@@ -20,13 +21,7 @@ import { ColorScaleRuleEditor } from "./color_scale_rule_editor";
 import { DataBarRuleEditor } from "./data_bar_rule_editor";
 import { IconSetRuleEditor } from "./icon_set_rule_editor";
 
-interface Props {
-  cf: ConditionalFormat;
-  isNewCf: boolean;
-  onCloseSidePanel: () => void;
-}
-
-export class ConditionalFormattingEditor extends Component<Props, SpreadsheetChildEnv> {
+export class ConditionalFormattingEditor extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ConditionalFormattingEditor";
   static components = {
     SelectionInput,
@@ -38,7 +33,11 @@ export class ConditionalFormattingEditor extends Component<Props, SpreadsheetChi
     IconSetRuleEditor,
     DataBarRuleEditor,
   };
-  static props = { cf: Object, isNewCf: Boolean, onCloseSidePanel: Function };
+  protected props = props({
+    cf: types.ConditionalFormat(),
+    isNewCf: types.boolean(),
+    onCloseSidePanel: types.function([]),
+  });
 
   private activeSheetId!: UID;
   private store!: Store<ConditionalFormattingEditorStore>;

--- a/src/components/side_panel/conditional_formatting/cf_editor/color_scale_rule_editor.ts
+++ b/src/components/side_panel/conditional_formatting/cf_editor/color_scale_rule_editor.ts
@@ -1,17 +1,16 @@
+import { props } from "@odoo/owl";
 import { Component } from "../../../../owl3_compatibility_layer";
 import { SpreadsheetChildEnv } from "../../../../types/spreadsheet_env";
-import { Store } from "../../../../types/store_engine";
+import { types } from "../../../props_validation";
 import { ConditionalFormattingEditorStore } from "./cf_editor_store";
 import { ColorScaleRuleEditorThreshold } from "./color_scale_rule_editor_threshold";
 
-interface Props {
-  store: Store<ConditionalFormattingEditorStore>;
-}
-
-export class ColorScaleRuleEditor extends Component<Props, SpreadsheetChildEnv> {
+export class ColorScaleRuleEditor extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ColorScaleRuleEditor";
   static components = {
     ColorScaleRuleEditorThreshold,
   };
-  static props = { store: Object };
+  protected props = props({
+    store: types.Store<ConditionalFormattingEditorStore>(),
+  });
 }

--- a/src/components/side_panel/conditional_formatting/cf_editor/color_scale_rule_editor_threshold.ts
+++ b/src/components/side_panel/conditional_formatting/cf_editor/color_scale_rule_editor_threshold.ts
@@ -1,3 +1,4 @@
+import { props } from "@odoo/owl";
 import { DEFAULT_COLOR_SCALE_MIDPOINT_COLOR } from "../../../../constants";
 import { colorNumberToHex } from "../../../../helpers/color";
 import { Component } from "../../../../owl3_compatibility_layer";
@@ -5,26 +6,29 @@ import { _t } from "../../../../translation";
 import { CommandResult } from "../../../../types/commands";
 import { ColorScaleThreshold } from "../../../../types/conditional_formatting";
 import { ValueAndLabel } from "../../../../types/misc";
+import { PropsOf } from "../../../../types/props_of";
 import { SpreadsheetChildEnv } from "../../../../types/spreadsheet_env";
-import { Store } from "../../../../types/store_engine";
 import { StandaloneComposer } from "../../../composer/standalone_composer/standalone_composer";
+import { types } from "../../../props_validation";
 import { Select } from "../../../select/select";
 import { RoundColorPicker } from "../../components/round_color_picker/round_color_picker";
 import { ConditionalFormattingEditorStore } from "./cf_editor_store";
 
-interface Props {
-  store: Store<ConditionalFormattingEditorStore>;
-  thresholdType: "minimum" | "midpoint" | "maximum";
-}
-
-export class ColorScaleRuleEditorThreshold extends Component<Props, SpreadsheetChildEnv> {
+export class ColorScaleRuleEditorThreshold extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ColorScaleRuleEditorThreshold";
   static components = {
     RoundColorPicker,
     StandaloneComposer,
     Select,
   };
-  static props = { store: Object, thresholdType: String };
+  protected props = props({
+    store: types.Store<ConditionalFormattingEditorStore>(),
+    thresholdType: types.or([
+      types.literal("minimum"),
+      types.literal("midpoint"),
+      types.literal("maximum"),
+    ]),
+  });
 
   get rule() {
     return this.props.store.state.rules.colorScale;
@@ -65,7 +69,7 @@ export class ColorScaleRuleEditorThreshold extends Component<Props, SpreadsheetC
     }
   }
 
-  getColorScaleComposerProps(): StandaloneComposer["props"] {
+  getColorScaleComposerProps(): PropsOf<StandaloneComposer> {
     const threshold = this.rule[this.props.thresholdType];
     if (!threshold) {
       throw new Error("Threshold not found");

--- a/src/components/side_panel/conditional_formatting/cf_editor/data_bar_rule_editor.ts
+++ b/src/components/side_panel/conditional_formatting/cf_editor/data_bar_rule_editor.ts
@@ -1,22 +1,21 @@
+import { props } from "@odoo/owl";
 import { colorNumberToHex } from "../../../../helpers/color";
 import { Component } from "../../../../owl3_compatibility_layer";
 import { SpreadsheetChildEnv } from "../../../../types/spreadsheet_env";
-import { Store } from "../../../../types/store_engine";
+import { types } from "../../../props_validation";
 import { SelectionInput } from "../../../selection_input/selection_input";
 import { RoundColorPicker } from "../../components/round_color_picker/round_color_picker";
 import { ConditionalFormattingEditorStore } from "./cf_editor_store";
 
-interface Props {
-  store: Store<ConditionalFormattingEditorStore>;
-}
-
-export class DataBarRuleEditor extends Component<Props, SpreadsheetChildEnv> {
+export class DataBarRuleEditor extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-DataBarRuleEditor";
   static components = {
     SelectionInput,
     RoundColorPicker,
   };
-  static props = { store: Object };
+  protected props = props({
+    store: types.Store<ConditionalFormattingEditorStore>(),
+  });
 
   get rule() {
     return this.props.store.state.rules.dataBar;

--- a/src/components/side_panel/conditional_formatting/cf_editor/icon_set_rule_editor.ts
+++ b/src/components/side_panel/conditional_formatting/cf_editor/icon_set_rule_editor.ts
@@ -1,26 +1,26 @@
+import { props } from "@odoo/owl";
 import { Component } from "../../../../owl3_compatibility_layer";
 import { _t } from "../../../../translation";
 import { CommandResult } from "../../../../types/commands";
 import { ValueAndLabel } from "../../../../types/misc";
+import { PropsOf } from "../../../../types/props_of";
 import { SpreadsheetChildEnv } from "../../../../types/spreadsheet_env";
-import { Store } from "../../../../types/store_engine";
 import { StandaloneComposer } from "../../../composer/standalone_composer/standalone_composer";
 import { IconPicker } from "../../../icon_picker/icon_picker";
+import { types } from "../../../props_validation";
 import { Select } from "../../../select/select";
 import { ConditionalFormattingEditorStore } from "./cf_editor_store";
 
-interface Props {
-  store: Store<ConditionalFormattingEditorStore>;
-}
-
-export class IconSetRuleEditor extends Component<Props, SpreadsheetChildEnv> {
+export class IconSetRuleEditor extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-IconSetRuleEditor";
   static components = {
     IconPicker,
     StandaloneComposer,
     Select,
   };
-  static props = { store: Object };
+  protected props = props({
+    store: types.Store<ConditionalFormattingEditorStore>(),
+  });
 
   get rule() {
     return this.props.store.state.rules.iconSet;
@@ -58,7 +58,7 @@ export class IconSetRuleEditor extends Component<Props, SpreadsheetChildEnv> {
 
   getColorIconSetComposerProps(
     inflectionPoint: "lowerInflectionPoint" | "upperInflectionPoint"
-  ): StandaloneComposer["props"] {
+  ): PropsOf<StandaloneComposer> {
     const inflection = this.props.store.state.rules.iconSet[inflectionPoint];
     const isInvalid = this.isInflectionPointInvalid(inflectionPoint);
     return {

--- a/src/components/side_panel/conditional_formatting/cf_preview/cf_preview.ts
+++ b/src/components/side_panel/conditional_formatting/cf_preview/cf_preview.ts
@@ -1,29 +1,24 @@
-import { signal } from "@odoo/owl";
+import { props, signal } from "@odoo/owl";
 import { HIGHLIGHT_COLOR, TEXT_BODY } from "../../../../constants";
 import { colorNumberToHex } from "../../../../helpers/color";
 import { Component } from "../../../../owl3_compatibility_layer";
 import { criterionEvaluatorRegistry } from "../../../../registries/criterion_registry";
-import { ConditionalFormat } from "../../../../types/conditional_formatting";
 import { Highlight } from "../../../../types/misc";
 import { SpreadsheetChildEnv } from "../../../../types/spreadsheet_env";
 import { cellStyleToCss, cssPropertiesToCss } from "../../../helpers/css";
 import { useHighlightsOnHover } from "../../../helpers/highlight_hook";
 import { ICONS } from "../../../icons/icons";
+import { types } from "../../../props_validation";
 import { CfTerms } from "../../../translations_terms";
 
-interface Props {
-  conditionalFormat: ConditionalFormat;
-  onMouseDown: (ev: MouseEvent) => void;
-  class: string;
-}
-
-export class ConditionalFormatPreview extends Component<Props, SpreadsheetChildEnv> {
+export class ConditionalFormatPreview extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ConditionalFormatPreview";
-  static props = {
-    conditionalFormat: Object,
-    onMouseDown: Function,
-    class: String,
-  };
+  protected props = props({
+    conditionalFormat: types.ConditionalFormat(),
+    onMouseDown: types.function<[ev: MouseEvent]>([types.instanceOf(MouseEvent)]),
+    class: types.string(),
+  });
+
   icons = ICONS;
   private cfPreviewRef = signal<HTMLElement | null>(null);
 

--- a/src/components/side_panel/conditional_formatting/cf_preview_list/cf_preview_list.ts
+++ b/src/components/side_panel/conditional_formatting/cf_preview_list/cf_preview_list.ts
@@ -1,4 +1,4 @@
-import { signal } from "@odoo/owl";
+import { props, signal } from "@odoo/owl";
 import { localizeCFRule } from "../../../../helpers/locale";
 import { UuidGenerator } from "../../../../helpers/uuid";
 import { zoneToXc } from "../../../../helpers/zones";
@@ -8,18 +8,16 @@ import { UID } from "../../../../types/misc";
 import { SpreadsheetChildEnv } from "../../../../types/spreadsheet_env";
 import { getBoundingRectAsPOJO } from "../../../helpers/dom_helpers";
 import { useDragAndDropListItems } from "../../../helpers/drag_and_drop_dom_items_hook";
+import { types } from "../../../props_validation";
 import { ConditionalFormatPreview } from "../cf_preview/cf_preview";
 
-interface Props {
-  onCloseSidePanel: () => void;
-}
-
-export class ConditionalFormatPreviewList extends Component<Props, SpreadsheetChildEnv> {
+export class ConditionalFormatPreviewList extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ConditionalFormatPreviewList";
-  static props = {
-    onCloseSidePanel: Function,
-  };
   static components = { ConditionalFormatPreview };
+
+  protected props = props({
+    onCloseSidePanel: types.function([]),
+  });
 
   private dragAndDrop = useDragAndDropListItems();
   private cfListRef = signal<HTMLElement | null>(null);

--- a/src/components/side_panel/criterion_form/criterion_form.ts
+++ b/src/components/side_panel/criterion_form/criterion_form.ts
@@ -2,24 +2,21 @@ import { useStore } from "../../../store_engine/store_hooks";
 import { GenericCriterion } from "../../../types/generic_criterion";
 import { ComposerFocusStore } from "../../composer/composer_focus_store";
 
+import { props } from "@odoo/owl";
 import { Component } from "../../../owl3_compatibility_layer";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
-interface Props<T extends GenericCriterion> {
-  criterion: T;
-  onCriterionChanged: (criterion: T) => void;
-  disableFormulas?: boolean;
-  autofocus?: boolean;
-}
+import { types } from "../../props_validation";
 
 export abstract class CriterionForm<
   T extends GenericCriterion = GenericCriterion
-> extends Component<Props<T>, SpreadsheetChildEnv> {
-  static props = {
-    criterion: Object,
-    onCriterionChanged: Function,
-    disableFormulas: { type: Boolean, optional: true },
-    autofocus: { type: Boolean, optional: true },
-  };
+> extends Component<SpreadsheetChildEnv> {
+  protected props = props({
+    criterion: types.object({}) as unknown as T,
+    onCriterionChanged: types.function<[criterion: T]>([types.object({}) as unknown as T]),
+    "disableFormulas?": types.boolean(),
+    "autofocus?": types.boolean(),
+  });
+
   setup() {
     const composerFocusStore = useStore(ComposerFocusStore);
     if (composerFocusStore.activeComposer.editionMode !== "inactive") {

--- a/src/components/side_panel/criterion_form/criterion_input/criterion_input.ts
+++ b/src/components/side_panel/criterion_form/criterion_input/criterion_input.ts
@@ -1,41 +1,35 @@
-import { proxy, signal } from "@odoo/owl";
+import { props, proxy, signal } from "@odoo/owl";
 import { canonicalizeContent } from "../../../../helpers/locale";
 import { Component, useLayoutEffect } from "../../../../owl3_compatibility_layer";
 import { criterionEvaluatorRegistry } from "../../../../registries/criterion_registry";
 import { _t } from "../../../../translation";
-import { DataValidationCriterionType } from "../../../../types/data_validation";
+import { PropsOf } from "../../../../types/props_of";
 import { SpreadsheetChildEnv } from "../../../../types/spreadsheet_env";
 import { StandaloneComposer } from "../../../composer/standalone_composer/standalone_composer";
+import { types } from "../../../props_validation";
 
-interface Props {
-  value: string;
-  criterionType: DataValidationCriterionType;
-  onValueChanged: (value: string) => void;
-  onKeyDown?: (ev: KeyboardEvent) => void;
-  focused: boolean;
-  onBlur: () => void;
-  disableFormulas?: boolean;
-}
-
-export class CriterionInput extends Component<Props, SpreadsheetChildEnv> {
+export class CriterionInput extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-CriterionInput";
-  static props = {
-    value: { type: String, optional: true },
-    criterionType: String,
-    onValueChanged: Function,
-    onKeyDown: { type: Function, optional: true },
-    focused: { type: Boolean, optional: true },
-    onBlur: { type: Function, optional: true },
-    onFocus: { type: Function, optional: true },
-    disableFormulas: { type: Boolean, optional: true },
-  };
-  static defaultProps = {
-    value: "",
-    onKeyDown: () => {},
-    focused: false,
-    onBlur: () => {},
-  };
   static components = { StandaloneComposer: StandaloneComposer };
+
+  protected props = props(
+    {
+      "value?": types.string(),
+      criterionType: types.DataValidationCriterionType(),
+      onValueChanged: types.function<[value: string]>([types.string()]),
+      "onKeyDown?": types.function<[ev: KeyboardEvent]>([types.instanceOf(KeyboardEvent)]),
+      "focused?": types.boolean(),
+      "onBlur?": types.function([]),
+      "onFocus?": types.function([]),
+      "disableFormulas?": types.boolean(),
+    },
+    {
+      value: "",
+      onKeyDown: () => {},
+      focused: false,
+      onBlur: () => {},
+    }
+  );
 
   inputRef = signal<HTMLInputElement | null>(null);
 
@@ -87,7 +81,7 @@ export class CriterionInput extends Component<Props, SpreadsheetChildEnv> {
     this.props.onValueChanged(str);
   }
 
-  getDataValidationRuleInputComposerProps(): StandaloneComposer["props"] {
+  getDataValidationRuleInputComposerProps(): PropsOf<StandaloneComposer> {
     return {
       onConfirm: (str: string) => this.onChangeComposerValue(str),
       composerContent: this.props.value,

--- a/src/components/side_panel/criterion_form/value_in_list_criterion/value_in_list_criterion.ts
+++ b/src/components/side_panel/criterion_form/value_in_list_criterion/value_in_list_criterion.ts
@@ -2,6 +2,7 @@ import { onWillStart, onWillUpdateProps, proxy } from "@odoo/owl";
 import { _t } from "../../../../translation";
 import { IsValueInListCriterion } from "../../../../types/data_validation";
 import { Color, ValueAndLabel } from "../../../../types/misc";
+import { PropsOf } from "../../../../types/props_of";
 import { Select } from "../../../select/select";
 import { RoundColorPicker } from "../../components/round_color_picker/round_color_picker";
 import { CriterionForm } from "../criterion_form";
@@ -38,7 +39,7 @@ export class ListCriterionForm extends CriterionForm<IsValueInListCriterion> {
       };
     });
 
-    const setupDefault = (props: this["props"]) => {
+    const setupDefault = (props: PropsOf<ListCriterionForm>) => {
       if (props.criterion.displayStyle === undefined) {
         this.updateCriterion({ displayStyle: "chip" });
       }

--- a/src/components/side_panel/criterion_form/value_in_range_criterion/value_in_range_criterion.ts
+++ b/src/components/side_panel/criterion_form/value_in_range_criterion/value_in_range_criterion.ts
@@ -2,6 +2,7 @@ import { onWillStart, onWillUpdateProps } from "@odoo/owl";
 import { _t } from "../../../../translation";
 import { IsValueInRangeCriterion } from "../../../../types/data_validation";
 import { Color, ValueAndLabel } from "../../../../types/misc";
+import { PropsOf } from "../../../../types/props_of";
 import { Select } from "../../../select/select";
 import { SelectionInput } from "../../../selection_input/selection_input";
 import { RoundColorPicker } from "../../components/round_color_picker/round_color_picker";
@@ -13,7 +14,7 @@ export class ValueInRangeCriterionForm extends CriterionForm<IsValueInRangeCrite
 
   setup() {
     super.setup();
-    const setupDefault = (props: this["props"]) => {
+    const setupDefault = (props: PropsOf<ValueInRangeCriterionForm>) => {
       if (props.criterion.displayStyle === undefined) {
         this.updateCriterion({ displayStyle: "chip" });
       }

--- a/src/components/side_panel/data_validation/data_validation_panel.ts
+++ b/src/components/side_panel/data_validation/data_validation_panel.ts
@@ -2,19 +2,19 @@ import { localizeDataValidationRule } from "../../../helpers/locale";
 import { UuidGenerator } from "../../../helpers/uuid";
 import { DataValidationRule } from "../../../types/data_validation";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
+import { types } from "../../props_validation";
 import { DataValidationPreview } from "./dv_preview/dv_preview";
 
+import { props } from "@odoo/owl";
 import { Component } from "../../../owl3_compatibility_layer";
-interface Props {
-  onCloseSidePanel: () => void;
-}
 
-export class DataValidationPanel extends Component<Props, SpreadsheetChildEnv> {
+export class DataValidationPanel extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-DataValidationPanel";
-  static props = {
-    onCloseSidePanel: Function,
-  };
   static components = { DataValidationPreview };
+
+  protected props = props({
+    onCloseSidePanel: types.function([]),
+  });
 
   addDataValidationRule() {
     this.env.replaceSidePanel("DataValidationEditor", "DataValidation", {

--- a/src/components/side_panel/data_validation/dv_editor/dv_editor.ts
+++ b/src/components/side_panel/data_validation/dv_editor/dv_editor.ts
@@ -1,4 +1,4 @@
-import { proxy } from "@odoo/owl";
+import { props, proxy } from "@odoo/owl";
 import { canonicalizeContent, localizeDataValidationRule } from "../../../../helpers/locale";
 import { zoneToXc } from "../../../../helpers/zones";
 import { Component, ComponentConstructor } from "../../../../owl3_compatibility_layer";
@@ -17,17 +17,12 @@ import {
 import { UID, ValueAndLabel } from "../../../../types/misc";
 import { SpreadsheetChildEnv } from "../../../../types/spreadsheet_env";
 import { DataValidationRuleData } from "../../../../types/workbook_data";
+import { types } from "../../../props_validation";
 import { Select } from "../../../select/select";
 import { SelectionInput } from "../../../selection_input/selection_input";
 import { DVTerms } from "../../../translations_terms";
 import { ValidationMessages } from "../../../validation_messages/validation_messages";
 import { Section } from "../../components/section/section";
-
-interface Props {
-  ruleId: UID;
-  onCancel?: () => void;
-  onCloseSidePanel: () => void;
-}
 
 interface State {
   rule: DataValidationRuleData;
@@ -35,14 +30,14 @@ interface State {
   isTypeUpdated: boolean;
 }
 
-export class DataValidationEditor extends Component<Props, SpreadsheetChildEnv> {
+export class DataValidationEditor extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-DataValidationEditor";
   static components = { SelectionInput, Select, Section, ValidationMessages };
-  static props = {
-    ruleId: String,
-    onCancel: { type: Function, optional: true },
-    onCloseSidePanel: Function,
-  };
+  protected props = props({
+    ruleId: types.UID(),
+    "onCancel?": types.function([]),
+    onCloseSidePanel: types.function([]),
+  });
 
   state = proxy<State>({
     rule: this.defaultDataValidationRule,

--- a/src/components/side_panel/data_validation/dv_preview/dv_preview.ts
+++ b/src/components/side_panel/data_validation/dv_preview/dv_preview.ts
@@ -1,21 +1,18 @@
-import { signal } from "@odoo/owl";
+import { props, signal } from "@odoo/owl";
 import { HIGHLIGHT_COLOR } from "../../../../constants";
 import { Component } from "../../../../owl3_compatibility_layer";
 import { criterionEvaluatorRegistry } from "../../../../registries/criterion_registry";
-import { DataValidationRule } from "../../../../types/data_validation";
 import { Highlight } from "../../../../types/misc";
 import { SpreadsheetChildEnv } from "../../../../types/spreadsheet_env";
 import { useHighlightsOnHover } from "../../../helpers/highlight_hook";
+import { types } from "../../../props_validation";
 
-interface Props {
-  rule: DataValidationRule;
-}
-
-export class DataValidationPreview extends Component<Props, SpreadsheetChildEnv> {
+export class DataValidationPreview extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-DataValidationPreview";
-  static props = {
-    rule: Object,
-  };
+
+  protected props = props({
+    rule: types.DataValidationRule(),
+  });
 
   private dvPreviewRef = signal<HTMLElement | null>(null);
 

--- a/src/components/side_panel/find_and_replace/find_and_replace.ts
+++ b/src/components/side_panel/find_and_replace/find_and_replace.ts
@@ -1,4 +1,4 @@
-import { onMounted, onWillUnmount, proxy, signal } from "@odoo/owl";
+import { onMounted, onWillUnmount, props, proxy, signal } from "@odoo/owl";
 import { debounce } from "../../../helpers/misc";
 import { zoneToXc } from "../../../helpers/zones";
 import { Component, useExternalListener } from "../../../owl3_compatibility_layer";
@@ -9,6 +9,7 @@ import { DebouncedFunction, ValueAndLabel } from "../../../types/misc";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
 import { Store } from "../../../types/store_engine";
 import { keyboardEventToShortcutString } from "../../helpers/dom_helpers";
+import { types } from "../../props_validation";
 import { Select } from "../../select/select";
 import { SelectionInput } from "../../selection_input/selection_input";
 import { ValidationMessages } from "../../validation_messages/validation_messages";
@@ -16,16 +17,12 @@ import { Checkbox } from "../components/checkbox/checkbox";
 import { Section } from "../components/section/section";
 import { FindAndReplaceStore } from "./find_and_replace_store";
 
-interface Props {
-  onCloseSidePanel: () => void;
-}
-
-export class FindAndReplacePanel extends Component<Props, SpreadsheetChildEnv> {
+export class FindAndReplacePanel extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-FindAndReplacePanel";
   static components = { SelectionInput, Section, Checkbox, ValidationMessages, Select };
-  static props = {
-    onCloseSidePanel: Function,
-  };
+  protected props = props({
+    onCloseSidePanel: types.function([]),
+  });
 
   private searchInputRef = signal<HTMLInputElement | null>(null);
   private store!: Store<FindAndReplaceStore>;

--- a/src/components/side_panel/more_formats/more_formats.ts
+++ b/src/components/side_panel/more_formats/more_formats.ts
@@ -1,29 +1,22 @@
-import { onWillStart, onWillUpdateProps } from "@odoo/owl";
+import { onWillStart, onWillUpdateProps, props } from "@odoo/owl";
 import { Component } from "../../../owl3_compatibility_layer";
 import { currenciesRegistry } from "../../../registries/currencies_registry";
 import { useLocalStore } from "../../../store_engine/store_hooks";
 import { Currency } from "../../../types/currency";
 import { ValueAndLabel } from "../../../types/misc";
+import { PropsOf } from "../../../types/props_of";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
 import { Store } from "../../../types/store_engine";
+import { types } from "../../props_validation";
 import { Select } from "../../select/select";
 import { TextInput } from "../../text_input/text_input";
 import { BadgeSelection } from "../components/badge_selection/badge_selection";
 import { Checkbox } from "../components/checkbox/checkbox";
 import { Section } from "../components/section/section";
-import { CustomFormatCategory, MoreFormatsStore } from "./more_formats_store";
+import { MoreFormatsStore } from "./more_formats_store";
 
-interface Props {
-  onCloseSidePanel: () => void;
-  category?: CustomFormatCategory;
-}
-
-export class MoreFormatsPanel extends Component<Props, SpreadsheetChildEnv> {
+export class MoreFormatsPanel extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-MoreFormatsPanel";
-  static props = {
-    onCloseSidePanel: Function,
-    category: { type: String, optional: true },
-  };
   static components = {
     BadgeSelection,
     Section,
@@ -32,12 +25,21 @@ export class MoreFormatsPanel extends Component<Props, SpreadsheetChildEnv> {
     Select,
   };
 
+  protected props = props({
+    onCloseSidePanel: types.function([]),
+    "category?": types.or([
+      types.literal("number"),
+      types.literal("date"),
+      types.literal("currency"),
+    ]),
+  });
+
   store!: Store<MoreFormatsStore>;
 
   setup() {
     this.store = useLocalStore(MoreFormatsStore, this.props.category);
     onWillStart(() => this.loadCurrencies());
-    onWillUpdateProps((nextProps: Props) => {
+    onWillUpdateProps((nextProps: PropsOf<MoreFormatsPanel>) => {
       if (nextProps.category && nextProps.category !== this.props.category) {
         this.store.changeCategory(nextProps.category);
       }

--- a/src/components/side_panel/named_ranges_panel/named_range_preview/named_range_preview.ts
+++ b/src/components/side_panel/named_ranges_panel/named_range_preview/named_range_preview.ts
@@ -1,28 +1,26 @@
-import { proxy, signal } from "@odoo/owl";
+import { props, proxy, signal } from "@odoo/owl";
 import { HIGHLIGHT_COLOR } from "../../../../constants";
 import { interactiveUpdateNamedRange } from "../../../../helpers/ui/named_range_interactive";
 import { Component } from "../../../../owl3_compatibility_layer";
-import { Highlight, NamedRange } from "../../../../types/misc";
+import { Highlight } from "../../../../types/misc";
 import { SpreadsheetChildEnv } from "../../../../types/spreadsheet_env";
 import { useHighlightsOnHover } from "../../../helpers/highlight_hook";
+import { types } from "../../../props_validation";
 import { SelectionInput } from "../../../selection_input/selection_input";
 import { TextInput } from "../../../text_input/text_input";
-
-interface Props {
-  namedRange: NamedRange;
-}
 
 interface State {
   isSelectionInputFocused?: boolean;
   currentRange?: string;
 }
 
-export class NamedRangePreview extends Component<Props, SpreadsheetChildEnv> {
+export class NamedRangePreview extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-NamedRangePreview";
-  static props = {
-    namedRange: Object,
-  };
   static components = { SelectionInput, TextInput };
+
+  protected props = props({
+    namedRange: types.NamedRange(),
+  });
 
   state = proxy<State>({});
 

--- a/src/components/side_panel/named_ranges_panel/named_ranges_panel.ts
+++ b/src/components/side_panel/named_ranges_panel/named_ranges_panel.ts
@@ -1,21 +1,21 @@
 import { getUniqueText } from "../../../helpers/misc";
 import { _t } from "../../../translation";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
+import { types } from "../../props_validation";
 import { SelectionInput } from "../../selection_input/selection_input";
 import { TextInput } from "../../text_input/text_input";
 import { NamedRangePreview } from "./named_range_preview/named_range_preview";
 
+import { props } from "@odoo/owl";
 import { Component } from "../../../owl3_compatibility_layer";
-interface Props {
-  onCloseSidePanel: () => void;
-}
 
-export class NamedRangesPanel extends Component<Props, SpreadsheetChildEnv> {
+export class NamedRangesPanel extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-NamedRangesPanel";
-  static props = {
-    onCloseSidePanel: Function,
-  };
   static components = { NamedRangePreview, SelectionInput, TextInput };
+
+  protected props = props({
+    onCloseSidePanel: types.function([]),
+  });
 
   get namedRanges() {
     return this.env.model.getters.getNamedRanges();

--- a/src/components/side_panel/perf_profile/perf_profile_panel.ts
+++ b/src/components/side_panel/perf_profile/perf_profile_panel.ts
@@ -1,4 +1,4 @@
-import { proxy } from "@odoo/owl";
+import { props, proxy } from "@odoo/owl";
 import { formatValue, humanizeNumber } from "../../../helpers/format/format";
 import { Component } from "../../../owl3_compatibility_layer";
 import { _t } from "../../../translation";
@@ -6,18 +6,18 @@ import { PerfProfile, RangeTiming } from "../../../types/functions";
 import { Highlight } from "../../../types/misc";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
 import { useHighlights } from "../../helpers/highlight_hook";
+import { types } from "../../props_validation";
 import { Section } from "../components/section/section";
 
 const HIGHLIGHT_COLOR = "#e28f08";
 
-interface Props {
-  onCloseSidePanel: () => void;
-}
-
-export class PerfProfilePanel extends Component<Props, SpreadsheetChildEnv> {
+export class PerfProfilePanel extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-PerfProfilePanel";
   static components = { Section };
-  static props = { onCloseSidePanel: Function };
+
+  protected props = props({
+    onCloseSidePanel: types.function([]),
+  });
 
   private state = proxy({
     selectedIndex: undefined as number | undefined,

--- a/src/components/side_panel/pivot/pivot_custom_groups_collapsible/pivot_custom_groups_collapsible.ts
+++ b/src/components/side_panel/pivot/pivot_custom_groups_collapsible/pivot_custom_groups_collapsible.ts
@@ -1,31 +1,28 @@
+import { props } from "@odoo/owl";
 import { deepCopy } from "../../../../helpers/misc";
 import { getUniquePivotGroupName } from "../../../../helpers/pivot/pivot_helpers";
+import { Component } from "../../../../owl3_compatibility_layer";
 import { _t } from "../../../../translation";
-import { UID } from "../../../../types/misc";
 import {
   PivotCoreDefinition,
   PivotCustomGroup,
   PivotCustomGroupedField,
 } from "../../../../types/pivot";
 import { SpreadsheetChildEnv } from "../../../../types/spreadsheet_env";
+import { types } from "../../../props_validation";
 import { TextInput } from "../../../text_input/text_input";
 import { Checkbox } from "../../components/checkbox/checkbox";
 import { SidePanelCollapsible } from "../../components/collapsible/side_panel_collapsible";
 
-import { Component } from "../../../../owl3_compatibility_layer";
-export interface Props {
-  pivotId: UID;
-  customField: PivotCustomGroupedField;
-  onCustomFieldUpdated: (definition: Partial<PivotCoreDefinition>) => void;
-}
-
-export class PivotCustomGroupsCollapsible extends Component<Props, SpreadsheetChildEnv> {
+export class PivotCustomGroupsCollapsible extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-PivotCustomGroupsCollapsible";
-  static props = {
-    pivotId: String,
-    customField: Object,
-    onCustomFieldUpdated: Function,
-  };
+  protected props = props({
+    pivotId: types.UID(),
+    customField: types.PivotCustomGroupedField(),
+    onCustomFieldUpdated: types.function<[definition: Partial<PivotCoreDefinition>]>([
+      types.object({}) as Partial<PivotCoreDefinition>,
+    ]),
+  });
   static components = { SidePanelCollapsible, TextInput, Checkbox };
 
   get groups() {

--- a/src/components/side_panel/pivot/pivot_defer_update/pivot_defer_update.ts
+++ b/src/components/side_panel/pivot/pivot_defer_update/pivot_defer_update.ts
@@ -1,26 +1,20 @@
-import { Checkbox } from "../../components/checkbox/checkbox";
-import { Section } from "../../components/section/section";
-
+import { props } from "@odoo/owl";
 import { Component } from "../../../../owl3_compatibility_layer";
 import { _t } from "../../../../translation";
 import { SpreadsheetChildEnv } from "../../../../types/spreadsheet_env";
-interface Props {
-  deferUpdate: boolean;
-  isDirty: boolean;
-  toggleDeferUpdate: (value: boolean) => void;
-  discard: () => void;
-  apply: () => void;
-}
+import { types } from "../../../props_validation";
+import { Checkbox } from "../../components/checkbox/checkbox";
+import { Section } from "../../components/section/section";
 
-export class PivotDeferUpdate extends Component<Props, SpreadsheetChildEnv> {
+export class PivotDeferUpdate extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-PivotDeferUpdate";
-  static props = {
-    deferUpdate: Boolean,
-    isDirty: Boolean,
-    toggleDeferUpdate: Function,
-    discard: Function,
-    apply: Function,
-  };
+  protected props = props({
+    deferUpdate: types.boolean(),
+    isDirty: types.boolean(),
+    toggleDeferUpdate: types.function<[value: boolean]>([types.boolean()]),
+    discard: types.function([]),
+    apply: types.function([]),
+  });
   static components = {
     Section,
     Checkbox,

--- a/src/components/side_panel/pivot/pivot_filter/pivot_filter.ts
+++ b/src/components/side_panel/pivot/pivot_filter/pivot_filter.ts
@@ -1,5 +1,5 @@
-import { onWillUpdateProps, proxy, signal } from "@odoo/owl";
-import { CellPosition, GenericCriterion, UID } from "../../../..";
+import { onWillUpdateProps, props, proxy, signal } from "@odoo/owl";
+import { CellPosition, GenericCriterion } from "../../../..";
 import { deepEquals } from "../../../../helpers/misc";
 import { SpreadsheetPivotRuntimeDefinition } from "../../../../helpers/pivot/spreadsheet_pivot/runtime_definition_spreadsheet_pivot";
 import { SpreadsheetPivot } from "../../../../helpers/pivot/spreadsheet_pivot/spreadsheet_pivot";
@@ -9,19 +9,14 @@ import { criterionEvaluatorRegistry } from "../../../../registries/criterion_reg
 import { _t } from "../../../../translation";
 import { Cell } from "../../../../types/cells";
 import { PivotFilter, SpreadsheetPivotCoreDefinition } from "../../../../types/pivot";
+import { PropsOf } from "../../../../types/props_of";
 import { SpreadsheetChildEnv } from "../../../../types/spreadsheet_env";
 import { DataFilterValue } from "../../../../types/table";
 import { PivotFilterMenu } from "../../../filters/pivot_filter_menu/pivot_filter_menu";
 import { isChildEvent } from "../../../helpers/dom_helpers";
 import { Popover } from "../../../popover/popover";
+import { types } from "../../../props_validation";
 import { PivotDimension } from "../pivot_layout_configurator/pivot_dimension/pivot_dimension";
-
-interface Props {
-  pivotId: UID;
-  definition: SpreadsheetPivotRuntimeDefinition;
-  filter: PivotFilter;
-  onFiltersUpdated: (definition: Partial<SpreadsheetPivotCoreDefinition>) => void;
-}
 
 interface Value {
   checked: boolean;
@@ -33,19 +28,22 @@ interface State {
   values: Value[];
 }
 
-export class PivotFilterEditor extends Component<Props, SpreadsheetChildEnv> {
+export class PivotFilterEditor extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-PivotFilterEditor";
   static components = {
     PivotDimension,
     Popover,
     PivotFilterMenu,
   };
-  static props = {
-    pivotId: String,
-    definition: Object,
-    filter: Object,
-    onFiltersUpdated: Function,
-  };
+
+  protected props = props({
+    pivotId: types.UID(),
+    definition: types.instanceOf(SpreadsheetPivotRuntimeDefinition),
+    filter: types.PivotFilter(),
+    onFiltersUpdated: types.function<[definition: Partial<SpreadsheetPivotCoreDefinition>]>([
+      types.SpreadsheetPivotCoreDefinition(),
+    ]),
+  });
 
   private state!: State;
 
@@ -58,7 +56,7 @@ export class PivotFilterEditor extends Component<Props, SpreadsheetChildEnv> {
         this.popover.isOpen = false;
       }
     });
-    onWillUpdateProps((nextProps: Props) => {
+    onWillUpdateProps((nextProps: PropsOf<PivotFilterEditor>) => {
       if (!deepEquals(nextProps.definition, this.props.definition)) {
         this.state.values = this.getFilterHiddenValues(nextProps);
       }
@@ -91,7 +89,7 @@ export class PivotFilterEditor extends Component<Props, SpreadsheetChildEnv> {
     }
   }
 
-  private getFilterHiddenValues(props: Props): Value[] {
+  private getFilterHiddenValues(props: PropsOf<PivotFilterEditor>): Value[] {
     const pivot = this.env.model.getters.getPivot(props.pivotId) as SpreadsheetPivot;
     if (pivot.type !== "SPREADSHEET") {
       throw new Error("Filters are only available on spreadsheet pivot table");

--- a/src/components/side_panel/pivot/pivot_layout_configurator/add_dimension_button/add_dimension_button.ts
+++ b/src/components/side_panel/pivot/pivot_layout_configurator/add_dimension_button/add_dimension_button.ts
@@ -1,4 +1,4 @@
-import { proxy, signal } from "@odoo/owl";
+import { props, proxy, signal } from "@odoo/owl";
 import { COMPOSER_ASSISTANT_COLOR } from "../../../../../constants";
 import { fuzzyLookup } from "../../../../../helpers/search";
 import { Component, useExternalListener } from "../../../../../owl3_compatibility_layer";
@@ -15,20 +15,15 @@ import { AutoCompleteStore } from "../../../../composer/autocomplete_dropdown/au
 import { useAutofocus } from "../../../../helpers/autofocus_hook";
 import { getHtmlContentFromPattern } from "../../../../helpers/html_content_helpers";
 import { Popover } from "../../../../popover/popover";
+import { types } from "../../../../props_validation";
 
-interface Props {
-  onFieldPicked: (field: string) => void;
-  fields: PivotField[];
-}
-
-export class AddDimensionButton extends Component<Props, SpreadsheetChildEnv> {
+export class AddDimensionButton extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-AddDimensionButton";
   static components = { Popover, TextValueProvider };
-  static props = {
-    onFieldPicked: Function,
-    fields: Array,
-    slots: { type: Object, optional: true },
-  };
+  protected props = props({
+    onFieldPicked: types.function<[field: string]>([types.string()]),
+    fields: types.array(),
+  });
 
   private buttonRef = signal<HTMLElement | null>(null);
   private popover = proxy({ isOpen: false });

--- a/src/components/side_panel/pivot/pivot_layout_configurator/pivot_dimension/pivot_dimension.ts
+++ b/src/components/side_panel/pivot/pivot_layout_configurator/pivot_dimension/pivot_dimension.ts
@@ -1,3 +1,4 @@
+import { props } from "@odoo/owl";
 import { collapseHierarchicalDisplayName } from "../../../../../helpers/pivot/pivot_helpers";
 import {
   PivotDimension as PivotDimensionType,
@@ -5,28 +6,32 @@ import {
   PivotMeasure,
 } from "../../../../../types/pivot";
 import { SpreadsheetChildEnv } from "../../../../../types/spreadsheet_env";
+import { types } from "../../../../props_validation";
 import { TextInput } from "../../../../text_input/text_input";
 import { CogWheelMenu } from "../../../components/cog_wheel_menu/cog_wheel_menu";
 
 import { Component } from "../../../../../owl3_compatibility_layer";
-interface Props {
-  dimension: PivotDimensionType | PivotMeasure | PivotFilter;
-  onRemoved: (dimension: PivotDimensionType | PivotMeasure | PivotFilter) => void;
-  onNameUpdated?: (
-    dimension: PivotDimensionType | PivotMeasure | PivotFilter,
-    name?: string
-  ) => void;
-  type: "row" | "col" | "measure" | "filter";
-}
 
-export class PivotDimension extends Component<Props, SpreadsheetChildEnv> {
+export class PivotDimension extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-PivotDimension";
-  static props = {
-    dimension: Object,
-    onRemoved: { type: Function, optional: true },
-    onNameUpdated: { type: Function, optional: true },
-    slots: { type: Object, optional: true },
-  };
+  protected props = props({
+    dimension: types.or([types.PivotDimension(), types.PivotMeasure(), types.PivotFilter()]),
+    "onRemoved?": types.function<[dimension: PivotDimensionType | PivotMeasure | PivotFilter]>([
+      types.or([types.PivotDimension(), types.PivotMeasure(), types.PivotFilter()]),
+    ]),
+    "onNameUpdated?": types.function<
+      [dimension: PivotDimensionType | PivotMeasure | PivotFilter, name?: string]
+    >([
+      types.or([types.PivotDimension(), types.PivotMeasure(), types.PivotFilter()]),
+      types.string(),
+    ]),
+    "type?": types.or([
+      types.literal("row"),
+      types.literal("col"),
+      types.literal("measure"),
+      types.literal("filter"),
+    ]),
+  });
   static components = { CogWheelMenu, TextInput };
 
   updateName(name: string) {

--- a/src/components/side_panel/pivot/pivot_layout_configurator/pivot_dimension_granularity/pivot_dimension_granularity.ts
+++ b/src/components/side_panel/pivot/pivot_layout_configurator/pivot_dimension_granularity/pivot_dimension_granularity.ts
@@ -1,26 +1,23 @@
+import { props } from "@odoo/owl";
 import { ALL_PERIODS } from "../../../../../helpers/pivot/pivot_helpers";
-import { PivotDimension } from "../../../../../types/pivot";
-
+import { Component } from "../../../../../owl3_compatibility_layer";
 import { ValueAndLabel } from "../../../../../types/misc";
+import { PivotDimension } from "../../../../../types/pivot";
 import { SpreadsheetChildEnv } from "../../../../../types/spreadsheet_env";
+import { types } from "../../../../props_validation";
 import { Select } from "../../../../select/select";
 
-import { Component } from "../../../../../owl3_compatibility_layer";
-interface Props {
-  dimension: PivotDimension;
-  onUpdated: (dimension: PivotDimension, ev: InputEvent) => void;
-  availableGranularities: Set<string>;
-  allGranularities: string[];
-}
-
-export class PivotDimensionGranularity extends Component<Props, SpreadsheetChildEnv> {
+export class PivotDimensionGranularity extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-PivotDimensionGranularity";
-  static props = {
-    dimension: Object,
-    onUpdated: Function,
-    availableGranularities: Set,
-    allGranularities: Array,
-  };
+  protected props = props({
+    dimension: types.PivotDimension(),
+    onUpdated: types.function<[dimension: PivotDimension, ev: InputEvent]>([
+      types.PivotDimension(),
+      types.instanceOf(InputEvent),
+    ]),
+    availableGranularities: types.SetOf<string>(),
+    allGranularities: types.array(),
+  });
   static components = { Select };
   periods = ALL_PERIODS;
 

--- a/src/components/side_panel/pivot/pivot_layout_configurator/pivot_dimension_order/pivot_dimension_order.ts
+++ b/src/components/side_panel/pivot/pivot_layout_configurator/pivot_dimension_order/pivot_dimension_order.ts
@@ -1,22 +1,21 @@
-import { PivotDimension } from "../../../../../types/pivot";
-
+import { props } from "@odoo/owl";
+import { Component } from "../../../../../owl3_compatibility_layer";
 import { _t } from "../../../../../translation";
 import { ValueAndLabel } from "../../../../../types/misc";
+import { PivotDimension } from "../../../../../types/pivot";
 import { SpreadsheetChildEnv } from "../../../../../types/spreadsheet_env";
+import { types } from "../../../../props_validation";
 import { Select } from "../../../../select/select";
 
-import { Component } from "../../../../../owl3_compatibility_layer";
-interface Props {
-  dimension: PivotDimension;
-  onUpdated: (dimension: PivotDimension, ev: InputEvent) => void;
-}
-
-export class PivotDimensionOrder extends Component<Props, SpreadsheetChildEnv> {
+export class PivotDimensionOrder extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-PivotDimensionOrder";
-  static props = {
-    dimension: Object,
-    onUpdated: Function,
-  };
+  protected props = props({
+    dimension: types.PivotDimension(),
+    onUpdated: types.function<[dimension: PivotDimension, ev: InputEvent]>([
+      types.PivotDimension(),
+      types.instanceOf(InputEvent),
+    ]),
+  });
   static components = { Select };
 
   get orderSelectOptions(): ValueAndLabel[] {

--- a/src/components/side_panel/pivot/pivot_layout_configurator/pivot_layout_configurator.ts
+++ b/src/components/side_panel/pivot/pivot_layout_configurator/pivot_layout_configurator.ts
@@ -1,4 +1,4 @@
-import { signal } from "@odoo/owl";
+import { props, signal } from "@odoo/owl";
 import { isDefined } from "../../../../helpers/misc";
 import {
   AGGREGATORS,
@@ -9,7 +9,7 @@ import { PivotRuntimeDefinition } from "../../../../helpers/pivot/pivot_runtime_
 import { Component } from "../../../../owl3_compatibility_layer";
 import { useStore } from "../../../../store_engine/store_hooks";
 import { _t } from "../../../../translation";
-import { SortDirection, UID } from "../../../../types/misc";
+import { SortDirection } from "../../../../types/misc";
 import {
   Aggregator,
   Granularity,
@@ -24,6 +24,7 @@ import { SpreadsheetChildEnv } from "../../../../types/spreadsheet_env";
 import { Store } from "../../../../types/store_engine";
 import { ComposerFocusStore } from "../../../composer/composer_focus_store";
 import { useDragAndDropListItems } from "../../../helpers/drag_and_drop_dom_items_hook";
+import { types } from "../../../props_validation";
 import { SidePanelCollapsible } from "../../components/collapsible/side_panel_collapsible";
 import { PivotCustomGroupsCollapsible } from "../pivot_custom_groups_collapsible/pivot_custom_groups_collapsible";
 import { AddDimensionButton } from "./add_dimension_button/add_dimension_button";
@@ -33,20 +34,7 @@ import { PivotDimensionOrder } from "./pivot_dimension_order/pivot_dimension_ord
 import { PivotMeasureEditor } from "./pivot_measure/pivot_measure";
 import { PivotSortSection } from "./pivot_sort_section/pivot_sort_section";
 
-interface Props {
-  definition: PivotRuntimeDefinition;
-  onDimensionsUpdated: (definition: Partial<PivotCoreDefinition>) => void;
-  onFiltersUpdated: (definition: Partial<PivotCoreDefinition>) => void;
-  unusedGroupableFields: PivotField[];
-  measureFields: PivotField[];
-  unusedGranularities: Record<string, Set<string>>;
-  dateGranularities: string[];
-  datetimeGranularities: string[];
-  getScrollableContainerEl?: () => HTMLElement;
-  pivotId: UID;
-}
-
-export class PivotLayoutConfigurator extends Component<Props, SpreadsheetChildEnv> {
+export class PivotLayoutConfigurator extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-PivotLayoutConfigurator";
   static components = {
     AddDimensionButton,
@@ -58,18 +46,22 @@ export class PivotLayoutConfigurator extends Component<Props, SpreadsheetChildEn
     PivotCustomGroupsCollapsible,
     SidePanelCollapsible,
   };
-  static props = {
-    definition: Object,
-    onDimensionsUpdated: Function,
-    onFiltersUpdated: Function,
-    unusedGroupableFields: Array,
-    measureFields: Array,
-    unusedGranularities: Object,
-    dateGranularities: Array,
-    datetimeGranularities: Array,
-    getScrollableContainerEl: { type: Function, optional: true },
-    pivotId: String,
-  };
+  protected props = props({
+    definition: types.instanceOf(PivotRuntimeDefinition),
+    onDimensionsUpdated: types.function<[definition: Partial<PivotCoreDefinition>]>([
+      types.PivotCoreDefinition(),
+    ]),
+    onFiltersUpdated: types.function<[definition: Partial<PivotCoreDefinition>]>([
+      types.PivotCoreDefinition(),
+    ]),
+    unusedGroupableFields: types.array(types.PivotField()),
+    measureFields: types.array(types.PivotField()),
+    unusedGranularities: types.RecordOf<Set<string>>(),
+    dateGranularities: types.array(types.string()),
+    datetimeGranularities: types.array(types.string()),
+    "getScrollableContainerEl?": types.function<[], HTMLElement>([], types.instanceOf(HTMLElement)),
+    pivotId: types.UID(),
+  });
 
   private dimensionsRef = signal<HTMLElement | null>(null);
   private dragAndDrop = useDragAndDropListItems();

--- a/src/components/side_panel/pivot/pivot_layout_configurator/pivot_measure/pivot_measure.ts
+++ b/src/components/side_panel/pivot/pivot_layout_configurator/pivot_measure/pivot_measure.ts
@@ -1,45 +1,40 @@
+import { props } from "@odoo/owl";
 import { PIVOT_TOKEN_COLOR } from "../../../../../constants";
 import { CompiledFormula } from "../../../../../formulas/compiler";
 import { Token } from "../../../../../formulas/tokenizer";
 import { unquote } from "../../../../../helpers/misc";
 import { getFieldDisplayName } from "../../../../../helpers/pivot/pivot_helpers";
-import { PivotRuntimeDefinition } from "../../../../../helpers/pivot/pivot_runtime_definition";
+import { Component } from "../../../../../owl3_compatibility_layer";
 import { createMeasureAutoComplete } from "../../../../../registries/auto_completes/pivot_dimension_auto_complete";
 import { _t } from "../../../../../translation";
 import { Color, ValueAndLabel } from "../../../../../types/misc";
 import { PivotMeasure } from "../../../../../types/pivot";
+import { SpreadsheetChildEnv } from "../../../../../types/spreadsheet_env";
 import { StandaloneComposer } from "../../../../composer/standalone_composer/standalone_composer";
+import { types } from "../../../../props_validation";
 import { Select } from "../../../../select/select";
 import { measureDisplayTerms } from "../../../../translations_terms";
 import { PivotDimension } from "../pivot_dimension/pivot_dimension";
 
-import { Component } from "../../../../../owl3_compatibility_layer";
-interface Props {
-  pivotId: string;
-  definition: PivotRuntimeDefinition;
-  measure: PivotMeasure;
-  onMeasureUpdated: (measure: PivotMeasure) => void;
-  onRemoved: () => void;
-  generateMeasureId: (fieldName: string, aggregator?: string) => string;
-  aggregators;
-}
-
-export class PivotMeasureEditor extends Component<Props> {
+export class PivotMeasureEditor extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-PivotMeasureEditor";
   static components = {
     PivotDimension,
     StandaloneComposer,
     Select,
   };
-  static props = {
-    definition: Object,
-    measure: Object,
-    onMeasureUpdated: Function,
-    onRemoved: Function,
-    generateMeasureId: Function,
-    aggregators: Object,
-    pivotId: String,
-  };
+  protected props = props({
+    pivotId: types.string(),
+    definition: types.PivotRuntimeDefinition(),
+    measure: types.PivotMeasure(),
+    onMeasureUpdated: types.function<[measure: PivotMeasure]>([types.PivotMeasure()]),
+    onRemoved: types.function([]),
+    generateMeasureId: types.function<[fieldName: string, aggregator?: string], string>(
+      [types.string(), types.string()],
+      types.string()
+    ),
+    aggregators: types.object({}),
+  });
 
   getMeasureAutocomplete() {
     return createMeasureAutoComplete(this.props.definition, this.props.measure);

--- a/src/components/side_panel/pivot/pivot_layout_configurator/pivot_sort_section/pivot_sort_section.ts
+++ b/src/components/side_panel/pivot/pivot_layout_configurator/pivot_sort_section/pivot_sort_section.ts
@@ -1,30 +1,25 @@
+import { props } from "@odoo/owl";
 import { formatValue } from "../../../../../helpers/format/format";
 import {
   getFieldDisplayName,
   isSortedColumnValid,
 } from "../../../../../helpers/pivot/pivot_helpers";
-import { PivotRuntimeDefinition } from "../../../../../helpers/pivot/pivot_runtime_definition";
+import { Component } from "../../../../../owl3_compatibility_layer";
 import { _t } from "../../../../../translation";
-import { UID } from "../../../../../types/misc";
 import { PivotDomain } from "../../../../../types/pivot";
 import { SpreadsheetChildEnv } from "../../../../../types/spreadsheet_env";
+import { types } from "../../../../props_validation";
 import { Section } from "../../../components/section/section";
 
-import { Component } from "../../../../../owl3_compatibility_layer";
-interface Props {
-  definition: PivotRuntimeDefinition;
-  pivotId: UID;
-}
-
-export class PivotSortSection extends Component<Props, SpreadsheetChildEnv> {
+export class PivotSortSection extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-PivotSortSection";
   static components = {
     Section,
   };
-  static props = {
-    definition: Object,
-    pivotId: String,
-  };
+  protected props = props({
+    definition: types.PivotRuntimeDefinition(),
+    pivotId: types.UID(),
+  });
 
   get hasValidSort() {
     const pivot = this.env.model.getters.getPivot(this.props.pivotId);

--- a/src/components/side_panel/pivot/pivot_measure_display_panel/pivot_measure_display_panel.ts
+++ b/src/components/side_panel/pivot/pivot_measure_display_panel/pivot_measure_display_panel.ts
@@ -1,8 +1,10 @@
+import { props } from "@odoo/owl";
+import { Component } from "../../../../owl3_compatibility_layer";
 import { useLocalStore } from "../../../../store_engine/store_hooks";
-import { UID, ValueAndLabel } from "../../../../types/misc";
-import { PivotCoreMeasure } from "../../../../types/pivot";
+import { ValueAndLabel } from "../../../../types/misc";
 import { SpreadsheetChildEnv } from "../../../../types/spreadsheet_env";
 import { Store } from "../../../../types/store_engine";
+import { types } from "../../../props_validation";
 import { Select } from "../../../select/select";
 import { measureDisplayTerms } from "../../../translations_terms";
 import { Checkbox } from "../../components/checkbox/checkbox";
@@ -10,20 +12,13 @@ import { RadioSelection } from "../../components/radio_selection/radio_selection
 import { Section } from "../../components/section/section";
 import { PivotMeasureDisplayPanelStore } from "./pivot_measure_display_panel_store";
 
-import { Component } from "../../../../owl3_compatibility_layer";
-interface Props {
-  onCloseSidePanel: () => void;
-  pivotId: UID;
-  measure: PivotCoreMeasure;
-}
-
-export class PivotMeasureDisplayPanel extends Component<Props, SpreadsheetChildEnv> {
+export class PivotMeasureDisplayPanel extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-PivotMeasureDisplayPanel";
-  static props = {
-    onCloseSidePanel: Function,
-    pivotId: String,
-    measure: Object,
-  };
+  protected props = props({
+    onCloseSidePanel: types.function([]),
+    pivotId: types.UID(),
+    measure: types.PivotCoreMeasure(),
+  });
   static components = { Section, Checkbox, RadioSelection, Select };
 
   measureDisplayTypeLabels = measureDisplayTerms.labels;

--- a/src/components/side_panel/pivot/pivot_side_panel/pivot_design_panel/pivot_design_panel.ts
+++ b/src/components/side_panel/pivot/pivot_side_panel/pivot_design_panel/pivot_design_panel.ts
@@ -1,26 +1,26 @@
+import { props } from "@odoo/owl";
 import { DEFAULT_PIVOT_STYLE } from "../../../../../helpers/pivot/pivot_helpers";
 import { PIVOT_TABLE_PRESETS } from "../../../../../helpers/pivot_table_presets";
+import { Component } from "../../../../../owl3_compatibility_layer";
 import { useLocalStore } from "../../../../../store_engine/store_hooks";
-import { UID } from "../../../../../types/misc";
 import { PivotStyle } from "../../../../../types/pivot";
 import { SpreadsheetChildEnv } from "../../../../../types/spreadsheet_env";
 import { Store } from "../../../../../types/store_engine";
 import { TableConfig, TableStyle } from "../../../../../types/table";
 import { NumberInput } from "../../../../number_input/number_input";
+import { types } from "../../../../props_validation";
 import { TableStylePicker } from "../../../../tables/table_style_picker/table_style_picker";
 import { Checkbox } from "../../../components/checkbox/checkbox";
 import { Section } from "../../../components/section/section";
 import { PivotSidePanelStore } from "../pivot_side_panel_store";
 
-import { Component } from "../../../../../owl3_compatibility_layer";
-interface Props {
-  pivotId: UID;
-}
-
-export class PivotDesignPanel extends Component<Props, SpreadsheetChildEnv> {
+export class PivotDesignPanel extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-PivotDesignPanel";
-  static props = { pivotId: String };
   static components = { Section, Checkbox, NumberInput, TableStylePicker };
+
+  protected props = props({
+    pivotId: types.UID(),
+  });
 
   store!: Store<PivotSidePanelStore>;
 

--- a/src/components/side_panel/pivot/pivot_side_panel/pivot_side_panel.ts
+++ b/src/components/side_panel/pivot/pivot_side_panel/pivot_side_panel.ts
@@ -1,43 +1,43 @@
-import { onWillUpdateProps, proxy } from "@odoo/owl";
+import { onWillUpdateProps, props, proxy } from "@odoo/owl";
 import { getPivotHighlights } from "../../../../helpers/pivot/pivot_highlight";
 import { pivotSidePanelRegistry } from "../../../../helpers/pivot/pivot_side_panel_registry";
 import { Component } from "../../../../owl3_compatibility_layer";
-import { UID } from "../../../../types/misc";
+import { PropsOf } from "../../../../types/props_of";
 import { SpreadsheetChildEnv } from "../../../../types/spreadsheet_env";
 import { useHighlights } from "../../../helpers/highlight_hook";
+import { types } from "../../../props_validation";
 import { Section } from "../../components/section/section";
 import { PivotLayoutConfigurator } from "../pivot_layout_configurator/pivot_layout_configurator";
 import { PivotDesignPanel } from "./pivot_design_panel/pivot_design_panel";
-
-interface Props {
-  pivotId: UID;
-  onCloseSidePanel: () => void;
-  openTab: "configuration" | "design";
-}
 
 interface State {
   panel: "configuration" | "design";
 }
 
-export class PivotSidePanel extends Component<Props, SpreadsheetChildEnv> {
+export class PivotSidePanel extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-PivotSidePanel";
-  static props = {
-    pivotId: String,
-    onCloseSidePanel: Function,
-    openTab: { type: String, optional: true },
-  };
-  static defaultProps = { openTab: "configuration" };
   static components = {
     PivotLayoutConfigurator,
     Section,
     PivotDesignPanel,
   };
 
+  protected props = props(
+    {
+      pivotId: types.UID(),
+      onCloseSidePanel: types.function([]),
+      "openTab?": types.or([types.literal("configuration"), types.literal("design")]),
+    },
+    {
+      openTab: "configuration",
+    }
+  );
+
   state = proxy<State>({ panel: this.props.openTab || "configuration" });
 
   setup() {
     useHighlights(this);
-    onWillUpdateProps((nextProps) => {
+    onWillUpdateProps((nextProps: PropsOf<PivotSidePanel>) => {
       if (nextProps.openTab && nextProps.openTab !== this.props.openTab) {
         this.switchPanel(nextProps.openTab);
       }

--- a/src/components/side_panel/pivot/pivot_side_panel/pivot_spreadsheet_side_panel/pivot_spreadsheet_side_panel.ts
+++ b/src/components/side_panel/pivot/pivot_side_panel/pivot_spreadsheet_side_panel/pivot_spreadsheet_side_panel.ts
@@ -1,12 +1,12 @@
-import { proxy, signal } from "@odoo/owl";
+import { props, proxy, signal } from "@odoo/owl";
 import { SpreadsheetPivotRuntimeDefinition } from "../../../../../helpers/pivot/spreadsheet_pivot/runtime_definition_spreadsheet_pivot";
 import { SpreadsheetPivot } from "../../../../../helpers/pivot/spreadsheet_pivot/spreadsheet_pivot";
 import { Component } from "../../../../../owl3_compatibility_layer";
 import { useLocalStore } from "../../../../../store_engine/store_hooks";
-import { UID } from "../../../../../types/misc";
 import { SpreadsheetPivotCoreDefinition } from "../../../../../types/pivot";
 import { SpreadsheetChildEnv } from "../../../../../types/spreadsheet_env";
 import { Store } from "../../../../../types/store_engine";
+import { types } from "../../../../props_validation";
 import { SelectionInput } from "../../../../selection_input/selection_input";
 import { Checkbox } from "../../../components/checkbox/checkbox";
 import { Section } from "../../../components/section/section";
@@ -17,17 +17,8 @@ import { PivotLayoutConfigurator } from "../../pivot_layout_configurator/pivot_l
 import { PivotTitleSection } from "../../pivot_title_section/pivot_title_section";
 import { PivotSidePanelStore } from "../pivot_side_panel_store";
 
-interface Props {
-  pivotId: UID;
-  onCloseSidePanel: () => void;
-}
-
-export class PivotSpreadsheetSidePanel extends Component<Props, SpreadsheetChildEnv> {
+export class PivotSpreadsheetSidePanel extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-PivotSpreadsheetSidePanel";
-  static props = {
-    pivotId: String,
-    onCloseSidePanel: Function,
-  };
   static components = {
     PivotLayoutConfigurator,
     Section,
@@ -38,6 +29,11 @@ export class PivotSpreadsheetSidePanel extends Component<Props, SpreadsheetChild
     AddDimensionButton,
     PivotFilterEditor,
   };
+
+  protected props = props({
+    pivotId: types.UID(),
+    onCloseSidePanel: types.function([]),
+  });
   store!: Store<PivotSidePanelStore>;
 
   state!: { range?: string; rangeHasChanged: boolean };

--- a/src/components/side_panel/pivot/pivot_title_section/pivot_title_section.ts
+++ b/src/components/side_panel/pivot/pivot_title_section/pivot_title_section.ts
@@ -1,26 +1,22 @@
+import { props } from "@odoo/owl";
 import { ActionSpec } from "../../../../actions/action";
 import { UuidGenerator } from "../../../../helpers/uuid";
+import { Component } from "../../../../owl3_compatibility_layer";
 import { _t } from "../../../../translation";
 import { CommandResult } from "../../../../types/commands";
-import { UID } from "../../../../types/misc";
 import { SpreadsheetChildEnv } from "../../../../types/spreadsheet_env";
+import { types } from "../../../props_validation";
 import { TextInput } from "../../../text_input/text_input";
 import { CogWheelMenu } from "../../components/cog_wheel_menu/cog_wheel_menu";
 import { Section } from "../../components/section/section";
 
-import { Component } from "../../../../owl3_compatibility_layer";
-interface Props {
-  pivotId: UID;
-  flipAxis: () => void;
-}
-
-export class PivotTitleSection extends Component<Props, SpreadsheetChildEnv> {
+export class PivotTitleSection extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-PivotTitleSection";
   static components = { CogWheelMenu, Section, TextInput };
-  static props = {
-    pivotId: String,
-    flipAxis: Function,
-  };
+  protected props = props({
+    pivotId: types.UID(),
+    flipAxis: types.function([]),
+  });
 
   get cogWheelMenuItems(): ActionSpec[] {
     return [

--- a/src/components/side_panel/remove_duplicates/remove_duplicates.ts
+++ b/src/components/side_panel/remove_duplicates/remove_duplicates.ts
@@ -1,27 +1,27 @@
-import { onWillUpdateProps, proxy } from "@odoo/owl";
+import { onWillUpdateProps, props, proxy } from "@odoo/owl";
 import { numberToLetters } from "../../../helpers/coordinates";
 import { zoneToDimension } from "../../../helpers/zones";
 import { Component } from "../../../owl3_compatibility_layer";
 import { _t } from "../../../translation";
 import { HeaderIndex } from "../../../types/misc";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
+import { types } from "../../props_validation";
 import { RemoveDuplicateTerms } from "../../translations_terms";
 import { ValidationMessages } from "../../validation_messages/validation_messages";
 import { Checkbox } from "../components/checkbox/checkbox";
 import { Section } from "../components/section/section";
 
-interface Props {
-  onCloseSidePanel: () => void;
-}
-
 interface RemoveDuplicatesState {
   hasHeader: boolean;
   columns: { [colIndex: number]: boolean };
 }
-export class RemoveDuplicatesPanel extends Component<Props, SpreadsheetChildEnv> {
+export class RemoveDuplicatesPanel extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-RemoveDuplicatesPanel";
   static components = { ValidationMessages, Section, Checkbox };
-  static props = { onCloseSidePanel: Function };
+
+  protected props = props({
+    onCloseSidePanel: types.function([]),
+  });
 
   state: RemoveDuplicatesState = proxy({
     hasHeader: false,

--- a/src/components/side_panel/settings/settings_panel.ts
+++ b/src/components/side_panel/settings/settings_panel.ts
@@ -1,4 +1,4 @@
-import { onWillStart } from "@odoo/owl";
+import { onWillStart, props } from "@odoo/owl";
 import { DAYS, formatValue } from "../../../helpers/format/format";
 import { getDateTimeFormat, isValidLocale } from "../../../helpers/locale";
 import { deepEquals } from "../../../helpers/misc";
@@ -6,19 +6,19 @@ import { Component } from "../../../owl3_compatibility_layer";
 import { Locale, LocaleCode } from "../../../types/locale";
 import { ValueAndLabel } from "../../../types/misc";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
+import { types } from "../../props_validation";
 import { Select } from "../../select/select";
 import { ValidationMessages } from "../../validation_messages/validation_messages";
 import { BadgeSelection } from "../components/badge_selection/badge_selection";
 import { Section } from "../components/section/section";
 
-interface Props {
-  onCloseSidePanel: () => void;
-}
-
-export class SettingsPanel extends Component<Props, SpreadsheetChildEnv> {
+export class SettingsPanel extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-SettingsPanel";
   static components = { Section, ValidationMessages, BadgeSelection, Select };
-  static props = { onCloseSidePanel: Function };
+
+  protected props = props({
+    onCloseSidePanel: types.function([]),
+  });
 
   loadedLocales: Locale[] = [];
 

--- a/src/components/side_panel/side_panel/side_panel.ts
+++ b/src/components/side_panel/side_panel/side_panel.ts
@@ -1,34 +1,24 @@
-import { SidePanelContent } from "../../../registries/side_panel_registry";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
 import { useSpreadsheetRect } from "../../helpers/position_hook";
-import { SidePanelComponentProps } from "./side_panel_store";
+import { types } from "../../props_validation";
 
+import { props } from "@odoo/owl";
 import { Component } from "../../../owl3_compatibility_layer";
-export interface SidePanelProps {
-  panelContent: SidePanelContent;
-  panelProps: SidePanelComponentProps;
-  onCloseSidePanel: () => void;
-  onStartHandleDrag: (ev: MouseEvent) => void;
-  onResetPanelSize: () => void;
-  isPinned?: boolean;
-  onTogglePinPanel?: () => void;
-  onToggleCollapsePanel?: () => void;
-  isCollapsed?: boolean;
-}
 
-export class SidePanel extends Component<SidePanelProps, SpreadsheetChildEnv> {
+export class SidePanel extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-SidePanel";
-  static props = {
-    panelContent: Object,
-    panelProps: Object,
-    onCloseSidePanel: Function,
-    onStartHandleDrag: Function,
-    onResetPanelSize: Function,
-    isPinned: { type: Boolean, optional: true },
-    onTogglePinPanel: { type: Function, optional: true },
-    onToggleCollapsePanel: { type: Function, optional: true },
-    isCollapsed: { type: Boolean, optional: true },
-  };
+
+  protected props = props({
+    panelContent: types.SidePanelContent(),
+    panelProps: types.SidePanelComponentProps(),
+    onCloseSidePanel: types.function([]),
+    onStartHandleDrag: types.function<[ev: MouseEvent]>([types.instanceOf(MouseEvent)]),
+    onResetPanelSize: types.function([]),
+    "isPinned?": types.boolean(),
+    "onTogglePinPanel?": types.function([]),
+    "onToggleCollapsePanel?": types.function([]),
+    "isCollapsed?": types.boolean(),
+  });
   spreadsheetRect = useSpreadsheetRect();
 
   getTitle() {

--- a/src/components/side_panel/side_panels/side_panels.ts
+++ b/src/components/side_panel/side_panels/side_panels.ts
@@ -1,17 +1,17 @@
 import { Component, useLayoutEffect } from "../../../owl3_compatibility_layer";
 import { sidePanelRegistry } from "../../../registries/side_panel_registry";
 import { useStore } from "../../../store_engine/store_hooks";
+import { PropsOf } from "../../../types/props_of";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
 import { Store } from "../../../types/store_engine";
 import { cssPropertiesToCss } from "../../helpers/css";
 import { startDnd } from "../../helpers/drag_and_drop";
 import { useSpreadsheetRect } from "../../helpers/position_hook";
-import { SidePanel, SidePanelProps } from "../side_panel/side_panel";
+import { SidePanel } from "../side_panel/side_panel";
 import { SidePanelStore } from "../side_panel/side_panel_store";
 
-export class SidePanels extends Component<{}, SpreadsheetChildEnv> {
+export class SidePanels extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-SidePanels";
-  static props = {};
   static components = { SidePanel };
   sidePanelStore!: Store<SidePanelStore>;
   spreadsheetRect = useSpreadsheetRect();
@@ -51,7 +51,7 @@ export class SidePanels extends Component<{}, SpreadsheetChildEnv> {
     startDnd(onMouseMove, cleanUp);
   }
 
-  get mainPanelProps(): SidePanel["props"] | undefined {
+  get mainPanelProps(): PropsOf<SidePanel> | undefined {
     const panelProps = this.sidePanelStore.mainPanelProps;
     if (!this.sidePanelStore.mainPanel || !panelProps) {
       return undefined;
@@ -69,7 +69,7 @@ export class SidePanels extends Component<{}, SpreadsheetChildEnv> {
     };
   }
 
-  get secondaryPanelProps(): SidePanelProps | undefined {
+  get secondaryPanelProps(): PropsOf<SidePanel> | undefined {
     const panelProps = this.sidePanelStore.secondaryPanelProps;
     if (!this.sidePanelStore.secondaryPanel || !panelProps) {
       return undefined;

--- a/src/components/side_panel/split_to_columns_panel/split_to_columns_panel.ts
+++ b/src/components/side_panel/split_to_columns_panel/split_to_columns_panel.ts
@@ -1,4 +1,4 @@
-import { onMounted, proxy } from "@odoo/owl";
+import { onMounted, props, proxy } from "@odoo/owl";
 import { NEWLINE } from "../../../constants";
 import { interactiveSplitToColumns } from "../../../helpers/ui/split_to_columns_interactive";
 import { Component, useLayoutEffect } from "../../../owl3_compatibility_layer";
@@ -7,6 +7,7 @@ import { _t } from "../../../translation";
 import { CommandResult } from "../../../types/commands";
 import { ValueAndLabel } from "../../../types/misc";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
+import { types } from "../../props_validation";
 import { Select } from "../../select/select";
 import { SplitToColumnsTerms } from "../../translations_terms";
 import { ValidationMessages } from "../../validation_messages/validation_messages";
@@ -25,20 +26,19 @@ const SEPARATORS: ValueAndLabel[] = [
   { label: _t("Line Break"), value: NEWLINE },
 ];
 
-interface Props {
-  onCloseSidePanel: () => void;
-}
-
 interface State {
   separatorValue: SeparatorValue;
   customSeparator: string;
   addNewColumns: boolean;
 }
 
-export class SplitIntoColumnsPanel extends Component<Props, SpreadsheetChildEnv> {
+export class SplitIntoColumnsPanel extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-SplitIntoColumnsPanel";
   static components = { ValidationMessages, Section, Checkbox, Select };
-  static props = { onCloseSidePanel: Function };
+
+  protected props = props({
+    onCloseSidePanel: types.function([]),
+  });
 
   state = proxy<State>({ separatorValue: "auto", addNewColumns: false, customSeparator: "" });
 

--- a/src/components/side_panel/table_panel/table_panel.ts
+++ b/src/components/side_panel/table_panel/table_panel.ts
@@ -1,25 +1,21 @@
-import { proxy } from "@odoo/owl";
+import { props, proxy } from "@odoo/owl";
 import { getZoneArea, positionToZone } from "../../../helpers/zones";
 import { Component } from "../../../owl3_compatibility_layer";
 import { CommandResult, DispatchResult } from "../../../types/commands";
 import { Zone } from "../../../types/misc";
 import { Range } from "../../../types/range";
-import { CoreTable, TableConfig } from "../../../types/table";
+import { TableConfig } from "../../../types/table";
 
 import { getTableTopLeft } from "../../../helpers/table_helpers";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
 import { NumberInput } from "../../number_input/number_input";
+import { types } from "../../props_validation";
 import { SelectionInput } from "../../selection_input/selection_input";
 import { TableStylePicker } from "../../tables/table_style_picker/table_style_picker";
 import { TableTerms } from "../../translations_terms";
 import { ValidationMessages } from "../../validation_messages/validation_messages";
 import { Checkbox } from "../components/checkbox/checkbox";
 import { Section } from "../components/section/section";
-
-interface Props {
-  table: CoreTable;
-  onCloseSidePanel: () => void;
-}
 
 interface State {
   tableZoneErrors: CommandResult[];
@@ -29,7 +25,7 @@ interface State {
   filtersEnabledIfPossible: boolean;
 }
 
-export class TablePanel extends Component<Props, SpreadsheetChildEnv> {
+export class TablePanel extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-TablePanel";
   static components = {
     TableStylePicker,
@@ -39,7 +35,10 @@ export class TablePanel extends Component<Props, SpreadsheetChildEnv> {
     Section,
     NumberInput,
   };
-  static props = { onCloseSidePanel: Function, table: Object };
+  protected props = props({
+    onCloseSidePanel: types.function([]),
+    table: types.CoreTable(),
+  });
 
   state!: State;
 

--- a/src/components/side_panel/table_style_editor_panel/table_style_editor_panel.ts
+++ b/src/components/side_panel/table_style_editor_panel/table_style_editor_panel.ts
@@ -1,4 +1,4 @@
-import { proxy } from "@odoo/owl";
+import { props, proxy } from "@odoo/owl";
 import { isColorValid } from "../../../helpers/color";
 import { TABLE_STYLES_TEMPLATES, buildTableStyle } from "../../../helpers/table_presets";
 import { UuidGenerator } from "../../../helpers/uuid";
@@ -7,17 +7,12 @@ import { Color } from "../../../types/misc";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
 import { TableConfig, TableStyle, TableStyleTemplateName } from "../../../types/table";
 import { cssPropertiesToCss } from "../../helpers/css";
+import { types } from "../../props_validation";
 import { TableStylePreview } from "../../tables/table_style_preview/table_style_preview";
 import { RoundColorPicker } from "../components/round_color_picker/round_color_picker";
 import { Section } from "../components/section/section";
 
 const DEFAULT_TABLE_STYLE_COLOR = "#3C78D8";
-
-export interface TableStyleEditorPanelProps {
-  onCloseSidePanel: () => void;
-  styleId?: string;
-  onStylePicked?: (styleId: string) => void;
-}
 
 interface State {
   pickerOpened: boolean;
@@ -26,17 +21,14 @@ interface State {
   styleName: string;
 }
 
-export class TableStyleEditorPanel extends Component<
-  TableStyleEditorPanelProps,
-  SpreadsheetChildEnv
-> {
+export class TableStyleEditorPanel extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-TableStyleEditorPanel";
   static components = { Section, RoundColorPicker, TableStylePreview };
-  static props = {
-    onCloseSidePanel: Function,
-    onStylePicked: { type: Function, optional: true },
-    styleId: { type: String, optional: true },
-  };
+  protected props = props({
+    onCloseSidePanel: types.function([]),
+    "onStylePicked?": types.function<[styleId: string]>([types.string()]),
+    "styleId?": types.string(),
+  });
 
   state = proxy<State>(this.getInitialState());
 

--- a/src/components/small_bottom_bar/ribbon_menu/ribbon_menu.ts
+++ b/src/components/small_bottom_bar/ribbon_menu/ribbon_menu.ts
@@ -1,11 +1,12 @@
-import { onMounted, proxy, signal } from "@odoo/owl";
+import { onMounted, props, proxy, signal } from "@odoo/owl";
 import { Action, getMenuItemsAndSeparators } from "../../../actions/action";
 import { Component, useExternalListener } from "../../../owl3_compatibility_layer";
 import { topbarMenuRegistry } from "../../../registries/menus/topbar_menu_registry";
 import { _t } from "../../../translation";
+import { PropsOf } from "../../../types/props_of";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
-import { cssPropertiesToCss } from "../../helpers/css";
-import { Menu, MenuProps } from "../../menu/menu";
+import { Menu } from "../../menu/menu";
+import { types } from "../../props_validation";
 
 export const itemHeight = 40;
 
@@ -15,17 +16,13 @@ interface State {
   parentState: State | undefined;
 }
 
-export interface RibbonMenuProps {
-  onClose: () => void;
-  height: number;
-}
-
-export class RibbonMenu extends Component<RibbonMenuProps, SpreadsheetChildEnv> {
+export class RibbonMenu extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-RibbonMenu";
-  static props = {
-    onClose: Function,
-  };
   static components = { Menu };
+
+  protected props = props({
+    onClose: types.function([]),
+  });
 
   rootItems = topbarMenuRegistry.getMenuItems();
   private menuRef = signal<HTMLElement | null>(null);
@@ -64,18 +61,12 @@ export class RibbonMenu extends Component<RibbonMenuProps, SpreadsheetChildEnv> 
     }
   }
 
-  get menuProps(): MenuProps {
+  get menuProps(): PropsOf<Menu> {
     return {
       menuItems: getMenuItemsAndSeparators(this.env, this.state.menuItems),
       onClose: this.props.onClose,
       onClickMenu: this.onClickMenu.bind(this),
     };
-  }
-
-  get style() {
-    return cssPropertiesToCss({
-      height: `${this.props.height}px`,
-    });
   }
 
   updateShadows() {

--- a/src/components/small_bottom_bar/small_bottom_bar.ts
+++ b/src/components/small_bottom_bar/small_bottom_bar.ts
@@ -1,29 +1,28 @@
-import { onMounted, onPatched, proxy, signal } from "@odoo/owl";
+import { onMounted, onPatched, props, proxy, signal } from "@odoo/owl";
 import { Component } from "../../owl3_compatibility_layer";
 import { useStore } from "../../store_engine/store_hooks";
 import { ComposerFocusType } from "../../types/misc";
+import { PropsOf } from "../../types/props_of";
 import { Rect } from "../../types/rendering";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 import { Store } from "../../types/store_engine";
 import { Ripple } from "../animation/ripple";
 import { BottomBar } from "../bottom_bar/bottom_bar";
 import { CellComposerStore } from "../composer/composer/cell_composer_store";
-import { CellComposerProps, Composer } from "../composer/composer/composer";
+import { Composer } from "../composer/composer/composer";
 import { ComposerFocusStore, ComposerInterface } from "../composer/composer_focus_store";
 import { cssPropertiesToCss } from "../helpers/css";
 import { getElBoundingRect } from "../helpers/dom_helpers";
+import { types } from "../props_validation";
 import { RibbonMenu } from "./ribbon_menu/ribbon_menu";
 
-interface Props {
-  onClick: () => void;
-}
-
-export class SmallBottomBar extends Component<Props, SpreadsheetChildEnv> {
+export class SmallBottomBar extends Component<SpreadsheetChildEnv> {
   static components = { Composer, BottomBar, Ripple, RibbonMenu };
   static template = "o-spreadsheet-SmallBottomBar";
-  static props = {
-    onClick: Function,
-  };
+
+  protected props = props({
+    onClick: types.function([]),
+  });
 
   private composerFocusStore!: Store<ComposerFocusStore>;
   private composerStore!: Store<CellComposerStore>;
@@ -83,7 +82,7 @@ export class SmallBottomBar extends Component<Props, SpreadsheetChildEnv> {
     return getElBoundingRect(this.composerRef());
   }
 
-  get composerProps(): CellComposerProps {
+  get composerProps(): PropsOf<Composer> {
     const { width, height } = this.env.model.getters.getSheetViewDimensionWithHeaders();
     return {
       rect: { ...this.rect },

--- a/src/components/spreadsheet/spreadsheet.ts
+++ b/src/components/spreadsheet/spreadsheet.ts
@@ -3,6 +3,7 @@ import {
   onPatched,
   onWillUnmount,
   onWillUpdateProps,
+  props,
   proxy,
   signal,
   useEffect,
@@ -27,6 +28,7 @@ import { _t } from "../../translation";
 import { CommandResult } from "../../types/commands";
 import { InformationNotification } from "../../types/env";
 import { CSSProperties, HeaderGroup, Pixel } from "../../types/misc";
+import { PropsOf } from "../../types/props_of";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 import { Store } from "../../types/store_engine";
 import { NotificationStoreMethods } from "../../types/stores/notification_store_methods";
@@ -44,6 +46,7 @@ import {
 } from "../helpers/dom_helpers";
 import { useSpreadsheetRect } from "../helpers/position_hook";
 import { useScreenWidth } from "../helpers/screen_width_hook";
+import { types } from "../props_validation";
 import { DEFAULT_SIDE_PANEL_SIZE, SidePanelStore } from "../side_panel/side_panel/side_panel_store";
 import { SidePanels } from "../side_panel/side_panels/side_panels";
 import { SmallBottomBar } from "../small_bottom_bar/small_bottom_bar";
@@ -62,18 +65,23 @@ import { instantiateClipboard } from "./../../helpers/clipboard/navigator_clipbo
 // </svg>
 // `;
 
-export interface SpreadsheetProps extends Partial<NotificationStoreMethods> {
-  model: Model;
-}
-
-export class Spreadsheet extends Component<SpreadsheetProps, SpreadsheetChildEnv> {
+export class Spreadsheet extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-Spreadsheet";
-  static props = {
-    model: Object,
-    notifyUser: { type: Function, optional: true },
-    raiseError: { type: Function, optional: true },
-    askConfirmation: { type: Function, optional: true },
-  };
+  protected props = props({
+    model: types.Model(),
+    "notifyUser?": types.function([
+      types.InformationNotification(),
+    ]) as unknown as NotificationStoreMethods["notifyUser"],
+    "raiseError?": types.function([
+      types.string(),
+      types.function([]),
+    ]) as unknown as NotificationStoreMethods["raiseError"],
+    "askConfirmation?": types.function([
+      types.string(),
+      types.function([]),
+      types.function([]),
+    ]) as unknown as NotificationStoreMethods["askConfirmation"],
+  });
   static components = {
     TopBar,
     Grid,
@@ -203,7 +211,7 @@ export class Spreadsheet extends Component<SpreadsheetProps, SpreadsheetChildEnv
       { capture: true }
     );
 
-    onWillUpdateProps((nextProps: SpreadsheetProps) => {
+    onWillUpdateProps((nextProps: PropsOf<Spreadsheet>) => {
       if (nextProps.model !== this.props.model) {
         throw new Error("Changing the props model is not supported at the moment.");
       }

--- a/src/components/spreadsheet_print/spreadsheet_print.ts
+++ b/src/components/spreadsheet_print/spreadsheet_print.ts
@@ -1,9 +1,10 @@
-import { onWillUnmount } from "@odoo/owl";
+import { onWillUnmount, props } from "@odoo/owl";
 import { Component, useExternalListener } from "../../owl3_compatibility_layer";
 import { useLocalStore } from "../../store_engine/store_hooks";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 import { Store } from "../../types/store_engine";
 import { cssPropertiesToCss } from "../helpers/css";
+import { types } from "../props_validation";
 import { Select } from "../select/select";
 import { BadgeSelection } from "../side_panel/components/badge_selection/badge_selection";
 import { Checkbox } from "../side_panel/components/checkbox/checkbox";
@@ -17,13 +18,11 @@ import {
   SpreadsheetPrintStore,
 } from "./spreadsheet_print_store";
 
-interface Props {
-  onExitPrintMode: () => void;
-}
-
-export class SpreadsheetPrint extends Component<Props, SpreadsheetChildEnv> {
+export class SpreadsheetPrint extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-SpreadsheetPrint";
-  static props = { onExitPrintMode: Function };
+  protected props = props({
+    onExitPrintMode: types.function([]),
+  });
   static components = { StandaloneGridCanvas, Section, Select, BadgeSelection, Checkbox };
 
   printStore!: Store<SpreadsheetPrintStore>;

--- a/src/components/standalone_grid_canvas/standalone_grid_canvas.ts
+++ b/src/components/standalone_grid_canvas/standalone_grid_canvas.ts
@@ -1,27 +1,23 @@
-import { onWillStart, onWillUpdateProps, signal } from "@odoo/owl";
+import { onWillStart, onWillUpdateProps, props, signal } from "@odoo/owl";
 import { Component } from "../../owl3_compatibility_layer";
 import { useLocalStore } from "../../store_engine/store_hooks";
 import { RendererStore } from "../../stores/renderer_store";
-import { UID, Zone } from "../../types/misc";
+import { PropsOf } from "../../types/props_of";
 import { GridRenderingContext } from "../../types/rendering";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 import { Store } from "../../types/store_engine";
 import { useGridDrawing } from "../helpers/draw_grid_hook";
+import { types } from "../props_validation";
 import { FigureRendererStore } from "./figure_renderer_store";
 
-interface Props {
-  sheetId: UID;
-  zone: Zone;
-  renderingCtx: Omit<GridRenderingContext, "ctx" | "thinLineWidth">;
-}
-
-export class StandaloneGridCanvas extends Component<Props, SpreadsheetChildEnv> {
+export class StandaloneGridCanvas extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-StandaloneGridCanvas";
-  static props = {
-    sheetId: String,
-    zone: Object,
-    renderingCtx: Object,
-  };
+
+  protected props = props({
+    sheetId: types.UID(),
+    zone: types.Zone(),
+    renderingCtx: types.object({}) as Omit<GridRenderingContext, "ctx" | "thinLineWidth">,
+  });
 
   private canvasRef = signal<HTMLElement | null>(null);
 
@@ -38,10 +34,12 @@ export class StandaloneGridCanvas extends Component<Props, SpreadsheetChildEnv> 
       changeCanvasSizeOnZoom: true,
     });
     onWillStart(async () => await this.loadImages(this.props));
-    onWillUpdateProps(async (nextProps: Props) => await this.loadImages(nextProps));
+    onWillUpdateProps(
+      async (nextProps: PropsOf<StandaloneGridCanvas>) => await this.loadImages(nextProps)
+    );
   }
 
-  private async loadImages(props: Props) {
+  private async loadImages(props: PropsOf<StandaloneGridCanvas>) {
     const imagePaths = props.renderingCtx.viewports
       .getVisibleFigures(props.sheetId)
       .filter((figure) => figure.tag === "image")

--- a/src/components/tables/table_dropdown_button/table_dropdown_button.ts
+++ b/src/components/tables/table_dropdown_button/table_dropdown_button.ts
@@ -1,4 +1,4 @@
-import { proxy } from "@odoo/owl";
+import { props, proxy } from "@odoo/owl";
 import { ActionSpec } from "../../../actions/action";
 import { DEFAULT_TABLE_CONFIG } from "../../../helpers/table_presets";
 import { interactiveCreateTable } from "../../../helpers/ui/table_interactive";
@@ -6,30 +6,29 @@ import { positions } from "../../../helpers/zones";
 import { Component } from "../../../owl3_compatibility_layer";
 import { _t } from "../../../translation";
 import { UID } from "../../../types/misc";
+import { PropsOf } from "../../../types/props_of";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
 import { TableConfig } from "../../../types/table";
 import { ActionButton } from "../../action_button/action_button";
 import { ToolBarDropdownStore, useToolBarDropdownStore } from "../../helpers/top_bar_tool_hook";
-import { PopoverProps } from "../../popover/popover";
+import { Popover } from "../../popover/popover";
+import { types } from "../../props_validation";
 import {
   CustomTablePopoverMouseEvent,
   TableStylesPopover,
 } from "../table_styles_popover/table_styles_popover";
 
 interface State {
-  popoverProps: PopoverProps | undefined;
+  popoverProps: PropsOf<Popover> | undefined;
 }
 
-interface Props {
-  class?: String;
-}
-
-export class TableDropdownButton extends Component<Props, SpreadsheetChildEnv> {
+export class TableDropdownButton extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-TableDropdownButton";
   static components = { TableStylesPopover, ActionButton };
-  static props = {
-    class: { type: String, optional: true },
-  };
+
+  protected props = props({
+    "class?": types.string(),
+  });
 
   topBarToolStore!: ToolBarDropdownStore;
   state = proxy<State>({ popoverProps: undefined });

--- a/src/components/tables/table_resizer/table_resizer.ts
+++ b/src/components/tables/table_resizer/table_resizer.ts
@@ -1,27 +1,26 @@
-import { proxy } from "@odoo/owl";
+import { props, proxy } from "@odoo/owl";
 import { Component } from "../../../owl3_compatibility_layer";
 import { HeaderIndex, Highlight, Zone } from "../../../types/misc";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
-import { Table } from "../../../types/table";
 import { cssPropertiesToCss } from "../../helpers/css";
 import { useDragAndDropBeyondTheViewport } from "../../helpers/drag_and_drop_grid_hook";
 import { useHighlights } from "../../helpers/highlight_hook";
 import { withZoom } from "../../helpers/zoom";
+import { types } from "../../props_validation";
 
 const SIZE = 3;
 const COLOR = "#777";
-
-interface Props {
-  table: Table;
-}
 
 interface State {
   highlightZone: Zone | undefined;
 }
 
-export class TableResizer extends Component<Props, SpreadsheetChildEnv> {
+export class TableResizer extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-TableResizer";
-  static props = { table: Object };
+
+  protected props = props({
+    table: types.Table(),
+  });
 
   state = proxy<State>({ highlightZone: undefined });
   dragNDropGrid = useDragAndDropBeyondTheViewport(this.env);

--- a/src/components/tables/table_style_picker/table_style_picker.ts
+++ b/src/components/tables/table_style_picker/table_style_picker.ts
@@ -1,34 +1,30 @@
-import { proxy } from "@odoo/owl";
+import { props, proxy } from "@odoo/owl";
 import { Component } from "../../../owl3_compatibility_layer";
+import { PropsOf } from "../../../types/props_of";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
-import { TableConfig, TableStyle } from "../../../types/table";
-import { PopoverProps } from "../../popover/popover";
+import { TableStyle } from "../../../types/table";
+import { Popover } from "../../popover/popover";
+import { types } from "../../props_validation";
 import { TableStylePreview } from "../table_style_preview/table_style_preview";
 import {
   CustomTablePopoverMouseEvent,
   TableStylesPopover,
 } from "../table_styles_popover/table_styles_popover";
 
-interface TableStylePickerProps {
-  tableConfig: TableConfig;
-  onStylePicked: (styleId: string) => void;
-  tableStyles: Record<string, TableStyle>;
-  type: "table" | "pivot";
-}
-
 interface TableStylePickerState {
-  popoverProps: PopoverProps | undefined;
+  popoverProps: PropsOf<Popover> | undefined;
 }
 
-export class TableStylePicker extends Component<TableStylePickerProps, SpreadsheetChildEnv> {
+export class TableStylePicker extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-TableStylePicker";
   static components = { TableStylesPopover, TableStylePreview };
-  static props = {
-    tableConfig: Object,
-    onStylePicked: Function,
-    tableStyles: Object,
-    type: String,
-  };
+
+  protected props = props({
+    tableConfig: types.TableConfig(),
+    onStylePicked: types.function<[styleId: string]>([types.string()]),
+    tableStyles: types.RecordOf<TableStyle>(),
+    type: types.or([types.literal("table"), types.literal("pivot")]),
+  });
 
   state = proxy<TableStylePickerState>({ popoverProps: undefined });
 

--- a/src/components/tables/table_style_preview/table_style_preview.ts
+++ b/src/components/tables/table_style_preview/table_style_preview.ts
@@ -1,39 +1,33 @@
-import { onWillUpdateProps, proxy, signal, useEffect } from "@odoo/owl";
+import { onWillUpdateProps, props, proxy, signal, useEffect } from "@odoo/owl";
 import { deepEquals } from "../../../helpers/misc";
 import { getComputedTableStyle } from "../../../helpers/table_helpers";
 import { Component } from "../../../owl3_compatibility_layer";
 import { createTableStyleContextMenuActions } from "../../../registries/menus/table_style_menu_registry";
+import { PropsOf } from "../../../types/props_of";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
-import { TableConfig, TableMetaData, TableStyle } from "../../../types/table";
+import { TableMetaData } from "../../../types/table";
 import { MenuPopover, MenuState } from "../../menu_popover/menu_popover";
+import { types } from "../../props_validation";
 import { drawPreviewTable } from "./table_canvas_helpers";
 
-interface Props {
-  tableConfig: TableConfig;
-  tableStyle: TableStyle;
-  styleId?: string;
-  selected?: boolean;
-  onClick?: () => void;
-  type: "table" | "pivot";
-}
-
-export class TableStylePreview extends Component<Props, SpreadsheetChildEnv> {
+export class TableStylePreview extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-TableStylePreview";
   static components = { MenuPopover };
-  static props = {
-    tableConfig: Object,
-    tableStyle: Object,
-    type: String,
-    styleId: { type: String, optional: true },
-    selected: { type: Boolean, optional: true },
-    onClick: { type: Function, optional: true },
-  };
+
+  protected props = props({
+    tableConfig: types.TableConfig(),
+    tableStyle: types.TableStyle(),
+    type: types.or([types.literal("table"), types.literal("pivot")]),
+    "styleId?": types.string(),
+    "selected?": types.boolean(),
+    "onClick?": types.function([]),
+  });
 
   private canvasRef = signal<HTMLCanvasElement | null>(null);
   menu: MenuState = proxy({ isOpen: false, anchorRect: null, menuItems: [] });
 
   setup() {
-    onWillUpdateProps((nextProps) => {
+    onWillUpdateProps((nextProps: PropsOf<TableStylePreview>) => {
       if (
         !deepEquals(this.props.tableConfig, nextProps.tableConfig) ||
         !deepEquals(this.props.tableStyle, nextProps.tableStyle)
@@ -56,7 +50,7 @@ export class TableStylePreview extends Component<Props, SpreadsheetChildEnv> {
     });
   }
 
-  private drawTable(props: Props) {
+  private drawTable(props: PropsOf<TableStylePreview>) {
     const canvas = this.canvasRef();
     if (!canvas) {
       return;

--- a/src/components/tables/table_styles_popover/table_styles_popover.ts
+++ b/src/components/tables/table_styles_popover/table_styles_popover.ts
@@ -1,22 +1,14 @@
-import { proxy, signal } from "@odoo/owl";
+import { props, proxy, signal } from "@odoo/owl";
 import { TABLE_STYLE_CATEGORIES } from "../../../helpers/table_presets";
 import { Component, useExternalListener } from "../../../owl3_compatibility_layer";
 import { _t } from "../../../translation";
+import { PropsOf } from "../../../types/props_of";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
 import { TableConfig, TableStyle } from "../../../types/table";
 import { isChildEvent } from "../../helpers/dom_helpers";
-import { Popover, PopoverProps } from "../../popover/popover";
+import { Popover } from "../../popover/popover";
+import { types } from "../../props_validation";
 import { TableStylePreview } from "../table_style_preview/table_style_preview";
-
-export interface TableStylesPopoverProps {
-  selectedStyleId?: string;
-  tableConfig: Omit<TableConfig, "styleId">;
-  closePopover: () => void;
-  onStylePicked: (styleId: string) => void;
-  popoverProps?: PopoverProps;
-  tableStyles: Record<string, TableStyle>;
-  type: "table" | "pivot";
-}
 
 export type CustomTablePopoverMouseEvent = MouseEvent & { hasClosedTableStylesPopover?: boolean };
 
@@ -24,18 +16,19 @@ export interface State {
   selectedCategory: string;
 }
 
-export class TableStylesPopover extends Component<TableStylesPopoverProps, SpreadsheetChildEnv> {
+export class TableStylesPopover extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-TableStylesPopover";
   static components = { Popover, TableStylePreview };
-  static props = {
-    tableConfig: Object,
-    popoverProps: { type: Object, optional: true },
-    closePopover: Function,
-    onStylePicked: Function,
-    selectedStyleId: { type: String, optional: true },
-    tableStyles: Object,
-    type: String,
-  };
+
+  protected props = props({
+    tableConfig: types.object({}) as Omit<TableConfig, "styleId">,
+    "popoverProps?": types.object({}) as PropsOf<Popover>,
+    closePopover: types.function([]),
+    onStylePicked: types.function<[styleId: string]>([types.string()]),
+    "selectedStyleId?": types.string(),
+    tableStyles: types.RecordOf<TableStyle>(),
+    type: types.or([types.literal("table"), types.literal("pivot")]),
+  });
 
   private tableStyleListRef = signal<HTMLElement | null>(null);
   state = proxy<State>({ selectedCategory: this.initialSelectedCategory });

--- a/src/components/text_input/text_input.ts
+++ b/src/components/text_input/text_input.ts
@@ -1,5 +1,11 @@
+import { props } from "@odoo/owl";
 import { isDefined } from "../../helpers/misc";
-import { GenericInput, GenericInputProps } from "../generic_input/generic_input";
+import {
+  GenericInput,
+  GenericInputProps,
+  genericInputPropsDefinition,
+} from "../generic_input/generic_input";
+import { types } from "../props_validation";
 
 interface Props extends GenericInputProps {
   alwaysShowBorder?: boolean;
@@ -10,10 +16,12 @@ interface Props extends GenericInputProps {
 export class TextInput extends GenericInput<Props> {
   static template = "o-spreadsheet-TextInput";
   static components = {};
-  static props = {
-    ...GenericInput.props,
-    errorMessage: { type: String, optional: true },
-  };
+
+  protected props: Props = props({
+    ...genericInputPropsDefinition,
+    value: types.string(),
+    "errorMessage?": types.string(),
+  }) as unknown as Props;
 
   get inputClass(): string {
     return [

--- a/src/components/top_bar/color_editor/color_editor.ts
+++ b/src/components/top_bar/color_editor/color_editor.ts
@@ -1,22 +1,21 @@
-import { proxy } from "@odoo/owl";
+import { props, proxy } from "@odoo/owl";
 import { setStyle } from "../../../actions/menu_items_actions";
 import { Component } from "../../../owl3_compatibility_layer";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
 import { ColorPickerWidget } from "../../color_picker/color_picker_widget";
 import { ToolBarDropdownStore, useToolBarDropdownStore } from "../../helpers/top_bar_tool_hook";
+import { types } from "../../props_validation";
 
-type Props = {
-  style: "textColor" | "fillColor";
-  icon: string;
-  class: string;
-  title: string;
-};
-
-export class TopBarColorEditor extends Component<Props, SpreadsheetChildEnv> {
+export class TopBarColorEditor extends Component<SpreadsheetChildEnv> {
   static components = { ColorPickerWidget };
-  static props = { class: String, style: String, icon: String, title: String };
-
   static template = "o-spreadsheet-ColorEditor";
+
+  protected props = props({
+    class: types.string(),
+    style: types.or([types.literal("textColor"), types.literal("fillColor")]),
+    icon: types.string(),
+    title: types.string(),
+  });
   topBarToolStore!: ToolBarDropdownStore;
 
   state = proxy({

--- a/src/components/top_bar/dropdown_action/dropdown_action.ts
+++ b/src/components/top_bar/dropdown_action/dropdown_action.ts
@@ -1,28 +1,23 @@
-import { signal } from "@odoo/owl";
-import { ActionSpec } from "../../../actions/action";
+import { props, signal } from "@odoo/owl";
 import { Component } from "../../../owl3_compatibility_layer";
+import { PropsOf } from "../../../types/props_of";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
 import { ActionButton } from "../../action_button/action_button";
 import { getElBoundingRect } from "../../helpers/dom_helpers";
 import { ToolBarDropdownStore, useToolBarDropdownStore } from "../../helpers/top_bar_tool_hook";
-import { Popover, PopoverProps } from "../../popover/popover";
+import { Popover } from "../../popover/popover";
+import { types } from "../../props_validation";
 
-interface Props {
-  parentAction: ActionSpec;
-  childActions: ActionSpec[];
-  class: string;
-  childClass: String;
-}
-
-export class DropdownAction extends Component<Props, SpreadsheetChildEnv> {
+export class DropdownAction extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-DropdownAction";
   static components = { ActionButton, Popover };
-  static props = {
-    parentAction: Object,
-    childActions: Array,
-    class: String,
-    childClass: String,
-  };
+
+  protected props = props({
+    parentAction: types.ActionSpec(),
+    childActions: types.array(types.ActionSpec()),
+    class: types.string(),
+    childClass: types.string(),
+  });
 
   topBarToolStore!: ToolBarDropdownStore;
   actionRef = signal<HTMLElement | null>(null);
@@ -43,7 +38,7 @@ export class DropdownAction extends Component<Props, SpreadsheetChildEnv> {
     return this.topBarToolStore.isActive;
   }
 
-  get popoverProps(): PopoverProps {
+  get popoverProps(): PropsOf<Popover> {
     return {
       anchorRect: getElBoundingRect(this.actionRef()),
       positioning: "bottom-left",

--- a/src/components/top_bar/font_size_editor/font_size_editor.ts
+++ b/src/components/top_bar/font_size_editor/font_size_editor.ts
@@ -1,3 +1,4 @@
+import { props, types } from "@odoo/owl";
 import { setStyle } from "../../../actions/menu_items_actions";
 import { DEFAULT_FONT_SIZE } from "../../../constants";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
@@ -5,15 +6,12 @@ import { FontSizeEditor } from "../../font_size_editor/font_size_editor";
 import { ToolBarDropdownStore, useToolBarDropdownStore } from "../../helpers/top_bar_tool_hook";
 
 import { Component } from "../../../owl3_compatibility_layer";
-type Props = {
-  class: string;
-};
 
-export class TopBarFontSizeEditor extends Component<Props, SpreadsheetChildEnv> {
+export class TopBarFontSizeEditor extends Component<SpreadsheetChildEnv> {
   static components = { FontSizeEditor };
-  static props = { class: String };
-
   static template = "o-spreadsheet-TopBarFontSizeEditor";
+
+  protected props = props({ class: types.string() });
   topBarToolStore!: ToolBarDropdownStore;
 
   setup() {

--- a/src/components/top_bar/number_formats_tool/number_formats_tool.ts
+++ b/src/components/top_bar/number_formats_tool/number_formats_tool.ts
@@ -1,4 +1,4 @@
-import { proxy, signal } from "@odoo/owl";
+import { props, proxy, signal } from "@odoo/owl";
 import { Action, createAction } from "../../../actions/action";
 import { Component } from "../../../owl3_compatibility_layer";
 import { formatNumberMenuItemSpec } from "../../../registries/menus/number_format_menu_registry";
@@ -8,20 +8,18 @@ import { ActionButton } from "../../action_button/action_button";
 import { getBoundingRectAsPOJO } from "../../helpers/dom_helpers";
 import { ToolBarDropdownStore, useToolBarDropdownStore } from "../../helpers/top_bar_tool_hook";
 import { MenuPopover } from "../../menu_popover/menu_popover";
-
-interface Props {
-  class: string;
-}
+import { types } from "../../props_validation";
 
 interface State {
   menuItems: Action[];
   anchorRect: Rect;
 }
 
-export class NumberFormatsTool extends Component<Props, SpreadsheetChildEnv> {
+export class NumberFormatsTool extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-NumberFormatsTool";
   static components = { MenuPopover, ActionButton };
-  static props = { class: String };
+
+  protected props = props({ class: types.string() });
   formatNumberMenuItemSpec = formatNumberMenuItemSpec;
   topBarToolStore!: ToolBarDropdownStore;
 

--- a/src/components/top_bar/top_bar.ts
+++ b/src/components/top_bar/top_bar.ts
@@ -1,4 +1,4 @@
-import { onMounted, onPatched, proxy, signal } from "@odoo/owl";
+import { onMounted, onPatched, props, proxy, signal } from "@odoo/owl";
 import { Action } from "../../actions/action";
 import { setStyle } from "../../actions/menu_items_actions";
 import { DEFAULT_FONT_SIZE } from "../../constants";
@@ -8,7 +8,8 @@ import { topbarMenuRegistry } from "../../registries/menus/topbar_menu_registry"
 import { topbarComponentRegistry } from "../../registries/topbar_component_registry";
 import { useStore } from "../../store_engine/store_hooks";
 import { FormulaFingerprintStore } from "../../stores/formula_fingerprints_store";
-import { Color, Pixel, UID } from "../../types/misc";
+import { Color, UID } from "../../types/misc";
+import { PropsOf } from "../../types/props_of";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 import { Store } from "../../types/store_engine";
 import { ComposerFocusStore } from "../composer/composer_focus_store";
@@ -21,7 +22,8 @@ import {
 import { useSpreadsheetRect } from "../helpers/position_hook";
 import { MenuPopover, MenuState } from "../menu_popover/menu_popover";
 import { NamedRangeSelector } from "../named_range_selector/named_range_selector";
-import { Popover, PopoverProps } from "../popover/popover";
+import { Popover } from "../popover/popover";
+import { types } from "../props_validation";
 import { TopBarToolStore } from "./top_bar_tool_store";
 import { topBarToolBarRegistry } from "./top_bar_tools_registry";
 
@@ -31,21 +33,16 @@ interface State {
   toolsPopoverState: { isOpen: boolean };
 }
 
-interface Props {
-  onClick: () => void;
-  dropdownMaxHeight: Pixel;
-}
-
 // -----------------------------------------------------------------------------
 // TopBar
 // -----------------------------------------------------------------------------
 
-export class TopBar extends Component<Props, SpreadsheetChildEnv> {
+export class TopBar extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-TopBar";
-  static props = {
-    onClick: Function,
-    dropdownMaxHeight: Number,
-  };
+  protected props = props({
+    onClick: types.function([]),
+    dropdownMaxHeight: types.Pixel(),
+  });
   static components = {
     MenuPopover,
     TopBarComposer,
@@ -263,7 +260,7 @@ export class TopBar extends Component<Props, SpreadsheetChildEnv> {
     this.state.toolsPopoverState.isOpen = !this.state.toolsPopoverState.isOpen;
   }
 
-  get toolsPopoverProps(): PopoverProps {
+  get toolsPopoverProps(): PropsOf<Popover> {
     const el = this.moreToolsButtonRef();
     const rect = el ? getBoundingRectAsPOJO(el) : { x: 0, y: 0, width: 0, height: 0 };
     return {

--- a/src/components/top_bar/zoom_editor/zoom_editor.ts
+++ b/src/components/top_bar/zoom_editor/zoom_editor.ts
@@ -1,17 +1,16 @@
+import { props } from "@odoo/owl";
 import { ZOOM_VALUES } from "../../../constants";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
 import { ToolBarDropdownStore, useToolBarDropdownStore } from "../../helpers/top_bar_tool_hook";
 import { NumberEditor } from "../../number_editor/number_editor";
 
 import { Component } from "../../../owl3_compatibility_layer";
-interface Props {
-  class: string;
-}
-
-export class ToolBarZoom extends Component<Props, SpreadsheetChildEnv> {
+import { types } from "../../props_validation";
+export class ToolBarZoom extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-TopBarZoom";
   static components = { NumberEditor };
-  static props = { class: String };
+
+  protected props = props({ class: types.string() });
   topBarToolStore!: ToolBarDropdownStore;
 
   valueList = ZOOM_VALUES;

--- a/src/components/validation_messages/validation_messages.ts
+++ b/src/components/validation_messages/validation_messages.ts
@@ -1,19 +1,17 @@
+import { props } from "@odoo/owl";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 
 import { Component } from "../../owl3_compatibility_layer";
-interface Props {
-  messages: string[];
-  msgType: "warning" | "error" | "info";
-  singleBox?: boolean;
-}
+import { types } from "../props_validation";
 
-export class ValidationMessages extends Component<Props, SpreadsheetChildEnv> {
+export class ValidationMessages extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ValidationMessages";
-  static props = {
-    messages: Array,
-    msgType: String,
-    singleBox: { type: Boolean, optional: true },
-  };
+
+  protected props = props({
+    messages: types.array(types.string()),
+    msgType: types.or([types.literal("warning"), types.literal("error"), types.literal("info")]),
+    "singleBox?": types.boolean(),
+  });
 
   get divClasses() {
     if (this.props.msgType === "warning") {

--- a/src/owl3_compatibility_layer.ts
+++ b/src/owl3_compatibility_layer.ts
@@ -60,23 +60,18 @@ import {
 
 const isOdooCompatLoaded = __ODOO_COMPATIBILITY_LAYER_ADDED__ === true;
 
-export interface ComponentConstructor<Props = any, Env = any> {
+export interface ComponentConstructor<Env = any> {
   new (...args: any[]): any;
   template: string;
 }
 
-class _Component<Props = any, Env = any> extends OwlComponent {
+class _Component<Env = any> extends OwlComponent {
   static template = "";
-  static props = {};
-  static defaultProps = {};
-  // @ts-ignore
-  public props: Props;
   // @ts-ignore
   public env: Env;
 
   constructor(node) {
     super(node);
-    this.props = props(null, this.constructor.defaultProps);
     this.env = useChildEnv();
     this.__owl__ = node;
   }
@@ -226,7 +221,12 @@ class VPortal extends blockDom.text("").constructor {
 
 class Portal extends OwlComponent {
   static template = xml`<t t-call-slot="default"/>`;
-  static props = { selector: String, slots: true };
+
+  constructor(node) {
+    super(node);
+    this.props = props();
+    this.__owl__ = node;
+  }
 
   setup() {
     const node = this.__owl__;
@@ -393,7 +393,7 @@ export {
   useLayoutEffect,
   useSubEnv,
 };
-export type Component<Props = any, Env = any> = _Component<Props, Env>;
+export type Component<Env = any> = _Component<Env>;
 export type useComponent = () => any;
 export type useExternalListener = (target, eventName, handler, eventParams?) => void;
 export type useLayoutEffect = (effect, computeDependencies: () => any) => void;

--- a/src/registries/side_panel_registry.ts
+++ b/src/registries/side_panel_registry.ts
@@ -16,15 +16,13 @@ import { SettingsPanel } from "../components/side_panel/settings/settings_panel"
 import { SidePanelState } from "../components/side_panel/side_panel/side_panel_store";
 import { SplitIntoColumnsPanel } from "../components/side_panel/split_to_columns_panel/split_to_columns_panel";
 import { TablePanel } from "../components/side_panel/table_panel/table_panel";
-import {
-  TableStyleEditorPanel,
-  TableStyleEditorPanelProps,
-} from "../components/side_panel/table_style_editor_panel/table_style_editor_panel";
+import { TableStyleEditorPanel } from "../components/side_panel/table_style_editor_panel/table_style_editor_panel";
 import { getTableTopLeft } from "../helpers/table_helpers";
 import { _t } from "../translation";
 import { ConditionalFormat } from "../types/conditional_formatting";
 import { Getters } from "../types/getters";
 import { UID } from "../types/misc";
+import { PropsOf } from "../types/props_of";
 import { SpreadsheetChildEnv } from "../types/spreadsheet_env";
 import { Registry } from "./registry";
 
@@ -145,7 +143,7 @@ sidePanelRegistry.add("TableSidePanel", {
 sidePanelRegistry.add("TableStyleEditorPanel", {
   title: _t("Create custom table style"),
   Body: TableStyleEditorPanel,
-  computeState: (getters: Getters, initialProps: TableStyleEditorPanelProps) => {
+  computeState: (getters: Getters, initialProps: PropsOf<TableStyleEditorPanel>) => {
     return {
       isOpen: true,
       props: { ...initialProps },
@@ -169,12 +167,12 @@ sidePanelRegistry.add("PivotSidePanel", {
 });
 
 sidePanelRegistry.add("PivotMeasureDisplayPanel", {
-  title: (env: SpreadsheetChildEnv, props: PivotMeasureDisplayPanel["props"]) => {
+  title: (env: SpreadsheetChildEnv, props: PropsOf<PivotMeasureDisplayPanel>) => {
     const measure = env.model.getters.getPivot(props.pivotId).getMeasure(props.measure.id);
     return _t('Measure "%s" options', measure.displayName);
   },
   Body: PivotMeasureDisplayPanel,
-  computeState: (getters: Getters, props: PivotMeasureDisplayPanel["props"]) => {
+  computeState: (getters: Getters, props: PropsOf<PivotMeasureDisplayPanel>) => {
     try {
       // This will throw if the pivot or measure does not exist
       getters.getPivot(props.pivotId).getMeasure(props.measure.id);

--- a/src/types/cell_popovers.ts
+++ b/src/types/cell_popovers.ts
@@ -45,7 +45,7 @@ export interface OpenCellPopover {
 type OpenCellPopoverComponent<C extends ComponentConstructor> = {
   isOpen: true;
   Component: C;
-  props: PropsOf<C>;
+  props: PropsOf<InstanceType<C>>;
   cellCorner: PopoverPropsPosition;
 };
 
@@ -58,7 +58,7 @@ export type PositionedCellPopoverComponent<
 > = {
   isOpen: true;
   Component: C;
-  props: PropsOf<C>;
+  props: PropsOf<InstanceType<C>>;
   anchorRect: Rect;
   cellCorner: PopoverPropsPosition;
 };

--- a/src/types/misc.ts
+++ b/src/types/misc.ts
@@ -269,17 +269,20 @@ export interface PaneDivision {
   ySplit: number;
 }
 
-export type BorderPosition =
-  | "all"
-  | "hv"
-  | "h"
-  | "v"
-  | "external"
-  | "left"
-  | "top"
-  | "right"
-  | "bottom"
-  | "clear";
+export const borderPositions = [
+  "all",
+  "hv",
+  "h",
+  "v",
+  "external",
+  "left",
+  "top",
+  "right",
+  "bottom",
+  "clear",
+] as const;
+
+export type BorderPosition = (typeof borderPositions)[number];
 
 export const enum DIRECTION {
   UP = "up",
@@ -421,7 +424,8 @@ export interface GridClickModifiers {
   expandZone: boolean;
 }
 
-export type ComposerFocusType = "inactive" | "cellFocus" | "contentFocus";
+export const composerFocusTypes = ["inactive", "cellFocus", "contentFocus"] as const;
+export type ComposerFocusType = (typeof composerFocusTypes)[number];
 
 export type EditionMode =
   | "editing"

--- a/src/types/props_of.ts
+++ b/src/types/props_of.ts
@@ -1,6 +1,11 @@
-import { ComponentConstructor } from "../owl3_compatibility_layer";
+import { Props, WithDefaults } from "@odoo/owl";
 
 /**
- * Return the prop's type of a component
+ * Return the prop's type of a component as seen from the caller (pre-default
+ * shape). Strips the owl3 `Props<...>` brand and unwraps `WithDefaults<R, D>`
+ * so that props with a default value stay optional for the caller.
  */
-export type PropsOf<C> = C extends ComponentConstructor<infer Props> ? Props : never;
+export type PropsOf<
+  C extends { [key: string]: any },
+  Key extends string = "props"
+> = C[Key] extends Props<infer P> ? (P extends WithDefaults<infer R, any> ? R : P) : C[Key];

--- a/tests/action_button.test.ts
+++ b/tests/action_button.test.ts
@@ -1,4 +1,4 @@
-import { xml } from "@odoo/owl";
+import { props, types, xml } from "@odoo/owl";
 import { ActionSpec } from "../src/actions/action";
 import { ActionButton } from "../src/components/action_button/action_button";
 import { Component } from "../src/owl3_compatibility_layer";
@@ -9,9 +9,11 @@ interface ParentProps {
   getAction: () => ActionSpec;
 }
 
-class Parent extends Component<ParentProps, SpreadsheetChildEnv> {
+class Parent extends Component<SpreadsheetChildEnv> {
   static components = { ActionButton };
-  static props = { getAction: Function };
+  protected props: ParentProps = props({
+    getAction: types.function(),
+  });
   static template = xml/*xml*/ `
       <ActionButton action="this.props.getAction()"/>
     `;

--- a/tests/autofill/autofill_component.test.ts
+++ b/tests/autofill/autofill_component.test.ts
@@ -1,4 +1,4 @@
-import { xml } from "@odoo/owl";
+import { props, types, xml } from "@odoo/owl";
 import { Spreadsheet } from "../../src";
 import { DEFAULT_CELL_WIDTH, HEADER_HEIGHT, HEADER_WIDTH } from "../../src/constants";
 import { Model } from "../../src/model";
@@ -209,7 +209,9 @@ describe("Autofill component", () => {
       static template = xml/* xml */ `
         <div class="custom_tooltip" t-out="this.props.content"/>
       `;
-      static props = { content: String };
+      protected props = props({
+        content: types.string(),
+      });
     }
     expect(fixture.querySelector(".o-autofill-nextvalue")).toBeNull();
     model.getters.getAutofillTooltip = jest.fn(() => {

--- a/tests/borders/border_editor_component.test.ts
+++ b/tests/borders/border_editor_component.test.ts
@@ -1,6 +1,7 @@
-import { BorderEditor, BorderEditorProps } from "../../src/components/border_editor/border_editor";
+import { BorderEditor } from "../../src/components/border_editor/border_editor";
 import { DEFAULT_BORDER_DESC } from "../../src/constants";
 import { Model } from "../../src/model";
+import { PropsOf } from "../../src/types/props_of";
 import { simulateClick } from "../test_helpers/dom_helper";
 import { makeTestFixture, mountComponentWithPortalTarget } from "../test_helpers/helpers";
 
@@ -17,7 +18,7 @@ async function setDefaultBorder(name: string) {
 }
 
 async function mountBorderEditor(
-  partialProps: Partial<BorderEditorProps> = {},
+  partialProps: Partial<PropsOf<BorderEditor>> = {},
   model = new Model()
 ) {
   const props = {

--- a/tests/borders/border_editor_widget_component.test.ts
+++ b/tests/borders/border_editor_widget_component.test.ts
@@ -4,6 +4,7 @@ import { BorderEditorWidget } from "../../src/components/border_editor/border_ed
 import { toHex } from "../../src/helpers/color";
 import { toZone } from "../../src/helpers/zones";
 import { Component } from "../../src/owl3_compatibility_layer";
+import { PropsOf } from "../../src/types/props_of";
 import { SpreadsheetChildEnv } from "../../src/types/spreadsheet_env";
 import { click, simulateClick } from "../test_helpers/dom_helper";
 import { mountComponent } from "../test_helpers/helpers";
@@ -11,7 +12,6 @@ import { extendMockGetBoundingClientRect } from "../test_helpers/mock_helpers";
 
 let fixture: HTMLElement;
 let model: Model;
-type Props = BorderEditorWidget["props"];
 
 async function setBorder({
   position,
@@ -35,7 +35,7 @@ async function setBorder({
   await simulateClick(`.o-line-item[name="${position}"]`);
 }
 
-class BorderWidgetContainer extends Component<Props, SpreadsheetChildEnv> {
+class BorderWidgetContainer extends Component<SpreadsheetChildEnv> {
   static template = xml/* xml */ `
     <div class="o-spreadsheet">
       <div class="container">
@@ -44,7 +44,6 @@ class BorderWidgetContainer extends Component<Props, SpreadsheetChildEnv> {
     </div>
   `;
   static components = { BorderEditorWidget };
-  static props = {};
   state!: { showBorderEditor: boolean };
 
   setup() {
@@ -53,7 +52,7 @@ class BorderWidgetContainer extends Component<Props, SpreadsheetChildEnv> {
     });
   }
 
-  get borderWidgetProps(): Props {
+  get borderWidgetProps(): PropsOf<BorderEditorWidget> {
     return { class: "border-widget" };
   }
 }

--- a/tests/colors/color_picker_component.test.ts
+++ b/tests/colors/color_picker_component.test.ts
@@ -1,6 +1,7 @@
 import { Color, Model } from "../../src";
-import { ColorPicker, ColorPickerProps } from "../../src/components/color_picker/color_picker";
+import { ColorPicker } from "../../src/components/color_picker/color_picker";
 import { toHex } from "../../src/helpers/color";
+import { PropsOf } from "../../src/types/props_of";
 import { setFormatting } from "../test_helpers/commands_helpers";
 import {
   getElComputedStyle,
@@ -11,7 +12,10 @@ import { mountComponentWithPortalTarget } from "../test_helpers/helpers";
 
 let fixture: HTMLElement;
 
-async function mountColorPicker(partialProps: Partial<ColorPickerProps> = {}, model = new Model()) {
+async function mountColorPicker(
+  partialProps: Partial<PropsOf<ColorPicker>> = {},
+  model = new Model()
+) {
   const props = {
     onColorPicked: partialProps.onColorPicked || (() => {}),
     currentColor: partialProps.currentColor || "#000000",

--- a/tests/components/number_input.test.ts
+++ b/tests/components/number_input.test.ts
@@ -1,4 +1,4 @@
-import { xml } from "@odoo/owl";
+import { props, xml } from "@odoo/owl";
 import { NumberInput } from "../../src/components/number_input/number_input";
 import { Component } from "../../src/owl3_compatibility_layer";
 import { SpreadsheetChildEnv } from "../../src/types/spreadsheet_env";
@@ -14,14 +14,14 @@ let fixture: HTMLElement;
 let parent: Component;
 type Props = NumberInput["props"];
 
-class NumberInputContainer extends Component<Props, SpreadsheetChildEnv> {
+class NumberInputContainer extends Component<SpreadsheetChildEnv> {
   static template = xml/* xml */ `
     <div class="container">
       <NumberInput t-props="this.props"/>
     </div>
   `;
   static components = { NumberInput };
-  static props = NumberInput.props;
+  protected props = props();
 }
 
 async function mountNumberInput(props: Props) {

--- a/tests/components/select_component.test.ts
+++ b/tests/components/select_component.test.ts
@@ -1,5 +1,6 @@
 import { ValueAndLabel } from "../../src";
 import { Select } from "../../src/components/select/select";
+import { PropsOf } from "../../src/types/props_of";
 import { keyDown, simulateClick, triggerMouseEvent } from "../test_helpers";
 import { mountComponentWithPortalTarget, nextTick } from "../test_helpers/helpers";
 
@@ -14,9 +15,9 @@ let fixture: HTMLElement;
 let selectEl: HTMLElement;
 let onChange: jest.Mock;
 
-async function mountSelectMenu(partialProps: Partial<Select["props"]> = {}) {
+async function mountSelectMenu(partialProps: Partial<PropsOf<Select>> = {}) {
   onChange = jest.fn();
-  const props: Select["props"] = {
+  const props: PropsOf<Select> = {
     values: testValues,
     onChange,
     ...partialProps,

--- a/tests/components/text_input.test.ts
+++ b/tests/components/text_input.test.ts
@@ -1,4 +1,4 @@
-import { xml } from "@odoo/owl";
+import { props, xml } from "@odoo/owl";
 import { TextInput } from "../../src/components/text_input/text_input";
 import { Component } from "../../src/owl3_compatibility_layer";
 import { SpreadsheetChildEnv } from "../../src/types/spreadsheet_env";
@@ -14,14 +14,14 @@ let fixture: HTMLElement;
 let parent: Component;
 type Props = TextInput["props"];
 
-class TextInputContainer extends Component<Props, SpreadsheetChildEnv> {
+class TextInputContainer extends Component<SpreadsheetChildEnv> {
   static template = xml/* xml */ `
     <div class="container">
       <TextInput t-props="this.props"/>
     </div>
   `;
   static components = { TextInput };
-  static props = TextInput.props;
+  protected props = props();
 }
 
 async function mountTextInput(props: Props) {

--- a/tests/composer/standalone_composer_component.test.ts
+++ b/tests/composer/standalone_composer_component.test.ts
@@ -1,4 +1,4 @@
-import { xml } from "@odoo/owl";
+import { props, xml } from "@odoo/owl";
 import { Model } from "../../src";
 import { ComposerFocusStore } from "../../src/components/composer/composer_focus_store";
 import { StandaloneComposer } from "../../src/components/composer/standalone_composer/standalone_composer";
@@ -24,7 +24,7 @@ let composerEl: HTMLElement;
 let composerFocusStore: Store<ComposerFocusStore>;
 let model: Model;
 
-class SidePanelWithComposer extends Component<any, any> {
+class SidePanelWithComposer extends Component<any> {
   static template = xml/*xml*/ `
       <div>
         <StandaloneComposer
@@ -36,8 +36,9 @@ class SidePanelWithComposer extends Component<any, any> {
           placeholder="this.props.placeholder"
         />
       </div>`;
-  static props = { "*": Object };
   static components = { StandaloneComposer };
+
+  protected props = props();
 }
 
 async function openSidePanelWithComposer(props?: Partial<StandaloneComposer["props"]>) {

--- a/tests/figures/figure_component.test.ts
+++ b/tests/figures/figure_component.test.ts
@@ -11,8 +11,6 @@ import {
 } from "../../src/constants";
 import { Component } from "../../src/owl3_compatibility_layer";
 
-import { FigureComponent } from "../../src/components/figures/figure/figure";
-import { ChartFigure } from "../../src/components/figures/figure_chart/figure_chart";
 import { downloadFile } from "../../src/components/helpers/dom_helpers";
 import { figureRegistry } from "../../src/registries/figures_registry";
 import { ClipboardMIMEType } from "../../src/types/clipboard";
@@ -131,9 +129,8 @@ const TEMPLATE = xml/* xml */ `
   </div>
 `;
 
-class TextFigure extends Component<FigureComponent["props"], SpreadsheetChildEnv> {
+class TextFigure extends Component<SpreadsheetChildEnv> {
   static template = TEMPLATE;
-  static props = ChartFigure.props;
 }
 
 mockChart();

--- a/tests/grid/grid_drag_and_drop_component.test.ts
+++ b/tests/grid/grid_drag_and_drop_component.test.ts
@@ -41,18 +41,13 @@ const TEMPLATE = xml/* xml */ `
   </div>
 `;
 
-interface Props {
-  model: Model;
-}
-
 let selectedCol: number | undefined = undefined;
 let selectedRow: number | undefined = undefined;
 
 const mouseUpFn = jest.fn();
 
-class FakeGridComponent extends Component<Props, SpreadsheetChildEnv> {
+class FakeGridComponent extends Component<SpreadsheetChildEnv> {
   static template = TEMPLATE;
-  static props = {};
 
   dragNDropGrid = useDragAndDropBeyondTheViewport(this.env);
 

--- a/tests/grid/highlight_component.test.ts
+++ b/tests/grid/highlight_component.test.ts
@@ -1,4 +1,4 @@
-import { xml } from "@odoo/owl";
+import { props, types, xml } from "@odoo/owl";
 import { Color, Model, Pixel, Range } from "../../src";
 import { Highlight } from "../../src/components/highlight/highlight/highlight";
 import {
@@ -121,18 +121,16 @@ let borderEl: Element;
 let spyDispatch: jest.SpyInstance;
 let spyHandleEvent: jest.Mock;
 
-interface Props {
-  range: Range;
-  model: Model;
-  color: Color;
-}
-
-class Parent extends Component<Props> {
+class Parent extends Component {
   static components = { Highlight };
   static template = xml/*xml*/ `
     <Highlight range="this.props.range" color="this.props.color"/>
   `;
-  static props = { ...Highlight.props, model: Object };
+  protected props = props({
+    range: types.object({}) as unknown as Range,
+    color: types.string(),
+    model: types.object({}) as unknown as Model,
+  });
 
   setup() {
     spyDispatch = jest.spyOn(model, "dispatch");

--- a/tests/menus/context_menu_component.test.ts
+++ b/tests/menus/context_menu_component.test.ts
@@ -1,4 +1,4 @@
-import { xml } from "@odoo/owl";
+import { props, types, xml } from "@odoo/owl";
 import { Action, ActionSpec, createActions } from "../../src/actions/action";
 import { MenuPopover } from "../../src/components/menu_popover/menu_popover";
 import {
@@ -175,7 +175,7 @@ interface Props {
   config: any;
 }
 
-class ContextMenuParent extends Component<Props> {
+class ContextMenuParent extends Component {
   static template = xml/* xml */ `
     <div class="o-spreadsheet">
       <MenuPopover
@@ -188,7 +188,13 @@ class ContextMenuParent extends Component<Props> {
     </div>
   `;
   static components = { MenuPopover };
-  static props = { x: Number, y: Number, width: Number, height: Number, config: Object };
+  protected props: Props = props({
+    x: types.number(),
+    y: types.number(),
+    width: types.number(),
+    height: types.number(),
+    config: types.object({}),
+  }) as any;
   menus!: Action[];
   anchorRect: Rect;
   onClose!: () => void;

--- a/tests/popover/popover_component.test.ts
+++ b/tests/popover/popover_component.test.ts
@@ -1,7 +1,8 @@
-import { App, xml } from "@odoo/owl";
+import { App, props, types, xml } from "@odoo/owl";
 import { Model, Pixel, Rect } from "../../src";
-import { Popover, PopoverProps } from "../../src/components/popover/popover";
+import { Popover } from "../../src/components/popover/popover";
 import { Component, useSubEnv } from "../../src/owl3_compatibility_layer";
+import { PropsOf } from "../../src/types/props_of";
 import { getStylePropertyInPx, mountComponent } from "../test_helpers/helpers";
 import { extendMockGetBoundingClientRect } from "../test_helpers/mock_helpers";
 
@@ -12,14 +13,14 @@ let fixture: HTMLElement;
 let model: Model;
 let app: App;
 
-interface MountPopoverArgs extends Partial<PopoverProps> {
+interface MountPopoverArgs extends Partial<PropsOf<Popover>> {
   childWidth?: Pixel;
   childHeight?: Pixel;
   containerRect?: Rect;
 }
 
 async function mountTestPopover(args: MountPopoverArgs) {
-  class Parent extends Component<any, any> {
+  class Parent extends Component<any> {
     static template = xml/* xml */ `
         <div class="o-spreadsheet">
           <Popover t-props="this.popoverProps">
@@ -28,7 +29,9 @@ async function mountTestPopover(args: MountPopoverArgs) {
         </div>
   `;
     static components = { Popover };
-    static props = { model: Object };
+    protected props = props({
+      model: types.object({}),
+    }) as any;
 
     setup() {
       const env: any = {

--- a/tests/selection_input/selection_input_component.test.ts
+++ b/tests/selection_input/selection_input_component.test.ts
@@ -1,4 +1,4 @@
-import { App, xml } from "@odoo/owl";
+import { App, props, types, xml } from "@odoo/owl";
 import { Color, Model } from "../../src";
 import { OPEN_CF_SIDEPANEL_ACTION } from "../../src/actions/menu_items_actions";
 import { SelectionInput } from "../../src/components/selection_input/selection_input";
@@ -70,7 +70,10 @@ class Parent extends Component<any> {
     />
   `;
   static components = { SelectionInput };
-  static props = { model: Object, config: Object };
+  protected props = props({
+    model: types.object({}),
+    config: types.object({}),
+  }) as any;
   model!: Model;
   initialRanges: string[] | undefined;
   hasSingleRange: boolean | undefined;
@@ -110,7 +113,9 @@ class MultiParent extends Component<any> {
     </div>
   `;
   static components = { SelectionInput };
-  static props = { model: Object };
+  protected props = props({
+    model: types.object({}),
+  }) as any;
 
   setup() {
     useSubEnv({

--- a/tests/side_panels/building_blocks/chart_title.test.ts
+++ b/tests/side_panels/building_blocks/chart_title.test.ts
@@ -1,12 +1,13 @@
 import { ChartTitle } from "../../../src/components/side_panel/chart/building_blocks/chart_title/chart_title";
 import { TextStyler } from "../../../src/components/side_panel/chart/building_blocks/text_styler/text_styler";
+import { PropsOf } from "../../../src/types/props_of";
 import { click, setInputValueAndTrigger } from "../../test_helpers/dom_helper";
 import { mountComponentWithPortalTarget } from "../../test_helpers/helpers";
 
 let fixture: HTMLElement;
 
-async function mountChartTitle(props: Partial<ChartTitle["props"]>) {
-  const defaultProps: ChartTitle["props"] = {
+async function mountChartTitle(props: Partial<PropsOf<ChartTitle>>) {
+  const defaultProps: PropsOf<ChartTitle> = {
     name: "Chart title",
     title: "My title",
     updateTitle: () => {},
@@ -19,8 +20,8 @@ async function mountChartTitle(props: Partial<ChartTitle["props"]>) {
   }));
 }
 
-async function mountTextStyler(props: Partial<TextStyler["props"]>) {
-  const defaultProps: TextStyler["props"] = {
+async function mountTextStyler(props: Partial<PropsOf<TextStyler>>) {
+  const defaultProps: PropsOf<TextStyler> = {
     updateStyle: () => {},
     style: {},
     defaultStyle: { fontSize: 10 },

--- a/tests/side_panels/building_blocks/data_series.test.ts
+++ b/tests/side_panels/building_blocks/data_series.test.ts
@@ -1,9 +1,10 @@
 import { ChartDataSeries } from "../../../src/components/side_panel/chart/building_blocks/data_series/data_series";
+import { PropsOf } from "../../../src/types/props_of";
 import { mountComponent } from "../../test_helpers/helpers";
 
 let fixture: HTMLElement;
 
-async function mountDataSeries(props: ChartDataSeries["props"]) {
+async function mountDataSeries(props: PropsOf<ChartDataSeries>) {
   ({ fixture } = await mountComponent(ChartDataSeries, { props }));
 }
 

--- a/tests/side_panels/building_blocks/error_section.test.ts
+++ b/tests/side_panels/building_blocks/error_section.test.ts
@@ -1,9 +1,10 @@
 import { ChartErrorSection } from "../../../src/components/side_panel/chart/building_blocks/error_section/error_section";
+import { PropsOf } from "../../../src/types/props_of";
 import { mountComponent } from "../../test_helpers/helpers";
 
 let fixture: HTMLElement;
 
-async function mountChartErrorSection(props: ChartErrorSection["props"]) {
+async function mountChartErrorSection(props: PropsOf<ChartErrorSection>) {
   ({ fixture } = await mountComponent(ChartErrorSection, { props }));
 }
 

--- a/tests/side_panels/building_blocks/label_range.test.ts
+++ b/tests/side_panels/building_blocks/label_range.test.ts
@@ -1,9 +1,10 @@
 import { ChartLabelRange } from "../../../src/components/side_panel/chart/building_blocks/label_range/label_range";
+import { PropsOf } from "../../../src/types/props_of";
 import { mountComponent } from "../../test_helpers/helpers";
 
 let fixture: HTMLElement;
 
-async function mountLabelRange(props: ChartLabelRange["props"]) {
+async function mountLabelRange(props: PropsOf<ChartLabelRange>) {
   ({ fixture } = await mountComponent(ChartLabelRange, { props }));
 }
 

--- a/tests/side_panels/building_blocks/round_color_picker.test.ts
+++ b/tests/side_panels/building_blocks/round_color_picker.test.ts
@@ -1,10 +1,11 @@
 import { RoundColorPicker } from "../../../src/components/side_panel/components/round_color_picker/round_color_picker";
+import { PropsOf } from "../../../src/types/props_of";
 import { click } from "../../test_helpers/dom_helper";
 import { mountComponentWithPortalTarget } from "../../test_helpers/helpers";
 
 let fixture: HTMLElement;
 
-async function mountChartColor(props: RoundColorPicker["props"]) {
+async function mountChartColor(props: PropsOf<RoundColorPicker>) {
   ({ fixture } = await mountComponentWithPortalTarget(RoundColorPicker, { props }));
 }
 

--- a/tests/side_panels/components/checkbox.test.ts
+++ b/tests/side_panels/components/checkbox.test.ts
@@ -1,10 +1,11 @@
 import { Checkbox } from "../../../src/components/side_panel/components/checkbox/checkbox";
+import { PropsOf } from "../../../src/types/props_of";
 import { click } from "../../test_helpers/dom_helper";
 import { mountComponent } from "../../test_helpers/helpers";
 
 let fixture: HTMLElement;
 
-async function mountCheckbox(props: Checkbox["props"]) {
+async function mountCheckbox(props: PropsOf<Checkbox>) {
   ({ fixture } = await mountComponent(Checkbox, { props }));
 }
 

--- a/tests/side_panels/components/section.test.ts
+++ b/tests/side_panels/components/section.test.ts
@@ -1,4 +1,4 @@
-import { xml } from "@odoo/owl";
+import { props, types, xml } from "@odoo/owl";
 import { Section } from "../../../src/components/side_panel/components/section/section";
 import { Component } from "../../../src/owl3_compatibility_layer";
 import { SpreadsheetChildEnv } from "../../../src/types/spreadsheet_env";
@@ -6,11 +6,13 @@ import { mountComponent } from "../../test_helpers/helpers";
 
 let fixture: HTMLElement;
 
-type Props = Section["props"];
+interface Props {
+  class?: string;
+}
 
 describe("Section", () => {
   test("Can render a section without a title", async () => {
-    class SectionContainer extends Component<Props, SpreadsheetChildEnv> {
+    class SectionContainer extends Component<SpreadsheetChildEnv> {
       static template = xml/* xml */ `
     <div class="container">
       <Section t-props="this.props">
@@ -19,15 +21,16 @@ describe("Section", () => {
     </div>
   `;
       static components = { Section };
-      static props = { class: String };
+      protected props: Props = props({
+        class: types.string(),
+      });
     }
-    const props = { class: "my-class" };
-    ({ fixture } = await mountComponent(SectionContainer, { props }));
+    ({ fixture } = await mountComponent(SectionContainer, { props: { class: "my-class" } }));
     expect(fixture).toMatchSnapshot();
   });
 
   test("Can render a section with a title slot", async () => {
-    class SectionContainer extends Component<Props, SpreadsheetChildEnv> {
+    class SectionContainer extends Component<SpreadsheetChildEnv> {
       static template = xml/* xml */ `
     <div class="container">
       <Section t-props="this.props">
@@ -37,15 +40,16 @@ describe("Section", () => {
     </div>
   `;
       static components = { Section };
-      static props = { class: String };
+      protected props: Props = props({
+        class: types.string(),
+      });
     }
-    const props = { class: "my-class" };
-    ({ fixture } = await mountComponent(SectionContainer, { props }));
+    ({ fixture } = await mountComponent(SectionContainer, { props: { class: "my-class" } }));
     expect(fixture).toMatchSnapshot();
   });
 
   test("Can render a section with a title props", async () => {
-    class SectionContainer extends Component<Props, SpreadsheetChildEnv> {
+    class SectionContainer extends Component<SpreadsheetChildEnv> {
       static template = xml/* xml */ `
     <div class="container">
       <Section t-props="this.props" title.translate="My title">
@@ -54,15 +58,16 @@ describe("Section", () => {
     </div>
   `;
       static components = { Section };
-      static props = { class: String };
+      protected props: Props = props({
+        class: types.string(),
+      });
     }
-    const props = { class: "my-class" };
-    ({ fixture } = await mountComponent(SectionContainer, { props }));
+    ({ fixture } = await mountComponent(SectionContainer, { props: { class: "my-class" } }));
     expect(fixture).toMatchSnapshot();
   });
 
   test("Can render a section with both title props and slot", async () => {
-    class SectionContainer extends Component<Props, SpreadsheetChildEnv> {
+    class SectionContainer extends Component<SpreadsheetChildEnv> {
       static template = xml/* xml */ `
     <div class="container">
       <Section t-props="this.props" title.translate="My title from props">
@@ -72,10 +77,11 @@ describe("Section", () => {
     </div>
   `;
       static components = { Section };
-      static props = { class: String };
+      protected props: Props = props({
+        class: types.string(),
+      });
     }
-    const props = { class: "my-class" };
-    ({ fixture } = await mountComponent(SectionContainer, { props }));
+    ({ fixture } = await mountComponent(SectionContainer, { props: { class: "my-class" } }));
     expect(fixture).toMatchSnapshot();
   });
 });

--- a/tests/spreadsheet/side_panel_component.test.ts
+++ b/tests/spreadsheet/side_panel_component.test.ts
@@ -1,4 +1,4 @@
-import { xml } from "@odoo/owl";
+import { props, types, xml } from "@odoo/owl";
 import { Model, Spreadsheet } from "../../src";
 import {
   COLLAPSED_SIDE_PANEL_SIZE,
@@ -29,35 +29,40 @@ let model: Model;
 let sidePanelStore: Store<SidePanelStore>;
 let notifyUser = jest.fn();
 
-class Body extends Component<any, any> {
+class Body extends Component<any> {
   static template = xml`
     <div>
       <div class="main_body">test</div>
       <div class="props_body" t-if="this.props.text"><t t-out="this.props.text"/></div>
       <input type="text" class="input" t-if="this.props.input" />
     </div>`;
-  static props = {
-    text: { type: String, optional: true },
-    input: { type: Boolean, optional: true },
-    onCloseSidePanel: Function,
-  };
+  protected props = props({
+    "text?": types.string(),
+    "input?": types.boolean(),
+    onCloseSidePanel: types.function(),
+  });
 }
 
-class Body2 extends Component<any, any> {
+class Body2 extends Component<any> {
   static template = xml`
     <div>
       <div class="main_body_2">Hello</div>
       <div class="props_body_2" t-if="this.props.field"><t t-out="this.props.field"/></div>
     </div>`;
-  static props = { field: { type: String, optional: true }, onCloseSidePanel: Function };
+  protected props = props({
+    "field?": types.string(),
+    onCloseSidePanel: types.function(),
+  });
 }
 
-class BodyWithoutProps extends Component<any, any> {
+class BodyWithoutProps extends Component<any> {
   static template = xml`
     <div>
       <div class="main_body_3">Hello</div>
     </div>`;
-  static props = { onCloseSidePanel: Function };
+  protected props = props({
+    onCloseSidePanel: types.function(),
+  });
 }
 
 beforeEach(async () => {

--- a/tests/spreadsheet/spreadsheet_component.test.ts
+++ b/tests/spreadsheet/spreadsheet_component.test.ts
@@ -477,7 +477,6 @@ test("*isSmall* is properly recomputed when changing window size", async () => {
   class Parent extends Component {
     static template = xml`<div class="o-spreadsheet"/>`;
     static components = { Spreadsheet };
-    static props = {};
 
     setup() {
       const screenSize = useScreenWidth();

--- a/tests/table/table_dropdown_button_component.test.ts
+++ b/tests/table/table_dropdown_button_component.test.ts
@@ -14,7 +14,7 @@ let model: Model;
 let sheetId: UID;
 let fixture: HTMLElement;
 
-class Parent extends Component<{}, SpreadsheetChildEnv> {
+class Parent extends Component<SpreadsheetChildEnv> {
   static components = { TableDropdownButton, SidePanels };
   static template = xml/*xml*/ `
   <div class="o-spreadsheet">
@@ -22,7 +22,6 @@ class Parent extends Component<{}, SpreadsheetChildEnv> {
     <SidePanels />
   </div>
   `;
-  static props = {};
 }
 
 beforeEach(async () => {

--- a/tests/table/table_style_editor_panel_component.test.ts
+++ b/tests/table/table_style_editor_panel_component.test.ts
@@ -1,7 +1,8 @@
 import { Model, TableStyle } from "../../src";
 import { SidePanels } from "../../src/components/side_panel/side_panels/side_panels";
-import { TableStyleEditorPanelProps } from "../../src/components/side_panel/table_style_editor_panel/table_style_editor_panel";
+import { TableStyleEditorPanel } from "../../src/components/side_panel/table_style_editor_panel/table_style_editor_panel";
 import { buildTableStyle } from "../../src/helpers/table_presets";
+import { PropsOf } from "../../src/types/props_of";
 import { SpreadsheetChildEnv } from "../../src/types/spreadsheet_env";
 import { createTableStyle } from "../test_helpers/commands_helpers";
 import { click, setInputValueAndTrigger } from "../test_helpers/dom_helper";
@@ -11,7 +12,7 @@ let model: Model;
 let fixture: HTMLElement;
 let env: SpreadsheetChildEnv;
 
-async function mountPanel(partialProps: Partial<TableStyleEditorPanelProps> = {}) {
+async function mountPanel(partialProps: Partial<PropsOf<TableStyleEditorPanel>> = {}) {
   ({ fixture, env } = await mountComponentWithPortalTarget(SidePanels, { model }));
   const props = { onCloseSidePanel: () => {}, ...partialProps };
   env.openSidePanel("TableStyleEditorPanel", { ...props });

--- a/tests/table/table_styles_popover_component.test.ts
+++ b/tests/table/table_styles_popover_component.test.ts
@@ -1,9 +1,7 @@
 import { Model } from "../../src";
-import {
-  TableStylesPopover,
-  TableStylesPopoverProps,
-} from "../../src/components/tables/table_styles_popover/table_styles_popover";
+import { TableStylesPopover } from "../../src/components/tables/table_styles_popover/table_styles_popover";
 import { DEFAULT_TABLE_CONFIG, TABLE_PRESETS } from "../../src/helpers/table_presets";
+import { PropsOf } from "../../src/types/props_of";
 import { createTableStyle } from "../test_helpers/commands_helpers";
 import { click, triggerMouseEvent } from "../test_helpers/dom_helper";
 import { mountComponentWithPortalTarget, nextTick } from "../test_helpers/helpers";
@@ -12,8 +10,8 @@ let model: Model;
 let fixture: HTMLElement;
 let openSidePanel: jest.Mock;
 
-async function mountPopover(partialProps: Partial<TableStylesPopoverProps> = {}) {
-  const props: TableStylesPopoverProps = {
+async function mountPopover(partialProps: Partial<PropsOf<TableStylesPopover>> = {}) {
+  const props: PropsOf<TableStylesPopover> = {
     tableConfig: DEFAULT_TABLE_CONFIG,
     closePopover: () => {},
     onStylePicked: () => {},

--- a/tests/test_helpers/helpers.ts
+++ b/tests/test_helpers/helpers.ts
@@ -1,15 +1,15 @@
-import { proxy, xml } from "@odoo/owl";
+import { props, proxy, xml } from "@odoo/owl";
 import { type ChartConfiguration } from "chart.js";
 import format from "xml-formatter";
 import { functionCache, type StoreConstructor } from "../../src";
 import { Action } from "../../src/actions/action";
 import { ComposerSelection } from "../../src/components/composer/composer/abstract_composer_store";
 import { CellComposerStore } from "../../src/components/composer/composer/cell_composer_store";
-import { CellComposerProps, Composer } from "../../src/components/composer/composer/composer";
+import { Composer } from "../../src/components/composer/composer/composer";
 import { ComposerFocusStore } from "../../src/components/composer/composer_focus_store";
 import { getCurrentSelection, isMobileOS } from "../../src/components/helpers/dom_helpers";
 import { SidePanelStore } from "../../src/components/side_panel/side_panel/side_panel_store";
-import { Spreadsheet, SpreadsheetProps } from "../../src/components/spreadsheet/spreadsheet";
+import { Spreadsheet } from "../../src/components/spreadsheet/spreadsheet";
 import { functionRegistry } from "../../src/functions/function_registry";
 import { matrixMap } from "../../src/functions/helpers";
 import { toCartesian, toXC } from "../../src/helpers/coordinates";
@@ -27,6 +27,7 @@ import { SheetUIPlugin } from "../../src/plugins/ui_feature/ui_sheet";
 import { UIPluginConstructor } from "../../src/plugins/ui_plugin";
 import { MenuItemRegistry } from "../../src/registries/menu_items_registry";
 import { Registry } from "../../src/registries/registry";
+import { PropsOf } from "../../src/types/props_of";
 
 import {
   CellPosition,
@@ -93,7 +94,7 @@ const functionsContentRestore = { ...functionsContent };
 const functionMapRestore = { ...functionMap };
 
 export function spyDispatch(parent: Spreadsheet): jest.SpyInstance {
-  return jest.spyOn(parent.props.model, "dispatch");
+  return jest.spyOn(parent["props"].model, "dispatch");
 }
 
 export function spyModelDispatch(model: Model): jest.SpyInstance {
@@ -273,21 +274,18 @@ export function testUndoRedo(model: Model, expect: jest.Expect, command: Command
 
 type ComponentProps = { [key: string]: any };
 
-interface ParentProps<ChildProps extends ComponentProps> {
-  childComponent: ComponentConstructor<ChildProps, SpreadsheetChildEnv>;
-  childProps: ChildProps;
+interface ParentProps {
+  childComponent: ComponentConstructor<SpreadsheetChildEnv>;
+  childProps: ComponentProps;
 }
 
-class ParentWithPortalTarget<Props extends ComponentProps> extends Component<
-  ParentProps<Props>,
-  SpreadsheetChildEnv
-> {
+class ParentWithPortalTarget extends Component<SpreadsheetChildEnv> {
   static template = xml/*xml*/ `
     <div class="o-spreadsheet" >
       <t t-component="this.props.childComponent" t-props="this.props.childProps"/>
     </div>
   `;
-  static props = { "*": Object };
+  protected props = props() as unknown as ParentProps;
 }
 
 interface MountComponentArgs<Props extends ComponentProps> {
@@ -300,25 +298,25 @@ interface MountComponentArgs<Props extends ComponentProps> {
 
 interface MountComponentReturn<Props extends ComponentProps> {
   app: App;
-  parent: Component<Props, SpreadsheetChildEnv>;
+  parent: Component<SpreadsheetChildEnv>;
   model: Model;
   fixture: HTMLElement;
   env: SpreadsheetChildEnv;
 }
 
 export async function mountComponentWithPortalTarget<Props extends ComponentProps>(
-  component: ComponentConstructor<Props, SpreadsheetChildEnv>,
+  component: ComponentConstructor<SpreadsheetChildEnv>,
   optionalArgs: MountComponentArgs<Props> = {}
-): Promise<MountComponentReturn<ParentProps<Props>>> {
+): Promise<MountComponentReturn<ParentProps>> {
   const args = {
     ...optionalArgs,
     props: { childComponent: component, childProps: optionalArgs.props || ({} as Props) },
   };
-  return mountComponent(ParentWithPortalTarget<Props>, args);
+  return mountComponent(ParentWithPortalTarget, args);
 }
 
 export async function mountComponent<Props extends { [key: string]: any }>(
-  component: ComponentConstructor<Props, SpreadsheetChildEnv>,
+  component: ComponentConstructor<SpreadsheetChildEnv>,
   optionalArgs: MountComponentArgs<Props> = {}
 ): Promise<MountComponentReturn<Props>> {
   const model = optionalArgs.model || optionalArgs.env?.model || new Model();
@@ -355,7 +353,7 @@ export async function mountComponent<Props extends { [key: string]: any }>(
 
 // Requires to be called wit jest realTimers
 export async function mountSpreadsheet(
-  props: SpreadsheetProps = { model: new Model() },
+  props: PropsOf<Spreadsheet> = { model: new Model() },
   partialEnv: Partial<SpreadsheetChildEnv> = {}
 ): Promise<{
   app: App;
@@ -1112,16 +1110,16 @@ export function getStylePropertyInPx(el: HTMLElement, property: string): number 
 
 type ComposerWrapperProps = {
   focusComposer: ComposerFocusType;
-  composerProps: Partial<CellComposerProps>;
+  composerProps: Partial<PropsOf<Composer>>;
 };
 
-export class ComposerWrapper extends Component<ComposerWrapperProps, SpreadsheetChildEnv> {
+export class ComposerWrapper extends Component<SpreadsheetChildEnv> {
   static components = { Composer };
   static template = xml/*xml*/ `
     <div class="o-spreadsheet"/>
     <Composer t-props="this.composerProps"/>
   `;
-  static props = { composerProps: Object, focusComposer: String };
+  protected props = props() as unknown as ComposerWrapperProps;
   state = proxy({ focusComposer: <ComposerFocusType>"inactive" });
   composerStore!: Store<CellComposerStore>;
 
@@ -1130,7 +1128,7 @@ export class ComposerWrapper extends Component<ComposerWrapperProps, Spreadsheet
     this.composerStore = useStore(CellComposerStore);
   }
 
-  get composerProps(): CellComposerProps {
+  get composerProps(): PropsOf<Composer> {
     return {
       ...this.props.composerProps,
       onComposerContentFocused: (selection) => {
@@ -1158,7 +1156,7 @@ export class ComposerWrapper extends Component<ComposerWrapperProps, Spreadsheet
 
 export async function mountComposerWrapper(
   model: Model = new Model(),
-  composerProps: Partial<CellComposerProps> = {},
+  composerProps: Partial<PropsOf<Composer>> = {},
   focusComposer: ComposerFocusType = "inactive"
 ): Promise<{
   parent: ComposerWrapper;

--- a/tests/top_bar_component.test.ts
+++ b/tests/top_bar_component.test.ts
@@ -100,7 +100,7 @@ let fixture: HTMLElement;
 let parent: Parent;
 let env: SpreadsheetChildEnv;
 
-class Parent extends Component<any, SpreadsheetChildEnv> {
+class Parent extends Component<SpreadsheetChildEnv> {
   static template = xml/* xml */ `
     <div class="o-spreadsheet">
       <TopBar
@@ -109,7 +109,6 @@ class Parent extends Component<any, SpreadsheetChildEnv> {
     </div>
   `;
   static components = { TopBar };
-  static props = {};
 
   get gridHeight(): Pixel {
     const { height } = this.env.model.getters.getSheetViewDimension();
@@ -119,7 +118,6 @@ class Parent extends Component<any, SpreadsheetChildEnv> {
 
 class Comp extends Component {
   static template = xml`<div class="o-topbar-test">Test</div>`;
-  static props = {};
 }
 
 class Comp1 extends Comp {


### PR DESCRIPTION
This commit removes this.props in owl3 compatibility layer and replaces it with protected props that use the props() function.

Task: 6236394

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo