### PR TITLE
[FIX] viewport: fix viewport jump with frozen pane

### DIFF
--- a/src/helpers/internal_viewport.ts
+++ b/src/helpers/internal_viewport.ts
@@ -142,7 +142,7 @@ export class InternalViewport {
     const { start, end } = this.getters.getColDimensions(sheetId, targetCol);
 
     if (this.offsetX + this.viewportWidth + this.offsetCorrectionX < end) {
-      this.offsetX = end - this.viewportWidth;
+      this.offsetX = end - this.viewportWidth - this.offsetCorrectionX;
     } else if (this.offsetX + this.offsetCorrectionX > start) {
       this.offsetX = start - this.offsetCorrectionX;
     }
@@ -153,7 +153,7 @@ export class InternalViewport {
     const sheetId = this.sheetId;
     const { start, end } = this.getters.getRowDimensions(sheetId, targetRow);
     if (this.offsetY + this.viewportHeight + this.offsetCorrectionY < end) {
-      this.offsetY = end - this.viewportHeight;
+      this.offsetY = end - this.viewportHeight - this.offsetCorrectionY;
     } else if (this.offsetY + this.offsetCorrectionY > start) {
       this.offsetY = start - this.offsetCorrectionY;
     }

--- a/tests/sheet/sheetview_plugin.test.ts
+++ b/tests/sheet/sheetview_plugin.test.ts
@@ -1303,6 +1303,51 @@ describe("Multi Panes viewport", () => {
     expect(model.getters.getSheetViewVisibleCols()).toEqual([]);
     expect(model.getters.getSheetViewVisibleRows()).toEqual([]);
   });
+
+  test("Move right beyond viewport with frozen columns correctly affects offset", () => {
+    freezeColumns(model, 3);
+    const { width } = model.getters.getSheetViewDimension();
+    const { right } = model.getters.getActiveMainViewport();
+    selectCell(model, toXC(right, 0));
+    expect(model.getters.getActiveSheetScrollInfo()).toMatchObject({
+      scrollX: DEFAULT_CELL_WIDTH * (right + 1) - width, // right is 0-indexed
+      scrollY: 0,
+    });
+
+    moveAnchorCell(model, "right");
+    expect(model.getters.getActiveMainViewport()).toMatchObject({
+      top: 0,
+      left: 4,
+      right: right + 1,
+    });
+    expect(model.getters.getActiveSheetScrollInfo()).toMatchObject({
+      scrollX: DEFAULT_CELL_WIDTH * (right + 2) - width,
+      scrollY: 0,
+    });
+  });
+
+  test("Move down beyond viewport with frozen rows correctly affects offset", () => {
+    freezeRows(model, 3);
+    const { height } = model.getters.getSheetViewDimension();
+    const { bottom } = model.getters.getActiveMainViewport();
+    selectCell(model, toXC(0, bottom));
+    expect(model.getters.getActiveSheetScrollInfo()).toMatchObject({
+      scrollX: 0,
+      scrollY: DEFAULT_CELL_HEIGHT * (bottom + 1) - height, // bottom is 0-indexed
+    });
+
+    moveAnchorCell(model, "down");
+    expect(model.getters.getActiveMainViewport()).toMatchObject({
+      left: 0,
+      right: 10,
+      top: 4,
+      bottom: bottom + 1,
+    });
+    expect(model.getters.getActiveSheetScrollInfo()).toMatchObject({
+      scrollX: 0,
+      scrollY: DEFAULT_CELL_HEIGHT * (bottom + 2) - height,
+    });
+  });
 });
 
 describe("multi sheet with different sizes", () => {


### PR DESCRIPTION
Fix the computation of offset when repositioning viewport.

Task: 6292764

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [6292764](https://www.odoo.com/odoo/2328/tasks/6292764)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo