### PR TITLE
[FIX] HeaderVisibility: fix  `getNextVisibleCellPosition` getter 

### DIFF
--- a/src/plugins/ui_feature/header_visibility_ui.ts
+++ b/src/plugins/ui_feature/header_visibility_ui.ts
@@ -32,8 +32,14 @@ export class HeaderVisibilityUIPlugin extends UIPlugin {
   getNextVisibleCellPosition({ sheetId, col, row }: CellPosition): CellPosition {
     return {
       sheetId,
-      col: this.findVisibleHeader(sheetId, "COL", col, this.getters.getNumberCols(sheetId) - 1)!,
-      row: this.findVisibleHeader(sheetId, "ROW", row, this.getters.getNumberRows(sheetId) - 1)!,
+      col:
+        this.findVisibleHeader(sheetId, "COL", col, this.getters.getNumberCols(sheetId) - 1) ||
+        this.findVisibleHeader(sheetId, "COL", col, 0) ||
+        0,
+      row:
+        this.findVisibleHeader(sheetId, "ROW", row, this.getters.getNumberRows(sheetId) - 1) ||
+        this.findVisibleHeader(sheetId, "ROW", row, 0) ||
+        0,
     };
   }
 

--- a/src/plugins/ui_stateful/edition.ts
+++ b/src/plugins/ui_stateful/edition.ts
@@ -204,7 +204,8 @@ export class EditionPlugin extends UIPlugin {
           this.cancelEdition();
           this.resetContent();
         }
-        if (cmd.sheetIdFrom !== cmd.sheetIdTo) {
+
+        if (this.selection.isListening(this) && cmd.sheetIdFrom !== cmd.sheetIdTo) {
           const activePosition = this.getters.getActivePosition();
           const { col, row } = this.getters.getNextVisibleCellPosition({
             sheetId: cmd.sheetIdTo,

--- a/tests/composer/edition_plugin.test.ts
+++ b/tests/composer/edition_plugin.test.ts
@@ -7,6 +7,7 @@ import {
   copy,
   createSheet,
   createSheetWithName,
+  hideRows,
   merge,
   moveAnchorCell,
   paste,
@@ -1215,5 +1216,16 @@ describe("edition", () => {
     const highlights = model.getters.getComposerHighlights();
     expect(highlights).toHaveLength(1);
     expect(highlights[0].zone).toMatchObject(toZone("A2"));
+  });
+
+  test("Can edit a sheet in which the old selection was hidden", () => {
+    const model = new Model();
+    const firstSheetId = model.getters.getActiveSheetId();
+    selectCell(model, "A100");
+    hideRows(model, [99]);
+    // right now, the selection is hidden as it's set on A100
+    createSheet(model, { sheetId: "sheet2", activate: true });
+    model.dispatch("START_EDITION", { text: `=` });
+    activateSheet(model, firstSheetId);
   });
 });

--- a/tests/headers/header_visibility_plugin.test.ts
+++ b/tests/headers/header_visibility_plugin.test.ts
@@ -17,7 +17,7 @@ import {
   unhideColumns,
   unhideRows,
 } from "../test_helpers/commands_helpers";
-import { getPlugin } from "../test_helpers/helpers";
+import { getPlugin, toCellPosition } from "../test_helpers/helpers";
 
 //------------------------------------------------------------------------------
 // Hide/unhide
@@ -323,4 +323,17 @@ describe("Hide Rows", () => {
     });
     expect(plugin.sizes["sheet2"].ROW.length).toEqual(101);
   });
+});
+
+test("getNextVisibleCellPosition getter work on hidden cells", () => {
+  model = new Model();
+  const sheetId = model.getters.getActiveSheetId();
+  hideRows(model, [0, 99]);
+  hideColumns(model, ["A", "Z"]);
+  expect(model.getters.getNextVisibleCellPosition(toCellPosition(sheetId, "A1"))).toMatchObject(
+    toCellPosition(sheetId, "B2")
+  );
+  expect(model.getters.getNextVisibleCellPosition(toCellPosition(sheetId, "Z100"))).toMatchObject(
+    toCellPosition(sheetId, "Y99")
+  );
 });


### PR DESCRIPTION
## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo