### PR TITLE
[FIX] Figure: only focus when the selected figure changes

### DIFF
--- a/src/components/figures/figure/figure.ts
+++ b/src/components/figures/figure/figure.ts
@@ -114,22 +114,25 @@ export class FigureComponent extends Component<SpreadsheetChildEnv> {
   setup() {
     const borderWidth = figureRegistry.get(this.props.figureUI.tag).borderWidth;
     this.borderWidth = borderWidth !== undefined ? borderWidth : BORDER_WIDTH;
-    useLayoutEffect(() => {
-      const selectedFigureIds = this.env.model.getters.getSelectedFigureIds();
-      const thisFigureId = this.props.figureUI.id;
-      const el = this.figureRef();
-      if (selectedFigureIds.includes(thisFigureId)) {
-        /** Scrolling on a newly inserted figure that overflows outside the viewport
-         * will break the whole layout.
-         * NOTE: `preventScroll`does not work on mobile but then again,
-         * mobile is not really supported ATM.
-         *
-         * TODO: When implementing proper mobile, we will need to scroll the viewport
-         * correctly (and render?) before focusing the element.
-         */
-        el?.focus({ preventScroll: true });
-      }
-    });
+    useLayoutEffect(
+      () => {
+        const selectedFigureIds = this.env.model.getters.getSelectedFigureIds();
+        const thisFigureId = this.props.figureUI.id;
+        const el = this.figureRef();
+        if (selectedFigureIds.includes(thisFigureId)) {
+          /** Scrolling on a newly inserted figure that overflows outside the viewport
+           * will break the whole layout.
+           * NOTE: `preventScroll`does not work on mobile but then again,
+           * mobile is not really supported ATM.
+           *
+           * TODO: When implementing proper mobile, we will need to scroll the viewport
+           * correctly (and render?) before focusing the element.
+           */
+          el?.focus({ preventScroll: true });
+        }
+      },
+      () => [this.env.model.getters.getSelectedFigureIds(), this.props.figureUI.id]
+    );
   }
 
   clickAnchor(dirX: ResizeDirection, dirY: ResizeDirection, ev: MouseEvent) {

--- a/tests/figures/chart/charts_component.test.ts
+++ b/tests/figures/chart/charts_component.test.ts
@@ -61,6 +61,7 @@ import { TEST_CHART_DATA } from "../../test_helpers/constants";
 import {
   click,
   clickAndDrag,
+  clickCell,
   doubleClick,
   editSelectComponent,
   focusAndKeyDown,
@@ -3400,6 +3401,40 @@ test("Can update the chart data source from the side panel", async () => {
   expect(definition2).toMatchObject(
     toChartDataSource({
       dataSets: [{ dataRange: "A1:A2", dataSetId: expect.any(String) }],
+      dataSetsHaveTitle: false,
+    })
+  );
+});
+
+test("Can edit a chart range", async () => {
+  model = new Model();
+  createChart(
+    model,
+    {
+      type: "bar",
+      ...toChartDataSource({
+        dataSets: [{ dataRange: "A1:A3" }],
+        dataSetsHaveTitle: false,
+      }),
+    },
+    chartId
+  );
+  await mountSpreadsheet();
+  selectFigure(model, model.getters.getFigureIdFromChartId(chartId)!);
+  await simulateClick(".o-figure");
+  env.openSidePanel("ChartPanel");
+  await nextTick();
+  expect(document.activeElement).toBe(fixture.querySelector(".o-figure")!);
+  await simulateClick(".o-selection-input input.o-input");
+  await clickCell(model, "B1");
+  await keyDown({ key: "ArrowDown" });
+
+  await simulateClick(".o-data-series .o-selection-ok");
+  const definition = model.getters.getChartDefinition(chartId) as BarChartDefinition<string>;
+
+  expect(definition).toMatchObject(
+    toChartDataSource({
+      dataSets: [{ dataRange: "B2", dataSetId: expect.any(String) }],
       dataSetsHaveTitle: false,
     })
   );

--- a/tests/figures/figure_component.test.ts
+++ b/tests/figures/figure_component.test.ts
@@ -1222,6 +1222,19 @@ describe("figures", () => {
     expect(document.activeElement).toBe(panelInput);
   });
 
+  test("Can navigate the figure menu with the keyboard", async () => {
+    createChart(model, { type: "bar" });
+    await nextTick();
+    await simulateClick(".o-figure-menu-item");
+    // NOTE: need to "force" a rendering such that the menu takes the focus back
+    // See task https://www.odoo.com/odoo/2328/tasks/6272762
+    await keyDown({ key: "ArrowDown" });
+    expect(document.activeElement).toHaveClass("o-menu-wrapper");
+    await keyDown({ key: "ArrowDown" });
+    expect(document.activeElement).toHaveClass("o-menu-item");
+    expect(document.activeElement).toHaveAttribute("data-name", "edit");
+  });
+
   describe("Figure drag & drop snap", () => {
     describe("Move figure", () => {
       test.each([


### PR DESCRIPTION
The condition of the useEffect to re-focus a figure were removed by mistake. This meant that every render, if there was a selected figure, its DOM element would be automatically focus.

There was a race condition with the component SelectionInput that sometimes let the latter have the focus, sometimes not, which lead to the weird behaviour described in the task:

- Insert a scorecard
- Add a key value
- Edit the key value and select it
- Hit backspace twice

=> The first press deletes the value, the second deletes the chart

Task: 6267606

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo