### PR TITLE
[IMP] header_size: make getters consistent

### DIFF
--- a/src/helpers/internal_viewport.ts
+++ b/src/helpers/internal_viewport.ts
@@ -261,7 +261,9 @@ export class InternalViewport {
     while (start <= end && start !== headers && end !== -1) {
       const mid: HeaderIndex = Math.floor((start + end) / 2);
       const offset = this.getters.getColRowOffset(dimension, startIndex, mid, this.sheetId);
-      const size = this.getters.getHeaderSize(sheetId, dimension, mid);
+      const size = this.getters.isHeaderHidden(sheetId, dimension, mid)
+        ? 0
+        : this.getters.getHeaderSize(sheetId, dimension, mid);
       if (position >= offset && position < offset + size) {
         return mid;
       } else if (position >= offset + size) {

--- a/src/plugins/core/sheet.ts
+++ b/src/plugins/core/sheet.ts
@@ -815,6 +815,8 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
     this.history.update("orderedSheetIds", orderedSheetIds);
     this.history.update("sheets", Object.assign({}, this.sheets, { [newSheet.id]: newSheet }));
 
+    // FIXME: probably a bad idea to dispatch UPDATE_CELL here. All the plugins try to handle an UPDATE_CELL on the new
+    // sheet before they receive the DUPLICATE_SHEET and have a chance to add this new sheet to their state.
     for (const cell of Object.values(this.getters.getCells(fromId))) {
       const { col, row } = this.getCellPosition(cell.id);
       this.dispatch("UPDATE_CELL", {

--- a/src/plugins/ui_core_views/header_sizes_ui.ts
+++ b/src/plugins/ui_core_views/header_sizes_ui.ts
@@ -160,9 +160,6 @@ export class HeaderSizeUIPlugin extends CoreViewPlugin<HeaderSizeState> implemen
   }
 
   getHeaderSize(sheetId: UID, dimension: Dimension, index: HeaderIndex): Pixel {
-    if (this.getters.isHeaderHidden(sheetId, dimension, index)) {
-      return 0;
-    }
     return dimension === "ROW"
       ? this.getRowSize(sheetId, index)
       : this.getters.getColSize(sheetId, index);

--- a/tests/headers/resizing_plugin.test.ts
+++ b/tests/headers/resizing_plugin.test.ts
@@ -20,6 +20,8 @@ import {
   deleteRows,
   freezeColumns,
   freezeRows,
+  hideColumns,
+  hideRows,
   merge,
   redo,
   resizeColumns,
@@ -693,6 +695,26 @@ describe("Model resizer", () => {
     resizeRows(model, [0], 26.6);
     expect(model.getters.getColSize(sheetId, 0)).toBe(26);
     expect(model.getters.getRowSize(sheetId, 0)).toBe(27);
+  });
+
+  test("getHeaderSize and getCol/RowSize give the same result with hidden rows", () => {
+    const model = new Model();
+    const sheetId = model.getters.getActiveSheetId();
+    resizeColumns(model, ["A"], 12);
+    expect(model.getters.getHeaderSize(sheetId, "COL", 0)).toBe(12);
+    expect(model.getters.getColSize(sheetId, 0)).toBe(12);
+
+    hideColumns(model, ["A"]);
+    expect(model.getters.getHeaderSize(sheetId, "COL", 0)).toBe(12);
+    expect(model.getters.getColSize(sheetId, 0)).toBe(12);
+
+    resizeRows(model, [0], 25);
+    expect(model.getters.getHeaderSize(sheetId, "ROW", 0)).toBe(25);
+    expect(model.getters.getRowSize(sheetId, 0)).toBe(25);
+
+    hideRows(model, [0]);
+    expect(model.getters.getHeaderSize(sheetId, "ROW", 0)).toBe(25);
+    expect(model.getters.getRowSize(sheetId, 0)).toBe(25);
   });
 
   test("Should use markdown label instead of full link for auto row height", () => {


### PR DESCRIPTION
## Description

Using the getter `getRowSize()` on an hidden row would return the size of the row, while calling `getHeaderSize()` on the same row would return 0. The different behaviour is confusing and not expected.

This commit make `getHeaderSize()` ignore hidden rows, we have to handle them manually when calling the getter.

Note: One could argue that `getCol/RowSize()` should also return 0 for hidden headers instead. But this crashed with the current plugin architecture on `DUPLICATE_SHEET`. The SheetPlugin dispatches `UPDATE_CELL` on sheet duplication, which is handled by all the plugins before every core plugin has received the `DUPLICATE_SHEET` and added the new sheet in its state. This causes some getters to crash, including `isColHidden()`.

Task: [6332479](https://www.odoo.com/odoo/2328/tasks/6332479)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo