### PR TITLE
[FIX] side_panel: autocomplete dropdown transparency issue on scroll

### DIFF
--- a/src/components/side_panel/pivot/pivot_layout_configurator/add_dimension_button/add_dimension_button.xml
+++ b/src/components/side_panel/pivot/pivot_layout_configurator/add_dimension_button/add_dimension_button.xml
@@ -2,7 +2,8 @@
   <t t-name="o-spreadsheet-AddDimensionButton">
     <button class="add-dimension o-button" t-on-click="togglePopover" t-ref="button">Add</button>
     <Popover t-if="popover.isOpen" t-props="popoverProps" class="'o-pivot-add-dimension-popover'">
-      <div class="p-2 border-bottom d-flex sticky-top align-items-baseline pivot-dimension-search">
+      <div
+        class="p-2 border-bottom d-flex sticky-top align-items-baseline pivot-dimension-search bg-white">
         <i class="pe-1 pivot-dimension-search-field-icon text-muted">
           <t t-call="o-spreadsheet-Icon.SEARCH"/>
         </i>


### PR DESCRIPTION
## Description:

Current behavior before PR:
- In commit 2f73242, the `bg-white` class was removed from the autocomplete search bar.
- This made the search bar `transparent`, causing dropdown items to appear behind it and break the UI.

Desired behavior after PR is merged:
- Added `bg-white` background for the search bar in addDomainSelector.
- Ensured consistent styling and prevented items from showing behind the search bar.

Task: [6254807](https://www.odoo.com/odoo/2328/tasks/6254807)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo