### PR TITLE
[IMP] env: remove isDashboard

### DIFF
--- a/src/components/figures/chart/gauge/gauge_chart_component.ts
+++ b/src/components/figures/chart/gauge/gauge_chart_component.ts
@@ -37,14 +37,14 @@ export class GaugeChartComponent extends Component<SpreadsheetChildEnv> {
     useLayoutEffect(
       () => {
         if (
-          this.env.isDashboard() &&
+          this.env.model.getters.isDashboard() &&
           lastRuntime === undefined && // first render
           this.animationStore?.animationPlayed[this.animationChartId] !== "gauge"
         ) {
           animation = this.drawGaugeWithAnimation();
           this.animationStore?.disableAnimationForChart(this.animationChartId, "gauge");
         } else if (
-          this.env.isDashboard() &&
+          this.env.model.getters.isDashboard() &&
           lastRuntime !== undefined && // not first render
           !deepEquals(this.runtime, lastRuntime)
         ) {

--- a/src/components/figures/figure/figure.ts
+++ b/src/components/figures/figure/figure.ts
@@ -70,7 +70,7 @@ export class FigureComponent extends Component<SpreadsheetChildEnv> {
   }
 
   private getBorderWidth(): Pixel {
-    if (this.env.isDashboard()) {
+    if (this.env.model.getters.isDashboard()) {
       return 0;
     }
     return this.isSelected ? ACTIVE_BORDER_WIDTH : this.borderWidth;
@@ -252,7 +252,7 @@ export class FigureComponent extends Component<SpreadsheetChildEnv> {
   }
 
   onContextMenu(ev: MouseEvent) {
-    if (this.env.isDashboard()) {
+    if (this.env.model.getters.isDashboard()) {
       return;
     }
     const zoomedMouseEvent = withZoom(this.env, ev);
@@ -295,7 +295,7 @@ export class FigureComponent extends Component<SpreadsheetChildEnv> {
     return (
       this.isSelected &&
       !this.env.isMobile() &&
-      !this.env.isDashboard() &&
+      !this.env.model.getters.isDashboard() &&
       !this.env.model.getters.isCurrentSheetLocked()
     );
   }

--- a/src/components/figures/figure/figure.xml
+++ b/src/components/figures/figure/figure.xml
@@ -24,7 +24,9 @@
           editFigureStyle.bind="this.editWrapperStyle"
           openContextMenu.bind="this.openContextMenu"
         />
-        <div class="o-figure-menu position-absolute m-2" t-if="!this.env.isDashboard()">
+        <div
+          class="o-figure-menu position-absolute m-2"
+          t-if="!this.env.model.getters.isDashboard()">
           <div
             class="o-figure-menu-item d-flex-align-items-center"
             t-if="!this.env.model.getters.isReadonly() and this.props.figureUI.tag !== 'carousel'"
@@ -41,7 +43,7 @@
           />
         </div>
         <div
-          t-if="!this.env.isDashboard()"
+          t-if="!this.env.model.getters.isDashboard()"
           class="position-absolute top-0 start-0 pe-none w-100 h-100">
           <div
             class="o-figure-border pe-auto w-100 h-0 position-absolute pb-2"

--- a/src/components/figures/figure_carousel/figure_carousel.xml
+++ b/src/components/figures/figure_carousel/figure_carousel.xml
@@ -7,8 +7,8 @@
       <div
         class="o-carousel-header d-flex align-items-baseline flex-shrink-0 pe-1 pe-auto"
         t-att-class="{
-          'border-bottom': this.env.isDashboard(),
-          'o-carousel-header-floating': !this.env.isDashboard() and selectedItem?.type === 'carouselDataView',
+          'border-bottom': this.env.model.getters.isDashboard(),
+          'o-carousel-header-floating': !this.env.model.getters.isDashboard() and selectedItem?.type === 'carouselDataView',
          }"
         t-att-style="this.headerStyle">
         <div
@@ -46,7 +46,7 @@
           />
         </div>
         <div
-          t-if="this.env.isDashboard()"
+          t-if="this.env.model.getters.isDashboard()"
           t-att-title="this.fullScreenButtonTitle"
           class="o-carousel-full-screen-button fa o-carousel-button rounded p-1 ms-1"
           t-att-class="{
@@ -57,7 +57,7 @@
           t-on-click="this.toggleFullScreen"
         />
         <div
-          t-if="!this.env.isDashboard()"
+          t-if="!this.env.model.getters.isDashboard()"
           class="o-carousel-menu-button o-carousel-button fa fa-ellipsis-v rounded ms-1"
           t-on-click="this.openContextMenu"
         />
@@ -79,7 +79,7 @@
           />
         </div>
         <ChartDashboardMenu
-          t-if="this.env.isDashboard()"
+          t-if="this.env.model.getters.isDashboard()"
           chartId="selectedItem.chartId"
           hasFullScreenButton="false"
           t-key="selectedItem.chartId"

--- a/src/components/figures/figure_chart/figure_chart.xml
+++ b/src/components/figures/figure_chart/figure_chart.xml
@@ -8,7 +8,7 @@
         isFullScreen="this.props.isFullScreen"
       />
     </div>
-    <div t-if="this.env.isDashboard()" class="position-absolute top-0 end-0">
+    <div t-if="this.env.model.getters.isDashboard()" class="position-absolute top-0 end-0">
       <ChartDashboardMenu chartId="this.chartId"/>
     </div>
   </t>

--- a/src/components/spreadsheet/spreadsheet.ts
+++ b/src/components/spreadsheet/spreadsheet.ts
@@ -120,7 +120,7 @@ export class Spreadsheet extends Component<SpreadsheetChildEnv> {
     if (this.state.printModeEnabled) {
       properties["display"] = `block`;
     } else {
-      if (this.env.isDashboard()) {
+      if (this.env.model.getters.isDashboard()) {
         properties["grid-template-rows"] = `auto`;
       } else {
         properties["grid-template-rows"] = `min-content auto min-content`;
@@ -162,7 +162,6 @@ export class Spreadsheet extends Component<SpreadsheetChildEnv> {
       imageProvider: fileStore ? new ImageProvider(fileStore) : undefined,
       loadCurrencies: this.model.config.external.loadCurrencies,
       loadLocales: this.model.config.external.loadLocales,
-      isDashboard: () => this.model.getters.isDashboard(),
       openSidePanel: this.sidePanel.open.bind(this.sidePanel),
       replaceSidePanel: this.sidePanel.replace.bind(this.sidePanel),
       toggleSidePanel: this.sidePanel.toggle.bind(this.sidePanel),

--- a/src/components/spreadsheet/spreadsheet.xml
+++ b/src/components/spreadsheet/spreadsheet.xml
@@ -8,7 +8,7 @@
       <t t-if="this.state.printModeEnabled">
         <SpreadsheetPrint onExitPrintMode.bind="this.exitPrintMode"/>
       </t>
-      <t t-elif="this.env.isDashboard()">
+      <t t-elif="this.env.model.getters.isDashboard()">
         <SpreadsheetDashboard getGridSize.bind="this.getGridSize"/>
         <FullScreenFigure/>
       </t>

--- a/src/components/spreadsheet_print/spreadsheet_print.xml
+++ b/src/components/spreadsheet_print/spreadsheet_print.xml
@@ -39,7 +39,7 @@
         </div>
         <div class="o-sidePanel flex-shrink-0 bg-white border-top border-start d-print-none">
           <div class="o-sidePanelBody pt-4">
-            <Section t-if="!this.env.isDashboard()">
+            <Section t-if="!this.env.model.getters.isDashboard()">
               <div class="o-section-title">Print content</div>
               <Select
                 selectedValue="this.printStore.printSelection"
@@ -78,7 +78,7 @@
               />
             </Section>
 
-            <Section t-if="!this.env.isDashboard()">
+            <Section t-if="!this.env.model.getters.isDashboard()">
               <div class="o-section-title">Formatting</div>
               <Checkbox
                 name="'showGridLines'"

--- a/src/types/spreadsheet_env.ts
+++ b/src/types/spreadsheet_env.ts
@@ -9,7 +9,6 @@ import { NotificationStoreMethods } from "./stores/notification_store_methods";
 export interface SpreadsheetChildEnv extends NotificationStoreMethods {
   model: Model;
   imageProvider?: ImageProviderInterface;
-  isDashboard: () => boolean;
   openSidePanel: (panel: string, panelProps?: any) => void;
   replaceSidePanel: (panel: string, currentPanel: string, panelProps?: any) => void;
   toggleSidePanel: (panel: string, panelProps?: any) => void;

--- a/tests/popover/popover_component.test.ts
+++ b/tests/popover/popover_component.test.ts
@@ -36,7 +36,6 @@ async function mountTestPopover(args: MountPopoverArgs) {
     setup() {
       const env: any = {
         model: this.props.model,
-        isDashboard: () => false,
       };
       if (args.containerRect) {
         env.getPopoverContainerRect = () => args.containerRect;

--- a/tests/test_helpers/helpers.ts
+++ b/tests/test_helpers/helpers.ts
@@ -230,7 +230,6 @@ export function makeTestEnv(
   const sidePanelStore = proxifyStoreMutation(store, () => container.trigger("store-updated"));
   return {
     model,
-    isDashboard: mockEnv.isDashboard || (() => model.getters.isDashboard()),
     openSidePanel: mockEnv.openSidePanel || sidePanelStore.open.bind(sidePanelStore),
     replaceSidePanel: mockEnv.replaceSidePanel || sidePanelStore.replace.bind(sidePanelStore),
     toggleSidePanel: mockEnv.toggleSidePanel || sidePanelStore.toggle.bind(sidePanelStore),

--- a/tests/top_bar_component.test.ts
+++ b/tests/top_bar_component.test.ts
@@ -134,7 +134,6 @@ async function mountParent(
   const partialEnv = {
     ...testEnv,
     model,
-    isDashboard: () => model.getters.isDashboard(),
   };
   let parent: Component;
   ({ parent, fixture, env } = await mountComponent(Parent, { env: partialEnv }));


### PR DESCRIPTION
In order to remove the use of this.env, this commit removes the isDashboard method from the environment and replaces its usage with direct calls to the model's getters.isDashboard method.

Task: 6276154

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [6276154](https://www.odoo.com/odoo/2328/tasks/6276154)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo