### PR TITLE
[IMP] charts: scorecard now uses formula instead of cell reference

### DIFF
--- a/src/components/side_panel/chart/main_chart_panel/main_chart_panel_store.ts
+++ b/src/components/side_panel/chart/main_chart_panel/main_chart_panel_store.ts
@@ -26,6 +26,10 @@ export class MainChartPanelStore extends SpreadsheetStore {
   changeChartType(chartId: UID, newDisplayType: string) {
     const currentCreationContext = this.getters.getContextCreationChart(chartId);
     const savedCreationContext = this.creationContexts[chartId] || {};
+    const auxiliaryRange =
+      currentCreationContext && "auxiliaryRange" in currentCreationContext
+        ? currentCreationContext.auxiliaryRange
+        : savedCreationContext.auxiliaryRange;
 
     let dataSetStyles = savedCreationContext.dataSetStyles ?? currentCreationContext?.dataSetStyles;
     let dataSource = {
@@ -66,6 +70,7 @@ export class MainChartPanelStore extends SpreadsheetStore {
         ...savedCreationContext.dataSource,
         ...currentCreationContext?.dataSource,
         dataSets: newRanges ?? [],
+        labelRange: auxiliaryRange,
       };
     }
 
@@ -104,8 +109,8 @@ export class MainChartPanelStore extends SpreadsheetStore {
     return currentDataSets.every((ds, i) => {
       const savedDs = savedDataSets[i];
       return (
-        deepEquals(ds.dataRange, savedDs.dataRange) &&
-        deepEquals(currentStyles?.[ds.dataSetId], savedStyles?.[savedDs.dataSetId])
+        deepEquals(ds.dataRange, savedDs?.dataRange) &&
+        deepEquals(currentStyles?.[ds.dataSetId], savedStyles?.[savedDs?.dataSetId])
       );
     });
   }

--- a/src/components/side_panel/chart/scorecard_chart_panel/scorecard_chart_config_panel.ts
+++ b/src/components/side_panel/chart/scorecard_chart_panel/scorecard_chart_config_panel.ts
@@ -5,8 +5,8 @@ import { BaselineMode, ScorecardChartDefinition } from "../../../../types/chart/
 import { CommandResult, DispatchResult } from "../../../../types/commands";
 import { ValueAndLabel } from "../../../../types/misc";
 import { SpreadsheetChildEnv } from "../../../../types/spreadsheet_env";
+import { StandaloneComposer } from "../../../composer/standalone_composer/standalone_composer";
 import { Select } from "../../../select/select";
-import { SelectionInput } from "../../../selection_input/selection_input";
 import { ChartTerms } from "../../../translations_terms";
 import { Section } from "../../components/section/section";
 import { ChartErrorSection } from "../building_blocks/error_section/error_section";
@@ -19,7 +19,7 @@ interface PanelState {
 
 export class ScorecardChartConfigPanel extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ScorecardChartConfigPanel";
-  static components = { SelectionInput, ChartErrorSection, Section, Select };
+  static components = { ChartErrorSection, Section, Select, StandaloneComposer };
   protected props = useProps(
     chartSidePanelPropsDefinition
   ) as unknown as ChartSidePanelProps<ScorecardChartDefinition>;
@@ -42,49 +42,25 @@ export class ScorecardChartConfigPanel extends Component<SpreadsheetChildEnv> {
     );
   }
 
-  get isKeyValueInvalid(): boolean {
-    return !!this.state.keyValueDispatchResult?.isCancelledBecause(
-      CommandResult.InvalidScorecardKeyValue
-    );
-  }
-
-  get isBaselineInvalid(): boolean {
-    return !!this.state.baselineDispatchResult?.isCancelledBecause(
-      CommandResult.InvalidScorecardBaseline
-    );
-  }
-
-  onKeyValueRangeChanged(ranges: string[]) {
-    this.keyValue = ranges[0];
-    this.state.keyValueDispatchResult = this.props.canUpdateChart(this.props.chartId, {
-      keyValue: this.keyValue,
-    });
-  }
-
-  updateKeyValueRange() {
+  onConfirmKeyValue(keyValue: string) {
+    this.keyValue = keyValue;
     this.state.keyValueDispatchResult = this.props.updateChart(this.props.chartId, {
       keyValue: this.keyValue,
     });
   }
 
-  getKeyValueRange(): string {
+  getKeyValue(): string {
     return this.keyValue || "";
   }
 
-  onBaselineRangeChanged(ranges: string[]) {
-    this.baseline = ranges[0];
-    this.state.baselineDispatchResult = this.props.canUpdateChart(this.props.chartId, {
-      baseline: this.baseline,
-    });
-  }
-
-  updateBaselineRange() {
+  onConfirmBaseline(baseline: string) {
+    this.baseline = baseline;
     this.state.baselineDispatchResult = this.props.updateChart(this.props.chartId, {
       baseline: this.baseline,
     });
   }
 
-  getBaselineRange(): string {
+  getBaseline(): string {
     return this.baseline || "";
   }
 

--- a/src/components/side_panel/chart/scorecard_chart_panel/scorecard_chart_config_panel.xml
+++ b/src/components/side_panel/chart/scorecard_chart_panel/scorecard_chart_config_panel.xml
@@ -2,23 +2,22 @@
   <t t-name="o-spreadsheet-ScorecardChartConfigPanel">
     <div>
       <Section class="'o-data-series'" title.translate="Key value">
-        <SelectionInput
-          ranges="[this.getKeyValueRange()]"
-          isInvalid="this.isKeyValueInvalid"
-          hasSingleRange="true"
-          required="true"
-          onSelectionChanged="(ranges) => this.onKeyValueRangeChanged(ranges)"
-          onSelectionConfirmed="() => this.updateKeyValueRange()"
+        <StandaloneComposer
+          placeholder.translate="Formula"
+          title.translate=""
+          composerContent="this.getKeyValue()"
+          defaultRangeSheetId="this.env.model.getters.getActiveSheetId()"
+          onConfirm.bind="this.onConfirmKeyValue"
         />
       </Section>
       <Section class="'o-data-labels'" title.translate="Baseline configuration">
         <div class="o-section-subtitle">Value</div>
-        <SelectionInput
-          ranges="[this.getBaselineRange()]"
-          isInvalid="this.isBaselineInvalid"
-          hasSingleRange="true"
-          onSelectionChanged="(ranges) => this.onBaselineRangeChanged(ranges)"
-          onSelectionConfirmed="() => this.updateBaselineRange()"
+        <StandaloneComposer
+          placeholder.translate="Formula"
+          title.translate=""
+          composerContent="this.getBaseline()"
+          defaultRangeSheetId="this.env.model.getters.getActiveSheetId()"
+          onConfirm.bind="this.onConfirmBaseline"
         />
         <div class="o-section-subtitle">Format</div>
         <Select

--- a/src/components/translations_terms.ts
+++ b/src/components/translations_terms.ts
@@ -56,9 +56,6 @@ export const ChartTerms: {
     // BASIC CHART ERRORS (LINE | BAR | PIE)
     [CommandResult.InvalidDataSet]: _t("The dataset is invalid"),
     [CommandResult.InvalidLabelRange]: _t("Labels are invalid"),
-    // SCORECARD CHART ERRORS
-    [CommandResult.InvalidScorecardKeyValue]: _t("The key value is invalid"),
-    [CommandResult.InvalidScorecardBaseline]: _t("The baseline value is invalid"),
     // GAUGE CHART ERRORS
     [CommandResult.InvalidGaugeDataRange]: _t("The data range is invalid"),
     [CommandResult.EmptyGaugeRangeMin]: _t("A minimum range limit value is needed"),

--- a/src/helpers/figures/charts/charts_suggestions_constants.ts
+++ b/src/helpers/figures/charts/charts_suggestions_constants.ts
@@ -232,8 +232,8 @@ function bubbleChart(
 function scorecardChart(
   titleText: string,
   keyValue: string,
-  opts: Partial<ScorecardChartDefinition<string>> = {}
-): ScorecardChartDefinition<string> {
+  opts: Partial<ScorecardChartDefinition> = {}
+): ScorecardChartDefinition {
   return {
     ...opts,
     type: "scorecard",
@@ -277,8 +277,8 @@ export const SINGLE_NUMBER_COLUMN_SUGGESTIONS: Suggestion<SingleNumberContext>[]
     description: _t("Highlights the most recent value compared to the previous one."),
     isApplicable: ({ rowCount }) => rowCount < 3,
     build: (ctx) =>
-      scorecardChart(ctx.title, ctx.lastCellXC, {
-        baseline: ctx.prevCellXC,
+      scorecardChart(ctx.title, `=${ctx.lastCellXC}`, {
+        baseline: ctx.prevCellXC ? `=${ctx.prevCellXC}` : undefined,
         baselineMode: "difference",
       }),
   },
@@ -311,8 +311,8 @@ export const SINGLE_PERCENTAGE_COLUMN_SUGGESTIONS: Suggestion<SinglePercentageCo
     description: _t("Shows the last percentage value with its baseline."),
     isApplicable: ({ rowCount }) => rowCount < 3,
     build: (ctx) =>
-      scorecardChart(ctx.title, ctx.lastCellXC, {
-        baseline: ctx.prevCellXC,
+      scorecardChart(ctx.title, `=${ctx.lastCellXC}`, {
+        baseline: ctx.prevCellXC ? `=${ctx.prevCellXC}` : undefined,
         baselineMode: "percentage",
       }),
   },
@@ -345,7 +345,7 @@ export const SINGLE_DATE_COLUMN_SUGGESTIONS: Suggestion<SingleDateContext>[] = [
   {
     description: _t("Shows the last date value."),
     isApplicable: ({ rowCount }) => rowCount === 1,
-    build: (ctx) => scorecardChart(ctx.title, ctx.lastCellXC),
+    build: (ctx) => scorecardChart(ctx.title, `=${ctx.lastCellXC}`),
   },
 ];
 
@@ -381,7 +381,7 @@ export const SINGLE_LABEL_COLUMN_SUGGESTIONS: Suggestion<SingleLabelContext>[] =
     description: _t("Displays a key performance indicator."),
     isApplicable: ({ rowCount }) => rowCount === 1,
     build: (ctx) =>
-      scorecardChart(ctx.title, ctx.lastCellXC, { baselineMode: "text", humanize: false }),
+      scorecardChart(ctx.title, `=${ctx.lastCellXC}`, { baselineMode: "text", humanize: false }),
   },
 ];
 
@@ -432,8 +432,8 @@ export const NUMBER_VS_NUMBER_SUGGESTIONS: Suggestion<NumberVsNumberContext>[] =
     description: _t("Highlights the second metric compared to the first one."),
     isApplicable: ({ rowCount1, rowCount2 }) => rowCount1 === 1 && rowCount2 === 1,
     build: (ctx) =>
-      scorecardChart(ctx.title, ctx.lastCellXC, {
-        baseline: ctx.prevCellXC,
+      scorecardChart(ctx.title, `=${ctx.lastCellXC}`, {
+        baseline: ctx.prevCellXC ? `=${ctx.prevCellXC}` : undefined,
         baselineMode: "difference",
       }),
   },
@@ -496,10 +496,10 @@ export const LABEL_VS_NUMBER_SUGGESTIONS: Suggestion<LabelVsNumberContext>[] = [
     isApplicable: ({ rowCount }) => rowCount === 1,
     // TODO(ANHE): remove falsy humanize when it's fixed in the scorecard chart.
     build: (ctx) =>
-      scorecardChart("", ctx.lastCellXC, {
+      scorecardChart("", `=${ctx.lastCellXC}`, {
         humanize: false,
         baselineMode: "text",
-        baseline: ctx.prevCellXC,
+        baseline: ctx.prevCellXC ? `=${ctx.prevCellXC}` : undefined,
       }),
   },
   {

--- a/src/helpers/figures/charts/scorecard_chart.ts
+++ b/src/helpers/figures/charts/scorecard_chart.ts
@@ -5,32 +5,65 @@ import {
   DEFAULT_SCORECARD_BASELINE_MODE,
   DEFAULT_TEXT_HIGHLIGHT_PERCENT,
 } from "../../../constants";
+import { CompiledFormula } from "../../../formulas/compiler";
+import { isMultipleElementMatrix, toScalar } from "../../../functions/helper_matrices";
 import { toNumber } from "../../../functions/helpers";
 import { ChartTypeBuilder } from "../../../registries/chart_registry";
-import { CellValueType, EvaluatedCell } from "../../../types/cells";
+import { CellValueType } from "../../../types/cells";
 import {
   BaselineArrowDirection,
   BaselineMode,
-  ScorecardChartDefinition,
   ScorecardChartRuntime,
 } from "../../../types/chart/scorecard_chart";
 import { CommandResult } from "../../../types/commands";
+import { Getters } from "../../../types/getters";
 import { Locale } from "../../../types/locale";
-import { Color, RangeAdapterFunctions } from "../../../types/misc";
+import { Color, FunctionResultObject, RangeAdapterFunctions, UID } from "../../../types/misc";
 import { Range } from "../../../types/range";
 import { lightenColor } from "../../color";
 import { formatValue, humanizeNumber } from "../../format/format";
+import { isFormula } from "../../misc";
 import { isNumber } from "../../numbers";
 import { createValidRange } from "../../range";
 import { rangeReference } from "../../references";
 import { clipTextWithEllipsis, drawDecoratedText } from "../../text_helper";
 import { AbstractChart } from "./abstract_chart";
-import { adaptChartRange, duplicateLabelRangeInDuplicatedSheet } from "./chart_common";
 import { ScorecardChartConfig } from "./scorecard_chart_config_builder";
 
+function getData(
+  value: string | undefined,
+  getters: Getters,
+  sheetId: UID
+): { scalar: FunctionResultObject | undefined; range: Range | undefined } {
+  if (!value) {
+    return { scalar: undefined, range: undefined };
+  }
+  if (!isFormula(value)) {
+    return { scalar: { value }, range: undefined };
+  }
+  const result = getters.evaluateFormulaResult(sheetId, value);
+  let scalar = isMultipleElementMatrix(result) ? result[0][0] : toScalar(result);
+  let range: Range | undefined = undefined;
+  const xc = getFormulaRangeXc(value);
+  if (xc) {
+    range = createValidRange(getters, sheetId, xc);
+    if (range) {
+      const cell = getters.getEvaluatedCell({
+        sheetId: range.sheetId,
+        col: range.zone.left,
+        row: range.zone.top,
+      });
+      if (cell.type === CellValueType.empty) {
+        scalar = undefined;
+      }
+    }
+  }
+  return { scalar, range };
+}
+
 function getBaselineText(
-  baseline: EvaluatedCell | undefined,
-  keyValue: EvaluatedCell | undefined,
+  baseline: FunctionResultObject | undefined,
+  keyValue: FunctionResultObject | undefined,
   baselineMode: BaselineMode,
   humanizeNumbers: boolean,
   locale: Locale
@@ -39,13 +72,13 @@ function getBaselineText(
     return "";
   } else if (
     baselineMode === "text" ||
-    keyValue?.type !== CellValueType.number ||
-    baseline.type !== CellValueType.number
+    typeof keyValue?.value !== "number" ||
+    typeof baseline.value !== "number"
   ) {
     if (humanizeNumbers) {
       return humanizeNumber(baseline, locale);
     }
-    return baseline.formattedValue;
+    return formatValue(baseline.value, { format: baseline.format, locale });
   }
   let { value, format } = baseline;
   if (baselineMode === "progress") {
@@ -70,31 +103,33 @@ function getBaselineText(
 }
 
 function getKeyValueText(
-  keyValueCell: EvaluatedCell | undefined,
+  keyValue: FunctionResultObject | undefined,
   humanizeNumbers: boolean,
   locale: Locale
 ): string {
-  if (!keyValueCell) {
+  if (keyValue?.value === undefined || keyValue?.value === null) {
     return "";
   }
   if (humanizeNumbers) {
-    return humanizeNumber(keyValueCell, locale);
+    return humanizeNumber(keyValue, locale);
   }
-  return keyValueCell.formattedValue ?? String(keyValueCell.value ?? "");
+  return keyValue.format
+    ? formatValue(keyValue.value, { format: keyValue.format, locale })
+    : String(keyValue.value ?? "");
 }
 
 function getBaselineColor(
-  baseline: EvaluatedCell | undefined,
+  baseline: FunctionResultObject | undefined,
   baselineMode: BaselineMode,
-  keyValue: EvaluatedCell | undefined,
+  keyValue: FunctionResultObject | undefined,
   colorUp: Color,
   colorDown: Color
 ): Color | undefined {
   if (
     baselineMode === "text" ||
     baselineMode === "progress" ||
-    baseline?.type !== CellValueType.number ||
-    keyValue?.type !== CellValueType.number
+    typeof baseline?.value !== "number" ||
+    typeof keyValue?.value !== "number"
   ) {
     return undefined;
   }
@@ -108,14 +143,14 @@ function getBaselineColor(
 }
 
 function getBaselineArrowDirection(
-  baseline: EvaluatedCell | undefined,
-  keyValue: EvaluatedCell | undefined,
+  baseline: FunctionResultObject | undefined,
+  keyValue: FunctionResultObject | undefined,
   baselineMode: BaselineMode
 ): BaselineArrowDirection {
   if (
     baselineMode === "text" ||
-    baseline?.type !== CellValueType.number ||
-    keyValue?.type !== CellValueType.number
+    typeof baseline?.value !== "number" ||
+    typeof keyValue?.value !== "number"
   ) {
     return "neutral";
   }
@@ -129,16 +164,13 @@ function getBaselineArrowDirection(
   return "neutral";
 }
 
-function checkKeyValue(definition: ScorecardChartDefinition): CommandResult {
-  return definition.keyValue && !rangeReference.test(definition.keyValue)
-    ? CommandResult.InvalidScorecardKeyValue
-    : CommandResult.Success;
-}
-
-function checkBaseline(definition: ScorecardChartDefinition): CommandResult {
-  return definition.baseline && !rangeReference.test(definition.baseline)
-    ? CommandResult.InvalidScorecardBaseline
-    : CommandResult.Success;
+// Only used to derive a Range when the formula is nothing but a bare reference (e.g. "=A1" or "=A1:B2")
+function getFormulaRangeXc(formula: string | undefined): string | undefined {
+  if (!formula || !isFormula(formula)) {
+    return undefined;
+  }
+  const content = formula.slice(1);
+  return rangeReference.test(content) ? content : undefined;
 }
 
 const Path2DConstructor = globalThis.Path2D;
@@ -166,62 +198,65 @@ export const ScorecardChart: ChartTypeBuilder<"scorecard"> = {
     "baselineColorDown",
   ],
 
-  fromStrDefinition(definition, sheetId, getters) {
-    const baseline = createValidRange(getters, sheetId, definition.baseline);
-    const keyValue = createValidRange(getters, sheetId, definition.keyValue);
-    const rangeDefinition: ScorecardChartDefinition<Range> = {
-      ...definition,
-      baseline,
-      keyValue,
-    };
-    return rangeDefinition;
-  },
+  fromStrDefinition: (definition) => definition,
 
   validateDefinition(validator, definition) {
-    return validator.checkValidations(definition, checkKeyValue, checkBaseline);
+    return CommandResult.Success;
   },
 
-  copyInSheetId: (definition) => definition,
+  copyInSheetId: (definition, sheetIdFrom, sheetIdTo, getters) => {
+    const adaptFormula = (formula: string) =>
+      getters.copyFormulaStringForSheet(sheetIdFrom, sheetIdTo, formula, "keepSameReference");
+    return {
+      ...definition,
+      keyValue: definition.keyValue ? adaptFormula(definition.keyValue) : definition.keyValue,
+      baseline: definition.baseline ? adaptFormula(definition.baseline) : definition.baseline,
+    };
+  },
 
   getDefinitionFromContextCreation(context, dataSourceBuilder) {
+    const dataRange =
+      context.dataSource?.type === "range"
+        ? context.dataSource?.dataSets?.[0]?.dataRange
+        : undefined;
+    // We should update the keyValue if one of these conditions is true:
+    // 1. The keyValue formula is undefined (i.e. the chart was created from another chart)
+    // 2. The keyValue formula is a bare reference (e.g. "=A1" or "=A1:B2")
+    const shouldUpdateKeyValue =
+      context.scorecardKeyValueFormula === undefined ||
+      getFormulaRangeXc(context.scorecardKeyValueFormula);
+    const keyValue =
+      shouldUpdateKeyValue && dataRange ? `=${dataRange}` : context.scorecardKeyValueFormula;
+    const shouldUpdateBaseline =
+      context.scorecardBaselineFormula === undefined ||
+      getFormulaRangeXc(context.scorecardBaselineFormula);
+    const baseline =
+      shouldUpdateBaseline && context.auxiliaryRange
+        ? `=${context.auxiliaryRange}`
+        : context.scorecardBaselineFormula;
     return {
       background: context.background,
       type: "scorecard",
-      keyValue:
-        context.dataSource?.type === "range"
-          ? context.dataSource?.dataSets?.[0]?.dataRange
-          : undefined,
+      keyValue,
       title: context.title || { text: "" },
       baselineMode: DEFAULT_SCORECARD_BASELINE_MODE,
       baselineColorUp: DEFAULT_SCORECARD_BASELINE_COLOR_UP,
       baselineColorDown: DEFAULT_SCORECARD_BASELINE_COLOR_DOWN,
-      baseline: context.auxiliaryRange || "",
+      baseline,
       humanize: context.humanize,
       annotationLink: context.annotationLink,
       annotationText: context.annotationText,
     };
   },
 
-  transformDefinition(definition, chartSheetId, { adaptRangeString }) {
+  transformDefinition(definition, chartSheetId, { adaptFormulaString }) {
     let baseline: string | undefined;
     let keyValue: string | undefined;
     if (definition.baseline) {
-      const { changeType, range: adaptedRange } = adaptRangeString(
-        chartSheetId,
-        definition.baseline
-      );
-      if (changeType !== "REMOVE") {
-        baseline = adaptedRange;
-      }
+      baseline = adaptFormulaString(chartSheetId, definition.baseline);
     }
     if (definition.keyValue) {
-      const { changeType, range: adaptedRange } = adaptRangeString(
-        chartSheetId,
-        definition.keyValue
-      );
-      if (changeType !== "REMOVE") {
-        keyValue = adaptedRange;
-      }
+      keyValue = adaptFormulaString(chartSheetId, definition.keyValue);
     }
     return {
       ...definition,
@@ -230,87 +265,85 @@ export const ScorecardChart: ChartTypeBuilder<"scorecard"> = {
     };
   },
 
-  duplicateInDuplicatedSheet(definition, sheetIdFrom, sheetIdTo): ScorecardChartDefinition<Range> {
-    const baseline = duplicateLabelRangeInDuplicatedSheet(
-      sheetIdFrom,
-      sheetIdTo,
-      definition.baseline
-    );
-    const keyValue = duplicateLabelRangeInDuplicatedSheet(
-      sheetIdFrom,
-      sheetIdTo,
-      definition.keyValue
-    );
-    return { ...definition, baseline, keyValue };
-  },
-
-  toStrDefinition(definition, sheetId, getters) {
+  duplicateInDuplicatedSheet(definition, sheetIdFrom, sheetIdTo, getters) {
+    const adaptFormula = (formula: string) =>
+      getters.copyFormulaStringForSheet(sheetIdFrom, sheetIdTo, formula, "moveReference");
     return {
       ...definition,
-      keyValue: definition.keyValue
-        ? getters.getRangeString(definition.keyValue, sheetId)
-        : undefined,
-      baseline: definition.baseline
-        ? getters.getRangeString(definition.baseline, sheetId)
-        : undefined,
+      keyValue: definition.keyValue ? adaptFormula(definition.keyValue) : definition.keyValue,
+      baseline: definition.baseline ? adaptFormula(definition.baseline) : definition.baseline,
     };
   },
 
+  toStrDefinition: (definition) => definition,
+
   getContextCreation(definition, dataSource) {
+    const keyValueXc = getFormulaRangeXc(definition.keyValue);
     return {
       ...definition,
       dataSource: {
         type: "range",
-        dataSets: definition.keyValue ? [{ dataRange: definition.keyValue, dataSetId: "0" }] : [],
+        dataSets: keyValueXc ? [{ dataRange: keyValueXc, dataSetId: "0" }] : [],
       },
-      auxiliaryRange: definition.baseline,
+      auxiliaryRange: getFormulaRangeXc(definition.baseline),
+      scorecardKeyValueFormula: definition.keyValue,
+      scorecardBaselineFormula: definition.baseline,
     };
   },
 
   getDefinitionForExcel: () => undefined,
 
-  updateRanges(definition, adapterFunctions: RangeAdapterFunctions) {
-    const baseline = adaptChartRange(definition.baseline, adapterFunctions);
-    const keyValue = adaptChartRange(definition.keyValue, adapterFunctions);
+  updateRanges(definition, adapterFunctions: RangeAdapterFunctions, sheetId) {
+    const baseline = definition.baseline
+      ? adapterFunctions.adaptFormulaString(sheetId, definition.baseline)
+      : definition.baseline;
+    const keyValue = definition.keyValue
+      ? adapterFunctions.adaptFormulaString(sheetId, definition.keyValue)
+      : definition.keyValue;
     if (definition.baseline === baseline && definition.keyValue === keyValue) {
       return definition;
     }
     return { ...definition, baseline, keyValue };
   },
 
-  getFormulas: () => [],
+  getFormulas(getters, sheetId, definition): CompiledFormula[] {
+    const formulas: CompiledFormula[] = [];
+    if (definition.keyValue && isFormula(definition.keyValue)) {
+      formulas.push(CompiledFormula.Compile(definition.keyValue, sheetId, getters));
+    }
+    if (definition.baseline && isFormula(definition.baseline)) {
+      formulas.push(CompiledFormula.Compile(definition.baseline, sheetId, getters));
+    }
+    return formulas;
+  },
 
-  getRuntime(getters, definition): ScorecardChartRuntime {
+  getRuntime(getters, definition, _dataExtractor, sheetId): ScorecardChartRuntime {
     let formattedKeyValue = "";
-    let keyValueCell: EvaluatedCell | undefined;
+    const { scalar: keyValue, range: keyValueRange } = getData(
+      definition.keyValue,
+      getters,
+      sheetId
+    );
     const locale = getters.getLocale();
-    if (definition.keyValue) {
-      const keyValuePosition = {
-        sheetId: definition.keyValue.sheetId,
-        col: definition.keyValue.zone.left,
-        row: definition.keyValue.zone.top,
-      };
-      keyValueCell = getters.getEvaluatedCell(keyValuePosition);
-      formattedKeyValue = getKeyValueText(keyValueCell, definition.humanize ?? true, locale);
+    if (keyValue !== null && keyValue !== undefined) {
+      formattedKeyValue = getKeyValueText(keyValue, definition.humanize ?? true, locale);
+    } else {
+      formattedKeyValue = "";
     }
-    let baselineCell: EvaluatedCell | undefined;
-    const baseline = definition.baseline;
-    if (baseline) {
-      const baselinePosition = {
-        sheetId: baseline.sheetId,
-        col: baseline.zone.left,
-        row: baseline.zone.top,
-      };
-      baselineCell = getters.getEvaluatedCell(baselinePosition);
-    }
+
+    const { scalar: baseline, range: baselineRange } = getData(
+      definition.baseline,
+      getters,
+      sheetId
+    );
     const { background, fontColor } = getters.getStyleOfSingleCellChart(
       definition.background,
-      definition.keyValue
+      keyValueRange
     );
 
     const baselineDisplay = getBaselineText(
-      baselineCell,
-      keyValueCell,
+      baseline,
+      keyValue,
       definition.baselineMode,
       definition.humanize ?? true,
       locale
@@ -328,11 +361,11 @@ export const ScorecardChart: ChartTypeBuilder<"scorecard"> = {
       keyValue: formattedKeyValue,
       keyDescr: definition.keyDescr?.text ? getters.dynamicTranslate(definition.keyDescr.text) : "",
       baselineDisplay,
-      baselineArrow: getBaselineArrowDirection(baselineCell, keyValueCell, definition.baselineMode),
+      baselineArrow: getBaselineArrowDirection(baseline, keyValue, definition.baselineMode),
       baselineColor: getBaselineColor(
-        baselineCell,
+        baseline,
         definition.baselineMode,
-        keyValueCell,
+        keyValue,
         definition.baselineColorUp,
         definition.baselineColorDown
       ),
@@ -345,11 +378,11 @@ export const ScorecardChart: ChartTypeBuilder<"scorecard"> = {
       baselineStyle: {
         ...(definition.baselineMode !== "percentage" &&
         definition.baselineMode !== "progress" &&
-        baseline
+        baselineRange
           ? getters.getCellComputedStyle({
-              sheetId: baseline.sheetId,
-              col: baseline.zone.left,
-              row: baseline.zone.top,
+              sheetId: baselineRange.sheetId,
+              col: baselineRange.zone.left,
+              row: baselineRange.zone.top,
             })
           : undefined),
         fontSize: definition.baselineDescr?.fontSize,
@@ -360,11 +393,11 @@ export const ScorecardChart: ChartTypeBuilder<"scorecard"> = {
         ...definition.baselineDescr,
       },
       keyValueStyle: {
-        ...(definition.keyValue
+        ...(keyValueRange
           ? getters.getCellComputedStyle({
-              sheetId: definition.keyValue.sheetId,
-              col: definition.keyValue.zone.left,
-              row: definition.keyValue.zone.top,
+              sheetId: keyValueRange.sheetId,
+              col: keyValueRange.zone.left,
+              row: keyValueRange.zone.top,
             })
           : undefined),
         fontSize: definition.keyDescr?.fontSize,

--- a/src/helpers/figures/charts/smart_chart_engine.ts
+++ b/src/helpers/figures/charts/smart_chart_engine.ts
@@ -352,7 +352,7 @@ function buildScorecard(zone: Zone, getters: Getters): ChartDefinition {
   return {
     type: "scorecard",
     title: {},
-    keyValue: getUnboundRange(getters, zone),
+    keyValue: `=${getUnboundRange(getters, zone)}`,
     background: cell?.style?.fillColor,
     baselineMode: DEFAULT_SCORECARD_BASELINE_MODE,
     baselineColorUp: DEFAULT_SCORECARD_BASELINE_COLOR_UP,

--- a/src/helpers/format/format.ts
+++ b/src/helpers/format/format.ts
@@ -746,7 +746,7 @@ function _roundFormat<T extends InternalFormat>(internalFormat: T): T {
 export function humanizeNumber({ value, format }: FunctionResultObject, locale: Locale): string {
   const numberValue = tryToNumber(value, locale);
   if (numberValue === undefined) {
-    return "";
+    return value?.toString() || "";
   }
   let numberFormat: Format | undefined = format;
   if (Math.abs(numberValue) < 1000) {

--- a/src/migrations/migration_steps.ts
+++ b/src/migrations/migration_steps.ts
@@ -639,6 +639,36 @@ migrationStepRegistry
       }
       return data;
     },
+  })
+  .add("19.5.1", {
+    migrate(data: WorkbookData): any {
+      function upgrade(definition: any): any {
+        if (definition.type !== "scorecard") {
+          return definition;
+        }
+        definition = { ...definition };
+        if (definition.keyValue) {
+          definition.keyValue = `=${definition.keyValue}`;
+        }
+        if (definition.baseline) {
+          definition.baseline = `=${definition.baseline}`;
+        }
+        return definition;
+      }
+      for (const sheet of data.sheets || []) {
+        for (const figure of sheet.figures || []) {
+          if (figure.tag === "chart") {
+            figure.data = upgrade(figure.data);
+          } else if (figure.tag === "carousel") {
+            for (const chartId in figure.data.chartDefinitions) {
+              const definition = figure.data.chartDefinitions[chartId];
+              figure.data.chartDefinitions[chartId] = upgrade(definition);
+            }
+          }
+        }
+      }
+      return data;
+    },
   });
 
 function fixOverlappingFilters(data: any): any {

--- a/src/types/chart/chart.ts
+++ b/src/types/chart/chart.ts
@@ -64,7 +64,7 @@ export type ChartDefinitionWithDataSource<T extends string | Range = Range> =
 
 export type ChartDefinition<T extends string | Range = string> =
   | ChartDefinitionWithDataSource<T>
-  | ScorecardChartDefinition<T>
+  | ScorecardChartDefinition
   | GaugeChartDefinition<T>
   | BubbleChartDefinition<T>;
 
@@ -275,6 +275,8 @@ export interface ChartCreationContext {
   readonly bubbleColorMode?: BubbleColorMode;
   readonly annotationText?: string;
   readonly annotationLink?: string;
+  readonly scorecardKeyValueFormula?: string;
+  readonly scorecardBaselineFormula?: string;
 }
 
 export type ChartAxisFormats = { [axisId: string]: Format | undefined } | undefined;

--- a/src/types/chart/scorecard_chart.ts
+++ b/src/types/chart/scorecard_chart.ts
@@ -1,14 +1,12 @@
 import { Color, Style } from "../misc";
-import { Range } from "../range";
 import { TitleDesign } from "./chart";
 import { NonDataSourceBaseChartDefinition } from "./common_chart";
 
-export interface ScorecardChartDefinition<T extends string | Range = string>
-  extends NonDataSourceBaseChartDefinition {
+export interface ScorecardChartDefinition extends NonDataSourceBaseChartDefinition {
   readonly type: "scorecard";
-  readonly keyValue?: T;
+  readonly keyValue?: string;
   readonly keyDescr?: TitleDesign;
-  readonly baseline?: T;
+  readonly baseline?: string;
   readonly baselineMode: BaselineMode;
   readonly baselineDescr?: TitleDesign;
   readonly baselineColorUp: Color;

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -1480,8 +1480,6 @@ export const enum CommandResult {
   InvalidXRange = "InvalidXRange",
   InvalidLabelRange = "InvalidLabelRange",
   InvalidBubbleSizeRange = "InvalidBubbleSizeRange",
-  InvalidScorecardKeyValue = "InvalidScorecardKeyValue",
-  InvalidScorecardBaseline = "InvalidScorecardBaseline",
   InvalidGaugeDataRange = "InvalidGaugeDataRange",
   EmptyGaugeRangeMin = "EmptyGaugeRangeMin",
   GaugeRangeMinNaN = "GaugeRangeMinNaN",

--- a/tests/figures/chart/chart_suggestion_preview.test.ts
+++ b/tests/figures/chart/chart_suggestion_preview.test.ts
@@ -105,7 +105,7 @@ describe("Chart suggestion preview snapshots", () => {
     ],
     [
       "Scorecard (KPI card, forces a legible key value font size)",
-      { type: "scorecard", keyValue: "B4", baseline: "B1", title: { text: "" } },
+      { type: "scorecard", keyValue: "=B4", baseline: "=B1", title: { text: "" } },
     ],
     [
       "Gauge (hides the chart title)",

--- a/tests/figures/chart/charts_component.test.ts
+++ b/tests/figures/chart/charts_component.test.ts
@@ -74,6 +74,7 @@ import {
 import { getCellContent, getChartDataSource } from "../../test_helpers/getters_helpers";
 import {
   createModelFromGrid,
+  editStandaloneComposer,
   mockChart,
   mockGeoJsonService,
   mountComponentWithPortalTarget,
@@ -160,6 +161,9 @@ let parent: Spreadsheet;
 let env: SpreadsheetChildEnv;
 
 const TEST_CHART_TYPES = ["basicChart", "scorecard", "gauge", "combo"] as const;
+// scorecard's key value is edited with a composer, not a SelectionInput: it has no
+// separate confirm/cancel button, so it doesn't fit the tests below.
+const SELECTION_INPUT_CHART_TYPES = TEST_CHART_TYPES.filter((type) => type !== "scorecard");
 
 describe("charts", () => {
   beforeEach(async () => {
@@ -401,10 +405,10 @@ describe("charts", () => {
         const keyValue = fixture.querySelector(".o-chart .o-data-series");
         const baseline = fixture.querySelector(".o-data-labels");
         expect(panelChartType.textContent).toBe("Scorecard");
-        expect((keyValue!.querySelector(" .o-selection input") as HTMLInputElement).value).toBe(
+        expect(keyValue!.querySelector(".o-composer")).toHaveText(
           TEST_CHART_DATA.scorecard.keyValue
         );
-        expect((baseline!.querySelector(".o-selection input") as HTMLInputElement).value).toBe(
+        expect(baseline!.querySelector(".o-composer")).toHaveText(
           TEST_CHART_DATA.scorecard.baseline
         );
         break;
@@ -455,11 +459,9 @@ describe("charts", () => {
         });
         break;
       case "scorecard": {
-        await setInputValueAndTrigger(dataSeriesValues, "B2:B4");
-        await nextTick();
-        await simulateClick(".o-data-series .o-selection-ok");
+        await editStandaloneComposer(".o-data-series .o-composer", "=B2:B4");
         const definition = model.getters.getChartDefinition(chartId) as ScorecardChartDefinition;
-        expect(definition.keyValue).toEqual("B2:B4");
+        expect(definition.keyValue).toEqual("=B2:B4");
         break;
       }
       case "gauge": {
@@ -1313,22 +1315,6 @@ describe("charts", () => {
     }
   );
 
-  test("remove ranges in scorecard chart", async () => {
-    createTestChart("scorecard");
-    await mountChartSidePanel();
-
-    expect(
-      (model.getters.getChartDefinition(chartId) as ScorecardChartDefinition)?.baseline
-    ).not.toBeUndefined();
-
-    await simulateClick(".o-data-labels input");
-    await setInputValueAndTrigger(".o-data-labels input", "");
-    await simulateClick(".o-data-labels .o-selection-ok");
-    expect(
-      (model.getters.getChartDefinition(chartId) as ScorecardChartDefinition).baseline
-    ).toBeUndefined();
-  });
-
   describe("reordering dataseries", () => {
     beforeEach(async () => {
       extendMockGetBoundingClientRect({
@@ -1939,7 +1925,6 @@ describe("charts", () => {
     test.each([
       ["basicChart" as const, []],
       ["combo" as const, []],
-      ["scorecard" as const, []],
     ])(
       "update %s with empty labels/baseline",
       async (chartType, expectedResults: CommandResult[]) => {
@@ -1957,7 +1942,7 @@ describe("charts", () => {
       }
     );
 
-    test.each(TEST_CHART_TYPES)(
+    test.each(SELECTION_INPUT_CHART_TYPES)(
       "update chart with valid dataset/keyValue/dataRange show confirm button",
       async (chartType) => {
         createTestChart(chartType);
@@ -1969,7 +1954,7 @@ describe("charts", () => {
       }
     );
 
-    test.each(TEST_CHART_TYPES)(
+    test.each(SELECTION_INPUT_CHART_TYPES)(
       "update chart with invalid dataset/keyValue/dataRange disable confirm button",
       async (chartType) => {
         createTestChart(chartType);
@@ -1992,7 +1977,7 @@ describe("charts", () => {
       expect(model.getters.getChartDefinition(chartId)).toMatchObject(TEST_CHART_DATA.basicChart);
     });
 
-    test.each(TEST_CHART_TYPES)(
+    test.each(SELECTION_INPUT_CHART_TYPES)(
       "Clicking on reset button on dataset/keyValue/dataRange put back the last valid dataset/keyValue/dataRange",
       async (chartType) => {
         createTestChart(chartType);
@@ -2012,7 +1997,7 @@ describe("charts", () => {
       }
     );
 
-    test.each(["basicChart", "combo", "scorecard"] as const)(
+    test.each(["basicChart", "combo"] as const)(
       "resetting chart label works as expected",
       async (chartType) => {
         createTestChart(chartType);
@@ -2035,35 +2020,6 @@ describe("charts", () => {
         );
       }
     );
-
-    test("Scorecard > no error when confirming unchanged key value", async () => {
-      createTestChart("scorecard");
-      await mountChartSidePanel();
-
-      expect(errorMessages()).toEqual([]);
-      await simulateClick(".o-data-series input");
-      await simulateClick(".o-data-series .o-selection-ok");
-      expect(errorMessages()).toEqual([]);
-    });
-
-    test("Scorecard > error displayed on input fields", async () => {
-      createTestChart("scorecard");
-      await mountChartSidePanel();
-
-      // empty dataset/key value
-      await simulateClick(".o-data-series input");
-      await setInputValueAndTrigger(".o-data-series input", "");
-      await simulateClick(".o-data-series .o-selection-ok");
-      expect(document.querySelector(".o-data-series input")?.classList).toContain("o-invalid");
-      expect(document.querySelector(".o-data-labels input")?.classList).not.toContain("o-invalid");
-
-      // invalid labels/baseline
-      await simulateClick(".o-data-labels input");
-      await setInputValueAndTrigger(".o-data-labels input", "Invalid Label Range");
-      await simulateClick(".o-data-labels .o-selection-ok");
-      expect(document.querySelector(".o-data-series input")?.classList).toContain("o-invalid");
-      expect(document.querySelector(".o-data-labels input")?.classList).toContain("o-invalid");
-    });
   });
 
   test.each(["basicChart", "combo", "scorecard"] as const)(
@@ -2077,7 +2033,7 @@ describe("charts", () => {
     }
   );
 
-  test.each(TEST_CHART_TYPES)(
+  test.each(SELECTION_INPUT_CHART_TYPES)(
     "Can edit a chart with empty main range without traceback",
     async (chartType) => {
       createTestChart(chartType);
@@ -2152,63 +2108,6 @@ describe("charts", () => {
     await nextTick();
     expect(store.isMainPanelOpen).toBeFalsy();
     expect(fixture.querySelector(".o-sidePanel")).toBeNull();
-  });
-
-  describe("Scorecard specific tests", () => {
-    test("can edit chart baseline colors", async () => {
-      createTestChart("scorecard");
-      const dispatch = spyModelDispatch(model);
-      await mountChartSidePanel();
-      await openChartDesignSidePanel(model, env, fixture, chartId);
-
-      // Change color of "up" value of baseline
-      const colorpickerUpButton = fixture.querySelectorAll(
-        ".o-chart-baseline-color .o-round-color-picker-button"
-      )[0];
-      await simulateClick(colorpickerUpButton);
-      const colorpickerUpItems = fixture.querySelectorAll(
-        ".o-color-picker-line-item"
-      ) as NodeListOf<HTMLElement>;
-      for (const el of colorpickerUpItems) {
-        if (toHex(el.style.backgroundColor) === "#0000FF") {
-          await simulateClick(el);
-          break;
-        }
-      }
-      expect(dispatch).toHaveBeenLastCalledWith("UPDATE_CHART", {
-        figureId: model.getters.getFigureIdFromChartId(chartId),
-        chartId,
-        sheetId,
-        definition: {
-          ...model.getters.getChartDefinition(chartId),
-          baselineColorUp: "#0000FF",
-        },
-      });
-
-      // Change color of "down" value of baseline
-      const colorpickerDownButton = fixture.querySelectorAll(
-        ".o-chart-baseline-color .o-round-color-picker-button"
-      )[1];
-      await simulateClick(colorpickerDownButton);
-      const colorpickerDownItems = fixture.querySelectorAll(
-        ".o-color-picker-line-item"
-      ) as NodeListOf<HTMLElement>;
-      for (const el of colorpickerDownItems) {
-        if (toHex(el.style.backgroundColor) === "#FF0000") {
-          await simulateClick(el);
-          break;
-        }
-      }
-      expect(dispatch).toHaveBeenLastCalledWith("UPDATE_CHART", {
-        figureId: model.getters.getFigureIdFromChartId(chartId),
-        chartId,
-        sheetId,
-        definition: {
-          ...model.getters.getChartDefinition(chartId),
-          baselineColorDown: "#FF0000",
-        },
-      });
-    });
   });
 
   describe("labelAsText", () => {
@@ -2806,6 +2705,43 @@ describe("charts", () => {
         }),
       });
     });
+
+    test("Scorecard formula is kept when switching to another chart type and back", async () => {
+      createScorecardChart(model, { keyValue: "=A1+22", baseline: "=B1+22" }, chartId);
+      await mountChartSidePanel(chartId);
+
+      await changeChartType("bar");
+      await changeChartType("scorecard");
+
+      expect(model.getters.getChartDefinition(chartId)).toMatchObject({
+        keyValue: "=A1+22",
+        baseline: "=B1+22",
+      });
+    });
+
+    test("Label range is not wrongly restored when switching from a chart with a label range to a scorecard then to another chart", async () => {
+      createChart(
+        model,
+        {
+          type: "line",
+          ...toChartDataSource({ dataSets: [{ dataRange: "A1" }], labelRange: "B3" }),
+        },
+        chartId
+      );
+      await mountChartSidePanel(chartId);
+      await openChartConfigSidePanel(model, env, chartId);
+
+      await changeChartType("scorecard");
+      expect(model.getters.getChartDefinition(chartId)).toMatchObject({ baseline: "=B3" });
+
+      await editStandaloneComposer(".o-data-labels .o-composer", "=A1+22");
+      expect(model.getters.getChartDefinition(chartId)).toMatchObject({ baseline: "=A1+22" });
+
+      await changeChartType("line");
+      expect(model.getters.getChartDefinition(chartId)).toMatchObject(
+        toChartDataSource({ dataSets: [{ dataRange: "A1" }], labelRange: undefined })
+      );
+    });
   });
 
   describe("trend line", () => {
@@ -3225,8 +3161,8 @@ describe("charts with multiple sheets", () => {
                 chartId: "2",
                 type: "scorecard",
                 title: { text: "demo scorecard" },
-                baseline: "Sheet1!A2:A4",
-                keyValue: "Sheet1!B1:B4",
+                baseline: "=Sheet1!A2:A4",
+                keyValue: "=Sheet1!B1:B4",
               },
             },
           ],
@@ -3285,7 +3221,7 @@ describe("Default background on runtime tests", () => {
       chartId,
       sheetId
     );
-    updateChart(model, chartId, { type: "scorecard", keyValue: "A1" }, sheetId);
+    updateChart(model, chartId, { type: "scorecard", keyValue: "=A1" }, sheetId);
     const runtime = model.getters.getChartRuntime(chartId) as ScorecardChartRuntime;
     expect(model.getters.getChartDefinition(chartId)?.background).toBeUndefined();
     expect(runtime.background).toBe("#FA0000");
@@ -3562,6 +3498,65 @@ describe("Change chart type", () => {
 
     await changeChartType("bar");
     expect(model.getters.getChartDefinition(chartId)).toMatchObject({ type: "bar" });
+  });
+
+  test("Keyvalue and baseline ranges update through chart type changes", async () => {
+    createScorecardChart(model, { keyValue: "=A1", baseline: "=B1" }, chartId);
+    await mountChartSidePanel(chartId);
+
+    await changeChartType("bar");
+    expect(model.getters.getChartDefinition(chartId)).toMatchObject({
+      type: "bar",
+      ...toChartDataSource({
+        dataSets: [{ dataRange: "A1" }],
+        labelRange: "B1",
+        dataSetsHaveTitle: false,
+      }),
+    });
+    updateChart(
+      model,
+      chartId,
+      {
+        type: "bar",
+        ...toChartDataSource({
+          dataSets: [{ dataRange: "A2" }],
+          labelRange: "B2",
+          dataSetsHaveTitle: false,
+        }),
+      },
+      sheetId
+    );
+    await changeChartType("scorecard");
+    expect(model.getters.getChartDefinition(chartId)).toMatchObject({
+      type: "scorecard",
+      keyValue: "=A2",
+      baseline: "=B2",
+    });
+  });
+  test("Keyvalue and baseline do not update through chart type changes", async () => {
+    createScorecardChart(model, { keyValue: "=SUM(1,2)", baseline: "hello" }, chartId);
+    await mountChartSidePanel(chartId);
+
+    await changeChartType("bar");
+    updateChart(
+      model,
+      chartId,
+      {
+        type: "bar",
+        ...toChartDataSource({
+          dataSets: [{ dataRange: "A2" }],
+          labelRange: "B2",
+          dataSetsHaveTitle: false,
+        }),
+      },
+      sheetId
+    );
+    await changeChartType("scorecard");
+    expect(model.getters.getChartDefinition(chartId)).toMatchObject({
+      type: "scorecard",
+      keyValue: "=SUM(1,2)",
+      baseline: "hello",
+    });
   });
 });
 

--- a/tests/figures/chart/common_chart_plugin.test.ts
+++ b/tests/figures/chart/common_chart_plugin.test.ts
@@ -42,7 +42,7 @@ describe("Single cell chart background color", () => {
 
   function createTestChart(chartType: string, mainCell: string, background?: Color) {
     if (chartType === "scorecard") {
-      createScorecardChart(model, { background, keyValue: mainCell }, chartId);
+      createScorecardChart(model, { background, keyValue: `=${mainCell}` }, chartId);
     } else if (chartType === "gauge") {
       createGaugeChart(model, { background, dataRange: mainCell }, chartId);
     }

--- a/tests/figures/chart/menu_item_insert_chart.test.ts
+++ b/tests/figures/chart/menu_item_insert_chart.test.ts
@@ -475,7 +475,7 @@ describe("Smart chart type detection", () => {
     const chartId = model.getters.getChartIds(model.getters.getActiveSheetId())[0];
     expect(model.getters.getChartDefinition(chartId)).toMatchObject({
       type: "scorecard",
-      keyValue: "C3",
+      keyValue: "=C3",
     });
   });
 

--- a/tests/figures/chart/scorecard/scorecard_chart_component.test.ts
+++ b/tests/figures/chart/scorecard/scorecard_chart_component.test.ts
@@ -1,9 +1,11 @@
 import { CellIsRule, Model, Pixel, UID } from "../../../../src";
+import { ChartPanel } from "../../../../src/components/side_panel/chart/main_chart_panel/main_chart_panel";
 import { SidePanels } from "../../../../src/components/side_panel/side_panels/side_panels";
 import {
   DEFAULT_SCORECARD_BASELINE_COLOR_DOWN,
   DEFAULT_SCORECARD_BASELINE_COLOR_UP,
 } from "../../../../src/constants";
+import { toHex } from "../../../../src/helpers/color";
 import { chartMutedFontColor } from "../../../../src/helpers/figures/charts/chart_common";
 import { drawScoreChart } from "../../../../src/helpers/figures/charts/scorecard_chart";
 import {
@@ -18,8 +20,11 @@ import {
 } from "../../../../src/types/chart/scorecard_chart";
 import { SpreadsheetChildEnv } from "../../../../src/types/spreadsheet_env";
 import { MockCanvasRenderingContext2D } from "../../../setup/canvas.mock";
-import { click } from "../../../test_helpers";
-import { openChartDesignSidePanel } from "../../../test_helpers/chart_helpers";
+import { click, simulateClick } from "../../../test_helpers";
+import {
+  openChartConfigSidePanel,
+  openChartDesignSidePanel,
+} from "../../../test_helpers/chart_helpers";
 import {
   addCfRule,
   createScorecardChart,
@@ -30,12 +35,15 @@ import {
   updateFigure,
   updateLocale,
 } from "../../../test_helpers/commands_helpers";
-import { FR_LOCALE } from "../../../test_helpers/constants";
+import { FR_LOCALE, TEST_CHART_DATA } from "../../../test_helpers/constants";
 import { getCellContent } from "../../../test_helpers/getters_helpers";
 import {
+  editStandaloneComposer,
   mountComponentWithPortalTarget,
   mountSpreadsheet,
   nextTick,
+  spyModelDispatch,
+  textContentAll,
 } from "../../../test_helpers/helpers";
 
 let model: Model;
@@ -86,6 +94,11 @@ function renderScorecardChart(model: Model, chartId: UID, sheetId: UID, canvas: 
   drawScoreChart(design, canvas);
 }
 
+async function mountChartSidePanel(id: UID = chartId, _model: Model = model) {
+  const props = { chartId: id, onCloseSidePanel: () => {} };
+  ({ fixture, env } = await mountComponentWithPortalTarget(ChartPanel, { props, model: _model }));
+}
+
 test("Scorecard chart canvas adapt to figure size", () => {
   chartId = "someuuid";
   sheetId = "Sheet1";
@@ -112,7 +125,7 @@ test("Scorecard chart canvas adapt to figure size", () => {
 
   createScorecardChart(
     model,
-    { keyValue: "A1", baseline: "B2", title: { text: "This is a title" } },
+    { keyValue: "=A1", baseline: "=B2", title: { text: "This is a title" } },
     chartId
   );
 
@@ -151,7 +164,12 @@ describe("Scorecard charts computation", () => {
   test("Chart display correct info", () => {
     createScorecardChart(
       model,
-      { keyValue: "A1", baseline: "B1", title: { text: "hello" }, baselineDescr: { text: "desc" } },
+      {
+        keyValue: "=A1",
+        baseline: "=B1",
+        title: { text: "hello" },
+        baselineDescr: { text: "desc" },
+      },
       chartId
     );
     const chartDesign = getChartDesign(model, chartId, sheetId);
@@ -165,7 +183,7 @@ describe("Scorecard charts computation", () => {
   test("Baseline = 0 correctly displayed", () => {
     setCellContent(model, "B1", "0");
     setCellContent(model, "A1", "0");
-    createScorecardChart(model, { keyValue: "A1", baseline: "B1" }, chartId);
+    createScorecardChart(model, { keyValue: "=A1", baseline: "=B1" }, chartId);
     const chartDesign = getChartDesign(model, chartId, sheetId);
 
     expect(chartDesign.key?.text).toEqual("0");
@@ -177,7 +195,7 @@ describe("Scorecard charts computation", () => {
   test("Percentage baseline display a percentage", () => {
     createScorecardChart(
       model,
-      { keyValue: "A1", baseline: "B1", baselineMode: "percentage" },
+      { keyValue: "=A1", baseline: "=B1", baselineMode: "percentage" },
       chartId
     );
     const chartDesign = getChartDesign(model, chartId, sheetId);
@@ -186,7 +204,11 @@ describe("Scorecard charts computation", () => {
   });
 
   test("Baseline with mode 'text' is plainly displayed", () => {
-    createScorecardChart(model, { keyValue: "A1", baseline: "B1", baselineMode: "text" }, chartId);
+    createScorecardChart(
+      model,
+      { keyValue: "=A1", baseline: "=B1", baselineMode: "text" },
+      chartId
+    );
     const chartDesign = getChartDesign(model, chartId, sheetId);
 
     expect(chartDesign.baseline?.text).toEqual("1");
@@ -196,7 +218,7 @@ describe("Scorecard charts computation", () => {
   test("Baseline description and arrow with mode 'progress' are not displayed", () => {
     createScorecardChart(
       model,
-      { keyValue: "A1", baseline: "B1", baselineMode: "progress" },
+      { keyValue: "=A1", baseline: "=B1", baselineMode: "progress" },
       chartId
     );
     const chartDesign = getChartDesign(model, chartId, sheetId);
@@ -210,7 +232,7 @@ describe("Scorecard charts computation", () => {
   test("Progress bar color is equal to up color for positive percentage", () => {
     createScorecardChart(
       model,
-      { keyValue: "A1", baseline: "B1", baselineMode: "progress" },
+      { keyValue: "=A1", baseline: "=B1", baselineMode: "progress" },
       chartId
     );
     const chartDesign = getChartDesign(model, chartId, sheetId);
@@ -224,7 +246,7 @@ describe("Scorecard charts computation", () => {
     setCellContent(model, "A1", "-5");
     createScorecardChart(
       model,
-      { keyValue: "A1", baseline: "B1", baselineMode: "progress" },
+      { keyValue: "=A1", baseline: "=B1", baselineMode: "progress" },
       chartId
     );
     const chartDesign = getChartDesign(model, chartId, sheetId);
@@ -237,7 +259,7 @@ describe("Scorecard charts computation", () => {
   test("Number are humanized if stipulated in the chart definition", () => {
     setCellContent(model, "A1", "123456789");
     setCellContent(model, "B1", "10.5");
-    createScorecardChart(model, { keyValue: "A1", baseline: "B1", humanize: true }, chartId);
+    createScorecardChart(model, { keyValue: "=A1", baseline: "=B1", humanize: true }, chartId);
     const chartDesign = getChartDesign(model, chartId, sheetId);
 
     expect(chartDesign.key?.text).toBe("123m");
@@ -249,7 +271,7 @@ describe("Scorecard charts computation", () => {
     setCellContent(model, "B1", "122222342");
     createScorecardChart(
       model,
-      { keyValue: "A1", baseline: "B1", humanize: true, baselineMode: "text" },
+      { keyValue: "=A1", baseline: "=B1", humanize: true, baselineMode: "text" },
       chartId
     );
     const chartDesign = getChartDesign(model, chartId, sheetId);
@@ -266,7 +288,7 @@ describe("Scorecard charts computation", () => {
     setFormat(model, "B1", accountingFormat);
     createScorecardChart(
       model,
-      { keyValue: "A1", baseline: "B1", humanize: true, baselineMode: "text" },
+      { keyValue: "=A1", baseline: "=B1", humanize: true, baselineMode: "text" },
       chartId
     );
     const chartDesign = getChartDesign(model, chartId, sheetId);
@@ -276,7 +298,7 @@ describe("Scorecard charts computation", () => {
   });
 
   test("Key < baseline display in red with down arrow", () => {
-    createScorecardChart(model, { keyValue: "A1", baseline: "B3" }, chartId);
+    createScorecardChart(model, { keyValue: "=A1", baseline: "=B3" }, chartId);
     const chartDesign = getChartDesign(model, chartId, sheetId);
 
     expect(chartDesign.baselineArrow?.direction).toBe("down");
@@ -290,7 +312,7 @@ describe("Scorecard charts computation", () => {
   });
 
   test("Key > baseline display in green with up arrow", () => {
-    createScorecardChart(model, { keyValue: "A1", baseline: "B1" }, chartId);
+    createScorecardChart(model, { keyValue: "=A1", baseline: "=B1" }, chartId);
     const chartDesign = getChartDesign(model, chartId, sheetId);
 
     expect(chartDesign.baselineArrow?.direction).toBe("up");
@@ -302,7 +324,7 @@ describe("Scorecard charts computation", () => {
   });
 
   test("Key = baseline display default font color with no arrow", () => {
-    createScorecardChart(model, { keyValue: "A1", baseline: "B2" }, chartId);
+    createScorecardChart(model, { keyValue: "=A1", baseline: "=B2" }, chartId);
     const chartDesign = getChartDesign(model, chartId, sheetId);
 
     expect(chartDesign.baselineArrow).toBeUndefined();
@@ -311,7 +333,7 @@ describe("Scorecard charts computation", () => {
   });
 
   test("Key value is displayed with the cell evaluated format", () => {
-    createScorecardChart(model, { keyValue: "C1" }, chartId);
+    createScorecardChart(model, { keyValue: "=C1" }, chartId);
     setCellContent(model, "C1", "=A1");
     setFormat(model, "A1", "0%");
     const chartDesign = getChartDesign(model, chartId, sheetId);
@@ -320,7 +342,7 @@ describe("Scorecard charts computation", () => {
 
   test("Baseline is displayed with the spreadsheet locale", () => {
     setCellContent(model, "C1", "=B2");
-    createScorecardChart(model, { keyValue: "A3", baseline: "C1" }, chartId);
+    createScorecardChart(model, { keyValue: "=A3", baseline: "=C1" }, chartId);
     let chartDesign = getChartDesign(model, chartId, sheetId);
     expect(chartDesign.baseline?.text).toEqual("0.12");
 
@@ -331,7 +353,7 @@ describe("Scorecard charts computation", () => {
 
   test("Baseline is displayed with the cell evaluated format", () => {
     setCellContent(model, "C1", "=B2");
-    createScorecardChart(model, { keyValue: "A3", baseline: "C1" }, chartId);
+    createScorecardChart(model, { keyValue: "=A3", baseline: "=C1" }, chartId);
     let chartDesign = getChartDesign(model, chartId, sheetId);
     expect(chartDesign.baseline?.text).toEqual("0.12");
 
@@ -342,14 +364,14 @@ describe("Scorecard charts computation", () => {
 
   test("Baseline with lot of decimal is truncated", () => {
     setCellContent(model, "C1", "=B2");
-    createScorecardChart(model, { keyValue: "A3", baseline: "B2" }, chartId);
+    createScorecardChart(model, { keyValue: "=A3", baseline: "=B2" }, chartId);
     const chartDesign = getChartDesign(model, chartId, sheetId);
     expect(chartDesign.baseline?.text).toEqual("0.12");
     expect(getCellContent(model, "A3")).toEqual("2.1234");
   });
 
   test("Baseline with lot of decimal isn't truncated if the cell has a format", () => {
-    createScorecardChart(model, { keyValue: "A3", baseline: "B2" }, chartId);
+    createScorecardChart(model, { keyValue: "=A3", baseline: "=B2" }, chartId);
     setFormat(model, "B2", "[$$]#,####0.0000");
     const chartDesign = getChartDesign(model, chartId, sheetId);
     expect(chartDesign.baseline?.text).toEqual("$0.1234");
@@ -358,7 +380,7 @@ describe("Scorecard charts computation", () => {
   test("Baseline percentage mode format has priority over cell format", () => {
     createScorecardChart(
       model,
-      { keyValue: "A1", baseline: "B1", baselineMode: "percentage" },
+      { keyValue: "=A1", baseline: "=B1", baselineMode: "percentage" },
       chartId
     );
     setFormat(model, "B2", "[$$]#,####0.0000");
@@ -367,7 +389,7 @@ describe("Scorecard charts computation", () => {
   });
 
   test("Key value and baseline are displayed with the cell style", () => {
-    createScorecardChart(model, { keyValue: "A1", baseline: "A1" }, chartId);
+    createScorecardChart(model, { keyValue: "=A1", baseline: "=A1" }, chartId);
     setFormatting(model, "A1", {
       textColor: "#FF0000",
       bold: true,
@@ -389,7 +411,7 @@ describe("Scorecard charts computation", () => {
     const string = "This is a long string that will be the keyvalue";
     setCellContent(model, "A3", string);
     setFormatting(model, "A3", { bold: true, italic: true });
-    createScorecardChart(model, { baseline: "A3", keyValue: "A3" }, chartId);
+    createScorecardChart(model, { baseline: "=A3", keyValue: "=A3" }, chartId);
     const chartDesign = getChartDesign(model, chartId, sheetId);
 
     expect(chartDesign.baseline?.style.font.includes("bold")).toBeTruthy();
@@ -401,7 +423,7 @@ describe("Scorecard charts computation", () => {
   test("Baseline mode percentage don't inherit of the style/format of the cell", () => {
     createScorecardChart(
       model,
-      { keyValue: "A1", baseline: "B1", baselineMode: "percentage" },
+      { keyValue: "=A1", baseline: "=B1", baselineMode: "percentage" },
       chartId
     );
     setFormatting(model, "A1", { bold: true });
@@ -415,8 +437,8 @@ describe("Scorecard charts computation", () => {
     createScorecardChart(
       model,
       {
-        keyValue: "A1",
-        baseline: "A1",
+        keyValue: "=A1",
+        baseline: "=A1",
         baselineDescr: { text: "descr" },
         title: { text: "title" },
         background: "#000000",
@@ -434,7 +456,7 @@ describe("Scorecard charts computation", () => {
   test("Font size stays the same if we put a long key value", () => {
     createScorecardChart(
       model,
-      { keyValue: "A1", baseline: "B2", title: { text: "This is a title" } },
+      { keyValue: "=A1", baseline: "=B2", title: { text: "This is a title" } },
       chartId
     );
     const chartDesign1 = getChartDesign(model, chartId, sheetId);
@@ -460,7 +482,7 @@ describe("Scorecard charts computation", () => {
     };
     addCfRule(model, "A1", rule);
     setCellContent(model, "A1", "30");
-    createScorecardChart(model, { keyValue: "A1" }, chartId);
+    createScorecardChart(model, { keyValue: "=A1" }, chartId);
     let chartDesign = getChartDesign(model, chartId, sheetId);
     expect(chartDesign.key?.style.color).toBeSameColorAs("#FF0000");
     setFormatting(model, "A1", { textColor: "#FFAAAA" });
@@ -546,13 +568,17 @@ describe("Scorecard charts rendering", () => {
   });
 
   test("Baseline with mode 'text' is plainly displayed", () => {
-    createScorecardChart(model, { keyValue: "A1", baseline: "B1", baselineMode: "text" }, chartId);
+    createScorecardChart(
+      model,
+      { keyValue: "=A1", baseline: "=B1", baselineMode: "text" },
+      chartId
+    );
     renderScorecardChart(model, chartId, sheetId, canvas);
     expect(scorecardChartStyle.baseline.color).toBeSameColorAs(mutedFontColor);
   });
 
   test("Key < baseline display in red with down arrow", () => {
-    createScorecardChart(model, { keyValue: "A1", baseline: "B3" }, chartId);
+    createScorecardChart(model, { keyValue: "=A1", baseline: "=B3" }, chartId);
     renderScorecardChart(model, chartId, sheetId, canvas);
     expect(scorecardChartStyle.baseline.color).toBeSameColorAs(
       DEFAULT_SCORECARD_BASELINE_COLOR_DOWN
@@ -560,13 +586,13 @@ describe("Scorecard charts rendering", () => {
   });
 
   test("Key > baseline display in green with up arrow", () => {
-    createScorecardChart(model, { keyValue: "A1", baseline: "B1" }, chartId);
+    createScorecardChart(model, { keyValue: "=A1", baseline: "=B1" }, chartId);
     renderScorecardChart(model, chartId, sheetId, canvas);
     expect(scorecardChartStyle.baseline.color).toBeSameColorAs(DEFAULT_SCORECARD_BASELINE_COLOR_UP);
   });
 
   test("Key = baseline display default font color with no arrow", () => {
-    createScorecardChart(model, { keyValue: "A1", baseline: "B2" }, chartId);
+    createScorecardChart(model, { keyValue: "=A1", baseline: "=B2" }, chartId);
     renderScorecardChart(model, chartId, sheetId, canvas);
     expect(scorecardChartStyle.baseline.color).toBeSameColorAs(mutedFontColor);
   });
@@ -577,7 +603,7 @@ describe("Scorecard charts rendering", () => {
       bold: true,
       italic: true,
     });
-    createScorecardChart(model, { keyValue: "A1", baseline: "A1" }, chartId);
+    createScorecardChart(model, { keyValue: "=A1", baseline: "=A1" }, chartId);
     renderScorecardChart(model, chartId, sheetId, canvas);
     for (const style of [scorecardChartStyle.key, scorecardChartStyle.baseline]) {
       expect(style.italic).toEqual(true);
@@ -590,9 +616,9 @@ describe("Scorecard charts rendering", () => {
     createScorecardChart(
       model,
       {
-        keyValue: "A1",
+        keyValue: "=A1",
         keyDescr: { text: "keykey", italic: true, bold: true, color: "#FF0000" },
-        baseline: "A1",
+        baseline: "=A1",
         baselineDescr: { text: "baselineDescr", italic: true, bold: true, color: "#FF0000" },
       },
       chartId
@@ -609,9 +635,9 @@ describe("Scorecard charts rendering", () => {
     createScorecardChart(
       model,
       {
-        keyValue: "A1",
+        keyValue: "=A1",
         keyDescr: { text: "keykey" },
-        baseline: "A1",
+        baseline: "=A1",
         baselineDescr: { text: "baselineDescr" },
       },
       chartId
@@ -647,9 +673,9 @@ describe("Scorecard charts rendering", () => {
     createScorecardChart(
       model,
       {
-        keyValue: "A1",
+        keyValue: "=A1",
         keyDescr: { text: "keykey" },
-        baseline: "A1",
+        baseline: "=A1",
         baselineDescr: { text: "baselineDescr" },
       },
       chartId
@@ -705,9 +731,9 @@ describe("Scorecard charts rendering", () => {
     createScorecardChart(
       model,
       {
-        keyValue: "A1",
+        keyValue: "=A1",
         keyDescr: { text: "keykey" },
-        baseline: "A1",
+        baseline: "=A1",
         baselineDescr: { text: "baselineDescr" },
       },
       chartId
@@ -764,7 +790,7 @@ describe("Scorecard charts rendering", () => {
     setFormat(model, "A1", "0.0");
     createScorecardChart(
       model,
-      { keyValue: "A1", baseline: "B1", baselineMode: "percentage" },
+      { keyValue: "=A1", baseline: "=B1", baselineMode: "percentage" },
       chartId
     );
     renderScorecardChart(model, chartId, sheetId, canvas);
@@ -786,4 +812,131 @@ test("Scorecard is re-render on element size change", async () => {
 
   window.resizers.resize();
   expect(spy).toHaveBeenCalledTimes(2);
+});
+
+describe("Scorecard chart side panel", () => {
+  test("can remove ranges in scorecard chart", async () => {
+    const model = new Model();
+    createScorecardChart(model, { keyValue: "=A1", baseline: "=B1" }, "chartId");
+    await mountChartSidePanel("chartId", model);
+
+    expect(
+      (model.getters.getChartDefinition("chartId") as ScorecardChartDefinition)?.baseline
+    ).not.toBeUndefined();
+
+    await editStandaloneComposer(".o-data-labels .o-composer", "");
+    expect(
+      (model.getters.getChartDefinition("chartId") as ScorecardChartDefinition).baseline
+    ).toBeFalsy();
+  });
+
+  test("no error when confirming unchanged key value", async () => {
+    const model = new Model();
+    createScorecardChart(model, { keyValue: "=A1", baseline: "=B1" }, "chartId");
+    await mountChartSidePanel("chartId", model);
+
+    expect(textContentAll(".o-validation-error")).toEqual([]);
+    await editStandaloneComposer(".o-data-series .o-composer", TEST_CHART_DATA.scorecard.keyValue);
+    expect(textContentAll(".o-validation-error")).toEqual([]);
+  });
+
+  test("Can use litteral value for keyValue and baseline", async () => {
+    const model = new Model();
+    createScorecardChart(model, {}, "chartId");
+    await mountChartSidePanel("chartId", model);
+
+    // typing content without a leading "=" still confirms as a formula
+    await editStandaloneComposer(".o-data-series .o-composer", "test");
+    expect((model.getters.getChartDefinition("chartId") as ScorecardChartDefinition).keyValue).toBe(
+      "test"
+    );
+
+    await editStandaloneComposer(".o-data-labels .o-composer", "testBaseline");
+    expect((model.getters.getChartDefinition("chartId") as ScorecardChartDefinition).baseline).toBe(
+      "testBaseline"
+    );
+
+    // clearing the composer entirely still confirms as empty: the lone "=" left behind is
+    // treated as "no value", it isn't turned into a keyValue/baseline of "="
+    await editStandaloneComposer(".o-data-series .o-composer", "");
+    expect(
+      (model.getters.getChartDefinition("chartId") as ScorecardChartDefinition).keyValue
+    ).toBeFalsy();
+  });
+
+  test("can edit a chart with empty main range without traceback", async () => {
+    const model = new Model();
+    createScorecardChart(model, {}, "chartId");
+    const { env, fixture } = await mountSpreadsheet({ model });
+    await openChartConfigSidePanel(model, env, "chartId");
+
+    await editStandaloneComposer(".o-data-series .o-composer", "=A1");
+    expect(fixture.querySelector(".o-figure")).toBeTruthy();
+  });
+
+  test("No error when confirming empty baseline", async () => {
+    const model = new Model();
+    createScorecardChart(model, {}, "chartId");
+    await mountChartSidePanel("chartId", model);
+
+    await editStandaloneComposer(".o-data-labels .o-composer", "");
+    expect(textContentAll(".o-validation-error")).toEqual([]);
+  });
+  test("can edit chart baseline colors", async () => {
+    const model = new Model();
+    const dispatch = spyModelDispatch(model);
+    const chartId = "chartId";
+    const sheetId = "Sheet1";
+    createScorecardChart(model, {}, chartId);
+    const { env, fixture } = await mountSpreadsheet({ model });
+    await openChartDesignSidePanel(model, env, fixture, chartId);
+
+    // Change color of "up" value of baseline
+    const colorpickerUpButton = fixture.querySelectorAll(
+      ".o-chart-baseline-color .o-round-color-picker-button"
+    )[0];
+    await simulateClick(colorpickerUpButton);
+    const colorpickerUpItems = fixture.querySelectorAll(
+      ".o-color-picker-line-item"
+    ) as NodeListOf<HTMLElement>;
+    for (const el of colorpickerUpItems) {
+      if (toHex(el.style.backgroundColor) === "#0000FF") {
+        await simulateClick(el);
+        break;
+      }
+    }
+    expect(dispatch).toHaveBeenLastCalledWith("UPDATE_CHART", {
+      figureId: model.getters.getFigureIdFromChartId(chartId),
+      chartId,
+      sheetId,
+      definition: {
+        ...model.getters.getChartDefinition(chartId),
+        baselineColorUp: "#0000FF",
+      },
+    });
+
+    // Change color of "down" value of baseline
+    const colorpickerDownButton = fixture.querySelectorAll(
+      ".o-chart-baseline-color .o-round-color-picker-button"
+    )[1];
+    await simulateClick(colorpickerDownButton);
+    const colorpickerDownItems = fixture.querySelectorAll(
+      ".o-color-picker-line-item"
+    ) as NodeListOf<HTMLElement>;
+    for (const el of colorpickerDownItems) {
+      if (toHex(el.style.backgroundColor) === "#FF0000") {
+        await simulateClick(el);
+        break;
+      }
+    }
+    expect(dispatch).toHaveBeenLastCalledWith("UPDATE_CHART", {
+      figureId: model.getters.getFigureIdFromChartId(chartId),
+      chartId,
+      sheetId,
+      definition: {
+        ...model.getters.getChartDefinition(chartId),
+        baselineColorDown: "#FF0000",
+      },
+    });
+  });
 });

--- a/tests/figures/chart/scorecard/scorecard_chart_plugin.test.ts
+++ b/tests/figures/chart/scorecard/scorecard_chart_plugin.test.ts
@@ -1,4 +1,4 @@
-import { CommandResult, Model } from "../../../../src";
+import { Model } from "../../../../src";
 import {
   DEFAULT_SCORECARD_BASELINE_COLOR_DOWN,
   DEFAULT_SCORECARD_BASELINE_COLOR_UP,
@@ -46,8 +46,8 @@ describe("datasource tests", function () {
     createScorecardChart(
       model,
       {
-        keyValue: "B8",
-        baseline: "B7",
+        keyValue: "=B8",
+        baseline: "=B7",
         type: "scorecard",
         baselineDescr: { text: "Description" },
         title: { text: "Title" },
@@ -69,7 +69,7 @@ describe("datasource tests", function () {
       model,
       {
         type: "scorecard",
-        keyValue: "A1",
+        keyValue: "=A1",
       },
       "1"
     );
@@ -92,8 +92,8 @@ describe("datasource tests", function () {
       type: "scorecard",
       background: "#123456",
       title: { text: "hello there" },
-      keyValue: "Sheet1!B1:B4",
-      baseline: "Sheet1!A1:A4",
+      keyValue: "=Sheet1!B1:B4",
+      baseline: "=Sheet1!A1:A4",
       baselineMode: DEFAULT_SCORECARD_BASELINE_MODE,
       baselineColorUp: DEFAULT_SCORECARD_BASELINE_COLOR_UP,
       baselineColorDown: DEFAULT_SCORECARD_BASELINE_COLOR_DOWN,
@@ -107,23 +107,23 @@ describe("datasource tests", function () {
     createScorecardChart(
       model,
       {
-        keyValue: "Sheet1!B1:B4",
-        baseline: "Sheet1!A2:A4",
+        keyValue: "=Sheet1!B1:B4",
+        baseline: "=Sheet1!A2:A4",
       },
       "1"
     );
     addColumns(model, "before", "A", 2);
     const chart = model.getters.getChartDefinition("1") as ScorecardChartDefinition;
-    expect(chart.keyValue!).toStrictEqual("Sheet1!D1:D4");
-    expect(chart.baseline!).toStrictEqual("Sheet1!C2:C4");
+    expect(chart.keyValue!).toStrictEqual("=Sheet1!D1:D4");
+    expect(chart.baseline!).toStrictEqual("=Sheet1!C2:C4");
   });
 
   test("can delete an imported scorecard chart", () => {
     createScorecardChart(
       model,
       {
-        keyValue: "B7:B8",
-        baseline: "B7",
+        keyValue: "=B7:B8",
+        baseline: "=B7",
         type: "scorecard",
       },
       "1"
@@ -142,45 +142,34 @@ describe("datasource tests", function () {
     createScorecardChart(
       model,
       {
-        keyValue: "B7:B8",
-        baseline: "B7",
+        keyValue: "=B7:B8",
+        baseline: "=B7",
       },
       "1"
     );
     updateChart(model, "1", {
-      keyValue: "A7",
-      baseline: "E3",
+      keyValue: "=A7",
+      baseline: "=E3",
       baselineMode: "percentage",
       baselineDescr: { text: "description" },
       title: { text: "hello1" },
     });
     expect(model.getters.getChartDefinition("1")).toMatchObject({
-      keyValue: "A7",
-      baseline: "E3",
+      keyValue: "=A7",
+      baseline: "=E3",
       baselineMode: "percentage",
       baselineDescr: { text: "description" },
       title: { text: "hello1" },
     });
   });
 
-  test("create scorecard chart with invalid ranges", () => {
-    let result = createScorecardChart(
-      model,
-      {
-        keyValue: "this is invalid",
-      },
-      "1"
-    );
-    expect(result).toBeCancelledBecause(CommandResult.InvalidScorecardKeyValue);
-    result = createScorecardChart(
-      model,
-      {
-        keyValue: "A1",
-        baseline: "this is invalid",
-      },
-      "1"
-    );
-    expect(result).toBeCancelledBecause(CommandResult.InvalidScorecardBaseline);
+  test("changing a scorecard chart type keeps the key value as the new chart's data range", () => {
+    createScorecardChart(model, { keyValue: "=B2:B4", baseline: "=A1" }, "1");
+    updateChart(model, "1", { type: "bar" } as any);
+    const def = model.getters.getChartDefinition("1") as any;
+    expect(def.type).toBe("bar");
+    expect(def.dataSource.dataSets).toMatchObject([{ dataRange: "B2:B4" }]);
+    expect(def.dataSource.labelRange).toEqual("A1");
   });
 
   test("Scorecard Chart is deleted on sheet deletion", () => {
@@ -188,7 +177,7 @@ describe("datasource tests", function () {
     createScorecardChart(
       model,
       {
-        keyValue: "Sheet1!B1:B4",
+        keyValue: "=Sheet1!B1:B4",
       },
       "1",
       "2"
@@ -205,8 +194,8 @@ describe("datasource tests", function () {
       model,
       {
         title: { text: "test" },
-        keyValue: "B1:B4",
-        baseline: "A1",
+        keyValue: "=B1:B4",
+        baseline: "=A1",
       },
       firstSheetId
     );
@@ -221,8 +210,8 @@ describe("datasource tests", function () {
       .getChart(duplicatedChartId)
       ?.getDefinition() as ScorecardChartDefinition;
     expect(newChart.title.text).toEqual("test");
-    expect(newChart.keyValue).toEqual("B1:B4");
-    expect(newChart.baseline).toEqual("A1");
+    expect(newChart.keyValue).toEqual("=B1:B4");
+    expect(newChart.baseline).toEqual("=A1");
 
     expect(duplicatedFigure).toMatchObject({ ...figure, id: expect.any(String) });
     expect(duplicatedFigure.id).not.toBe(figure?.id);
@@ -232,12 +221,35 @@ describe("datasource tests", function () {
     expect(model.getters.getFigures(secondSheetId)).toEqual([duplicatedFigure]);
   });
 
+  test("Explicit sheet references are correctly updated on sheet duplication", () => {
+    const firstSheetId = model.getters.getActiveSheetId();
+    const secondSheetId = "secondSheetId";
+    const thirdSheetId = "thirdSheetId";
+    createSheet(model, { sheetId: secondSheetId });
+    setCellContent(model, "B1", "99", "secondSheetId");
+    createScorecardChart(
+      model,
+      {
+        keyValue: `=${model.getters.getSheetName(secondSheetId)}!B1`,
+        baseline: `=${model.getters.getSheetName(firstSheetId)}!A1`,
+      },
+      firstSheetId
+    );
+    duplicateSheet(model, firstSheetId, thirdSheetId, "Sheet1Copy");
+    const duplicatedChartId = model.getters.getChartIds(thirdSheetId)[0];
+    const newChart = model.getters
+      .getChart(duplicatedChartId)
+      ?.getDefinition() as ScorecardChartDefinition;
+    expect(newChart.keyValue).toEqual("=Sheet2!B1");
+    expect(newChart.baseline).toEqual("=Sheet1Copy!A1");
+  });
+
   test("percentage with key value smaller than baseline", () => {
     setCellContent(model, "A1", "40");
     setCellContent(model, "A2", "100");
     createScorecardChart(model, {
-      keyValue: "A1",
-      baseline: "A2",
+      keyValue: "=A1",
+      baseline: "=A2",
       baselineMode: "percentage",
     });
     const [scorecardId] = model.getters.getChartIds(model.getters.getActiveSheetId());
@@ -253,8 +265,8 @@ describe("datasource tests", function () {
     setCellContent(model, "A1", "140");
     setCellContent(model, "A2", "100");
     createScorecardChart(model, {
-      keyValue: "A1",
-      baseline: "A2",
+      keyValue: "=A1",
+      baseline: "=A2",
       baselineMode: "percentage",
     });
     const [scorecardId] = model.getters.getChartIds(model.getters.getActiveSheetId());
@@ -270,8 +282,8 @@ describe("datasource tests", function () {
     setCellContent(model, "A1", "140");
     setCellContent(model, "A2", "140");
     createScorecardChart(model, {
-      keyValue: "A1",
-      baseline: "A2",
+      keyValue: "=A1",
+      baseline: "=A2",
       baselineMode: "percentage",
     });
     const [scorecardId] = model.getters.getChartIds(model.getters.getActiveSheetId());
@@ -286,8 +298,8 @@ describe("datasource tests", function () {
   test("percentage with key value not defined", () => {
     setCellContent(model, "A2", "140");
     createScorecardChart(model, {
-      keyValue: "A1",
-      baseline: "A2",
+      keyValue: "=A1",
+      baseline: "=A2",
       baselineMode: "percentage",
     });
     const [scorecardId] = model.getters.getChartIds(model.getters.getActiveSheetId());
@@ -302,8 +314,8 @@ describe("datasource tests", function () {
   test("percentage with baseline value not defined", () => {
     setCellContent(model, "A1", "140");
     createScorecardChart(model, {
-      keyValue: "A1",
-      baseline: "A2",
+      keyValue: "=A1",
+      baseline: "=A2",
       baselineMode: "percentage",
     });
     const [scorecardId] = model.getters.getChartIds(model.getters.getActiveSheetId());
@@ -317,8 +329,8 @@ describe("datasource tests", function () {
 
   test("percentage with key value not defined and baseline value not defined", () => {
     createScorecardChart(model, {
-      keyValue: "A1",
-      baseline: "A2",
+      keyValue: "=A1",
+      baseline: "=A2",
       baselineMode: "percentage",
     });
     const [scorecardId] = model.getters.getChartIds(model.getters.getActiveSheetId());
@@ -334,8 +346,8 @@ describe("datasource tests", function () {
     setCellContent(model, "A1", "1");
     setCellContent(model, "A2", "0");
     createScorecardChart(model, {
-      keyValue: "A1",
-      baseline: "A2",
+      keyValue: "=A1",
+      baseline: "=A2",
       baselineMode: "percentage",
     });
     const [scorecardId] = model.getters.getChartIds(model.getters.getActiveSheetId());
@@ -350,8 +362,8 @@ describe("datasource tests", function () {
     setCellContent(model, "A1", "0");
     setCellContent(model, "A2", "0");
     createScorecardChart(model, {
-      keyValue: "A1",
-      baseline: "A2",
+      keyValue: "=A1",
+      baseline: "=A2",
       baselineMode: "percentage",
     });
     const [scorecardId] = model.getters.getChartIds(model.getters.getActiveSheetId());
@@ -366,8 +378,8 @@ describe("datasource tests", function () {
     setCellContent(model, "A1", "40");
     setCellContent(model, "A2", "100");
     createScorecardChart(model, {
-      keyValue: "A1",
-      baseline: "A2",
+      keyValue: "=A1",
+      baseline: "=A2",
       baselineMode: "progress",
     });
     const [scorecardId] = model.getters.getChartIds(model.getters.getActiveSheetId());
@@ -386,8 +398,8 @@ describe("datasource tests", function () {
     setCellContent(model, "A1", "-40");
     setCellContent(model, "A2", "100");
     createScorecardChart(model, {
-      keyValue: "A1",
-      baseline: "A2",
+      keyValue: "=A1",
+      baseline: "=A2",
       baselineMode: "progress",
     });
     const [scorecardId] = model.getters.getChartIds(model.getters.getActiveSheetId());
@@ -424,7 +436,7 @@ describe("multiple sheets", () => {
               data: {
                 type: "scorecard",
                 title: "demo chart",
-                keyValue: "Sheet2!A1",
+                keyValue: "=Sheet2!A1",
                 baselineMode: "difference",
                 baselineColorDown: DEFAULT_SCORECARD_BASELINE_COLOR_DOWN,
                 baselineColorUp: DEFAULT_SCORECARD_BASELINE_COLOR_UP,
@@ -448,21 +460,21 @@ describe("multiple sheets", () => {
     createScorecardChart(
       model,
       {
-        keyValue: "Sheet1!B1",
-        baseline: "Sheet1!C1",
+        keyValue: "=Sheet1!B1",
+        baseline: "=Sheet1!C1",
       },
       "28"
     );
     const chart = model.getters.getChartDefinition("28") as ScorecardChartDefinition;
-    expect(chart.keyValue).toEqual("Sheet1!B1");
-    expect(chart.baseline).toEqual("Sheet1!C1");
+    expect(chart.keyValue).toEqual("=Sheet1!B1");
+    expect(chart.baseline).toEqual("=Sheet1!C1");
   });
 });
 
 describe("undo/redo", () => {
   test("undo/redo scorecard chart creation", () => {
     const before = model.exportData();
-    createScorecardChart(model, { keyValue: "Sheet1!B1:B4" });
+    createScorecardChart(model, { keyValue: "=Sheet1!B1:B4" });
     const after = model.exportData();
     undo(model);
     expect(model).toExport(before);
@@ -474,7 +486,7 @@ describe("undo/redo", () => {
     createScorecardChart(
       model,
       {
-        keyValue: "Sheet1!A2",
+        keyValue: "=Sheet1!A2",
       },
       "27"
     );
@@ -498,7 +510,7 @@ test("font color is white with a dark background color", () => {
   createScorecardChart(
     model,
     {
-      keyValue: "Sheet1!A2",
+      keyValue: "=Sheet1!A2",
       background: "#000000",
     },
     "1"
@@ -514,8 +526,8 @@ test("Scorecard with formula cell", () => {
   createScorecardChart(
     model,
     {
-      keyValue: "A1",
-      baseline: "A2",
+      keyValue: "=A1",
+      baseline: "=A2",
       baselineMode: "percentage",
     },
     "1"
@@ -523,4 +535,54 @@ test("Scorecard with formula cell", () => {
   const runtime = model.getters.getChartRuntime("1") as ScorecardChartRuntime;
   expect(runtime.keyValue).toEqual("4");
   expect(runtime.baselineDisplay).toEqual("100.0%");
+});
+
+describe("Keyvalue formula", () => {
+  test("keyValue formula is evaluated", () => {
+    const model = new Model();
+    createScorecardChart(model, { keyValue: "=SUM(1, 2)" }, "1");
+    expect(model.getters.getChartRuntime("1")).toMatchObject({ keyValue: "3" });
+  });
+
+  test("keyValue updates when referenced cell changes", () => {
+    const model = new Model();
+    setCellContent(model, "A1", "5");
+    createScorecardChart(model, { keyValue: "=A1" }, "1");
+    expect(model.getters.getChartRuntime("1")).toMatchObject({ keyValue: "5" });
+    setCellContent(model, "A1", "99");
+    expect(model.getters.getChartRuntime("1")).toMatchObject({ keyValue: "99" });
+  });
+
+  test("keyValue string is adapted on column insertion", () => {
+    const model = new Model();
+    createScorecardChart(model, { keyValue: "=SUM(A1, B1)" }, "1");
+    addColumns(model, "before", "A", 1);
+    const chart = model.getters.getChartDefinition("1") as ScorecardChartDefinition;
+    expect(chart.keyValue).toEqual("=SUM(B1, C1)");
+  });
+});
+
+describe("Baseline formula", () => {
+  test("baseline formula is evaluated", () => {
+    const model = new Model();
+    createScorecardChart(model, { baseline: "=SUM(3, 4)" }, "1");
+    expect(model.getters.getChartRuntime("1")).toMatchObject({ baselineDisplay: "7" });
+  });
+
+  test("baseline updates when referenced cell changes", () => {
+    const model = new Model();
+    setCellContent(model, "A1", "5");
+    createScorecardChart(model, { baseline: "=A1" }, "1");
+    expect(model.getters.getChartRuntime("1")).toMatchObject({ baselineDisplay: "5" });
+    setCellContent(model, "A1", "99");
+    expect(model.getters.getChartRuntime("1")).toMatchObject({ baselineDisplay: "99" });
+  });
+
+  test("baseline string is adapted  on column insertion", () => {
+    const model = new Model();
+    createScorecardChart(model, { baseline: "=SUM(A1, B1)" }, "1");
+    addColumns(model, "before", "A", 1);
+    const chart = model.getters.getChartDefinition("1") as ScorecardChartDefinition;
+    expect(chart.baseline).toEqual("=SUM(B1, C1)");
+  });
 });

--- a/tests/model/model_import_export.test.ts
+++ b/tests/model/model_import_export.test.ts
@@ -909,6 +909,36 @@ test("migrate version 19.3.2: change datasets to dataSource", () => {
   );
 });
 
+test("migrate version 19.5.1: scorecard keyValue/baseline become formulas", () => {
+  const model = new Model({
+    version: "19.3.2",
+    sheets: [
+      {
+        id: "sh1",
+        figures: [
+          {
+            id: "chartFigure1",
+            tag: "chart",
+            data: {
+              chartId: "chartFigure1",
+              type: "scorecard",
+              keyValue: "A1:A3",
+              baseline: "B1",
+              title: { text: "Test scorecard" },
+            },
+          },
+        ],
+      },
+    ],
+  });
+  const exportedData = model.exportData();
+
+  expect(exportedData.sheets[0].figures[0].data).toMatchObject({
+    keyValue: "=A1:A3",
+    baseline: "=B1",
+  });
+});
+
 describe("Import", () => {
   test("Import sheet with rows/cols size defined.", () => {
     const model = new Model({

--- a/tests/test_helpers/chart_helpers.ts
+++ b/tests/test_helpers/chart_helpers.ts
@@ -239,4 +239,6 @@ export const GENERAL_CHART_CREATION_CONTEXT: Required<ChartCreationContext> = {
   bubbleColorMode: { color: FIRST_CHART_COLOR },
   annotationLink: "https://www.odoo.com",
   annotationText: "This is an annotation text",
+  scorecardKeyValueFormula: "=Sheet1!B1:B4",
+  scorecardBaselineFormula: "=Sheet1!A1:A4",
 };

--- a/tests/test_helpers/constants.ts
+++ b/tests/test_helpers/constants.ts
@@ -54,8 +54,8 @@ export const TEST_CHART_DATA = {
   },
   scorecard: {
     type: "scorecard" as const,
-    keyValue: "B1:B4",
-    baseline: "A2:A4",
+    keyValue: "=B1:B4",
+    baseline: "=A2:A4",
     title: { text: "hello" },
     baselineDescr: { text: "description" },
     baselineMode: "difference" as const,
@@ -63,7 +63,7 @@ export const TEST_CHART_DATA = {
   },
   funnel: {
     type: "funnel" as const,
-    keyValue: "B1:B4",
+    keyValue: "=B1:B4",
     baseline: "A2:A4",
     title: { text: "hello" },
     baselineDescr: { text: "description" },


### PR DESCRIPTION
## Task Description

This commits changes the way the scorecard is now defined, using a
formula for the baseline and the keyValue. The side panel now use a
standalone composer instead of the previous selection input for both
value, and automatically start by "=" when we focus on an empty
composer to allow the user to select directly a cell in the sheet, in
the same way as it was working before.

This allows us to use formula as keyValue and baseline, which will be
used in another task (data analysis tools) to insert directly some KPI
as scorecard in a sheet.

## Related Task:
- Task: [6343843](https://www.odoo.com/odoo/2328/tasks/6343843)