### PR TITLE
[FIX] Formats: support non-standard space characters

### DIFF
--- a/src/helpers/format/format_tokenizer.ts
+++ b/src/helpers/format/format_tokenizer.ts
@@ -57,6 +57,7 @@ export type FormatToken =
   | RepeatCharToken;
 
 export function tokenizeFormat(str: string): FormatToken[][] {
+  str = str.replace(/\s/g, " ");
   const chars = new TokenizingChars(str);
   const result: FormatToken[][] = [];
 

--- a/tests/formats/format_helpers.test.ts
+++ b/tests/formats/format_helpers.test.ts
@@ -358,6 +358,12 @@ describe("formatValue on number", () => {
     }
   });
 
+  test("Unicode space characters are normalized to ASCII space in format strings", () => {
+    expect(formatValue(5, { format: "0 ", locale })).toBe("5 "); // nbsp
+    expect(formatValue(5, { format: "0 ", locale })).toBe("5 "); // nnbsp
+    expect(formatValue(5, { format: "0 ", locale })).toBe("5 "); // thin space
+  });
+
   test("Escaped string in the middle of a number format", () => {
     expect(formatValue(1234, { format: '0"Str"000', locale })).toBe("1Str234");
     expect(formatValue(1234, { format: '#,##0"Str"0', locale })).toBe("1,23Str4");


### PR DESCRIPTION
The current format tokenizer only supports the standard ASCII space character but not any of its unicode variants (nbsp, nnbsp, ...). When processing those characters, the tokenizer currently crashes.

Since a space is "just a space", this revision simply replaces the variants by the ASCII space character when tokenizing the format itself.

Task: 6259325

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo