### PR TITLE
[FIX] server: log commands on newline

### DIFF
--- a/tools/server/main.cjs
+++ b/tools/server/main.cjs
@@ -76,7 +76,11 @@ function log(message) {
 function logMessage(msg) {
   switch (msg.type) {
     case "REMOTE_REVISION":
-      log(`${msg.type}: ${msg.nextRevisionId} : ${JSON.stringify(msg.commands)}`);
+      log(
+        `${msg.type}: ${msg.nextRevisionId} :\n\t${msg.commands
+          .map((x) => JSON.stringify(x))
+          .join("\n\t")}`
+      );
       break;
     case "REVISION_UNDONE":
       log(`${msg.type}: ${msg.undoneRevisionId}`);


### PR DESCRIPTION
It is more readable to have a command per line in
revisions, instead of all in one line

Example of new log:
```
[server           ] [1:06:07 PM]: REMOTE_REVISION: 43cc7245-008b-490e-b857-d468888baa04 :
[server           ] 	{"sheetId":"sh1","col":4,"row":15,"content":"qsd","type":"UPDATE_CELL"}
[server           ] [1:06:10 PM]: REMOTE_REVISION: 89d93163-b667-4dd8-a2d0-ae0eba4b80fa :
[server           ] 	{"sheetId":"sh1","col":4,"row":16,"content":"sdfqs","style":{"fillColor":"#F8D8AA"},"format":"","type":"UPDATE_CELL"}
[server           ] 	{"sheetId":"sh1","col":4,"row":17,"content":"qsdsdfq","style":{"fillColor":"#F8D8AA"},"format":"","type":"UPDATE_CELL"}
[server           ] 	{"sheetId":"sh1","col":4,"row":18,"content":"sdf","style":{"fillColor":"#F8D8AA"},"format":"","type":"UPDATE_CELL"}
```

Task: 0