### PR TITLE
[FIX] autofill: hide autofill handler when selection is hidden

### DIFF
--- a/src/components/autofill/autofill.ts
+++ b/src/components/autofill/autofill.ts
@@ -79,6 +79,7 @@ export class Autofill extends Component<Props, SpreadsheetChildEnv> {
     return cssPropertiesToCss({
       top: `${top}px`,
       left: `${left}px`,
+      visibility: this.props.isVisible ? "visible" : "hidden",
     });
   }
 

--- a/tests/grid/__snapshots__/grid_component.test.ts.snap
+++ b/tests/grid/__snapshots__/grid_component.test.ts.snap
@@ -116,7 +116,7 @@ exports[`Grid component simple rendering snapshot 1`] = `
   />
   <div
     class="o-autofill-handler"
-    style="top:45px; left:140px; "
+    style="top:45px; left:140px; visibility:visible; "
   />
   
   

--- a/tests/spreadsheet/__snapshots__/spreadsheet_component.test.ts.snap
+++ b/tests/spreadsheet/__snapshots__/spreadsheet_component.test.ts.snap
@@ -858,7 +858,7 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
         />
         <div
           class="o-autofill-handler"
-          style="top:45px; left:140px; "
+          style="top:45px; left:140px; visibility:visible; "
         />
         
         
@@ -1802,7 +1802,7 @@ exports[`components take the small screen into account 1`] = `
         />
         <div
           class="o-autofill-handler"
-          style="top:45px; left:140px; "
+          style="top:45px; left:140px; visibility:visible; "
         />
         
         


### PR DESCRIPTION
Before this commit:
It was possible to see the autofill handler when the selection was hidden, and to drag and drop the autofill handler to autofill the rows below the selection, even if the selection was hidden.

Task: [6317808](https://www.odoo.com/odoo/2328/tasks/6317808)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo