### PR TITLE
[REM] grid overlay: remove unused props `onGridMoved`

### DIFF
--- a/src/components/dashboard/dashboard.xml
+++ b/src/components/dashboard/dashboard.xml
@@ -11,7 +11,6 @@
         t-att-style="this.gridContainer">
         <GridOverlay
           onGridResized.bind="this.onGridResized"
-          onGridMoved.bind="this.moveCanvas"
           gridOverlayDimensions="this.gridOverlayDimensions">
           <div
             t-foreach="this.getClickableCells()"

--- a/src/components/grid/grid.xml
+++ b/src/components/grid/grid.xml
@@ -13,7 +13,6 @@
         onCellDoubleClicked.bind="this.onCellDoubleClicked"
         onCellRightClicked.bind="this.onCellRightClicked"
         onGridResized.bind="this.onGridResized"
-        onGridMoved.bind="this.moveCanvas"
         gridOverlayDimensions="this.gridOverlayDimensions"
       />
       <HeadersOverlay onOpenContextMenu="(type, x, y) => this.toggleContextMenu(type, x, y)"/>

--- a/src/components/grid_overlay/grid_overlay.ts
+++ b/src/components/grid_overlay/grid_overlay.ts
@@ -4,7 +4,7 @@ import { isPointInsideRect } from "../../helpers/rectangle";
 import { positionToZone } from "../../helpers/zones";
 import { Component, useExternalListener } from "../../owl3_compatibility_layer";
 import { useStore } from "../../store_engine/store_hooks";
-import { GridClickModifiers, HeaderIndex, Pixel, Position } from "../../types/misc";
+import { GridClickModifiers, HeaderIndex, Position } from "../../types/misc";
 import { DOMCoordinates } from "../../types/rendering";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 import { Store } from "../../types/store_engine";
@@ -152,7 +152,6 @@ export class GridOverlay extends Component<SpreadsheetChildEnv> {
       "onCellRightClicked?":
         types.function<(col: HeaderIndex, row: HeaderIndex, coordinates: DOMCoordinates) => void>(),
       "onGridResized?": types.function(),
-      onGridMoved: types.function<(deltaX: Pixel, deltaY: Pixel) => void>(),
       gridOverlayDimensions: types.string(),
     },
     {


### PR DESCRIPTION
## Description



Task: [0](https://www.odoo.com/odoo/2328/tasks/0)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo