### PR TITLE
[REF] components: introduce owl plugin for model

### DIFF
--- a/src/actions/action.ts
+++ b/src/actions/action.ts
@@ -1,4 +1,5 @@
 import { isMacOS } from "../components/helpers/dom_helpers";
+import { Model } from "../model";
 import { Color } from "../types/misc";
 import { SpreadsheetChildEnv } from "../types/spreadsheet_env";
 
@@ -13,8 +14,8 @@ export interface ActionSpec {
   /**
    * String or a function to compute the name
    */
-  name: string | ((env: SpreadsheetChildEnv) => string);
-  description?: string | ((env: SpreadsheetChildEnv) => string);
+  name: string | ((model: Model, env: SpreadsheetChildEnv) => string);
+  description?: string | ((model: Model, env: SpreadsheetChildEnv) => string);
   shortcut?: string;
   /**
    * which represents its position inside the
@@ -28,24 +29,24 @@ export interface ActionSpec {
   /**
    * Can be defined to compute the visibility of the item
    */
-  isVisible?: (env: SpreadsheetChildEnv) => boolean;
+  isVisible?: (model: Model, env: SpreadsheetChildEnv) => boolean;
   /**
    * Can be defined to compute if the user can click on the action
    */
-  isEnabled?: (env: SpreadsheetChildEnv) => boolean;
+  isEnabled?: (model: Model, env: SpreadsheetChildEnv) => boolean;
   /**
    * Can be defined to compute if the action is active
    */
-  isActive?: (env: SpreadsheetChildEnv) => boolean;
+  isActive?: (model: Model, env: SpreadsheetChildEnv) => boolean;
   /**
    * Can be defined to display an icon
    */
-  icon?: string | ((env: SpreadsheetChildEnv) => string);
+  icon?: string | ((model: Model, env: SpreadsheetChildEnv) => string);
   iconColor?: Color;
   /**
    * Can be defined to display another icon on the right of the item.
    */
-  secondaryIcon?: string | ((env: SpreadsheetChildEnv) => string);
+  secondaryIcon?: string | ((model: Model, env: SpreadsheetChildEnv) => string);
   /**
    * is the action allowed when running spreadsheet in readonly mode
    */
@@ -59,7 +60,7 @@ export interface ActionSpec {
    * Execute the action. The action can return a result.
    * The result will be carried by a `menu-clicked` event to the menu parent component.
    */
-  execute?: (env: SpreadsheetChildEnv, isMiddleClick?: boolean) => unknown;
+  execute?: (model: Model, env: SpreadsheetChildEnv, isMiddleClick?: boolean) => unknown;
   /**
    * subitems associated to this item
    * NB: an action without an execute function or children is not displayed !
@@ -71,30 +72,30 @@ export interface ActionSpec {
    */
   separator?: boolean;
   textColor?: Color;
-  onStartHover?: (env: SpreadsheetChildEnv) => void;
-  onStopHover?: (env: SpreadsheetChildEnv) => void;
+  onStartHover?: (model: Model, env: SpreadsheetChildEnv) => void;
+  onStopHover?: (model: Model, env: SpreadsheetChildEnv) => void;
 }
 
 export interface Action {
-  name: (env: SpreadsheetChildEnv) => string;
-  description: (env: SpreadsheetChildEnv) => string;
+  name: (model: Model, env: SpreadsheetChildEnv) => string;
+  description: (model: Model, env: SpreadsheetChildEnv) => string;
   shortcut: string;
   sequence: number;
   id: string;
-  isVisible: (env: SpreadsheetChildEnv) => boolean;
-  isEnabled: (env: SpreadsheetChildEnv) => boolean;
-  isActive?: (env: SpreadsheetChildEnv) => boolean;
-  icon: (env: SpreadsheetChildEnv) => string;
+  isVisible: (model: Model, env: SpreadsheetChildEnv) => boolean;
+  isEnabled: (model: Model, env: SpreadsheetChildEnv) => boolean;
+  isActive?: (model: Model, env: SpreadsheetChildEnv) => boolean;
+  icon: (model: Model, env: SpreadsheetChildEnv) => string;
   iconColor?: Color;
-  secondaryIcon: (env: SpreadsheetChildEnv) => string;
+  secondaryIcon: (model: Model, env: SpreadsheetChildEnv) => string;
   isReadonlyAllowed: boolean;
   isEnabledOnLockedSheet: boolean;
-  execute?: (env: SpreadsheetChildEnv, isMiddleClick?: boolean) => unknown;
-  children: (env: SpreadsheetChildEnv) => Action[];
+  execute?: (model: Model, env: SpreadsheetChildEnv, isMiddleClick?: boolean) => unknown;
+  children: (model: Model, env: SpreadsheetChildEnv) => Action[];
   separator: boolean;
   textColor?: Color;
-  onStartHover?: (env: SpreadsheetChildEnv) => void;
-  onStopHover?: (env: SpreadsheetChildEnv) => void;
+  onStartHover?: (model: Model, env: SpreadsheetChildEnv) => void;
+  onStopHover?: (model: Model, env: SpreadsheetChildEnv) => void;
 }
 
 export interface ComputedAction
@@ -105,7 +106,7 @@ export interface ComputedAction
   secondaryIcon: string;
 }
 
-export type ActionBuilder = (env: SpreadsheetChildEnv) => ActionSpec[];
+export type ActionBuilder = (model: Model, env: SpreadsheetChildEnv) => ActionSpec[];
 type ActionChildren = (ActionSpec | ActionBuilder)[];
 
 export function createActions(menuItems: ActionSpec[]): Action[] {
@@ -134,17 +135,17 @@ export function createAction(item: ActionSpec): Action {
     isEnabled: isEnabled,
     isActive: item.isActive,
     execute: item.execute
-      ? (env, isMiddleClick) => {
-          if (isEnabled(env)) {
-            return item.execute!(env, isMiddleClick);
+      ? (model, env, isMiddleClick) => {
+          if (isEnabled(model, env)) {
+            return item.execute!(model, env, isMiddleClick);
           }
           return undefined;
         }
       : undefined,
     children: children
-      ? (env) => {
+      ? (model, env) => {
           return children
-            .map((child) => (typeof child === "function" ? child(env) : child))
+            .map((child) => (typeof child === "function" ? child(model, env) : child))
             .flat()
             .map(createAction)
             .sort((a, b) => a.sequence - b.sequence);
@@ -166,13 +167,17 @@ export function createAction(item: ActionSpec): Action {
 }
 
 export function getMenuItemsAndSeparators(
+  model: Model,
   env: SpreadsheetChildEnv,
   actions: Action[]
 ): MenuItemOrSeparator[] {
   const menuItemsAndSeparators: MenuItemOrSeparator[] = [];
   for (let i = 0; i < actions.length; i++) {
     const menuItem = actions[i];
-    if (menuItem.isVisible(env) && (!isRootMenu(menuItem) || hasVisibleChildren(env, menuItem))) {
+    if (
+      menuItem.isVisible(model, env) &&
+      (!isRootMenu(menuItem) || hasVisibleChildren(model, env, menuItem))
+    ) {
       menuItemsAndSeparators.push(menuItem);
     }
     if (
@@ -196,17 +201,17 @@ export function isRootMenu(menu: Action) {
   return !menu.execute;
 }
 
-export function hasVisibleChildren(env: SpreadsheetChildEnv, menu: Action) {
-  return menu.children(env).some((child) => child.isVisible(env));
+export function hasVisibleChildren(model: Model, env: SpreadsheetChildEnv, menu: Action) {
+  return menu.children(model, env).some((child) => child.isVisible(model, env));
 }
 
-export function isMenuItemEnabled(env: SpreadsheetChildEnv, menu: Action): boolean {
-  const children = menu.children?.(env);
+export function isMenuItemEnabled(model: Model, env: SpreadsheetChildEnv, menu: Action): boolean {
+  const children = menu.children?.(model, env);
   if (children.length) {
-    return children.some((child) => isMenuItemEnabled(env, child));
+    return children.some((child) => isMenuItemEnabled(model, env, child));
   } else {
-    if (menu.isEnabled(env)) {
-      return env.model.getters.isReadonly() ? menu.isReadonlyAllowed : true;
+    if (menu.isEnabled(model, env)) {
+      return model.getters.isReadonly() ? menu.isReadonlyAllowed : true;
     }
     return false;
   }

--- a/src/actions/data_actions.ts
+++ b/src/actions/data_actions.ts
@@ -12,10 +12,10 @@ export const sortRange: ActionSpec = {
 
 export const sortAscending: ActionSpec = {
   name: _t("Ascending (A ⟶ Z)"),
-  execute: (env) => {
-    const { anchor, zones } = env.model.getters.getSelection();
-    const sheetId = env.model.getters.getActiveSheetId();
-    interactiveSortSelection(env, sheetId, anchor.cell, zones[0], "asc");
+  execute: (model, env) => {
+    const { anchor, zones } = model.getters.getSelection();
+    const sheetId = model.getters.getActiveSheetId();
+    interactiveSortSelection(model, env, sheetId, anchor.cell, zones[0], "asc");
   },
   icon: "o-spreadsheet-Icon.SORT_ASCENDING",
 };
@@ -27,28 +27,28 @@ export const dataCleanup: ActionSpec = {
 
 export const removeDuplicates: ActionSpec = {
   name: _t("Remove duplicates"),
-  execute: (env) => {
-    if (getZoneArea(env.model.getters.getSelectedZone()) === 1) {
-      env.model.selection.selectTableAroundSelection();
+  execute: (model, env) => {
+    if (getZoneArea(model.getters.getSelectedZone()) === 1) {
+      model.selection.selectTableAroundSelection();
     }
     env.openSidePanel("RemoveDuplicates", {});
   },
-  isEnabled: (env) => !env.isSmall,
+  isEnabled: (model, env) => !env.isSmall,
 };
 
 export const trimWhitespace: ActionSpec = {
   name: _t("Trim whitespace"),
-  execute: (env) => {
-    env.model.dispatch("TRIM_WHITESPACE");
+  execute: (model) => {
+    model.dispatch("TRIM_WHITESPACE");
   },
 };
 
 export const sortDescending: ActionSpec = {
   name: _t("Descending (Z ⟶ A)"),
-  execute: (env) => {
-    const { anchor, zones } = env.model.getters.getSelection();
-    const sheetId = env.model.getters.getActiveSheetId();
-    interactiveSortSelection(env, sheetId, anchor.cell, zones[0], "desc");
+  execute: (model, env) => {
+    const { anchor, zones } = model.getters.getSelection();
+    const sheetId = model.getters.getActiveSheetId();
+    interactiveSortSelection(model, env, sheetId, anchor.cell, zones[0], "desc");
   },
   icon: "o-spreadsheet-Icon.SORT_DESCENDING",
 };
@@ -65,14 +65,14 @@ export const createRemoveFilterTool: ActionSpec = {
 export const splitToColumns: ActionSpec = {
   name: _t("Split text to columns"),
   sequence: 1,
-  execute: (env) => env.openSidePanel("SplitToColumns", {}),
-  isEnabled: (env) => !env.isSmall && env.model.getters.isSingleColSelected(),
+  execute: (model, env) => env.openSidePanel("SplitToColumns", {}),
+  isEnabled: (model, env) => !env.isSmall && model.getters.isSingleColSelected(),
   icon: "o-spreadsheet-Icon.SPLIT_TEXT",
 };
 
 export const columnStatistics: ActionSpec = {
   name: _t("Column statistics"),
-  execute: (env) => env.openSidePanel("ColumnStats", {}),
+  execute: (model, env) => env.openSidePanel("ColumnStats", {}),
   icon: "o-spreadsheet-Icon.COLUMN_STATS",
 };
 
@@ -82,8 +82,8 @@ export const reinsertDynamicPivotMenu: ActionSpec = {
   sequence: 60,
   icon: "o-spreadsheet-Icon.INSERT_PIVOT",
   children: [ACTIONS.REINSERT_DYNAMIC_PIVOT_CHILDREN],
-  isVisible: (env) =>
-    env.model.getters.getPivotIds().some((id) => env.model.getters.getPivot(id).isValid()),
+  isVisible: (model) =>
+    model.getters.getPivotIds().some((id) => model.getters.getPivot(id).isValid()),
 };
 
 export const reinsertStaticPivotMenu: ActionSpec = {
@@ -92,6 +92,6 @@ export const reinsertStaticPivotMenu: ActionSpec = {
   sequence: 70,
   icon: "o-spreadsheet-Icon.INSERT_PIVOT",
   children: [ACTIONS.REINSERT_STATIC_PIVOT_CHILDREN],
-  isVisible: (env) =>
-    env.model.getters.getPivotIds().some((id) => env.model.getters.getPivot(id).isValid()),
+  isVisible: (model) =>
+    model.getters.getPivotIds().some((id) => model.getters.getPivot(id).isValid()),
 };

--- a/src/actions/edit_actions.ts
+++ b/src/actions/edit_actions.ts
@@ -2,6 +2,7 @@ import { interactiveCut } from "../helpers/ui/cut_interactive";
 import { interactiveAddMerge } from "../helpers/ui/merge_interactive";
 import { handlePasteResult } from "../helpers/ui/paste_interactive";
 import { doesAnyZoneCrossFrozenPane, getZoneArea, hasOverlappingZones } from "../helpers/zones";
+import { Model } from "../model";
 import { _t } from "../translation";
 import { SpreadsheetChildEnv } from "../types/spreadsheet_env";
 import { ActionSpec } from "./action";
@@ -10,8 +11,8 @@ import * as ACTIONS from "./menu_items_actions";
 export const undo: ActionSpec = {
   name: _t("Undo"),
   shortcut: "Ctrl+Z",
-  execute: (env) => env.model.dispatch("REQUEST_UNDO"),
-  isEnabled: (env) => env.model.getters.canUndo(),
+  execute: (model) => model.dispatch("REQUEST_UNDO"),
+  isEnabled: (model) => model.getters.canUndo(),
   isEnabledOnLockedSheet: true,
   icon: "o-spreadsheet-Icon.UNDO",
 };
@@ -19,8 +20,8 @@ export const undo: ActionSpec = {
 export const redo: ActionSpec = {
   name: _t("Redo"),
   shortcut: "Ctrl+Y",
-  execute: (env) => env.model.dispatch("REQUEST_REDO"),
-  isEnabled: (env) => env.model.getters.canRedo(),
+  execute: (model) => model.dispatch("REQUEST_REDO"),
+  isEnabled: (model) => model.getters.canRedo(),
   isEnabledOnLockedSheet: true,
   icon: "o-spreadsheet-Icon.REDO",
 };
@@ -29,9 +30,9 @@ export const copy: ActionSpec = {
   name: _t("Copy"),
   shortcut: "Ctrl+C",
   isReadonlyAllowed: true,
-  execute: async (env) => {
-    env.model.dispatch("COPY");
-    await env.clipboard.write(await env.model.getters.getClipboardTextAndImageContent());
+  execute: async (model, env) => {
+    model.dispatch("COPY");
+    await env.clipboard.write(await model.getters.getClipboardTextAndImageContent());
   },
   isEnabledOnLockedSheet: true,
   icon: "o-spreadsheet-Icon.CLIPBOARD",
@@ -40,9 +41,9 @@ export const copy: ActionSpec = {
 export const cut: ActionSpec = {
   name: _t("Cut"),
   shortcut: "Ctrl+X",
-  execute: async (env) => {
-    interactiveCut(env);
-    await env.clipboard.write(await env.model.getters.getClipboardTextAndImageContent());
+  execute: async (model, env) => {
+    interactiveCut(model, env);
+    await env.clipboard.write(await model.getters.getClipboardTextAndImageContent());
   },
   icon: "o-spreadsheet-Icon.CUT",
 };
@@ -56,8 +57,8 @@ export const paste: ActionSpec = {
 
 export const pasteSpecial: ActionSpec = {
   name: _t("Paste special"),
-  isVisible: (env): boolean => {
-    return !env.model.getters.isCutOperation();
+  isVisible: (model): boolean => {
+    return !model.getters.isCutOperation();
   },
   icon: "o-spreadsheet-Icon.PASTE",
 };
@@ -78,26 +79,26 @@ export const findAndReplace: ActionSpec = {
   shortcut: "Ctrl+H",
   isReadonlyAllowed: true,
   isEnabledOnLockedSheet: true,
-  execute: (env) => {
+  execute: (model, env) => {
     env.openSidePanel("FindAndReplace", {});
   },
-  isEnabled: (env) => !env.isSmall,
+  isEnabled: (model, env) => !env.isSmall,
   icon: "o-spreadsheet-Icon.SEARCH",
 };
 
 export const deleteValues: ActionSpec = {
   name: _t("Delete values"),
-  execute: (env) =>
-    env.model.dispatch("DELETE_UNFILTERED_CONTENT", {
-      sheetId: env.model.getters.getActiveSheetId(),
-      target: env.model.getters.getSelectedZones(),
+  execute: (model, env) =>
+    model.dispatch("DELETE_UNFILTERED_CONTENT", {
+      sheetId: model.getters.getActiveSheetId(),
+      target: model.getters.getSelectedZones(),
     }),
 };
 
 export const deleteRows: ActionSpec = {
   name: ACTIONS.REMOVE_ROWS_NAME,
   execute: ACTIONS.REMOVE_ROWS_ACTION,
-  isVisible: (env: SpreadsheetChildEnv) => ACTIONS.CAN_REMOVE_COLUMNS_ROWS("ROW", env),
+  isVisible: (model) => ACTIONS.CAN_REMOVE_COLUMNS_ROWS(model, "ROW"),
 };
 
 export const deleteRow: ActionSpec = {
@@ -113,7 +114,7 @@ export const clearRows: ActionSpec = {
 export const deleteCols: ActionSpec = {
   name: ACTIONS.REMOVE_COLUMNS_NAME,
   execute: ACTIONS.REMOVE_COLUMNS_ACTION,
-  isVisible: (env: SpreadsheetChildEnv) => ACTIONS.CAN_REMOVE_COLUMNS_ROWS("COL", env),
+  isVisible: (model) => ACTIONS.CAN_REMOVE_COLUMNS_ROWS(model, "COL"),
 };
 
 export const deleteCol: ActionSpec = {
@@ -133,33 +134,33 @@ export const deleteCells: ActionSpec = {
 
 export const deleteCellShiftUp: ActionSpec = {
   name: _t("Delete cell and shift up"),
-  execute: (env) => {
-    const zone = env.model.getters.getSelectedZone();
-    const result = env.model.dispatch("DELETE_CELL", { zone, shiftDimension: "ROW" });
-    handlePasteResult(env, result);
+  execute: (model, env) => {
+    const zone = model.getters.getSelectedZone();
+    const result = model.dispatch("DELETE_CELL", { zone, shiftDimension: "ROW" });
+    handlePasteResult(model, env, result);
   },
 };
 
 export const deleteCellShiftLeft: ActionSpec = {
   name: _t("Delete cell and shift left"),
-  execute: (env) => {
-    const zone = env.model.getters.getSelectedZone();
-    const result = env.model.dispatch("DELETE_CELL", { zone, shiftDimension: "COL" });
-    handlePasteResult(env, result);
+  execute: (model, env) => {
+    const zone = model.getters.getSelectedZone();
+    const result = model.dispatch("DELETE_CELL", { zone, shiftDimension: "COL" });
+    handlePasteResult(model, env, result);
   },
 };
 
 export const mergeCells: ActionSpec = {
   name: _t("Merge cells"),
-  isEnabled: (env) => !cannotMerge(env),
-  isActive: (env) => hasMergeInAnySelectedZone(env),
-  execute: (env) => toggleMerge(env),
+  isEnabled: (model) => !cannotMerge(model),
+  isActive: (model) => hasMergeInAnySelectedZone(model),
+  execute: (model, env) => toggleMerge(model, env),
   icon: "o-spreadsheet-Icon.MERGE_CELL",
 };
 
 export const editTable: ActionSpec = {
   name: () => _t("Edit table"),
-  execute: (env) => env.openSidePanel("TableSidePanel", {}),
+  execute: (model, env) => env.openSidePanel("TableSidePanel", {}),
   icon: "o-spreadsheet-Icon.EDIT_TABLE",
 };
 
@@ -169,10 +170,10 @@ export const deleteTable: ActionSpec = {
   icon: "o-spreadsheet-Icon.DELETE_TABLE",
 };
 
-function cannotMerge(env: SpreadsheetChildEnv): boolean {
-  const zones = env.model.getters.getSelectedZones();
-  const { sheetId } = env.model.getters.getActivePosition();
-  const { xSplit, ySplit } = env.model.getters.getPaneDivisions(sheetId);
+function cannotMerge(model: Model): boolean {
+  const zones = model.getters.getSelectedZones();
+  const { sheetId } = model.getters.getActivePosition();
+  const { xSplit, ySplit } = model.getters.getPaneDivisions(sheetId);
   return (
     zones.every((zone) => getZoneArea(zone) === 1) ||
     doesAnyZoneCrossFrozenPane(zones, xSplit, ySplit) ||
@@ -180,31 +181,29 @@ function cannotMerge(env: SpreadsheetChildEnv): boolean {
   );
 }
 
-function hasMergeInAnySelectedZone(env: SpreadsheetChildEnv): boolean {
-  if (cannotMerge(env)) {
+function hasMergeInAnySelectedZone(model: Model): boolean {
+  if (cannotMerge(model)) {
     return false;
   }
 
-  const sheetId = env.model.getters.getActiveSheetId();
-  const zones = env.model.getters.getSelectedZones();
+  const sheetId = model.getters.getActiveSheetId();
+  const zones = model.getters.getSelectedZones();
   return zones.some((zone) => {
-    return env.model.getters.getMergesInZone(sheetId, zone).length > 0;
+    return model.getters.getMergesInZone(sheetId, zone).length > 0;
   });
 }
 
-function toggleMerge(env: SpreadsheetChildEnv) {
-  if (cannotMerge(env)) {
+function toggleMerge(model: Model, env: SpreadsheetChildEnv) {
+  if (cannotMerge(model)) {
     return;
   }
 
-  const target = env.model.getters.getSelectedZones();
-  const sheetId = env.model.getters.getActiveSheetId();
-  if (hasMergeInAnySelectedZone(env)) {
-    const mergesToRemove = target.flatMap((zone) =>
-      env.model.getters.getMergesInZone(sheetId, zone)
-    );
-    env.model.dispatch("REMOVE_MERGE", { sheetId, target: mergesToRemove });
+  const target = model.getters.getSelectedZones();
+  const sheetId = model.getters.getActiveSheetId();
+  if (hasMergeInAnySelectedZone(model)) {
+    const mergesToRemove = target.flatMap((zone) => model.getters.getMergesInZone(sheetId, zone));
+    model.dispatch("REMOVE_MERGE", { sheetId, target: mergesToRemove });
   } else {
-    interactiveAddMerge(env, sheetId, target);
+    interactiveAddMerge(model, env, sheetId, target);
   }
 }

--- a/src/actions/figure_menu_actions.ts
+++ b/src/actions/figure_menu_actions.ts
@@ -1,64 +1,63 @@
-import { UID } from "..";
+import { Model, UID } from "..";
 import { downloadFile } from "../components/helpers/dom_helpers";
 import { chartToImageFile, chartToImageUrl } from "../helpers/figures/charts/chart_ui_common";
 import { getMaxFigureSize } from "../helpers/figures/figure/figure";
 import { deepEquals } from "../helpers/misc";
 import { _t } from "../translation";
-import { SpreadsheetChildEnv } from "../types/spreadsheet_env";
 import { Action, ActionSpec, createActions } from "./action";
 
-export function getChartMenuActions(figureId: UID, env: SpreadsheetChildEnv): Action[] {
-  const chartId = env.model.getters.getChartIdFromFigureId(figureId);
+export function getChartMenuActions(figureId: UID, model: Model): Action[] {
+  const chartId = model.getters.getChartIdFromFigureId(figureId);
   if (!chartId) {
     return [];
   }
   const menuItemSpecs: ActionSpec[] = [
-    getMergeCarouselMenuItem(figureId, env),
+    getMergeCarouselMenuItem(figureId),
     {
       id: "edit",
       name: _t("Edit"),
-      execute: () => {
-        env.model.dispatch("SELECT_FIGURE", { figureId });
+      execute: (model, env) => {
+        model.dispatch("SELECT_FIGURE", { figureId });
         env.openSidePanel("ChartPanel");
       },
       icon: "o-spreadsheet-Icon.EDIT",
-      isEnabled: (env) => !env.isSmall,
+      isEnabled: (model, env) => !env.isSmall,
     },
-    getCopyMenuItem(figureId, env),
-    getCutMenuItem(figureId, env),
-    getCopyAsImageMenuItem(figureId, env),
-    getDownloadChartMenuItem(figureId, env),
-    getDeleteMenuItem(figureId, env),
+    getCopyMenuItem(figureId),
+    getCutMenuItem(figureId),
+    getCopyAsImageMenuItem(figureId),
+    getDownloadChartMenuItem(figureId),
+    getDeleteMenuItem(figureId),
   ];
   return createActions(menuItemSpecs).filter((action) =>
-    env.model.getters.isReadonly() ? action.isReadonlyAllowed : true
+    model.getters.isReadonly() ? action.isReadonlyAllowed : true
   );
 }
 
-export function getImageMenuActions(figureId: UID, env: SpreadsheetChildEnv): Action[] {
+export function getImageMenuActions(figureId: UID): Action[] {
   const menuItemSpecs: ActionSpec[] = [
-    getCopyMenuItem(figureId, env, _t("Image copied to clipboard")),
-    getCutMenuItem(figureId, env),
+    getCopyMenuItem(figureId, _t("Image copied to clipboard")),
+    getCutMenuItem(figureId),
     {
       id: "reset_size",
       name: _t("Reset size"),
-      execute: async () => {
-        const sheetId = env.model.getters.getActiveSheetId();
-        const figure = env.model.getters.getFigure(sheetId, figureId);
+      execute: async (model, env) => {
+        const sheetId = model.getters.getActiveSheetId();
+        const figure = model.getters.getFigure(sheetId, figureId);
         if (!figure) {
           return;
         }
-        const imagePath = env.model.getters.getImagePath(figureId);
+        const imagePath = model.getters.getImagePath(figureId);
         const size =
-          env.model.getters.getImageSize(figureId) ??
+          model.getters.getImageSize(figureId) ??
           (await env.imageProvider?.getImageOriginalSize(imagePath));
-        if (!env.model.getters.getImageSize(figureId)) {
-          const image = env.model.getters.getImage(figureId);
+        if (!model.getters.getImageSize(figureId)) {
+          const image = model.getters.getImage(figureId);
           image.size = size;
         }
         const { col, row } = figure;
-        const { height, width } = getMaxFigureSize(env.model.getters, size);
-        env.model.dispatch("UPDATE_FIGURE", {
+        const { height, width } = getMaxFigureSize(model.getters, size);
+        model.dispatch("UPDATE_FIGURE", {
           sheetId,
           figureId,
           height,
@@ -72,39 +71,39 @@ export function getImageMenuActions(figureId: UID, env: SpreadsheetChildEnv): Ac
     {
       id: "download",
       name: _t("Download"),
-      execute: async () => {
-        env.model.dispatch("SELECT_FIGURE", { figureId });
-        const path = env.model.getters.getImagePath(figureId);
+      execute: async (model) => {
+        model.dispatch("SELECT_FIGURE", { figureId });
+        const path = model.getters.getImagePath(figureId);
         downloadFile(path, "image");
       },
       icon: "o-spreadsheet-Icon.DOWNLOAD",
     },
-    getDeleteMenuItem(figureId, env),
+    getDeleteMenuItem(figureId),
   ];
   return createActions(menuItemSpecs);
 }
 
-export function getCarouselMenuActions(figureId: UID, env: SpreadsheetChildEnv): Action[] {
-  const isChartSelected = (env: SpreadsheetChildEnv) =>
-    env.model.getters.getSelectedCarouselItem(figureId)?.type === "chart";
+export function getCarouselMenuActions(figureId: UID, model: Model): Action[] {
+  const isChartSelected = (model: Model) =>
+    model.getters.getSelectedCarouselItem(figureId)?.type === "chart";
   const menuItemSpecs: ActionSpec[] = [
     {
       id: "edit_carousel",
       name: _t("Edit carousel"),
-      execute: () => {
-        env.model.dispatch("SELECT_FIGURE", { figureId });
+      execute: (model, env) => {
+        model.dispatch("SELECT_FIGURE", { figureId });
         env.openSidePanel("CarouselPanel", { figureId });
       },
       icon: "o-spreadsheet-Icon.EDIT",
-      isEnabled: (env) => !env.isSmall,
+      isEnabled: (model, env) => !env.isSmall,
     },
     {
-      ...getCopyMenuItem(figureId, env, _t("Carousel copied to clipboard")),
+      ...getCopyMenuItem(figureId, _t("Carousel copied to clipboard")),
       name: _t("Copy carousel"),
     },
-    { ...getCutMenuItem(figureId, env), name: _t("Cut carousel") },
+    { ...getCutMenuItem(figureId), name: _t("Cut carousel") },
     {
-      ...getDeleteMenuItem(figureId, env),
+      ...getDeleteMenuItem(figureId),
       name: _t("Delete carousel"),
       separator: true,
     },
@@ -112,21 +111,21 @@ export function getCarouselMenuActions(figureId: UID, env: SpreadsheetChildEnv):
     {
       id: "edit_chart",
       name: _t("Edit chart"),
-      execute: () => {
-        env.model.dispatch("SELECT_FIGURE", { figureId });
+      execute: (model, env) => {
+        model.dispatch("SELECT_FIGURE", { figureId });
         env.openSidePanel("ChartPanel", {});
       },
       icon: "o-spreadsheet-Icon.EDIT",
-      isEnabled: (env) => !env.isSmall,
+      isEnabled: (model, env) => !env.isSmall,
       isVisible: isChartSelected,
     },
     {
-      ...getCopyAsImageMenuItem(figureId, env),
+      ...getCopyAsImageMenuItem(figureId),
       isVisible: isChartSelected,
       name: _t("Copy chart as image"),
     },
     {
-      ...getDownloadChartMenuItem(figureId, env),
+      ...getDownloadChartMenuItem(figureId),
       isVisible: isChartSelected,
       name: _t("Download chart"),
     },
@@ -134,62 +133,58 @@ export function getCarouselMenuActions(figureId: UID, env: SpreadsheetChildEnv):
       id: "popout_chart",
       name: _t("Pop out chart"),
       icon: "o-spreadsheet-Icon.EXTERNAL",
-      execute: () => {
-        const selectedItem = env.model.getters.getSelectedCarouselItem(figureId);
+      execute: (model) => {
+        const selectedItem = model.getters.getSelectedCarouselItem(figureId);
         if (!selectedItem || selectedItem.type !== "chart") {
           return;
         }
-        env.model.dispatch("POPOUT_CHART_FROM_CAROUSEL", {
+        model.dispatch("POPOUT_CHART_FROM_CAROUSEL", {
           carouselId: figureId,
           chartId: selectedItem.chartId,
-          sheetId: env.model.getters.getActiveSheetId(),
+          sheetId: model.getters.getActiveSheetId(),
         });
       },
       isVisible: isChartSelected,
     },
     {
       id: "delete_carousel_item",
-      name: (env) => {
-        const item = env.model.getters.getSelectedCarouselItem(figureId);
+      name: (model) => {
+        const item = model.getters.getSelectedCarouselItem(figureId);
         return item?.type === "chart" ? _t("Delete chart") : _t("Delete data view");
       },
-      execute: () => {
-        const item = env.model.getters.getSelectedCarouselItem(figureId);
+      execute: (model) => {
+        const item = model.getters.getSelectedCarouselItem(figureId);
         if (!item) {
           return;
         }
-        const carousel = env.model.getters.getCarousel(figureId);
+        const carousel = model.getters.getCarousel(figureId);
         const items = carousel.items.filter((itm) => !deepEquals(itm, item));
-        env.model.dispatch("UPDATE_CAROUSEL", {
+        model.dispatch("UPDATE_CAROUSEL", {
           figureId,
-          sheetId: env.model.getters.getActiveSheetId(),
+          sheetId: model.getters.getActiveSheetId(),
           definition: { ...carousel, items },
         });
       },
       icon: "o-spreadsheet-Icon.TRASH",
-      isVisible: (env) => env.model.getters.getCarousel(figureId).items.length >= 1,
+      isVisible: (model) => model.getters.getCarousel(figureId).items.length >= 1,
     },
   ];
   return createActions(menuItemSpecs).filter((action) =>
-    env.model.getters.isReadonly() ? action.isReadonlyAllowed : true
+    model.getters.isReadonly() ? action.isReadonlyAllowed : true
   );
 }
 
-function getCopyMenuItem(
-  figureId: UID,
-  env: SpreadsheetChildEnv,
-  copiedNotificationMessage?: string
-): ActionSpec {
+function getCopyMenuItem(figureId: UID, copiedNotificationMessage?: string): ActionSpec {
   return {
     id: "copy",
     name: _t("Copy"),
     shortcut: "Ctrl+C",
-    execute: async () => {
-      if (!env.model.getters.getSelectedFigureIds().includes(figureId)) {
-        env.model.dispatch("SELECT_FIGURE", { figureId });
+    execute: async (model, env) => {
+      if (!model.getters.getSelectedFigureIds().includes(figureId)) {
+        model.dispatch("SELECT_FIGURE", { figureId });
       }
-      env.model.dispatch("COPY");
-      const osClipboardContent = await env.model.getters.getClipboardTextAndImageContent();
+      model.dispatch("COPY");
+      const osClipboardContent = await model.getters.getClipboardTextAndImageContent();
       await env.clipboard.write(osClipboardContent);
       if (copiedNotificationMessage) {
         env.notifyUser({ sticky: false, type: "success", text: copiedNotificationMessage });
@@ -200,36 +195,36 @@ function getCopyMenuItem(
   };
 }
 
-function getCutMenuItem(figureId: UID, env: SpreadsheetChildEnv): ActionSpec {
+function getCutMenuItem(figureId: UID): ActionSpec {
   return {
     id: "cut",
     name: _t("Cut"),
     shortcut: "Ctrl+X",
-    execute: async () => {
-      if (!env.model.getters.getSelectedFigureIds().includes(figureId)) {
-        env.model.dispatch("SELECT_FIGURE", { figureId });
+    execute: async (model, env) => {
+      if (!model.getters.getSelectedFigureIds().includes(figureId)) {
+        model.dispatch("SELECT_FIGURE", { figureId });
       }
-      env.model.dispatch("CUT");
-      await env.clipboard.write(await env.model.getters.getClipboardTextAndImageContent());
+      model.dispatch("CUT");
+      await env.clipboard.write(await model.getters.getClipboardTextAndImageContent());
     },
     icon: "o-spreadsheet-Icon.CUT",
   };
 }
 
-function getCopyAsImageMenuItem(figureId: UID, env: SpreadsheetChildEnv): ActionSpec {
+function getCopyAsImageMenuItem(figureId: UID): ActionSpec {
   return {
     id: "copy_as_image",
     name: _t("Copy as image"),
     icon: "o-spreadsheet-Icon.COPY_AS_IMAGE",
-    execute: async () => {
-      const figureSheetId = env.model.getters.getFigureSheetId(figureId)!;
-      const figure = env.model.getters.getFigure(figureSheetId, figureId)!;
-      const chartId = env.model.getters.getChartIdFromFigureId(figureId);
+    execute: async (model, env) => {
+      const figureSheetId = model.getters.getFigureSheetId(figureId)!;
+      const figure = model.getters.getFigure(figureSheetId, figureId)!;
+      const chartId = model.getters.getChartIdFromFigureId(figureId);
       if (!chartId) {
         return;
       }
-      const chartType = env.model.getters.getChartType(chartId);
-      const runtime = env.model.getters.getChartRuntime(chartId);
+      const chartType = model.getters.getChartType(chartId);
+      const runtime = model.getters.getChartRuntime(chartId);
       const blob = await chartToImageFile(runtime, figure, chartType);
       if (!blob) {
         return;
@@ -256,52 +251,52 @@ function getCopyAsImageMenuItem(figureId: UID, env: SpreadsheetChildEnv): Action
       });
       env.notifyUser({ sticky: false, type: "success", text: _t("Chart copied to clipboard") });
     },
-    isVisible: (env) => env.model.getters.getSelectedFigureIds().length <= 1,
+    isVisible: (model) => model.getters.getSelectedFigureIds().length <= 1,
     isReadonlyAllowed: true,
     isEnabledOnLockedSheet: true,
   };
 }
 
-function getDownloadChartMenuItem(figureId: UID, env: SpreadsheetChildEnv): ActionSpec {
+function getDownloadChartMenuItem(figureId: UID): ActionSpec {
   return {
     id: "download",
     name: _t("Download"),
     icon: "o-spreadsheet-Icon.DOWNLOAD",
-    execute: async () => {
-      const figureSheetId = env.model.getters.getFigureSheetId(figureId)!;
-      const figure = env.model.getters.getFigure(figureSheetId, figureId)!;
-      const chartId = env.model.getters.getChartIdFromFigureId(figureId);
+    execute: async (model, env) => {
+      const figureSheetId = model.getters.getFigureSheetId(figureId)!;
+      const figure = model.getters.getFigure(figureSheetId, figureId)!;
+      const chartId = model.getters.getChartIdFromFigureId(figureId);
       if (!chartId) {
         return;
       }
-      const chartType = env.model.getters.getChartType(chartId);
-      const runtime = env.model.getters.getChartRuntime(chartId);
+      const chartType = model.getters.getChartType(chartId);
+      const runtime = model.getters.getChartRuntime(chartId);
       const url = await chartToImageUrl(runtime, figure, chartType);
       if (!url) {
         return;
       }
       downloadFile(url, "chart");
     },
-    isVisible: (env) => env.model.getters.getSelectedFigureIds().length <= 1,
+    isVisible: (model) => model.getters.getSelectedFigureIds().length <= 1,
     isReadonlyAllowed: true,
     isEnabledOnLockedSheet: true,
   };
 }
 
-function getDeleteMenuItem(figureId: UID, env: SpreadsheetChildEnv): ActionSpec {
+function getDeleteMenuItem(figureId: UID): ActionSpec {
   return {
     id: "delete",
     name: _t("Delete"),
-    execute: () => {
-      const selectedFiguresIds = env.model.getters.getSelectedFigureIds();
+    execute: (model) => {
+      const selectedFiguresIds = model.getters.getSelectedFigureIds();
       if (selectedFiguresIds.includes(figureId)) {
-        env.model.dispatch("DELETE_FIGURES", {
-          sheetId: env.model.getters.getActiveSheetId(),
+        model.dispatch("DELETE_FIGURES", {
+          sheetId: model.getters.getActiveSheetId(),
           figureIds: selectedFiguresIds,
         });
       } else {
-        env.model.dispatch("DELETE_FIGURE", {
-          sheetId: env.model.getters.getActiveSheetId(),
+        model.dispatch("DELETE_FIGURE", {
+          sheetId: model.getters.getActiveSheetId(),
           figureId,
         });
       }
@@ -310,23 +305,23 @@ function getDeleteMenuItem(figureId: UID, env: SpreadsheetChildEnv): ActionSpec 
   };
 }
 
-function getMergeCarouselMenuItem(figureId: UID, env: SpreadsheetChildEnv): ActionSpec {
+function getMergeCarouselMenuItem(figureId: UID): ActionSpec {
   return {
     id: "mergeCarousel",
     name: _t("Create carousel"),
-    isVisible: (env) => {
-      const selectedFiguresIds = env.model.getters.getSelectedFigureIds();
+    isVisible: (model) => {
+      const selectedFiguresIds = model.getters.getSelectedFigureIds();
       if (selectedFiguresIds.length < 2 || !selectedFiguresIds.includes(figureId)) {
         return false;
       }
-      const sheetId = env.model.getters.getActiveSheetId();
-      const figures = selectedFiguresIds.map((id) => env.model.getters.getFigure(sheetId, id));
+      const sheetId = model.getters.getActiveSheetId();
+      const figures = selectedFiguresIds.map((id) => model.getters.getFigure(sheetId, id));
       return !figures.some((f) => f === undefined || f.tag !== "chart");
     },
-    execute: () => {
-      const sheetId = env.model.getters.getActiveSheetId();
-      const chartFigureIds = env.model.getters.getSelectedFigureIds();
-      env.model.dispatch("MERGE_CHART_FIGURES_INTO_CAROUSEL", {
+    execute: (model) => {
+      const sheetId = model.getters.getActiveSheetId();
+      const chartFigureIds = model.getters.getSelectedFigureIds();
+      model.dispatch("MERGE_CHART_FIGURES_INTO_CAROUSEL", {
         sheetId,
         baseFigureId: figureId,
         chartFigureIds,

--- a/src/actions/format_actions.ts
+++ b/src/actions/format_actions.ts
@@ -14,23 +14,23 @@ import {
   roundFormat,
 } from "../helpers/format/format";
 import { getDateTimeFormat } from "../helpers/locale";
+import { Model } from "../model";
 import { _t } from "../translation";
 import { CellValue } from "../types/cells";
 import { Format } from "../types/format";
 import { DEFAULT_LOCALE } from "../types/locale";
 import { Align, VerticalAlign, Wrapping } from "../types/misc";
-import { SpreadsheetChildEnv } from "../types/spreadsheet_env";
 import { ActionSpec } from "./action";
 import * as ACTIONS from "./menu_items_actions";
 import { setFormatter, setStyle } from "./menu_items_actions";
 
 export interface NumberFormatActionSpec extends ActionSpec {
-  format?: Format | ((env: SpreadsheetChildEnv) => Format);
+  format?: Format | ((model: Model) => Format);
 }
 
 /**
  * Create a format action specification for a given format.
- * The format can be dynamically computed from the environment.
+ * The format can be dynamically computed from the model.
  */
 export function createFormatActionSpec({
   name,
@@ -39,32 +39,32 @@ export function createFormatActionSpec({
 }: {
   name: string;
   descriptionValue: CellValue;
-  format: Format | ((env: SpreadsheetChildEnv) => Format);
+  format: Format | ((model: Model) => Format);
 }): NumberFormatActionSpec {
   const formatCallback = typeof format === "function" ? format : () => format;
   return {
     name,
-    description: (env) =>
+    description: (model) =>
       formatValue(descriptionValue, {
-        format: formatCallback(env),
-        locale: env.model.getters.getLocale(),
+        format: formatCallback(model),
+        locale: model.getters.getLocale(),
       }),
-    execute: (env) => setFormatter(env, formatCallback(env)),
-    isActive: (env) => isFormatSelected(env, formatCallback(env)),
+    execute: (model) => setFormatter(model, formatCallback(model)),
+    isActive: (model) => isFormatSelected(model, formatCallback(model)),
     format,
   };
 }
 
 export const formatNumberAutomatic: NumberFormatActionSpec = {
   name: _t("Automatic"),
-  execute: (env) => setFormatter(env, ""),
-  isActive: (env) => isAutomaticFormatSelected(env),
+  execute: (model) => setFormatter(model, ""),
+  isActive: (model) => isAutomaticFormatSelected(model),
 };
 
 export const formatNumberPlainText: NumberFormatActionSpec = {
   name: _t("Plain text"),
-  execute: (env) => setFormatter(env, "@"),
-  isActive: (env) => isFormatSelected(env, "@"),
+  execute: (model) => setFormatter(model, "@"),
+  isActive: (model) => isFormatSelected(model, "@"),
 };
 
 export const formatNumberNumber = createFormatActionSpec({
@@ -94,20 +94,18 @@ export const formatNumberScientific = createFormatActionSpec({
 export const formatNumberCurrency = createFormatActionSpec({
   name: _t("Currency"),
   descriptionValue: 1000.12,
-  format: (env) => createCurrencyFormat(env.model.config.defaultCurrency || DEFAULT_CURRENCY),
+  format: (model) => createCurrencyFormat(model.config.defaultCurrency || DEFAULT_CURRENCY),
 });
 
 export const formatNumberCurrencyRounded: NumberFormatActionSpec = {
   ...createFormatActionSpec({
     name: _t("Currency rounded"),
     descriptionValue: 1000,
-    format: (env) =>
-      roundFormat(createCurrencyFormat(env.model.config.defaultCurrency || DEFAULT_CURRENCY)),
+    format: (model) =>
+      roundFormat(createCurrencyFormat(model.config.defaultCurrency || DEFAULT_CURRENCY)),
   }),
-  isVisible: (env) => {
-    const currencyFormat = createCurrencyFormat(
-      env.model.config.defaultCurrency || DEFAULT_CURRENCY
-    );
+  isVisible: (model) => {
+    const currencyFormat = createCurrencyFormat(model.config.defaultCurrency || DEFAULT_CURRENCY);
     const roundedFormat = roundFormat(currencyFormat);
     return currencyFormat !== roundedFormat;
   },
@@ -116,34 +114,34 @@ export const formatNumberCurrencyRounded: NumberFormatActionSpec = {
 export const formatNumberAccounting = createFormatActionSpec({
   name: _t("Accounting"),
   descriptionValue: -1000.12,
-  format: (env) => createAccountingFormat(env.model.config.defaultCurrency || DEFAULT_CURRENCY),
+  format: (model) => createAccountingFormat(model.config.defaultCurrency || DEFAULT_CURRENCY),
 });
 
 export const EXAMPLE_DATE = parseLiteral("2023/09/26 10:43:00 PM", DEFAULT_LOCALE);
 
 export const formatCustomCurrency: ActionSpec = {
   name: _t("Custom currency"),
-  isVisible: (env) => env.loadCurrencies !== undefined && !env.isSmall,
-  execute: (env) => env.openSidePanel("MoreFormats", { category: "currency" }),
+  isVisible: (model, env) => env.loadCurrencies !== undefined && !env.isSmall,
+  execute: (model, env) => env.openSidePanel("MoreFormats", { category: "currency" }),
 };
 
 export const formatNumberDate = createFormatActionSpec({
   name: _t("Date"),
   descriptionValue: EXAMPLE_DATE,
-  format: (env) => env.model.getters.getLocale().dateFormat,
+  format: (model) => model.getters.getLocale().dateFormat,
 });
 
 export const formatNumberTime = createFormatActionSpec({
   name: _t("Time"),
   descriptionValue: EXAMPLE_DATE,
-  format: (env) => env.model.getters.getLocale().timeFormat,
+  format: (model) => model.getters.getLocale().timeFormat,
 });
 
 export const formatNumberDateTime = createFormatActionSpec({
   name: _t("Date time"),
   descriptionValue: EXAMPLE_DATE,
-  format: (env) => {
-    const locale = env.model.getters.getLocale();
+  format: (model) => {
+    const locale = model.getters.getLocale();
     return getDateTimeFormat(locale);
   },
 });
@@ -156,14 +154,14 @@ export const formatNumberDuration = createFormatActionSpec({
 
 export const customDateFormat: ActionSpec = {
   name: _t("Custom date and time"),
-  isVisible: (env) => !env.isSmall,
-  execute: (env) => env.openSidePanel("MoreFormats", { category: "date" }),
+  isVisible: (model, env) => !env.isSmall,
+  execute: (model, env) => env.openSidePanel("MoreFormats", { category: "date" }),
 };
 
 export const customNumberFormat: ActionSpec = {
   name: _t("Custom number format"),
-  isVisible: (env) => !env.isSmall,
-  execute: (env) => env.openSidePanel("MoreFormats", { category: "number" }),
+  isVisible: (model, env) => !env.isSmall,
+  execute: (model, env) => env.openSidePanel("MoreFormats", { category: "number" }),
 };
 
 export const formatNumberFullDateTime = createFormatActionSpec({
@@ -175,10 +173,10 @@ export const formatNumberFullDateTime = createFormatActionSpec({
 export const increaseDecimalPlaces: ActionSpec = {
   name: _t("Increase decimal places"),
   icon: "o-spreadsheet-Icon.INCREASE_DECIMAL",
-  execute: (env) =>
-    env.model.dispatch("SET_DECIMAL", {
-      sheetId: env.model.getters.getActiveSheetId(),
-      target: env.model.getters.getSelectedZones(),
+  execute: (model) =>
+    model.dispatch("SET_DECIMAL", {
+      sheetId: model.getters.getActiveSheetId(),
+      target: model.getters.getSelectedZones(),
       step: 1,
     }),
 };
@@ -186,10 +184,10 @@ export const increaseDecimalPlaces: ActionSpec = {
 export const decreaseDecimalPlaces: ActionSpec = {
   name: _t("Decrease decimal places"),
   icon: "o-spreadsheet-Icon.DECRASE_DECIMAL",
-  execute: (env) =>
-    env.model.dispatch("SET_DECIMAL", {
-      sheetId: env.model.getters.getActiveSheetId(),
-      target: env.model.getters.getSelectedZones(),
+  execute: (model) =>
+    model.dispatch("SET_DECIMAL", {
+      sheetId: model.getters.getActiveSheetId(),
+      target: model.getters.getSelectedZones(),
       step: -1,
     }),
 };
@@ -197,39 +195,39 @@ export const decreaseDecimalPlaces: ActionSpec = {
 export const formatBold: ActionSpec = {
   name: _t("Bold"),
   shortcut: "Ctrl+B",
-  execute: (env) => setStyle(env, { bold: !env.model.getters.getCurrentStyle().bold }),
+  execute: (model) => setStyle(model, { bold: !model.getters.getCurrentStyle().bold }),
   icon: "o-spreadsheet-Icon.BOLD",
-  isActive: (env) => !!env.model.getters.getCurrentStyle().bold,
+  isActive: (model) => !!model.getters.getCurrentStyle().bold,
 };
 
 export const formatItalic: ActionSpec = {
   name: _t("Italic"),
   shortcut: "Ctrl+I",
-  execute: (env) => setStyle(env, { italic: !env.model.getters.getCurrentStyle().italic }),
+  execute: (model) => setStyle(model, { italic: !model.getters.getCurrentStyle().italic }),
   icon: "o-spreadsheet-Icon.ITALIC",
-  isActive: (env) => !!env.model.getters.getCurrentStyle().italic,
+  isActive: (model) => !!model.getters.getCurrentStyle().italic,
 };
 
 export const formatUnderline: ActionSpec = {
   name: _t("Underline"),
   shortcut: "Ctrl+U",
-  execute: (env) => setStyle(env, { underline: !env.model.getters.getCurrentStyle().underline }),
+  execute: (model) => setStyle(model, { underline: !model.getters.getCurrentStyle().underline }),
   icon: "o-spreadsheet-Icon.UNDERLINE",
-  isActive: (env) => !!env.model.getters.getCurrentStyle().underline,
+  isActive: (model) => !!model.getters.getCurrentStyle().underline,
 };
 
 export const formatRotation: ActionSpec = {
   name: _t("Rotation"),
-  icon: (env) => getRotationIcon(env),
+  icon: (model) => getRotationIcon(model),
 };
 
-function setRotation(env: SpreadsheetChildEnv, rotation: number) {
+function setRotation(model: Model, rotation: number) {
   rotation = Math.trunc(rotation / ROTATION_EPSILON) * ROTATION_EPSILON;
-  setStyle(env, { rotation });
+  setStyle(model, { rotation });
 }
 
-function currentRotationEqual(env: SpreadsheetChildEnv, rotation: number): boolean {
-  const current = env.model.getters.getCurrentStyle().rotation;
+function currentRotationEqual(model: Model, rotation: number): boolean {
+  const current = model.getters.getCurrentStyle().rotation;
   if (current === undefined) {
     return rotation === 0;
   }
@@ -238,45 +236,45 @@ function currentRotationEqual(env: SpreadsheetChildEnv, rotation: number): boole
 
 export const formatNoRotation: ActionSpec = {
   name: _t("No rotation"),
-  execute: (env) => setStyle(env, { rotation: 0 }),
+  execute: (model) => setStyle(model, { rotation: 0 }),
   icon: "o-spreadsheet-Icon.ROTATION-0",
-  isActive: (env) => currentRotationEqual(env, 0),
+  isActive: (model) => currentRotationEqual(model, 0),
 };
 
 export const formatRotation45: ActionSpec = {
   name: _t("45° rotation"),
-  execute: (env) => setRotation(env, Math.PI / 4),
+  execute: (model) => setRotation(model, Math.PI / 4),
   icon: "o-spreadsheet-Icon.ROTATION-45",
-  isActive: (env) => currentRotationEqual(env, Math.PI / 4),
+  isActive: (model) => currentRotationEqual(model, Math.PI / 4),
 };
 
 export const formatRotation90: ActionSpec = {
   name: _t("90° rotation"),
-  execute: (env) => setRotation(env, Math.PI / 2),
+  execute: (model) => setRotation(model, Math.PI / 2),
   icon: "o-spreadsheet-Icon.ROTATION-90",
-  isActive: (env) => currentRotationEqual(env, Math.PI / 2),
+  isActive: (model) => currentRotationEqual(model, Math.PI / 2),
 };
 
 export const formatRotation270: ActionSpec = {
   name: _t("-90° rotation"),
-  execute: (env) => setRotation(env, -Math.PI / 2),
+  execute: (model) => setRotation(model, -Math.PI / 2),
   icon: "o-spreadsheet-Icon.ROTATION-270",
-  isActive: (env) => currentRotationEqual(env, -Math.PI / 2),
+  isActive: (model) => currentRotationEqual(model, -Math.PI / 2),
 };
 
 export const formatRotation315: ActionSpec = {
   name: _t("-45° rotation"),
-  execute: (env) => setRotation(env, -Math.PI / 4),
+  execute: (model) => setRotation(model, -Math.PI / 4),
   icon: "o-spreadsheet-Icon.ROTATION-315",
-  isActive: (env) => currentRotationEqual(env, -Math.PI / 4),
+  isActive: (model) => currentRotationEqual(model, -Math.PI / 4),
 };
 
 export const formatStrikethrough: ActionSpec = {
   name: _t("Strikethrough"),
-  execute: (env) =>
-    setStyle(env, { strikethrough: !env.model.getters.getCurrentStyle().strikethrough }),
+  execute: (model) =>
+    setStyle(model, { strikethrough: !model.getters.getCurrentStyle().strikethrough }),
   icon: "o-spreadsheet-Icon.STRIKE",
-  isActive: (env) => !!env.model.getters.getCurrentStyle().strikethrough,
+  isActive: (model) => !!model.getters.getCurrentStyle().strikethrough,
 };
 
 export const formatFontSize: ActionSpec = {
@@ -292,56 +290,56 @@ export const formatAlignment: ActionSpec = {
 
 export const formatAlignmentHorizontal: ActionSpec = {
   name: _t("Horizontal align"),
-  icon: (env) => getHorizontalAlignmentIcon(env),
+  icon: (model) => getHorizontalAlignmentIcon(model),
 };
 
 export const formatAlignmentLeft: ActionSpec = {
   name: _t("Left"),
   shortcut: "Ctrl+Shift+L",
-  execute: (env) => ACTIONS.setStyle(env, { align: "left" }),
-  isActive: (env) => getHorizontalAlign(env) === "left",
+  execute: (model) => ACTIONS.setStyle(model, { align: "left" }),
+  isActive: (model) => getHorizontalAlign(model) === "left",
   icon: "o-spreadsheet-Icon.ALIGN_LEFT",
 };
 
 export const formatAlignmentCenter: ActionSpec = {
   name: _t("Center"),
   shortcut: "Ctrl+Shift+E",
-  execute: (env) => ACTIONS.setStyle(env, { align: "center" }),
-  isActive: (env) => getHorizontalAlign(env) === "center",
+  execute: (model) => ACTIONS.setStyle(model, { align: "center" }),
+  isActive: (model) => getHorizontalAlign(model) === "center",
   icon: "o-spreadsheet-Icon.ALIGN_CENTER",
 };
 
 export const formatAlignmentRight: ActionSpec = {
   name: _t("Right"),
   shortcut: "Ctrl+Shift+R",
-  execute: (env) => ACTIONS.setStyle(env, { align: "right" }),
-  isActive: (env) => getHorizontalAlign(env) === "right",
+  execute: (model) => ACTIONS.setStyle(model, { align: "right" }),
+  isActive: (model) => getHorizontalAlign(model) === "right",
   icon: "o-spreadsheet-Icon.ALIGN_RIGHT",
 };
 
 export const formatAlignmentVertical: ActionSpec = {
   name: _t("Vertical align"),
-  icon: (env) => getVerticalAlignmentIcon(env),
+  icon: (model) => getVerticalAlignmentIcon(model),
 };
 
 export const formatAlignmentTop: ActionSpec = {
   name: _t("Top"),
-  execute: (env) => ACTIONS.setStyle(env, { verticalAlign: "top" }),
-  isActive: (env) => getVerticalAlign(env) === "top",
+  execute: (model) => ACTIONS.setStyle(model, { verticalAlign: "top" }),
+  isActive: (model) => getVerticalAlign(model) === "top",
   icon: "o-spreadsheet-Icon.ALIGN_TOP",
 };
 
 export const formatAlignmentMiddle: ActionSpec = {
   name: _t("Middle"),
-  execute: (env) => ACTIONS.setStyle(env, { verticalAlign: "middle" }),
-  isActive: (env) => getVerticalAlign(env) === "middle",
+  execute: (model) => ACTIONS.setStyle(model, { verticalAlign: "middle" }),
+  isActive: (model) => getVerticalAlign(model) === "middle",
   icon: "o-spreadsheet-Icon.ALIGN_MIDDLE",
 };
 
 export const formatAlignmentBottom: ActionSpec = {
   name: _t("Bottom"),
-  execute: (env) => ACTIONS.setStyle(env, { verticalAlign: "bottom" }),
-  isActive: (env) => getVerticalAlign(env) === "bottom",
+  execute: (model) => ACTIONS.setStyle(model, { verticalAlign: "bottom" }),
+  isActive: (model) => getVerticalAlign(model) === "bottom",
   icon: "o-spreadsheet-Icon.ALIGN_BOTTOM",
 };
 
@@ -352,27 +350,27 @@ export const formatWrappingIcon: ActionSpec = {
 
 export const formatWrapping: ActionSpec = {
   name: _t("Wrapping"),
-  icon: (env) => getWrapModeIcon(env),
+  icon: (model) => getWrapModeIcon(model),
 };
 
 export const formatWrappingOverflow: ActionSpec = {
   name: _t("Overflow"),
-  execute: (env) => ACTIONS.setStyle(env, { wrapping: "overflow" }),
-  isActive: (env) => getWrappingMode(env) === "overflow",
+  execute: (model) => ACTIONS.setStyle(model, { wrapping: "overflow" }),
+  isActive: (model) => getWrappingMode(model) === "overflow",
   icon: "o-spreadsheet-Icon.WRAPPING_OVERFLOW",
 };
 
 export const formatWrappingWrap: ActionSpec = {
   name: _t("Wrap"),
-  execute: (env) => ACTIONS.setStyle(env, { wrapping: "wrap" }),
-  isActive: (env) => getWrappingMode(env) === "wrap",
+  execute: (model) => ACTIONS.setStyle(model, { wrapping: "wrap" }),
+  isActive: (model) => getWrappingMode(model) === "wrap",
   icon: "o-spreadsheet-Icon.WRAPPING_WRAP",
 };
 
 export const formatWrappingClip: ActionSpec = {
   name: _t("Clip"),
-  execute: (env) => ACTIONS.setStyle(env, { wrapping: "clip" }),
-  isActive: (env) => getWrappingMode(env) === "clip",
+  execute: (model) => ACTIONS.setStyle(model, { wrapping: "clip" }),
+  isActive: (model) => getWrappingMode(model) === "clip",
   icon: "o-spreadsheet-Icon.WRAPPING_CLIP",
 };
 
@@ -389,7 +387,7 @@ export const fillColor: ActionSpec = {
 export const formatCF: ActionSpec = {
   name: _t("Conditional formatting"),
   execute: ACTIONS.OPEN_CF_SIDEPANEL_ACTION,
-  isEnabled: (env) => !env.isSmall,
+  isEnabled: (model, env) => !env.isSmall,
   isEnabledOnLockedSheet: true,
   icon: "o-spreadsheet-Icon.CONDITIONAL_FORMAT",
 };
@@ -397,10 +395,10 @@ export const formatCF: ActionSpec = {
 export const clearFormat: ActionSpec = {
   name: _t("Clear formatting"),
   shortcut: "Ctrl+<",
-  execute: (env) =>
-    env.model.dispatch("CLEAR_FORMATTING", {
-      sheetId: env.model.getters.getActiveSheetId(),
-      target: env.model.getters.getSelectedZones(),
+  execute: (model) =>
+    model.dispatch("CLEAR_FORMATTING", {
+      sheetId: model.getters.getActiveSheetId(),
+      target: model.getters.getSelectedZones(),
     }),
 
   icon: "o-spreadsheet-Icon.CLEAR_FORMAT",
@@ -412,62 +410,62 @@ function fontSizeMenuBuilder(): ActionSpec[] {
       name: fs.toString(),
       sequence: fs,
       id: `font_size_${fs}`,
-      execute: (env) => ACTIONS.setStyle(env, { fontSize: fs }),
-      isActive: (env) => isFontSizeSelected(env, fs),
+      execute: (model) => ACTIONS.setStyle(model, { fontSize: fs }),
+      isActive: (model) => isFontSizeSelected(model, fs),
     };
   });
 }
 
-function isAutomaticFormatSelected(env: SpreadsheetChildEnv): boolean {
-  const activePosition = env.model.getters.getActivePosition();
-  const pivotCell = env.model.getters.getPivotCellFromPosition(activePosition);
+function isAutomaticFormatSelected(model: Model): boolean {
+  const activePosition = model.getters.getActivePosition();
+  const pivotCell = model.getters.getPivotCellFromPosition(activePosition);
   if (pivotCell.type === "VALUE") {
-    return !env.model.getters.getEvaluatedCell(activePosition).format;
+    return !model.getters.getEvaluatedCell(activePosition).format;
   }
-  return !env.model.getters.getCell(activePosition)?.format;
+  return !model.getters.getCell(activePosition)?.format;
 }
 
-function isFormatSelected(env: SpreadsheetChildEnv, format: string): boolean {
-  const activePosition = env.model.getters.getActivePosition();
-  const pivotCell = env.model.getters.getPivotCellFromPosition(activePosition);
+function isFormatSelected(model: Model, format: string): boolean {
+  const activePosition = model.getters.getActivePosition();
+  const pivotCell = model.getters.getPivotCellFromPosition(activePosition);
   if (pivotCell.type === "VALUE") {
-    return env.model.getters.getEvaluatedCell(activePosition).format === format;
+    return model.getters.getEvaluatedCell(activePosition).format === format;
   }
-  return env.model.getters.getCell(activePosition)?.format === format;
+  return model.getters.getCell(activePosition)?.format === format;
 }
 
-function isFontSizeSelected(env: SpreadsheetChildEnv, fontSize: number): boolean {
-  const currentFontSize = env.model.getters.getCurrentStyle().fontSize || DEFAULT_FONT_SIZE;
+function isFontSizeSelected(model: Model, fontSize: number): boolean {
+  const currentFontSize = model.getters.getCurrentStyle().fontSize || DEFAULT_FONT_SIZE;
   return currentFontSize === fontSize;
 }
 
-function getHorizontalAlign(env: SpreadsheetChildEnv): Align {
-  const style = env.model.getters.getCurrentStyle();
+function getHorizontalAlign(model: Model): Align {
+  const style = model.getters.getCurrentStyle();
   if (style.align) {
     return style.align;
   }
-  const cell = env.model.getters.getActiveCell();
+  const cell = model.getters.getActiveCell();
   return cell.defaultAlign;
 }
 
-function getVerticalAlign(env: SpreadsheetChildEnv): VerticalAlign {
-  const style = env.model.getters.getCurrentStyle();
+function getVerticalAlign(model: Model): VerticalAlign {
+  const style = model.getters.getCurrentStyle();
   if (style.verticalAlign) {
     return style.verticalAlign;
   }
   return DEFAULT_VERTICAL_ALIGN;
 }
 
-function getWrappingMode(env: SpreadsheetChildEnv): Wrapping {
-  const style = env.model.getters.getCurrentStyle();
+function getWrappingMode(model: Model): Wrapping {
+  const style = model.getters.getCurrentStyle();
   if (style.wrapping) {
     return style.wrapping;
   }
   return DEFAULT_WRAPPING_MODE;
 }
 
-function getHorizontalAlignmentIcon(env: SpreadsheetChildEnv) {
-  const horizontalAlign = getHorizontalAlign(env);
+function getHorizontalAlignmentIcon(model: Model) {
+  const horizontalAlign = getHorizontalAlign(model);
 
   switch (horizontalAlign) {
     case "right":
@@ -479,8 +477,8 @@ function getHorizontalAlignmentIcon(env: SpreadsheetChildEnv) {
   }
 }
 
-function getVerticalAlignmentIcon(env: SpreadsheetChildEnv) {
-  const verticalAlign = getVerticalAlign(env);
+function getVerticalAlignmentIcon(model: Model) {
+  const verticalAlign = getVerticalAlign(model);
 
   switch (verticalAlign) {
     case "top":
@@ -492,8 +490,8 @@ function getVerticalAlignmentIcon(env: SpreadsheetChildEnv) {
   }
 }
 
-function getWrapModeIcon(env: SpreadsheetChildEnv) {
-  const wrapMode = getWrappingMode(env);
+function getWrapModeIcon(model: Model) {
+  const wrapMode = getWrappingMode(model);
 
   switch (wrapMode) {
     case "wrap":
@@ -505,14 +503,14 @@ function getWrapModeIcon(env: SpreadsheetChildEnv) {
   }
 }
 
-function getRotationIcon(env: SpreadsheetChildEnv) {
-  if (currentRotationEqual(env, Math.PI / 2)) {
+function getRotationIcon(model: Model) {
+  if (currentRotationEqual(model, Math.PI / 2)) {
     return "o-spreadsheet-Icon.ROTATION-90";
-  } else if (currentRotationEqual(env, -Math.PI / 2)) {
+  } else if (currentRotationEqual(model, -Math.PI / 2)) {
     return "o-spreadsheet-Icon.ROTATION-270";
-  } else if (currentRotationEqual(env, Math.PI / 4)) {
+  } else if (currentRotationEqual(model, Math.PI / 4)) {
     return "o-spreadsheet-Icon.ROTATION-45";
-  } else if (currentRotationEqual(env, -Math.PI / 4)) {
+  } else if (currentRotationEqual(model, -Math.PI / 4)) {
     return "o-spreadsheet-Icon.ROTATION-315";
   }
   return "o-spreadsheet-Icon.ROTATION-0";

--- a/src/actions/insert_actions.ts
+++ b/src/actions/insert_actions.ts
@@ -2,35 +2,36 @@ import { functionRegistry } from "../functions/function_registry";
 import { isDefined } from "../helpers/misc";
 import { handlePasteResult } from "../helpers/ui/paste_interactive";
 import { UuidGenerator } from "../helpers/uuid";
+import { Model } from "../model";
 import { _t } from "../translation";
 import { ActionBuilder, ActionSpec } from "./action";
 import * as ACTIONS from "./menu_items_actions";
 
 export const insertRow: ActionSpec = {
-  name: (env) => {
-    const number = getRowsNumber(env);
+  name: (model) => {
+    const number = getRowsNumber(model);
     return number === 1 ? _t("Insert row") : _t("Insert %s rows", number.toString());
   },
-  isVisible: (env) => ACTIONS.CAN_INSERT_HEADER(env, "ROW"),
+  isVisible: (model) => ACTIONS.CAN_INSERT_HEADER(model, "ROW"),
 
   icon: "o-spreadsheet-Icon.INSERT_ROW",
 };
 
 export const rowInsertRowBefore: ActionSpec = {
-  name: (env) => {
-    const number = getRowsNumber(env);
+  name: (model) => {
+    const number = getRowsNumber(model);
     return number === 1 ? _t("Insert row above") : _t("Insert %s rows above", number.toString());
   },
   execute: ACTIONS.INSERT_ROWS_BEFORE_ACTION,
-  isVisible: (env) => ACTIONS.CAN_INSERT_HEADER(env, "ROW"),
+  isVisible: (model) => ACTIONS.CAN_INSERT_HEADER(model, "ROW"),
 
   icon: "o-spreadsheet-Icon.INSERT_ROW_BEFORE",
 };
 
 export const topBarInsertRowsBefore: ActionSpec = {
   ...rowInsertRowBefore,
-  name: (env) => {
-    const number = getRowsNumber(env);
+  name: (model) => {
+    const number = getRowsNumber(model);
     if (number === 1) {
       return _t("Row above");
     }
@@ -40,8 +41,8 @@ export const topBarInsertRowsBefore: ActionSpec = {
 
 export const cellInsertRowsBefore: ActionSpec = {
   ...rowInsertRowBefore,
-  name: (env) => {
-    const number = getRowsNumber(env);
+  name: (model) => {
+    const number = getRowsNumber(model);
     if (number === 1) {
       return _t("Insert row");
     }
@@ -53,19 +54,19 @@ export const cellInsertRowsBefore: ActionSpec = {
 
 export const rowInsertRowsAfter: ActionSpec = {
   execute: ACTIONS.INSERT_ROWS_AFTER_ACTION,
-  name: (env) => {
-    const number = getRowsNumber(env);
+  name: (model) => {
+    const number = getRowsNumber(model);
     return number === 1 ? _t("Insert row below") : _t("Insert %s rows below", number.toString());
   },
-  isVisible: (env) => ACTIONS.CAN_INSERT_HEADER(env, "ROW"),
+  isVisible: (model) => ACTIONS.CAN_INSERT_HEADER(model, "ROW"),
 
   icon: "o-spreadsheet-Icon.INSERT_ROW_AFTER",
 };
 
 export const topBarInsertRowsAfter: ActionSpec = {
   ...rowInsertRowsAfter,
-  name: (env) => {
-    const number = getRowsNumber(env);
+  name: (model) => {
+    const number = getRowsNumber(model);
     if (number === 1) {
       return _t("Row below");
     }
@@ -74,32 +75,32 @@ export const topBarInsertRowsAfter: ActionSpec = {
 };
 
 export const insertCol: ActionSpec = {
-  name: (env) => {
-    const number = getColumnsNumber(env);
+  name: (model) => {
+    const number = getColumnsNumber(model);
     return number === 1 ? _t("Insert column") : _t("Insert %s columns", number.toString());
   },
-  isVisible: (env) => ACTIONS.CAN_INSERT_HEADER(env, "COL"),
+  isVisible: (model) => ACTIONS.CAN_INSERT_HEADER(model, "COL"),
 
   icon: "o-spreadsheet-Icon.INSERT_COL",
 };
 
 export const colInsertColsBefore: ActionSpec = {
-  name: (env) => {
-    const number = getColumnsNumber(env);
+  name: (model) => {
+    const number = getColumnsNumber(model);
     return number === 1
       ? _t("Insert column left")
       : _t("Insert %s columns left", number.toString());
   },
   execute: ACTIONS.INSERT_COLUMNS_BEFORE_ACTION,
-  isVisible: (env) => ACTIONS.CAN_INSERT_HEADER(env, "COL"),
+  isVisible: (model) => ACTIONS.CAN_INSERT_HEADER(model, "COL"),
 
   icon: "o-spreadsheet-Icon.INSERT_COL_BEFORE",
 };
 
 export const topBarInsertColsBefore: ActionSpec = {
   ...colInsertColsBefore,
-  name: (env) => {
-    const number = getColumnsNumber(env);
+  name: (model) => {
+    const number = getColumnsNumber(model);
     if (number === 1) {
       return _t("Column left");
     }
@@ -109,8 +110,8 @@ export const topBarInsertColsBefore: ActionSpec = {
 
 export const cellInsertColsBefore: ActionSpec = {
   ...colInsertColsBefore,
-  name: (env) => {
-    const number = getColumnsNumber(env);
+  name: (model) => {
+    const number = getColumnsNumber(model);
     if (number === 1) {
       return _t("Insert column");
     }
@@ -121,22 +122,22 @@ export const cellInsertColsBefore: ActionSpec = {
 };
 
 export const colInsertColsAfter: ActionSpec = {
-  name: (env) => {
-    const number = getColumnsNumber(env);
+  name: (model) => {
+    const number = getColumnsNumber(model);
     return number === 1
       ? _t("Insert column right")
       : _t("Insert %s columns right", number.toString());
   },
   execute: ACTIONS.INSERT_COLUMNS_AFTER_ACTION,
-  isVisible: (env) => ACTIONS.CAN_INSERT_HEADER(env, "COL"),
+  isVisible: (model) => ACTIONS.CAN_INSERT_HEADER(model, "COL"),
 
   icon: "o-spreadsheet-Icon.INSERT_COL_AFTER",
 };
 
 export const topBarInsertColsAfter: ActionSpec = {
   ...colInsertColsAfter,
-  name: (env) => {
-    const number = getColumnsNumber(env);
+  name: (model) => {
+    const number = getColumnsNumber(model);
     if (number === 1) {
       return _t("Column right");
     }
@@ -147,56 +148,56 @@ export const topBarInsertColsAfter: ActionSpec = {
 
 export const insertCell: ActionSpec = {
   name: _t("Insert cells"),
-  isVisible: (env) =>
-    ACTIONS.IS_ONLY_ONE_RANGE(env) &&
-    env.model.getters.getActiveCols().size === 0 &&
-    env.model.getters.getActiveRows().size === 0,
+  isVisible: (model) =>
+    ACTIONS.IS_ONLY_ONE_RANGE(model) &&
+    model.getters.getActiveCols().size === 0 &&
+    model.getters.getActiveRows().size === 0,
 
   icon: "o-spreadsheet-Icon.INSERT_CELL",
 };
 
 export const insertCellShiftDown: ActionSpec = {
   name: _t("Insert cells and shift down"),
-  execute: (env) => {
-    const zone = env.model.getters.getSelectedZone();
-    const result = env.model.dispatch("INSERT_CELL", { zone, shiftDimension: "ROW" });
-    handlePasteResult(env, result);
+  execute: (model, env) => {
+    const zone = model.getters.getSelectedZone();
+    const result = model.dispatch("INSERT_CELL", { zone, shiftDimension: "ROW" });
+    handlePasteResult(model, env, result);
   },
-  isVisible: (env) =>
-    env.model.getters.getActiveRows().size === 0 && env.model.getters.getActiveCols().size === 0,
+  isVisible: (model) =>
+    model.getters.getActiveRows().size === 0 && model.getters.getActiveCols().size === 0,
   icon: "o-spreadsheet-Icon.INSERT_CELL_SHIFT_DOWN",
 };
 
 export const insertCellShiftRight: ActionSpec = {
   name: _t("Insert cells and shift right"),
-  execute: (env) => {
-    const zone = env.model.getters.getSelectedZone();
-    const result = env.model.dispatch("INSERT_CELL", { zone, shiftDimension: "COL" });
-    handlePasteResult(env, result);
+  execute: (model, env) => {
+    const zone = model.getters.getSelectedZone();
+    const result = model.dispatch("INSERT_CELL", { zone, shiftDimension: "COL" });
+    handlePasteResult(model, env, result);
   },
-  isVisible: (env) =>
-    env.model.getters.getActiveRows().size === 0 && env.model.getters.getActiveCols().size === 0,
+  isVisible: (model) =>
+    model.getters.getActiveRows().size === 0 && model.getters.getActiveCols().size === 0,
   icon: "o-spreadsheet-Icon.INSERT_CELL_SHIFT_RIGHT",
 };
 
 export const insertChart: ActionSpec = {
   name: _t("Chart"),
   execute: ACTIONS.CREATE_CHART,
-  isEnabled: (env) => !env.isSmall,
+  isEnabled: (model, env) => !env.isSmall,
   icon: "o-spreadsheet-Icon.INSERT_CHART",
 };
 
 export const insertCarousel: ActionSpec = {
   name: _t("Carousel"),
   execute: ACTIONS.CREATE_CAROUSEL,
-  isEnabled: (env) => !env.isSmall,
+  isEnabled: (model, env) => !env.isSmall,
   icon: "o-spreadsheet-Icon.CAROUSEL",
 };
 
 export const insertPivot: ActionSpec = {
   name: _t("Pivot table"),
   execute: ACTIONS.CREATE_PIVOT,
-  isEnabled: (env) => !env.isSmall,
+  isEnabled: (model, env) => !env.isSmall,
   isEnabledOnLockedSheet: true,
   icon: "o-spreadsheet-Icon.PIVOT",
 };
@@ -205,8 +206,8 @@ export const insertImage: ActionSpec = {
   name: _t("Image"),
   shortcut: "Ctrl+O",
   execute: ACTIONS.CREATE_IMAGE,
-  isVisible: (env) => env.imageProvider !== undefined,
-  isEnabled: (env) => !env.isSmall,
+  isVisible: (model, env) => env.imageProvider !== undefined,
+  isEnabled: (model, env) => !env.isSmall,
   icon: "o-spreadsheet-Icon.INSERT_IMAGE",
 };
 
@@ -214,9 +215,9 @@ export const insertTable: ActionSpec = {
   name: () => _t("Table"),
   shortcut: "Alt+T",
   execute: ACTIONS.INSERT_TABLE,
-  isVisible: (env) =>
-    ACTIONS.IS_SELECTION_CONTINUOUS(env) && !env.model.getters.getFirstTableInSelection(),
-  isEnabled: (env) => !env.isSmall,
+  isVisible: (model) =>
+    ACTIONS.IS_SELECTION_CONTINUOUS(model) && !model.getters.getFirstTableInSelection(),
+  isEnabled: (model, env) => !env.isSmall,
   icon: "o-spreadsheet-Icon.PAINT_TABLE",
 };
 
@@ -227,27 +228,27 @@ export const insertFunction: ActionSpec = {
 
 export const insertFunctionSum: ActionSpec = {
   name: _t("SUM"),
-  execute: (env) => env.startCellEdition(`=SUM(`),
+  execute: (model, env) => env.startCellEdition(`=SUM(`),
 };
 
 export const insertFunctionAverage: ActionSpec = {
   name: _t("AVERAGE"),
-  execute: (env) => env.startCellEdition(`=AVERAGE(`),
+  execute: (model, env) => env.startCellEdition(`=AVERAGE(`),
 };
 
 export const insertFunctionCount: ActionSpec = {
   name: _t("COUNT"),
-  execute: (env) => env.startCellEdition(`=COUNT(`),
+  execute: (model, env) => env.startCellEdition(`=COUNT(`),
 };
 
 export const insertFunctionMax: ActionSpec = {
   name: _t("MAX"),
-  execute: (env) => env.startCellEdition(`=MAX(`),
+  execute: (model, env) => env.startCellEdition(`=MAX(`),
 };
 
 export const insertFunctionMin: ActionSpec = {
   name: _t("MIN"),
-  execute: (env) => env.startCellEdition(`=MIN(`),
+  execute: (model, env) => env.startCellEdition(`=MIN(`),
 };
 
 export const categorieFunctionAll: ActionSpec = {
@@ -292,11 +293,11 @@ export const insertLink: ActionSpec = {
 
 export const insertCheckbox: ActionSpec = {
   name: _t("Checkbox"),
-  execute: (env) => {
-    const zones = env.model.getters.getSelectedZones();
-    const sheetId = env.model.getters.getActiveSheetId();
-    const ranges = zones.map((zone) => env.model.getters.getRangeDataFromZone(sheetId, zone));
-    env.model.dispatch("ADD_DATA_VALIDATION_RULE", {
+  execute: (model) => {
+    const zones = model.getters.getSelectedZones();
+    const sheetId = model.getters.getActiveSheetId();
+    const ranges = zones.map((zone) => model.getters.getRangeDataFromZone(sheetId, zone));
+    model.dispatch("ADD_DATA_VALIDATION_RULE", {
       ranges,
       sheetId,
       rule: {
@@ -314,12 +315,12 @@ export const insertCheckbox: ActionSpec = {
 
 export const insertDropdown: ActionSpec = {
   name: _t("Dropdown list"),
-  execute: (env) => {
-    const zones = env.model.getters.getSelectedZones();
-    const sheetId = env.model.getters.getActiveSheetId();
-    const ranges = zones.map((zone) => env.model.getters.getRangeDataFromZone(sheetId, zone));
+  execute: (model, env) => {
+    const zones = model.getters.getSelectedZones();
+    const sheetId = model.getters.getActiveSheetId();
+    const ranges = zones.map((zone) => model.getters.getRangeDataFromZone(sheetId, zone));
     const ruleId = UuidGenerator.smallUuid();
-    env.model.dispatch("ADD_DATA_VALIDATION_RULE", {
+    model.dispatch("ADD_DATA_VALIDATION_RULE", {
       ranges,
       sheetId,
       rule: {
@@ -331,34 +332,34 @@ export const insertDropdown: ActionSpec = {
         },
       },
     });
-    const rule = env.model.getters.getDataValidationRule(sheetId, ruleId);
+    const rule = model.getters.getDataValidationRule(sheetId, ruleId);
     if (!rule) {
       return;
     }
     env.openSidePanel("DataValidationEditor", {
       ruleId,
       onCancel: () => {
-        env.model.dispatch("REMOVE_DATA_VALIDATION_RULE", { sheetId, id: ruleId });
+        model.dispatch("REMOVE_DATA_VALIDATION_RULE", { sheetId, id: ruleId });
       },
     });
   },
-  isEnabled: (env) => !env.isSmall,
+  isEnabled: (model, env) => !env.isSmall,
   icon: "o-spreadsheet-Icon.INSERT_DROPDOWN",
 };
 
 export const insertSheet: ActionSpec = {
   name: _t("Insert sheet"),
   shortcut: "Shift+F11",
-  execute: (env) => {
-    const activeSheetId = env.model.getters.getActiveSheetId();
-    const position = env.model.getters.getSheetIds().indexOf(activeSheetId) + 1;
+  execute: (model) => {
+    const activeSheetId = model.getters.getActiveSheetId();
+    const position = model.getters.getSheetIds().indexOf(activeSheetId) + 1;
     const sheetId = UuidGenerator.smallUuid();
-    env.model.dispatch("CREATE_SHEET", {
+    model.dispatch("CREATE_SHEET", {
       sheetId,
       position,
-      name: env.model.getters.getNextSheetName(),
+      name: model.getters.getNextSheetName(),
     });
-    env.model.dispatch("ACTIVATE_SHEET", { sheetIdFrom: activeSheetId, sheetIdTo: sheetId });
+    model.dispatch("ACTIVATE_SHEET", { sheetIdFrom: activeSheetId, sheetIdTo: sheetId });
   },
   icon: "o-spreadsheet-Icon.INSERT_SHEET",
 };
@@ -368,27 +369,27 @@ function createFormulaFunctions(fnNames: string[]): ActionSpec[] {
     return {
       name: fnName,
       sequence: i * 10,
-      execute: (env) => env.startCellEdition(`=${fnName}(`),
+      execute: (model, env) => env.startCellEdition(`=${fnName}(`),
     };
   });
 }
 
-function getRowsNumber(env): number {
-  const activeRows = env.model.getters.getActiveRows();
+function getRowsNumber(model: Model): number {
+  const activeRows = model.getters.getActiveRows();
   if (activeRows.size) {
     return activeRows.size;
   } else {
-    const zone = env.model.getters.getSelectedZones()[0];
+    const zone = model.getters.getSelectedZones()[0];
     return zone.bottom - zone.top + 1;
   }
 }
 
-function getColumnsNumber(env): number {
-  const activeCols = env.model.getters.getActiveCols();
+function getColumnsNumber(model: Model): number {
+  const activeCols = model.getters.getActiveCols();
   if (activeCols.size) {
     return activeCols.size;
   } else {
-    const zone = env.model.getters.getSelectedZones()[0];
+    const zone = model.getters.getSelectedZones()[0];
     return zone.right - zone.left + 1;
   }
 }

--- a/src/actions/menu_items_actions.ts
+++ b/src/actions/menu_items_actions.ts
@@ -18,6 +18,7 @@ import { interactivePaste, interactivePasteFromOS } from "../helpers/ui/paste_in
 import { interactiveCreateTable } from "../helpers/ui/table_interactive";
 import { UuidGenerator } from "../helpers/uuid";
 import { areZonesContinuous, getZoneArea, isEqual } from "../helpers/zones";
+import { Model } from "../model";
 import { _t } from "../translation";
 import { ClipboardMIMEType, ClipboardPasteOptions } from "../types/clipboard";
 import { Format } from "../types/format";
@@ -29,18 +30,18 @@ import { ActionSpec } from "./action";
 // Helpers
 //------------------------------------------------------------------------------
 
-export function setFormatter(env: SpreadsheetChildEnv, format: Format) {
-  env.model.dispatch("SET_FORMATTING_WITH_PIVOT", {
-    sheetId: env.model.getters.getActiveSheetId(),
-    target: env.model.getters.getSelectedZones(),
+export function setFormatter(model: Model, format: Format) {
+  model.dispatch("SET_FORMATTING_WITH_PIVOT", {
+    sheetId: model.getters.getActiveSheetId(),
+    target: model.getters.getSelectedZones(),
     format,
   });
 }
 
-export function setStyle(env: SpreadsheetChildEnv, style: Style) {
-  env.model.dispatch("SET_FORMATTING", {
-    sheetId: env.model.getters.getActiveSheetId(),
-    target: env.model.getters.getSelectedZones(),
+export function setStyle(model: Model, style: Style) {
+  model.dispatch("SET_FORMATTING", {
+    sheetId: model.getters.getActiveSheetId(),
+    target: model.getters.getSelectedZones(),
     style,
   });
 }
@@ -49,25 +50,26 @@ export function setStyle(env: SpreadsheetChildEnv, style: Style) {
 // Simple actions
 //------------------------------------------------------------------------------
 
-export const PASTE_ACTION = async (env: SpreadsheetChildEnv) => paste(env);
-export const PASTE_AS_VALUE_ACTION = async (env: SpreadsheetChildEnv) => paste(env, "asValue");
+export const PASTE_ACTION = async (model: Model, env: SpreadsheetChildEnv) => paste(model, env);
+export const PASTE_AS_VALUE_ACTION = async (model: Model, env: SpreadsheetChildEnv) =>
+  paste(model, env, "asValue");
 
-async function paste(env: SpreadsheetChildEnv, pasteOption?: ClipboardPasteOptions) {
+async function paste(model: Model, env: SpreadsheetChildEnv, pasteOption?: ClipboardPasteOptions) {
   const osClipboard = await env.clipboard.read();
   switch (osClipboard.status) {
     case "ok":
-      const clipboardId = env.model.getters.getClipboardId();
-      const target = env.model.getters.getSelectedZones();
+      const clipboardId = model.getters.getClipboardId();
+      const target = model.getters.getSelectedZones();
       const htmlClipboardId = getOSheetClipboardIdFromHTML(
         osClipboard.content[ClipboardMIMEType.Html]
       );
       if (clipboardId === htmlClipboardId) {
-        interactivePaste(env, target, pasteOption);
+        interactivePaste(model, env, target, pasteOption);
       } else {
         const osClipboardContent = parseOSClipboardContent(osClipboard.content);
-        await interactivePasteFromOS(env, target, osClipboardContent, pasteOption);
+        await interactivePasteFromOS(model, env, target, osClipboardContent, pasteOption);
       }
-      if (env.model.getters.isCutOperation() && pasteOption !== "asValue") {
+      if (model.getters.isCutOperation() && pasteOption !== "asValue") {
         await env.clipboard.write({ [ClipboardMIMEType.PlainText]: "" });
       }
       break;
@@ -88,24 +90,25 @@ async function paste(env: SpreadsheetChildEnv, pasteOption?: ClipboardPasteOptio
   }
 }
 
-export const PASTE_FORMAT_ACTION = (env: SpreadsheetChildEnv) => paste(env, "onlyFormat");
+export const PASTE_FORMAT_ACTION = (model: Model, env: SpreadsheetChildEnv) =>
+  paste(model, env, "onlyFormat");
 
 //------------------------------------------------------------------------------
 // Grid manipulations
 //------------------------------------------------------------------------------
 
-export const DELETE_CONTENT_ROWS_NAME = (env: SpreadsheetChildEnv) => {
-  if (env.model.getters.getSelectedZones().length > 1) {
+export const DELETE_CONTENT_ROWS_NAME = (model: Model) => {
+  if (model.getters.getSelectedZones().length > 1) {
     return _t("Clear rows");
   }
   let first: number;
   let last: number;
-  const activesRows = env.model.getters.getActiveRows();
+  const activesRows = model.getters.getActiveRows();
   if (activesRows.size !== 0) {
     first = largeMin([...activesRows]);
     last = largeMax([...activesRows]);
   } else {
-    const zone = env.model.getters.getSelectedZones()[0];
+    const zone = model.getters.getSelectedZones()[0];
     first = zone.top;
     last = zone.bottom;
   }
@@ -115,29 +118,29 @@ export const DELETE_CONTENT_ROWS_NAME = (env: SpreadsheetChildEnv) => {
   return _t("Clear rows %s - %s", (first + 1).toString(), (last + 1).toString());
 };
 
-export const DELETE_CONTENT_ROWS_ACTION = (env: SpreadsheetChildEnv) => {
-  const sheetId = env.model.getters.getActiveSheetId();
-  const target = [...env.model.getters.getActiveRows()].map((index) =>
-    env.model.getters.getRowsZone(sheetId, index, index)
+export const DELETE_CONTENT_ROWS_ACTION = (model: Model) => {
+  const sheetId = model.getters.getActiveSheetId();
+  const target = [...model.getters.getActiveRows()].map((index) =>
+    model.getters.getRowsZone(sheetId, index, index)
   );
-  env.model.dispatch("DELETE_CONTENT", {
+  model.dispatch("DELETE_CONTENT", {
     target,
-    sheetId: env.model.getters.getActiveSheetId(),
+    sheetId: model.getters.getActiveSheetId(),
   });
 };
 
-export const DELETE_CONTENT_COLUMNS_NAME = (env: SpreadsheetChildEnv) => {
-  if (env.model.getters.getSelectedZones().length > 1) {
+export const DELETE_CONTENT_COLUMNS_NAME = (model: Model) => {
+  if (model.getters.getSelectedZones().length > 1) {
     return _t("Clear columns");
   }
   let first: number;
   let last: number;
-  const activeCols = env.model.getters.getActiveCols();
+  const activeCols = model.getters.getActiveCols();
   if (activeCols.size !== 0) {
     first = largeMin([...activeCols]);
     last = largeMax([...activeCols]);
   } else {
-    const zone = env.model.getters.getSelectedZones()[0];
+    const zone = model.getters.getSelectedZones()[0];
     first = zone.left;
     last = zone.right;
   }
@@ -147,29 +150,29 @@ export const DELETE_CONTENT_COLUMNS_NAME = (env: SpreadsheetChildEnv) => {
   return _t("Clear columns %s - %s", numberToLetters(first), numberToLetters(last));
 };
 
-export const DELETE_CONTENT_COLUMNS_ACTION = (env: SpreadsheetChildEnv) => {
-  const sheetId = env.model.getters.getActiveSheetId();
-  const target = [...env.model.getters.getActiveCols()].map((index) =>
-    env.model.getters.getColsZone(sheetId, index, index)
+export const DELETE_CONTENT_COLUMNS_ACTION = (model: Model) => {
+  const sheetId = model.getters.getActiveSheetId();
+  const target = [...model.getters.getActiveCols()].map((index) =>
+    model.getters.getColsZone(sheetId, index, index)
   );
-  env.model.dispatch("DELETE_CONTENT", {
+  model.dispatch("DELETE_CONTENT", {
     target,
-    sheetId: env.model.getters.getActiveSheetId(),
+    sheetId: model.getters.getActiveSheetId(),
   });
 };
 
-export const REMOVE_ROWS_NAME = (env: SpreadsheetChildEnv) => {
-  if (env.model.getters.getSelectedZones().length > 1) {
+export const REMOVE_ROWS_NAME = (model: Model) => {
+  if (model.getters.getSelectedZones().length > 1) {
     return _t("Delete rows");
   }
   let first: number;
   let last: number;
-  const activesRows = env.model.getters.getActiveRows();
+  const activesRows = model.getters.getActiveRows();
   if (activesRows.size !== 0) {
     first = largeMin([...activesRows]);
     last = largeMax([...activesRows]);
   } else {
-    const zone = env.model.getters.getSelectedZones()[0];
+    const zone = model.getters.getSelectedZones()[0];
     first = zone.top;
     last = zone.bottom;
   }
@@ -179,41 +182,38 @@ export const REMOVE_ROWS_NAME = (env: SpreadsheetChildEnv) => {
   return _t("Delete rows %s - %s", (first + 1).toString(), (last + 1).toString());
 };
 
-export const REMOVE_ROWS_ACTION = (env: SpreadsheetChildEnv) => {
-  const rows = [...env.model.getters.getActiveRows()];
+export const REMOVE_ROWS_ACTION = (model: Model) => {
+  const rows = [...model.getters.getActiveRows()];
   if (!rows.length) {
-    const zone = env.model.getters.getSelectedZones()[0];
+    const zone = model.getters.getSelectedZones()[0];
     for (let i = zone.top; i <= zone.bottom; i++) {
       rows.push(i);
     }
   }
-  env.model.dispatch("REMOVE_COLUMNS_ROWS", {
-    sheetId: env.model.getters.getActiveSheetId(),
-    sheetName: env.model.getters.getActiveSheetName(),
+  model.dispatch("REMOVE_COLUMNS_ROWS", {
+    sheetId: model.getters.getActiveSheetId(),
+    sheetName: model.getters.getActiveSheetName(),
     dimension: "ROW",
     elements: rows,
   });
 };
 
-export const CAN_REMOVE_COLUMNS_ROWS = (
-  dimension: Dimension,
-  env: SpreadsheetChildEnv
-): boolean => {
+export const CAN_REMOVE_COLUMNS_ROWS = (model: Model, dimension: Dimension): boolean => {
   if (
-    (dimension === "COL" && env.model.getters.getActiveRows().size > 0) ||
-    (dimension === "ROW" && env.model.getters.getActiveCols().size > 0)
+    (dimension === "COL" && model.getters.getActiveRows().size > 0) ||
+    (dimension === "ROW" && model.getters.getActiveCols().size > 0)
   ) {
     return false;
   }
-  const sheetId = env.model.getters.getActiveSheetId();
-  const selectedElements = env.model.getters.getElementsFromSelection(dimension);
+  const sheetId = model.getters.getActiveSheetId();
+  const selectedElements = model.getters.getElementsFromSelection(dimension);
 
-  const includesAllVisibleHeaders = env.model.getters.checkElementsIncludeAllVisibleHeaders(
+  const includesAllVisibleHeaders = model.getters.checkElementsIncludeAllVisibleHeaders(
     sheetId,
     dimension,
     selectedElements
   );
-  const includesAllNonFrozenHeaders = env.model.getters.checkElementsIncludeAllNonFrozenHeaders(
+  const includesAllNonFrozenHeaders = model.getters.checkElementsIncludeAllNonFrozenHeaders(
     sheetId,
     dimension,
     selectedElements
@@ -222,18 +222,18 @@ export const CAN_REMOVE_COLUMNS_ROWS = (
   return !includesAllVisibleHeaders && !includesAllNonFrozenHeaders;
 };
 
-export const REMOVE_COLUMNS_NAME = (env: SpreadsheetChildEnv) => {
-  if (env.model.getters.getSelectedZones().length > 1) {
+export const REMOVE_COLUMNS_NAME = (model: Model) => {
+  if (model.getters.getSelectedZones().length > 1) {
     return _t("Delete columns");
   }
   let first: number;
   let last: number;
-  const activeCols = env.model.getters.getActiveCols();
+  const activeCols = model.getters.getActiveCols();
   if (activeCols.size !== 0) {
     first = largeMin([...activeCols]);
     last = largeMax([...activeCols]);
   } else {
-    const zone = env.model.getters.getSelectedZones()[0];
+    const zone = model.getters.getSelectedZones()[0];
     first = zone.left;
     last = zone.right;
   }
@@ -243,49 +243,49 @@ export const REMOVE_COLUMNS_NAME = (env: SpreadsheetChildEnv) => {
   return _t("Delete columns %s - %s", numberToLetters(first), numberToLetters(last));
 };
 
-export const NOT_ALL_VISIBLE_ROWS_SELECTED = (env: SpreadsheetChildEnv) => {
-  const sheetId = env.model.getters.getActiveSheetId();
-  const selectedRows = env.model.getters.getElementsFromSelection("ROW");
-  return !env.model.getters.checkElementsIncludeAllVisibleHeaders(sheetId, "ROW", selectedRows);
+export const NOT_ALL_VISIBLE_ROWS_SELECTED = (model: Model) => {
+  const sheetId = model.getters.getActiveSheetId();
+  const selectedRows = model.getters.getElementsFromSelection("ROW");
+  return !model.getters.checkElementsIncludeAllVisibleHeaders(sheetId, "ROW", selectedRows);
 };
 
-export const REMOVE_COLUMNS_ACTION = (env: SpreadsheetChildEnv) => {
-  const columns = [...env.model.getters.getActiveCols()];
+export const REMOVE_COLUMNS_ACTION = (model: Model) => {
+  const columns = [...model.getters.getActiveCols()];
   if (!columns.length) {
-    const zone = env.model.getters.getSelectedZones()[0];
+    const zone = model.getters.getSelectedZones()[0];
     for (let i = zone.left; i <= zone.right; i++) {
       columns.push(i);
     }
   }
-  env.model.dispatch("REMOVE_COLUMNS_ROWS", {
-    sheetId: env.model.getters.getActiveSheetId(),
-    sheetName: env.model.getters.getActiveSheetName(),
+  model.dispatch("REMOVE_COLUMNS_ROWS", {
+    sheetId: model.getters.getActiveSheetId(),
+    sheetName: model.getters.getActiveSheetName(),
     dimension: "COL",
     elements: columns,
   });
 };
 
-export const NOT_ALL_VISIBLE_COLS_SELECTED = (env: SpreadsheetChildEnv) => {
-  const sheetId = env.model.getters.getActiveSheetId();
-  const selectedCols = env.model.getters.getElementsFromSelection("COL");
-  return !env.model.getters.checkElementsIncludeAllVisibleHeaders(sheetId, "COL", selectedCols);
+export const NOT_ALL_VISIBLE_COLS_SELECTED = (model: Model) => {
+  const sheetId = model.getters.getActiveSheetId();
+  const selectedCols = model.getters.getElementsFromSelection("COL");
+  return !model.getters.checkElementsIncludeAllVisibleHeaders(sheetId, "COL", selectedCols);
 };
 
-export const INSERT_ROWS_BEFORE_ACTION = (env: SpreadsheetChildEnv) => {
-  const activeRows = env.model.getters.getActiveRows();
+export const INSERT_ROWS_BEFORE_ACTION = (model: Model) => {
+  const activeRows = model.getters.getActiveRows();
   let row: number;
   let quantity: number;
   if (activeRows.size) {
     row = largeMin([...activeRows]);
     quantity = activeRows.size;
   } else {
-    const zone = env.model.getters.getSelectedZones()[0];
+    const zone = model.getters.getSelectedZones()[0];
     row = zone.top;
     quantity = zone.bottom - zone.top + 1;
   }
-  env.model.dispatch("ADD_COLUMNS_ROWS", {
-    sheetId: env.model.getters.getActiveSheetId(),
-    sheetName: env.model.getters.getActiveSheetName(),
+  model.dispatch("ADD_COLUMNS_ROWS", {
+    sheetId: model.getters.getActiveSheetId(),
+    sheetName: model.getters.getActiveSheetName(),
     position: "before",
     base: row,
     quantity,
@@ -293,21 +293,21 @@ export const INSERT_ROWS_BEFORE_ACTION = (env: SpreadsheetChildEnv) => {
   });
 };
 
-export const INSERT_ROWS_AFTER_ACTION = (env: SpreadsheetChildEnv) => {
-  const activeRows = env.model.getters.getActiveRows();
+export const INSERT_ROWS_AFTER_ACTION = (model: Model) => {
+  const activeRows = model.getters.getActiveRows();
   let row: number;
   let quantity: number;
   if (activeRows.size) {
     row = largeMax([...activeRows]);
     quantity = activeRows.size;
   } else {
-    const zone = env.model.getters.getSelectedZones()[0];
+    const zone = model.getters.getSelectedZones()[0];
     row = zone.bottom;
     quantity = zone.bottom - zone.top + 1;
   }
-  env.model.dispatch("ADD_COLUMNS_ROWS", {
-    sheetId: env.model.getters.getActiveSheetId(),
-    sheetName: env.model.getters.getActiveSheetName(),
+  model.dispatch("ADD_COLUMNS_ROWS", {
+    sheetId: model.getters.getActiveSheetId(),
+    sheetName: model.getters.getActiveSheetName(),
     position: "after",
     base: row,
     quantity,
@@ -315,21 +315,21 @@ export const INSERT_ROWS_AFTER_ACTION = (env: SpreadsheetChildEnv) => {
   });
 };
 
-export const INSERT_COLUMNS_BEFORE_ACTION = (env: SpreadsheetChildEnv) => {
-  const activeCols = env.model.getters.getActiveCols();
+export const INSERT_COLUMNS_BEFORE_ACTION = (model: Model) => {
+  const activeCols = model.getters.getActiveCols();
   let column: number;
   let quantity: number;
   if (activeCols.size) {
     column = largeMin([...activeCols]);
     quantity = activeCols.size;
   } else {
-    const zone = env.model.getters.getSelectedZones()[0];
+    const zone = model.getters.getSelectedZones()[0];
     column = zone.left;
     quantity = zone.right - zone.left + 1;
   }
-  env.model.dispatch("ADD_COLUMNS_ROWS", {
-    sheetId: env.model.getters.getActiveSheetId(),
-    sheetName: env.model.getters.getActiveSheetName(),
+  model.dispatch("ADD_COLUMNS_ROWS", {
+    sheetId: model.getters.getActiveSheetId(),
+    sheetName: model.getters.getActiveSheetName(),
     position: "before",
     dimension: "COL",
     base: column,
@@ -337,21 +337,21 @@ export const INSERT_COLUMNS_BEFORE_ACTION = (env: SpreadsheetChildEnv) => {
   });
 };
 
-export const INSERT_COLUMNS_AFTER_ACTION = (env: SpreadsheetChildEnv) => {
-  const activeCols = env.model.getters.getActiveCols();
+export const INSERT_COLUMNS_AFTER_ACTION = (model: Model) => {
+  const activeCols = model.getters.getActiveCols();
   let column: number;
   let quantity: number;
   if (activeCols.size) {
     column = largeMax([...activeCols]);
     quantity = activeCols.size;
   } else {
-    const zone = env.model.getters.getSelectedZones()[0];
+    const zone = model.getters.getSelectedZones()[0];
     column = zone.right;
     quantity = zone.right - zone.left + 1;
   }
-  env.model.dispatch("ADD_COLUMNS_ROWS", {
-    sheetId: env.model.getters.getActiveSheetId(),
-    sheetName: env.model.getters.getActiveSheetName(),
+  model.dispatch("ADD_COLUMNS_ROWS", {
+    sheetId: model.getters.getActiveSheetId(),
+    sheetName: model.getters.getActiveSheetName(),
     position: "after",
     dimension: "COL",
     base: column,
@@ -359,8 +359,8 @@ export const INSERT_COLUMNS_AFTER_ACTION = (env: SpreadsheetChildEnv) => {
   });
 };
 
-export const HIDE_COLUMNS_NAME = (env: SpreadsheetChildEnv) => {
-  const cols = env.model.getters.getElementsFromSelection("COL");
+export const HIDE_COLUMNS_NAME = (model: Model) => {
+  const cols = model.getters.getElementsFromSelection("COL");
   const first = cols[0];
   const last = cols[cols.length - 1];
   if (cols.length === 1) {
@@ -376,8 +376,8 @@ export const HIDE_COLUMNS_NAME = (env: SpreadsheetChildEnv) => {
   }
 };
 
-export const HIDE_ROWS_NAME = (env: SpreadsheetChildEnv) => {
-  const rows = env.model.getters.getElementsFromSelection("ROW");
+export const HIDE_ROWS_NAME = (model: Model) => {
+  const rows = model.getters.getElementsFromSelection("ROW");
   const first = rows[0];
   const last = rows[rows.length - 1];
   if (rows.length === 1) {
@@ -393,21 +393,21 @@ export const HIDE_ROWS_NAME = (env: SpreadsheetChildEnv) => {
 // Charts
 //------------------------------------------------------------------------------
 
-export const CREATE_CHART = (env: SpreadsheetChildEnv) => {
-  const getters = env.model.getters;
+export const CREATE_CHART = (model: Model, env: SpreadsheetChildEnv) => {
+  const getters = model.getters;
   const figureId = UuidGenerator.smallUuid();
   const sheetId = getters.getActiveSheetId();
   let zones = getters.getSelectedZones();
 
   if (zones.length === 1 && getZoneArea(zones[0]) === 1) {
-    env.model.selection.selectTableAroundSelection();
+    model.selection.selectTableAroundSelection();
     zones = getters.getSelectedZones();
   }
 
   const size = { width: DEFAULT_FIGURE_WIDTH, height: DEFAULT_FIGURE_HEIGHT };
   const { col, row, offset } = centerFigurePosition(getters, size);
 
-  const result = env.model.dispatch("CREATE_CHART", {
+  const result = model.dispatch("CREATE_CHART", {
     sheetId,
     figureId,
     chartId: UuidGenerator.smallUuid(),
@@ -415,23 +415,23 @@ export const CREATE_CHART = (env: SpreadsheetChildEnv) => {
     row,
     offset,
     size,
-    definition: getSmartChartDefinition(zones, env.model.getters),
+    definition: getSmartChartDefinition(zones, model.getters),
   });
   if (result.isSuccessful) {
-    env.model.dispatch("SELECT_FIGURE", { figureId });
+    model.dispatch("SELECT_FIGURE", { figureId });
     env.openSidePanel("ChartPanel");
   }
 };
 
-export const CREATE_CAROUSEL = (env: SpreadsheetChildEnv) => {
-  const getters = env.model.getters;
+export const CREATE_CAROUSEL = (model: Model, env: SpreadsheetChildEnv) => {
+  const getters = model.getters;
   const figureId = UuidGenerator.smallUuid();
   const sheetId = getters.getActiveSheetId();
 
   const size = { width: DEFAULT_FIGURE_WIDTH, height: DEFAULT_FIGURE_HEIGHT };
   const { col, row, offset } = centerFigurePosition(getters, size);
 
-  const result = env.model.dispatch("CREATE_CAROUSEL", {
+  const result = model.dispatch("CREATE_CAROUSEL", {
     sheetId,
     figureId,
     col,
@@ -441,7 +441,7 @@ export const CREATE_CAROUSEL = (env: SpreadsheetChildEnv) => {
     definition: { items: [] },
   });
   if (result.isSuccessful) {
-    env.model.dispatch("SELECT_FIGURE", { figureId });
+    model.dispatch("SELECT_FIGURE", { figureId });
     env.openSidePanel("CarouselPanel", { figureId });
   }
 };
@@ -450,77 +450,77 @@ export const CREATE_CAROUSEL = (env: SpreadsheetChildEnv) => {
 // Pivots
 //------------------------------------------------------------------------------
 
-export const CREATE_PIVOT = (env: SpreadsheetChildEnv) => {
+export const CREATE_PIVOT = (model: Model, env: SpreadsheetChildEnv) => {
   const pivotId = UuidGenerator.smallUuid();
   const newSheetId = UuidGenerator.smallUuid();
-  const result = env.model.dispatch("INSERT_NEW_PIVOT", { pivotId, newSheetId });
+  const result = model.dispatch("INSERT_NEW_PIVOT", { pivotId, newSheetId });
   if (result.isSuccessful) {
     env.openSidePanel("PivotSidePanel", { pivotId });
   }
 };
 
-export const REINSERT_DYNAMIC_PIVOT_CHILDREN = (env: SpreadsheetChildEnv) =>
-  env.model.getters.getPivotIds().map((pivotId, index) => ({
-    id: `reinsert_dynamic_pivot_${env.model.getters.getPivotFormulaId(pivotId)}`,
-    name: env.model.getters.getPivotDisplayName(pivotId),
+export const REINSERT_DYNAMIC_PIVOT_CHILDREN = (model: Model) =>
+  model.getters.getPivotIds().map((pivotId, index) => ({
+    id: `reinsert_dynamic_pivot_${model.getters.getPivotFormulaId(pivotId)}`,
+    name: model.getters.getPivotDisplayName(pivotId),
     sequence: index,
-    execute: (env: SpreadsheetChildEnv) => {
-      const zone = env.model.getters.getSelectedZone();
-      const table = env.model.getters.getPivot(pivotId).getCollapsedTableStructure().export();
-      env.model.dispatch("INSERT_PIVOT_WITH_TABLE", {
+    execute: (model: Model) => {
+      const zone = model.getters.getSelectedZone();
+      const table = model.getters.getPivot(pivotId).getCollapsedTableStructure().export();
+      model.dispatch("INSERT_PIVOT_WITH_TABLE", {
         pivotId,
         table,
         col: zone.left,
         row: zone.top,
-        sheetId: env.model.getters.getActiveSheetId(),
+        sheetId: model.getters.getActiveSheetId(),
         pivotMode: "dynamic",
       });
-      env.model.dispatch("REFRESH_PIVOT", { id: pivotId });
+      model.dispatch("REFRESH_PIVOT", { id: pivotId });
     },
-    isVisible: (env: SpreadsheetChildEnv) => env.model.getters.getPivot(pivotId).isValid(),
+    isVisible: (model: Model) => model.getters.getPivot(pivotId).isValid(),
   }));
 
-export const REINSERT_STATIC_PIVOT_CHILDREN = (env: SpreadsheetChildEnv) =>
-  env.model.getters.getPivotIds().map((pivotId, index) => ({
-    id: `reinsert_static_pivot_${env.model.getters.getPivotFormulaId(pivotId)}`,
-    name: env.model.getters.getPivotDisplayName(pivotId),
+export const REINSERT_STATIC_PIVOT_CHILDREN = (model: Model) =>
+  model.getters.getPivotIds().map((pivotId, index) => ({
+    id: `reinsert_static_pivot_${model.getters.getPivotFormulaId(pivotId)}`,
+    name: model.getters.getPivotDisplayName(pivotId),
     sequence: index,
-    execute: (env: SpreadsheetChildEnv) => {
-      const zone = env.model.getters.getSelectedZone();
-      const table = env.model.getters.getPivot(pivotId).getExpandedTableStructure();
+    execute: (model: Model, env: SpreadsheetChildEnv) => {
+      const zone = model.getters.getSelectedZone();
+      const table = model.getters.getPivot(pivotId).getExpandedTableStructure();
       if (table.numberOfCells > PIVOT_MAX_NUMBER_OF_CELLS) {
         env.notifyUser({
           type: "warning",
-          text: getPivotTooBigErrorMessage(table.numberOfCells, env.model.getters.getLocale()),
+          text: getPivotTooBigErrorMessage(table.numberOfCells, model.getters.getLocale()),
           sticky: true,
         });
         return;
       }
-      env.model.dispatch("INSERT_PIVOT_WITH_TABLE", {
+      model.dispatch("INSERT_PIVOT_WITH_TABLE", {
         pivotId,
         table: table.export(),
         col: zone.left,
         row: zone.top,
-        sheetId: env.model.getters.getActiveSheetId(),
+        sheetId: model.getters.getActiveSheetId(),
         pivotMode: "static",
       });
-      env.model.dispatch("REFRESH_PIVOT", { id: pivotId });
+      model.dispatch("REFRESH_PIVOT", { id: pivotId });
     },
-    isVisible: (env: SpreadsheetChildEnv) => env.model.getters.getPivot(pivotId).isValid(),
+    isVisible: (model: Model) => model.getters.getPivot(pivotId).isValid(),
   }));
 
 //------------------------------------------------------------------------------
 // Image
 //------------------------------------------------------------------------------
 
-export const CREATE_IMAGE = async (env: SpreadsheetChildEnv) => {
+export const CREATE_IMAGE = async (model: Model, env: SpreadsheetChildEnv) => {
   if (env.imageProvider) {
-    const sheetId = env.model.getters.getActiveSheetId();
+    const sheetId = model.getters.getActiveSheetId();
     const figureId = UuidGenerator.smallUuid();
     const image = await env.imageProvider.requestImage();
-    const size = getMaxFigureSize(env.model.getters, image.size);
-    const { col, row, offset } = centerFigurePosition(env.model.getters, size);
-    env.model.dispatch("CREATE_IMAGE", {
+    const size = getMaxFigureSize(model.getters, image.size);
+    const { col, row, offset } = centerFigurePosition(model.getters, size);
+    model.dispatch("CREATE_IMAGE", {
       sheetId,
       figureId,
       col,
@@ -536,16 +536,16 @@ export const CREATE_IMAGE = async (env: SpreadsheetChildEnv) => {
 // Style/Format
 //------------------------------------------------------------------------------
 
-export const FORMAT_PERCENT_ACTION = (env: SpreadsheetChildEnv) => setFormatter(env, "0.00%");
+export const FORMAT_PERCENT_ACTION = (model: Model) => setFormatter(model, "0.00%");
 
 //------------------------------------------------------------------------------
 // Side panel
 //------------------------------------------------------------------------------
-export const OPEN_CF_SIDEPANEL_ACTION = (env: SpreadsheetChildEnv) => {
-  const sheetId = env.model.getters.getActiveSheetId();
-  const zones = env.model.getters.getSelectedZones();
-  const rules = env.model.getters.getConditionalFormats(sheetId);
-  const ruleIds = env.model.getters.getRulesSelection(sheetId, zones);
+export const OPEN_CF_SIDEPANEL_ACTION = (model: Model, env: SpreadsheetChildEnv) => {
+  const sheetId = model.getters.getActiveSheetId();
+  const zones = model.getters.getSelectedZones();
+  const rules = model.getters.getConditionalFormats(sheetId);
+  const ruleIds = model.getters.getRulesSelection(sheetId, zones);
   if (ruleIds.length === 1) {
     return env.openSidePanel("ConditionalFormattingEditor", {
       cf: rules.find((r) => r.id === ruleIds[0]),
@@ -555,15 +555,15 @@ export const OPEN_CF_SIDEPANEL_ACTION = (env: SpreadsheetChildEnv) => {
   return env.openSidePanel("ConditionalFormatting");
 };
 
-export const INSERT_LINK = (env: SpreadsheetChildEnv) => {
-  const { col, row } = env.model.getters.getActivePosition();
+export const INSERT_LINK = (model: Model, env: SpreadsheetChildEnv) => {
+  const { col, row } = model.getters.getActivePosition();
   env.getStore(CellPopoverStore).open({ col, row }, "LinkEditor");
 };
 
-export const INSERT_LINK_NAME = (env: SpreadsheetChildEnv) => {
-  const sheetId = env.model.getters.getActiveSheetId();
-  const { col, row } = env.model.getters.getActivePosition();
-  const cell = env.model.getters.getEvaluatedCell({ sheetId, col, row });
+export const INSERT_LINK_NAME = (model: Model, env: SpreadsheetChildEnv) => {
+  const sheetId = model.getters.getActiveSheetId();
+  const { col, row } = model.getters.getActivePosition();
+  const cell = model.getters.getEvaluatedCell({ sheetId, col, row });
 
   return cell && cell.link ? _t("Edit link") : _t("Insert link");
 };
@@ -572,27 +572,27 @@ export const INSERT_LINK_NAME = (env: SpreadsheetChildEnv) => {
 // Filters action
 //------------------------------------------------------------------------------
 
-export const SELECTED_TABLE_HAS_FILTERS = (env: SpreadsheetChildEnv): boolean => {
-  const table = env.model.getters.getFirstTableInSelection();
+export const SELECTED_TABLE_HAS_FILTERS = (model: Model): boolean => {
+  const table = model.getters.getFirstTableInSelection();
   return table?.config.hasFilters || false;
 };
 
-export const SELECTION_CONTAINS_SINGLE_TABLE = (env: SpreadsheetChildEnv): boolean => {
-  const sheetId = env.model.getters.getActiveSheetId();
-  const selectedZones = env.model.getters.getSelectedZones();
-  const tables = env.model.getters.getTablesOverlappingZones(sheetId, selectedZones);
+export const SELECTION_CONTAINS_SINGLE_TABLE = (model: Model): boolean => {
+  const sheetId = model.getters.getActiveSheetId();
+  const selectedZones = model.getters.getSelectedZones();
+  const tables = model.getters.getTablesOverlappingZones(sheetId, selectedZones);
   return tables.length === 1 && !tables[0].isPivotTable;
 };
 
-export const IS_SELECTION_CONTINUOUS = (env: SpreadsheetChildEnv): boolean => {
-  return areZonesContinuous(env.model.getters.getSelectedZones());
+export const IS_SELECTION_CONTINUOUS = (model: Model): boolean => {
+  return areZonesContinuous(model.getters.getSelectedZones());
 };
 
-export const ADD_DATA_FILTER = (env: SpreadsheetChildEnv) => {
-  const sheetId = env.model.getters.getActiveSheetId();
-  const table = env.model.getters.getFirstTableInSelection();
+export const ADD_DATA_FILTER = (model: Model, env: SpreadsheetChildEnv) => {
+  const sheetId = model.getters.getActiveSheetId();
+  const table = model.getters.getFirstTableInSelection();
   if (table) {
-    env.model.dispatch("UPDATE_TABLE", {
+    model.dispatch("UPDATE_TABLE", {
       sheetId,
       zone: table.range.zone,
       config: { hasFilters: true },
@@ -604,39 +604,39 @@ export const ADD_DATA_FILTER = (env: SpreadsheetChildEnv) => {
       bandedRows: false,
       styleId: "TableStyleLight11",
     };
-    interactiveCreateTable(env, sheetId, tableConfig);
+    interactiveCreateTable(model, env, sheetId, tableConfig);
   }
 };
 
-export const REMOVE_DATA_FILTER = (env: SpreadsheetChildEnv) => {
-  const sheetId = env.model.getters.getActiveSheetId();
-  const table = env.model.getters.getFirstTableInSelection();
+export const REMOVE_DATA_FILTER = (model: Model) => {
+  const sheetId = model.getters.getActiveSheetId();
+  const table = model.getters.getFirstTableInSelection();
   if (!table) {
     return;
   }
-  env.model.dispatch("UPDATE_TABLE", {
+  model.dispatch("UPDATE_TABLE", {
     sheetId,
     zone: table.range.zone,
     config: { hasFilters: false },
   });
 };
 
-export const INSERT_TABLE = (env: SpreadsheetChildEnv) => {
-  const sheetId = env.model.getters.getActiveSheetId();
+export const INSERT_TABLE = (model: Model, env: SpreadsheetChildEnv) => {
+  const sheetId = model.getters.getActiveSheetId();
 
-  const result = interactiveCreateTable(env, sheetId);
+  const result = interactiveCreateTable(model, env, sheetId);
   if (result.isSuccessful) {
     env.openSidePanel("TableSidePanel", {});
   }
 };
 
-export const DELETE_SELECTED_TABLE = (env: SpreadsheetChildEnv) => {
-  const table = env.model.getters.getFirstTableInSelection();
+export const DELETE_SELECTED_TABLE = (model: Model) => {
+  const table = model.getters.getFirstTableInSelection();
   if (!table) {
     return;
   }
-  env.model.dispatch("REMOVE_TABLE", {
-    sheetId: env.model.getters.getActiveSheetId(),
+  model.dispatch("REMOVE_TABLE", {
+    sheetId: model.getters.getActiveSheetId(),
     target: [table.range.zone],
   });
 };
@@ -645,29 +645,29 @@ export const DELETE_SELECTED_TABLE = (env: SpreadsheetChildEnv) => {
 // Sorting action
 //------------------------------------------------------------------------------
 
-export const IS_ONLY_ONE_RANGE = (env: SpreadsheetChildEnv): boolean => {
-  return env.model.getters.getSelectedZones().length === 1;
+export const IS_ONLY_ONE_RANGE = (model: Model): boolean => {
+  return model.getters.getSelectedZones().length === 1;
 };
 
-export const CAN_INSERT_HEADER = (env: SpreadsheetChildEnv, dimension: Dimension): boolean => {
-  if (!IS_ONLY_ONE_RANGE(env)) {
+export const CAN_INSERT_HEADER = (model: Model, dimension: Dimension): boolean => {
+  if (!IS_ONLY_ONE_RANGE(model)) {
     return false;
   }
   const activeHeaders =
-    dimension === "COL" ? env.model.getters.getActiveCols() : env.model.getters.getActiveRows();
+    dimension === "COL" ? model.getters.getActiveCols() : model.getters.getActiveRows();
   const ortogonalActiveHeaders =
-    dimension === "COL" ? env.model.getters.getActiveRows() : env.model.getters.getActiveCols();
-  const sheetId = env.model.getters.getActiveSheetId();
-  const zone = env.model.getters.getSelectedZone();
-  const allSheetSelected = isEqual(zone, env.model.getters.getSheetZone(sheetId));
+    dimension === "COL" ? model.getters.getActiveRows() : model.getters.getActiveCols();
+  const sheetId = model.getters.getActiveSheetId();
+  const zone = model.getters.getSelectedZone();
+  const allSheetSelected = isEqual(zone, model.getters.getSheetZone(sheetId));
   return isConsecutive(activeHeaders) && (ortogonalActiveHeaders.size === 0 || allSheetSelected);
 };
 
 export const CREATE_OR_REMOVE_FILTER_ACTION: ActionSpec = {
-  name: (env) =>
-    SELECTED_TABLE_HAS_FILTERS(env) ? _t("Remove selected filters") : _t("Add filters"),
-  isEnabled: (env) => IS_SELECTION_CONTINUOUS(env),
-  execute: (env) =>
-    SELECTED_TABLE_HAS_FILTERS(env) ? REMOVE_DATA_FILTER(env) : ADD_DATA_FILTER(env),
+  name: (model) =>
+    SELECTED_TABLE_HAS_FILTERS(model) ? _t("Remove selected filters") : _t("Add filters"),
+  isEnabled: (model) => IS_SELECTION_CONTINUOUS(model),
+  execute: (model, env) =>
+    SELECTED_TABLE_HAS_FILTERS(model) ? REMOVE_DATA_FILTER(model) : ADD_DATA_FILTER(model, env),
   icon: "o-spreadsheet-Icon.FILTER_ICON_ACTIVE",
 };

--- a/src/actions/sheet_actions.ts
+++ b/src/actions/sheet_actions.ts
@@ -6,10 +6,8 @@ import { ActionSpec } from "./action";
 export const linkSheet: ActionSpec = {
   name: _t("Link sheet"),
   children: [
-    (env) => {
-      const sheets = env.model.getters
-        .getSheetIds()
-        .map((sheetId) => env.model.getters.getSheet(sheetId));
+    (model) => {
+      const sheets = model.getters.getSheetIds().map((sheetId) => model.getters.getSheet(sheetId));
       return sheets.map((sheet) => ({
         id: sheet.id,
         name: sheet.name,
@@ -21,15 +19,15 @@ export const linkSheet: ActionSpec = {
 
 export const deleteSheet: ActionSpec = {
   name: _t("Delete"),
-  isVisible: (env) => {
-    return env.model.getters.getVisibleSheetIds().length > 1;
+  isVisible: (model) => {
+    return model.getters.getVisibleSheetIds().length > 1;
   },
 
-  execute: (env) =>
+  execute: (model, env) =>
     env.askConfirmation(_t("Are you sure you want to delete this sheet?"), () => {
-      env.model.dispatch("DELETE_SHEET", {
-        sheetId: env.model.getters.getActiveSheetId(),
-        sheetName: env.model.getters.getActiveSheetName(),
+      model.dispatch("DELETE_SHEET", {
+        sheetId: model.getters.getActiveSheetId(),
+        sheetName: model.getters.getActiveSheetName(),
       });
     }),
   icon: "o-spreadsheet-Icon.TRASH",
@@ -37,17 +35,17 @@ export const deleteSheet: ActionSpec = {
 
 export const duplicateSheet: ActionSpec = {
   name: _t("Duplicate"),
-  execute: (env) => {
-    const sheetIdFrom = env.model.getters.getActiveSheetId();
-    const sheetNameFrom = env.model.getters.getSheetName(sheetIdFrom);
+  execute: (model, env) => {
+    const sheetIdFrom = model.getters.getActiveSheetId();
+    const sheetNameFrom = model.getters.getSheetName(sheetIdFrom);
     const sheetIdTo = UuidGenerator.smallUuid();
-    const sheetNameTo = env.model.getters.getDuplicateSheetName(sheetNameFrom);
-    env.model.dispatch("DUPLICATE_SHEET", {
+    const sheetNameTo = model.getters.getDuplicateSheetName(sheetNameFrom);
+    model.dispatch("DUPLICATE_SHEET", {
       sheetId: sheetIdFrom,
       sheetIdTo,
       sheetNameTo,
     });
-    env.model.dispatch("ACTIVATE_SHEET", { sheetIdFrom, sheetIdTo });
+    model.dispatch("ACTIVATE_SHEET", { sheetIdFrom, sheetIdTo });
   },
   isEnabledOnLockedSheet: true,
   icon: "o-spreadsheet-Icon.COPY",
@@ -73,14 +71,14 @@ export const changeSheetColor = (args: {
 
 export const sheetMoveRight: ActionSpec = {
   name: _t("Move right"),
-  isVisible: (env) => {
-    const sheetId = env.model.getters.getActiveSheetId();
-    const sheetIds = env.model.getters.getVisibleSheetIds();
+  isVisible: (model) => {
+    const sheetId = model.getters.getActiveSheetId();
+    const sheetIds = model.getters.getVisibleSheetIds();
     return sheetIds.indexOf(sheetId) !== sheetIds.length - 1;
   },
-  execute: (env) =>
-    env.model.dispatch("MOVE_SHEET", {
-      sheetId: env.model.getters.getActiveSheetId(),
+  execute: (model) =>
+    model.dispatch("MOVE_SHEET", {
+      sheetId: model.getters.getActiveSheetId(),
       delta: 1,
     }),
   isEnabledOnLockedSheet: true,
@@ -89,13 +87,13 @@ export const sheetMoveRight: ActionSpec = {
 
 export const sheetMoveLeft: ActionSpec = {
   name: _t("Move left"),
-  isVisible: (env) => {
-    const sheetId = env.model.getters.getActiveSheetId();
-    return env.model.getters.getVisibleSheetIds()[0] !== sheetId;
+  isVisible: (model) => {
+    const sheetId = model.getters.getActiveSheetId();
+    return model.getters.getVisibleSheetIds()[0] !== sheetId;
   },
-  execute: (env) =>
-    env.model.dispatch("MOVE_SHEET", {
-      sheetId: env.model.getters.getActiveSheetId(),
+  execute: (model) =>
+    model.dispatch("MOVE_SHEET", {
+      sheetId: model.getters.getActiveSheetId(),
       delta: -1,
     }),
   isEnabledOnLockedSheet: true,
@@ -104,21 +102,20 @@ export const sheetMoveLeft: ActionSpec = {
 
 export const hideSheet: ActionSpec = {
   name: _t("Hide sheet"),
-  isVisible: (env) => env.model.getters.getVisibleSheetIds().length !== 1,
-  execute: (env) =>
-    env.model.dispatch("HIDE_SHEET", { sheetId: env.model.getters.getActiveSheetId() }),
+  isVisible: (model) => model.getters.getVisibleSheetIds().length !== 1,
+  execute: (model) => model.dispatch("HIDE_SHEET", { sheetId: model.getters.getActiveSheetId() }),
   isEnabledOnLockedSheet: true,
   icon: "o-spreadsheet-Icon.HIDE_SHEET",
 };
 
 export const lockSheet: ActionSpec = {
   name: _t("Lock sheet"),
-  isVisible: (env) => {
-    return !env.model.getters.isCurrentSheetLocked();
+  isVisible: (model) => {
+    return !model.getters.isCurrentSheetLocked();
   },
-  execute: (env) => {
-    env.model.dispatch("LOCK_SHEET", {
-      sheetId: env.model.getters.getActiveSheetId(),
+  execute: (model) => {
+    model.dispatch("LOCK_SHEET", {
+      sheetId: model.getters.getActiveSheetId(),
     });
   },
   icon: "o-spreadsheet-Icon.LOCK",
@@ -126,12 +123,12 @@ export const lockSheet: ActionSpec = {
 
 export const unlockSheet: ActionSpec = {
   name: _t("Unlock sheet"),
-  isVisible: (env) => {
-    return env.model.getters.isCurrentSheetLocked();
+  isVisible: (model) => {
+    return model.getters.isCurrentSheetLocked();
   },
-  execute: (env) => {
-    env.model.dispatch("UNLOCK_SHEET", {
-      sheetId: env.model.getters.getActiveSheetId(),
+  execute: (model) => {
+    model.dispatch("UNLOCK_SHEET", {
+      sheetId: model.getters.getActiveSheetId(),
     });
   },
   isEnabledOnLockedSheet: true,

--- a/src/actions/view_actions.ts
+++ b/src/actions/view_actions.ts
@@ -1,19 +1,19 @@
 import { SidePanelStore } from "../components/side_panel/side_panel/side_panel_store";
 import { numberToLetters } from "../helpers/coordinates";
 import { interactiveFreezeColumnsRows } from "../helpers/ui/freeze_interactive";
+import { Model } from "../model";
 import { FormulaFingerprintStore } from "../stores/formula_fingerprints_store";
 import { _t } from "../translation";
 import { Dimension } from "../types/misc";
-import { SpreadsheetChildEnv } from "../types/spreadsheet_env";
 import { ActionSpec } from "./action";
 import * as ACTIONS from "./menu_items_actions";
 
 export const hideCols: ActionSpec = {
   name: ACTIONS.HIDE_COLUMNS_NAME,
-  execute: (env) => {
-    const columns = env.model.getters.getElementsFromSelection("COL");
-    env.model.dispatch("HIDE_COLUMNS_ROWS", {
-      sheetId: env.model.getters.getActiveSheetId(),
+  execute: (model) => {
+    const columns = model.getters.getElementsFromSelection("COL");
+    model.dispatch("HIDE_COLUMNS_ROWS", {
+      sheetId: model.getters.getActiveSheetId(),
       dimension: "COL",
       elements: columns,
     });
@@ -25,19 +25,17 @@ export const hideCols: ActionSpec = {
 
 export const unhideCols: ActionSpec = {
   name: _t("Unhide columns"),
-  execute: (env) => {
-    const columns = env.model.getters.getElementsFromSelection("COL");
-    env.model.dispatch("UNHIDE_COLUMNS_ROWS", {
-      sheetId: env.model.getters.getActiveSheetId(),
+  execute: (model) => {
+    const columns = model.getters.getElementsFromSelection("COL");
+    model.dispatch("UNHIDE_COLUMNS_ROWS", {
+      sheetId: model.getters.getActiveSheetId(),
       dimension: "COL",
       elements: columns,
     });
   },
-  isVisible: (env: SpreadsheetChildEnv) => {
-    const hiddenCols = env.model.getters
-      .getHiddenColsGroups(env.model.getters.getActiveSheetId())
-      .flat();
-    const currentCols = env.model.getters.getElementsFromSelection("COL");
+  isVisible: (model: Model) => {
+    const hiddenCols = model.getters.getHiddenColsGroups(model.getters.getActiveSheetId()).flat();
+    const currentCols = model.getters.getElementsFromSelection("COL");
     return currentCols.some((col) => hiddenCols.includes(col));
   },
 
@@ -46,26 +44,26 @@ export const unhideCols: ActionSpec = {
 
 export const unhideAllCols: ActionSpec = {
   name: _t("Unhide all columns"),
-  execute: (env) => {
-    const sheetId = env.model.getters.getActiveSheetId();
-    env.model.dispatch("UNHIDE_COLUMNS_ROWS", {
+  execute: (model) => {
+    const sheetId = model.getters.getActiveSheetId();
+    model.dispatch("UNHIDE_COLUMNS_ROWS", {
       sheetId,
       dimension: "COL",
-      elements: Array.from(Array(env.model.getters.getNumberCols(sheetId)).keys()),
+      elements: Array.from(Array(model.getters.getNumberCols(sheetId)).keys()),
     });
   },
-  isVisible: (env: SpreadsheetChildEnv) =>
-    env.model.getters.getHiddenColsGroups(env.model.getters.getActiveSheetId()).length > 0,
+  isVisible: (model: Model) =>
+    model.getters.getHiddenColsGroups(model.getters.getActiveSheetId()).length > 0,
 
   icon: "o-spreadsheet-Icon.UNHIDE_COL",
 };
 
 export const hideRows: ActionSpec = {
   name: ACTIONS.HIDE_ROWS_NAME,
-  execute: (env) => {
-    const rows = env.model.getters.getElementsFromSelection("ROW");
-    env.model.dispatch("HIDE_COLUMNS_ROWS", {
-      sheetId: env.model.getters.getActiveSheetId(),
+  execute: (model) => {
+    const rows = model.getters.getElementsFromSelection("ROW");
+    model.dispatch("HIDE_COLUMNS_ROWS", {
+      sheetId: model.getters.getActiveSheetId(),
       dimension: "ROW",
       elements: rows,
     });
@@ -77,19 +75,17 @@ export const hideRows: ActionSpec = {
 
 export const unhideRows: ActionSpec = {
   name: _t("Unhide rows"),
-  execute: (env) => {
-    const columns = env.model.getters.getElementsFromSelection("ROW");
-    env.model.dispatch("UNHIDE_COLUMNS_ROWS", {
-      sheetId: env.model.getters.getActiveSheetId(),
+  execute: (model) => {
+    const columns = model.getters.getElementsFromSelection("ROW");
+    model.dispatch("UNHIDE_COLUMNS_ROWS", {
+      sheetId: model.getters.getActiveSheetId(),
       dimension: "ROW",
       elements: columns,
     });
   },
-  isVisible: (env: SpreadsheetChildEnv) => {
-    const hiddenRows = env.model.getters
-      .getHiddenRowsGroups(env.model.getters.getActiveSheetId())
-      .flat();
-    const currentRows = env.model.getters.getElementsFromSelection("ROW");
+  isVisible: (model: Model) => {
+    const hiddenRows = model.getters.getHiddenRowsGroups(model.getters.getActiveSheetId()).flat();
+    const currentRows = model.getters.getElementsFromSelection("ROW");
     return currentRows.some((col) => hiddenRows.includes(col));
   },
 
@@ -98,31 +94,29 @@ export const unhideRows: ActionSpec = {
 
 export const unhideAllRows: ActionSpec = {
   name: _t("Unhide all rows"),
-  execute: (env) => {
-    const sheetId = env.model.getters.getActiveSheetId();
-    env.model.dispatch("UNHIDE_COLUMNS_ROWS", {
+  execute: (model) => {
+    const sheetId = model.getters.getActiveSheetId();
+    model.dispatch("UNHIDE_COLUMNS_ROWS", {
       sheetId,
       dimension: "ROW",
-      elements: Array.from(Array(env.model.getters.getNumberRows(sheetId)).keys()),
+      elements: Array.from(Array(model.getters.getNumberRows(sheetId)).keys()),
     });
   },
-  isVisible: (env: SpreadsheetChildEnv) =>
-    env.model.getters.getHiddenRowsGroups(env.model.getters.getActiveSheetId()).length > 0,
+  isVisible: (model: Model) =>
+    model.getters.getHiddenRowsGroups(model.getters.getActiveSheetId()).length > 0,
 
   icon: "o-spreadsheet-Icon.UNHIDE_ROW",
 };
 
 export const unFreezePane: ActionSpec = {
   name: _t("Unfreeze"),
-  isVisible: (env) => {
-    const { xSplit, ySplit } = env.model.getters.getPaneDivisions(
-      env.model.getters.getActiveSheetId()
-    );
+  isVisible: (model) => {
+    const { xSplit, ySplit } = model.getters.getPaneDivisions(model.getters.getActiveSheetId());
     return xSplit + ySplit > 0;
   },
-  execute: (env) =>
-    env.model.dispatch("UNFREEZE_COLUMNS_ROWS", {
-      sheetId: env.model.getters.getActiveSheetId(),
+  execute: (model) =>
+    model.dispatch("UNFREEZE_COLUMNS_ROWS", {
+      sheetId: model.getters.getActiveSheetId(),
     }),
 
   icon: "o-spreadsheet-Icon.UNFREEZE",
@@ -135,78 +129,76 @@ export const freezePane: ActionSpec = {
 
 export const unFreezeRows: ActionSpec = {
   name: _t("No rows"),
-  execute: (env) =>
-    env.model.dispatch("UNFREEZE_ROWS", {
-      sheetId: env.model.getters.getActiveSheetId(),
+  execute: (model) =>
+    model.dispatch("UNFREEZE_ROWS", {
+      sheetId: model.getters.getActiveSheetId(),
     }),
-  isVisible: (env) =>
-    !!env.model.getters.getPaneDivisions(env.model.getters.getActiveSheetId()).ySplit,
+  isVisible: (model) => !!model.getters.getPaneDivisions(model.getters.getActiveSheetId()).ySplit,
 };
 
 export const freezeFirstRow: ActionSpec = {
   name: _t("1 row"),
-  execute: (env) => interactiveFreezeColumnsRows(env, "ROW", 1),
+  execute: (model, env) => interactiveFreezeColumnsRows(model, env, "ROW", 1),
 };
 
 export const freezeSecondRow: ActionSpec = {
   name: _t("2 rows"),
-  execute: (env) => interactiveFreezeColumnsRows(env, "ROW", 2),
+  execute: (model, env) => interactiveFreezeColumnsRows(model, env, "ROW", 2),
 };
 
 export const freezeCurrentRow: ActionSpec = {
   name: _t("Up to current row"),
-  execute: (env) => {
-    const { bottom } = env.model.getters.getSelectedZone();
-    interactiveFreezeColumnsRows(env, "ROW", bottom + 1);
+  execute: (model, env) => {
+    const { bottom } = model.getters.getSelectedZone();
+    interactiveFreezeColumnsRows(model, env, "ROW", bottom + 1);
   },
 };
 
 export const unFreezeCols: ActionSpec = {
   name: _t("No columns"),
-  execute: (env) =>
-    env.model.dispatch("UNFREEZE_COLUMNS", {
-      sheetId: env.model.getters.getActiveSheetId(),
+  execute: (model) =>
+    model.dispatch("UNFREEZE_COLUMNS", {
+      sheetId: model.getters.getActiveSheetId(),
     }),
-  isVisible: (env) =>
-    !!env.model.getters.getPaneDivisions(env.model.getters.getActiveSheetId()).xSplit,
+  isVisible: (model) => !!model.getters.getPaneDivisions(model.getters.getActiveSheetId()).xSplit,
 };
 
 export const freezeFirstCol: ActionSpec = {
   name: _t("1 column"),
-  execute: (env) => interactiveFreezeColumnsRows(env, "COL", 1),
+  execute: (model, env) => interactiveFreezeColumnsRows(model, env, "COL", 1),
 };
 
 export const freezeSecondCol: ActionSpec = {
   name: _t("2 columns"),
-  execute: (env) => interactiveFreezeColumnsRows(env, "COL", 2),
+  execute: (model, env) => interactiveFreezeColumnsRows(model, env, "COL", 2),
 };
 
 export const freezeCurrentCol: ActionSpec = {
   name: _t("Up to current column"),
-  execute: (env) => {
-    const { right } = env.model.getters.getSelectedZone();
-    interactiveFreezeColumnsRows(env, "COL", right + 1);
+  execute: (model, env) => {
+    const { right } = model.getters.getSelectedZone();
+    interactiveFreezeColumnsRows(model, env, "COL", right + 1);
   },
 };
 
 export const viewGridlines: ActionSpec = {
   name: _t("Gridlines"),
-  execute: (env) => {
-    const sheetId = env.model.getters.getActiveSheetId();
-    env.model.dispatch("SET_GRID_LINES_VISIBILITY", {
+  execute: (model) => {
+    const sheetId = model.getters.getActiveSheetId();
+    model.dispatch("SET_GRID_LINES_VISIBILITY", {
       sheetId,
-      areGridLinesVisible: !env.model.getters.getGridLinesVisibility(sheetId),
+      areGridLinesVisible: !model.getters.getGridLinesVisibility(sheetId),
     });
   },
-  isActive: (env) => {
-    const sheetId = env.model.getters.getActiveSheetId();
-    return env.model.getters.getGridLinesVisibility(sheetId);
+  isActive: (model) => {
+    const sheetId = model.getters.getActiveSheetId();
+    return model.getters.getGridLinesVisibility(sheetId);
   },
 };
 
 export const irregularityMap: ActionSpec = {
   name: _t("Irregularity map"),
-  execute: (env) => {
+  execute: (model, env) => {
     const fingerprintStore = env.getStore(FormulaFingerprintStore);
     if (fingerprintStore.isEnabled) {
       fingerprintStore.disable();
@@ -222,10 +214,10 @@ export const irregularityMap: ActionSpec = {
 export function zoomAction(zoom: number): ActionSpec {
   return {
     name: _t("%(zoom_percentage)s%", { zoom_percentage: zoom }),
-    execute: (env) => {
-      env.model.dispatch("SET_ZOOM", { zoom: zoom / 100 });
+    execute: (model) => {
+      model.dispatch("SET_ZOOM", { zoom: zoom / 100 });
     },
-    isActive: (env: SpreadsheetChildEnv) => env.model.getters.getViewportZoomLevel() === zoom / 100,
+    isActive: (model: Model) => model.getters.getViewportZoomLevel() === zoom / 100,
     isReadonlyAllowed: true,
     isEnabledOnLockedSheet: true,
     sequence: zoom,
@@ -234,16 +226,16 @@ export function zoomAction(zoom: number): ActionSpec {
 
 export const viewFormulas: ActionSpec = {
   name: _t("Formulas"),
-  isActive: (env: SpreadsheetChildEnv) => env.model.getters.shouldShowFormulas(),
-  execute: (env) =>
-    env.model.dispatch("SET_FORMULA_VISIBILITY", { show: !env.model.getters.shouldShowFormulas() }),
+  isActive: (model: Model) => model.getters.shouldShowFormulas(),
+  execute: (model) =>
+    model.dispatch("SET_FORMULA_VISIBILITY", { show: !model.getters.shouldShowFormulas() }),
   isReadonlyAllowed: true,
   isEnabledOnLockedSheet: true,
 };
 
 export const groupColumns: ActionSpec = {
-  name: (env) => {
-    const selection = env.model.getters.getSelectedZone();
+  name: (model) => {
+    const selection = model.getters.getSelectedZone();
     if (selection.left === selection.right) {
       return _t("Group column %s", numberToLetters(selection.left));
     }
@@ -253,14 +245,14 @@ export const groupColumns: ActionSpec = {
       numberToLetters(selection.right)
     );
   },
-  execute: (env) => groupHeadersAction(env, "COL"),
-  isVisible: (env) => {
-    const sheetId = env.model.getters.getActiveSheetId();
-    const selection = env.model.getters.getSelectedZone();
-    const groups = env.model.getters.getHeaderGroupsInZone(sheetId, "COL", selection);
+  execute: (model) => groupHeadersAction(model, "COL"),
+  isVisible: (model) => {
+    const sheetId = model.getters.getActiveSheetId();
+    const selection = model.getters.getSelectedZone();
+    const groups = model.getters.getHeaderGroupsInZone(sheetId, "COL", selection);
 
     return (
-      ACTIONS.IS_ONLY_ONE_RANGE(env) &&
+      ACTIONS.IS_ONLY_ONE_RANGE(model) &&
       !groups.some((group) => group.start === selection.left && group.end === selection.right)
     );
   },
@@ -269,21 +261,21 @@ export const groupColumns: ActionSpec = {
 };
 
 export const groupRows: ActionSpec = {
-  name: (env) => {
-    const selection = env.model.getters.getSelectedZone();
+  name: (model) => {
+    const selection = model.getters.getSelectedZone();
     if (selection.top === selection.bottom) {
       return _t("Group row %s", String(selection.top + 1));
     }
     return _t("Group rows %s - %s", String(selection.top + 1), String(selection.bottom + 1));
   },
-  execute: (env) => groupHeadersAction(env, "ROW"),
-  isVisible: (env) => {
-    const sheetId = env.model.getters.getActiveSheetId();
-    const selection = env.model.getters.getSelectedZone();
-    const groups = env.model.getters.getHeaderGroupsInZone(sheetId, "ROW", selection);
+  execute: (model) => groupHeadersAction(model, "ROW"),
+  isVisible: (model) => {
+    const sheetId = model.getters.getActiveSheetId();
+    const selection = model.getters.getSelectedZone();
+    const groups = model.getters.getHeaderGroupsInZone(sheetId, "ROW", selection);
 
     return (
-      ACTIONS.IS_ONLY_ONE_RANGE(env) &&
+      ACTIONS.IS_ONLY_ONE_RANGE(model) &&
       !groups.some((group) => group.start === selection.top && group.end === selection.bottom)
     );
   },
@@ -292,8 +284,8 @@ export const groupRows: ActionSpec = {
 };
 
 export const ungroupColumns: ActionSpec = {
-  name: (env) => {
-    const selection = env.model.getters.getSelectedZone();
+  name: (model) => {
+    const selection = model.getters.getSelectedZone();
     if (selection.left === selection.right) {
       return _t("Ungroup column %s", numberToLetters(selection.left));
     }
@@ -303,28 +295,28 @@ export const ungroupColumns: ActionSpec = {
       numberToLetters(selection.right)
     );
   },
-  execute: (env) => ungroupHeaders(env, "COL"),
+  execute: (model) => ungroupHeaders(model, "COL"),
 
   icon: "o-spreadsheet-Icon.UNGROUP_COLUMNS",
 };
 
 export const ungroupRows: ActionSpec = {
-  name: (env) => {
-    const selection = env.model.getters.getSelectedZone();
+  name: (model) => {
+    const selection = model.getters.getSelectedZone();
     if (selection.top === selection.bottom) {
       return _t("Ungroup row %s", String(selection.top + 1));
     }
     return _t("Ungroup rows %s - %s", String(selection.top + 1), String(selection.bottom + 1));
   },
-  execute: (env) => ungroupHeaders(env, "ROW"),
+  execute: (model) => ungroupHeaders(model, "ROW"),
 
   icon: "o-spreadsheet-Icon.UNGROUP_ROWS",
 };
 
-function groupHeadersAction(env: SpreadsheetChildEnv, dim: Dimension) {
-  const selection = env.model.getters.getSelectedZone();
-  const sheetId = env.model.getters.getActiveSheetId();
-  env.model.dispatch("GROUP_HEADERS", {
+function groupHeadersAction(model: Model, dim: Dimension) {
+  const selection = model.getters.getSelectedZone();
+  const sheetId = model.getters.getActiveSheetId();
+  model.dispatch("GROUP_HEADERS", {
     sheetId,
     dimension: dim,
     start: dim === "COL" ? selection.left : selection.top,
@@ -332,10 +324,10 @@ function groupHeadersAction(env: SpreadsheetChildEnv, dim: Dimension) {
   });
 }
 
-function ungroupHeaders(env: SpreadsheetChildEnv, dim: Dimension) {
-  const selection = env.model.getters.getSelectedZone();
-  const sheetId = env.model.getters.getActiveSheetId();
-  env.model.dispatch("UNGROUP_HEADERS", {
+function ungroupHeaders(model: Model, dim: Dimension) {
+  const selection = model.getters.getSelectedZone();
+  const sheetId = model.getters.getActiveSheetId();
+  model.dispatch("UNGROUP_HEADERS", {
     sheetId,
     dimension: dim,
     start: dim === "COL" ? selection.left : selection.top,
@@ -343,26 +335,26 @@ function ungroupHeaders(env: SpreadsheetChildEnv, dim: Dimension) {
   });
 }
 
-export function canUngroupHeaders(env: SpreadsheetChildEnv, dimension: Dimension): boolean {
-  const sheetId = env.model.getters.getActiveSheetId();
-  const selection = env.model.getters.getSelectedZones();
+export function canUngroupHeaders(model: Model, dimension: Dimension): boolean {
+  const sheetId = model.getters.getActiveSheetId();
+  const selection = model.getters.getSelectedZones();
   return (
     selection.length === 1 &&
-    env.model.getters.getHeaderGroupsInZone(sheetId, dimension, selection[0]).length > 0
+    model.getters.getHeaderGroupsInZone(sheetId, dimension, selection[0]).length > 0
   );
 }
 
 export const togglePinPanel: ActionSpec = {
-  name: (env) => {
+  name: (model, env) => {
     const sidepanelStore = env.getStore(SidePanelStore);
     return sidepanelStore.mainPanel && sidepanelStore.mainPanel.isPinned
       ? _t("Unpin the side panel")
       : _t("Pin the side panel");
   },
-  isVisible: (env) => {
+  isVisible: (model, env) => {
     return env.getStore(SidePanelStore).isMainPanelOpen;
   },
-  execute: (env) => {
+  execute: (model, env) => {
     env.getStore(SidePanelStore).togglePinPanel();
   },
   icon: "o-spreadsheet-Icon.THUMB_TACK",

--- a/src/components/action_button/action_button.ts
+++ b/src/components/action_button/action_button.ts
@@ -4,6 +4,7 @@ import { Component } from "../../owl3_compatibility_layer";
 import { PropsOf } from "../../types/props_of";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 import { cssPropertiesToCss } from "../helpers/css";
+import { useModel } from "../owl_plugins/model_plugin";
 import { types } from "../props_validation";
 
 export class ActionButton extends Component<SpreadsheetChildEnv> {
@@ -19,6 +20,7 @@ export class ActionButton extends Component<SpreadsheetChildEnv> {
 
   private actionButton = createAction(this.props.action);
 
+  private model = useModel();
   setup() {
     onWillUpdateProps((nextProps: PropsOf<ActionButton>) => {
       if (nextProps.action !== this.props.action) {
@@ -28,33 +30,34 @@ export class ActionButton extends Component<SpreadsheetChildEnv> {
   }
 
   get isVisible() {
-    return this.actionButton.isVisible(this.env);
+    return this.actionButton.isVisible(this.model(), this.env);
   }
 
   get isEnabled() {
     const isLockedAvailable =
-      this.actionButton.isEnabledOnLockedSheet || !this.env.model.getters.isCurrentSheetLocked();
-    return this.actionButton.isEnabled(this.env) && isLockedAvailable;
+      this.actionButton.isEnabledOnLockedSheet || !this.model().getters.isCurrentSheetLocked();
+    return this.actionButton.isEnabled(this.model(), this.env) && isLockedAvailable;
   }
 
   get isActive() {
-    return this.actionButton.isActive?.(this.env);
+    return this.actionButton.isActive?.(this.model(), this.env);
   }
 
   get title() {
-    const name = this.actionButton.name(this.env);
-    const description = this.actionButton.description(this.env) || this.actionButton.shortcut;
+    const name = this.actionButton.name(this.model(), this.env);
+    const description =
+      this.actionButton.description(this.model(), this.env) || this.actionButton.shortcut;
     return name + (description ? ` (${description})` : "");
   }
 
   get iconTitle() {
-    return this.actionButton.icon(this.env);
+    return this.actionButton.icon(this.model(), this.env);
   }
 
   onClick(ev: MouseEvent) {
     if (this.isEnabled) {
       this.props.onClick?.(ev);
-      this.actionButton.execute?.(this.env);
+      this.actionButton.execute?.(this.model(), this.env);
     }
   }
 

--- a/src/components/autofill/autofill.ts
+++ b/src/components/autofill/autofill.ts
@@ -7,6 +7,7 @@ import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 import { cssPropertiesToCss } from "../helpers/css";
 import { useDragAndDropBeyondTheViewport } from "../helpers/drag_and_drop_grid_hook";
 import { withZoom } from "../helpers/zoom";
+import { useModel } from "../owl_plugins/model_plugin";
 import { types } from "../props_validation";
 
 // -----------------------------------------------------------------------------
@@ -25,12 +26,13 @@ export class Autofill extends Component<SpreadsheetChildEnv> {
     position: types.DOMCoordinates(),
     isVisible: types.boolean(),
   });
+  private model = useModel();
   state: State = proxy({
     position: { x: 0, y: 0 },
     handler: false,
   });
 
-  dragNDropGrid = useDragAndDropBeyondTheViewport(this.env);
+  dragNDropGrid = useDragAndDropBeyondTheViewport(this.model());
 
   get style() {
     const { x, y } = this.props.position;
@@ -57,7 +59,7 @@ export class Autofill extends Component<SpreadsheetChildEnv> {
   }
 
   getTooltip() {
-    const tooltip = this.env.model.getters.getAutofillTooltip();
+    const tooltip = this.model().getters.getAutofillTooltip();
     if (tooltip && !tooltip.component) {
       tooltip.component = TooltipComponent;
     }
@@ -66,8 +68,8 @@ export class Autofill extends Component<SpreadsheetChildEnv> {
 
   onMouseDown(ev: PointerEvent) {
     this.state.handler = true;
-    const zoomedMouseEvent = withZoom(this.env, ev);
-    const zoom = this.env.model.getters.getViewportZoomLevel();
+    const zoomedMouseEvent = withZoom(this.model(), ev);
+    const zoom = this.model().getters.getViewportZoomLevel();
     let lastCol: HeaderIndex | undefined;
     let lastRow: HeaderIndex | undefined;
     const start = {
@@ -77,7 +79,7 @@ export class Autofill extends Component<SpreadsheetChildEnv> {
     const onMouseUp = () => {
       this.state.handler = false;
       this.state.position = { ...this.props.position };
-      this.env.model.dispatch("AUTOFILL");
+      this.model().dispatch("AUTOFILL");
     };
 
     const onMouseMove = (col: HeaderIndex, row: HeaderIndex, ev: MouseEvent) => {
@@ -86,13 +88,13 @@ export class Autofill extends Component<SpreadsheetChildEnv> {
         y: ev.clientY / zoom - start.y,
       };
       if (lastCol !== col || lastRow !== row) {
-        const activeSheetId = this.env.model.getters.getActiveSheetId();
-        const numberOfCols = this.env.model.getters.getNumberCols(activeSheetId);
-        const numberOfRows = this.env.model.getters.getNumberRows(activeSheetId);
+        const activeSheetId = this.model().getters.getActiveSheetId();
+        const numberOfCols = this.model().getters.getNumberCols(activeSheetId);
+        const numberOfRows = this.model().getters.getNumberRows(activeSheetId);
         lastCol = col === -1 ? lastCol : clip(col, 0, numberOfCols);
         lastRow = row === -1 ? lastRow : clip(row, 0, numberOfRows);
         if (lastCol !== undefined && lastRow !== undefined) {
-          this.env.model.dispatch("AUTOFILL_SELECT", { col: lastCol, row: lastRow });
+          this.model().dispatch("AUTOFILL_SELECT", { col: lastCol, row: lastRow });
         }
       }
     };
@@ -100,7 +102,7 @@ export class Autofill extends Component<SpreadsheetChildEnv> {
   }
 
   onDblClick() {
-    this.env.model.dispatch("AUTOFILL_AUTO");
+    this.model().dispatch("AUTOFILL_AUTO");
   }
 }
 

--- a/src/components/border_editor/border_editor_widget.ts
+++ b/src/components/border_editor/border_editor_widget.ts
@@ -6,6 +6,7 @@ import { Rect } from "../../types/rendering";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 import { getElBoundingRect } from "../helpers/dom_helpers";
 import { ToolBarDropdownStore, useToolBarDropdownStore } from "../helpers/top_bar_tool_hook";
+import { useModel } from "../owl_plugins/model_plugin";
 import { types } from "../props_validation";
 import { BorderEditor } from "./border_editor";
 
@@ -33,6 +34,7 @@ export class BorderEditorWidget extends Component<SpreadsheetChildEnv> {
     currentPosition: undefined,
   });
 
+  private model = useModel();
   setup() {
     this.topBarToolStore = useToolBarDropdownStore();
     onWillUpdateProps(() => {
@@ -43,7 +45,7 @@ export class BorderEditorWidget extends Component<SpreadsheetChildEnv> {
   }
 
   get dropdownMaxHeight(): Pixel {
-    return this.env.model.getters.getSheetViewDimension().height;
+    return this.model().getters.getSheetViewDimension().height;
   }
 
   get borderEditorAnchorRect(): Rect {
@@ -81,9 +83,9 @@ export class BorderEditorWidget extends Component<SpreadsheetChildEnv> {
     if (this.state.currentPosition === undefined) {
       return;
     }
-    this.env.model.dispatch("SET_ZONE_BORDERS", {
-      sheetId: this.env.model.getters.getActiveSheetId(),
-      target: this.env.model.getters.getSelectedZones(),
+    this.model().dispatch("SET_ZONE_BORDERS", {
+      sheetId: this.model().getters.getActiveSheetId(),
+      target: this.model().getters.getSelectedZones(),
       border: {
         position: this.state.currentPosition,
         color: this.state.currentColor,

--- a/src/components/border_editor/border_editor_widget.xml
+++ b/src/components/border_editor/border_editor_widget.xml
@@ -2,7 +2,7 @@
   <t t-name="o-spreadsheet-BorderEditorWidget">
     <div
       class="d-flex position-relative"
-      t-att-class="{'o-disabled': this.env.model.getters.isCurrentSheetLocked()}"
+      t-att-class="{'o-disabled': this.model().getters.isCurrentSheetLocked()}"
       title="Borders">
       <span
         t-ref="this.borderEditorButtonRef"

--- a/src/components/bottom_bar/bottom_bar.ts
+++ b/src/components/bottom_bar/bottom_bar.ts
@@ -10,6 +10,7 @@ import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 import { Ripple } from "../animation/ripple";
 import { useDragAndDropListItems } from "../helpers/drag_and_drop_dom_items_hook";
 import { MenuPopover, MenuState } from "../menu_popover/menu_popover";
+import { useModel } from "../owl_plugins/model_plugin";
 import { BottomBarSheet } from "./bottom_bar_sheet/bottom_bar_sheet";
 import { BottomBarStatistic } from "./bottom_bar_statistic/bottom_bar_statistic";
 
@@ -54,9 +55,12 @@ export class BottomBar extends Component<SpreadsheetChildEnv> {
     menuItems: [],
   });
 
-  sheetList = this.getVisibleSheets();
+  sheetList: BottomBarSheetItem[] = [];
+
+  private model = useModel();
 
   setup() {
+    this.sheetList = this.getVisibleSheets();
     onWillUpdateProps(() => {
       this.updateScrollState();
       const visibleSheets = this.getVisibleSheets();
@@ -69,40 +73,44 @@ export class BottomBar extends Component<SpreadsheetChildEnv> {
   }
 
   clickAddSheet(ev: MouseEvent) {
-    const activeSheetId = this.env.model.getters.getActiveSheetId();
+    const activeSheetId = this.model().getters.getActiveSheetId();
     const position =
-      this.env.model.getters.getSheetIds().findIndex((sheetId) => sheetId === activeSheetId) + 1;
+      this.model()
+        .getters.getSheetIds()
+        .findIndex((sheetId) => sheetId === activeSheetId) + 1;
     const sheetId = UuidGenerator.smallUuid();
-    const name = this.env.model.getters.getNextSheetName(_t("Sheet"));
-    this.env.model.dispatch("CREATE_SHEET", { sheetId, position, name });
-    this.env.model.dispatch("ACTIVATE_SHEET", { sheetIdFrom: activeSheetId, sheetIdTo: sheetId });
+    const name = this.model().getters.getNextSheetName(_t("Sheet"));
+    this.model().dispatch("CREATE_SHEET", { sheetId, position, name });
+    this.model().dispatch("ACTIVATE_SHEET", { sheetIdFrom: activeSheetId, sheetIdTo: sheetId });
   }
 
   getVisibleSheets(): BottomBarSheetItem[] {
-    return this.env.model.getters.getVisibleSheetIds().map((sheetId) => {
-      const sheet = this.env.model.getters.getSheet(sheetId);
-      return { id: sheet.id, name: sheet.name };
-    });
+    return this.model()
+      .getters.getVisibleSheetIds()
+      .map((sheetId) => {
+        const sheet = this.model().getters.getSheet(sheetId);
+        return { id: sheet.id, name: sheet.name };
+      });
   }
 
   clickListSheets(ev: MouseEvent) {
     const registry = new MenuItemRegistry();
-    const from = this.env.model.getters.getActiveSheetId();
+    const from = this.model().getters.getActiveSheetId();
     let i = 0;
-    for (const sheetId of this.env.model.getters.getSheetIds()) {
-      const sheet = this.env.model.getters.getSheet(sheetId);
+    for (const sheetId of this.model().getters.getSheetIds()) {
+      const sheet = this.model().getters.getSheet(sheetId);
       registry.add(sheetId, {
         name: sheet.name,
         sequence: i,
         isReadonlyAllowed: true,
         textColor: sheet.isVisible ? undefined : "#808080",
-        execute: (env) => {
-          if (!this.env.model.getters.isSheetVisible(sheetId)) {
-            this.env.model.dispatch("SHOW_SHEET", { sheetId });
+        execute: (model) => {
+          if (!model.getters.isSheetVisible(sheetId)) {
+            model.dispatch("SHOW_SHEET", { sheetId });
           }
-          env.model.dispatch("ACTIVATE_SHEET", { sheetIdFrom: from, sheetIdTo: sheetId });
+          model.dispatch("ACTIVATE_SHEET", { sheetIdFrom: from, sheetIdTo: sheetId });
         },
-        isEnabled: (env) => (env.model.getters.isReadonly() ? sheet.isVisible : true),
+        isEnabled: (model) => (model.getters.isReadonly() ? sheet.isVisible : true),
         icon: sheet.color ? "o-spreadsheet-Icon.SMALL_DOT_RIGHT_ALIGN" : undefined,
         iconColor: sheet.color,
         isEnabledOnLockedSheet: true,
@@ -195,7 +203,7 @@ export class BottomBar extends Component<SpreadsheetChildEnv> {
   }
 
   onSheetMouseDown(sheetId: UID, event: MouseEvent) {
-    if (event.button !== 0 || this.env.model.getters.isReadonly()) {
+    if (event.button !== 0 || this.model().getters.isReadonly()) {
       return;
     }
     this.closeMenu();
@@ -225,7 +233,7 @@ export class BottomBar extends Component<SpreadsheetChildEnv> {
     const originalIndex = this.getVisibleSheets().findIndex((sheet) => sheet.id === sheetId);
     const delta = finalIndex - originalIndex;
     if (sheetId && delta !== 0) {
-      this.env.model.dispatch("MOVE_SHEET", {
+      this.model().dispatch("MOVE_SHEET", {
         sheetId: sheetId,
         delta: delta,
       });

--- a/src/components/bottom_bar/bottom_bar.xml
+++ b/src/components/bottom_bar/bottom_bar.xml
@@ -7,7 +7,7 @@
       <Ripple class="'add-sheet-container'">
         <div
           class="o-sheet-item o-add-sheet me-2 p-1"
-          t-if="!this.env.model.getters.isReadonly()"
+          t-if="!this.model().getters.isReadonly()"
           t-on-click="this.clickAddSheet">
           <t t-call="o-spreadsheet-Icon.PLUS"/>
         </div>

--- a/src/components/bottom_bar/bottom_bar_sheet/bottom_bar_sheet.ts
+++ b/src/components/bottom_bar/bottom_bar_sheet/bottom_bar_sheet.ts
@@ -15,6 +15,7 @@ import { Ripple } from "../../animation/ripple";
 import { ColorPicker } from "../../color_picker/color_picker";
 import { cssPropertiesToCss } from "../../helpers/css";
 import { getElBoundingRect } from "../../helpers/dom_helpers";
+import { useModel } from "../../owl_plugins/model_plugin";
 
 interface State {
   isEditing: boolean;
@@ -62,6 +63,7 @@ export class BottomBarSheet extends Component<SpreadsheetChildEnv> {
 
   private editionState: "initializing" | "editing" = "initializing";
 
+  private model = useModel();
   private DOMFocusableElementStore!: Store<DOMFocusableElementStore>;
   setup() {
     this.DOMFocusableElementStore = useStore(DOMFocusableElementStore);
@@ -88,7 +90,7 @@ export class BottomBarSheet extends Component<SpreadsheetChildEnv> {
           this.scrollToSheet();
         }
       },
-      () => [this.env.model.getters.getActiveSheetId()]
+      () => [this.model().getters.getActiveSheetId()]
     );
 
     onMounted(() => {
@@ -100,7 +102,7 @@ export class BottomBarSheet extends Component<SpreadsheetChildEnv> {
         800
       );
 
-      this.env.model.on(
+      this.model().on(
         "command-rejected",
         this,
         async ({ command, result }: { command: Command; result: DispatchResult }) => {
@@ -118,7 +120,7 @@ export class BottomBarSheet extends Component<SpreadsheetChildEnv> {
       );
     });
     onWillUnmount(() => {
-      this.env.model.off("command-rejected", this);
+      this.model().off("command-rejected", this);
     });
   }
 
@@ -164,15 +166,15 @@ export class BottomBarSheet extends Component<SpreadsheetChildEnv> {
   }
 
   private activateSheet() {
-    this.env.model.dispatch("ACTIVATE_SHEET", {
-      sheetIdFrom: this.env.model.getters.getActiveSheetId(),
+    this.model().dispatch("ACTIVATE_SHEET", {
+      sheetIdFrom: this.model().getters.getActiveSheetId(),
       sheetIdTo: this.props.sheetId,
     });
     this.scrollToSheet();
   }
 
   onDblClick() {
-    if (this.env.model.getters.isReadonly() || this.isSheetLocked) {
+    if (this.model().getters.isReadonly() || this.isSheetLocked) {
       return;
     }
     this.startEdition();
@@ -215,7 +217,9 @@ export class BottomBarSheet extends Component<SpreadsheetChildEnv> {
 
     const inputValue = this.getInputContent() || "";
 
-    interactiveRenameSheet(this.env, this.props.sheetId, inputValue, () => this.startEdition());
+    interactiveRenameSheet(this.model(), this.env, this.props.sheetId, inputValue, () =>
+      this.startEdition()
+    );
   }
 
   private cancelEdition() {
@@ -256,7 +260,7 @@ export class BottomBarSheet extends Component<SpreadsheetChildEnv> {
 
   onColorPicked(color: string) {
     this.state.pickerOpened = false;
-    this.env.model.dispatch("COLOR_SHEET", { sheetId: this.props.sheetId, color });
+    this.model().dispatch("COLOR_SHEET", { sheetId: this.props.sheetId, color });
   }
 
   get colorPickerAnchorRect(): Rect {
@@ -277,19 +281,19 @@ export class BottomBarSheet extends Component<SpreadsheetChildEnv> {
   }
 
   get isSheetActive() {
-    return this.env.model.getters.getActiveSheetId() === this.props.sheetId;
+    return this.model().getters.getActiveSheetId() === this.props.sheetId;
   }
 
   get sheetName() {
-    return this.env.model.getters.getSheetName(this.props.sheetId);
+    return this.model().getters.getSheetName(this.props.sheetId);
   }
 
   get sheetColorStyle() {
-    const color = this.env.model.getters.getSheet(this.props.sheetId).color || "";
+    const color = this.model().getters.getSheet(this.props.sheetId).color || "";
     return cssPropertiesToCss({ background: color });
   }
 
   get isSheetLocked() {
-    return this.env.model.getters.isSheetLocked(this.props.sheetId);
+    return this.model().getters.isSheetLocked(this.props.sheetId);
   }
 }

--- a/src/components/bottom_bar/bottom_bar_statistic/bottom_bar_statistic.ts
+++ b/src/components/bottom_bar/bottom_bar_statistic/bottom_bar_statistic.ts
@@ -6,6 +6,7 @@ import { useStore } from "../../../store_engine/store_hooks";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
 import { Store } from "../../../types/store_engine";
 import { Ripple } from "../../animation/ripple";
+import { useModel } from "../../owl_plugins/model_plugin";
 import { AggregateStatisticsStore } from "./aggregate_statistics_store";
 
 // -----------------------------------------------------------------------------
@@ -27,6 +28,8 @@ export class BottomBarStatistic extends Component<SpreadsheetChildEnv> {
 
   private state = proxy({ selectedStatisticFn: "" });
   private store!: Store<AggregateStatisticsStore>;
+
+  private model = useModel();
 
   setup() {
     this.store = useStore(AggregateStatisticsStore);
@@ -72,7 +75,7 @@ export class BottomBarStatistic extends Component<SpreadsheetChildEnv> {
   }
 
   private getComposedFnName(fnName: string): string {
-    const locale = this.env.model.getters.getLocale();
+    const locale = this.model().getters.getLocale();
     const fnValue = this.store.statisticFnResults[fnName];
     return (
       fnName +

--- a/src/components/collaborative_client_tag/collaborative_client_tag.ts
+++ b/src/components/collaborative_client_tag/collaborative_client_tag.ts
@@ -1,8 +1,8 @@
-import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
-import { cssPropertiesToCss } from "../helpers/css";
-
 import { props } from "@odoo/owl";
 import { Component } from "../../owl3_compatibility_layer";
+import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
+import { cssPropertiesToCss } from "../helpers/css";
+import { useModel } from "../owl_plugins/model_plugin";
 import { types } from "../props_validation";
 
 export class ClientTag extends Component<SpreadsheetChildEnv> {
@@ -15,15 +15,18 @@ export class ClientTag extends Component<SpreadsheetChildEnv> {
     col: types.HeaderIndex(),
     row: types.HeaderIndex(),
   });
+
+  private model = useModel();
+
   get tagStyle(): string {
     const { col, row, color } = this.props;
-    const { height } = this.env.model.getters.getSheetViewDimensionWithHeaders();
-    const visible = this.env.model.getters.isVisibleInViewport({
-      sheetId: this.env.model.getters.getActiveSheetId(),
+    const { height } = this.model().getters.getSheetViewDimensionWithHeaders();
+    const visible = this.model().getters.isVisibleInViewport({
+      sheetId: this.model().getters.getActiveSheetId(),
       col,
       row,
     });
-    const { x, y } = this.env.model.getters.getVisibleRect({
+    const { x, y } = this.model().getters.getVisibleRect({
       left: col,
       top: row,
       right: col,

--- a/src/components/color_picker/color_picker.ts
+++ b/src/components/color_picker/color_picker.ts
@@ -16,6 +16,7 @@ import { PropsOf } from "../../types/props_of";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 import { cssPropertiesToCss } from "../helpers/css";
 import { startDnd } from "../helpers/drag_and_drop";
+import { useModel } from "../owl_plugins/model_plugin";
 import { Popover } from "../popover/popover";
 import { types } from "../props_validation";
 
@@ -61,6 +62,8 @@ export class ColorPicker extends Component<SpreadsheetChildEnv> {
       : { h: 0, s: 100, l: 100, a: 1 },
     customHexColor: isColorValid(this.props.currentColor) ? toHex(this.props.currentColor) : "",
   });
+
+  protected model = useModel();
 
   get colorPickerStyle(): string {
     if (this.props.maxHeight !== undefined && this.props.maxHeight <= 0) {

--- a/src/components/color_picker/color_picker.xml
+++ b/src/components/color_picker/color_picker.xml
@@ -33,7 +33,7 @@
             </div>
           </div>
           <div
-            t-foreach="this.env.model.getters.getCustomColors()"
+            t-foreach="this.model().getters.getCustomColors()"
             t-as="color"
             t-key="color"
             class="o-color-picker-line-item os-theme-dependant"

--- a/src/components/composer/composer/composer.ts
+++ b/src/components/composer/composer/composer.ts
@@ -20,6 +20,7 @@ import { cssPropertiesToCss } from "../../helpers/css";
 import { isIOS, keyboardEventToShortcutString } from "../../helpers/dom_helpers";
 import { useSpreadsheetRect } from "../../helpers/position_hook";
 import { updateSelectionWithArrowKeys } from "../../helpers/selection_helpers";
+import { useModel } from "../../owl_plugins/model_plugin";
 import { types } from "../../props_validation";
 import { TextValueProvider } from "../autocomplete_dropdown/autocomplete_dropdown";
 import { ContentEditableHelper } from "../content_editable_helper";
@@ -88,6 +89,8 @@ export class Composer extends Component<SpreadsheetChildEnv> {
   );
 
   private DOMFocusableElementStore!: Store<DOMFocusableElementStore>;
+
+  private model = useModel();
 
   composerRef = signal<HTMLElement | null>(null);
   containerRef = signal<HTMLElement | null>(null);
@@ -270,7 +273,7 @@ export class Composer extends Component<SpreadsheetChildEnv> {
       // Prevent the default content editable behavior which moves the cursor
       ev.preventDefault();
       ev.stopPropagation();
-      updateSelectionWithArrowKeys(ev, this.env.model.selection);
+      updateSelectionWithArrowKeys(ev, this.model().selection);
       return;
     }
     const content = this.props.composerStore.currentContent;
@@ -353,7 +356,7 @@ export class Composer extends Component<SpreadsheetChildEnv> {
   private processNumpadDecimal(ev: KeyboardEvent) {
     ev.stopPropagation();
     ev.preventDefault();
-    const locale = this.env.model.getters.getLocale();
+    const locale = this.model().getters.getLocale();
     const selection = this.contentHelper.getCurrentSelection();
     const currentContent = this.props.composerStore.currentContent;
     const content =
@@ -504,7 +507,7 @@ export class Composer extends Component<SpreadsheetChildEnv> {
   }
 
   onMouseup() {
-    if (this.env.model.getters.isReadonly()) {
+    if (this.model().getters.isReadonly()) {
       return;
     }
     const selection = this.contentHelper.getCurrentSelection();
@@ -514,7 +517,7 @@ export class Composer extends Component<SpreadsheetChildEnv> {
   }
 
   onClick() {
-    if (this.env.model.getters.isReadonly()) {
+    if (this.model().getters.isReadonly()) {
       return;
     }
     const newSelection = this.contentHelper.getCurrentSelection();
@@ -527,7 +530,7 @@ export class Composer extends Component<SpreadsheetChildEnv> {
   }
 
   onDblClick() {
-    if (this.env.model.getters.isReadonly()) {
+    if (this.model().getters.isReadonly()) {
       return;
     }
     const composerContent = this.props.composerStore.currentContent;

--- a/src/components/composer/composer/composer.xml
+++ b/src/components/composer/composer/composer.xml
@@ -21,11 +21,11 @@
         </span>
         <div
           class="o-composer w-100 text-start"
-          t-att-class="{ 'text-muted': this.env.model.getters.isReadonly(), 'active': this.props.focus !== 'inactive' }"
+          t-att-class="{ 'text-muted': this.model().getters.isReadonly(), 'active': this.props.focus !== 'inactive' }"
           t-att-style="this.props.inputStyle"
           t-ref="this.composerRef"
           tabindex="1"
-          t-att-contenteditable="this.env.model.getters.isReadonly() ? 'false' : 'plaintext-only'"
+          t-att-contenteditable="this.model().getters.isReadonly() ? 'false' : 'plaintext-only'"
           t-att-placeHolder="this.props.placeholder"
           t-att-inputmode="this.props.inputMode"
           spellcheck="false"

--- a/src/components/composer/formula_assistant/formula_assistant.ts
+++ b/src/components/composer/formula_assistant/formula_assistant.ts
@@ -2,6 +2,7 @@ import { props, proxy } from "@odoo/owl";
 import { Component } from "../../../owl3_compatibility_layer";
 import { PropsOf } from "../../../types/props_of";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
+import { useModel } from "../../owl_plugins/model_plugin";
 import { types } from "../../props_validation";
 import { Collapse } from "../../side_panel/components/collapse/collapse";
 
@@ -19,6 +20,8 @@ export class FunctionDescriptionProvider extends Component<SpreadsheetChildEnv> 
     isCollapsed: true,
   });
 
+  private model = useModel();
+
   toggle() {
     this.state.isCollapsed = !this.state.isCollapsed;
   }
@@ -29,7 +32,7 @@ export class FunctionDescriptionProvider extends Component<SpreadsheetChildEnv> 
 
   get formulaHeaderContent(): { content: string; focused?: boolean }[] {
     const { functionDescription, repeatingArgGroupIndex, argsToFocus } = this.props;
-    const argSeparator = this.env.model.getters.getLocale().formulaArgSeparator + " ";
+    const argSeparator = this.model().getters.getLocale().formulaArgSeparator + " ";
 
     const result: { content: string; focused?: boolean }[] = [
       { content: functionDescription.name + " ( " },

--- a/src/components/composer/grid_composer/grid_composer.ts
+++ b/src/components/composer/grid_composer/grid_composer.ts
@@ -13,6 +13,7 @@ import { Rect } from "../../../types/rendering";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
 import { Store } from "../../../types/store_engine";
 import { cssPropertiesToCss, getTextDecoration } from "../../helpers/css";
+import { useModel } from "../../owl_plugins/model_plugin";
 import { types } from "../../props_validation";
 import { CellComposerStore } from "../composer/cell_composer_store";
 import { Composer } from "../composer/composer";
@@ -37,12 +38,9 @@ export class GridComposer extends Component<SpreadsheetChildEnv> {
   private rect: Rect = this.defaultRect;
   private isEditing: boolean = false;
   private isCellReferenceVisible: boolean = false;
-  private currentEditedCell: CellPosition = {
-    col: 0,
-    row: 0,
-    sheetId: this.env.model.getters.getActiveSheetId(),
-  };
+  private currentEditedCell!: CellPosition;
 
+  private model = useModel();
   private composerStore!: Store<CellComposerStore>;
   composerFocusStore!: Store<ComposerFocusStore>;
 
@@ -53,6 +51,7 @@ export class GridComposer extends Component<SpreadsheetChildEnv> {
   }
 
   setup() {
+    this.currentEditedCell = { col: 0, row: 0, sheetId: this.model().getters.getActiveSheetId() };
     const composerStore = useStore(CellComposerStore);
     this.composerStore = composerStore;
     this.composerFocusStore = useStore(ComposerFocusStore);
@@ -78,9 +77,9 @@ export class GridComposer extends Component<SpreadsheetChildEnv> {
 
   get cellReference(): string {
     const { col, row, sheetId } = this.composerStore.currentEditedCell;
-    const prefixSheet = sheetId !== this.env.model.getters.getActiveSheetId();
+    const prefixSheet = sheetId !== this.model().getters.getActiveSheetId();
     return getFullReference(
-      prefixSheet ? this.env.model.getters.getSheetName(sheetId) : undefined,
+      prefixSheet ? this.model().getters.getSheetName(sheetId) : undefined,
       toXC(col, row)
     );
   }
@@ -100,7 +99,7 @@ export class GridComposer extends Component<SpreadsheetChildEnv> {
   }
 
   get composerProps(): PropsOf<Composer> {
-    const { width, height } = this.env.model.getters.getSheetViewDimensionWithHeaders();
+    const { width, height } = this.model().getters.getSheetViewDimensionWithHeaders();
     // Remove the wrapper border width
     const maxHeight = this.props.gridDims.height - this.rect.y - 2 * COMPOSER_BORDER_WIDTH;
     return {
@@ -133,9 +132,9 @@ export class GridComposer extends Component<SpreadsheetChildEnv> {
       return `z-index: -1000; opacity: 0;`; // opacity 0 for safari on ios
     }
     const _isFormula = isFormula(this.composerStore.currentContent);
-    const cell = this.env.model.getters.getActiveCell();
-    const position = this.env.model.getters.getActivePosition();
-    const style = this.env.model.getters.getCellComputedStyle(position);
+    const cell = this.model().getters.getActiveCell();
+    const position = this.model().getters.getActivePosition();
+    const style = this.model().getters.getCellComputedStyle(position);
 
     // position style
     const { x: left, y: top, width, height } = this.rect;
@@ -210,9 +209,9 @@ export class GridComposer extends Component<SpreadsheetChildEnv> {
     }
 
     if (shouldRecomputeRect) {
-      const position = this.env.model.getters.getActivePosition();
-      const zone = this.env.model.getters.expandZone(position.sheetId, positionToZone(position));
-      this.rect = this.env.model.getters.getVisibleRect(zone);
+      const position = this.model().getters.getActivePosition();
+      const zone = this.model().getters.expandZone(position.sheetId, positionToZone(position));
+      this.rect = this.model().getters.getVisibleRect(zone);
     }
   }
 
@@ -224,9 +223,9 @@ export class GridComposer extends Component<SpreadsheetChildEnv> {
     if (this.isCellReferenceVisible) {
       return;
     }
-    const sheetId = this.env.model.getters.getActiveSheetId();
-    const zone = positionToZone(this.env.model.getters.getSelection().anchor.cell);
-    const rect = this.env.model.getters.getVisibleRect(zone);
+    const sheetId = this.model().getters.getActiveSheetId();
+    const zone = positionToZone(this.model().getters.getSelection().anchor.cell);
+    const rect = this.model().getters.getVisibleRect(zone);
     if (!deepEquals(rect, this.rect) || sheetId !== this.composerStore.currentEditedCell.sheetId) {
       this.isCellReferenceVisible = true;
     }

--- a/src/components/composer/top_bar_composer/top_bar_composer.ts
+++ b/src/components/composer/top_bar_composer/top_bar_composer.ts
@@ -1,21 +1,22 @@
 import { DESKTOP_TOPBAR_TOOLBAR_HEIGHT } from "../../../constants";
+import { Component } from "../../../owl3_compatibility_layer";
 import { useStore } from "../../../store_engine/store_hooks";
 import { CSSProperties, ComposerFocusType } from "../../../types/misc";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
 import { Store } from "../../../types/store_engine";
 import { cssPropertiesToCss } from "../../helpers/css";
+import { useModel } from "../../owl_plugins/model_plugin";
 import { ComposerSelection } from "../composer/abstract_composer_store";
 import { CellComposerStore } from "../composer/cell_composer_store";
 import { Composer } from "../composer/composer";
 import { ComposerFocusStore, ComposerInterface } from "../composer_focus_store";
-
-import { Component } from "../../../owl3_compatibility_layer";
 const COMPOSER_MAX_HEIGHT = 300;
 
 export class TopBarComposer extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-TopBarComposer";
   static components = { Composer };
 
+  private model = useModel();
   private composerFocusStore!: Store<ComposerFocusStore>;
   private composerStore!: Store<CellComposerStore>;
   private composerInterface!: ComposerInterface;
@@ -55,7 +56,7 @@ export class TopBarComposer extends Component<SpreadsheetChildEnv> {
       "max-height": `${COMPOSER_MAX_HEIGHT}px`,
       "line-height": "24px",
     };
-    if (this.env.model.getters.isCurrentSheetLocked()) {
+    if (this.model().getters.isCurrentSheetLocked()) {
       style["pointer-events"] = "none";
     }
     style.height = this.focus === "inactive" ? `${DESKTOP_TOPBAR_TOOLBAR_HEIGHT}px` : "fit-content";

--- a/src/components/composer/top_bar_composer/top_bar_composer.xml
+++ b/src/components/composer/top_bar_composer/top_bar_composer.xml
@@ -4,7 +4,7 @@
       <div
         class="o-topbar-composer position-relative bg-white user-select-text d-flex border"
         t-att-class="{
-          'o-topbar-composer-readonly': this.env.model.getters.isReadonly(),
+          'o-topbar-composer-readonly': this.model().getters.isReadonly(),
           'o-topbar-composer-active': this.focus !== 'inactive',
           'o-topbar-composer-inactive': this.focus === 'inactive',
         }"

--- a/src/components/dashboard/clickable_cell_sort_icon/clickable_cell_sort_icon.ts
+++ b/src/components/dashboard/clickable_cell_sort_icon/clickable_cell_sort_icon.ts
@@ -1,16 +1,16 @@
+import { props } from "@odoo/owl";
 import { TEXT_BODY_MUTED } from "../../../constants";
 import { blendColors } from "../../../helpers/color";
 import { computeTextFontSizeInPixels } from "../../../helpers/text_helper";
+import { Component } from "../../../owl3_compatibility_layer";
 import { useStore } from "../../../store_engine/store_hooks";
 import { Color, Style } from "../../../types/misc";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
 import { Store } from "../../../types/store_engine";
 import { cssPropertiesToCss } from "../../helpers/css";
-import { HoveredTableStore } from "../../tables/hovered_table_store";
-
-import { props } from "@odoo/owl";
-import { Component } from "../../../owl3_compatibility_layer";
+import { useModel } from "../../owl_plugins/model_plugin";
 import { types } from "../../props_validation";
+import { HoveredTableStore } from "../../tables/hovered_table_store";
 
 export class ClickableCellSortIcon extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ClickableCellSortIcon";
@@ -21,12 +21,14 @@ export class ClickableCellSortIcon extends Component<SpreadsheetChildEnv> {
   });
   private hoveredTableStore!: Store<HoveredTableStore>;
 
+  private model = useModel();
+
   setup(): void {
     this.hoveredTableStore = useStore(HoveredTableStore);
   }
 
   get style() {
-    const cellStyle = this.env.model.getters.getCellComputedStyle(this.props.position);
+    const cellStyle = this.model().getters.getCellComputedStyle(this.props.position);
     const size = computeTextFontSizeInPixels(cellStyle);
     return cssPropertiesToCss({
       height: `${size}px`,
@@ -37,7 +39,7 @@ export class ClickableCellSortIcon extends Component<SpreadsheetChildEnv> {
   }
 
   get verticalJustifyClass() {
-    const cellStyle = this.env.model.getters.getCellComputedStyle(this.props.position);
+    const cellStyle = this.model().getters.getCellComputedStyle(this.props.position);
     switch (cellStyle.verticalAlign) {
       case "top":
         return "justify-content-start";

--- a/src/components/dashboard/clickable_cell_store.ts
+++ b/src/components/dashboard/clickable_cell_store.ts
@@ -1,6 +1,7 @@
 import { markRaw } from "@odoo/owl";
 import { toXC } from "../../helpers/coordinates";
 import { positionToZone } from "../../helpers/zones";
+import { Model } from "../../model";
 import { ComponentConstructor } from "../../owl3_compatibility_layer";
 import { CellClickableItem, clickableCellRegistry } from "../../registries/cell_clickable_registry";
 import { SpreadsheetStore } from "../../stores/spreadsheet_store";
@@ -13,7 +14,12 @@ export interface ClickableCell {
   coordinates: Rect;
   position: CellPosition;
   title: string;
-  action: (position: CellPosition, env: SpreadsheetChildEnv, isMiddleClick?: boolean) => void;
+  action: (
+    position: CellPosition,
+    model: Model,
+    env: SpreadsheetChildEnv,
+    isMiddleClick?: boolean
+  ) => void;
   component: ComponentConstructor | undefined;
   componentProps: Record<string, unknown>;
 }

--- a/src/components/dashboard/dashboard.ts
+++ b/src/components/dashboard/dashboard.ts
@@ -15,6 +15,7 @@ import { useGridDrawing } from "../helpers/draw_grid_hook";
 import { useTouchHandlers } from "../helpers/touch_handlers_hook";
 import { useWheelHandler } from "../helpers/wheel_hook";
 import { getZoomedRect } from "../helpers/zoom";
+import { useModel } from "../owl_plugins/model_plugin";
 import { CellPopoverStore } from "../popover/cell_popover_store";
 import { Popover } from "../popover/popover";
 import { types } from "../props_validation";
@@ -46,6 +47,8 @@ export class SpreadsheetDashboard extends Component<SpreadsheetChildEnv> {
   private gridRef = signal<HTMLElement | null>(null);
   private canvasRef = signal<HTMLElement | null>(null);
 
+  private model = useModel();
+
   setup() {
     this.hoveredCell = useStore(DelayedHoveredCellStore);
     this.clickableCellsStore = useStore(ClickableCellsStore);
@@ -54,15 +57,15 @@ export class SpreadsheetDashboard extends Component<SpreadsheetChildEnv> {
     const rendererStore = useLocalStore(RendererStore, layers);
     useChildSubEnv({
       getPopoverContainerRect: () =>
-        getZoomedRect(this.env.model.getters.getViewportZoomLevel(), this.getGridRect()),
+        getZoomedRect(this.model().getters.getViewportZoomLevel(), this.getGridRect()),
     });
     useGridDrawing({
       canvasRef: this.canvasRef,
       rendererStore,
       renderingCtx: () => ({
         dpr: window.devicePixelRatio || 1,
-        viewports: this.env.model.getters.getViewportCollection(),
-        ...this.env.model.getters.getSelectionState(),
+        viewports: this.model().getters.getViewportCollection(),
+        ...this.model().getters.getSelectionState(),
         hideGridLines: true,
       }),
     });
@@ -75,16 +78,16 @@ export class SpreadsheetDashboard extends Component<SpreadsheetChildEnv> {
     useTouchHandlers(this.gridRef, {
       updateScroll: this.moveCanvas.bind(this),
       canMoveUp: () => {
-        const { scrollY } = this.env.model.getters.getActiveSheetScrollInfo();
+        const { scrollY } = this.model().getters.getActiveSheetScrollInfo();
         return scrollY > 0;
       },
       canMoveDown: () => {
-        const { maxOffsetY } = this.env.model.getters.getMaximumSheetOffset();
-        const { scrollY } = this.env.model.getters.getActiveSheetScrollInfo();
+        const { maxOffsetY } = this.model().getters.getMaximumSheetOffset();
+        const { scrollY } = this.model().getters.getActiveSheetScrollInfo();
         return scrollY < maxOffsetY;
       },
-      getZoom: () => this.env.model.getters.getViewportZoomLevel(),
-      setZoom: (zoom: number) => this.env.model.dispatch("SET_ZOOM", { zoom }),
+      getZoom: () => this.model().getters.getViewportZoomLevel(),
+      setZoom: (zoom: number) => this.model().dispatch("SET_ZOOM", { zoom }),
     });
   }
 
@@ -121,7 +124,7 @@ export class SpreadsheetDashboard extends Component<SpreadsheetChildEnv> {
 
   selectClickableCell(ev: MouseEvent, clickableCell: ClickableCell) {
     const { position, action } = clickableCell;
-    action(position, this.env, isMiddleClickOrCtrlClick(ev));
+    action(position, this.model(), this.env, isMiddleClickOrCtrlClick(ev));
   }
 
   onClosePopover() {
@@ -131,7 +134,7 @@ export class SpreadsheetDashboard extends Component<SpreadsheetChildEnv> {
   onGridResized() {
     const { height, width } = this.props.getGridSize();
     const maxWidth = this.getMaxSheetWidth();
-    this.env.model.dispatch("RESIZE_SHEETVIEW", {
+    this.model().dispatch("RESIZE_SHEETVIEW", {
       width: Math.min(maxWidth, width),
       height,
       gridOffsetX: 0,
@@ -140,8 +143,8 @@ export class SpreadsheetDashboard extends Component<SpreadsheetChildEnv> {
   }
 
   private moveCanvas(deltaX: Pixel, deltaY: Pixel) {
-    const { scrollX, scrollY } = this.env.model.getters.getActiveSheetScrollInfo();
-    this.env.model.dispatch("SET_VIEWPORT_OFFSET", {
+    const { scrollX, scrollY } = this.model().getters.getActiveSheetScrollInfo();
+    this.model().dispatch("SET_VIEWPORT_OFFSET", {
       offsetX: scrollX + deltaX,
       offsetY: scrollY + deltaY,
     });
@@ -150,18 +153,18 @@ export class SpreadsheetDashboard extends Component<SpreadsheetChildEnv> {
   private getGridRect(): Rect {
     return {
       ...getElBoundingRect(this.gridRef()),
-      ...this.env.model.getters.getSheetViewDimensionWithHeaders(),
+      ...this.model().getters.getSheetViewDimensionWithHeaders(),
     };
   }
 
   private getMaxSheetWidth(): Pixel {
-    const sheetId = this.env.model.getters.getActiveSheetId();
-    const { right } = this.env.model.getters.getSheetZone(sheetId);
-    return this.env.model.getters.getColDimensions(sheetId, right).end;
+    const sheetId = this.model().getters.getActiveSheetId();
+    const { right } = this.model().getters.getSheetZone(sheetId);
+    return this.model().getters.getColDimensions(sheetId, right).end;
   }
 
   get dashboardStyle() {
-    const zoomLevel = this.env.model.getters.getViewportZoomLevel();
+    const zoomLevel = this.model().getters.getViewportZoomLevel();
     return cssPropertiesToCss({ zoom: `${zoomLevel}` });
   }
 }

--- a/src/components/error_tooltip/error_tooltip.ts
+++ b/src/components/error_tooltip/error_tooltip.ts
@@ -8,6 +8,7 @@ import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 
 import { props } from "@odoo/owl";
 import { Component } from "../../owl3_compatibility_layer";
+import { useModel } from "../owl_plugins/model_plugin";
 import { types } from "../props_validation";
 const ERROR_TOOLTIP_MAX_HEIGHT = 80;
 
@@ -20,12 +21,14 @@ export class ErrorToolTip extends Component<SpreadsheetChildEnv> {
     "onClosed?": types.function([]),
   });
 
+  private model = useModel();
+
   get dataValidationErrorMessage() {
-    return this.env.model.getters.getInvalidDataValidationMessage(this.props.cellPosition);
+    return this.model().getters.getInvalidDataValidationMessage(this.props.cellPosition);
   }
 
   get evaluationError() {
-    const cell = this.env.model.getters.getEvaluatedCell(this.props.cellPosition);
+    const cell = this.model().getters.getEvaluatedCell(this.props.cellPosition);
     if (cell.message) {
       return cell;
     }
@@ -33,7 +36,7 @@ export class ErrorToolTip extends Component<SpreadsheetChildEnv> {
   }
 
   get errorOriginPositionString() {
-    if (this.env.model.getters.isDashboard()) {
+    if (this.model().getters.isDashboard()) {
       return "";
     }
     const evaluationError = this.evaluationError;
@@ -42,9 +45,9 @@ export class ErrorToolTip extends Component<SpreadsheetChildEnv> {
       return "";
     }
     const sheetId = position.sheetId;
-    return this.env.model.getters.getRangeString(
-      this.env.model.getters.getRangeFromZone(sheetId, positionToZone(position)),
-      this.env.model.getters.getActiveSheetId()
+    return this.model().getters.getRangeString(
+      this.model().getters.getRangeFromZone(sheetId, positionToZone(position)),
+      this.model().getters.getActiveSheetId()
     );
   }
 
@@ -53,14 +56,14 @@ export class ErrorToolTip extends Component<SpreadsheetChildEnv> {
     if (!position) {
       return;
     }
-    const activeSheetId = this.env.model.getters.getActiveSheetId();
+    const activeSheetId = this.model().getters.getActiveSheetId();
     if (position.sheetId !== activeSheetId) {
-      this.env.model.dispatch("ACTIVATE_SHEET", {
+      this.model().dispatch("ACTIVATE_SHEET", {
         sheetIdFrom: activeSheetId,
         sheetIdTo: position.sheetId,
       });
     }
-    this.env.model.selection.selectCell(position.col, position.row);
+    this.model().selection.selectCell(position.col, position.row);
   }
 
   get isSpillErrorBecauseOfMissingHeaders() {
@@ -68,7 +71,7 @@ export class ErrorToolTip extends Component<SpreadsheetChildEnv> {
     return (
       evaluationError?.value === CellErrorType.SpilledBlocked &&
       !evaluationError.errorOriginPosition &&
-      !this.env.model.getters.getSpreadZone(this.props.cellPosition, { ignoreSpillError: true })
+      !this.model().getters.getSpreadZone(this.props.cellPosition, { ignoreSpillError: true })
     );
   }
 
@@ -76,36 +79,32 @@ export class ErrorToolTip extends Component<SpreadsheetChildEnv> {
     if (!this.isSpillErrorBecauseOfMissingHeaders) {
       return;
     }
-    const cell = this.env.model.getters.getCell(this.props.cellPosition);
+    const cell = this.model().getters.getCell(this.props.cellPosition);
     if (!cell || !cell.isFormula) {
       return;
     }
-    const formula = cell.compiledFormula.toFormulaString(this.env.model.getters);
-    return getMissingHeadersForSpreadResult(
-      this.env.model.getters,
-      this.props.cellPosition,
-      formula
-    );
+    const formula = cell.compiledFormula.toFormulaString(this.model().getters);
+    return getMissingHeadersForSpreadResult(this.model().getters, this.props.cellPosition, formula);
   }
 
   addMissingHeaders({ missingCols, missingRows }: { missingCols: number; missingRows: number }) {
     const sheetId = this.props.cellPosition.sheetId;
     if (missingCols > 0) {
-      this.env.model.dispatch("ADD_COLUMNS_ROWS", {
+      this.model().dispatch("ADD_COLUMNS_ROWS", {
         sheetId,
-        sheetName: this.env.model.getters.getSheetName(sheetId),
+        sheetName: this.model().getters.getSheetName(sheetId),
         dimension: "COL",
-        base: this.env.model.getters.getNumberCols(sheetId) - 1,
+        base: this.model().getters.getNumberCols(sheetId) - 1,
         position: "after",
         quantity: missingCols + 20,
       });
     }
     if (missingRows > 0) {
-      this.env.model.dispatch("ADD_COLUMNS_ROWS", {
+      this.model().dispatch("ADD_COLUMNS_ROWS", {
         sheetId,
-        sheetName: this.env.model.getters.getSheetName(sheetId),
+        sheetName: this.model().getters.getSheetName(sheetId),
         dimension: "ROW",
-        base: this.env.model.getters.getNumberRows(sheetId) - 1,
+        base: this.model().getters.getNumberRows(sheetId) - 1,
         position: "after",
         quantity: missingRows + 50,
       });

--- a/src/components/figures/chart/chartJs/chartjs.ts
+++ b/src/components/figures/chart/chartJs/chartjs.ts
@@ -10,6 +10,7 @@ import { useStore } from "../../../../store_engine/store_hooks";
 import { ChartJSRuntime } from "../../../../types/chart/chart";
 import { SpreadsheetChildEnv } from "../../../../types/spreadsheet_env";
 import { Store } from "../../../../types/store_engine";
+import { useModel } from "../../../owl_plugins/model_plugin";
 import { ChartAnimationStore } from "./chartjs_animation_store";
 import { chartBackgroundPlugin } from "./chartjs_background_plugin";
 import { getCalendarChartController } from "./chartjs_calendar_chart";
@@ -84,6 +85,7 @@ export class ChartJsComponent extends Component<SpreadsheetChildEnv> {
     "isFullScreen?": types.boolean(),
   });
 
+  protected model = useModel();
   protected canvas = signal<HTMLCanvasElement | null>(null);
   protected chart?: Chart;
   protected currentRuntime!: ChartJSRuntime;
@@ -92,7 +94,7 @@ export class ChartJsComponent extends Component<SpreadsheetChildEnv> {
   private currentDevicePixelRatio = window.devicePixelRatio;
 
   get chartRuntime(): ChartJSRuntime {
-    const runtime = this.env.model.getters.getChartRuntime(this.props.chartId);
+    const runtime = this.model().getters.getChartRuntime(this.props.chartId);
     if (!("chartJsConfig" in runtime)) {
       throw new Error("Unsupported chart runtime");
     }
@@ -133,7 +135,7 @@ export class ChartJsComponent extends Component<SpreadsheetChildEnv> {
   }
 
   private get shouldAnimate(): boolean {
-    return this.env.model.getters.isDashboard();
+    return this.model().getters.isDashboard();
   }
 
   protected createChart(chartRuntime: ChartJSRuntime) {
@@ -142,7 +144,7 @@ export class ChartJsComponent extends Component<SpreadsheetChildEnv> {
     }
     let chartData = chartRuntime.chartJsConfig as ChartConfiguration<any>;
     if (this.shouldAnimate && this.animationStore) {
-      const chartType = this.env.model.getters.getChartDefinition(this.props.chartId)?.type;
+      const chartType = this.model().getters.getChartDefinition(this.props.chartId)?.type;
       if (chartType && this.animationStore.animationPlayed[this.animationChartId] !== chartType) {
         chartData = this.enableAnimationInChartData(chartData);
         this.animationStore.disableAnimationForChart(this.animationChartId, chartType);
@@ -160,7 +162,7 @@ export class ChartJsComponent extends Component<SpreadsheetChildEnv> {
   protected updateChartJs(chartRuntime: ChartJSRuntime) {
     let chartData = chartRuntime.chartJsConfig as ChartConfiguration<any>;
     if (this.shouldAnimate) {
-      const chartType = this.env.model.getters.getChartDefinition(this.props.chartId)?.type;
+      const chartType = this.model().getters.getChartDefinition(this.props.chartId)?.type;
       if (chartType && this.hasChartDataChanged() && this.animationStore) {
         chartData = this.enableAnimationInChartData(chartData);
         this.animationStore.disableAnimationForChart(this.animationChartId, chartType);

--- a/src/components/figures/chart/chartJs/zoomable_chart/zoomable_chartjs.ts
+++ b/src/components/figures/chart/chartJs/zoomable_chart/zoomable_chartjs.ts
@@ -47,7 +47,7 @@ export class ZoomableChartJsComponent extends ChartJsComponent {
   }
 
   get masterChartContainerStyle() {
-    const runtime = this.env.model.getters.getChartRuntime(this.props.chartId) as ChartJSRuntime;
+    const runtime = this.model().getters.getChartRuntime(this.props.chartId) as ChartJSRuntime;
     if (runtime && !runtime.chartJsConfig.data.datasets.some((ds) => ds.data.length > 1)) {
       return "opacity: 0.3;";
     }
@@ -58,7 +58,7 @@ export class ZoomableChartJsComponent extends ChartJsComponent {
     if (this.props.isFullScreen) {
       return true;
     }
-    const definition = this.env.model.getters.getChartDefinition(this.props.chartId);
+    const definition = this.model().getters.getChartDefinition(this.props.chartId);
     return ("zoomable" in definition && definition.zoomable) ?? false;
   }
 
@@ -369,7 +369,11 @@ export class ZoomableChartJsComponent extends ChartJsComponent {
 
   onMasterChartPointerDown(ev: PointerEvent) {
     this.removeEventListeners();
-    const zoomedEvent = withZoom(this.env, ev, this.masterChartCanvas()?.getBoundingClientRect());
+    const zoomedEvent = withZoom(
+      this.model(),
+      ev,
+      this.masterChartCanvas()?.getBoundingClientRect()
+    );
     const position = zoomedEvent.offsetX;
     if (!this.masterChart?.chartArea || !this.chart?.scales?.x) {
       return;
@@ -440,7 +444,11 @@ export class ZoomableChartJsComponent extends ChartJsComponent {
     };
 
     const onMasterChartDrag = (ev: PointerEvent) => {
-      const zoomedEvent = withZoom(this.env, ev, this.masterChartCanvas()?.getBoundingClientRect());
+      const zoomedEvent = withZoom(
+        this.model(),
+        ev,
+        this.masterChartCanvas()?.getBoundingClientRect()
+      );
       const position = zoomedEvent.offsetX;
       if (Math.abs(position - startingEventPosition) < 5) {
         return;
@@ -478,7 +486,7 @@ export class ZoomableChartJsComponent extends ChartJsComponent {
   updateMasterChartCursor(ev: PointerEvent) {
     const target = ev.target;
     const { offsetX: x, offsetY: y } = withZoom(
-      this.env,
+      this.model(),
       ev,
       (target as HTMLElement)?.getBoundingClientRect()
     );
@@ -515,7 +523,11 @@ export class ZoomableChartJsComponent extends ChartJsComponent {
 
   onMasterChartDoubleClick(ev: PointerEvent) {
     this.mode = undefined;
-    const zoomedEvent = withZoom(this.env, ev, this.masterChartCanvas()?.getBoundingClientRect());
+    const zoomedEvent = withZoom(
+      this.model(),
+      ev,
+      this.masterChartCanvas()?.getBoundingClientRect()
+    );
     const position = zoomedEvent.offsetX;
     if (!this.masterChart?.chartArea || !this.chart?.scales.x) {
       return;

--- a/src/components/figures/chart/chart_dashboard_menu/chart_dashboard_menu.ts
+++ b/src/components/figures/chart/chart_dashboard_menu/chart_dashboard_menu.ts
@@ -11,6 +11,7 @@ import { Store } from "../../../../types/store_engine";
 import { FullScreenFigureStore } from "../../../full_screen_figure/full_screen_figure_store";
 import { getBoundingRectAsPOJO } from "../../../helpers/dom_helpers";
 import { MenuPopover, MenuState } from "../../../menu_popover/menu_popover";
+import { useModel } from "../../../owl_plugins/model_plugin";
 import { types } from "../../../props_validation";
 import { Select } from "../../../select/select";
 
@@ -38,6 +39,7 @@ export class ChartDashboardMenu extends Component<SpreadsheetChildEnv> {
 
   private fullScreenFigureStore!: Store<FullScreenFigureStore>;
 
+  private model = useModel();
   private menuState: MenuState = proxy({ isOpen: false, anchorRect: null, menuItems: [] });
   setup() {
     super.setup();
@@ -49,25 +51,25 @@ export class ChartDashboardMenu extends Component<SpreadsheetChildEnv> {
   }
 
   get backgroundColor() {
-    const color = this.env.model.getters.getChartDefinition(this.props.chartId).background;
+    const color = this.model().getters.getChartDefinition(this.props.chartId).background;
     return (
-      "background-color: " + (color || this.env.model.getters.getSpreadsheetTheme().backgroundColor)
+      "background-color: " + (color || this.model().getters.getSpreadsheetTheme().backgroundColor)
     );
   }
 
   openContextMenu(ev: MouseEvent) {
     this.menuState.isOpen = true;
     this.menuState.anchorRect = getBoundingRectAsPOJO(ev.currentTarget as HTMLElement);
-    const figureId = this.env.model.getters.getFigureIdFromChartId(this.props.chartId);
-    this.menuState.menuItems = getChartMenuActions(figureId, this.env);
+    const figureId = this.model().getters.getFigureIdFromChartId(this.props.chartId);
+    this.menuState.menuItems = getChartMenuActions(figureId, this.model());
   }
 
   get fullScreenMenuItem(): MenuItem | undefined {
     if (!this.props.hasFullScreenButton) {
       return undefined;
     }
-    const definition = this.env.model.getters.getChartDefinition(this.props.chartId);
-    const figureId = this.env.model.getters.getFigureIdFromChartId(this.props.chartId);
+    const definition = this.model().getters.getChartDefinition(this.props.chartId);
+    const figureId = this.model().getters.getFigureIdFromChartId(this.props.chartId);
     if (definition.type === "scorecard") {
       return undefined;
     }
@@ -83,23 +85,23 @@ export class ChartDashboardMenu extends Component<SpreadsheetChildEnv> {
   }
 
   get regionOptions(): ValueAndLabel[] {
-    return this.env.model.getters
-      .getAvailableChartRegions(this.props.chartId)
+    return this.model()
+      .getters.getAvailableChartRegions(this.props.chartId)
       .map((r) => ({ value: r.id, label: r.label }));
   }
 
   get selectedRegion(): string {
-    const definition = this.env.model.getters.getChartDefinition(this.props.chartId);
+    const definition = this.model().getters.getChartDefinition(this.props.chartId);
     if (!definition.type.includes("geo")) {
       return "";
     }
     const geoDef = definition as GeoChartDefinition<string>;
-    const availableRegions = this.env.model.getters.getGeoChartAvailableRegions();
+    const availableRegions = this.model().getters.getGeoChartAvailableRegions();
     return geoDef.region || availableRegions[0]?.id || "";
   }
 
   onRegionSelected(region: string) {
-    this.env.model.dispatch("UPDATE_CHART_REGION", {
+    this.model().dispatch("UPDATE_CHART_REGION", {
       chartId: this.props.chartId,
       region,
     });

--- a/src/components/figures/chart/gauge/gauge_chart_component.ts
+++ b/src/components/figures/chart/gauge/gauge_chart_component.ts
@@ -7,6 +7,7 @@ import { useStore } from "../../../../store_engine/store_hooks";
 import { GaugeChartRuntime } from "../../../../types/chart/gauge_chart";
 import { SpreadsheetChildEnv } from "../../../../types/spreadsheet_env";
 import { Store } from "../../../../types/store_engine";
+import { useModel } from "../../../owl_plugins/model_plugin";
 import { ChartAnimationStore } from "../chartJs/chartjs_animation_store";
 
 const ANIMATION_DURATION = 1000;
@@ -23,12 +24,14 @@ export class GaugeChartComponent extends Component<SpreadsheetChildEnv> {
 
   private animationStore: Store<ChartAnimationStore> | undefined;
 
+  private model = useModel();
+
   get runtime(): GaugeChartRuntime {
-    return this.env.model.getters.getChartRuntime(this.props.chartId) as GaugeChartRuntime;
+    return this.model().getters.getChartRuntime(this.props.chartId) as GaugeChartRuntime;
   }
 
   setup() {
-    if (this.env.model.getters.isDashboard()) {
+    if (this.model().getters.isDashboard()) {
       this.animationStore = useStore(ChartAnimationStore);
     }
 
@@ -37,21 +40,21 @@ export class GaugeChartComponent extends Component<SpreadsheetChildEnv> {
     useLayoutEffect(
       () => {
         if (
-          this.env.model.getters.isDashboard() &&
+          this.model().getters.isDashboard() &&
           lastRuntime === undefined && // first render
           this.animationStore?.animationPlayed[this.animationChartId] !== "gauge"
         ) {
           animation = this.drawGaugeWithAnimation();
           this.animationStore?.disableAnimationForChart(this.animationChartId, "gauge");
         } else if (
-          this.env.model.getters.isDashboard() &&
+          this.model().getters.isDashboard() &&
           lastRuntime !== undefined && // not first render
           !deepEquals(this.runtime, lastRuntime)
         ) {
           animation = this.drawGaugeWithAnimation();
           this.animationStore?.disableAnimationForChart(this.animationChartId, "gauge");
         } else {
-          const zoom = this.env.model.getters.getViewportZoomLevel();
+          const zoom = this.model().getters.getViewportZoomLevel();
           drawGaugeChart(this.canvasEl, this.runtime, zoom);
         }
 
@@ -72,7 +75,7 @@ export class GaugeChartComponent extends Component<SpreadsheetChildEnv> {
         animation.stop();
         animation = null;
       }
-      drawGaugeChart(this.canvasEl, this.runtime, this.env.model.getters.getViewportZoomLevel());
+      drawGaugeChart(this.canvasEl, this.runtime, this.model().getters.getViewportZoomLevel());
     });
     onMounted(() => {
       const canvas = this.canvas();

--- a/src/components/figures/chart/scorecard/chart_scorecard.ts
+++ b/src/components/figures/chart/scorecard/chart_scorecard.ts
@@ -5,6 +5,7 @@ import { Component, useLayoutEffect } from "../../../../owl3_compatibility_layer
 import { ScorecardChartRuntime } from "../../../../types/chart/scorecard_chart";
 import { SpreadsheetChildEnv } from "../../../../types/spreadsheet_env";
 import { getZoomedRect } from "../../../helpers/zoom";
+import { useModel } from "../../../owl_plugins/model_plugin";
 
 export class ScorecardChart extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ScorecardChart";
@@ -15,13 +16,15 @@ export class ScorecardChart extends Component<SpreadsheetChildEnv> {
   });
   private canvas = signal<HTMLCanvasElement | null>(null);
 
+  private model = useModel();
+
   get runtime(): ScorecardChartRuntime {
-    return this.env.model.getters.getChartRuntime(this.props.chartId) as ScorecardChartRuntime;
+    return this.model().getters.getChartRuntime(this.props.chartId) as ScorecardChartRuntime;
   }
 
   get title(): string {
-    const title = this.env.model.getters.getChartDefinition(this.props.chartId).title.text;
-    return title ? this.env.model.getters.dynamicTranslate(title) : "";
+    const title = this.model().getters.getChartDefinition(this.props.chartId).title.text;
+    return title ? this.model().getters.dynamicTranslate(title) : "";
   }
 
   setup() {
@@ -48,7 +51,7 @@ export class ScorecardChart extends Component<SpreadsheetChildEnv> {
     if (!canvas) {
       return;
     }
-    const zoom = this.env.model.getters.getViewportZoomLevel();
+    const zoom = this.model().getters.getViewportZoomLevel();
     const config = getScorecardConfiguration(
       getZoomedRect(1 / zoom, canvas.getBoundingClientRect()),
       this.runtime

--- a/src/components/figures/figure/figure.ts
+++ b/src/components/figures/figure/figure.ts
@@ -14,6 +14,7 @@ import {
 } from "../../helpers/dom_helpers";
 import { withZoom } from "../../helpers/zoom";
 import { MenuPopover, MenuState } from "../../menu_popover/menu_popover";
+import { useModel } from "../../owl_plugins/model_plugin";
 import { types } from "../../props_validation";
 
 type ResizeAnchor =
@@ -59,10 +60,11 @@ export class FigureComponent extends Component<SpreadsheetChildEnv> {
   private figureWrapperRef = signal<HTMLElement | null>(null);
   private menuButtonRef = signal<HTMLElement | null>(null);
 
+  private model = useModel();
   private borderWidth!: number;
 
   get isSelected(): boolean {
-    return this.env.model.getters.getSelectedFigureIds().includes(this.props.figureUI.id);
+    return this.model().getters.getSelectedFigureIds().includes(this.props.figureUI.id);
   }
 
   get figureRegistry() {
@@ -70,7 +72,7 @@ export class FigureComponent extends Component<SpreadsheetChildEnv> {
   }
 
   private getBorderWidth(): Pixel {
-    if (this.env.model.getters.isDashboard()) {
+    if (this.model().getters.isDashboard()) {
       return 0;
     }
     return this.isSelected ? ACTIVE_BORDER_WIDTH : this.borderWidth;
@@ -115,7 +117,7 @@ export class FigureComponent extends Component<SpreadsheetChildEnv> {
     const borderWidth = figureRegistry.get(this.props.figureUI.tag).borderWidth;
     this.borderWidth = borderWidth !== undefined ? borderWidth : BORDER_WIDTH;
     useLayoutEffect(() => {
-      const selectedFigureIds = this.env.model.getters.getSelectedFigureIds();
+      const selectedFigureIds = this.model().getters.getSelectedFigureIds();
       const thisFigureId = this.props.figureUI.id;
       const el = this.figureRef();
       if (selectedFigureIds.includes(thisFigureId)) {
@@ -153,9 +155,9 @@ export class FigureComponent extends Component<SpreadsheetChildEnv> {
     switch (keyDownShortcut) {
       case "Delete":
       case "Backspace":
-        this.env.model.dispatch("DELETE_FIGURES", {
-          sheetId: this.env.model.getters.getActiveSheetId(),
-          figureIds: this.env.model.getters.getSelectedFigureIds(),
+        this.model().dispatch("DELETE_FIGURES", {
+          sheetId: this.model().getters.getActiveSheetId(),
+          figureIds: this.model().getters.getSelectedFigureIds(),
         });
         ev.preventDefault();
         ev.stopPropagation();
@@ -168,11 +170,11 @@ export class FigureComponent extends Component<SpreadsheetChildEnv> {
       case "ArrowLeft":
       case "ArrowRight":
       case "ArrowUp":
-        const sheetId = this.env.model.getters.getActiveSheetId();
-        const figureIds = this.env.model.getters.getSelectedFigureIds();
+        const sheetId = this.model().getters.getActiveSheetId();
+        const figureIds = this.model().getters.getSelectedFigureIds();
         const figures: MoveFiguresPayload[] = [];
         for (const figureId of figureIds) {
-          const figure = this.env.model.getters.getFigure(sheetId, figureId);
+          const figure = this.model().getters.getFigure(sheetId, figureId);
           if (!figure) {
             continue;
           }
@@ -180,13 +182,13 @@ export class FigureComponent extends Component<SpreadsheetChildEnv> {
             sheetId,
             figureId,
             ...this.postionInBoundary(
-              this.env.model.getters.getFigureUI(sheetId, figure),
+              this.model().getters.getFigureUI(sheetId, figure),
               ev.key,
               ev.shiftKey
             ),
           });
         }
-        this.env.model.dispatch("MOVE_FIGURES", { figures });
+        this.model().dispatch("MOVE_FIGURES", { figures });
         ev.preventDefault();
         ev.stopPropagation();
         break;
@@ -198,9 +200,9 @@ export class FigureComponent extends Component<SpreadsheetChildEnv> {
       case "Ctrl+Y":
       case "Ctrl+Z":
         if (keyDownShortcut === "Ctrl+Y") {
-          this.env.model.dispatch("REQUEST_REDO");
+          this.model().dispatch("REQUEST_REDO");
         } else if (keyDownShortcut === "Ctrl+Z") {
-          this.env.model.dispatch("REQUEST_UNDO");
+          this.model().dispatch("REQUEST_UNDO");
         }
         ev.preventDefault();
         ev.stopPropagation();
@@ -209,7 +211,7 @@ export class FigureComponent extends Component<SpreadsheetChildEnv> {
   }
 
   private postionInBoundary(position: AnchorOffset, key: string, shift: boolean): AnchorOffset {
-    const sheetId = this.env.model.getters.getActiveSheetId();
+    const sheetId = this.model().getters.getActiveSheetId();
     const shiftAmount = shift ? 1 : 5;
     let { col, row, offset } = position;
     offset = { ...offset };
@@ -217,7 +219,7 @@ export class FigureComponent extends Component<SpreadsheetChildEnv> {
       case "ArrowUp":
         if (offset.y < shiftAmount) {
           row--;
-          offset.y = this.env.model.getters.getRowSize(sheetId, row) - shiftAmount + offset.y;
+          offset.y = this.model().getters.getRowSize(sheetId, row) - shiftAmount + offset.y;
         } else {
           offset.y -= shiftAmount;
         }
@@ -225,13 +227,13 @@ export class FigureComponent extends Component<SpreadsheetChildEnv> {
       case "ArrowLeft":
         if (offset.x < shiftAmount) {
           col--;
-          offset.x = this.env.model.getters.getColSize(sheetId, col) - shiftAmount + offset.x;
+          offset.x = this.model().getters.getColSize(sheetId, col) - shiftAmount + offset.x;
         } else {
           offset.x -= shiftAmount;
         }
         break;
       case "ArrowDown":
-        const rowSize = this.env.model.getters.getRowSize(sheetId, row);
+        const rowSize = this.model().getters.getRowSize(sheetId, row);
         if (offset.y + shiftAmount >= rowSize) {
           row++;
           offset.y = offset.y + shiftAmount - rowSize;
@@ -240,7 +242,7 @@ export class FigureComponent extends Component<SpreadsheetChildEnv> {
         }
         break;
       case "ArrowRight":
-        const colSize = this.env.model.getters.getColSize(sheetId, col);
+        const colSize = this.model().getters.getColSize(sheetId, col);
         if (offset.x + shiftAmount >= colSize) {
           col++;
           offset.x = offset.x + shiftAmount - colSize;
@@ -252,10 +254,10 @@ export class FigureComponent extends Component<SpreadsheetChildEnv> {
   }
 
   onContextMenu(ev: MouseEvent) {
-    if (this.env.model.getters.isDashboard()) {
+    if (this.model().getters.isDashboard()) {
       return;
     }
-    const zoomedMouseEvent = withZoom(this.env, ev);
+    const zoomedMouseEvent = withZoom(this.model(), ev);
     this.openContextMenu({
       x: zoomedMouseEvent.clientX,
       y: zoomedMouseEvent.clientY,
@@ -266,7 +268,7 @@ export class FigureComponent extends Component<SpreadsheetChildEnv> {
 
   showMenu(ev: MouseEvent) {
     if (!this.isSelected) {
-      this.env.model.dispatch("SELECT_FIGURE", {
+      this.model().dispatch("SELECT_FIGURE", {
         figureId: this.props.figureUI.id,
         selectMultiple: ev.shiftKey || isCtrlKey(ev),
       });
@@ -279,7 +281,7 @@ export class FigureComponent extends Component<SpreadsheetChildEnv> {
     this.menuState.anchorRect = anchorRect;
     this.menuState.menuItems = figureRegistry
       .get(this.props.figureUI.tag)
-      .menuBuilder(this.props.figureUI.id, this.env);
+      .menuBuilder(this.props.figureUI.id, this.model());
   }
 
   editWrapperStyle(properties: CSSProperties) {
@@ -295,8 +297,8 @@ export class FigureComponent extends Component<SpreadsheetChildEnv> {
     return (
       this.isSelected &&
       !this.env.isMobile() &&
-      !this.env.model.getters.isDashboard() &&
-      !this.env.model.getters.isCurrentSheetLocked()
+      !this.model().getters.isDashboard() &&
+      !this.model().getters.isCurrentSheetLocked()
     );
   }
 }

--- a/src/components/figures/figure/figure.xml
+++ b/src/components/figures/figure/figure.xml
@@ -10,7 +10,7 @@
         t-att-class="this.props.class"
         t-on-pointerdown.stop="(ev) => this.onMouseDown(ev)"
         t-on-click="this.onClick"
-        t-on-contextmenu.prevent.stop="(ev) => !this.env.model.getters.isReadonly() and this.onContextMenu(ev)"
+        t-on-contextmenu.prevent.stop="(ev) => !this.model().getters.isReadonly() and this.onContextMenu(ev)"
         t-ref="this.figureRef"
         t-att-style="this.props.style"
         t-att-data-id="this.props.figureUI.id"
@@ -24,12 +24,10 @@
           editFigureStyle.bind="this.editWrapperStyle"
           openContextMenu.bind="this.openContextMenu"
         />
-        <div
-          class="o-figure-menu position-absolute m-2"
-          t-if="!this.env.model.getters.isDashboard()">
+        <div class="o-figure-menu position-absolute m-2" t-if="!this.model().getters.isDashboard()">
           <div
             class="o-figure-menu-item d-flex-align-items-center"
-            t-if="!this.env.model.getters.isReadonly() and this.props.figureUI.tag !== 'carousel'"
+            t-if="!this.model().getters.isReadonly() and this.props.figureUI.tag !== 'carousel'"
             t-on-click="this.showMenu"
             t-ref="this.menuButtonRef"
             t-on-contextmenu.prevent.stop="this.showMenu">
@@ -43,7 +41,7 @@
           />
         </div>
         <div
-          t-if="!this.env.model.getters.isDashboard()"
+          t-if="!this.model().getters.isDashboard()"
           class="position-absolute top-0 start-0 pe-none w-100 h-100">
           <div
             class="o-figure-border pe-auto w-100 h-0 position-absolute pb-2"

--- a/src/components/figures/figure_carousel/figure_carousel.ts
+++ b/src/components/figures/figure_carousel/figure_carousel.ts
@@ -17,6 +17,7 @@ import { FullScreenFigureStore } from "../../full_screen_figure/full_screen_figu
 import { cellTextStyleToCss, cssPropertiesToCss } from "../../helpers/css";
 import { getBoundingRectAsPOJO, getElBoundingRect } from "../../helpers/dom_helpers";
 import { MenuPopover, MenuState } from "../../menu_popover/menu_popover";
+import { useModel } from "../../owl_plugins/model_plugin";
 import { types } from "../../props_validation";
 import { ChartAnimationStore } from "../chart/chartJs/chartjs_animation_store";
 import { ChartDashboardMenu } from "../chart/chart_dashboard_menu/chart_dashboard_menu";
@@ -44,6 +45,8 @@ export class CarouselFigure extends Component<SpreadsheetChildEnv> {
   protected animationStore: Store<ChartAnimationStore> | undefined;
   private fullScreenFigureStore!: Store<FullScreenFigureStore>;
 
+  private model = useModel();
+
   setup(): void {
     this.animationStore = useStore(ChartAnimationStore);
     this.fullScreenFigureStore = useStore(FullScreenFigureStore);
@@ -59,11 +62,11 @@ export class CarouselFigure extends Component<SpreadsheetChildEnv> {
   }
 
   get carousel(): Carousel {
-    return this.env.model.getters.getCarousel(this.props.figureUI.id);
+    return this.model().getters.getCarousel(this.props.figureUI.id);
   }
 
   get selectedCarouselItem(): CarouselItem | undefined {
-    return this.env.model.getters.getSelectedCarouselItem(this.props.figureUI.id);
+    return this.model().getters.getSelectedCarouselItem(this.props.figureUI.id);
   }
 
   get chartComponent(): new (...args: any) => Component {
@@ -71,7 +74,7 @@ export class CarouselFigure extends Component<SpreadsheetChildEnv> {
     if (selectedItem?.type !== "chart") {
       throw new Error("Selected item is not a chart");
     }
-    const type = this.env.model.getters.getChartType(selectedItem.chartId);
+    const type = this.model().getters.getChartType(selectedItem.chartId);
     const component = chartComponentRegistry.get(type);
     if (!component) {
       throw new Error(`Component is not defined for type ${type}`);
@@ -80,7 +83,7 @@ export class CarouselFigure extends Component<SpreadsheetChildEnv> {
   }
 
   onCarouselDoubleClick() {
-    this.env.model.dispatch("SELECT_FIGURE", { figureId: this.props.figureUI.id });
+    this.model().dispatch("SELECT_FIGURE", { figureId: this.props.figureUI.id });
     this.env.openSidePanel("CarouselPanel", { figureId: this.props.figureUI.id });
   }
 
@@ -90,13 +93,13 @@ export class CarouselFigure extends Component<SpreadsheetChildEnv> {
   }
 
   getItemTitle(item: CarouselItem): string {
-    return getCarouselItemTitle(this.env.model.getters, item);
+    return getCarouselItemTitle(this.model().getters, item);
   }
 
   onCarouselTabClick(item: CarouselItem) {
-    this.env.model.dispatch("UPDATE_CAROUSEL_ACTIVE_ITEM", {
+    this.model().dispatch("UPDATE_CAROUSEL_ACTIVE_ITEM", {
       figureId: this.props.figureUI.id,
-      sheetId: this.env.model.getters.getActiveSheetId(),
+      sheetId: this.model().getters.getActiveSheetId(),
       item,
     });
     if (item.type === "chart") {
@@ -107,9 +110,9 @@ export class CarouselFigure extends Component<SpreadsheetChildEnv> {
 
   get headerStyle(): string {
     const cssProperties: CSSProperties = {};
-    const backgroundColor = this.env.model.getters.getSpreadsheetTheme().backgroundColor;
+    const backgroundColor = this.model().getters.getSpreadsheetTheme().backgroundColor;
     if (this.selectedCarouselItem?.type === "chart") {
-      const chart = this.env.model.getters.getChartRuntime(this.selectedCarouselItem.chartId);
+      const chart = this.model().getters.getChartRuntime(this.selectedCarouselItem.chartId);
       if ("background" in chart && chart.background) {
         cssProperties["background-color"] = chart.background;
       } else if ("chartJsConfig" in chart) {

--- a/src/components/figures/figure_carousel/figure_carousel.xml
+++ b/src/components/figures/figure_carousel/figure_carousel.xml
@@ -7,8 +7,8 @@
       <div
         class="o-carousel-header d-flex align-items-baseline flex-shrink-0 pe-1 pe-auto"
         t-att-class="{
-          'border-bottom': this.env.model.getters.isDashboard(),
-          'o-carousel-header-floating': !this.env.model.getters.isDashboard() and selectedItem?.type === 'carouselDataView',
+          'border-bottom': this.model().getters.isDashboard(),
+          'o-carousel-header-floating': !this.model().getters.isDashboard() and selectedItem?.type === 'carouselDataView',
          }"
         t-att-style="this.headerStyle">
         <div
@@ -46,7 +46,7 @@
           />
         </div>
         <div
-          t-if="this.env.model.getters.isDashboard()"
+          t-if="this.model().getters.isDashboard()"
           t-att-title="this.fullScreenButtonTitle"
           class="o-carousel-full-screen-button fa o-carousel-button rounded p-1 ms-1"
           t-att-class="{
@@ -57,7 +57,7 @@
           t-on-click="this.toggleFullScreen"
         />
         <div
-          t-if="!this.env.model.getters.isDashboard()"
+          t-if="!this.model().getters.isDashboard()"
           class="o-carousel-menu-button o-carousel-button fa fa-ellipsis-v rounded ms-1"
           t-on-click="this.openContextMenu"
         />
@@ -79,7 +79,7 @@
           />
         </div>
         <ChartDashboardMenu
-          t-if="this.env.model.getters.isDashboard()"
+          t-if="this.model().getters.isDashboard()"
           chartId="selectedItem.chartId"
           hasFullScreenButton="false"
           t-key="selectedItem.chartId"

--- a/src/components/figures/figure_chart/figure_chart.ts
+++ b/src/components/figures/figure_chart/figure_chart.ts
@@ -1,13 +1,13 @@
+import { props } from "@odoo/owl";
+import { Component } from "../../../owl3_compatibility_layer";
 import { chartComponentRegistry } from "../../../registries/chart_component_registry";
 import { ChartType } from "../../../types/chart/chart";
 import { CSSProperties, UID } from "../../../types/misc";
 import { Rect } from "../../../types/rendering";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
-import { ChartDashboardMenu } from "../chart/chart_dashboard_menu/chart_dashboard_menu";
-
-import { props } from "@odoo/owl";
-import { Component } from "../../../owl3_compatibility_layer";
+import { useModel } from "../../owl_plugins/model_plugin";
 import { types } from "../../props_validation";
+import { ChartDashboardMenu } from "../chart/chart_dashboard_menu/chart_dashboard_menu";
 
 export class ChartFigure extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ChartFigure";
@@ -23,17 +23,19 @@ export class ChartFigure extends Component<SpreadsheetChildEnv> {
     ]),
   });
 
+  private model = useModel();
+
   onDoubleClick() {
-    this.env.model.dispatch("SELECT_FIGURE", { figureId: this.props.figureUI.id });
+    this.model().dispatch("SELECT_FIGURE", { figureId: this.props.figureUI.id });
     this.env.openSidePanel("ChartPanel");
   }
 
   get chartType(): ChartType {
-    return this.env.model.getters.getChartType(this.chartId);
+    return this.model().getters.getChartType(this.chartId);
   }
 
   get chartId(): UID {
-    const chartId = this.env.model.getters.getChartIdFromFigureId(this.props.figureUI.id);
+    const chartId = this.model().getters.getChartIdFromFigureId(this.props.figureUI.id);
     if (!chartId) {
       throw new Error(`No chart found for figure ID: ${this.props.figureUI.id}`);
     }

--- a/src/components/figures/figure_chart/figure_chart.xml
+++ b/src/components/figures/figure_chart/figure_chart.xml
@@ -8,7 +8,7 @@
         isFullScreen="this.props.isFullScreen"
       />
     </div>
-    <div t-if="this.env.model.getters.isDashboard()" class="position-absolute top-0 end-0">
+    <div t-if="this.model().getters.isDashboard()" class="position-absolute top-0 end-0">
       <ChartDashboardMenu chartId="this.chartId"/>
     </div>
   </t>

--- a/src/components/figures/figure_container/figure_container.ts
+++ b/src/components/figures/figure_container/figure_container.ts
@@ -19,6 +19,7 @@ import {
   snapForMove,
   snapForResize,
 } from "../../helpers/figure_snap_helper";
+import { useModel } from "../../owl_plugins/model_plugin";
 import { FigureComponent } from "../figure/figure";
 
 type ContainerType = "topLeft" | "topRight" | "bottomLeft" | "bottomRight" | "dnd";
@@ -120,6 +121,8 @@ export class FiguresContainer extends Component<SpreadsheetChildEnv> {
     overlappingCarousel: undefined,
   });
 
+  private model = useModel();
+
   setup() {
     onMounted(() => {
       // horrible, but necessary
@@ -132,9 +135,9 @@ export class FiguresContainer extends Component<SpreadsheetChildEnv> {
       this.render();
     });
     onWillUpdateProps(() => {
-      const sheetId = this.env.model.getters.getActiveSheetId();
+      const sheetId = this.model().getters.getActiveSheetId();
       const draggedFigureId = this.dnd.draggedFigure?.id;
-      if (draggedFigureId && !this.env.model.getters.getFigure(sheetId, draggedFigureId)) {
+      if (draggedFigureId && !this.model().getters.getFigure(sheetId, draggedFigureId)) {
         this.dnd.cancelDnd?.();
         this.dnd.draggedFigure = undefined;
         this.dnd.selectedFigures = undefined;
@@ -148,7 +151,7 @@ export class FiguresContainer extends Component<SpreadsheetChildEnv> {
   }
 
   private getVisibleFigures(): FigureUI[] {
-    const visibleFigures = this.env.model.getters.getVisibleFigures();
+    const visibleFigures = this.model().getters.getVisibleFigures();
     for (const figure of this.dnd.selectedFigures || []) {
       if (!visibleFigures.some((figureUI) => figureUI.id === figure.id)) {
         visibleFigures.push(figure);
@@ -207,8 +210,8 @@ export class FiguresContainer extends Component<SpreadsheetChildEnv> {
   }
 
   private getContainerRect(container: ContainerType): Rect {
-    const { width: viewWidth, height: viewHeight } = this.env.model.getters.getSheetViewDimension();
-    const { x: viewportX, y: viewportY } = this.env.model.getters.getMainViewportCoordinates();
+    const { width: viewWidth, height: viewHeight } = this.model().getters.getSheetViewDimension();
+    const { x: viewportX, y: viewportY } = this.model().getters.getMainViewportCoordinates();
 
     const x = ["bottomRight", "topRight"].includes(container) ? viewportX : 0;
     const width = viewWidth - x;
@@ -223,8 +226,8 @@ export class FiguresContainer extends Component<SpreadsheetChildEnv> {
   }
 
   private getInverseViewportPositionStyle(container: ContainerType): string {
-    const { scrollX, scrollY } = this.env.model.getters.getActiveSheetScrollInfo();
-    const { x: viewportX, y: viewportY } = this.env.model.getters.getMainViewportCoordinates();
+    const { scrollX, scrollY } = this.model().getters.getActiveSheetScrollInfo();
+    const { x: viewportX, y: viewportY } = this.model().getters.getMainViewportCoordinates();
 
     let left = 0;
     let top = 0;
@@ -247,7 +250,7 @@ export class FiguresContainer extends Component<SpreadsheetChildEnv> {
   }
 
   private getFigureContainer(figureUI: FigureUI): ContainerType {
-    const { x: viewportX, y: viewportY } = this.env.model.getters.getMainViewportCoordinates();
+    const { x: viewportX, y: viewportY } = this.model().getters.getMainViewportCoordinates();
     if (this.dnd.selectedFigures?.some((f) => f.id === figureUI.id)) {
       return "dnd";
     } else if (figureUI.x < viewportX && figureUI.y < viewportY) {
@@ -270,7 +273,7 @@ export class FiguresContainer extends Component<SpreadsheetChildEnv> {
 
   private toBottomRightViewport(figureUI: FigureUI): FigureUI {
     const container = this.getFigureContainer(figureUI);
-    const initialScrollPosition = this.env.model.getters.getActiveSheetScrollInfo();
+    const initialScrollPosition = this.model().getters.getActiveSheetScrollInfo();
     const bottomRightFigure = { ...figureUI };
 
     if (["bottomLeft", "topLeft"].includes(container)) {
@@ -291,13 +294,13 @@ export class FiguresContainer extends Component<SpreadsheetChildEnv> {
   }
 
   startDraggingFigure(figureUI: FigureUI, ev: MouseEvent) {
-    if (ev.button > 0 || this.env.model.getters.isReadonly() || this.isMenuClick(ev)) {
+    if (ev.button > 0 || this.model().getters.isReadonly() || this.isMenuClick(ev)) {
       // not main button, probably a context menu and no d&d in readonly mode
       return;
     }
-    const selected = this.env.model.getters.getSelectedFigureIds().includes(figureUI.id);
+    const selected = this.model().getters.getSelectedFigureIds().includes(figureUI.id);
     if (!selected) {
-      const selectResult = this.env.model.dispatch("SELECT_FIGURE", {
+      const selectResult = this.model().dispatch("SELECT_FIGURE", {
         figureId: figureUI.id,
         selectMultiple: ev.shiftKey || isCtrlKey(ev),
       });
@@ -306,38 +309,38 @@ export class FiguresContainer extends Component<SpreadsheetChildEnv> {
       }
     }
 
-    if (this.env.isMobile() || this.env.model.getters.isCurrentSheetLocked()) {
+    if (this.env.isMobile() || this.model().getters.isCurrentSheetLocked()) {
       return;
     }
 
-    const sheetId = this.env.model.getters.getActiveSheetId();
-    const zoom = this.env.model.getters.getViewportZoomLevel();
+    const sheetId = this.model().getters.getActiveSheetId();
+    const zoom = this.model().getters.getViewportZoomLevel();
 
     const initialMousePosition = { x: ev.clientX / zoom, y: ev.clientY / zoom };
-    const initialScrollPosition = this.env.model.getters.getActiveSheetScrollInfo();
+    const initialScrollPosition = this.model().getters.getActiveSheetScrollInfo();
 
-    const initialFigures = this.env.model.getters
-      .getSelectedFigureIds()
-      .map((id) => this.env.model.getters.getFigure(sheetId, id))
+    const initialFigures = this.model()
+      .getters.getSelectedFigureIds()
+      .map((id) => this.model().getters.getFigure(sheetId, id))
       .filter(isDefined)
-      .map((f) => this.env.model.getters.getFigureUI(sheetId, f))
+      .map((f) => this.model().getters.getFigureUI(sheetId, f))
       .map(this.toBottomRightViewport.bind(this));
     const draggedFigureId = figureUI.id;
 
     const maxDimensions = {
-      maxX: this.env.model.getters.getColDimensions(
+      maxX: this.model().getters.getColDimensions(
         sheetId,
-        this.env.model.getters.getNumberCols(sheetId) - 1
+        this.model().getters.getNumberCols(sheetId) - 1
       ).end,
-      maxY: this.env.model.getters.getRowDimensions(
+      maxY: this.model().getters.getRowDimensions(
         sheetId,
-        this.env.model.getters.getNumberRows(sheetId) - 1
+        this.model().getters.getNumberRows(sheetId) - 1
       ).end,
     };
 
     let hasStartedDnd = false;
     const onMouseMove = (ev: MouseEvent) => {
-      const getters = this.env.model.getters;
+      const getters = this.model().getters;
       const currentMousePosition = { x: ev.clientX / zoom, y: ev.clientY / zoom };
 
       const offsetX = Math.abs(currentMousePosition.x - initialMousePosition.x);
@@ -385,9 +388,9 @@ export class FiguresContainer extends Component<SpreadsheetChildEnv> {
         // on click without move
         if (selected) {
           if (ev.shiftKey || isCtrlKey(ev)) {
-            this.env.model.dispatch("UNSELECT_FIGURE", { figureId: figureUI.id });
+            this.model().dispatch("UNSELECT_FIGURE", { figureId: figureUI.id });
           } else {
-            this.env.model.dispatch("SELECT_FIGURE", { figureId: figureUI.id });
+            this.model().dispatch("SELECT_FIGURE", { figureId: figureUI.id });
           }
         }
         return;
@@ -398,14 +401,14 @@ export class FiguresContainer extends Component<SpreadsheetChildEnv> {
             return {
               sheetId,
               figureId: f.id,
-              ...this.env.model.getters.getPositionAnchorOffset(f),
+              ...this.model().getters.getPositionAnchorOffset(f),
             };
           }) || [];
-        this.env.model.dispatch("MOVE_FIGURES", { figures: payloads });
+        this.model().dispatch("MOVE_FIGURES", { figures: payloads });
       } else {
         const carouselFigureId = this.dnd.overlappingCarousel.id;
         const chartFigureIds = this.dnd.selectedFigures?.map((f) => f.id) || [];
-        this.env.model.dispatch("ADD_FIGURES_CHART_TO_CAROUSEL", {
+        this.model().dispatch("ADD_FIGURES_CHART_TO_CAROUSEL", {
           sheetId,
           carouselFigureId,
           chartFigureIds: chartFigureIds,
@@ -434,23 +437,23 @@ export class FiguresContainer extends Component<SpreadsheetChildEnv> {
    */
   startResize(figureUI: FigureUI, dirX: ResizeDirection, dirY: ResizeDirection, ev: MouseEvent) {
     ev.stopPropagation();
-    const initialScrollPosition = this.env.model.getters.getActiveSheetScrollInfo();
+    const initialScrollPosition = this.model().getters.getActiveSheetScrollInfo();
 
     const keepRatio = figureRegistry.get(figureUI.tag).keepRatio || false;
     const minFigSize = figureRegistry.get(figureUI.tag).minFigSize || MIN_FIG_SIZE;
-    const zoom = this.env.model.getters.getViewportZoomLevel();
-    const sheetId = this.env.model.getters.getActiveSheetId();
+    const zoom = this.model().getters.getViewportZoomLevel();
+    const sheetId = this.model().getters.getActiveSheetId();
 
     const initialMousePosition = { x: ev.clientX / zoom, y: ev.clientY / zoom };
 
     const maxDimensions = {
-      maxX: this.env.model.getters.getColDimensions(
+      maxX: this.model().getters.getColDimensions(
         sheetId,
-        this.env.model.getters.getNumberCols(sheetId) - 1
+        this.model().getters.getNumberCols(sheetId) - 1
       ).end,
-      maxY: this.env.model.getters.getRowDimensions(
+      maxY: this.model().getters.getRowDimensions(
         sheetId,
-        this.env.model.getters.getNumberRows(sheetId) - 1
+        this.model().getters.getNumberRows(sheetId) - 1
       ).end,
     };
 
@@ -465,13 +468,13 @@ export class FiguresContainer extends Component<SpreadsheetChildEnv> {
         keepRatio,
         minFigSize,
         initialScrollPosition,
-        this.env.model.getters.getActiveSheetScrollInfo(),
+        this.model().getters.getActiveSheetScrollInfo(),
         maxDimensions
       );
 
       const otherFigures = this.getOtherFigures([figureUI.id]);
       const snapResult = snapForResize(
-        this.env.model.getters,
+        this.model().getters,
         dirX,
         dirY,
         draggedFigure,
@@ -488,7 +491,7 @@ export class FiguresContainer extends Component<SpreadsheetChildEnv> {
       if (!this.dnd.draggedFigure) {
         return;
       }
-      const update: Partial<Figure> & AnchorOffset = this.env.model.getters.getPositionAnchorOffset(
+      const update: Partial<Figure> & AnchorOffset = this.model().getters.getPositionAnchorOffset(
         this.dnd.draggedFigure
       );
       if (dirX) {
@@ -497,8 +500,8 @@ export class FiguresContainer extends Component<SpreadsheetChildEnv> {
       if (dirY) {
         update.height = this.dnd.draggedFigure.height;
       }
-      this.env.model.dispatch("UPDATE_FIGURE", {
-        sheetId: this.env.model.getters.getActiveSheetId(),
+      this.model().dispatch("UPDATE_FIGURE", {
+        sheetId: this.model().getters.getActiveSheetId(),
         figureId: figureUI.id,
         ...update,
       });
@@ -540,7 +543,7 @@ export class FiguresContainer extends Component<SpreadsheetChildEnv> {
     if (!snapLine || !this.dnd.draggedFigure) {
       return undefined;
     }
-    const { scrollX, scrollY } = this.env.model.getters.getActiveSheetScrollInfo();
+    const { scrollX, scrollY } = this.model().getters.getActiveSheetScrollInfo();
     const figureVisibleRects = snapLine.matchedFigIds
       .map((id) => this.getVisibleFigures().find((figureUI) => figureUI.id === id))
       .filter(isDefined)
@@ -575,7 +578,7 @@ export class FiguresContainer extends Component<SpreadsheetChildEnv> {
     if (!snapLine) {
       return "";
     }
-    const { scrollX, scrollY } = this.env.model.getters.getActiveSheetScrollInfo();
+    const { scrollX, scrollY } = this.model().getters.getActiveSheetScrollInfo();
     if (["top", "vCenter", "bottom"].includes(snapLine.snappedAxisType)) {
       return cssPropertiesToCss({
         top: `${snapLine.position - containerRect.y - scrollY}px`,

--- a/src/components/figures/figure_image/figure_image.ts
+++ b/src/components/figures/figure_image/figure_image.ts
@@ -1,9 +1,9 @@
+import { props } from "@odoo/owl";
+import { Component } from "../../../owl3_compatibility_layer";
 import { CSSProperties, UID } from "../../../types/misc";
 import { Rect } from "../../../types/rendering";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
-
-import { props } from "@odoo/owl";
-import { Component } from "../../../owl3_compatibility_layer";
+import { useModel } from "../../owl_plugins/model_plugin";
 import { types } from "../../props_validation";
 
 export class ImageFigure extends Component<SpreadsheetChildEnv> {
@@ -19,6 +19,8 @@ export class ImageFigure extends Component<SpreadsheetChildEnv> {
     ]),
   });
 
+  private model = useModel();
+
   // ---------------------------------------------------------------------------
   // Getters
   // ---------------------------------------------------------------------------
@@ -28,6 +30,6 @@ export class ImageFigure extends Component<SpreadsheetChildEnv> {
   }
 
   get getImagePath(): string {
-    return this.env.model.getters.getImagePath(this.figureId);
+    return this.model().getters.getImagePath(this.figureId);
   }
 }

--- a/src/components/filters/filter_menu/filter_menu.ts
+++ b/src/components/filters/filter_menu/filter_menu.ts
@@ -17,6 +17,7 @@ import {
   filterNumberCriterionOperators,
   filterTextCriterionOperators,
 } from "../../../types/table";
+import { useModel } from "../../owl_plugins/model_plugin";
 import { types } from "../../props_validation";
 import { SidePanelCollapsible } from "../../side_panel/components/collapsible/side_panel_collapsible";
 import { FilterMenuCriterion } from "../filter_menu_criterion/filter_menu_criterion";
@@ -47,6 +48,8 @@ export class FilterMenu extends Component<SpreadsheetChildEnv> {
   private criterionCategory: CriterionCategory = "text";
   private updatedCriterionValue: DataFilterValue | undefined;
 
+  private model = useModel();
+
   setup() {
     onWillUpdateProps((nextProps: PropsOf<FilterMenu>) => {
       if (!deepEquals(nextProps.filterPosition, this.props.filterPosition)) {
@@ -65,29 +68,29 @@ export class FilterMenu extends Component<SpreadsheetChildEnv> {
     if (!this.table) {
       return false;
     }
-    const coreTable = this.env.model.getters.getCoreTableMatchingTopLeft(
+    const coreTable = this.model().getters.getCoreTableMatchingTopLeft(
       this.table.range.sheetId,
       this.table.range.zone
     );
-    return !this.env.model.getters.isReadonly() && coreTable?.type !== "dynamic";
+    return !this.model().getters.isReadonly() && coreTable?.type !== "dynamic";
   }
 
   get table() {
-    const sheetId = this.env.model.getters.getActiveSheetId();
+    const sheetId = this.model().getters.getActiveSheetId();
     const position = this.props.filterPosition;
-    return this.env.model.getters.getTable({ sheetId, ...position });
+    return this.model().getters.getTable({ sheetId, ...position });
   }
 
   get filterValueType() {
-    const sheetId = this.env.model.getters.getActiveSheetId();
+    const sheetId = this.model().getters.getActiveSheetId();
     const position = this.props.filterPosition;
-    const filterValue = this.env.model.getters.getFilterValue({ sheetId, ...position });
+    const filterValue = this.model().getters.getFilterValue({ sheetId, ...position });
     return filterValue?.filterType;
   }
 
   private getCriterionCategory(position: Position): CriterionCategory {
-    const sheetId = this.env.model.getters.getActiveSheetId();
-    const filter = this.env.model.getters.getFilter({ sheetId, ...position });
+    const sheetId = this.model().getters.getActiveSheetId();
+    const filter = this.model().getters.getFilter({ sheetId, ...position });
     if (!filter || !filter.filteredRange) {
       return "text";
     }
@@ -100,7 +103,7 @@ export class FilterMenu extends Component<SpreadsheetChildEnv> {
       if (row > 100) {
         break;
       }
-      const cell = this.env.model.getters.getEvaluatedCell({ sheetId, row, col: position.col });
+      const cell = this.model().getters.getEvaluatedCell({ sheetId, row, col: position.col });
       if (cell.type === CellValueType.text || cell.type === CellValueType.boolean) {
         cellTypesCount.text++;
       } else if (cell.type === CellValueType.number) {
@@ -131,9 +134,9 @@ export class FilterMenu extends Component<SpreadsheetChildEnv> {
       return;
     }
     const position = this.props.filterPosition;
-    this.env.model.dispatch("UPDATE_FILTER", {
+    this.model().dispatch("UPDATE_FILTER", {
       ...position,
-      sheetId: this.env.model.getters.getActiveSheetId(),
+      sheetId: this.model().getters.getActiveSheetId(),
       value: this.updatedCriterionValue,
     });
     this.props.onClosed?.();
@@ -159,30 +162,38 @@ export class FilterMenu extends Component<SpreadsheetChildEnv> {
     if (!filterPosition || !tableZone || tableZone.top === tableZone.bottom) {
       return;
     }
-    const sheetId = this.env.model.getters.getActiveSheetId();
+    const sheetId = this.model().getters.getActiveSheetId();
     const contentZone = { ...tableZone, top: tableZone.top + 1 };
     const sortAnchor = { col: filterPosition.col, row: contentZone.top };
     const sortOptions = { emptyCellAsZero: true, sortHeaders: true };
-    interactiveSort(this.env, sheetId, sortAnchor, contentZone, sortDirection, sortOptions);
+    interactiveSort(
+      this.model(),
+      this.env,
+      sheetId,
+      sortAnchor,
+      contentZone,
+      sortDirection,
+      sortOptions
+    );
     this.props.onClosed?.();
   }
 
   private getFilterHiddenValues(position: Position): Value[] {
-    const sheetId = this.env.model.getters.getActiveSheetId();
-    const filter = this.env.model.getters.getFilter({ sheetId, ...position });
+    const sheetId = this.model().getters.getActiveSheetId();
+    const filter = this.model().getters.getFilter({ sheetId, ...position });
     if (!filter?.filteredRange) {
       return [];
     }
-    const filterValue = this.env.model.getters.getFilterValue({ sheetId, ...position });
+    const filterValue = this.model().getters.getFilterValue({ sheetId, ...position });
     let cellPositions = positions(filter.filteredRange.zone);
     if (filterValue?.filterType !== "criterion") {
       cellPositions = cellPositions.filter(
-        (currentPosition) => !this.env.model.getters.isRowHidden(sheetId, currentPosition.row)
+        (currentPosition) => !this.model().getters.isRowHidden(sheetId, currentPosition.row)
       );
     }
     const cellValues = cellPositions.map(
       (currentPosition) =>
-        this.env.model.getters.getEvaluatedCell({ sheetId, ...currentPosition }).formattedValue
+        this.model().getters.getEvaluatedCell({ sheetId, ...currentPosition }).formattedValue
     );
 
     const filterValues = filterValue?.filterType === "values" ? filterValue.hiddenValues : [];
@@ -216,8 +227,8 @@ export class FilterMenu extends Component<SpreadsheetChildEnv> {
   }
 
   getFilterCriterionValue(position: Position): CriterionFilter {
-    const sheetId = this.env.model.getters.getActiveSheetId();
-    const filterValue = this.env.model.getters.getFilterCriterionValue({ sheetId, ...position });
+    const sheetId = this.model().getters.getActiveSheetId();
+    const filterValue = this.model().getters.getFilterCriterionValue({ sheetId, ...position });
     return filterValue?.filterType === "criterion"
       ? deepCopy(filterValue)
       : { filterType: "criterion", type: "none", values: [] };

--- a/src/components/filters/pivot_filter_menu/pivot_filter_menu.ts
+++ b/src/components/filters/pivot_filter_menu/pivot_filter_menu.ts
@@ -11,6 +11,7 @@ import {
   filterNumberCriterionOperators,
   filterTextCriterionOperators,
 } from "../../../types/table";
+import { useModel } from "../../owl_plugins/model_plugin";
 import { types } from "../../props_validation";
 import { SidePanelCollapsible } from "../../side_panel/components/collapsible/side_panel_collapsible";
 import { FilterMenuCriterion } from "../filter_menu_criterion/filter_menu_criterion";
@@ -25,6 +26,7 @@ export class PivotFilterMenu extends Component<SpreadsheetChildEnv> {
 
   private criterionCategory: CriterionCategory = "char";
   private updatedCriterionValue: DataFilterValue | undefined;
+  private model = useModel();
 
   protected props = props({
     pivotId: types.UID(),
@@ -54,7 +56,7 @@ export class PivotFilterMenu extends Component<SpreadsheetChildEnv> {
   }
 
   private getCriterionCategory(): CriterionCategory {
-    const pivot = this.env.model.getters.getPivot(this.props.pivotId);
+    const pivot = this.model().getters.getPivot(this.props.pivotId);
     const fields = pivot.getFields();
     const criterionCategory = fields[this.props.filter.fieldName]?.type;
     return (criterionCategory || "char") as CriterionCategory;

--- a/src/components/full_screen_figure/full_screen_figure.ts
+++ b/src/components/full_screen_figure/full_screen_figure.ts
@@ -7,6 +7,7 @@ import { Store } from "../../types/store_engine";
 import { ChartAnimationStore } from "../figures/chart/chartJs/chartjs_animation_store";
 import { ChartFigure } from "../figures/figure_chart/figure_chart";
 import { useSpreadsheetRect } from "../helpers/position_hook";
+import { useModel } from "../owl_plugins/model_plugin";
 import { FullScreenFigureStore } from "./full_screen_figure_store";
 
 export class FullScreenFigure extends Component<SpreadsheetChildEnv> {
@@ -19,6 +20,8 @@ export class FullScreenFigure extends Component<SpreadsheetChildEnv> {
   spreadsheetRect = useSpreadsheetRect();
 
   figureRegistry = figureRegistry;
+
+  private model = useModel();
 
   setup() {
     this.fullScreenFigureStore = useStore(FullScreenFigureStore);
@@ -43,7 +46,7 @@ export class FullScreenFigure extends Component<SpreadsheetChildEnv> {
     if (!this.figureUI) {
       return undefined;
     }
-    return this.env.model.getters.getChartIdFromFigureId(this.figureUI?.id);
+    return this.model().getters.getChartIdFromFigureId(this.figureUI?.id);
   }
 
   exitFullScreen() {

--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -77,6 +77,7 @@ import { useWheelHandler } from "../helpers/wheel_hook";
 import { ZoomedMouseEvent } from "../helpers/zoom";
 import { Highlight } from "../highlight/highlight/highlight";
 import { MenuPopover, MenuState } from "../menu_popover/menu_popover";
+import { useModel } from "../owl_plugins/model_plugin";
 import { PaintFormatStore } from "../paint_format_button/paint_format_store";
 import { CellPopoverStore } from "../popover/cell_popover_store";
 import { Popover } from "../popover/popover";
@@ -143,6 +144,7 @@ export class Grid extends Component<SpreadsheetChildEnv> {
 
   readonly HEADER_HEIGHT = HEADER_HEIGHT;
   readonly HEADER_WIDTH = HEADER_WIDTH;
+  private model = useModel();
   private menuState!: MenuState;
   private gridRef = signal<HTMLElement | null>(null);
   private canvasRef = signal<HTMLElement | null>(null);
@@ -153,7 +155,7 @@ export class Grid extends Component<SpreadsheetChildEnv> {
   private paintFormatStore!: Store<PaintFormatStore>;
   private clientFocusStore!: Store<ClientFocusStore>;
 
-  dragNDropGrid = useDragAndDropBeyondTheViewport(this.env);
+  dragNDropGrid = useDragAndDropBeyondTheViewport(this.model());
 
   onMouseWheel!: (ev: WheelEvent) => void;
   hoveredCell!: Store<DelayedHoveredCellStore>;
@@ -184,8 +186,8 @@ export class Grid extends Component<SpreadsheetChildEnv> {
       canvasRef: this.canvasRef,
       renderingCtx: () => ({
         dpr: window.devicePixelRatio || 1,
-        viewports: this.env.model.getters.getViewportCollection(),
-        ...this.env.model.getters.getSelectionState(),
+        viewports: this.model().getters.getViewportCollection(),
+        ...this.model().getters.getSelectionState(),
       }),
     });
     this.onMouseWheel = useWheelHandler((deltaX, deltaY) => {
@@ -206,16 +208,16 @@ export class Grid extends Component<SpreadsheetChildEnv> {
     useTouchHandlers(this.gridRef, {
       updateScroll: this.moveCanvas.bind(this),
       canMoveUp: () => {
-        const { scrollY } = this.env.model.getters.getActiveSheetScrollInfo();
+        const { scrollY } = this.model().getters.getActiveSheetScrollInfo();
         return scrollY > 0;
       },
       canMoveDown: () => {
-        const { maxOffsetY } = this.env.model.getters.getMaximumSheetOffset();
-        const { scrollY } = this.env.model.getters.getActiveSheetScrollInfo();
+        const { maxOffsetY } = this.model().getters.getMaximumSheetOffset();
+        const { scrollY } = this.model().getters.getActiveSheetScrollInfo();
         return scrollY < maxOffsetY;
       },
-      getZoom: () => this.env.model.getters.getViewportZoomLevel(),
-      setZoom: (zoom: number) => this.env.model.dispatch("SET_ZOOM", { zoom }),
+      getZoom: () => this.model().getters.getViewportZoomLevel(),
+      setZoom: (zoom: number) => this.model().dispatch("SET_ZOOM", { zoom }),
     });
   }
 
@@ -224,7 +226,7 @@ export class Grid extends Component<SpreadsheetChildEnv> {
   }
 
   get gridOverlayDimensions() {
-    const scrollbarWidth = this.env.model.getters.getScrollBarWidth();
+    const scrollbarWidth = this.model().getters.getScrollBarWidth();
     return cssPropertiesToCss({
       top: `${HEADER_HEIGHT}px`,
       left: `${HEADER_WIDTH}px`,
@@ -251,15 +253,15 @@ export class Grid extends Component<SpreadsheetChildEnv> {
       this.focusComposerFromActiveCell();
     },
     Delete: () => {
-      this.env.model.dispatch("DELETE_UNFILTERED_CONTENT", {
-        sheetId: this.env.model.getters.getActiveSheetId(),
-        target: this.env.model.getters.getSelectedZones(),
+      this.model().dispatch("DELETE_UNFILTERED_CONTENT", {
+        sheetId: this.model().getters.getActiveSheetId(),
+        target: this.model().getters.getSelectedZones(),
       });
     },
     Backspace: () => {
-      this.env.model.dispatch("DELETE_UNFILTERED_CONTENT", {
-        sheetId: this.env.model.getters.getActiveSheetId(),
-        target: this.env.model.getters.getSelectedZones(),
+      this.model().dispatch("DELETE_UNFILTERED_CONTENT", {
+        sheetId: this.model().getters.getActiveSheetId(),
+        target: this.model().getters.getSelectedZones(),
       });
     },
     Escape: () => {
@@ -271,169 +273,169 @@ export class Grid extends Component<SpreadsheetChildEnv> {
       } else if (this.paintFormatStore.isActive) {
         this.paintFormatStore.cancel();
       } else {
-        this.env.model.dispatch("CLEAN_CLIPBOARD_HIGHLIGHT");
+        this.model().dispatch("CLEAN_CLIPBOARD_HIGHLIGHT");
       }
     },
-    "Ctrl+A": () => this.env.model.selection.loopSelection(),
-    "Ctrl+Z": () => this.env.model.dispatch("REQUEST_UNDO"),
-    "Ctrl+Y": () => this.env.model.dispatch("REQUEST_REDO"),
-    F4: () => this.env.model.dispatch("REQUEST_REDO"),
+    "Ctrl+A": () => this.model().selection.loopSelection(),
+    "Ctrl+Z": () => this.model().dispatch("REQUEST_UNDO"),
+    "Ctrl+Y": () => this.model().dispatch("REQUEST_REDO"),
+    F4: () => this.model().dispatch("REQUEST_REDO"),
     "Ctrl+B": () =>
-      this.env.model.dispatch("SET_FORMATTING", {
-        sheetId: this.env.model.getters.getActiveSheetId(),
-        target: this.env.model.getters.getSelectedZones(),
-        style: { bold: !this.env.model.getters.getCurrentStyle().bold },
+      this.model().dispatch("SET_FORMATTING", {
+        sheetId: this.model().getters.getActiveSheetId(),
+        target: this.model().getters.getSelectedZones(),
+        style: { bold: !this.model().getters.getCurrentStyle().bold },
       }),
     "Ctrl+I": () =>
-      this.env.model.dispatch("SET_FORMATTING", {
-        sheetId: this.env.model.getters.getActiveSheetId(),
-        target: this.env.model.getters.getSelectedZones(),
-        style: { italic: !this.env.model.getters.getCurrentStyle().italic },
+      this.model().dispatch("SET_FORMATTING", {
+        sheetId: this.model().getters.getActiveSheetId(),
+        target: this.model().getters.getSelectedZones(),
+        style: { italic: !this.model().getters.getCurrentStyle().italic },
       }),
     "Ctrl+U": () =>
-      this.env.model.dispatch("SET_FORMATTING", {
-        sheetId: this.env.model.getters.getActiveSheetId(),
-        target: this.env.model.getters.getSelectedZones(),
-        style: { underline: !this.env.model.getters.getCurrentStyle().underline },
+      this.model().dispatch("SET_FORMATTING", {
+        sheetId: this.model().getters.getActiveSheetId(),
+        target: this.model().getters.getSelectedZones(),
+        style: { underline: !this.model().getters.getCurrentStyle().underline },
       }),
-    "Ctrl+O": () => CREATE_IMAGE(this.env),
+    "Ctrl+O": () => CREATE_IMAGE(this.model(), this.env),
     "Alt+=": () => {
-      const sheetId = this.env.model.getters.getActiveSheetId();
+      const sheetId = this.model().getters.getActiveSheetId();
 
-      const mainSelectedZone = this.env.model.getters.getSelectedZone();
-      const { anchor } = this.env.model.getters.getSelection();
-      const sums = this.env.model.getters.getAutomaticSums(sheetId, mainSelectedZone, anchor.cell);
+      const mainSelectedZone = this.model().getters.getSelectedZone();
+      const { anchor } = this.model().getters.getSelection();
+      const sums = this.model().getters.getAutomaticSums(sheetId, mainSelectedZone, anchor.cell);
       if (
-        this.env.model.getters.isSingleCellOrMerge(sheetId, mainSelectedZone) ||
-        (this.env.model.getters.isEmpty(sheetId, mainSelectedZone) && sums.length <= 1)
+        this.model().getters.isSingleCellOrMerge(sheetId, mainSelectedZone) ||
+        (this.model().getters.isEmpty(sheetId, mainSelectedZone) && sums.length <= 1)
       ) {
         const zone = sums[0]?.zone;
-        const zoneXc = zone ? this.env.model.getters.zoneToXC(sheetId, sums[0].zone) : "";
+        const zoneXc = zone ? this.model().getters.zoneToXC(sheetId, sums[0].zone) : "";
         const formula = `=SUM(${zoneXc})`;
         this.onComposerCellFocused(formula, { start: 5, end: 5 + zoneXc.length });
       } else {
-        this.env.model.dispatch("SUM_SELECTION");
+        this.model().dispatch("SUM_SELECTION");
       }
     },
     "Alt+Enter": () => {
-      const cell = this.env.model.getters.getActiveCell();
+      const cell = this.model().getters.getActiveCell();
       if (cell.link) {
-        openLink(cell.link, this.env);
+        openLink(cell.link, this.model(), this.env);
       }
     },
     "Ctrl+Home": () => {
-      const sheetId = this.env.model.getters.getActiveSheetId();
-      const { col, row } = this.env.model.getters.getNextVisibleCellPosition({
+      const sheetId = this.model().getters.getActiveSheetId();
+      const { col, row } = this.model().getters.getNextVisibleCellPosition({
         sheetId,
         col: 0,
         row: 0,
       });
-      this.env.model.selection.selectCell(col, row);
+      this.model().selection.selectCell(col, row);
     },
     "Ctrl+End": () => {
-      const sheetId = this.env.model.getters.getActiveSheetId();
-      const col = this.env.model.getters.findVisibleHeader(
+      const sheetId = this.model().getters.getActiveSheetId();
+      const col = this.model().getters.findVisibleHeader(
         sheetId,
         "COL",
-        this.env.model.getters.getNumberCols(sheetId) - 1,
+        this.model().getters.getNumberCols(sheetId) - 1,
         0
       )!;
-      const row = this.env.model.getters.findVisibleHeader(
+      const row = this.model().getters.findVisibleHeader(
         sheetId,
         "ROW",
-        this.env.model.getters.getNumberRows(sheetId) - 1,
+        this.model().getters.getNumberRows(sheetId) - 1,
         0
       )!;
-      this.env.model.selection.selectCell(col, row);
+      this.model().selection.selectCell(col, row);
     },
     "Shift+ ": () => {
-      const sheetId = this.env.model.getters.getActiveSheetId();
+      const sheetId = this.model().getters.getActiveSheetId();
       const newZone = {
-        ...this.env.model.getters.getSelectedZone(),
+        ...this.model().getters.getSelectedZone(),
         left: 0,
-        right: this.env.model.getters.getNumberCols(sheetId) - 1,
+        right: this.model().getters.getNumberCols(sheetId) - 1,
       };
-      const position = this.env.model.getters.getActivePosition();
-      this.env.model.selection.selectZone({ cell: position, zone: newZone });
+      const position = this.model().getters.getActivePosition();
+      this.model().selection.selectZone({ cell: position, zone: newZone });
     },
     "Ctrl+ ": () => {
-      const sheetId = this.env.model.getters.getActiveSheetId();
+      const sheetId = this.model().getters.getActiveSheetId();
       const newZone = {
-        ...this.env.model.getters.getSelectedZone(),
+        ...this.model().getters.getSelectedZone(),
         top: 0,
-        bottom: this.env.model.getters.getNumberRows(sheetId) - 1,
+        bottom: this.model().getters.getNumberRows(sheetId) - 1,
       };
-      const position = this.env.model.getters.getActivePosition();
-      this.env.model.selection.selectZone({ cell: position, zone: newZone });
+      const position = this.model().getters.getActivePosition();
+      this.model().selection.selectZone({ cell: position, zone: newZone });
     },
     "Ctrl+D": () => {
-      handleCopyPasteResult(this.env, { type: "COPY_PASTE_CELLS_ABOVE" });
+      handleCopyPasteResult(this.model(), this.env, { type: "COPY_PASTE_CELLS_ABOVE" });
     },
     "Ctrl+R": () => {
-      handleCopyPasteResult(this.env, { type: "COPY_PASTE_CELLS_ON_LEFT" });
+      handleCopyPasteResult(this.model(), this.env, { type: "COPY_PASTE_CELLS_ON_LEFT" });
     },
     "Ctrl+Enter": () => {
-      handleCopyPasteResult(this.env, { type: "COPY_PASTE_CELLS_ON_ZONE" });
+      handleCopyPasteResult(this.model(), this.env, { type: "COPY_PASTE_CELLS_ON_ZONE" });
     },
     "Ctrl+H": () => this.sidePanel.open("FindAndReplace", {}),
     "Ctrl+F": () => this.sidePanel.open("FindAndReplace", {}),
     "Ctrl+Shift+E": () => this.setHorizontalAlign("center"),
     "Ctrl+Shift+L": () => this.setHorizontalAlign("left"),
     "Ctrl+Shift+R": () => this.setHorizontalAlign("right"),
-    "Ctrl+Shift+V": () => PASTE_AS_VALUE_ACTION(this.env),
+    "Ctrl+Shift+V": () => PASTE_AS_VALUE_ACTION(this.model(), this.env),
     "Ctrl+Shift+<": () => this.clearFormatting(), // for qwerty
     "Ctrl+<": () => this.clearFormatting(), // for azerty
     "Ctrl+Shift+ ": () => {
-      this.env.model.selection.selectAll();
+      this.model().selection.selectAll();
     },
     "Ctrl+Alt+=": () => {
-      const activeCols = this.env.model.getters.getActiveCols();
-      const activeRows = this.env.model.getters.getActiveRows();
-      const isSingleSelection = this.env.model.getters.getSelectedZones().length === 1;
+      const activeCols = this.model().getters.getActiveCols();
+      const activeRows = this.model().getters.getActiveRows();
+      const isSingleSelection = this.model().getters.getSelectedZones().length === 1;
       const areFullCols = activeCols.size > 0 && isSingleSelection;
       const areFullRows = activeRows.size > 0 && isSingleSelection;
       if (areFullCols && !areFullRows) {
-        INSERT_COLUMNS_BEFORE_ACTION(this.env);
+        INSERT_COLUMNS_BEFORE_ACTION(this.model());
       } else if (areFullRows && !areFullCols) {
-        INSERT_ROWS_BEFORE_ACTION(this.env);
+        INSERT_ROWS_BEFORE_ACTION(this.model());
       }
     },
     "Ctrl+Alt+-": () => {
-      const columns = [...this.env.model.getters.getActiveCols()];
-      const rows = [...this.env.model.getters.getActiveRows()];
+      const columns = [...this.model().getters.getActiveCols()];
+      const rows = [...this.model().getters.getActiveRows()];
       if (columns.length > 0 && rows.length === 0) {
-        this.env.model.dispatch("REMOVE_COLUMNS_ROWS", {
-          sheetId: this.env.model.getters.getActiveSheetId(),
-          sheetName: this.env.model.getters.getActiveSheetName(),
+        this.model().dispatch("REMOVE_COLUMNS_ROWS", {
+          sheetId: this.model().getters.getActiveSheetId(),
+          sheetName: this.model().getters.getActiveSheetName(),
           dimension: "COL",
           elements: columns,
         });
       } else if (rows.length > 0 && columns.length === 0) {
-        this.env.model.dispatch("REMOVE_COLUMNS_ROWS", {
-          sheetId: this.env.model.getters.getActiveSheetId(),
-          sheetName: this.env.model.getters.getActiveSheetName(),
+        this.model().dispatch("REMOVE_COLUMNS_ROWS", {
+          sheetId: this.model().getters.getActiveSheetId(),
+          sheetName: this.model().getters.getActiveSheetName(),
           dimension: "ROW",
           elements: rows,
         });
       }
     },
     "Shift+PageDown": () => {
-      this.env.model.dispatch("ACTIVATE_NEXT_SHEET");
+      this.model().dispatch("ACTIVATE_NEXT_SHEET");
     },
     "Shift+PageUp": () => {
-      this.env.model.dispatch("ACTIVATE_PREVIOUS_SHEET");
+      this.model().dispatch("ACTIVATE_PREVIOUS_SHEET");
     },
     "Shift+F11": () => {
-      insertSheet.execute?.(this.env);
+      insertSheet.execute?.(this.model(), this.env);
     },
     "Alt+T": () => {
-      insertTable.execute?.(this.env);
+      insertTable.execute?.(this.model(), this.env);
     },
-    PageDown: () => this.env.model.dispatch("SHIFT_VIEWPORT_DOWN"),
-    PageUp: () => this.env.model.dispatch("SHIFT_VIEWPORT_UP"),
+    PageDown: () => this.model().dispatch("SHIFT_VIEWPORT_DOWN"),
+    PageUp: () => this.model().dispatch("SHIFT_VIEWPORT_UP"),
     "Ctrl+Shift+K": () => {
       this.closeMenu();
-      INSERT_LINK(this.env);
+      INSERT_LINK(this.model(), this.env);
     },
     "Alt+Shift+ArrowRight": () => this.processHeaderGroupingKey("right"),
     "Alt+Shift+ArrowLeft": () => this.processHeaderGroupingKey("left"),
@@ -442,7 +444,7 @@ export class Grid extends Component<SpreadsheetChildEnv> {
   };
 
   private focusComposerFromActiveCell() {
-    const cell = this.env.model.getters.getActiveCell();
+    const cell = this.model().getters.getActiveCell();
     cell.type === CellValueType.empty
       ? this.onComposerCellFocused()
       : this.onComposerContentFocused();
@@ -453,26 +455,26 @@ export class Grid extends Component<SpreadsheetChildEnv> {
       this.focusComposerFromActiveCell();
       return;
     }
-    moveAnchorWithinSelection(this.env.model.getters, this.env.model.selection, direction);
+    moveAnchorWithinSelection(this.model().getters, this.model().selection, direction);
   }
 
   private moveInSelection(direction: "left" | "right") {
     if (this.isSingleCellOrMergeSelection()) {
-      this.env.model.selection.moveAnchorCell(direction, 1);
+      this.model().selection.moveAnchorCell(direction, 1);
       return;
     }
-    moveAnchorWithinSelection(this.env.model.getters, this.env.model.selection, direction);
+    moveAnchorWithinSelection(this.model().getters, this.model().selection, direction);
   }
 
   private isSingleCellOrMergeSelection(): boolean {
-    const sheetId = this.env.model.getters.getActiveSheetId();
-    const selectedZone = this.env.model.getters.getSelectedZone();
-    return this.env.model.getters.isSingleCellOrMerge(sheetId, selectedZone);
+    const sheetId = this.model().getters.getActiveSheetId();
+    const selectedZone = this.model().getters.getSelectedZone();
+    return this.model().getters.isSingleCellOrMerge(sheetId, selectedZone);
   }
 
   focusDefaultElement() {
     if (
-      !this.env.model.getters.getSelectedFigureIds().length &&
+      !this.model().getters.getSelectedFigureIds().length &&
       this.composerFocusStore.activeComposer.editionMode === "inactive"
     ) {
       this.DOMFocusableElementStore.focus();
@@ -488,8 +490,8 @@ export class Grid extends Component<SpreadsheetChildEnv> {
   }
 
   getAutofillPosition() {
-    const zone = this.env.model.getters.getSelectedZone();
-    const rect = this.env.model.getters.getVisibleRect(zone);
+    const zone = this.model().getters.getSelectedZone();
+    const rect = this.model().getters.getVisibleRect(zone);
     return {
       x: rect.x + rect.width - AUTOFILL_EDGE_LENGTH / 2,
       y: rect.y + rect.height - AUTOFILL_EDGE_LENGTH / 2,
@@ -497,11 +499,11 @@ export class Grid extends Component<SpreadsheetChildEnv> {
   }
 
   get isAutofillVisible(): boolean {
-    if (this.env.model.getters.isCurrentSheetLocked()) {
+    if (this.model().getters.isCurrentSheetLocked()) {
       return false;
     }
-    const zone = this.env.model.getters.getSelectedZone();
-    const rect = this.env.model.getters.getVisibleRect({
+    const zone = this.model().getters.getSelectedZone();
+    const rect = this.model().getters.getVisibleRect({
       left: zone.right,
       right: zone.right,
       top: zone.bottom,
@@ -512,7 +514,7 @@ export class Grid extends Component<SpreadsheetChildEnv> {
 
   onGridResized() {
     const { height, width } = this.props.getGridSize();
-    this.env.model.dispatch("RESIZE_SHEETVIEW", {
+    this.model().dispatch("RESIZE_SHEETVIEW", {
       width: width - HEADER_WIDTH,
       height: height - HEADER_HEIGHT,
       gridOffsetX: HEADER_WIDTH,
@@ -521,22 +523,20 @@ export class Grid extends Component<SpreadsheetChildEnv> {
   }
 
   private moveCanvas(deltaX: number, deltaY: number) {
-    const { scrollX, scrollY } = this.env.model.getters.getActiveSheetScrollInfo();
-    this.env.model.dispatch("SET_VIEWPORT_OFFSET", {
+    const { scrollX, scrollY } = this.model().getters.getActiveSheetScrollInfo();
+    this.model().dispatch("SET_VIEWPORT_OFFSET", {
       offsetX: scrollX + deltaX,
       offsetY: scrollY + deltaY,
     });
   }
 
   private processSpaceKey(ev: KeyboardEvent) {
-    if (
-      this.env.model.getters.hasBooleanValidationInZones(this.env.model.getters.getSelectedZones())
-    ) {
+    if (this.model().getters.hasBooleanValidationInZones(this.model().getters.getSelectedZones())) {
       ev.preventDefault();
       ev.stopPropagation();
-      this.env.model.dispatch("TOGGLE_CHECKBOX", {
-        sheetId: this.env.model.getters.getActiveSheetId(),
-        target: this.env.model.getters.getSelectedZones(),
+      this.model().dispatch("TOGGLE_CHECKBOX", {
+        sheetId: this.model().getters.getActiveSheetId(),
+        target: this.model().getters.getSelectedZones(),
       });
     }
   }
@@ -554,8 +554,8 @@ export class Grid extends Component<SpreadsheetChildEnv> {
   }
 
   private getGridRect(): Rect {
-    const zoom = this.env.model.getters.getViewportZoomLevel();
-    const { width, height } = this.env.model.getters.getSheetViewDimensionWithHeaders();
+    const zoom = this.model().getters.getViewportZoomLevel();
+    const { width, height } = this.model().getters.getSheetViewDimensionWithHeaders();
     return {
       ...getElBoundingRect(this.gridRef()),
       width: width * zoom,
@@ -578,11 +578,11 @@ export class Grid extends Component<SpreadsheetChildEnv> {
       this.composerFocusStore.activeComposer.stopEdition();
     }
     if (modifiers.expandZone) {
-      this.env.model.selection.setAnchorCorner(col, row);
+      this.model().selection.setAnchorCorner(col, row);
     } else if (modifiers.addZone) {
-      this.env.model.selection.addCellToSelection(col, row);
+      this.model().selection.addCellToSelection(col, row);
     } else {
-      this.env.model.selection.selectCell(col, row);
+      this.model().selection.selectCell(col, row);
     }
 
     if (this.env.isMobile()) {
@@ -600,22 +600,22 @@ export class Grid extends Component<SpreadsheetChildEnv> {
       if ((col !== prevCol && col !== -1) || (row !== prevRow && row !== -1)) {
         prevCol = col === -1 ? prevCol : col;
         prevRow = row === -1 ? prevRow : row;
-        this.env.model.selection.setAnchorCorner(prevCol, prevRow);
+        this.model().selection.setAnchorCorner(prevCol, prevRow);
       }
     };
     const onMouseUp = () => {
-      this.env.model.selection.commitSelection();
+      this.model().selection.commitSelection();
       if (this.paintFormatStore.isActive) {
-        this.paintFormatStore.pasteFormat(this.env.model.getters.getSelectedZones());
+        this.paintFormatStore.pasteFormat(this.model().getters.getSelectedZones());
       }
     };
     this.dragNDropGrid.start(zoomedMouseEvent, onMouseMove, onMouseUp);
   }
 
   onCellDoubleClicked(col: HeaderIndex, row: HeaderIndex) {
-    const sheetId = this.env.model.getters.getActiveSheetId();
-    ({ col, row } = this.env.model.getters.getMainCellPosition({ sheetId, col, row }));
-    const cell = this.env.model.getters.getEvaluatedCell({ sheetId, col, row });
+    const sheetId = this.model().getters.getActiveSheetId();
+    ({ col, row } = this.model().getters.getMainCellPosition({ sheetId, col, row }));
+    const cell = this.model().getters.getEvaluatedCell({ sheetId, col, row });
     if (cell.type === CellValueType.empty) {
       this.onComposerCellFocused();
     } else {
@@ -634,10 +634,10 @@ export class Grid extends Component<SpreadsheetChildEnv> {
       this.cellPopovers.close();
     }
 
-    updateSelectionWithArrowKeys(ev, this.env.model.selection);
+    updateSelectionWithArrowKeys(ev, this.model().selection);
 
     if (this.paintFormatStore.isActive) {
-      this.paintFormatStore.pasteFormat(this.env.model.getters.getSelectedZones());
+      this.paintFormatStore.pasteFormat(this.model().getters.getSelectedZones());
     }
   }
 
@@ -669,31 +669,31 @@ export class Grid extends Component<SpreadsheetChildEnv> {
 
   onInputContextMenu(ev: MouseEvent) {
     ev.preventDefault();
-    const lastZone = this.env.model.getters.getSelectedZone();
+    const lastZone = this.model().getters.getSelectedZone();
     const { left: col, top: row } = lastZone;
     let type: ContextMenuType = "CELL";
     this.composerFocusStore.activeComposer.stopEdition();
-    if (this.env.model.getters.getActiveCols().has(col)) {
+    if (this.model().getters.getActiveCols().has(col)) {
       type = "COL";
-    } else if (this.env.model.getters.getActiveRows().has(row)) {
+    } else if (this.model().getters.getActiveRows().has(row)) {
       type = "ROW";
     }
-    const { x, y, width } = this.env.model.getters.getVisibleRectWithZoom(lastZone);
+    const { x, y, width } = this.model().getters.getVisibleRectWithZoom(lastZone);
     const gridRect = this.getGridRect();
     this.toggleContextMenu(type, gridRect.x + x + width, gridRect.y + y);
   }
 
   onCellRightClicked(col: HeaderIndex, row: HeaderIndex, { x, y }: DOMCoordinates) {
-    const zones = this.env.model.getters.getSelectedZones();
+    const zones = this.model().getters.getSelectedZones();
     const lastZone = zones[zones.length - 1];
     let type: ContextMenuType = "CELL";
     if (!isInside(col, row, lastZone)) {
-      this.env.model.selection.getBackToDefault();
-      this.env.model.selection.selectCell(col, row);
+      this.model().selection.getBackToDefault();
+      this.model().selection.selectCell(col, row);
     } else {
-      if (this.env.model.getters.getActiveCols().has(col)) {
+      if (this.model().getters.getActiveCols().has(col)) {
         type = "COL";
-      } else if (this.env.model.getters.getActiveRows().has(row)) {
+      } else if (this.model().getters.getActiveRows().has(row)) {
         type = "ROW";
       }
     }
@@ -722,11 +722,11 @@ export class Grid extends Component<SpreadsheetChildEnv> {
       return;
     }
     if (cut) {
-      interactiveCut(this.env);
+      interactiveCut(this.model(), this.env);
     } else {
-      this.env.model.dispatch("COPY");
+      this.model().dispatch("COPY");
     }
-    const osContent = await this.env.model.getters.getClipboardTextAndImageContent();
+    const osContent = await this.model().getters.getClipboardTextAndImageContent();
     await this.env.clipboard.write(osContent);
     ev.preventDefault();
   }
@@ -756,18 +756,18 @@ export class Grid extends Component<SpreadsheetChildEnv> {
       osClipboard.content[image.type] = image;
     }
 
-    const target = this.env.model.getters.getSelectedZones();
-    const isCutOperation = this.env.model.getters.isCutOperation();
+    const target = this.model().getters.getSelectedZones();
+    const isCutOperation = this.model().getters.isCutOperation();
 
-    const clipboardId = this.env.model.getters.getClipboardId();
+    const clipboardId = this.model().getters.getClipboardId();
     const htmlClipboardId = getOSheetClipboardIdFromHTML(
       osClipboard.content[ClipboardMIMEType.Html]
     );
     if (clipboardId === htmlClipboardId) {
-      interactivePaste(this.env, target);
+      interactivePaste(this.model(), this.env, target);
     } else {
       const osClipboardContent = parseOSClipboardContent(osClipboard.content);
-      await interactivePasteFromOS(this.env, target, osClipboardContent);
+      await interactivePasteFromOS(this.model(), this.env, target, osClipboardContent);
     }
     if (isCutOperation) {
       await this.env.clipboard.write({ [ClipboardMIMEType.PlainText]: "" });
@@ -775,16 +775,16 @@ export class Grid extends Component<SpreadsheetChildEnv> {
   }
 
   private clearFormatting() {
-    this.env.model.dispatch("CLEAR_FORMATTING", {
-      sheetId: this.env.model.getters.getActiveSheetId(),
-      target: this.env.model.getters.getSelectedZones(),
+    this.model().dispatch("CLEAR_FORMATTING", {
+      sheetId: this.model().getters.getActiveSheetId(),
+      target: this.model().getters.getSelectedZones(),
     });
   }
 
   private setHorizontalAlign(align: Align) {
-    this.env.model.dispatch("SET_FORMATTING", {
-      sheetId: this.env.model.getters.getActiveSheetId(),
-      target: this.env.model.getters.getSelectedZones(),
+    this.model().dispatch("SET_FORMATTING", {
+      sheetId: this.model().getters.getActiveSheetId(),
+      target: this.model().getters.getSelectedZones(),
       style: { align },
     });
   }
@@ -795,12 +795,12 @@ export class Grid extends Component<SpreadsheetChildEnv> {
   }
 
   private processHeaderGroupingKey(direction: Direction) {
-    if (this.env.model.getters.getSelectedZones().length !== 1) {
+    if (this.model().getters.getSelectedZones().length !== 1) {
       return;
     }
 
-    const selectingRows = this.env.model.getters.getActiveRows().size > 0;
-    const selectingCols = this.env.model.getters.getActiveCols().size > 0;
+    const selectingRows = this.model().getters.getActiveRows().size > 0;
+    const selectingCols = this.model().getters.getActiveCols().size > 0;
 
     if (selectingCols && selectingRows) {
       this.processHeaderGroupingEventOnWholeSheet(direction);
@@ -814,78 +814,78 @@ export class Grid extends Component<SpreadsheetChildEnv> {
   }
 
   private processHeaderGroupingEventOnHeaders(direction: Direction, dimension: Dimension) {
-    const sheetId = this.env.model.getters.getActiveSheetId();
+    const sheetId = this.model().getters.getActiveSheetId();
 
-    const zone = this.env.model.getters.getSelectedZone();
+    const zone = this.model().getters.getSelectedZone();
     const start = dimension === "COL" ? zone.left : zone.top;
     const end = dimension === "COL" ? zone.right : zone.bottom;
 
     switch (direction) {
       case "right":
-        this.env.model.dispatch("GROUP_HEADERS", { sheetId, dimension: dimension, start, end });
+        this.model().dispatch("GROUP_HEADERS", { sheetId, dimension: dimension, start, end });
         break;
       case "left":
-        this.env.model.dispatch("UNGROUP_HEADERS", { sheetId, dimension: dimension, start, end });
+        this.model().dispatch("UNGROUP_HEADERS", { sheetId, dimension: dimension, start, end });
         break;
       case "down":
-        this.env.model.dispatch("UNFOLD_HEADER_GROUPS_IN_ZONE", { sheetId, dimension, zone });
+        this.model().dispatch("UNFOLD_HEADER_GROUPS_IN_ZONE", { sheetId, dimension, zone });
         break;
       case "up":
-        this.env.model.dispatch("FOLD_HEADER_GROUPS_IN_ZONE", { sheetId, dimension, zone });
+        this.model().dispatch("FOLD_HEADER_GROUPS_IN_ZONE", { sheetId, dimension, zone });
         break;
     }
   }
 
   private processHeaderGroupingEventOnWholeSheet(direction: Direction) {
-    const sheetId = this.env.model.getters.getActiveSheetId();
+    const sheetId = this.model().getters.getActiveSheetId();
     if (direction === "up") {
-      this.env.model.dispatch("FOLD_ALL_HEADER_GROUPS", { sheetId, dimension: "ROW" });
-      this.env.model.dispatch("FOLD_ALL_HEADER_GROUPS", { sheetId, dimension: "COL" });
+      this.model().dispatch("FOLD_ALL_HEADER_GROUPS", { sheetId, dimension: "ROW" });
+      this.model().dispatch("FOLD_ALL_HEADER_GROUPS", { sheetId, dimension: "COL" });
     } else if (direction === "down") {
-      this.env.model.dispatch("UNFOLD_ALL_HEADER_GROUPS", { sheetId, dimension: "ROW" });
-      this.env.model.dispatch("UNFOLD_ALL_HEADER_GROUPS", { sheetId, dimension: "COL" });
+      this.model().dispatch("UNFOLD_ALL_HEADER_GROUPS", { sheetId, dimension: "ROW" });
+      this.model().dispatch("UNFOLD_ALL_HEADER_GROUPS", { sheetId, dimension: "COL" });
     }
   }
 
   private processHeaderGroupingEventOnGrid(direction: Direction) {
-    const sheetId = this.env.model.getters.getActiveSheetId();
-    const zone = this.env.model.getters.getSelectedZone();
+    const sheetId = this.model().getters.getActiveSheetId();
+    const zone = this.model().getters.getSelectedZone();
     switch (direction) {
       case "down":
-        this.env.model.dispatch("UNFOLD_HEADER_GROUPS_IN_ZONE", {
+        this.model().dispatch("UNFOLD_HEADER_GROUPS_IN_ZONE", {
           sheetId,
           dimension: "ROW",
           zone: zone,
         });
-        this.env.model.dispatch("UNFOLD_HEADER_GROUPS_IN_ZONE", {
+        this.model().dispatch("UNFOLD_HEADER_GROUPS_IN_ZONE", {
           sheetId,
           dimension: "COL",
           zone: zone,
         });
         break;
       case "up":
-        this.env.model.dispatch("FOLD_HEADER_GROUPS_IN_ZONE", {
+        this.model().dispatch("FOLD_HEADER_GROUPS_IN_ZONE", {
           sheetId,
           dimension: "ROW",
           zone: zone,
         });
-        this.env.model.dispatch("FOLD_HEADER_GROUPS_IN_ZONE", {
+        this.model().dispatch("FOLD_HEADER_GROUPS_IN_ZONE", {
           sheetId,
           dimension: "COL",
           zone: zone,
         });
         break;
       case "right": {
-        const { x, y, width } = this.env.model.getters.getVisibleRectWithZoom(zone);
+        const { x, y, width } = this.model().getters.getVisibleRectWithZoom(zone);
         const gridRect = this.getGridRect();
         this.toggleContextMenu("GROUP_HEADERS", x + width + gridRect.x, y + gridRect.y);
         break;
       }
       case "left": {
-        if (!canUngroupHeaders(this.env, "COL") && !canUngroupHeaders(this.env, "ROW")) {
+        if (!canUngroupHeaders(this.model(), "COL") && !canUngroupHeaders(this.model(), "ROW")) {
           return;
         }
-        const { x, y, width } = this.env.model.getters.getVisibleRectWithZoom(zone);
+        const { x, y, width } = this.model().getters.getVisibleRectWithZoom(zone);
         const gridRect = this.getGridRect();
         this.toggleContextMenu("UNGROUP_HEADERS", x + width + gridRect.x, y + gridRect.y);
         break;
@@ -902,8 +902,8 @@ export class Grid extends Component<SpreadsheetChildEnv> {
   }
 
   get staticTables(): Table[] {
-    const sheetId = this.env.model.getters.getActiveSheetId();
-    return this.env.model.getters.getCoreTables(sheetId).filter(isStaticTable);
+    const sheetId = this.model().getters.getActiveSheetId();
+    return this.model().getters.getCoreTables(sheetId).filter(isStaticTable);
   }
 
   get displaySelectionHandler() {

--- a/src/components/grid/grid.xml
+++ b/src/components/grid/grid.xml
@@ -18,13 +18,13 @@
       />
       <HeadersOverlay onOpenContextMenu="(type, x, y) => this.toggleContextMenu(type, x, y)"/>
       <GridComposer
-        gridDims="this.env.model.getters.getSheetViewDimensionWithHeaders()"
+        gridDims="this.model().getters.getSheetViewDimensionWithHeaders()"
         onInputContextMenu.bind="this.onInputContextMenu"
       />
       <canvas t-ref="this.canvasRef" class="os-theme-dependant pe-none"/>
       <t t-set="focused" t-value="this.focusedClients"/>
       <t
-        t-foreach="this.env.model.getters.getClientsToDisplay()"
+        t-foreach="this.model().getters.getClientsToDisplay()"
         t-as="client"
         t-key="this.getClientPositionKey(client)">
         <ClientTag
@@ -41,12 +41,12 @@
         onMouseWheel.bind="this.onMouseWheel"
         onClosePopover.bind="this.onClosePopover"
       />
-      <t t-if="this.env.model.getters.isGridSelectionActive() and !this.env.isMobile()">
+      <t t-if="this.model().getters.isGridSelectionActive() and !this.env.isMobile()">
         <Autofill position="this.getAutofillPosition()" isVisible="this.isAutofillVisible"/>
       </t>
       <t t-foreach="this.highlights" t-as="highlight" t-key="highlight_index">
         <t
-          t-if="highlight.interactive and highlight.range.sheetId === this.env.model.getters.getActiveSheetId()">
+          t-if="highlight.interactive and highlight.range.sheetId === this.model().getters.getActiveSheetId()">
           <Highlight range="highlight.range" color="highlight.color"/>
         </t>
       </t>
@@ -58,7 +58,7 @@
         onClose="() => this.closeMenu()"
       />
       <t
-        t-if="!this.env.model.getters.isReadonly()"
+        t-if="!this.model().getters.isReadonly()"
         t-foreach="this.staticTables"
         t-as="table"
         t-key="table.id">

--- a/src/components/grid_add_rows_footer/grid_add_rows_footer.ts
+++ b/src/components/grid_add_rows_footer/grid_add_rows_footer.ts
@@ -6,6 +6,7 @@ import { _t } from "../../translation";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 import { Store } from "../../types/store_engine";
 import { cssPropertiesToCss } from "../helpers/css";
+import { useModel } from "../owl_plugins/model_plugin";
 import { ValidationMessages } from "../validation_messages/validation_messages";
 
 export class GridAddRowsFooter extends Component<SpreadsheetChildEnv> {
@@ -20,16 +21,18 @@ export class GridAddRowsFooter extends Component<SpreadsheetChildEnv> {
     errorFlag: false,
   });
 
+  private model = useModel();
+
   setup() {
     this.DOMFocusableElementStore = useStore(DOMFocusableElementStore);
     useExternalListener(window, "click", this.onExternalClick, { capture: true });
   }
 
   get addRowsPosition() {
-    const activeSheetId = this.env.model.getters.getActiveSheetId();
-    const { numberOfRows } = this.env.model.getters.getSheetSize(activeSheetId);
-    const { scrollY } = this.env.model.getters.getActiveSheetScrollInfo();
-    const rowDimensions = this.env.model.getters.getRowDimensions(activeSheetId, numberOfRows - 1);
+    const activeSheetId = this.model().getters.getActiveSheetId();
+    const { numberOfRows } = this.model().getters.getSheetSize(activeSheetId);
+    const { scrollY } = this.model().getters.getActiveSheetScrollInfo();
+    const rowDimensions = this.model().getters.getRowDimensions(activeSheetId, numberOfRows - 1);
     const top = rowDimensions.end - scrollY;
 
     return cssPropertiesToCss({
@@ -61,11 +64,11 @@ export class GridAddRowsFooter extends Component<SpreadsheetChildEnv> {
       return;
     }
     const quantity = Number(this.state.inputValue);
-    const activeSheetId = this.env.model.getters.getActiveSheetId();
-    const rowNumber = this.env.model.getters.getNumberRows(activeSheetId);
-    this.env.model.dispatch("ADD_COLUMNS_ROWS", {
+    const activeSheetId = this.model().getters.getActiveSheetId();
+    const rowNumber = this.model().getters.getNumberRows(activeSheetId);
+    this.model().dispatch("ADD_COLUMNS_ROWS", {
       sheetId: activeSheetId,
-      sheetName: this.env.model.getters.getSheetName(activeSheetId),
+      sheetName: this.model().getters.getSheetName(activeSheetId),
       position: "after",
       base: rowNumber - 1,
       quantity,
@@ -74,12 +77,9 @@ export class GridAddRowsFooter extends Component<SpreadsheetChildEnv> {
     this.focusDefaultElement();
 
     // After adding new rows, scroll down to the new last row
-    const { scrollX } = this.env.model.getters.getActiveSheetScrollInfo();
-    const { end } = this.env.model.getters.getRowDimensions(
-      activeSheetId,
-      rowNumber + quantity - 1
-    );
-    this.env.model.dispatch("SET_VIEWPORT_OFFSET", {
+    const { scrollX } = this.model().getters.getActiveSheetScrollInfo();
+    const { end } = this.model().getters.getRowDimensions(activeSheetId, rowNumber + quantity - 1);
+    this.model().dispatch("SET_VIEWPORT_OFFSET", {
       offsetX: scrollX,
       offsetY: end,
     });

--- a/src/components/grid_overlay/grid_overlay.ts
+++ b/src/components/grid_overlay/grid_overlay.ts
@@ -2,6 +2,7 @@ import { onMounted, onWillUnmount, props, Signal, signal, useListener } from "@o
 import { deepEquals } from "../../helpers/misc";
 import { isPointInsideRect } from "../../helpers/rectangle";
 import { positionToZone } from "../../helpers/zones";
+import { Model } from "../../model";
 import { Component, useExternalListener } from "../../owl3_compatibility_layer";
 import { useStore } from "../../store_engine/store_hooks";
 import { GridClickModifiers, HeaderIndex, Pixel, Position } from "../../types/misc";
@@ -15,6 +16,7 @@ import { cssPropertiesToCss } from "../helpers/css";
 import { getElBoundingRect, isChildEvent, isCtrlKey } from "../helpers/dom_helpers";
 import { useInterval } from "../helpers/time_hooks";
 import { withZoom, ZoomedMouseEvent } from "../helpers/zoom";
+import { useModel } from "../owl_plugins/model_plugin";
 import { PaintFormatStore } from "../paint_format_button/paint_format_store";
 import { CellPopoverStore } from "../popover/cell_popover_store";
 import { types } from "../props_validation";
@@ -22,6 +24,7 @@ import { HoveredTableStore } from "../tables/hovered_table_store";
 import { HoveredIconStore } from "./hovered_icon_store";
 
 function useCellHovered(
+  model: Model,
   env: SpreadsheetChildEnv,
   gridRef: Signal<HTMLElement | null>
 ): Partial<Position> {
@@ -40,8 +43,8 @@ function useCellHovered(
     if (x === undefined || y === undefined) {
       return { col: -1, row: -1 };
     }
-    const col = env.model.getters.getColIndex(x);
-    const row = env.model.getters.getRowIndex(y);
+    const col = model.getters.getColIndex(x);
+    const row = model.getters.getRowIndex(y);
     return { col, row };
   }
 
@@ -86,7 +89,7 @@ function useCellHovered(
   }
 
   function onMouseLeave(e: MouseEvent) {
-    const zoomedMouseEvent = withZoom(env, e);
+    const zoomedMouseEvent = withZoom(model, e);
     const { x, y } = getOffsetRelativeToOverlay(zoomedMouseEvent);
     const gridRect = getElBoundingRect(gridRef());
 
@@ -100,7 +103,7 @@ function useCellHovered(
   useListener(
     gridRef,
     "pointermove",
-    (ev: MouseEvent) => !env.isMobile() && updateMousePosition(withZoom(env, ev))
+    (ev: MouseEvent) => !env.isMobile() && updateMousePosition(withZoom(model, ev))
   );
   useListener(gridRef, "mouseleave", onMouseLeave);
   useListener(gridRef, "mouseenter", resume);
@@ -108,7 +111,7 @@ function useCellHovered(
   useListener(
     gridRef,
     "pointerdown",
-    (ev: MouseEvent) => env.isMobile() && updateMousePosition(withZoom(env, ev))
+    (ev: MouseEvent) => env.isMobile() && updateMousePosition(withZoom(model, ev))
   );
 
   useExternalListener(window, "click", handleGlobalClick);
@@ -170,13 +173,14 @@ export class GridOverlay extends Component<SpreadsheetChildEnv> {
       onGridResized: () => {},
     }
   );
+  private model = useModel();
   private gridOverlayRef: Signal<HTMLElement | null> = signal(null);
   private cellPopovers!: Store<CellPopoverStore>;
   private paintFormatStore!: Store<PaintFormatStore>;
   private hoveredIconStore!: Store<HoveredIconStore>;
 
   setup() {
-    useCellHovered(this.env, this.gridOverlayRef);
+    useCellHovered(this.model(), this.env, this.gridOverlayRef);
     const resizeObserver = new ResizeObserver(() => {
       this.props.onGridResized();
     });
@@ -215,7 +219,7 @@ export class GridOverlay extends Component<SpreadsheetChildEnv> {
     if (this.env.isMobile()) {
       return;
     }
-    const icon = this.getInteractiveIconAtEvent(withZoom(this.env, ev));
+    const icon = this.getInteractiveIconAtEvent(withZoom(this.model(), ev));
     const hoveredIcon = icon?.type ? { id: icon.type, position: icon.position } : undefined;
     if (!deepEquals(hoveredIcon, this.hoveredIconStore.hoveredIcon)) {
       this.hoveredIconStore.setHoveredIcon(hoveredIcon);
@@ -227,7 +231,7 @@ export class GridOverlay extends Component<SpreadsheetChildEnv> {
       // not main button, probably a context menu
       return;
     }
-    this.onCellClicked(withZoom(this.env, ev));
+    this.onCellClicked(withZoom(this.model(), ev));
   }
 
   onClick(ev: MouseEvent) {
@@ -235,7 +239,7 @@ export class GridOverlay extends Component<SpreadsheetChildEnv> {
       // not main button, probably a context menu
       return;
     }
-    this.onCellClicked(withZoom(this.env, ev));
+    this.onCellClicked(withZoom(this.model(), ev));
   }
 
   onCellClicked(zoomedMouseEvent: ZoomedMouseEvent<MouseEvent | PointerEvent>) {
@@ -243,7 +247,7 @@ export class GridOverlay extends Component<SpreadsheetChildEnv> {
     const [col, row] = this.getCartesianCoordinates(zoomedMouseEvent);
     const clickedIcon = this.getInteractiveIconAtEvent(zoomedMouseEvent);
     if (clickedIcon) {
-      this.env.model.selection.getBackToDefault();
+      this.model().selection.getBackToDefault();
     }
     this.props.onCellClicked(
       col,
@@ -256,7 +260,7 @@ export class GridOverlay extends Component<SpreadsheetChildEnv> {
     );
 
     if (clickedIcon?.onClick) {
-      clickedIcon.onClick(clickedIcon.position, this.env);
+      clickedIcon.onClick(clickedIcon.position, this.model(), this.env);
     }
 
     if (
@@ -271,7 +275,7 @@ export class GridOverlay extends Component<SpreadsheetChildEnv> {
   }
 
   onDoubleClick(ev: MouseEvent) {
-    const zoomedMouseEvent = withZoom(this.env, ev);
+    const zoomedMouseEvent = withZoom(this.model(), ev);
     if (this.getInteractiveIconAtEvent(zoomedMouseEvent)) {
       return;
     }
@@ -281,40 +285,40 @@ export class GridOverlay extends Component<SpreadsheetChildEnv> {
   }
 
   onContextMenu(ev: MouseEvent) {
-    const [col, row] = this.getCartesianCoordinates(withZoom(this.env, ev));
+    const [col, row] = this.getCartesianCoordinates(withZoom(this.model(), ev));
     this.props.onCellRightClicked(col, row, { x: ev.clientX, y: ev.clientY });
   }
 
   private getCartesianCoordinates(
     zoomedMouseEvent: ZoomedMouseEvent<MouseEvent>
   ): [HeaderIndex, HeaderIndex] {
-    const colIndex = this.env.model.getters.getColIndex(zoomedMouseEvent.offsetX);
-    const rowIndex = this.env.model.getters.getRowIndex(zoomedMouseEvent.offsetY);
+    const colIndex = this.model().getters.getColIndex(zoomedMouseEvent.offsetX);
+    const rowIndex = this.model().getters.getRowIndex(zoomedMouseEvent.offsetY);
     return [colIndex, rowIndex];
   }
 
   private getInteractiveIconAtEvent(zoomedMouseEvent: ZoomedMouseEvent<MouseEvent>) {
     const gridOverLayRect = getElBoundingRect(this.gridOverlayRef());
-    const gridOffset = this.env.model.getters.getGridOffset();
+    const gridOffset = this.model().getters.getGridOffset();
     const x = zoomedMouseEvent.clientX - gridOverLayRect.x + gridOffset.x;
     const y = zoomedMouseEvent.clientY - gridOverLayRect.y + gridOffset.y;
 
     const [col, row] = this.getCartesianCoordinates(zoomedMouseEvent);
-    const sheetId = this.env.model.getters.getActiveSheetId();
+    const sheetId = this.model().getters.getActiveSheetId();
 
     let position = { col, row, sheetId };
-    const merge = this.env.model.getters.getMerge(position);
+    const merge = this.model().getters.getMerge(position);
     if (merge) {
       position = { col: merge.left, row: merge.top, sheetId };
     }
 
-    const icons = this.env.model.getters.getCellIcons(position);
+    const icons = this.model().getters.getCellIcons(position);
     const icon = icons.find((icon) => {
-      const merge = this.env.model.getters.getMerge(position);
+      const merge = this.model().getters.getMerge(position);
       const zone = merge || positionToZone(position);
-      const cellRect = this.env.model.getters.getRect(zone);
+      const cellRect = this.model().getters.getRect(zone);
 
-      return isPointInsideRect(x, y, this.env.model.getters.getCellIconRect(icon, cellRect));
+      return isPointInsideRect(x, y, this.model().getters.getCellIconRect(icon, cellRect));
     });
     return icon?.onClick ? icon : undefined;
   }

--- a/src/components/grid_overlay/grid_overlay.xml
+++ b/src/components/grid_overlay/grid_overlay.xml
@@ -14,8 +14,8 @@
       t-on-dblclick.self="this.onDoubleClick"
       t-on-contextmenu.stop.prevent="this.onContextMenu">
       <GridAddRowsFooter
-        t-if="!this.env.model.getters.isReadonly()"
-        t-key="this.env.model.getters.getActiveSheetId()"
+        t-if="!this.model().getters.isReadonly()"
+        t-key="this.model().getters.getActiveSheetId()"
       />
       <t t-call-slot="default"/>
     </div>

--- a/src/components/grid_popover/grid_popover.ts
+++ b/src/components/grid_popover/grid_popover.ts
@@ -3,6 +3,7 @@ import { ClosedCellPopover, PositionedCellPopoverComponent } from "../../types/c
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 import { Store } from "../../types/store_engine";
 import { getZoomedRect } from "../helpers/zoom";
+import { useModel } from "../owl_plugins/model_plugin";
 import { CellPopoverStore } from "../popover/cell_popover_store";
 import { Popover } from "../popover/popover";
 import { types } from "../props_validation";
@@ -21,6 +22,8 @@ export class GridPopover extends Component<SpreadsheetChildEnv> {
   });
   protected cellPopovers!: Store<CellPopoverStore>;
 
+  private model = useModel();
+
   setup() {
     this.cellPopovers = useStore(CellPopoverStore);
   }
@@ -30,7 +33,7 @@ export class GridPopover extends Component<SpreadsheetChildEnv> {
     if (!popover.isOpen) {
       return { isOpen: false };
     }
-    const zoom = this.env.model.getters.getViewportZoomLevel();
+    const zoom = this.model().getters.getViewportZoomLevel();
     const anchorRect = getZoomedRect(zoom, popover.anchorRect);
     return {
       ...popover,

--- a/src/components/header_group/header_group.ts
+++ b/src/components/header_group/header_group.ts
@@ -2,14 +2,14 @@ import { props } from "@odoo/owl";
 import { Action } from "../../actions/action";
 import { GROUP_LAYER_WIDTH, HEADER_HEIGHT, HEADER_WIDTH } from "../../constants";
 import { interactiveToggleGroup } from "../../helpers/ui/toggle_group_interactive";
+import { Component } from "../../owl3_compatibility_layer";
 import { getHeaderGroupContextMenu } from "../../registries/menus/header_group_registry";
 import { Dimension } from "../../types/misc";
 import { DOMCoordinates, Rect } from "../../types/rendering";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 import { cssPropertiesToCss } from "../helpers/css";
+import { useModel } from "../owl_plugins/model_plugin";
 import { types } from "../props_validation";
-
-import { Component } from "../../owl3_compatibility_layer";
 
 interface GroupBox {
   groupRect: Rect;
@@ -31,10 +31,12 @@ abstract class AbstractHeaderGroup extends Component<SpreadsheetChildEnv> {
 
   abstract dimension: Dimension;
 
+  protected model = useModel();
+
   toggleGroup() {
-    const sheetId = this.env.model.getters.getActiveSheetId();
+    const sheetId = this.model().getters.getActiveSheetId();
     const { start, end } = this.props.group;
-    interactiveToggleGroup(this.env, sheetId, this.dimension, start, end);
+    interactiveToggleGroup(this.model(), this.env, sheetId, this.dimension, start, end);
   }
 
   get groupBoxStyle(): string {
@@ -61,16 +63,16 @@ abstract class AbstractHeaderGroup extends Component<SpreadsheetChildEnv> {
   }
 
   get isGroupFolded(): boolean {
-    const sheetId = this.env.model.getters.getActiveSheetId();
+    const sheetId = this.model().getters.getActiveSheetId();
     const group = this.props.group;
-    return this.env.model.getters.isGroupFolded(sheetId, this.dimension, group.start, group.end);
+    return this.model().getters.isGroupFolded(sheetId, this.dimension, group.start, group.end);
   }
 
   /** The box that will be used to draw the header group. */
   abstract get groupBox(): GroupBox;
 
   onContextMenu(ev: MouseEvent) {
-    const sheetId = this.env.model.getters.getActiveSheetId();
+    const sheetId = this.model().getters.getActiveSheetId();
     const position = { x: ev.clientX, y: ev.clientY };
     const group = this.props.group;
     const menuItems = getHeaderGroupContextMenu(sheetId, this.dimension, group.start, group.end);
@@ -105,16 +107,16 @@ export class RowGroup extends AbstractHeaderGroup {
   }
 
   get groupBox(): GroupBox {
-    const sheetId = this.env.model.getters.getActiveSheetId();
+    const sheetId = this.model().getters.getActiveSheetId();
 
     const { start: startRow, end: endRow } = this.props.group;
-    const startCoordinates = this.env.model.getters.getRowDimensions(sheetId, startRow).start;
-    const endCoordinates = this.env.model.getters.getRowDimensions(sheetId, endRow).end;
+    const startCoordinates = this.model().getters.getRowDimensions(sheetId, startRow).start;
+    const endCoordinates = this.model().getters.getRowDimensions(sheetId, endRow).end;
 
     let groupHeaderY: number = 0;
     let groupHeaderHeight = HEADER_HEIGHT;
     if (startRow !== 0) {
-      const headerRowDims = this.env.model.getters.getRowDimensions(sheetId, startRow - 1);
+      const headerRowDims = this.model().getters.getRowDimensions(sheetId, startRow - 1);
       groupHeaderY = HEADER_HEIGHT + headerRowDims.start;
       groupHeaderHeight = headerRowDims.end - headerRowDims.start;
     }
@@ -135,7 +137,7 @@ export class RowGroup extends AbstractHeaderGroup {
     return {
       headerRect,
       groupRect,
-      isEndHidden: this.env.model.getters.isRowHidden(sheetId, endRow),
+      isEndHidden: this.model().getters.isRowHidden(sheetId, endRow),
     };
   }
 }
@@ -166,16 +168,16 @@ export class ColGroup extends AbstractHeaderGroup {
   }
 
   get groupBox(): GroupBox {
-    const sheetId = this.env.model.getters.getActiveSheetId();
+    const sheetId = this.model().getters.getActiveSheetId();
 
     const { start: startCol, end: endCol } = this.props.group;
-    const startCoordinates = this.env.model.getters.getColDimensions(sheetId, startCol).start;
-    const endCoordinates = this.env.model.getters.getColDimensions(sheetId, endCol).end;
+    const startCoordinates = this.model().getters.getColDimensions(sheetId, startCol).start;
+    const endCoordinates = this.model().getters.getColDimensions(sheetId, endCol).end;
 
     let groupHeaderX = 0;
     let groupHeaderWidth: number = HEADER_WIDTH;
     if (startCol !== 0) {
-      const headerRowDims = this.env.model.getters.getColDimensions(sheetId, startCol - 1);
+      const headerRowDims = this.model().getters.getColDimensions(sheetId, startCol - 1);
       groupHeaderX = HEADER_WIDTH + headerRowDims.start;
       groupHeaderWidth = headerRowDims.end - headerRowDims.start;
     }
@@ -196,7 +198,7 @@ export class ColGroup extends AbstractHeaderGroup {
     return {
       headerRect,
       groupRect,
-      isEndHidden: this.env.model.getters.isColHidden(sheetId, endCol),
+      isEndHidden: this.model().getters.isColHidden(sheetId, endCol),
     };
   }
 }

--- a/src/components/header_group/header_group_container.ts
+++ b/src/components/header_group/header_group_container.ts
@@ -8,6 +8,7 @@ import { DOMCoordinates } from "../../types/rendering";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 import { cssPropertiesToCss } from "../helpers/css";
 import { MenuPopover, MenuState } from "../menu_popover/menu_popover";
+import { useModel } from "../owl_plugins/model_plugin";
 import { types } from "../props_validation";
 import { ColGroup, RowGroup } from "./header_group";
 
@@ -22,12 +23,14 @@ export class HeaderGroupContainer extends Component<SpreadsheetChildEnv> {
 
   menu: MenuState = proxy({ isOpen: false, anchorRect: null, menuItems: [] });
 
+  private model = useModel();
+
   getLayerOffset(layerIndex: number): number {
     return layerIndex * GROUP_LAYER_WIDTH;
   }
 
   onContextMenu(event: MouseEvent) {
-    const sheetId = this.env.model.getters.getActiveSheetId();
+    const sheetId = this.model().getters.getActiveSheetId();
     const position = { x: event.clientX, y: event.clientY };
     const menuItems = createHeaderGroupContainerContextMenu(sheetId, this.props.dimension);
     this.openContextMenu(position, menuItems);
@@ -50,12 +53,12 @@ export class HeaderGroupContainer extends Component<SpreadsheetChildEnv> {
   }
 
   get hasFrozenPane(): boolean {
-    const viewportCoordinates = this.env.model.getters.getMainViewportCoordinates();
+    const viewportCoordinates = this.model().getters.getMainViewportCoordinates();
     return this.props.dimension === "COL" ? viewportCoordinates.x > 0 : viewportCoordinates.y > 0;
   }
 
   get scrollContainerStyle(): string {
-    const { scrollX, scrollY } = this.env.model.getters.getActiveSheetScrollInfo();
+    const { scrollX, scrollY } = this.model().getters.getActiveSheetScrollInfo();
 
     const cssProperties: CSSProperties = {};
     if (this.props.dimension === "COL") {
@@ -81,7 +84,7 @@ export class HeaderGroupContainer extends Component<SpreadsheetChildEnv> {
       return 0;
     }
 
-    const viewportCoordinates = this.env.model.getters.getMainViewportCoordinates();
+    const viewportCoordinates = this.model().getters.getMainViewportCoordinates();
     if (this.props.dimension === "COL") {
       return HEADER_WIDTH + viewportCoordinates.x;
     } else {

--- a/src/components/headers_overlay/headers_overlay.ts
+++ b/src/components/headers_overlay/headers_overlay.ts
@@ -13,6 +13,7 @@ import { isCtrlKey } from "../helpers/dom_helpers";
 import { startDnd } from "../helpers/drag_and_drop";
 import { useDragAndDropBeyondTheViewport } from "../helpers/drag_and_drop_grid_hook";
 import { withZoom, ZoomedMouseEvent } from "../helpers/zoom";
+import { useModel } from "../owl_plugins/model_plugin";
 import { types } from "../props_validation";
 import { MergeErrorMessage, TableHeaderMoveErrorMessage } from "../translations_terms";
 import { ComposerFocusStore } from "./../composer/composer_focus_store";
@@ -48,6 +49,7 @@ export const resizerPropsDefinition = {
 abstract class AbstractResizer extends Component<SpreadsheetChildEnv> {
   protected props = props(resizerPropsDefinition);
   private composerFocusStore!: Store<ComposerFocusStore>;
+  protected model = useModel();
 
   PADDING: number = 0;
   MAX_SIZE_MARGIN: number = 0;
@@ -69,7 +71,7 @@ abstract class AbstractResizer extends Component<SpreadsheetChildEnv> {
     position: "before",
   });
 
-  dragNDropGrid = useDragAndDropBeyondTheViewport(this.env);
+  dragNDropGrid = useDragAndDropBeyondTheViewport(this.model());
 
   abstract _getEvOffset(zoomedMouseEvent: ZoomedMouseEvent<MouseEvent>): Pixel;
 
@@ -154,14 +156,14 @@ abstract class AbstractResizer extends Component<SpreadsheetChildEnv> {
   onMouseMove(ev: MouseEvent) {
     if (
       this.env.isMobile() ||
-      this.env.model.getters.isReadonly() ||
+      this.model().getters.isReadonly() ||
       this.state.isResizing ||
       this.state.isMoving ||
       this.state.isSelecting
     ) {
       return;
     }
-    const zoomedMouseEvent = withZoom(this.env, ev);
+    const zoomedMouseEvent = withZoom(this.model(), ev);
     this._computeHandleDisplay(zoomedMouseEvent);
     this._computeGrabDisplay(zoomedMouseEvent);
   }
@@ -172,7 +174,7 @@ abstract class AbstractResizer extends Component<SpreadsheetChildEnv> {
   }
 
   onDblClick(ev: MouseEvent) {
-    const zoomedMouseEvent = withZoom(this.env, ev);
+    const zoomedMouseEvent = withZoom(this.model(), ev);
     this._fitElementSize(this.state.activeElement);
     this.state.isResizing = false;
     this._computeHandleDisplay(zoomedMouseEvent);
@@ -185,7 +187,7 @@ abstract class AbstractResizer extends Component<SpreadsheetChildEnv> {
     }
     this.state.isResizing = true;
     this.state.delta = 0;
-    const zoomedMouseEvent = withZoom(this.env, ev);
+    const zoomedMouseEvent = withZoom(this.model(), ev);
 
     const initialPosition = this._getClientPosition(zoomedMouseEvent);
     const styleValue = this.state.draggerLinePosition;
@@ -199,7 +201,7 @@ abstract class AbstractResizer extends Component<SpreadsheetChildEnv> {
       }
     };
     const onMouseMove = (ev: MouseEvent) => {
-      this.state.delta = this._getClientPosition(withZoom(this.env, ev)) - initialPosition;
+      this.state.delta = this._getClientPosition(withZoom(this.model(), ev)) - initialPosition;
       this.state.draggerLinePosition = styleValue + this.state.delta;
       if (this.state.draggerLinePosition < minSize) {
         this.state.draggerLinePosition = minSize;
@@ -221,7 +223,7 @@ abstract class AbstractResizer extends Component<SpreadsheetChildEnv> {
       // not main button, probably a context menu
       return;
     }
-    const zoomedMouseEvent = withZoom(this.env, ev);
+    const zoomedMouseEvent = withZoom(this.model(), ev);
     const index = this._getElementIndex(this._getEvOffset(zoomedMouseEvent));
     this._selectElement(index, false);
   }
@@ -234,17 +236,17 @@ abstract class AbstractResizer extends Component<SpreadsheetChildEnv> {
       // not main button, probably a context menu
       return;
     }
-    const zoomedMouseEvent = withZoom(this.env, ev);
+    const zoomedMouseEvent = withZoom(this.model(), ev);
     const index = this._getElementIndex(this._getEvOffset(zoomedMouseEvent));
     if (index < 0) {
       return;
     }
-    if (this.env.model.getters.isReadonly()) {
+    if (this.model().getters.isReadonly()) {
       this._selectElement(index, false);
       return;
     }
     if (!isCtrlKey(ev) && this.state.waitingForMove) {
-      if (!this.env.model.getters.isGridSelectionActive()) {
+      if (!this.model().getters.isGridSelectionActive()) {
         this._selectElement(index, false);
       } else {
         // FIXME: Consider reintroducing this feature for all type of selection if we find
@@ -254,7 +256,7 @@ abstract class AbstractResizer extends Component<SpreadsheetChildEnv> {
       return;
     }
     if (this.composerFocusStore.activeComposer.editionMode === "editing") {
-      this.env.model.selection.getBackToDefault();
+      this.model().selection.getBackToDefault();
     }
     this.startSelection(ev, index);
   }
@@ -262,7 +264,7 @@ abstract class AbstractResizer extends Component<SpreadsheetChildEnv> {
   private startMovement(ev: PointerEvent) {
     this.state.waitingForMove = false;
     this.state.isMoving = true;
-    const zoomedMouseEvent = withZoom(this.env, ev);
+    const zoomedMouseEvent = withZoom(this.model(), ev);
     const startDimensions = this._getDimensionsInViewport(this._getSelectedZoneStart());
     const endDimensions = this._getDimensionsInViewport(this._getSelectedZoneEnd());
     const defaultPosition = startDimensions.start;
@@ -297,7 +299,7 @@ abstract class AbstractResizer extends Component<SpreadsheetChildEnv> {
       if (this.state.base !== this._getSelectedZoneStart()) {
         this._moveElements();
       }
-      const zoomedMouseEvent = withZoom(this.env, ev);
+      const zoomedMouseEvent = withZoom(this.model(), ev);
       this._computeGrabDisplay(zoomedMouseEvent);
     };
     this.dragNDropGrid.start(zoomedMouseEvent, mouseMoveMovement, mouseUpMovement);
@@ -314,7 +316,7 @@ abstract class AbstractResizer extends Component<SpreadsheetChildEnv> {
       this._selectElement(index, isCtrlKey(ev));
     }
     this.lastSelectedElementIndex = index;
-    const zoomedMouseEvent = withZoom(this.env, ev);
+    const zoomedMouseEvent = withZoom(this.model(), ev);
 
     const mouseMoveSelect = (col: HeaderIndex, row: HeaderIndex) => {
       const newIndex = this._getType() === "COL" ? col : row;
@@ -324,7 +326,7 @@ abstract class AbstractResizer extends Component<SpreadsheetChildEnv> {
       }
     };
     const mouseUpSelect = () => {
-      this.env.model.selection.commitSelection();
+      this.model().selection.commitSelection();
       this.state.isSelecting = false;
       this.lastSelectedElementIndex = null;
       this._computeGrabDisplay(zoomedMouseEvent);
@@ -334,7 +336,7 @@ abstract class AbstractResizer extends Component<SpreadsheetChildEnv> {
 
   onContextMenu(ev: MouseEvent) {
     ev.preventDefault();
-    const index = this._getElementIndex(this._getEvOffset(withZoom(this.env, ev)));
+    const index = this._getElementIndex(this._getEvOffset(withZoom(this.model(), ev)));
     if (index < 0) {
       return;
     }
@@ -360,7 +362,7 @@ export class ColResizer extends AbstractResizer {
   }
 
   get sheetId() {
-    return this.env.model.getters.getActiveSheetId();
+    return this.model().getters.getActiveSheetId();
   }
 
   _getEvOffset(zoomedMouseEvent: ZoomedMouseEvent<MouseEvent>): Pixel {
@@ -368,7 +370,7 @@ export class ColResizer extends AbstractResizer {
   }
 
   _getViewportOffset(): Pixel {
-    return this.env.model.getters.getActiveMainViewport().left;
+    return this.model().getters.getActiveMainViewport().left;
   }
 
   _getClientPosition(zoomedMouseEvent: ZoomedMouseEvent<MouseEvent>): Pixel {
@@ -376,27 +378,27 @@ export class ColResizer extends AbstractResizer {
   }
 
   _getElementIndex(position: Pixel): HeaderIndex {
-    return this.env.model.getters.getColIndex(position);
+    return this.model().getters.getColIndex(position);
   }
 
   _getSelectedZoneStart(): HeaderIndex {
-    return this.env.model.getters.getSelectedZone().left;
+    return this.model().getters.getSelectedZone().left;
   }
 
   _getSelectedZoneEnd(): HeaderIndex {
-    return this.env.model.getters.getSelectedZone().right;
+    return this.model().getters.getSelectedZone().right;
   }
 
   _getEdgeScroll(position: Pixel): EdgeScrollInfo {
-    return this.env.model.getters.getEdgeScrollCol(position, position, position);
+    return this.model().getters.getEdgeScrollCol(position, position, position);
   }
 
   _getDimensionsInViewport(index: HeaderIndex): HeaderDimensions {
-    return this.env.model.getters.getColDimensionsInViewport(this.sheetId, index);
+    return this.model().getters.getColDimensionsInViewport(this.sheetId, index);
   }
 
   _getElementSize(index: HeaderIndex): Pixel {
-    return this.env.model.getters.getColSize(this.sheetId, index);
+    return this.model().getters.getColSize(this.sheetId, index);
   }
 
   _getMaxSize(): Pixel {
@@ -406,8 +408,8 @@ export class ColResizer extends AbstractResizer {
   _updateSize(): void {
     const index = this.state.activeElement;
     const size = this.state.delta + this._getElementSize(index);
-    const cols = this.env.model.getters.getActiveCols();
-    this.env.model.dispatch("RESIZE_COLUMNS_ROWS", {
+    const cols = this.model().getters.getActiveCols();
+    this.model().dispatch("RESIZE_COLUMNS_ROWS", {
       dimension: "COL",
       sheetId: this.sheetId,
       elements: cols.has(index) ? [...cols] : [index],
@@ -422,9 +424,9 @@ export class ColResizer extends AbstractResizer {
     for (let colIndex = start; colIndex <= end; colIndex++) {
       elements.push(colIndex);
     }
-    const result = this.env.model.dispatch("MOVE_COLUMNS_ROWS", {
+    const result = this.model().dispatch("MOVE_COLUMNS_ROWS", {
       sheetId: this.sheetId,
-      sheetName: this.env.model.getters.getActiveSheetName(),
+      sheetName: this.model().getters.getActiveSheetName(),
       dimension: "COL",
       base: this.state.base,
       elements,
@@ -436,19 +438,19 @@ export class ColResizer extends AbstractResizer {
   }
 
   _selectElement(index: HeaderIndex, addDistinctHeader: boolean): void {
-    this.env.model.selection.selectColumn(
+    this.model().selection.selectColumn(
       index,
       addDistinctHeader ? "newAnchor" : "overrideSelection"
     );
   }
 
   _increaseSelection(index: HeaderIndex): void {
-    this.env.model.selection.selectColumn(index, "updateAnchor");
+    this.model().selection.selectColumn(index, "updateAnchor");
   }
 
   _fitElementSize(index: HeaderIndex): void {
-    const cols = this.env.model.getters.getActiveCols();
-    this.env.model.dispatch("AUTORESIZE_COLUMNS", {
+    const cols = this.model().getters.getActiveCols();
+    this.model().dispatch("AUTORESIZE_COLUMNS", {
       sheetId: this.sheetId,
       cols: cols.has(index) ? [...cols] : [index],
     });
@@ -459,14 +461,14 @@ export class ColResizer extends AbstractResizer {
   }
 
   _getActiveElements(): Set<HeaderIndex> {
-    return this.env.model.getters.getActiveCols();
+    return this.model().getters.getActiveCols();
   }
 
   _getPreviousVisibleElement(index: HeaderIndex): HeaderIndex {
     const sheetId = this.sheetId;
     let row: HeaderIndex;
     for (row = index - 1; row >= 0; row--) {
-      if (!this.env.model.getters.isColHidden(sheetId, row)) {
+      if (!this.model().getters.isColHidden(sheetId, row)) {
         break;
       }
     }
@@ -474,7 +476,7 @@ export class ColResizer extends AbstractResizer {
   }
 
   unhide(hiddenElements: HeaderIndex[]) {
-    this.env.model.dispatch("UNHIDE_COLUMNS_ROWS", {
+    this.model().dispatch("UNHIDE_COLUMNS_ROWS", {
       sheetId: this.sheetId,
       elements: hiddenElements,
       dimension: "COL",
@@ -482,20 +484,20 @@ export class ColResizer extends AbstractResizer {
   }
 
   get mainUnhideHeadersProps() {
-    const { left, right } = this.env.model.getters.getActiveMainViewport();
-    const { xSplit } = this.env.model.getters.getPaneDivisions(this.sheetId);
-    const hiddenGroups = this.env.model.getters.getHiddenColsGroups(this.sheetId);
+    const { left, right } = this.model().getters.getActiveMainViewport();
+    const { xSplit } = this.model().getters.getPaneDivisions(this.sheetId);
+    const hiddenGroups = this.model().getters.getHiddenColsGroups(this.sheetId);
     const index = hiddenGroups.findIndex((group) => group[0] >= xSplit - 1);
     return {
       headersGroups: index === -1 ? [] : hiddenGroups.slice(index),
-      offset: this.env.model.getters.getMainViewportCoordinates().x,
+      offset: this.model().getters.getMainViewportCoordinates().x,
       headerRange: { start: left, end: right },
     };
   }
 
   get frozenUnhideHeadersProps() {
-    const { xSplit } = this.env.model.getters.getPaneDivisions(this.sheetId);
-    const hiddenGroups = this.env.model.getters.getHiddenColsGroups(this.sheetId);
+    const { xSplit } = this.model().getters.getPaneDivisions(this.sheetId);
+    const hiddenGroups = this.model().getters.getHiddenColsGroups(this.sheetId);
     const index = hiddenGroups.findIndex((group) => group[0] >= xSplit - 1);
 
     return {
@@ -506,12 +508,12 @@ export class ColResizer extends AbstractResizer {
 
   get frozenContainerStyle() {
     return cssPropertiesToCss({
-      width: this.env.model.getters.getMainViewportCoordinates().x + "px",
+      width: this.model().getters.getMainViewportCoordinates().x + "px",
     });
   }
 
   get hasFrozenPane(): boolean {
-    return this.env.model.getters.getPaneDivisions(this.sheetId).xSplit > 0;
+    return this.model().getters.getPaneDivisions(this.sheetId).xSplit > 0;
   }
 }
 
@@ -529,7 +531,7 @@ export class RowResizer extends AbstractResizer {
   }
 
   get sheetId() {
-    return this.env.model.getters.getActiveSheetId();
+    return this.model().getters.getActiveSheetId();
   }
 
   _getEvOffset(zoomedMouseEvent: ZoomedMouseEvent<MouseEvent>): Pixel {
@@ -537,7 +539,7 @@ export class RowResizer extends AbstractResizer {
   }
 
   _getViewportOffset(): Pixel {
-    return this.env.model.getters.getActiveMainViewport().top;
+    return this.model().getters.getActiveMainViewport().top;
   }
 
   _getClientPosition(zoomedMouseEvent: ZoomedMouseEvent<MouseEvent>): Pixel {
@@ -545,27 +547,27 @@ export class RowResizer extends AbstractResizer {
   }
 
   _getElementIndex(position: Pixel): HeaderIndex {
-    return this.env.model.getters.getRowIndex(position);
+    return this.model().getters.getRowIndex(position);
   }
 
   _getSelectedZoneStart(): HeaderIndex {
-    return this.env.model.getters.getSelectedZone().top;
+    return this.model().getters.getSelectedZone().top;
   }
 
   _getSelectedZoneEnd(): HeaderIndex {
-    return this.env.model.getters.getSelectedZone().bottom;
+    return this.model().getters.getSelectedZone().bottom;
   }
 
   _getEdgeScroll(position: Pixel): EdgeScrollInfo {
-    return this.env.model.getters.getEdgeScrollRow(position, position, position);
+    return this.model().getters.getEdgeScrollRow(position, position, position);
   }
 
   _getDimensionsInViewport(index: HeaderIndex): HeaderDimensions {
-    return this.env.model.getters.getRowDimensionsInViewport(this.sheetId, index);
+    return this.model().getters.getRowDimensionsInViewport(this.sheetId, index);
   }
 
   _getElementSize(index: HeaderIndex): Pixel {
-    return this.env.model.getters.getRowSize(this.sheetId, index);
+    return this.model().getters.getRowSize(this.sheetId, index);
   }
 
   _getMaxSize(): Pixel {
@@ -575,8 +577,8 @@ export class RowResizer extends AbstractResizer {
   _updateSize(): void {
     const index = this.state.activeElement;
     const size = this.state.delta + this._getElementSize(index);
-    const rows = this.env.model.getters.getActiveRows();
-    this.env.model.dispatch("RESIZE_COLUMNS_ROWS", {
+    const rows = this.model().getters.getActiveRows();
+    this.model().dispatch("RESIZE_COLUMNS_ROWS", {
       dimension: "ROW",
       sheetId: this.sheetId,
       elements: rows.has(index) ? [...rows] : [index],
@@ -591,9 +593,9 @@ export class RowResizer extends AbstractResizer {
     for (let rowIndex = start; rowIndex <= end; rowIndex++) {
       elements.push(rowIndex);
     }
-    const result = this.env.model.dispatch("MOVE_COLUMNS_ROWS", {
+    const result = this.model().dispatch("MOVE_COLUMNS_ROWS", {
       sheetId: this.sheetId,
-      sheetName: this.env.model.getters.getActiveSheetName(),
+      sheetName: this.model().getters.getActiveSheetName(),
       dimension: "ROW",
       base: this.state.base,
       elements,
@@ -610,19 +612,16 @@ export class RowResizer extends AbstractResizer {
   }
 
   _selectElement(index: HeaderIndex, addDistinctHeader: boolean): void {
-    this.env.model.selection.selectRow(
-      index,
-      addDistinctHeader ? "newAnchor" : "overrideSelection"
-    );
+    this.model().selection.selectRow(index, addDistinctHeader ? "newAnchor" : "overrideSelection");
   }
 
   _increaseSelection(index: HeaderIndex): void {
-    this.env.model.selection.selectRow(index, "updateAnchor");
+    this.model().selection.selectRow(index, "updateAnchor");
   }
 
   _fitElementSize(index: HeaderIndex): void {
-    const rows = this.env.model.getters.getActiveRows();
-    this.env.model.dispatch("AUTORESIZE_ROWS", {
+    const rows = this.model().getters.getActiveRows();
+    this.model().dispatch("AUTORESIZE_ROWS", {
       sheetId: this.sheetId,
       rows: rows.has(index) ? [...rows] : [index],
     });
@@ -633,14 +632,14 @@ export class RowResizer extends AbstractResizer {
   }
 
   _getActiveElements(): Set<HeaderIndex> {
-    return this.env.model.getters.getActiveRows();
+    return this.model().getters.getActiveRows();
   }
 
   _getPreviousVisibleElement(index: HeaderIndex): HeaderIndex {
     const sheetId = this.sheetId;
     let row: HeaderIndex;
     for (row = index - 1; row >= 0; row--) {
-      if (!this.env.model.getters.isRowHidden(sheetId, row)) {
+      if (!this.model().getters.isRowHidden(sheetId, row)) {
         break;
       }
     }
@@ -648,20 +647,20 @@ export class RowResizer extends AbstractResizer {
   }
 
   get mainUnhideHeadersProps() {
-    const { top, bottom } = this.env.model.getters.getActiveMainViewport();
-    const { ySplit } = this.env.model.getters.getPaneDivisions(this.sheetId);
-    const hiddenGroups = this.env.model.getters.getHiddenRowsGroups(this.sheetId);
+    const { top, bottom } = this.model().getters.getActiveMainViewport();
+    const { ySplit } = this.model().getters.getPaneDivisions(this.sheetId);
+    const hiddenGroups = this.model().getters.getHiddenRowsGroups(this.sheetId);
     const index = hiddenGroups.findIndex((group) => group[0] >= ySplit - 1);
     return {
       headersGroups: index === -1 ? [] : hiddenGroups.slice(index),
-      offset: this.env.model.getters.getMainViewportCoordinates().y,
+      offset: this.model().getters.getMainViewportCoordinates().y,
       headerRange: { start: top, end: bottom },
     };
   }
 
   get frozenUnhideHeadersProps() {
-    const { ySplit } = this.env.model.getters.getPaneDivisions(this.sheetId);
-    const hiddenGroups = this.env.model.getters.getHiddenRowsGroups(this.sheetId);
+    const { ySplit } = this.model().getters.getPaneDivisions(this.sheetId);
+    const hiddenGroups = this.model().getters.getHiddenRowsGroups(this.sheetId);
     const index = hiddenGroups.findIndex((group) => group[0] >= ySplit - 1);
 
     return {
@@ -672,12 +671,12 @@ export class RowResizer extends AbstractResizer {
 
   get frozenContainerStyle() {
     return cssPropertiesToCss({
-      height: this.env.model.getters.getMainViewportCoordinates().y + "px",
+      height: this.model().getters.getMainViewportCoordinates().y + "px",
     });
   }
 
   get hasFrozenPane(): boolean {
-    return this.env.model.getters.getPaneDivisions(this.sheetId).ySplit > 0;
+    return this.model().getters.getPaneDivisions(this.sheetId).ySplit > 0;
   }
 }
 
@@ -687,7 +686,9 @@ export class HeadersOverlay extends Component<SpreadsheetChildEnv> {
   protected props = props(resizerPropsDefinition);
   static components = { ColResizer, RowResizer };
 
+  private model = useModel();
+
   selectAll() {
-    this.env.model.selection.selectAll();
+    this.model().selection.selectAll();
   }
 }

--- a/src/components/headers_overlay/headers_overlay.xml
+++ b/src/components/headers_overlay/headers_overlay.xml
@@ -36,7 +36,7 @@
           <div class="dragging-resizer" t-if="this.state.isResizing"/>
         </div>
       </t>
-      <t t-if="this.env.model.getters.getHiddenRowsGroups(this.sheetId).length">
+      <t t-if="this.model().getters.getHiddenRowsGroups(this.sheetId).length">
         <t t-if="this.hasFrozenPane">
           <div
             class="position-relative pe-none overflow-hidden"
@@ -80,7 +80,7 @@
           <div class="dragging-resizer" t-if="this.state.isResizing"/>
         </div>
       </t>
-      <t t-if="this.env.model.getters.getHiddenColsGroups(this.sheetId).length">
+      <t t-if="this.model().getters.getHiddenColsGroups(this.sheetId).length">
         <t t-if="this.hasFrozenPane">
           <div
             class="position-relative pe-none h-100 flex-shrink-0"

--- a/src/components/headers_overlay/unhide_headers.ts
+++ b/src/components/headers_overlay/unhide_headers.ts
@@ -1,12 +1,12 @@
 import { props } from "@odoo/owl";
 import { HEADER_HEIGHT, HEADER_WIDTH } from "../../constants";
 import { positionToZone } from "../../helpers/zones";
+import { Component } from "../../owl3_compatibility_layer";
 import { HeaderIndex } from "../../types/misc";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 import { cssPropertiesToCss } from "../helpers/css";
+import { useModel } from "../owl_plugins/model_plugin";
 import { types } from "../props_validation";
-
-import { Component } from "../../owl3_compatibility_layer";
 
 export class UnhideRowHeaders extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-UnhideRowHeaders";
@@ -23,24 +23,26 @@ export class UnhideRowHeaders extends Component<SpreadsheetChildEnv> {
     { offset: 0 }
   );
 
+  private model = useModel();
+
   get sheetId() {
-    return this.env.model.getters.getActiveSheetId();
+    return this.model().getters.getActiveSheetId();
   }
 
   getUnhidePreviousButtonStyle(hiddenIndex: HeaderIndex): string {
-    const rect = this.env.model.getters.getRect(positionToZone({ col: 0, row: hiddenIndex }));
+    const rect = this.model().getters.getRect(positionToZone({ col: 0, row: hiddenIndex }));
     const y = rect.y + rect.height - HEADER_HEIGHT;
     return cssPropertiesToCss({ top: y - this.props.offset + "px", "margin-right": "1px" });
   }
 
   getUnhideNextButtonStyle(hiddenIndex: HeaderIndex): string {
-    const rect = this.env.model.getters.getRect(positionToZone({ col: 0, row: hiddenIndex }));
+    const rect = this.model().getters.getRect(positionToZone({ col: 0, row: hiddenIndex }));
     const y = rect.y - HEADER_HEIGHT;
     return cssPropertiesToCss({ top: y - this.props.offset + "px", "margin-right": "1px" });
   }
 
   unhide(hiddenElements: HeaderIndex[]) {
-    this.env.model.dispatch("UNHIDE_COLUMNS_ROWS", {
+    this.model().dispatch("UNHIDE_COLUMNS_ROWS", {
       sheetId: this.sheetId,
       dimension: "ROW",
       elements: hiddenElements,
@@ -67,24 +69,26 @@ export class UnhideColumnHeaders extends Component<SpreadsheetChildEnv> {
     { offset: 0 }
   );
 
+  private model = useModel();
+
   get sheetId() {
-    return this.env.model.getters.getActiveSheetId();
+    return this.model().getters.getActiveSheetId();
   }
 
   getUnhidePreviousButtonStyle(hiddenIndex: HeaderIndex): string {
-    const rect = this.env.model.getters.getRect(positionToZone({ col: hiddenIndex, row: 0 }));
+    const rect = this.model().getters.getRect(positionToZone({ col: hiddenIndex, row: 0 }));
     const x = rect.x + rect.width - HEADER_WIDTH;
     return cssPropertiesToCss({ left: x - this.props.offset + "px" });
   }
 
   getUnhideNextButtonStyle(hiddenIndex: HeaderIndex): string {
-    const rect = this.env.model.getters.getRect(positionToZone({ col: hiddenIndex, row: 0 }));
+    const rect = this.model().getters.getRect(positionToZone({ col: hiddenIndex, row: 0 }));
     const x = rect.x - HEADER_WIDTH;
     return cssPropertiesToCss({ left: x - this.props.offset + "px" });
   }
 
   unhide(hiddenElements: HeaderIndex[]) {
-    this.env.model.dispatch("UNHIDE_COLUMNS_ROWS", {
+    this.model().dispatch("UNHIDE_COLUMNS_ROWS", {
       sheetId: this.sheetId,
       dimension: "COL",
       elements: hiddenElements,

--- a/src/components/helpers/drag_and_drop_grid_hook.ts
+++ b/src/components/helpers/drag_and_drop_grid_hook.ts
@@ -1,8 +1,8 @@
 import { onWillUnmount } from "@odoo/owl";
 import { MAX_DELAY } from "../../helpers/edge_scrolling";
+import { Model } from "../../model";
 import { useLayoutEffect } from "../../owl3_compatibility_layer";
 import { HeaderIndex, Pixel } from "../../types/misc";
-import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 import { gridOverlayPosition } from "./dom_helpers";
 import { startDnd } from "./drag_and_drop";
 import { withZoom } from "./zoom";
@@ -18,14 +18,14 @@ export type DnDDirection = "all" | "vertical" | "horizontal";
  * (occurrence of the current column and the current row). Second intended for actions
  * performed during the pointerup event.
  */
-export function useDragAndDropBeyondTheViewport(env: SpreadsheetChildEnv) {
+export function useDragAndDropBeyondTheViewport(model: Model) {
   let timeOutId: any = null;
   let currentEv: PointerEvent;
   let previousEvClientPosition: { clientX: number; clientY: number };
   let startingX: number;
   let startingY: number;
   let scrollDirection: DnDDirection = "all";
-  const getters = env.model.getters;
+  const getters = model.getters;
 
   const blockKeyboard = (ev: KeyboardEvent) => ev.preventDefault();
   const cleanUpBlockKeyboard = () =>
@@ -50,9 +50,9 @@ export function useDragAndDropBeyondTheViewport(env: SpreadsheetChildEnv) {
     }
 
     const sheetId = getters.getActiveSheetId();
-    const zoomLevel = env.model.getters.getViewportZoomLevel();
+    const zoomLevel = model.getters.getViewportZoomLevel();
     const position = gridOverlayPosition(zoomLevel);
-    const zoomedMouseEvent = withZoom(env, currentEv, position);
+    const zoomedMouseEvent = withZoom(model, currentEv, position);
     const { x: offsetCorrectionX, y: offsetCorrectionY } = getters.getMainViewportCoordinates();
     const { top, left, bottom, right } = getters.getActiveMainViewport();
     let { scrollX, scrollY } = getters.getActiveSheetScrollInfo();
@@ -80,7 +80,7 @@ export function useDragAndDropBeyondTheViewport(env: SpreadsheetChildEnv) {
             break;
           case -1:
             colIndex = left - 1;
-            while (env.model.getters.isColHidden(sheetId, colIndex)) {
+            while (model.getters.isColHidden(sheetId, colIndex)) {
               colIndex--;
             }
             newTarget = colIndex;
@@ -110,13 +110,13 @@ export function useDragAndDropBeyondTheViewport(env: SpreadsheetChildEnv) {
             break;
           case -1:
             rowIndex = top - 1;
-            while (env.model.getters.isRowHidden(sheetId, rowIndex)) {
+            while (model.getters.isRowHidden(sheetId, rowIndex)) {
               rowIndex--;
             }
             newTarget = rowIndex;
             break;
         }
-        scrollY = env.model.getters.getRowDimensions(sheetId, newTarget).start - offsetCorrectionY;
+        scrollY = model.getters.getRowDimensions(sheetId, newTarget).start - offsetCorrectionY;
       }
     }
 
@@ -127,7 +127,7 @@ export function useDragAndDropBeyondTheViewport(env: SpreadsheetChildEnv) {
 
     pointerMoveCallback?.(colIndex, rowIndex, currentEv);
     if (canEdgeScroll) {
-      env.model.dispatch("SET_VIEWPORT_OFFSET", { offsetX: scrollX, offsetY: scrollY });
+      model.dispatch("SET_VIEWPORT_OFFSET", { offsetX: scrollX, offsetY: scrollY });
       timeOutId = setTimeout(() => {
         timeOutId = null;
         pointerMoveHandler(currentEv);
@@ -151,7 +151,7 @@ export function useDragAndDropBeyondTheViewport(env: SpreadsheetChildEnv) {
     startScrollDirection: DnDDirection = "all"
   ) => {
     cleanUp();
-    const zoomLevel = env.model.getters.getViewportZoomLevel();
+    const zoomLevel = model.getters.getViewportZoomLevel();
     const position = gridOverlayPosition(zoomLevel);
     scrollDirection = startScrollDirection;
     startingX = initialPointerCoordinates.clientX - position.x;

--- a/src/components/helpers/zoom.ts
+++ b/src/components/helpers/zoom.ts
@@ -1,6 +1,6 @@
+import { Model } from "../../model";
 import { Pixel } from "../../types/misc";
 import { DOMCoordinates, Rect } from "../../types/rendering";
-import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 import { zoomCorrectedElementRect } from "./dom_helpers";
 
 export type ZoomedMouseEvent<T extends MouseEvent | PointerEvent> = {
@@ -19,11 +19,11 @@ export type ZoomedMouseEvent<T extends MouseEvent | PointerEvent> = {
  * @returns a ZoomedMouseEvent
  */
 export function withZoom<T extends MouseEvent>(
-  env: SpreadsheetChildEnv,
+  model: Model,
   ev: T,
   originalTargetPosition?: DOMCoordinates | null
 ): ZoomedMouseEvent<T> {
-  const zoomLevel = env.model.getters.getViewportZoomLevel();
+  const zoomLevel = model.getters.getViewportZoomLevel();
   if (originalTargetPosition === undefined) {
     originalTargetPosition = getZoomTargetPosition(ev, zoomLevel);
   }

--- a/src/components/highlight/border/border.ts
+++ b/src/components/highlight/border/border.ts
@@ -1,9 +1,9 @@
 import { props } from "@odoo/owl";
+import { Component } from "../../../owl3_compatibility_layer";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
 import { cssPropertiesToCss } from "../../helpers/css";
+import { useModel } from "../../owl_plugins/model_plugin";
 import { types } from "../../props_validation";
-
-import { Component } from "../../../owl3_compatibility_layer";
 
 export class Border extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-Border";
@@ -19,6 +19,8 @@ export class Border extends Component<SpreadsheetChildEnv> {
     isMoving: types.boolean(),
     onMoveHighlight: types.function<[ev: PointerEvent]>([types.instanceOf(PointerEvent)]),
   });
+  private model = useModel();
+
   get style() {
     const isTop = ["n", "w", "e"].includes(this.props.orientation);
     const isLeft = ["n", "w", "s"].includes(this.props.orientation);
@@ -28,7 +30,7 @@ export class Border extends Component<SpreadsheetChildEnv> {
     const z = this.props.zone;
     const margin = 2;
 
-    const rect = this.env.model.getters.getVisibleRect(z);
+    const rect = this.model().getters.getVisibleRect(z);
 
     const left = rect.x;
     const right = rect.x + rect.width - 2 * margin;

--- a/src/components/highlight/corner/corner.ts
+++ b/src/components/highlight/corner/corner.ts
@@ -1,11 +1,11 @@
 import { props } from "@odoo/owl";
 import { AUTOFILL_EDGE_LENGTH } from "../../../constants";
+import { Component } from "../../../owl3_compatibility_layer";
 import { ResizeDirection } from "../../../types/figure";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
 import { cssPropertiesToCss } from "../../helpers/css";
+import { useModel } from "../../owl_plugins/model_plugin";
 import { types } from "../../props_validation";
-
-import { Component } from "../../../owl3_compatibility_layer";
 const MOBILE_HANDLER_WIDTH = 40;
 
 type Orientation = "nw" | "ne" | "sw" | "se" | "n" | "s" | "e" | "w";
@@ -31,6 +31,7 @@ export class Corner extends Component<SpreadsheetChildEnv> {
       [ev: PointerEvent, dirX: ResizeDirection, dirY: ResizeDirection]
     >([types.instanceOf(PointerEvent), types.ResizeDirection(), types.ResizeDirection()]),
   });
+  private model = useModel();
   private dirX!: ResizeDirection;
   private dirY!: ResizeDirection;
 
@@ -43,7 +44,7 @@ export class Corner extends Component<SpreadsheetChildEnv> {
   get handlerStyle() {
     const z = this.props.zone;
 
-    const rect = this.env.model.getters.getVisibleRect({
+    const rect = this.model().getters.getVisibleRect({
       left: this.dirX === 1 ? z.right : z.left,
       right: this.dirX === -1 ? z.left : z.right,
       top: this.dirY === 1 ? z.bottom : z.top,

--- a/src/components/highlight/highlight/highlight.ts
+++ b/src/components/highlight/highlight/highlight.ts
@@ -11,6 +11,7 @@ import {
   useDragAndDropBeyondTheViewport,
 } from "../../helpers/drag_and_drop_grid_hook";
 import { withZoom } from "../../helpers/zoom";
+import { useModel } from "../../owl_plugins/model_plugin";
 import { types } from "../../props_validation";
 import { Border } from "../border/border";
 import { Corner } from "../corner/corner";
@@ -29,11 +30,12 @@ export class Highlight extends Component<SpreadsheetChildEnv> {
     range: types.Range(),
     color: types.Color(),
   });
+  private model = useModel();
 
   highlightState: HighlightState = proxy({
     shiftingMode: "none",
   });
-  dragNDropGrid = useDragAndDropBeyondTheViewport(this.env);
+  dragNDropGrid = useDragAndDropBeyondTheViewport(this.model());
 
   get cornerOrientations(): Array<"nw" | "ne" | "sw" | "se" | "n" | "s" | "e" | "w"> {
     if (!this.env.isMobile()) {
@@ -50,8 +52,8 @@ export class Highlight extends Component<SpreadsheetChildEnv> {
   }
 
   onResizeHighlight(ev: PointerEvent, dirX: ResizeDirection, dirY: ResizeDirection) {
-    const activeSheetId = this.env.model.getters.getActiveSheetId();
-    const zoomedMouseEvent = withZoom(this.env, ev);
+    const activeSheetId = this.model().getters.getActiveSheetId();
+    const zoomedMouseEvent = withZoom(this.model(), ev);
     this.highlightState.shiftingMode = "isResizing";
     const z = this.props.range.zone;
 
@@ -68,7 +70,7 @@ export class Highlight extends Component<SpreadsheetChildEnv> {
       scrollDirection = dirX === 0 ? "vertical" : dirY === 0 ? "horizontal" : "all";
     }
 
-    this.env.model.dispatch("START_CHANGE_HIGHLIGHT", { zone: currentZone });
+    this.model().dispatch("START_CHANGE_HIGHLIGHT", { zone: currentZone });
 
     const mouseMove = (col: HeaderIndex, row: HeaderIndex) => {
       if (lastCol !== col || lastRow !== row) {
@@ -78,7 +80,7 @@ export class Highlight extends Component<SpreadsheetChildEnv> {
           lastRow = lastRow = clip(
             row === -1 ? lastRow : row,
             0,
-            this.env.model.getters.getNumberRows(activeSheetId) - 1
+            this.model().getters.getNumberRows(activeSheetId) - 1
           );
           top = Math.min(pivotRow, lastRow);
           bottom = Math.max(pivotRow, lastRow);
@@ -88,7 +90,7 @@ export class Highlight extends Component<SpreadsheetChildEnv> {
           lastCol = clip(
             col === -1 ? lastCol : col,
             0,
-            this.env.model.getters.getNumberCols(activeSheetId) - 1
+            this.model().getters.getNumberCols(activeSheetId) - 1
           );
           left = Math.min(pivotCol, lastCol);
           right = Math.max(pivotCol, lastCol);
@@ -96,7 +98,7 @@ export class Highlight extends Component<SpreadsheetChildEnv> {
 
         const newZone: Zone = { left, right, top, bottom };
         if (!isEqual(newZone, currentZone)) {
-          this.env.model.selection.selectZone(
+          this.model().selection.selectZone(
             {
               cell: { col: newZone.left, row: newZone.top },
               zone: newZone,
@@ -118,23 +120,23 @@ export class Highlight extends Component<SpreadsheetChildEnv> {
     this.highlightState.shiftingMode = "isMoving";
     const z = this.props.range.zone;
 
-    const zoomLevel = this.env.model.getters.getViewportZoomLevel();
+    const zoomLevel = this.model().getters.getViewportZoomLevel();
     const position = gridOverlayPosition(zoomLevel);
-    const zoomedMouseEvent = withZoom(this.env, ev, position);
+    const zoomedMouseEvent = withZoom(this.model(), ev, position);
 
-    const activeSheetId = this.env.model.getters.getActiveSheetId();
+    const activeSheetId = this.model().getters.getActiveSheetId();
 
-    const initCol = this.env.model.getters.getColIndex(zoomedMouseEvent.clientX - position.x);
-    const initRow = this.env.model.getters.getRowIndex(zoomedMouseEvent.clientY - position.y);
+    const initCol = this.model().getters.getColIndex(zoomedMouseEvent.clientX - position.x);
+    const initRow = this.model().getters.getRowIndex(zoomedMouseEvent.clientY - position.y);
 
     const deltaColMin = -z.left;
-    const deltaColMax = this.env.model.getters.getNumberCols(activeSheetId) - z.right - 1;
+    const deltaColMax = this.model().getters.getNumberCols(activeSheetId) - z.right - 1;
 
     const deltaRowMin = -z.top;
-    const deltaRowMax = this.env.model.getters.getNumberRows(activeSheetId) - z.bottom - 1;
+    const deltaRowMax = this.model().getters.getNumberRows(activeSheetId) - z.bottom - 1;
 
     let currentZone = z;
-    this.env.model.dispatch("START_CHANGE_HIGHLIGHT", { zone: currentZone });
+    this.model().dispatch("START_CHANGE_HIGHLIGHT", { zone: currentZone });
 
     let lastCol = initCol;
     let lastRow = initRow;
@@ -154,7 +156,7 @@ export class Highlight extends Component<SpreadsheetChildEnv> {
         };
 
         if (!isEqual(newZone, currentZone)) {
-          this.env.model.selection.selectZone(
+          this.model().selection.selectZone(
             {
               cell: { col: newZone.left, row: newZone.top },
               zone: newZone,

--- a/src/components/link/link_display/link_display.ts
+++ b/src/components/link/link_display/link_display.ts
@@ -12,6 +12,7 @@ import { CellPopoverStore } from "../../popover/cell_popover_store";
 
 import { props } from "@odoo/owl";
 import { Component } from "../../../owl3_compatibility_layer";
+import { useModel } from "../../owl_plugins/model_plugin";
 import { types } from "../../props_validation";
 
 export class LinkDisplay extends Component<SpreadsheetChildEnv> {
@@ -24,14 +25,16 @@ export class LinkDisplay extends Component<SpreadsheetChildEnv> {
 
   protected cellPopovers!: Store<CellPopoverStore>;
 
+  private model = useModel();
+
   setup() {
     this.cellPopovers = useStore(CellPopoverStore);
   }
 
   get cell(): EvaluatedCell {
     const { col, row } = this.props.cellPosition;
-    const sheetId = this.env.model.getters.getActiveSheetId();
-    return this.env.model.getters.getEvaluatedCell({ sheetId, col, row });
+    const sheetId = this.model().getters.getActiveSheetId();
+    return this.model().getters.getEvaluatedCell({ sheetId, col, row });
   }
 
   get link(): Link {
@@ -45,25 +48,25 @@ export class LinkDisplay extends Component<SpreadsheetChildEnv> {
   }
 
   getUrlRepresentation(link: Link): string {
-    return urlRepresentation(link, this.env.model.getters);
+    return urlRepresentation(link, this.model().getters);
   }
 
   openLink(ev: MouseEvent) {
-    openLink(this.link, this.env, isMiddleClickOrCtrlClick(ev));
+    openLink(this.link, this.model(), this.env, isMiddleClickOrCtrlClick(ev));
   }
 
   edit() {
     const { col, row } = this.props.cellPosition;
-    this.env.model.selection.selectCell(col, row);
+    this.model().selection.selectCell(col, row);
     this.cellPopovers.open({ col, row }, "LinkEditor");
   }
 
   unlink() {
-    const sheetId = this.env.model.getters.getActiveSheetId();
+    const sheetId = this.model().getters.getActiveSheetId();
     const { col, row } = this.props.cellPosition;
-    const style = this.env.model.getters.getCellComputedStyle({ sheetId, col, row });
+    const style = this.model().getters.getCellComputedStyle({ sheetId, col, row });
     const textColor = style?.textColor === LINK_COLOR ? undefined : style?.textColor;
-    this.env.model.dispatch("UPDATE_CELL", {
+    this.model().dispatch("UPDATE_CELL", {
       col,
       row,
       sheetId,

--- a/src/components/link/link_display/link_display.xml
+++ b/src/components/link/link_display/link_display.xml
@@ -26,14 +26,14 @@
         <t t-out="this.getUrlRepresentation(this.link)"/>
       </a>
       <span
-        t-if="!this.env.model.getters.isReadonly()"
+        t-if="!this.model().getters.isReadonly()"
         class="o-link-icon o-unlink"
         t-on-click="this.unlink"
         title="Remove link">
         <t t-call="o-spreadsheet-Icon.UNLINK"/>
       </span>
       <span
-        t-if="!this.env.model.getters.isReadonly()"
+        t-if="!this.model().getters.isReadonly()"
         class="o-link-icon o-edit-link"
         t-on-click="this.edit"
         title="Edit link">

--- a/src/components/link/link_editor/link_editor.ts
+++ b/src/components/link/link_editor/link_editor.ts
@@ -8,6 +8,7 @@ import { CellPopoverComponent, PopoverBuilders } from "../../../types/cell_popov
 import { Link } from "../../../types/misc";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
 import { MenuPopover } from "../../menu_popover/menu_popover";
+import { useModel } from "../../owl_plugins/model_plugin";
 import { types } from "../../props_validation";
 
 interface LinkProposal {
@@ -36,6 +37,7 @@ export class LinkEditor extends Component<SpreadsheetChildEnv> {
   });
   static size = { maxHeight: 500 };
 
+  private model = useModel();
   urlInput = signal<HTMLElement | null>(null);
   suggestionListRef = signal<HTMLElement | null>(null);
   urlInputContainer = signal<HTMLElement | null>(null);
@@ -59,11 +61,11 @@ export class LinkEditor extends Component<SpreadsheetChildEnv> {
     const inputVal = this.state.url;
     for (const category of urlRegistry.getKeys()) {
       const spec = urlRegistry.get(category);
-      const linkProposals = spec.getLinkProposals?.(this.env) || [];
+      const linkProposals = spec.getLinkProposals?.(this.model(), this.env) || [];
       const links =
         inputVal && this.state.isUrlEditable
           ? fuzzyLookup(inputVal, linkProposals, (link) =>
-              spec.urlRepresentation(link.url, this.env.model.getters)
+              spec.urlRepresentation(link.url, this.model().getters)
             )
           : linkProposals;
 
@@ -72,7 +74,7 @@ export class LinkEditor extends Component<SpreadsheetChildEnv> {
       }
       proposals[spec.title] = links.map((link) => {
         counter++;
-        const text = spec.urlRepresentation(link.url, this.env.model.getters);
+        const text = spec.urlRepresentation(link.url, this.model().getters);
         const index = counter;
         return {
           text,
@@ -93,8 +95,8 @@ export class LinkEditor extends Component<SpreadsheetChildEnv> {
 
   get defaultState(): LinkState {
     const { col, row } = this.props.cellPosition;
-    const sheetId = this.env.model.getters.getActiveSheetId();
-    const cell = this.env.model.getters.getEvaluatedCell({ sheetId, col, row });
+    const sheetId = this.model().getters.getActiveSheetId();
+    const cell = this.model().getters.getEvaluatedCell({ sheetId, col, row });
     if (cell.link) {
       return {
         url: cell.link.url,
@@ -116,7 +118,7 @@ export class LinkEditor extends Component<SpreadsheetChildEnv> {
   }
 
   getUrlRepresentation(link: Link): string {
-    return urlRepresentation(link, this.env.model.getters);
+    return urlRepresentation(link, this.model().getters);
   }
 
   removeLink() {
@@ -127,14 +129,14 @@ export class LinkEditor extends Component<SpreadsheetChildEnv> {
 
   save() {
     const { col, row } = this.props.cellPosition;
-    const locale = this.env.model.getters.getLocale();
+    const locale = this.model().getters.getLocale();
     const label = this.state.label
       ? canonicalizeNumberContent(this.state.label, locale)
       : this.state.url;
-    this.env.model.dispatch("UPDATE_CELL", {
+    this.model().dispatch("UPDATE_CELL", {
       col: col,
       row: row,
-      sheetId: this.env.model.getters.getActiveSheetId(),
+      sheetId: this.model().getters.getActiveSheetId(),
       content: markdownLink(label, this.state.url),
     });
     this.props.onClosed?.();

--- a/src/components/menu/menu.ts
+++ b/src/components/menu/menu.ts
@@ -5,6 +5,7 @@ import { Pixel } from "../../types/misc";
 import { Rect } from "../../types/rendering";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 import { cssPropertiesToCss } from "../helpers/css";
+import { useModel } from "../owl_plugins/model_plugin";
 import { types } from "../props_validation";
 
 //------------------------------------------------------------------------------
@@ -47,6 +48,7 @@ export class Menu extends Component<SpreadsheetChildEnv> {
     "onKeyDown?": types.function<[ev: KeyboardEvent]>([types.instanceOf(KeyboardEvent)]),
     "disableKeyboardNavigation?": types.boolean(),
   });
+  private model = useModel();
 
   private menuRef = signal<HTMLElement | null>(null);
 
@@ -73,10 +75,10 @@ export class Menu extends Component<SpreadsheetChildEnv> {
   }
 
   getIconName(menu: Action) {
-    if (menu.icon(this.env)) {
-      return menu.icon(this.env);
+    if (menu.icon(this.model(), this.env)) {
+      return menu.icon(this.model(), this.env);
     }
-    if (menu.isActive?.(this.env)) {
+    if (menu.isActive?.(this.model(), this.env)) {
       return "o-spreadsheet-Icon.CHECK";
     }
 
@@ -92,7 +94,7 @@ export class Menu extends Component<SpreadsheetChildEnv> {
   }
 
   getName(menu: Action) {
-    return menu.name(this.env);
+    return menu.name(this.model(), this.env);
   }
 
   isRoot(menu: Action) {
@@ -100,7 +102,7 @@ export class Menu extends Component<SpreadsheetChildEnv> {
   }
 
   isEnabled(menu: Action) {
-    return isMenuItemEnabled(this.env, menu);
+    return isMenuItemEnabled(this.model(), this.env, menu);
   }
 
   get menuStyle() {

--- a/src/components/menu/menu.xml
+++ b/src/components/menu/menu.xml
@@ -37,13 +37,16 @@
                 class="o-menu-item-name align-middle text-truncate"
                 t-out="this.getName(menuItem)"
               />
-              <t t-set="description" t-value="menuItem.description(this.env) or menuItem.shortcut"/>
+              <t
+                t-set="description"
+                t-value="menuItem.description(this.model(), this.env) or menuItem.shortcut"
+              />
               <div
                 t-if="description"
                 class="o-menu-item-description ms-auto text-truncate"
                 t-out="description"
               />
-              <t t-set="secondaryIcon" t-value="menuItem.secondaryIcon(this.env)"/>
+              <t t-set="secondaryIcon" t-value="menuItem.secondaryIcon(this.model(), this.env)"/>
               <div
                 t-if="isMenuRoot || secondaryIcon"
                 class="o-menu-item-root ms-auto align-items-center d-flex gap-1">

--- a/src/components/menu_popover/menu_popover.ts
+++ b/src/components/menu_popover/menu_popover.ts
@@ -18,6 +18,7 @@ import {
 } from "../helpers/dom_helpers";
 import { useTimeOut } from "../helpers/time_hooks";
 import { Menu } from "../menu/menu";
+import { useModel } from "../owl_plugins/model_plugin";
 import { Popover } from "../popover/popover";
 import { types } from "../props_validation";
 
@@ -68,6 +69,7 @@ export class MenuPopover extends Component<SpreadsheetChildEnv> {
       popoverPositioning: "top-right",
     }
   );
+  private model = useModel();
   private subMenu: MenuState = proxy({
     isOpen: false,
     anchorRect: null,
@@ -103,7 +105,7 @@ export class MenuPopover extends Component<SpreadsheetChildEnv> {
       }
     });
     onWillUnmount(() => {
-      this.state.hoveredMenu?.onStopHover?.(this.env);
+      this.state.hoveredMenu?.onStopHover?.(this.model(), this.env);
       if (this.menuRef()?.contains(document.activeElement)) {
         domFocusableElementStore.focus();
       }
@@ -158,10 +160,10 @@ export class MenuPopover extends Component<SpreadsheetChildEnv> {
   }
 
   getIconName(menu: Action) {
-    if (menu.icon(this.env)) {
-      return menu.icon(this.env);
+    if (menu.icon(this.model(), this.env)) {
+      return menu.icon(this.model(), this.env);
     }
-    if (menu.isActive?.(this.env)) {
+    if (menu.isActive?.(this.model(), this.env)) {
       return "o-spreadsheet-Icon.CHECK";
     }
 
@@ -177,7 +179,7 @@ export class MenuPopover extends Component<SpreadsheetChildEnv> {
   }
 
   async activateMenu(menu: Action, isMiddleClick?: boolean) {
-    const result = await menu.execute?.(this.env, isMiddleClick);
+    const result = await menu.execute?.(this.model(), this.env, isMiddleClick);
     this.close();
     this.props.onMenuClicked?.({ detail: result } as CustomEvent);
   }
@@ -198,11 +200,11 @@ export class MenuPopover extends Component<SpreadsheetChildEnv> {
   }
 
   get menuItems() {
-    return getMenuItemsAndSeparators(this.env, this.props.menuItems);
+    return getMenuItemsAndSeparators(this.model(), this.env, this.props.menuItems);
   }
 
   getName(menu: Action) {
-    return menu.name(this.env);
+    return menu.name(this.model(), this.env);
   }
 
   isRoot(menu: Action) {
@@ -231,7 +233,7 @@ export class MenuPopover extends Component<SpreadsheetChildEnv> {
       width: this.props.width || MENU_WIDTH,
       height: DESKTOP_MENU_ITEM_HEIGHT,
     };
-    this.subMenu.menuItems = menu.children(this.env);
+    this.subMenu.menuItems = menu.children(this.model(), this.env);
     this.subMenu.isOpen = true;
     this.subMenu.parentMenu = menu;
     this.subMenu.autoSelectFirstItem = autoSelectFirstItem;
@@ -256,7 +258,7 @@ export class MenuPopover extends Component<SpreadsheetChildEnv> {
 
   onMenuItemMouseEnter(menu: Action, ev: PointerEvent) {
     this.state.hoveredMenu = menu;
-    menu.onStartHover?.(this.env);
+    menu.onStartHover?.(this.model(), this.env);
 
     if (this.isParentMenu(this.subMenu, menu)) {
       this.openingTimeOut.clear();
@@ -282,7 +284,7 @@ export class MenuPopover extends Component<SpreadsheetChildEnv> {
 
   onMouseLeave(menu: Action) {
     this.state.hoveredMenu = undefined;
-    menu.onStopHover?.(this.env);
+    menu.onStopHover?.(this.model(), this.env);
 
     this.openingTimeOut.schedule(this.closeSubMenu.bind(this), TIMEOUT_DELAY);
   }
@@ -309,7 +311,10 @@ export class MenuPopover extends Component<SpreadsheetChildEnv> {
             this.openSubMenu(selectedMenuItem, rect.y, true);
             return "eventHandled";
           }
-        } else if (selectedMenuItem && isMenuItemEnabled(this.env, selectedMenuItem)) {
+        } else if (
+          selectedMenuItem &&
+          isMenuItemEnabled(this.model(), this.env, selectedMenuItem)
+        ) {
           void this.activateMenu(selectedMenuItem);
           return "eventHandled";
         }
@@ -368,7 +373,7 @@ export class MenuPopover extends Component<SpreadsheetChildEnv> {
 
     for (let offset = 1; offset <= menuItems.length; offset++) {
       const item = menuItems[(start + offset) % menuItems.length];
-      if (isMenuItemEnabled(this.env, item)) {
+      if (isMenuItemEnabled(this.model(), this.env, item)) {
         return item;
       }
     }
@@ -385,7 +390,7 @@ export class MenuPopover extends Component<SpreadsheetChildEnv> {
 
     for (let offset = 1; offset <= menuItems.length; offset++) {
       const item = menuItems[(start - offset + menuItems.length) % menuItems.length];
-      if (isMenuItemEnabled(this.env, item)) {
+      if (isMenuItemEnabled(this.model(), this.env, item)) {
         return item;
       }
     }

--- a/src/components/named_range_selector/named_range_selector.ts
+++ b/src/components/named_range_selector/named_range_selector.ts
@@ -21,6 +21,7 @@ import { Store } from "../../types/store_engine";
 import { getElBoundingRect } from "../helpers/dom_helpers";
 import { ToolBarDropdownStore, useToolBarDropdownStore } from "../helpers/top_bar_tool_hook";
 import { MenuPopover, MenuState } from "../menu_popover/menu_popover";
+import { useModel } from "../owl_plugins/model_plugin";
 import { TextInput } from "../text_input/text_input";
 
 interface State extends Omit<MenuState, "isOpen"> {
@@ -31,6 +32,7 @@ export class NamedRangeSelector extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-NamedRangeSelector";
   static components = { TextInput, MenuPopover };
 
+  private model = useModel();
   private DOMFocusableElementStore!: Store<DOMFocusableElementStore>;
 
   topBarToolStore!: ToolBarDropdownStore;
@@ -55,43 +57,43 @@ export class NamedRangeSelector extends Component<SpreadsheetChildEnv> {
     }
     newValue = newValue.replace(/ /g, "_");
 
-    const sheetId = this.env.model.getters.getActiveSheetId();
+    const sheetId = this.model().getters.getActiveSheetId();
     const selection = this.selectedZone;
     if (rangeReference.test(newValue)) {
-      const range = this.env.model.getters.getRangeFromSheetXC(sheetId, newValue);
+      const range = this.model().getters.getRangeFromSheetXC(sheetId, newValue);
       this.navigateToRange(range);
       return;
     }
 
-    const namedRange = this.env.model.getters.getNamedRange(newValue);
+    const namedRange = this.model().getters.getNamedRange(newValue);
     if (namedRange) {
       this.navigateToRange(namedRange.range);
       return;
     }
 
-    const namedRangeInZone = this.env.model.getters.getNamedRangeFromZone(sheetId, selection);
+    const namedRangeInZone = this.model().getters.getNamedRangeFromZone(sheetId, selection);
     if (!namedRangeInZone) {
-      interactiveCreateNamedRange(this.env, {
+      interactiveCreateNamedRange(this.model(), this.env, {
         name: newValue,
-        ranges: [this.env.model.getters.getRangeDataFromZone(sheetId, selection)],
+        ranges: [this.model().getters.getRangeDataFromZone(sheetId, selection)],
       });
     } else {
-      interactiveUpdateNamedRange(this.env, {
+      interactiveUpdateNamedRange(this.model(), this.env, {
         newRangeName: newValue,
         oldRangeName: namedRangeInZone.name,
-        ranges: [this.env.model.getters.getRangeData(namedRangeInZone.range)],
+        ranges: [this.model().getters.getRangeData(namedRangeInZone.range)],
       });
     }
   }
 
   get inputValue() {
-    const sheetId = this.env.model.getters.getActiveSheetId();
-    const namedRange = this.env.model.getters.getNamedRangeFromZone(sheetId, this.selectedZone);
+    const sheetId = this.model().getters.getActiveSheetId();
+    const namedRange = this.model().getters.getNamedRangeFromZone(sheetId, this.selectedZone);
     return namedRange?.name || zoneToXc(this.selectedZone);
   }
 
   get selectedZone() {
-    return this.env.model.getters.getSelectedZone();
+    return this.model().getters.getSelectedZone();
   }
 
   openDropdown() {
@@ -102,7 +104,7 @@ export class NamedRangeSelector extends Component<SpreadsheetChildEnv> {
 
   getNamedRangeMenuItems(): Action[] {
     let actionsSpecs: ActionSpec[] = [];
-    for (const { name: name, range } of this.env.model.getters.getNamedRanges()) {
+    for (const { name: name, range } of this.model().getters.getNamedRanges()) {
       const highlightProvider = {
         get highlights(): Highlight[] {
           return [{ range, color: HIGHLIGHT_COLOR, noFill: true }];
@@ -114,10 +116,10 @@ export class NamedRangeSelector extends Component<SpreadsheetChildEnv> {
           this.navigateToRange(range);
           this.stopEditingNamedRange();
         },
-        description: (env) => env.model.getters.getRangeString(range),
+        description: (model) => model.getters.getRangeString(range),
         icon: "o-spreadsheet-Icon.NAMED_RANGE",
-        onStartHover: (env) => env.getStore(HighlightStore).register(highlightProvider),
-        onStopHover: (env) => env.getStore(HighlightStore).unRegister(highlightProvider),
+        onStartHover: (model, env) => env.getStore(HighlightStore).register(highlightProvider),
+        onStopHover: (model, env) => env.getStore(HighlightStore).unRegister(highlightProvider),
       });
     }
 
@@ -155,7 +157,7 @@ export class NamedRangeSelector extends Component<SpreadsheetChildEnv> {
 
   private navigateToRange(range: Range) {
     const { sheetId, zone } = range;
-    const doesRangeExist = this.env.model.getters.checkZonesExistInSheet(sheetId, [zone]);
+    const doesRangeExist = this.model().getters.checkZonesExistInSheet(sheetId, [zone]);
     if (doesRangeExist !== CommandResult.Success) {
       this.env.raiseError(
         _t(
@@ -164,21 +166,21 @@ export class NamedRangeSelector extends Component<SpreadsheetChildEnv> {
       );
       return;
     }
-    const activeSheetId = this.env.model.getters.getActiveSheetId();
+    const activeSheetId = this.model().getters.getActiveSheetId();
     if (activeSheetId !== sheetId) {
-      this.env.model.dispatch("ACTIVATE_SHEET", { sheetIdFrom: activeSheetId, sheetIdTo: sheetId });
+      this.model().dispatch("ACTIVATE_SHEET", { sheetIdFrom: activeSheetId, sheetIdTo: sheetId });
     }
 
     // First select the bottom-right cell to try to scroll the sheet so that the whole range is visible
-    this.env.model.selection.selectCell(zone.right, zone.bottom);
-    this.env.model.selection.selectZone({
+    this.model().selection.selectCell(zone.right, zone.bottom);
+    this.model().selection.selectZone({
       cell: { col: zone.left, row: zone.top },
       zone,
     });
   }
 
   get selectionKey(): string {
-    const sheetId = this.env.model.getters.getActiveSheetId();
+    const sheetId = this.model().getters.getActiveSheetId();
     return `${sheetId}-${zoneToXc(this.selectedZone)}`;
   }
 

--- a/src/components/owl_plugins/model_plugin.ts
+++ b/src/components/owl_plugins/model_plugin.ts
@@ -1,0 +1,24 @@
+import { config, onWillDestroy, Plugin, plugin, signal, types } from "@odoo/owl";
+import { Model } from "../../model";
+
+export class ModelPlugin extends Plugin {
+  private _model: Model = config("model", types.instanceOf(Model));
+  public model = () => {
+    this.version();
+    return this._model;
+  };
+  private version = signal(0);
+
+  setup() {
+    this._model.on("update", this, () => {
+      this.version.set(this.version() + 1);
+    });
+    onWillDestroy(() => {
+      this._model.off("update", this);
+    });
+  }
+}
+
+export function useModel() {
+  return plugin(ModelPlugin).model;
+}

--- a/src/components/paint_format_button/paint_format_button.ts
+++ b/src/components/paint_format_button/paint_format_button.ts
@@ -1,11 +1,11 @@
+import { props } from "@odoo/owl";
+import { Component } from "../../owl3_compatibility_layer";
 import { useStore } from "../../store_engine/store_hooks";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 import { Store } from "../../types/store_engine";
-import { PaintFormatStore } from "./paint_format_store";
-
-import { props } from "@odoo/owl";
-import { Component } from "../../owl3_compatibility_layer";
+import { useModel } from "../owl_plugins/model_plugin";
 import { types } from "../props_validation";
+import { PaintFormatStore } from "./paint_format_store";
 export class PaintFormatButton extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-PaintFormatButton";
 
@@ -13,6 +13,7 @@ export class PaintFormatButton extends Component<SpreadsheetChildEnv> {
     "class?": types.string(),
   });
 
+  protected model = useModel();
   private paintFormatStore!: Store<PaintFormatStore>;
 
   setup() {

--- a/src/components/paint_format_button/paint_format_button.xml
+++ b/src/components/paint_format_button/paint_format_button.xml
@@ -3,7 +3,7 @@
     <span
       class="o-menu-item-button"
       title="Paint Format"
-      t-att-class="{'active': this.isActive, 'o-disabled': this.env.model.getters.isCurrentSheetLocked()}"
+      t-att-class="{'active': this.isActive, 'o-disabled': this.model().getters.isCurrentSheetLocked()}"
       t-attf-class="{{this.props.class}}"
       t-on-click="this.togglePaintFormat"
       t-on-dblclick="this.onDblClick">

--- a/src/components/pivot_html_renderer/pivot_html_renderer.ts
+++ b/src/components/pivot_html_renderer/pivot_html_renderer.ts
@@ -5,6 +5,7 @@ import { formatValue } from "../../helpers/format/format";
 import { generatePivotArgs } from "../../helpers/pivot/pivot_helpers";
 import { Component } from "../../owl3_compatibility_layer";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
+import { useModel } from "../owl_plugins/model_plugin";
 import { types } from "../props_validation";
 import { Checkbox } from "../side_panel/components/checkbox/checkbox";
 
@@ -47,7 +48,8 @@ export class PivotHTMLRenderer extends Component<SpreadsheetChildEnv> {
     onCellClicked: types.function<[formula: string]>([types.string()]),
   });
 
-  private pivot = this.env.model.getters.getPivot(this.props.pivotId);
+  private model = useModel();
+  private pivot = this.model().getters.getPivot(this.props.pivotId);
   data: TableData = {
     columns: [],
     rows: [],
@@ -59,7 +61,7 @@ export class PivotHTMLRenderer extends Component<SpreadsheetChildEnv> {
 
   setup() {
     const table = this.pivot.getExpandedTableStructure();
-    const formulaId = this.env.model.getters.getPivotFormulaId(this.props.pivotId);
+    const formulaId = this.model().getters.getPivotFormulaId(this.props.pivotId);
     this.data = {
       columns: this._buildColHeaders(formulaId, table),
       rows: this._buildRowHeaders(formulaId, table),
@@ -68,7 +70,7 @@ export class PivotHTMLRenderer extends Component<SpreadsheetChildEnv> {
   }
 
   get tracker() {
-    return this.env.model.getters.getPivotPresenceTracker(this.props.pivotId);
+    return this.model().getters.getPivotPresenceTracker(this.props.pivotId);
   }
 
   // ---------------------------------------------------------------------
@@ -244,7 +246,7 @@ export class PivotHTMLRenderer extends Component<SpreadsheetChildEnv> {
           args.push({ value: cell.fields[i] }, { value: cell.values[i] });
         }
         const domain = this.pivot.parseArgsToPivotDomain(args);
-        const locale = this.env.model.getters.getLocale();
+        const locale = this.model().getters.getLocale();
         if (domain.at(-1)?.field === "measure") {
           const { value, format } = this.pivot.getPivotMeasureValue(
             toString(domain.at(-1)!.value),
@@ -286,7 +288,7 @@ export class PivotHTMLRenderer extends Component<SpreadsheetChildEnv> {
       }
       const domain = this.pivot.parseArgsToPivotDomain(args);
       const { value, format } = this.pivot.getPivotHeaderValueAndFormat(domain);
-      const locale = this.env.model.getters.getLocale();
+      const locale = this.model().getters.getLocale();
       const cell: PivotDialogRow = {
         formula: `=PIVOT.HEADER(${generatePivotArgs(id, domain).join(",")})`,
         value: formatValue(value, { format, locale }),
@@ -314,7 +316,7 @@ export class PivotHTMLRenderer extends Component<SpreadsheetChildEnv> {
         }
         const domain = this.pivot.parseArgsToPivotDomain(args);
         const { value, format } = this.pivot.getPivotCellValueAndFormat(measure, domain);
-        const locale = this.env.model.getters.getLocale();
+        const locale = this.model().getters.getLocale();
         current.push({
           formula: `=PIVOT.VALUE(${generatePivotArgs(id, domain, measure).join(",")})`,
           value: formatValue(value, { format, locale }),

--- a/src/components/scrollbar/scrollbar_horizontal.ts
+++ b/src/components/scrollbar/scrollbar_horizontal.ts
@@ -2,6 +2,7 @@ import { props, xml } from "@odoo/owl";
 import { Component } from "../../owl3_compatibility_layer";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 import { isBrowserFirefox } from "../helpers/dom_helpers";
+import { useModel } from "../owl_plugins/model_plugin";
 import { types } from "../props_validation";
 import { ScrollBar } from "./scrollbar";
 
@@ -26,24 +27,26 @@ export class HorizontalScrollBar extends Component<SpreadsheetChildEnv> {
     }
   );
 
+  private model = useModel();
+
   get offset() {
-    return this.env.model.getters.getActiveSheetScrollInfo().scrollX;
+    return this.model().getters.getActiveSheetScrollInfo().scrollX;
   }
 
   get width() {
-    return this.env.model.getters.getMainViewportRect().width;
+    return this.model().getters.getMainViewportRect().width;
   }
 
   get isDisplayed() {
-    const { xRatio } = this.env.model.getters.getFrozenSheetViewRatio(
-      this.env.model.getters.getActiveSheetId()
+    const { xRatio } = this.model().getters.getFrozenSheetViewRatio(
+      this.model().getters.getActiveSheetId()
     );
     return xRatio < 1;
   }
 
   get position() {
-    const { x } = this.env.model.getters.getMainViewportRect();
-    const scrollbarWidth = this.env.model.getters.getScrollBarWidth();
+    const { x } = this.model().getters.getMainViewportRect();
+    const scrollbarWidth = this.model().getters.getScrollBarWidth();
     return {
       left: `${this.props.leftOffset + x}px`,
       bottom: "0px",
@@ -53,8 +56,8 @@ export class HorizontalScrollBar extends Component<SpreadsheetChildEnv> {
   }
 
   onScroll(offset) {
-    const { scrollY } = this.env.model.getters.getActiveSheetScrollInfo();
-    this.env.model.dispatch("SET_VIEWPORT_OFFSET", {
+    const { scrollY } = this.model().getters.getActiveSheetScrollInfo();
+    this.model().dispatch("SET_VIEWPORT_OFFSET", {
       offsetX: offset,
       offsetY: scrollY, // offsetY is the same
     });

--- a/src/components/scrollbar/scrollbar_vertical.ts
+++ b/src/components/scrollbar/scrollbar_vertical.ts
@@ -2,6 +2,7 @@ import { props, xml } from "@odoo/owl";
 import { Component } from "../../owl3_compatibility_layer";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 import { isBrowserFirefox } from "../helpers/dom_helpers";
+import { useModel } from "../owl_plugins/model_plugin";
 import { types } from "../props_validation";
 import { ScrollBar } from "./scrollbar";
 
@@ -26,24 +27,26 @@ export class VerticalScrollBar extends Component<SpreadsheetChildEnv> {
     }
   );
 
+  private model = useModel();
+
   get offset() {
-    return this.env.model.getters.getActiveSheetScrollInfo().scrollY;
+    return this.model().getters.getActiveSheetScrollInfo().scrollY;
   }
 
   get height() {
-    return this.env.model.getters.getMainViewportRect().height;
+    return this.model().getters.getMainViewportRect().height;
   }
 
   get isDisplayed() {
-    const { yRatio } = this.env.model.getters.getFrozenSheetViewRatio(
-      this.env.model.getters.getActiveSheetId()
+    const { yRatio } = this.model().getters.getFrozenSheetViewRatio(
+      this.model().getters.getActiveSheetId()
     );
     return yRatio < 1;
   }
 
   get position() {
-    const { y } = this.env.model.getters.getMainViewportRect();
-    const scrollbarWidth = this.env.model.getters.getScrollBarWidth();
+    const { y } = this.model().getters.getMainViewportRect();
+    const scrollbarWidth = this.model().getters.getScrollBarWidth();
     return {
       top: `${this.props.topOffset + y}px`,
       right: "0px",
@@ -53,8 +56,8 @@ export class VerticalScrollBar extends Component<SpreadsheetChildEnv> {
   }
 
   onScroll(offset) {
-    const { scrollX } = this.env.model.getters.getActiveSheetScrollInfo();
-    this.env.model.dispatch("SET_VIEWPORT_OFFSET", {
+    const { scrollX } = this.model().getters.getActiveSheetScrollInfo();
+    this.model().dispatch("SET_VIEWPORT_OFFSET", {
       offsetX: scrollX, // offsetX is the same
       offsetY: offset,
     });

--- a/src/components/selection/selection.ts
+++ b/src/components/selection/selection.ts
@@ -1,20 +1,23 @@
 import { SELECTION_BORDER_COLOR } from "../../constants";
+import { Component } from "../../owl3_compatibility_layer";
 import { PropsOf } from "../../types/props_of";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 import { Highlight } from "../highlight/highlight/highlight";
+import { useModel } from "../owl_plugins/model_plugin";
 
-import { Component } from "../../owl3_compatibility_layer";
 export class Selection extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-Selection";
   static components = { Highlight };
 
+  private model = useModel();
+
   get highlightProps(): PropsOf<Highlight> {
-    const sheetId = this.env.model.getters.getActiveSheetId();
-    const zone = this.env.model.getters.getUnboundedZone(
+    const sheetId = this.model().getters.getActiveSheetId();
+    const zone = this.model().getters.getUnboundedZone(
       sheetId,
-      this.env.model.getters.getSelectedZone()
+      this.model().getters.getSelectedZone()
     );
-    const range = this.env.model.getters.getRangeFromZone(sheetId, zone);
+    const range = this.model().getters.getRangeFromZone(sheetId, zone);
     return { range, color: SELECTION_BORDER_COLOR };
   }
 }

--- a/src/components/selection_input/selection_input.ts
+++ b/src/components/selection_input/selection_input.ts
@@ -10,6 +10,7 @@ import { Store } from "../../types/store_engine";
 import { cssPropertiesToCss } from "../helpers/css";
 import { useDragAndDropListItems } from "../helpers/drag_and_drop_dom_items_hook";
 import { updateSelectionWithArrowKeys } from "../helpers/selection_helpers";
+import { useModel } from "../owl_plugins/model_plugin";
 import { types } from "../props_validation";
 import { RangeInputValue, SelectionInputStore } from "./selection_input_store";
 
@@ -63,6 +64,7 @@ export class SelectionInput extends Component<SpreadsheetChildEnv> {
   private focusedInputRef = signal<HTMLInputElement | null>(null);
   unfocusedInputRef = signal<HTMLInputElement | null>(null);
   private selectionRef = signal<HTMLElement | null>(null);
+  private model = useModel();
   private DOMFocusableElementStore!: Store<DOMFocusableElementStore>;
   private store!: Store<SelectionInputStore>;
 
@@ -213,7 +215,7 @@ export class SelectionInput extends Component<SpreadsheetChildEnv> {
       ev.stopPropagation();
       if (this.store.mode === "select-range") {
         ev.preventDefault();
-        updateSelectionWithArrowKeys(ev, this.env.model.selection);
+        updateSelectionWithArrowKeys(ev, this.model().selection);
       }
     } else if (ev.key === "Enter") {
       const target = ev.target as HTMLInputElement;
@@ -265,7 +267,7 @@ export class SelectionInput extends Component<SpreadsheetChildEnv> {
   confirm() {
     this.store.confirm();
     const anyValidInput = this.store.selectionInputs.some((range) =>
-      this.env.model.getters.isRangeValid(range.xc)
+      this.model().getters.isRangeValid(range.xc)
     );
     if (this.props.required && !anyValidInput) {
       this.state.isMissing = true;

--- a/src/components/side_panel/carousel_panel/carousel_panel.ts
+++ b/src/components/side_panel/carousel_panel/carousel_panel.ts
@@ -12,6 +12,7 @@ import { UID } from "../../../types/misc";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
 import { getBoundingRectAsPOJO } from "../../helpers/dom_helpers";
 import { useDragAndDropListItems } from "../../helpers/drag_and_drop_dom_items_hook";
+import { useModel } from "../../owl_plugins/model_plugin";
 import { types } from "../../props_validation";
 import { TextInput } from "../../text_input/text_input";
 import { TextStyler } from "../chart/building_blocks/text_styler/text_styler";
@@ -29,6 +30,7 @@ export class CarouselPanel extends Component<SpreadsheetChildEnv> {
 
   DEFAULT_CAROUSEL_TITLE_STYLE = DEFAULT_CAROUSEL_TITLE_STYLE;
 
+  private model = useModel();
   private dragAndDrop = useDragAndDropListItems();
   private previewListRef = signal<HTMLElement | null>(null);
 
@@ -43,15 +45,15 @@ export class CarouselPanel extends Component<SpreadsheetChildEnv> {
   }
 
   get carouselItems(): CarouselItem[] {
-    return this.env.model.getters.getCarousel(this.props.figureId).items;
+    return this.model().getters.getCarousel(this.props.figureId).items;
   }
 
   get title(): TitleDesign | undefined {
-    return this.env.model.getters.getCarousel(this.props.figureId).title;
+    return this.model().getters.getCarousel(this.props.figureId).title;
   }
 
   get carousel() {
-    return this.env.model.getters.getCarousel(this.props.figureId);
+    return this.model().getters.getCarousel(this.props.figureId);
   }
 
   getPreviewDivStyle(item: CarouselItem): string {
@@ -63,7 +65,7 @@ export class CarouselPanel extends Component<SpreadsheetChildEnv> {
   }
 
   addNewChartToCarousel() {
-    this.env.model.dispatch("ADD_NEW_CHART_TO_CAROUSEL", {
+    this.model().dispatch("ADD_NEW_CHART_TO_CAROUSEL", {
       figureId: this.props.figureId,
       sheetId: this.carouselSheetId,
     });
@@ -74,17 +76,17 @@ export class CarouselPanel extends Component<SpreadsheetChildEnv> {
   }
 
   isCarouselItemActive(item: CarouselItem): boolean {
-    const activeItem = this.env.model.getters.getSelectedCarouselItem(this.props.figureId);
+    const activeItem = this.model().getters.getSelectedCarouselItem(this.props.figureId);
     return deepEquals(activeItem, item);
   }
 
   addDataViewToCarousel() {
-    const carousel = this.env.model.getters.getCarousel(this.props.figureId);
+    const carousel = this.model().getters.getCarousel(this.props.figureId);
     this.updateItems([...carousel.items, { type: "carouselDataView" }]);
   }
 
   activateCarouselItem(item: CarouselItem) {
-    this.env.model.dispatch("UPDATE_CAROUSEL_ACTIVE_ITEM", {
+    this.model().dispatch("UPDATE_CAROUSEL_ACTIVE_ITEM", {
       figureId: this.props.figureId,
       sheetId: this.carouselSheetId,
       item,
@@ -94,7 +96,7 @@ export class CarouselPanel extends Component<SpreadsheetChildEnv> {
   editCarouselItem(item: CarouselItem) {
     if (item.type === "chart") {
       this.activateCarouselItem(item);
-      this.env.model.dispatch("SELECT_FIGURE", { figureId: this.props.figureId });
+      this.model().dispatch("SELECT_FIGURE", { figureId: this.props.figureId });
       this.env.openSidePanel("ChartPanel", { chartId: item.chartId });
     }
   }
@@ -113,7 +115,7 @@ export class CarouselPanel extends Component<SpreadsheetChildEnv> {
   }
 
   deleteCarouselItem(item: CarouselItem) {
-    const carousel = this.env.model.getters.getCarousel(this.props.figureId);
+    const carousel = this.model().getters.getCarousel(this.props.figureId);
     const items = carousel.items.filter((itm) => !deepEquals(itm, item));
     this.updateItems(items);
   }
@@ -122,7 +124,7 @@ export class CarouselPanel extends Component<SpreadsheetChildEnv> {
     if (item.type !== "chart") {
       return;
     }
-    this.env.model.dispatch("POPOUT_CHART_FROM_CAROUSEL", {
+    this.model().dispatch("POPOUT_CHART_FROM_CAROUSEL", {
       sheetId: this.carouselSheetId,
       carouselId: this.props.figureId,
       chartId: item.chartId,
@@ -133,7 +135,7 @@ export class CarouselPanel extends Component<SpreadsheetChildEnv> {
     if (item.type !== "chart") {
       return;
     }
-    this.env.model.dispatch("DUPLICATE_CAROUSEL_CHART", {
+    this.model().dispatch("DUPLICATE_CAROUSEL_CHART", {
       sheetId: this.carouselSheetId,
       carouselId: this.props.figureId,
       chartId: item.chartId,
@@ -171,7 +173,7 @@ export class CarouselPanel extends Component<SpreadsheetChildEnv> {
     if (originalIndex === -1 || originalIndex === finalIndex) {
       return;
     }
-    const carousel = this.env.model.getters.getCarousel(this.props.figureId);
+    const carousel = this.model().getters.getCarousel(this.props.figureId);
     const items = [...carousel.items];
     items.splice(originalIndex, 1);
     items.splice(finalIndex, 0, item);
@@ -179,15 +181,15 @@ export class CarouselPanel extends Component<SpreadsheetChildEnv> {
   }
 
   getItemTitle(item: CarouselItem): string {
-    return getCarouselItemTitle(this.env.model.getters, item);
+    return getCarouselItemTitle(this.model().getters, item);
   }
 
   getItemPreview(item: CarouselItem): string {
-    return getCarouselItemPreview(this.env.model.getters, item);
+    return getCarouselItemPreview(this.model().getters, item);
   }
 
   updateItems(items: CarouselItem[]) {
-    this.env.model.dispatch("UPDATE_CAROUSEL", {
+    this.model().dispatch("UPDATE_CAROUSEL", {
       figureId: this.props.figureId,
       sheetId: this.carouselSheetId,
       definition: { ...this.carousel, items },
@@ -195,8 +197,8 @@ export class CarouselPanel extends Component<SpreadsheetChildEnv> {
   }
 
   updateTitleText(title: string) {
-    const carousel = this.env.model.getters.getCarousel(this.props.figureId);
-    this.env.model.dispatch("UPDATE_CAROUSEL", {
+    const carousel = this.model().getters.getCarousel(this.props.figureId);
+    this.model().dispatch("UPDATE_CAROUSEL", {
       figureId: this.props.figureId,
       sheetId: this.carouselSheetId,
       definition: {
@@ -210,8 +212,8 @@ export class CarouselPanel extends Component<SpreadsheetChildEnv> {
   }
 
   updateTitleStyle(style: TitleDesign) {
-    const carousel = this.env.model.getters.getCarousel(this.props.figureId);
-    this.env.model.dispatch("UPDATE_CAROUSEL", {
+    const carousel = this.model().getters.getCarousel(this.props.figureId);
+    this.model().dispatch("UPDATE_CAROUSEL", {
       figureId: this.props.figureId,
       sheetId: this.carouselSheetId,
       definition: {
@@ -258,7 +260,7 @@ export class CarouselPanel extends Component<SpreadsheetChildEnv> {
   }
 
   get carouselSheetId(): UID {
-    const sheetId = this.env.model.getters.getFigureSheetId(this.props.figureId);
+    const sheetId = this.model().getters.getFigureSheetId(this.props.figureId);
     if (!sheetId) {
       throw new Error("Could not find the sheetId of the carousel figure");
     }

--- a/src/components/side_panel/chart/bubble_chart/bubble_chart_config_panel.ts
+++ b/src/components/side_panel/chart/bubble_chart/bubble_chart_config_panel.ts
@@ -6,6 +6,7 @@ import { _t } from "../../../../translation";
 import { BubbleChartDefinition } from "../../../../types/chart/bubble_chart";
 import { CommandResult, DispatchResult } from "../../../../types/commands";
 import { SpreadsheetChildEnv } from "../../../../types/spreadsheet_env";
+import { useModel } from "../../../owl_plugins/model_plugin";
 import { ChartTerms } from "../../../translations_terms";
 import { ChartDataSeries } from "../building_blocks/data_series/data_series";
 import { ChartErrorSection } from "../building_blocks/error_section/error_section";
@@ -37,6 +38,7 @@ export class BubbleChartConfigPanel extends Component<SpreadsheetChildEnv> {
     sizeRangeDispatchResult: undefined,
   });
 
+  private model = useModel();
   protected yRanges: string[] = [];
   protected labelRange?: string;
   protected datasetOrientation: "rows" | "columns" | undefined;
@@ -184,7 +186,7 @@ export class BubbleChartConfigPanel extends Component<SpreadsheetChildEnv> {
       return undefined;
     }
     const dataRange = this.yRanges[0] ?? this.xRange ?? "";
-    const getters = this.env.model.getters;
+    const getters = this.model().getters;
     const sheetId = getters.getActiveSheetId();
     const zone = createValidRange(getters, sheetId, dataRange || "")?.zone;
     if (zone) {
@@ -197,7 +199,7 @@ export class BubbleChartConfigPanel extends Component<SpreadsheetChildEnv> {
     let anyRow = false;
     let anyColumn = false;
     for (const yRange of this.yRanges) {
-      const getters = this.env.model.getters;
+      const getters = this.model().getters;
       const sheetId = getters.getActiveSheetId();
       const zone = createValidRange(getters, sheetId, yRange)?.zone;
       if (!zone) {

--- a/src/components/side_panel/chart/building_blocks/axis_design/axis_design_editor.ts
+++ b/src/components/side_panel/chart/building_blocks/axis_design/axis_design_editor.ts
@@ -20,6 +20,7 @@ import { UID } from "../../../../../types/misc";
 import { SpreadsheetChildEnv } from "../../../../../types/spreadsheet_env";
 import { DateInput } from "../../../../date_input/date_input";
 import { NumberInput } from "../../../../number_input/number_input";
+import { useModel } from "../../../../owl_plugins/model_plugin";
 import { types } from "../../../../props_validation";
 import { BadgeSelection } from "../../../components/badge_selection/badge_selection";
 import { Checkbox } from "../../../components/checkbox/checkbox";
@@ -45,6 +46,7 @@ export class AxisDesignEditor extends Component<SpreadsheetChildEnv> {
     axesList: types.ArrayOf<AxisDefinition>(),
   });
 
+  private model = useModel();
   state: { currentAxis: AxisId } = proxy({ currentAxis: "x" });
 
   defaultFontSize = CHART_AXIS_TITLE_FONT_SIZE;
@@ -251,7 +253,7 @@ export class AxisDesignEditor extends Component<SpreadsheetChildEnv> {
   }
 
   private parseTimeAxisBoundaryValue(value: string): number | undefined | null {
-    const dateNumber = toNumber(value, this.env.model.getters.getLocale());
+    const dateNumber = toNumber(value, this.model().getters.getLocale());
     return Number.isNaN(dateNumber) ? null : dateNumber;
   }
 
@@ -259,11 +261,11 @@ export class AxisDesignEditor extends Component<SpreadsheetChildEnv> {
     if (value === undefined) {
       return undefined;
     }
-    return formatValue(value, { format: "yyyy-mm-dd", locale: this.env.model.getters.getLocale() });
+    return formatValue(value, { format: "yyyy-mm-dd", locale: this.model().getters.getLocale() });
   }
 
   private getXAxisType(): AxisType | undefined {
-    const runtime = this.env.model.getters.getChartRuntime(this.props.chartId) as LineChartRuntime;
+    const runtime = this.model().getters.getChartRuntime(this.props.chartId) as LineChartRuntime;
     return runtime?.chartJsConfig.options?.scales?.x?.type as AxisType | undefined;
   }
 }

--- a/src/components/side_panel/chart/building_blocks/humanize_numbers/humanize_numbers.ts
+++ b/src/components/side_panel/chart/building_blocks/humanize_numbers/humanize_numbers.ts
@@ -1,12 +1,13 @@
+import { props } from "@odoo/owl";
 import { formatLargeNumber, formatValue } from "../../../../../helpers/format/format";
+import { Component } from "../../../../../owl3_compatibility_layer";
 import { _t } from "../../../../../translation";
 import { ChartDefinitionWithDataSource } from "../../../../../types/chart/chart";
 import { SpreadsheetChildEnv } from "../../../../../types/spreadsheet_env";
+import { useModel } from "../../../../owl_plugins/model_plugin";
 import { Checkbox } from "../../../components/checkbox/checkbox";
 import { ChartSidePanelProps, chartSidePanelPropsDefinition } from "../../common";
 
-import { props } from "@odoo/owl";
-import { Component } from "../../../../../owl3_compatibility_layer";
 export class ChartHumanizeNumbers extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ChartHumanizeNumbers";
   static components = {
@@ -16,8 +17,10 @@ export class ChartHumanizeNumbers extends Component<SpreadsheetChildEnv> {
     ChartDefinitionWithDataSource<string>
   >;
 
+  private model = useModel();
+
   get title() {
-    const locale = this.env.model.getters.getLocale();
+    const locale = this.model().getters.getLocale();
     const format = formatLargeNumber({ value: 1234567 }, undefined, locale);
     const value = formatValue(1234567, { format, locale });
     return _t("E.g. 1234567 -> %(value)s", { value });

--- a/src/components/side_panel/chart/building_blocks/range_data_source/range_data_source.ts
+++ b/src/components/side_panel/chart/building_blocks/range_data_source/range_data_source.ts
@@ -25,6 +25,7 @@ import {
 import { CommandResult, DispatchResult } from "../../../../../types/commands";
 import { UID, Zone } from "../../../../../types/misc";
 import { SpreadsheetChildEnv } from "../../../../../types/spreadsheet_env";
+import { useModel } from "../../../../owl_plugins/model_plugin";
 import { types } from "../../../../props_validation";
 import { ChartTerms } from "../../../../translations_terms";
 import { ChartDataSeries } from "../data_series/data_series";
@@ -72,6 +73,7 @@ export class ChartRangeDataSourceComponent extends Component<SpreadsheetChildEnv
     labelsDispatchResult: undefined,
   });
 
+  private model = useModel();
   protected dataSets: ChartRangeDataSourceType<string>["dataSets"] = [];
   private labelRange: string | undefined;
   private datasetOrientation: ChartDatasetOrientation | undefined = undefined;
@@ -151,7 +153,7 @@ export class ChartRangeDataSourceComponent extends Component<SpreadsheetChildEnv
   get canChangeDatasetOrientation(): boolean {
     const sheetNames = new Set<string>();
     const datasetZones: Zone[] = [];
-    const currentSheetName = this.env.model.getters.getActiveSheetName();
+    const currentSheetName = this.model().getters.getActiveSheetName();
     const ranges = this.dataSets.map((ds) => ds.dataRange);
     if (this.labelRange) {
       ranges.push(this.labelRange);
@@ -298,7 +300,7 @@ export class ChartRangeDataSourceComponent extends Component<SpreadsheetChildEnv
       dataSetStyles,
     });
     if (this.state.datasetDispatchResult.isSuccessful) {
-      const newDefinition = this.env.model.getters.getChartDefinition(
+      const newDefinition = this.model().getters.getChartDefinition(
         this.props.chartId
       ) as ChartDefinitionWithDataSource<string>;
       if (newDefinition.dataSource.type === "range") {
@@ -311,13 +313,13 @@ export class ChartRangeDataSourceComponent extends Component<SpreadsheetChildEnv
   splitRanges() {
     const postProcessedRanges: ChartRangeDataSourceType<string>["dataSets"] = [];
     const postProcessedStyles: DataSetStyle = {};
-    const definition = this.env.model.getters.getChartDefinition(
+    const definition = this.model().getters.getChartDefinition(
       this.props.chartId
     ) as ChartDefinitionWithDataSource<string>;
     const dataSetStyles = definition.dataSetStyles || {};
     for (const dataSet of this.dataSets) {
       const range = dataSet.dataRange;
-      if (!this.env.model.getters.isRangeValid(range)) {
+      if (!this.model().getters.isRangeValid(range)) {
         postProcessedRanges.push(dataSet); // ignore invalid range
         continue;
       }
@@ -449,7 +451,7 @@ export class ChartRangeDataSourceComponent extends Component<SpreadsheetChildEnv
     if (this.isDatasetInvalid || this.isLabelInvalid) {
       return undefined;
     }
-    const getters = this.env.model.getters;
+    const getters = this.model().getters;
     const sheetId = getters.getActiveSheetId();
     const labelRange = createValidRange(getters, sheetId, this.labelRange);
     const dataSets = createDataSets(getters, sheetId, this.props.dataSource);
@@ -471,7 +473,7 @@ export class ChartRangeDataSourceComponent extends Component<SpreadsheetChildEnv
     dataRanges: (string | undefined)[],
     datasetOrientation: ChartDatasetOrientation | undefined
   ): { dataRange: string; dataSetId: UID }[] {
-    const getters = this.env.model.getters;
+    const getters = this.model().getters;
     if (datasetOrientation === undefined) {
       return dataRanges
         .filter(isDefined)

--- a/src/components/side_panel/chart/building_blocks/series_design/series_design_editor.ts
+++ b/src/components/side_panel/chart/building_blocks/series_design/series_design_editor.ts
@@ -8,6 +8,7 @@ import {
 import { DispatchResult } from "../../../../../types/commands";
 import { UID, ValueAndLabel } from "../../../../../types/misc";
 import { SpreadsheetChildEnv } from "../../../../../types/spreadsheet_env";
+import { useModel } from "../../../../owl_plugins/model_plugin";
 import { types } from "../../../../props_validation";
 import { Select } from "../../../../select/select";
 import { SidePanelCollapsible } from "../../../components/collapsible/side_panel_collapsible";
@@ -36,10 +37,12 @@ export class SeriesDesignEditor extends Component<SpreadsheetChildEnv> {
     >([types.UID(), types.object({})], types.DispatchResult()),
   });
 
+  private model = useModel();
+
   protected state = proxy({ dataSetId: this.getDataSeries()[0]?.dataSetId || "" });
 
   private getRuntime(): CustomizableSeriesChartRuntime {
-    const runtime = this.env.model.getters.getChartRuntime(this.props.chartId);
+    const runtime = this.model().getters.getChartRuntime(this.props.chartId);
     if (!runtime || !("customizableSeries" in runtime)) {
       throw new Error(
         "SeriesDesignEditor: chart runtime is not compatible with series customization."

--- a/src/components/side_panel/chart/building_blocks/series_design/series_with_axis_design_editor.ts
+++ b/src/components/side_panel/chart/building_blocks/series_design/series_with_axis_design_editor.ts
@@ -14,6 +14,7 @@ import { DispatchResult } from "../../../../../types/commands";
 import { Color, UID, ValueAndLabel } from "../../../../../types/misc";
 import { SpreadsheetChildEnv } from "../../../../../types/spreadsheet_env";
 import { NumberInput } from "../../../../number_input/number_input";
+import { useModel } from "../../../../owl_plugins/model_plugin";
 import { types } from "../../../../props_validation";
 import { Select } from "../../../../select/select";
 import { Checkbox } from "../../../components/checkbox/checkbox";
@@ -139,7 +140,7 @@ export class SeriesWithAxisDesignEditor extends Component<SpreadsheetChildEnv> {
   }
 
   getMaxPolynomialDegree(dataSetId: UID) {
-    const runtime = this.env.model.getters.getChartRuntime(
+    const runtime = this.model().getters.getChartRuntime(
       this.props.chartId
     ) as CustomizableSeriesChartRuntime;
     const index = runtime.customizableSeries.findIndex((series) => series.dataSetId === dataSetId);
@@ -164,7 +165,7 @@ export class SeriesWithAxisDesignEditor extends Component<SpreadsheetChildEnv> {
       return "";
     }
     const color = dataSets[dataSetId]?.backgroundColor;
-    const runtime = this.env.model.getters.getChartRuntime(
+    const runtime = this.model().getters.getChartRuntime(
       this.props.chartId
     ) as CustomizableSeriesChartRuntime;
     const index = runtime.customizableSeries.findIndex((series) => series.dataSetId === dataSetId);
@@ -195,4 +196,6 @@ export class SeriesWithAxisDesignEditor extends Component<SpreadsheetChildEnv> {
     };
     this.props.updateChart(this.props.chartId, { dataSetStyles });
   }
+
+  private model = useModel();
 }

--- a/src/components/side_panel/chart/calendar_chart/calendar_chart_config_panel.ts
+++ b/src/components/side_panel/chart/calendar_chart/calendar_chart_config_panel.ts
@@ -12,6 +12,7 @@ import {
 import { ChartRangeDataSource } from "../../../../types/chart/chart";
 import { DEFAULT_LOCALE } from "../../../../types/locale";
 import { ValueAndLabel } from "../../../../types/misc";
+import { useModel } from "../../../owl_plugins/model_plugin";
 import { Select } from "../../../select/select";
 import { GenericChartConfigPanel } from "../building_blocks/generic_side_panel/config_panel";
 import { ChartSidePanelProps } from "../common";
@@ -28,24 +29,24 @@ export class CalendarChartConfigPanel extends GenericChartConfigPanel<
   }));
 
   getGroupByOptions(): ValueAndLabel[] {
-    const sheetId = this.env.model.getters.getFigureSheetId(
-      this.env.model.getters.getFigureIdFromChartId(this.props.chartId)
+    const sheetId = this.model().getters.getFigureSheetId(
+      this.model().getters.getFigureIdFromChartId(this.props.chartId)
     )!;
     const definition = SpreadsheetChart.fromStrDefinition(
-      this.env.model.getters,
+      this.model().getters,
       sheetId,
       this.props.definition
     ).getRangeDefinition() as CalendarChartDefinition;
     const data = getBarChartData(
       definition,
-      getChartData(this.env.model.getters, definition.dataSource as ChartRangeDataSource),
-      this.env.model.getters
+      getChartData(this.model().getters, definition.dataSource as ChartRangeDataSource),
+      this.model().getters
     );
     const labels = data.labels.filter((l) => isDateTime(l, DEFAULT_LOCALE));
     if (labels.length === 0) {
       return [];
     }
-    const dates = labels.map((label) => toJsDate(label, this.env.model.getters.getLocale()));
+    const dates = labels.map((label) => toJsDate(label, this.model().getters.getLocale()));
     const uniqueYears = new Set<number>();
     const uniqueMonths = new Set<number>();
     const uniqueDays = new Set<number>();
@@ -97,4 +98,6 @@ export class CalendarChartConfigPanel extends GenericChartConfigPanel<
       [currentAxis === "horizontal" ? "horizontalGroupBy" : "verticalGroupBy"]: value,
     });
   }
+
+  private model = useModel();
 }

--- a/src/components/side_panel/chart/chart_type_picker/chart_type_picker.ts
+++ b/src/components/side_panel/chart/chart_type_picker/chart_type_picker.ts
@@ -12,6 +12,7 @@ import { PropsOf } from "../../../../types/props_of";
 import { SpreadsheetChildEnv } from "../../../../types/spreadsheet_env";
 import { cssPropertiesToCss } from "../../../helpers/css";
 import { isChildEvent } from "../../../helpers/dom_helpers";
+import { useModel } from "../../../owl_plugins/model_plugin";
 import { Popover } from "../../../popover/popover";
 import { types } from "../../../props_validation";
 import { Section } from "../../components/section/section";
@@ -39,10 +40,11 @@ export class ChartTypePicker extends Component<SpreadsheetChildEnv> {
 
   state = proxy<ChartTypePickerState>({ popoverProps: undefined, popoverStyle: "" });
 
+  private model = useModel();
   setup(): void {
     useExternalListener(window, "pointerdown", this.onExternalClick, { capture: true });
 
-    const definition = this.env.model.getters.getChartDefinition(this.props.chartId);
+    const definition = this.model().getters.getChartDefinition(this.props.chartId);
     const supportedTypes = this.getSupportedChartTypes(definition);
 
     for (const subtypeProperties of chartSubtypeRegistry.getAll()) {
@@ -90,7 +92,7 @@ export class ChartTypePicker extends Component<SpreadsheetChildEnv> {
   }
 
   private getChartDefinition(chartId: UID): ChartDefinition {
-    return this.env.model.getters.getChartDefinition(chartId);
+    return this.model().getters.getChartDefinition(chartId);
   }
 
   getSelectedChartSubtypeProperties(): ChartSubtypeProperties {

--- a/src/components/side_panel/chart/combo_chart/combo_chart_design_panel.ts
+++ b/src/components/side_panel/chart/combo_chart/combo_chart_design_panel.ts
@@ -2,6 +2,7 @@ import { _t } from "../../../../translation";
 import { CustomizableSeriesChartRuntime } from "../../../../types/chart/chart";
 import { ComboChartDefinition } from "../../../../types/chart/combo_chart";
 import { UID } from "../../../../types/misc";
+import { useModel } from "../../../owl_plugins/model_plugin";
 import { RadioSelection } from "../../components/radio_selection/radio_selection";
 import { ChartShowDataMarkers } from "../building_blocks/show_data_markers/show_data_markers";
 import { ChartSidePanelProps } from "../common";
@@ -35,7 +36,7 @@ export class ComboChartDesignPanel extends GenericZoomableChartDesignPanel<
       .dataSetStyles as ComboChartDefinition["dataSetStyles"];
     const type = dataSetStyles?.[dataSetId]?.type;
     if (!type) {
-      const runtime = this.env.model.getters.getChartRuntime(
+      const runtime = this.model().getters.getChartRuntime(
         this.props.chartId
       ) as CustomizableSeriesChartRuntime;
       const dataSetIndex = runtime.customizableSeries.findIndex(
@@ -45,4 +46,6 @@ export class ComboChartDesignPanel extends GenericZoomableChartDesignPanel<
     }
     return type;
   }
+
+  private model = useModel();
 }

--- a/src/components/side_panel/chart/funnel_chart_panel/funnel_chart_design_panel.ts
+++ b/src/components/side_panel/chart/funnel_chart_panel/funnel_chart_design_panel.ts
@@ -14,6 +14,7 @@ import { ChartShowValues } from "../building_blocks/show_values/show_values";
 import { ChartSidePanelProps, chartSidePanelPropsDefinition } from "../common";
 
 import { Component } from "../../../../owl3_compatibility_layer";
+import { useModel } from "../../../owl_plugins/model_plugin";
 
 type Props = ChartSidePanelProps<FunnelChartDefinition<string>>;
 
@@ -34,9 +35,7 @@ export class FunnelChartDesignPanel extends Component<SpreadsheetChildEnv> {
   }) as unknown as Props;
 
   getFunnelColorItems() {
-    const runtime = this.env.model.getters.getChartRuntime(
-      this.props.chartId
-    ) as FunnelChartRuntime;
+    const runtime = this.model().getters.getChartRuntime(this.props.chartId) as FunnelChartRuntime;
     const labels: string[] = (runtime.chartJsConfig.data.labels || []) as string[];
     const colors = getFunnelLabelColors(labels, this.props.definition.funnelColors);
     return labels.map((label, index) => ({
@@ -49,4 +48,6 @@ export class FunnelChartDesignPanel extends Component<SpreadsheetChildEnv> {
     const funnelColors = replaceItemAtIndex(this.props.definition.funnelColors || [], color, index);
     this.props.updateChart(this.props.chartId, { funnelColors });
   }
+
+  private model = useModel();
 }

--- a/src/components/side_panel/chart/gauge_chart_panel/gauge_chart_design_panel.ts
+++ b/src/components/side_panel/chart/gauge_chart_panel/gauge_chart_design_panel.ts
@@ -10,6 +10,7 @@ import { Color, ValueAndLabel } from "../../../../types/misc";
 import { PropsOf } from "../../../../types/props_of";
 import { SpreadsheetChildEnv } from "../../../../types/spreadsheet_env";
 import { StandaloneComposer } from "../../../composer/standalone_composer/standalone_composer";
+import { useModel } from "../../../owl_plugins/model_plugin";
 import { Select } from "../../../select/select";
 import { ChartTerms } from "../../../translations_terms";
 import { SidePanelCollapsible } from "../../components/collapsible/side_panel_collapsible";
@@ -43,6 +44,7 @@ export class GaugeChartDesignPanel extends Component<SpreadsheetChildEnv> {
 
   protected state!: PanelState;
 
+  private model = useModel();
   setup() {
     this.state = proxy<PanelState>({
       sectionRuleCancelledReasons: new Set(
@@ -185,11 +187,11 @@ export class GaugeChartDesignPanel extends Component<SpreadsheetChildEnv> {
   }
 
   private valueIsValidNumber(value: string): boolean {
-    const locale = this.env.model.getters.getLocale();
+    const locale = this.model().getters.getLocale();
     if (!value.startsWith("=")) {
       return tryToNumber(value, locale) !== undefined;
     }
-    const evaluatedValue = this.env.model.getters.evaluateFormula(this.sheetId, value);
+    const evaluatedValue = this.model().getters.evaluateFormula(this.sheetId, value);
     if (isMultipleElementMatrix(evaluatedValue)) {
       return false;
     }
@@ -197,7 +199,7 @@ export class GaugeChartDesignPanel extends Component<SpreadsheetChildEnv> {
   }
 
   get sheetId() {
-    const chart = this.env.model.getters.getChart(this.props.chartId);
+    const chart = this.model().getters.getChart(this.props.chartId);
     if (!chart) {
       throw new Error("Chart not found with id " + this.props.chartId);
     }

--- a/src/components/side_panel/chart/geo_chart_panel/geo_chart_region_select_section.ts
+++ b/src/components/side_panel/chart/geo_chart_panel/geo_chart_region_select_section.ts
@@ -7,6 +7,7 @@ import { Select } from "../../../select/select";
 import { Section } from "../../components/section/section";
 
 import { Component } from "../../../../owl3_compatibility_layer";
+import { useModel } from "../../../owl_plugins/model_plugin";
 import { types } from "../../../props_validation";
 export class GeoChartRegionSelectSection extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-GeoChartRegionSelectSection";
@@ -26,7 +27,7 @@ export class GeoChartRegionSelectSection extends Component<SpreadsheetChildEnv> 
   }
 
   get availableRegions() {
-    return this.env.model.getters.getGeoChartAvailableRegions();
+    return this.model().getters.getGeoChartAvailableRegions();
   }
 
   get selectedRegion() {
@@ -36,4 +37,6 @@ export class GeoChartRegionSelectSection extends Component<SpreadsheetChildEnv> 
   get regionOptions(): ValueAndLabel[] {
     return this.availableRegions.map((region) => ({ value: region.id, label: region.label }));
   }
+
+  private model = useModel();
 }

--- a/src/components/side_panel/chart/line_chart/line_chart_config_panel.ts
+++ b/src/components/side_panel/chart/line_chart/line_chart_config_panel.ts
@@ -1,17 +1,18 @@
 import { canChartParseLabels } from "../../../../helpers/figures/charts/runtime/chart_data_extractor";
 import { AxesDesign } from "../../../../types/chart/chart";
 import { LineChartDefinition } from "../../../../types/chart/line_chart";
+import { useModel } from "../../../owl_plugins/model_plugin";
 import { GenericChartConfigPanel } from "../building_blocks/generic_side_panel/config_panel";
 
 export class LineConfigPanel extends GenericChartConfigPanel {
   static template = "o-spreadsheet-LineConfigPanel";
 
   get canTreatLabelsAsText() {
-    const chart = this.env.model.getters.getChart(this.props.chartId);
+    const chart = this.model().getters.getChart(this.props.chartId);
     const definition = chart?.getRangeDefinition();
     const sheetId = chart?.sheetId;
     if (sheetId && definition?.type === "line") {
-      return canChartParseLabels(chart.getData(this.env.model.getters, this.props.chartId));
+      return canChartParseLabels(chart.getData(this.model().getters, this.props.chartId));
     }
     return false;
   }
@@ -67,4 +68,6 @@ export class LineConfigPanel extends GenericChartConfigPanel {
       cumulative,
     });
   }
+
+  private model = useModel();
 }

--- a/src/components/side_panel/chart/main_chart_panel/main_chart_panel.ts
+++ b/src/components/side_panel/chart/main_chart_panel/main_chart_panel.ts
@@ -5,6 +5,7 @@ import { ChartDefinition, ChartType } from "../../../../types/chart/chart";
 import { UID } from "../../../../types/misc";
 import { SpreadsheetChildEnv } from "../../../../types/spreadsheet_env";
 import { Store } from "../../../../types/store_engine";
+import { useModel } from "../../../owl_plugins/model_plugin";
 import { types } from "../../../props_validation";
 import { Section } from "../../components/section/section";
 import { ChartSidePanel, chartSidePanelComponentRegistry } from "../chart_side_panel_registry";
@@ -26,6 +27,7 @@ export class ChartPanel extends Component<SpreadsheetChildEnv> {
     return this.props.chartId;
   }
 
+  private model = useModel();
   setup(): void {
     this.store = useLocalStore(MainChartPanelStore);
   }
@@ -35,7 +37,7 @@ export class ChartPanel extends Component<SpreadsheetChildEnv> {
   }
 
   updateChart<T extends ChartDefinition>(chartId: UID, updateDefinition: Partial<T>) {
-    const figureId = this.env.model.getters.getFigureIdFromChartId(chartId);
+    const figureId = this.model().getters.getFigureIdFromChartId(chartId);
     if (chartId !== this.chartId) {
       return;
     }
@@ -43,28 +45,28 @@ export class ChartPanel extends Component<SpreadsheetChildEnv> {
       ...(this.getChartDefinition(this.chartId) as T),
       ...updateDefinition,
     };
-    return this.env.model.dispatch("UPDATE_CHART", {
+    return this.model().dispatch("UPDATE_CHART", {
       definition,
       chartId,
       figureId,
-      sheetId: this.env.model.getters.getFigureSheetId(figureId)!,
+      sheetId: this.model().getters.getFigureSheetId(figureId)!,
     });
   }
 
   canUpdateChart<T extends ChartDefinition>(chartId: UID, updateDefinition: Partial<T>) {
-    const figureId = this.env.model.getters.getFigureIdFromChartId(chartId);
-    if (chartId !== this.chartId || !this.env.model.getters.isChartDefined(chartId)) {
+    const figureId = this.model().getters.getFigureIdFromChartId(chartId);
+    if (chartId !== this.chartId || !this.model().getters.isChartDefined(chartId)) {
       return;
     }
     const definition: T = {
       ...(this.getChartDefinition(this.chartId) as T),
       ...updateDefinition,
     };
-    return this.env.model.canDispatch("UPDATE_CHART", {
+    return this.model().canDispatch("UPDATE_CHART", {
       definition,
       chartId,
       figureId,
-      sheetId: this.env.model.getters.getFigureSheetId(figureId)!,
+      sheetId: this.model().getters.getFigureSheetId(figureId)!,
     });
   }
 
@@ -79,7 +81,7 @@ export class ChartPanel extends Component<SpreadsheetChildEnv> {
     if (!this.chartId) {
       throw new Error("Chart not defined.");
     }
-    const type = this.env.model.getters.getChartType(this.chartId);
+    const type = this.model().getters.getChartType(this.chartId);
     if (!type) {
       throw new Error("Chart not defined.");
     }
@@ -91,6 +93,6 @@ export class ChartPanel extends Component<SpreadsheetChildEnv> {
   }
 
   private getChartDefinition(chartId: UID): ChartDefinition {
-    return this.env.model.getters.getChartDefinition(chartId);
+    return this.model().getters.getChartDefinition(chartId);
   }
 }

--- a/src/components/side_panel/chart/pie_chart/pie_chart_design_panel.ts
+++ b/src/components/side_panel/chart/pie_chart/pie_chart_design_panel.ts
@@ -5,6 +5,7 @@ import { PieChartDefinition, PieChartRuntime } from "../../../../types/chart/pie
 import { ValueAndLabel } from "../../../../types/misc";
 import { SpreadsheetChildEnv } from "../../../../types/spreadsheet_env";
 import { DEFAULT_DOUGHNUT_CHART_HOLE_SIZE } from "../../../../xlsx/constants";
+import { useModel } from "../../../owl_plugins/model_plugin";
 import { Select } from "../../../select/select";
 import { Checkbox } from "../../components/checkbox/checkbox";
 import { SidePanelCollapsible } from "../../components/collapsible/side_panel_collapsible";
@@ -38,7 +39,7 @@ export class PieChartDesignPanel extends Component<SpreadsheetChildEnv> {
   protected state = proxy({ index: 0 });
 
   get runtime() {
-    return this.env.model.getters.getChartRuntime(this.props.chartId) as PieChartRuntime;
+    return this.model().getters.getChartRuntime(this.props.chartId) as PieChartRuntime;
   }
 
   get isLegendDisabled() {
@@ -93,4 +94,6 @@ export class PieChartDesignPanel extends Component<SpreadsheetChildEnv> {
       label,
     }));
   }
+
+  private model = useModel();
 }

--- a/src/components/side_panel/chart/scatter_chart/scatter_chart_config_panel.ts
+++ b/src/components/side_panel/chart/scatter_chart/scatter_chart_config_panel.ts
@@ -1,17 +1,18 @@
 import { canChartParseLabels } from "../../../../helpers/figures/charts/runtime/chart_data_extractor";
 import { AxesDesign } from "../../../../types/chart/chart";
 import { LineChartDefinition } from "../../../../types/chart/line_chart";
+import { useModel } from "../../../owl_plugins/model_plugin";
 import { GenericChartConfigPanel } from "../building_blocks/generic_side_panel/config_panel";
 
 export class ScatterConfigPanel extends GenericChartConfigPanel {
   static template = "o-spreadsheet-ScatterConfigPanel";
 
   get canTreatLabelsAsText() {
-    const chart = this.env.model.getters.getChart(this.props.chartId);
+    const chart = this.model().getters.getChart(this.props.chartId);
     const definition = chart?.getRangeDefinition();
     const sheetId = chart?.sheetId;
     if (sheetId && definition?.type === "scatter") {
-      return canChartParseLabels(chart.getData(this.env.model.getters, this.props.chartId));
+      return canChartParseLabels(chart.getData(this.model().getters, this.props.chartId));
     }
     return false;
   }
@@ -48,4 +49,6 @@ export class ScatterConfigPanel extends GenericChartConfigPanel {
     }
     return options;
   }
+
+  private model = useModel();
 }

--- a/src/components/side_panel/chart/scorecard_chart_panel/scorecard_chart_design_panel.ts
+++ b/src/components/side_panel/chart/scorecard_chart_panel/scorecard_chart_design_panel.ts
@@ -19,6 +19,7 @@ import { ChartSidePanelProps, chartSidePanelPropsDefinition } from "../common";
 
 import { props } from "@odoo/owl";
 import { Component } from "../../../../owl3_compatibility_layer";
+import { useModel } from "../../../owl_plugins/model_plugin";
 type ColorPickerId = undefined | "backgroundColor" | "baselineColorUp" | "baselineColorDown";
 
 export class ScorecardChartDesignPanel extends Component<SpreadsheetChildEnv> {
@@ -47,7 +48,7 @@ export class ScorecardChartDesignPanel extends Component<SpreadsheetChildEnv> {
   }
 
   translate(term: string): string {
-    return this.env.model.getters.dynamicTranslate(term);
+    return this.model().getters.dynamicTranslate(term);
   }
 
   setColor(color: Color, colorPickerId: ColorPickerId) {
@@ -101,4 +102,6 @@ export class ScorecardChartDesignPanel extends Component<SpreadsheetChildEnv> {
     const baselineDescr = { ...this.baselineStyle, ...style };
     this.props.updateChart(this.props.chartId, { baselineDescr });
   }
+
+  private model = useModel();
 }

--- a/src/components/side_panel/chart/sunburst_chart/sunburst_chart_design_panel.ts
+++ b/src/components/side_panel/chart/sunburst_chart/sunburst_chart_design_panel.ts
@@ -20,6 +20,7 @@ import { ChartSidePanelProps, chartSidePanelPropsDefinition } from "../common";
 
 import { props } from "@odoo/owl";
 import { Component } from "../../../../owl3_compatibility_layer";
+import { useModel } from "../../../owl_plugins/model_plugin";
 export class SunburstChartDesignPanel extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-SunburstChartDesignPanel";
   static components = {
@@ -50,7 +51,7 @@ export class SunburstChartDesignPanel extends Component<SpreadsheetChildEnv> {
 
   get groupColors() {
     const chartId = this.props.chartId;
-    const runtime = this.env.model.getters.getChartRuntime(chartId) as SunburstChartRuntime;
+    const runtime = this.model().getters.getChartRuntime(chartId) as SunburstChartRuntime;
     const dataset = runtime.chartJsConfig.data.datasets[0] as SunburstChartJSDataset;
     return dataset?.groupColors || [];
   }
@@ -67,4 +68,6 @@ export class SunburstChartDesignPanel extends Component<SpreadsheetChildEnv> {
       pieHolePercentage,
     });
   }
+
+  private model = useModel();
 }

--- a/src/components/side_panel/chart/treemap_chart/treemap_category_color/treemap_category_color.ts
+++ b/src/components/side_panel/chart/treemap_chart/treemap_category_color/treemap_category_color.ts
@@ -15,6 +15,7 @@ import { Checkbox } from "../../../components/checkbox/checkbox";
 import { RoundColorPicker } from "../../../components/round_color_picker/round_color_picker";
 
 import { Component } from "../../../../../owl3_compatibility_layer";
+import { useModel } from "../../../../owl_plugins/model_plugin";
 
 export class TreeMapCategoryColors extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-TreeMapCategoryColors";
@@ -42,9 +43,7 @@ export class TreeMapCategoryColors extends Component<SpreadsheetChildEnv> {
   }
 
   getTreeGroupAndColors(): DeepPartial<TreeMapGroupColor[]> {
-    const runtime = this.env.model.getters.getChartRuntime(
-      this.props.chartId
-    ) as TreeMapChartRuntime;
+    const runtime = this.model().getters.getChartRuntime(this.props.chartId) as TreeMapChartRuntime;
     const config = runtime.chartJsConfig as ChartConfiguration<"treemap">;
     return config.data.datasets[0]?.groupColors || [];
   }
@@ -61,4 +60,6 @@ export class TreeMapCategoryColors extends Component<SpreadsheetChildEnv> {
     }
     this.props.onColorChanged({ ...this.coloringOptions, useValueBasedGradient });
   }
+
+  private model = useModel();
 }

--- a/src/components/side_panel/column_stats/column_stats_panel.ts
+++ b/src/components/side_panel/column_stats/column_stats_panel.ts
@@ -12,6 +12,7 @@ import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
 import { Store } from "../../../types/store_engine";
 import { useHighlights } from "../../helpers/highlight_hook";
 import { NumberInput } from "../../number_input/number_input";
+import { useModel } from "../../owl_plugins/model_plugin";
 import { types } from "../../props_validation";
 import { BadgeSelection } from "../components/badge_selection/badge_selection";
 import { SidePanelCollapsible } from "../components/collapsible/side_panel_collapsible";
@@ -36,6 +37,7 @@ export class ColumnStatsPanel extends Component<SpreadsheetChildEnv> {
   private chartCanvasRef = signal<HTMLCanvasElement | null>(null);
   private chart?: Chart;
 
+  private model = useModel();
   setup() {
     this.store = useStore(ColumnStatisticsStore);
     useHighlights(this);
@@ -52,8 +54,8 @@ export class ColumnStatsPanel extends Component<SpreadsheetChildEnv> {
     if (this.store.selectedColumn === undefined) {
       return "";
     }
-    const cell = this.env.model.getters.getEvaluatedCell({
-      sheetId: this.env.model.getters.getActiveSheetId(),
+    const cell = this.model().getters.getEvaluatedCell({
+      sheetId: this.model().getters.getActiveSheetId(),
       col: this.store.selectedColumn,
       row: 0,
     });
@@ -284,7 +286,7 @@ export class ColumnStatsPanel extends Component<SpreadsheetChildEnv> {
     }
     return [
       {
-        range: this.env.model.getters.getRangeFromZone(this.env.model.getters.getActiveSheetId(), {
+        range: this.model().getters.getRangeFromZone(this.model().getters.getActiveSheetId(), {
           top: this.store.ignoredRows,
           left: column,
           bottom: undefined,
@@ -294,8 +296,8 @@ export class ColumnStatsPanel extends Component<SpreadsheetChildEnv> {
         interactive: false,
       },
       ...this.state.highlightPositions.map((position) => ({
-        range: this.env.model.getters.getRangeFromZone(
-          this.env.model.getters.getActiveSheetId(),
+        range: this.model().getters.getRangeFromZone(
+          this.model().getters.getActiveSheetId(),
           positionToZone(position)
         ),
         color: "#ffeb3b9a",

--- a/src/components/side_panel/conditional_formatting/cf_editor/cf_editor.ts
+++ b/src/components/side_panel/conditional_formatting/cf_editor/cf_editor.ts
@@ -10,6 +10,7 @@ import { _t } from "../../../../translation";
 import { UID } from "../../../../types/misc";
 import { SpreadsheetChildEnv } from "../../../../types/spreadsheet_env";
 import { Store } from "../../../../types/store_engine";
+import { useModel } from "../../../owl_plugins/model_plugin";
 import { types } from "../../../props_validation";
 import { SelectionInput } from "../../../selection_input/selection_input";
 import { ValidationMessages } from "../../../validation_messages/validation_messages";
@@ -42,8 +43,9 @@ export class ConditionalFormattingEditor extends Component<SpreadsheetChildEnv> 
   private activeSheetId!: UID;
   private store!: Store<ConditionalFormattingEditorStore>;
 
+  private model = useModel();
   setup() {
-    this.activeSheetId = this.env.model.getters.getActiveSheetId();
+    this.activeSheetId = this.model().getters.getActiveSheetId();
     this.store = useLocalStore(
       ConditionalFormattingEditorStore,
       deepCopy(this.props.cf),
@@ -58,15 +60,15 @@ export class ConditionalFormattingEditor extends Component<SpreadsheetChildEnv> 
           );
         }
       },
-      () => [this.env.model.getters.getActiveSheetId(), this.isEditedCfRemoved]
+      () => [this.model().getters.getActiveSheetId(), this.isEditedCfRemoved]
     );
     useExternalListener(window as any, "click", () => this.store.closeMenus());
   }
 
   get isEditedCfRemoved() {
     return !Boolean(
-      this.env.model.getters
-        .getConditionalFormats(this.activeSheetId)
+      this.model()
+        .getters.getConditionalFormats(this.activeSheetId)
         .find((cf) => cf.id === this.props.cf.id)
     );
   }
@@ -94,15 +96,15 @@ export class ConditionalFormattingEditor extends Component<SpreadsheetChildEnv> 
   onCancel() {
     if (this.store.state.hasEditedCf) {
       if (this.props.isNewCf) {
-        this.env.model.dispatch("REMOVE_CONDITIONAL_FORMAT", {
+        this.model().dispatch("REMOVE_CONDITIONAL_FORMAT", {
           sheetId: this.activeSheetId,
           id: this.props.cf.id,
         });
       } else {
-        this.env.model.dispatch("ADD_CONDITIONAL_FORMAT", {
+        this.model().dispatch("ADD_CONDITIONAL_FORMAT", {
           cf: this.props.cf,
           ranges: this.props.cf.ranges.map((range) =>
-            this.env.model.getters.getRangeDataFromXc(this.activeSheetId, range)
+            this.model().getters.getRangeDataFromXc(this.activeSheetId, range)
           ),
           sheetId: this.activeSheetId,
         });

--- a/src/components/side_panel/conditional_formatting/cf_editor/color_scale_rule_editor_threshold.ts
+++ b/src/components/side_panel/conditional_formatting/cf_editor/color_scale_rule_editor_threshold.ts
@@ -9,6 +9,7 @@ import { ValueAndLabel } from "../../../../types/misc";
 import { PropsOf } from "../../../../types/props_of";
 import { SpreadsheetChildEnv } from "../../../../types/spreadsheet_env";
 import { StandaloneComposer } from "../../../composer/standalone_composer/standalone_composer";
+import { useModel } from "../../../owl_plugins/model_plugin";
 import { types } from "../../../props_validation";
 import { Select } from "../../../select/select";
 import { RoundColorPicker } from "../../components/round_color_picker/round_color_picker";
@@ -85,7 +86,7 @@ export class ColorScaleRuleEditorThreshold extends Component<SpreadsheetChildEnv
       defaultStatic: true,
       invalid: isInvalid,
       class: "o-sidePanel-composer",
-      defaultRangeSheetId: this.env.model.getters.getActiveSheetId(),
+      defaultRangeSheetId: this.model().getters.getActiveSheetId(),
     };
   }
 
@@ -101,4 +102,6 @@ export class ColorScaleRuleEditorThreshold extends Component<SpreadsheetChildEnv
     }
     return [{ value: "value", label: _t("Cell values") }, ...options];
   }
+
+  private model = useModel();
 }

--- a/src/components/side_panel/conditional_formatting/cf_editor/icon_set_rule_editor.ts
+++ b/src/components/side_panel/conditional_formatting/cf_editor/icon_set_rule_editor.ts
@@ -7,6 +7,7 @@ import { PropsOf } from "../../../../types/props_of";
 import { SpreadsheetChildEnv } from "../../../../types/spreadsheet_env";
 import { StandaloneComposer } from "../../../composer/standalone_composer/standalone_composer";
 import { IconPicker } from "../../../icon_picker/icon_picker";
+import { useModel } from "../../../owl_plugins/model_plugin";
 import { types } from "../../../props_validation";
 import { Select } from "../../../select/select";
 import { ConditionalFormattingEditorStore } from "./cf_editor_store";
@@ -71,7 +72,7 @@ export class IconSetRuleEditor extends Component<SpreadsheetChildEnv> {
       defaultStatic: true,
       invalid: isInvalid,
       class: "o-sidePanel-composer",
-      defaultRangeSheetId: this.env.model.getters.getActiveSheetId(),
+      defaultRangeSheetId: this.model().getters.getActiveSheetId(),
     };
   }
 
@@ -90,4 +91,6 @@ export class IconSetRuleEditor extends Component<SpreadsheetChildEnv> {
       { value: "ge", label: ">=" },
     ];
   }
+
+  private model = useModel();
 }

--- a/src/components/side_panel/conditional_formatting/cf_preview/cf_preview.ts
+++ b/src/components/side_panel/conditional_formatting/cf_preview/cf_preview.ts
@@ -8,6 +8,7 @@ import { SpreadsheetChildEnv } from "../../../../types/spreadsheet_env";
 import { cellStyleToCss, cssPropertiesToCss } from "../../../helpers/css";
 import { useHighlightsOnHover } from "../../../helpers/highlight_hook";
 import { ICONS } from "../../../icons/icons";
+import { useModel } from "../../../owl_plugins/model_plugin";
 import { types } from "../../../props_validation";
 import { CfTerms } from "../../../translations_terms";
 
@@ -22,6 +23,7 @@ export class ConditionalFormatPreview extends Component<SpreadsheetChildEnv> {
   icons = ICONS;
   private cfPreviewRef = signal<HTMLElement | null>(null);
 
+  private model = useModel();
   setup() {
     useHighlightsOnHover(this.cfPreviewRef, this);
   }
@@ -52,7 +54,7 @@ export class ConditionalFormatPreview extends Component<SpreadsheetChildEnv> {
       case "CellIsRule":
         return criterionEvaluatorRegistry
           .get(cf.rule.operator)
-          .getPreview({ ...cf.rule, type: cf.rule.operator }, this.env.model.getters);
+          .getPreview({ ...cf.rule, type: cf.rule.operator }, this.model().getters);
       case "ColorScaleRule":
         return CfTerms.ColorScale;
       case "IconSetRule":
@@ -63,9 +65,9 @@ export class ConditionalFormatPreview extends Component<SpreadsheetChildEnv> {
   }
 
   get highlights(): Highlight[] {
-    const sheetId = this.env.model.getters.getActiveSheetId();
+    const sheetId = this.model().getters.getActiveSheetId();
     return this.props.conditionalFormat.ranges.map((range) => ({
-      range: this.env.model.getters.getRangeFromSheetXC(sheetId, range),
+      range: this.model().getters.getRangeFromSheetXC(sheetId, range),
       color: HIGHLIGHT_COLOR,
       fillAlpha: 0.06,
     }));
@@ -79,9 +81,9 @@ export class ConditionalFormatPreview extends Component<SpreadsheetChildEnv> {
   }
 
   deleteConditionalFormat() {
-    this.env.model.dispatch("REMOVE_CONDITIONAL_FORMAT", {
+    this.model().dispatch("REMOVE_CONDITIONAL_FORMAT", {
       id: this.props.conditionalFormat.id,
-      sheetId: this.env.model.getters.getActiveSheetId(),
+      sheetId: this.model().getters.getActiveSheetId(),
     });
   }
 }

--- a/src/components/side_panel/conditional_formatting/cf_preview_list/cf_preview_list.ts
+++ b/src/components/side_panel/conditional_formatting/cf_preview_list/cf_preview_list.ts
@@ -8,6 +8,7 @@ import { UID } from "../../../../types/misc";
 import { SpreadsheetChildEnv } from "../../../../types/spreadsheet_env";
 import { getBoundingRectAsPOJO } from "../../../helpers/dom_helpers";
 import { useDragAndDropListItems } from "../../../helpers/drag_and_drop_dom_items_hook";
+import { useModel } from "../../../owl_plugins/model_plugin";
 import { types } from "../../../props_validation";
 import { ConditionalFormatPreview } from "../cf_preview/cf_preview";
 
@@ -23,12 +24,10 @@ export class ConditionalFormatPreviewList extends Component<SpreadsheetChildEnv>
   private cfListRef = signal<HTMLElement | null>(null);
 
   get conditionalFormats(): ConditionalFormat[] {
-    const cfs = this.env.model.getters.getConditionalFormats(
-      this.env.model.getters.getActiveSheetId()
-    );
+    const cfs = this.model().getters.getConditionalFormats(this.model().getters.getActiveSheetId());
     return cfs.map((cf) => ({
       ...cf,
-      rule: localizeCFRule(cf.rule, this.env.model.getters.getLocale()),
+      rule: localizeCFRule(cf.rule, this.model().getters.getLocale()),
     }));
   }
 
@@ -62,8 +61,8 @@ export class ConditionalFormatPreviewList extends Component<SpreadsheetChildEnv>
   }
 
   onAddConditionalFormat() {
-    const sheetId = this.env.model.getters.getActiveSheetId();
-    const zones = this.env.model.getters.getSelectedZones();
+    const sheetId = this.model().getters.getActiveSheetId();
+    const zones = this.model().getters.getSelectedZones();
     const cf: Omit<ConditionalFormat, "ranges"> = {
       id: UuidGenerator.smallUuid(),
       rule: {
@@ -73,17 +72,15 @@ export class ConditionalFormatPreviewList extends Component<SpreadsheetChildEnv>
         values: [],
       },
     };
-    this.env.model.dispatch("ADD_CONDITIONAL_FORMAT", {
+    this.model().dispatch("ADD_CONDITIONAL_FORMAT", {
       cf,
-      ranges: zones.map((zone) => this.env.model.getters.getRangeDataFromZone(sheetId, zone)),
+      ranges: zones.map((zone) => this.model().getters.getRangeDataFromZone(sheetId, zone)),
       sheetId,
     });
     return this.env.replaceSidePanel("ConditionalFormattingEditor", "ConditionalFormatting", {
       cf: {
         ...cf,
-        ranges: zones.map((zone) =>
-          zoneToXc(this.env.model.getters.getUnboundedZone(sheetId, zone))
-        ),
+        ranges: zones.map((zone) => zoneToXc(this.model().getters.getUnboundedZone(sheetId, zone))),
       },
       isNewCf: true,
     });
@@ -93,11 +90,13 @@ export class ConditionalFormatPreviewList extends Component<SpreadsheetChildEnv>
     const originalIndex = this.conditionalFormats.findIndex((sheet) => sheet.id === cfId);
     const delta = originalIndex - finalIndex;
     if (delta !== 0) {
-      this.env.model.dispatch("CHANGE_CONDITIONAL_FORMAT_PRIORITY", {
+      this.model().dispatch("CHANGE_CONDITIONAL_FORMAT_PRIORITY", {
         cfId,
         delta,
-        sheetId: this.env.model.getters.getActiveSheetId(),
+        sheetId: this.model().getters.getActiveSheetId(),
       });
     }
   }
+
+  private model = useModel();
 }

--- a/src/components/side_panel/criterion_form/criterion_input/criterion_input.ts
+++ b/src/components/side_panel/criterion_form/criterion_input/criterion_input.ts
@@ -6,6 +6,7 @@ import { _t } from "../../../../translation";
 import { PropsOf } from "../../../../types/props_of";
 import { SpreadsheetChildEnv } from "../../../../types/spreadsheet_env";
 import { StandaloneComposer } from "../../../composer/standalone_composer/standalone_composer";
+import { useModel } from "../../../owl_plugins/model_plugin";
 import { types } from "../../../props_validation";
 
 export class CriterionInput extends Component<SpreadsheetChildEnv> {
@@ -33,6 +34,7 @@ export class CriterionInput extends Component<SpreadsheetChildEnv> {
 
   inputRef = signal<HTMLInputElement | null>(null);
 
+  private model = useModel();
   setup() {
     useLayoutEffect(
       () => {
@@ -87,7 +89,7 @@ export class CriterionInput extends Component<SpreadsheetChildEnv> {
       composerContent: this.props.value,
       placeholder: this.placeholder,
       class: "o-sidePanel-composer",
-      defaultRangeSheetId: this.env.model.getters.getActiveSheetId(),
+      defaultRangeSheetId: this.model().getters.getActiveSheetId(),
       invalid: this.state.shouldDisplayError && !!this.errorMessage,
       defaultStatic: true,
       autofocus: this.props.focused,
@@ -98,9 +100,9 @@ export class CriterionInput extends Component<SpreadsheetChildEnv> {
     if (!this.state.shouldDisplayError) {
       return undefined;
     }
-    return this.env.model.getters.getDataValidationInvalidCriterionValueMessage(
+    return this.model().getters.getDataValidationInvalidCriterionValueMessage(
       this.props.criterionType,
-      canonicalizeContent(this.props.value, this.env.model.getters.getLocale())
+      canonicalizeContent(this.props.value, this.model().getters.getLocale())
     );
   }
 }

--- a/src/components/side_panel/criterion_form/value_in_range_criterion/value_in_range_criterion.ts
+++ b/src/components/side_panel/criterion_form/value_in_range_criterion/value_in_range_criterion.ts
@@ -3,6 +3,7 @@ import { _t } from "../../../../translation";
 import { IsValueInRangeCriterion } from "../../../../types/data_validation";
 import { Color, ValueAndLabel } from "../../../../types/misc";
 import { PropsOf } from "../../../../types/props_of";
+import { useModel } from "../../../owl_plugins/model_plugin";
 import { Select } from "../../../select/select";
 import { SelectionInput } from "../../../selection_input/selection_input";
 import { RoundColorPicker } from "../../components/round_color_picker/round_color_picker";
@@ -12,6 +13,7 @@ export class ValueInRangeCriterionForm extends CriterionForm<IsValueInRangeCrite
   static template = "o-spreadsheet-ValueInRangeCriterionForm";
   static components = { RoundColorPicker, SelectionInput, Select };
 
+  private model = useModel();
   setup() {
     super.setup();
     const setupDefault = (props: PropsOf<ValueInRangeCriterionForm>) => {
@@ -38,11 +40,8 @@ export class ValueInRangeCriterionForm extends CriterionForm<IsValueInRangeCrite
   }
 
   get values() {
-    const sheetId = this.env.model.getters.getActiveSheetId();
-    const values = this.env.model.getters.getDataValidationRangeValues(
-      sheetId,
-      this.props.criterion
-    );
+    const sheetId = this.model().getters.getActiveSheetId();
+    const values = this.model().getters.getDataValidationRangeValues(sheetId, this.props.criterion);
     return new Set(values);
   }
 

--- a/src/components/side_panel/data_validation/data_validation_panel.ts
+++ b/src/components/side_panel/data_validation/data_validation_panel.ts
@@ -7,6 +7,7 @@ import { DataValidationPreview } from "./dv_preview/dv_preview";
 
 import { props } from "@odoo/owl";
 import { Component } from "../../../owl3_compatibility_layer";
+import { useModel } from "../../owl_plugins/model_plugin";
 
 export class DataValidationPanel extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-DataValidationPanel";
@@ -26,12 +27,14 @@ export class DataValidationPanel extends Component<SpreadsheetChildEnv> {
     if (!rule) {
       return rule;
     }
-    const locale = this.env.model.getters.getLocale();
+    const locale = this.model().getters.getLocale();
     return localizeDataValidationRule(rule, locale);
   }
 
   get validationRules() {
-    const sheetId = this.env.model.getters.getActiveSheetId();
-    return this.env.model.getters.getDataValidationRules(sheetId);
+    const sheetId = this.model().getters.getActiveSheetId();
+    return this.model().getters.getDataValidationRules(sheetId);
   }
+
+  private model = useModel();
 }

--- a/src/components/side_panel/data_validation/dv_editor/dv_editor.ts
+++ b/src/components/side_panel/data_validation/dv_editor/dv_editor.ts
@@ -17,6 +17,7 @@ import {
 import { UID, ValueAndLabel } from "../../../../types/misc";
 import { SpreadsheetChildEnv } from "../../../../types/spreadsheet_env";
 import { DataValidationRuleData } from "../../../../types/workbook_data";
+import { useModel } from "../../../owl_plugins/model_plugin";
 import { types } from "../../../props_validation";
 import { Select } from "../../../select/select";
 import { SelectionInput } from "../../../selection_input/selection_input";
@@ -38,6 +39,7 @@ export class DataValidationEditor extends Component<SpreadsheetChildEnv> {
     "onCancel?": types.function([]),
     onCloseSidePanel: types.function([]),
   });
+  private model = useModel();
 
   state = proxy<State>({
     rule: this.defaultDataValidationRule,
@@ -47,17 +49,14 @@ export class DataValidationEditor extends Component<SpreadsheetChildEnv> {
   private editingSheetId!: UID;
 
   setup() {
-    this.editingSheetId = this.env.model.getters.getActiveSheetId();
-    const rule = this.env.model.getters.getDataValidationRule(
-      this.editingSheetId,
-      this.props.ruleId
-    );
+    this.editingSheetId = this.model().getters.getActiveSheetId();
+    const rule = this.model().getters.getDataValidationRule(this.editingSheetId, this.props.ruleId);
     if (rule) {
-      const locale = this.env.model.getters.getLocale();
+      const locale = this.model().getters.getLocale();
       this.state.rule = {
         ...localizeDataValidationRule(rule, locale),
         ranges: rule.ranges.map((range) =>
-          this.env.model.getters.getRangeString(range, this.editingSheetId)
+          this.model().getters.getRangeString(range, this.editingSheetId)
         ),
       };
     }
@@ -86,7 +85,7 @@ export class DataValidationEditor extends Component<SpreadsheetChildEnv> {
   }
 
   onSave() {
-    const result = this.env.model.dispatch("ADD_DATA_VALIDATION_RULE", this.dispatchPayload);
+    const result = this.model().dispatch("ADD_DATA_VALIDATION_RULE", this.dispatchPayload);
     if (!result.isSuccessful) {
       this.state.errors = result.reasons;
       return;
@@ -96,7 +95,7 @@ export class DataValidationEditor extends Component<SpreadsheetChildEnv> {
 
   get dispatchPayload(): Omit<AddDataValidationCommand, "type"> {
     const rule = { ...this.state.rule, ranges: undefined };
-    const locale = this.env.model.getters.getLocale();
+    const locale = this.model().getters.getLocale();
 
     const criterion = rule.criterion;
     const criterionEvaluator = criterionEvaluatorRegistry.get(criterion.type);
@@ -109,7 +108,7 @@ export class DataValidationEditor extends Component<SpreadsheetChildEnv> {
     return {
       sheetId: this.editingSheetId,
       ranges: this.state.rule.ranges.map((xc) =>
-        this.env.model.getters.getRangeDataFromXc(this.editingSheetId, xc)
+        this.model().getters.getRangeDataFromXc(this.editingSheetId, xc)
       ),
       rule,
     };
@@ -120,10 +119,10 @@ export class DataValidationEditor extends Component<SpreadsheetChildEnv> {
   }
 
   get defaultDataValidationRule(): DataValidationRuleData {
-    const sheetId = this.env.model.getters.getActiveSheetId();
-    const ranges = this.env.model.getters
-      .getSelectedZones()
-      .map((zone) => zoneToXc(this.env.model.getters.getUnboundedZone(sheetId, zone)));
+    const sheetId = this.model().getters.getActiveSheetId();
+    const ranges = this.model()
+      .getters.getSelectedZones()
+      .map((zone) => zoneToXc(this.model().getters.getUnboundedZone(sheetId, zone)));
     return {
       id: this.props.ruleId,
       criterion: { type: "containsText", values: [""] },

--- a/src/components/side_panel/data_validation/dv_preview/dv_preview.ts
+++ b/src/components/side_panel/data_validation/dv_preview/dv_preview.ts
@@ -5,6 +5,7 @@ import { criterionEvaluatorRegistry } from "../../../../registries/criterion_reg
 import { Highlight } from "../../../../types/misc";
 import { SpreadsheetChildEnv } from "../../../../types/spreadsheet_env";
 import { useHighlightsOnHover } from "../../../helpers/highlight_hook";
+import { useModel } from "../../../owl_plugins/model_plugin";
 import { types } from "../../../props_validation";
 
 export class DataValidationPreview extends Component<SpreadsheetChildEnv> {
@@ -16,6 +17,7 @@ export class DataValidationPreview extends Component<SpreadsheetChildEnv> {
 
   private dvPreviewRef = signal<HTMLElement | null>(null);
 
+  private model = useModel();
   setup() {
     useHighlightsOnHover(this.dvPreviewRef, this);
   }
@@ -27,8 +29,8 @@ export class DataValidationPreview extends Component<SpreadsheetChildEnv> {
   }
 
   deleteDataValidation() {
-    const sheetId = this.env.model.getters.getActiveSheetId();
-    this.env.model.dispatch("REMOVE_DATA_VALIDATION_RULE", { sheetId, id: this.props.rule.id });
+    const sheetId = this.model().getters.getActiveSheetId();
+    this.model().dispatch("REMOVE_DATA_VALIDATION_RULE", { sheetId, id: this.props.rule.id });
   }
 
   get highlights(): Highlight[] {
@@ -40,15 +42,15 @@ export class DataValidationPreview extends Component<SpreadsheetChildEnv> {
   }
 
   get rangesString(): string {
-    const sheetId = this.env.model.getters.getActiveSheetId();
+    const sheetId = this.model().getters.getActiveSheetId();
     return this.props.rule.ranges
-      .map((range) => this.env.model.getters.getRangeString(range, sheetId))
+      .map((range) => this.model().getters.getRangeString(range, sheetId))
       .join(", ");
   }
 
   get descriptionString(): string {
     return criterionEvaluatorRegistry
       .get(this.props.rule.criterion.type)
-      .getPreview(this.props.rule.criterion, this.env.model.getters);
+      .getPreview(this.props.rule.criterion, this.model().getters);
   }
 }

--- a/src/components/side_panel/find_and_replace/find_and_replace.ts
+++ b/src/components/side_panel/find_and_replace/find_and_replace.ts
@@ -9,6 +9,7 @@ import { DebouncedFunction, ValueAndLabel } from "../../../types/misc";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
 import { Store } from "../../../types/store_engine";
 import { keyboardEventToShortcutString } from "../../helpers/dom_helpers";
+import { useModel } from "../../owl_plugins/model_plugin";
 import { types } from "../../props_validation";
 import { Select } from "../../select/select";
 import { SelectionInput } from "../../selection_input/selection_input";
@@ -44,7 +45,7 @@ export class FindAndReplacePanel extends Component<SpreadsheetChildEnv> {
   get currentSheetMatchesCount() {
     return _t("%(matches)s matches in %(sheetName)s", {
       matches: this.store.activeSheetMatchesCount,
-      sheetName: this.env.model.getters.getSheetName(this.env.model.getters.getActiveSheetId()),
+      sheetName: this.model().getters.getSheetName(this.model().getters.getActiveSheetId()),
     });
   }
 
@@ -57,7 +58,7 @@ export class FindAndReplacePanel extends Component<SpreadsheetChildEnv> {
     return _t("%(matches)s matches in range %(range)s of %(sheetName)s", {
       matches: this.store.specificRangeMatchesCount,
       range: zoneToXc(zone),
-      sheetName: this.env.model.getters.getSheetName(sheetId),
+      sheetName: this.model().getters.getSheetName(sheetId),
     });
   }
 
@@ -72,6 +73,7 @@ export class FindAndReplacePanel extends Component<SpreadsheetChildEnv> {
     ];
   }
 
+  private model = useModel();
   setup() {
     this.store = useLocalStore(FindAndReplaceStore);
     this.state = proxy({ dataRange: "" });
@@ -149,8 +151,8 @@ export class FindAndReplacePanel extends Component<SpreadsheetChildEnv> {
     if (!this.state.dataRange || this.searchOptions.searchScope !== "specificRange") {
       return;
     }
-    const specificRange = this.env.model.getters.getRangeFromSheetXC(
-      this.env.model.getters.getActiveSheetId(),
+    const specificRange = this.model().getters.getRangeFromSheetXC(
+      this.model().getters.getActiveSheetId(),
       this.state.dataRange
     );
     this.store.updateSearchOptions({ specificRange });
@@ -158,7 +160,7 @@ export class FindAndReplacePanel extends Component<SpreadsheetChildEnv> {
 
   get specificRange(): string {
     const range = this.store.searchOptions.specificRange;
-    return range ? this.env.model.getters.getRangeString(range, "forceSheetReference") : "";
+    return range ? this.model().getters.getRangeString(range, "forceSheetReference") : "";
   }
 
   get pendingSearch() {
@@ -170,7 +172,7 @@ export class FindAndReplacePanel extends Component<SpreadsheetChildEnv> {
     // and have specific behaviour linked to it (eg. go back to the initial sheet after confirmation).
     // We don't want all those behaviors here, so we force the recreation of the component when the active sheet changes.
     // The only drawback is that the input loses focus when changing sheet.
-    return this.env.model.getters.getActiveSheetId();
+    return this.model().getters.getActiveSheetId();
   }
 
   get searchScopeOptions(): ValueAndLabel[] {

--- a/src/components/side_panel/find_and_replace/find_and_replace.xml
+++ b/src/components/side_panel/find_and_replace/find_and_replace.xml
@@ -78,7 +78,7 @@
           <ValidationMessages msgType="'info'" messages="this.searchInfo" singleBox="true"/>
         </div>
       </Section>
-      <t t-if="!this.env.model.getters.isReadonly()">
+      <t t-if="!this.model().getters.isReadonly()">
         <Section class="'pt-0'" title.translate="Replace">
           <div class="o-input-search-container">
             <input

--- a/src/components/side_panel/named_ranges_panel/named_range_preview/named_range_preview.ts
+++ b/src/components/side_panel/named_ranges_panel/named_range_preview/named_range_preview.ts
@@ -5,6 +5,7 @@ import { Component } from "../../../../owl3_compatibility_layer";
 import { Highlight } from "../../../../types/misc";
 import { SpreadsheetChildEnv } from "../../../../types/spreadsheet_env";
 import { useHighlightsOnHover } from "../../../helpers/highlight_hook";
+import { useModel } from "../../../owl_plugins/model_plugin";
 import { types } from "../../../props_validation";
 import { SelectionInput } from "../../../selection_input/selection_input";
 import { TextInput } from "../../../text_input/text_input";
@@ -26,6 +27,7 @@ export class NamedRangePreview extends Component<SpreadsheetChildEnv> {
 
   private namedRangePreviewRef = signal<HTMLElement | null>(null);
 
+  private model = useModel();
   setup() {
     useHighlightsOnHover(this.namedRangePreviewRef, this);
   }
@@ -38,17 +40,17 @@ export class NamedRangePreview extends Component<SpreadsheetChildEnv> {
   }
 
   deleteNamedRange() {
-    this.env.model.dispatch("DELETE_NAMED_RANGE", {
+    this.model().dispatch("DELETE_NAMED_RANGE", {
       name: this.props.namedRange.name,
     });
   }
 
   updateNamedRangeName(newName: string) {
     newName = newName.replace(/ /g, "_");
-    interactiveUpdateNamedRange(this.env, {
+    interactiveUpdateNamedRange(this.model(), this.env, {
       oldRangeName: this.props.namedRange.name,
       newRangeName: newName,
-      ranges: [this.env.model.getters.getRangeData(this.props.namedRange.range)],
+      ranges: [this.model().getters.getRangeData(this.props.namedRange.range)],
     });
   }
 
@@ -59,18 +61,18 @@ export class NamedRangePreview extends Component<SpreadsheetChildEnv> {
   onSelectionInputConfirmed() {
     this.state.isSelectionInputFocused = false;
     if (this.state.currentRange) {
-      const range = this.env.model.getters.getRangeFromSheetXC(
-        this.env.model.getters.getActiveSheetId(),
+      const range = this.model().getters.getRangeFromSheetXC(
+        this.model().getters.getActiveSheetId(),
         this.state.currentRange
       );
       if (range.invalidSheetName || range.invalidXc) {
         return;
       }
 
-      interactiveUpdateNamedRange(this.env, {
+      interactiveUpdateNamedRange(this.model(), this.env, {
         oldRangeName: this.props.namedRange.name,
         newRangeName: this.props.namedRange.name,
-        ranges: [this.env.model.getters.getRangeData(range)],
+        ranges: [this.model().getters.getRangeData(range)],
       });
     }
   }
@@ -80,9 +82,9 @@ export class NamedRangePreview extends Component<SpreadsheetChildEnv> {
   }
 
   get rangeString(): string {
-    return this.env.model.getters.getRangeString(
+    return this.model().getters.getRangeString(
       this.props.namedRange.range,
-      this.env.model.getters.getActiveSheetId()
+      this.model().getters.getActiveSheetId()
     );
   }
 }

--- a/src/components/side_panel/named_ranges_panel/named_ranges_panel.ts
+++ b/src/components/side_panel/named_ranges_panel/named_ranges_panel.ts
@@ -8,6 +8,7 @@ import { NamedRangePreview } from "./named_range_preview/named_range_preview";
 
 import { props } from "@odoo/owl";
 import { Component } from "../../../owl3_compatibility_layer";
+import { useModel } from "../../owl_plugins/model_plugin";
 
 export class NamedRangesPanel extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-NamedRangesPanel";
@@ -18,18 +19,20 @@ export class NamedRangesPanel extends Component<SpreadsheetChildEnv> {
   });
 
   get namedRanges() {
-    return this.env.model.getters.getNamedRanges();
+    return this.model().getters.getNamedRanges();
   }
 
   addNewNamedRange() {
     const existingNames = this.namedRanges.map((nr) => nr.name);
-    const sheetId = this.env.model.getters.getActiveSheetId();
-    const selection = this.env.model.getters.getSelectedZone();
-    this.env.model.dispatch("CREATE_NAMED_RANGE", {
+    const sheetId = this.model().getters.getActiveSheetId();
+    const selection = this.model().getters.getSelectedZone();
+    this.model().dispatch("CREATE_NAMED_RANGE", {
       name: getUniqueText(_t("Named_Range"), existingNames, {
         compute: (text, index) => `${text}${index}`,
       }),
-      ranges: [this.env.model.getters.getRangeDataFromZone(sheetId, selection)],
+      ranges: [this.model().getters.getRangeDataFromZone(sheetId, selection)],
     });
   }
+
+  private model = useModel();
 }

--- a/src/components/side_panel/perf_profile/perf_profile_panel.ts
+++ b/src/components/side_panel/perf_profile/perf_profile_panel.ts
@@ -6,6 +6,7 @@ import { PerfProfile, RangeTiming } from "../../../types/functions";
 import { Highlight } from "../../../types/misc";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
 import { useHighlights } from "../../helpers/highlight_hook";
+import { useModel } from "../../owl_plugins/model_plugin";
 import { types } from "../../props_validation";
 import { Section } from "../components/section/section";
 
@@ -24,12 +25,13 @@ export class PerfProfilePanel extends Component<SpreadsheetChildEnv> {
     lastProfiledTime: 0,
   });
 
+  private model = useModel();
   setup() {
     useHighlights(this);
   }
 
   get perfProfile(): PerfProfile | undefined {
-    return this.env.model.getters.getPerfProfile();
+    return this.model().getters.getPerfProfile();
   }
 
   get highlights(): Highlight[] {
@@ -45,7 +47,7 @@ export class PerfProfilePanel extends Component<SpreadsheetChildEnv> {
   }
 
   stringifyRange({ range }: RangeTiming) {
-    return this.env.model.getters.getRangeString(range, "forceSheetReference");
+    return this.model().getters.getRangeString(range, "forceSheetReference");
   }
 
   startProfiling(event: MouseEvent) {
@@ -53,7 +55,7 @@ export class PerfProfilePanel extends Component<SpreadsheetChildEnv> {
       return;
     }
     this.state.selectedIndex = undefined;
-    this.env.model.dispatch("EVALUATE_CELLS", { profiling: true });
+    this.model().dispatch("EVALUATE_CELLS", { profiling: true });
     this.state.lastProfiledTime = performance.now(); // has the same reference time as event.timeStamp. Don't use Date.now().
   }
 
@@ -64,12 +66,12 @@ export class PerfProfilePanel extends Component<SpreadsheetChildEnv> {
   selectEntry(index: number) {
     this.state.selectedIndex = index;
     const entry = this.perfProfile?.entries[index];
-    if (!entry || !this.env.model.getters.tryGetSheet(entry.range.sheetId)) {
+    if (!entry || !this.model().getters.tryGetSheet(entry.range.sheetId)) {
       return;
     }
-    const activeSheetId = this.env.model.getters.getActiveSheetId();
+    const activeSheetId = this.model().getters.getActiveSheetId();
     if (entry.range.sheetId !== activeSheetId) {
-      this.env.model.dispatch("ACTIVATE_SHEET", {
+      this.model().dispatch("ACTIVATE_SHEET", {
         sheetIdFrom: activeSheetId,
         sheetIdTo: entry.range.sheetId,
       });
@@ -77,12 +79,12 @@ export class PerfProfilePanel extends Component<SpreadsheetChildEnv> {
     const zone = entry.range.zone;
     // Select the bottom right cell of the range first to ensure most of
     // the range is visible.
-    this.env.model.selection.selectCell(zone.right, zone.bottom);
-    this.env.model.selection.selectCell(zone.left, zone.top);
+    this.model().selection.selectCell(zone.right, zone.bottom);
+    this.model().selection.selectCell(zone.left, zone.top);
   }
 
   formatTime(ms: number): string {
-    const locale = this.env.model.getters.getLocale();
+    const locale = this.model().getters.getLocale();
     if (ms >= 1000) {
       return _t("%(seconds)s s", {
         seconds: formatValue(ms / 1000, { format: "0.00", locale }),
@@ -94,7 +96,7 @@ export class PerfProfilePanel extends Component<SpreadsheetChildEnv> {
   }
 
   humanize(time: number): string {
-    const locale = this.env.model.getters.getLocale();
+    const locale = this.model().getters.getLocale();
     return humanizeNumber({ value: time }, locale);
   }
 
@@ -105,7 +107,7 @@ export class PerfProfilePanel extends Component<SpreadsheetChildEnv> {
     }
     return formatValue(time / total, {
       format: "0.0%",
-      locale: this.env.model.getters.getLocale(),
+      locale: this.model().getters.getLocale(),
     });
   }
 

--- a/src/components/side_panel/pivot/pivot_custom_groups_collapsible/pivot_custom_groups_collapsible.ts
+++ b/src/components/side_panel/pivot/pivot_custom_groups_collapsible/pivot_custom_groups_collapsible.ts
@@ -9,6 +9,7 @@ import {
   PivotCustomGroupedField,
 } from "../../../../types/pivot";
 import { SpreadsheetChildEnv } from "../../../../types/spreadsheet_env";
+import { useModel } from "../../../owl_plugins/model_plugin";
 import { types } from "../../../props_validation";
 import { TextInput } from "../../../text_input/text_input";
 import { Checkbox } from "../../components/checkbox/checkbox";
@@ -67,9 +68,11 @@ export class PivotCustomGroupsCollapsible extends Component<SpreadsheetChildEnv>
   }
 
   private updateCustomField(customField: PivotCustomGroupedField) {
-    const definition = this.env.model.getters.getPivotCoreDefinition(this.props.pivotId);
+    const definition = this.model().getters.getPivotCoreDefinition(this.props.pivotId);
     this.props.onCustomFieldUpdated({
       customFields: { ...definition.customFields, [customField.name]: customField },
     });
   }
+
+  private model = useModel();
 }

--- a/src/components/side_panel/pivot/pivot_filter/pivot_filter.ts
+++ b/src/components/side_panel/pivot/pivot_filter/pivot_filter.ts
@@ -14,6 +14,7 @@ import { SpreadsheetChildEnv } from "../../../../types/spreadsheet_env";
 import { DataFilterValue } from "../../../../types/table";
 import { PivotFilterMenu } from "../../../filters/pivot_filter_menu/pivot_filter_menu";
 import { isChildEvent } from "../../../helpers/dom_helpers";
+import { useModel } from "../../../owl_plugins/model_plugin";
 import { Popover } from "../../../popover/popover";
 import { types } from "../../../props_validation";
 import { PivotDimension } from "../pivot_layout_configurator/pivot_dimension/pivot_dimension";
@@ -50,6 +51,7 @@ export class PivotFilterEditor extends Component<SpreadsheetChildEnv> {
   private buttonFilter = signal<HTMLElement | null>(null);
   private popover!: { isOpen: boolean };
 
+  private model = useModel();
   setup() {
     useExternalListener(window, "click", (ev) => {
       if (!isChildEvent(this.buttonFilter(), ev)) {
@@ -74,7 +76,7 @@ export class PivotFilterEditor extends Component<SpreadsheetChildEnv> {
       }
       return criterionEvaluatorRegistry
         .get(this.props.filter.type)
-        .getPreview(this.props.filter as GenericCriterion, this.env.model.getters);
+        .getPreview(this.props.filter as GenericCriterion, this.model().getters);
     }
 
     const numberOfHiddenValues = this.props.filter.hiddenValues.length;
@@ -90,7 +92,7 @@ export class PivotFilterEditor extends Component<SpreadsheetChildEnv> {
   }
 
   private getFilterHiddenValues(props: PropsOf<PivotFilterEditor>): Value[] {
-    const pivot = this.env.model.getters.getPivot(props.pivotId) as SpreadsheetPivot;
+    const pivot = this.model().getters.getPivot(props.pivotId) as SpreadsheetPivot;
     if (pivot.type !== "SPREADSHEET") {
       throw new Error("Filters are only available on spreadsheet pivot table");
     }
@@ -134,7 +136,7 @@ export class PivotFilterEditor extends Component<SpreadsheetChildEnv> {
   }
 
   getCell(position: CellPosition): Cell | undefined {
-    return this.env.model.getters.getCell(position);
+    return this.model().getters.getCell(position);
   }
 
   removeFilter(filter: PivotFilter) {

--- a/src/components/side_panel/pivot/pivot_layout_configurator/pivot_layout_configurator.ts
+++ b/src/components/side_panel/pivot/pivot_layout_configurator/pivot_layout_configurator.ts
@@ -24,6 +24,7 @@ import { SpreadsheetChildEnv } from "../../../../types/spreadsheet_env";
 import { Store } from "../../../../types/store_engine";
 import { ComposerFocusStore } from "../../../composer/composer_focus_store";
 import { useDragAndDropListItems } from "../../../helpers/drag_and_drop_dom_items_hook";
+import { useModel } from "../../../owl_plugins/model_plugin";
 import { types } from "../../../props_validation";
 import { SidePanelCollapsible } from "../../components/collapsible/side_panel_collapsible";
 import { PivotCustomGroupsCollapsible } from "../pivot_custom_groups_collapsible/pivot_custom_groups_collapsible";
@@ -70,6 +71,7 @@ export class PivotLayoutConfigurator extends Component<SpreadsheetChildEnv> {
 
   isDateOrDatetimeField = isDateOrDatetimeField;
 
+  private model = useModel();
   setup() {
     this.composerFocus = useStore(ComposerFocusStore);
   }
@@ -260,7 +262,7 @@ export class PivotLayoutConfigurator extends Component<SpreadsheetChildEnv> {
 
   addCalculatedMeasure() {
     const { measures }: { measures: PivotCoreMeasure[] } = this.props.definition;
-    const measureName = this.env.model.getters.generateNewCalculatedMeasureName(measures);
+    const measureName = this.model().getters.generateNewCalculatedMeasureName(measures);
     const aggregator = "sum";
     this.props.onDimensionsUpdated({
       measures: measures.concat([
@@ -269,7 +271,7 @@ export class PivotLayoutConfigurator extends Component<SpreadsheetChildEnv> {
           fieldName: measureName,
           aggregator,
           computedBy: {
-            sheetId: this.env.model.getters.getActiveSheetId(),
+            sheetId: this.model().getters.getActiveSheetId(),
             formula: "=0",
           },
         },
@@ -278,7 +280,7 @@ export class PivotLayoutConfigurator extends Component<SpreadsheetChildEnv> {
   }
 
   getCustomField(dimension: PivotDimensionType) {
-    const definition = this.env.model.getters.getPivotCoreDefinition(this.props.pivotId);
+    const definition = this.model().getters.getPivotCoreDefinition(this.props.pivotId);
     return definition.customFields?.[dimension.nameWithGranularity];
   }
 
@@ -323,7 +325,7 @@ export class PivotLayoutConfigurator extends Component<SpreadsheetChildEnv> {
   }
 
   getHugeDimensionErrorMessage(dimension: PivotDimensionType) {
-    const pivot = this.env.model.getters.getPivot(this.props.pivotId);
+    const pivot = this.model().getters.getPivot(this.props.pivotId);
     const possibleValues = pivot.getPossibleFieldValues(dimension);
     return possibleValues.length > 100
       ? _t(

--- a/src/components/side_panel/pivot/pivot_layout_configurator/pivot_measure/pivot_measure.ts
+++ b/src/components/side_panel/pivot/pivot_layout_configurator/pivot_measure/pivot_measure.ts
@@ -11,6 +11,7 @@ import { Color, ValueAndLabel } from "../../../../../types/misc";
 import { PivotMeasure } from "../../../../../types/pivot";
 import { SpreadsheetChildEnv } from "../../../../../types/spreadsheet_env";
 import { StandaloneComposer } from "../../../../composer/standalone_composer/standalone_composer";
+import { useModel } from "../../../../owl_plugins/model_plugin";
 import { types } from "../../../../props_validation";
 import { Select } from "../../../../select/select";
 import { measureDisplayTerms } from "../../../../translations_terms";
@@ -44,7 +45,7 @@ export class PivotMeasureEditor extends Component<SpreadsheetChildEnv> {
     this.props.onMeasureUpdated({
       ...this.props.measure,
       computedBy: {
-        sheetId: this.env.model.getters.getActiveSheetId(),
+        sheetId: this.model().getters.getActiveSheetId(),
         formula: formula[0] === "=" ? formula : "=" + formula,
       },
     });
@@ -126,7 +127,7 @@ export class PivotMeasureEditor extends Component<SpreadsheetChildEnv> {
     if (!measureDisplay || measureDisplay.type === "no_calculations") {
       return "";
     }
-    const pivot = this.env.model.getters.getPivot(this.props.pivotId);
+    const pivot = this.model().getters.getPivot(this.props.pivotId);
     const field = [...pivot.definition.columns, ...pivot.definition.rows].find(
       (f) => f.nameWithGranularity === measureDisplay.fieldNameWithGranularity
     );
@@ -134,4 +135,6 @@ export class PivotMeasureEditor extends Component<SpreadsheetChildEnv> {
     const value = measureDisplay.value?.toString() || "";
     return measureDisplayTerms.descriptions[measureDisplay.type](fieldName, value);
   }
+
+  private model = useModel();
 }

--- a/src/components/side_panel/pivot/pivot_layout_configurator/pivot_sort_section/pivot_sort_section.ts
+++ b/src/components/side_panel/pivot/pivot_layout_configurator/pivot_sort_section/pivot_sort_section.ts
@@ -8,6 +8,7 @@ import { Component } from "../../../../../owl3_compatibility_layer";
 import { _t } from "../../../../../translation";
 import { PivotDomain } from "../../../../../types/pivot";
 import { SpreadsheetChildEnv } from "../../../../../types/spreadsheet_env";
+import { useModel } from "../../../../owl_plugins/model_plugin";
 import { types } from "../../../../props_validation";
 import { Section } from "../../../components/section/section";
 
@@ -22,7 +23,7 @@ export class PivotSortSection extends Component<SpreadsheetChildEnv> {
   });
 
   get hasValidSort() {
-    const pivot = this.env.model.getters.getPivot(this.props.pivotId);
+    const pivot = this.model().getters.getPivot(this.props.pivotId);
     return (
       !!this.props.definition.sortedColumn &&
       isSortedColumnValid(this.props.definition.sortedColumn, pivot)
@@ -42,8 +43,8 @@ export class PivotSortSection extends Component<SpreadsheetChildEnv> {
     if (!sortedColumn) {
       return [];
     }
-    const pivot = this.env.model.getters.getPivot(this.props.pivotId);
-    const locale = this.env.model.getters.getLocale();
+    const pivot = this.model().getters.getPivot(this.props.pivotId);
+    const locale = this.model().getters.getLocale();
 
     const currentDomain: PivotDomain = [];
     const sortValues: { field?: string; value: string }[] = [];
@@ -63,4 +64,6 @@ export class PivotSortSection extends Component<SpreadsheetChildEnv> {
 
     return sortValues;
   }
+
+  private model = useModel();
 }

--- a/src/components/side_panel/pivot/pivot_side_panel/pivot_design_panel/pivot_design_panel.ts
+++ b/src/components/side_panel/pivot/pivot_side_panel/pivot_design_panel/pivot_design_panel.ts
@@ -8,6 +8,7 @@ import { SpreadsheetChildEnv } from "../../../../../types/spreadsheet_env";
 import { Store } from "../../../../../types/store_engine";
 import { TableConfig, TableStyle } from "../../../../../types/table";
 import { NumberInput } from "../../../../number_input/number_input";
+import { useModel } from "../../../../owl_plugins/model_plugin";
 import { types } from "../../../../props_validation";
 import { TableStylePicker } from "../../../../tables/table_style_picker/table_style_picker";
 import { Checkbox } from "../../../components/checkbox/checkbox";
@@ -24,6 +25,7 @@ export class PivotDesignPanel extends Component<SpreadsheetChildEnv> {
 
   store!: Store<PivotSidePanelStore>;
 
+  private model = useModel();
   setup() {
     this.store = useLocalStore(PivotSidePanelStore, this.props.pivotId, "neverDefer");
   }
@@ -38,7 +40,7 @@ export class PivotDesignPanel extends Component<SpreadsheetChildEnv> {
   }
 
   get pivotStyle() {
-    const pivot = this.env.model.getters.getPivotCoreDefinition(this.props.pivotId);
+    const pivot = this.model().getters.getPivotCoreDefinition(this.props.pivotId);
     return pivot.style || {};
   }
 

--- a/src/components/side_panel/pivot/pivot_side_panel/pivot_side_panel.ts
+++ b/src/components/side_panel/pivot/pivot_side_panel/pivot_side_panel.ts
@@ -5,6 +5,7 @@ import { Component } from "../../../../owl3_compatibility_layer";
 import { PropsOf } from "../../../../types/props_of";
 import { SpreadsheetChildEnv } from "../../../../types/spreadsheet_env";
 import { useHighlights } from "../../../helpers/highlight_hook";
+import { useModel } from "../../../owl_plugins/model_plugin";
 import { types } from "../../../props_validation";
 import { Section } from "../../components/section/section";
 import { PivotLayoutConfigurator } from "../pivot_layout_configurator/pivot_layout_configurator";
@@ -35,6 +36,7 @@ export class PivotSidePanel extends Component<SpreadsheetChildEnv> {
 
   state = proxy<State>({ panel: this.props.openTab || "configuration" });
 
+  private model = useModel();
   setup() {
     useHighlights(this);
     onWillUpdateProps((nextProps: PropsOf<PivotSidePanel>) => {
@@ -45,7 +47,7 @@ export class PivotSidePanel extends Component<SpreadsheetChildEnv> {
   }
 
   get sidePanelEditor() {
-    const pivot = this.env.model.getters.getPivotCoreDefinition(this.props.pivotId);
+    const pivot = this.model().getters.getPivotCoreDefinition(this.props.pivotId);
     if (!pivot) {
       throw new Error("pivotId does not correspond to a pivot.");
     }
@@ -54,7 +56,7 @@ export class PivotSidePanel extends Component<SpreadsheetChildEnv> {
 
   get highlights() {
     return this.state.panel === "configuration"
-      ? getPivotHighlights(this.env.model.getters, this.props.pivotId)
+      ? getPivotHighlights(this.model().getters, this.props.pivotId)
       : [];
   }
 

--- a/src/components/side_panel/pivot/pivot_side_panel/pivot_spreadsheet_side_panel/pivot_spreadsheet_side_panel.ts
+++ b/src/components/side_panel/pivot/pivot_side_panel/pivot_spreadsheet_side_panel/pivot_spreadsheet_side_panel.ts
@@ -6,6 +6,7 @@ import { useLocalStore } from "../../../../../store_engine/store_hooks";
 import { SpreadsheetPivotCoreDefinition } from "../../../../../types/pivot";
 import { SpreadsheetChildEnv } from "../../../../../types/spreadsheet_env";
 import { Store } from "../../../../../types/store_engine";
+import { useModel } from "../../../../owl_plugins/model_plugin";
 import { types } from "../../../../props_validation";
 import { SelectionInput } from "../../../../selection_input/selection_input";
 import { Checkbox } from "../../../components/checkbox/checkbox";
@@ -40,6 +41,7 @@ export class PivotSpreadsheetSidePanel extends Component<SpreadsheetChildEnv> {
 
   pivotSidePanelRef = signal<HTMLElement | null>(null);
 
+  private model = useModel();
   setup() {
     this.store = useLocalStore(PivotSidePanelStore, this.props.pivotId);
     this.state = proxy({
@@ -60,7 +62,7 @@ export class PivotSpreadsheetSidePanel extends Component<SpreadsheetChildEnv> {
       return [this.state.range];
     }
     if (this.definition.range) {
-      return [this.env.model.getters.getRangeString(this.definition.range, "forceSheetReference")];
+      return [this.model().getters.getRangeString(this.definition.range, "forceSheetReference")];
     }
     return [];
   }
@@ -84,8 +86,8 @@ export class PivotSpreadsheetSidePanel extends Component<SpreadsheetChildEnv> {
 
   onSelectionConfirmed() {
     if (this.state.range) {
-      const range = this.env.model.getters.getRangeFromSheetXC(
-        this.env.model.getters.getActiveSheetId(),
+      const range = this.model().getters.getRangeFromSheetXC(
+        this.model().getters.getActiveSheetId(),
         this.state.range
       );
       if (range.invalidSheetName || range.invalidXc) {
@@ -116,7 +118,7 @@ export class PivotSpreadsheetSidePanel extends Component<SpreadsheetChildEnv> {
   }
 
   addFilter(fieldName: string) {
-    const { filters } = this.env.model.getters.getPivotCoreDefinition(this.props.pivotId);
+    const { filters } = this.model().getters.getPivotCoreDefinition(this.props.pivotId);
     this.onFiltersUpdated({
       filters: (filters ?? []).concat([
         {

--- a/src/components/side_panel/pivot/pivot_side_panel/pivot_spreadsheet_side_panel/pivot_spreadsheet_side_panel.xml
+++ b/src/components/side_panel/pivot/pivot_side_panel/pivot_spreadsheet_side_panel/pivot_spreadsheet_side_panel.xml
@@ -1,6 +1,6 @@
 <templates>
   <t t-name="o-spreadsheet-PivotSpreadsheetSidePanel">
-    <t t-set="isReadonly" t-value="this.env.model.getters.isReadonly()"/>
+    <t t-set="isReadonly" t-value="this.model().getters.isReadonly()"/>
     <div class="d-flex flex-column h-100 justify-content-between overflow-hidden">
       <div
         class="h-100 position-relative overflow-x-hidden overflow-y-auto"

--- a/src/components/side_panel/pivot/pivot_title_section/pivot_title_section.ts
+++ b/src/components/side_panel/pivot/pivot_title_section/pivot_title_section.ts
@@ -5,6 +5,7 @@ import { Component } from "../../../../owl3_compatibility_layer";
 import { _t } from "../../../../translation";
 import { CommandResult } from "../../../../types/commands";
 import { SpreadsheetChildEnv } from "../../../../types/spreadsheet_env";
+import { useModel } from "../../../owl_plugins/model_plugin";
 import { types } from "../../../props_validation";
 import { TextInput } from "../../../text_input/text_input";
 import { CogWheelMenu } from "../../components/cog_wheel_menu/cog_wheel_menu";
@@ -42,17 +43,17 @@ export class PivotTitleSection extends Component<SpreadsheetChildEnv> {
   }
 
   get name() {
-    return this.env.model.getters.getPivotName(this.props.pivotId);
+    return this.model().getters.getPivotName(this.props.pivotId);
   }
 
   get displayName() {
-    return this.env.model.getters.getPivotDisplayName(this.props.pivotId);
+    return this.model().getters.getPivotDisplayName(this.props.pivotId);
   }
 
   duplicatePivot() {
     const newPivotId = UuidGenerator.smallUuid();
     const newSheetId = UuidGenerator.smallUuid();
-    const result = this.env.model.dispatch("DUPLICATE_PIVOT_IN_NEW_SHEET", {
+    const result = this.model().dispatch("DUPLICATE_PIVOT_IN_NEW_SHEET", {
       pivotId: this.props.pivotId,
       newPivotId,
       newSheetId,
@@ -78,13 +79,13 @@ export class PivotTitleSection extends Component<SpreadsheetChildEnv> {
 
   delete() {
     this.env.askConfirmation(_t("Are you sure you want to delete this pivot?"), () => {
-      this.env.model.dispatch("REMOVE_PIVOT", { pivotId: this.props.pivotId });
+      this.model().dispatch("REMOVE_PIVOT", { pivotId: this.props.pivotId });
     });
   }
 
   onNameChanged(name: string) {
-    const pivot = this.env.model.getters.getPivotCoreDefinition(this.props.pivotId);
-    this.env.model.dispatch("UPDATE_PIVOT", {
+    const pivot = this.model().getters.getPivotCoreDefinition(this.props.pivotId);
+    this.model().dispatch("UPDATE_PIVOT", {
       pivotId: this.props.pivotId,
       pivot: {
         ...pivot,
@@ -92,4 +93,6 @@ export class PivotTitleSection extends Component<SpreadsheetChildEnv> {
       },
     });
   }
+
+  private model = useModel();
 }

--- a/src/components/side_panel/remove_duplicates/remove_duplicates.ts
+++ b/src/components/side_panel/remove_duplicates/remove_duplicates.ts
@@ -5,6 +5,7 @@ import { Component } from "../../../owl3_compatibility_layer";
 import { _t } from "../../../translation";
 import { HeaderIndex } from "../../../types/misc";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
+import { useModel } from "../../owl_plugins/model_plugin";
 import { types } from "../../props_validation";
 import { RemoveDuplicateTerms } from "../../translations_terms";
 import { ValidationMessages } from "../../validation_messages/validation_messages";
@@ -28,6 +29,7 @@ export class RemoveDuplicatesPanel extends Component<SpreadsheetChildEnv> {
     columns: {},
   });
 
+  private model = useModel();
   setup() {
     this.updateColumns();
     onWillUpdateProps(() => this.updateColumns());
@@ -49,7 +51,7 @@ export class RemoveDuplicatesPanel extends Component<SpreadsheetChildEnv> {
   }
 
   onRemoveDuplicates() {
-    this.env.model.dispatch("REMOVE_DUPLICATES", {
+    this.model().dispatch("REMOVE_DUPLICATES", {
       hasHeader: this.state.hasHeader,
       columns: this.getColsToAnalyze(),
     });
@@ -59,9 +61,9 @@ export class RemoveDuplicatesPanel extends Component<SpreadsheetChildEnv> {
     const col = parseInt(colKey);
     let colLabel = _t("Column %s", numberToLetters(col));
     if (this.state.hasHeader) {
-      const sheetId = this.env.model.getters.getActiveSheetId();
-      const row = this.env.model.getters.getSelectedZone().top;
-      const colHeader = this.env.model.getters.getEvaluatedCell({ sheetId, col, row });
+      const sheetId = this.model().getters.getActiveSheetId();
+      const row = this.model().getters.getSelectedZone().top;
+      const colHeader = this.model().getters.getEvaluatedCell({ sheetId, col, row });
       if (colHeader.type !== "empty") {
         colLabel += ` - ${colHeader.value}`;
       }
@@ -74,7 +76,7 @@ export class RemoveDuplicatesPanel extends Component<SpreadsheetChildEnv> {
   }
 
   get errorMessages(): string[] {
-    const cancelledReasons = this.env.model.canDispatch("REMOVE_DUPLICATES", {
+    const cancelledReasons = this.model().canDispatch("REMOVE_DUPLICATES", {
       hasHeader: this.state.hasHeader,
       columns: this.getColsToAnalyze(),
     }).reasons;
@@ -88,7 +90,7 @@ export class RemoveDuplicatesPanel extends Component<SpreadsheetChildEnv> {
   }
 
   get selectionStatisticalInformation(): string {
-    const dimension = zoneToDimension(this.env.model.getters.getSelectedZone());
+    const dimension = zoneToDimension(this.model().getters.getSelectedZone());
     return _t("%(row_count)s rows and %(column_count)s columns selected", {
       row_count: dimension.numberOfRows,
       column_count: dimension.numberOfCols,
@@ -104,7 +106,7 @@ export class RemoveDuplicatesPanel extends Component<SpreadsheetChildEnv> {
   // ---------------------------------------------------------------------------
 
   private updateColumns() {
-    const zone = this.env.model.getters.getSelectedZone();
+    const zone = this.model().getters.getSelectedZone();
     const oldColumns = this.state.columns;
     const newColumns = {};
     for (let i = zone.left; i <= zone.right; i++) {

--- a/src/components/side_panel/settings/settings_panel.ts
+++ b/src/components/side_panel/settings/settings_panel.ts
@@ -6,6 +6,7 @@ import { Component } from "../../../owl3_compatibility_layer";
 import { Locale, LocaleCode } from "../../../types/locale";
 import { ValueAndLabel } from "../../../types/misc";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
+import { useModel } from "../../owl_plugins/model_plugin";
 import { types } from "../../props_validation";
 import { Select } from "../../select/select";
 import { ValidationMessages } from "../../validation_messages/validation_messages";
@@ -22,6 +23,7 @@ export class SettingsPanel extends Component<SpreadsheetChildEnv> {
 
   loadedLocales: Locale[] = [];
 
+  private model = useModel();
   setup() {
     onWillStart(() => this.loadLocales());
   }
@@ -31,7 +33,7 @@ export class SettingsPanel extends Component<SpreadsheetChildEnv> {
     if (!locale) {
       return;
     }
-    this.env.model.dispatch("UPDATE_LOCALE", { locale });
+    this.model().dispatch("UPDATE_LOCALE", { locale });
   }
 
   private async loadLocales() {
@@ -47,23 +49,23 @@ export class SettingsPanel extends Component<SpreadsheetChildEnv> {
   }
 
   get numberFormatPreview() {
-    const locale = this.env.model.getters.getLocale();
+    const locale = this.model().getters.getLocale();
     return formatValue(1234567.89, { format: "#,##0.00", locale });
   }
 
   get dateFormatPreview() {
-    const locale = this.env.model.getters.getLocale();
+    const locale = this.model().getters.getLocale();
     return formatValue(1.6, { format: locale.dateFormat, locale });
   }
 
   get dateTimeFormatPreview() {
-    const locale = this.env.model.getters.getLocale();
+    const locale = this.model().getters.getLocale();
     const dateTimeFormat = getDateTimeFormat(locale);
     return formatValue(1.6, { format: dateTimeFormat, locale });
   }
 
   get firstDayOfWeek() {
-    const locale = this.env.model.getters.getLocale();
+    const locale = this.model().getters.getLocale();
     const weekStart = locale.weekStart;
     // Week start: 1 = Monday, 7 = Sunday
     // Days: 0 = Sunday, 6 = Saturday
@@ -71,7 +73,7 @@ export class SettingsPanel extends Component<SpreadsheetChildEnv> {
   }
 
   get currentLocale() {
-    return this.env.model.getters.getLocale();
+    return this.model().getters.getLocale();
   }
 
   get supportedLocales() {

--- a/src/components/side_panel/side_panel/side_panel.ts
+++ b/src/components/side_panel/side_panel/side_panel.ts
@@ -4,6 +4,7 @@ import { types } from "../../props_validation";
 
 import { props } from "@odoo/owl";
 import { Component } from "../../../owl3_compatibility_layer";
+import { useModel } from "../../owl_plugins/model_plugin";
 
 export class SidePanel extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-SidePanel";
@@ -20,11 +21,12 @@ export class SidePanel extends Component<SpreadsheetChildEnv> {
     "isCollapsed?": types.boolean(),
   });
   spreadsheetRect = useSpreadsheetRect();
+  private model = useModel();
 
   getTitle() {
     const panel = this.props.panelContent;
     return typeof panel.title === "function"
-      ? panel.title(this.env, this.props.panelProps)
+      ? panel.title(this.model(), this.env, this.props.panelProps)
       : panel.title;
   }
 }

--- a/src/components/side_panel/split_to_columns_panel/split_to_columns_panel.ts
+++ b/src/components/side_panel/split_to_columns_panel/split_to_columns_panel.ts
@@ -7,6 +7,7 @@ import { _t } from "../../../translation";
 import { CommandResult } from "../../../types/commands";
 import { ValueAndLabel } from "../../../types/misc";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
+import { useModel } from "../../owl_plugins/model_plugin";
 import { types } from "../../props_validation";
 import { Select } from "../../select/select";
 import { SplitToColumnsTerms } from "../../translations_terms";
@@ -42,6 +43,7 @@ export class SplitIntoColumnsPanel extends Component<SpreadsheetChildEnv> {
 
   state = proxy<State>({ separatorValue: "auto", addNewColumns: false, customSeparator: "" });
 
+  private model = useModel();
   setup() {
     const composerFocusStore = useStore(ComposerFocusStore);
     // The feature makes no sense if we are editing a cell, because then the selection isn't active
@@ -77,6 +79,7 @@ export class SplitIntoColumnsPanel extends Component<SpreadsheetChildEnv> {
 
   confirm() {
     const result = interactiveSplitToColumns(
+      this.model(),
       this.env,
       this.separatorValue,
       this.state.addNewColumns
@@ -88,7 +91,7 @@ export class SplitIntoColumnsPanel extends Component<SpreadsheetChildEnv> {
   }
 
   get errorMessages(): string[] {
-    const cancelledReasons = this.env.model.canDispatch("SPLIT_TEXT_INTO_COLUMNS", {
+    const cancelledReasons = this.model().canDispatch("SPLIT_TEXT_INTO_COLUMNS", {
       separator: this.separatorValue,
       addNewColumns: this.state.addNewColumns,
       force: true,
@@ -110,7 +113,7 @@ export class SplitIntoColumnsPanel extends Component<SpreadsheetChildEnv> {
 
   get warningMessages(): string[] {
     const warnings: string[] = [];
-    const cancelledReasons = this.env.model.canDispatch("SPLIT_TEXT_INTO_COLUMNS", {
+    const cancelledReasons = this.model().canDispatch("SPLIT_TEXT_INTO_COLUMNS", {
       separator: this.separatorValue,
       addNewColumns: this.state.addNewColumns,
       force: false,
@@ -127,7 +130,7 @@ export class SplitIntoColumnsPanel extends Component<SpreadsheetChildEnv> {
     if (this.state.separatorValue === "custom") {
       return this.state.customSeparator;
     } else if (this.state.separatorValue === "auto") {
-      return this.env.model.getters.getAutomaticSeparator();
+      return this.model().getters.getAutomaticSeparator();
     }
     return this.state.separatorValue;
   }

--- a/src/components/side_panel/table_panel/table_panel.ts
+++ b/src/components/side_panel/table_panel/table_panel.ts
@@ -9,6 +9,7 @@ import { TableConfig } from "../../../types/table";
 import { getTableTopLeft } from "../../../helpers/table_helpers";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
 import { NumberInput } from "../../number_input/number_input";
+import { useModel } from "../../owl_plugins/model_plugin";
 import { types } from "../../props_validation";
 import { SelectionInput } from "../../selection_input/selection_input";
 import { TableStylePicker } from "../../tables/table_style_picker/table_style_picker";
@@ -42,11 +43,12 @@ export class TablePanel extends Component<SpreadsheetChildEnv> {
 
   state!: State;
 
+  private model = useModel();
   setup() {
-    const sheetId = this.env.model.getters.getActiveSheetId();
+    const sheetId = this.model().getters.getActiveSheetId();
     this.state = proxy({
       tableZoneErrors: [],
-      tableXc: this.env.model.getters.getRangeString(this.props.table.range, sheetId),
+      tableXc: this.model().getters.getRangeString(this.props.table.range, sheetId),
       filtersEnabledIfPossible: this.props.table.config.hasFilters,
     });
   }
@@ -57,8 +59,8 @@ export class TablePanel extends Component<SpreadsheetChildEnv> {
   }
 
   updateTableConfig(attName: keyof TableConfig, value: boolean | string | number): DispatchResult {
-    const sheetId = this.env.model.getters.getActiveSheetId();
-    return this.env.model.dispatch("UPDATE_TABLE", {
+    const sheetId = this.model().getters.getActiveSheetId();
+    return this.model().dispatch("UPDATE_TABLE", {
       sheetId,
       zone: this.props.table.range.zone,
       config: { [attName]: value },
@@ -75,21 +77,21 @@ export class TablePanel extends Component<SpreadsheetChildEnv> {
     if (newTableType === this.props.table.type) {
       return;
     }
-    const uiTable = this.env.model.getters.getTable(getTableTopLeft(this.props.table));
+    const uiTable = this.model().getters.getTable(getTableTopLeft(this.props.table));
     if (!uiTable) {
       return;
     }
-    const sheetId = this.env.model.getters.getActiveSheetId();
-    const result = this.env.model.dispatch("UPDATE_TABLE", {
+    const sheetId = this.model().getters.getActiveSheetId();
+    const result = this.model().dispatch("UPDATE_TABLE", {
       sheetId,
       zone: this.props.table.range.zone,
-      newTableRange: this.env.model.getters.getRangeData(uiTable.range),
+      newTableRange: this.model().getters.getRangeData(uiTable.range),
       tableType: newTableType,
     });
-    const updatedTable = this.env.model.getters.getCoreTable(getTableTopLeft(this.props.table));
+    const updatedTable = this.model().getters.getCoreTable(getTableTopLeft(this.props.table));
     if (result.isSuccessful && updatedTable) {
       const newTableRange = updatedTable.range;
-      this.state.tableXc = this.env.model.getters.getRangeString(newTableRange, sheetId);
+      this.state.tableXc = this.model().getters.getRangeString(newTableRange, sheetId);
       this.state.tableZoneErrors = [];
     }
   }
@@ -102,32 +104,32 @@ export class TablePanel extends Component<SpreadsheetChildEnv> {
   private updateNumberOfHeaders(numberOfHeaders: number) {
     const hasFilters =
       numberOfHeaders > 0 && (this.tableConfig.hasFilters || this.state.filtersEnabledIfPossible);
-    return this.env.model.dispatch("UPDATE_TABLE", {
-      sheetId: this.env.model.getters.getActiveSheetId(),
+    return this.model().dispatch("UPDATE_TABLE", {
+      sheetId: this.model().getters.getActiveSheetId(),
       zone: this.props.table.range.zone,
       config: { numberOfHeaders, hasFilters },
     });
   }
 
   onRangeChanged(ranges: string[]) {
-    const sheetId = this.env.model.getters.getActiveSheetId();
+    const sheetId = this.model().getters.getActiveSheetId();
 
     this.state.tableXc = ranges[0];
-    const newTableRange = this.env.model.getters.getRangeFromSheetXC(sheetId, this.state.tableXc);
-    this.state.tableZoneErrors = this.env.model.canDispatch("UPDATE_TABLE", {
+    const newTableRange = this.model().getters.getRangeFromSheetXC(sheetId, this.state.tableXc);
+    this.state.tableZoneErrors = this.model().canDispatch("UPDATE_TABLE", {
       sheetId,
       zone: this.props.table.range.zone,
-      newTableRange: this.env.model.getters.getRangeDataFromXc(sheetId, this.state.tableXc),
+      newTableRange: this.model().getters.getRangeDataFromXc(sheetId, this.state.tableXc),
       tableType: this.getNewTableType(newTableRange.zone),
     }).reasons;
   }
 
   onRangeConfirmed() {
-    const sheetId = this.env.model.getters.getActiveSheetId();
-    let newRange: Range = this.env.model.getters.getRangeFromSheetXC(sheetId, this.state.tableXc);
+    const sheetId = this.model().getters.getActiveSheetId();
+    let newRange: Range = this.model().getters.getRangeFromSheetXC(sheetId, this.state.tableXc);
     if (getZoneArea(newRange.zone) === 1) {
-      const extendedZone = this.env.model.getters.getContiguousZone(sheetId, newRange.zone);
-      newRange = this.env.model.getters.getRangeFromZone(sheetId, extendedZone);
+      const extendedZone = this.model().getters.getContiguousZone(sheetId, newRange.zone);
+      newRange = this.model().getters.getRangeFromZone(sheetId, extendedZone);
     }
     const newTableZone = newRange.zone;
     const oldTableZone = this.props.table.range.zone;
@@ -135,30 +137,30 @@ export class TablePanel extends Component<SpreadsheetChildEnv> {
       newTableZone.top === oldTableZone.top && newTableZone.left === oldTableZone.left
         ? "RESIZE_TABLE"
         : "UPDATE_TABLE";
-    const result = this.env.model.dispatch(cmdToCall, {
+    const result = this.model().dispatch(cmdToCall, {
       sheetId,
       zone: this.props.table.range.zone,
-      newTableRange: this.env.model.getters.getRangeData(newRange),
+      newTableRange: this.model().getters.getRangeData(newRange),
       tableType: this.getNewTableType(newRange.zone),
     });
 
     const position = { sheetId, col: newRange.zone.left, row: newRange.zone.top };
-    const updatedTable = this.env.model.getters.getCoreTable(position);
+    const updatedTable = this.model().getters.getCoreTable(position);
 
     if (result.isSuccessful && updatedTable) {
       const newTopLeft = getTableTopLeft(updatedTable);
-      this.env.model.selection.selectZone({
+      this.model().selection.selectZone({
         zone: positionToZone(newTopLeft),
         cell: newTopLeft,
       });
       const newTableRange = updatedTable.range;
-      this.state.tableXc = this.env.model.getters.getRangeString(newTableRange, sheetId);
+      this.state.tableXc = this.model().getters.getRangeString(newTableRange, sheetId);
     }
   }
 
   onStylePicked(styleId: string) {
-    const sheetId = this.env.model.getters.getActiveSheetId();
-    this.env.model.dispatch("UPDATE_TABLE", {
+    const sheetId = this.model().getters.getActiveSheetId();
+    this.model().dispatch("UPDATE_TABLE", {
       sheetId,
       zone: this.props.table.range.zone,
       config: { styleId: styleId },
@@ -166,8 +168,8 @@ export class TablePanel extends Component<SpreadsheetChildEnv> {
   }
 
   deleteTable() {
-    const sheetId = this.env.model.getters.getActiveSheetId();
-    this.env.model.dispatch("REMOVE_TABLE", {
+    const sheetId = this.model().getters.getActiveSheetId();
+    this.model().dispatch("REMOVE_TABLE", {
       sheetId,
       target: [this.props.table.range.zone],
     });
@@ -177,8 +179,8 @@ export class TablePanel extends Component<SpreadsheetChildEnv> {
     if (this.props.table.type === "forceStatic") {
       return "forceStatic";
     }
-    const sheetId = this.env.model.getters.getActiveSheetId();
-    return this.env.model.getters.canCreateDynamicTableOnZones(sheetId, [newTableZone])
+    const sheetId = this.model().getters.getActiveSheetId();
+    return this.model().getters.canCreateDynamicTableOnZones(sheetId, [newTableZone])
       ? "dynamic"
       : "static";
   }
@@ -207,10 +209,10 @@ export class TablePanel extends Component<SpreadsheetChildEnv> {
   }
 
   get canBeDynamic() {
-    const sheetId = this.env.model.getters.getActiveSheetId();
+    const sheetId = this.model().getters.getActiveSheetId();
     return (
       this.props.table.type === "dynamic" ||
-      this.env.model.getters.canCreateDynamicTableOnZones(sheetId, [this.props.table.range.zone])
+      this.model().getters.canCreateDynamicTableOnZones(sheetId, [this.props.table.range.zone])
     );
   }
 

--- a/src/components/side_panel/table_panel/table_panel.xml
+++ b/src/components/side_panel/table_panel/table_panel.xml
@@ -66,7 +66,7 @@
         <TableStylePicker
           tableConfig="this.props.table.config"
           onStylePicked.bind="this.onStylePicked"
-          tableStyles="this.env.model.getters.getTableStyles()"
+          tableStyles="this.model().getters.getTableStyles()"
           type="'table'"
         />
       </Section>

--- a/src/components/side_panel/table_style_editor_panel/table_style_editor_panel.ts
+++ b/src/components/side_panel/table_style_editor_panel/table_style_editor_panel.ts
@@ -7,6 +7,7 @@ import { Color } from "../../../types/misc";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
 import { TableConfig, TableStyle, TableStyleTemplateName } from "../../../types/table";
 import { cssPropertiesToCss } from "../../helpers/css";
+import { useModel } from "../../owl_plugins/model_plugin";
 import { types } from "../../props_validation";
 import { TableStylePreview } from "../../tables/table_style_preview/table_style_preview";
 import { RoundColorPicker } from "../components/round_color_picker/round_color_picker";
@@ -30,6 +31,8 @@ export class TableStyleEditorPanel extends Component<SpreadsheetChildEnv> {
     "styleId?": types.string(),
   });
 
+  private model = useModel();
+
   state = proxy<State>(this.getInitialState());
 
   setup() {
@@ -38,13 +41,13 @@ export class TableStyleEditorPanel extends Component<SpreadsheetChildEnv> {
 
   getInitialState(): State {
     const editedStyle = this.props.styleId
-      ? this.env.model.getters.getTableStyle(this.props.styleId)
+      ? this.model().getters.getTableStyle(this.props.styleId)
       : null;
     return {
       pickerOpened: false,
       primaryColor: editedStyle?.primaryColor || DEFAULT_TABLE_STYLE_COLOR,
       selectedTemplateName: editedStyle?.templateName || "lightColoredText",
-      styleName: editedStyle?.displayName || this.env.model.getters.getNewCustomTableStyleName(),
+      styleName: editedStyle?.displayName || this.model().getters.getNewCustomTableStyleName(),
     };
   }
 
@@ -63,7 +66,7 @@ export class TableStyleEditorPanel extends Component<SpreadsheetChildEnv> {
 
   onConfirm() {
     const tableStyleId = this.props.styleId || UuidGenerator.smallUuid();
-    this.env.model.dispatch("CREATE_TABLE_STYLE", {
+    this.model().dispatch("CREATE_TABLE_STYLE", {
       tableStyleId,
       tableStyleName: this.state.styleName,
       templateName: this.state.selectedTemplateName,
@@ -81,7 +84,7 @@ export class TableStyleEditorPanel extends Component<SpreadsheetChildEnv> {
     if (!this.props.styleId) {
       return;
     }
-    this.env.model.dispatch("REMOVE_TABLE_STYLE", { tableStyleId: this.props.styleId });
+    this.model().dispatch("REMOVE_TABLE_STYLE", { tableStyleId: this.props.styleId });
     this.props.onCloseSidePanel();
   }
 

--- a/src/components/small_bottom_bar/ribbon_menu/ribbon_menu.ts
+++ b/src/components/small_bottom_bar/ribbon_menu/ribbon_menu.ts
@@ -6,6 +6,7 @@ import { _t } from "../../../translation";
 import { PropsOf } from "../../../types/props_of";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
 import { Menu } from "../../menu/menu";
+import { useModel } from "../../owl_plugins/model_plugin";
 import { types } from "../../props_validation";
 
 export const itemHeight = 40;
@@ -23,6 +24,8 @@ export class RibbonMenu extends Component<SpreadsheetChildEnv> {
   protected props = props({
     onClose: types.function([]),
   });
+
+  private model = useModel();
 
   rootItems = topbarMenuRegistry.getMenuItems();
   private menuRef = signal<HTMLElement | null>(null);
@@ -46,24 +49,24 @@ export class RibbonMenu extends Component<SpreadsheetChildEnv> {
   }
 
   onClickMenu(menu: Action) {
-    const children = menu.children(this.env);
+    const children = menu.children(this.model(), this.env);
     if (children.length) {
       this.state.parentState = { ...this.state };
       this.state.menuItems = children;
-      this.state.title = menu.name(this.env);
+      this.state.title = menu.name(this.model(), this.env);
       this.containerRef()?.scrollTo({ top: 0 });
     } else {
       this.state.menuItems = this.rootItems;
       this.state.title = undefined;
       this.state.parentState = undefined;
-      menu.execute?.(this.env);
+      menu.execute?.(this.model(), this.env);
       this.props.onClose();
     }
   }
 
   get menuProps(): PropsOf<Menu> {
     return {
-      menuItems: getMenuItemsAndSeparators(this.env, this.state.menuItems),
+      menuItems: getMenuItemsAndSeparators(this.model(), this.env, this.state.menuItems),
       onClose: this.props.onClose,
       onClickMenu: this.onClickMenu.bind(this),
     };

--- a/src/components/small_bottom_bar/small_bottom_bar.ts
+++ b/src/components/small_bottom_bar/small_bottom_bar.ts
@@ -13,6 +13,7 @@ import { Composer } from "../composer/composer/composer";
 import { ComposerFocusStore, ComposerInterface } from "../composer/composer_focus_store";
 import { cssPropertiesToCss } from "../helpers/css";
 import { getElBoundingRect } from "../helpers/dom_helpers";
+import { useModel } from "../owl_plugins/model_plugin";
 import { types } from "../props_validation";
 import { RibbonMenu } from "./ribbon_menu/ribbon_menu";
 
@@ -33,6 +34,7 @@ export class SmallBottomBar extends Component<SpreadsheetChildEnv> {
     isOpen: false,
   });
 
+  private model = useModel();
   setup(): void {
     this.composerFocusStore = useStore(ComposerFocusStore);
     const composerStore = useStore(CellComposerStore);
@@ -83,7 +85,7 @@ export class SmallBottomBar extends Component<SpreadsheetChildEnv> {
   }
 
   get composerProps(): PropsOf<Composer> {
-    const { width, height } = this.env.model.getters.getSheetViewDimensionWithHeaders();
+    const { width, height } = this.model().getters.getSheetViewDimensionWithHeaders();
     return {
       rect: { ...this.rect },
       delimitation: {

--- a/src/components/spreadsheet/spreadsheet.ts
+++ b/src/components/spreadsheet/spreadsheet.ts
@@ -4,6 +4,7 @@ import {
   onWillUnmount,
   onWillUpdateProps,
   props,
+  providePlugins,
   proxy,
   signal,
   useEffect,
@@ -46,6 +47,7 @@ import {
 } from "../helpers/dom_helpers";
 import { useSpreadsheetRect } from "../helpers/position_hook";
 import { useScreenWidth } from "../helpers/screen_width_hook";
+import { ModelPlugin, useModel } from "../owl_plugins/model_plugin";
 import { types } from "../props_validation";
 import { DEFAULT_SIDE_PANEL_SIZE, SidePanelStore } from "../side_panel/side_panel/side_panel_store";
 import { SidePanels } from "../side_panel/side_panels/side_panels";
@@ -105,22 +107,19 @@ export class Spreadsheet extends Component<SpreadsheetChildEnv> {
   private isViewportTooSmall: boolean = false;
   private notificationStore!: Store<NotificationStore>;
   private composerFocusStore!: Store<ComposerFocusStore>;
-
-  get model(): Model {
-    return this.props.model;
-  }
+  private model!: () => Model;
 
   getStyle(): string {
     const properties: CSSProperties = {};
-    const scrollbarWidth = this.env.model.getters.getScrollBarWidth();
+    const scrollbarWidth = this.model().getters.getScrollBarWidth();
     properties["--os-scrollbar-width"] = `${scrollbarWidth}px`;
     properties["--os-dark-mode-filter"] = DARK_MODE_FILTER_STRING;
-    properties["color-scheme"] = this.props.model.getters.isDarkMode() ? "dark" : "light";
+    properties["color-scheme"] = this.model().getters.isDarkMode() ? "dark" : "light";
 
     if (this.state.printModeEnabled) {
       properties["display"] = `block`;
     } else {
-      if (this.env.model.getters.isDashboard()) {
+      if (this.model().getters.isDashboard()) {
         properties["grid-template-rows"] = `auto`;
       } else {
         properties["grid-template-rows"] = `min-content auto min-content`;
@@ -135,6 +134,9 @@ export class Spreadsheet extends Component<SpreadsheetChildEnv> {
   }
 
   setup() {
+    providePlugins([ModelPlugin], { model: this.props.model });
+    this.model = useModel();
+
     if (!("isSmall" in this.env)) {
       const screenSize = useScreenWidth();
       useSubEnv({
@@ -145,7 +147,7 @@ export class Spreadsheet extends Component<SpreadsheetChildEnv> {
     }
 
     const stores = useStoreProvider();
-    stores.inject(ModelStore, this.model);
+    stores.inject(ModelStore, this.model());
 
     const env = this.env;
     stores.get(ScreenWidthStore).setSmallThreshhold(() => {
@@ -155,13 +157,12 @@ export class Spreadsheet extends Component<SpreadsheetChildEnv> {
     this.notificationStore = useStore(NotificationStore);
     this.composerFocusStore = useStore(ComposerFocusStore);
     this.sidePanel = useStore(SidePanelStore);
-    const fileStore = this.model.config.external.fileStore;
+    const fileStore = this.model().config.external.fileStore;
 
     useSubEnv({
-      model: this.model,
       imageProvider: fileStore ? new ImageProvider(fileStore) : undefined,
-      loadCurrencies: this.model.config.external.loadCurrencies,
-      loadLocales: this.model.config.external.loadLocales,
+      loadCurrencies: this.model().config.external.loadCurrencies,
+      loadLocales: this.model().config.external.loadLocales,
       openSidePanel: this.sidePanel.open.bind(this.sidePanel),
       replaceSidePanel: this.sidePanel.replace.bind(this.sidePanel),
       toggleSidePanel: this.sidePanel.toggle.bind(this.sidePanel),
@@ -252,8 +253,8 @@ export class Spreadsheet extends Component<SpreadsheetChildEnv> {
   }
 
   private bindModelEvents() {
-    this.model.on("update", this, () => this.render(true));
-    this.model.on("command-rejected", this, ({ result }) => {
+    this.model().on("update", this, () => this.render(true));
+    this.model().on("command-rejected", this, ({ result }) => {
       if (result.isCancelledBecause(CommandResult.SheetLocked)) {
         this.notificationStore.notifyUser({
           type: "info",
@@ -263,22 +264,22 @@ export class Spreadsheet extends Component<SpreadsheetChildEnv> {
       }
     });
 
-    this.model.on("notify-ui", this, (notification: InformationNotification) =>
+    this.model().on("notify-ui", this, (notification: InformationNotification) =>
       this.notificationStore.notifyUser(notification)
     );
-    this.model.on("raise-error-ui", this, ({ text }) => this.notificationStore.raiseError(text));
+    this.model().on("raise-error-ui", this, ({ text }) => this.notificationStore.raiseError(text));
   }
 
   private unbindModelEvents() {
-    this.model.off("update", this);
-    this.model.off("command-rejected", this);
-    this.model.off("notify-ui", this);
-    this.model.off("raise-error-ui", this);
+    this.model().off("update", this);
+    this.model().off("command-rejected", this);
+    this.model().off("notify-ui", this);
+    this.model().off("raise-error-ui", this);
   }
 
   private checkViewportSize() {
-    const { xRatio, yRatio } = this.env.model.getters.getFrozenSheetViewRatio(
-      this.env.model.getters.getActiveSheetId()
+    const { xRatio, yRatio } = this.model().getters.getFrozenSheetViewRatio(
+      this.model().getters.getActiveSheetId()
     );
 
     if (!isFinite(xRatio) || !isFinite(yRatio)) {
@@ -311,13 +312,13 @@ export class Spreadsheet extends Component<SpreadsheetChildEnv> {
   }
 
   get gridHeight(): Pixel {
-    return this.env.model.getters.getSheetViewDimension().height;
+    return this.model().getters.getSheetViewDimension().height;
   }
 
   get gridContainerStyle(): string {
     const gridColSize = GROUP_LAYER_WIDTH * this.rowLayers.length;
     const gridRowSize = GROUP_LAYER_WIDTH * this.colLayers.length;
-    const zoom = this.env.model.getters.getViewportZoomLevel();
+    const zoom = this.model().getters.getViewportZoomLevel();
     return cssPropertiesToCss({
       "grid-template-columns": `${gridColSize ? gridColSize + 2 : 0}px auto`, // +2: margins
       "grid-template-rows": `${gridRowSize ? gridRowSize + 2 : 0}px auto`,
@@ -326,13 +327,13 @@ export class Spreadsheet extends Component<SpreadsheetChildEnv> {
   }
 
   get rowLayers(): HeaderGroup[][] {
-    const sheetId = this.env.model.getters.getActiveSheetId();
-    return this.env.model.getters.getVisibleGroupLayers(sheetId, "ROW");
+    const sheetId = this.model().getters.getActiveSheetId();
+    return this.model().getters.getVisibleGroupLayers(sheetId, "ROW");
   }
 
   get colLayers(): HeaderGroup[][] {
-    const sheetId = this.env.model.getters.getActiveSheetId();
-    return this.env.model.getters.getVisibleGroupLayers(sheetId, "COL");
+    const sheetId = this.model().getters.getActiveSheetId();
+    return this.model().getters.getVisibleGroupLayers(sheetId, "COL");
   }
 
   getGridSize() {
@@ -341,8 +342,8 @@ export class Spreadsheet extends Component<SpreadsheetChildEnv> {
       return { width: 0, height: 0 };
     }
 
-    const zoom = this.env.model.getters.getViewportZoomLevel();
-    const scrollbarWidth = this.env.model.getters.getScrollBarWidth();
+    const zoom = this.model().getters.getViewportZoomLevel();
+    const scrollbarWidth = this.model().getters.getScrollBarWidth();
 
     const getHeight = (s: string) =>
       (el.querySelector(s) && zoomCorrectedElementRect(el.querySelector(s)!, zoom).height) || 0;
@@ -366,7 +367,7 @@ export class Spreadsheet extends Component<SpreadsheetChildEnv> {
   getSpreadSheetClasses() {
     return [
       this.env.isSmall ? "o-spreadsheet-mobile" : "",
-      this.props.model.getters.isDarkMode() ? "dark" : "",
+      this.model().getters.isDarkMode() ? "dark" : "",
     ].join(" ");
   }
 

--- a/src/components/spreadsheet/spreadsheet.xml
+++ b/src/components/spreadsheet/spreadsheet.xml
@@ -8,7 +8,7 @@
       <t t-if="this.state.printModeEnabled">
         <SpreadsheetPrint onExitPrintMode.bind="this.exitPrintMode"/>
       </t>
-      <t t-elif="this.env.model.getters.isDashboard()">
+      <t t-elif="this.model().getters.isDashboard()">
         <SpreadsheetDashboard getGridSize.bind="this.getGridSize"/>
         <FullScreenFigure/>
       </t>

--- a/src/components/spreadsheet_print/spreadsheet_print.ts
+++ b/src/components/spreadsheet_print/spreadsheet_print.ts
@@ -4,6 +4,7 @@ import { useLocalStore } from "../../store_engine/store_hooks";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 import { Store } from "../../types/store_engine";
 import { cssPropertiesToCss } from "../helpers/css";
+import { useModel } from "../owl_plugins/model_plugin";
 import { types } from "../props_validation";
 import { Select } from "../select/select";
 import { BadgeSelection } from "../side_panel/components/badge_selection/badge_selection";
@@ -24,6 +25,7 @@ export class SpreadsheetPrint extends Component<SpreadsheetChildEnv> {
     onExitPrintMode: types.function([]),
   });
   static components = { StandaloneGridCanvas, Section, Select, BadgeSelection, Checkbox };
+  protected model = useModel();
 
   printStore!: Store<SpreadsheetPrintStore>;
 

--- a/src/components/spreadsheet_print/spreadsheet_print.xml
+++ b/src/components/spreadsheet_print/spreadsheet_print.xml
@@ -39,7 +39,7 @@
         </div>
         <div class="o-sidePanel flex-shrink-0 bg-white border-top border-start d-print-none">
           <div class="o-sidePanelBody pt-4">
-            <Section t-if="!this.env.model.getters.isDashboard()">
+            <Section t-if="!this.model().getters.isDashboard()">
               <div class="o-section-title">Print content</div>
               <Select
                 selectedValue="this.printStore.printSelection"
@@ -78,7 +78,7 @@
               />
             </Section>
 
-            <Section t-if="!this.env.model.getters.isDashboard()">
+            <Section t-if="!this.model().getters.isDashboard()">
               <div class="o-section-title">Formatting</div>
               <Checkbox
                 name="'showGridLines'"

--- a/src/components/standalone_grid_canvas/standalone_grid_canvas.ts
+++ b/src/components/standalone_grid_canvas/standalone_grid_canvas.ts
@@ -7,6 +7,7 @@ import { GridRenderingContext } from "../../types/rendering";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 import { Store } from "../../types/store_engine";
 import { useGridDrawing } from "../helpers/draw_grid_hook";
+import { useModel } from "../owl_plugins/model_plugin";
 import { types } from "../props_validation";
 import { FigureRendererStore } from "./figure_renderer_store";
 
@@ -24,6 +25,7 @@ export class StandaloneGridCanvas extends Component<SpreadsheetChildEnv> {
   rendererStore!: Store<RendererStore>;
   figureRendererStore!: Store<FigureRendererStore>;
 
+  private model = useModel();
   setup() {
     this.rendererStore = useLocalStore(RendererStore, ["Background", "Chart"]);
     this.figureRendererStore = useLocalStore(FigureRendererStore, this.rendererStore);
@@ -43,7 +45,7 @@ export class StandaloneGridCanvas extends Component<SpreadsheetChildEnv> {
     const imagePaths = props.renderingCtx.viewports
       .getVisibleFigures(props.sheetId)
       .filter((figure) => figure.tag === "image")
-      .map((figure) => this.env.model.getters.getImagePath(figure.id))
+      .map((figure) => this.model().getters.getImagePath(figure.id))
       .filter((path) => path && !this.figureRendererStore.loadedImages[path]);
 
     await Promise.all(

--- a/src/components/tables/table_dropdown_button/table_dropdown_button.ts
+++ b/src/components/tables/table_dropdown_button/table_dropdown_button.ts
@@ -11,6 +11,7 @@ import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
 import { TableConfig } from "../../../types/table";
 import { ActionButton } from "../../action_button/action_button";
 import { ToolBarDropdownStore, useToolBarDropdownStore } from "../../helpers/top_bar_tool_hook";
+import { useModel } from "../../owl_plugins/model_plugin";
 import { Popover } from "../../popover/popover";
 import { types } from "../../props_validation";
 import {
@@ -33,14 +34,15 @@ export class TableDropdownButton extends Component<SpreadsheetChildEnv> {
   topBarToolStore!: ToolBarDropdownStore;
   state = proxy<State>({ popoverProps: undefined });
 
+  private model = useModel();
   setup() {
     this.topBarToolStore = useToolBarDropdownStore();
   }
 
   onStylePicked(styleId: string) {
-    const sheetId = this.env.model.getters.getActiveSheetId();
+    const sheetId = this.model().getters.getActiveSheetId();
     const tableConfig = { ...this.tableConfig, styleId };
-    const result = interactiveCreateTable(this.env, sheetId, tableConfig);
+    const result = interactiveCreateTable(this.model(), this.env, sheetId, tableConfig);
     if (result.isSuccessful) {
       this.env.openSidePanel("TableSidePanel", {});
     }
@@ -57,7 +59,7 @@ export class TableDropdownButton extends Component<SpreadsheetChildEnv> {
       this.env.openSidePanel("PivotSidePanel", { pivotId, openTab: "design" });
       return;
     }
-    if (this.env.model.getters.getFirstTableInSelection()) {
+    if (this.model().getters.getFirstTableInSelection()) {
       this.topBarToolStore.closeDropdowns();
       this.env.toggleSidePanel("TableSidePanel", {});
       return;
@@ -87,10 +89,10 @@ export class TableDropdownButton extends Component<SpreadsheetChildEnv> {
     }
 
     return {
-      name: (env) =>
-        env.model.getters.getFirstTableInSelection() ? _t("Edit table") : _t("Insert table"),
-      icon: (env) =>
-        env.model.getters.getFirstTableInSelection()
+      name: (model) =>
+        model.getters.getFirstTableInSelection() ? _t("Edit table") : _t("Insert table"),
+      icon: (model) =>
+        model.getters.getFirstTableInSelection()
           ? "o-spreadsheet-Icon.EDIT_TABLE"
           : "o-spreadsheet-Icon.PAINT_TABLE",
     };
@@ -101,15 +103,15 @@ export class TableDropdownButton extends Component<SpreadsheetChildEnv> {
   }
 
   get tableStyles() {
-    return this.env.model.getters.getTableStyles();
+    return this.model().getters.getTableStyles();
   }
 
   get pivotIdInSelection(): UID | undefined {
-    const selection = this.env.model.getters.getSelectedZones();
+    const selection = this.model().getters.getSelectedZones();
     for (const zone of selection) {
       for (const position of positions(zone)) {
-        const sheetId = this.env.model.getters.getActiveSheetId();
-        const pivotId = this.env.model.getters.getPivotIdFromPosition({ sheetId, ...position });
+        const sheetId = this.model().getters.getActiveSheetId();
+        const pivotId = this.model().getters.getPivotIdFromPosition({ sheetId, ...position });
         if (pivotId) {
           return pivotId;
         }
@@ -120,7 +122,7 @@ export class TableDropdownButton extends Component<SpreadsheetChildEnv> {
 
   get class() {
     return `${this.props.class ? this.props.class : ""} ${
-      this.env.model.getters.isCurrentSheetLocked() ? "o-disabled" : ""
+      this.model().getters.isCurrentSheetLocked() ? "o-disabled" : ""
     }`;
   }
 }

--- a/src/components/tables/table_resizer/table_resizer.ts
+++ b/src/components/tables/table_resizer/table_resizer.ts
@@ -6,6 +6,7 @@ import { cssPropertiesToCss } from "../../helpers/css";
 import { useDragAndDropBeyondTheViewport } from "../../helpers/drag_and_drop_grid_hook";
 import { useHighlights } from "../../helpers/highlight_hook";
 import { withZoom } from "../../helpers/zoom";
+import { useModel } from "../../owl_plugins/model_plugin";
 import { types } from "../../props_validation";
 
 const SIZE = 3;
@@ -22,8 +23,9 @@ export class TableResizer extends Component<SpreadsheetChildEnv> {
     table: types.Table(),
   });
 
+  private model = useModel();
   state = proxy<State>({ highlightZone: undefined });
-  dragNDropGrid = useDragAndDropBeyondTheViewport(this.env);
+  dragNDropGrid = useDragAndDropBeyondTheViewport(this.model());
 
   setup(): void {
     useHighlights(this);
@@ -33,11 +35,11 @@ export class TableResizer extends Component<SpreadsheetChildEnv> {
     const tableZone = this.props.table.range.zone;
     const sheetId = this.props.table.range.sheetId;
 
-    if (this.env.model.getters.isReadonly() || this.env.model.getters.isSheetLocked(sheetId)) {
+    if (this.model().getters.isReadonly() || this.model().getters.isSheetLocked(sheetId)) {
       return cssPropertiesToCss({ display: "none" });
     }
     const bottomRight = { ...tableZone, left: tableZone.right, top: tableZone.bottom };
-    const rect = this.env.model.getters.getVisibleRect(bottomRight);
+    const rect = this.model().getters.getVisibleRect(bottomRight);
     if (rect.height === 0 || rect.width === 0) {
       return cssPropertiesToCss({ display: "none" });
     }
@@ -52,7 +54,7 @@ export class TableResizer extends Component<SpreadsheetChildEnv> {
     const tableZone = this.props.table.range.zone;
     const topLeft = { col: tableZone.left, row: tableZone.top };
     document.body.style.cursor = "nwse-resize";
-    const zoomedMouseEvent = withZoom(this.env, ev);
+    const zoomedMouseEvent = withZoom(this.model(), ev);
 
     const onMouseUp = () => {
       document.body.style.cursor = "";
@@ -61,10 +63,10 @@ export class TableResizer extends Component<SpreadsheetChildEnv> {
         return;
       }
       const sheetId = this.props.table.range.sheetId;
-      this.env.model.dispatch("RESIZE_TABLE", {
+      this.model().dispatch("RESIZE_TABLE", {
         sheetId,
         zone: this.props.table.range.zone,
-        newTableRange: this.env.model.getters.getRangeDataFromZone(sheetId, newTableZone),
+        newTableRange: this.model().getters.getRangeDataFromZone(sheetId, newTableZone),
       });
       this.state.highlightZone = undefined;
     };
@@ -86,7 +88,7 @@ export class TableResizer extends Component<SpreadsheetChildEnv> {
     }
     return [
       {
-        range: this.env.model.getters.getRangeFromZone(
+        range: this.model().getters.getRangeFromZone(
           this.props.table.range.sheetId,
           this.state.highlightZone
         ),

--- a/src/components/tables/table_style_preview/table_style_preview.ts
+++ b/src/components/tables/table_style_preview/table_style_preview.ts
@@ -7,6 +7,7 @@ import { PropsOf } from "../../../types/props_of";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
 import { TableMetaData } from "../../../types/table";
 import { MenuPopover, MenuState } from "../../menu_popover/menu_popover";
+import { useModel } from "../../owl_plugins/model_plugin";
 import { types } from "../../props_validation";
 import { drawPreviewTable } from "./table_canvas_helpers";
 
@@ -26,6 +27,7 @@ export class TableStylePreview extends Component<SpreadsheetChildEnv> {
   private canvasRef = signal<HTMLCanvasElement | null>(null);
   menu: MenuState = proxy({ isOpen: false, anchorRect: null, menuItems: [] });
 
+  private model = useModel();
   setup() {
     onWillUpdateProps((nextProps: PropsOf<TableStylePreview>) => {
       if (
@@ -88,7 +90,7 @@ export class TableStylePreview extends Component<SpreadsheetChildEnv> {
     if (!this.props.styleId) {
       return;
     }
-    this.menu.menuItems = createTableStyleContextMenuActions(this.env, this.props.styleId);
+    this.menu.menuItems = createTableStyleContextMenuActions(this.model(), this.props.styleId);
     this.menu.isOpen = true;
     this.menu.anchorRect = { x: event.clientX, y: event.clientY, width: 0, height: 0 };
   }
@@ -110,7 +112,7 @@ export class TableStylePreview extends Component<SpreadsheetChildEnv> {
     if (!this.props.styleId) {
       return false;
     }
-    return this.env.model.getters.isTableStyleEditable(this.props.styleId);
+    return this.model().getters.isTableStyleEditable(this.props.styleId);
   }
 
   editTableStyle() {

--- a/src/components/top_bar/color_editor/color_editor.ts
+++ b/src/components/top_bar/color_editor/color_editor.ts
@@ -4,6 +4,7 @@ import { Component } from "../../../owl3_compatibility_layer";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
 import { ColorPickerWidget } from "../../color_picker/color_picker_widget";
 import { ToolBarDropdownStore, useToolBarDropdownStore } from "../../helpers/top_bar_tool_hook";
+import { useModel } from "../../owl_plugins/model_plugin";
 import { types } from "../../props_validation";
 
 export class TopBarColorEditor extends Component<SpreadsheetChildEnv> {
@@ -22,18 +23,19 @@ export class TopBarColorEditor extends Component<SpreadsheetChildEnv> {
     isOpen: false,
   });
 
+  private model = useModel();
   setup() {
     this.topBarToolStore = useToolBarDropdownStore();
   }
   get currentColor(): string {
     return (
-      this.env.model.getters.getCurrentStyle()[this.props.style] ||
+      this.model().getters.getCurrentStyle()[this.props.style] ||
       (this.props.style === "textColor" ? "#000000" : "#ffffff")
     );
   }
 
   setColor(color: string) {
-    setStyle(this.env, { [this.props.style]: color });
+    setStyle(this.model(), { [this.props.style]: color });
     this.state.isOpen = false;
   }
 

--- a/src/components/top_bar/color_editor/color_editor.xml
+++ b/src/components/top_bar/color_editor/color_editor.xml
@@ -2,7 +2,7 @@
   <t t-name="o-spreadsheet-ColorEditor">
     <div
       class="d-flex align-items-center"
-      t-att-class="{'o-disabled': this.env.model.getters.isCurrentSheetLocked() }">
+      t-att-class="{'o-disabled': this.model().getters.isCurrentSheetLocked() }">
       <ColorPickerWidget
         currentColor="this.currentColor"
         toggleColorPicker.bind="this.onClick"

--- a/src/components/top_bar/font_size_editor/font_size_editor.ts
+++ b/src/components/top_bar/font_size_editor/font_size_editor.ts
@@ -6,6 +6,7 @@ import { FontSizeEditor } from "../../font_size_editor/font_size_editor";
 import { ToolBarDropdownStore, useToolBarDropdownStore } from "../../helpers/top_bar_tool_hook";
 
 import { Component } from "../../../owl3_compatibility_layer";
+import { useModel } from "../../owl_plugins/model_plugin";
 
 export class TopBarFontSizeEditor extends Component<SpreadsheetChildEnv> {
   static components = { FontSizeEditor };
@@ -14,15 +15,16 @@ export class TopBarFontSizeEditor extends Component<SpreadsheetChildEnv> {
   protected props = props({ class: types.string() });
   topBarToolStore!: ToolBarDropdownStore;
 
+  private model = useModel();
   setup() {
     this.topBarToolStore = useToolBarDropdownStore();
   }
 
   get currentFontSize(): number {
-    return this.env.model.getters.getCurrentStyle().fontSize || DEFAULT_FONT_SIZE;
+    return this.model().getters.getCurrentStyle().fontSize || DEFAULT_FONT_SIZE;
   }
   setFontSize(fontSize: number) {
-    setStyle(this.env, { fontSize });
+    setStyle(this.model(), { fontSize });
   }
 
   onToggle() {
@@ -42,8 +44,6 @@ export class TopBarFontSizeEditor extends Component<SpreadsheetChildEnv> {
   }
 
   get class() {
-    return `${this.props.class} ${
-      this.env.model.getters.isCurrentSheetLocked() ? "o-disabled" : ""
-    }`;
+    return `${this.props.class} ${this.model().getters.isCurrentSheetLocked() ? "o-disabled" : ""}`;
   }
 }

--- a/src/components/top_bar/number_formats_tool/number_formats_tool.ts
+++ b/src/components/top_bar/number_formats_tool/number_formats_tool.ts
@@ -8,6 +8,7 @@ import { ActionButton } from "../../action_button/action_button";
 import { getBoundingRectAsPOJO } from "../../helpers/dom_helpers";
 import { ToolBarDropdownStore, useToolBarDropdownStore } from "../../helpers/top_bar_tool_hook";
 import { MenuPopover } from "../../menu_popover/menu_popover";
+import { useModel } from "../../owl_plugins/model_plugin";
 import { types } from "../../props_validation";
 
 interface State {
@@ -20,6 +21,7 @@ export class NumberFormatsTool extends Component<SpreadsheetChildEnv> {
   static components = { MenuPopover, ActionButton };
 
   protected props = props({ class: types.string() });
+  private model = useModel();
   formatNumberMenuItemSpec = formatNumberMenuItemSpec;
   topBarToolStore!: ToolBarDropdownStore;
 
@@ -38,7 +40,9 @@ export class NumberFormatsTool extends Component<SpreadsheetChildEnv> {
       this.topBarToolStore.closeDropdowns();
     } else {
       const menu = createAction(this.formatNumberMenuItemSpec);
-      this.state.menuItems = menu.children(this.env).sort((a, b) => a.sequence - b.sequence);
+      this.state.menuItems = menu
+        .children(this.model(), this.env)
+        .sort((a, b) => a.sequence - b.sequence);
       this.state.anchorRect = getBoundingRectAsPOJO(this.buttonRef()!);
       this.topBarToolStore.openDropdown();
     }

--- a/src/components/top_bar/top_bar.ts
+++ b/src/components/top_bar/top_bar.ts
@@ -22,6 +22,7 @@ import {
 import { useSpreadsheetRect } from "../helpers/position_hook";
 import { MenuPopover, MenuState } from "../menu_popover/menu_popover";
 import { NamedRangeSelector } from "../named_range_selector/named_range_selector";
+import { useModel } from "../owl_plugins/model_plugin";
 import { Popover } from "../popover/popover";
 import { types } from "../props_validation";
 import { TopBarToolStore } from "./top_bar_tool_store";
@@ -79,6 +80,7 @@ export class TopBar extends Component<SpreadsheetChildEnv> {
 
   spreadsheetRect = useSpreadsheetRect();
 
+  private model = useModel();
   setup() {
     this.composerFocusStore = useStore(ComposerFocusStore);
     this.fingerprints = useStore(FormulaFingerprintStore);
@@ -102,7 +104,7 @@ export class TopBar extends Component<SpreadsheetChildEnv> {
   }
 
   setVisibilityToolsGroups() {
-    if (this.env.model.getters.isReadonly()) {
+    if (this.model().getters.isReadonly()) {
       return;
     }
     const hiddenCategories: string[] = [];
@@ -154,7 +156,7 @@ export class TopBar extends Component<SpreadsheetChildEnv> {
   }
 
   get currentFontSize(): number {
-    return this.env.model.getters.getCurrentStyle().fontSize || DEFAULT_FONT_SIZE;
+    return this.model().getters.getCurrentStyle().fontSize || DEFAULT_FONT_SIZE;
   }
 
   onExternalClick(ev: MouseEvent) {
@@ -220,7 +222,7 @@ export class TopBar extends Component<SpreadsheetChildEnv> {
     this.state.menuState.isOpen = true;
     this.state.menuState.anchorRect = getBoundingRectAsPOJO(target);
     this.state.menuState.menuItems = menu
-      .children(this.env)
+      .children(this.model(), this.env)
       .sort((a, b) => a.sequence - b.sequence);
     this.state.menuState.parentMenu = menu;
     this.state.menuState.autoSelectFirstItem = autoSelectFirstItem;
@@ -241,16 +243,16 @@ export class TopBar extends Component<SpreadsheetChildEnv> {
   }
 
   getMenuName(menu: Action) {
-    return menu.name(this.env);
+    return menu.name(this.model(), this.env);
   }
 
   setColor(target: string, color: Color) {
-    setStyle(this.env, { [target]: color });
+    setStyle(this.model(), { [target]: color });
     this.onClick();
   }
 
   setFontSize(fontSize: number) {
-    setStyle(this.env, { fontSize });
+    setStyle(this.model(), { fontSize });
   }
 
   toggleMoreTools() {

--- a/src/components/top_bar/top_bar.xml
+++ b/src/components/top_bar/top_bar.xml
@@ -29,14 +29,14 @@
       <!-- Toolbar and Cell Content -->
       <div
         class="d-flex o-topbar-responsive"
-        t-att-class="{'o-topbar-responsive': !this.env.model.getters.isReadonly()}"
+        t-att-class="{'o-topbar-responsive': !this.model().getters.isReadonly()}"
         t-ref="this.toolBarContainerRef">
         <div
           class="o-topbar-toolbar d-flex flex-grow-1"
-          t-att-class="{'flex-shrink-0': this.env.model.getters.isReadonly()}">
+          t-att-class="{'flex-shrink-0': this.model().getters.isReadonly()}">
           <!-- Toolbar -->
           <div
-            t-if="this.env.model.getters.isReadonly()"
+            t-if="this.model().getters.isReadonly()"
             class="o-readonly-toolbar d-flex flex-grow-1 align-items-center text-muted">
             <span>
               <i class="fa fa-eye"/>

--- a/src/components/top_bar/zoom_editor/zoom_editor.ts
+++ b/src/components/top_bar/zoom_editor/zoom_editor.ts
@@ -5,6 +5,7 @@ import { ToolBarDropdownStore, useToolBarDropdownStore } from "../../helpers/top
 import { NumberEditor } from "../../number_editor/number_editor";
 
 import { Component } from "../../../owl3_compatibility_layer";
+import { useModel } from "../../owl_plugins/model_plugin";
 import { types } from "../../props_validation";
 export class ToolBarZoom extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-TopBarZoom";
@@ -15,17 +16,18 @@ export class ToolBarZoom extends Component<SpreadsheetChildEnv> {
 
   valueList = ZOOM_VALUES;
 
+  private model = useModel();
   setup() {
     this.topBarToolStore = useToolBarDropdownStore();
   }
 
   get currentFontSize(): number {
-    const zoom = this.env.model.getters.getViewportZoomLevel() || 1;
+    const zoom = this.model().getters.getViewportZoomLevel() || 1;
     return zoom * 100;
   }
 
   setZoom(fontSize: number) {
-    this.env.model.dispatch("SET_ZOOM", { zoom: fontSize / 100 });
+    this.model().dispatch("SET_ZOOM", { zoom: fontSize / 100 });
   }
 
   toggle() {

--- a/src/helpers/links.ts
+++ b/src/helpers/links.ts
@@ -1,3 +1,4 @@
+import { Model } from "../model";
 import { Registry } from "../registries/registry";
 import { _t } from "../translation";
 import { CellValue } from "../types/cells";
@@ -35,11 +36,19 @@ export interface LinkSpec {
    * - a link to a sheet displays the sheet name
    */
   readonly urlRepresentation: (url: string, getters: CoreGetters) => string;
-  readonly open: (url: string, env: SpreadsheetChildEnv, isMiddleClick?: boolean) => void;
+  readonly open: (
+    url: string,
+    model: Model,
+    env: SpreadsheetChildEnv,
+    isMiddleClick?: boolean
+  ) => void;
   readonly sequence: number;
   readonly title: string;
   readonly icon?: string;
-  readonly getLinkProposals?: (env: SpreadsheetChildEnv) => (Link & { icon: string })[];
+  readonly getLinkProposals?: (
+    model: Model,
+    env: SpreadsheetChildEnv
+  ) => (Link & { icon: string })[];
 }
 
 export const urlRegistry = new Registry<LinkSpec>();
@@ -68,10 +77,10 @@ urlRegistry.add("sheet_URL", {
     const sheetId = parseSheetUrl(url);
     return getters.tryGetSheetName(sheetId) || _t("Invalid sheet");
   },
-  open(url, env) {
+  open(url, model, env) {
     const sheetId = parseSheetUrl(url);
-    const result = env.model.dispatch("ACTIVATE_SHEET", {
-      sheetIdFrom: env.model.getters.getActiveSheetId(),
+    const result = model.dispatch("ACTIVATE_SHEET", {
+      sheetIdFrom: model.getters.getActiveSheetId(),
       sheetIdTo: sheetId,
     });
     if (result.isCancelledBecause(CommandResult.SheetIsHidden)) {
@@ -84,9 +93,9 @@ urlRegistry.add("sheet_URL", {
   },
   sequence: 0,
   title: _t("Sheets"),
-  getLinkProposals(env) {
-    return env.model.getters.getSheetIds().map((sheetId) => {
-      const sheet = env.model.getters.getSheet(sheetId);
+  getLinkProposals(model, env) {
+    return model.getters.getSheetIds().map((sheetId) => {
+      const sheet = model.getters.getSheet(sheetId);
       return {
         ...this.createLink(buildSheetLink(sheetId), sheet.name),
         icon: "o-spreadsheet-Icon.INSERT_SHEET",
@@ -117,8 +126,13 @@ export function urlRepresentation(link: Link, getters: CoreGetters): string {
   return findMatchingSpec(link.url).urlRepresentation(link.url, getters);
 }
 
-export function openLink(link: Link, env: SpreadsheetChildEnv, isMiddleClick?: boolean) {
-  findMatchingSpec(link.url).open(link.url, env, isMiddleClick);
+export function openLink(
+  link: Link,
+  model: Model,
+  env: SpreadsheetChildEnv,
+  isMiddleClick?: boolean
+) {
+  findMatchingSpec(link.url).open(link.url, model, env, isMiddleClick);
 }
 
 export function detectLink(value: CellValue | null): Link | undefined {

--- a/src/helpers/pivot/pivot_helpers.ts
+++ b/src/helpers/pivot/pivot_helpers.ts
@@ -9,6 +9,7 @@ import {
   toString,
   toValue,
 } from "../../functions/helpers";
+import { Model } from "../../model";
 import { Registry } from "../../registries/registry";
 import { _t } from "../../translation";
 import { CellValue } from "../../types/cells";
@@ -30,7 +31,6 @@ import {
   PivotTableCell,
 } from "../../types/pivot";
 import { Pivot } from "../../types/pivot_runtime";
-import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 import { replaceSymbolInFormula } from "../formulas";
 import { deepEquals, getUniqueText, isDefined } from "../misc";
 import { PivotRuntimeDefinition } from "./pivot_runtime_definition";
@@ -435,13 +435,13 @@ export function getCustomFieldWithParentField(
   );
 }
 
-export function togglePivotCollapse(position: CellPosition, env: SpreadsheetChildEnv) {
-  const pivotCell = env.model.getters.getPivotCellFromPosition(position);
-  const pivotId = env.model.getters.getPivotIdFromPosition(position);
+export function togglePivotCollapse(position: CellPosition, model: Model) {
+  const pivotCell = model.getters.getPivotCellFromPosition(position);
+  const pivotId = model.getters.getPivotIdFromPosition(position);
   if (!pivotId || pivotCell.type !== "HEADER") {
     return;
   }
-  const definition = env.model.getters.getPivotCoreDefinition(pivotId);
+  const definition = model.getters.getPivotCoreDefinition(pivotId);
 
   const collapsedDomains = definition.collapsedDomains?.[pivotCell.dimension]
     ? [...definition.collapsedDomains[pivotCell.dimension]]
@@ -457,7 +457,7 @@ export function togglePivotCollapse(position: CellPosition, env: SpreadsheetChil
     ? { ...definition.collapsedDomains }
     : { COL: [], ROW: [] };
   newDomains[pivotCell.dimension] = collapsedDomains;
-  env.model.dispatch("UPDATE_PIVOT", {
+  model.dispatch("UPDATE_PIVOT", {
     pivotId,
     pivot: { ...definition, collapsedDomains: newDomains },
   });

--- a/src/helpers/pivot/pivot_menu_items.ts
+++ b/src/helpers/pivot/pivot_menu_items.ts
@@ -1,4 +1,5 @@
 import { ActionSpec } from "../../actions/action";
+import { Model } from "../../model";
 import { _t } from "../../translation";
 import { CellValue, CellValueType } from "../../types/cells";
 import { Getters } from "../../types/getters";
@@ -12,7 +13,6 @@ import {
   PivotFields,
   PivotHeaderCell,
 } from "../../types/pivot";
-import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 import { deepCopy, deepEquals } from "../misc";
 import { cellPositions } from "../zones";
 import { domainToColRowDomain } from "./pivot_domain_helpers";
@@ -27,15 +27,15 @@ import { pivotRegistry } from "./pivot_registry";
 
 export const pivotProperties: ActionSpec = {
   name: _t("See pivot properties"),
-  execute(env) {
-    const position = env.model.getters.getActivePosition();
-    const pivotId = env.model.getters.getPivotIdFromPosition(position);
+  execute(model, env) {
+    const position = model.getters.getActivePosition();
+    const pivotId = model.getters.getPivotIdFromPosition(position);
     env.openSidePanel("PivotSidePanel", { pivotId });
   },
-  isVisible: (env) => {
-    const position = env.model.getters.getActivePosition();
-    const pivotId = env.model.getters.getPivotIdFromPosition(position);
-    return (!env.isSmall && pivotId && env.model.getters.isExistingPivot(pivotId)) || false;
+  isVisible: (model, env) => {
+    const position = model.getters.getActivePosition();
+    const pivotId = model.getters.getPivotIdFromPosition(position);
+    return (!env.isSmall && pivotId && model.getters.isExistingPivot(pivotId)) || false;
   },
   isReadonlyAllowed: true,
   isEnabledOnLockedSheet: true,
@@ -44,58 +44,58 @@ export const pivotProperties: ActionSpec = {
 
 export const pivotSortingAsc: ActionSpec = {
   name: _t("Ascending"),
-  execute: (env) => sortPivot(env, env.model.getters.getActivePosition(), "asc"),
-  isActive: (env) =>
-    env.model.getters.getPivotCellSortDirection(env.model.getters.getActivePosition()) === "asc",
+  execute: (model) => sortPivot(model, model.getters.getActivePosition(), "asc"),
+  isActive: (model) =>
+    model.getters.getPivotCellSortDirection(model.getters.getActivePosition()) === "asc",
 };
 
 export const pivotSortingDesc: ActionSpec = {
   name: _t("Descending"),
-  execute: (env) => sortPivot(env, env.model.getters.getActivePosition(), "desc"),
-  isActive: (env) =>
-    env.model.getters.getPivotCellSortDirection(env.model.getters.getActivePosition()) === "desc",
+  execute: (model) => sortPivot(model, model.getters.getActivePosition(), "desc"),
+  isActive: (model) =>
+    model.getters.getPivotCellSortDirection(model.getters.getActivePosition()) === "desc",
 };
 
 export const noPivotSorting: ActionSpec = {
   name: _t("No sorting"),
-  execute: (env) => sortPivot(env, env.model.getters.getActivePosition(), "none"),
-  isActive: (env) =>
-    env.model.getters.getPivotCellSortDirection(env.model.getters.getActivePosition()) === "none",
+  execute: (model) => sortPivot(model, model.getters.getActivePosition(), "none"),
+  isActive: (model) =>
+    model.getters.getPivotCellSortDirection(model.getters.getActivePosition()) === "none",
 };
 
 export const FIX_FORMULAS: ActionSpec = {
   name: _t("Convert to individual formulas"),
-  execute(env) {
-    const position = env.model.getters.getActivePosition();
-    const cell = env.model.getters.getCorrespondingFormulaCell(position);
-    const pivotId = env.model.getters.getPivotIdFromPosition(position);
+  execute(model) {
+    const position = model.getters.getActivePosition();
+    const cell = model.getters.getCorrespondingFormulaCell(position);
+    const pivotId = model.getters.getPivotIdFromPosition(position);
     if (!cell || !pivotId) {
       return;
     }
-    const { sheetId, col, row } = env.model.getters.getCellPosition(cell.id);
-    const pivot = env.model.getters.getPivot(pivotId);
+    const { sheetId, col, row } = model.getters.getCellPosition(cell.id);
+    const pivot = model.getters.getPivot(pivotId);
     pivot.init();
     if (!pivot.isValid()) {
       return;
     }
-    env.model.dispatch("SPLIT_PIVOT_FORMULA", {
+    model.dispatch("SPLIT_PIVOT_FORMULA", {
       sheetId,
       col,
       row,
       pivotId,
     });
   },
-  isVisible: (env) => {
-    const position = env.model.getters.getActivePosition();
-    const pivotId = env.model.getters.getPivotIdFromPosition(position);
+  isVisible: (model) => {
+    const position = model.getters.getActivePosition();
+    const pivotId = model.getters.getPivotIdFromPosition(position);
     if (!pivotId) {
       return false;
     }
-    const pivot = env.model.getters.getPivot(pivotId);
-    const cell = env.model.getters.getEvaluatedCell(position);
+    const pivot = model.getters.getPivot(pivotId);
+    const cell = model.getters.getEvaluatedCell(position);
     return (
       pivot.isValid() &&
-      env.model.getters.isSpillPivotFormula(position) &&
+      model.getters.isSpillPivotFormula(position) &&
       cell.type !== CellValueType.error
     );
   },
@@ -104,14 +104,14 @@ export const FIX_FORMULAS: ActionSpec = {
 
 export const groupPivotHeaders: ActionSpec = {
   name: _t("Group pivot dimensions"),
-  execute: (env) => {
-    const matchingHeaders = getMatchingPivotHeadersInSelection(env);
+  execute: (model) => {
+    const matchingHeaders = getMatchingPivotHeadersInSelection(model);
     if (!matchingHeaders) {
       return;
     }
     const { pivotId, values, field } = matchingHeaders;
-    const pivot = env.model.getters.getPivot(pivotId);
-    const definition = deepCopy(env.model.getters.getPivotCoreDefinition(pivotId));
+    const pivot = model.getters.getPivot(pivotId);
+    const definition = deepCopy(model.getters.getPivotCoreDefinition(pivotId));
 
     if (!field.isCustomField) {
       groupValuesInNormalField(definition, values, field, pivot.getFields());
@@ -123,15 +123,15 @@ export const groupPivotHeaders: ActionSpec = {
       groupValuesInCustomField(customField, values);
     }
 
-    env.model.dispatch("UPDATE_PIVOT", { pivotId, pivot: definition });
+    model.dispatch("UPDATE_PIVOT", { pivotId, pivot: definition });
   },
-  isVisible: (env) => {
-    const matchingHeaders = getMatchingPivotHeadersInSelection(env);
+  isVisible: (model) => {
+    const matchingHeaders = getMatchingPivotHeadersInSelection(model);
     if (!matchingHeaders) {
       return false;
     }
     const { pivotId, values, field } = matchingHeaders;
-    const pivot = env.model.getters.getPivot(pivotId);
+    const pivot = model.getters.getPivot(pivotId);
     return (
       values.length > 1 &&
       (field.isCustomField || pivotRegistry.get(pivot.type).canHaveCustomGroup(field))
@@ -141,14 +141,14 @@ export const groupPivotHeaders: ActionSpec = {
 
 export const groupRemainingPivotHeadersAction: ActionSpec = {
   name: _t("Group all remaining dimensions"),
-  execute: (env) => {
-    const matchingHeaders = getMatchingPivotHeadersInSelection(env);
+  execute: (model) => {
+    const matchingHeaders = getMatchingPivotHeadersInSelection(model);
     if (!matchingHeaders) {
       return;
     }
     const { pivotId, field } = matchingHeaders;
-    const pivot = env.model.getters.getPivot(pivotId);
-    const definition = deepCopy(env.model.getters.getPivotCoreDefinition(pivotId));
+    const pivot = model.getters.getPivot(pivotId);
+    const definition = deepCopy(model.getters.getPivotCoreDefinition(pivotId));
 
     const customField = field.isCustomField
       ? (definition.customFields || {})[field.name]
@@ -162,40 +162,40 @@ export const groupRemainingPivotHeadersAction: ActionSpec = {
       isOtherGroup: true,
     });
     addDimensionToPivotDefinition(definition, field.name, customField.name);
-    env.model.dispatch("UPDATE_PIVOT", { pivotId, pivot: definition });
+    model.dispatch("UPDATE_PIVOT", { pivotId, pivot: definition });
   },
-  isVisible: (env) => {
-    const matchingHeaders = getMatchingPivotHeadersInSelection(env);
+  isVisible: (model) => {
+    const matchingHeaders = getMatchingPivotHeadersInSelection(model);
     if (!matchingHeaders) {
       return false;
     }
     const { pivotId, field, values } = matchingHeaders;
-    return valuesAreAllNonGroupedValues(env, pivotId, values, field);
+    return valuesAreAllNonGroupedValues(model, pivotId, values, field);
   },
 };
 
 export const ungroupPivotHeadersAction: ActionSpec = {
   name: _t("Ungroup pivot dimensions"),
-  execute: (env) => {
-    const matchingHeaders = getMatchingPivotHeadersInSelection(env);
+  execute: (model) => {
+    const matchingHeaders = getMatchingPivotHeadersInSelection(model);
     if (!matchingHeaders) {
       return;
     }
     const { pivotId, values, field } = matchingHeaders;
-    const pivot = env.model.getters.getPivot(pivotId);
-    const definition = deepCopy(env.model.getters.getPivotCoreDefinition(pivotId));
+    const pivot = model.getters.getPivot(pivotId);
+    const definition = deepCopy(model.getters.getPivotCoreDefinition(pivotId));
     ungroupPivotHeaders(definition, values, field, pivot.getFields());
 
-    env.model.dispatch("UPDATE_PIVOT", { pivotId, pivot: definition });
+    model.dispatch("UPDATE_PIVOT", { pivotId, pivot: definition });
   },
-  isVisible: (env) => {
-    const matchingHeaders = getMatchingPivotHeadersInSelection(env);
+  isVisible: (model) => {
+    const matchingHeaders = getMatchingPivotHeadersInSelection(model);
     if (!matchingHeaders) {
       return false;
     }
     const { pivotId, values, field } = matchingHeaders;
-    const pivot = env.model.getters.getPivot(pivotId);
-    const definition = env.model.getters.getPivotCoreDefinition(pivotId);
+    const pivot = model.getters.getPivot(pivotId);
+    const definition = model.getters.getPivotCoreDefinition(pivotId);
 
     if (!field.isCustomField) {
       // Check if the parent custom grouped field is in the pivot
@@ -211,37 +211,37 @@ export const ungroupPivotHeadersAction: ActionSpec = {
 };
 
 export const toggleCollapsePivotGroupAction: ActionSpec = {
-  name: (env) => {
-    const position = env.model.getters.getActivePosition();
-    const pivotCellState = getPivotCellCollapseState(env.model.getters, position);
+  name: (model) => {
+    const position = model.getters.getActivePosition();
+    const pivotCellState = getPivotCellCollapseState(model.getters, position);
     if (pivotCellState.isPivotGroup) {
       return pivotCellState.isCollapsed ? _t("Expand") : _t("Collapse");
     }
     return "";
   },
-  execute(env) {
-    const position = env.model.getters.getActivePosition();
-    togglePivotCollapse(position, env);
+  execute(model) {
+    const position = model.getters.getActivePosition();
+    togglePivotCollapse(position, model);
   },
-  isVisible: (env) => {
-    const position = env.model.getters.getActivePosition();
-    const pivotCellState = getPivotCellCollapseState(env.model.getters, position);
-    const pivotStyle = env.model.getters.getPivotStyleAtPosition(position);
+  isVisible: (model) => {
+    const position = model.getters.getActivePosition();
+    const pivotCellState = getPivotCellCollapseState(model.getters, position);
+    const pivotStyle = model.getters.getPivotStyleAtPosition(position);
     return pivotCellState.isPivotGroup && !pivotStyle?.pivotStyle.tabularForm;
   },
 };
 
 export const collapseAllPivotGroupAction: ActionSpec = {
   name: _t("Collapse all"),
-  execute(env) {
-    const position = env.model.getters.getActivePosition();
-    const pivotCellState = getPivotCellCollapseState(env.model.getters, position);
+  execute(model) {
+    const position = model.getters.getActivePosition();
+    const pivotCellState = getPivotCellCollapseState(model.getters, position);
     if (!pivotCellState.isPivotGroup) {
       return;
     }
     const { pivotCell, pivotId, siblingDomains } = pivotCellState;
 
-    const definition = deepCopy(env.model.getters.getPivotCoreDefinition(pivotId));
+    const definition = deepCopy(model.getters.getPivotCoreDefinition(pivotId));
     definition.collapsedDomains = definition.collapsedDomains || { COL: [], ROW: [] };
     const newCollapsed = [
       ...(definition.collapsedDomains[pivotCell.dimension] || []),
@@ -253,18 +253,18 @@ export const collapseAllPivotGroupAction: ActionSpec = {
     );
 
     definition.collapsedDomains[pivotCell.dimension] = filteredCollapsed;
-    env.model.dispatch("UPDATE_PIVOT", { pivotId, pivot: definition });
+    model.dispatch("UPDATE_PIVOT", { pivotId, pivot: definition });
   },
-  isVisible: (env) => {
-    const position = env.model.getters.getActivePosition();
-    const pivotCellState = getPivotCellCollapseState(env.model.getters, position);
-    const pivotStyle = env.model.getters.getPivotStyleAtPosition(position);
+  isVisible: (model) => {
+    const position = model.getters.getActivePosition();
+    const pivotCellState = getPivotCellCollapseState(model.getters, position);
+    const pivotStyle = model.getters.getPivotStyleAtPosition(position);
     if (!pivotCellState.isPivotGroup || pivotStyle?.pivotStyle.tabularForm) {
       return false;
     }
 
     const { pivotCell, pivotId, siblingDomains } = pivotCellState;
-    const definition = env.model.getters.getPivotCoreDefinition(pivotId);
+    const definition = model.getters.getPivotCoreDefinition(pivotId);
 
     return !siblingDomains.every((domain) =>
       (definition.collapsedDomains?.[pivotCell.dimension] || []).some((d) => deepEquals(d, domain))
@@ -274,15 +274,15 @@ export const collapseAllPivotGroupAction: ActionSpec = {
 
 export const expandAllPivotGroupAction: ActionSpec = {
   name: _t("Expand all"),
-  execute(env) {
-    const position = env.model.getters.getActivePosition();
-    const pivotCellState = getPivotCellCollapseState(env.model.getters, position);
+  execute(model) {
+    const position = model.getters.getActivePosition();
+    const pivotCellState = getPivotCellCollapseState(model.getters, position);
     if (!pivotCellState.isPivotGroup) {
       return;
     }
     const { pivotCell, pivotId, siblingDomains } = pivotCellState;
 
-    const definition = deepCopy(env.model.getters.getPivotCoreDefinition(pivotId));
+    const definition = deepCopy(model.getters.getPivotCoreDefinition(pivotId));
     definition.collapsedDomains = definition.collapsedDomains || { COL: [], ROW: [] };
 
     const domains = definition.collapsedDomains[pivotCell.dimension] || [];
@@ -291,18 +291,18 @@ export const expandAllPivotGroupAction: ActionSpec = {
     );
 
     definition.collapsedDomains[pivotCell.dimension] = filteredDomains;
-    env.model.dispatch("UPDATE_PIVOT", { pivotId, pivot: definition });
+    model.dispatch("UPDATE_PIVOT", { pivotId, pivot: definition });
   },
-  isVisible: (env) => {
-    const position = env.model.getters.getActivePosition();
-    const pivotCellState = getPivotCellCollapseState(env.model.getters, position);
-    const pivotStyle = env.model.getters.getPivotStyleAtPosition(position);
+  isVisible: (model) => {
+    const position = model.getters.getActivePosition();
+    const pivotCellState = getPivotCellCollapseState(model.getters, position);
+    const pivotStyle = model.getters.getPivotStyleAtPosition(position);
     if (!pivotCellState.isPivotGroup || pivotStyle?.pivotStyle.tabularForm) {
       return false;
     }
 
     const { pivotCell, pivotId, siblingDomains } = pivotCellState;
-    const definition = env.model.getters.getPivotCoreDefinition(pivotId);
+    const definition = model.getters.getPivotCoreDefinition(pivotId);
     const collapsedDomains = definition.collapsedDomains?.[pivotCell.dimension] || [];
     return collapsedDomains.some((domain) => siblingDomains.some((d) => deepEquals(d, domain)));
   },
@@ -365,13 +365,9 @@ export function canSortPivot(getters: Getters, position: CellPosition): boolean 
   return pivotCell.type === "VALUE" || pivotCell.type === "MEASURE_HEADER";
 }
 
-export function sortPivot(
-  env: SpreadsheetChildEnv,
-  position: CellPosition,
-  order: SortDirection | "none"
-) {
-  const pivotId = env.model.getters.getPivotIdFromPosition(position);
-  const pivotCell = env.model.getters.getPivotCellFromPosition(position);
+export function sortPivot(model: Model, position: CellPosition, order: SortDirection | "none") {
+  const pivotId = model.getters.getPivotIdFromPosition(position);
+  const pivotCell = model.getters.getPivotCellFromPosition(position);
   if (
     pivotCell.type === "EMPTY" ||
     pivotCell.type === "HEADER" ||
@@ -382,22 +378,22 @@ export function sortPivot(
   }
 
   if (order === "none") {
-    env.model.dispatch("UPDATE_PIVOT", {
+    model.dispatch("UPDATE_PIVOT", {
       pivotId: pivotId,
       pivot: {
-        ...env.model.getters.getPivotCoreDefinition(pivotId),
+        ...model.getters.getPivotCoreDefinition(pivotId),
         sortedColumn: undefined,
       },
     });
     return;
   }
 
-  const pivot = env.model.getters.getPivot(pivotId);
+  const pivot = model.getters.getPivot(pivotId);
   const colDomain = domainToColRowDomain(pivot, pivotCell.domain).colDomain;
-  env.model.dispatch("UPDATE_PIVOT", {
+  model.dispatch("UPDATE_PIVOT", {
     pivotId: pivotId,
     pivot: {
-      ...env.model.getters.getPivotCoreDefinition(pivotId),
+      ...model.getters.getPivotCoreDefinition(pivotId),
       sortedColumn: { domain: colDomain, order, measure: pivotCell.measure },
     },
   });
@@ -407,14 +403,14 @@ export function sortPivot(
  * Get the values of the pivot headers in the current selection, if all the pivot headers on the selection belong
  * to the same pivot, the same field and that the pivot formula is a dynamic pivot. Otherwise return undefined.
  */
-function getMatchingPivotHeadersInSelection(env: SpreadsheetChildEnv) {
+function getMatchingPivotHeadersInSelection(model: Model) {
   let pivotId: string | undefined;
   let fieldName: string | undefined;
   const pivotHeaders: PivotHeaderCell[] = [];
-  for (const zone of env.model.getters.getSelectedZones()) {
-    const sheetId = env.model.getters.getActiveSheetId();
+  for (const zone of model.getters.getSelectedZones()) {
+    const sheetId = model.getters.getActiveSheetId();
     for (const position of cellPositions(sheetId, zone)) {
-      const cellPivotId = env.model.getters.getPivotIdFromPosition(position);
+      const cellPivotId = model.getters.getPivotIdFromPosition(position);
       if (!pivotId) {
         pivotId = cellPivotId;
       } else if (cellPivotId && pivotId !== cellPivotId) {
@@ -423,8 +419,8 @@ function getMatchingPivotHeadersInSelection(env: SpreadsheetChildEnv) {
       if (!pivotId) {
         continue;
       }
-      const pivotCell = env.model.getters.getPivotCellFromPosition(position);
-      if (pivotCell.type !== "HEADER" || !env.model.getters.isSpillPivotFormula(position)) {
+      const pivotCell = model.getters.getPivotCellFromPosition(position);
+      if (pivotCell.type !== "HEADER" || !model.getters.isSpillPivotFormula(position)) {
         continue;
       }
       const cellLeafField = pivotCell.domain.at(-1)?.field;
@@ -440,7 +436,7 @@ function getMatchingPivotHeadersInSelection(env: SpreadsheetChildEnv) {
     return undefined;
   }
 
-  const field = env.model.getters.getPivot(pivotId).getFields()[fieldName];
+  const field = model.getters.getPivot(pivotId).getFields()[fieldName];
   if (!field) {
     return undefined;
   }
@@ -572,13 +568,13 @@ function areFieldValuesInGroups(
 
 /** Checks that the values given are equal to all the values that are not grouped in the pivot dimension. */
 function valuesAreAllNonGroupedValues(
-  env: SpreadsheetChildEnv,
+  model: Model,
   pivotId: string,
   values: CellValue[],
   field: PivotField
 ): boolean {
-  const pivot = env.model.getters.getPivot(pivotId);
-  const definition = env.model.getters.getPivotCoreDefinition(pivotId);
+  const pivot = model.getters.getPivot(pivotId);
+  const definition = model.getters.getPivotCoreDefinition(pivotId);
   const customField = field.isCustomField
     ? (definition.customFields || {})[field.name]
     : Object.values(definition.customFields || {}).find((f) => f.parentField === field.name);

--- a/src/helpers/sort_interactive.ts
+++ b/src/helpers/sort_interactive.ts
@@ -1,3 +1,4 @@
+import { Model } from "../model";
 import { _t } from "../translation";
 import { CommandResult } from "../types/commands";
 import { Position, SortDirection, SortOptions, UID, Zone } from "../types/misc";
@@ -5,6 +6,7 @@ import { SpreadsheetChildEnv } from "../types/spreadsheet_env";
 import { isEqual } from "./zones";
 
 export function interactiveSortSelection(
+  model: Model,
   env: SpreadsheetChildEnv,
   sheetId: UID,
   anchor: Position,
@@ -13,13 +15,13 @@ export function interactiveSortSelection(
 ) {
   //several columns => bypass the contiguity check
   let multiColumns: boolean = zone.right > zone.left;
-  if (env.model.getters.doesIntersectMerge(sheetId, zone)) {
+  if (model.getters.doesIntersectMerge(sheetId, zone)) {
     multiColumns = false;
     let table: UID[];
     for (let row = zone.top; row <= zone.bottom; row++) {
       table = [];
       for (let col = zone.left; col <= zone.right; col++) {
-        const merge = env.model.getters.getMerge({ sheetId, col, row });
+        const merge = model.getters.getMerge({ sheetId, col, row });
         if (merge && !table.includes(merge.id.toString())) {
           table.push(merge.id.toString());
         }
@@ -32,25 +34,26 @@ export function interactiveSortSelection(
   }
 
   if (multiColumns) {
-    interactiveSort(env, sheetId, anchor, zone, sortDirection);
+    interactiveSort(model, env, sheetId, anchor, zone, sortDirection);
     return;
   }
 
-  const contiguousZone = env.model.getters.getContiguousZone(sheetId, zone);
+  const contiguousZone = model.getters.getContiguousZone(sheetId, zone);
   if (isEqual(contiguousZone, zone)) {
-    interactiveSort(env, sheetId, anchor, zone, sortDirection);
+    interactiveSort(model, env, sheetId, anchor, zone, sortDirection);
   } else {
     env.askConfirmation(
       _t(
         "We found data next to your selection. Since this data was not selected, it will not be sorted. Do you want to extend your selection?"
       ),
-      () => interactiveSort(env, sheetId, anchor, contiguousZone, sortDirection),
-      () => interactiveSort(env, sheetId, anchor, zone, sortDirection)
+      () => interactiveSort(model, env, sheetId, anchor, contiguousZone, sortDirection),
+      () => interactiveSort(model, env, sheetId, anchor, zone, sortDirection)
     );
   }
 }
 
 export function interactiveSort(
+  model: Model,
   env: SpreadsheetChildEnv,
   sheetId: UID,
   anchor: Position,
@@ -58,7 +61,7 @@ export function interactiveSort(
   sortDirection: SortDirection,
   sortOptions?: SortOptions
 ) {
-  const result = env.model.dispatch("SORT_CELLS", {
+  const result = model.dispatch("SORT_CELLS", {
     sheetId,
     col: anchor.col,
     row: anchor.row,
@@ -68,14 +71,14 @@ export function interactiveSort(
   });
   if (result.isCancelledBecause(CommandResult.InvalidSortZone)) {
     const { col, row } = anchor;
-    env.model.selection.selectZone({ cell: { col, row }, zone });
+    model.selection.selectZone({ cell: { col, row }, zone });
     env.raiseError(
       _t("Cannot sort. To sort, select only cells or only merges that have the same size.")
     );
   }
   if (result.isCancelledBecause(CommandResult.SortZoneWithArrayFormulas)) {
     const { col, row } = anchor;
-    env.model.selection.selectZone({ cell: { col, row }, zone });
+    model.selection.selectZone({ cell: { col, row }, zone });
     env.raiseError(_t("Cannot sort a zone with array formulas."));
   }
 }

--- a/src/helpers/ui/cut_interactive.ts
+++ b/src/helpers/ui/cut_interactive.ts
@@ -1,9 +1,10 @@
+import { Model } from "../../model";
 import { _t } from "../../translation";
 import { CommandResult } from "../../types/commands";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 
-export function interactiveCut(env: SpreadsheetChildEnv) {
-  const result = env.model.dispatch("CUT");
+export function interactiveCut(model: Model, env: SpreadsheetChildEnv) {
+  const result = model.dispatch("CUT");
 
   if (!result.isSuccessful) {
     if (result.isCancelledBecause(CommandResult.WrongCutSelection)) {

--- a/src/helpers/ui/freeze_interactive.ts
+++ b/src/helpers/ui/freeze_interactive.ts
@@ -1,16 +1,18 @@
+import { Model } from "../..";
 import { MergeErrorMessage } from "../../components/translations_terms";
 import { CommandResult } from "../../types/commands";
 import { Dimension, HeaderIndex } from "../../types/misc";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 
 export function interactiveFreezeColumnsRows(
+  model: Model,
   env: SpreadsheetChildEnv,
   dimension: Dimension,
   base: HeaderIndex
 ) {
-  const sheetId = env.model.getters.getActiveSheetId();
+  const sheetId = model.getters.getActiveSheetId();
   const cmd = dimension === "COL" ? "FREEZE_COLUMNS" : "FREEZE_ROWS";
-  const result = env.model.dispatch(cmd, { sheetId, quantity: base });
+  const result = model.dispatch(cmd, { sheetId, quantity: base });
 
   if (result.isCancelledBecause(CommandResult.MergeOverlap)) {
     env.raiseError(MergeErrorMessage);

--- a/src/helpers/ui/merge_interactive.ts
+++ b/src/helpers/ui/merge_interactive.ts
@@ -1,3 +1,4 @@
+import { Model } from "../../model";
 import { _t } from "../../translation";
 import { CommandResult } from "../../types/commands";
 import { UID, Zone } from "../../types/misc";
@@ -10,13 +11,18 @@ export const AddMergeInteractiveContent = {
   MergeInFilter: _t("You can't merge cells inside of an existing filter."),
 };
 
-export function interactiveAddMerge(env: SpreadsheetChildEnv, sheetId: UID, target: Zone[]) {
-  const result = env.model.dispatch("ADD_MERGE", { sheetId, target });
+export function interactiveAddMerge(
+  model: Model,
+  env: SpreadsheetChildEnv,
+  sheetId: UID,
+  target: Zone[]
+) {
+  const result = model.dispatch("ADD_MERGE", { sheetId, target });
   if (result.isCancelledBecause(CommandResult.MergeInTable)) {
     env.raiseError(AddMergeInteractiveContent.MergeInFilter);
   } else if (result.isCancelledBecause(CommandResult.MergeIsDestructive)) {
     env.askConfirmation(AddMergeInteractiveContent.MergeIsDestructive, () => {
-      env.model.dispatch("ADD_MERGE", { sheetId, target, force: true });
+      model.dispatch("ADD_MERGE", { sheetId, target, force: true });
     });
   }
 }

--- a/src/helpers/ui/named_range_interactive.ts
+++ b/src/helpers/ui/named_range_interactive.ts
@@ -1,3 +1,4 @@
+import { Model } from "../../model";
 import { _t } from "../../translation";
 import {
   CommandResult,
@@ -8,18 +9,20 @@ import {
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 
 export function interactiveCreateNamedRange(
+  model: Model,
   env: SpreadsheetChildEnv,
   payload: Omit<CreateNamedRangeCommand, "type">
 ) {
-  const result = env.model.dispatch("CREATE_NAMED_RANGE", payload);
+  const result = model.dispatch("CREATE_NAMED_RANGE", payload);
   handleResult(env, result);
 }
 
 export function interactiveUpdateNamedRange(
+  model: Model,
   env: SpreadsheetChildEnv,
   payload: Omit<UpdateNamedRangeCommand, "type">
 ) {
-  const result = env.model.dispatch("UPDATE_NAMED_RANGE", payload);
+  const result = model.dispatch("UPDATE_NAMED_RANGE", payload);
   handleResult(env, result);
 }
 

--- a/src/helpers/ui/paste_interactive.ts
+++ b/src/helpers/ui/paste_interactive.ts
@@ -1,5 +1,6 @@
 import { MergeErrorMessage, RemoveDuplicateTerms } from "../../components/translations_terms";
 import { getCurrentVersion } from "../../migrations/data";
+import { Model } from "../../model";
 import { _t } from "../../translation";
 import {
   ClipboardPasteOptions,
@@ -17,10 +18,11 @@ import { Zone } from "../../types/misc";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 
 export const handleCopyPasteResult = (
+  model: Model,
   env: SpreadsheetChildEnv,
   command: CopyPasteCellsAboveCommand | CopyPasteCellsOnLeftCommand | CopyPasteCellsOnZoneCommand
 ) => {
-  const result = env.model.dispatch(command.type);
+  const result = model.dispatch(command.type);
   if (result.isCancelledBecause(CommandResult.WillRemoveExistingMerge)) {
     env.raiseError(MergeErrorMessage);
   }
@@ -33,7 +35,7 @@ export const PasteInteractiveContent = {
   frozenPaneOverlap: _t("This operation is not allowed due to an overlapping frozen pane."),
 };
 
-export function handlePasteResult(env: SpreadsheetChildEnv, result: DispatchResult) {
+export function handlePasteResult(model: Model, env: SpreadsheetChildEnv, result: DispatchResult) {
   if (!result.isSuccessful) {
     if (result.reasons.includes(CommandResult.WrongPasteSelection)) {
       env.raiseError(PasteInteractiveContent.wrongPasteSelection);
@@ -48,15 +50,17 @@ export function handlePasteResult(env: SpreadsheetChildEnv, result: DispatchResu
 }
 
 export function interactivePaste(
+  model: Model,
   env: SpreadsheetChildEnv,
   target: Zone[],
   pasteOption?: ClipboardPasteOptions
 ) {
-  const result = env.model.dispatch("PASTE", { target, pasteOption });
-  handlePasteResult(env, result);
+  const result = model.dispatch("PASTE", { target, pasteOption });
+  handlePasteResult(model, env, result);
 }
 
 export async function interactivePasteFromOS(
+  model: Model,
   env: SpreadsheetChildEnv,
   target: Zone[],
   parsedClipboardContent: ParsedOSClipboardContent,
@@ -85,11 +89,11 @@ export async function interactivePasteFromOS(
     delete parsedClipboardContent.imageBlob;
   }
 
-  const result = env.model.dispatch("PASTE_FROM_OS_CLIPBOARD", {
+  const result = model.dispatch("PASTE_FROM_OS_CLIPBOARD", {
     target,
     clipboardContent: parsedClipboardContent,
     pasteOption,
   });
 
-  handlePasteResult(env, result);
+  handlePasteResult(model, env, result);
 }

--- a/src/helpers/ui/sheet_interactive.ts
+++ b/src/helpers/ui/sheet_interactive.ts
@@ -1,19 +1,21 @@
 import { FORBIDDEN_SHEETNAME_CHARS } from "../../constants";
+import { Model } from "../../model";
 import { _t } from "../../translation";
 import { CommandResult } from "../../types/commands";
 import { UID } from "../../types/misc";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 
 export function interactiveRenameSheet(
+  model: Model,
   env: SpreadsheetChildEnv,
   sheetId: UID,
   name: string,
   errorCallback: () => void
 ) {
-  const result = env.model.dispatch("RENAME_SHEET", {
+  const result = model.dispatch("RENAME_SHEET", {
     sheetId,
     newName: name,
-    oldName: env.model.getters.getSheetName(sheetId),
+    oldName: model.getters.getSheetName(sheetId),
   });
   if (result.reasons.includes(CommandResult.MissingSheetName)) {
     env.raiseError(_t("The sheet name cannot be empty."), errorCallback);

--- a/src/helpers/ui/split_to_columns_interactive.ts
+++ b/src/helpers/ui/split_to_columns_interactive.ts
@@ -1,3 +1,4 @@
+import { Model } from "../../model";
 import { _t } from "../../translation";
 import { CommandResult, DispatchResult } from "../../types/commands";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
@@ -7,14 +8,15 @@ export const SplitToColumnsInteractiveContent = {
 };
 
 export function interactiveSplitToColumns(
+  model: Model,
   env: SpreadsheetChildEnv,
   separator: string,
   addNewColumns: boolean
 ): DispatchResult {
-  let result = env.model.dispatch("SPLIT_TEXT_INTO_COLUMNS", { separator, addNewColumns });
+  let result = model.dispatch("SPLIT_TEXT_INTO_COLUMNS", { separator, addNewColumns });
   if (result.isCancelledBecause(CommandResult.SplitWillOverwriteContent)) {
     env.askConfirmation(SplitToColumnsInteractiveContent.SplitIsDestructive, () => {
-      result = env.model.dispatch("SPLIT_TEXT_INTO_COLUMNS", {
+      result = model.dispatch("SPLIT_TEXT_INTO_COLUMNS", {
         separator,
         addNewColumns,
         force: true,

--- a/src/helpers/ui/table_interactive.ts
+++ b/src/helpers/ui/table_interactive.ts
@@ -1,6 +1,7 @@
 import { CommandResult, DispatchResult } from "../../types/commands";
 import { UID } from "../../types/misc";
 
+import { Model } from "../..";
 import { TableTerms } from "../../components/translations_terms";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 import { TableConfig } from "../../types/table";
@@ -12,21 +13,22 @@ import { getZoneArea } from "../zones";
  * If a single cell is selected, expand the selection to non-empty adjacent cells to create a table.
  */
 export function interactiveCreateTable(
+  model: Model,
   env: SpreadsheetChildEnv,
   sheetId: UID,
   tableConfig: TableConfig = DEFAULT_TABLE_CONFIG
 ): DispatchResult {
-  let target = env.model.getters.getSelectedZones();
-  let isDynamic = env.model.getters.canCreateDynamicTableOnZones(sheetId, target);
+  let target = model.getters.getSelectedZones();
+  let isDynamic = model.getters.canCreateDynamicTableOnZones(sheetId, target);
 
   if (target.length === 1 && !isDynamic && getZoneArea(target[0]) === 1) {
-    env.model.selection.selectTableAroundSelection();
-    target = env.model.getters.getSelectedZones();
-    isDynamic = env.model.getters.canCreateDynamicTableOnZones(sheetId, target);
+    model.selection.selectTableAroundSelection();
+    target = model.getters.getSelectedZones();
+    isDynamic = model.getters.canCreateDynamicTableOnZones(sheetId, target);
   }
 
-  const ranges = target.map((zone) => env.model.getters.getRangeDataFromZone(sheetId, zone));
-  const result = env.model.dispatch("CREATE_TABLE", {
+  const ranges = target.map((zone) => model.getters.getRangeDataFromZone(sheetId, zone));
+  const result = model.dispatch("CREATE_TABLE", {
     ranges,
     sheetId,
     config: tableConfig,

--- a/src/helpers/ui/toggle_group_interactive.ts
+++ b/src/helpers/ui/toggle_group_interactive.ts
@@ -1,3 +1,4 @@
+import { Model } from "../../model";
 import { _t } from "../../translation";
 import { CommandResult } from "../../types/commands";
 import { Dimension, HeaderIndex, UID } from "../../types/misc";
@@ -9,18 +10,19 @@ export const ToggleGroupInteractiveContent = {
 };
 
 export function interactiveToggleGroup(
+  model: Model,
   env: SpreadsheetChildEnv,
   sheetId: UID,
   dimension: Dimension,
   start: HeaderIndex,
   end: HeaderIndex
 ) {
-  const group = env.model.getters.getHeaderGroup(sheetId, dimension, start, end);
+  const group = model.getters.getHeaderGroup(sheetId, dimension, start, end);
   if (!group) {
     return;
   }
   const command = group.isFolded ? "UNFOLD_HEADER_GROUP" : "FOLD_HEADER_GROUP";
-  const result = env.model.dispatch(command, {
+  const result = model.dispatch(command, {
     sheetId,
     dimension,
     start: group.start,

--- a/src/owl3_compatibility_layer.ts
+++ b/src/owl3_compatibility_layer.ts
@@ -76,8 +76,6 @@ class _Component<Env = any> extends OwlComponent {
     this.__owl__ = node;
   }
 
-  setup() {}
-
   render(deep = false) {
     void this.__owl__.render(deep === true);
   }

--- a/src/registries/cell_clickable_registry.ts
+++ b/src/registries/cell_clickable_registry.ts
@@ -7,10 +7,16 @@ import { CellPosition, SortDirection } from "../types/misc";
 import { SpreadsheetChildEnv } from "../types/spreadsheet_env";
 import { Registry } from "./registry";
 
+import { Model } from "../model";
 import { ComponentConstructor } from "../owl3_compatibility_layer";
 export interface CellClickableItem {
   condition: (position: CellPosition, getters: Getters) => boolean;
-  execute: (position: CellPosition, env: SpreadsheetChildEnv, isMiddleClick?: boolean) => void;
+  execute: (
+    position: CellPosition,
+    model: Model,
+    env: SpreadsheetChildEnv,
+    isMiddleClick?: boolean
+  ) => void;
   title?: string | ((position: CellPosition, getters: Getters) => string);
   sequence: number;
   component?: ComponentConstructor;
@@ -23,8 +29,12 @@ clickableCellRegistry.add("link", {
   condition: (position: CellPosition, getters: Getters) => {
     return !!getters.getEvaluatedCell(position).link;
   },
-  execute: (position: CellPosition, env: SpreadsheetChildEnv, isMiddleClick?: boolean) =>
-    openLink(env.model.getters.getEvaluatedCell(position).link!, env, isMiddleClick),
+  execute: (
+    position: CellPosition,
+    model: Model,
+    env: SpreadsheetChildEnv,
+    isMiddleClick?: boolean
+  ) => openLink(model.getters.getEvaluatedCell(position).link!, model, env, isMiddleClick),
   title: (position, getters) => {
     const link = getters.getEvaluatedCell(position).link;
     if (!link) {
@@ -47,8 +57,8 @@ clickableCellRegistry.add("dashboard_pivot_sorting", {
     const pivotCell = getters.getPivotCellFromPosition(position);
     return canSortPivot(getters, position) && pivotCell.type === "MEASURE_HEADER";
   },
-  execute: (position: CellPosition, env: SpreadsheetChildEnv) => {
-    sortPivot(env, position, getNextSortDirection(env.model.getters, position));
+  execute: (position: CellPosition, model: Model) => {
+    sortPivot(model, position, getNextSortDirection(model.getters, position));
   },
   component: ClickableCellSortIcon,
   componentProps: (position: CellPosition, getters: Getters) => {

--- a/src/registries/figures_registry.ts
+++ b/src/registries/figures_registry.ts
@@ -7,8 +7,8 @@ import {
 import { CarouselFigure } from "../components/figures/figure_carousel/figure_carousel";
 import { ChartFigure } from "../components/figures/figure_chart/figure_chart";
 import { ImageFigure } from "../components/figures/figure_image/figure_image";
+import { Model } from "../model";
 import { UID } from "../types/misc";
-import { SpreadsheetChildEnv } from "../types/spreadsheet_env";
 import { Registry } from "./registry";
 
 //------------------------------------------------------------------------------
@@ -24,7 +24,7 @@ import { Registry } from "./registry";
 
 export interface FigureContent {
   Component: any;
-  menuBuilder: (figureId: UID, env: SpreadsheetChildEnv) => Action[];
+  menuBuilder: (figureId: UID, model: Model) => Action[];
   SidePanelComponent?: string;
   keepRatio?: boolean;
   minFigSize?: number;

--- a/src/registries/icons_on_cell_registry.ts
+++ b/src/registries/icons_on_cell_registry.ts
@@ -18,6 +18,7 @@ import {
 import { deepEquals } from "../helpers/misc";
 import { DEFAULT_PIVOT_STYLE, togglePivotCollapse } from "../helpers/pivot/pivot_helpers";
 import { computeTextFontSizeInPixels } from "../helpers/text_helper";
+import { Model } from "../model";
 import { Getters } from "../types/getters";
 import { ImageSVG } from "../types/image";
 import { Align, CellPosition } from "../types/misc";
@@ -35,7 +36,7 @@ export interface GridIcon {
   svg?: ImageSVG;
   hoverSvg?: ImageSVG;
   priority: number;
-  onClick?: (position: CellPosition, env: SpreadsheetChildEnv) => void;
+  onClick?: (position: CellPosition, model: Model, env: SpreadsheetChildEnv) => void;
 }
 
 type ImageSvgCallback = (getters: Getters, position: CellPosition) => GridIcon | undefined;
@@ -68,15 +69,15 @@ iconsOnCellRegistry.add("data_validation_checkbox", (getters, position) => {
       margin: GRID_ICON_MARGIN,
       position,
       type: "data_validation_checkbox",
-      onClick: (position, env) => {
-        const cell = env.model.getters.getCell(position);
-        const isDisabled = env.model.getters.isReadonly() || !!cell?.isFormula;
+      onClick: (position, model) => {
+        const cell = model.getters.getCell(position);
+        const isDisabled = model.getters.isReadonly() || !!cell?.isFormula;
         if (isDisabled) {
           return;
         }
 
         const cellContent = value ? "FALSE" : "TRUE";
-        env.model.dispatch("UPDATE_CELL", { ...position, content: cellContent });
+        model.dispatch("UPDATE_CELL", { ...position, content: cellContent });
       },
     };
   }
@@ -102,9 +103,9 @@ iconsOnCellRegistry.add("data_validation_list_chip_icon", (getters, position) =>
     size: computeTextFontSizeInPixels(cellStyle),
     margin: 4,
     position,
-    onClick: (position, env) => {
+    onClick: (position, model, env) => {
       const { col, row } = position;
-      env.model.selection.selectCell(col, row);
+      model.selection.selectCell(col, row);
       env.startCellEdition();
     },
     type: "data_validation_list_chip_icon",

--- a/src/registries/interactive_icon_on_cell_registry.ts
+++ b/src/registries/interactive_icon_on_cell_registry.ts
@@ -19,7 +19,7 @@ iconsOnCellRegistry.add("filter_icon", (getters, position) => {
       size: GRID_ICON_EDGE_LENGTH,
       margin: GRID_ICON_MARGIN,
       position,
-      onClick: (position, env) => {
+      onClick: (position, model, env) => {
         const cellPopovers = env.getStore(CellPopoverStore);
         const activePopover = cellPopovers.persistentCellPopover;
         if (

--- a/src/registries/menus/cell_menu_registry.ts
+++ b/src/registries/menus/cell_menu_registry.ts
@@ -92,7 +92,7 @@ cellMenuRegistry
   .add("edit_table", {
     ...ACTION_EDIT.editTable,
     isVisible: ACTIONS.SELECTION_CONTAINS_SINGLE_TABLE,
-    isEnabled: (env) => !env.isSmall,
+    isEnabled: (model, env) => !env.isSmall,
     sequence: 140,
   })
   .add("delete_table", {
@@ -143,9 +143,9 @@ cellMenuRegistry
     name: _t("Sort pivot"),
     sequence: 155,
     icon: "o-spreadsheet-Icon.SORT_RANGE",
-    isVisible: (env) => {
-      const position = env.model.getters.getActivePosition();
-      return ACTIONS_PIVOT.canSortPivot(env.model.getters, position);
+    isVisible: (model) => {
+      const position = model.getters.getActivePosition();
+      return ACTIONS_PIVOT.canSortPivot(model.getters, position);
     },
   })
   .add("pivot_fix_formulas", {

--- a/src/registries/menus/col_menu_registry.ts
+++ b/src/registries/menus/col_menu_registry.ts
@@ -37,8 +37,8 @@ colMenuRegistry
   })
   .add("sort_columns", {
     ...ACTION_DATA.sortRange,
-    name: (env) =>
-      env.model.getters.getActiveCols().size > 1 ? _t("Sort columns") : _t("Sort column"),
+    name: (model) =>
+      model.getters.getActiveCols().size > 1 ? _t("Sort columns") : _t("Sort column"),
     sequence: 50,
     separator: true,
   })

--- a/src/registries/menus/header_group_registry.ts
+++ b/src/registries/menus/header_group_registry.ts
@@ -13,16 +13,16 @@ export function createHeaderGroupContainerContextMenu(
     {
       id: "unfold_all",
       name: dimension === "ROW" ? _t("Expand all row groups") : _t("Expand all column groups"),
-      execute: (env) => {
-        env.model.dispatch("UNFOLD_ALL_HEADER_GROUPS", { sheetId, dimension });
+      execute: (model) => {
+        model.dispatch("UNFOLD_ALL_HEADER_GROUPS", { sheetId, dimension });
       },
       icon: "o-spreadsheet-Icon.EXPAND",
     },
     {
       id: "fold_all",
       name: dimension === "ROW" ? _t("Collapse all row groups") : _t("Collapse all column groups"),
-      execute: (env) => {
-        env.model.dispatch("FOLD_ALL_HEADER_GROUPS", { sheetId, dimension });
+      execute: (model) => {
+        model.dispatch("FOLD_ALL_HEADER_GROUPS", { sheetId, dimension });
       },
       icon: "o-spreadsheet-Icon.COLLAPSE",
     },
@@ -38,31 +38,31 @@ export function getHeaderGroupContextMenu(
   const groupActions: Action[] = createActions([
     {
       id: "toggle_group",
-      name: (env) => {
-        const sheetId = env.model.getters.getActiveSheetId();
-        const groupIsFolded = env.model.getters.isGroupFolded(sheetId, dimension, start, end);
+      name: (model) => {
+        const sheetId = model.getters.getActiveSheetId();
+        const groupIsFolded = model.getters.isGroupFolded(sheetId, dimension, start, end);
         if (groupIsFolded) {
           return dimension === "ROW" ? _t("Expand row group") : _t("Expand column group");
         } else {
           return dimension === "ROW" ? _t("Collapse row group") : _t("Collapse column group");
         }
       },
-      execute: (env) => {
-        const sheetId = env.model.getters.getActiveSheetId();
-        interactiveToggleGroup(env, sheetId, dimension, start, end);
+      execute: (model, env) => {
+        const sheetId = model.getters.getActiveSheetId();
+        interactiveToggleGroup(model, env, sheetId, dimension, start, end);
       },
-      icon: (env) => {
-        const sheetId = env.model.getters.getActiveSheetId();
-        const groupIsFolded = env.model.getters.isGroupFolded(sheetId, dimension, start, end);
+      icon: (model) => {
+        const sheetId = model.getters.getActiveSheetId();
+        const groupIsFolded = model.getters.isGroupFolded(sheetId, dimension, start, end);
         return groupIsFolded ? "o-spreadsheet-Icon.EXPAND" : "o-spreadsheet-Icon.COLLAPSE";
       },
     },
     {
       id: "remove_group",
       name: dimension === "ROW" ? _t("Remove row group") : _t("Remove column group"),
-      execute: (env) => {
-        const sheetId = env.model.getters.getActiveSheetId();
-        env.model.dispatch("UNGROUP_HEADERS", { sheetId, dimension, start, end });
+      execute: (model) => {
+        const sheetId = model.getters.getActiveSheetId();
+        model.dispatch("UNGROUP_HEADERS", { sheetId, dimension, start, end });
       },
       icon: "o-spreadsheet-Icon.TRASH",
       separator: true,

--- a/src/registries/menus/number_format_menu_registry.ts
+++ b/src/registries/menus/number_format_menu_registry.ts
@@ -1,10 +1,10 @@
+import { Model } from "../..";
 import { ActionSpec } from "../../actions/action";
 import * as ACTION_FORMAT from "../../actions/format_actions";
 import { isDateTimeFormat } from "../../helpers/format/format";
 import { memoize } from "../../helpers/misc";
 import { _t } from "../../translation";
 import { Format } from "../../types/format";
-import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 import { Registry } from "../registry";
 
 export const numberFormatMenuRegistry = new Registry<ACTION_FORMAT.NumberFormatActionSpec>();
@@ -91,18 +91,16 @@ numberFormatMenuRegistry
     sequence: 140,
   });
 
-export function getCustomNumberFormats(
-  env: SpreadsheetChildEnv
-): ACTION_FORMAT.NumberFormatActionSpec[] {
+export function getCustomNumberFormats(model: Model): ACTION_FORMAT.NumberFormatActionSpec[] {
   const defaultFormats = new Set(
     numberFormatMenuRegistry
       .getAll()
-      .map((f) => (typeof f.format === "function" ? f.format(env) : f.format))
+      .map((f) => (typeof f.format === "function" ? f.format(model) : f.format))
   );
 
   const customFormats = new Map<Format, ACTION_FORMAT.NumberFormatActionSpec>();
-  for (const sheetId of env.model.getters.getSheetIds()) {
-    const cells = env.model.getters.getEvaluatedCells(sheetId);
+  for (const sheetId of model.getters.getSheetIds()) {
+    const cells = model.getters.getEvaluatedCells(sheetId);
     for (const cellId in cells) {
       const cell = cells[cellId];
 
@@ -137,8 +135,8 @@ export const formatNumberMenuItemSpec: ActionSpec = {
   name: _t("More formats"),
   icon: "o-spreadsheet-Icon.NUMBER_FORMATS",
   children: [
-    (env) => {
-      const customFormats = getCustomNumberFormats(env).map((action) => ({
+    (model) => {
+      const customFormats = getCustomNumberFormats(model).map((action) => ({
         ...action,
         sequence: 110,
       }));

--- a/src/registries/menus/table_style_menu_registry.ts
+++ b/src/registries/menus/table_style_menu_registry.ts
@@ -1,26 +1,23 @@
 import { Action, createActions } from "../../actions/action";
+import { Model } from "../../model";
 import { _t } from "../../translation";
-import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 
-export function createTableStyleContextMenuActions(
-  env: SpreadsheetChildEnv,
-  styleId: string
-): Action[] {
-  if (!env.model.getters.isTableStyleEditable(styleId)) {
+export function createTableStyleContextMenuActions(model: Model, styleId: string): Action[] {
+  if (!model.getters.isTableStyleEditable(styleId)) {
     return [];
   }
   return createActions([
     {
       id: "editTableStyle",
       name: _t("Edit table style"),
-      execute: (env) => env.openSidePanel("TableStyleEditorPanel", { styleId }),
-      isEnabled: (env) => !env.isSmall,
+      execute: (model, env) => env.openSidePanel("TableStyleEditorPanel", { styleId }),
+      isEnabled: (model, env) => !env.isSmall,
       icon: "o-spreadsheet-Icon.EDIT",
     },
     {
       id: "deleteTableStyle",
       name: _t("Delete table style"),
-      execute: (env) => env.model.dispatch("REMOVE_TABLE_STYLE", { tableStyleId: styleId }),
+      execute: (model) => model.dispatch("REMOVE_TABLE_STYLE", { tableStyleId: styleId }),
       icon: "o-spreadsheet-Icon.TRASH",
     },
   ]);

--- a/src/registries/menus/topbar_menu_registry.ts
+++ b/src/registries/menus/topbar_menu_registry.ts
@@ -26,15 +26,15 @@ topbarMenuRegistry
   .addChild("print", ["file"], {
     name: _t("Print"),
     sequence: 190,
-    execute: (env) => env.printSpreadsheet(),
-    isEnabled: (env) => !env.isSmall,
+    execute: (model, env) => env.printSpreadsheet(),
+    isEnabled: (model, env) => !env.isSmall,
     icon: "o-spreadsheet-Icon.PRINT",
   })
   .addChild("settings", ["file"], {
     name: _t("Settings"),
     sequence: 200,
-    execute: (env) => env.openSidePanel("Settings"),
-    isEnabled: (env) => !env.isSmall,
+    execute: (model, env) => env.openSidePanel("Settings"),
+    isEnabled: (model, env) => !env.isSmall,
     isEnabledOnLockedSheet: true,
     icon: "o-spreadsheet-Icon.COG",
   })
@@ -187,7 +187,7 @@ topbarMenuRegistry
   })
   .addChild("ungroup_columns", ["view", "group_headers"], {
     ...ACTION_VIEW.ungroupColumns,
-    isVisible: (env) => ACTION_VIEW.canUngroupHeaders(env, "COL"),
+    isVisible: (model) => ACTION_VIEW.canUngroupHeaders(model, "COL"),
     sequence: 10,
   })
   .addChild("group_rows", ["view", "group_headers"], {
@@ -196,7 +196,7 @@ topbarMenuRegistry
   })
   .addChild("ungroup_rows", ["view", "group_headers"], {
     ...ACTION_VIEW.ungroupRows,
-    isVisible: (env) => ACTION_VIEW.canUngroupHeaders(env, "ROW"),
+    isVisible: (model) => ACTION_VIEW.canUngroupHeaders(model, "ROW"),
     sequence: 20,
   })
   .addChild("show", ["view"], {
@@ -228,8 +228,8 @@ topbarMenuRegistry
   .addChild("perf_profile", ["view"], {
     name: _t("Performance"),
     sequence: 45,
-    execute: (env) => env.openSidePanel("PerfProfile"),
-    isVisible: (env) => !env.isSmall,
+    execute: (model, env) => env.openSidePanel("PerfProfile"),
+    isVisible: (model, env) => !env.isSmall,
     isEnabledOnLockedSheet: true,
     icon: "o-spreadsheet-Icon.AVG_TIME",
     separator: true,
@@ -492,20 +492,20 @@ topbarMenuRegistry
   })
   .addChild("data_validation", ["data"], {
     name: _t("Data Validation"),
-    execute: (env) => {
+    execute: (model, env) => {
       env.openSidePanel("DataValidation");
     },
-    isEnabled: (env) => !env.isSmall,
+    isEnabled: (model, env) => !env.isSmall,
     isEnabledOnLockedSheet: true,
     icon: "o-spreadsheet-Icon.DATA_VALIDATION",
     sequence: 30,
   })
   .addChild("named_range", ["data"], {
     name: _t("Named ranges"),
-    execute: (env) => {
+    execute: (model, env) => {
       env.openSidePanel("NamedRangesPanel");
     },
-    isEnabled: (env) => !env.isSmall,
+    isEnabled: (model, env) => !env.isSmall,
     isEnabledOnLockedSheet: true,
     icon: "o-spreadsheet-Icon.NAMED_RANGE",
     sequence: 35,
@@ -520,13 +520,13 @@ topbarMenuRegistry
     name: _t("Pivot"),
     sequence: 50,
     icon: "o-spreadsheet-Icon.PIVOT",
-    secondaryIcon: (env) =>
-      env.model.getters.getPivotIds().some((pivotId) => env.model.getters.isPivotUnused(pivotId))
+    secondaryIcon: (model) =>
+      model.getters.getPivotIds().some((pivotId) => model.getters.isPivotUnused(pivotId))
         ? "o-spreadsheet-Icon.UNUSED_PIVOT_WARNING"
         : "",
     children: [
-      (env) => {
-        const { getters } = env.model;
+      (model, env) => {
+        const { getters } = model;
         return getters.getPivotIds().map((pivotId, sequence) => {
           const highlightProvider = {
             get highlights() {
@@ -539,11 +539,11 @@ topbarMenuRegistry
             sequence,
             isReadonlyAllowed: true,
             isEnabledOnLockedSheet: true,
-            execute: () => env.openSidePanel("PivotSidePanel", { pivotId }),
-            isEnabled: () => !env.isSmall,
-            onStartHover: () => env.getStore(HighlightStore).register(highlightProvider),
-            onStopHover: () => env.getStore(HighlightStore).unRegister(highlightProvider),
-            secondaryIcon: () =>
+            execute: (model, env) => env.openSidePanel("PivotSidePanel", { pivotId }),
+            isEnabled: (model, env) => !env.isSmall,
+            onStartHover: (model, env) => env.getStore(HighlightStore).register(highlightProvider),
+            onStopHover: (model, env) => env.getStore(HighlightStore).unRegister(highlightProvider),
+            secondaryIcon: (model, env) =>
               getters.isPivotUnused(pivotId)
                 ? "o-spreadsheet-Icon.UNUSED_PIVOT_WARNING"
                 : undefined,

--- a/src/registries/side_panel_registry.ts
+++ b/src/registries/side_panel_registry.ts
@@ -18,6 +18,7 @@ import { SplitIntoColumnsPanel } from "../components/side_panel/split_to_columns
 import { TablePanel } from "../components/side_panel/table_panel/table_panel";
 import { TableStyleEditorPanel } from "../components/side_panel/table_style_editor_panel/table_style_editor_panel";
 import { getTableTopLeft } from "../helpers/table_helpers";
+import { Model } from "../model";
 import { _t } from "../translation";
 import { ConditionalFormat } from "../types/conditional_formatting";
 import { Getters } from "../types/getters";
@@ -31,7 +32,7 @@ import { Registry } from "./registry";
 //------------------------------------------------------------------------------
 
 export interface SidePanelContent {
-  title: string | ((env: SpreadsheetChildEnv, props: object) => string);
+  title: string | ((model: Model, env: SpreadsheetChildEnv, props: object) => string);
   Body: any;
   Footer?: any;
   /**
@@ -153,8 +154,8 @@ sidePanelRegistry.add("TableStyleEditorPanel", {
 });
 
 sidePanelRegistry.add("PivotSidePanel", {
-  title: (env: SpreadsheetChildEnv, props: { pivotId: UID }) => {
-    return _t("Pivot #%s", env.model.getters.getPivotFormulaId(props.pivotId));
+  title: (model: Model, env: SpreadsheetChildEnv, props: { pivotId: UID }) => {
+    return _t("Pivot #%s", model.getters.getPivotFormulaId(props.pivotId));
   },
   Body: PivotSidePanel,
   computeState: (getters: Getters, props: { pivotId: UID }) => {
@@ -167,8 +168,8 @@ sidePanelRegistry.add("PivotSidePanel", {
 });
 
 sidePanelRegistry.add("PivotMeasureDisplayPanel", {
-  title: (env: SpreadsheetChildEnv, props: PropsOf<PivotMeasureDisplayPanel>) => {
-    const measure = env.model.getters.getPivot(props.pivotId).getMeasure(props.measure.id);
+  title: (model: Model, env: SpreadsheetChildEnv, props: PropsOf<PivotMeasureDisplayPanel>) => {
+    const measure = model.getters.getPivot(props.pivotId).getMeasure(props.measure.id);
     return _t('Measure "%s" options', measure.displayName);
   },
   Body: PivotMeasureDisplayPanel,

--- a/src/registries/toolbar_menu_registry.ts
+++ b/src/registries/toolbar_menu_registry.ts
@@ -1,6 +1,7 @@
 import { PropsOf } from "../types/props_of";
 import { SpreadsheetChildEnv } from "../types/spreadsheet_env";
 
+import { Model } from "../model";
 import { ComponentConstructor } from "../owl3_compatibility_layer";
 import { Registry } from "./registry";
 
@@ -9,7 +10,7 @@ type ToolBarItem<C extends ComponentConstructor = ComponentConstructor> = {
   component: C;
   props: PropsOf<C>;
   sequence: number;
-  isVisible?: (env: SpreadsheetChildEnv) => boolean;
+  isVisible?: (model: Model, env: SpreadsheetChildEnv) => boolean;
 };
 
 export class ToolBarRegistry extends Registry<ToolBarItem[]> {

--- a/src/types/spreadsheet_env.ts
+++ b/src/types/spreadsheet_env.ts
@@ -1,4 +1,3 @@
-import { Model } from "../model";
 import { ClipboardInterface } from "./clipboard/clipboard_interface";
 import { Currency } from "./currency";
 import { ImageProviderInterface } from "./files";
@@ -7,7 +6,6 @@ import { Get } from "./store_engine";
 import { NotificationStoreMethods } from "./stores/notification_store_methods";
 
 export interface SpreadsheetChildEnv extends NotificationStoreMethods {
-  model: Model;
   imageProvider?: ImageProviderInterface;
   openSidePanel: (panel: string, panelProps?: any) => void;
   replaceSidePanel: (panel: string, currentPanel: string, panelProps?: any) => void;

--- a/tests/autofill/autofill_component.test.ts
+++ b/tests/autofill/autofill_component.test.ts
@@ -240,21 +240,21 @@ describe("Autofill component", () => {
   });
 
   test("Autofill does not reset the viewport position if not near the viewport edge", async () => {
-    setSelection(parent.model, ["A1:A100"]);
-    setViewportOffset(parent.model, 400, 400);
-    const firstViewport = parent.model.getters.getActiveMainViewport();
+    setSelection(model, ["A1:A100"]);
+    setViewportOffset(model, 400, 400);
+    const firstViewport = model.getters.getActiveMainViewport();
     const autofill = fixture.querySelector(".o-autofill");
     triggerMouseEvent(autofill, "pointerdown", 4, 4);
     await nextTick();
     const newX =
       HEADER_WIDTH +
-      parent.model.getters.getColDimensions(parent.model.getters.getActiveSheetId(), 0)!.start +
+      model.getters.getColDimensions(model.getters.getActiveSheetId(), 0)!.start +
       2 * DEFAULT_CELL_WIDTH;
     triggerMouseEvent(autofill, "pointermove", newX, HEADER_HEIGHT + 4);
     await nextTick();
     triggerMouseEvent(autofill, "pointerup", newX, HEADER_HEIGHT + 4);
     await nextTick();
-    expect(firstViewport).toMatchObject(parent.model.getters.getActiveMainViewport());
+    expect(firstViewport).toMatchObject(model.getters.getActiveMainViewport());
   });
 
   test("Autofill is not loaded when the grid selection does not have the focus", async () => {

--- a/tests/bottom_bar/bottom_bar_component.test.ts
+++ b/tests/bottom_bar/bottom_bar_component.test.ts
@@ -394,8 +394,8 @@ describe("BottomBar component", () => {
     const sheetName = "New name";
     const raiseError = jest.fn();
     const model = new Model({}, { mode: "readonly" });
-    const env = makeTestEnv({ model, raiseError });
-    interactiveRenameSheet(env, model.getters.getActiveSheetId(), sheetName, raiseError);
+    const env = makeTestEnv(model, { raiseError });
+    interactiveRenameSheet(model, env, model.getters.getActiveSheetId(), sheetName, raiseError);
     expect(raiseError).not.toHaveBeenCalled();
     expect(model.getters.getActiveSheet().name).toEqual("Sheet1");
   });

--- a/tests/components/owl_plugins/model_plugin.test.ts
+++ b/tests/components/owl_plugins/model_plugin.test.ts
@@ -1,0 +1,55 @@
+import { providePlugins, xml } from "@odoo/owl";
+import { ModelPlugin, useModel } from "../../../src/components/owl_plugins/model_plugin";
+import { Model } from "../../../src/model";
+import { App, Component } from "../../../src/owl3_compatibility_layer";
+import { makeTestFixture, nextTick } from "../../test_helpers/helpers";
+
+describe("ModelPlugin", () => {
+  test("Should render component when model is updated", async () => {
+    const model = new Model();
+
+    class Spreadsheet extends Component {
+      static template = xml`
+        <div>
+          <t t-out="this.getFirstCellValue()"/>
+        </div>
+      `;
+
+      private model = useModel();
+
+      getFirstCellValue() {
+        const sheetId = this.model().getters.getActiveSheetId();
+        return this.model().getters.getCellText({ sheetId, col: 0, row: 0 });
+      }
+    }
+    class Parent extends Component {
+      static template = xml`
+        <div>
+          <Spreadsheet/>
+        </div>
+      `;
+      static components = { Spreadsheet };
+
+      setup() {
+        providePlugins([ModelPlugin], { model });
+      }
+    }
+
+    const app = new App({
+      test: true,
+    });
+    const root = app.createRoot(Parent);
+    const fixture = makeTestFixture();
+    await root.mount(fixture);
+    expect(fixture.textContent).toBe("");
+
+    model.dispatch("UPDATE_CELL", {
+      sheetId: model.getters.getActiveSheetId(),
+      col: 0,
+      row: 0,
+      content: "Test",
+    });
+    await nextTick();
+    expect(fixture.textContent).toBe("Test");
+  });
+});

--- a/tests/components/pivot_html_renderer.test.ts
+++ b/tests/components/pivot_html_renderer.test.ts
@@ -18,7 +18,7 @@ async function mountPivotHtmlRenderer(
   };
   model.dispatch("PIVOT_START_PRESENCE_TRACKING", { pivotId });
   evaluateCells(model);
-  ({ fixture } = await mountComponent(PivotHTMLRenderer, { env: { model }, props }));
+  ({ fixture } = await mountComponent(PivotHTMLRenderer, { model, props }));
 }
 
 describe("Pivot HTML Renderer", () => {

--- a/tests/composer/composer_integration_component.test.ts
+++ b/tests/composer/composer_integration_component.test.ts
@@ -730,13 +730,13 @@ describe("Grid composer", () => {
     test("Grid Composer Position is recomputed if we change the edited cell", async () => {
       const expectedTop = (index: HeaderIndex) => HEADER_HEIGHT + index * DEFAULT_CELL_HEIGHT;
       const expectedLeft = (index: HeaderIndex) => HEADER_WIDTH + index * DEFAULT_CELL_WIDTH - 1; //-1 to include cell border
-      env.model.selection.selectCell(2, 4);
+      model.selection.selectCell(2, 4);
       await typeInComposerGrid("coucou", true);
       expect(getElComputedStyle(composerContainerSelector, "top")).toBe(expectedTop(4) + "px");
       expect(getElComputedStyle(composerContainerSelector, "left")).toBe(expectedLeft(2) + "px");
 
-      env.model.selection.getBackToDefault();
-      env.model.selection.selectCell(1, 1);
+      model.selection.getBackToDefault();
+      model.selection.selectCell(1, 1);
       env.startCellEdition();
       await nextTick();
       expect(getElComputedStyle(composerContainerSelector, "top")).toBe(expectedTop(1) + "px");

--- a/tests/composer/formula_assistant_component.test.ts
+++ b/tests/composer/formula_assistant_component.test.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_LOCALE, setTranslationMethod } from "../../src";
+import { DEFAULT_LOCALE, Model, setTranslationMethod } from "../../src";
 import { CellComposerStore } from "../../src/components/composer/composer/cell_composer_store";
 import { arg } from "../../src/functions/arguments";
 import { functionRegistry } from "../../src/functions/function_registry";
@@ -20,6 +20,7 @@ import {
 let composerEl: Element;
 let fixture: HTMLElement;
 let parent: ComposerWrapper;
+let model: Model;
 let composerStore: Store<CellComposerStore>;
 
 const queryFormulaArgName =
@@ -48,7 +49,7 @@ async function typeInComposer(text: string, fromScratch: boolean = true) {
 }
 
 beforeEach(async () => {
-  ({ fixture, parent } = await mountComposerWrapper());
+  ({ fixture, parent, model } = await mountComposerWrapper());
   // start composition
   parent.startComposition();
   await nextTick();
@@ -350,7 +351,7 @@ describe("formula assistant", () => {
       });
 
       test("arguments separator is localized", async () => {
-        updateLocale(parent.env.model, { ...DEFAULT_LOCALE, formulaArgSeparator: ";" });
+        updateLocale(model, { ...DEFAULT_LOCALE, formulaArgSeparator: ";" });
         await typeInComposer("=FUNC1(");
         expect(fixture.querySelectorAll(".o-formula-assistant-head")[0].textContent).toBe(
           "FUNC1 ( f1ArgA; f1ArgB )"

--- a/tests/figures/carousel/carousel_figure_component.test.ts
+++ b/tests/figures/carousel/carousel_figure_component.test.ts
@@ -336,19 +336,19 @@ describe("Carousel figure component", () => {
     let openSidePanel: jest.Mock;
 
     function getCarouselMenuItem(figureId: UID, actionId: string) {
-      return getCarouselMenuActions(figureId, env).find((action) => action.id === actionId);
+      return getCarouselMenuActions(figureId, model).find((action) => action.id === actionId);
     }
 
     beforeEach(() => {
       openSidePanel = jest.fn();
-      env = makeTestEnv({ model, openSidePanel });
+      env = makeTestEnv(model, { openSidePanel });
     });
 
     test("Can edit the carousel", () => {
       createCarousel(model, { items: [] }, "carouselId");
 
       const action = getCarouselMenuItem("carouselId", "edit_carousel");
-      action?.execute?.(env);
+      action?.execute?.(model, env);
       expect(openSidePanel).toHaveBeenCalledWith("CarouselPanel", { figureId: "carouselId" });
     });
 
@@ -357,7 +357,7 @@ describe("Carousel figure component", () => {
       addNewChartToCarousel(model, "carouselId", { type: "radar" });
 
       const action = getCarouselMenuItem("carouselId", "edit_chart");
-      action?.execute?.(env);
+      action?.execute?.(model, env);
       expect(openSidePanel).toHaveBeenCalledWith("ChartPanel", {});
     });
 
@@ -365,7 +365,7 @@ describe("Carousel figure component", () => {
       createCarousel(model, { items: [] }, "carouselId");
 
       const action = getCarouselMenuItem("carouselId", "delete");
-      action?.execute?.(env);
+      action?.execute?.(model, env);
       expect(model.getters.getFigures(sheetId)).toHaveLength(0);
     });
 
@@ -373,17 +373,17 @@ describe("Carousel figure component", () => {
       createCarousel(model, { items: [{ type: "carouselDataView" }] }, "carouselId");
 
       const action = getCarouselMenuItem("carouselId", "delete_carousel_item");
-      expect(action?.isVisible(env)).toBe(true);
-      action?.execute?.(env);
+      expect(action?.isVisible(model, env)).toBe(true);
+      action?.execute?.(model, env);
 
       expect(model.getters.getCarousel("carouselId").items).toHaveLength(0);
-      expect(action?.isVisible(env)).toBe(false);
+      expect(action?.isVisible(model, env)).toBe(false);
     });
 
     test("Can copy the carousel", () => {
       createCarousel(model, { items: [] }, "carouselId");
       const action = getCarouselMenuItem("carouselId", "copy");
-      action?.execute?.(env);
+      action?.execute?.(model, env);
 
       paste(model, "A1");
       expect(model.getters.getFigures(sheetId)).toHaveLength(2);
@@ -392,7 +392,7 @@ describe("Carousel figure component", () => {
     test("Can cut the carousel", () => {
       createCarousel(model, { items: [] }, "carouselId");
       const action = getCarouselMenuItem("carouselId", "cut");
-      action?.execute?.(env);
+      action?.execute?.(model, env);
 
       paste(model, "A1");
       expect(model.getters.getFigures(sheetId)).toHaveLength(1);
@@ -403,7 +403,7 @@ describe("Carousel figure component", () => {
       createCarousel(model, { items: [] }, "carouselId");
       addNewChartToCarousel(model, "carouselId", { type: "radar" });
       const action = getCarouselMenuItem("carouselId", "copy_as_image");
-      action?.execute?.(env);
+      action?.execute?.(model, env);
       await nextTick();
 
       const clipboard = await env.clipboard.read!();
@@ -425,7 +425,7 @@ describe("Carousel figure component", () => {
       addNewChartToCarousel(model, "carouselId", { type: "radar" });
 
       const action = getCarouselMenuItem("carouselId", "download");
-      action?.execute?.(env);
+      action?.execute?.(model, env);
       await nextTick();
       expect(downloadFile).toHaveBeenCalled();
     });
@@ -433,14 +433,14 @@ describe("Carousel figure component", () => {
     test("Chart menu items are not visible when the carousel selected item is not a chart", () => {
       createCarousel(model, { items: [] }, "carouselId");
 
-      expect(getCarouselMenuItem("carouselId", "edit_chart")?.isVisible(env)).toBe(false);
-      expect(getCarouselMenuItem("carouselId", "copy_as_image")?.isVisible(env)).toBe(false);
-      expect(getCarouselMenuItem("carouselId", "download")?.isVisible(env)).toBe(false);
+      expect(getCarouselMenuItem("carouselId", "edit_chart")?.isVisible(model, env)).toBe(false);
+      expect(getCarouselMenuItem("carouselId", "copy_as_image")?.isVisible(model, env)).toBe(false);
+      expect(getCarouselMenuItem("carouselId", "download")?.isVisible(model, env)).toBe(false);
 
       addNewChartToCarousel(model, "carouselId", { type: "radar" });
-      expect(getCarouselMenuItem("carouselId", "edit_chart")?.isVisible(env)).toBe(true);
-      expect(getCarouselMenuItem("carouselId", "copy_as_image")?.isVisible(env)).toBe(true);
-      expect(getCarouselMenuItem("carouselId", "download")?.isVisible(env)).toBe(true);
+      expect(getCarouselMenuItem("carouselId", "edit_chart")?.isVisible(model, env)).toBe(true);
+      expect(getCarouselMenuItem("carouselId", "copy_as_image")?.isVisible(model, env)).toBe(true);
+      expect(getCarouselMenuItem("carouselId", "download")?.isVisible(model, env)).toBe(true);
     });
   });
 });

--- a/tests/figures/chart/menu_item_insert_chart.test.ts
+++ b/tests/figures/chart/menu_item_insert_chart.test.ts
@@ -87,7 +87,7 @@ describe("Insert chart menu item", () => {
   let openSidePanelSpy: jest.Mock<any, any>;
 
   async function insertChart() {
-    await doAction(["insert", "insert_chart"], env);
+    await doAction(["insert", "insert_chart"], model, env);
   }
 
   async function mountTestSpreadsheet() {
@@ -97,11 +97,10 @@ describe("Insert chart menu item", () => {
 
   beforeEach(async () => {
     openSidePanelSpy = jest.fn();
-    env = makeTestEnv({
-      model: new Model(data),
+    model = new Model(data);
+    env = makeTestEnv(model, {
       openSidePanel: (type, props) => openSidePanelSpy(type, props),
     });
-    model = env.model;
 
     mockChart();
     dispatchSpy = spyModelDispatch(model);
@@ -277,7 +276,7 @@ describe("Insert chart menu item", () => {
 
   test("Chart is inserted at correct position on a scrolled viewport", async () => {
     setSelection(model, ["B2:B3"]);
-    const { width, height } = env.model.getters.getSheetViewDimension();
+    const { width, height } = model.getters.getSheetViewDimension();
     addColumns(model, "after", "D", 100);
     addRows(model, "after", 4, 100);
     setViewportOffset(model, 2 * DEFAULT_CELL_WIDTH, 4 * DEFAULT_CELL_HEIGHT);
@@ -422,7 +421,7 @@ describe("Smart chart type detection", () => {
 
   beforeEach(() => {
     model = new Model();
-    env = makeTestEnv({ model });
+    env = makeTestEnv(model);
   });
 
   /**
@@ -462,7 +461,7 @@ describe("Smart chart type detection", () => {
   test("Single cell: create a scorecard", async () => {
     setCellContent(model, "C3", "100");
     setSelection(model, ["C3"]);
-    await doAction(["insert", "insert_chart"], env);
+    await doAction(["insert", "insert_chart"], model, env);
     const chartId = model.getters.getChartIds(model.getters.getActiveSheetId())[0];
     expect(model.getters.getChartDefinition(chartId)).toMatchObject({
       type: "scorecard",
@@ -479,7 +478,7 @@ describe("Smart chart type detection", () => {
     [["date_with_header"], { type: "line", dataSetsHaveTitle: true }],
   ] as const)("Single column %s creates chart", async (datasetPattern, expected) => {
     createDatasetFromDescription([...datasetPattern]);
-    await doAction(["insert", "insert_chart"], env);
+    await doAction(["insert", "insert_chart"], model, env);
 
     const chartId = model.getters.getChartIds(model.getters.getActiveSheetId())[0];
 
@@ -508,7 +507,7 @@ describe("Smart chart type detection", () => {
     [["number", "number_with_header"], { type: "scatter", dataSetsHaveTitle: true }],
   ])("Two columns %s creates %s chart", async (datasetPattern, expected) => {
     createDatasetFromDescription(datasetPattern);
-    await doAction(["insert", "insert_chart"], env);
+    await doAction(["insert", "insert_chart"], model, env);
 
     const expectedDataset =
       expected.type === "treemap" ? [{ dataRange: "A1:A6" }] : [{ dataRange: "B1:B6" }];
@@ -535,7 +534,7 @@ describe("Smart chart type detection", () => {
     "Multiple text columns  %s create a %s hierarchical chart",
     async (datasetPattern, expected) => {
       createDatasetFromDescription(datasetPattern);
-      await doAction(["insert", "insert_chart"], env);
+      await doAction(["insert", "insert_chart"], model, env);
 
       const datasetLastCol = datasetPattern.findIndex((p) => !p.includes("text"));
       const expectedDatasets: ChartRangeDataSource<string>["dataSets"] = [];
@@ -576,7 +575,7 @@ describe("Smart chart type detection", () => {
     [["text", "number", "date_with_header"], { type: "bar", dataSetsHaveTitle: true }],
   ])("Multiple columns  %s create a %s chart", async (datasetPattern, expected) => {
     createDatasetFromDescription(datasetPattern);
-    await doAction(["insert", "insert_chart"], env);
+    await doAction(["insert", "insert_chart"], model, env);
 
     const expectedDatasets: ChartRangeDataSource<string>["dataSets"] = [];
     for (let i = 1; i < datasetPattern.length; i++) {
@@ -599,7 +598,7 @@ describe("Smart chart type detection", () => {
 
   test("Empty columns are passed in the chart dataset if the whole selection is empty", async () => {
     setSelection(model, ["A1:B6"]);
-    await doAction(["insert", "insert_chart"], env);
+    await doAction(["insert", "insert_chart"], model, env);
     const chartId = model.getters.getChartIds(model.getters.getActiveSheetId())[0];
     expect(model.getters.getChartDefinition(chartId)).toMatchObject({
       type: "bar",
@@ -613,7 +612,7 @@ describe("Smart chart type detection", () => {
   test("Empty columns are ignored in the chart dataset if other columns are not empty", async () => {
     createDatasetFromDescription(["number", "empty", "number"]);
     setSelection(model, ["A1:C6"]);
-    await doAction(["insert", "insert_chart"], env);
+    await doAction(["insert", "insert_chart"], model, env);
     const chartId = model.getters.getChartIds(model.getters.getActiveSheetId())[0];
     expect(model.getters.getChartDefinition(chartId)).toMatchObject({
       type: "scatter",
@@ -634,7 +633,7 @@ describe("Smart chart type detection", () => {
     "Pie charts and charts with more than one column in their dataset %s have a legend",
     async (datasetPattern, expected) => {
       createDatasetFromDescription(datasetPattern);
-      await doAction(["insert", "insert_chart"], env);
+      await doAction(["insert", "insert_chart"], model, env);
 
       const chartId = model.getters.getChartIds(model.getters.getActiveSheetId())[0];
       expect(model.getters.getChartDefinition(chartId)).toMatchObject(expected);

--- a/tests/formats/formatting_plugin.test.ts
+++ b/tests/formats/formatting_plugin.test.ts
@@ -408,8 +408,8 @@ describe("pivot contextual formatting", () => {
   });
 
   test("topbar menu correctly indicates the format of the selected pivot cell", () => {
-    const env = makeTestEnv();
-    const { model } = env;
+    const model = new Model();
+    const env = makeTestEnv(model);
 
     setCellContent(model, "A1", "Price");
     setCellContent(model, "A2", "10");
@@ -421,8 +421,8 @@ describe("pivot contextual formatting", () => {
     setContextualFormat(model, "C3", "[$$]#,##0.00");
     selectCell(model, "C3");
 
-    const action = getNode(["format", "format_number", "format_number_currency"], env);
-    expect(action.isActive?.(env)).toBe(true);
+    const action = getNode(["format", "format_number", "format_number_currency"], model, env);
+    expect(action.isActive?.(model, env)).toBe(true);
   });
 });
 

--- a/tests/grid/dashboard_grid_component.test.ts
+++ b/tests/grid/dashboard_grid_component.test.ts
@@ -193,7 +193,7 @@ describe("Grid component in dashboard mode", () => {
           : cell.compiledFormula.toFormulaString(getters);
         return !!content?.startsWith("__");
       },
-      execute: (_, __, isMiddleClick) => fn(isMiddleClick),
+      execute: (_, __, ___, isMiddleClick) => fn(isMiddleClick),
       sequence: 5,
     });
     setCellContent(model, "A1", "__test1");

--- a/tests/grid/grid_component.test.ts
+++ b/tests/grid/grid_component.test.ts
@@ -2088,7 +2088,7 @@ describe("Copy paste keyboard shortcut", () => {
     setCellContent(model, "A1", "a1");
     merge(model, "A2:A3");
     setSelection(model, ["A1:A3"]);
-    handleCopyPasteResult(env, { type: "COPY_PASTE_CELLS_ON_ZONE" });
+    handleCopyPasteResult(model, env, { type: "COPY_PASTE_CELLS_ON_ZONE" });
     const notificationStore = env.getStore(NotificationStore);
     expect(notificationStore.raiseError).toHaveBeenCalled();
   });

--- a/tests/grid/grid_drag_and_drop_component.test.ts
+++ b/tests/grid/grid_drag_and_drop_component.test.ts
@@ -1,6 +1,7 @@
 import { App, xml } from "@odoo/owl";
 import { Model, UID } from "../../src";
 import { useDragAndDropBeyondTheViewport } from "../../src/components/helpers/drag_and_drop_grid_hook";
+import { useModel } from "../../src/components/owl_plugins/model_plugin";
 import { DEFAULT_CELL_HEIGHT, DEFAULT_CELL_WIDTH } from "../../src/constants";
 import { numberToLetters } from "../../src/helpers/coordinates";
 import { Component } from "../../src/owl3_compatibility_layer";
@@ -49,7 +50,8 @@ const mouseUpFn = jest.fn();
 class FakeGridComponent extends Component<SpreadsheetChildEnv> {
   static template = TEMPLATE;
 
-  dragNDropGrid = useDragAndDropBeyondTheViewport(this.env);
+  private model = useModel();
+  dragNDropGrid = useDragAndDropBeyondTheViewport(this.model());
 
   onMouseDown(ev: PointerEvent) {
     this.dragNDropGrid.start(

--- a/tests/grid/highlight_component.test.ts
+++ b/tests/grid/highlight_component.test.ts
@@ -160,6 +160,7 @@ async function mountHighlight(
   let parent: Component;
   const sheetId = model.getters.getActiveSheetId();
   ({ fixture, parent } = await mountComponent(Parent, {
+    model,
     props: { range: model.getters.getRangeFromZone(sheetId, toZone(zone)), color, model },
   }));
   return { parent: parent as Parent, model };

--- a/tests/helpers/ui_helpers.test.ts
+++ b/tests/helpers/ui_helpers.test.ts
@@ -70,7 +70,7 @@ describe("Interactive rename sheet", () => {
       callback();
     });
     model = new Model({});
-    env = makeTestEnv({ model, raiseError: raiseErrorSpy });
+    env = makeTestEnv(model, { raiseError: raiseErrorSpy });
   });
 
   test.each([
@@ -84,7 +84,13 @@ describe("Interactive rename sheet", () => {
     "Rename a sheet with interaction with wrong name %s",
     async (sheetName, expectedErrorMessage) => {
       const errorCallback = jest.fn();
-      interactiveRenameSheet(env, model.getters.getActiveSheetId(), sheetName, errorCallback);
+      interactiveRenameSheet(
+        model,
+        env,
+        model.getters.getActiveSheetId(),
+        sheetName,
+        errorCallback
+      );
       expect(raiseErrorSpy).toHaveBeenCalledTimes(1);
       expect(errorCallback).toHaveBeenCalled();
       expect(errorTextSpy).toHaveBeenCalledWith(expectedErrorMessage);
@@ -95,7 +101,7 @@ describe("Interactive rename sheet", () => {
     const sheetName = "ThisSheetExistsAlready";
     createSheet(model, { name: sheetName });
     const errorCallback = jest.fn();
-    interactiveRenameSheet(env, model.getters.getActiveSheetId(), sheetName, errorCallback);
+    interactiveRenameSheet(model, env, model.getters.getActiveSheetId(), sheetName, errorCallback);
     expect(raiseErrorSpy).toHaveBeenCalledTimes(1);
     expect(errorCallback).toHaveBeenCalled();
     expect(errorTextSpy).toHaveBeenCalledWith(
@@ -112,8 +118,8 @@ describe("Interactive Freeze columns/rows", () => {
     const model = new Model();
     merge(model, "A1:D4");
     const raiseError = jest.fn();
-    const env = makeTestEnv({ model, raiseError });
-    interactiveFreezeColumnsRows(env, dimension as Dimension, 2);
+    const env = makeTestEnv(model, { raiseError });
+    interactiveFreezeColumnsRows(model, env, dimension as Dimension, 2);
     expect(raiseError).toHaveBeenCalled();
   });
 });
@@ -136,20 +142,20 @@ describe("UI Helpers", () => {
     const askConfirmation = (content: string, confirm: () => any, cancel?: () => any) => {
       askConfirmationTextSpy(content.toString());
     };
-    env = makeTestEnv({ model, raiseError, askConfirmation });
+    env = makeTestEnv(model, { raiseError, askConfirmation });
   });
 
   describe("Interactive Create table", () => {
     test("Successfully create a table", () => {
       setSelection(model, ["A1:B5"]);
-      interactiveCreateTable(env, sheetId);
+      interactiveCreateTable(model, env, sheetId);
       expect(notifyUserTextSpy).toHaveBeenCalledTimes(0);
     });
 
     test("Create a table across a merge", () => {
       merge(model, "A1:B1");
       setSelection(model, ["A1:B1"]);
-      interactiveCreateTable(env, sheetId);
+      interactiveCreateTable(model, env, sheetId);
       expect(notifyUserTextSpy).not.toHaveBeenCalled();
       expect(model.getters.getMerges(sheetId)).toEqual([]);
       expect(model.getters.getTables(sheetId)).toMatchObject([
@@ -160,13 +166,13 @@ describe("UI Helpers", () => {
     test("Create a table across another table", () => {
       createTable(model, "A1:A2");
       setSelection(model, ["A1:B5"]);
-      interactiveCreateTable(env, sheetId);
+      interactiveCreateTable(model, env, sheetId);
       expect(notifyUserTextSpy).toHaveBeenCalledWith(TableTerms.Errors.TableOverlap.toString());
     });
 
     test("Create table with non-continuous zones", () => {
       setSelection(model, ["A1:A2", "C3"]);
-      interactiveCreateTable(env, sheetId);
+      interactiveCreateTable(model, env, sheetId);
       expect(notifyUserTextSpy).toHaveBeenCalledWith(
         TableTerms.Errors.NonContinuousTargets.toString()
       );
@@ -175,7 +181,7 @@ describe("UI Helpers", () => {
 
   describe("Interactive paste", () => {
     test("paste without copied value interactively", () => {
-      interactivePaste(env, target("D2"));
+      interactivePaste(model, env, target("D2"));
       expect(getCellContent(model, "D2")).toBe("");
     });
 
@@ -185,10 +191,10 @@ describe("UI Helpers", () => {
       setCellStyle(model, "A1", style);
 
       copy(model, "A1");
-      const env = makeTestEnv({ model });
-      interactivePaste(env, target("B1"), "onlyFormat");
-      interactivePaste(env, target("B2"), "asValue");
-      interactivePaste(env, target("B3"));
+      const env = makeTestEnv(model);
+      interactivePaste(model, env, target("B1"), "onlyFormat");
+      interactivePaste(model, env, target("B2"), "asValue");
+      interactivePaste(model, env, target("B3"));
 
       expect(getCellText(model, "B1")).toBe("");
       expect(getCell(model, "B1")!.style).toEqual(style);
@@ -205,7 +211,7 @@ describe("UI Helpers", () => {
 
       selectCell(model, "C4");
       addCellToSelection(model, "F6");
-      interactivePaste(env, model.getters.getSelectedZones());
+      interactivePaste(model, env, model.getters.getSelectedZones());
       expect(notifyUserTextSpy).toHaveBeenCalledWith(
         PasteInteractiveContent.wrongPasteSelection.toString()
       );
@@ -218,7 +224,7 @@ describe("UI Helpers", () => {
       selectCell(model, "C4");
       addCellToSelection(model, "F6");
 
-      interactivePaste(env, model.getters.getSelectedZones());
+      interactivePaste(model, env, model.getters.getSelectedZones());
       expect(notifyUserTextSpy).toHaveBeenCalledWith(
         PasteInteractiveContent.wrongPasteSelection.toString()
       );
@@ -226,7 +232,7 @@ describe("UI Helpers", () => {
 
     test("will warn user if paste in several selection", () => {
       copy(model, "A1", "C1");
-      interactivePaste(env, target("A2, B2"));
+      interactivePaste(model, env, target("A2, B2"));
       expect(notifyUserTextSpy).toHaveBeenCalledWith(
         PasteInteractiveContent.wrongPasteSelection.toString()
       );
@@ -236,7 +242,7 @@ describe("UI Helpers", () => {
       createChart(model, { type: "bar" }, "chartId", undefined, { figureId: "figureId" });
       selectFigure(model, "figureId");
       copy(model);
-      interactivePaste(env, target("A1"), "onlyFormat");
+      interactivePaste(model, env, target("A1"), "onlyFormat");
       expect(notifyUserTextSpy).toHaveBeenCalledWith(
         PasteInteractiveContent.wrongFigurePasteOption.toString()
       );
@@ -246,7 +252,7 @@ describe("UI Helpers", () => {
       merge(model, "B2:C3");
       copy(model, "B2");
       selectCell(model, "A1");
-      interactivePaste(env, model.getters.getSelectedZones());
+      interactivePaste(model, env, model.getters.getSelectedZones());
       expect(notifyUserTextSpy).toHaveBeenCalledWith(
         PasteInteractiveContent.willRemoveExistingMerge.toString()
       );
@@ -256,7 +262,7 @@ describe("UI Helpers", () => {
       const clipboardString = "a\t1\nb\t2";
 
       test("Can interactive paste", async () => {
-        await interactivePasteFromOS(env, target("D2"), { text: clipboardString });
+        await interactivePasteFromOS(model, env, target("D2"), { text: clipboardString });
         expect(getCellContent(model, "D2")).toBe("a");
         expect(getCellContent(model, "E2")).toBe("1");
         expect(getCellContent(model, "D3")).toBe("b");
@@ -266,7 +272,7 @@ describe("UI Helpers", () => {
       test("Pasting content that will destroy a merge will notify the user", async () => {
         merge(model, "B2:C3");
         selectCell(model, "A1");
-        await interactivePasteFromOS(env, model.getters.getSelectedZones(), {
+        await interactivePasteFromOS(model, env, model.getters.getSelectedZones(), {
           text: clipboardString,
         });
         expect(notifyUserTextSpy).toHaveBeenCalledWith(
@@ -281,7 +287,7 @@ describe("UI Helpers", () => {
       copy(model, "F4:G5");
 
       selectCell(model, "B4");
-      interactivePaste(env, model.getters.getSelectedZones());
+      interactivePaste(model, env, model.getters.getSelectedZones());
       expect(notifyUserTextSpy).toHaveBeenCalledWith(
         PasteInteractiveContent.frozenPaneOverlap.toString()
       );
@@ -293,7 +299,7 @@ describe("UI Helpers", () => {
       copy(model, "F4:G5");
 
       selectCell(model, "B2");
-      interactivePaste(env, model.getters.getSelectedZones());
+      interactivePaste(model, env, model.getters.getSelectedZones());
       expect(notifyUserTextSpy).toHaveBeenCalledWith(
         PasteInteractiveContent.frozenPaneOverlap.toString()
       );
@@ -303,7 +309,7 @@ describe("UI Helpers", () => {
   describe("Interactive cut", () => {
     test("cutting with multiple selection will warn user", async () => {
       setSelection(model, ["A1", "A2"]);
-      interactiveCut(env);
+      interactiveCut(model, env);
       expect(notifyUserTextSpy).toHaveBeenCalledWith(
         PasteInteractiveContent.wrongPasteSelection.toString()
       );
@@ -312,14 +318,14 @@ describe("UI Helpers", () => {
 
   describe("Interactive Merge", () => {
     test("Successfully Create a merge", () => {
-      interactiveAddMerge(env, sheetId, target("A1:B5"));
+      interactiveAddMerge(model, env, sheetId, target("A1:B5"));
       expect(askConfirmationTextSpy).toHaveBeenCalledTimes(0);
       expect(notifyUserTextSpy).toHaveBeenCalledTimes(0);
     });
 
     test("Destructive merge", () => {
       setCellContent(model, "A2", ":)");
-      interactiveAddMerge(env, sheetId, target("A1:B5"));
+      interactiveAddMerge(model, env, sheetId, target("A1:B5"));
       expect(askConfirmationTextSpy).toHaveBeenCalledWith(
         AddMergeInteractiveContent.MergeIsDestructive.toString()
       );
@@ -327,7 +333,7 @@ describe("UI Helpers", () => {
 
     test("Create a merge inside a table", () => {
       createTable(model, "A1:A2");
-      interactiveAddMerge(env, sheetId, target("A1:B5"));
+      interactiveAddMerge(model, env, sheetId, target("A1:B5"));
       expect(notifyUserTextSpy).toHaveBeenCalledWith(
         AddMergeInteractiveContent.MergeInFilter.toString()
       );
@@ -336,7 +342,7 @@ describe("UI Helpers", () => {
     test("Destructive merge inside a table", () => {
       createTable(model, "A1:A2");
       setCellContent(model, "A2", ":)");
-      interactiveAddMerge(env, sheetId, target("A1:B5"));
+      interactiveAddMerge(model, env, sheetId, target("A1:B5"));
       expect(notifyUserTextSpy).toHaveBeenCalledWith(
         AddMergeInteractiveContent.MergeInFilter.toString()
       );
@@ -348,7 +354,7 @@ describe("UI Helpers", () => {
     test("Cannot fold all rows", () => {
       const numberOfRows = model.getters.getNumberRows(sheetId);
       groupHeaders(model, "ROW", 0, numberOfRows - 1);
-      interactiveToggleGroup(env, sheetId, "ROW", 0, numberOfRows - 1);
+      interactiveToggleGroup(model, env, sheetId, "ROW", 0, numberOfRows - 1);
       expect(notifyUserTextSpy).toHaveBeenCalledWith(
         ToggleGroupInteractiveContent.CannotHideAllRows.toString()
       );
@@ -357,7 +363,7 @@ describe("UI Helpers", () => {
     test("Cannot fold all columns", () => {
       const numberOfColumns = model.getters.getNumberCols(sheetId);
       groupHeaders(model, "COL", 0, numberOfColumns - 1);
-      interactiveToggleGroup(env, sheetId, "COL", 0, numberOfColumns - 1);
+      interactiveToggleGroup(model, env, sheetId, "COL", 0, numberOfColumns - 1);
       expect(notifyUserTextSpy).toHaveBeenCalledWith(
         ToggleGroupInteractiveContent.CannotHideAllColumns.toString()
       );
@@ -394,8 +400,8 @@ describe("UI Helpers", () => {
       model = new Model(modelData);
       const zone = toZone("A2:A3");
       anchor = toCartesian("A2");
-      const env = makeTestEnv({ model, askConfirmation });
-      interactiveSortSelection(env, sheetId, anchor, zone, "desc");
+      const env = makeTestEnv(model, { askConfirmation });
+      interactiveSortSelection(model, env, sheetId, anchor, zone, "desc");
       expect(askConfirmation).toHaveBeenCalled();
     });
     test("Sort without adjacent values to the selection does not ask for confirmation", () => {
@@ -403,8 +409,8 @@ describe("UI Helpers", () => {
       model = new Model(modelData);
       const zone = toZone("A2:A3");
       const contiguousZone = model.getters.getContiguousZone(sheetId, zone);
-      const env = makeTestEnv({ model, askConfirmation });
-      interactiveSortSelection(env, sheetId, anchor, contiguousZone, "desc");
+      const env = makeTestEnv(model, { askConfirmation });
+      interactiveSortSelection(model, env, sheetId, anchor, contiguousZone, "desc");
       expect(askConfirmation).not.toHaveBeenCalled();
     });
 
@@ -413,8 +419,8 @@ describe("UI Helpers", () => {
       model = new Model(modelData);
       const zone = toZone("A3:A4");
       anchor = toCartesian("A3");
-      const env = makeTestEnv({ model, askConfirmation });
-      interactiveSortSelection(env, sheetId, anchor, zone, "desc");
+      const env = makeTestEnv(model, { askConfirmation });
+      interactiveSortSelection(model, env, sheetId, anchor, zone, "desc");
       expect(getCellsObject(model, sheetId)).toMatchObject({
         A1: { content: "Zulu" },
         A2: { content: "Tango" },
@@ -433,8 +439,8 @@ describe("UI Helpers", () => {
       model = new Model(modelData);
       const zone = toZone("A3:A4");
       anchor = toCartesian("A3");
-      const env = makeTestEnv({ model, askConfirmation });
-      interactiveSortSelection(env, sheetId, anchor, zone, "desc");
+      const env = makeTestEnv(model, { askConfirmation });
+      interactiveSortSelection(model, env, sheetId, anchor, zone, "desc");
       expect(getCellsObject(model, sheetId)).toMatchObject({
         A1: { content: "Alpha" },
         A2: { content: "Tango" },
@@ -453,23 +459,23 @@ describe("UI Helpers", () => {
   test("Cannot sort on zone with array formulas that spread", () => {
     const raiseError = jest.fn();
     model = createModelFromGrid({ A1: "9", A2: "8", A3: "=CHOOSECOLS(A1:A2, 1)" });
-    const env = makeTestEnv({ model, raiseError });
+    const env = makeTestEnv(model, { raiseError });
 
-    interactiveSortSelection(env, sheetId, toCartesian("A1"), toZone("A1:A4"), "asc");
+    interactiveSortSelection(model, env, sheetId, toCartesian("A1"), toZone("A1:A4"), "asc");
     expect(raiseError).toHaveBeenCalledWith("Cannot sort a zone with array formulas.");
   });
 
   test("Can sort on zone with array formulas that do not spread", () => {
     const raiseError = jest.fn();
     model = createModelFromGrid({ A1: "9", A2: "8", B1: "1", C1: "=MMULT(A1:A2, A1:B1)" });
-    const env = makeTestEnv({ model, raiseError });
+    const env = makeTestEnv(model, { raiseError });
 
-    interactiveSortSelection(env, sheetId, toCartesian("C1"), toZone("C1:D2"), "asc");
+    interactiveSortSelection(model, env, sheetId, toCartesian("C1"), toZone("C1:D2"), "asc");
     expect(raiseError).toHaveBeenCalledTimes(1);
     expect(raiseError).toHaveBeenCalledWith("Cannot sort a zone with array formulas.");
 
     setCellContent(model, "C1", "=MMULT( A1:B1, A1:A2)");
-    interactiveSortSelection(env, sheetId, toCartesian("C1"), toZone("C1:D2"), "asc");
+    interactiveSortSelection(model, env, sheetId, toCartesian("C1"), toZone("C1:D2"), "asc");
     expect(raiseError).toHaveBeenCalledTimes(1);
   });
 
@@ -519,8 +525,8 @@ describe("UI Helpers", () => {
       const zone = toZone("B2:B8");
       const contiguousZone = model.getters.getContiguousZone(sheetId, zone);
       anchor = toCartesian("B2");
-      const env = makeTestEnv({ model, raiseError });
-      interactiveSortSelection(env, sheetId, anchor, contiguousZone, "asc");
+      const env = makeTestEnv(model, { raiseError });
+      interactiveSortSelection(model, env, sheetId, anchor, contiguousZone, "asc");
       expect(raiseError).toHaveBeenCalled();
       expect(model.getters.getSelection()).toEqual({
         anchor: { cell: anchor, zone: contiguousZone },
@@ -546,8 +552,8 @@ describe("UI Helpers", () => {
       const contiguousZone = model.getters.getContiguousZone(sheetId, zone);
 
       const anchor = toCartesian("B2");
-      const env = makeTestEnv({ model, raiseError });
-      interactiveSortSelection(env, sheetId, anchor, contiguousZone, "asc");
+      const env = makeTestEnv(model, { raiseError });
+      interactiveSortSelection(model, env, sheetId, anchor, contiguousZone, "asc");
       expect(raiseError).toHaveBeenCalled();
       expect(model.getters.getSelection()).toEqual({
         anchor: { cell: anchor, zone: contiguousZone },

--- a/tests/menus/context_menu_component.test.ts
+++ b/tests/menus/context_menu_component.test.ts
@@ -27,6 +27,7 @@ import {
 import { getCell, getCellContent, getEvaluatedCell } from "../test_helpers/getters_helpers";
 
 import { Rect } from "../../src";
+import { useModel } from "../../src/components/owl_plugins/model_plugin";
 import { PopoverPropsPosition } from "../../src/types/cell_popovers";
 import {
   getStylePropertyInPx,
@@ -195,6 +196,7 @@ class ContextMenuParent extends Component {
     height: types.number(),
     config: types.object({}),
   }) as any;
+  private model = useModel();
   menus!: Action[];
   anchorRect: Rect;
   onClose!: () => void;
@@ -209,7 +211,7 @@ class ContextMenuParent extends Component {
       height: 0,
     };
     this.menus = this.props.config.menuItems || createActions([makeTestMenuItem("Action")]);
-    resizeSheetView(this.env.model, this.props.height, this.props.width);
+    resizeSheetView(this.model(), this.props.height, this.props.width);
   }
 }
 
@@ -774,7 +776,7 @@ describe("Context MenuPopover internal tests", () => {
       {
         id: "menuItem",
         name: "menuItem",
-        execute: (_, isMiddleClick) => mockCallback(isMiddleClick),
+        execute: (_, __, isMiddleClick) => mockCallback(isMiddleClick),
       },
     ]);
     await renderContextMenu(300, 300, { menuItems });

--- a/tests/menus/menu_component.test.ts
+++ b/tests/menus/menu_component.test.ts
@@ -43,7 +43,7 @@ describe("Menu component", () => {
     model.updateMode("readonly");
     const { fixture } = await mountComponent(Menu, {
       props: { menuItems, onClose: () => {}, onClickMenu: () => callback() },
-      env: { model },
+      model,
     });
 
     expect(fixture.querySelector(selector)!.classList).toContain("disabled");

--- a/tests/menus/menu_items_registry.test.ts
+++ b/tests/menus/menu_items_registry.test.ts
@@ -126,25 +126,26 @@ describe("Top Bar MenuPopover Item Registry", () => {
         sequence: 1,
       }));
     });
-    const env = makeTestEnv();
+    const model = new Model();
+    const env = makeTestEnv(model);
     const [item] = topbarMenuRegistry.getMenuItems();
 
-    const children = item.children && item.children(env);
+    const children = item.children && item.children(model, env);
     expect(children).toHaveLength(1);
     const child = children[0];
-    expect(child.name(env)).toBe("Child1");
+    expect(child.name(model, env)).toBe("Child1");
     expect(child.id).toBe("child1");
-    expect(child.children(env)).toHaveLength(3);
-    const subChild = child.children(env)[0];
-    expect(subChild.name(env)).toBe("Child2");
-    expect(subChild.description(env)).toBe("coucou");
+    expect(child.children(model, env)).toHaveLength(3);
+    const subChild = child.children(model, env)[0];
+    expect(subChild.name(model, env)).toBe("Child2");
+    expect(subChild.description(model, env)).toBe("coucou");
     expect(subChild.id).toBe("child2");
 
-    const allChildren = child.children(env);
+    const allChildren = child.children(model, env);
     expect(allChildren).toHaveLength(3);
-    expect(allChildren[0].name(env)).toBe("Child2");
-    expect(allChildren[1].name(env)).toBe("test1");
-    expect(allChildren[2].name(env)).toBe("test2");
+    expect(allChildren[0].name(model, env)).toBe("Child2");
+    expect(allChildren[1].name(model, env)).toBe("test1");
+    expect(allChildren[2].name(model, env)).toBe("test2");
   });
 
   test("Adding a child to non-existing item throws", () => {
@@ -168,27 +169,26 @@ describe("Menu Item actions", () => {
   let dispatch: jest.SpyInstance;
 
   beforeEach(async () => {
-    env = makeTestEnv();
-    model = env.model;
+    (model = new Model()), (env = makeTestEnv(model));
     dispatch = spyModelDispatch(model);
     sheetId = model.getters.getActiveSheetId();
   });
 
   test("Edit -> undo", async () => {
     setCellContent(model, "A1", "coucou");
-    await doAction(["edit", "undo"], env);
+    await doAction(["edit", "undo"], model, env);
     expect(dispatch).toHaveBeenCalledWith("REQUEST_UNDO");
   });
 
   test("Edit -> redo", async () => {
     setCellContent(model, "A1", "coucou");
-    await doAction(["edit", "redo"], env);
+    await doAction(["edit", "redo"], model, env);
     expect(dispatch).toHaveBeenCalledWith("REQUEST_REDO");
   });
 
   test("Edit -> copy", async () => {
     const spyWriteClipboard = jest.spyOn(env.clipboard!, "write");
-    await doAction(["edit", "copy"], env);
+    await doAction(["edit", "copy"], model, env);
     expect(dispatch).toHaveBeenCalledWith("COPY");
     expect(spyWriteClipboard).toHaveBeenCalledWith(
       await model.getters.getClipboardTextAndImageContent()
@@ -197,7 +197,7 @@ describe("Menu Item actions", () => {
 
   test("Edit -> cut", async () => {
     const spyWriteClipboard = jest.spyOn(env.clipboard!, "write");
-    await doAction(["edit", "cut"], env);
+    await doAction(["edit", "cut"], model, env);
     expect(dispatch).toHaveBeenCalledWith("CUT");
     expect(spyWriteClipboard).toHaveBeenCalledWith(
       await model.getters.getClipboardTextAndImageContent()
@@ -207,29 +207,29 @@ describe("Menu Item actions", () => {
   test("Edit -> paste from OS clipboard if copied from outside world last", async () => {
     setCellContent(model, "A1", "a1");
     selectCell(model, "A1");
-    await doAction(["edit", "copy"], env); // first copy from grid
+    await doAction(["edit", "copy"], model, env); // first copy from grid
     await env.clipboard!.writeText("Then copy in OS clipboard");
     selectCell(model, "C3");
-    await doAction(["edit", "paste"], env);
+    await doAction(["edit", "paste"], model, env);
     expect(getCellContent(model, "C3")).toEqual("Then copy in OS clipboard");
   });
 
   test("Edit -> paste if copied from grid last", async () => {
     await env.clipboard!.writeText("First copy in OS clipboard");
-    await doAction(["edit", "copy"], env); // then copy from grid
-    await doAction(["edit", "paste"], env);
-    interactivePaste(env, target("A1"));
+    await doAction(["edit", "copy"], model, env); // then copy from grid
+    await doAction(["edit", "paste"], model, env);
+    interactivePaste(model, env, target("A1"));
     expect(getCellContent(model, "A1")).toEqual("");
   });
 
   test("'Edit -> paste' if copied from grid and content altered before paste", async () => {
     setCellContent(model, "A1", "a1");
-    await doAction(["edit", "copy"], env); // first copy from grid
+    await doAction(["edit", "copy"], model, env); // first copy from grid
     setCellContent(model, "A1", "os clipboard");
     selectCell(model, "C3");
-    await doAction(["edit", "paste"], env);
+    await doAction(["edit", "paste"], model, env);
     expect(dispatch).toHaveBeenCalledWith("PASTE", {
-      target: env.model.getters.getSelectedZones(),
+      target: model.getters.getSelectedZones(),
       pasteOption: undefined,
     });
     expect(getCellContent(model, "C3")).toEqual("a1");
@@ -238,7 +238,7 @@ describe("Menu Item actions", () => {
   test("Paste only-format from OS clipboard should paste nothing", async () => {
     await env.clipboard!.writeText("Copy in OS clipboard");
     selectCell(model, "A1");
-    await doAction(["edit", "paste_special", "paste_special_format"], env);
+    await doAction(["edit", "paste_special", "paste_special_format"], model, env);
     expect(dispatch).toHaveBeenCalledWith("PASTE_FROM_OS_CLIPBOARD", {
       clipboardContent: { text: "Copy in OS clipboard" },
       target: target("A1"),
@@ -251,24 +251,24 @@ describe("Menu Item actions", () => {
     setCellContent(model, "C1", "c1");
     setFormatting(model, "C1", { fillColor: "#FA0000" });
     selectCell(model, "C1");
-    await doAction(["edit", "copy"], env); // first copy from grid
+    await doAction(["edit", "copy"], model, env); // first copy from grid
     await env.clipboard!.writeText("Then copy in OS clipboard");
     selectCell(model, "A1");
-    await doAction(["edit", "paste_special", "paste_special_format"], env);
+    await doAction(["edit", "paste_special", "paste_special_format"], model, env);
     expect(getStyle(model, "A1").fillColor).toBeUndefined();
     expect(getCellContent(model, "A1")).toEqual("");
   });
 
   test("Edit -> paste_special should be hidden after a CUT ", () => {
     cut(model);
-    expect(getNode(["edit", "paste_special"], env).isVisible(env)).toBeFalsy();
+    expect(getNode(["edit", "paste_special"], model, env).isVisible(model, env)).toBeFalsy();
   });
 
   test("Data -> Pivot groups pivot data sources in a submenu", () => {
     const pivotModel = createModelWithPivot("A1:I22");
-    const pivotEnv = makeTestEnv({ model: pivotModel });
+    const pivotEnv = makeTestEnv(pivotModel);
 
-    const pivotSubmenu = getNode(["data", "pivot_data_sources"], pivotEnv);
+    const pivotSubmenu = getNode(["data", "pivot_data_sources"], model, pivotEnv);
     const pivotIds = pivotModel.getters.getPivotIds();
     const firstPivotId = pivotIds[0];
     const pivotItem = getNode(
@@ -277,34 +277,39 @@ describe("Menu Item actions", () => {
         "pivot_data_sources",
         `item_pivot_${pivotModel.getters.getPivotFormulaId(firstPivotId)}`,
       ],
+      pivotModel,
       pivotEnv
     );
 
-    expect(getName(["data", "pivot_data_sources"], pivotEnv)).toBe("Pivot");
-    expect(pivotSubmenu.isVisible(pivotEnv)).toBeTruthy();
-    expect(pivotSubmenu.children(pivotEnv)).toHaveLength(pivotIds.length);
-    expect(pivotItem.name(pivotEnv)).toBe(pivotModel.getters.getPivotDisplayName(firstPivotId));
+    expect(getName(["data", "pivot_data_sources"], model, pivotEnv)).toBe("Pivot");
+    expect(pivotSubmenu.isVisible(pivotModel, pivotEnv)).toBeTruthy();
+    expect(pivotSubmenu.children(pivotModel, pivotEnv)).toHaveLength(pivotIds.length);
+    expect(pivotItem.name(pivotModel, pivotEnv)).toBe(
+      pivotModel.getters.getPivotDisplayName(firstPivotId)
+    );
   });
 
   test("Data -> Pivot submenu shows a warning icon when at least one pivot is unused", () => {
     const pivotModel = createModelWithTestPivotDataset();
     addPivot(pivotModel, "A1:E18", { name: "Unused pivot" }, "2");
-    const pivotEnv = makeTestEnv({ model: pivotModel });
+    const pivotEnv = makeTestEnv(pivotModel);
 
-    const pivotSubmenu = getNode(["data", "pivot_data_sources"], pivotEnv);
-    expect(pivotSubmenu.secondaryIcon(pivotEnv)).toBe("o-spreadsheet-Icon.UNUSED_PIVOT_WARNING");
+    const pivotSubmenu = getNode(["data", "pivot_data_sources"], model, pivotEnv);
+    expect(pivotSubmenu.secondaryIcon(pivotModel, pivotEnv)).toBe(
+      "o-spreadsheet-Icon.UNUSED_PIVOT_WARNING"
+    );
   });
 
   test("Edit -> paste_special should not be hidden after a COPY ", () => {
-    copy(model, env.model.getters.getSelectedZones().map(zoneToXc).join(","));
-    expect(getNode(["edit", "paste_special"], env).isVisible(env)).toBeTruthy();
+    copy(model, model.getters.getSelectedZones().map(zoneToXc).join(","));
+    expect(getNode(["edit", "paste_special"], model, env).isVisible(model, env)).toBeTruthy();
   });
 
   test("Edit -> paste_special -> paste_special_value", async () => {
-    await doAction(["edit", "copy"], env);
-    await doAction(["edit", "paste_special", "paste_special_value"], env);
+    await doAction(["edit", "copy"], model, env);
+    await doAction(["edit", "paste_special", "paste_special_value"], model, env);
     expect(dispatch).toHaveBeenCalledWith("PASTE", {
-      target: env.model.getters.getSelectedZones(),
+      target: model.getters.getSelectedZones(),
       pasteOption: "asValue",
     });
   });
@@ -312,7 +317,7 @@ describe("Menu Item actions", () => {
   test("Edit -> paste_special -> paste_special_value from OS clipboard", async () => {
     const text = "in OS clipboard";
     await env.clipboard!.writeText(text);
-    await doAction(["edit", "paste_special", "paste_special_value"], env);
+    await doAction(["edit", "paste_special", "paste_special_value"], model, env);
     expect(dispatch).toHaveBeenCalledWith("PASTE_FROM_OS_CLIPBOARD", {
       target: target("A1"),
       clipboardContent: { text },
@@ -321,10 +326,10 @@ describe("Menu Item actions", () => {
   });
 
   test("Edit -> paste_special -> paste_special_format", async () => {
-    await doAction(["edit", "copy"], env);
-    await doAction(["edit", "paste_special", "paste_special_format"], env);
+    await doAction(["edit", "copy"], model, env);
+    await doAction(["edit", "paste_special", "paste_special_format"], model, env);
     expect(dispatch).toHaveBeenCalledWith("PASTE", {
-      target: env.model.getters.getSelectedZones(),
+      target: model.getters.getSelectedZones(),
       pasteOption: "onlyFormat",
     });
   });
@@ -332,7 +337,7 @@ describe("Menu Item actions", () => {
   test("Edit -> paste_special -> paste_special_format from OS clipboard", async () => {
     const text = "in OS clipboard";
     await env.clipboard!.writeText(text);
-    await doAction(["edit", "paste_special", "paste_special_format"], env);
+    await doAction(["edit", "paste_special", "paste_special_format"], model, env);
     expect(dispatch).toHaveBeenCalledWith("PASTE_FROM_OS_CLIPBOARD", {
       target: target("A1"),
       clipboardContent: { text },
@@ -341,10 +346,10 @@ describe("Menu Item actions", () => {
   });
 
   test("Edit -> edit_delete_cell_values", async () => {
-    await doAction(["edit", "delete", "edit_delete_cell_values"], env);
+    await doAction(["edit", "delete", "edit_delete_cell_values"], model, env);
     expect(dispatch).toHaveBeenCalledWith("DELETE_UNFILTERED_CONTENT", {
-      sheetId: env.model.getters.getActiveSheetId(),
-      target: env.model.getters.getSelectedZones(),
+      sheetId: model.getters.getActiveSheetId(),
+      target: model.getters.getSelectedZones(),
     });
   });
 
@@ -353,17 +358,17 @@ describe("Menu Item actions", () => {
 
     test("A selected row", () => {
       selectRow(model, 4, "overrideSelection");
-      expect(getName(path, env)).toBe("Delete row 5");
+      expect(getName(path, model, env)).toBe("Delete row 5");
     });
 
     test("Multiple selected rows", async () => {
       selectRow(model, 4, "overrideSelection");
       selectRow(model, 5, "updateAnchor");
-      expect(getName(path, env)).toBe("Delete rows 5 - 6");
-      await doAction(path, env);
+      expect(getName(path, model, env)).toBe("Delete rows 5 - 6");
+      await doAction(path, model, env);
       expect(dispatch).toHaveBeenLastCalledWith("REMOVE_COLUMNS_ROWS", {
-        sheetId: env.model.getters.getActiveSheetId(),
-        sheetName: env.model.getters.getActiveSheetName(),
+        sheetId: model.getters.getActiveSheetId(),
+        sheetName: model.getters.getActiveSheetName(),
         dimension: "ROW",
         elements: [4, 5],
       });
@@ -372,11 +377,11 @@ describe("Menu Item actions", () => {
     test("Multiple zones of selected rows", async () => {
       selectRow(model, 4, "newAnchor");
       selectRow(model, 5, "updateAnchor");
-      expect(getName(path, env)).toBe("Delete rows");
-      await doAction(path, env);
+      expect(getName(path, model, env)).toBe("Delete rows");
+      await doAction(path, model, env);
       expect(dispatch).toHaveBeenLastCalledWith("REMOVE_COLUMNS_ROWS", {
-        sheetId: env.model.getters.getActiveSheetId(),
-        sheetName: env.model.getters.getActiveSheetName(),
+        sheetId: model.getters.getActiveSheetId(),
+        sheetName: model.getters.getActiveSheetName(),
         dimension: "ROW",
         elements: [4, 5],
       });
@@ -384,17 +389,17 @@ describe("Menu Item actions", () => {
 
     test("A selected cell", () => {
       selectCell(model, "D4");
-      expect(getName(path, env)).toBe("Delete row 4");
+      expect(getName(path, model, env)).toBe("Delete row 4");
     });
 
     test("Multiple selected cells", async () => {
       selectCell(model, "D4");
       setAnchorCorner(model, "E5");
-      expect(getName(path, env)).toBe("Delete rows 4 - 5");
-      await doAction(path, env);
+      expect(getName(path, model, env)).toBe("Delete rows 4 - 5");
+      await doAction(path, model, env);
       expect(dispatch).toHaveBeenLastCalledWith("REMOVE_COLUMNS_ROWS", {
-        sheetId: env.model.getters.getActiveSheetId(),
-        sheetName: env.model.getters.getActiveSheetName(),
+        sheetId: model.getters.getActiveSheetId(),
+        sheetName: model.getters.getActiveSheetName(),
         dimension: "ROW",
         elements: [3, 4],
       });
@@ -408,7 +413,7 @@ describe("Menu Item actions", () => {
       selectRow(model, 4, "newAnchor");
       selectRow(model, lastRow, "updateAnchor");
 
-      expect(getNode(path, env).isVisible(env)).toBeFalsy();
+      expect(getNode(path, model, env).isVisible(model, env)).toBeFalsy();
     });
 
     test("Delete row option unavailable when selecting all rows with folded row grouping", () => {
@@ -419,12 +424,12 @@ describe("Menu Item actions", () => {
 
       selectRow(model, 3, "newAnchor");
       selectRow(model, lastRow, "updateAnchor");
-      expect(getNode(path, env).isVisible(env)).toBeFalsy();
+      expect(getNode(path, model, env).isVisible(model, env)).toBeFalsy();
     });
 
     test("Selecting column should hide the option for row deletion", async () => {
       selectColumn(model, 4, "overrideSelection");
-      expect(getNode(path, env).isVisible(env)).toBeFalsy();
+      expect(getNode(path, model, env).isVisible(model, env)).toBeFalsy();
     });
   });
 
@@ -433,11 +438,11 @@ describe("Menu Item actions", () => {
 
     test("A selected column", async () => {
       selectColumn(model, 4, "overrideSelection");
-      expect(getName(path, env)).toBe("Delete column E");
-      await doAction(path, env);
+      expect(getName(path, model, env)).toBe("Delete column E");
+      await doAction(path, model, env);
       expect(dispatch).toHaveBeenLastCalledWith("REMOVE_COLUMNS_ROWS", {
-        sheetId: env.model.getters.getActiveSheetId(),
-        sheetName: env.model.getters.getActiveSheetName(),
+        sheetId: model.getters.getActiveSheetId(),
+        sheetName: model.getters.getActiveSheetName(),
         dimension: "COL",
         elements: [4],
       });
@@ -446,11 +451,11 @@ describe("Menu Item actions", () => {
     test("Multiple selected columns", async () => {
       selectColumn(model, 4, "overrideSelection");
       selectColumn(model, 5, "updateAnchor");
-      expect(getName(path, env)).toBe("Delete columns E - F");
-      await doAction(path, env);
+      expect(getName(path, model, env)).toBe("Delete columns E - F");
+      await doAction(path, model, env);
       expect(dispatch).toHaveBeenLastCalledWith("REMOVE_COLUMNS_ROWS", {
-        sheetId: env.model.getters.getActiveSheetId(),
-        sheetName: env.model.getters.getActiveSheetName(),
+        sheetId: model.getters.getActiveSheetId(),
+        sheetName: model.getters.getActiveSheetName(),
         dimension: "COL",
         elements: [4, 5],
       });
@@ -459,11 +464,11 @@ describe("Menu Item actions", () => {
     test("Multiple zones of selected columns", async () => {
       selectColumn(model, 4, "newAnchor");
       selectColumn(model, 5, "updateAnchor");
-      expect(getName(path, env)).toBe("Delete columns");
-      await doAction(path, env);
+      expect(getName(path, model, env)).toBe("Delete columns");
+      await doAction(path, model, env);
       expect(dispatch).toHaveBeenLastCalledWith("REMOVE_COLUMNS_ROWS", {
-        sheetId: env.model.getters.getActiveSheetId(),
-        sheetName: env.model.getters.getActiveSheetName(),
+        sheetId: model.getters.getActiveSheetId(),
+        sheetName: model.getters.getActiveSheetName(),
         dimension: "COL",
         elements: [4, 5],
       });
@@ -471,11 +476,11 @@ describe("Menu Item actions", () => {
 
     test("A selected cell", async () => {
       selectCell(model, "D4");
-      expect(getName(path, env)).toBe("Delete column D");
-      await doAction(path, env);
+      expect(getName(path, model, env)).toBe("Delete column D");
+      await doAction(path, model, env);
       expect(dispatch).toHaveBeenLastCalledWith("REMOVE_COLUMNS_ROWS", {
-        sheetId: env.model.getters.getActiveSheetId(),
-        sheetName: env.model.getters.getActiveSheetName(),
+        sheetId: model.getters.getActiveSheetId(),
+        sheetName: model.getters.getActiveSheetName(),
         dimension: "COL",
         elements: [3],
       });
@@ -484,11 +489,11 @@ describe("Menu Item actions", () => {
     test("Multiple selected cells", async () => {
       selectCell(model, "D4");
       setAnchorCorner(model, "E5");
-      expect(getName(path, env)).toBe("Delete columns D - E");
-      await doAction(path, env);
+      expect(getName(path, model, env)).toBe("Delete columns D - E");
+      await doAction(path, model, env);
       expect(dispatch).toHaveBeenLastCalledWith("REMOVE_COLUMNS_ROWS", {
-        sheetId: env.model.getters.getActiveSheetId(),
-        sheetName: env.model.getters.getActiveSheetName(),
+        sheetId: model.getters.getActiveSheetId(),
+        sheetName: model.getters.getActiveSheetName(),
         dimension: "COL",
         elements: [3, 4],
       });
@@ -502,12 +507,12 @@ describe("Menu Item actions", () => {
       selectColumn(model, 3, "newAnchor");
       selectColumn(model, lastColumn, "updateAnchor");
 
-      expect(getNode(path, env).isVisible(env)).toBeFalsy();
+      expect(getNode(path, model, env).isVisible(model, env)).toBeFalsy();
     });
 
     test("Selecting row should hide the option for column deletion", async () => {
       selectRow(model, 4, "overrideSelection");
-      expect(getNode(path, env).isVisible(env)).toBeFalsy();
+      expect(getNode(path, model, env).isVisible(model, env)).toBeFalsy();
     });
   });
 
@@ -516,57 +521,57 @@ describe("Menu Item actions", () => {
 
     test("A selected row", () => {
       selectRow(model, 4, "overrideSelection");
-      expect(getName(insertRowBeforePath, env)).toBe("Row above");
-      expect(getNode(insertRowBeforePath, env).isVisible(env)).toBeTruthy();
+      expect(getName(insertRowBeforePath, model, env)).toBe("Row above");
+      expect(getNode(insertRowBeforePath, model, env).isVisible(model, env)).toBeTruthy();
     });
 
     test("Multiple consecutive selected rows", async () => {
       selectRow(model, 4, "overrideSelection");
       selectRow(model, 5, "updateAnchor");
-      expect(getName(insertRowBeforePath, env)).toBe("2 Rows above");
-      await doAction(insertRowBeforePath, env);
+      expect(getName(insertRowBeforePath, model, env)).toBe("2 Rows above");
+      await doAction(insertRowBeforePath, model, env);
       expect(dispatch).toHaveBeenLastCalledWith("ADD_COLUMNS_ROWS", {
-        sheetId: env.model.getters.getActiveSheetId(),
-        sheetName: env.model.getters.getActiveSheetName(),
+        sheetId: model.getters.getActiveSheetId(),
+        sheetName: model.getters.getActiveSheetName(),
         dimension: "ROW",
         base: 4,
         quantity: 2,
         position: "before",
       });
-      expect(getNode(insertRowBeforePath, env).isVisible(env)).toBeTruthy();
+      expect(getNode(insertRowBeforePath, model, env).isVisible(model, env)).toBeTruthy();
     });
 
     test("Multiple inconsecutive selected rows", () => {
       selectRow(model, 4, "overrideSelection");
       selectRow(model, 6, "newAnchor");
-      expect(getNode(insertRowBeforePath, env).isVisible(env)).toBeFalsy();
+      expect(getNode(insertRowBeforePath, model, env).isVisible(model, env)).toBeFalsy();
     });
 
     test("A selected column should hide the item", () => {
       selectColumn(model, 4, "overrideSelection");
-      expect(getNode(insertRowBeforePath, env).isVisible(env)).toBeFalsy();
+      expect(getNode(insertRowBeforePath, model, env).isVisible(model, env)).toBeFalsy();
     });
 
     test("A selected cell", () => {
       selectCell(model, "D4");
-      expect(getName(insertRowBeforePath, env)).toBe("Row above");
-      expect(getNode(insertRowBeforePath, env).isVisible(env)).toBeTruthy();
+      expect(getName(insertRowBeforePath, model, env)).toBe("Row above");
+      expect(getNode(insertRowBeforePath, model, env).isVisible(model, env)).toBeTruthy();
     });
 
     test("Multiple selected cells", async () => {
       selectCell(model, "D4");
       setAnchorCorner(model, "E5");
-      expect(getName(insertRowBeforePath, env)).toBe("2 Rows above");
-      await doAction(insertRowBeforePath, env);
+      expect(getName(insertRowBeforePath, model, env)).toBe("2 Rows above");
+      await doAction(insertRowBeforePath, model, env);
       expect(dispatch).toHaveBeenLastCalledWith("ADD_COLUMNS_ROWS", {
-        sheetId: env.model.getters.getActiveSheetId(),
-        sheetName: env.model.getters.getActiveSheetName(),
+        sheetId: model.getters.getActiveSheetId(),
+        sheetName: model.getters.getActiveSheetName(),
         dimension: "ROW",
         base: 3,
         quantity: 2,
         position: "before",
       });
-      expect(getNode(insertRowBeforePath, env).isVisible(env)).toBeTruthy();
+      expect(getNode(insertRowBeforePath, model, env).isVisible(model, env)).toBeTruthy();
     });
   });
 
@@ -575,35 +580,43 @@ describe("Menu Item actions", () => {
 
     test("A selected row", () => {
       selectRow(model, 4, "overrideSelection");
-      expect(getName(addRowBeforePath, env, rowMenuRegistry)).toBe("Insert row above");
-      expect(getNode(addRowBeforePath, env, rowMenuRegistry).isVisible(env)).toBeTruthy();
+      expect(getName(addRowBeforePath, model, env, rowMenuRegistry)).toBe("Insert row above");
+      expect(
+        getNode(addRowBeforePath, model, env, rowMenuRegistry).isVisible(model, env)
+      ).toBeTruthy();
     });
 
     test("Multiple consecutive selected rows", async () => {
       selectRow(model, 4, "overrideSelection");
       selectRow(model, 5, "updateAnchor");
-      expect(getName(addRowBeforePath, env, rowMenuRegistry)).toBe("Insert 2 rows above");
-      await doAction(addRowBeforePath, env, rowMenuRegistry);
+      expect(getName(addRowBeforePath, model, env, rowMenuRegistry)).toBe("Insert 2 rows above");
+      await doAction(addRowBeforePath, model, env, rowMenuRegistry);
       expect(dispatch).toHaveBeenLastCalledWith("ADD_COLUMNS_ROWS", {
-        sheetId: env.model.getters.getActiveSheetId(),
-        sheetName: env.model.getters.getActiveSheetName(),
+        sheetId: model.getters.getActiveSheetId(),
+        sheetName: model.getters.getActiveSheetName(),
         dimension: "ROW",
         base: 4,
         quantity: 2,
         position: "before",
       });
-      expect(getNode(addRowBeforePath, env, rowMenuRegistry).isVisible(env)).toBeTruthy();
+      expect(
+        getNode(addRowBeforePath, model, env, rowMenuRegistry).isVisible(model, env)
+      ).toBeTruthy();
     });
 
     test("Multiple inconsecutive selected rows", () => {
       selectRow(model, 4, "overrideSelection");
       selectRow(model, 6, "newAnchor");
-      expect(getNode(addRowBeforePath, env, rowMenuRegistry).isVisible(env)).toBeFalsy();
+      expect(
+        getNode(addRowBeforePath, model, env, rowMenuRegistry).isVisible(model, env)
+      ).toBeFalsy();
     });
 
     test("Full sheet selected", () => {
       selectAll(model);
-      expect(getNode(addRowBeforePath, env, rowMenuRegistry).isVisible(env)).toBeTruthy();
+      expect(
+        getNode(addRowBeforePath, model, env, rowMenuRegistry).isVisible(model, env)
+      ).toBeTruthy();
     });
   });
 
@@ -612,57 +625,57 @@ describe("Menu Item actions", () => {
 
     test("A selected row", () => {
       selectRow(model, 4, "overrideSelection");
-      expect(getName(insertRowAfterPath, env)).toBe("Row below");
-      expect(getNode(insertRowAfterPath, env).isVisible(env)).toBeTruthy();
+      expect(getName(insertRowAfterPath, model, env)).toBe("Row below");
+      expect(getNode(insertRowAfterPath, model, env).isVisible(model, env)).toBeTruthy();
     });
 
     test("Multiple consecutive selected rows", async () => {
       selectRow(model, 4, "overrideSelection");
       selectRow(model, 5, "updateAnchor");
-      expect(getName(insertRowAfterPath, env)).toBe("2 Rows below");
-      await doAction(insertRowAfterPath, env);
+      expect(getName(insertRowAfterPath, model, env)).toBe("2 Rows below");
+      await doAction(insertRowAfterPath, model, env);
       expect(dispatch).toHaveBeenLastCalledWith("ADD_COLUMNS_ROWS", {
-        sheetId: env.model.getters.getActiveSheetId(),
-        sheetName: env.model.getters.getActiveSheetName(),
+        sheetId: model.getters.getActiveSheetId(),
+        sheetName: model.getters.getActiveSheetName(),
         dimension: "ROW",
         base: 5,
         quantity: 2,
         position: "after",
       });
-      expect(getNode(insertRowAfterPath, env).isVisible(env)).toBeTruthy();
+      expect(getNode(insertRowAfterPath, model, env).isVisible(model, env)).toBeTruthy();
     });
 
     test("Multiple inconsecutive selected rows", () => {
       selectRow(model, 4, "overrideSelection");
       selectRow(model, 6, "newAnchor");
-      expect(getNode(insertRowAfterPath, env).isVisible(env)).toBeFalsy();
+      expect(getNode(insertRowAfterPath, model, env).isVisible(model, env)).toBeFalsy();
     });
 
     test("A selected column should hide the item", () => {
       selectColumn(model, 4, "overrideSelection");
-      expect(getNode(insertRowAfterPath, env).isVisible(env)).toBeFalsy();
+      expect(getNode(insertRowAfterPath, model, env).isVisible(model, env)).toBeFalsy();
     });
 
     test("A selected cell", () => {
       selectCell(model, "D4");
-      expect(getName(insertRowAfterPath, env)).toBe("Row below");
-      expect(getNode(insertRowAfterPath, env).isVisible(env)).toBeTruthy();
+      expect(getName(insertRowAfterPath, model, env)).toBe("Row below");
+      expect(getNode(insertRowAfterPath, model, env).isVisible(model, env)).toBeTruthy();
     });
 
     test("Multiple selected cells", async () => {
       selectCell(model, "D4");
       setAnchorCorner(model, "E5");
-      expect(getName(insertRowAfterPath, env)).toBe("2 Rows below");
-      await doAction(insertRowAfterPath, env);
+      expect(getName(insertRowAfterPath, model, env)).toBe("2 Rows below");
+      await doAction(insertRowAfterPath, model, env);
       expect(dispatch).toHaveBeenLastCalledWith("ADD_COLUMNS_ROWS", {
-        sheetId: env.model.getters.getActiveSheetId(),
-        sheetName: env.model.getters.getActiveSheetName(),
+        sheetId: model.getters.getActiveSheetId(),
+        sheetName: model.getters.getActiveSheetName(),
         dimension: "ROW",
         base: 4,
         quantity: 2,
         position: "after",
       });
-      expect(getNode(insertRowAfterPath, env).isVisible(env)).toBeTruthy();
+      expect(getNode(insertRowAfterPath, model, env).isVisible(model, env)).toBeTruthy();
     });
   });
 
@@ -671,35 +684,43 @@ describe("Menu Item actions", () => {
 
     test("A selected row", () => {
       selectRow(model, 4, "overrideSelection");
-      expect(getName(addRowAfterPath, env, rowMenuRegistry)).toBe("Insert row below");
-      expect(getNode(addRowAfterPath, env, rowMenuRegistry).isVisible(env)).toBeTruthy();
+      expect(getName(addRowAfterPath, model, env, rowMenuRegistry)).toBe("Insert row below");
+      expect(
+        getNode(addRowAfterPath, model, env, rowMenuRegistry).isVisible(model, env)
+      ).toBeTruthy();
     });
 
     test("Multiple consecutive selected rows", async () => {
       selectRow(model, 4, "overrideSelection");
       selectRow(model, 5, "updateAnchor");
-      expect(getName(addRowAfterPath, env, rowMenuRegistry)).toBe("Insert 2 rows below");
-      await doAction(addRowAfterPath, env, rowMenuRegistry);
+      expect(getName(addRowAfterPath, model, env, rowMenuRegistry)).toBe("Insert 2 rows below");
+      await doAction(addRowAfterPath, model, env, rowMenuRegistry);
       expect(dispatch).toHaveBeenLastCalledWith("ADD_COLUMNS_ROWS", {
-        sheetId: env.model.getters.getActiveSheetId(),
-        sheetName: env.model.getters.getActiveSheetName(),
+        sheetId: model.getters.getActiveSheetId(),
+        sheetName: model.getters.getActiveSheetName(),
         dimension: "ROW",
         base: 5,
         quantity: 2,
         position: "after",
       });
-      expect(getNode(addRowAfterPath, env, rowMenuRegistry).isVisible(env)).toBeTruthy();
+      expect(
+        getNode(addRowAfterPath, model, env, rowMenuRegistry).isVisible(model, env)
+      ).toBeTruthy();
     });
 
     test("Multiple inconsecutive selected rows", () => {
       selectRow(model, 4, "overrideSelection");
       selectRow(model, 6, "newAnchor");
-      expect(getNode(addRowAfterPath, env, rowMenuRegistry).isVisible(env)).toBeFalsy();
+      expect(
+        getNode(addRowAfterPath, model, env, rowMenuRegistry).isVisible(model, env)
+      ).toBeFalsy();
     });
 
     test("Full sheet selected", () => {
       selectAll(model);
-      expect(getNode(addRowAfterPath, env, rowMenuRegistry).isVisible(env)).toBeTruthy();
+      expect(
+        getNode(addRowAfterPath, model, env, rowMenuRegistry).isVisible(model, env)
+      ).toBeTruthy();
     });
   });
 
@@ -708,57 +729,57 @@ describe("Menu Item actions", () => {
 
     test("A selected column", () => {
       selectColumn(model, 4, "overrideSelection");
-      expect(getName(insertColBeforePath, env)).toBe("Column left");
-      expect(getNode(insertColBeforePath, env).isVisible(env)).toBeTruthy();
+      expect(getName(insertColBeforePath, model, env)).toBe("Column left");
+      expect(getNode(insertColBeforePath, model, env).isVisible(model, env)).toBeTruthy();
     });
 
     test("Multiple consecutive selected columns", async () => {
       selectColumn(model, 4, "overrideSelection");
       selectColumn(model, 5, "updateAnchor");
-      expect(getName(insertColBeforePath, env)).toBe("2 Columns left");
-      await doAction(insertColBeforePath, env);
+      expect(getName(insertColBeforePath, model, env)).toBe("2 Columns left");
+      await doAction(insertColBeforePath, model, env);
       expect(dispatch).toHaveBeenLastCalledWith("ADD_COLUMNS_ROWS", {
-        sheetId: env.model.getters.getActiveSheetId(),
-        sheetName: env.model.getters.getActiveSheetName(),
+        sheetId: model.getters.getActiveSheetId(),
+        sheetName: model.getters.getActiveSheetName(),
         base: 4,
         dimension: "COL",
         quantity: 2,
         position: "before",
       });
-      expect(getNode(insertColBeforePath, env).isVisible(env)).toBeTruthy();
+      expect(getNode(insertColBeforePath, model, env).isVisible(model, env)).toBeTruthy();
     });
 
     test("Multiple inconsecutive selected columns", () => {
       selectColumn(model, 4, "overrideSelection");
       selectColumn(model, 6, "newAnchor");
-      expect(getNode(insertColBeforePath, env).isVisible(env)).toBeFalsy();
+      expect(getNode(insertColBeforePath, model, env).isVisible(model, env)).toBeFalsy();
     });
 
     test("A selected row should hide the item", () => {
       selectRow(model, 4, "overrideSelection");
-      expect(getNode(insertColBeforePath, env).isVisible(env)).toBeFalsy();
+      expect(getNode(insertColBeforePath, model, env).isVisible(model, env)).toBeFalsy();
     });
 
     test("A selected cell", () => {
       selectCell(model, "D4");
-      expect(getName(insertColBeforePath, env)).toBe("Column left");
-      expect(getNode(insertColBeforePath, env).isVisible(env)).toBeTruthy();
+      expect(getName(insertColBeforePath, model, env)).toBe("Column left");
+      expect(getNode(insertColBeforePath, model, env).isVisible(model, env)).toBeTruthy();
     });
 
     test("Multiple selected cells", async () => {
       selectCell(model, "D4");
       setAnchorCorner(model, "E5");
-      expect(getName(insertColBeforePath, env)).toBe("2 Columns left");
-      await doAction(insertColBeforePath, env);
+      expect(getName(insertColBeforePath, model, env)).toBe("2 Columns left");
+      await doAction(insertColBeforePath, model, env);
       expect(dispatch).toHaveBeenLastCalledWith("ADD_COLUMNS_ROWS", {
-        sheetId: env.model.getters.getActiveSheetId(),
-        sheetName: env.model.getters.getActiveSheetName(),
+        sheetId: model.getters.getActiveSheetId(),
+        sheetName: model.getters.getActiveSheetName(),
         base: 3,
         dimension: "COL",
         quantity: 2,
         position: "before",
       });
-      expect(getNode(insertColBeforePath, env).isVisible(env)).toBeTruthy();
+      expect(getNode(insertColBeforePath, model, env).isVisible(model, env)).toBeTruthy();
     });
   });
 
@@ -767,35 +788,43 @@ describe("Menu Item actions", () => {
 
     test("A selected column", () => {
       selectColumn(model, 4, "overrideSelection");
-      expect(getName(addColBeforePath, env, colMenuRegistry)).toBe("Insert column left");
-      expect(getNode(addColBeforePath, env, colMenuRegistry).isVisible(env)).toBeTruthy();
+      expect(getName(addColBeforePath, model, env, colMenuRegistry)).toBe("Insert column left");
+      expect(
+        getNode(addColBeforePath, model, env, colMenuRegistry).isVisible(model, env)
+      ).toBeTruthy();
     });
 
     test("Multiple consecutive selected columns", async () => {
       selectColumn(model, 4, "overrideSelection");
       selectColumn(model, 5, "updateAnchor");
-      expect(getName(addColBeforePath, env, colMenuRegistry)).toBe("Insert 2 columns left");
-      await doAction(addColBeforePath, env, colMenuRegistry);
+      expect(getName(addColBeforePath, model, env, colMenuRegistry)).toBe("Insert 2 columns left");
+      await doAction(addColBeforePath, model, env, colMenuRegistry);
       expect(dispatch).toHaveBeenLastCalledWith("ADD_COLUMNS_ROWS", {
-        sheetId: env.model.getters.getActiveSheetId(),
-        sheetName: env.model.getters.getActiveSheetName(),
+        sheetId: model.getters.getActiveSheetId(),
+        sheetName: model.getters.getActiveSheetName(),
         base: 4,
         dimension: "COL",
         quantity: 2,
         position: "before",
       });
-      expect(getNode(addColBeforePath, env, colMenuRegistry).isVisible(env)).toBeTruthy();
+      expect(
+        getNode(addColBeforePath, model, env, colMenuRegistry).isVisible(model, env)
+      ).toBeTruthy();
     });
 
     test("Multiple inconsecutive selected columns", () => {
       selectColumn(model, 4, "overrideSelection");
       selectColumn(model, 6, "newAnchor");
-      expect(getNode(addColBeforePath, env, colMenuRegistry).isVisible(env)).toBeFalsy();
+      expect(
+        getNode(addColBeforePath, model, env, colMenuRegistry).isVisible(model, env)
+      ).toBeFalsy();
     });
 
     test("Full sheet selected", () => {
       selectAll(model);
-      expect(getNode(addColBeforePath, env, colMenuRegistry).isVisible(env)).toBeTruthy();
+      expect(
+        getNode(addColBeforePath, model, env, colMenuRegistry).isVisible(model, env)
+      ).toBeTruthy();
     });
   });
 
@@ -804,57 +833,57 @@ describe("Menu Item actions", () => {
 
     test("A selected column", () => {
       selectColumn(model, 4, "overrideSelection");
-      expect(getName(insertColAfterPath, env)).toBe("Column right");
-      expect(getNode(insertColAfterPath, env).isVisible(env)).toBeTruthy();
+      expect(getName(insertColAfterPath, model, env)).toBe("Column right");
+      expect(getNode(insertColAfterPath, model, env).isVisible(model, env)).toBeTruthy();
     });
 
     test("Multiple consecutive selected columns", async () => {
       selectColumn(model, 4, "overrideSelection");
       selectColumn(model, 5, "updateAnchor");
-      expect(getName(insertColAfterPath, env)).toBe("2 Columns right");
-      await doAction(insertColAfterPath, env);
+      expect(getName(insertColAfterPath, model, env)).toBe("2 Columns right");
+      await doAction(insertColAfterPath, model, env);
       expect(dispatch).toHaveBeenLastCalledWith("ADD_COLUMNS_ROWS", {
-        sheetId: env.model.getters.getActiveSheetId(),
-        sheetName: env.model.getters.getActiveSheetName(),
+        sheetId: model.getters.getActiveSheetId(),
+        sheetName: model.getters.getActiveSheetName(),
         base: 5,
         dimension: "COL",
         quantity: 2,
         position: "after",
       });
-      expect(getNode(insertColAfterPath, env).isVisible(env)).toBeTruthy();
+      expect(getNode(insertColAfterPath, model, env).isVisible(model, env)).toBeTruthy();
     });
 
     test("Multiple inconsecutive selected columns", () => {
       selectColumn(model, 4, "overrideSelection");
       selectColumn(model, 6, "newAnchor");
-      expect(getNode(insertColAfterPath, env).isVisible(env)).toBeFalsy();
+      expect(getNode(insertColAfterPath, model, env).isVisible(model, env)).toBeFalsy();
     });
 
     test("A selected row should hide the item", () => {
       selectRow(model, 4, "overrideSelection");
-      expect(getNode(insertColAfterPath, env).isVisible(env)).toBeFalsy();
+      expect(getNode(insertColAfterPath, model, env).isVisible(model, env)).toBeFalsy();
     });
 
     test("A selected cell", () => {
       selectCell(model, "D4");
-      expect(getName(insertColAfterPath, env)).toBe("Column right");
-      expect(getNode(insertColAfterPath, env).isVisible(env)).toBeTruthy();
+      expect(getName(insertColAfterPath, model, env)).toBe("Column right");
+      expect(getNode(insertColAfterPath, model, env).isVisible(model, env)).toBeTruthy();
     });
 
     test("Multiple selected cells", async () => {
       selectCell(model, "D4");
       setAnchorCorner(model, "E5");
-      expect(getName(insertColAfterPath, env)).toBe("2 Columns right");
-      await doAction(insertColAfterPath, env);
+      expect(getName(insertColAfterPath, model, env)).toBe("2 Columns right");
+      await doAction(insertColAfterPath, model, env);
       expect(dispatch).toHaveBeenLastCalledWith("ADD_COLUMNS_ROWS", {
-        sheetId: env.model.getters.getActiveSheetId(),
-        sheetName: env.model.getters.getActiveSheetName(),
+        sheetId: model.getters.getActiveSheetId(),
+        sheetName: model.getters.getActiveSheetName(),
         base: 4,
         dimension: "COL",
         quantity: 2,
         position: "after",
       });
-      expect(getNode(insertColAfterPath, env).isVisible(env)).toBeTruthy();
+      expect(getNode(insertColAfterPath, model, env).isVisible(model, env)).toBeTruthy();
     });
   });
 
@@ -863,35 +892,43 @@ describe("Menu Item actions", () => {
 
     test("A selected column", () => {
       selectColumn(model, 4, "overrideSelection");
-      expect(getName(addColAfterPath, env, colMenuRegistry)).toBe("Insert column right");
-      expect(getNode(addColAfterPath, env, colMenuRegistry).isVisible(env)).toBeTruthy();
+      expect(getName(addColAfterPath, model, env, colMenuRegistry)).toBe("Insert column right");
+      expect(
+        getNode(addColAfterPath, model, env, colMenuRegistry).isVisible(model, env)
+      ).toBeTruthy();
     });
 
     test("Multiple consecutive selected columns", async () => {
       selectColumn(model, 4, "overrideSelection");
       selectColumn(model, 5, "updateAnchor");
-      expect(getName(addColAfterPath, env, colMenuRegistry)).toBe("Insert 2 columns right");
-      await doAction(addColAfterPath, env, colMenuRegistry);
+      expect(getName(addColAfterPath, model, env, colMenuRegistry)).toBe("Insert 2 columns right");
+      await doAction(addColAfterPath, model, env, colMenuRegistry);
       expect(dispatch).toHaveBeenLastCalledWith("ADD_COLUMNS_ROWS", {
-        sheetId: env.model.getters.getActiveSheetId(),
-        sheetName: env.model.getters.getActiveSheetName(),
+        sheetId: model.getters.getActiveSheetId(),
+        sheetName: model.getters.getActiveSheetName(),
         base: 5,
         dimension: "COL",
         quantity: 2,
         position: "after",
       });
-      expect(getNode(addColAfterPath, env, colMenuRegistry).isVisible(env)).toBeTruthy();
+      expect(
+        getNode(addColAfterPath, model, env, colMenuRegistry).isVisible(model, env)
+      ).toBeTruthy();
     });
 
     test("Multiple inconsecutive selected columns", () => {
       selectColumn(model, 4, "overrideSelection");
       selectColumn(model, 6, "newAnchor");
-      expect(getNode(addColAfterPath, env, colMenuRegistry).isVisible(env)).toBeFalsy();
+      expect(
+        getNode(addColAfterPath, model, env, colMenuRegistry).isVisible(model, env)
+      ).toBeFalsy();
     });
 
     test("Full sheet selected", () => {
       selectAll(model);
-      expect(getNode(addColAfterPath, env, colMenuRegistry).isVisible(env)).toBeTruthy();
+      expect(
+        getNode(addColAfterPath, model, env, colMenuRegistry).isVisible(model, env)
+      ).toBeTruthy();
     });
   });
 
@@ -900,59 +937,59 @@ describe("Menu Item actions", () => {
 
     test("A selected row should hide the item", () => {
       selectRow(model, 4, "overrideSelection");
-      expect(getNode(insertCellShiftDownPath, env).isVisible(env)).toBeFalsy();
+      expect(getNode(insertCellShiftDownPath, model, env).isVisible(model, env)).toBeFalsy();
     });
 
     test("A selected column should hide the item", () => {
       selectColumn(model, 4, "overrideSelection");
-      expect(getNode(insertCellShiftDownPath, env).isVisible(env)).toBeFalsy();
+      expect(getNode(insertCellShiftDownPath, model, env).isVisible(model, env)).toBeFalsy();
     });
 
     test("Multiple consecutive selected columns should hide the item", () => {
       selectColumn(model, 4, "overrideSelection");
       selectColumn(model, 5, "updateAnchor");
-      expect(getNode(insertCellShiftDownPath, env).isVisible(env)).toBeFalsy();
+      expect(getNode(insertCellShiftDownPath, model, env).isVisible(model, env)).toBeFalsy();
     });
 
     test("Multiple inconsecutive selected columns should hide the item", () => {
       selectColumn(model, 4, "overrideSelection");
       selectColumn(model, 6, "newAnchor");
-      expect(getNode(insertCellShiftDownPath, env).isVisible(env)).toBeFalsy();
+      expect(getNode(insertCellShiftDownPath, model, env).isVisible(model, env)).toBeFalsy();
     });
 
     test("Multiple consecutive selected rows should hide the item", () => {
       selectRow(model, 4, "overrideSelection");
       selectRow(model, 5, "updateAnchor");
-      expect(getNode(insertCellShiftDownPath, env).isVisible(env)).toBeFalsy();
+      expect(getNode(insertCellShiftDownPath, model, env).isVisible(model, env)).toBeFalsy();
     });
 
     test("Multiple inconsecutive selected rows should hide the item", () => {
       selectRow(model, 4, "overrideSelection");
       selectRow(model, 6, "newAnchor");
-      expect(getNode(insertCellShiftDownPath, env).isVisible(env)).toBeFalsy();
+      expect(getNode(insertCellShiftDownPath, model, env).isVisible(model, env)).toBeFalsy();
     });
 
     test("A selected cell", async () => {
       selectCell(model, "D4");
-      expect(getName(insertCellShiftDownPath, env)).toBe("Shift down");
-      await doAction(insertCellShiftDownPath, env);
+      expect(getName(insertCellShiftDownPath, model, env)).toBe("Shift down");
+      await doAction(insertCellShiftDownPath, model, env);
       expect(dispatch).toHaveBeenLastCalledWith("INSERT_CELL", {
-        zone: env.model.getters.getSelectedZone(),
+        zone: model.getters.getSelectedZone(),
         shiftDimension: "ROW",
       });
-      expect(getNode(insertCellShiftDownPath, env).isVisible(env)).toBeTruthy();
+      expect(getNode(insertCellShiftDownPath, model, env).isVisible(model, env)).toBeTruthy();
     });
 
     test("Multiple selected cells", async () => {
       selectCell(model, "D4");
       setAnchorCorner(model, "E5");
-      expect(getName(insertCellShiftDownPath, env)).toBe("Shift down");
-      await doAction(insertCellShiftDownPath, env);
+      expect(getName(insertCellShiftDownPath, model, env)).toBe("Shift down");
+      await doAction(insertCellShiftDownPath, model, env);
       expect(dispatch).toHaveBeenLastCalledWith("INSERT_CELL", {
-        zone: env.model.getters.getSelectedZone(),
+        zone: model.getters.getSelectedZone(),
         shiftDimension: "ROW",
       });
-      expect(getNode(insertCellShiftDownPath, env).isVisible(env)).toBeTruthy();
+      expect(getNode(insertCellShiftDownPath, model, env).isVisible(model, env)).toBeTruthy();
     });
   });
 
@@ -961,66 +998,66 @@ describe("Menu Item actions", () => {
 
     test("A selected row should hide the item", () => {
       selectRow(model, 4, "overrideSelection");
-      expect(getNode(insertCellShiftRightPath, env).isVisible(env)).toBeFalsy();
+      expect(getNode(insertCellShiftRightPath, model, env).isVisible(model, env)).toBeFalsy();
     });
 
     test("A selected column should hide the item", () => {
       selectColumn(model, 4, "overrideSelection");
-      expect(getNode(insertCellShiftRightPath, env).isVisible(env)).toBeFalsy();
+      expect(getNode(insertCellShiftRightPath, model, env).isVisible(model, env)).toBeFalsy();
     });
 
     test("Multiple consecutive selected columns should hide the item", () => {
       selectColumn(model, 4, "overrideSelection");
       selectColumn(model, 5, "updateAnchor");
-      expect(getNode(insertCellShiftRightPath, env).isVisible(env)).toBeFalsy();
+      expect(getNode(insertCellShiftRightPath, model, env).isVisible(model, env)).toBeFalsy();
     });
 
     test("Multiple inconsecutive selected columns should hide the item", () => {
       selectColumn(model, 4, "overrideSelection");
       selectColumn(model, 6, "newAnchor");
-      expect(getNode(insertCellShiftRightPath, env).isVisible(env)).toBeFalsy();
+      expect(getNode(insertCellShiftRightPath, model, env).isVisible(model, env)).toBeFalsy();
     });
 
     test("Multiple consecutive selected rows should hide the item", () => {
       selectRow(model, 4, "overrideSelection");
       selectRow(model, 5, "updateAnchor");
-      expect(getNode(insertCellShiftRightPath, env).isVisible(env)).toBeFalsy();
+      expect(getNode(insertCellShiftRightPath, model, env).isVisible(model, env)).toBeFalsy();
     });
 
     test("Multiple inconsecutive selected rows should hide the item", () => {
       selectRow(model, 4, "overrideSelection");
       selectRow(model, 6, "newAnchor");
-      expect(getNode(insertCellShiftRightPath, env).isVisible(env)).toBeFalsy();
+      expect(getNode(insertCellShiftRightPath, model, env).isVisible(model, env)).toBeFalsy();
     });
 
     test("A selected cell", async () => {
       selectCell(model, "D4");
-      expect(getName(insertCellShiftRightPath, env)).toBe("Shift right");
-      await doAction(insertCellShiftRightPath, env);
+      expect(getName(insertCellShiftRightPath, model, env)).toBe("Shift right");
+      await doAction(insertCellShiftRightPath, model, env);
       expect(dispatch).toHaveBeenLastCalledWith("INSERT_CELL", {
-        zone: env.model.getters.getSelectedZone(),
+        zone: model.getters.getSelectedZone(),
         shiftDimension: "COL",
       });
-      expect(getNode(insertCellShiftRightPath, env).isVisible(env)).toBeTruthy();
+      expect(getNode(insertCellShiftRightPath, model, env).isVisible(model, env)).toBeTruthy();
     });
 
     test("Multiple selected cells", async () => {
       selectCell(model, "D4");
       setAnchorCorner(model, "E5");
-      expect(getName(insertCellShiftRightPath, env)).toBe("Shift right");
-      await doAction(insertCellShiftRightPath, env);
+      expect(getName(insertCellShiftRightPath, model, env)).toBe("Shift right");
+      await doAction(insertCellShiftRightPath, model, env);
       expect(dispatch).toHaveBeenLastCalledWith("INSERT_CELL", {
-        zone: env.model.getters.getSelectedZone(),
+        zone: model.getters.getSelectedZone(),
         shiftDimension: "COL",
       });
-      expect(getNode(insertCellShiftRightPath, env).isVisible(env)).toBeTruthy();
+      expect(getNode(insertCellShiftRightPath, model, env).isVisible(model, env)).toBeTruthy();
     });
   });
 
   test("Insert -> new sheet", async () => {
-    const activeSheetId = env.model.getters.getActiveSheetId();
-    await doAction(["insert", "insert_sheet"], env);
-    const newSheetId = env.model.getters.getSheetIds()[1];
+    const activeSheetId = model.getters.getActiveSheetId();
+    await doAction(["insert", "insert_sheet"], model, env);
+    const newSheetId = model.getters.getSheetIds()[1];
     expect(dispatch).toHaveBeenNthCalledWith(1, "CREATE_SHEET", {
       sheetId: newSheetId,
       name: "Sheet2",
@@ -1034,7 +1071,7 @@ describe("Menu Item actions", () => {
 
   test("Insert -> Function", async () => {
     const spyStartCell = jest.spyOn(env, "startCellEdition");
-    await doAction(["insert", "insert_function", "insert_function_sum"], env);
+    await doAction(["insert", "insert_function", "insert_function_sum"], model, env);
     expect(spyStartCell).toHaveBeenCalled();
   });
 
@@ -1044,17 +1081,19 @@ describe("Menu Item actions", () => {
       compute: () => 42,
       description: "Test function",
     });
-    const env = makeTestEnv();
+    const model = new Model();
+    const env = makeTestEnv(model);
     const allFunctions = getNode(
       ["insert", "insert_function", "categorie_function_all"],
+      model,
       env
-    ).children(env);
-    expect(allFunctions.map((f) => f.name(env))).toContain("TEST.FUNC");
+    ).children(model, env);
+    expect(allFunctions.map((f) => f.name(model, env))).toContain("TEST.FUNC");
   });
 
   test("Insert -> Checkbox", async () => {
     selectCell(model, "A1");
-    await doAction(["insert", "insert_checkbox"], env);
+    await doAction(["insert", "insert_checkbox"], model, env);
     expect(getDataValidationRules(model, sheetId)).toMatchObject([
       { criterion: { type: "isBoolean" }, ranges: ["A1"] },
     ]);
@@ -1070,38 +1109,43 @@ describe("Menu Item actions", () => {
       hidden: true,
       category: "hidden",
     });
-    const env = makeTestEnv();
-    const functionCategories = getNode(["insert", "insert_function"], env).children(env);
-    expect(functionCategories.map((f) => f.name(env))).not.toContain("hidden");
+    const model = new Model();
+    const env = makeTestEnv(model);
+    const functionCategories = getNode(["insert", "insert_function"], model, env).children(
+      model,
+      env
+    );
+    expect(functionCategories.map((f) => f.name(model, env))).not.toContain("hidden");
     const allFunctions = getNode(
       ["insert", "insert_function", "categorie_function_all"],
+      model,
       env
-    ).children(env);
-    expect(allFunctions.map((f) => f.name(env))).not.toContain("HIDDEN.FUNC");
+    ).children(model, env);
+    expect(allFunctions.map((f) => f.name(model, env))).not.toContain("HIDDEN.FUNC");
   });
 
   describe("Format -> numbers", () => {
     test("Automatic", () => {
-      const action = getNode(["format", "format_number", "format_number_automatic"], env);
-      action.execute?.(env);
+      const action = getNode(["format", "format_number", "format_number_automatic"], model, env);
+      action.execute?.(model, env);
       expect(dispatch).toHaveBeenCalledWith("SET_FORMATTING_WITH_PIVOT", {
-        sheetId: env.model.getters.getActiveSheetId(),
-        target: env.model.getters.getSelectedZones(),
+        sheetId: model.getters.getActiveSheetId(),
+        target: model.getters.getSelectedZones(),
         format: "",
       });
-      expect(action.isActive?.(env)).toBe(true);
+      expect(action.isActive?.(model, env)).toBe(true);
     });
 
     test("Number", () => {
-      const action = getNode(["format", "format_number", "format_number_number"], env);
-      expect(action.isActive?.(env)).toBe(false);
-      action.execute?.(env);
+      const action = getNode(["format", "format_number", "format_number_number"], model, env);
+      expect(action.isActive?.(model, env)).toBe(false);
+      action.execute?.(model, env);
       expect(dispatch).toHaveBeenCalledWith("SET_FORMATTING_WITH_PIVOT", {
-        sheetId: env.model.getters.getActiveSheetId(),
-        target: env.model.getters.getSelectedZones(),
+        sheetId: model.getters.getActiveSheetId(),
+        target: model.getters.getSelectedZones(),
         format: "#,##0.00",
       });
-      expect(action.isActive?.(env)).toBe(true);
+      expect(action.isActive?.(model, env)).toBe(true);
     });
 
     test.each([
@@ -1114,8 +1158,8 @@ describe("Menu Item actions", () => {
       ["format_number_date_time", "9/26/2023 10:43:00 PM"],
       ["format_number_duration", "27:51:38"],
     ])("number formatting description with default locale", (actionId, expectedDescription) => {
-      const action = getNode(["format", "format_number", actionId], env);
-      expect(action.description(env)).toBe(expectedDescription);
+      const action = getNode(["format", "format_number", actionId], model, env);
+      expect(action.description(model, env)).toBe(expectedDescription);
     });
 
     test.each([
@@ -1129,110 +1173,122 @@ describe("Menu Item actions", () => {
       ["format_number_duration", "27:51:38"],
     ])("number formatting description with custom locale", (actionId, expectedDescription) => {
       updateLocale(model, FR_LOCALE);
-      const action = getNode(["format", "format_number", actionId], env);
-      expect(action.description(env)).toBe(expectedDescription);
+      const action = getNode(["format", "format_number", actionId], model, env);
+      expect(action.description(model, env)).toBe(expectedDescription);
     });
 
     test("Percent", async () => {
-      await doAction(["format", "format_number", "format_number_percent"], env);
+      await doAction(["format", "format_number", "format_number_percent"], model, env);
       expect(dispatch).toHaveBeenCalledWith("SET_FORMATTING_WITH_PIVOT", {
-        sheetId: env.model.getters.getActiveSheetId(),
-        target: env.model.getters.getSelectedZones(),
+        sheetId: model.getters.getActiveSheetId(),
+        target: model.getters.getSelectedZones(),
         format: "0.00%",
       });
     });
 
     test("currency format with default currency", () => {
-      const action = getNode(["format", "format_number", "format_number_currency"], env);
-      expect(action.description(env)).toBe("$1,000.12");
-      action.execute?.(env);
+      const action = getNode(["format", "format_number", "format_number_currency"], model, env);
+      expect(action.description(model, env)).toBe("$1,000.12");
+      action.execute?.(model, env);
       expect(getCell(model, "A1")?.format).toBe("[$$]#,##0.00");
     });
 
     test("rounded currency format with default currency", () => {
-      const action = getNode(["format", "format_number", "format_number_currency_rounded"], env);
-      expect(action.description(env)).toBe("$1,000");
-      action.execute?.(env);
+      const action = getNode(
+        ["format", "format_number", "format_number_currency_rounded"],
+        model,
+        env
+      );
+      expect(action.description(model, env)).toBe("$1,000");
+      action.execute?.(model, env);
       expect(getCell(model, "A1")?.format).toBe("[$$]#,##0");
     });
 
     test("currency format with custom default currency", () => {
       const model = new Model({}, { defaultCurrency: TEST_CURRENCY });
-      env = makeTestEnv({ model });
-      const action = getNode(["format", "format_number", "format_number_currency"], env);
-      expect(action.description(env)).toBe("€1,000.120");
-      action.execute?.(env);
+      env = makeTestEnv(model);
+      const action = getNode(["format", "format_number", "format_number_currency"], model, env);
+      expect(action.description(model, env)).toBe("€1,000.120");
+      action.execute?.(model, env);
       expect(getCell(model, "A1")?.format).toBe("[$€]#,##0.000");
     });
 
     test("rounded currency format with custom default currency", () => {
       const model = new Model({}, { defaultCurrency: TEST_CURRENCY });
-      env = makeTestEnv({ model });
-      const action = getNode(["format", "format_number", "format_number_currency_rounded"], env);
-      expect(action.description(env)).toBe("€1,000");
-      action.execute?.(env);
+      env = makeTestEnv(model);
+      const action = getNode(
+        ["format", "format_number", "format_number_currency_rounded"],
+        model,
+        env
+      );
+      expect(action.description(model, env)).toBe("€1,000");
+      action.execute?.(model, env);
       expect(getCell(model, "A1")?.format).toBe("[$€]#,##0");
     });
 
     test("rounded currency format is invisible if the custom default format is already rounded", () => {
       const model = new Model({}, { defaultCurrency: { decimalPlaces: 0 } });
-      env = makeTestEnv({ model });
-      const action = getNode(["format", "format_number", "format_number_currency_rounded"], env);
-      expect(action.isVisible(env)).toBe(false);
+      env = makeTestEnv(model);
+      const action = getNode(
+        ["format", "format_number", "format_number_currency_rounded"],
+        model,
+        env
+      );
+      expect(action.isVisible(model, env)).toBe(false);
     });
 
     test("currency format description with locale and custom default currency", () => {
       const model = new Model({}, { defaultCurrency: TEST_CURRENCY });
-      env = makeTestEnv({ model });
+      env = makeTestEnv(model);
       updateLocale(model, FR_LOCALE);
-      const action = getNode(["format", "format_number", "format_number_currency"], env);
-      expect(action.description(env)).toBe("€1 000,120");
+      const action = getNode(["format", "format_number", "format_number_currency"], model, env);
+      expect(action.description(model, env)).toBe("€1 000,120");
     });
 
     test("accounting format menu item", () => {
       const model = new Model({}, { defaultCurrency: { ...TEST_CURRENCY, decimalPlaces: 0 } });
-      env = makeTestEnv({ model });
-      const action = getNode(["format", "format_number", "format_number_accounting"], env);
-      expect(action.isVisible(env)).toBe(true);
-      action.execute?.(env);
+      env = makeTestEnv(model);
+      const action = getNode(["format", "format_number", "format_number_accounting"], model, env);
+      expect(action.isVisible(model, env)).toBe(true);
+      action.execute?.(model, env);
       expect(getCell(model, "A1")?.format).toBe("[$€]*  #,##0 ;[$€]* (#,##0);[$€]*   -  ");
     });
 
     test.each(DEFAULT_LOCALES)("Date", async (locale) => {
-      env.model.dispatch("UPDATE_LOCALE", { locale });
-      await doAction(["format", "format_number", "format_number_date"], env);
+      model.dispatch("UPDATE_LOCALE", { locale });
+      await doAction(["format", "format_number", "format_number_date"], model, env);
       expect(dispatch).toHaveBeenCalledWith("SET_FORMATTING_WITH_PIVOT", {
-        sheetId: env.model.getters.getActiveSheetId(),
-        target: env.model.getters.getSelectedZones(),
+        sheetId: model.getters.getActiveSheetId(),
+        target: model.getters.getSelectedZones(),
         format: locale.dateFormat,
       });
     });
 
     test.each(DEFAULT_LOCALES)("Time", async (locale) => {
-      env.model.dispatch("UPDATE_LOCALE", { locale });
-      await doAction(["format", "format_number", "format_number_time"], env);
+      model.dispatch("UPDATE_LOCALE", { locale });
+      await doAction(["format", "format_number", "format_number_time"], model, env);
       expect(dispatch).toHaveBeenCalledWith("SET_FORMATTING_WITH_PIVOT", {
-        sheetId: env.model.getters.getActiveSheetId(),
-        target: env.model.getters.getSelectedZones(),
+        sheetId: model.getters.getActiveSheetId(),
+        target: model.getters.getSelectedZones(),
         format: locale.timeFormat,
       });
     });
 
     test.each(DEFAULT_LOCALES)("Date time", async (locale) => {
-      env.model.dispatch("UPDATE_LOCALE", { locale });
-      await doAction(["format", "format_number", "format_number_date_time"], env);
+      model.dispatch("UPDATE_LOCALE", { locale });
+      await doAction(["format", "format_number", "format_number_date_time"], model, env);
       expect(dispatch).toHaveBeenCalledWith("SET_FORMATTING_WITH_PIVOT", {
-        sheetId: env.model.getters.getActiveSheetId(),
-        target: env.model.getters.getSelectedZones(),
+        sheetId: model.getters.getActiveSheetId(),
+        target: model.getters.getSelectedZones(),
         format: `${locale.dateFormat} ${locale.timeFormat}`,
       });
     });
 
     test("Duration", async () => {
-      await doAction(["format", "format_number", "format_number_duration"], env);
+      await doAction(["format", "format_number", "format_number_duration"], model, env);
       expect(dispatch).toHaveBeenCalledWith("SET_FORMATTING_WITH_PIVOT", {
-        sheetId: env.model.getters.getActiveSheetId(),
-        target: env.model.getters.getSelectedZones(),
+        sheetId: model.getters.getActiveSheetId(),
+        target: model.getters.getSelectedZones(),
         format: "hhhh:mm:ss",
       });
     });
@@ -1240,51 +1296,53 @@ describe("Menu Item actions", () => {
     test("Custom formats", async () => {
       const spyOpenSidePanel = jest.spyOn(env, "openSidePanel");
 
-      await doAction(["format", "format_number", "format_custom_currency"], env);
+      await doAction(["format", "format_number", "format_custom_currency"], model, env);
       expect(spyOpenSidePanel).toHaveBeenCalledWith("MoreFormats", { category: "currency" });
 
-      await doAction(["format", "format_number", "format_custom_date"], env);
+      await doAction(["format", "format_number", "format_custom_date"], model, env);
       expect(spyOpenSidePanel).toHaveBeenCalledWith("MoreFormats", { category: "date" });
 
-      await doAction(["format", "format_number", "format_custom_number"], env);
+      await doAction(["format", "format_number", "format_custom_number"], model, env);
       expect(spyOpenSidePanel).toHaveBeenCalledWith("MoreFormats", { category: "number" });
     });
 
     test("Automatic format is active when format is computed", () => {
-      selectCell(env.model, "A1");
-      setCellContent(env.model, "A1", "1");
+      selectCell(model, "A1");
+      setCellContent(model, "A1", "1");
       const setNumberFormatAction = getNode(
         ["format", "format_number", "format_number_number"],
+        model,
         env
       );
       const setAutoFormatAction = getNode(
         ["format", "format_number", "format_number_automatic"],
+        model,
         env
       );
-      setNumberFormatAction.execute?.(env);
+      setNumberFormatAction.execute?.(model, env);
       expect(getCell(model, "A1")?.format).toBe("#,##0.00");
-      setCellContent(env.model, "B1", "=A1");
+      setCellContent(model, "B1", "=A1");
       expect(getCell(model, "B1")?.format).toBeUndefined();
       expect(getEvaluatedCell(model, "B1")?.format).toBe("#,##0.00");
-      selectCell(env.model, "B1");
-      expect(setAutoFormatAction.isActive?.(env)).toBe(true);
-      expect(setNumberFormatAction.isActive?.(env)).toBe(false);
+      selectCell(model, "B1");
+      expect(setAutoFormatAction.isActive?.(model, env)).toBe(true);
+      expect(setNumberFormatAction.isActive?.(model, env)).toBe(false);
     });
 
     test("cancel edition when setting a format", async () => {
       const composerStore = env.getStore(CellComposerStore);
       composerStore.startEdition("hello");
       expect(composerStore.editionMode).toBe("editing");
-      await doAction(["format", "format_number", "format_number_percent"], env);
+      await doAction(["format", "format_number", "format_number_percent"], model, env);
       expect(composerStore.editionMode).toBe("inactive");
       expect(getCellContent(model, "A1")).toBe("");
     });
 
     describe("Custom number formats", () => {
       function getNumberFormatsInMenu() {
-        return getNode(["format", "format_number"], env)
-          .children(env)
-          .map((node) => node.name(env));
+        return getNode(["format", "format_number"], model, env)
+          .children(model, env)
+          .map((node) => node.name(model, env));
       }
 
       test("Custom date and currency formats are present in the number format item", () => {
@@ -1310,102 +1368,102 @@ describe("Menu Item actions", () => {
   });
 
   test("Format -> bold", async () => {
-    await doAction(["format", "format_bold"], env);
+    await doAction(["format", "format_bold"], model, env);
     expect(dispatch).toHaveBeenCalledWith("SET_FORMATTING", {
-      sheetId: env.model.getters.getActiveSheetId(),
-      target: env.model.getters.getSelectedZones(),
+      sheetId: model.getters.getActiveSheetId(),
+      target: model.getters.getSelectedZones(),
       style: { bold: true },
     });
   });
 
   test("Format -> italic", async () => {
-    await doAction(["format", "format_italic"], env);
+    await doAction(["format", "format_italic"], model, env);
     expect(dispatch).toHaveBeenCalledWith("SET_FORMATTING", {
-      sheetId: env.model.getters.getActiveSheetId(),
-      target: env.model.getters.getSelectedZones(),
+      sheetId: model.getters.getActiveSheetId(),
+      target: model.getters.getSelectedZones(),
       style: { italic: true },
     });
   });
 
   test("Format -> underline", async () => {
-    await doAction(["format", "format_underline"], env);
+    await doAction(["format", "format_underline"], model, env);
     expect(dispatch).toHaveBeenCalledWith("SET_FORMATTING", {
-      sheetId: env.model.getters.getActiveSheetId(),
-      target: env.model.getters.getSelectedZones(),
+      sheetId: model.getters.getActiveSheetId(),
+      target: model.getters.getSelectedZones(),
       style: { underline: true },
     });
   });
 
   test("Format -> strikethrough", async () => {
-    await doAction(["format", "format_strikethrough"], env);
+    await doAction(["format", "format_strikethrough"], model, env);
     expect(dispatch).toHaveBeenCalledWith("SET_FORMATTING", {
-      sheetId: env.model.getters.getActiveSheetId(),
-      target: env.model.getters.getSelectedZones(),
+      sheetId: model.getters.getActiveSheetId(),
+      target: model.getters.getSelectedZones(),
       style: { strikethrough: true },
     });
   });
 
   test("Format -> font-size", async () => {
     const fontSize = FONT_SIZES[0];
-    await doAction(["format", "format_font_size", `font_size_${fontSize}`], env);
+    await doAction(["format", "format_font_size", `font_size_${fontSize}`], model, env);
     expect(dispatch).toHaveBeenCalledWith("SET_FORMATTING", {
-      sheetId: env.model.getters.getActiveSheetId(),
-      target: env.model.getters.getSelectedZones(),
+      sheetId: model.getters.getActiveSheetId(),
+      target: model.getters.getSelectedZones(),
       style: { fontSize },
     });
   });
 
   describe("Format -> Alignment", () => {
     test("Left", async () => {
-      await doAction(["format", "format_alignment", "format_alignment_left"], env);
+      await doAction(["format", "format_alignment", "format_alignment_left"], model, env);
       expect(dispatch).toHaveBeenCalledWith("SET_FORMATTING", {
-        sheetId: env.model.getters.getActiveSheetId(),
-        target: env.model.getters.getSelectedZones(),
+        sheetId: model.getters.getActiveSheetId(),
+        target: model.getters.getSelectedZones(),
         style: { align: "left" },
       });
     });
 
     test("Center", async () => {
-      await doAction(["format", "format_alignment", "format_alignment_center"], env);
+      await doAction(["format", "format_alignment", "format_alignment_center"], model, env);
       expect(dispatch).toHaveBeenCalledWith("SET_FORMATTING", {
-        sheetId: env.model.getters.getActiveSheetId(),
-        target: env.model.getters.getSelectedZones(),
+        sheetId: model.getters.getActiveSheetId(),
+        target: model.getters.getSelectedZones(),
         style: { align: "center" },
       });
     });
 
     test("Right", async () => {
-      await doAction(["format", "format_alignment", "format_alignment_right"], env);
+      await doAction(["format", "format_alignment", "format_alignment_right"], model, env);
       expect(dispatch).toHaveBeenCalledWith("SET_FORMATTING", {
-        sheetId: env.model.getters.getActiveSheetId(),
-        target: env.model.getters.getSelectedZones(),
+        sheetId: model.getters.getActiveSheetId(),
+        target: model.getters.getSelectedZones(),
         style: { align: "right" },
       });
     });
 
     test("Top", async () => {
-      await doAction(["format", "format_alignment", "format_alignment_top"], env);
+      await doAction(["format", "format_alignment", "format_alignment_top"], model, env);
       expect(dispatch).toHaveBeenCalledWith("SET_FORMATTING", {
-        sheetId: env.model.getters.getActiveSheetId(),
-        target: env.model.getters.getSelectedZones(),
+        sheetId: model.getters.getActiveSheetId(),
+        target: model.getters.getSelectedZones(),
         style: { verticalAlign: "top" },
       });
     });
 
     test("Middle", async () => {
-      await doAction(["format", "format_alignment", "format_alignment_middle"], env);
+      await doAction(["format", "format_alignment", "format_alignment_middle"], model, env);
       expect(dispatch).toHaveBeenCalledWith("SET_FORMATTING", {
-        sheetId: env.model.getters.getActiveSheetId(),
-        target: env.model.getters.getSelectedZones(),
+        sheetId: model.getters.getActiveSheetId(),
+        target: model.getters.getSelectedZones(),
         style: { verticalAlign: "middle" },
       });
     });
 
     test("Bottom", async () => {
-      await doAction(["format", "format_alignment", "format_alignment_bottom"], env);
+      await doAction(["format", "format_alignment", "format_alignment_bottom"], model, env);
       expect(dispatch).toHaveBeenCalledWith("SET_FORMATTING", {
-        sheetId: env.model.getters.getActiveSheetId(),
-        target: env.model.getters.getSelectedZones(),
+        sheetId: model.getters.getActiveSheetId(),
+        target: model.getters.getSelectedZones(),
         style: { verticalAlign: "bottom" },
       });
     });
@@ -1413,28 +1471,28 @@ describe("Menu Item actions", () => {
 
   describe("Format -> wrapping", () => {
     test("Overflow", async () => {
-      await doAction(["format", "format_wrapping", "format_wrapping_overflow"], env);
+      await doAction(["format", "format_wrapping", "format_wrapping_overflow"], model, env);
       expect(dispatch).toHaveBeenCalledWith("SET_FORMATTING", {
-        sheetId: env.model.getters.getActiveSheetId(),
-        target: env.model.getters.getSelectedZones(),
+        sheetId: model.getters.getActiveSheetId(),
+        target: model.getters.getSelectedZones(),
         style: { wrapping: "overflow" },
       });
     });
 
     test("Wrap", async () => {
-      await doAction(["format", "format_wrapping", "format_wrapping_wrap"], env);
+      await doAction(["format", "format_wrapping", "format_wrapping_wrap"], model, env);
       expect(dispatch).toHaveBeenCalledWith("SET_FORMATTING", {
-        sheetId: env.model.getters.getActiveSheetId(),
-        target: env.model.getters.getSelectedZones(),
+        sheetId: model.getters.getActiveSheetId(),
+        target: model.getters.getSelectedZones(),
         style: { wrapping: "wrap" },
       });
     });
 
     test("Clip", async () => {
-      await doAction(["format", "format_wrapping", "format_wrapping_clip"], env);
+      await doAction(["format", "format_wrapping", "format_wrapping_clip"], model, env);
       expect(dispatch).toHaveBeenCalledWith("SET_FORMATTING", {
-        sheetId: env.model.getters.getActiveSheetId(),
-        target: env.model.getters.getSelectedZones(),
+        sheetId: model.getters.getActiveSheetId(),
+        target: model.getters.getSelectedZones(),
         style: { wrapping: "clip" },
       });
     });
@@ -1442,26 +1500,26 @@ describe("Menu Item actions", () => {
 
   test("Data -> Split to columns action", async () => {
     const spyOpenSidePanel = jest.spyOn(env, "openSidePanel");
-    await doAction(["data", "split_to_columns"], env);
+    await doAction(["data", "split_to_columns"], model, env);
     expect(spyOpenSidePanel).toHaveBeenCalledWith("SplitToColumns", {});
   });
 
   test("Data -> Split to columns is disabled when multiple cols are selected", () => {
     setSelection(model, ["A1"]);
-    expect(getNode(["data", "split_to_columns"], env).isEnabled(env)).toBeTruthy();
+    expect(getNode(["data", "split_to_columns"], model, env).isEnabled(model, env)).toBeTruthy();
 
     setSelection(model, ["A1:C1"]);
-    expect(getNode(["data", "split_to_columns"], env).isEnabled(env)).toBeFalsy();
+    expect(getNode(["data", "split_to_columns"], model, env).isEnabled(model, env)).toBeFalsy();
 
     setSelection(model, ["A1", "B1"]);
-    expect(getNode(["data", "split_to_columns"], env).isEnabled(env)).toBeFalsy();
+    expect(getNode(["data", "split_to_columns"], model, env).isEnabled(model, env)).toBeFalsy();
   });
 
   test("Data -> Sort ascending", async () => {
-    await doAction(["data", "sort_range", "sort_ascending"], env);
-    const { anchor, zones } = env.model.getters.getSelection();
+    await doAction(["data", "sort_range", "sort_ascending"], model, env);
+    const { anchor, zones } = model.getters.getSelection();
     expect(dispatch).toHaveBeenCalledWith("SORT_CELLS", {
-      sheetId: env.model.getters.getActiveSheetId(),
+      sheetId: model.getters.getActiveSheetId(),
       ...anchor.cell,
       zone: zones[0],
       sortDirection: "asc",
@@ -1469,10 +1527,10 @@ describe("Menu Item actions", () => {
   });
 
   test("Data -> Sort descending", async () => {
-    await doAction(["data", "sort_range", "sort_descending"], env);
-    const { anchor, zones } = env.model.getters.getSelection();
+    await doAction(["data", "sort_range", "sort_descending"], model, env);
+    const { anchor, zones } = model.getters.getSelection();
     expect(dispatch).toHaveBeenCalledWith("SORT_CELLS", {
-      sheetId: env.model.getters.getActiveSheetId(),
+      sheetId: model.getters.getActiveSheetId(),
       ...anchor.cell,
       zone: zones[0],
       sortDirection: "desc",
@@ -1484,13 +1542,13 @@ describe("Menu Item actions", () => {
 
     test("A selected zone", () => {
       setSelection(model, ["A1:A2"]);
-      expect(getName(pathSort, env)).toBe("Sort range");
-      expect(getNode(pathSort, env).isVisible(env)).toBeTruthy();
+      expect(getName(pathSort, model, env)).toBe("Sort range");
+      expect(getNode(pathSort, model, env).isVisible(model, env)).toBeTruthy();
     });
 
     test("Multiple selected zones", () => {
       setSelection(model, ["A1:A2", "B1:B2"]);
-      expect(getNode(pathSort, env).isVisible(env)).toBeFalsy();
+      expect(getNode(pathSort, model, env).isVisible(model, env)).toBeFalsy();
     });
   });
   describe("Hide/Unhide Columns", () => {
@@ -1498,33 +1556,33 @@ describe("Menu Item actions", () => {
     const unhidePath = ["unhide_columns"];
     test("Action on single column selection", async () => {
       selectColumn(model, 1, "overrideSelection");
-      expect(getName(hidePath, env, colMenuRegistry)).toBe("Hide column B");
-      expect(getNode(hidePath, env, colMenuRegistry).isVisible(env)).toBeTruthy();
-      await doAction(hidePath, env, colMenuRegistry);
+      expect(getName(hidePath, model, env, colMenuRegistry)).toBe("Hide column B");
+      expect(getNode(hidePath, model, env, colMenuRegistry).isVisible(model, env)).toBeTruthy();
+      await doAction(hidePath, model, env, colMenuRegistry);
       expect(dispatch).toHaveBeenCalledWith("HIDE_COLUMNS_ROWS", {
-        sheetId: env.model.getters.getActiveSheetId(),
+        sheetId: model.getters.getActiveSheetId(),
         elements: [1],
         dimension: "COL",
       });
     });
     test("Action with at least one active column", async () => {
       setSelection(model, ["B1:B100", "C5"]);
-      expect(getName(hidePath, env, colMenuRegistry)).toBe("Hide columns B - C");
-      expect(getNode(hidePath, env, colMenuRegistry).isVisible(env)).toBeTruthy();
-      await doAction(hidePath, env, colMenuRegistry);
+      expect(getName(hidePath, model, env, colMenuRegistry)).toBe("Hide columns B - C");
+      expect(getNode(hidePath, model, env, colMenuRegistry).isVisible(model, env)).toBeTruthy();
+      await doAction(hidePath, model, env, colMenuRegistry);
       expect(dispatch).toHaveBeenCalledWith("HIDE_COLUMNS_ROWS", {
-        sheetId: env.model.getters.getActiveSheetId(),
+        sheetId: model.getters.getActiveSheetId(),
         elements: [1, 2],
         dimension: "COL",
       });
     });
     test("Action without any active column", async () => {
       setSelection(model, ["B1"]);
-      expect(getName(hidePath, env, colMenuRegistry)).toBe("Hide columns");
-      expect(getNode(hidePath, env, colMenuRegistry).isVisible(env)).toBeTruthy();
-      await doAction(hidePath, env, colMenuRegistry);
+      expect(getName(hidePath, model, env, colMenuRegistry)).toBe("Hide columns");
+      expect(getNode(hidePath, model, env, colMenuRegistry).isVisible(model, env)).toBeTruthy();
+      await doAction(hidePath, model, env, colMenuRegistry);
       expect(dispatch).toHaveBeenCalledWith("HIDE_COLUMNS_ROWS", {
-        sheetId: env.model.getters.getActiveSheetId(),
+        sheetId: model.getters.getActiveSheetId(),
         elements: [],
         dimension: "COL",
       });
@@ -1532,31 +1590,35 @@ describe("Menu Item actions", () => {
 
     test("Inactive menu item on invalid selection", () => {
       setSelection(model, ["A1:A100", "A4:Z4"]);
-      expect(getNode(hidePath, env, colMenuRegistry).isVisible(env)).toBeFalsy();
+      expect(getNode(hidePath, model, env, colMenuRegistry).isVisible(model, env)).toBeFalsy();
     });
 
     test("Unhide cols from Col menu", async () => {
       hideColumns(model, ["C"]);
       setSelection(model, ["B1:E100"]);
-      expect(getNode(unhidePath, env, colMenuRegistry).isVisible(env)).toBeTruthy();
-      await doAction(unhidePath, env, colMenuRegistry);
+      expect(getNode(unhidePath, model, env, colMenuRegistry).isVisible(model, env)).toBeTruthy();
+      await doAction(unhidePath, model, env, colMenuRegistry);
       expect(dispatch).toHaveBeenCalledWith("UNHIDE_COLUMNS_ROWS", {
-        sheetId: env.model.getters.getActiveSheetId(),
+        sheetId: model.getters.getActiveSheetId(),
         elements: [1, 2, 3, 4],
         dimension: "COL",
       });
     });
     test("Unhide rows from Col menu without hidden cols", () => {
       setSelection(model, ["B1:E100"]);
-      expect(getNode(unhidePath, env, colMenuRegistry).isVisible(env)).toBeFalsy();
+      expect(getNode(unhidePath, model, env, colMenuRegistry).isVisible(model, env)).toBeFalsy();
     });
     test("Unhide all cols from top menu", async () => {
       // no hidden rows
-      expect(getNode(["edit", "edit_unhide_columns"], env).isVisible(env)).toBeFalsy();
+      expect(
+        getNode(["edit", "edit_unhide_columns"], model, env).isVisible(model, env)
+      ).toBeFalsy();
       hideColumns(model, ["C"]);
-      expect(getNode(["edit", "edit_unhide_columns"], env).isVisible(env)).toBeTruthy();
-      await doAction(["edit", "edit_unhide_columns"], env);
-      const sheetId = env.model.getters.getActiveSheetId();
+      expect(
+        getNode(["edit", "edit_unhide_columns"], model, env).isVisible(model, env)
+      ).toBeTruthy();
+      await doAction(["edit", "edit_unhide_columns"], model, env);
+      const sheetId = model.getters.getActiveSheetId();
       expect(dispatch).toHaveBeenCalledWith("UNHIDE_COLUMNS_ROWS", {
         sheetId,
         dimension: "COL",
@@ -1569,33 +1631,33 @@ describe("Menu Item actions", () => {
     const unhidePath = ["unhide_rows"];
     test("Action on single row selection", async () => {
       selectRow(model, 1, "overrideSelection");
-      expect(getName(hidePath, env, rowMenuRegistry)).toBe("Hide row 2");
-      expect(getNode(hidePath, env, rowMenuRegistry).isVisible(env)).toBeTruthy();
-      await doAction(hidePath, env, rowMenuRegistry);
+      expect(getName(hidePath, model, env, rowMenuRegistry)).toBe("Hide row 2");
+      expect(getNode(hidePath, model, env, rowMenuRegistry).isVisible(model, env)).toBeTruthy();
+      await doAction(hidePath, model, env, rowMenuRegistry);
       expect(dispatch).toHaveBeenCalledWith("HIDE_COLUMNS_ROWS", {
-        sheetId: env.model.getters.getActiveSheetId(),
+        sheetId: model.getters.getActiveSheetId(),
         elements: [1],
         dimension: "ROW",
       });
     });
     test("Action with at least one active row", async () => {
       setSelection(model, ["A2:Z2", "C3"]);
-      expect(getName(hidePath, env, rowMenuRegistry)).toBe("Hide rows 2 - 3");
-      expect(getNode(hidePath, env, rowMenuRegistry).isVisible(env)).toBeTruthy();
-      await doAction(hidePath, env, rowMenuRegistry);
+      expect(getName(hidePath, model, env, rowMenuRegistry)).toBe("Hide rows 2 - 3");
+      expect(getNode(hidePath, model, env, rowMenuRegistry).isVisible(model, env)).toBeTruthy();
+      await doAction(hidePath, model, env, rowMenuRegistry);
       expect(dispatch).toHaveBeenCalledWith("HIDE_COLUMNS_ROWS", {
-        sheetId: env.model.getters.getActiveSheetId(),
+        sheetId: model.getters.getActiveSheetId(),
         elements: [1, 2],
         dimension: "ROW",
       });
     });
     test("Action without any active column", async () => {
       setSelection(model, ["B1"]);
-      expect(getName(hidePath, env, rowMenuRegistry)).toBe("Hide rows");
-      expect(getNode(hidePath, env, rowMenuRegistry).isVisible(env)).toBeTruthy();
-      await doAction(hidePath, env, rowMenuRegistry);
+      expect(getName(hidePath, model, env, rowMenuRegistry)).toBe("Hide rows");
+      expect(getNode(hidePath, model, env, rowMenuRegistry).isVisible(model, env)).toBeTruthy();
+      await doAction(hidePath, model, env, rowMenuRegistry);
       expect(dispatch).toHaveBeenCalledWith("HIDE_COLUMNS_ROWS", {
-        sheetId: env.model.getters.getActiveSheetId(),
+        sheetId: model.getters.getActiveSheetId(),
         elements: [],
         dimension: "ROW",
       });
@@ -1603,32 +1665,32 @@ describe("Menu Item actions", () => {
 
     test("Inactive menu item on invalid selection", () => {
       setSelection(model, ["A1:A100", "A4:Z4"]);
-      expect(getNode(hidePath, env, rowMenuRegistry).isVisible(env)).toBeFalsy();
+      expect(getNode(hidePath, model, env, rowMenuRegistry).isVisible(model, env)).toBeFalsy();
     });
 
     test("Unhide rows from Row menu with hidden rows", async () => {
       hideRows(model, [2]);
       setSelection(model, ["A1:Z4"]);
-      expect(getNode(unhidePath, env, rowMenuRegistry).isVisible(env)).toBeTruthy();
-      await doAction(unhidePath, env, rowMenuRegistry);
+      expect(getNode(unhidePath, model, env, rowMenuRegistry).isVisible(model, env)).toBeTruthy();
+      await doAction(unhidePath, model, env, rowMenuRegistry);
       expect(dispatch).toHaveBeenCalledWith("UNHIDE_COLUMNS_ROWS", {
-        sheetId: env.model.getters.getActiveSheetId(),
+        sheetId: model.getters.getActiveSheetId(),
         elements: [0, 1, 2, 3],
         dimension: "ROW",
       });
     });
     test("Unhide rows from Row menu without hidden rows", () => {
       setSelection(model, ["A1:Z4"]);
-      expect(getNode(unhidePath, env, rowMenuRegistry).isVisible(env)).toBeFalsy();
+      expect(getNode(unhidePath, model, env, rowMenuRegistry).isVisible(model, env)).toBeFalsy();
     });
 
     test("Unhide all rows from top menu", async () => {
       // no hidden rows
-      expect(getNode(["edit", "edit_unhide_rows"], env).isVisible(env)).toBeFalsy();
+      expect(getNode(["edit", "edit_unhide_rows"], model, env).isVisible(model, env)).toBeFalsy();
       hideRows(model, [2]);
-      expect(getNode(["edit", "edit_unhide_rows"], env).isVisible(env)).toBeTruthy();
-      await doAction(["edit", "edit_unhide_rows"], env);
-      const sheetId = env.model.getters.getActiveSheetId();
+      expect(getNode(["edit", "edit_unhide_rows"], model, env).isVisible(model, env)).toBeTruthy();
+      await doAction(["edit", "edit_unhide_rows"], model, env);
+      const sheetId = model.getters.getActiveSheetId();
       expect(dispatch).toHaveBeenCalledWith("UNHIDE_COLUMNS_ROWS", {
         sheetId,
         elements: Array.from(Array(model.getters.getNumberRows(sheetId)).keys()),
@@ -1644,7 +1706,7 @@ describe("Menu Item actions", () => {
 
       selectRow(model, 3, "newAnchor");
       selectRow(model, lastRow, "updateAnchor");
-      expect(getNode(hidePath, env, rowMenuRegistry).isVisible(env)).toBeFalsy();
+      expect(getNode(hidePath, model, env, rowMenuRegistry).isVisible(model, env)).toBeFalsy();
     });
 
     describe("Table and filters", () => {
@@ -1654,8 +1716,8 @@ describe("Menu Item actions", () => {
 
       test("Insert -> Table", async () => {
         setSelection(model, ["A1:A5"]);
-        expect(getName(insertTablePath, env)).toBe("Table");
-        await doAction(insertTablePath, env);
+        expect(getName(insertTablePath, model, env)).toBe("Table");
+        await doAction(insertTablePath, model, env);
         expect(model.getters.getTable({ sheetId, row: 0, col: 0 })).toMatchObject({
           range: { zone: toZone("A1:A5") },
         });
@@ -1663,8 +1725,8 @@ describe("Menu Item actions", () => {
 
       test("Insert -> Table on a whole column make it into an unbounded zone", async () => {
         setSelection(model, ["A1:A100"]);
-        expect(getName(insertTablePath, env)).toBe("Table");
-        await doAction(insertTablePath, env);
+        expect(getName(insertTablePath, model, env)).toBe("Table");
+        await doAction(insertTablePath, model, env);
         expect(model.getters.getTable({ sheetId, row: 0, col: 0 })).toMatchObject({
           range: { unboundedZone: toUnboundedZone("A:A") },
         });
@@ -1672,19 +1734,19 @@ describe("Menu Item actions", () => {
 
       test("Insert -> Table is not visible if there is already a table in the selection, or if the selection is not continuous", () => {
         setSelection(model, ["A1", "B2"]);
-        expect(getNode(insertTablePath, env).isVisible(env)).toBeFalsy();
+        expect(getNode(insertTablePath, model, env).isVisible(model, env)).toBeFalsy();
 
         setSelection(model, ["A1:A5"]);
-        expect(getNode(insertTablePath, env).isVisible(env)).toBeTruthy();
+        expect(getNode(insertTablePath, model, env).isVisible(model, env)).toBeTruthy();
 
         createTable(model, "A1:A5");
-        expect(getNode(insertTablePath, env).isVisible(env)).toBeFalsy();
+        expect(getNode(insertTablePath, model, env).isVisible(model, env)).toBeFalsy();
       });
 
       test("Insert -> Table creates a dynamic table if it's called on a spreading cell", async () => {
         setCellContent(model, "A1", "=MUNIT(5)");
         setSelection(model, ["A1"]);
-        await doAction(insertTablePath, env);
+        await doAction(insertTablePath, model, env);
         expect(model.getters.getCoreTable({ sheetId, row: 0, col: 0 })).toMatchObject({
           range: { zone: toZone("A1") },
           type: "dynamic",
@@ -1697,7 +1759,7 @@ describe("Menu Item actions", () => {
       test("Insert -> select the whole spreading zone and create a dynamic if it is called on a single spreaded cell", async () => {
         setCellContent(model, "A1", "=MUNIT(5)");
         setSelection(model, ["B1"]);
-        await doAction(insertTablePath, env);
+        await doAction(insertTablePath, model, env);
         expect(model.getters.getSelectedZone()).toEqual(toZone("A1:E5"));
         expect(model.getters.getCoreTable({ sheetId, row: 0, col: 0 })).toMatchObject({
           range: { zone: toZone("A1") },
@@ -1711,7 +1773,7 @@ describe("Menu Item actions", () => {
       test("Insert -> Table creates a dynamic table if it's called on all the spreading cells of a formula", async () => {
         setCellContent(model, "A1", "=MUNIT(5)");
         setSelection(model, ["A1:E5"]);
-        await doAction(insertTablePath, env);
+        await doAction(insertTablePath, model, env);
         expect(model.getters.getCoreTable({ sheetId, row: 0, col: 0 })).toMatchObject({
           range: { zone: toZone("A1") },
           type: "dynamic",
@@ -1725,7 +1787,7 @@ describe("Menu Item actions", () => {
         setCellContent(model, "A1", "=MUNIT(500)");
         setSelection(model, ["A1"]);
         expect(getEvaluatedCell(model, "A1")?.value).toBe("#SPILL!");
-        await doAction(insertTablePath, env);
+        await doAction(insertTablePath, model, env);
         expect(model.getters.getCoreTable({ sheetId, row: 0, col: 0 })).toMatchObject({
           range: { zone: toZone("A1") },
           type: "dynamic",
@@ -1737,7 +1799,7 @@ describe("Menu Item actions", () => {
         setCellContent(model, "A3", "=MUNIT(500)");
         expect(getEvaluatedCell(model, "A1")?.value).toBe("#SPILL!");
         setSelection(model, ["A1"]);
-        await doAction(insertTablePath, env);
+        await doAction(insertTablePath, model, env);
         expect(model.getters.getCoreTable({ sheetId, row: 0, col: 0 })).toMatchObject({
           range: { zone: toZone("A1") },
           type: "static",
@@ -1747,29 +1809,29 @@ describe("Menu Item actions", () => {
       test("Edit -> Table (topbar)", async () => {
         const spyOpenSidePanel = jest.spyOn(env, "openSidePanel");
         createTable(model, "A1:A5");
-        expect(getName(editTablePath, env)).toBe("Edit table");
-        await doAction(editTablePath, env);
+        expect(getName(editTablePath, model, env)).toBe("Edit table");
+        await doAction(editTablePath, model, env);
         expect(spyOpenSidePanel).toHaveBeenCalledWith("TableSidePanel", {});
       });
 
       test("Edit -> Table (topbar) is not visible if there is no table in the selection", () => {
-        expect(getNode(editTablePath, env).isVisible(env)).toBeFalsy();
+        expect(getNode(editTablePath, model, env).isVisible(model, env)).toBeFalsy();
         createTable(model, "A1:A5");
-        expect(getNode(editTablePath, env).isVisible(env)).toBeTruthy();
+        expect(getNode(editTablePath, model, env).isVisible(model, env)).toBeTruthy();
       });
 
       test("Edit table (cellRegistry)", async () => {
         const spyOpenSidePanel = jest.spyOn(env, "openSidePanel");
         createTable(model, "A1:A5");
-        expect(getName(["edit_table"], env, cellMenuRegistry)).toBe("Edit table");
-        await doAction(["edit_table"], env, cellMenuRegistry);
+        expect(getName(["edit_table"], model, env, cellMenuRegistry)).toBe("Edit table");
+        await doAction(["edit_table"], model, env, cellMenuRegistry);
         expect(spyOpenSidePanel).toHaveBeenCalledWith("TableSidePanel", {});
       });
 
       test("Delete table (cellRegistry)", async () => {
         createTable(model, "A1:A5");
-        expect(getName(["delete_table"], env, cellMenuRegistry)).toBe("Delete table");
-        await doAction(["delete_table"], env, cellMenuRegistry);
+        expect(getName(["delete_table"], model, env, cellMenuRegistry)).toBe("Delete table");
+        await doAction(["delete_table"], model, env, cellMenuRegistry);
         expect(model.getters.getTable({ sheetId, row: 0, col: 0 })).toBeUndefined();
       });
 
@@ -1778,7 +1840,7 @@ describe("Menu Item actions", () => {
         expect(model.getters.getTable({ sheetId, row: 1, col: 0 })).toBeDefined();
 
         setSelection(model, ["A1:A2"], { anchor: "A1" });
-        await doAction(["delete_table"], env, cellMenuRegistry);
+        await doAction(["delete_table"], model, env, cellMenuRegistry);
         expect(model.getters.getTable({ sheetId, row: 1, col: 0 })).toBeUndefined();
       });
 
@@ -1786,31 +1848,47 @@ describe("Menu Item actions", () => {
         setCellContent(model, "A1", "=MUNIT(5)");
         createDynamicTable(model, "A1");
         setSelection(model, ["C3"]);
-        await doAction(["delete_table"], env, cellMenuRegistry);
+        await doAction(["delete_table"], model, env, cellMenuRegistry);
         expect(model.getters.getTable({ sheetId, row: 0, col: 0 })).toBeUndefined();
       });
 
       test("Edit/delete table (cellRegistry) visible only with a single table in the selection", () => {
-        expect(getNode(["edit_table"], env, cellMenuRegistry).isVisible(env)).toBeFalsy();
-        expect(getNode(["delete_table"], env, cellMenuRegistry).isVisible(env)).toBeFalsy();
+        expect(
+          getNode(["edit_table"], model, env, cellMenuRegistry).isVisible(model, env)
+        ).toBeFalsy();
+        expect(
+          getNode(["delete_table"], model, env, cellMenuRegistry).isVisible(model, env)
+        ).toBeFalsy();
 
         createTable(model, "A1:A5");
-        expect(getNode(["edit_table"], env, cellMenuRegistry).isVisible(env)).toBeTruthy();
-        expect(getNode(["delete_table"], env, cellMenuRegistry).isVisible(env)).toBeTruthy();
+        expect(
+          getNode(["edit_table"], model, env, cellMenuRegistry).isVisible(model, env)
+        ).toBeTruthy();
+        expect(
+          getNode(["delete_table"], model, env, cellMenuRegistry).isVisible(model, env)
+        ).toBeTruthy();
 
         setSelection(model, ["A1:B5"]);
-        expect(getNode(["edit_table"], env, cellMenuRegistry).isVisible(env)).toBeTruthy();
-        expect(getNode(["delete_table"], env, cellMenuRegistry).isVisible(env)).toBeTruthy();
+        expect(
+          getNode(["edit_table"], model, env, cellMenuRegistry).isVisible(model, env)
+        ).toBeTruthy();
+        expect(
+          getNode(["delete_table"], model, env, cellMenuRegistry).isVisible(model, env)
+        ).toBeTruthy();
 
         createTable(model, "B1:B5");
-        expect(getNode(["edit_table"], env, cellMenuRegistry).isVisible(env)).toBeFalsy();
-        expect(getNode(["delete_table"], env, cellMenuRegistry).isVisible(env)).toBeFalsy();
+        expect(
+          getNode(["edit_table"], model, env, cellMenuRegistry).isVisible(model, env)
+        ).toBeFalsy();
+        expect(
+          getNode(["delete_table"], model, env, cellMenuRegistry).isVisible(model, env)
+        ).toBeFalsy();
       });
 
       test("Filters -> Create filter", async () => {
         setSelection(model, ["A1:A5"]);
-        expect(getName(filterPath, env)).toBe("Add filters");
-        await doAction(filterPath, env);
+        expect(getName(filterPath, model, env)).toBe("Add filters");
+        await doAction(filterPath, model, env);
         expect(model.getters.getTable({ sheetId, row: 0, col: 0 })).toMatchObject({
           range: { zone: toZone("A1:A5") },
           config: { hasFilters: true },
@@ -1820,15 +1898,15 @@ describe("Menu Item actions", () => {
       test("Filters -> Add filters on existing table", async () => {
         createTable(model, "A1:A5");
         updateTableConfig(model, "A1:A5", { hasFilters: false });
-        await doAction(filterPath, env);
+        await doAction(filterPath, model, env);
         expect(model.getters.getTable({ sheetId, row: 0, col: 0 })?.config.hasFilters).toBe(true);
       });
 
       test("Filters -> Remove filter", async () => {
         createTableWithFilter(model, "A1:A5");
         setSelection(model, ["A1:A5"]);
-        expect(getName(filterPath, env)).toBe("Remove selected filters");
-        await doAction(filterPath, env);
+        expect(getName(filterPath, model, env)).toBe("Remove selected filters");
+        await doAction(filterPath, model, env);
         const table = model.getters.getTable({ sheetId, row: 0, col: 0 });
         expect(table?.config.hasFilters).toBe(false);
       });
@@ -1840,13 +1918,13 @@ describe("Menu Item actions", () => {
         updateTableConfig(model, "B1:B5", { hasFilters: false });
 
         setSelection(model, ["A1:B5"]);
-        await doAction(filterPath, env);
+        await doAction(filterPath, model, env);
         expect(model.getters.getTables(sheetId)).toMatchObject([
           { range: { zone: toZone("A1:A5") }, config: { hasFilters: true } },
           { range: { zone: toZone("B1:B5") }, config: { hasFilters: false } },
         ]);
 
-        await doAction(filterPath, env);
+        await doAction(filterPath, model, env);
         expect(model.getters.getTables(sheetId)).toMatchObject([
           { range: { zone: toZone("A1:A5") }, config: { hasFilters: false } },
           { range: { zone: toZone("B1:B5") }, config: { hasFilters: false } },
@@ -1855,31 +1933,31 @@ describe("Menu Item actions", () => {
 
       test("Filters -> Create filter is disabled when the selection is not continuous", () => {
         setSelection(model, ["A1", "B6"]);
-        expect(getNode(filterPath, env).isVisible(env)).toBeTruthy();
-        expect(getNode(filterPath, env).isEnabled(env)).toBeFalsy();
+        expect(getNode(filterPath, model, env).isVisible(model, env)).toBeTruthy();
+        expect(getNode(filterPath, model, env).isEnabled(model, env)).toBeFalsy();
       });
 
       test("Filters -> Create filter is enabled for continuous selection of multiple zones", () => {
         setSelection(model, ["A1", "A2:A5", "B1:B5"]);
-        expect(getNode(filterPath, env).isVisible(env)).toBeTruthy();
-        expect(getNode(filterPath, env).isEnabled(env)).toBeTruthy();
+        expect(getNode(filterPath, model, env).isVisible(model, env)).toBeTruthy();
+        expect(getNode(filterPath, model, env).isEnabled(model, env)).toBeTruthy();
       });
 
       test("Filters -> Remove filter is displayed instead of add filter when the selection contains a filter", () => {
         setSelection(model, ["A1:A5"]);
-        expect(getName(filterPath, env)).toBe("Add filters");
+        expect(getName(filterPath, model, env)).toBe("Add filters");
 
         createTableWithFilter(model, "A1:B5");
-        expect(getName(filterPath, env)).toBe("Remove selected filters");
+        expect(getName(filterPath, model, env)).toBe("Remove selected filters");
 
         setSelection(model, ["A1:B9"]);
-        expect(getName(filterPath, env)).toBe("Remove selected filters");
+        expect(getName(filterPath, model, env)).toBe("Remove selected filters");
       });
     });
 
     test("Insert -> Carousel", async () => {
-      expect(getName(["insert", "insert_carousel"], env)).toBe("Carousel");
-      await doAction(["insert", "insert_carousel"], env);
+      expect(getName(["insert", "insert_carousel"], model, env)).toBe("Carousel");
+      await doAction(["insert", "insert_carousel"], model, env);
       expect(model.getters.getFigures(model.getters.getActiveSheetId())[0]).toMatchObject({
         tag: "carousel",
       });
@@ -1892,23 +1970,23 @@ describe("Menu Item actions", () => {
 
     setGridLinesVisibility(model, true);
 
-    expect(getName(path_gridlines, env)).toBe("Gridlines");
-    expect(getNode(path_gridlines, env).isVisible(env)).toBeTruthy();
-    expect(getNode(path_gridlines, env).isActive?.(env)).toBeTruthy();
+    expect(getName(path_gridlines, model, env)).toBe("Gridlines");
+    expect(getNode(path_gridlines, model, env).isVisible(model, env)).toBeTruthy();
+    expect(getNode(path_gridlines, model, env).isActive?.(model, env)).toBeTruthy();
 
     setGridLinesVisibility(model, false);
-    expect(getName(path_gridlines, env)).toBe("Gridlines");
-    expect(getNode(path_gridlines, env).isVisible(env)).toBeTruthy();
-    expect(getNode(path_gridlines, env).isActive?.(env)).toBeFalsy();
+    expect(getName(path_gridlines, model, env)).toBe("Gridlines");
+    expect(getNode(path_gridlines, model, env).isVisible(model, env)).toBeTruthy();
+    expect(getNode(path_gridlines, model, env).isActive?.(model, env)).toBeFalsy();
 
-    await doAction(path_gridlines, env);
+    await doAction(path_gridlines, model, env);
     expect(dispatch).toHaveBeenCalledWith("SET_GRID_LINES_VISIBILITY", {
       sheetId,
       areGridLinesVisible: true,
     });
     setGridLinesVisibility(model, true);
 
-    await doAction(path_gridlines, env);
+    await doAction(path_gridlines, model, env);
     expect(dispatch).toHaveBeenCalledWith("SET_GRID_LINES_VISIBILITY", {
       sheetId,
       areGridLinesVisible: false,
@@ -1919,16 +1997,16 @@ describe("Menu Item actions", () => {
     const path_formulas = ["view", "show", "view_formulas"];
     expect(model.getters.shouldShowFormulas()).toBe(false);
 
-    expect(getName(path_formulas, env)).toBe("Formulas");
-    expect(getNode(path_formulas, env).isVisible(env)).toBeTruthy();
-    expect(getNode(path_formulas, env).isActive?.(env)).toBeFalsy();
-    await doAction(path_formulas, env);
+    expect(getName(path_formulas, model, env)).toBe("Formulas");
+    expect(getNode(path_formulas, model, env).isVisible(model, env)).toBeTruthy();
+    expect(getNode(path_formulas, model, env).isActive?.(model, env)).toBeFalsy();
+    await doAction(path_formulas, model, env);
     expect(model.getters.shouldShowFormulas()).toBe(true);
 
-    expect(getName(path_formulas, env)).toBe("Formulas");
-    expect(getNode(path_formulas, env).isVisible(env)).toBeTruthy();
-    expect(getNode(path_formulas, env).isActive?.(env)).toBeTruthy();
-    await doAction(path_formulas, env);
+    expect(getName(path_formulas, model, env)).toBe("Formulas");
+    expect(getNode(path_formulas, model, env).isVisible(model, env)).toBeTruthy();
+    expect(getNode(path_formulas, model, env).isActive?.(model, env)).toBeTruthy();
+    await doAction(path_formulas, model, env);
     expect(model.getters.shouldShowFormulas()).toBe(false);
   });
 
@@ -1940,8 +2018,8 @@ describe("Menu Item actions", () => {
 
     test("Can group columns", async () => {
       setSelection(model, ["A1:C3"]);
-      expect(getName(groupColsPath, env)).toBe("Group columns A - C");
-      await doAction(groupColsPath, env);
+      expect(getName(groupColsPath, model, env)).toBe("Group columns A - C");
+      await doAction(groupColsPath, model, env);
       expect(model.getters.getHeaderGroups(sheetId, "COL")[0]).toMatchObject({
         start: 0,
         end: 2,
@@ -1950,35 +2028,35 @@ describe("Menu Item actions", () => {
 
     test("Cannot group multiple selections", () => {
       setSelection(model, ["A1:B3", "C1:C3"]);
-      expect(getNode(groupColsPath, env).isVisible(env)).toBeFalsy();
+      expect(getNode(groupColsPath, model, env).isVisible(model, env)).toBeFalsy();
     });
 
     test("Cannot re-group same selection of columns", () => {
       setSelection(model, ["A1:B3"]);
-      getNode(groupColsPath, env).execute?.(env);
-      expect(getNode(groupColsPath, env).isVisible(env)).toBeFalsy();
+      getNode(groupColsPath, model, env).execute?.(model, env);
+      expect(getNode(groupColsPath, model, env).isVisible(model, env)).toBeFalsy();
     });
 
     test("Can ungroup columns", async () => {
       groupColumns(model, "A", "C");
       setSelection(model, ["A1:C3"]);
-      expect(getName(ungroupColsPath, env)).toBe("Ungroup columns A - C");
-      await doAction(ungroupColsPath, env);
+      expect(getName(ungroupColsPath, model, env)).toBe("Ungroup columns A - C");
+      await doAction(ungroupColsPath, model, env);
       expect(model.getters.getHeaderGroups(sheetId, "COL")).toHaveLength(0);
     });
 
     test("Cannot ungroup columns when there's no group in the selection", () => {
       setSelection(model, ["A1:C3"]);
-      expect(getNode(ungroupColsPath, env).isVisible(env)).toBeFalsy();
+      expect(getNode(ungroupColsPath, model, env).isVisible(model, env)).toBeFalsy();
 
       groupColumns(model, "A", "C");
-      expect(getNode(ungroupColsPath, env).isVisible(env)).toBeTruthy();
+      expect(getNode(ungroupColsPath, model, env).isVisible(model, env)).toBeTruthy();
     });
 
     test("Can group rows", async () => {
       setSelection(model, ["A1:C3"]);
-      expect(getName(groupRowsPath, env)).toBe("Group rows 1 - 3");
-      await doAction(groupRowsPath, env);
+      expect(getName(groupRowsPath, model, env)).toBe("Group rows 1 - 3");
+      await doAction(groupRowsPath, model, env);
       expect(model.getters.getHeaderGroups(sheetId, "ROW")[0]).toMatchObject({
         start: 0,
         end: 2,
@@ -1987,56 +2065,56 @@ describe("Menu Item actions", () => {
 
     test("Cannot group multiple selections", () => {
       setSelection(model, ["A1:C1", "A2:C2"]);
-      expect(getNode(groupRowsPath, env).isVisible(env)).toBeFalsy();
+      expect(getNode(groupRowsPath, model, env).isVisible(model, env)).toBeFalsy();
     });
 
     test("Cannot re-group same selection of rows", () => {
       setSelection(model, ["A1:B3"]);
-      getNode(groupRowsPath, env).execute?.(env);
-      expect(getNode(groupRowsPath, env).isVisible(env)).toBeFalsy();
+      getNode(groupRowsPath, model, env).execute?.(model, env);
+      expect(getNode(groupRowsPath, model, env).isVisible(model, env)).toBeFalsy();
     });
 
     test("Can ungroup rows", async () => {
       groupRows(model, 0, 2);
       setSelection(model, ["A1:C3"]);
-      expect(getName(ungroupRowsPath, env)).toBe("Ungroup rows 1 - 3");
-      await doAction(ungroupRowsPath, env);
+      expect(getName(ungroupRowsPath, model, env)).toBe("Ungroup rows 1 - 3");
+      await doAction(ungroupRowsPath, model, env);
       expect(model.getters.getHeaderGroups(sheetId, "ROW")).toHaveLength(0);
     });
 
     test("Cannot ungroup rows when there's no group in the selection", () => {
       setSelection(model, ["A1:C3"]);
-      expect(getNode(ungroupRowsPath, env).isVisible(env)).toBeFalsy();
+      expect(getNode(ungroupRowsPath, model, env).isVisible(model, env)).toBeFalsy();
 
       groupRows(model, 0, 2);
-      expect(getNode(ungroupRowsPath, env).isVisible(env)).toBeTruthy();
+      expect(getNode(ungroupRowsPath, model, env).isVisible(model, env)).toBeTruthy();
     });
   });
 
   describe("Freeze rows and columns", () => {
     test("Columns", async () => {
       const sheetId = model.getters.getActiveSheetId();
-      await doAction(["view", "freeze_panes", "freeze_first_col"], env);
+      await doAction(["view", "freeze_panes", "freeze_first_col"], model, env);
       expect(model.getters.getPaneDivisions(sheetId)).toEqual({ xSplit: 1, ySplit: 0 });
-      await doAction(["view", "freeze_panes", "freeze_second_col"], env);
+      await doAction(["view", "freeze_panes", "freeze_second_col"], model, env);
       expect(model.getters.getPaneDivisions(sheetId)).toEqual({ xSplit: 2, ySplit: 0 });
       setSelection(model, ["G5"]);
-      await doAction(["view", "freeze_panes", "freeze_current_col"], env);
+      await doAction(["view", "freeze_panes", "freeze_current_col"], model, env);
       expect(model.getters.getPaneDivisions(sheetId)).toEqual({ xSplit: 7, ySplit: 0 });
-      await doAction(["view", "freeze_panes", "unfreeze_columns"], env);
+      await doAction(["view", "freeze_panes", "unfreeze_columns"], model, env);
       expect(model.getters.getPaneDivisions(sheetId)).toEqual({ xSplit: 0, ySplit: 0 });
     });
 
     test("Rows", async () => {
       const sheetId = model.getters.getActiveSheetId();
-      await doAction(["view", "freeze_panes", "freeze_first_row"], env);
+      await doAction(["view", "freeze_panes", "freeze_first_row"], model, env);
       expect(model.getters.getPaneDivisions(sheetId)).toEqual({ xSplit: 0, ySplit: 1 });
-      await doAction(["view", "freeze_panes", "freeze_second_row"], env);
+      await doAction(["view", "freeze_panes", "freeze_second_row"], model, env);
       expect(model.getters.getPaneDivisions(sheetId)).toEqual({ xSplit: 0, ySplit: 2 });
       setSelection(model, ["G5"]);
-      await doAction(["view", "freeze_panes", "freeze_current_row"], env);
+      await doAction(["view", "freeze_panes", "freeze_current_row"], model, env);
       expect(model.getters.getPaneDivisions(sheetId)).toEqual({ xSplit: 0, ySplit: 5 });
-      await doAction(["view", "freeze_panes", "unfreeze_rows"], env);
+      await doAction(["view", "freeze_panes", "unfreeze_rows"], model, env);
       expect(model.getters.getPaneDivisions(sheetId)).toEqual({ xSplit: 0, ySplit: 0 });
     });
 
@@ -2044,39 +2122,39 @@ describe("Menu Item actions", () => {
       const sheetId = model.getters.getActiveSheetId();
       const view = topbarMenuRegistry.getMenuItems().find((item) => item.id === "view")!;
       const unfreeze_panes = view
-        .children({} as SpreadsheetChildEnv)
+        .children(model, {} as SpreadsheetChildEnv)
         .find((item) => item.id === "unfreeze_panes")!;
-      expect(unfreeze_panes.isVisible(env)).toBe(false);
+      expect(unfreeze_panes.isVisible(model, env)).toBe(false);
       freezeColumns(model, 1);
-      expect(unfreeze_panes.isVisible(env)).toBe(true);
-      unfreeze_panes.execute?.(env);
+      expect(unfreeze_panes.isVisible(model, env)).toBe(true);
+      unfreeze_panes.execute?.(model, env);
       expect(model.getters.getPaneDivisions(sheetId));
-      expect(unfreeze_panes.isVisible(env)).toBe(false);
+      expect(unfreeze_panes.isVisible(model, env)).toBe(false);
       freezeRows(model, 3);
-      expect(unfreeze_panes.isVisible(env)).toBe(true);
-      unfreeze_panes.execute?.(env);
+      expect(unfreeze_panes.isVisible(model, env)).toBe(true);
+      unfreeze_panes.execute?.(model, env);
       expect(model.getters.getPaneDivisions(sheetId));
-      expect(unfreeze_panes.isVisible(env)).toBe(false);
+      expect(unfreeze_panes.isVisible(model, env)).toBe(false);
     });
 
     test("unfreeze actions visibility", () => {
-      const unfreezeColAction = getNode(["view", "freeze_panes", "unfreeze_columns"], env);
-      const unfreezeRowAction = getNode(["view", "freeze_panes", "unfreeze_rows"], env);
-      const unfreezeAllAction = getNode(["view", "unfreeze_panes"], env);
+      const unfreezeColAction = getNode(["view", "freeze_panes", "unfreeze_columns"], model, env);
+      const unfreezeRowAction = getNode(["view", "freeze_panes", "unfreeze_rows"], model, env);
+      const unfreezeAllAction = getNode(["view", "unfreeze_panes"], model, env);
 
-      expect(unfreezeColAction.isVisible(env)).toBe(false);
-      expect(unfreezeRowAction.isVisible(env)).toBe(false);
-      expect(unfreezeAllAction.isVisible(env)).toBe(false);
+      expect(unfreezeColAction.isVisible(model, env)).toBe(false);
+      expect(unfreezeRowAction.isVisible(model, env)).toBe(false);
+      expect(unfreezeAllAction.isVisible(model, env)).toBe(false);
 
       freezeColumns(model, 1);
-      expect(unfreezeColAction.isVisible(env)).toBe(true);
-      expect(unfreezeRowAction.isVisible(env)).toBe(false);
-      expect(unfreezeAllAction.isVisible(env)).toBe(true);
+      expect(unfreezeColAction.isVisible(model, env)).toBe(true);
+      expect(unfreezeRowAction.isVisible(model, env)).toBe(false);
+      expect(unfreezeAllAction.isVisible(model, env)).toBe(true);
 
       freezeRows(model, 3);
-      expect(unfreezeColAction.isVisible(env)).toBe(true);
-      expect(unfreezeRowAction.isVisible(env)).toBe(true);
-      expect(unfreezeAllAction.isVisible(env)).toBe(true);
+      expect(unfreezeColAction.isVisible(model, env)).toBe(true);
+      expect(unfreezeRowAction.isVisible(model, env)).toBe(true);
+      expect(unfreezeAllAction.isVisible(model, env)).toBe(true);
     });
   });
 
@@ -2089,13 +2167,14 @@ describe("Menu Item actions", () => {
     };
 
     const action = createAction(ActionSpec);
-    action.execute?.(env);
+    action.execute?.(model, env);
     expect(executeMock).not.toHaveBeenCalled();
   });
 });
 
 test("Menu children are sorted by sequence", async () => {
-  const env = makeTestEnv();
+  const model = new Model();
+  const env = makeTestEnv(model);
   const menuItems = createActions([
     {
       id: "menu_1",
@@ -2118,7 +2197,7 @@ test("Menu children are sorted by sequence", async () => {
     },
   ]);
 
-  const children = menuItems[0].children(env);
+  const children = menuItems[0].children(model, env);
   expect(children[0].id).toBe("firstItem");
   expect(children[1].id).toBe("secondItem");
 });

--- a/tests/menus/menu_items_registry_cross_spreadsheet.test.ts
+++ b/tests/menus/menu_items_registry_cross_spreadsheet.test.ts
@@ -7,10 +7,10 @@ import { SpreadsheetChildEnv } from "../../src/types/spreadsheet_env";
 
 describe("cross spreadsheet copy/paste", () => {
   test("should copy/paste from Edit menu", async () => {
-    const envA: SpreadsheetChildEnv = makeTestEnv();
-    const envB: SpreadsheetChildEnv = makeTestEnv();
-    const modelA: Model = envA.model;
-    const modelB: Model = envB.model;
+    const modelA = new Model();
+    const modelB = new Model();
+    const envA: SpreadsheetChildEnv = makeTestEnv(modelA);
+    const envB: SpreadsheetChildEnv = makeTestEnv(modelB);
 
     const cellStyle = { bold: true, fillColor: "#00FF00", fontSize: 20 };
 
@@ -22,7 +22,7 @@ describe("cross spreadsheet copy/paste", () => {
     });
 
     selectCell(modelA, "A1");
-    await doAction(["edit", "copy"], envA);
+    await doAction(["edit", "copy"], modelA, envA);
 
     /**
      * Copy the clipboard from envA to envB because
@@ -34,7 +34,7 @@ describe("cross spreadsheet copy/paste", () => {
     envB.clipboard = envA.clipboard;
 
     selectCell(modelB, "B1");
-    await doAction(["edit", "paste"], envB);
+    await doAction(["edit", "paste"], modelB, envB);
 
     expect(getCellRawContent(modelB, "B1")).toEqual("a1");
     expect(getCell(modelB, "B1")?.style).toMatchObject(cellStyle);

--- a/tests/pivots/pivot_menu_items.test.ts
+++ b/tests/pivots/pivot_menu_items.test.ts
@@ -48,13 +48,13 @@ describe("Pivot properties menu item", () => {
   let env: SpreadsheetChildEnv;
 
   beforeEach(async () => {
-    env = makeTestEnv();
-    model = env.model;
+    model = new Model();
+    env = makeTestEnv(model);
   });
   test("It should not display pivot_properties if there is no pivot in the cell", () => {
     selectCell(model, "A1");
     expect(model.getters.getPivotIdFromPosition(model.getters.getActivePosition())).toBeUndefined();
-    expect(cellMenuRegistry.get("pivot_properties").isVisible!(env)).toBe(false);
+    expect(cellMenuRegistry.get("pivot_properties").isVisible!(model, env)).toBe(false);
   });
 
   test("It should display pivot_properties if there is a pivot in the cell", () => {
@@ -62,7 +62,7 @@ describe("Pivot properties menu item", () => {
     addPivot(model, "M1:N1", {}, "1");
     setCellContent(model, "A1", `=PIVOT("1")`);
     expect(model.getters.getPivotIdFromPosition(model.getters.getActivePosition())).toBe("1");
-    expect(cellMenuRegistry.get("pivot_properties").isVisible!(env)).toBe(true);
+    expect(cellMenuRegistry.get("pivot_properties").isVisible!(model, env)).toBe(true);
   });
 
   test("It should not display pivot_properties if the pivot does not exist", () => {
@@ -70,7 +70,7 @@ describe("Pivot properties menu item", () => {
     addPivot(model, "M1:N1", {}, "1");
     setCellContent(model, "A1", `=PIVOT("2")`);
     expect(model.getters.getPivotIdFromPosition(model.getters.getActivePosition())).toBeUndefined();
-    expect(cellMenuRegistry.get("pivot_properties").isVisible!(env)).toBe(false);
+    expect(cellMenuRegistry.get("pivot_properties").isVisible!(model, env)).toBe(false);
   });
 
   test("It should display pivot_properties if there are multiple pivots in the cell", () => {
@@ -79,7 +79,7 @@ describe("Pivot properties menu item", () => {
     addPivot(model, "M1:N1", {}, "2");
     setCellContent(model, "A1", `=PIVOT("1") + PIVOT("2")`);
     expect(model.getters.getPivotIdFromPosition(model.getters.getActivePosition())).toBe("1");
-    expect(cellMenuRegistry.get("pivot_properties").isVisible!(env)).toBe(true);
+    expect(cellMenuRegistry.get("pivot_properties").isVisible!(model, env)).toBe(true);
   });
 
   test("It should open the pivot side panel when clicking on pivot_properties", () => {
@@ -87,7 +87,7 @@ describe("Pivot properties menu item", () => {
     addPivot(model, "M1:N1", {}, "1");
     setCellContent(model, "A1", `=PIVOT("1")`);
     const openSidePanel = jest.spyOn(env, "openSidePanel");
-    cellMenuRegistry.get("pivot_properties").execute!(env);
+    cellMenuRegistry.get("pivot_properties").execute!(model, env);
     expect(openSidePanel).toHaveBeenCalledWith("PivotSidePanel", { pivotId: "1" });
   });
 
@@ -97,7 +97,7 @@ describe("Pivot properties menu item", () => {
     addPivot(model, "M1:N1", {}, "2");
     setCellContent(model, "A1", `=PIVOT("1") + PIVOT("2")`);
     const openSidePanel = jest.spyOn(env, "openSidePanel");
-    cellMenuRegistry.get("pivot_properties").execute!(env);
+    cellMenuRegistry.get("pivot_properties").execute!(model, env);
     expect(openSidePanel).toHaveBeenCalledWith("PivotSidePanel", { pivotId: "1" });
   });
 });
@@ -115,7 +115,7 @@ describe("Pivot fix formula menu item", () => {
       A8: "=PIVOT(1)",
     };
     const model = createModelFromGrid(grid);
-    const env = makeTestEnv({ model });
+    const env = makeTestEnv(model);
     addPivot(model, "A1:E6", {
       columns: [{ fieldName: "Customer", order: "asc" }],
       rows: [{ fieldName: "Date", order: "asc", granularity: "month_number" }],
@@ -123,7 +123,7 @@ describe("Pivot fix formula menu item", () => {
     });
     // Zone of the pivot is from A8 to E14
     selectCell(model, "B8");
-    cellMenuRegistry.get("pivot_fix_formulas").execute!(env);
+    cellMenuRegistry.get("pivot_fix_formulas").execute!(model, env);
 
     // prettier-ignore
     expect(getEvaluatedGrid(model, "A8:E14")).toEqual([
@@ -198,7 +198,7 @@ describe("Pivot fix formula menu item", () => {
       A3: "",         B3: "20",
     };
     const model = createModelFromGrid(grid);
-    const env = makeTestEnv({ model });
+    const env = makeTestEnv(model);
     addPivot(model, "A1:B3", {
       columns: [],
       rows: [{ fieldName: "Customer", order: "asc" }],
@@ -214,7 +214,7 @@ describe("Pivot fix formula menu item", () => {
     ]);
 
     selectCell(model, "C2");
-    cellMenuRegistry.get("pivot_fix_formulas").execute!(env);
+    cellMenuRegistry.get("pivot_fix_formulas").execute!(model, env);
 
     // prettier-ignore
     expect(getEvaluatedGrid(model, "C1:D4")).toEqual([
@@ -239,7 +239,7 @@ describe("Pivot fix formula menu item", () => {
      A3: "Bob",      B3: "30",
    };
     const model = createModelFromGrid(grid);
-    const env = makeTestEnv({ model });
+    const env = makeTestEnv(model);
 
     addPivot(model, "A1:B3", {
       columns: [],
@@ -258,7 +258,7 @@ describe("Pivot fix formula menu item", () => {
     });
 
     selectCell(model, "C1");
-    cellMenuRegistry.get("pivot_fix_formulas").execute!(env);
+    cellMenuRegistry.get("pivot_fix_formulas").execute!(model, env);
 
     expect(model.getters.getTables(sheetId)).toHaveLength(1);
     expect(model.getters.getCoreTable(activePosition)).toMatchObject({
@@ -276,7 +276,7 @@ describe("Pivot fix formula menu item", () => {
     };
     const model = createModelFromGrid(grid);
     const sheetId = model.getters.getActiveSheetId();
-    const env = makeTestEnv({ model });
+    const env = makeTestEnv(model);
     addPivot(model, "A1:A2", {
       columns: [],
       rows: [{ fieldName: "Customer" }],
@@ -291,7 +291,7 @@ describe("Pivot fix formula menu item", () => {
     });
     // Zone of the pivot is from A8 to E14
     selectCell(model, "A3");
-    cellMenuRegistry.get("pivot_fix_formulas").execute?.(env);
+    cellMenuRegistry.get("pivot_fix_formulas").execute?.(model, env);
     // prettier-ignore
     expect(getEvaluatedGrid(model, "A3:B6")).toEqual([
       ["",      "Total"],
@@ -322,22 +322,22 @@ describe("Pivot fix formula menu item", () => {
       rows: [{ fieldName: "Invalid" }],
       measures: [{ id: "Price:sum", fieldName: "Price", aggregator: "sum" }],
     });
-    const env = makeTestEnv({ model });
+    const env = makeTestEnv(model);
     const pivot = model.getters.getPivot("1")!;
     expect(pivot.isValid()).toBe(false);
     selectCell(model, "C1");
-    expect(cellMenuRegistry.get("pivot_fix_formulas").isVisible!(env)).toBe(false);
+    expect(cellMenuRegistry.get("pivot_fix_formulas").isVisible!(model, env)).toBe(false);
   });
 
   test("It should  be invisible when the pivot cannot spill", () => {
     const model = createModelWithPivot("A1:I5");
     setCellContent(model, "A24", "=pivot(1)");
     setCellContent(model, "A25", "block the spill");
-    const env = makeTestEnv({ model });
+    const env = makeTestEnv(model);
 
     expect(getCellContent(model, "A24")).toEqual("#SPILL!");
     selectCell(model, "A24");
-    expect(cellMenuRegistry.get("pivot_fix_formulas").isVisible!(env)).toBe(false);
+    expect(cellMenuRegistry.get("pivot_fix_formulas").isVisible!(model, env)).toBe(false);
   });
 
   test("It should ignore hidden measures", () => {
@@ -365,9 +365,9 @@ describe("Pivot fix formula menu item", () => {
         },
       ],
     });
-    const env = makeTestEnv({ model });
+    const env = makeTestEnv(model);
     selectCell(model, "A4");
-    cellMenuRegistry.get("pivot_fix_formulas").execute?.(env);
+    cellMenuRegistry.get("pivot_fix_formulas").execute?.(model, env);
     setFormulaVisibility(model, true);
 
     // prettier-ignore
@@ -386,7 +386,7 @@ describe("Pivot fix formula menu item", () => {
      A3: "Bob",      B3: "30",    C3: "1/1/2024",
    };
     const model = createModelFromGrid(grid);
-    const env = makeTestEnv({ model });
+    const env = makeTestEnv(model);
 
     addPivot(model, "A1:C3", {
       columns: [{ fieldName: "Customer" }],
@@ -396,7 +396,7 @@ describe("Pivot fix formula menu item", () => {
     });
 
     selectCell(model, "E1");
-    cellMenuRegistry.get("pivot_fix_formulas").execute!(env);
+    cellMenuRegistry.get("pivot_fix_formulas").execute!(model, env);
 
     setFormulaVisibility(model, true);
     expect(getEvaluatedGrid(model, "E1:F1")).toEqual([
@@ -427,9 +427,9 @@ describe("Pivot reinsertion menu item", () => {
         measures: [{ id: "Quantity:sum", fieldName: "Quantity", aggregator: "sum" }],
         style: { tableStyleId: PIVOT_INSERT_TABLE_STYLE_ID },
       });
-      const env = makeTestEnv({ model });
+      const env = makeTestEnv(model);
       selectCell(model, "B8");
-      await doAction(reinsertDynamicPivotPath, env, topbarMenuRegistry);
+      await doAction(reinsertDynamicPivotPath, model, env, topbarMenuRegistry);
       expect(getCellText(model, "B8")).toEqual(`=PIVOT(1)`);
       expect(getTable(model, "B8")).toMatchObject({
         range: { zone: toZone("B8:C11") },
@@ -450,8 +450,8 @@ describe("Pivot reinsertion menu item", () => {
         measures: [{ id: "Quantity:sum", fieldName: "Quantity", aggregator: "sum" }],
       });
       createSheet(model, { sheetId: "smallSheet", rows: 1, cols: 1, activate: true });
-      const env = makeTestEnv({ model });
-      await doAction(reinsertDynamicPivotPath, env, topbarMenuRegistry);
+      const env = makeTestEnv(model);
+      await doAction(reinsertDynamicPivotPath, model, env, topbarMenuRegistry);
       expect(getCellText(model, "A1")).toEqual(`=PIVOT(1)`);
       expect(model.getters.getPivot(model.getters.getPivotId("1")!).isValid()).toBeTruthy();
       expect(model.getters.getNumberCols("smallSheet")).toEqual(2);
@@ -471,9 +471,9 @@ describe("Pivot reinsertion menu item", () => {
         measures: [{ id: "Quantity:sum", fieldName: "Quantity", aggregator: "sum" }],
         style: { tableStyleId: PIVOT_INSERT_TABLE_STYLE_ID },
       });
-      const env = makeTestEnv({ model });
+      const env = makeTestEnv(model);
       selectCell(model, "B8");
-      await doAction(reinsertDynamicPivotPath, env, topbarMenuRegistry);
+      await doAction(reinsertDynamicPivotPath, model, env, topbarMenuRegistry);
       expect(getCellText(model, "B8")).toEqual(`=PIVOT(1)`);
       expect(getTable(model, "B8")).toBeDefined();
       undo(model);
@@ -498,9 +498,9 @@ describe("Pivot reinsertion menu item", () => {
         rows: [{ fieldName: "Customer" }],
         measures: [{ id: "Quantity:sum", fieldName: "Quantity", aggregator: "sum" }],
       });
-      const env = makeTestEnv({ model });
+      const env = makeTestEnv(model);
       selectCell(model, "B8");
-      await doAction(reinsertStaticPivotPath, env, topbarMenuRegistry);
+      await doAction(reinsertStaticPivotPath, model, env, topbarMenuRegistry);
       expect(getCellText(model, "B10")).toEqual(`=PIVOT.HEADER(1,"Customer","Alice")`);
       expect(
         model.getters.getCoreTable({
@@ -527,8 +527,8 @@ describe("Pivot reinsertion menu item", () => {
         measures: [{ id: "Quantity:sum", fieldName: "Quantity", aggregator: "sum" }],
       });
       createSheet(model, { sheetId: "smallSheet", rows: 1, cols: 1, activate: true });
-      const env = makeTestEnv({ model });
-      await doAction(reinsertStaticPivotPath, env, topbarMenuRegistry);
+      const env = makeTestEnv(model);
+      await doAction(reinsertStaticPivotPath, model, env, topbarMenuRegistry);
       expect(getCellText(model, "A3")).toEqual(`=PIVOT.HEADER(1,"Customer","Alice")`);
       expect(model.getters.getPivot(model.getters.getPivotId("1")!).isValid()).toBeTruthy();
       expect(model.getters.getNumberCols("smallSheet")).toEqual(2);
@@ -541,10 +541,10 @@ describe("Pivot reinsertion menu item", () => {
       addPivot(model, "A1:B2", {});
 
       const notifyUser = jest.fn();
-      const env = makeTestEnv({ model, notifyUser });
+      const env = makeTestEnv(model, { notifyUser });
       jest.spyOn(SpreadsheetPivotTable.prototype, "numberOfCells", "get").mockReturnValue(1000000);
 
-      await doAction(reinsertStaticPivotPath, env, topbarMenuRegistry);
+      await doAction(reinsertStaticPivotPath, model, env, topbarMenuRegistry);
       expect(notifyUser).toHaveBeenCalledWith({
         sticky: true,
         text: getPivotTooBigErrorMessage(1000000, model.getters.getLocale()),
@@ -565,9 +565,9 @@ describe("Pivot reinsertion menu item", () => {
         rows: [{ fieldName: "Customer" }],
         measures: [{ id: "Quantity:sum", fieldName: "Quantity", aggregator: "sum" }],
       });
-      const env = makeTestEnv({ model });
+      const env = makeTestEnv(model);
       selectCell(model, "B8");
-      await doAction(reinsertStaticPivotPath, env, topbarMenuRegistry);
+      await doAction(reinsertStaticPivotPath, model, env, topbarMenuRegistry);
       expect(getCellText(model, "B10")).toEqual(`=PIVOT.HEADER(1,"Customer","Alice")`);
       expect(getTable(model, "B10")).toBeDefined();
       undo(model);
@@ -591,11 +591,15 @@ describe("Pivot reinsertion menu item", () => {
       rows: [{ fieldName: "Customer" }],
       measures: [{ id: "quantity:sum", fieldName: "Quantity", aggregator: "sum" }],
     });
-    const env = makeTestEnv({ model });
+    const env = makeTestEnv(model);
     selectCell(model, "B8");
     expect(model.getters.getPivot("1")!.isValid()).toBeFalsy();
-    expect(getNode(reinsertDynamicPivotPath, env, topbarMenuRegistry).isVisible(env)).toBeFalsy();
-    expect(getNode(reinsertStaticPivotPath, env, topbarMenuRegistry).isVisible(env)).toBeFalsy();
+    expect(
+      getNode(reinsertDynamicPivotPath, model, env, topbarMenuRegistry).isVisible(model, env)
+    ).toBeFalsy();
+    expect(
+      getNode(reinsertStaticPivotPath, model, env, topbarMenuRegistry).isVisible(model, env)
+    ).toBeFalsy();
   });
 
   test("Verify re-insert pivot menu items invisibility when no pivots present", () => {
@@ -608,10 +612,14 @@ describe("Pivot reinsertion menu item", () => {
             A2: "Alice",    B2: "Jambon",
           };
     const model = createModelFromGrid(grid);
-    const env = makeTestEnv({ model });
+    const env = makeTestEnv(model);
 
-    expect(getNode(reinsertDynamicPivotPath, env, topbarMenuRegistry).isVisible(env)).toBeFalsy();
-    expect(getNode(reinsertStaticPivotPath, env, topbarMenuRegistry).isVisible(env)).toBeFalsy();
+    expect(
+      getNode(reinsertDynamicPivotPath, model, env, topbarMenuRegistry).isVisible(model, env)
+    ).toBeFalsy();
+    expect(
+      getNode(reinsertStaticPivotPath, model, env, topbarMenuRegistry).isVisible(model, env)
+    ).toBeFalsy();
 
     addPivot(model, "A1:B2", {
       columns: [],
@@ -619,17 +627,21 @@ describe("Pivot reinsertion menu item", () => {
       measures: [{ id: "quantity:sum", fieldName: "Quantity", aggregator: "sum" }],
     });
 
-    expect(getNode(reinsertDynamicPivotPath, env, topbarMenuRegistry).isVisible(env)).toBeTruthy();
-    expect(getNode(reinsertStaticPivotPath, env, topbarMenuRegistry).isVisible(env)).toBeTruthy();
+    expect(
+      getNode(reinsertDynamicPivotPath, model, env, topbarMenuRegistry).isVisible(model, env)
+    ).toBeTruthy();
+    expect(
+      getNode(reinsertStaticPivotPath, model, env, topbarMenuRegistry).isVisible(model, env)
+    ).toBeTruthy();
   });
 
   test("Insert a pivot", async () => {
     const model = new Model();
     const sheetId = model.getters.getActiveSheetId();
-    const env = makeTestEnv({ model });
+    const env = makeTestEnv(model);
     setGrid(model, { A1: "Header1", B1: "Header2", A2: "Data1", B2: "Data2" });
     setSelection(model, ["A1:B2"]);
-    await doAction(insertPivotPath, env, topbarMenuRegistry);
+    await doAction(insertPivotPath, model, env, topbarMenuRegistry);
     expect(model.getters.getActiveSheetId()).not.toEqual(sheetId);
     expect(model.getters.getPivotIds()).toHaveLength(1);
     expect(getCellText(model, "A1")).toEqual(`=PIVOT(1)`);
@@ -654,7 +666,7 @@ describe("Pivot sorting menu item", () => {
     } else {
       path.push("pivot_sorting_none");
     }
-    await doAction(path, env, cellMenuRegistry);
+    await doAction(path, model, env, cellMenuRegistry);
   }
 
   function getPivotSortedColumn() {
@@ -664,8 +676,8 @@ describe("Pivot sorting menu item", () => {
 
   beforeEach(() => {
     model = createModelWithTestPivotDataset();
-    env = makeTestEnv({ model });
-    sortAction = getNode(["pivot_sorting"], env, cellMenuRegistry);
+    env = makeTestEnv(model);
+    sortAction = getNode(["pivot_sorting"], model, env, cellMenuRegistry);
   });
 
   test("Can sort and un-sort the pivot when clicking on a value cell", async () => {
@@ -703,30 +715,30 @@ describe("Pivot sorting menu item", () => {
     setCellContent(model, "A1", "Not Created On");
     expect(getEvaluatedCell(model, "A20").value).toEqual("#ERROR");
     selectCell(model, "A20");
-    expect(sortAction.isVisible(env)).toBe(false);
+    expect(sortAction.isVisible(model, env)).toBe(false);
   });
 
   test("Sort menu item is only visible on pivot values and measure header", () => {
     selectCell(model, "A1"); // Random cell
-    expect(sortAction.isVisible(env)).toBe(false);
+    expect(sortAction.isVisible(model, env)).toBe(false);
 
     selectCell(model, "A20"); // Pivot header
-    expect(sortAction.isVisible(env)).toBe(false);
+    expect(sortAction.isVisible(model, env)).toBe(false);
 
     selectCell(model, "A21"); // Empty pivot cell
-    expect(sortAction.isVisible(env)).toBe(false);
+    expect(sortAction.isVisible(model, env)).toBe(false);
 
     selectCell(model, "A22"); // Pivot row header
-    expect(sortAction.isVisible(env)).toBe(false);
+    expect(sortAction.isVisible(model, env)).toBe(false);
 
     selectCell(model, "B20"); // Pivot col header
-    expect(sortAction.isVisible(env)).toBe(false);
+    expect(sortAction.isVisible(model, env)).toBe(false);
 
     selectCell(model, "B21"); // Pivot measure header
-    expect(sortAction.isVisible(env)).toBe(true);
+    expect(sortAction.isVisible(model, env)).toBe(true);
 
     selectCell(model, "B23"); // Pivot value cell
-    expect(sortAction.isVisible(env)).toBe(true);
+    expect(sortAction.isVisible(model, env)).toBe(true);
   });
 
   test("Sort menu item is not visible on static pivot formulas", () => {
@@ -739,22 +751,37 @@ describe("Pivot sorting menu item", () => {
     });
 
     selectCell(model, "A21");
-    expect(sortAction.isVisible(env)).toBe(false);
+    expect(sortAction.isVisible(model, env)).toBe(false);
 
     selectCell(model, "A22");
-    expect(sortAction.isVisible(env)).toBe(false);
+    expect(sortAction.isVisible(model, env)).toBe(false);
   });
 
   test("Menu item corresponding to the current sorting of the pivot is active", async () => {
     function getActiveSortOrder() {
       const activeNodes: string[] = [];
-      if (getNode(["pivot_sorting", "pivot_sorting_asc"], env, cellMenuRegistry).isActive?.(env)) {
+      if (
+        getNode(["pivot_sorting", "pivot_sorting_asc"], model, env, cellMenuRegistry).isActive?.(
+          model,
+          env
+        )
+      ) {
         activeNodes.push("pivot_sorting_asc");
       }
-      if (getNode(["pivot_sorting", "pivot_sorting_desc"], env, cellMenuRegistry).isActive?.(env)) {
+      if (
+        getNode(["pivot_sorting", "pivot_sorting_desc"], model, env, cellMenuRegistry).isActive?.(
+          model,
+          env
+        )
+      ) {
         activeNodes.push("pivot_sorting_desc");
       }
-      if (getNode(["pivot_sorting", "pivot_sorting_none"], env, cellMenuRegistry).isActive?.(env)) {
+      if (
+        getNode(["pivot_sorting", "pivot_sorting_none"], model, env, cellMenuRegistry).isActive?.(
+          model,
+          env
+        )
+      ) {
         activeNodes.push("pivot_sorting_none");
       }
       return activeNodes;
@@ -784,7 +811,7 @@ describe("Pivot (un)grouping menu items", () => {
     model = createModelWithPivot("A1:I22");
     openSidePanel = jest.fn();
 
-    env = makeTestEnv({ model, openSidePanel });
+    env = makeTestEnv(model, { openSidePanel });
     pivotId = model.getters.getPivotIds()[0];
     updatePivot(model, pivotId, {
       rows: [],
@@ -815,22 +842,22 @@ describe("Pivot (un)grouping menu items", () => {
       });
 
       setSelection(model, ["A1"]); // No pivot header selected
-      expect(cellMenuRegistry.get("pivot_headers_group").isVisible!(env)).toBe(false);
+      expect(cellMenuRegistry.get("pivot_headers_group").isVisible!(model, env)).toBe(false);
 
       setSelection(model, ["A25"]); // Pivot title
-      expect(cellMenuRegistry.get("pivot_headers_group").isVisible!(env)).toBe(false);
+      expect(cellMenuRegistry.get("pivot_headers_group").isVisible!(model, env)).toBe(false);
 
       setSelection(model, ["A27"]); // Single Salesperson header
-      expect(cellMenuRegistry.get("pivot_headers_group").isVisible!(env)).toBe(false);
+      expect(cellMenuRegistry.get("pivot_headers_group").isVisible!(model, env)).toBe(false);
 
       setSelection(model, ["A27", "A32"]); // Salesperson headers
-      expect(cellMenuRegistry.get("pivot_headers_group").isVisible!(env)).toBe(true);
+      expect(cellMenuRegistry.get("pivot_headers_group").isVisible!(model, env)).toBe(true);
 
       setSelection(model, ["A28:A29"]); // Stage headers
-      expect(cellMenuRegistry.get("pivot_headers_group").isVisible!(env)).toBe(true);
+      expect(cellMenuRegistry.get("pivot_headers_group").isVisible!(model, env)).toBe(true);
 
       setSelection(model, ["A27:A29"]); // Salesperson and Stage headers
-      expect(cellMenuRegistry.get("pivot_headers_group").isVisible!(env)).toBe(false);
+      expect(cellMenuRegistry.get("pivot_headers_group").isVisible!(model, env)).toBe(false);
     });
 
     test("Menu item is not visible when selecting non-groupable fields", () => {
@@ -840,10 +867,10 @@ describe("Pivot (un)grouping menu items", () => {
       });
 
       setSelection(model, ["A27:A28"]); // "Created on" headers
-      expect(cellMenuRegistry.get("pivot_headers_group").isVisible!(env)).toBe(false);
+      expect(cellMenuRegistry.get("pivot_headers_group").isVisible!(model, env)).toBe(false);
 
       setSelection(model, ["B25:C25"]); // "Expected MMR" headers
-      expect(cellMenuRegistry.get("pivot_headers_group").isVisible!(env)).toBe(false);
+      expect(cellMenuRegistry.get("pivot_headers_group").isVisible!(model, env)).toBe(false);
     });
 
     test("Menu item is not visible on static pivot formulas", () => {
@@ -854,7 +881,7 @@ describe("Pivot (un)grouping menu items", () => {
       model.dispatch("SPLIT_PIVOT_FORMULA", { sheetId, col: 0, row: 24, pivotId });
 
       setSelection(model, ["A27", "A32"]); // Salesperson headers
-      expect(cellMenuRegistry.get("pivot_headers_group").isVisible!(env)).toBe(false);
+      expect(cellMenuRegistry.get("pivot_headers_group").isVisible!(model, env)).toBe(false);
     });
 
     test("Can group pivot headers", async () => {
@@ -863,7 +890,7 @@ describe("Pivot (un)grouping menu items", () => {
       });
 
       setSelection(model, ["A27:A28"]); // Salesperson and Stage headers
-      await doAction(["pivot_headers_group"], env, cellMenuRegistry);
+      await doAction(["pivot_headers_group"], model, env, cellMenuRegistry);
 
       expect(model.getters.getPivotCoreDefinition(pivotId)).toMatchObject({
         rows: [{ fieldName: "Stage2" }, { fieldName: "Stage" }],
@@ -880,7 +907,7 @@ describe("Pivot (un)grouping menu items", () => {
       updatePivotWithGroups([{ name: "CustomGroup", values: ["New", "Won"] }]);
 
       setSelection(model, ["A28:A29", "A31"]); // "New", "Won" and"Proposition" headers
-      await doAction(["pivot_headers_group"], env, cellMenuRegistry);
+      await doAction(["pivot_headers_group"], model, env, cellMenuRegistry);
 
       expect(model.getters.getPivotCoreDefinition(pivotId)).toMatchObject({
         rows: [{ fieldName: "Stage2" }, { fieldName: "Stage" }],
@@ -893,7 +920,7 @@ describe("Pivot (un)grouping menu items", () => {
       });
 
       setSelection(model, ["A28:A29"]); // "New" and "Won" headers
-      await doAction(["pivot_headers_group"], env, cellMenuRegistry);
+      await doAction(["pivot_headers_group"], model, env, cellMenuRegistry);
 
       expect(model.getters.getPivotCoreDefinition(pivotId).customFields?.Stage2.groups).toEqual([
         { name: "Group", values: ["New", "Won"] },
@@ -904,8 +931,8 @@ describe("Pivot (un)grouping menu items", () => {
       updatePivotWithGroups([{ name: "MyGroup", values: ["New", "Won"] }]);
 
       setSelection(model, ["A27", "A30"]); // "MyGroup" + "Proposition" headers
-      expect(cellMenuRegistry.get("pivot_headers_group").isVisible!(env)).toBe(true);
-      await doAction(["pivot_headers_group"], env, cellMenuRegistry);
+      expect(cellMenuRegistry.get("pivot_headers_group").isVisible!(model, env)).toBe(true);
+      await doAction(["pivot_headers_group"], model, env, cellMenuRegistry);
 
       expect(model.getters.getPivotCoreDefinition(pivotId)).toMatchObject({
         rows: [{ fieldName: "Stage2" }, { fieldName: "Stage" }],
@@ -924,8 +951,8 @@ describe("Pivot (un)grouping menu items", () => {
       ]);
 
       setSelection(model, ["A27", "A30"]); // "MyGroup" + "Group2" headers
-      expect(cellMenuRegistry.get("pivot_headers_group").isVisible!(env)).toBe(true);
-      await doAction(["pivot_headers_group"], env, cellMenuRegistry);
+      expect(cellMenuRegistry.get("pivot_headers_group").isVisible!(model, env)).toBe(true);
+      await doAction(["pivot_headers_group"], model, env, cellMenuRegistry);
 
       expect(model.getters.getPivotCoreDefinition(pivotId)).toMatchObject({
         rows: [{ fieldName: "Stage2" }, { fieldName: "Stage" }],
@@ -944,7 +971,7 @@ describe("Pivot (un)grouping menu items", () => {
       ]);
 
       setSelection(model, ["A27", "A30"]); // MyGroup + Others headers
-      await doAction(["pivot_headers_group"], env, cellMenuRegistry);
+      await doAction(["pivot_headers_group"], model, env, cellMenuRegistry);
 
       expect(model.getters.getPivotCoreDefinition(pivotId)).toMatchObject({
         rows: [{ fieldName: "Stage2" }, { fieldName: "Stage" }],
@@ -962,22 +989,22 @@ describe("Pivot (un)grouping menu items", () => {
       updatePivotWithGroups([{ name: "MyGroup", values: ["New", "Won"] }]);
 
       setSelection(model, ["A1"]); // No pivot header selected
-      expect(cellMenuRegistry.get("pivot_headers_ungroup").isVisible!(env)).toBe(false);
+      expect(cellMenuRegistry.get("pivot_headers_ungroup").isVisible!(model, env)).toBe(false);
 
       setSelection(model, ["A25"]); // Pivot title
-      expect(cellMenuRegistry.get("pivot_headers_ungroup").isVisible!(env)).toBe(false);
+      expect(cellMenuRegistry.get("pivot_headers_ungroup").isVisible!(model, env)).toBe(false);
 
       setSelection(model, ["A27"]); // "MyGroup" header
-      expect(cellMenuRegistry.get("pivot_headers_ungroup").isVisible!(env)).toBe(true);
+      expect(cellMenuRegistry.get("pivot_headers_ungroup").isVisible!(model, env)).toBe(true);
 
       setSelection(model, ["A28"]); // "New" header inside MyGroup
-      expect(cellMenuRegistry.get("pivot_headers_ungroup").isVisible!(env)).toBe(true);
+      expect(cellMenuRegistry.get("pivot_headers_ungroup").isVisible!(model, env)).toBe(true);
 
       setSelection(model, ["A30"]); // Proposition header in dimension Stage2
-      expect(cellMenuRegistry.get("pivot_headers_ungroup").isVisible!(env)).toBe(false);
+      expect(cellMenuRegistry.get("pivot_headers_ungroup").isVisible!(model, env)).toBe(false);
 
       setSelection(model, ["A31"]); // Proposition header in dimension Stage
-      expect(cellMenuRegistry.get("pivot_headers_ungroup").isVisible!(env)).toBe(false);
+      expect(cellMenuRegistry.get("pivot_headers_ungroup").isVisible!(model, env)).toBe(false);
     });
 
     test("Menu item is not visible on grouped values when grouped field is not in the pivot", () => {
@@ -994,7 +1021,7 @@ describe("Pivot (un)grouping menu items", () => {
 
       setSelection(model, ["A27"]); // "New" header inside Stage
       expect(getEvaluatedCell(model, "A27").value).toEqual("New");
-      expect(cellMenuRegistry.get("pivot_headers_ungroup").isVisible!(env)).toBe(false);
+      expect(cellMenuRegistry.get("pivot_headers_ungroup").isVisible!(model, env)).toBe(false);
     });
 
     test("Un-grouping header deletes the group it belongs to", async () => {
@@ -1004,7 +1031,7 @@ describe("Pivot (un)grouping menu items", () => {
       ]);
 
       setSelection(model, ["A28"]); // "New" header inside MyGroup
-      await doAction(["pivot_headers_ungroup"], env, cellMenuRegistry);
+      await doAction(["pivot_headers_ungroup"], model, env, cellMenuRegistry);
 
       expect(model.getters.getPivotCoreDefinition(pivotId).customFields?.Stage2.groups).toEqual([
         { name: "SecondGroup", values: ["Proposition", "Qualified"] },
@@ -1018,7 +1045,7 @@ describe("Pivot (un)grouping menu items", () => {
       ]);
 
       setSelection(model, ["A28", "A31"]); // "New" header inside MyGroup and Proposition header in Others group
-      await doAction(["pivot_headers_ungroup"], env, cellMenuRegistry);
+      await doAction(["pivot_headers_ungroup"], model, env, cellMenuRegistry);
 
       expect(model.getters.getPivotCoreDefinition(pivotId).customFields?.Stage2).toBeUndefined();
       expect(model.getters.getPivotCoreDefinition(pivotId).rows).toEqual([{ fieldName: "Stage" }]);
@@ -1037,7 +1064,7 @@ describe("Pivot (un)grouping menu items", () => {
       });
 
       setSelection(model, ["A27"]); // "MyGroup" header
-      await doAction(["pivot_headers_ungroup"], env, cellMenuRegistry);
+      await doAction(["pivot_headers_ungroup"], model, env, cellMenuRegistry);
 
       expect(model.getters.getPivotCoreDefinition(pivotId).customFields?.Stage2).toBeUndefined();
       expect(model.getters.getPivotCoreDefinition(pivotId).rows).toEqual([{ fieldName: "Stage" }]);
@@ -1050,7 +1077,7 @@ describe("Pivot (un)grouping menu items", () => {
       ]);
 
       setSelection(model, ["A27"]); // "MyGroup" header
-      await doAction(["pivot_headers_ungroup"], env, cellMenuRegistry);
+      await doAction(["pivot_headers_ungroup"], model, env, cellMenuRegistry);
 
       expect(model.getters.getPivotCoreDefinition(pivotId).customFields?.Stage2.groups).toEqual([
         { name: "Others", values: [], isOtherGroup: true },
@@ -1064,7 +1091,7 @@ describe("Pivot (un)grouping menu items", () => {
       ]);
 
       setSelection(model, ["A30"]); // "MyGroup" header
-      await doAction(["pivot_headers_ungroup"], env, cellMenuRegistry);
+      await doAction(["pivot_headers_ungroup"], model, env, cellMenuRegistry);
 
       expect(model.getters.getPivotCoreDefinition(pivotId).customFields?.Stage2.groups).toEqual([
         { name: "MyGroup", values: ["New", "Won"] },
@@ -1077,32 +1104,32 @@ describe("Pivot (un)grouping menu items", () => {
       updatePivotWithGroups([{ name: "MyGroup", values: ["New", "Won"] }]);
 
       setSelection(model, ["A1"]); // No pivot header selected
-      expect(cellMenuRegistry.get("pivot_group_remaining").isVisible!(env)).toBe(false);
+      expect(cellMenuRegistry.get("pivot_group_remaining").isVisible!(model, env)).toBe(false);
 
       setSelection(model, ["A25"]); // Pivot title
-      expect(cellMenuRegistry.get("pivot_group_remaining").isVisible!(env)).toBe(false);
+      expect(cellMenuRegistry.get("pivot_group_remaining").isVisible!(model, env)).toBe(false);
 
       setSelection(model, ["A27"]); // "MyGroup" header
-      expect(cellMenuRegistry.get("pivot_group_remaining").isVisible!(env)).toBe(false);
+      expect(cellMenuRegistry.get("pivot_group_remaining").isVisible!(model, env)).toBe(false);
 
       setSelection(model, ["A28"]); // "New" header inside MyGroup
-      expect(cellMenuRegistry.get("pivot_group_remaining").isVisible!(env)).toBe(false);
+      expect(cellMenuRegistry.get("pivot_group_remaining").isVisible!(model, env)).toBe(false);
 
       setSelection(model, ["A30"]); // "Proposition" header in dimension Stage2
-      expect(cellMenuRegistry.get("pivot_group_remaining").isVisible!(env)).toBe(false);
+      expect(cellMenuRegistry.get("pivot_group_remaining").isVisible!(model, env)).toBe(false);
 
       setSelection(model, ["A30", "A32"]); // "Proposition" and "Qualified" headers in dimension Stage2
-      expect(cellMenuRegistry.get("pivot_group_remaining").isVisible!(env)).toBe(true);
+      expect(cellMenuRegistry.get("pivot_group_remaining").isVisible!(model, env)).toBe(true);
 
       setSelection(model, ["A31", "A33"]); // "Proposition" and "Qualified" headers in dimension Stage
-      expect(cellMenuRegistry.get("pivot_group_remaining").isVisible!(env)).toBe(true);
+      expect(cellMenuRegistry.get("pivot_group_remaining").isVisible!(model, env)).toBe(true);
     });
 
     test("Can group remaining groups", async () => {
       updatePivotWithGroups([{ name: "MyGroup", values: ["New", "Won"] }]);
 
       setSelection(model, ["A30", "A32"]); // "Proposition", "Qualified" headers inside Stage field
-      await doAction(["pivot_group_remaining"], env, cellMenuRegistry);
+      await doAction(["pivot_group_remaining"], model, env, cellMenuRegistry);
 
       expect(model.getters.getPivotCoreDefinition(pivotId).customFields?.Stage2.groups).toEqual([
         { name: "MyGroup", values: ["New", "Won"] },
@@ -1111,7 +1138,7 @@ describe("Pivot (un)grouping menu items", () => {
 
       undo(model);
       setSelection(model, ["A31", "A33"]); // "Proposition", "Qualified" headers inside Stage field
-      await doAction(["pivot_group_remaining"], env, cellMenuRegistry);
+      await doAction(["pivot_group_remaining"], model, env, cellMenuRegistry);
       expect(model.getters.getPivotCoreDefinition(pivotId).customFields?.Stage2.groups).toEqual([
         { name: "MyGroup", values: ["New", "Won"] },
         { name: "Others", values: [], isOtherGroup: true },
@@ -1125,7 +1152,7 @@ describe("Pivot (un)grouping menu items", () => {
       ]);
 
       setSelection(model, ["A28", "A31"]); // "New" header inside MyGroup and Proposition header in Others group
-      await doAction(["pivot_headers_ungroup"], env, cellMenuRegistry);
+      await doAction(["pivot_headers_ungroup"], model, env, cellMenuRegistry);
 
       expect(model.getters.getPivotCoreDefinition(pivotId).customFields?.Stage2).toBeUndefined();
     });
@@ -1137,7 +1164,7 @@ describe("Pivot (un)grouping menu items", () => {
       ]);
 
       setSelection(model, ["A27"]); // "MyGroup" header
-      await doAction(["pivot_headers_ungroup"], env, cellMenuRegistry);
+      await doAction(["pivot_headers_ungroup"], model, env, cellMenuRegistry);
 
       expect(model.getters.getPivotCoreDefinition(pivotId).customFields?.Stage2.groups).toEqual([
         { name: "Others", values: [], isOtherGroup: true },
@@ -1151,7 +1178,7 @@ describe("Pivot (un)grouping menu items", () => {
       ]);
 
       setSelection(model, ["A30"]); // "MyGroup" header
-      await doAction(["pivot_headers_ungroup"], env, cellMenuRegistry);
+      await doAction(["pivot_headers_ungroup"], model, env, cellMenuRegistry);
 
       expect(model.getters.getPivotCoreDefinition(pivotId).customFields?.Stage2.groups).toEqual([
         { name: "MyGroup", values: ["New", "Won"] },
@@ -1168,7 +1195,7 @@ describe("Pivot (un)collapse menu items", () => {
   beforeEach(() => {
     model = createModelWithPivot("A1:I22");
 
-    env = makeTestEnv({ model });
+    env = makeTestEnv(model);
     pivotId = model.getters.getPivotIds()[0];
     updatePivot(model, pivotId, {
       rows: [],
@@ -1181,80 +1208,80 @@ describe("Pivot (un)collapse menu items", () => {
 
   test("Expand/collapse menu item visibility", () => {
     const path = ["collapse_pivot", "toggle_collapse_pivot_cell"];
-    const menuItem = getNode(path, env, cellMenuRegistry);
+    const menuItem = getNode(path, model, env, cellMenuRegistry);
     updatePivot(model, pivotId, {
       rows: [{ fieldName: "Salesperson" }, { fieldName: "Stage" }],
     });
 
     setSelection(model, ["A1"]); // No pivot header selected
-    expect(menuItem.isVisible!(env)).toBe(false);
+    expect(menuItem.isVisible!(model, env)).toBe(false);
 
     setSelection(model, ["A25"]); // Pivot title
-    expect(menuItem.isVisible!(env)).toBe(false);
+    expect(menuItem.isVisible!(model, env)).toBe(false);
 
     setSelection(model, ["A27"]); // "Kevin" Salesperson header
-    expect(menuItem.isVisible!(env)).toBe(true);
+    expect(menuItem.isVisible!(model, env)).toBe(true);
 
     setSelection(model, ["A28"]); // "New" Stage header
-    expect(menuItem.isVisible!(env)).toBe(false);
+    expect(menuItem.isVisible!(model, env)).toBe(false);
   });
 
   test("Can expand/collapse pivot header", () => {
     const path = ["collapse_pivot", "toggle_collapse_pivot_cell"];
-    const menuItem = getNode(path, env, cellMenuRegistry);
+    const menuItem = getNode(path, model, env, cellMenuRegistry);
     updatePivot(model, pivotId, {
       rows: [{ fieldName: "Salesperson" }, { fieldName: "Stage" }],
     });
 
     setSelection(model, ["A27"]); // "Kevin" Salesperson header
-    expect(menuItem.name(env)).toBe("Collapse");
-    menuItem.execute!(env);
+    expect(menuItem.name(model, env)).toBe("Collapse");
+    menuItem.execute!(model, env);
     expect(model.getters.getPivot(pivotId).definition.collapsedDomains?.ROW).toEqual([
       [{ field: "Salesperson", value: "Kevin", type: "char" }],
     ]);
 
-    expect(menuItem.name(env)).toBe("Expand");
-    menuItem.execute!(env);
+    expect(menuItem.name(model, env)).toBe("Expand");
+    menuItem.execute!(model, env);
     expect(model.getters.getPivot(pivotId).definition.collapsedDomains?.ROW).toHaveLength(0);
   });
 
   test("Expand all/Collapse all menu items visibility", () => {
     const collapseAllPath = ["collapse_pivot", "collapse_all_pivot"];
     const expandAllPath = ["collapse_pivot", "expand_all_pivot"];
-    const collapseAllMenuItem = getNode(collapseAllPath, env, cellMenuRegistry);
-    const expandAllMenuItem = getNode(expandAllPath, env, cellMenuRegistry);
+    const collapseAllMenuItem = getNode(collapseAllPath, model, env, cellMenuRegistry);
+    const expandAllMenuItem = getNode(expandAllPath, model, env, cellMenuRegistry);
     updatePivot(model, pivotId, {
       rows: [{ fieldName: "Salesperson" }, { fieldName: "Stage" }],
     });
 
     setSelection(model, ["A1"]); // No pivot header selected
-    expect(collapseAllMenuItem.isVisible!(env)).toBe(false);
-    expect(expandAllMenuItem.isVisible!(env)).toBe(false);
+    expect(collapseAllMenuItem.isVisible!(model, env)).toBe(false);
+    expect(expandAllMenuItem.isVisible!(model, env)).toBe(false);
 
     setSelection(model, ["A25"]); // Pivot title
-    expect(collapseAllMenuItem.isVisible!(env)).toBe(false);
-    expect(expandAllMenuItem.isVisible!(env)).toBe(false);
+    expect(collapseAllMenuItem.isVisible!(model, env)).toBe(false);
+    expect(expandAllMenuItem.isVisible!(model, env)).toBe(false);
 
     setSelection(model, ["A28"]); // "New" Stage header
-    expect(collapseAllMenuItem.isVisible!(env)).toBe(false);
-    expect(expandAllMenuItem.isVisible!(env)).toBe(false);
+    expect(collapseAllMenuItem.isVisible!(model, env)).toBe(false);
+    expect(expandAllMenuItem.isVisible!(model, env)).toBe(false);
 
     setSelection(model, ["A27"]); // "Kevin" Salesperson header
-    expect(collapseAllMenuItem.isVisible!(env)).toBe(true);
-    expect(expandAllMenuItem.isVisible!(env)).toBe(false);
+    expect(collapseAllMenuItem.isVisible!(model, env)).toBe(true);
+    expect(expandAllMenuItem.isVisible!(model, env)).toBe(false);
 
-    collapseAllMenuItem.execute!(env);
-    expect(collapseAllMenuItem.isVisible!(env)).toBe(false);
-    expect(expandAllMenuItem.isVisible!(env)).toBe(true);
+    collapseAllMenuItem.execute!(model, env);
+    expect(collapseAllMenuItem.isVisible!(model, env)).toBe(false);
+    expect(expandAllMenuItem.isVisible!(model, env)).toBe(true);
   });
 
   test("Expand/collapse menu items not visible in tabular pivot", () => {
     const collapseAllPath = ["collapse_pivot", "collapse_all_pivot"];
     const expandAllPath = ["collapse_pivot", "expand_all_pivot"];
     const collapsePath = ["collapse_pivot", "toggle_collapse_pivot_cell"];
-    const collapseAllMenuItem = getNode(collapseAllPath, env, cellMenuRegistry);
-    const expandAllMenuItem = getNode(expandAllPath, env, cellMenuRegistry);
-    const collapseMenuItem = getNode(collapsePath, env, cellMenuRegistry);
+    const collapseAllMenuItem = getNode(collapseAllPath, model, env, cellMenuRegistry);
+    const expandAllMenuItem = getNode(expandAllPath, model, env, cellMenuRegistry);
+    const collapseMenuItem = getNode(collapsePath, model, env, cellMenuRegistry);
     updatePivot(model, pivotId, {
       rows: [{ fieldName: "Salesperson" }, { fieldName: "Stage" }],
       collapsedDomains: {
@@ -1264,33 +1291,33 @@ describe("Pivot (un)collapse menu items", () => {
     });
 
     setSelection(model, ["A27"]); // "Kevin" Salesperson header
-    expect(collapseAllMenuItem.isVisible!(env)).toBe(true);
-    expect(expandAllMenuItem.isVisible!(env)).toBe(true);
-    expect(collapseMenuItem.isVisible!(env)).toBe(true);
+    expect(collapseAllMenuItem.isVisible!(model, env)).toBe(true);
+    expect(expandAllMenuItem.isVisible!(model, env)).toBe(true);
+    expect(collapseMenuItem.isVisible!(model, env)).toBe(true);
 
     updatePivot(model, pivotId, { style: { tabularForm: true } });
-    expect(collapseAllMenuItem.isVisible!(env)).toBe(false);
-    expect(expandAllMenuItem.isVisible!(env)).toBe(false);
-    expect(collapseMenuItem.isVisible!(env)).toBe(false);
+    expect(collapseAllMenuItem.isVisible!(model, env)).toBe(false);
+    expect(expandAllMenuItem.isVisible!(model, env)).toBe(false);
+    expect(collapseMenuItem.isVisible!(model, env)).toBe(false);
   });
 
   test("Can collapse all/expand all pivot groups", () => {
     const collapseAllPath = ["collapse_pivot", "collapse_all_pivot"];
     const expandAllPath = ["collapse_pivot", "expand_all_pivot"];
-    const collapseAllMenuItem = getNode(collapseAllPath, env, cellMenuRegistry);
-    const expandAllMenuItem = getNode(expandAllPath, env, cellMenuRegistry);
+    const collapseAllMenuItem = getNode(collapseAllPath, model, env, cellMenuRegistry);
+    const expandAllMenuItem = getNode(expandAllPath, model, env, cellMenuRegistry);
     updatePivot(model, pivotId, {
       columns: [{ fieldName: "Salesperson" }, { fieldName: "Stage" }],
     });
 
     setSelection(model, ["B25"]); // "Kevin" Salesperson header
-    collapseAllMenuItem.execute!(env);
+    collapseAllMenuItem.execute!(model, env);
     expect(model.getters.getPivot(pivotId).definition.collapsedDomains?.COL).toEqual([
       [{ field: "Salesperson", value: "Kevin", type: "char" }],
       [{ field: "Salesperson", value: "Eden", type: "char" }],
     ]);
 
-    expandAllMenuItem.execute!(env);
+    expandAllMenuItem.execute!(model, env);
     expect(model.getters.getPivot(pivotId).definition.collapsedDomains?.COL).toHaveLength(0);
   });
 });

--- a/tests/pivots/spreadsheet_pivot/spreadsheet_pivot_side_panel.test.ts
+++ b/tests/pivots/spreadsheet_pivot/spreadsheet_pivot_side_panel.test.ts
@@ -772,7 +772,7 @@ describe("Spreadsheet pivot side panel", () => {
     const sheet2Id = "sheet2";
     createSheet(model, { sheetId: sheet2Id, activate: true });
     const reinsertStaticPivotPath = ["data", "reinsert_static_pivot", "reinsert_static_pivot_1"];
-    await doAction(reinsertStaticPivotPath, env, topbarMenuRegistry);
+    await doAction(reinsertStaticPivotPath, model, env, topbarMenuRegistry);
     env.openSidePanel("PivotSidePanel", { pivotId: "2" });
     await nextTick();
     // update the pivot

--- a/tests/selection_input/selection_input_component.test.ts
+++ b/tests/selection_input/selection_input_component.test.ts
@@ -348,7 +348,7 @@ describe("Selection Input", () => {
 
   test("ctrl + select cell --> add new input", async () => {
     const { env, model, fixture } = await mountSpreadsheet();
-    OPEN_CF_SIDEPANEL_ACTION(env);
+    OPEN_CF_SIDEPANEL_ACTION(model, env);
     await nextTick();
     await simulateClick(".o-cf-add");
     await nextTick();
@@ -456,7 +456,7 @@ describe("Selection Input", () => {
 
   test("Input is in text-edit by default and switched to range-select when selecting on grid", async () => {
     const { env, model, fixture } = await mountSpreadsheet();
-    OPEN_CF_SIDEPANEL_ACTION(env);
+    OPEN_CF_SIDEPANEL_ACTION(model, env);
     await nextTick();
     await simulateClick(".o-cf-add");
     await nextTick();
@@ -499,7 +499,7 @@ describe("Selection Input", () => {
   test("can select full col/row grid selection as selection input data series range", async () => {
     const { env, model, fixture } = await mountSpreadsheet();
     await selectColumnByClicking(model, "B");
-    OPEN_CF_SIDEPANEL_ACTION(env);
+    OPEN_CF_SIDEPANEL_ACTION(model, env);
     await nextTick();
     await simulateClick(".o-cf-add");
     await nextTick();
@@ -585,7 +585,7 @@ describe("Selection Input", () => {
 
   test("pressing and releasing control has no effect on future clicks", async () => {
     const { env, model, fixture } = await mountSpreadsheet();
-    OPEN_CF_SIDEPANEL_ACTION(env);
+    OPEN_CF_SIDEPANEL_ACTION(model, env);
     await nextTick();
     await simulateClick(".o-cf-add");
     await nextTick();

--- a/tests/spreadsheet/side_panel_component.test.ts
+++ b/tests/spreadsheet/side_panel_component.test.ts
@@ -151,7 +151,7 @@ describe("Side Panel", () => {
 
   test("Can open a custom side panel with custom title based on props", async () => {
     addToRegistry(sidePanelRegistry, "CUSTOM_PANEL", {
-      title: (env, props: any) => `Title: ${props.text}`,
+      title: (model, env, props: any) => `Title: ${props.text}`,
       Body: Body,
     });
     parent.env.openSidePanel("CUSTOM_PANEL", { text: "1" });
@@ -380,7 +380,7 @@ describe("Side Panel", () => {
       expect(sidePanelStore.mainPanel?.isPinned).toBeFalsy();
       expect(".o-pin-panel").toHaveCount(0);
 
-      await doAction(["view", "toggle_pin_panel"], parent.env);
+      await doAction(["view", "toggle_pin_panel"], model, parent.env);
       await nextTick();
       expect(sidePanelStore.mainPanel?.isPinned).toBe(true);
       expect(".o-pin-panel").toHaveCount(1);
@@ -396,7 +396,7 @@ describe("Side Panel", () => {
     });
 
     test("Can unpin a side panel with the icon", async () => {
-      await doAction(["view", "toggle_pin_panel"], parent.env);
+      await doAction(["view", "toggle_pin_panel"], model, parent.env);
       await nextTick();
       expect(sidePanelStore.mainPanel?.isPinned).toBe(true);
       await click(fixture, ".o-pin-panel");
@@ -404,10 +404,10 @@ describe("Side Panel", () => {
     });
 
     test("Can unpin a side panel with the menu", async () => {
-      await doAction(["view", "toggle_pin_panel"], parent.env);
+      await doAction(["view", "toggle_pin_panel"], model, parent.env);
       expect(sidePanelStore.mainPanel?.isPinned).toBe(true);
       await nextTick();
-      await doAction(["view", "toggle_pin_panel"], parent.env);
+      await doAction(["view", "toggle_pin_panel"], model, parent.env);
       expect(sidePanelStore.mainPanel?.isPinned).toBeFalsy();
     });
 
@@ -475,7 +475,7 @@ describe("Side Panel", () => {
         }),
       });
 
-      await doAction(["view", "toggle_pin_panel"], parent.env);
+      await doAction(["view", "toggle_pin_panel"], model, parent.env);
       parent.env.openSidePanel("OTHER_PANEL", { key: panelKey });
       await nextTick();
       expect(".o-sidePanel").toHaveCount(1);
@@ -483,7 +483,7 @@ describe("Side Panel", () => {
     });
 
     test("Reopening main panel from secondary panel closes secondary panel", async () => {
-      await doAction(["view", "toggle_pin_panel"], parent.env);
+      await doAction(["view", "toggle_pin_panel"], model, parent.env);
 
       parent.env.openSidePanel("CUSTOM_PANEL_2");
       await nextTick();
@@ -496,7 +496,7 @@ describe("Side Panel", () => {
     });
 
     test("Reopening main panel directly does not close secondary panel", async () => {
-      await doAction(["view", "toggle_pin_panel"], parent.env);
+      await doAction(["view", "toggle_pin_panel"], model, parent.env);
 
       parent.env.openSidePanel("CUSTOM_PANEL_2");
       await nextTick();
@@ -508,7 +508,7 @@ describe("Side Panel", () => {
     });
 
     test("Re-opening the same panel un-collapses it", async () => {
-      await doAction(["view", "toggle_pin_panel"], parent.env);
+      await doAction(["view", "toggle_pin_panel"], model, parent.env);
       await click(fixture, ".o-collapse-panel");
 
       expect(".o-sidePanel").toHaveClass("collapsed");
@@ -521,7 +521,7 @@ describe("Side Panel", () => {
     });
 
     test("Reopening main panel from secondary panel should expand it if collapsed", async () => {
-      await doAction(["view", "toggle_pin_panel"], parent.env);
+      await doAction(["view", "toggle_pin_panel"], model, parent.env);
       await click(fixture, ".o-collapse-panel");
 
       expect(".o-sidePanel").toHaveClass("collapsed");

--- a/tests/spreadsheet/spreadsheet_component.test.ts
+++ b/tests/spreadsheet/spreadsheet_component.test.ts
@@ -212,9 +212,9 @@ describe("Simple Spreadsheet Component", () => {
   test("Insert a function properly sets the edition", async () => {
     ({ model, parent, fixture, env } = await mountSpreadsheet());
     const composerStore = env.getStore(CellComposerStore);
-    await doAction(["insert", "insert_function", "insert_function_sum"], env);
+    await doAction(["insert", "insert_function", "insert_function_sum"], model, env);
     expect(composerStore.currentContent).toBe("=SUM(");
-    await doAction(["insert", "insert_function", "insert_function_sum"], env);
+    await doAction(["insert", "insert_function", "insert_function_sum"], model, env);
     expect(composerStore.currentContent).toBe("=SUM(");
   });
 });
@@ -356,7 +356,7 @@ describe("Composer / selectionInput interactions", () => {
     const composerStore = env.getStore(CellComposerStore);
     //open cf sidepanel
     selectCell(model, "B2");
-    OPEN_CF_SIDEPANEL_ACTION(env);
+    OPEN_CF_SIDEPANEL_ACTION(model, env);
     await nextTick();
     await simulateClick(".o-selection-input input");
 
@@ -379,7 +379,7 @@ describe("Composer / selectionInput interactions", () => {
     "Switching from grid composer to selection input should update the highlights and hide the highlight components",
     async (composerContent) => {
       selectCell(model, "B2");
-      OPEN_CF_SIDEPANEL_ACTION(env);
+      OPEN_CF_SIDEPANEL_ACTION(model, env);
       await nextTick();
 
       await startGridComposition(composerContent);
@@ -394,7 +394,7 @@ describe("Composer / selectionInput interactions", () => {
   test("Switching from composer to selection input should update the highlights and the highlight components", async () => {
     const highlightStore = env.getStore(HighlightStore);
     selectCell(model, "B2");
-    OPEN_CF_SIDEPANEL_ACTION(env);
+    OPEN_CF_SIDEPANEL_ACTION(model, env);
     await nextTick();
 
     await simulateClick(".o-spreadsheet-topbar .o-composer");
@@ -432,7 +432,7 @@ describe("Composer / selectionInput interactions", () => {
 
   test("switching to selection input deactivates the autofill", async () => {
     selectCell(model, "B2");
-    OPEN_CF_SIDEPANEL_ACTION(env);
+    OPEN_CF_SIDEPANEL_ACTION(model, env);
     await nextTick();
 
     expect(fixture.querySelector(".o-autofill")).not.toBeNull();
@@ -487,8 +487,7 @@ test("*isSmall* is properly recomputed when changing window size", async () => {
       });
     }
   }
-  const env = { model };
-  const { parent } = await mountComponent(Parent, { env });
+  const { parent } = await mountComponent(Parent, { model });
   expect(parent.env.isSmall).toBeFalsy();
   spreadsheetWidth = 500;
   parent.render();

--- a/tests/test_helpers/helpers.ts
+++ b/tests/test_helpers/helpers.ts
@@ -53,6 +53,7 @@ import {
   UID,
   Zone,
 } from "../../src";
+import { ModelPlugin } from "../../src/components/owl_plugins/model_plugin";
 import { getItemId } from "../../src/helpers/data_normalization";
 import { detectDateFormat } from "../../src/helpers/format/format";
 import { topbarMenuRegistry } from "../../src/registries/menus/topbar_menu_registry";
@@ -190,9 +191,9 @@ interface SpreadsheetChildEnvWithStores extends SpreadsheetChildEnv {
 }
 
 export function makeTestEnv(
+  model: Model,
   mockEnv: Partial<SpreadsheetChildEnvWithStores> = {}
 ): SpreadsheetChildEnvWithStores {
-  const model = mockEnv.model || new Model();
   if (mockEnv.__spreadsheet_stores__) {
     throw new Error("Cannot call makeTestEnv on a partial env that already have a store container");
   }
@@ -229,7 +230,6 @@ export function makeTestEnv(
   const store = container.get(SidePanelStore);
   const sidePanelStore = proxifyStoreMutation(store, () => container.trigger("store-updated"));
   return {
-    model,
     openSidePanel: mockEnv.openSidePanel || sidePanelStore.open.bind(sidePanelStore),
     replaceSidePanel: mockEnv.replaceSidePanel || sidePanelStore.replace.bind(sidePanelStore),
     toggleSidePanel: mockEnv.toggleSidePanel || sidePanelStore.toggle.bind(sidePanelStore),
@@ -318,35 +318,33 @@ export async function mountComponent<Props extends { [key: string]: any }>(
   component: ComponentConstructor<SpreadsheetChildEnv>,
   optionalArgs: MountComponentArgs<Props> = {}
 ): Promise<MountComponentReturn<Props>> {
-  const model = optionalArgs.model || optionalArgs.env?.model || new Model();
+  const model = optionalArgs.model || new Model();
   model.drawLayer = () => {};
-  const env = makeTestEnv({ ...optionalArgs.env, model: model });
+  const env = makeTestEnv(model, { ...optionalArgs.env });
   const props = optionalArgs.props || ({} as Props);
   const app = new App({
     test: true,
     translateFn: _t,
+    plugins: [ModelPlugin],
+    config: { model },
   });
   const root = app.createRoot(component, { props, env });
   const fixture = optionalArgs?.fixture || makeTestFixture();
-  const parent = await root.mount(fixture);
+  const parent = (await root.mount(fixture)) as Component;
 
-  //@ts-ignore
   const render = batched(parent.render.bind(parent, true));
   if (optionalArgs.renderOnModelUpdate === undefined || optionalArgs.renderOnModelUpdate) {
     model.on("update", null, render);
   }
-  // @ts-ignore
   env.__spreadsheet_stores__.on("store-updated", null, render);
 
   registerCleanup(() => {
     app.destroy();
     fixture.remove();
     model.off("update", null);
-    // @ts-ignore
     env.__spreadsheet_stores__.off("store-updated", null);
   });
 
-  // @ts-ignore
   return { app, parent, model, fixture, env: parent.env };
 }
 
@@ -1034,15 +1032,17 @@ export function getCellsObject(model: Model, sheetId: UID): Record<string, CellO
 
 export async function doAction(
   path: string[],
+  model: Model,
   env: SpreadsheetChildEnv,
   menuRegistry: MenuItemRegistry = topbarMenuRegistry
 ) {
-  const node = getNode(path, env, menuRegistry);
-  await node.execute?.(env);
+  const node = getNode(path, model, env, menuRegistry);
+  await node.execute?.(model, env);
 }
 
 export function getNode(
   _path: string[],
+  model: Model,
   env: SpreadsheetChildEnv,
   menuRegistry: MenuItemRegistry = topbarMenuRegistry
 ): Action {
@@ -1057,18 +1057,19 @@ export function getNode(
     if (path.length === 0) {
       return item;
     }
-    items = item.children(env);
+    items = item.children(model, env);
   }
   throw new Error(`Menu item not found`);
 }
 
 export function getName(
   path: string[],
+  model: Model,
   env: SpreadsheetChildEnv,
   menuRegistry: MenuItemRegistry = topbarMenuRegistry
 ): string {
-  const node = getNode(path, env, menuRegistry);
-  return node.name(env).toString();
+  const node = getNode(path, model, env, menuRegistry);
+  return node.name(model, env).toString();
 }
 
 export function getFigureIds(model: Model, sheetId: UID, type?: string): UID[] {

--- a/tests/top_bar_component.test.ts
+++ b/tests/top_bar_component.test.ts
@@ -1,6 +1,7 @@
 import { xml } from "@odoo/owl";
 import { Currency, Model, Pixel, Style } from "../src";
 import { CellComposerStore } from "../src/components/composer/composer/cell_composer_store";
+import { useModel } from "../src/components/owl_plugins/model_plugin";
 import { PaintFormatStore } from "../src/components/paint_format_button/paint_format_store";
 import { TopBar } from "../src/components/top_bar/top_bar";
 import { topBarToolBarRegistry } from "../src/components/top_bar/top_bar_tools_registry";
@@ -109,9 +110,10 @@ class Parent extends Component<SpreadsheetChildEnv> {
     </div>
   `;
   static components = { TopBar };
+  private model = useModel();
 
   get gridHeight(): Pixel {
-    const { height } = this.env.model.getters.getSheetViewDimension();
+    const { height } = this.model().getters.getSheetViewDimension();
     return height;
   }
 }
@@ -136,7 +138,7 @@ async function mountParent(
     model,
   };
   let parent: Component;
-  ({ parent, fixture, env } = await mountComponent(Parent, { env: partialEnv }));
+  ({ parent, fixture, env } = await mountComponent(Parent, { env: partialEnv, model }));
   return { parent: parent as Parent, model, fixture };
 }
 
@@ -302,10 +304,10 @@ describe("TopBar component", () => {
   });
 
   test("irregularity map tool", async () => {
-    const { parent } = await mountParent();
-    const menu = getNode(["view", "view_irregularity_map"], parent.env, topbarMenuRegistry);
+    const { parent, model } = await mountParent();
+    const menu = getNode(["view", "view_irregularity_map"], model, parent.env, topbarMenuRegistry);
     expect(".irregularity-map").toHaveCount(0);
-    menu.execute?.(parent.env);
+    menu.execute?.(model, parent.env);
     await nextTick();
     expect(".irregularity-map").toHaveCount(1);
     await click(fixture, ".irregularity-map");
@@ -596,35 +598,37 @@ describe("TopBar component", () => {
   });
 
   test("Can open a Topbar menu", async () => {
-    const { parent } = await mountParent();
+    const { parent, model } = await mountParent();
     expect(fixture.querySelectorAll(".o-menu")).toHaveLength(0);
     const env = parent.env;
     const items = topbarMenuRegistry.getMenuItems();
     const number = items.filter(
-      (item) => item.children(env).length !== 0 && item.isVisible(env)
+      (item) => item.children(model, env).length !== 0 && item.isVisible(model, env)
     ).length;
     expect(fixture.querySelectorAll(".o-topbar-menu")).toHaveLength(number);
     await click(fixture, ".o-topbar-menu[data-id='edit']");
     expect(fixture.querySelectorAll(".o-menu")).toHaveLength(1);
-    const edit = getNode(["edit"], env, topbarMenuRegistry);
-    const numberChild = edit.children(parent.env).filter((item) => item.isVisible(env)).length;
+    const edit = getNode(["edit"], model, env, topbarMenuRegistry);
+    const numberChild = edit
+      .children(model, parent.env)
+      .filter((item) => item.isVisible(model, env)).length;
     expect(fixture.querySelectorAll(".o-menu-item")).toHaveLength(numberChild);
     await click(fixture, ".o-spreadsheet-topbar");
     expect(fixture.querySelectorAll(".o-menu")).toHaveLength(0);
   });
 
   test("Can open a Topbar menu with pointermove", async () => {
-    const { parent } = await mountParent();
+    const { parent, model } = await mountParent();
     const env = parent.env;
     await click(fixture, ".o-topbar-menu[data-id='edit']");
-    const edit = getNode(["edit"], env, topbarMenuRegistry);
-    let numberChild = edit.children(env).filter((item) => item.isVisible(env)).length;
+    const edit = getNode(["edit"], model, env, topbarMenuRegistry);
+    let numberChild = edit.children(model, env).filter((item) => item.isVisible(model, env)).length;
     expect(fixture.querySelectorAll(".o-menu-item")).toHaveLength(numberChild);
     expect(fixture.querySelectorAll(".o-menu")).toHaveLength(1);
     triggerMouseEvent(".o-topbar-menu[data-id='insert']", "mouseover");
     await nextTick();
-    const insert = getNode(["insert"], env, topbarMenuRegistry);
-    numberChild = insert?.children(parent.env).filter((item) => item.isVisible(parent.env)).length;
+    const insert = getNode(["insert"], model, env, topbarMenuRegistry);
+    numberChild = insert?.children(model, env).filter((item) => item.isVisible(model, env)).length;
     expect(fixture.querySelectorAll(".o-menu-item")).toHaveLength(numberChild);
     expect(fixture.querySelectorAll(".o-menu")).toHaveLength(1);
   });


### PR DESCRIPTION
This commit introduces a `ModelPlugin` (Owl plugin) provided once by the
root `Spreadsheet` component to all its children. Components access the
model with the `useModel()` hook, which returns a getter that subscribes
the caller to a signal bumped on every model `update` event —
so render invalidation stays scoped to components that actually read it.

Note that the render is not yet fined-grained as we still use a render(true). This
will be removed in the future.

The consequence is that the model is not anymore in the env (the env will
be removed in the future as well), so all actions of registries now takes the
model in addition to the env.

Task: 6280733