### PR TITLE
[FIX] print: handle hidden headers

### DIFF
--- a/src/components/spreadsheet_print/spreadsheet_print_store.ts
+++ b/src/components/spreadsheet_print/spreadsheet_print_store.ts
@@ -134,14 +134,16 @@ export class SpreadsheetPrintStore extends SpreadsheetStore {
 
     const start = dimension === "COL" ? printZone.left : printZone.top;
     const end = dimension === "COL" ? printZone.right : printZone.bottom;
-    const getHeaderSize =
-      dimension === "COL" ? this.getters.getColDimensions : this.getters.getRowDimensions;
+    const getHeaderSize = (index: HeaderIndex) =>
+      this.getters.isHeaderHidden(sheetId, dimension, index)
+        ? 0
+        : this.getters.getHeaderDimensions(sheetId, dimension, index).size;
     const max = dimension === "COL" ? printWidth : printHeight;
 
     const breaks: number[] = [];
     let current = 0;
     for (let i = start; i <= end; i++) {
-      const headerSize = getHeaderSize(sheetId, i).size * zoom;
+      const headerSize = getHeaderSize(i) * zoom;
       current += headerSize;
       if (current >= max) {
         breaks.push(i);

--- a/src/components/spreadsheet_print/spreadsheet_print_store.ts
+++ b/src/components/spreadsheet_print/spreadsheet_print_store.ts
@@ -134,14 +134,12 @@ export class SpreadsheetPrintStore extends SpreadsheetStore {
 
     const start = dimension === "COL" ? printZone.left : printZone.top;
     const end = dimension === "COL" ? printZone.right : printZone.bottom;
-    const getHeaderSize =
-      dimension === "COL" ? this.getters.getColDimensions : this.getters.getRowDimensions;
     const max = dimension === "COL" ? printWidth : printHeight;
 
     const breaks: number[] = [];
     let current = 0;
     for (let i = start; i <= end; i++) {
-      const headerSize = getHeaderSize(sheetId, i).size * zoom;
+      const headerSize = this.getters.getHeaderSize(sheetId, dimension, i) * zoom;
       current += headerSize;
       if (current >= max) {
         breaks.push(i);

--- a/src/plugins/ui_stateful/header_positions.ts
+++ b/src/plugins/ui_stateful/header_positions.ts
@@ -4,7 +4,12 @@ import { Dimension, HeaderDimensions, HeaderIndex, Pixel, UID } from "../../type
 import { UIPlugin } from "../ui_plugin";
 
 export class HeaderPositionsUIPlugin extends UIPlugin {
-  static getters = ["getColDimensions", "getRowDimensions", "getColRowOffset"] as const;
+  static getters = [
+    "getColDimensions",
+    "getRowDimensions",
+    "getHeaderDimensions",
+    "getColRowOffset",
+  ] as const;
 
   private headerPositions: Record<UID, Record<Dimension, Record<HeaderIndex, Pixel>>> = {};
   private isDirty = true;
@@ -94,6 +99,12 @@ export class HeaderPositionsUIPlugin extends UIPlugin {
       size: size,
       end: start + (isRowHidden ? 0 : size),
     };
+  }
+
+  getHeaderDimensions(sheetId: UID, dim: Dimension, index: HeaderIndex): HeaderDimensions {
+    return dim === "COL"
+      ? this.getColDimensions(sheetId, index)
+      : this.getRowDimensions(sheetId, index);
   }
 
   /**

--- a/tests/spreadsheet/spreadsheet_print_store.test.ts
+++ b/tests/spreadsheet/spreadsheet_print_store.test.ts
@@ -1,6 +1,13 @@
 import { Model } from "../../src";
 import { SpreadsheetPrintStore } from "../../src/components/spreadsheet_print/spreadsheet_print_store";
-import { createChart, createSheet, setCellContent, setSelection } from "../test_helpers";
+import {
+  createChart,
+  createSheet,
+  hideColumns,
+  hideRows,
+  setCellContent,
+  setSelection,
+} from "../test_helpers";
 import { makeStore } from "../test_helpers/stores";
 
 describe("Spreadsheet print rendering", () => {
@@ -32,6 +39,35 @@ describe("Spreadsheet print rendering", () => {
       { sheetId, left: 0, top: 0, right: 0, bottom: 43 },
       { sheetId, left: 0, top: 44, right: 0, bottom: 87 },
       { sheetId, left: 0, top: 88, right: 0, bottom: 99 },
+    ]);
+  });
+
+  test("Print pages break take hidden rows into account", () => {
+    setCellContent(model, "A1", "=SEQUENCE(80)");
+    expect(getPrintedZones()).toEqual([
+      { sheetId, left: 0, top: 0, right: 0, bottom: 43 },
+      { sheetId, left: 0, top: 44, right: 0, bottom: 79 },
+    ]);
+
+    hideRows(model, [5, 6, 7, 8, 9]);
+    expect(getPrintedZones()).toEqual([
+      { sheetId, left: 0, top: 0, right: 0, bottom: 48 },
+      { sheetId, left: 0, top: 49, right: 0, bottom: 79 },
+    ]);
+  });
+
+  test("Print pages breaks take hidden columns into account", () => {
+    setCellContent(model, "A1", "=TRANSPOSE(SEQUENCE(12))");
+    printStore.changePrintScale("fitToHeight");
+    expect(getPrintedZones()).toEqual([
+      { sheetId, left: 0, top: 0, right: 6, bottom: 0 },
+      { sheetId, left: 7, top: 0, right: 11, bottom: 0 },
+    ]);
+
+    hideColumns(model, ["B", "C", "D"]);
+    expect(getPrintedZones()).toEqual([
+      { sheetId, left: 0, top: 0, right: 9, bottom: 0 },
+      { sheetId, left: 10, top: 0, right: 11, bottom: 0 },
     ]);
   });
 


### PR DESCRIPTION
## Description

To determine the page break, the print store would use the header size without taking into account if the header is hidden or not.

Task: [6332587](https://www.odoo.com/odoo/2328/tasks/6332587)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo