### PR TITLE
[FIX] typing: exclude non-exported symbols in type resolution

### DIFF
--- a/src/types/props_of.ts
+++ b/src/types/props_of.ts
@@ -1,5 +1,9 @@
 import { GetPropsWithOptionals } from "@odoo/owl";
 
+// Strips symbol-keyed properties so the expanded type doesn't reference
+// inaccessible `unique symbol` tokens from @odoo/owl in generated .d.ts files.
+type DropSymbolKeys<T> = { [K in keyof T as K extends symbol ? never : K]: T[K] };
+
 /**
  * Return the prop's type of a component as seen from the caller (pre-default
  * shape). Strips the owl3 `Props<...>` / `PropsWithDefaults<...>` brand and
@@ -7,8 +11,9 @@ import { GetPropsWithOptionals } from "@odoo/owl";
  * not a `Props<...>` brand (e.g. typed with a plain interface), returns it
  * as-is instead of `never`.
  */
-export type PropsOf<C extends { [key: string]: any }, Key extends string = "props"> = [
-  GetPropsWithOptionals<C[Key]>
-] extends [never]
-  ? C[Key]
-  : GetPropsWithOptionals<C[Key]>;
+export type PropsOf<
+  C extends { [key: string]: any },
+  Key extends string = "props"
+> = DropSymbolKeys<
+  [GetPropsWithOptionals<C[Key]>] extends [never] ? C[Key] : GetPropsWithOptionals<C[Key]>
+>;


### PR DESCRIPTION
Owl's internal prop types use `unique symbol` constants (`hasDefault`, `isOptional`, `typeBrand`, `isProps`) that are declared but not exported. When `PropsOf<SidePanel>` is used as an explicit annotation, TypeScript emits it by name in `.d.ts` without expanding it. But without the annotation, TypeScript infers and expands the full type, which references those unexportable symbols.

This causes an issue in the component `SidePanels` where the getter `panelList` is typed implicitely, which has no effect at ts compilation time but will cause the aforementioned issue when generetin a types file.

Task: 0

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo