### PR TITLE
[FIX] ChartDataSeries: ensure utdate props to children

### DIFF
--- a/src/components/side_panel/chart/building_blocks/data_series/data_series.ts
+++ b/src/components/side_panel/chart/building_blocks/data_series/data_series.ts
@@ -5,7 +5,9 @@ import { SpreadsheetChildEnv } from "../../../../../types/spreadsheet_env";
 import { SelectionInput } from "../../../../selection_input/selection_input";
 import { Section } from "../../../components/section/section";
 
+import { onWillUpdateProps } from "@odoo/owl";
 import { Component } from "../../../../../owl3_compatibility_layer";
+
 interface Props {
   ranges: { dataRange: string; dataSetId: UID }[];
   dataSetStyles?: DataSetStyle;
@@ -41,6 +43,11 @@ export class ChartDataSeries extends Component<Props, SpreadsheetChildEnv> {
 
   get ranges(): string[] {
     return this.props.ranges.map((r) => r.dataRange);
+  }
+  setup() {
+    // TODO: remove this hook.
+    // Required to ensure that it's part of the same update cycle as its child component so it can pass the correct version of the props.
+    onWillUpdateProps(async () => {});
   }
 
   get disabledRanges(): boolean[] {

--- a/tests/figures/chart/charts_component.test.ts
+++ b/tests/figures/chart/charts_component.test.ts
@@ -46,6 +46,7 @@ import {
   deleteFigure,
   deleteSheet,
   paste,
+  resizeAnchorZone,
   selectCell,
   selectFigure,
   setCellContent,
@@ -3363,4 +3364,43 @@ describe("Change chart type", () => {
     await changeChartType("bar");
     expect(model.getters.getChartDefinition(chartId)).toMatchObject({ type: "bar" });
   });
+});
+
+test("Can update the chart data source from the side panel", async () => {
+  model = new Model();
+  createChart(model, { type: "bar" }, chartId);
+  await mountSpreadsheet();
+  selectFigure(model, model.getters.getFigureIdFromChartId(chartId)!);
+  env.openSidePanel("ChartPanel");
+  await nextTick();
+  const dataSeries = fixture.querySelectorAll(".o-chart .o-data-series")[0] as HTMLInputElement;
+  const dataSeriesValues = dataSeries.querySelector("input")!;
+  await setInputValueAndTrigger(dataSeriesValues, "B1:B5");
+  await nextTick();
+  await simulateClick(".o-data-series .o-selection-ok");
+  const definition = model.getters.getChartDefinition(chartId) as BarChartDefinition<string>;
+
+  expect(definition).toMatchObject(
+    toChartDataSource({
+      dataSets: [{ dataRange: "B1:B5", dataSetId: expect.any(String) }],
+      dataSetsHaveTitle: false,
+    })
+  );
+  await click(dataSeriesValues);
+
+  selectCell(model, "A1");
+  // required to mimic a realisticuser interaction
+  await nextTick();
+  resizeAnchorZone(model, "down", 1);
+  await nextTick();
+
+  await simulateClick(".o-data-series .o-selection-ok");
+  const definition2 = model.getters.getChartDefinition(chartId) as BarChartDefinition<string>;
+
+  expect(definition2).toMatchObject(
+    toChartDataSource({
+      dataSets: [{ dataRange: "A1:A2", dataSetId: expect.any(String) }],
+      dataSetsHaveTitle: false,
+    })
+  );
 });


### PR DESCRIPTION
Task: 6245615

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [6245615](https://www.odoo.com/odoo/2328/tasks/6245615)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo