### PR TITLE
[IMP] headers: resize rows and columns from context menu

### DIFF
--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -1,4 +1,5 @@
 import { onMounted, providePlugins, proxy, signal, useListener, useProps } from "@odoo/owl";
+import { Action, createAction } from "../../actions/action";
 import { insertSheet, insertTable } from "../../actions/insert_actions";
 import {
   CREATE_IMAGE,
@@ -21,7 +22,7 @@ import {
   interactivePaste,
   interactivePasteFromOS,
 } from "../../helpers/ui/paste_interactive";
-import { isInside } from "../../helpers/zones";
+import { isInside, positionToZone } from "../../helpers/zones";
 import { Component, useLayoutEffect } from "../../owl3_compatibility_layer";
 import { cellMenuRegistry } from "../../registries/menus/cell_menu_registry";
 import { colMenuRegistry } from "../../registries/menus/col_menu_registry";
@@ -40,6 +41,7 @@ import { ClipboardStore } from "../../stores/clipboard_store";
 import { HighlightStore } from "../../stores/highlight_store";
 import { ViewportsStore } from "../../stores/viewports_store";
 import { ZoomStore } from "../../stores/zoom_store";
+import { _t } from "../../translation";
 import { CellValueType } from "../../types/cells";
 import { ClipboardMIMEType } from "../../types/clipboard";
 import { Client } from "../../types/collaborative/session";
@@ -64,6 +66,7 @@ import { GridComposer } from "../composer/grid_composer/grid_composer";
 import { FiguresContainer } from "../figures/figure_container/figure_container";
 import { GridOverlay } from "../grid_overlay/grid_overlay";
 import { GridPopover } from "../grid_popover/grid_popover";
+import { HeaderResizeEditor } from "../header_resize_editor/header_resize_editor";
 import { HeadersOverlay } from "../headers_overlay/headers_overlay";
 import { cssPropertiesToCss } from "../helpers/css";
 import { getElBoundingRect, keyboardEventToShortcutString } from "../helpers/dom_helpers";
@@ -117,6 +120,11 @@ const registries = {
   UNGROUP_HEADERS: unGroupHeadersMenuRegistry,
 };
 
+interface HeaderResizeEditorTarget {
+  dimension: Dimension;
+  index: HeaderIndex;
+}
+
 // -----------------------------------------------------------------------------
 // JS
 // -----------------------------------------------------------------------------
@@ -126,6 +134,7 @@ export class Grid extends Component<SpreadsheetChildEnv> {
     GridComposer,
     GridOverlay,
     GridPopover,
+    HeaderResizeEditor,
     HeadersOverlay,
     MenuPopover,
     Autofill,
@@ -147,6 +156,7 @@ export class Grid extends Component<SpreadsheetChildEnv> {
   readonly HEADER_HEIGHT = HEADER_HEIGHT;
   readonly HEADER_WIDTH = HEADER_WIDTH;
   private menuState!: MenuState;
+  private headerResizeEditorTarget = signal<HeaderResizeEditorTarget | null>(null);
   private gridRef = signal.ref();
   private canvasRef = signal.ref(HTMLCanvasElement);
   private highlightStore!: Store<HighlightStore>;
@@ -687,8 +697,8 @@ export class Grid extends Component<SpreadsheetChildEnv> {
 
   onInputContextMenu(ev: MouseEvent) {
     ev.preventDefault();
-    const lastZone = this.env.model.getters.getSelectedZone();
-    const { left: col, top: row } = lastZone;
+    const position = this.env.model.getters.getActivePosition();
+    const { col, row, sheetId } = position;
     let type: ContextMenuType = "CELL";
     this.composerFocusStore.activeComposer.stopEdition();
     if (this.env.model.getters.getActiveCols().has(col)) {
@@ -696,12 +706,18 @@ export class Grid extends Component<SpreadsheetChildEnv> {
     } else if (this.env.model.getters.getActiveRows().has(row)) {
       type = "ROW";
     }
-    const { x, y, width } = this.viewStore.viewports.getVisibleRectWithZoom(
-      this.env.model.getters.getActiveSheetId(),
-      lastZone
-    );
+
+    let anchorZone = positionToZone(position);
+    const sheetZone = this.env.model.getters.getSheetZone(sheetId);
+    // Full-height/full-width header zones remain visible when the active cell is offscreen.
+    if (type === "COL") {
+      anchorZone = { ...sheetZone, left: col, right: col };
+    } else if (type === "ROW") {
+      anchorZone = { ...sheetZone, top: row, bottom: row };
+    }
+    const { x, y } = this.viewStore.viewports.getVisibleRectWithZoom(sheetId, anchorZone);
     const gridRect = this.getGridRect();
-    this.toggleContextMenu(type, gridRect.x + x + width, gridRect.y + y);
+    this.toggleContextMenu(type, gridRect.x + x, gridRect.y + y);
   }
 
   onCellRightClicked(col: HeaderIndex, row: HeaderIndex, { x, y }: DOMCoordinates) {
@@ -721,6 +737,60 @@ export class Grid extends Component<SpreadsheetChildEnv> {
     this.toggleContextMenu(type, x, y);
   }
 
+  private getMenuItems(type: ContextMenuType, col: HeaderIndex, row: HeaderIndex): Action[] {
+    const menuItems = registries[type].getMenuItems();
+    const headerIndex = type === "COL" ? col : type === "ROW" ? row : -1;
+    if (headerIndex === -1) {
+      return menuItems;
+    }
+
+    // Build the resize action on demand so it captures the target header index.
+    const isColumn = type === "COL";
+    const unhideAction = menuItems.find(
+      ({ id }) => id === (isColumn ? "unhide_columns" : "unhide_rows")
+    );
+    if (!unhideAction) {
+      throw new Error("Missing unhide action in the header menu");
+    }
+    menuItems.push(
+      createAction({
+        id: isColumn ? "resize_columns" : "resize_rows",
+        name: isColumn ? _t("Resize column") : _t("Resize row"),
+        sequence: unhideAction.sequence + 1,
+        separator: true,
+        icon: isColumn
+          ? "o-spreadsheet-Icon.RESIZE_HORIZONTAL"
+          : "o-spreadsheet-Icon.RESIZE_VERTICAL",
+        children: [
+          {
+            name: _t("Fit to data"),
+            execute: (env) => {
+              const sheetId = env.model.getters.getActiveSheetId();
+              return isColumn
+                ? env.model.dispatch("AUTORESIZE_COLUMNS", {
+                    sheetId,
+                    cols: [...env.model.getters.getActiveCols()],
+                  })
+                : env.model.dispatch("AUTORESIZE_ROWS", {
+                    sheetId,
+                    rows: [...env.model.getters.getActiveRows()],
+                  });
+            },
+          },
+          {
+            name: _t("Custom size"),
+            execute: () =>
+              this.headerResizeEditorTarget.set({
+                dimension: isColumn ? "COL" : "ROW",
+                index: headerIndex,
+              }),
+          },
+        ],
+      })
+    );
+    return menuItems.sort((a, b) => a.sequence - b.sequence);
+  }
+
   /**
    * expects x and y coordinates in true pixels (not zoomed)
    */
@@ -728,9 +798,47 @@ export class Grid extends Component<SpreadsheetChildEnv> {
     if (this.cellPopovers.isOpen) {
       this.cellPopovers.close();
     }
+    const gridRect = this.getGridRect();
+    const zoom = this.zoomStore.zoomLevel;
+    // x/y are client coords; getCartesianCoordinates expects unzoomed offsets
+    // relative to the top-left of the cell grid (right of row headers, below column headers).
+    const [col, row] = this.viewStore.getCartesianCoordinates(
+      (x - gridRect.x) / zoom - HEADER_WIDTH,
+      (y - gridRect.y) / zoom - HEADER_HEIGHT
+    );
+    this.headerResizeEditorTarget.set(null);
     this.menuState.isOpen = true;
     this.menuState.anchorRect = { x, y, width: 0, height: 0 };
-    this.menuState.menuItems = registries[type].getMenuItems();
+    this.menuState.menuItems = this.getMenuItems(type, col, row);
+  }
+
+  closeHeaderResizeEditor() {
+    this.headerResizeEditorTarget.set(null);
+    this.focusDefaultElement();
+  }
+
+  get headerResizeEditorAnchorRect(): Rect | null {
+    const target = this.headerResizeEditorTarget();
+    if (!target) {
+      return null;
+    }
+    const { dimension, index } = target;
+    const sheetId = this.env.model.getters.getActiveSheetId();
+    const gridRect = this.getGridRect();
+    let unzoomedHeaderRect: Rect;
+    if (dimension === "COL") {
+      const { start, size } = this.viewStore.viewports.getColDimensionsInViewport(sheetId, index);
+      unzoomedHeaderRect = { x: HEADER_WIDTH + start, y: 0, width: size, height: HEADER_HEIGHT };
+    } else {
+      const { start, size } = this.viewStore.viewports.getRowDimensionsInViewport(sheetId, index);
+      unzoomedHeaderRect = { x: 0, y: HEADER_HEIGHT + start, width: HEADER_WIDTH, height: size };
+    }
+    const zoomedHeaderRect = this.zoomStore.getZoomedRect(unzoomedHeaderRect);
+    return {
+      ...zoomedHeaderRect,
+      x: gridRect.x + zoomedHeaderRect.x,
+      y: gridRect.y + zoomedHeaderRect.y,
+    };
   }
 
   async copy(cut: boolean, ev: ClipboardEvent) {
@@ -812,7 +920,11 @@ export class Grid extends Component<SpreadsheetChildEnv> {
 
   closeMenu() {
     this.menuState.isOpen = false;
-    this.focusDefaultElement();
+    this.menuState.anchorRect = null;
+    this.menuState.menuItems = [];
+    if (!this.headerResizeEditorTarget()) {
+      this.focusDefaultElement();
+    }
   }
 
   private processHeaderGroupingKey(direction: Direction) {

--- a/src/components/grid/grid.xml
+++ b/src/components/grid/grid.xml
@@ -18,7 +18,7 @@
         onGridResized.bind="this.onGridResized"
         gridOverlayDimensions="this.gridOverlayDimensions"
       />
-      <HeadersOverlay onOpenContextMenu="(type, x, y) => this.toggleContextMenu(type, x, y)"/>
+      <HeadersOverlay onOpenContextMenu.bind="this.toggleContextMenu"/>
       <GridComposer
         gridDims="this.viewStore.viewports.getSheetViewDimensionWithHeaders()"
         onInputContextMenu.bind="this.onInputContextMenu"
@@ -55,6 +55,14 @@
         menuItems="this.menuState.menuItems"
         anchorRect="this.menuState.anchorRect"
         onClose="() => this.closeMenu()"
+      />
+      <t t-set="headerResizeEditorTarget" t-value="this.headerResizeEditorTarget()"/>
+      <HeaderResizeEditor
+        t-if="headerResizeEditorTarget"
+        dimension="headerResizeEditorTarget.dimension"
+        anchorIndex="headerResizeEditorTarget.index"
+        anchorRect="this.headerResizeEditorAnchorRect"
+        onClose.bind="this.closeHeaderResizeEditor"
       />
       <t
         t-if="this.displayTableResizer"

--- a/src/components/grid_overlay/grid_overlay.ts
+++ b/src/components/grid_overlay/grid_overlay.ts
@@ -242,7 +242,10 @@ export class GridOverlay extends Component<SpreadsheetChildEnv> {
 
   onCellClicked(zoomedMouseEvent: ZoomedMouseEvent<MouseEvent | PointerEvent>) {
     const openedPopover = this.cellPopovers.persistentCellPopover;
-    const [col, row] = this.getCartesianCoordinates(zoomedMouseEvent);
+    const [col, row] = this.viewStore.getCartesianCoordinates(
+      zoomedMouseEvent.offsetX,
+      zoomedMouseEvent.offsetY
+    );
     const clickedIcon = this.getInteractiveIconAtEvent(zoomedMouseEvent);
     if (clickedIcon) {
       this.env.model.selection.getBackToDefault();
@@ -278,22 +281,20 @@ export class GridOverlay extends Component<SpreadsheetChildEnv> {
       return;
     }
 
-    const [col, row] = this.getCartesianCoordinates(zoomedMouseEvent);
+    const [col, row] = this.viewStore.getCartesianCoordinates(
+      zoomedMouseEvent.offsetX,
+      zoomedMouseEvent.offsetY
+    );
     this.props.onCellDoubleClicked(col, row, ev);
   }
 
   onContextMenu(ev: MouseEvent) {
-    const [col, row] = this.getCartesianCoordinates(this.zoomStore.getZoomedEvent(ev));
+    const zoomedMouseEvent = this.zoomStore.getZoomedEvent(ev);
+    const [col, row] = this.viewStore.getCartesianCoordinates(
+      zoomedMouseEvent.offsetX,
+      zoomedMouseEvent.offsetY
+    );
     this.props.onCellRightClicked(col, row, { x: ev.clientX, y: ev.clientY });
-  }
-
-  private getCartesianCoordinates(
-    zoomedMouseEvent: ZoomedMouseEvent<MouseEvent>
-  ): [HeaderIndex, HeaderIndex] {
-    const sheetId = this.viewStore.displayedSheetId;
-    const colIndex = this.viewStore.viewports.getColIndex(sheetId, zoomedMouseEvent.offsetX);
-    const rowIndex = this.viewStore.viewports.getRowIndex(sheetId, zoomedMouseEvent.offsetY);
-    return [colIndex, rowIndex];
   }
 
   private getInteractiveIconAtEvent(zoomedMouseEvent: ZoomedMouseEvent<MouseEvent>) {
@@ -302,7 +303,10 @@ export class GridOverlay extends Component<SpreadsheetChildEnv> {
     const x = zoomedMouseEvent.clientX - gridOverLayRect.x + gridOffset.x;
     const y = zoomedMouseEvent.clientY - gridOverLayRect.y + gridOffset.y;
 
-    const [col, row] = this.getCartesianCoordinates(zoomedMouseEvent);
+    const [col, row] = this.viewStore.getCartesianCoordinates(
+      zoomedMouseEvent.offsetX,
+      zoomedMouseEvent.offsetY
+    );
     const sheetId = this.viewStore.displayedSheetId;
 
     let position = { col, row, sheetId };

--- a/src/components/header_resize_editor/header_resize_editor.ts
+++ b/src/components/header_resize_editor/header_resize_editor.ts
@@ -1,0 +1,138 @@
+import { onMounted, signal, useListener, useProps } from "@odoo/owl";
+import {
+  DEFAULT_CELL_WIDTH,
+  MAX_HEADER_SIZE,
+  MIN_COL_WIDTH,
+  MIN_ROW_HEIGHT,
+} from "../../constants";
+import { Component } from "../../owl3_compatibility_layer";
+import { _t } from "../../translation";
+import { DispatchResult } from "../../types/commands";
+import { PropsOf } from "../../types/props_of";
+import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
+import { isChildEvent } from "../helpers/dom_helpers";
+import { Popover } from "../popover/popover";
+import { types } from "../props_validation";
+
+export class HeaderResizeEditor extends Component<SpreadsheetChildEnv> {
+  static template = "o-spreadsheet-HeaderResizeEditor";
+  static components = { Popover };
+
+  protected props = useProps({
+    dimension: types.Dimension(),
+    anchorIndex: types.HeaderIndex(),
+    anchorRect: types.Rect(),
+    onClose: types.function(),
+  });
+
+  errorMessage = signal("");
+  isInputEmpty = signal(false);
+  private inputRef = signal.ref(HTMLInputElement);
+  private editorRef = signal.ref();
+
+  setup() {
+    useListener(window, "click", this.onExternalClick.bind(this), { capture: true });
+    onMounted(() => {
+      const input = this.inputRef();
+      if (input) {
+        input.value = this.currentSize.toString();
+        input.select();
+      }
+    });
+  }
+
+  get popoverProps(): PropsOf<Popover> {
+    return {
+      anchorRect: this.props.anchorRect,
+      positioning: this.props.dimension === "COL" ? "bottom-left" : "top-right",
+      onPopoverHidden: this.props.onClose,
+    };
+  }
+
+  get minSize(): number {
+    return this.props.dimension === "COL" ? MIN_COL_WIDTH : MIN_ROW_HEIGHT;
+  }
+
+  get currentSize(): number {
+    const sheetId = this.env.model.getters.getActiveSheetId();
+    return this.props.dimension === "COL"
+      ? this.env.model.getters.getColSize(sheetId, this.props.anchorIndex)
+      : this.env.model.getters.getRowSize(sheetId, this.props.anchorIndex);
+  }
+
+  onExternalClick(ev: MouseEvent) {
+    if (!isChildEvent(this.editorRef(), ev)) {
+      this.props.onClose();
+    }
+  }
+
+  onInput(ev: InputEvent) {
+    const input = ev.target as HTMLInputElement;
+    this.errorMessage.set("");
+    this.isInputEmpty.set(!input.value && !input.validity.badInput);
+  }
+
+  get emptyInputHint(): string {
+    return this.props.dimension === "COL"
+      ? _t("Empty value resets width to %s px", DEFAULT_CELL_WIDTH.toString())
+      : _t("Empty value fits height to content");
+  }
+
+  onKeydown(ev: KeyboardEvent) {
+    if (ev.key === "Enter") {
+      ev.preventDefault();
+      ev.stopPropagation();
+      this.apply();
+    } else if (ev.key === "Escape") {
+      ev.preventDefault();
+      ev.stopPropagation();
+      this.props.onClose();
+    }
+  }
+
+  apply() {
+    const size = this.validateAndParseSize();
+    if (size === undefined) {
+      return;
+    }
+    const result: DispatchResult = this.env.model.dispatch("RESIZE_COLUMNS_ROWS", {
+      sheetId: this.env.model.getters.getActiveSheetId(),
+      dimension: this.props.dimension,
+      elements:
+        this.props.dimension === "COL"
+          ? [...this.env.model.getters.getActiveCols()]
+          : [...this.env.model.getters.getActiveRows()],
+      size,
+    });
+    if (result.isSuccessful) {
+      this.props.onClose();
+    }
+  }
+
+  private validateAndParseSize(): number | null | undefined {
+    const input = this.inputRef();
+    if (!input) {
+      return;
+    }
+    if (!input.value && !input.validity.badInput) {
+      // A null size removes the custom size and restores the default.
+      return null;
+    }
+    const size = input.valueAsNumber;
+    if (!Number.isInteger(size)) {
+      this.errorMessage.set(_t("Size must be an integer"));
+      return;
+    }
+    if (size < this.minSize || size > MAX_HEADER_SIZE) {
+      this.errorMessage.set(
+        _t(
+          "Size must be between %s and %s pixels",
+          this.minSize.toString(),
+          MAX_HEADER_SIZE.toString()
+        )
+      );
+      return;
+    }
+    return size;
+  }
+}

--- a/src/components/header_resize_editor/header_resize_editor.xml
+++ b/src/components/header_resize_editor/header_resize_editor.xml
@@ -1,0 +1,24 @@
+<templates>
+  <t t-name="o-spreadsheet-HeaderResizeEditor">
+    <Popover t-props="this.popoverProps">
+      <div class="p-3" t-ref="this.editorRef">
+        <div class="d-flex align-items-center gap-3">
+          <input
+            type="number"
+            class="o-input"
+            t-on-input="this.onInput"
+            t-on-keydown="this.onKeydown"
+            t-ref="this.inputRef"
+          />
+          <button type="button" class="o-button primary" t-on-click="this.apply">Apply</button>
+        </div>
+        <small t-if="this.isInputEmpty()" class="text-muted" t-out="this.emptyInputHint"/>
+        <div
+          t-if="this.errorMessage()"
+          class="o-validation o-validation-error mt-2 px-2 py-1"
+          t-out="this.errorMessage()"
+        />
+      </div>
+    </Popover>
+  </t>
+</templates>

--- a/src/components/headers_overlay/headers_overlay.ts
+++ b/src/components/headers_overlay/headers_overlay.ts
@@ -1,5 +1,5 @@
 import { proxy, signal, useProps } from "@odoo/owl";
-import { MIN_COL_WIDTH, MIN_ROW_HEIGHT } from "../../constants";
+import { MAX_HEADER_SIZE, MIN_COL_WIDTH, MIN_ROW_HEIGHT } from "../../constants";
 import { Component } from "../../owl3_compatibility_layer";
 import { useStore } from "../../store_engine/store_hooks";
 import { ViewportsStore } from "../../stores/viewports_store";
@@ -193,7 +193,7 @@ abstract class AbstractResizer extends Component<SpreadsheetChildEnv> {
     const styleValue = this.state.draggerLinePosition;
     const size = this._getElementSize(this.state.activeElement);
     const minSize = styleValue - size + this.MIN_ELEMENT_SIZE;
-    const maxSize = this._getMaxSize();
+    const maxSize = Math.min(this._getMaxSize(), styleValue - size + MAX_HEADER_SIZE);
     const onMouseUp = (ev: MouseEvent) => {
       this.state.isResizing = false;
       if (this.state.delta !== 0) {

--- a/src/components/icons/icons.xml
+++ b/src/components/icons/icons.xml
@@ -220,6 +220,16 @@
       />
     </svg>
   </t>
+  <t t-name="o-spreadsheet-Icon.RESIZE_HORIZONTAL">
+    <div class="o-icon">
+      <i class="oi" data-icon="width"/>
+    </div>
+  </t>
+  <t t-name="o-spreadsheet-Icon.RESIZE_VERTICAL">
+    <div class="o-icon">
+      <i class="oi" data-icon="height"/>
+    </div>
+  </t>
   <t t-name="o-spreadsheet-Icon.INSERT_CELL">
     <svg class="o-icon" viewBox="0 0 18 18">
       <path

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -138,6 +138,7 @@ export const COLOR_PICKER_DEFAULTS: Color[] = [
 // Dimensions
 export const MIN_ROW_HEIGHT = 10;
 export const MIN_COL_WIDTH = 5;
+export const MAX_HEADER_SIZE = 2000;
 export const HEADER_HEIGHT = 26;
 export const HEADER_WIDTH = 48;
 export const DESKTOP_TOPBAR_TOOLBAR_HEIGHT = 34;

--- a/src/plugins/evaluation/header_sizes_ui.ts
+++ b/src/plugins/evaluation/header_sizes_ui.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_CELL_HEIGHT } from "../../constants";
+import { DEFAULT_CELL_HEIGHT, MAX_HEADER_SIZE } from "../../constants";
 import {
   deepCopy,
   getAddHeaderStartIndex,
@@ -216,7 +216,10 @@ export class HeaderSizeUIPlugin
 
     const cell = this.getters.getCell(position);
     const colSize = this.getters.getColSize(position.sheetId, position.col);
-    return getDefaultCellHeight(this.ctx, cell, this.getters.getLocale(), colSize);
+    return Math.min(
+      getDefaultCellHeight(this.ctx, cell, this.getters.getLocale(), colSize),
+      MAX_HEADER_SIZE
+    );
   }
 
   private isInMultiRowMerge(position: CellPosition): boolean {

--- a/src/plugins/ui_feature/ui_sheet.ts
+++ b/src/plugins/ui_feature/ui_sheet.ts
@@ -2,6 +2,7 @@ import {
   DATA_VALIDATION_CHIP_MARGIN,
   DEFAULT_CELL_HEIGHT,
   DEFAULT_VERTICAL_ALIGN,
+  MAX_HEADER_SIZE,
   MIN_CELL_TEXT_MARGIN,
   PADDING_AUTORESIZE_HORIZONTAL,
 } from "../../constants";
@@ -61,7 +62,7 @@ export class SheetUIPlugin extends UIPlugin {
     switch (cmd.type) {
       case "AUTORESIZE_COLUMNS":
         for (const col of cmd.cols) {
-          const size = this.getColMaxWidth(cmd.sheetId, col);
+          const size = Math.min(this.getColMaxWidth(cmd.sheetId, col), MAX_HEADER_SIZE);
           if (size !== 0) {
             this.dispatch("RESIZE_COLUMNS_ROWS", {
               elements: [col],
@@ -333,7 +334,7 @@ export class SheetUIPlugin extends UIPlugin {
           }
         }
       }
-      rowSizes.push(evaluatedRowSize || null);
+      rowSizes.push(evaluatedRowSize ? Math.min(evaluatedRowSize, MAX_HEADER_SIZE) : null);
     }
 
     const groupedSizes = new Map<number | null, HeaderIndex[]>(rowSizes.map((size) => [size, []]));

--- a/src/registries/menus/col_menu_registry.ts
+++ b/src/registries/menus/col_menu_registry.ts
@@ -80,12 +80,10 @@ colMenuRegistry
   .add("hide_columns", {
     ...ACTION_VIEW.hideCols,
     sequence: 105,
-    separator: true,
   })
   .add("unhide_columns", {
     ...ACTION_VIEW.unhideCols,
     sequence: 106,
-    separator: true,
   })
   .add("conditional_formatting", {
     ...ACTION_FORMAT.formatCF,

--- a/src/registries/menus/row_menu_registry.ts
+++ b/src/registries/menus/row_menu_registry.ts
@@ -53,12 +53,10 @@ rowMenuRegistry
   .add("hide_rows", {
     ...ACTION_VIEW.hideRows,
     sequence: 85,
-    separator: true,
   })
   .add("unhide_rows", {
     ...ACTION_VIEW.unhideRows,
     sequence: 86,
-    separator: true,
   })
   .add("conditional_formatting", {
     ...ACTION_FORMAT.formatCF,

--- a/src/stores/viewports_store.ts
+++ b/src/stores/viewports_store.ts
@@ -48,6 +48,7 @@ export class ViewportsStore extends SpreadsheetStore {
     "setViewportArgs",
     "rebuildViewports",
   ] as const;
+  storeGetters = ["getCartesianCoordinates"] as const;
 
   private zoomStore = this.get(ZoomStore);
   private getHeaderDimensionsCallback = this.getters.getHeaderDimensions;
@@ -219,6 +220,13 @@ export class ViewportsStore extends SpreadsheetStore {
 
   get gridOffset(): DOMCoordinates {
     return this.viewports.getGridOffset();
+  }
+
+  getCartesianCoordinates(x: Pixel, y: Pixel): [HeaderIndex, HeaderIndex] {
+    return [
+      this.viewports.getColIndex(this.displayedSheetId, x),
+      this.viewports.getRowIndex(this.displayedSheetId, y),
+    ];
   }
 
   /** type as pane, not viewport but basically pane extends viewport */

--- a/tests/grid/__snapshots__/grid_component.test.ts.snap
+++ b/tests/grid/__snapshots__/grid_component.test.ts.snap
@@ -127,6 +127,7 @@ exports[`Grid component simple rendering snapshot 1`] = `
   
   
   
+  
   <div
     class="o-scrollbar vertical"
     style="top: 26px; right: 0px; width: 15px; bottom: 15px;"

--- a/tests/grid/grid_component.test.ts
+++ b/tests/grid/grid_component.test.ts
@@ -74,6 +74,7 @@ import {
   clickGridIcon,
   doubleClick,
   edgeScrollDelay,
+  focusAndKeyDown,
   getElComputedStyle,
   getGridIconEventPosition,
   gridMouseEvent,
@@ -1363,6 +1364,81 @@ describe("Grid component", () => {
     expect(document.activeElement).toBe(fixture.querySelector(".o-grid div.o-composer"));
   });
 
+  test("Column resize actions use the clicked column", async () => {
+    const sheetId = model.getters.getActiveSheetId();
+    selectColumn(model, 1, "overrideSelection");
+    selectColumn(model, 2, "updateAnchor");
+    const dispatch = spyModelDispatch(model);
+    const rightClickCellWithClientCoordinates = (xc: string) => {
+      const { col, row } = toCartesian(xc);
+      return rightClickCell(env, xc, {
+        clientX: HEADER_WIDTH + col * DEFAULT_CELL_WIDTH,
+        clientY: HEADER_HEIGHT + row * DEFAULT_CELL_HEIGHT,
+        bubbles: true,
+      });
+    };
+
+    await rightClickCellWithClientCoordinates("C5");
+    expect(".o-menu-item[data-name='resize_columns']").toHaveCount(1);
+    expect(".o-menu-item[data-name='resize_columns'] [data-icon='width']").toHaveCount(1);
+    const menuItems = [...fixture.querySelectorAll<HTMLElement>(".o-menu-item")];
+    const hideIndex = menuItems.findIndex((item) => item.dataset.name === "hide_columns");
+    const resizeIndex = menuItems.findIndex((item) => item.dataset.name === "resize_columns");
+    expect(resizeIndex).toBe(hideIndex + 1);
+    await simulateClick(".o-menu-item[data-name='resize_columns']");
+    expect(".o-menu-item[title='Fit to data']").toHaveCount(1);
+    expect(".o-menu-item[title='Custom size']").toHaveCount(1);
+
+    await simulateClick(".o-menu-item[title='Fit to data']");
+    expect(dispatch).toHaveBeenCalledWith("AUTORESIZE_COLUMNS", {
+      sheetId,
+      cols: [1, 2],
+    });
+
+    await rightClickCellWithClientCoordinates("C5");
+    await simulateClick(".o-menu-item[data-name='resize_columns']");
+    await simulateClick(".o-menu-item[title='Custom size']");
+    expect(".o-popover").toHaveStyle({
+      left: `${HEADER_WIDTH + 2 * DEFAULT_CELL_WIDTH}px`, // column C
+      top: `${HEADER_HEIGHT}px`,
+    });
+
+    await rightClickCellWithClientCoordinates("D5");
+    expect(".o-popover input").toHaveCount(0);
+    expect(".o-menu-item[data-name='resize_columns']").toHaveCount(0);
+  });
+
+  test("Row resize actions use the clicked row", async () => {
+    const sheetId = model.getters.getActiveSheetId();
+    selectRow(model, 0, "overrideSelection");
+    selectRow(model, 1, "updateAnchor");
+    const dispatch = spyModelDispatch(model);
+    const contextMenuOptions = { clientY: HEADER_HEIGHT + 10, bubbles: true };
+
+    triggerMouseEvent(".o-row-resizer", "contextmenu", 10, 10, contextMenuOptions);
+    await nextTick();
+    expect(".o-menu-item[data-name='resize_rows']").toHaveCount(1);
+    expect(".o-menu-item[data-name='resize_rows'] [data-icon='height']").toHaveCount(1);
+    await simulateClick(".o-menu-item[data-name='resize_rows']");
+    expect(".o-menu-item[title='Fit to data']").toHaveCount(1);
+    expect(".o-menu-item[title='Custom size']").toHaveCount(1);
+
+    await simulateClick(".o-menu-item[title='Fit to data']");
+    expect(dispatch).toHaveBeenCalledWith("AUTORESIZE_ROWS", {
+      sheetId,
+      rows: [0, 1],
+    });
+
+    triggerMouseEvent(".o-row-resizer", "contextmenu", 10, 10, contextMenuOptions);
+    await nextTick();
+    await simulateClick(".o-menu-item[data-name='resize_rows']");
+    await simulateClick(".o-menu-item[title='Custom size']");
+    expect(".o-popover").toHaveStyle({
+      left: `${HEADER_WIDTH}px`,
+      top: `${HEADER_HEIGHT}px`,
+    });
+  });
+
   test("can use keyboard to navigate the context menu", async () => {
     await rightClickCell(env, "B2");
     expect(document.activeElement).toHaveClass("o-menu-wrapper");
@@ -1390,6 +1466,66 @@ describe("Grid component", () => {
     expect(document.activeElement).toBe(fixture.querySelector(".o-grid div.o-composer"));
   });
 
+  test("Can open and close the column resize editor from the keyboard context menu", async () => {
+    selectColumn(model, 1, "overrideSelection");
+    selectColumn(model, 2, "updateAnchor");
+    triggerMouseEvent(".o-grid div.o-composer", "contextmenu");
+    await nextTick();
+
+    expect(".o-popover").toHaveStyle({
+      left: `${HEADER_WIDTH + DEFAULT_CELL_WIDTH}px`,
+      top: `${HEADER_HEIGHT}px`,
+    });
+    await simulateClick(".o-menu-item[data-name='resize_columns']");
+    await simulateClick(".o-menu-item[title='Custom size']");
+    expect(".o-popover").toHaveStyle({
+      left: `${HEADER_WIDTH + DEFAULT_CELL_WIDTH}px`,
+      top: `${HEADER_HEIGHT}px`,
+    });
+    await focusAndKeyDown(".o-popover input", { key: "Escape" });
+    expect(".o-popover input").toHaveCount(0);
+    expect(document.activeElement).toBe(fixture.querySelector(".o-grid div.o-composer"));
+  });
+
+  test("Keyboard context menu follows the active column when its cell is offscreen", async () => {
+    selectColumn(model, 1, "overrideSelection");
+    selectColumn(model, 3, "updateAnchor");
+    await keyDown({ key: "Tab" });
+    expect(getSelectionAnchorCellXc(model)).toBe("C1");
+    setViewportOffset(env, 0, DEFAULT_CELL_HEIGHT);
+    expect(viewStore.viewports.isVisibleInViewport(model.getters.getActivePosition())).toBe(false);
+
+    triggerMouseEvent(".o-grid div.o-composer", "contextmenu");
+    await nextTick();
+
+    expect(".o-popover").toHaveStyle({
+      left: `${HEADER_WIDTH + 2 * DEFAULT_CELL_WIDTH}px`,
+      top: `${HEADER_HEIGHT}px`,
+    });
+    expect(".o-menu-item[data-name='resize_columns']").toHaveCount(1);
+  });
+
+  test("Keyboard context menu opens for an offscreen column selection", async () => {
+    selectColumn(model, 1, "overrideSelection");
+    selectColumn(model, 3, "updateAnchor");
+    await keyDown({ key: "Tab" });
+    expect(getSelectionAnchorCellXc(model)).toBe("C1");
+    setViewportOffset(env, 5 * DEFAULT_CELL_WIDTH, 0);
+    const sheetId = model.getters.getActiveSheetId();
+    expect(
+      viewStore.viewports.isZoneVisibleInViewport(sheetId, model.getters.getSelectedZone())
+    ).toBe(false);
+
+    triggerMouseEvent(".o-grid div.o-composer", "contextmenu");
+    await nextTick();
+
+    expect(".o-popover").toHaveStyle({
+      left: `${HEADER_WIDTH}px`,
+      top: `${HEADER_HEIGHT}px`,
+    });
+    expect(".o-menu-item[data-name='resize_columns']").toHaveCount(1);
+  });
+
   test("Can open context menu with a keyboard input ", async () => {
     const mockGridPosition = {
       x: 40,
@@ -1407,9 +1543,7 @@ describe("Grid component", () => {
     await nextTick();
     expect(fixture.querySelector(".o-menu")).toBeTruthy();
     const popover = fixture.querySelector<HTMLElement>(".o-popover")!;
-    expect(parseInt(popover.style.left)).toBe(
-      mockGridPosition.x + HEADER_WIDTH + DEFAULT_CELL_WIDTH
-    );
+    expect(parseInt(popover.style.left)).toBe(mockGridPosition.x + HEADER_WIDTH);
     expect(parseInt(popover.style.top)).toBe(mockGridPosition.y + HEADER_HEIGHT);
   });
 

--- a/tests/grid/grid_overlay_component.test.ts
+++ b/tests/grid/grid_overlay_component.test.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_CELL_WIDTH,
   HEADER_HEIGHT,
   HEADER_WIDTH,
+  MAX_HEADER_SIZE,
   MIN_COL_WIDTH,
   MIN_ROW_HEIGHT,
   PADDING_AUTORESIZE_HORIZONTAL,
@@ -53,8 +54,8 @@ let fixture: HTMLElement;
 let model: Model;
 let env: SpreadsheetChildEnv;
 
-ColResizer.prototype._getMaxSize = () => 1000;
-RowResizer.prototype._getMaxSize = () => 1000;
+ColResizer.prototype._getMaxSize = () => MAX_HEADER_SIZE * 2;
+RowResizer.prototype._getMaxSize = () => MAX_HEADER_SIZE * 2;
 
 function fillData() {
   for (let i = 0; i < 8; i++) {
@@ -406,12 +407,12 @@ describe("Resizer component", () => {
 
   test("Max boundaries resizing columns", async () => {
     await resizeColumn("C", 10000000);
-    expect(model.getters.getColSize(model.getters.getActiveSheetId(), 1)).toBe(904);
+    expect(model.getters.getColSize(model.getters.getActiveSheetId(), 1)).toBe(MAX_HEADER_SIZE);
   });
 
   test("Max boundaries resizing rows", async () => {
     await resizeRow(2, 10000000);
-    expect(model.getters.getRowSize(model.getters.getActiveSheetId(), 1)).toBe(977);
+    expect(model.getters.getRowSize(model.getters.getActiveSheetId(), 1)).toBe(MAX_HEADER_SIZE);
   });
 
   test("Double click: Modify the size of a column", async () => {

--- a/tests/headers/header_resize_editor_component.test.ts
+++ b/tests/headers/header_resize_editor_component.test.ts
@@ -1,0 +1,179 @@
+import { Model } from "../../src";
+import { HeaderResizeEditor } from "../../src/components/header_resize_editor/header_resize_editor";
+import { DEFAULT_CELL_WIDTH, MAX_HEADER_SIZE, MIN_COL_WIDTH } from "../../src/constants";
+import { UID } from "../../src/types/misc";
+import { PropsOf } from "../../src/types/props_of";
+import {
+  resizeColumns,
+  resizeRows,
+  selectColumn,
+  selectRow,
+} from "../test_helpers/commands_helpers";
+import {
+  focusAndKeyDown,
+  setInputValueAndTrigger,
+  simulateClick,
+} from "../test_helpers/dom_helper";
+import { mountComponentWithPortalTarget, spyModelDispatch } from "../test_helpers/helpers";
+
+const SELECTORS = {
+  applyButton: ".o-popover .o-button.primary",
+  error: ".o-validation-error",
+  hint: ".o-popover .text-muted",
+  sizeInput: ".o-popover input[type='number']",
+};
+
+describe("Header resize editor", () => {
+  let model: Model;
+  let fixture: HTMLElement;
+  let sheetId: UID;
+  let dispatch: jest.SpyInstance;
+  let onClose: jest.Mock;
+
+  beforeEach(() => {
+    model = new Model();
+    sheetId = model.getters.getActiveSheetId();
+    onClose = jest.fn();
+  });
+
+  async function mountHeaderResizeEditor(
+    props: Partial<PropsOf<HeaderResizeEditor>> = {}
+  ): Promise<void> {
+    ({ fixture } = await mountComponentWithPortalTarget(HeaderResizeEditor, {
+      model,
+      props: {
+        dimension: props.dimension ?? "COL",
+        anchorIndex: props.anchorIndex ?? 0,
+        anchorRect: props.anchorRect ?? { x: 0, y: 0, width: 0, height: 0 },
+        onClose: props.onClose ?? onClose,
+      },
+    }));
+    dispatch = spyModelDispatch(model);
+  }
+
+  test("sets a custom width for selected columns", async () => {
+    resizeColumns(model, ["A"], 123);
+    selectColumn(model, 0, "overrideSelection");
+    await mountHeaderResizeEditor({ dimension: "COL", anchorIndex: 0 });
+
+    const input = fixture.querySelector<HTMLInputElement>(SELECTORS.sizeInput)!;
+    expect(input.value).toBe("123");
+
+    await setInputValueAndTrigger(input, "147");
+    await simulateClick(SELECTORS.applyButton);
+
+    expect(dispatch).toHaveBeenCalledWith("RESIZE_COLUMNS_ROWS", {
+      sheetId,
+      dimension: "COL",
+      elements: [0],
+      size: 147,
+    });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  test("sets a custom height for selected rows", async () => {
+    resizeRows(model, [1], 33);
+    selectRow(model, 1, "overrideSelection");
+    await mountHeaderResizeEditor({ dimension: "ROW", anchorIndex: 1 });
+
+    const input = fixture.querySelector<HTMLInputElement>(SELECTORS.sizeInput)!;
+    expect(input.value).toBe("33");
+
+    await setInputValueAndTrigger(input, "");
+    expect(SELECTORS.hint).toHaveText("Empty value fits height to content");
+    await setInputValueAndTrigger(input, "42");
+    await simulateClick(SELECTORS.applyButton);
+
+    expect(dispatch).toHaveBeenCalledWith("RESIZE_COLUMNS_ROWS", {
+      sheetId,
+      dimension: "ROW",
+      elements: [1],
+      size: 42,
+    });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  test("applying an empty input restores the default width", async () => {
+    resizeColumns(model, ["B"], 147);
+    selectColumn(model, 1, "overrideSelection");
+    await mountHeaderResizeEditor({ dimension: "COL", anchorIndex: 1 });
+
+    await setInputValueAndTrigger(SELECTORS.sizeInput, "");
+    expect(SELECTORS.hint).toHaveText(`Empty value resets width to ${DEFAULT_CELL_WIDTH} px`);
+    await simulateClick(SELECTORS.applyButton);
+
+    expect(dispatch).toHaveBeenCalledWith("RESIZE_COLUMNS_ROWS", {
+      sheetId,
+      dimension: "COL",
+      elements: [1],
+      size: null,
+    });
+    expect(model.getters.getColSize(sheetId, 1)).toBe(DEFAULT_CELL_WIDTH);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  test("invalid number input does not reset the size", async () => {
+    resizeColumns(model, ["B"], 147);
+    selectColumn(model, 1, "overrideSelection");
+    await mountHeaderResizeEditor({ dimension: "COL", anchorIndex: 1 });
+    const input = fixture.querySelector<HTMLInputElement>(SELECTORS.sizeInput)!;
+    Object.defineProperty(input.validity, "badInput", { value: true });
+
+    await setInputValueAndTrigger(input, "");
+    expect(SELECTORS.hint).toHaveCount(0);
+    await simulateClick(SELECTORS.applyButton);
+
+    expect(SELECTORS.error).toHaveText("Size must be an integer");
+    expect(model.getters.getColSize(sheetId, 1)).toBe(147);
+  });
+
+  test.each([MIN_COL_WIDTH - 1, MAX_HEADER_SIZE + 1])(
+    "size %s outside the allowed range is not applied",
+    async (size) => {
+      await mountHeaderResizeEditor({ dimension: "COL", anchorIndex: 1 });
+      await setInputValueAndTrigger(SELECTORS.sizeInput, size.toString());
+      await simulateClick(SELECTORS.applyButton);
+
+      expect(SELECTORS.error).toHaveText(
+        `Size must be between ${MIN_COL_WIDTH} and ${MAX_HEADER_SIZE} pixels`
+      );
+      expect(dispatch).not.toHaveBeenCalled();
+      expect(onClose).not.toHaveBeenCalled();
+    }
+  );
+
+  test("Enter validates and applies the size", async () => {
+    selectColumn(model, 1, "overrideSelection");
+    await mountHeaderResizeEditor({ dimension: "COL", anchorIndex: 1 });
+
+    await setInputValueAndTrigger(SELECTORS.sizeInput, "10.5");
+    await focusAndKeyDown(SELECTORS.sizeInput, { key: "Enter" });
+    expect(SELECTORS.error).toHaveText("Size must be an integer");
+    expect(dispatch).not.toHaveBeenCalled();
+
+    await setInputValueAndTrigger(SELECTORS.sizeInput, "147");
+    expect(SELECTORS.error).toHaveCount(0);
+    await focusAndKeyDown(SELECTORS.sizeInput, { key: "Enter" });
+
+    expect(dispatch).toHaveBeenCalledWith("RESIZE_COLUMNS_ROWS", {
+      sheetId,
+      dimension: "COL",
+      elements: [1],
+      size: 147,
+    });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  test("Escape closes the editor without resizing", async () => {
+    await mountHeaderResizeEditor({ dimension: "COL", anchorIndex: 1 });
+    await focusAndKeyDown(SELECTORS.sizeInput, { key: "Escape" });
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  test("clicking outside closes the editor", async () => {
+    await mountHeaderResizeEditor({ dimension: "COL", anchorIndex: 1 });
+    await simulateClick(".o-spreadsheet");
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/tests/headers/resizing_plugin.test.ts
+++ b/tests/headers/resizing_plugin.test.ts
@@ -2,6 +2,7 @@ import { CommandResult, DEFAULT_LOCALE, Sheet, Wrapping } from "../../src";
 import {
   DEFAULT_CELL_HEIGHT,
   DEFAULT_CELL_WIDTH,
+  MAX_HEADER_SIZE,
   MIN_CELL_TEXT_MARGIN,
   PADDING_AUTORESIZE_VERTICAL,
 } from "../../src/constants";
@@ -109,6 +110,31 @@ describe("Model resizer", () => {
     undo(model);
     expect(model.getters.getRowSize(sheetId, 1)).toBe(initialSize);
     expect(viewStore.mainViewportRect.height).toBe(initialHeight);
+  });
+
+  test("Column autoresize cannot exceed the maximum header size", () => {
+    const model = new Model();
+    const sheetId = model.getters.getActiveSheetId();
+    setCellContent(model, "A1", "A".repeat(MAX_HEADER_SIZE));
+    autoresizeColumns(model, [0]);
+    expect(model.getters.getColSize(sheetId, 0)).toBe(MAX_HEADER_SIZE);
+  });
+
+  test("Row autoresize cannot exceed the maximum header size", () => {
+    const model = new Model();
+    const sheetId = model.getters.getActiveSheetId();
+    setCellContent(model, "A1", "=A2");
+    setCellContent(model, "A2", "A\n".repeat(200));
+    autoresizeRows(model, [0]);
+    expect(model.getters.getUserRowSize(sheetId, 0)).toBe(MAX_HEADER_SIZE);
+  });
+
+  test("Dynamic row height cannot exceed the maximum header size", () => {
+    const model = new Model();
+    const sheetId = model.getters.getActiveSheetId();
+    setCellContent(model, "A1", "A\n".repeat(200));
+    expect(model.getters.getUserRowSize(sheetId, 0)).toBeUndefined();
+    expect(model.getters.getRowSize(sheetId, 0)).toBe(MAX_HEADER_SIZE);
   });
 
   test("Can resize row of inactive sheet", async () => {

--- a/tests/spreadsheet/__snapshots__/spreadsheet_component.test.ts.snap
+++ b/tests/spreadsheet/__snapshots__/spreadsheet_component.test.ts.snap
@@ -967,6 +967,7 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
         
         
         
+        
         <div
           class="o-scrollbar vertical"
           style="top: 26px; right: 0px; width: 15px; bottom: 15px;"
@@ -2023,6 +2024,7 @@ exports[`components take the small screen into account 1`] = `
           class="o-autofill-handler"
           style="top: 45px; left: 140px; visibility: visible;"
         />
+        
         
         
         


### PR DESCRIPTION
## Description:

Before this PR, the row and column context menus did not provide
any resizing actions.

This PR allows users to fit selected rows or columns to their data,
or set a custom size through a floating editor displayed next to the
clicked header. An empty custom size restores the default width or
height.

Task: [6234780](https://www.odoo.com/odoo/2328/tasks/6234780)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo