### PR TITLE
[REF] scrollbars: explicitly add scrollbar end margin

### DIFF
--- a/src/components/helpers/dom_helpers.ts
+++ b/src/components/helpers/dom_helpers.ts
@@ -257,13 +257,6 @@ export function downloadFile(dataUrl: string, fileName: string) {
   document.body.removeChild(a);
 }
 
-/**
- * Detects if the current browser is Firefox
- */
-export function isBrowserFirefox() {
-  return /Firefox/i.test(navigator.userAgent);
-}
-
 // Mobile detection
 function maxTouchPoints() {
   return navigator.maxTouchPoints || 1;

--- a/src/components/scrollbar/scrollbar.css
+++ b/src/components/scrollbar/scrollbar.css
@@ -1,9 +1,17 @@
 .o-spreadsheet {
   .o-scrollbar {
     position: absolute;
-    overflow: auto;
     z-index: var(--os-components-importance-scroll-bar);
     background-color: var(--os-background-gray-color);
+
+    &.vertical {
+      overflow: hidden auto;
+    }
+
+    &.horizontal {
+      overflow: auto hidden;
+    }
+
     &.corner {
       box-sizing: content-box;
       right: 0px;

--- a/src/components/scrollbar/scrollbar_horizontal.ts
+++ b/src/components/scrollbar/scrollbar_horizontal.ts
@@ -1,7 +1,6 @@
 import { props, xml } from "@odoo/owl";
 import { Component } from "../../owl3_compatibility_layer";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
-import { isBrowserFirefox } from "../helpers/dom_helpers";
 import { types } from "../props_validation";
 import { ScrollBar } from "./scrollbar";
 
@@ -48,7 +47,7 @@ export class HorizontalScrollBar extends Component<SpreadsheetChildEnv> {
       left: `${this.props.leftOffset + x}px`,
       bottom: "0px",
       height: `${scrollbarWidth}px`,
-      right: isBrowserFirefox() ? `${scrollbarWidth}px` : "0",
+      right: `${scrollbarWidth}px`,
     };
   }
 

--- a/src/components/scrollbar/scrollbar_vertical.ts
+++ b/src/components/scrollbar/scrollbar_vertical.ts
@@ -1,7 +1,6 @@
 import { props, xml } from "@odoo/owl";
 import { Component } from "../../owl3_compatibility_layer";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
-import { isBrowserFirefox } from "../helpers/dom_helpers";
 import { types } from "../props_validation";
 import { ScrollBar } from "./scrollbar";
 
@@ -48,7 +47,7 @@ export class VerticalScrollBar extends Component<SpreadsheetChildEnv> {
       top: `${this.props.topOffset + y}px`,
       right: "0px",
       width: `${scrollbarWidth}px`,
-      bottom: isBrowserFirefox() ? `${scrollbarWidth}px` : "0",
+      bottom: `${scrollbarWidth}px`,
     };
   }
 

--- a/tests/grid/__snapshots__/dashboard_grid_component.test.ts.snap
+++ b/tests/grid/__snapshots__/dashboard_grid_component.test.ts.snap
@@ -42,7 +42,7 @@ exports[`Grid component in dashboard mode simple dashboard rendering snapshot 1`
   </div>
   <div
     class="o-scrollbar vertical"
-    style="top: 0px; right: 0px; width: 15px; bottom: 0px;"
+    style="top: 0px; right: 0px; width: 15px; bottom: 15px;"
   >
     <div
       style="width: 1px; height: 2300px;"
@@ -51,7 +51,7 @@ exports[`Grid component in dashboard mode simple dashboard rendering snapshot 1`
   
   <div
     class="o-scrollbar horizontal"
-    style="left: 0px; bottom: 0px; height: 15px; right: 0px;"
+    style="left: 0px; bottom: 0px; height: 15px; right: 15px;"
   >
     <div
       style="width: 2496px; height: 1px;"

--- a/tests/grid/__snapshots__/grid_component.test.ts.snap
+++ b/tests/grid/__snapshots__/grid_component.test.ts.snap
@@ -129,7 +129,7 @@ exports[`Grid component simple rendering snapshot 1`] = `
   
   <div
     class="o-scrollbar vertical"
-    style="top: 26px; right: 0px; width: 15px; bottom: 0px;"
+    style="top: 26px; right: 0px; width: 15px; bottom: 15px;"
   >
     <div
       style="width: 1px; height: 2346px;"
@@ -138,7 +138,7 @@ exports[`Grid component simple rendering snapshot 1`] = `
   
   <div
     class="o-scrollbar horizontal"
-    style="left: 48px; bottom: 0px; height: 15px; right: 0px;"
+    style="left: 48px; bottom: 0px; height: 15px; right: 15px;"
   >
     <div
       style="width: 2496px; height: 1px;"

--- a/tests/spreadsheet/__snapshots__/spreadsheet_component.test.ts.snap
+++ b/tests/spreadsheet/__snapshots__/spreadsheet_component.test.ts.snap
@@ -958,7 +958,7 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
         
         <div
           class="o-scrollbar vertical"
-          style="top: 26px; right: 0px; width: 15px; bottom: 0px;"
+          style="top: 26px; right: 0px; width: 15px; bottom: 15px;"
         >
           <div
             style="width: 1px; height: 2346px;"
@@ -967,7 +967,7 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
         
         <div
           class="o-scrollbar horizontal"
-          style="left: 48px; bottom: 0px; height: 15px; right: 0px;"
+          style="left: 48px; bottom: 0px; height: 15px; right: 15px;"
         >
           <div
             style="width: 2496px; height: 1px;"
@@ -1992,7 +1992,7 @@ exports[`components take the small screen into account 1`] = `
         
         <div
           class="o-scrollbar vertical"
-          style="top: 26px; right: 0px; width: 15px; bottom: 0px;"
+          style="top: 26px; right: 0px; width: 15px; bottom: 15px;"
         >
           <div
             style="width: 1px; height: 2346px;"
@@ -2001,7 +2001,7 @@ exports[`components take the small screen into account 1`] = `
         
         <div
           class="o-scrollbar horizontal"
-          style="left: 48px; bottom: 0px; height: 15px; right: 0px;"
+          style="left: 48px; bottom: 0px; height: 15px; right: 15px;"
         >
           <div
             style="width: 2496px; height: 1px;"


### PR DESCRIPTION
## Description

In the grid, we have fake a scrollbar div that spans the entirety of the sheetView height. But we also want a small empty corner bottom-right where the two scrollbar meet. How does it work ? Black magic.

We spawn a tall div inside a smaller div, which creates a vertical scrollbar. But. On chrome, I'm 90% sure that since the div is not wide enough, the browser also spawns a horizontal scrollbar. Which is not visible because the div is too narrow. But since it's there, it takes space and pushes the scrollbar up, leaving a gap. If we change `SCROLLBAR_WIDTH` from 15px to 16px, the gap disappear. Obviously, it doesn't work the same way in firefox 🙃.

With this commit, we explicitly set the scrollbar bottom/right position to leave a gap, and remove the overflow in the axis where we don't want a scrollbar.

Task: [6295886](https://www.odoo.com/odoo/2328/tasks/6295886)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo