### PR TITLE
[statistics bottom bar] clicking on the open statistics menu does not close it

### DIFF
--- a/src/components/bottom_bar/bottom_bar_statistic/bottom_bar_statistic.ts
+++ b/src/components/bottom_bar/bottom_bar_statistic/bottom_bar_statistic.ts
@@ -3,6 +3,7 @@ import { formatValue } from "../../../helpers/format/format";
 import { Component } from "../../../owl3_compatibility_layer";
 import { MenuItemRegistry } from "../../../registries/menu_items_registry";
 import { useStore } from "../../../store_engine/store_hooks";
+import { MenuMouseEvent } from "../../../types/misc";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
 import { Store } from "../../../types/store_engine";
 import { Ripple } from "../../animation/ripple";
@@ -49,7 +50,11 @@ export class BottomBarStatistic extends Component<SpreadsheetChildEnv> {
     return this.getComposedFnName(this.state.selectedStatisticFn);
   }
 
-  listSelectionStatistics(ev: MouseEvent) {
+  listSelectionStatistics(ev: MenuMouseEvent) {
+    if (ev.closedMenuId === "listSelectionStatistics") {
+      this.props.closeContextMenu();
+      return;
+    }
     const registry = new MenuItemRegistry();
     let i = 0;
     for (const [fnName] of Object.entries(this.store.statisticFnResults)) {

--- a/tests/bottom_bar/bottom_bar_component.test.ts
+++ b/tests/bottom_bar/bottom_bar_component.test.ts
@@ -682,6 +682,18 @@ describe("BottomBar component", () => {
     expect(fixture.querySelector(".o-menu")).toMatchSnapshot();
   });
 
+  test("Can close the list of statistics by clicking on the statistic button", async () => {
+    const { model } = await mountBottomBar();
+    setCellContent(model, "A2", "24");
+    selectCell(model, "A2");
+    await nextTick();
+
+    await click(fixture, ".o-selection-statistic");
+    expect(fixture.querySelector(".o-menu")).toBeTruthy();
+    await click(fixture, ".o-selection-statistic");
+    expect(fixture.querySelector(".o-menu")).toBeFalsy();
+  });
+
   test("Can open the list of statistics if another menu is already open", async () => {
     const model = new Model();
     const nonMockedDispatch = model.dispatch;


### PR DESCRIPTION
## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [6316288](https://www.odoo.com/odoo/2328/tasks/6316288)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo