### PR TITLE
[PERF] menu: avoid quadratic complexity with proxies

### DIFF
--- a/src/components/menu/menu.xml
+++ b/src/components/menu/menu.xml
@@ -1,6 +1,7 @@
 <templates>
   <t t-name="o-spreadsheet-Menu">
     <Popover t-if="menuItemsAndSeparators.length" t-props="popoverProps">
+      <t t-set="shouldDisplayIcons" t-value="this.childrenHaveIcon"/>
       <div
         t-ref="menu"
         class="o-menu"
@@ -22,7 +23,7 @@
               t-att-class="{ 'o-menu-root': isMenuRoot, 'disabled': !isMenuEnabled, 'o-menu-item-active': isParentMenu(subMenu, menuItem)}"
               t-att-style="getColor(menuItem)">
               <div class="d-flex w-100">
-                <div t-if="childrenHaveIcon" class="o-menu-item-icon align-middle flex-shrink-0">
+                <div t-if="shouldDisplayIcons" class="o-menu-item-icon align-middle flex-shrink-0">
                   <t t-if="getIconName(menuItem)" t-call="{{getIconName(menuItem)}}"/>
                 </div>
                 <div class="o-menu-item-name align-middle text-truncate" t-esc="getName(menuItem)"/>


### PR DESCRIPTION
In the menu component, we would compute whether to display the icons for each menu item. But to compute that, we need to loop on each menu items, leading to a quadratic complexity.

This could have been good enough as menus aren't too large, but the menu items are proxified by Owl, making the loop very slow.

Task: [6250318](https://www.odoo.com/odoo/2328/tasks/6250318)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo