### PR TITLE
[FIX] sheet: add sheet tab color to custom colors

### DIFF
--- a/src/components/bottom_bar/bottom_bar_sheet/bottom_bar_sheet.ts
+++ b/src/components/bottom_bar/bottom_bar_sheet/bottom_bar_sheet.ts
@@ -71,6 +71,7 @@ interface Props {
 interface State {
   isEditing: boolean;
   pickerOpened: boolean;
+  currentPickerColor?: string;
 }
 
 export class BottomBarSheet extends Component<Props, SpreadsheetChildEnv> {
@@ -255,6 +256,8 @@ export class BottomBarSheet extends Component<Props, SpreadsheetChildEnv> {
       },
       openSheetColorPickerCallback: () => {
         this.state.pickerOpened = true;
+        const sheet = this.env.model.getters.getSheet(this.props.sheetId);
+        this.state.currentPickerColor = sheet.color;
       },
     });
   }

--- a/src/components/bottom_bar/bottom_bar_sheet/bottom_bar_sheet.ts
+++ b/src/components/bottom_bar/bottom_bar_sheet/bottom_bar_sheet.ts
@@ -105,7 +105,7 @@ export class BottomBarSheet extends Component<Props, SpreadsheetChildEnv> {
       }
     });
     this.DOMFocusableElementStore = useStore(DOMFocusableElementStore);
-    useExternalListener(window, "click", () => (this.state.pickerOpened = false));
+    useExternalListener(window, "click", this.onExternalClick.bind(this), { capture: true });
 
     useEffect(
       (sheetId) => {
@@ -115,6 +115,13 @@ export class BottomBarSheet extends Component<Props, SpreadsheetChildEnv> {
       },
       () => [this.env.model.getters.getActiveSheetId()]
     );
+  }
+
+  onExternalClick(ev: MouseEvent) {
+    const target = ev.target as HTMLElement;
+    if (!target.closest(".o-color-picker")) {
+      this.state.pickerOpened = false;
+    }
   }
 
   private focusInputAndSelectContent() {

--- a/src/components/bottom_bar/bottom_bar_sheet/bottom_bar_sheet.xml
+++ b/src/components/bottom_bar/bottom_bar_sheet/bottom_bar_sheet.xml
@@ -42,7 +42,7 @@
       t-if="state.pickerOpened"
       anchorRect="colorPickerAnchorRect"
       onColorPicked.bind="onColorPicked"
-      currentColor="props.currentColor"
+      currentColor="this.state.currentPickerColor"
     />
   </t>
 </templates>

--- a/src/plugins/ui_core_views/custom_colors.ts
+++ b/src/plugins/ui_core_views/custom_colors.ts
@@ -93,6 +93,11 @@ export class CustomColorsPlugin extends UIPlugin<CustomColorState> {
       case "CREATE_CHART":
         this.tryToAddColors(this.getChartColors(cmd.id));
         break;
+      case "COLOR_SHEET":
+        if (cmd.color) {
+          this.tryToAddColors([cmd.color]);
+        }
+        break;
       case "UPDATE_CELL":
       case "ADD_CONDITIONAL_FORMAT":
       case "SET_BORDER":
@@ -120,12 +125,18 @@ export class CustomColorsPlugin extends UIPlugin<CustomColorState> {
     let usedColors: Color[] = [];
     for (const sheetId of this.getters.getSheetIds()) {
       usedColors = usedColors.concat(
+        this.getSheetColors(sheetId),
         this.getColorsFromCells(sheetId),
         this.getFormattingColors(sheetId),
         this.getTableColors(sheetId)
       );
     }
     return [...new Set([...usedColors])];
+  }
+
+  private getSheetColors(sheetId: UID): Color[] {
+    const sheet = this.getters.getSheet(sheetId);
+    return sheet.color ? [sheet.color] : [];
   }
 
   private getColorsFromCells(sheetId: UID): Color[] {

--- a/tests/bottom_bar/bottom_bar_component.test.ts
+++ b/tests/bottom_bar/bottom_bar_component.test.ts
@@ -7,6 +7,7 @@ import { DOMFocusableElementStore } from "../../src/stores/DOM_focus_store";
 import { Pixel, SpreadsheetChildEnv, UID } from "../../src/types";
 import {
   activateSheet,
+  colorSheet,
   createSheet,
   deleteSheet,
   hideSheet,
@@ -1037,6 +1038,17 @@ describe("BottomBar component", () => {
       expect(menuItemsIcons[0]?.children).toHaveLength(0);
       expect(getElComputedStyle(menuItemsIcons[1], "color")).toBeSameColorAs("#FFFF00");
       expect(getElComputedStyle(menuItemsIcons[2], "color")).toBeSameColorAs("#FF0000");
+    });
+
+    test("Color picker has the correct color selected when opening it", async () => {
+      const { model } = await mountBottomBar();
+
+      // Tab color
+      colorSheet(model, model.getters.getActiveSheetId(), "#FFFF00");
+      triggerMouseEvent(".o-sheet", "contextmenu");
+      await nextTick();
+      await click(fixture, ".o-menu-item[data-name='change_color'");
+      expect(".o-color-picker-line-item[data-color='#FFFF00']").toHaveText(" ✓ ");
     });
   });
 });

--- a/tests/bottom_bar/bottom_bar_component.test.ts
+++ b/tests/bottom_bar/bottom_bar_component.test.ts
@@ -140,6 +140,17 @@ describe("BottomBar component", () => {
     expect(fixture.querySelectorAll(".o-menu")).toHaveLength(0);
   });
 
+  test("Click on the arrow when a color picker is open should close it", async () => {
+    await mountBottomBar();
+    await click(fixture, ".o-sheet-icon");
+    await click(fixture, ".o-menu-item[data-name='change_color'");
+    expect(".o-color-picker").toHaveCount(1);
+
+    await click(fixture, ".o-sheet-icon");
+    expect(".o-menu").toHaveCount(1);
+    expect(".o-color-picker").toHaveCount(0);
+  });
+
   test("Can open context menu of a sheet with the arrow if another menu is already open", async () => {
     await mountBottomBar();
 

--- a/tests/colors/custom_colors_plugin.test.ts
+++ b/tests/colors/custom_colors_plugin.test.ts
@@ -2,6 +2,7 @@ import { Model } from "../../src";
 import { TABLE_PRESETS } from "../../src/helpers/table_presets";
 import { TableStyle, UID } from "../../src/types";
 import {
+  colorSheet,
   createChart,
   createScorecardChart,
   createTable,
@@ -172,6 +173,12 @@ describe("custom colors are correctly handled when editing charts", () => {
       "1"
     );
     expect(model.getters.getCustomColors()).toEqual(["#112233", "#123456"]);
+  });
+
+  test("Sheet colors are taken into account", () => {
+    colorSheet(model, model.getters.getActiveSheetId(), "#FFFF16");
+
+    expect(model.getters.getCustomColors()).toEqual(["#FFFF16"]);
   });
 
   test("Chart data series colors are taken into account", () => {


### PR DESCRIPTION
## Description

The custom colors were missing the sheet tab color, and the color picker didn't have a checkmark for the selected color.

Task: [6322171](https://www.odoo.com/odoo/2328/tasks/6322171)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo