### PR TITLE
[FIX] Fonts: Add default font for Linux

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -174,7 +174,7 @@ export const DEFAULT_WRAPPING_MODE = DEFAULT_STYLE.wrapping;
 export const DEFAULT_FONT_WEIGHT = "400";
 export const DEFAULT_FONT_SIZE = DEFAULT_STYLE.fontSize;
 export const HEADER_FONT_SIZE = 11;
-export const DEFAULT_FONT = "'Roboto', arial";
+export const DEFAULT_FONT = "'Roboto', arial, 'Liberation Sans'";
 
 // Borders
 export const DEFAULT_BORDER_DESC: BorderDescr = { style: "thin", color: "#000000" };


### PR DESCRIPTION
We currently have a font family set for the canvas and the composers. However, both fonts are proprietary:
- Roboto -> Google
- Arial -> Microsoft

For users using an 'open' operating system without any of those proprietary fonts, the font family has 0 matches and defaults on a 'Times new Roman' like font which is quite ugly.

This revision adds a fallback to 'Liberation Sans' which is the opensource equivalent to Arial [1].

[1]: https://wiki.archlinux.org/title/Metric-compatible_fonts

Task: 6328646

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo