### PR TITLE
[FIX] charts: pie chart shows empty chart for text entries

### DIFF
--- a/src/helpers/figures/charts/chart_data_sources.ts
+++ b/src/helpers/figures/charts/chart_data_sources.ts
@@ -298,7 +298,7 @@ function getChartDatasetValues(getters: Getters, dataSets: DataSet[]): DatasetVa
       data.filter(isTextResult).length > 1
     ) {
       // Convert categorical data into counts
-      data = data.map((cell) => (cell.value && isErrorResult(cell) ? ONE : EMPTY));
+      data = data.map((cell) => (cell.value && !isErrorResult(cell) ? ONE : EMPTY));
     } else if (data.every((cell) => !isNumberResult(cell))) {
       hidden = true;
     }

--- a/tests/figures/chart/chart_plugin.test.ts
+++ b/tests/figures/chart/chart_plugin.test.ts
@@ -1429,7 +1429,7 @@ describe("datasource tests", function () {
       "1"
     );
     const { chartJsConfig } = model.getters.getChartRuntime("1") as BarChartRuntime;
-    expect(chartJsConfig.data.datasets[0].data.length).toBe(0);
+    expect(chartJsConfig.data.datasets[0].data.length).toBe(3);
   });
 });
 
@@ -3743,6 +3743,24 @@ describe("Pie chart invalid values", () => {
     // In pie charts we want to remove non-number values even if they have a label, because they won't show on the pie
     // but will pollute the legend
     expect(data.datasets[0].data).toEqual([45]);
+  });
+
+  test("Pie chart with only text entries counts each distinct value as 1", () => {
+    setCellContent(model, "H1", "apple");
+    setCellContent(model, "H2", "banana");
+    setCellContent(model, "H3", "cherry");
+    createChart(
+      model,
+      {
+        ...toChartDataSource({ dataSets: [{ dataRange: "H:H" }], dataSetsHaveTitle: false }),
+        type: "pie",
+      },
+      "1"
+    );
+
+    const data = getChartConfiguration(model, "1").data;
+    expect(data.datasets[0].data.length).toBe(3);
+    expect(data.datasets[0].data).toEqual([1, 1, 1]);
   });
 });
 


### PR DESCRIPTION
## Description:

Current behavior before PR:
- Commit 233051c accidentally changed the condition for counting text values.
  As a result, counting failed for valid text data, causing pie charts with only
  text entries to render empty.

Desired behavior after PR is merged:
- Fixed the condition for counting text values. Pie charts now correctly
  represent counts of distinct text entries.

Task: [6275525](https://www.odoo.com/odoo/2328/tasks/6275525)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo