### PR TITLE
[IMP] carousel: open chart panel on chart double click

### DIFF
--- a/src/components/figures/figure_carousel/figure_carousel.ts
+++ b/src/components/figures/figure_carousel/figure_carousel.ts
@@ -85,6 +85,15 @@ export class CarouselFigure extends Component<Props, SpreadsheetChildEnv> {
     this.env.openSidePanel("CarouselPanel", { figureId: this.props.figureUI.id });
   }
 
+  onCarouselChartDoubleClick() {
+    if (this.selectedCarouselItem?.type !== "chart") {
+      return;
+    }
+    const chartId = this.selectedCarouselItem.chartId;
+    this.env.model.dispatch("SELECT_FIGURE", { figureId: this.props.figureUI.id });
+    this.env.openSidePanel("ChartPanel", { chartId });
+  }
+
   isItemSelected(item: CarouselItem): boolean {
     const selectedItem = this.selectedCarouselItem;
     return deepEquals(selectedItem, item);

--- a/src/components/figures/figure_carousel/figure_carousel.xml
+++ b/src/components/figures/figure_carousel/figure_carousel.xml
@@ -70,7 +70,9 @@
       <div
         t-elif="selectedItem.type === 'chart'"
         class="o-carousel-content w-100 flex-fill position-relative">
-        <div class="o-chart-container w-100 h-100">
+        <div
+          class="o-chart-container w-100 h-100"
+          t-on-dblclick.stop="this.onCarouselChartDoubleClick">
           <t
             t-component="this.chartComponent"
             chartId="selectedItem.chartId"

--- a/tests/figures/carousel/carousel_figure_component.test.ts
+++ b/tests/figures/carousel/carousel_figure_component.test.ts
@@ -14,7 +14,13 @@ import {
   selectFigure,
   updateCarousel,
 } from "../../test_helpers/commands_helpers";
-import { click, clickAndDrag, getElStyle, triggerMouseEvent } from "../../test_helpers/dom_helper";
+import {
+  click,
+  clickAndDrag,
+  doubleClick,
+  getElStyle,
+  triggerMouseEvent,
+} from "../../test_helpers/dom_helper";
 import { makeTestEnv, mockChart, mountSpreadsheet, nextTick } from "../../test_helpers/helpers";
 import { extendMockGetBoundingClientRect } from "../../test_helpers/mock_helpers";
 
@@ -326,6 +332,20 @@ describe("Carousel figure component", () => {
 
     await click(fixture, ".o-figure .o-carousel-menu-button");
     expect(".o-popover .o-menu").toHaveCount(1);
+  });
+
+  test("Double Click opens either the carousel or the chart side panel", async () => {
+    createCarousel(model, { items: [] }, "carouselId");
+    const chartId = addNewChartToCarousel(model, "carouselId", { type: "radar" });
+
+    const { fixture, env } = await mountSpreadsheet({ model }, {});
+    const openSidePanel = jest.spyOn(env, "openSidePanel");
+
+    await doubleClick(fixture, ".o-chart-container");
+    expect(openSidePanel).toHaveBeenLastCalledWith("ChartPanel", { chartId });
+
+    await doubleClick(fixture, ".o-carousel-header");
+    expect(openSidePanel).toHaveBeenLastCalledWith("CarouselPanel", { figureId: "carouselId" });
   });
 
   describe("Carousel menu items", () => {


### PR DESCRIPTION
## Description

When double clicking in a chart that is inside a carousel, we should open the chart side panel. Double clicking on the carousel header should open the carousel side panel.

Task: [6264291](https://www.odoo.com/odoo/2328/tasks/6264291)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo