### PR TITLE
[FIX] Tables: invalidate computed style on `DELETE_CONTENT`

### DIFF
--- a/src/plugins/ui_feature/table_computed_style.ts
+++ b/src/plugins/ui_feature/table_computed_style.ts
@@ -203,6 +203,7 @@ const invalidateTableStyleCommands = [
   "RESIZE_TABLE",
   "CREATE_TABLE_STYLE",
   "REMOVE_TABLE_STYLE",
+  "DELETE_CONTENT",
 ] as const;
 const invalidateTableStyleCommandsSet = new Set<CommandTypes>(invalidateTableStyleCommands);
 

--- a/tests/collaborative/collaborative.test.ts
+++ b/tests/collaborative/collaborative.test.ts
@@ -26,6 +26,7 @@ import {
   createTable,
   createTableStyle,
   createTableWithFilter,
+  deleteContent,
   deleteRows,
   deleteSheet,
   duplicateSheet,
@@ -57,6 +58,7 @@ import {
   createEqualCF,
   getDataValidationRules,
   target,
+  toCellPosition,
   toRangesData,
 } from "../test_helpers/helpers";
 import { addPivot, updatePivot } from "../test_helpers/pivot_helpers";
@@ -974,6 +976,22 @@ describe("Multi users synchronisation", () => {
     expect([alice, bob, charlie]).toHaveSynchronizedValue(
       (user) => getStyle(user, "A1")!.fillColor,
       undefined
+    );
+  });
+
+  test("deleting a cell content properly deletes the table and invalidates its computed style", () => {
+    const sheetId = alice.getters.getActiveSheetId();
+    setCellContent(alice, "A1", "hello");
+    createTable(alice, "A1:A2");
+    const A1 = toCellPosition(sheetId, "A1");
+    expect([alice, bob, charlie]).toHaveSynchronizedValue(
+      (user) => user.getters.getCellComputedStyle(A1),
+      { bold: true, fillColor: "#346B90", textColor: "#FFFFFF" }
+    );
+    deleteContent(alice, ["A1:A2"]);
+    expect([alice, bob, charlie]).toHaveSynchronizedValue(
+      (user) => user.getters.getCellComputedStyle(A1),
+      {}
     );
   });
 


### PR DESCRIPTION
The command `DELETE_CONTENT` can sometimes dispatch a subcommand that deletes a table, which implies that the table style and therefore the cell computed style need to be invalidated. Since the subcommand does not reach Ui feature plugins when replaying commands, we need to explicitely invalidate the table & cell styles on `DELETE_CONTENT`.

Task: 6253199

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [6253199](https://www.odoo.com/odoo/2328/tasks/6253199)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo