### PR TITLE
[FIX] helpers: add helper to detect interactive elements in event tree

### DIFF
--- a/src/components/helpers/dom_helpers.ts
+++ b/src/components/helpers/dom_helpers.ts
@@ -288,3 +288,25 @@ function isOtherMobileOS() {
 export function isMobileOS() {
   return isAndroid() || isIOS() || isOtherMobileOS();
 }
+
+const INTERACTIVE_ELEMENT_SELECTOR =
+  "select, input, textarea, button, .o-select, .os-input, .o-input, .o-button, .o-button-icon, .o-button-link, .o-composer";
+
+/** Check if there is an interactive element (input, select, button, ...) between the event.target and event.currentTarget (inclusive)*/
+export function hasInteractiveElementInEventTree(event: Event) {
+  const target = event.target as HTMLElement | null;
+  const root = event.currentTarget as HTMLElement | null;
+  if (!root || !target || !root.contains(target)) {
+    return false;
+  }
+
+  let node: HTMLElement | null = target;
+  while (node && node !== root) {
+    if (node.matches(INTERACTIVE_ELEMENT_SELECTOR)) {
+      return true;
+    }
+    node = node.parentElement;
+  }
+
+  return root.matches(INTERACTIVE_ELEMENT_SELECTOR);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -332,6 +332,7 @@ import "./registries/chart_types";
 
 import "./clipboard_handlers";
 import { Composer } from "./components/composer/composer/composer";
+import { hasInteractiveElementInEventTree } from "./components/helpers/dom_helpers";
 import { Select } from "./components/select/select";
 import { ChartRangeDataSourceComponent } from "./components/side_panel/chart/building_blocks/range_data_source/range_data_source";
 import { TopBar } from "./components/top_bar/top_bar";
@@ -417,6 +418,7 @@ export const helpers = {
   isFormula,
   domainToColRowDomain,
   collapseHierarchicalDisplayName,
+  hasInteractiveElementInEventTree,
 };
 
 export const links = {


### PR DESCRIPTION
Current behavior before PR:
- Drag & drop relied on pointerdown.stop='' or early returns
- Logic was scattered and not consistent across implementations
- This made the behavior confusing and harder to maintain

Desired behavior after PR is merged:
- Use the helper function introduced in bdf14c6 for the pivot dnd check.
- Centralized check to detect interactive elements in event tree
- Early return is now handled in a consistent and clear way

Task: [6219600](https://www.odoo.com/odoo/2328/tasks/6219600)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo