### PR TITLE
[FIX] calendar chart: skip missing value tooltips

### DIFF
--- a/src/helpers/figures/charts/runtime/chartjs_dataset.ts
+++ b/src/helpers/figures/charts/runtime/chartjs_dataset.ts
@@ -144,7 +144,7 @@ export function getCalendarChartDatasetAndLabels(
       borderWidth: 1,
       barPercentage: 1,
       categoryPercentage: 1,
-      values: dataSetValues.data.map((cell) => (isNumberResult(cell) ? cell.value : NaN)),
+      values: dataSetValues.data.map((cell) => (isNumberResult(cell) ? cell.value : undefined)),
     });
   }
 

--- a/tests/figures/chart/calendar/calendar_chart_plugin.test.ts
+++ b/tests/figures/chart/calendar/calendar_chart_plugin.test.ts
@@ -251,6 +251,34 @@ describe("calendar chart", () => {
     }
   );
 
+  test("Missing values do not have a tooltip", () => {
+    const model = new Model();
+    setCellContent(model, "A1", "=DATE(2024,7,8)");
+    setCellContent(model, "B1", "10");
+    setCellContent(model, "A2", "=DATE(2024,8,4)");
+    setCellContent(model, "B2", "20");
+    createCalendarChart(
+      model,
+      {
+        type: "calendar",
+        ...toChartDataSource({
+          dataSets: [{ dataRange: "B1:B2" }],
+          labelRange: "A1:A2",
+          dataSetsHaveTitle: false,
+        }),
+      },
+      "chartId"
+    );
+    const runtime = model.getters.getChartRuntime("chartId") as CalendarChartRuntime;
+    const [augustDataset, julyDataset] = runtime.chartJsConfig.data.datasets as any[];
+    const tooltipFilter = (runtime.chartJsConfig.options?.plugins?.tooltip as any).filter;
+
+    expect(augustDataset.values).toEqual([20, undefined]);
+    expect(julyDataset.values).toEqual([undefined, 10]);
+    expect(tooltipFilter({ dataset: augustDataset, dataIndex: 0 })).toBe(true);
+    expect(tooltipFilter({ dataset: augustDataset, dataIndex: 1 })).toBe(false);
+  });
+
   test("Axis borders are not shown in calendar charts", () => {
     const model = new Model();
     createCalendarChart(


### PR DESCRIPTION
## Description:

Calendar chart datasets use `data` as a Chart.js rendering payload, where every bucket is drawn with a constant value. The actual cell values are stored separately in `values`, which is only used by our tooltips and show-values plugin.

Before this commit, missing calendar values were stored as `NaN` in `values`. This is the right sentinel for Chart.js data points, but not for this metadata: the tooltip filter only skips `undefined`, so missing buckets still displayed a tooltip and formatted `NaN` as `1.00e-NaN`.

This commit stores missing calendar metadata as `undefined`, keeping empty buckets out of tooltips/show-values while preserving real numeric values.

Task: [6276800](https://www.odoo.com/odoo/2328/tasks/6276800)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo