### PR TITLE
[FIX] table: "delete table" menu item does not always work

### DIFF
--- a/src/actions/menu_items_actions.ts
+++ b/src/actions/menu_items_actions.ts
@@ -585,13 +585,12 @@ export const INSERT_TABLE = (env: SpreadsheetChildEnv) => {
 };
 
 export const DELETE_SELECTED_TABLE = (env: SpreadsheetChildEnv) => {
-  const position = env.model.getters.getActivePosition();
-  const table = env.model.getters.getTable(position);
+  const table = env.model.getters.getFirstTableInSelection();
   if (!table) {
     return;
   }
   env.model.dispatch("REMOVE_TABLE", {
-    sheetId: position.sheetId,
+    sheetId: env.model.getters.getActiveSheetId(),
     target: [table.range.zone],
   });
 };

--- a/tests/menus/menu_items_registry.test.ts
+++ b/tests/menus/menu_items_registry.test.ts
@@ -1681,6 +1681,15 @@ describe("Menu Item actions", () => {
         expect(model.getters.getTable({ sheetId, row: 0, col: 0 })).toBeUndefined();
       });
 
+      test("Delete table (cellRegistry) works with a table in the selection but not on the active cell", () => {
+        createTable(model, "A2:A5");
+        expect(model.getters.getTable({ sheetId, row: 1, col: 0 })).toBeDefined();
+
+        setSelection(model, ["A1:A2"], { anchor: "A1" });
+        doAction(["delete_table"], env, cellMenuRegistry);
+        expect(model.getters.getTable({ sheetId, row: 1, col: 0 })).toBeUndefined();
+      });
+
       test("Delete table (cellRegistry) on a dynamic table", () => {
         setCellContent(model, "A1", "=MUNIT(5)");
         createDynamicTable(model, "A1");


### PR DESCRIPTION
## Description

The menu item "delete table" was not working if a table was in the selection but not on the active cell.

This commit changes it to be consistent with "Edit table", it will now delete the first table in the selection.

Task: [6247743](https://www.odoo.com/odoo/2328/tasks/6247743)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo