### PR TITLE
[FIX] charts: pass `onDataSetHover` to chart config

### DIFF
--- a/src/helpers/figures/chart.ts
+++ b/src/helpers/figures/chart.ts
@@ -3,7 +3,11 @@ import {
   ChartDataSourceBuilder,
   chartDataSourceRegistry,
 } from "../../registries/chart_data_source_registry";
-import { ChartTypeBuilder, chartTypeRegistry } from "../../registries/chart_registry";
+import {
+  ChartJsEventHandlers,
+  ChartTypeBuilder,
+  chartTypeRegistry,
+} from "../../registries/chart_registry";
 import {
   ChartCreationContext,
   ChartData,
@@ -193,7 +197,7 @@ export class SpreadsheetChart {
           extractData: () => ({ dataSetsValues: [], labelValues: [] }),
           extractHierarchicalData: () => ({ dataSetsValues: [], labelValues: [] }),
         };
-    const eventHandlers = {
+    const eventHandlers: ChartJsEventHandlers = {
       onClick: (event, items, chartJsChart) => {
         return this.dataSourceBuilder.onDataSetClick?.(
           this.definition.type,
@@ -204,6 +208,14 @@ export class SpreadsheetChart {
           getters
         );
       },
+      onHover: (event, items, chartJsChart) =>
+        this.dataSourceBuilder.onDataSetHover?.(
+          this.definition.type,
+          chartId,
+          event,
+          items,
+          chartJsChart
+        ),
     };
     return this.chartTypeBuilder.getRuntime(
       getters,

--- a/src/registries/chart_data_source_registry.ts
+++ b/src/registries/chart_data_source_registry.ts
@@ -1,3 +1,4 @@
+import type * as ChartJS from "chart.js";
 import {
   ChartCreationContext,
   ChartData,
@@ -49,11 +50,17 @@ export interface ChartDataSourceBuilder<TExternal, TInternal> {
   onDataSetClick?: (
     chartType: ChartType,
     chartId: UID,
-    // chartjs internals
-    event: unknown,
-    items: unknown,
-    chartJsChart: unknown,
+    event: ChartJS.ChartEvent,
+    items: ChartJS.ActiveElement[],
+    chartJsChart: ChartJS.Chart,
     getters: Getters
+  ) => void;
+  onDataSetHover?: (
+    chartType: ChartType,
+    chartId: UID,
+    event: ChartJS.ChartEvent,
+    items: ChartJS.ActiveElement[],
+    chartJsChart: ChartJS.Chart
   ) => void;
 }
 

--- a/src/registries/chart_registry.ts
+++ b/src/registries/chart_registry.ts
@@ -1,3 +1,4 @@
+import { CoreChartOptions } from "chart.js";
 import { Getters, Range } from "../types";
 import {
   ChartCreationContext,
@@ -109,20 +110,7 @@ interface ChartDataExtractors {
   extractHierarchicalData(): ChartData;
 }
 
-interface ChartJsEventHandlers {
-  onClick?: (
-    // chartjs internals
-    event: unknown,
-    items: unknown,
-    chartJsChart: unknown
-  ) => void;
-  onHover?: (
-    // chartjs internals
-    event: unknown,
-    items: unknown,
-    chartJsChart: unknown
-  ) => void;
-}
+export type ChartJsEventHandlers = Pick<CoreChartOptions<any>, "onClick" | "onHover">;
 
 export interface ChartTypeRegistry extends Registry<ChartTypeBuilder<any>> {
   add<T extends ChartType>(type: T, builder: ChartTypeBuilder<T>): this;

--- a/tests/figures/chart/__snapshots__/chart_plugin.test.ts.snap
+++ b/tests/figures/chart/__snapshots__/chart_plugin.test.ts.snap
@@ -54,6 +54,7 @@ exports[`datasource tests create a chart with stacked bar 1`] = `
       },
       "maintainAspectRatio": false,
       "onClick": [Function],
+      "onHover": [Function],
       "plugins": {
         "background": {
           "color": undefined,
@@ -200,6 +201,7 @@ exports[`datasource tests create a chart with stacked bar 1`] = `
       },
       "maintainAspectRatio": false,
       "onClick": [Function],
+      "onHover": [Function],
       "plugins": {
         "background": {
           "color": undefined,
@@ -333,6 +335,7 @@ exports[`datasource tests create chart with column datasets 1`] = `
       },
       "maintainAspectRatio": false,
       "onClick": [Function],
+      "onHover": [Function],
       "plugins": {
         "background": {
           "color": undefined,
@@ -501,6 +504,7 @@ exports[`datasource tests create chart with column datasets 1`] = `
       },
       "maintainAspectRatio": false,
       "onClick": [Function],
+      "onHover": [Function],
       "plugins": {
         "background": {
           "color": undefined,


### PR DESCRIPTION
## Description

The handler `onDataSetHover` of the chart data source was never actually passed to the chartJS config.

Also the event handlers were not correctly typed.

Task: [6233312](https://www.odoo.com/odoo/2328/tasks/6233312)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo