### PR TITLE
[formula] when using {}, delimiter is taken into account in helper but shouldn't

### DIFF
--- a/src/formulas/composer_tokenizer.ts
+++ b/src/formulas/composer_tokenizer.ts
@@ -129,6 +129,7 @@ function mapParenthesisCode(tokens: EnrichedToken[]): EnrichedToken[] {
 function mapParentFunction(tokens: EnrichedToken[]): EnrichedToken[] {
   const stack: FunctionContext[] = [];
   let functionStarted = "";
+  let braceDepth = 0;
 
   function pushTokenToFunctionContext(token: Token) {
     if (stack.length === 0) {
@@ -144,7 +145,7 @@ function mapParentFunction(tokens: EnrichedToken[]): EnrichedToken[] {
     }
   }
 
-  return tokens.map((token, i) => {
+  return tokens.map((token) => {
     if (!["SPACE", "LEFT_PAREN"].includes(token.type)) {
       functionStarted = "";
     }
@@ -164,8 +165,16 @@ function mapParentFunction(tokens: EnrichedToken[]): EnrichedToken[] {
         child?.argsTokens?.flat().forEach(pushTokenToFunctionContext);
         pushTokenToFunctionContext(token);
         break;
+      case "LEFT_BRACE":
+        braceDepth++;
+        pushTokenToFunctionContext(token);
+        break;
+      case "RIGHT_BRACE":
+        braceDepth--;
+        pushTokenToFunctionContext(token);
+        break;
       case "ARG_SEPARATOR":
-        if (stack.length) {
+        if (stack.length && braceDepth === 0) {
           // increment position on current function
           stack[stack.length - 1].argPosition++;
         }

--- a/tests/evaluation/composer_tokenizer.test.ts
+++ b/tests/evaluation/composer_tokenizer.test.ts
@@ -286,6 +286,24 @@ describe("composerTokenizer base tests", () => {
     ]);
   });
 
+  test("comma after array literal increments argPosition of parent function", () => {
+    const firstArgContext = { parent: "SUM", argPosition: 0 };
+    const secondArgContext = { parent: "SUM", argPosition: 1 };
+    expect(composerTokenize("=SUM({1,2},3)", DEFAULT_LOCALE)).toMatchObject([
+      { type: "OPERATOR", value: "=" },
+      { type: "SYMBOL", value: "SUM" },
+      { type: "LEFT_PAREN", value: "(", functionContext: firstArgContext },
+      { type: "LEFT_BRACE", value: "{", functionContext: firstArgContext },
+      { type: "NUMBER", value: "1", functionContext: firstArgContext },
+      { type: "ARG_SEPARATOR", value: ",", functionContext: firstArgContext },
+      { type: "NUMBER", value: "2", functionContext: firstArgContext },
+      { type: "RIGHT_BRACE", value: "}", functionContext: firstArgContext },
+      { type: "ARG_SEPARATOR", value: ",", functionContext: secondArgContext },
+      { type: "NUMBER", value: "3", functionContext: secondArgContext },
+      { type: "RIGHT_PAREN", value: ")" },
+    ]);
+  });
+
   test("debug formula token", () => {
     expect(composerTokenize("=?1", DEFAULT_LOCALE)).toEqual([
       { start: 0, end: 1, length: 1, type: "OPERATOR", value: "=", parenthesesCode: "" },


### PR DESCRIPTION

Use {} in a formula that expects several arguments. The comma in the {} is taken into account as the argument delimiter but shouldn't


Task: [6303210](https://www.odoo.com/odoo/2328/tasks/6303210)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo