### PR TITLE
[FIX] autofill: make tooltip readable in dark mode

### DIFF
--- a/src/components/autofill/autofill.css
+++ b/src/components/autofill/autofill.css
@@ -18,8 +18,8 @@
 
   .o-autofill-nextvalue {
     position: absolute;
-    background-color: #ffffff;
-    border: 1px solid black;
+    background-color: var(--os-white);
+    border: 1px solid var(--os-black);
     padding: 5px;
     font-size: 12px;
     pointer-events: none;


### PR DESCRIPTION
## Description:

The autofill tooltip used a hardcoded white background while inheriting the spreadsheet text color. In dark mode, this made the tooltip content almost unreadable.

Use the theme-aware black/white variables so the tooltip keeps its current light mode appearance and is reversed in dark mode.

Task: [6289977](https://www.odoo.com/odoo/2328/tasks/6289977)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo