### PR TITLE
[IMP] tools: run esm version is node

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "postdist": " npm run bundle:xml -- --outDir dist && npm run bundle:css -- --out dist",
     "test": "tsc --noEmit --project tests/tsconfig.json && jest",
     "monkey": "SPREADSHEET_MONKEY_COUNT=$npm_config_monkey_count jest 'tests/collaborative/collaborative_monkey_party.test.ts'",
-    "model-in-node": "npm run dist && node tools/run_in_node.cjs",
+    "model-in-node": "npm run dist && node tools/run_in_node.mjs",
     "zipXlsx": "node tools/bundle_xlsx/zip_xlsx_demo.cjs",
     "unzipXlsx": "node tools/bundle_xlsx/unzip_xlsx_demo.cjs",
     "runbot": "npm run check-formatting && npm run model-in-node && npm run test --"

--- a/src/owl3_compatibility_layer.ts
+++ b/src/owl3_compatibility_layer.ts
@@ -33,33 +33,34 @@
  * The end goal is to eliminate all compatibility shims.
  */
 
-import {
+import * as owl from "@odoo/owl";
+
+const {
   __ODOO_COMPATIBILITY_LAYER_ADDED__,
   blockDom,
   config,
   onMounted,
   onPatched, // Exported by Odoo compat layer
   onWillUnmount,
-  App as OwlApp,
-  Component as OwlComponent, // Exported by Odoo compat layer
-  EnvPlugin as OwlEnvPlugin, // Exported by Odoo compat layer
-  useChildEnv as OwlUseChildEnv, // Exported by Odoo compat layer
-  useChildSubEnv as OwlUseChildSubEnv,
-  useComponent as OwlUseComponent, // Exported by Odoo compat layer
-  useEnv as OwlUseEnv, // Exported by Odoo compat layer
-  useExternalListener as OwlUseExternalListener, // Exported by Odoo compat layer
-  useLayoutEffect as OwlUseLayoutEffect, // Exported by Odoo compat layer
-  useSubEnv as OwlUseSubEnv, // Exported by Odoo compat layer
+  App: OwlApp,
+  Component: OwlComponent, // Exported by Odoo compat layer
+  EnvPlugin: OwlEnvPlugin, // Exported by Odoo compat layer
+  useChildEnv: OwlUseChildEnv, // Exported by Odoo compat layer
+  useChildSubEnv: OwlUseChildSubEnv,
+  useComponent: OwlUseComponent, // Exported by Odoo compat layer
+  useEnv: OwlUseEnv, // Exported by Odoo compat layer
+  useExternalListener: OwlUseExternalListener, // Exported by Odoo compat layer
+  useLayoutEffect: OwlUseLayoutEffect, // Exported by Odoo compat layer
+  useSubEnv: OwlUseSubEnv, // Exported by Odoo compat layer
   Plugin,
   plugin,
   props,
   providePlugins, // Exported by Odoo compat layer
   useScope,
   xml,
-} from "@odoo/owl";
+} = owl;
 
 const isOdooCompatLoaded = __ODOO_COMPATIBILITY_LAYER_ADDED__ === true;
-
 export interface ComponentConstructor<Env = any> {
   new (...args: any[]): any;
   template: string;

--- a/tools/run_in_node.cjs
+++ b/tools/run_in_node.cjs
@@ -1,3 +1,0 @@
-const spreadsheet = require("../dist/o_spreadsheet.cjs");
-
-new spreadsheet.Model();

--- a/tools/run_in_node.mjs
+++ b/tools/run_in_node.mjs
@@ -1,0 +1,3 @@
+const { Model } = await import("../dist/o_spreadsheet.esm.js");
+
+new Model();


### PR DESCRIPTION
The script `run_in_node` does not work with owl3 because they changed the default type of the lib to 'module', which defines how nodeJs should interprete `.js` files [1]. The script relied on the common js version which unfortunately ends with the suffix `.js` and not `.cjs`. Therefore, we nodeJs tries to interprete the commonJs file as a module, which does not work quite well.

Since the lib is mainly used (i.e. in Odoo) with the module js version and that it seems to become the norm, we adapt the script to run as moduleJs. We could consider dropping the common js version in the future but one thing at a time...

[1]: https://docs.npmjs.com/cli/v11/configuring-npm/package-json#type

Task: 0

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo