### PR TITLE
[FIX] conditional_formatting: handle zero color scale midpoint

### DIFF
--- a/src/plugins/ui_core_views/evaluation_conditional_format.ts
+++ b/src/plugins/ui_core_views/evaluation_conditional_format.ts
@@ -293,7 +293,7 @@ export class EvaluationConditionalFormatPlugin extends UIPlugin {
       minValue === null ||
       maxValue === null ||
       minValue >= maxValue ||
-      (midValue && (minValue >= midValue || midValue >= maxValue))
+      (midValue !== null && (minValue >= midValue || midValue >= maxValue))
     ) {
       return;
     }
@@ -303,7 +303,7 @@ export class EvaluationConditionalFormatPlugin extends UIPlugin {
       minColor: number;
       colorDiffUnit: [number, number, number];
     }[] = [];
-    if (rule.midpoint && midValue) {
+    if (rule.midpoint && midValue !== null) {
       colorCellArgs.push({
         minValue,
         minColor: rule.minimum.color,
@@ -342,7 +342,7 @@ export class EvaluationConditionalFormatPlugin extends UIPlugin {
         if (cell.type === CellValueType.number) {
           const value = clip(cell.value, minValue, maxValue);
           let color;
-          if (colorCellArgs.length === 2 && midValue) {
+          if (colorCellArgs.length === 2 && midValue !== null) {
             color =
               value <= midValue
                 ? this.colorCell(

--- a/tests/conditional_formatting/conditional_formatting_plugin.test.ts
+++ b/tests/conditional_formatting/conditional_formatting_plugin.test.ts
@@ -2285,6 +2285,27 @@ describe("conditional formats types", () => {
       });
     });
 
+    test("3 points, value scale with midpoint = 0", () => {
+      setCellContent(model, "A1", "-5");
+      setCellContent(model, "A2", "0");
+      setCellContent(model, "A3", "5");
+
+      model.dispatch("ADD_CONDITIONAL_FORMAT", {
+        cf: createColorScale(
+          "1",
+          { type: "value", color: 0xff0000 },
+          { type: "value", color: 0x00ff00 },
+          { type: "number", color: 0xffffff, value: "0" }
+        ),
+        ranges: toRangesData(sheetId, "A1:A3"),
+        sheetId,
+      });
+
+      expect(getStyle(model, "A2")).toEqual({
+        fillColor: "#FFFFFF",
+      });
+    });
+
     test("2 points, value scale with same min/max", () => {
       setCellContent(model, "A1", "10");
       setCellContent(model, "A2", "10");


### PR DESCRIPTION
## Description:

A color scale midpoint value of 0 was treated as absent because the evaluation logic checked the parsed midpoint with truthiness.

As a result, three-point color scales with a midpoint at 0 were evaluated as two-point scales, interpolating directly from minimum to maximum color. This made the midpoint cell use a mixed color instead of the configured midpoint color.


Task: [6312961](https://www.odoo.com/odoo/2328/tasks/6312961)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo