### PR TITLE
[FIX] Pivot: runtime definition might not be loaded

### DIFF
--- a/src/plugins/ui_core_views/pivot_ui.ts
+++ b/src/plugins/ui_core_views/pivot_ui.ts
@@ -356,8 +356,8 @@ export class PivotUIPlugin extends UIPlugin {
     }
 
     for (const pivotId of this.getters.getPivotIds()) {
-      const pivot = this.getters.getPivot(pivotId);
-      for (const measure of pivot.definition.measures) {
+      const pivot = this.getters.getPivotCoreDefinition(pivotId);
+      for (const measure of pivot.measures) {
         if (measure.computedBy) {
           const { sheetId } = measure.computedBy;
           const formula = this.getters.getMeasureCompiledFormula(pivotId, measure);

--- a/src/plugins/ui_core_views/pivot_ui.ts
+++ b/src/plugins/ui_core_views/pivot_ui.ts
@@ -83,10 +83,12 @@ export class PivotUIPlugin extends UIPlugin {
         this.refreshPivot(cmd.id);
         break;
       case "ADD_PIVOT": {
+        this.unusedPivots?.push(cmd.pivotId);
         this.setupPivot(cmd.pivotId);
         break;
       }
       case "DUPLICATE_PIVOT": {
+        this.unusedPivots?.push(cmd.newPivotId);
         this.setupPivot(cmd.newPivotId);
         break;
       }
@@ -336,7 +338,7 @@ export class PivotUIPlugin extends UIPlugin {
     }
   }
 
-  _getUnusedPivots() {
+  private _getUnusedPivots() {
     if (this.unusedPivots !== undefined) {
       return this.unusedPivots;
     }

--- a/tests/pivots/pivot_plugin.test.ts
+++ b/tests/pivots/pivot_plugin.test.ts
@@ -6,7 +6,12 @@ import { EMPTY_PIVOT_CELL } from "../../src/helpers/pivot/table_spreadsheet_pivo
 import { getEvaluatedCell } from "../test_helpers";
 import { renameSheet, selectCell, setCellContent } from "../test_helpers/commands_helpers";
 import { createModelFromGrid, toCellPosition } from "../test_helpers/helpers";
-import { addPivot, createModelWithPivot, updatePivot } from "../test_helpers/pivot_helpers";
+import {
+  addPivot,
+  createModelWithPivot,
+  duplicatePivot,
+  updatePivot,
+} from "../test_helpers/pivot_helpers";
 
 describe("Pivot plugin", () => {
   test("isSpillPivotFormula", () => {
@@ -426,6 +431,15 @@ describe("Pivot plugin", () => {
 
       expect(model.getters.isPivotUnused("1")).toBe(false);
       expect(model.getters.isPivotUnused("2")).toBe(false);
+    });
+
+    test("pivots that are only added, not used, are marked as unused", () => {
+      const model = createModelWithPivot("A1:I5");
+      expect(model.getters.isPivotUnused("1")).toBe(true);
+      addPivot(model, "A1:I5", { name: "Unused Pivot" }, "2");
+      expect(model.getters.isPivotUnused("2")).toBe(true);
+      duplicatePivot(model, "1", "3");
+      expect(model.getters.isPivotUnused("3")).toBe(true);
     });
   });
 

--- a/tests/test_helpers/pivot_helpers.ts
+++ b/tests/test_helpers/pivot_helpers.ts
@@ -49,6 +49,16 @@ export function addPivot(
   return result;
 }
 
+export function duplicatePivot(model: Model, pivotId: UID, newPivotId: UID) {
+  const result = model.dispatch("DUPLICATE_PIVOT", { pivotId, newPivotId });
+  if (!result.isSuccessful) {
+    return result;
+  }
+  const instance = model.getters.getPivot(newPivotId);
+  instance?.init();
+  return result;
+}
+
 export function updatePivot(
   model: Model,
   pivotId: UID,


### PR DESCRIPTION
the fix in #8539 relies on the runtime definition of a Pivot to access its measures. Unfortunately, such definition is lazy loaded through the evaluation process so its not loaded (and will throw a loading error) if called when the pivot is not actually used.. which corresponds to the situation we try to fix in #8539.

Since the measures exist on the core definition of the pivot, we can use the core definition safely.

Note that an integration test is added in Odoo is added as well.

Task: 6267596

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo