### PR TITLE
[FIX] rolldown: Fix cjs file extension

### DIFF
--- a/rolldown.config.js
+++ b/rolldown.config.js
@@ -3,14 +3,21 @@ import { bundle } from "./tools/bundle.cjs";
 
 const outro = bundle.outro();
 
+const EXTENSION = {
+  esm: "esm.js", //TODO Change it to mjs
+  cjs: "cjs",
+  iife: "iife.js",
+};
+
 /**
  * Get the rolldown config based on the arguments
  * @param {"esm" | "cjs" | "iife"} format format of the bundle
  * @param {boolean} minified should it be minified
  */
 function getConfigForFormat(format, minified = false) {
+  const extension = EXTENSION[format];
   return {
-    file: minified ? `dist/o-spreadsheet.${format}.min.js` : `dist/o-spreadsheet.${format}.js`,
+    file: minified ? `dist/o-spreadsheet.${format}.min.js` : `dist/o-spreadsheet.${extension}`,
     format,
     name: "o_spreadsheet",
     extend: true,


### PR DESCRIPTION
With the recent change of config file, we broke the extension naming of the commonJS bundle (.cjs.js ≠ .cjs)

Task: 0

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo