### PR TITLE
[FIX] carousel: custom color don't use carousels

### DIFF
--- a/src/plugins/ui_core_views/custom_colors.ts
+++ b/src/plugins/ui_core_views/custom_colors.ts
@@ -87,11 +87,18 @@ export class CustomColorsPlugin extends CoreViewPlugin<CustomColorState> {
           for (const chartId of this.getters.getChartIds(sheetId)) {
             this.tryToAddColors(this.getChartColors(chartId));
           }
+          for (const figureId of this.getters.getFigures(sheetId)) {
+            this.tryToAddColors(this.getCarouselColors(sheetId, figureId.id));
+          }
         }
         break;
       case "UPDATE_CHART":
       case "CREATE_CHART":
         this.tryToAddColors(this.getChartColors(cmd.chartId));
+        break;
+      case "CREATE_CAROUSEL":
+      case "UPDATE_CAROUSEL":
+        this.tryToAddColors(this.getCarouselColors(cmd.sheetId, cmd.figureId));
         break;
       case "UPDATE_CELL":
       case "ADD_CONDITIONAL_FORMAT":
@@ -170,6 +177,15 @@ export class CustomColorsPlugin extends CoreViewPlugin<CustomColorState> {
     const stringifiedChart = JSON.stringify(chart.getDefinition());
     const colors = stringifiedChart.matchAll(chartColorRegex);
     return [...colors].map((color) => color[1]); // color[1] is the first capturing group of the regex
+  }
+
+  private getCarouselColors(sheetId: UID, figureId: UID): Color[] {
+    const figure = this.getters.getFigure(sheetId, figureId);
+    if (figure?.tag !== "carousel") {
+      return [];
+    }
+    const titleColor = this.getters.getCarousel(figureId).title?.color;
+    return titleColor ? [titleColor] : [];
   }
 
   private getTableColors(sheetId: UID): Color[] {

--- a/tests/colors/custom_colors_plugin.test.ts
+++ b/tests/colors/custom_colors_plugin.test.ts
@@ -2,12 +2,14 @@ import { Model } from "../../src";
 import { TABLE_PRESETS } from "../../src/helpers/table_presets";
 import { TableStyle, UID } from "../../src/types";
 import {
+  createCarousel,
   createChart,
   createScorecardChart,
   createTable,
   redo,
   setStyle,
   undo,
+  updateCarousel,
 } from "../test_helpers/commands_helpers";
 import { createColorScale, createEqualCF, target, toRangesData } from "../test_helpers/helpers";
 
@@ -220,6 +222,18 @@ describe("custom colors are correctly handled when editing charts", () => {
     createChart(model, { type: "bar", background: "#654987" }, "1", sheetId);
     const importedModel = new Model(model.exportData());
     expect(importedModel.getters.getCustomColors()).toEqual(["#654987", "#123456"]);
+  });
+
+  test("Carousel title color are taken into account", () => {
+    expect(model.getters.getCustomColors()).toEqual([]);
+    createCarousel(model, { title: { text: "Hello", color: "#123456" }, items: [] }, "id");
+    expect(model.getters.getCustomColors()).toEqual(["#123456"]);
+
+    updateCarousel(model, "id", { title: { text: "Hello", color: "#654321" }, items: [] });
+    expect(model.getters.getCustomColors()).toEqual(["#654321", "#123456"]);
+
+    const model2 = new Model(model.exportData());
+    expect(model2.getters.getCustomColors()).toEqual(["#654321"]);
   });
 });
 


### PR DESCRIPTION
## Description

The custom color plugin was not extracting colors from the carousel title.

Task: [6263128](https://www.odoo.com/odoo/2328/tasks/6263128)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo