### PR TITLE
[IMP] carousel: pick chart type when adding chart to carousel

### DIFF
--- a/src/components/side_panel/carousel_panel/carousel_panel.ts
+++ b/src/components/side_panel/carousel_panel/carousel_panel.ts
@@ -1,4 +1,4 @@
-import { onWillUpdateProps, signal, useProps } from "@odoo/owl";
+import { onWillUpdateProps, proxy, signal, useProps } from "@odoo/owl";
 import { ActionSpec } from "../../../actions/action";
 import { DEFAULT_CAROUSEL_TITLE_STYLE } from "../../../constants";
 import {
@@ -6,25 +6,36 @@ import {
   getCarouselItemTitle,
   getPoppedOutChartAnchor,
 } from "../../../helpers/carousel_helpers";
+import { SpreadsheetChart } from "../../../helpers/figures/chart";
 import { deepEquals } from "../../../helpers/misc";
 import { UuidGenerator } from "../../../helpers/uuid";
 import { Component } from "../../../owl3_compatibility_layer";
+import { chartDataSourceRegistry } from "../../../registries/chart_data_source_registry";
+import { chartTypeRegistry } from "../../../registries/chart_registry";
+import { chartSubtypeRegistry } from "../../../registries/chart_subtype_registry";
 import { _t } from "../../../translation";
-import { TitleDesign } from "../../../types/chart/chart";
+import { CHART_TYPES, ChartDefinition, TitleDesign } from "../../../types/chart/chart";
 import { CarouselItem } from "../../../types/figure";
 import { UID } from "../../../types/misc";
+import { PropsOf } from "../../../types/props_of";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
 import { getBoundingRectAsPOJO } from "../../helpers/dom_helpers";
 import { useDragAndDropListItems } from "../../helpers/drag_and_drop_dom_items_hook";
+import { Popover } from "../../popover/popover";
 import { types } from "../../props_validation";
 import { TextInput } from "../../text_input/text_input";
 import { TextStyler } from "../chart/building_blocks/text_styler/text_styler";
+import { ChartTypePickerPopover } from "../chart/chart_type_picker_popover/chart_type_picker_popover";
 import { CogWheelMenu } from "../components/cog_wheel_menu/cog_wheel_menu";
 import { Section } from "../components/section/section";
 
+interface CarouselPanelState {
+  popoverProps: PropsOf<Popover> | undefined;
+}
+
 export class CarouselPanel extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-CarouselPanel";
-  static components = { Section, TextInput, TextStyler, CogWheelMenu };
+  static components = { Section, TextInput, TextStyler, CogWheelMenu, ChartTypePickerPopover };
 
   protected props = useProps({
     onCloseSidePanel: types.function(),
@@ -35,6 +46,9 @@ export class CarouselPanel extends Component<SpreadsheetChildEnv> {
 
   private dragAndDrop = useDragAndDropListItems();
   private previewListRef = signal<HTMLElement | null>(null);
+  addChartButton = signal<HTMLElement | null>(null);
+
+  state = proxy<CarouselPanelState>({ popoverProps: undefined });
 
   setup() {
     let lastCarouselItems: CarouselItem[] = [...this.carouselItems];
@@ -66,11 +80,46 @@ export class CarouselPanel extends Component<SpreadsheetChildEnv> {
     return item.type === "chart" ? item.chartId : "transparent-carousel";
   }
 
-  addNewChartToCarousel() {
+  addNewChartToCarousel(ev: MouseEvent) {
+    if (this.state.popoverProps) {
+      this.state.popoverProps = undefined;
+      return;
+    }
+    const target = ev.currentTarget as HTMLElement;
+    const { bottom, right } = target.getBoundingClientRect();
+    this.state.popoverProps = {
+      anchorRect: { x: right, y: bottom, width: 0, height: 0 },
+      positioning: "top-right",
+      verticalOffset: 0,
+      maxWidth: target.parentElement?.getBoundingClientRect().width || 300,
+    };
+  }
+
+  get supportedChartTypes() {
+    return new Set(CHART_TYPES);
+  }
+
+  closePopover() {
+    this.state.popoverProps = undefined;
+  }
+
+  onSelectChartType(type: string) {
+    const newChartInfo = chartSubtypeRegistry.get(type);
+    const ChartTypeBuilder = chartTypeRegistry.get(newChartInfo.chartType);
+    const DataSourceBuilder = chartDataSourceRegistry.get("range");
+    const definition = SpreadsheetChart.deleteInvalidKeys({
+      ...ChartTypeBuilder.getDefinitionFromContextCreation({}, DataSourceBuilder),
+      ...newChartInfo.subtypeDefinition,
+    } as ChartDefinition);
+
     this.env.model.dispatch("ADD_NEW_CHART_TO_CAROUSEL", {
       figureId: this.props.figureId,
       sheetId: this.carouselSheetId,
+      newChartId: UuidGenerator.smallUuid(),
+      chartDefinition: definition,
     });
+    this.env.model.dispatch("SELECT_FIGURE", { figureId: this.props.figureId });
+    this.env.openSidePanel("ChartPanel");
   }
 
   get hasDataView(): boolean {

--- a/src/components/side_panel/carousel_panel/carousel_panel.xml
+++ b/src/components/side_panel/carousel_panel/carousel_panel.xml
@@ -51,19 +51,32 @@
           </div>
         </t>
       </div>
-      <div
-        class="o-button-link o-carousel-add-chart float-end d-flex align-items-center py-4 pe-4 gap-2"
-        t-on-click="this.addNewChartToCarousel"
-        t-att-title="this.carouselAddChartInfoMessage">
-        + Add chart
-      </div>
-      <div
-        t-if="!this.hasDataView"
-        class="o-button-link o-carousel-add-data-view float-end py-4 pe-4"
-        t-on-click="this.addDataViewToCarousel"
-        t-att-title="this.carouselDataViewMessage">
-        + Add data view
-      </div>
+      <Section class="'pt-0'">
+        <div>
+          <div
+            class="o-button-link o-carousel-add-chart float-end d-flex align-items-center my-4"
+            t-on-click="this.addNewChartToCarousel"
+            t-ref="this.addChartButton"
+            t-att-title="this.carouselAddChartInfoMessage">
+            + Add chart
+          </div>
+          <div
+            t-if="!this.hasDataView"
+            class="o-button-link o-carousel-add-data-view float-end my-4 me-4"
+            t-on-click="this.addDataViewToCarousel"
+            t-att-title="this.carouselDataViewMessage">
+            + Add data view
+          </div>
+        </div>
+      </Section>
     </div>
+    <ChartTypePickerPopover
+      t-if="this.state.popoverProps"
+      popoverProps="this.state.popoverProps"
+      onClose.bind="this.closePopover"
+      onSelectSubType.bind="this.onSelectChartType"
+      parentRef="this.addChartButton"
+      supportedTypes="this.supportedChartTypes"
+    />
   </t>
 </templates>

--- a/src/components/side_panel/chart/chart_type_picker/chart_type_picker.css
+++ b/src/components/side_panel/chart/chart_type_picker/chart_type_picker.css
@@ -12,22 +12,4 @@
       height: 24px;
     }
   }
-
-  .o-popover .o-chart-select-popover {
-    .o-chart-type-item {
-      cursor: pointer;
-      padding: 2px 5px;
-      margin: 1px 2px;
-      border: 1px solid transparent;
-      &.selected,
-      &:hover {
-        border-color: var(--os-action-color);
-        background: var(--os-badge-selected-color);
-      }
-      .o-chart-preview {
-        width: 48px;
-        height: 48px;
-      }
-    }
-  }
 }

--- a/src/components/side_panel/chart/chart_type_picker/chart_type_picker.ts
+++ b/src/components/side_panel/chart/chart_type_picker/chart_type_picker.ts
@@ -1,65 +1,39 @@
 import { proxy, signal, useProps } from "@odoo/owl";
-import { Component, useExternalListener } from "../../../../owl3_compatibility_layer";
+import { Component } from "../../../../owl3_compatibility_layer";
 import { chartDataSourceRegistry } from "../../../../registries/chart_data_source_registry";
 import { chartSubtypeRegistry } from "../../../../registries/chart_subtype_registry";
 import { CHART_TYPES, ChartDefinition, ChartType } from "../../../../types/chart/chart";
-import {
-  chartCategories,
-  ChartSubtypeProperties,
-} from "../../../../types/chart_subtype_properties";
+import { ChartSubtypeProperties } from "../../../../types/chart_subtype_properties";
 import { UID } from "../../../../types/misc";
 import { PropsOf } from "../../../../types/props_of";
 import { SpreadsheetChildEnv } from "../../../../types/spreadsheet_env";
-import { cssPropertiesToCss } from "../../../helpers/css";
-import { isChildEvent } from "../../../helpers/dom_helpers";
 import { Popover } from "../../../popover/popover";
 import { types } from "../../../props_validation";
 import { Section } from "../../components/section/section";
+import { ChartTypePickerPopover } from "../chart_type_picker_popover/chart_type_picker_popover";
 import { MainChartPanelStore } from "../main_chart_panel/main_chart_panel_store";
 
 interface ChartTypePickerState {
   popoverProps: PropsOf<Popover> | undefined;
-  popoverStyle: string;
 }
 
 export class ChartTypePicker extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ChartTypePicker";
-  static components = { Section, Popover };
+  static components = { Section, ChartTypePickerPopover };
 
   protected props = useProps({
     chartId: types.UID(),
     chartPanelStore: types.Store<MainChartPanelStore>(),
   });
 
-  categories = chartCategories;
-  chartTypeByCategories: Record<string, ChartSubtypeProperties[]> = {};
-
-  popoverRef = signal<HTMLElement | null>(null);
   selectRef = signal<HTMLElement | null>(null);
 
-  state = proxy<ChartTypePickerState>({ popoverProps: undefined, popoverStyle: "" });
+  state = proxy<ChartTypePickerState>({ popoverProps: undefined });
 
-  setup(): void {
-    useExternalListener(window, "pointerdown", this.onExternalClick, { capture: true });
-
-    const definition = this.env.model.getters.getChartDefinition(this.props.chartId);
-    const supportedTypes = this.getSupportedChartTypes(definition);
-
-    for (const subtypeProperties of chartSubtypeRegistry.getAll()) {
-      if (!supportedTypes.has(subtypeProperties.chartType)) {
-        continue;
-      }
-      if (this.chartTypeByCategories[subtypeProperties.category]) {
-        this.chartTypeByCategories[subtypeProperties.category].push(subtypeProperties);
-      } else {
-        this.chartTypeByCategories[subtypeProperties.category] = [subtypeProperties];
-      }
-    }
-  }
-
-  private getSupportedChartTypes(definition: ChartDefinition): Set<ChartType> {
+  getSupportedChartTypes(): Set<ChartType> {
     let supportedTypes: Set<ChartType>;
 
+    const definition = this.getChartDefinition(this.props.chartId);
     if (definition.dataSource) {
       const dataSourceBuilder = chartDataSourceRegistry.get(definition.dataSource.type);
       supportedTypes = new Set(dataSourceBuilder.supportedChartTypes);
@@ -77,16 +51,8 @@ export class ChartTypePicker extends Component<SpreadsheetChildEnv> {
     return supportedTypes;
   }
 
-  onExternalClick(ev: MouseEvent) {
-    if (isChildEvent(this.popoverRef()?.parentElement, ev) || isChildEvent(this.selectRef(), ev)) {
-      return;
-    }
-    this.closePopover();
-  }
-
   onTypeChange(type: ChartType) {
     this.props.chartPanelStore.changeChartType(this.props.chartId, type);
-    this.closePopover();
   }
 
   private getChartDefinition(chartId: UID): ChartDefinition {
@@ -112,12 +78,11 @@ export class ChartTypePicker extends Component<SpreadsheetChildEnv> {
       anchorRect: { x: right, y: bottom, width: 0, height: 0 },
       positioning: "top-right",
       verticalOffset: 0,
+      maxWidth: width,
     };
-
-    this.state.popoverStyle = cssPropertiesToCss({ width: `${width}px` });
   }
 
-  private closePopover() {
+  closePopover() {
     this.state.popoverProps = undefined;
   }
 }

--- a/src/components/side_panel/chart/chart_type_picker/chart_type_picker.xml
+++ b/src/components/side_panel/chart/chart_type_picker/chart_type_picker.xml
@@ -14,32 +14,14 @@
         </div>
       </div>
     </Section>
-    <Popover t-if="this.state.popoverProps" t-props="this.state.popoverProps">
-      <div
-        t-ref="this.popoverRef"
-        class="o-chart-select-popover px-3 pb-4"
-        t-att-style="this.state.popoverStyle">
-        <t t-foreach="this.categories" t-as="category" t-key="category">
-          <t t-if="this.chartTypeByCategories[category]">
-            <h5 class="my-3" t-out="category_value"/>
-            <div class="d-flex flex-wrap">
-              <t
-                t-foreach="this.chartTypeByCategories[category]"
-                t-as="properties"
-                t-key="properties.chartSubtype">
-                <div
-                  class="o-chart-type-item"
-                  t-att-title="properties.displayName"
-                  t-on-click="() => this.onTypeChange(properties.chartSubtype)"
-                  t-att-data-id="properties.chartSubtype"
-                  t-att-class="{'selected': properties === selectedChartProperties}">
-                  <t t-call="{{properties.preview}}"/>
-                </div>
-              </t>
-            </div>
-          </t>
-        </t>
-      </div>
-    </Popover>
+    <ChartTypePickerPopover
+      t-if="this.state.popoverProps"
+      popoverProps="this.state.popoverProps"
+      onClose.bind="this.closePopover"
+      onSelectSubType.bind="this.onTypeChange"
+      parentRef="this.selectRef"
+      supportedTypes="this.getSupportedChartTypes()"
+      selectedChartSubType="selectedChartProperties.chartSubtype"
+    />
   </t>
 </templates>

--- a/src/components/side_panel/chart/chart_type_picker_popover/chart_type_picker_popover.css
+++ b/src/components/side_panel/chart/chart_type_picker_popover/chart_type_picker_popover.css
@@ -1,0 +1,19 @@
+.o-spreadsheet {
+  .o-popover .o-chart-select-popover {
+    .o-chart-type-item {
+      cursor: pointer;
+      padding: 2px 5px;
+      margin: 1px 2px;
+      border: 1px solid transparent;
+      &.selected,
+      &:hover {
+        border-color: var(--os-action-color);
+        background: var(--os-badge-selected-color);
+      }
+      .o-chart-preview {
+        width: 48px;
+        height: 48px;
+      }
+    }
+  }
+}

--- a/src/components/side_panel/chart/chart_type_picker_popover/chart_type_picker_popover.ts
+++ b/src/components/side_panel/chart/chart_type_picker_popover/chart_type_picker_popover.ts
@@ -1,0 +1,62 @@
+import { props, signal } from "@odoo/owl";
+import { Component, useExternalListener } from "../../../../owl3_compatibility_layer";
+import { chartSubtypeRegistry } from "../../../../registries/chart_subtype_registry";
+import { ChartType } from "../../../../types/chart/chart";
+import {
+  chartCategories,
+  ChartSubtypeProperties,
+} from "../../../../types/chart_subtype_properties";
+import { PropsOf } from "../../../../types/props_of";
+import { SpreadsheetChildEnv } from "../../../../types/spreadsheet_env";
+import { isChildEvent } from "../../../helpers/dom_helpers";
+import { Popover } from "../../../popover/popover";
+import { types } from "../../../props_validation";
+
+export class ChartTypePickerPopover extends Component<SpreadsheetChildEnv> {
+  static template = "o-spreadsheet-ChartTypePickerPopover";
+  static components = { Popover };
+
+  protected props = props({
+    parentRef: types.signal<HTMLElement | null>().optional(),
+    onClose: types.function(),
+    onSelectSubType: types.function<(type: string) => void>(),
+    supportedTypes: types.object<Set<ChartType>>(),
+    selectedChartSubType: types.string().optional(),
+    popoverProps: types.object<PropsOf<Popover>>(),
+  });
+
+  categories = chartCategories;
+  chartTypeByCategories: Record<string, ChartSubtypeProperties[]> = {};
+
+  popoverRef = signal<HTMLElement | null>(null);
+
+  setup(): void {
+    useExternalListener(window, "pointerdown", this.onExternalClick, { capture: true });
+
+    for (const subtypeProperties of chartSubtypeRegistry.getAll()) {
+      if (!this.props.supportedTypes.has(subtypeProperties.chartType)) {
+        continue;
+      }
+      if (this.chartTypeByCategories[subtypeProperties.category]) {
+        this.chartTypeByCategories[subtypeProperties.category].push(subtypeProperties);
+      } else {
+        this.chartTypeByCategories[subtypeProperties.category] = [subtypeProperties];
+      }
+    }
+  }
+
+  onExternalClick(ev: MouseEvent) {
+    if (
+      isChildEvent(this.popoverRef()?.parentElement, ev) ||
+      isChildEvent(this.props.parentRef?.(), ev)
+    ) {
+      return;
+    }
+    this.props.onClose();
+  }
+
+  onTypeChange(type: ChartType) {
+    this.props.onSelectSubType(type);
+    this.props.onClose();
+  }
+}

--- a/src/components/side_panel/chart/chart_type_picker_popover/chart_type_picker_popover.ts
+++ b/src/components/side_panel/chart/chart_type_picker_popover/chart_type_picker_popover.ts
@@ -1,5 +1,5 @@
-import { props, signal } from "@odoo/owl";
-import { Component, useExternalListener } from "../../../../owl3_compatibility_layer";
+import { signal, useListener, useProps } from "@odoo/owl";
+import { Component } from "../../../../owl3_compatibility_layer";
 import { chartSubtypeRegistry } from "../../../../registries/chart_subtype_registry";
 import { ChartType } from "../../../../types/chart/chart";
 import {
@@ -16,7 +16,7 @@ export class ChartTypePickerPopover extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ChartTypePickerPopover";
   static components = { Popover };
 
-  protected props = props({
+  protected props = useProps({
     parentRef: types.signal<HTMLElement | null>().optional(),
     onClose: types.function(),
     onSelectSubType: types.function<(type: string) => void>(),
@@ -31,7 +31,7 @@ export class ChartTypePickerPopover extends Component<SpreadsheetChildEnv> {
   popoverRef = signal<HTMLElement | null>(null);
 
   setup(): void {
-    useExternalListener(window, "pointerdown", this.onExternalClick, { capture: true });
+    useListener(window, "pointerdown", this.onExternalClick.bind(this), { capture: true });
 
     for (const subtypeProperties of chartSubtypeRegistry.getAll()) {
       if (!this.props.supportedTypes.has(subtypeProperties.chartType)) {

--- a/src/components/side_panel/chart/chart_type_picker_popover/chart_type_picker_popover.xml
+++ b/src/components/side_panel/chart/chart_type_picker_popover/chart_type_picker_popover.xml
@@ -1,0 +1,31 @@
+<templates>
+  <t t-name="o-spreadsheet-ChartTypePickerPopover">
+    <Popover t-props="this.props.popoverProps">
+      <div
+        t-ref="this.popoverRef"
+        class="o-chart-select-popover px-3 pb-4"
+        t-att-style="this.popoverStyle">
+        <t t-foreach="this.categories" t-as="category" t-key="category">
+          <t t-if="this.chartTypeByCategories[category]">
+            <h5 class="my-3" t-out="category_value"/>
+            <div class="d-flex flex-wrap">
+              <t
+                t-foreach="this.chartTypeByCategories[category]"
+                t-as="properties"
+                t-key="properties.chartSubtype">
+                <div
+                  class="o-chart-type-item"
+                  t-att-title="properties.displayName"
+                  t-on-click="() => this.onTypeChange(properties.chartSubtype)"
+                  t-att-data-id="properties.chartSubtype"
+                  t-att-class="{'selected': properties.chartSubtype === this.props.selectedChartSubType}">
+                  <t t-call="{{properties.preview}}"/>
+                </div>
+              </t>
+            </div>
+          </t>
+        </t>
+      </div>
+    </Popover>
+  </t>
+</templates>

--- a/src/helpers/carousel_helpers.ts
+++ b/src/helpers/carousel_helpers.ts
@@ -1,21 +1,10 @@
 import { chartSubtypeRegistry } from "../registries/chart_subtype_registry";
 import { ViewportsStore } from "../stores/viewports_store";
 import { _t } from "../translation";
-import { ChartDefinition } from "../types/chart/chart";
 import { AnchorOffset, CarouselItem } from "../types/figure";
 import { Getters } from "../types/getters";
 import { UID } from "../types/misc";
 import { SpreadsheetChildEnv } from "../types/spreadsheet_env";
-
-export const CAROUSEL_DEFAULT_CHART_DEFINITION: ChartDefinition = {
-  type: "bar",
-  title: {},
-  stacked: false,
-  dataSetStyles: {},
-  dataSource: { type: "range", dataSets: [], dataSetsHaveTitle: false },
-  legendPosition: "top",
-  humanize: true,
-};
 
 /**
  * Compute the anchor of a chart popped out of a carousel: slightly offset from the

--- a/src/plugins/ui_stateful/carousel_ui.ts
+++ b/src/plugins/ui_stateful/carousel_ui.ts
@@ -1,7 +1,7 @@
-import { CAROUSEL_DEFAULT_CHART_DEFINITION } from "../../helpers/carousel_helpers";
 import { SpreadsheetChart } from "../../helpers/figures/chart";
 import { deepEquals, insertItemsAtIndex } from "../../helpers/misc";
 import { UuidGenerator } from "../../helpers/uuid";
+import { ChartDefinition } from "../../types/chart/chart";
 import {
   Command,
   CommandResult,
@@ -67,7 +67,7 @@ export class CarouselUIPlugin extends UIPlugin {
   handle(cmd: Command) {
     switch (cmd.type) {
       case "ADD_NEW_CHART_TO_CAROUSEL":
-        this.addNewChartToCarousel(cmd.figureId, cmd.sheetId);
+        this.addNewChartToCarousel(cmd.figureId, cmd.newChartId, cmd.sheetId, cmd.chartDefinition);
         break;
       case "ADD_FIGURES_CHART_TO_CAROUSEL":
         cmd.chartFigureIds.forEach((figureId) => {
@@ -195,21 +195,24 @@ export class CarouselUIPlugin extends UIPlugin {
     }
   }
 
-  private addNewChartToCarousel(figureId: string, sheetId: string) {
+  private addNewChartToCarousel(
+    figureId: string,
+    chartId: string,
+    sheetId: string,
+    chartDefinition: ChartDefinition<string>
+  ) {
     const carousel = this.getters.getCarousel(figureId);
-    const chartId = UuidGenerator.smallUuid();
     this.dispatch("CREATE_CHART", {
       chartId,
       figureId,
       sheetId,
-      definition: CAROUSEL_DEFAULT_CHART_DEFINITION,
+      definition: chartDefinition,
     });
 
-    const definition: Carousel = {
-      ...carousel,
-      items: [...carousel.items, { type: "chart", chartId }],
-    };
+    const carouselItem: CarouselItem = { type: "chart", chartId };
+    const definition: Carousel = { ...carousel, items: [...carousel.items, carouselItem] };
     this.dispatch("UPDATE_CAROUSEL", { sheetId, figureId, definition });
+    this.dispatch("UPDATE_CAROUSEL_ACTIVE_ITEM", { figureId, sheetId, item: carouselItem });
   }
 
   private addFigureChartToCarousel(figureId: UID, chartFigureId: UID, sheetId: string) {

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -655,6 +655,8 @@ export interface UpdateCarouselCommand extends SheetDependentCommand {
 export interface AddNewChartToCarouselCommand extends SheetDependentCommand {
   type: "ADD_NEW_CHART_TO_CAROUSEL";
   figureId: UID;
+  newChartId: UID;
+  chartDefinition: ChartDefinition<string>;
 }
 
 export interface AddFiguresChartToCarouselCommand extends SheetDependentCommand {

--- a/tests/figures/carousel/carousel_figure_component.test.ts
+++ b/tests/figures/carousel/carousel_figure_component.test.ts
@@ -53,6 +53,7 @@ describe("Carousel figure component", () => {
     createCarousel(model, { items: [] }, "carouselId");
     const radarId = addNewChartToCarousel(model, "carouselId", { type: "radar" });
     const barId = addNewChartToCarousel(model, "carouselId", { type: "bar" });
+    selectCarouselItem(model, "carouselId", { type: "chart", chartId: radarId });
     const { fixture } = await mountSpreadsheet({ model });
 
     expect(model.getters.getSelectedCarouselItem("carouselId")).toMatchObject({ chartId: radarId });
@@ -71,6 +72,7 @@ describe("Carousel figure component", () => {
   test("Carousel data view make the figure un-clickable", async () => {
     createCarousel(model, { items: [{ type: "carouselDataView" }] }, "carouselId");
     addNewChartToCarousel(model, "carouselId", { type: "radar" });
+    selectCarouselItem(model, "carouselId", { type: "carouselDataView" });
 
     const { fixture } = await mountSpreadsheet({ model });
     expect(".o-carousel-header").toHaveClass("pe-auto");
@@ -315,7 +317,10 @@ describe("Carousel figure component", () => {
     expect(".o-carousel-header").toHaveStyle({ "background-color": "#FFFFFF" });
 
     // Carousel with chart
-    const chartId = addNewChartToCarousel(model, "carouselId", { background: "#123456" });
+    const chartId = addNewChartToCarousel(model, "carouselId", {
+      background: "#123456",
+      type: "bar",
+    });
     selectCarouselItem(model, "carouselId", { type: "chart", chartId });
     await nextTick();
     expect(".o-carousel-header").toHaveStyle({ "background-color": "#123456" });
@@ -324,6 +329,7 @@ describe("Carousel figure component", () => {
   test("display chart menu", async () => {
     createCarousel(model, { items: [{ type: "carouselDataView" }] }, "carouselId");
     addNewChartToCarousel(model, "carouselId", { type: "bar" });
+    selectCarouselItem(model, "carouselId", { type: "carouselDataView" });
     model.updateMode("dashboard");
     const { fixture } = await mountSpreadsheet({ model });
     expect(".o-chart-menu-item").toHaveCount(0); // nothing for the data view

--- a/tests/figures/carousel/carousel_full_screen.test.ts
+++ b/tests/figures/carousel/carousel_full_screen.test.ts
@@ -1,5 +1,9 @@
 import { Model } from "../../../src";
-import { addNewChartToCarousel, createCarousel } from "../../test_helpers/commands_helpers";
+import {
+  addNewChartToCarousel,
+  createCarousel,
+  selectCarouselItem,
+} from "../../test_helpers/commands_helpers";
 import { click } from "../../test_helpers/dom_helper";
 import { mockChart, mountSpreadsheet, nextTick } from "../../test_helpers/helpers";
 
@@ -47,6 +51,7 @@ describe("full screen carousel", () => {
   test("Cannot use the data view in full screen", async () => {
     createCarousel(model, { items: [{ type: "carouselDataView" }] }, "carouselId");
     addNewChartToCarousel(model, "carouselId", { type: "radar" });
+    selectCarouselItem(model, "carouselId", { type: "carouselDataView" });
     model.updateMode("dashboard");
     await nextTick();
     expect(".o-figure .o-carousel-full-screen-button").toHaveClass("invisible");

--- a/tests/figures/carousel/carousel_panel_component.test.ts
+++ b/tests/figures/carousel/carousel_panel_component.test.ts
@@ -41,9 +41,13 @@ describe("Carousel panel component", () => {
     await mountCarouselPanel(model, "carouselId");
 
     await click(fixture, ".o-carousel-add-chart");
+    await click(fixture, '.o-popover [data-id="radar"]');
+    const chartId = model.getters.getChartIds(model.getters.getActiveSheetId())[0];
     expect(model.getters.getCarousel("carouselId")).toMatchObject({
-      items: [{ type: "chart", chartId: expect.any(String) }],
+      items: [{ type: "chart", chartId }],
     });
+    expect(model.getters.getChartDefinition(chartId)).toMatchObject({ type: "radar" });
+    expect(".o-sidePanel .o-chart").toHaveCount(1); // Chart side panel is open for the new chart
   });
 
   test("Can add a data view to the carousel", async () => {
@@ -159,6 +163,7 @@ describe("Carousel panel component", () => {
   test("Selected carousel item is highlighted", async () => {
     createCarousel(model, { items: [{ type: "carouselDataView" }] }, "carouselId");
     const radarId = addNewChartToCarousel(model, "carouselId", { type: "radar" });
+    selectCarouselItem(model, "carouselId", { type: "carouselDataView" });
     await mountCarouselPanel(model, "carouselId");
 
     await setInputValueAndTrigger(".o-carousel-preview .os-input", "New Chart Name");

--- a/tests/figures/carousel/carousel_plugin.test.ts
+++ b/tests/figures/carousel/carousel_plugin.test.ts
@@ -1,5 +1,4 @@
 import { CommandResult, Model, UID } from "../../../src";
-import { CAROUSEL_DEFAULT_CHART_DEFINITION } from "../../../src/helpers/carousel_helpers";
 import { toChartDataSource } from "../../test_helpers/chart_helpers";
 import {
   addChartFigureToCarousel,
@@ -12,6 +11,7 @@ import {
   updateCarousel,
   updateChart,
 } from "../../test_helpers/commands_helpers";
+import { TEST_CHART_DATA } from "../../test_helpers/constants";
 
 let model: Model;
 let sheetId: UID;
@@ -42,10 +42,20 @@ describe("Carousel figure", () => {
       createChart(model, { type: "bar" }, "chartId", undefined, { figureId: "chartFigureId" });
 
       const sheetId = model.getters.getActiveSheetId();
-      let result = model.dispatch("ADD_NEW_CHART_TO_CAROUSEL", { figureId: "invalidId", sheetId });
+      let result = model.dispatch("ADD_NEW_CHART_TO_CAROUSEL", {
+        figureId: "invalidId",
+        sheetId,
+        newChartId: "chartId",
+        chartDefinition: TEST_CHART_DATA.combo,
+      });
       expect(result).toBeCancelledBecause(CommandResult.InvalidFigureId);
 
-      result = model.dispatch("ADD_NEW_CHART_TO_CAROUSEL", { figureId: "chartFigureId", sheetId });
+      result = model.dispatch("ADD_NEW_CHART_TO_CAROUSEL", {
+        figureId: "chartFigureId",
+        sheetId,
+        newChartId: "chartId",
+        chartDefinition: TEST_CHART_DATA.combo,
+      });
       expect(result).toBeCancelledBecause(CommandResult.InvalidFigureId);
     });
 
@@ -141,13 +151,13 @@ describe("Carousel figure", () => {
   test("Can add a new chart to a carousel", () => {
     createCarousel(model, { items: [] }, "carouselId");
 
-    addNewChartToCarousel(model, "carouselId");
+    addNewChartToCarousel(model, "carouselId", { type: "radar" });
 
     const carouselItems = model.getters.getCarousel("carouselId").items;
     expect(carouselItems).toMatchObject([{ type: "chart", chartId: expect.any(String) }]);
-    expect(model.getters.getChartDefinition(carouselItems[0]["chartId"])).toEqual(
-      CAROUSEL_DEFAULT_CHART_DEFINITION
-    );
+    expect(model.getters.getChartDefinition(carouselItems[0]["chartId"])).toMatchObject({
+      type: "radar",
+    });
     expect(model.getters.getFigureIdFromChartId(carouselItems[0]["chartId"])).toBe("carouselId");
   });
 
@@ -186,13 +196,13 @@ describe("Carousel figure", () => {
 
   test("Can duplicate a sheet with a carousel", () => {
     createCarousel(model, { items: [] }, "carouselId");
-    const chartId = addNewChartToCarousel(model, "carouselId");
+    const chartId = addNewChartToCarousel(model, "carouselId", { type: "funnel" });
 
     duplicateSheet(model, sheetId, "newSheetId");
 
     const carouselItems = model.getters.getCarousel("carouselId").items;
     expect(carouselItems).toMatchObject([{ type: "chart", chartId }]);
-    expect(model.getters.getChartDefinition(chartId)).toEqual(CAROUSEL_DEFAULT_CHART_DEFINITION);
+    expect(model.getters.getChartDefinition(chartId)).toMatchObject({ type: "funnel" });
     expect(model.getters.getFigureIdFromChartId(chartId)).toBe("carouselId");
 
     const newCarouselId = model.getters.getFigures("newSheetId")[0].id;
@@ -202,9 +212,9 @@ describe("Carousel figure", () => {
     expect(model.getters.getCarousel(newCarouselId).items).toEqual([
       { type: "chart", chartId: newChartId },
     ]);
-    expect(model.getters.getChartDefinition("newSheetId??" + chartId)).toEqual(
-      CAROUSEL_DEFAULT_CHART_DEFINITION
-    );
+    expect(model.getters.getChartDefinition("newSheetId??" + chartId)).toMatchObject({
+      type: "funnel",
+    });
     expect(model.getters.getFigureIdFromChartId("newSheetId??" + chartId)).toBe(newCarouselId);
   });
 

--- a/tests/test_helpers/commands_helpers.ts
+++ b/tests/test_helpers/commands_helpers.ts
@@ -1879,16 +1879,16 @@ export function popOutChartFromCarousel(
 export function addNewChartToCarousel(
   model: Model,
   carouselId: UID,
-  definition?: Partial<ChartDefinition>
+  creationContext?: Partial<ChartCreationContext> & { type: ChartType }
 ): UID {
+  creationContext = creationContext || { type: "bar" };
+  const chartId = UuidGenerator.smallUuid();
   model.dispatch("ADD_NEW_CHART_TO_CAROUSEL", {
     figureId: carouselId,
     sheetId: model.getters.getActiveSheetId(),
+    newChartId: chartId,
+    chartDefinition: createChartDefinitionFromContext(creationContext.type, creationContext),
   });
-  const chartId = model.getters.getCarousel(carouselId).items.at(-1)!["chartId"];
-  if (definition) {
-    updateChart(model, chartId, definition);
-  }
   return chartId;
 }
 


### PR DESCRIPTION
## Description:

### [IMP] carousel: pick chart type when adding chart to carousel

The button "Add chart" in the carousel panel would always create a
bar chart. It'd be better to allow the user which chart they want to
create, and to directly open the chart side panel.

### [REF] chart: extract chart type picker popover

This commit extracts the chart type picker popover to a separate
component so it can be re-used separately from the `select`.

Task: [6263706](https://www.odoo.com/odoo/2328/tasks/6263706)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo