### PR TITLE
[FIX] Actions: convert shortcut name in components

### DIFF
--- a/src/actions/action.ts
+++ b/src/actions/action.ts
@@ -112,8 +112,8 @@ export function createActions(menuItems: ActionSpec[]): Action[] {
   return menuItems.map(createAction).sort((a, b) => a.sequence - b.sequence);
 }
 
-function adaptShortcutMacOs(shortcut: string) {
-  return shortcut.replace("Ctrl", "⌘").replace("Alt", "⌃");
+export function adaptShortcutMacOs(shortcut: string | undefined) {
+  return shortcut && isMacOS() ? shortcut.replace("Ctrl", "⌘").replace("Alt", "⌃") : shortcut;
 }
 
 let nextItemId = 1;
@@ -122,7 +122,7 @@ export function createAction(item: ActionSpec): Action {
   const name = item.name;
   const children = item.children;
   const description = item.description;
-  const shortcut = item.shortcut && isMacOS() ? adaptShortcutMacOs(item.shortcut) : item.shortcut;
+  const shortcut = item.shortcut;
   const icon = item.icon;
   const secondaryIcon = item.secondaryIcon;
   const itemId = item.id || nextItemId++;

--- a/src/actions/action.ts
+++ b/src/actions/action.ts
@@ -112,8 +112,13 @@ export function createActions(menuItems: ActionSpec[]): Action[] {
   return menuItems.map(createAction).sort((a, b) => a.sequence - b.sequence);
 }
 
-export function adaptShortcutMacOs(shortcut: string | undefined) {
+export function adaptShortcutStringToMacOs(shortcut: string | undefined) {
   return shortcut && isMacOS() ? shortcut.replace("Ctrl", "⌘").replace("Alt", "⌃") : shortcut;
+}
+
+function filterActionShortcutForMacOs(shortcut: string | undefined) {
+  // we filter out the alt key from shortcuts because on macOs, it's used for special characters input and it creates conflicts with o-spreadsheet shortcuts
+  return shortcut && isMacOS() && shortcut.match(/\+?Alt\+?/) ? "" : shortcut;
 }
 
 let nextItemId = 1;
@@ -122,7 +127,7 @@ export function createAction(item: ActionSpec): Action {
   const name = item.name;
   const children = item.children;
   const description = item.description;
-  const shortcut = item.shortcut;
+  const shortcut = filterActionShortcutForMacOs(item.shortcut);
   const icon = item.icon;
   const secondaryIcon = item.secondaryIcon;
   const itemId = item.id || nextItemId++;

--- a/src/components/action_button/action_button.ts
+++ b/src/components/action_button/action_button.ts
@@ -1,5 +1,5 @@
 import { onWillUpdateProps, props } from "@odoo/owl";
-import { createAction } from "../../actions/action";
+import { adaptShortcutMacOs, createAction } from "../../actions/action";
 import { Component } from "../../owl3_compatibility_layer";
 import { PropsOf } from "../../types/props_of";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
@@ -43,7 +43,8 @@ export class ActionButton extends Component<SpreadsheetChildEnv> {
 
   get title() {
     const name = this.actionButton.name(this.env);
-    const description = this.actionButton.description(this.env) || this.actionButton.shortcut;
+    const description =
+      this.actionButton.description(this.env) || adaptShortcutMacOs(this.actionButton.shortcut);
     return name + (description ? ` (${description})` : "");
   }
 
@@ -52,6 +53,7 @@ export class ActionButton extends Component<SpreadsheetChildEnv> {
   }
 
   onClick(ev: MouseEvent) {
+    r;
     if (this.isEnabled) {
       this.props.onClick?.(ev);
       this.actionButton.execute?.(this.env);

--- a/src/components/action_button/action_button.ts
+++ b/src/components/action_button/action_button.ts
@@ -1,5 +1,5 @@
 import { onWillUpdateProps, props } from "@odoo/owl";
-import { adaptShortcutMacOs, createAction } from "../../actions/action";
+import { adaptShortcutStringToMacOs, createAction } from "../../actions/action";
 import { Component } from "../../owl3_compatibility_layer";
 import { PropsOf } from "../../types/props_of";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
@@ -44,7 +44,8 @@ export class ActionButton extends Component<SpreadsheetChildEnv> {
   get title() {
     const name = this.actionButton.name(this.env);
     const description =
-      this.actionButton.description(this.env) || adaptShortcutMacOs(this.actionButton.shortcut);
+      this.actionButton.description(this.env) ||
+      adaptShortcutStringToMacOs(this.actionButton.shortcut);
     return name + (description ? ` (${description})` : "");
   }
 
@@ -53,7 +54,6 @@ export class ActionButton extends Component<SpreadsheetChildEnv> {
   }
 
   onClick(ev: MouseEvent) {
-    r;
     if (this.isEnabled) {
       this.props.onClick?.(ev);
       this.actionButton.execute?.(this.env);

--- a/src/components/menu/menu.ts
+++ b/src/components/menu/menu.ts
@@ -1,7 +1,7 @@
 import { props, signal } from "@odoo/owl";
 import {
   Action,
-  adaptShortcutMacOs,
+  adaptShortcutStringToMacOs,
   isMenuItemEnabled,
   isRootMenu,
   MenuItemOrSeparator,
@@ -81,7 +81,7 @@ export class Menu extends Component<SpreadsheetChildEnv> {
   }
 
   getShortcut(menu: Action) {
-    return adaptShortcutMacOs(menu.shortcut);
+    return adaptShortcutStringToMacOs(menu.shortcut);
   }
 
   getColor(menu: Action) {

--- a/src/components/menu/menu.ts
+++ b/src/components/menu/menu.ts
@@ -1,5 +1,11 @@
 import { props, signal } from "@odoo/owl";
-import { Action, isMenuItemEnabled, isRootMenu, MenuItemOrSeparator } from "../../actions/action";
+import {
+  Action,
+  adaptShortcutMacOs,
+  isMenuItemEnabled,
+  isRootMenu,
+  MenuItemOrSeparator,
+} from "../../actions/action";
 import { Component, useLayoutEffect } from "../../owl3_compatibility_layer";
 import { Pixel } from "../../types/misc";
 import { Rect } from "../../types/rendering";
@@ -72,6 +78,10 @@ export class Menu extends Component<SpreadsheetChildEnv> {
     }
 
     return "";
+  }
+
+  getShortcut(menu: Action) {
+    return adaptShortcutMacOs(menu.shortcut);
   }
 
   getColor(menu: Action) {

--- a/src/components/menu/menu.xml
+++ b/src/components/menu/menu.xml
@@ -37,7 +37,10 @@
                 class="o-menu-item-name align-middle text-truncate"
                 t-out="this.getName(menuItem)"
               />
-              <t t-set="description" t-value="menuItem.description(this.env) or menuItem.shortcut"/>
+              <t
+                t-set="description"
+                t-value="menuItem.description(this.env) or this.getShortcut(menuItem)"
+              />
               <div
                 t-if="description"
                 class="o-menu-item-description ms-auto text-truncate"

--- a/tests/menus/menu_items_registry.test.ts
+++ b/tests/menus/menu_items_registry.test.ts
@@ -2122,3 +2122,17 @@ test("Menu children are sorted by sequence", async () => {
   expect(children[0].id).toBe("firstItem");
   expect(children[1].id).toBe("secondItem");
 });
+
+test("menu shortcuts that involve the altkey are ignored in macOs", async () => {
+  const mockUserAgent = jest.spyOn(navigator, "userAgent", "get");
+  mockUserAgent.mockImplementation(
+    () => "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Firefox/119.0"
+  );
+  const env = makeTestEnv();
+
+  let menuItem = getNode(["insert", "insert_table"], env, topbarMenuRegistry);
+  expect(menuItem.shortcut).toBe("");
+  mockUserAgent.mockReset();
+  menuItem = getNode(["insert", "insert_table"], env, topbarMenuRegistry);
+  expect(menuItem.shortcut).toBe("Alt+T");
+});

--- a/tests/spreadsheet/spreadsheet_component.test.ts
+++ b/tests/spreadsheet/spreadsheet_component.test.ts
@@ -204,7 +204,10 @@ describe("Simple Spreadsheet Component", () => {
     ({ model, parent, fixture } = await mountSpreadsheet({
       model: new Model({ sheets: [{ id: "sh1" }] }),
     }));
+    // menu shortcut
     await click(fixture, ".o-topbar-menu[data-id='format']");
+    expect('[data-name="format_bold"]').toHaveText("Bold⌘+B");
+    // action button
     expect(document.querySelectorAll('span[title="Bold (⌘+B)"]').length).toBe(1);
     mockUserAgent.mockReset();
   });


### PR DESCRIPTION
## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo