### PR TITLE
[FIX] chart: zoomable chart height issue with rjsmin minification

### DIFF
--- a/src/components/figures/chart/chartJs/zoomable_chart/zoomable_chartjs.ts
+++ b/src/components/figures/chart/chartJs/zoomable_chart/zoomable_chartjs.ts
@@ -8,7 +8,7 @@ import {
 } from "../../../../../helpers/figures/charts/chart_common";
 import { Store, useStore } from "../../../../../store_engine";
 import { ChartJSRuntime } from "../../../../../types";
-import { css } from "../../../../helpers";
+import { css, cssPropertiesToCss } from "../../../../helpers";
 import { chartJsExtensionRegistry } from "../chart_js_extension";
 import { ChartJsComponent } from "../chartjs";
 import { Boundaries, ZoomableChartStore } from "./zoomable_chart_store";
@@ -54,10 +54,9 @@ export class ZoomableChartJsComponent extends ChartJsComponent {
   }
 
   get containerStyle() {
-    const height = this.sliceable ? `calc(100% - ${MASTER_CHART_HEIGHT}px)` : "100%";
-    return `
-      height:${height};
-    `;
+    return cssPropertiesToCss({
+      height: this.sliceable ? `calc(100% - ${MASTER_CHART_HEIGHT}px)` : "100%",
+    });
   }
 
   get masterChartContainerStyle() {


### PR DESCRIPTION
Current behavior before PR:
- In Odoo, when `debug=assets` is not enabled, the spreadsheet bundle is served in a minified form using rjsmin.
- 'rjsmin' does not preserve spaces inside nested template literals.
- When using nested backticks, CSS values like: `calc(100% - 10px)` become `calc(100%-10px)` after minification.
- This breaks CSS expectations and can lead to incorrect rendering.
- As a result, the zoomable chart fails to compute and apply the correct height.

Desired behavior after PR is merged:
- Replace nested template literal CSS generation with`cssPropertiesToCss`.
- This avoids using nested template literals, preventing incorrect space removal during minification.
- Fixes incorrect height calculation in zoomable charts in production mode.

Task: [6306092](https://www.odoo.com/odoo/2328/tasks/6306092)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo