### PR TITLE
[REF] components: use new props definition syntax

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "19.4.0-alpha.14",
       "license": "LGPL-3.0-or-later",
       "dependencies": {
-        "@odoo/owl": "3.0.0-alpha.34",
+        "@odoo/owl": "3.0.0-alpha.36",
         "bootstrap": "5.3.3",
         "font-awesome": "^4.7.0",
         "rbush": "^3.0.1"
@@ -2576,9 +2576,9 @@
       }
     },
     "node_modules/@odoo/owl": {
-      "version": "3.0.0-alpha.34",
-      "resolved": "https://registry.npmjs.org/@odoo/owl/-/owl-3.0.0-alpha.34.tgz",
-      "integrity": "sha512-8mWofo1SVNUBRPQjPvkFsVlQZ3ZQ3yzTMWo4+M9ZX4n5+eAZx+YaySo0GoSNIXlGaqfDMeWtLqbamfcICMsekw==",
+      "version": "3.0.0-alpha.36",
+      "resolved": "https://registry.npmjs.org/@odoo/owl/-/owl-3.0.0-alpha.36.tgz",
+      "integrity": "sha512-yZxu5vllft85U4hLS1xbsx/lcIe+Ans/ny6TckDzzMBZNeC6JH8MtU/0nEHCUtePNvlGboofvJjlijJq1FNZCg==",
       "license": "LGPL-3.0-only",
       "engines": {
         "node": ">=20.0.0"

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "xmlSelfClosingSpace": false
   },
   "dependencies": {
-    "@odoo/owl": "3.0.0-alpha.34",
+    "@odoo/owl": "3.0.0-alpha.36",
     "bootstrap": "5.3.3",
     "font-awesome": "^4.7.0",
     "rbush": "^3.0.1"

--- a/src/components/action_button/action_button.ts
+++ b/src/components/action_button/action_button.ts
@@ -11,10 +11,10 @@ export class ActionButton extends Component<SpreadsheetChildEnv> {
 
   protected props = props({
     action: types.ActionSpec(),
-    "hasTriangleDownIcon?": types.boolean(),
-    "selectedColor?": types.string(),
-    "class?": types.string(),
-    "onClick?": types.function<(ev: MouseEvent) => void>(),
+    hasTriangleDownIcon: types.boolean().optional(),
+    selectedColor: types.string().optional(),
+    class: types.string().optional(),
+    onClick: types.function<(ev: MouseEvent) => void>().optional(),
   });
 
   private actionButton = createAction(this.props.action);

--- a/src/components/animation/ripple.ts
+++ b/src/components/animation/ripple.ts
@@ -90,34 +90,24 @@ export class Ripple extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-Ripple";
   static components = { RippleEffect };
 
-  protected props = props(
-    {
-      "color?": types.string(),
-      "opacity?": types.number(),
-      "duration?": types.number(),
+  protected props = props({
+    color: types.string().optional("#aaaaaa"),
+    opacity: types.number().optional(0.4),
+    duration: types.number().optional(800),
 
-      /** If true, the ripple will play from the element center instead of the position of the click */
-      "ignoreClickPosition?": types.boolean(),
-      /** Width of the ripple. Defaults to the width of the element the ripple is on (without margins). */
-      "width?": types.number(),
-      /** Height of the ripple. Defaults to the height of the element the ripple is on (without margins). */
-      "height?": types.number(),
-      "offsetY?": types.number(),
-      "offsetX?": types.number(),
-      "allowOverflow?": types.boolean(),
-      "enabled?": types.boolean(),
-      "onAnimationEnd?": types.function(),
-      "class?": types.string(),
-    },
-    {
-      color: "#aaaaaa",
-      opacity: 0.4,
-      duration: 800,
-      enabled: true,
-      onAnimationEnd: () => {},
-      class: "",
-    }
-  );
+    /** If true, the ripple will play from the element center instead of the position of the click */
+    ignoreClickPosition: types.boolean().optional(),
+    /** Width of the ripple. Defaults to the width of the element the ripple is on (without margins). */
+    width: types.number().optional(),
+    /** Height of the ripple. Defaults to the height of the element the ripple is on (without margins). */
+    height: types.number().optional(),
+    offsetY: types.number().optional(),
+    offsetX: types.number().optional(),
+    allowOverflow: types.boolean().optional(),
+    enabled: types.boolean().optional(true),
+    onAnimationEnd: types.function().optional(() => () => {}),
+    class: types.string().optional(""),
+  });
 
   private childContainerRef = signal<HTMLElement | null>(null);
 

--- a/src/components/border_editor/border_editor.ts
+++ b/src/components/border_editor/border_editor.ts
@@ -41,14 +41,14 @@ export class BorderEditor extends Component<SpreadsheetChildEnv> {
   static components = { ColorPickerWidget, Popover };
 
   protected props = props({
-    "class?": types.string(),
+    class: types.string().optional(),
     currentBorderColor: types.Color(),
     currentBorderStyle: types.BorderStyle(),
-    "currentBorderPosition?": types.BorderPosition(),
+    currentBorderPosition: types.BorderPosition().optional(),
     onBorderColorPicked: types.function<(color: Color) => void>(),
     onBorderStylePicked: types.function<(style: BorderStyle) => void>(),
     onBorderPositionPicked: types.function<(position: BorderPosition) => void>(),
-    "maxHeight?": types.Pixel(),
+    maxHeight: types.Pixel().optional(),
     anchorRect: types.Rect(),
   });
   BORDER_POSITIONS = BORDER_POSITIONS;

--- a/src/components/border_editor/border_editor_widget.ts
+++ b/src/components/border_editor/border_editor_widget.ts
@@ -20,9 +20,9 @@ export class BorderEditorWidget extends Component<SpreadsheetChildEnv> {
   static components = { BorderEditor };
 
   protected props = props({
-    "disabled?": types.boolean(),
-    "dropdownMaxHeight?": types.Pixel(),
-    "class?": types.string(),
+    disabled: types.boolean().optional(),
+    dropdownMaxHeight: types.Pixel().optional(),
+    class: types.string().optional(),
   });
   topBarToolStore!: ToolBarDropdownStore;
 

--- a/src/components/bottom_bar/bottom_bar_sheet/bottom_bar_sheet.ts
+++ b/src/components/bottom_bar/bottom_bar_sheet/bottom_bar_sheet.ts
@@ -39,18 +39,12 @@ const getSheetLockAnimation = (
 export class BottomBarSheet extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-BottomBarSheet";
   static components = { Ripple, ColorPicker };
-  protected props = props(
-    {
-      sheetId: types.string(),
-      openContextMenu: types.function<(registry: MenuItemRegistry, ev: MouseEvent) => void>(),
-      "style?": types.string(),
-      "onMouseDown?": types.function<(ev: PointerEvent) => void>(),
-    },
-    {
-      onMouseDown: () => {},
-      style: "",
-    }
-  );
+  protected props = props({
+    sheetId: types.string(),
+    openContextMenu: types.function<(registry: MenuItemRegistry, ev: MouseEvent) => void>(),
+    style: types.string().optional(""),
+    onMouseDown: types.function<(ev: PointerEvent) => void>().optional(() => () => {}),
+  });
 
   private state = proxy<State>({ isEditing: false, pickerOpened: false });
 

--- a/src/components/color_picker/color_picker.ts
+++ b/src/components/color_picker/color_picker.ts
@@ -41,16 +41,13 @@ export class ColorPicker extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ColorPicker";
   static components = { Popover };
 
-  protected props = props(
-    {
-      onColorPicked: types.function<(color: string) => void>(),
-      "currentColor?": types.string(),
-      "maxHeight?": types.Pixel(),
-      anchorRect: types.Rect(),
-      "disableNoColor?": types.boolean(),
-    },
-    { currentColor: "" }
-  );
+  protected props = props({
+    onColorPicked: types.function<(color: string) => void>(),
+    currentColor: types.string().optional(""),
+    maxHeight: types.Pixel().optional(),
+    anchorRect: types.Rect(),
+    disableNoColor: types.boolean().optional(),
+  });
 
   COLORS = COLOR_PICKER_DEFAULTS;
 

--- a/src/components/color_picker/color_picker_widget.ts
+++ b/src/components/color_picker/color_picker_widget.ts
@@ -11,15 +11,15 @@ export class ColorPickerWidget extends Component<SpreadsheetChildEnv> {
   static components = { ColorPicker };
 
   protected props = props({
-    "currentColor?": types.string(),
+    currentColor: types.string().optional(),
     toggleColorPicker: types.function(),
     showColorPicker: types.boolean(),
     onColorPicked: types.function<(color: string) => void>(),
     icon: types.string(),
-    "title?": types.string(),
-    "disabled?": types.boolean(),
-    "dropdownMaxHeight?": types.Pixel(),
-    "class?": types.string(),
+    title: types.string().optional(),
+    disabled: types.boolean().optional(),
+    dropdownMaxHeight: types.Pixel().optional(),
+    class: types.string().optional(),
   });
 
   colorPickerButtonRef = signal<HTMLElement | null>(null);

--- a/src/components/composer/autocomplete_dropdown/autocomplete_dropdown.ts
+++ b/src/components/composer/autocomplete_dropdown/autocomplete_dropdown.ts
@@ -10,7 +10,7 @@ export class TextValueProvider extends Component<any> {
 
   protected props = props({
     proposals: types.array(types.AutoCompleteProposal()),
-    "selectedIndex?": types.number(),
+    selectedIndex: types.number().optional(),
     onValueSelected: types.function<(proposal: AutoCompleteProposal) => void>(),
     onValueHovered: types.function<(index: string) => void>(),
   });

--- a/src/components/composer/composer/composer.ts
+++ b/src/components/composer/composer/composer.ts
@@ -62,28 +62,20 @@ export class Composer extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-Composer";
   static components = { TextValueProvider, FunctionDescriptionProvider, SpeechBubble };
 
-  protected props = props(
-    {
-      focus: types.ComposerFocusType(),
-      "inputStyle?": types.string(),
-      "rect?": types.Rect(),
-      "delimitation?": types.DOMDimension(),
-      "onComposerCellFocused?": types.function<(content: string) => void>(),
-      onComposerContentFocused: types.function<(selection: ComposerSelection) => void>(),
-      "isDefaultFocus?": types.boolean(),
-      "onInputContextMenu?": types.function<(event: MouseEvent) => void>(),
-      composerStore: types.Store<AbstractComposerStore>(),
-      "placeholder?": types.string(),
-      "inputMode?": types.string(),
-      "showAssistant?": types.boolean(),
-    },
-    {
-      inputStyle: "",
-      isDefaultFocus: false,
-      inputMode: "text",
-      showAssistant: true,
-    }
-  );
+  protected props = props({
+    focus: types.ComposerFocusType(),
+    inputStyle: types.string().optional(""),
+    rect: types.Rect().optional(),
+    delimitation: types.DOMDimension().optional(),
+    onComposerCellFocused: types.function<(content: string) => void>().optional(),
+    onComposerContentFocused: types.function<(selection: ComposerSelection) => void>(),
+    isDefaultFocus: types.boolean().optional(false),
+    onInputContextMenu: types.function<(event: MouseEvent) => void>().optional(),
+    composerStore: types.Store<AbstractComposerStore>(),
+    placeholder: types.string().optional(),
+    inputMode: types.string().optional("text"),
+    showAssistant: types.boolean().optional(true),
+  });
 
   private DOMFocusableElementStore!: Store<DOMFocusableElementStore>;
 

--- a/src/components/composer/formula_assistant/formula_assistant.ts
+++ b/src/components/composer/formula_assistant/formula_assistant.ts
@@ -12,7 +12,7 @@ export class FunctionDescriptionProvider extends Component<SpreadsheetChildEnv> 
   protected props = props({
     functionDescription: types.FunctionDescription(),
     argsToFocus: types.array(types.number()),
-    "repeatingArgGroupIndex?": types.number(),
+    repeatingArgGroupIndex: types.number().optional(),
   });
 
   private state: { isCollapsed: boolean } = proxy({

--- a/src/components/composer/standalone_composer/standalone_composer.ts
+++ b/src/components/composer/standalone_composer/standalone_composer.ts
@@ -17,25 +17,19 @@ export class StandaloneComposer extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-StandaloneComposer";
   static components = { Composer };
 
-  protected props = props(
-    {
-      onConfirm: types.function<(content: string) => void>(),
-      "composerContent?": types.string(),
-      defaultRangeSheetId: types.UID(),
-      "defaultStatic?": types.boolean(),
-      "contextualAutocomplete?": types.AutoCompleteProviderDefinition(),
-      "placeholder?": types.string(),
-      "title?": types.string(),
-      "class?": types.string(),
-      "invalid?": types.boolean(),
-      "autofocus?": types.boolean(),
-      "getContextualColoredSymbolToken?": types.function<(token: Token) => Color>(),
-    },
-    {
-      composerContent: "",
-      defaultStatic: false,
-    }
-  );
+  protected props = props({
+    onConfirm: types.function<(content: string) => void>(),
+    composerContent: types.string().optional(""),
+    defaultRangeSheetId: types.UID(),
+    defaultStatic: types.boolean().optional(false),
+    contextualAutocomplete: types.AutoCompleteProviderDefinition().optional(),
+    placeholder: types.string().optional(),
+    title: types.string().optional(),
+    class: types.string().optional(),
+    invalid: types.boolean().optional(),
+    autofocus: types.boolean().optional(),
+    getContextualColoredSymbolToken: types.function<(token: Token) => Color>().optional(),
+  });
 
   private composerFocusStore!: Store<ComposerFocusStore>;
   private standaloneComposerStore!: Store<StandaloneComposerStore>;

--- a/src/components/error_tooltip/error_tooltip.ts
+++ b/src/components/error_tooltip/error_tooltip.ts
@@ -17,7 +17,7 @@ export class ErrorToolTip extends Component<SpreadsheetChildEnv> {
 
   protected props = props({
     cellPosition: types.CellPosition(),
-    "onClosed?": types.function(),
+    onClosed: types.function().optional(),
   });
 
   get dataValidationErrorMessage() {

--- a/src/components/figures/chart/chartJs/chartjs.ts
+++ b/src/components/figures/chart/chartJs/chartjs.ts
@@ -82,7 +82,7 @@ export class ChartJsComponent extends Component<SpreadsheetChildEnv> {
 
   protected props = props({
     chartId: types.string(),
-    "isFullScreen?": types.boolean(),
+    isFullScreen: types.boolean().optional(),
   });
 
   protected canvas = signal<HTMLCanvasElement | null>(null);

--- a/src/components/figures/chart/chart_dashboard_menu/chart_dashboard_menu.ts
+++ b/src/components/figures/chart/chart_dashboard_menu/chart_dashboard_menu.ts
@@ -26,15 +26,10 @@ export class ChartDashboardMenu extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ChartDashboardMenu";
   static components = { MenuPopover, Select };
 
-  protected props = props(
-    {
-      chartId: types.UID(),
-      "hasFullScreenButton?": types.boolean(),
-    },
-    {
-      hasFullScreenButton: true,
-    }
-  );
+  protected props = props({
+    chartId: types.UID(),
+    hasFullScreenButton: types.boolean().optional(true),
+  });
 
   private fullScreenFigureStore!: Store<FullScreenFigureStore>;
 

--- a/src/components/figures/chart/gauge/gauge_chart_component.ts
+++ b/src/components/figures/chart/gauge/gauge_chart_component.ts
@@ -17,7 +17,7 @@ export class GaugeChartComponent extends Component<SpreadsheetChildEnv> {
 
   protected props = props({
     chartId: types.string(),
-    "isFullScreen?": types.boolean(),
+    isFullScreen: types.boolean().optional(),
   });
 
   private canvas = signal<HTMLCanvasElement | null>(null);

--- a/src/components/figures/chart/scorecard/chart_scorecard.ts
+++ b/src/components/figures/chart/scorecard/chart_scorecard.ts
@@ -12,7 +12,7 @@ export class ScorecardChart extends Component<SpreadsheetChildEnv> {
 
   protected props = props({
     chartId: types.string(),
-    "isFullScreen?": types.boolean(),
+    isFullScreen: types.boolean().optional(),
   });
   private canvas = signal<HTMLCanvasElement | null>(null);
 

--- a/src/components/figures/figure/figure.ts
+++ b/src/components/figures/figure/figure.ts
@@ -37,20 +37,15 @@ export class FigureComponent extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-FigureComponent";
   static components = { MenuPopover };
 
-  protected props = props(
-    {
-      figureUI: types.FigureUI(),
-      style: types.string(),
-      class: types.string(),
-      "onMouseDown?": types.function<(ev: MouseEvent) => void>(),
-      "onClickAnchor?":
-        types.function<(dirX: ResizeDirection, dirY: ResizeDirection, ev: MouseEvent) => void>(),
-    },
-    {
-      onMouseDown: () => {},
-      onClickAnchor: () => {},
-    }
-  );
+  protected props = props({
+    figureUI: types.FigureUI(),
+    style: types.string(),
+    class: types.string(),
+    onMouseDown: types.function<(ev: MouseEvent) => void>().optional(() => () => {}),
+    onClickAnchor: types
+      .function<(dirX: ResizeDirection, dirY: ResizeDirection, ev: MouseEvent) => void>()
+      .optional(() => () => {}),
+  });
 
   private menuState: MenuState = proxy({ isOpen: false, anchorRect: null, menuItems: [] });
 

--- a/src/components/figures/figure_carousel/figure_carousel.ts
+++ b/src/components/figures/figure_carousel/figure_carousel.ts
@@ -26,9 +26,9 @@ export class CarouselFigure extends Component<SpreadsheetChildEnv> {
 
   protected props = props({
     figureUI: types.FigureUI(),
-    "editFigureStyle?": types.function<(properties: CSSProperties) => void>(),
-    "isFullScreen?": types.boolean(),
-    "openContextMenu?": types.function<(anchorRect: Rect, onClose?: () => void) => void>(),
+    editFigureStyle: types.function<(properties: CSSProperties) => void>().optional(),
+    isFullScreen: types.boolean().optional(),
+    openContextMenu: types.function<(anchorRect: Rect, onClose?: () => void) => void>().optional(),
   });
 
   private carouselTabsRef = signal<HTMLElement | null>(null);

--- a/src/components/figures/figure_chart/figure_chart.ts
+++ b/src/components/figures/figure_chart/figure_chart.ts
@@ -15,9 +15,9 @@ export class ChartFigure extends Component<SpreadsheetChildEnv> {
 
   protected props = props({
     figureUI: types.FigureUI(),
-    "editFigureStyle?": types.function<(properties: CSSProperties) => void>(),
-    "isFullScreen?": types.boolean(),
-    "openContextMenu?": types.function<(anchorRect: Rect, onClose?: () => void) => void>(),
+    editFigureStyle: types.function<(properties: CSSProperties) => void>().optional(),
+    isFullScreen: types.boolean().optional(),
+    openContextMenu: types.function<(anchorRect: Rect, onClose?: () => void) => void>().optional(),
   });
 
   onDoubleClick() {

--- a/src/components/figures/figure_image/figure_image.ts
+++ b/src/components/figures/figure_image/figure_image.ts
@@ -12,8 +12,8 @@ export class ImageFigure extends Component<SpreadsheetChildEnv> {
 
   protected props = props({
     figureUI: types.FigureUI(),
-    "editFigureStyle?": types.function<(properties: CSSProperties) => void>(),
-    "openContextMenu?": types.function<(anchorRect: Rect, onClose?: () => void) => void>(),
+    editFigureStyle: types.function<(properties: CSSProperties) => void>().optional(),
+    openContextMenu: types.function<(anchorRect: Rect, onClose?: () => void) => void>().optional(),
   });
 
   // ---------------------------------------------------------------------------

--- a/src/components/filters/filter_menu/filter_menu.ts
+++ b/src/components/filters/filter_menu/filter_menu.ts
@@ -40,7 +40,7 @@ export class FilterMenu extends Component<SpreadsheetChildEnv> {
 
   private props = props({
     filterPosition: types.Position(),
-    "onClosed?": types.function(),
+    onClosed: types.function().optional(),
   });
 
   private state!: State;

--- a/src/components/filters/filter_menu_item/filter_menu_value_item.ts
+++ b/src/components/filters/filter_menu_item/filter_menu_value_item.ts
@@ -14,7 +14,7 @@ export class FilterMenuValueItem extends Component<SpreadsheetChildEnv> {
     isSelected: types.boolean(),
     onMouseMove: types.function<(ev: MouseEvent) => void>(),
     onClick: types.function<(ev: MouseEvent) => void>(),
-    "scrolledTo?": types.or([types.literal("top"), types.literal("bottom")]),
+    scrolledTo: types.or([types.literal("top"), types.literal("bottom")]).optional(),
   });
 
   itemRef = signal<HTMLElement | null>(null);

--- a/src/components/filters/filter_menu_value_list/filter_menu_value_list.ts
+++ b/src/components/filters/filter_menu_value_list/filter_menu_value_list.ts
@@ -30,7 +30,7 @@ export class FilterMenuValueList extends Component<SpreadsheetChildEnv> {
       types.object({
         checked: types.boolean(),
         string: types.string(),
-        "scrolledTo?": types.or([types.literal("top"), types.literal("bottom")]),
+        scrolledTo: types.or([types.literal("top"), types.literal("bottom")]).optional(),
       })
     ),
     onUpdateHiddenValues: types.function<(values: string[]) => void>(),

--- a/src/components/filters/pivot_filter_menu/pivot_filter_menu.ts
+++ b/src/components/filters/pivot_filter_menu/pivot_filter_menu.ts
@@ -34,10 +34,10 @@ export class PivotFilterMenu extends Component<SpreadsheetChildEnv> {
       types.object({
         checked: types.boolean(),
         string: types.string(),
-        "scrolledTo?": types.or([types.literal("top"), types.literal("bottom")]),
+        scrolledTo: types.or([types.literal("top"), types.literal("bottom")]).optional(),
       })
     ),
-    "onClosed?": types.function(),
+    onClosed: types.function().optional(),
     onConfirmed: types.function<(updatedCriterionValue: DataFilterValue) => void>(),
   });
 

--- a/src/components/font_size_editor/font_size_editor.ts
+++ b/src/components/font_size_editor/font_size_editor.ts
@@ -9,18 +9,13 @@ export class FontSizeEditor extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-FontSizeEditor";
   static components = { NumberEditor };
 
-  protected props = props(
-    {
-      currentFontSize: types.number(),
-      onFontSizeChanged: types.function<(fontSize: number) => void>(),
-      "onToggle?": types.function(),
-      "onFocusInput?": types.function(),
-      class: types.string(),
-    },
-    {
-      onFocusInput: () => {},
-    }
-  );
+  protected props = props({
+    currentFontSize: types.number(),
+    onFontSizeChanged: types.function<(fontSize: number) => void>(),
+    onToggle: types.function().optional(),
+    onFocusInput: types.function().optional(() => () => {}),
+    class: types.string(),
+  });
 
   fontSizes: number[] = FONT_SIZES;
 }

--- a/src/components/generic_input/generic_input.ts
+++ b/src/components/generic_input/generic_input.ts
@@ -21,16 +21,16 @@ export interface GenericInputProps {
 export const genericInputPropsDefinition = {
   value: types.or([types.number(), types.string()]),
   onChange: types.function<(value: string) => void>(),
-  "onFocused?": types.function(),
-  "onBlur?": types.function(),
-  "onInput?": types.function<(value: string) => void>(),
-  "class?": types.string(),
-  "id?": types.string(),
-  "placeholder?": types.string(),
-  "autofocus?": types.boolean(),
-  "alwaysShowBorder?": types.boolean(),
-  "selectContentOnFocus?": types.boolean(),
-  "resetOnBlur?": types.boolean(),
+  onFocused: types.function().optional(),
+  onBlur: types.function().optional(),
+  onInput: types.function<(value: string) => void>().optional(),
+  class: types.string().optional(),
+  id: types.string().optional(),
+  placeholder: types.string().optional(),
+  autofocus: types.boolean().optional(),
+  alwaysShowBorder: types.boolean().optional(),
+  selectContentOnFocus: types.boolean().optional(),
+  resetOnBlur: types.boolean().optional(),
 };
 
 export class GenericInput<T extends GenericInputProps> extends Component<SpreadsheetChildEnv> {

--- a/src/components/grid_overlay/grid_overlay.ts
+++ b/src/components/grid_overlay/grid_overlay.ts
@@ -137,30 +137,26 @@ export class GridOverlay extends Component<SpreadsheetChildEnv> {
     GridAddRowsFooter,
   };
 
-  protected props = props(
-    {
-      "onCellDoubleClicked?": types.function<(col: HeaderIndex, row: HeaderIndex) => void>(),
-      "onCellClicked?":
-        types.function<
-          (
-            col: HeaderIndex,
-            row: HeaderIndex,
-            modifiers: GridClickModifiers,
-            zoomedMouseEvent: ZoomedMouseEvent<MouseEvent | PointerEvent>
-          ) => void
-        >(),
-      "onCellRightClicked?":
-        types.function<(col: HeaderIndex, row: HeaderIndex, coordinates: DOMCoordinates) => void>(),
-      "onGridResized?": types.function(),
-      gridOverlayDimensions: types.string(),
-    },
-    {
-      onCellDoubleClicked: () => {},
-      onCellClicked: () => {},
-      onCellRightClicked: () => {},
-      onGridResized: () => {},
-    }
-  );
+  protected props = props({
+    onCellDoubleClicked: types
+      .function<(col: HeaderIndex, row: HeaderIndex) => void>()
+      .optional(() => () => {}),
+    onCellClicked: types
+      .function<
+        (
+          col: HeaderIndex,
+          row: HeaderIndex,
+          modifiers: GridClickModifiers,
+          zoomedMouseEvent: ZoomedMouseEvent<MouseEvent | PointerEvent>
+        ) => void
+      >()
+      .optional(() => () => {}),
+    onCellRightClicked: types
+      .function<(col: HeaderIndex, row: HeaderIndex, coordinates: DOMCoordinates) => void>()
+      .optional(() => () => {}),
+    onGridResized: types.function().optional(() => () => {}),
+    gridOverlayDimensions: types.string(),
+  });
   private gridOverlayRef: Signal<HTMLElement | null> = signal(null);
   private cellPopovers!: Store<CellPopoverStore>;
   private paintFormatStore!: Store<PaintFormatStore>;

--- a/src/components/headers_overlay/unhide_headers.ts
+++ b/src/components/headers_overlay/unhide_headers.ts
@@ -11,17 +11,14 @@ import { Component } from "../../owl3_compatibility_layer";
 export class UnhideRowHeaders extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-UnhideRowHeaders";
 
-  protected props = props(
-    {
-      headersGroups: types.array(),
-      headerRange: types.object({
-        start: types.HeaderIndex(),
-        end: types.HeaderIndex(),
-      }),
-      "offset?": types.number(),
-    },
-    { offset: 0 }
-  );
+  protected props = props({
+    headersGroups: types.array(),
+    headerRange: types.object({
+      start: types.HeaderIndex(),
+      end: types.HeaderIndex(),
+    }),
+    offset: types.number().optional(0),
+  });
 
   get sheetId() {
     return this.env.model.getters.getActiveSheetId();
@@ -55,17 +52,14 @@ export class UnhideRowHeaders extends Component<SpreadsheetChildEnv> {
 export class UnhideColumnHeaders extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-UnhideColumnHeaders";
 
-  protected props = props(
-    {
-      headersGroups: types.array(),
-      headerRange: types.object({
-        start: types.HeaderIndex(),
-        end: types.HeaderIndex(),
-      }),
-      "offset?": types.number(),
-    },
-    { offset: 0 }
-  );
+  protected props = props({
+    headersGroups: types.array(),
+    headerRange: types.object({
+      start: types.HeaderIndex(),
+      end: types.HeaderIndex(),
+    }),
+    offset: types.number().optional(0),
+  });
 
   get sheetId() {
     return this.env.model.getters.getActiveSheetId();

--- a/src/components/link/link_display/link_display.ts
+++ b/src/components/link/link_display/link_display.ts
@@ -19,7 +19,7 @@ export class LinkDisplay extends Component<SpreadsheetChildEnv> {
 
   protected props = props({
     cellPosition: types.CellPosition(),
-    "onClosed?": types.function(),
+    onClosed: types.function().optional(),
   });
 
   protected cellPopovers!: Store<CellPopoverStore>;

--- a/src/components/link/link_editor/link_editor.ts
+++ b/src/components/link/link_editor/link_editor.ts
@@ -32,7 +32,7 @@ export class LinkEditor extends Component<SpreadsheetChildEnv> {
 
   protected props = props({
     cellPosition: types.CellPosition(),
-    "onClosed?": types.function(),
+    onClosed: types.function().optional(),
   });
   static size = { maxHeight: 500 };
 

--- a/src/components/menu/menu.ts
+++ b/src/components/menu/menu.ts
@@ -28,15 +28,15 @@ export class Menu extends Component<SpreadsheetChildEnv> {
   protected props = props({
     menuItems: types.ArrayOf<MenuItemOrSeparator>(),
     onClose: types.function(),
-    "onClickMenu?": types.function<(menu: Action, ev: PointerEvent) => void>(),
-    "onMouseEnter?": types.function<(menu: Action, ev: PointerEvent) => void>(),
-    "onMouseLeave?": types.function<(menu: Action, ev: PointerEvent) => void>(),
-    "width?": types.number(),
-    "hoveredMenuId?": types.string(),
-    "isHoveredMenuFocused?": types.boolean(),
-    "onScroll?": types.function<(ev: CustomEvent) => void>(),
-    "onKeyDown?": types.function<(ev: KeyboardEvent) => void>(),
-    "disableKeyboardNavigation?": types.boolean(),
+    onClickMenu: types.function<(menu: Action, ev: PointerEvent) => void>().optional(),
+    onMouseEnter: types.function<(menu: Action, ev: PointerEvent) => void>().optional(),
+    onMouseLeave: types.function<(menu: Action, ev: PointerEvent) => void>().optional(),
+    width: types.number().optional(),
+    hoveredMenuId: types.string().optional(),
+    isHoveredMenuFocused: types.boolean().optional(),
+    onScroll: types.function<(ev: CustomEvent) => void>().optional(),
+    onKeyDown: types.function<(ev: KeyboardEvent) => void>().optional(),
+    disableKeyboardNavigation: types.boolean().optional(),
   });
 
   private menuRef = signal<HTMLElement | null>(null);

--- a/src/components/menu_popover/menu_popover.ts
+++ b/src/components/menu_popover/menu_popover.ts
@@ -45,27 +45,23 @@ export class MenuPopover extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-Menu-Popover";
   static components = { MenuPopover, Menu, Popover };
 
-  protected props = props(
-    {
-      anchorRect: types.Rect(),
-      "popoverPositioning?": types.or([types.literal("top-right"), types.literal("bottom-left")]),
-      menuItems: types.ArrayOf<Action>(),
-      "depth?": types.number(),
-      "maxHeight?": types.Pixel(),
-      onClose: types.function(),
-      "onMenuClicked?": types.function<(ev: CustomEvent) => void>(),
-      "menuId?": types.UID(),
-      "onMouseOver?": types.function(),
-      "width?": types.number(),
-      "autoSelectFirstItem?": types.boolean(),
-      "disableKeyboardNavigation?": types.boolean(),
-      "onKeyboardNavigation?": types.function<(ev: KeyboardEvent) => void>(),
-    },
-    {
-      depth: 0,
-      popoverPositioning: "top-right",
-    }
-  );
+  protected props = props({
+    anchorRect: types.Rect(),
+    popoverPositioning: types
+      .or([types.literal("top-right"), types.literal("bottom-left")])
+      .optional("top-right"),
+    menuItems: types.ArrayOf<Action>(),
+    depth: types.number().optional(0),
+    maxHeight: types.Pixel().optional(),
+    onClose: types.function(),
+    onMenuClicked: types.function<(ev: CustomEvent) => void>().optional(),
+    menuId: types.UID().optional(),
+    onMouseOver: types.function().optional(),
+    width: types.number().optional(),
+    autoSelectFirstItem: types.boolean().optional(),
+    disableKeyboardNavigation: types.boolean().optional(),
+    onKeyboardNavigation: types.function<(ev: KeyboardEvent) => void>().optional(),
+  });
   private subMenu: MenuState = proxy({
     isOpen: false,
     anchorRect: null,

--- a/src/components/number_editor/number_editor.ts
+++ b/src/components/number_editor/number_editor.ts
@@ -18,23 +18,18 @@ export class NumberEditor extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-NumberEditor";
   static components = { Popover };
 
-  protected props = props(
-    {
-      currentValue: types.number(),
-      onValueChange: types.function<(fontSize: number) => void>(),
-      "onToggle?": types.function(),
-      "onFocusInput?": types.function(),
-      class: types.string(),
-      "valueIcon?": types.string(),
-      min: types.number(),
-      max: types.number(),
-      title: types.string(),
-      valueList: types.array(types.number()),
-    },
-    {
-      onFocusInput: () => {},
-    }
-  );
+  protected props = props({
+    currentValue: types.number(),
+    onValueChange: types.function<(fontSize: number) => void>(),
+    onToggle: types.function().optional(),
+    onFocusInput: types.function().optional(() => () => {}),
+    class: types.string(),
+    valueIcon: types.string().optional(),
+    min: types.number(),
+    max: types.number(),
+    title: types.string(),
+    valueList: types.array(types.number()),
+  });
 
   dropdown: State = proxy({ isOpen: false });
 

--- a/src/components/number_input/number_input.ts
+++ b/src/components/number_input/number_input.ts
@@ -20,9 +20,9 @@ export class NumberInput extends GenericInput<Props> {
 
   protected props: Props = props({
     ...genericInputPropsDefinition,
-    "min?": types.number(),
-    "max?": types.number(),
-  }) as unknown as Props;
+    min: types.number().optional(),
+    max: types.number().optional(),
+  });
 
   // Very short debounce to prevent up/down arrow on number input to spam the onChange
   debouncedOnChange = debounce(this.props.onChange.bind(this), 100, true);

--- a/src/components/paint_format_button/paint_format_button.ts
+++ b/src/components/paint_format_button/paint_format_button.ts
@@ -10,7 +10,7 @@ export class PaintFormatButton extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-PaintFormatButton";
 
   protected props = props({
-    "class?": types.string(),
+    class: types.string().optional(),
   });
 
   private paintFormatStore!: Store<PaintFormatStore>;

--- a/src/components/popover/popover.ts
+++ b/src/components/popover/popover.ts
@@ -13,28 +13,21 @@ type DisplayValue = "none" | "block";
 export class Popover extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-Popover";
 
-  protected props = props(
-    {
-      anchorRect: types.Rect(),
-      "containerRect?": types.object({}),
-      "positioning?": types.or([types.literal("top-right"), types.literal("bottom-left")]),
-      "maxWidth?": types.Pixel(),
-      "maxHeight?": types.Pixel(),
-      "verticalOffset?": types.number(),
-      "onMouseWheel?": types.function(),
-      "onPopoverHidden?": types.function(),
-      "onPopoverMoved?": types.function(),
-      "zIndex?": types.number(),
-      "class?": types.string(),
-    },
-    {
-      positioning: "bottom-left",
-      verticalOffset: 0,
-      onMouseWheel: () => {},
-      onPopoverMoved: () => {},
-      onPopoverHidden: () => {},
-    }
-  );
+  protected props = props({
+    anchorRect: types.Rect(),
+    containerRect: types.object({}).optional(),
+    positioning: types
+      .or([types.literal("top-right"), types.literal("bottom-left")])
+      .optional("bottom-left"),
+    maxWidth: types.Pixel().optional(),
+    maxHeight: types.Pixel().optional(),
+    verticalOffset: types.number().optional(0),
+    onMouseWheel: types.function().optional(() => () => {}),
+    onPopoverHidden: types.function().optional(() => () => {}),
+    onPopoverMoved: types.function().optional(() => () => {}),
+    zIndex: types.number().optional(),
+    class: types.string().optional(),
+  });
 
   private popoverRef = signal<HTMLElement | null>(null);
   private popoverContentRef = signal<HTMLElement | null>(null);

--- a/src/components/props_validation.ts
+++ b/src/components/props_validation.ts
@@ -1,4 +1,4 @@
-import { types as owlTypes } from "@odoo/owl";
+import { types as owlTypes, Type } from "@odoo/owl";
 import { Action, ActionSpec, MenuItemOrSeparator } from "../actions/action";
 import { Token } from "../formulas/tokenizer";
 import { PivotRuntimeDefinition } from "../helpers/pivot/pivot_runtime_definition";
@@ -94,28 +94,28 @@ import type { SidePanelComponentProps } from "./side_panel/side_panel/side_panel
 /**
  * Validate that a prop is a number, but with a more specific type than just `number` (e.g. `Pixel`).
  */
-function validateNumber<T extends number>(): T {
+function validateNumber<T extends number>(): Type<T> {
   return owlTypes.number() as any;
 }
 
 /**
  * Validate that a prop is a string, but with a more specific type than just `string` (e.g. `Color`).
  */
-function validateString<T extends string>(): T {
+function validateString<T extends string>(): Type<T> {
   return owlTypes.string() as any;
 }
 
 /**
  * Validate that a prop is an object, but with a more specific type than just `object` (e.g. `ActionSpec`).
  */
-function validateObject<T>(): T {
+function validateObject<T>(): Type<T> {
   return owlTypes.object() as any;
 }
 
 /**
  * Validate that a prop is an array, but with a more specific element type than `any[]`.
  */
-function validateArrayOf<T>(): T[] {
+function validateArrayOf<T>(): Type<T[]> {
   return owlTypes.array() as any;
 }
 
@@ -123,18 +123,18 @@ function validateArrayOf<T>(): T[] {
  * Validate that a prop is a record (string-keyed dictionary), but with a more
  * specific value type than `any`.
  */
-function validateRecordOf<T>(): Record<string, T> {
+function validateRecordOf<T>(): Type<Record<string, T>> {
   return owlTypes.record() as any;
 }
 
 /**
  * Validate that a prop is a `Set`, typed with a specific element type.
  */
-function validateSetOf<T>(): Set<T> {
+function validateSetOf<T>(): Type<Set<T>> {
   return owlTypes.instanceOf(Set) as any;
 }
 
-function validateRect(): Rect {
+function validateRect(): Type<Rect> {
   return owlTypes.object({
     x: owlTypes.number(),
     y: owlTypes.number(),
@@ -143,57 +143,57 @@ function validateRect(): Rect {
   }) as any;
 }
 
-function validateBorderPosition(): BorderPosition {
+function validateBorderPosition(): Type<BorderPosition> {
   return owlTypes.customValidator(validateString<BorderPosition>(), (position) =>
     borderPositions.includes(position)
   ) as any;
 }
 
-function validateBorderStyle(): BorderStyle {
+function validateBorderStyle(): Type<BorderStyle> {
   return owlTypes.customValidator(validateString<BorderStyle>(), (style) =>
     borderStyles.includes(style)
   ) as any;
 }
 
-function validateDOMCoordinates(): DOMCoordinates {
+function validateDOMCoordinates(): Type<DOMCoordinates> {
   return owlTypes.object({
     x: owlTypes.number(),
     y: owlTypes.number(),
   }) as any;
 }
 
-function validateDOMDimension(): DOMDimension {
+function validateDOMDimension(): Type<DOMDimension> {
   return owlTypes.object({
     width: owlTypes.number(),
     height: owlTypes.number(),
   }) as any;
 }
 
-function validateSortDirection(): SortDirection {
+function validateSortDirection(): Type<SortDirection> {
   return owlTypes.customValidator(validateString<SortDirection>(), (direction) =>
     ["asc", "desc"].includes(direction)
   ) as any;
 }
 
-function validateResizeDirection(): ResizeDirection {
+function validateResizeDirection(): Type<ResizeDirection> {
   return owlTypes.customValidator(validateNumber<ResizeDirection>(), (direction) =>
     [-1, 0, 1].includes(direction)
   ) as any;
 }
 
-function validateComposerFocusType(): ComposerFocusType {
+function validateComposerFocusType(): Type<ComposerFocusType> {
   return owlTypes.customValidator(validateString<ComposerFocusType>(), (value) =>
     composerFocusTypes.includes(value)
   ) as any;
 }
 
-function validateDimension(): Dimension {
+function validateDimension(): Type<Dimension> {
   return owlTypes.customValidator(validateString<Dimension>(), (value) =>
     ["COL", "ROW"].includes(value)
   ) as any;
 }
 
-function validateContextMenuType(): ContextMenuType {
+function validateContextMenuType(): Type<ContextMenuType> {
   return owlTypes.customValidator(validateString<ContextMenuType>(), (value) =>
     ["ROW", "COL", "CELL", "FILTER", "GROUP_HEADERS", "UNGROUP_HEADERS"].includes(value)
   ) as any;
@@ -203,11 +203,11 @@ function validateContextMenuType(): ContextMenuType {
  * Validate that a prop is a store. Typed as the CQS-wrapped `Store<T>` to
  * match what `useStore(...)` returns at the call site.
  */
-function validateStore<T>(): Store<T> {
+function validateStore<T>(): Type<Store<T>> {
   return owlTypes.object() as any;
 }
 
-function validateFunction<T = () => void>(): T {
+function validateFunction<T = () => void>(): Type<T> {
   return owlTypes.function() as any;
 }
 

--- a/src/components/scrollbar/scrollbar.ts
+++ b/src/components/scrollbar/scrollbar.ts
@@ -17,22 +17,16 @@ export class ScrollBar extends Component<any> {
     </div>
   `;
 
-  protected props = props(
-    {
-      "width?": types.Pixel(),
-      "height?": types.Pixel(),
-      direction: types.customValidator(types.string() as ScrollDirection, (direction) =>
-        ["horizontal", "vertical"].includes(direction)
-      ),
-      position: types.CSSProperties(),
-      offset: types.Pixel(),
-      onScroll: types.function<(offset: Pixel) => void>(),
-    },
-    {
-      width: 1,
-      height: 1,
-    }
-  );
+  protected props = props({
+    width: types.Pixel().optional(1),
+    height: types.Pixel().optional(1),
+    direction: types.customValidator(types.string() as ScrollDirection, (direction) =>
+      ["horizontal", "vertical"].includes(direction)
+    ),
+    position: types.CSSProperties(),
+    offset: types.Pixel(),
+    onScroll: types.function<(offset: Pixel) => void>(),
+  });
 
   private scrollbarRef = signal<HTMLElement | null>(null);
   private scrollbar!: ScrollBarElement;

--- a/src/components/scrollbar/scrollbar_horizontal.ts
+++ b/src/components/scrollbar/scrollbar_horizontal.ts
@@ -16,14 +16,9 @@ export class HorizontalScrollBar extends Component<SpreadsheetChildEnv> {
         onScroll.bind="this.onScroll"
       />`;
 
-  protected props = props(
-    {
-      "leftOffset?": types.number(),
-    },
-    {
-      leftOffset: 0,
-    }
-  );
+  protected props = props({
+    leftOffset: types.number().optional(0),
+  });
 
   get offset() {
     return this.env.model.getters.getActiveSheetScrollInfo().scrollX;

--- a/src/components/scrollbar/scrollbar_vertical.ts
+++ b/src/components/scrollbar/scrollbar_vertical.ts
@@ -16,14 +16,9 @@ export class VerticalScrollBar extends Component<SpreadsheetChildEnv> {
       onScroll.bind="(offset) => this.onScroll(offset)"
     />`;
 
-  protected props = props(
-    {
-      "topOffset?": types.number(),
-    },
-    {
-      topOffset: 0,
-    }
-  );
+  protected props = props({
+    topOffset: types.number().optional(0),
+  });
 
   get offset() {
     return this.env.model.getters.getActiveSheetScrollInfo().scrollY;

--- a/src/components/select/select.ts
+++ b/src/components/select/select.ts
@@ -19,11 +19,11 @@ export class Select extends Component<SpreadsheetChildEnv> {
   protected props = props({
     onChange: types.function<(value: string) => void>(),
     values: types.array() as ValueAndLabel[],
-    "selectedValue?": types.string(),
-    "class?": types.string(),
-    "popoverClass?": types.string(),
-    "name?": types.string(),
-    "title?": types.string(),
+    selectedValue: types.string().optional(),
+    class: types.string().optional(),
+    popoverClass: types.string().optional(),
+    name: types.string().optional(),
+    title: types.string().optional(),
   });
 
   private selectRef = signal<HTMLElement | null>(null);

--- a/src/components/selection_input/selection_input.ts
+++ b/src/components/selection_input/selection_input.ts
@@ -34,28 +34,22 @@ interface SelectionRange extends Omit<RangeInputValue, "color"> {
 export class SelectionInput extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-SelectionInput";
 
-  protected props = props(
-    {
-      ranges: types.array(types.string()),
-      "hasSingleRange?": types.boolean(),
-      "required?": types.boolean(),
-      "autofocus?": types.boolean(),
-      "isInvalid?": types.boolean(),
-      "class?": types.string(),
-      "onSelectionChanged?": types.function<(ranges: string[]) => void>(),
-      "onSelectionConfirmed?": types.function(),
-      "onSelectionReordered?": types.function<(indexes: number[]) => void>(),
-      "onSelectionRemoved?": types.function<(index: number) => void>(),
-      "onInputFocused?": types.function(),
-      "colors?": types.ArrayOf<Color>(),
-      "disabledRanges?": types.array(types.boolean()),
-      "disabledRangeTitle?": types.string(),
-    },
-    {
-      colors: [],
-      disabledRanges: [],
-    }
-  );
+  protected props = props({
+    ranges: types.array(types.string()),
+    hasSingleRange: types.boolean().optional(),
+    required: types.boolean().optional(),
+    autofocus: types.boolean().optional(),
+    isInvalid: types.boolean().optional(),
+    class: types.string().optional(),
+    onSelectionChanged: types.function<(ranges: string[]) => void>().optional(),
+    onSelectionConfirmed: types.function().optional(),
+    onSelectionReordered: types.function<(indexes: number[]) => void>().optional(),
+    onSelectionRemoved: types.function<(index: number) => void>().optional(),
+    onInputFocused: types.function().optional(),
+    colors: types.ArrayOf<Color>().optional([]),
+    disabledRanges: types.array(types.boolean()).optional([]),
+    disabledRangeTitle: types.string().optional(),
+  });
   private state: State = proxy({
     isMissing: false,
   });

--- a/src/components/side_panel/chart/building_blocks/chart_title/chart_title.ts
+++ b/src/components/side_panel/chart/building_blocks/chart_title/chart_title.ts
@@ -11,21 +11,15 @@ export class ChartTitle extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet.ChartTitle";
   static components = { Section, TextStyler, TextInput };
 
-  protected props = props(
-    {
-      "title?": types.string(),
-      "placeholder?": types.string(),
-      updateTitle: types.function<(title: string) => void>(),
-      "name?": types.string(),
-      style: types.TitleDesign(),
-      "defaultStyle?": types.object({}) as Partial<TitleDesign>,
-      updateStyle: types.function<(style: TitleDesign) => void>(),
-    },
-    {
-      title: "",
-      placeholder: "",
-    }
-  );
+  protected props = props({
+    title: types.string().optional(""),
+    placeholder: types.string().optional(""),
+    updateTitle: types.function<(title: string) => void>(),
+    name: types.string().optional(),
+    style: types.TitleDesign(),
+    defaultStyle: types.object<Partial<TitleDesign>>().optional(),
+    updateStyle: types.function<(style: TitleDesign) => void>(),
+  });
 
   updateTitle(value: string) {
     this.props.updateTitle(value);

--- a/src/components/side_panel/chart/building_blocks/color_scale/color_scale_picker.ts
+++ b/src/components/side_panel/chart/building_blocks/color_scale/color_scale_picker.ts
@@ -27,7 +27,7 @@ export class ColorScalePicker extends Component<SpreadsheetChildEnv> {
   };
 
   protected props = props({
-    definition: types.object({ "colorScale?": types.ChartColorScale() }),
+    definition: types.object({ colorScale: types.ChartColorScale().optional() }),
     onUpdateColorScale: types.function<(colorscale: ChartColorScale) => void>(),
   });
 

--- a/src/components/side_panel/chart/building_blocks/data_series/data_series.ts
+++ b/src/components/side_panel/chart/building_blocks/data_series/data_series.ts
@@ -15,17 +15,17 @@ export class ChartDataSeries extends Component<SpreadsheetChildEnv> {
 
   protected props = props({
     ranges: types.ArrayOf<{ dataRange: string; dataSetId: UID }>(),
-    "dataSetStyles?": types.DataSetStyle(),
-    "hasSingleRange?": types.boolean(),
+    dataSetStyles: types.DataSetStyle().optional(),
+    hasSingleRange: types.boolean().optional(),
     onSelectionChanged: types.function<(ranges: string[]) => void>(),
-    "onSelectionReordered?": types.function<(indexes: number[]) => void>(),
-    "onSelectionRemoved?": types.function<(index: number) => void>(),
+    onSelectionReordered: types.function<(indexes: number[]) => void>().optional(),
+    onSelectionRemoved: types.function<(index: number) => void>().optional(),
     onSelectionConfirmed: types.function(),
-    "maxNumberOfUsedRanges?": types.number(),
-    "title?": types.string(),
-    "datasetOrientation?": types.or([types.literal("rows"), types.literal("columns")]),
-    "canChangeDatasetOrientation?": types.boolean(),
-    "onFlipAxis?": types.function<(structure: string) => void>(),
+    maxNumberOfUsedRanges: types.number().optional(),
+    title: types.string().optional(),
+    datasetOrientation: types.or([types.literal("rows"), types.literal("columns")]).optional(),
+    canChangeDatasetOrientation: types.boolean().optional(),
+    onFlipAxis: types.function<(structure: string) => void>().optional(),
   });
 
   get ranges(): string[] {

--- a/src/components/side_panel/chart/building_blocks/data_source/data_source.ts
+++ b/src/components/side_panel/chart/building_blocks/data_source/data_source.ts
@@ -20,14 +20,18 @@ export class ChartDataSourceComponent extends Component<SpreadsheetChildEnv> {
     definition: types.ChartDefinitionWithDataSource(),
     updateChart: types.function<ChartUpdateFunction<ChartDefinitionWithDataSource<string>>>(),
     canUpdateChart: types.function<ChartUpdateFunction<ChartDefinitionWithDataSource<string>>>(),
-    "dataSeriesTitle?": types.string(),
-    "labelRangeTitle?": types.string(),
-    "getLabelRangeOptions?": types.function as unknown as () => Array<{
-      name: string;
-      label: string;
-      value: boolean;
-      onChange: (value: boolean) => void;
-    }>,
+    dataSeriesTitle: types.string().optional(),
+    labelRangeTitle: types.string().optional(),
+    getLabelRangeOptions: types
+      .function<
+        () => Array<{
+          name: string;
+          label: string;
+          value: boolean;
+          onChange: (value: boolean) => void;
+        }>
+      >()
+      .optional(),
   });
 
   get DataSourceComponent() {

--- a/src/components/side_panel/chart/building_blocks/general_design/general_design_editor.ts
+++ b/src/components/side_panel/chart/building_blocks/general_design/general_design_editor.ts
@@ -26,18 +26,13 @@ export class GeneralDesignEditor extends Component<SpreadsheetChildEnv> {
     RadioSelection,
   };
 
-  protected props = props(
-    {
-      chartId: types.UID(),
-      definition: types.ChartDefinition(),
-      canUpdateChart: types.function<ChartUpdateFunction>(),
-      updateChart: types.function<ChartUpdateFunction>(),
-      "defaultChartTitleFontSize?": types.number(),
-    },
-    {
-      defaultChartTitleFontSize: CHART_TITLE_FONT_SIZE,
-    }
-  );
+  protected props = props({
+    chartId: types.UID(),
+    definition: types.ChartDefinition(),
+    canUpdateChart: types.function<ChartUpdateFunction>(),
+    updateChart: types.function<ChartUpdateFunction>(),
+    defaultChartTitleFontSize: types.number().optional(CHART_TITLE_FONT_SIZE),
+  });
   private state!: GeneralDesignEditorState;
 
   setup() {

--- a/src/components/side_panel/chart/building_blocks/label_range/label_range.ts
+++ b/src/components/side_panel/chart/building_blocks/label_range/label_range.ts
@@ -11,26 +11,22 @@ export class ChartLabelRange extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet.ChartLabelRange";
   static components = { SelectionInput, Checkbox, Section };
 
-  protected props = props(
-    {
-      "title?": types.string(),
-      range: types.string(),
-      "class?": types.string(),
-      isInvalid: types.boolean(),
-      onSelectionChanged: types.function<(range: string) => void>(),
-      onSelectionConfirmed: types.function(),
-      "options?": types.ArrayOf<{
+  protected props = props({
+    title: types.string().optional(_t("Categories / Labels")),
+    range: types.string(),
+    class: types.string().optional(),
+    isInvalid: types.boolean(),
+    onSelectionChanged: types.function<(range: string) => void>(),
+    onSelectionConfirmed: types.function(),
+    options: types
+      .ArrayOf<{
         name: string;
         label: string;
         value: boolean;
         onChange: (value: boolean) => void;
-      }>(),
-    },
-    {
-      title: _t("Categories / Labels"),
-      options: [],
-    }
-  );
+      }>()
+      .optional([]),
+  });
 
   get sectionClass() {
     return "o-data-labels" + (this.props.class ? ` ${this.props.class}` : "");

--- a/src/components/side_panel/chart/building_blocks/legend/legend.ts
+++ b/src/components/side_panel/chart/building_blocks/legend/legend.ts
@@ -17,18 +17,13 @@ export class ChartLegend extends Component<SpreadsheetChildEnv> {
     Select,
   };
 
-  protected props = props(
-    {
-      chartId: types.string(),
-      definition: types.ChartDefinitionWithDataSource(),
-      canUpdateChart: types.function<ChartUpdateFunction>(),
-      updateChart: types.function<ChartUpdateFunction>(),
-      "isDisabled?": types.boolean(),
-    },
-    {
-      isDisabled: false,
-    }
-  );
+  protected props = props({
+    chartId: types.string(),
+    definition: types.ChartDefinitionWithDataSource(),
+    canUpdateChart: types.function<ChartUpdateFunction>(),
+    updateChart: types.function<ChartUpdateFunction>(),
+    isDisabled: types.boolean().optional(false),
+  });
 
   updateLegendPosition(value: LegendPosition) {
     this.props.updateChart(this.props.chartId, {

--- a/src/components/side_panel/chart/building_blocks/range_data_source/range_data_source.ts
+++ b/src/components/side_panel/chart/building_blocks/range_data_source/range_data_source.ts
@@ -49,15 +49,19 @@ export class ChartRangeDataSourceComponent extends Component<SpreadsheetChildEnv
     dataSource: types.ChartRangeDataSource(),
     updateChart: types.function<ChartUpdateFunction<ChartDefinitionWithDataSource<string>>>(),
     canUpdateChart: types.function<ChartUpdateFunction<ChartDefinitionWithDataSource<string>>>(),
-    "onErrorMessagesChanged?": types.function<(errorMessages: string[]) => void>(),
-    "dataSeriesTitle?": types.string(),
-    "labelRangeTitle?": types.string(),
-    "getLabelRangeOptions?": types.function as unknown as () => Array<{
-      name: string;
-      label: string;
-      value: boolean;
-      onChange: (value: boolean) => void;
-    }>,
+    onErrorMessagesChanged: types.function<(errorMessages: string[]) => void>().optional(),
+    dataSeriesTitle: types.string().optional(),
+    labelRangeTitle: types.string().optional(),
+    getLabelRangeOptions: types
+      .function<
+        () => Array<{
+          name: string;
+          label: string;
+          value: boolean;
+          onChange: (value: boolean) => void;
+        }>
+      >()
+      .optional(),
   });
 
   protected state: ChartRangeDataSourceState = proxy({

--- a/src/components/side_panel/chart/building_blocks/show_values/show_values.ts
+++ b/src/components/side_panel/chart/building_blocks/show_values/show_values.ts
@@ -24,6 +24,6 @@ export class ChartShowValues extends Component<SpreadsheetChildEnv> {
       types.function<
         (chartId: UID, definition: Partial<ChartDefinitionWithDataSource<string>>) => DispatchResult
       >(),
-    "defaultValue?": types.boolean(),
+    defaultValue: types.boolean().optional(),
   });
 }

--- a/src/components/side_panel/chart/building_blocks/text_styler/text_styler.ts
+++ b/src/components/side_panel/chart/building_blocks/text_styler/text_styler.ts
@@ -22,11 +22,11 @@ export class TextStyler extends Component<SpreadsheetChildEnv> {
   protected props = props({
     style: types.ChartStyle(),
     updateStyle: types.function<(style: ChartStyle) => void>(),
-    "defaultStyle?": types.object({}) as Partial<ChartStyle>,
-    "hasVerticalAlign?": types.boolean(),
-    "hasHorizontalAlign?": types.boolean(),
-    "hasBackgroundColor?": types.boolean(),
-    "class?": types.string(),
+    defaultStyle: types.object<Partial<ChartStyle>>().optional(),
+    hasVerticalAlign: types.boolean().optional(),
+    hasHorizontalAlign: types.boolean().optional(),
+    hasBackgroundColor: types.boolean().optional(),
+    class: types.string().optional(),
   });
   openedEl: HTMLElement | null = null;
 

--- a/src/components/side_panel/components/checkbox/checkbox.ts
+++ b/src/components/side_panel/components/checkbox/checkbox.ts
@@ -13,20 +13,15 @@ import { types } from "../../../props_validation";
 export class Checkbox extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet.Checkbox";
 
-  protected props = props(
-    {
-      "label?": types.string(),
-      "value?": types.boolean(),
-      "className?": types.string(),
-      "name?": types.string(),
-      "title?": types.string(),
-      "disabled?": types.boolean(),
-      onChange: types.function<(value: boolean) => void>(),
-    },
-    {
-      value: false,
-    }
-  );
+  protected props = props({
+    label: types.string().optional(),
+    value: types.boolean().optional(false),
+    className: types.string().optional(),
+    name: types.string().optional(),
+    title: types.string().optional(),
+    disabled: types.boolean().optional(),
+    onChange: types.function<(value: boolean) => void>(),
+  });
 
   onChange(ev: InputEvent) {
     const value = (ev.target as HTMLInputElement).checked;

--- a/src/components/side_panel/components/collapsible/side_panel_collapsible.ts
+++ b/src/components/side_panel/components/collapsible/side_panel_collapsible.ts
@@ -8,9 +8,9 @@ export class SidePanelCollapsible extends Component<any> {
   static components = { Collapse };
 
   protected props = props({
-    "title?": types.string(),
-    "isInitiallyCollapsed?": types.boolean(),
-    "class?": types.string(),
+    title: types.string().optional(),
+    isInitiallyCollapsed: types.boolean().optional(),
+    class: types.string().optional(),
   });
 
   private state: { isCollapsed: boolean } = proxy({

--- a/src/components/side_panel/components/radio_selection/radio_selection.ts
+++ b/src/components/side_panel/components/radio_selection/radio_selection.ts
@@ -18,16 +18,13 @@ interface Choice {
 export class RadioSelection extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet.RadioSelection";
 
-  protected props = props(
-    {
-      choices: types.ArrayOf<Choice>(),
-      onChange: types.function<(value: unknown) => void>(),
-      selectedValue: types.string(),
-      name: types.string(),
-      "direction?": types.or([types.literal("horizontal"), types.literal("vertical")]),
-    },
-    {
-      direction: "horizontal",
-    }
-  );
+  protected props = props({
+    choices: types.ArrayOf<Choice>(),
+    onChange: types.function<(value: unknown) => void>(),
+    selectedValue: types.string(),
+    name: types.string(),
+    direction: types
+      .or([types.literal("horizontal"), types.literal("vertical")])
+      .optional("horizontal"),
+  });
 }

--- a/src/components/side_panel/components/round_color_picker/round_color_picker.ts
+++ b/src/components/side_panel/components/round_color_picker/round_color_picker.ts
@@ -23,10 +23,10 @@ export class RoundColorPicker extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet.RoundColorPicker";
   static components = { Section, ColorPicker };
   protected props = props({
-    "currentColor?": types.string(),
-    "title?": types.string(),
+    currentColor: types.string().optional(),
+    title: types.string().optional(),
     onColorPicked: types.function<(color: string) => void>(),
-    "disableNoColor?": types.boolean(),
+    disableNoColor: types.boolean().optional(),
   });
 
   colorPickerButtonRef = signal<HTMLElement | null>(null);

--- a/src/components/side_panel/components/section/section.ts
+++ b/src/components/side_panel/components/section/section.ts
@@ -8,8 +8,8 @@ export class Section extends Component<SpreadsheetChildEnv> {
   static template = "o_spreadsheet.Section";
 
   protected props = props({
-    "class?": types.string(),
-    "title?": types.string(),
+    class: types.string().optional(),
+    title: types.string().optional(),
     slots: types.object(),
   });
 }

--- a/src/components/side_panel/criterion_form/criterion_form.ts
+++ b/src/components/side_panel/criterion_form/criterion_form.ts
@@ -7,15 +7,22 @@ import { Component } from "../../../owl3_compatibility_layer";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
 import { types } from "../../props_validation";
 
+interface CriterionFormProps<T extends GenericCriterion> {
+  criterion: T;
+  onCriterionChanged: (criterion: T) => void;
+  disableFormulas?: boolean;
+  autofocus?: boolean;
+}
+
 export abstract class CriterionForm<
   T extends GenericCriterion = GenericCriterion
 > extends Component<SpreadsheetChildEnv> {
-  protected props = props({
-    criterion: types.object({}) as unknown as T,
+  protected props: CriterionFormProps<T> = props({
+    criterion: types.object(),
     onCriterionChanged: types.function<(criterion: T) => void>(),
-    "disableFormulas?": types.boolean(),
-    "autofocus?": types.boolean(),
-  });
+    disableFormulas: types.boolean().optional(),
+    autofocus: types.boolean().optional(),
+  }) as unknown as CriterionFormProps<T>;
 
   setup() {
     const composerFocusStore = useStore(ComposerFocusStore);

--- a/src/components/side_panel/criterion_form/criterion_input/criterion_input.ts
+++ b/src/components/side_panel/criterion_form/criterion_input/criterion_input.ts
@@ -12,24 +12,16 @@ export class CriterionInput extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-CriterionInput";
   static components = { StandaloneComposer: StandaloneComposer };
 
-  protected props = props(
-    {
-      "value?": types.string(),
-      criterionType: types.DataValidationCriterionType(),
-      onValueChanged: types.function<(value: string) => void>(),
-      "onKeyDown?": types.function<(ev: KeyboardEvent) => void>(),
-      "focused?": types.boolean(),
-      "onBlur?": types.function(),
-      "onFocus?": types.function(),
-      "disableFormulas?": types.boolean(),
-    },
-    {
-      value: "",
-      onKeyDown: () => {},
-      focused: false,
-      onBlur: () => {},
-    }
-  );
+  protected props = props({
+    value: types.string().optional(""),
+    criterionType: types.DataValidationCriterionType(),
+    onValueChanged: types.function<(value: string) => void>(),
+    onKeyDown: types.function<(ev: KeyboardEvent) => void>().optional(() => () => {}),
+    focused: types.boolean().optional(false),
+    onBlur: types.function().optional(() => () => {}),
+    onFocus: types.function().optional(),
+    disableFormulas: types.boolean().optional(),
+  });
 
   inputRef = signal<HTMLInputElement | null>(null);
 

--- a/src/components/side_panel/data_validation/dv_editor/dv_editor.ts
+++ b/src/components/side_panel/data_validation/dv_editor/dv_editor.ts
@@ -34,7 +34,7 @@ export class DataValidationEditor extends Component<SpreadsheetChildEnv> {
   static components = { SelectionInput, Select, Section, ValidationMessages };
   protected props = props({
     ruleId: types.UID(),
-    "onCancel?": types.function(),
+    onCancel: types.function().optional(),
     onCloseSidePanel: types.function(),
   });
 

--- a/src/components/side_panel/more_formats/more_formats.ts
+++ b/src/components/side_panel/more_formats/more_formats.ts
@@ -27,11 +27,9 @@ export class MoreFormatsPanel extends Component<SpreadsheetChildEnv> {
 
   protected props = props({
     onCloseSidePanel: types.function(),
-    "category?": types.or([
-      types.literal("number"),
-      types.literal("date"),
-      types.literal("currency"),
-    ]),
+    category: types
+      .or([types.literal("number"), types.literal("date"), types.literal("currency")])
+      .optional(),
   });
 
   store!: Store<MoreFormatsStore>;

--- a/src/components/side_panel/pivot/pivot_layout_configurator/pivot_dimension/pivot_dimension.ts
+++ b/src/components/side_panel/pivot/pivot_layout_configurator/pivot_dimension/pivot_dimension.ts
@@ -16,18 +16,22 @@ export class PivotDimension extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-PivotDimension";
   protected props = props({
     dimension: types.or([types.PivotDimension(), types.PivotMeasure(), types.PivotFilter()]),
-    "onRemoved?":
-      types.function<(dimension: PivotDimensionType | PivotMeasure | PivotFilter) => void>(),
-    "onNameUpdated?":
-      types.function<
+    onRemoved: types
+      .function<(dimension: PivotDimensionType | PivotMeasure | PivotFilter) => void>()
+      .optional(),
+    onNameUpdated: types
+      .function<
         (dimension: PivotDimensionType | PivotMeasure | PivotFilter, name?: string) => void
-      >(),
-    "type?": types.or([
-      types.literal("row"),
-      types.literal("col"),
-      types.literal("measure"),
-      types.literal("filter"),
-    ]),
+      >()
+      .optional(),
+    type: types
+      .or([
+        types.literal("row"),
+        types.literal("col"),
+        types.literal("measure"),
+        types.literal("filter"),
+      ])
+      .optional(),
   });
   static components = { CogWheelMenu, TextInput };
 

--- a/src/components/side_panel/pivot/pivot_layout_configurator/pivot_dimension_order/pivot_dimension_order.ts
+++ b/src/components/side_panel/pivot/pivot_layout_configurator/pivot_dimension_order/pivot_dimension_order.ts
@@ -12,7 +12,7 @@ export class PivotDimensionOrder extends Component<SpreadsheetChildEnv> {
   protected props = props({
     dimension: types.PivotDimension(),
     onUpdated: types.function<(dimension: PivotDimension, ev: InputEvent) => void>(),
-    "isMeasureSorted?": types.boolean(),
+    isMeasureSorted: types.boolean().optional(),
   });
   static components = { Select };
 

--- a/src/components/side_panel/pivot/pivot_layout_configurator/pivot_layout_configurator.ts
+++ b/src/components/side_panel/pivot/pivot_layout_configurator/pivot_layout_configurator.ts
@@ -55,7 +55,7 @@ export class PivotLayoutConfigurator extends Component<SpreadsheetChildEnv> {
     unusedGranularities: types.RecordOf<Set<string>>(),
     dateGranularities: types.array(types.string()),
     datetimeGranularities: types.array(types.string()),
-    "getScrollableContainerEl?": types.function<() => HTMLElement>(),
+    getScrollableContainerEl: types.function<() => HTMLElement>().optional(),
     pivotId: types.UID(),
   });
 

--- a/src/components/side_panel/pivot/pivot_side_panel/pivot_side_panel.ts
+++ b/src/components/side_panel/pivot/pivot_side_panel/pivot_side_panel.ts
@@ -22,16 +22,13 @@ export class PivotSidePanel extends Component<SpreadsheetChildEnv> {
     PivotDesignPanel,
   };
 
-  protected props = props(
-    {
-      pivotId: types.UID(),
-      onCloseSidePanel: types.function(),
-      "openTab?": types.or([types.literal("configuration"), types.literal("design")]),
-    },
-    {
-      openTab: "configuration",
-    }
-  );
+  protected props = props({
+    pivotId: types.UID(),
+    onCloseSidePanel: types.function(),
+    openTab: types
+      .or([types.literal("configuration"), types.literal("design")])
+      .optional("configuration"),
+  });
 
   state = proxy<State>({ panel: this.props.openTab || "configuration" });
 

--- a/src/components/side_panel/side_panel/side_panel.ts
+++ b/src/components/side_panel/side_panel/side_panel.ts
@@ -14,10 +14,10 @@ export class SidePanel extends Component<SpreadsheetChildEnv> {
     onCloseSidePanel: types.function(),
     onStartHandleDrag: types.function<(ev: MouseEvent) => void>(),
     onResetPanelSize: types.function(),
-    "isPinned?": types.boolean(),
-    "onTogglePinPanel?": types.function(),
-    "onToggleCollapsePanel?": types.function(),
-    "isCollapsed?": types.boolean(),
+    isPinned: types.boolean().optional(),
+    onTogglePinPanel: types.function().optional(),
+    onToggleCollapsePanel: types.function().optional(),
+    isCollapsed: types.boolean().optional(),
   });
   spreadsheetRect = useSpreadsheetRect();
 

--- a/src/components/side_panel/table_style_editor_panel/table_style_editor_panel.ts
+++ b/src/components/side_panel/table_style_editor_panel/table_style_editor_panel.ts
@@ -26,8 +26,8 @@ export class TableStyleEditorPanel extends Component<SpreadsheetChildEnv> {
   static components = { Section, RoundColorPicker, TableStylePreview };
   protected props = props({
     onCloseSidePanel: types.function(),
-    "onStylePicked?": types.function<(styleId: string) => void>(),
-    "styleId?": types.string(),
+    onStylePicked: types.function<(styleId: string) => void>().optional(),
+    styleId: types.string().optional(),
   });
 
   state = proxy<State>(this.getInitialState());

--- a/src/components/spreadsheet/spreadsheet.ts
+++ b/src/components/spreadsheet/spreadsheet.ts
@@ -69,9 +69,9 @@ export class Spreadsheet extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-Spreadsheet";
   protected props = props({
     model: types.Model(),
-    "notifyUser?": types.function<NotificationStoreMethods["notifyUser"]>(),
-    "raiseError?": types.function<NotificationStoreMethods["raiseError"]>(),
-    "askConfirmation?": types.function<NotificationStoreMethods["askConfirmation"]>(),
+    notifyUser: types.function<NotificationStoreMethods["notifyUser"]>().optional(),
+    raiseError: types.function<NotificationStoreMethods["raiseError"]>().optional(),
+    askConfirmation: types.function<NotificationStoreMethods["askConfirmation"]>().optional(),
   });
   static components = {
     TopBar,

--- a/src/components/standalone_grid_canvas/standalone_grid_canvas.ts
+++ b/src/components/standalone_grid_canvas/standalone_grid_canvas.ts
@@ -16,7 +16,7 @@ export class StandaloneGridCanvas extends Component<SpreadsheetChildEnv> {
   protected props = props({
     sheetId: types.UID(),
     zone: types.Zone(),
-    renderingCtx: types.object({}) as Omit<GridRenderingContext, "ctx" | "thinLineWidth">,
+    renderingCtx: types.object<Omit<GridRenderingContext, "ctx" | "thinLineWidth">>(),
   });
 
   private canvasRef = signal<HTMLElement | null>(null);

--- a/src/components/tables/table_dropdown_button/table_dropdown_button.ts
+++ b/src/components/tables/table_dropdown_button/table_dropdown_button.ts
@@ -27,7 +27,7 @@ export class TableDropdownButton extends Component<SpreadsheetChildEnv> {
   static components = { TableStylesPopover, ActionButton };
 
   protected props = props({
-    "class?": types.string(),
+    class: types.string().optional(),
   });
 
   topBarToolStore!: ToolBarDropdownStore;

--- a/src/components/tables/table_style_preview/table_style_preview.ts
+++ b/src/components/tables/table_style_preview/table_style_preview.ts
@@ -18,9 +18,9 @@ export class TableStylePreview extends Component<SpreadsheetChildEnv> {
     tableConfig: types.TableConfig(),
     tableStyle: types.TableStyle(),
     type: types.or([types.literal("table"), types.literal("pivot")]),
-    "styleId?": types.string(),
-    "selected?": types.boolean(),
-    "onClick?": types.function(),
+    styleId: types.string().optional(),
+    selected: types.boolean().optional(),
+    onClick: types.function().optional(),
   });
 
   private canvasRef = signal<HTMLCanvasElement | null>(null);

--- a/src/components/tables/table_styles_popover/table_styles_popover.ts
+++ b/src/components/tables/table_styles_popover/table_styles_popover.ts
@@ -21,11 +21,11 @@ export class TableStylesPopover extends Component<SpreadsheetChildEnv> {
   static components = { Popover, TableStylePreview };
 
   protected props = props({
-    tableConfig: types.object({}) as Omit<TableConfig, "styleId">,
-    "popoverProps?": types.object({}) as PropsOf<Popover>,
+    tableConfig: types.object<Omit<TableConfig, "styleId">>(),
+    popoverProps: types.object<PropsOf<Popover>>().optional(),
     closePopover: types.function(),
     onStylePicked: types.function<(styleId: string) => void>(),
-    "selectedStyleId?": types.string(),
+    selectedStyleId: types.string().optional(),
     tableStyles: types.RecordOf<TableStyle>(),
     type: types.or([types.literal("table"), types.literal("pivot")]),
   });

--- a/src/components/text_input/text_input.ts
+++ b/src/components/text_input/text_input.ts
@@ -20,7 +20,7 @@ export class TextInput extends GenericInput<Props> {
   protected props: Props = props({
     ...genericInputPropsDefinition,
     value: types.string(),
-    "errorMessage?": types.string(),
+    errorMessage: types.string().optional(),
   }) as unknown as Props;
 
   get inputClass(): string {

--- a/src/components/validation_messages/validation_messages.ts
+++ b/src/components/validation_messages/validation_messages.ts
@@ -10,7 +10,7 @@ export class ValidationMessages extends Component<SpreadsheetChildEnv> {
   protected props = props({
     messages: types.array(types.string()),
     msgType: types.or([types.literal("warning"), types.literal("error"), types.literal("info")]),
-    "singleBox?": types.boolean(),
+    singleBox: types.boolean().optional(),
   });
 
   get divClasses() {

--- a/src/types/props_of.ts
+++ b/src/types/props_of.ts
@@ -1,11 +1,14 @@
-import { Props, WithDefaults } from "@odoo/owl";
+import { GetPropsWithOptionals } from "@odoo/owl";
 
 /**
  * Return the prop's type of a component as seen from the caller (pre-default
- * shape). Strips the owl3 `Props<...>` brand and unwraps `WithDefaults<R, D>`
- * so that props with a default value stay optional for the caller.
+ * shape). Strips the owl3 `Props<...>` / `PropsWithDefaults<...>` brand and
+ * makes props with a default value optional for the caller. If the field is
+ * not a `Props<...>` brand (e.g. typed with a plain interface), returns it
+ * as-is instead of `never`.
  */
-export type PropsOf<
-  C extends { [key: string]: any },
-  Key extends string = "props"
-> = C[Key] extends Props<infer P> ? (P extends WithDefaults<infer R, any> ? R : P) : C[Key];
+export type PropsOf<C extends { [key: string]: any }, Key extends string = "props"> = [
+  GetPropsWithOptionals<C[Key]>
+] extends [never]
+  ? C[Key]
+  : GetPropsWithOptionals<C[Key]>;

--- a/tests/spreadsheet/side_panel_component.test.ts
+++ b/tests/spreadsheet/side_panel_component.test.ts
@@ -38,8 +38,8 @@ class Body extends Component<any> {
       <input type="text" class="input" t-if="this.props.input" />
     </div>`;
   protected props = props({
-    "text?": types.string(),
-    "input?": types.boolean(),
+    text: types.string().optional(),
+    input: types.boolean().optional(),
     onCloseSidePanel: types.function(),
   });
 }
@@ -51,7 +51,7 @@ class Body2 extends Component<any> {
       <div class="props_body_2" t-if="this.props.field"><t t-out="this.props.field"/></div>
     </div>`;
   protected props = props({
-    "field?": types.string(),
+    field: types.string().optional(),
     onCloseSidePanel: types.function(),
   });
 }


### PR DESCRIPTION
Since owl 35 and 36, props should be defined using a new way.

Task: 6298603

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo