### PR TITLE
[FIX] charts: handle undefined values in treemap chart

### DIFF
--- a/src/helpers/figures/charts/runtime/chart_data_extractor.ts
+++ b/src/helpers/figures/charts/runtime/chart_data_extractor.ts
@@ -787,7 +787,7 @@ function filterInvalidHierarchicalPoints(
     values.length,
     ...hierarchy.map((dataset) => dataset.data?.length || 0)
   );
-  const isEmpty = (value: CellValue) => value === null || value === "";
+  const isEmpty = (value: CellValue) => value === undefined || value === null || value === "";
   const dataPointsIndexes = range(0, numberOfDataPoints).filter((dataPointIndex) => {
     const groups = hierarchy.map((dataset) => dataset.data?.[dataPointIndex]);
     if (isEmpty(groups[0]?.value)) {

--- a/tests/figures/chart/treemap/treemap_chart_plugin.test.ts
+++ b/tests/figures/chart/treemap/treemap_chart_plugin.test.ts
@@ -209,6 +209,23 @@ describe("TreeMap chart", () => {
     });
   });
 
+  test("TreeMap chart does not crash when hierarchy range starts at a different row than value range", () => {
+    // prettier-ignore
+    setGrid(model, {
+                    B1: "Sales",
+      A2: "Group1", B2: "100",
+      A3: "Group2", B3: "200",
+    });
+    const chartId = createTreeMapChart(model, {
+      ...toChartDataSource({
+        dataSets: [{ dataRange: "A2:A3" }],
+        labelRange: "B1:B3",
+        dataSetsHaveTitle: true,
+      }),
+    });
+    expect(() => getTreeMapDatasetConfig(chartId)).not.toThrow();
+  });
+
   test("Can have a hierarchical dataset with some categories more detailed that others", () => {
     // prettier-ignore
     setGrid(model, {


### PR DESCRIPTION
## Description:

Current behavior before PR:
- In b559bfd, undefined label values were handled for sunburst charts
but not for treemap charts.
- When using ranges of different sizes (for example A2 and B1),
treemap computations could raise a traceback.

Desired behavior after PR is merged:
- Handle undefined label values in treemap charts the same way
as in previous versions.
- This prevents the traceback. Label mapping for hierarchical charts is still
incorrect when ranges do not match and will be improved later if needed.

Task: [6329404](https://www.odoo.com/odoo/2328/tasks/6329404)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo