### PR TITLE
[IMP] CarouselPanel: make preview tiles opaque

### DIFF
--- a/src/components/side_panel/carousel_panel/carousel_panel.css
+++ b/src/components/side_panel/carousel_panel/carousel_panel.css
@@ -2,6 +2,7 @@
   .o-carousel-preview {
     height: 60px;
     border-left: 5px solid transparent;
+    background-color: var(--os-white-bg);
 
     &:not(:hover):not(.o-dragging) .o-drag-handle {
       display: none !important;

--- a/src/components/side_panel/carousel_panel/carousel_panel.xml
+++ b/src/components/side_panel/carousel_panel/carousel_panel.xml
@@ -24,7 +24,7 @@
           <div
             class="o-carousel-preview border-bottom pe-2 position-relative w-100 d-flex align-items-center"
             t-att-class="{
-              'o-dragging': this.dragAndDrop.draggedItemId === this.getItemId(item),
+              'o-dragging border-top': this.dragAndDrop.draggedItemId === this.getItemId(item),
               'o-selected': this.isCarouselItemActive(item)
             }"
             t-att-style="this.getPreviewDivStyle(item)">


### PR DESCRIPTION
the preview tiles are currently transparent, and as such, we see and overlap of titles/icons when drag&dropping the tiles to reorder them. This reduces the readability of the tiles.

this revision adds a background to the tiles to avoid that.

Task: 6303214

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo