### PR TITLE
[IMP] Model: plugins only see the grid selection

### DIFF
--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -910,4 +910,12 @@ export class Grid extends Component<SpreadsheetChildEnv> {
   get displaySelectionHandler() {
     return this.env.isMobile() && this.composerFocusStore.activeComposer.editionMode === "inactive";
   }
+
+  get displayTableResizer() {
+    return (
+      this.env.model.getters.isGridSelectionActive() &&
+      !this.env.model.getters.isReadonly() &&
+      !this.env.model.getters.isSheetLocked(this.env.model.getters.getActiveSheetId())
+    );
+  }
 }

--- a/src/components/grid/grid.xml
+++ b/src/components/grid/grid.xml
@@ -57,7 +57,7 @@
         onClose="() => this.closeMenu()"
       />
       <t
-        t-if="!this.env.model.getters.isReadonly()"
+        t-if="this.displayTableResizer"
         t-foreach="this.staticTables"
         t-as="table"
         t-key="table.id">

--- a/src/components/tables/table_resizer/table_resizer.ts
+++ b/src/components/tables/table_resizer/table_resizer.ts
@@ -31,11 +31,6 @@ export class TableResizer extends Component<SpreadsheetChildEnv> {
 
   get containerStyle(): string {
     const tableZone = this.props.table.range.zone;
-    const sheetId = this.props.table.range.sheetId;
-
-    if (this.env.model.getters.isReadonly() || this.env.model.getters.isSheetLocked(sheetId)) {
-      return cssPropertiesToCss({ display: "none" });
-    }
     const bottomRight = { ...tableZone, left: tableZone.right, top: tableZone.bottom };
     const rect = this.env.model.getters.getVisibleRect(bottomRight);
     if (rect.height === 0 || rect.width === 0) {

--- a/src/model.ts
+++ b/src/model.ts
@@ -24,7 +24,10 @@ import {
   statefulUIPluginRegistry,
 } from "./plugins/plugin_registries";
 import { UIPlugin, UIPluginConfig, UIPluginConstructor } from "./plugins/ui_plugin";
-import { SelectionStreamProcessorImpl } from "./selection_stream/selection_stream_processor";
+import {
+  selectionModifiers,
+  SelectionStreamProcessorImpl,
+} from "./selection_stream/selection_stream_processor";
 import { StateObserver } from "./state_observer";
 import { _t, setDefaultTranslationMethod } from "./translation";
 import { StateUpdateMessage } from "./types/collaborative/transport_service";
@@ -121,6 +124,7 @@ export class Model extends EventBus<any> implements CommandDispatcher {
   private state: StateObserver;
 
   readonly selection: SelectionStreamProcessor;
+  readonly pluginSelection: SelectionStreamProcessor;
 
   /**
    * Getters are the main way the rest of the UI read data from the model. Also,
@@ -187,6 +191,21 @@ export class Model extends EventBus<any> implements CommandDispatcher {
 
     // Initiate stream processor
     this.selection = new SelectionStreamProcessorImpl(this.getters);
+    this.pluginSelection = new Proxy(this.selection, {
+      observable: false,
+      get: (target, prop, receiver) => {
+        const value = Reflect.get(target, prop, receiver);
+        if (typeof value !== "function" || !selectionModifiers.has(prop)) {
+          return value;
+        }
+        return (...args: unknown[]) => {
+          if (!this.getters.isGridSelectionActive()) {
+            this.selection.getBackToDefault();
+          }
+          return (value as Function).apply(target, args);
+        };
+      },
+    } as ProxyHandler<SelectionStreamProcessorImpl>);
 
     this.coreHandlers.push(this.range);
     this.handlers.push(this.range);
@@ -433,7 +452,7 @@ export class Model extends EventBus<any> implements CommandDispatcher {
       stateObserver: this.state,
       dispatch: this.dispatch,
       canDispatch: this.canDispatch,
-      selection: this.selection,
+      selection: this.pluginSelection,
       moveClient: this.session.move.bind(this.session),
       custom: this.config.custom,
       uiActions: this.config,

--- a/src/selection_stream/selection_stream_processor.ts
+++ b/src/selection_stream/selection_stream_processor.ts
@@ -14,7 +14,7 @@ import {
   SelectionStep,
   Zone,
 } from "../types/misc";
-import { SelectionStreamProcessor } from "../types/selection_stream_processor";
+import { SelectionProcessor, SelectionStreamProcessor } from "../types/selection_stream_processor";
 import { EventStream, StreamCallbacks } from "./event_stream";
 
 type Delta = [number, number];
@@ -686,3 +686,21 @@ export class SelectionStreamProcessorImpl implements SelectionStreamProcessor {
     );
   }
 }
+
+export const selectionModifiers: Set<string | symbol> = new Set<
+  Exclude<keyof SelectionProcessor, "isListening">
+>([
+  "selectZone",
+  "selectCell",
+  "moveAnchorCell",
+  "updateAnchorCell",
+  "setAnchorCorner",
+  "addCellToSelection",
+  "resizeAnchorZone",
+  "selectColumn",
+  "selectRow",
+  "selectAll",
+  "loopSelection",
+  "selectTableAroundSelection",
+  "commitSelection",
+]);

--- a/src/types/selection_stream_processor.ts
+++ b/src/types/selection_stream_processor.ts
@@ -17,7 +17,7 @@ type StatefulStream<Event, State> = {
 /**
  * Allows to select cells in the grid and update the selection
  */
-interface SelectionProcessor {
+export interface SelectionProcessor {
   selectZone(anchor: AnchorZone, options?: SelectionEventOptions): DispatchResult;
 
   selectCell(col: number, row: number, options?: SelectionEventOptions): DispatchResult;

--- a/tests/model/model.test.ts
+++ b/tests/model/model.test.ts
@@ -420,4 +420,41 @@ describe("Model", () => {
       type: "SNAPSHOT",
     });
   });
+
+  test("Selection Processor falls back to gridSelection when invoked from the plugins", () => {
+    class MyUIPlugin extends UIPlugin {
+      handle(cmd: Command) {
+        // @ts-ignore
+        if (cmd.type === "CAPTURE") {
+          this.selection.capture(
+            this,
+            {
+              cell: { col: 0, row: 0 },
+              zone: toZone("A1"),
+            },
+            {
+              handleEvent: () => {
+                throw new Error("Should not be called");
+              },
+            }
+          );
+        }
+        // @ts-ignore
+        else if (cmd.type === "MOVE") {
+          this.selection.selectCell(0, 1);
+        }
+      }
+    }
+    addTestPlugin(featurePluginRegistry, MyUIPlugin);
+    const model = new Model();
+    expect(model.getters.isGridSelectionActive()).toBe(true);
+    expect(model.getters.getSelectedZone()).toEqual(toZone("A1"));
+    // @ts-ignore
+    model.dispatch("CAPTURE");
+    expect(model.getters.isGridSelectionActive()).toBe(false);
+    // @ts-ignore
+    model.dispatch("MOVE");
+    expect(model.getters.isGridSelectionActive()).toBe(true);
+    expect(model.getters.getSelectedZone()).toEqual(toZone("A2"));
+  });
 });

--- a/tests/table/table_resizer_component.test.ts
+++ b/tests/table/table_resizer_component.test.ts
@@ -1,4 +1,5 @@
 import { Model, UID } from "../../src";
+import { CellComposerStore } from "../../src/components/composer/composer/cell_composer_store";
 import { Grid } from "../../src/components/grid/grid";
 import { DEFAULT_CELL_HEIGHT, DEFAULT_CELL_WIDTH } from "../../src/constants";
 import { toZone, zoneToXc } from "../../src/helpers/zones";
@@ -111,6 +112,16 @@ describe("Table resizer component", () => {
     await nextTick();
     expect(".o-table-resizer").toHaveCount(1);
     model.updateMode("readonly");
+    await nextTick();
+    expect(".o-table-resizer").toHaveCount(0);
+  });
+
+  test("table resizer is not loaded when the grid selection is not active", async () => {
+    createTable(model, "A1:B2");
+    await nextTick();
+    expect(".o-table-resizer").toHaveCount(1);
+    // start the edition and steal the selection from the grid
+    env.getStore(CellComposerStore).startEdition();
     await nextTick();
     expect(".o-table-resizer").toHaveCount(0);
   });


### PR DESCRIPTION
## Description:

Except from the grid selection, the other actors of the
SelectionProcessor only live in the stores, the plugins don't know about
them.
Since the plugins sometimes call the processor, it means they always
assume that they will impact the grid selection.

With this revision, every call to the selection processor coming from
the plugins will ensure that the grid selection is active.

Task: [6268168](https://www.odoo.com/odoo/2328/tasks/6268168)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo