### PR TITLE
[IMP] toolbar registry: make tool bar registry a real Registry

### DIFF
--- a/src/components/top_bar/top_bar_tools_registry.ts
+++ b/src/components/top_bar/top_bar_tools_registry.ts
@@ -18,6 +18,7 @@ export const topBarToolBarRegistry = new ToolBarRegistry();
 topBarToolBarRegistry
   .add("edit")
   .addChild("edit", {
+    name: "undo",
     component: ActionButton,
     props: {
       action: ACTION_EDIT.undo,
@@ -26,6 +27,7 @@ topBarToolBarRegistry
     sequence: 1,
   })
   .addChild("edit", {
+    name: "redo",
     component: ActionButton,
     props: {
       action: ACTION_EDIT.redo,
@@ -34,6 +36,7 @@ topBarToolBarRegistry
     sequence: 2,
   })
   .addChild("edit", {
+    name: "paintFormat",
     component: PaintFormatButton,
     props: {
       class: "o-hoverable-button o-toolbar-button o-mobile-disabled",
@@ -41,6 +44,7 @@ topBarToolBarRegistry
     sequence: 3,
   })
   .addChild("edit", {
+    name: "clearFormat",
     component: ActionButton,
     props: {
       action: ACTION_FORMAT.clearFormat,
@@ -49,6 +53,7 @@ topBarToolBarRegistry
     sequence: 4,
   })
   .addChild("edit", {
+    name: "zoom",
     component: ToolBarZoom,
     props: {
       class: "o-menu-item-button o-hoverable-button o-toolbar-button",
@@ -58,6 +63,7 @@ topBarToolBarRegistry
 
   .add("numberFormat")
   .addChild("numberFormat", {
+    name: "formatPercent",
     component: ActionButton,
     props: {
       action: ACTION_FORMAT.formatPercent,
@@ -66,6 +72,7 @@ topBarToolBarRegistry
     sequence: 1,
   })
   .addChild("numberFormat", {
+    name: "decreaseDecimalPlaces",
     component: ActionButton,
     props: {
       action: ACTION_FORMAT.decreaseDecimalPlaces,
@@ -74,6 +81,7 @@ topBarToolBarRegistry
     sequence: 2,
   })
   .addChild("numberFormat", {
+    name: "increaseDecimalPlaces",
     component: ActionButton,
     props: {
       action: ACTION_FORMAT.increaseDecimalPlaces,
@@ -82,6 +90,7 @@ topBarToolBarRegistry
     sequence: 3,
   })
   .addChild("numberFormat", {
+    name: "numberFormatsTool",
     component: NumberFormatsTool,
     props: {
       class: "o-menu-item-button o-hoverable-button o-toolbar-button",
@@ -90,6 +99,7 @@ topBarToolBarRegistry
   })
   .add("fontSize")
   .addChild("fontSize", {
+    name: "fontSizeEditor",
     component: TopBarFontSizeEditor,
     props: {
       class: "o-hoverable-button o-toolbar-button",
@@ -98,6 +108,7 @@ topBarToolBarRegistry
   })
   .add("textStyle")
   .addChild("textStyle", {
+    name: "bold",
     component: ActionButton,
     props: {
       action: ACTION_FORMAT.formatBold,
@@ -106,6 +117,7 @@ topBarToolBarRegistry
     sequence: 1,
   })
   .addChild("textStyle", {
+    name: "italic",
     component: ActionButton,
     props: {
       action: ACTION_FORMAT.formatItalic,
@@ -114,6 +126,7 @@ topBarToolBarRegistry
     sequence: 2,
   })
   .addChild("textStyle", {
+    name: "strikethrough",
     component: ActionButton,
     props: {
       action: ACTION_FORMAT.formatStrikethrough,
@@ -122,6 +135,7 @@ topBarToolBarRegistry
     sequence: 3,
   })
   .addChild("textStyle", {
+    name: "textColor",
     component: TopBarColorEditor,
     props: {
       class: "o-hoverable-button o-menu-item-button o-toolbar-button",
@@ -133,6 +147,7 @@ topBarToolBarRegistry
   })
   .add("cellStyle")
   .addChild("cellStyle", {
+    name: "fillColor",
     component: TopBarColorEditor,
     props: {
       class: "o-hoverable-button o-menu-item-button o-toolbar-button",
@@ -143,6 +158,7 @@ topBarToolBarRegistry
     sequence: 1,
   })
   .addChild("cellStyle", {
+    name: "borderEditor",
     component: BorderEditorWidget,
     props: {
       class: "o-hoverable-button o-menu-item-button o-toolbar-button",
@@ -150,6 +166,7 @@ topBarToolBarRegistry
     sequence: 2,
   })
   .addChild("cellStyle", {
+    name: "mergeCells",
     component: ActionButton,
     props: {
       action: ACTION_EDIT.mergeCells,
@@ -159,6 +176,7 @@ topBarToolBarRegistry
   })
   .add("alignment")
   .addChild("alignment", {
+    name: "alignmentHorizontal",
     component: DropdownAction,
     props: {
       parentAction: ACTION_FORMAT.formatAlignmentHorizontal,
@@ -173,6 +191,7 @@ topBarToolBarRegistry
     sequence: 1,
   })
   .addChild("alignment", {
+    name: "alignmentVertical",
     component: DropdownAction,
     props: {
       parentAction: ACTION_FORMAT.formatAlignmentVertical,
@@ -187,6 +206,7 @@ topBarToolBarRegistry
     sequence: 2,
   })
   .addChild("alignment", {
+    name: "formatWrapping",
     component: DropdownAction,
     props: {
       parentAction: ACTION_FORMAT.formatWrapping,
@@ -201,6 +221,7 @@ topBarToolBarRegistry
     sequence: 3,
   })
   .addChild("alignment", {
+    name: "formatRotation",
     component: DropdownAction,
     props: {
       parentAction: ACTION_FORMAT.formatRotation,
@@ -218,11 +239,13 @@ topBarToolBarRegistry
   })
   .add("misc")
   .addChild("misc", {
+    name: "tableDropdown",
     component: TableDropdownButton,
     props: { class: "o-toolbar-button o-hoverable-button o-menu-item-button o-mobile-disabled" },
     sequence: 1,
   })
   .addChild("misc", {
+    name: "createRemoveFilterTool",
     component: ActionButton,
     props: {
       action: ACTION_DATA.createRemoveFilterTool,

--- a/src/registries/toolbar_menu_registry.ts
+++ b/src/registries/toolbar_menu_registry.ts
@@ -2,35 +2,53 @@ import { PropsOf } from "../types/props_of";
 import { SpreadsheetChildEnv } from "../types/spreadsheet_env";
 
 import { ComponentConstructor } from "../owl3_compatibility_layer";
+import { Registry } from "./registry";
+
 type ToolBarItem<C extends ComponentConstructor = ComponentConstructor> = {
+  name: string;
   component: C;
   props: PropsOf<C>;
   sequence: number;
   isVisible?: (env: SpreadsheetChildEnv) => boolean;
 };
 
-export class ToolBarRegistry {
-  content: { [key: string]: ToolBarItem[] } = {};
+export class ToolBarRegistry extends Registry<ToolBarItem[]> {
   add(key: string): this {
-    if (key in this.content) {
-      throw new Error(`${key} is already present in this registry!`);
+    return super.add(key, []);
+  }
+
+  addChild(category: string, item: ToolBarItem): this {
+    if (!(category in this.content)) {
+      throw new Error(`${category} is not present in this registry!`);
     }
-    this.content[key] = [];
+    this.content[category].push(item);
     return this;
   }
 
-  addChild(key: string, value: ToolBarItem): this {
-    this.content[key].push(value);
+  replaceChild(category: string, item: ToolBarItem): this {
+    if (!(category in this.content)) {
+      throw new Error(`${category} is not present in this registry!`);
+    }
+    const index = this.content[category].findIndex((elt) => elt.name === item.name);
+    if (index !== -1) {
+      this.content[category][index] = item;
+    }
     return this;
   }
 
-  remove(key: string) {
-    delete this.content[key];
+  removeChild(category: string, itemName: string): this {
+    if (!(category in this.content)) {
+      throw new Error(`${category} is not present in this registry!`);
+    }
+    const index = this.content[category].findIndex((elt) => elt.name === itemName);
+    if (index !== -1) {
+      this.content[category].splice(index, 1);
+    }
     return this;
   }
 
-  getEntries(id: string): ToolBarItem[] {
-    return this.content[id].sort((a, b) => a.sequence - b.sequence);
+  getEntries(category: string): ToolBarItem[] {
+    return this.content[category].sort((a, b) => a.sequence - b.sequence);
   }
 
   getCategories(): string[] {


### PR DESCRIPTION
This commit refactors the toolbar registry to be an extension of the base Registry class. This allows us to benefit from the features of the base Registry, such as remove, ...

In addition, a name property is added to each tool, which allows us to remove or replace a specific tool in the registry.

Task: 6254795

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo