### PR TITLE
Master faster visit matching ranges lul

### DIFF
--- a/src/functions/helpers.ts
+++ b/src/functions/helpers.ts
@@ -522,16 +522,18 @@ export function conditionalVisitBoolean(args: Arg[], cb: (a: boolean) => boolean
 // -----------------------------------------------------------------------------
 
 type Operator = ">" | ">=" | "<" | "<=" | "<>" | "=";
-interface Predicate {
-  operator: Operator;
-  operand: number | string | boolean;
-  operandHasWildcard: boolean;
-  lowerCaseOperand: string;
-}
+type PredicateFunction = (value: CellValue | undefined) => boolean;
 
-function getPredicate(descr: string, locale: Locale): Predicate {
+/**
+ * Parse a criterion (e.g. ">30", "<>abc", "5") and compile it to a function
+ * checking a single value against the criterion.
+ *
+ * Branching on the operator and the operand type is done once here, instead
+ * of for each visited value.
+ */
+function compilePredicate(descr: string, locale: Locale, isQuery: boolean): PredicateFunction {
   let operator: Operator;
-  let operand: Maybe<CellValue>;
+  let operand: string | number | boolean;
 
   let subString = descr.substring(0, 2);
 
@@ -555,16 +557,56 @@ function getPredicate(descr: string, locale: Locale): Predicate {
     operand = toBoolean(operand);
   }
 
-  const predicate: Predicate = {
-    operator,
-    operand,
-    operandHasWildcard:
-      typeof operand === "string" &&
-      (operator === "=" || operator === "<>") &&
-      hasWildcard(operand),
-    lowerCaseOperand: typeof operand === "string" ? operand.toLowerCase() : "",
-  };
-  return predicate;
+  if (isQuery && typeof operand === "string") {
+    operand += "*";
+  }
+
+  if (operator === "=" && typeof operand === "number") {
+    const numberOperand = operand;
+    return (value = "") => {
+      if (typeof value === "string" && (isNumber(value, locale) || isDateTime(value, locale))) {
+        return toNumber(value, locale) === numberOperand;
+      }
+      return value === numberOperand;
+    };
+  }
+
+  if (operator === "=" || operator === "<>") {
+    let isEqualToOperand: PredicateFunction;
+    if (typeof operand === "string") {
+      // Skip regex when the operand has no wildcards.
+      if (hasWildcard(operand)) {
+        const regExp = wildcardToRegExp(operand);
+        isEqualToOperand = (value = "") => typeof value === "string" && regExp.test(value);
+      } else {
+        const operandLength = operand.length;
+        const lowerCaseOperand = operand.toLowerCase();
+        isEqualToOperand = (value = "") =>
+          typeof value === "string" &&
+          value.length === operandLength &&
+          value.toLowerCase() === lowerCaseOperand;
+      }
+    } else {
+      const scalarOperand = operand;
+      isEqualToOperand = (value = "") => value === scalarOperand;
+    }
+    if (operator === "=") {
+      return isEqualToOperand;
+    }
+    return (value = "") => !isEqualToOperand(value);
+  }
+
+  const operandType = typeof operand;
+  switch (operator) {
+    case "<":
+      return (value = "") => typeof value === operandType && value !== null && value < operand;
+    case ">":
+      return (value = "") => typeof value === operandType && value !== null && value > operand;
+    case "<=":
+      return (value = "") => typeof value === operandType && value !== null && value <= operand;
+    case ">=":
+      return (value = "") => typeof value === operandType && value !== null && value >= operand;
+  }
 }
 
 function hasWildcard(s: string): boolean {
@@ -612,58 +654,6 @@ const wildcardToRegExp = memoize(function wildcardToRegExp(operand: string): Reg
   return new RegExp("^" + exp + "$", "i");
 });
 
-function evaluatePredicate(
-  value: CellValue | undefined = "",
-  criterion: Predicate,
-  locale: Locale
-): boolean {
-  const { operator, operand } = criterion;
-
-  if (operand === undefined || value === null || operand === null) {
-    return false;
-  }
-  if (typeof operand === "number" && operator === "=") {
-    if (typeof value === "string" && (isNumber(value, locale) || isDateTime(value, locale))) {
-      return toNumber(value, locale) === operand;
-    }
-    return value === operand;
-  }
-
-  if (operator === "<>" || operator === "=") {
-    let result: boolean;
-    if (typeof value === typeof operand) {
-      if (typeof value === "string" && typeof operand === "string") {
-        // Skip regex when the operand has no wildcards.
-        if (criterion.operandHasWildcard) {
-          result = wildcardToRegExp(operand).test(value);
-        } else {
-          result =
-            value.length === operand.length && value.toLowerCase() === criterion.lowerCaseOperand;
-        }
-      } else {
-        result = value === operand;
-      }
-    } else {
-      result = false;
-    }
-    return operator === "=" ? result : !result;
-  }
-
-  if (typeof value === typeof operand) {
-    switch (operator) {
-      case "<":
-        return value < operand;
-      case ">":
-        return value > operand;
-      case "<=":
-        return value <= operand;
-      case ">=":
-        return value >= operand;
-    }
-  }
-  return false;
-}
-
 /**
  * Functions used especially for predicate evaluation on ranges.
  *
@@ -706,7 +696,7 @@ export function visitMatchingRanges(
   const dimRow = firstArg.length;
   const dimCol = firstArg[0].length;
 
-  const predicates: Predicate[] = [];
+  const predicates: PredicateFunction[] = [];
 
   for (let i = 0; i < countArg - 1; i += 2) {
     const criteriaRange = toMatrix(args[i]);
@@ -718,12 +708,7 @@ export function visitMatchingRanges(
     }
 
     const description = toString(args[i + 1] as Maybe<FunctionResultObject>);
-    const predicate = getPredicate(description, locale);
-    if (isQuery && typeof predicate.operand === "string") {
-      predicate.operand += "*";
-      predicate.operandHasWildcard = true;
-    }
-    predicates.push(predicate);
+    predicates.push(compilePredicate(description, locale, isQuery));
   }
 
   for (let i = 0; i < dimRow; i++) {
@@ -731,8 +716,7 @@ export function visitMatchingRanges(
       let validatedPredicates = true;
       for (let k = 0; k < countArg - 1; k += 2) {
         const criteriaValue = toMatrix(args[k])[i][j].value;
-        const criterion = predicates[k / 2];
-        validatedPredicates = evaluatePredicate(criteriaValue ?? undefined, criterion, locale);
+        validatedPredicates = predicates[k / 2](criteriaValue ?? undefined);
         if (!validatedPredicates) {
           break;
         }

--- a/src/functions/helpers.ts
+++ b/src/functions/helpers.ts
@@ -525,6 +525,8 @@ type Operator = ">" | ">=" | "<" | "<=" | "<>" | "=";
 interface Predicate {
   operator: Operator;
   operand: number | string | boolean;
+  operandHasWildcard: boolean;
+  lowerCaseOperand: string;
 }
 
 function getPredicate(descr: string, locale: Locale): Predicate {
@@ -553,7 +555,27 @@ function getPredicate(descr: string, locale: Locale): Predicate {
     operand = toBoolean(operand);
   }
 
-  return { operator, operand };
+  const predicate: Predicate = {
+    operator,
+    operand,
+    operandHasWildcard:
+      typeof operand === "string" &&
+      (operator === "=" || operator === "<>") &&
+      hasWildcard(operand),
+    lowerCaseOperand: typeof operand === "string" ? operand.toLowerCase() : "",
+  };
+  return predicate;
+}
+
+function hasWildcard(s: string): boolean {
+  for (let i = 0; i < s.length; i++) {
+    const c = s.charCodeAt(i);
+    if (c === 42 || c === 63) {
+      // '*' = 42, '?' = 63
+      return true;
+    }
+  }
+  return false;
 }
 
 /**
@@ -610,11 +632,14 @@ function evaluatePredicate(
   if (operator === "<>" || operator === "=") {
     let result: boolean;
     if (typeof value === typeof operand) {
-      if (value === "" && operand === "") {
-        // fast path to avoid regex evaluation
-        result = true;
-      } else if (typeof value === "string" && typeof operand === "string") {
-        result = wildcardToRegExp(operand).test(value);
+      if (typeof value === "string" && typeof operand === "string") {
+        // Skip regex when the operand has no wildcards.
+        if (criterion.operandHasWildcard) {
+          result = wildcardToRegExp(operand).test(value);
+        } else {
+          result =
+            value.length === operand.length && value.toLowerCase() === criterion.lowerCaseOperand;
+        }
       } else {
         result = value === operand;
       }
@@ -696,6 +721,7 @@ export function visitMatchingRanges(
     const predicate = getPredicate(description, locale);
     if (isQuery && typeof predicate.operand === "string") {
       predicate.operand += "*";
+      predicate.operandHasWildcard = true;
     }
     predicates.push(predicate);
   }


### PR DESCRIPTION
## Description:

### Bunch tool

```
cells imported in
  6ed4851d7:  Mean: 2650.00 ms, StdErr: 6.15 ms
  1e2fdf985:  Mean: 2643.66 ms, StdErr: 5.65 ms → ⚫ (vs prev: -0%, Δ=-6.34 ms, combined StdErr=8.35 ms, |Δ|/SE=-0.8x; n=20)
  0ac99c06d:  Mean: 2647.70 ms, StdErr: 4.96 ms → ⚫ (vs prev: +0%, vs baseline: -0%, Δ=+4.03 ms, combined StdErr=7.52 ms, |Δ|/SE=0.5x; n=20)

evaluate all cells
  6ed4851d7:  Mean: 2381.09 ms, StdErr: 9.10 ms
  1e2fdf985:  Mean: 2025.87 ms, StdErr: 7.22 ms → 🟢 (vs prev: -15%, Δ=-355.23 ms, combined StdErr=11.61 ms, |Δ|/SE=-30.6x; n=20)
  0ac99c06d:  Mean: 1902.54 ms, StdErr: 5.89 ms → 🟢 (vs prev: -6%, vs baseline: -20%, Δ=-123.33 ms, combined StdErr=9.32 ms, |Δ|/SE=-13.2x; n=20)

Model created in
  6ed4851d7:  Mean: 5886.37 ms, StdErr: 10.83 ms
  1e2fdf985:  Mean: 5519.48 ms, StdErr: 8.33 ms  → 🟢 (vs prev: -6%, Δ=-366.89 ms, combined StdErr=13.66 ms, |Δ|/SE=-26.9x; n=20)
  0ac99c06d:  Mean: 5398.08 ms, StdErr: 7.92 ms  → 🟢 (vs prev: -2%, vs baseline: -8%, Δ=-121.40 ms, combined StdErr=11.49 ms, |Δ|/SE=-10.6x; n=20)


Legend:
  ⚫: no measurable change |Δ|/SE < 2
  🔴: slower Δ > 0 and |Δ|/SE >= 2
  🟢: faster Δ < 0 and |Δ|/SE >= 2
```
Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo