### PR TITLE
[IMP] charts: adapt the behavior for boolean column

### DIFF
--- a/src/helpers/figures/charts/chart_data_sources.ts
+++ b/src/helpers/figures/charts/chart_data_sources.ts
@@ -17,12 +17,17 @@ import { CellErrorType } from "../../../types/errors";
 import { Getters } from "../../../types/getters";
 import { FunctionResultObject } from "../../../types/misc";
 import { Range } from "../../../types/range";
-import { isErrorResult, isNumberResult, isTextResult } from "../../cells/cell_evaluation";
+import {
+  isBooleanResult,
+  isErrorResult,
+  isNumberResult,
+  isTextResult,
+} from "../../cells/cell_evaluation";
 import { formatValue } from "../../format/format";
 import { isDefined } from "../../misc";
 import { createValidRange, duplicateRangeInDuplicatedSheet } from "../../range";
 import { recomputeZones } from "../../recompute_zones";
-import { getZoneArea } from "../../zones";
+import { getZoneArea, isEqual } from "../../zones";
 import {
   checkDataset,
   checkLabelRange,
@@ -261,7 +266,7 @@ export function getChartData(getters: Getters, dataSource: ChartRangeDataSource)
   const dataSets = dataSource.dataSets;
   const labelRange = dataSource.labelRange;
   const labelValues = getChartLabelValues(getters, dataSets, labelRange);
-  const dataSetsValues = getChartDatasetValues(getters, dataSets);
+  const dataSetsValues = getChartDatasetValues(getters, dataSets, labelRange);
   const data = { labelValues, dataSetsValues };
   // FIXME nested ternary
   const numberOfDataPoints = dataSetsValues.length
@@ -279,7 +284,11 @@ export function getChartData(getters: Getters, dataSource: ChartRangeDataSource)
   return data;
 }
 
-function getChartDatasetValues(getters: Getters, dataSets: DataSet[]): DatasetValues[] {
+function getChartDatasetValues(
+  getters: Getters,
+  dataSets: DataSet[],
+  labelRange: Range | undefined
+): DatasetValues[] {
   const datasetValues: DatasetValues[] = [];
   for (const [dsIndex, ds] of Object.entries(dataSets)) {
     let label = `${ChartTerms.Series} ${parseInt(dsIndex) + 1}`;
@@ -293,7 +302,24 @@ function getChartDatasetValues(getters: Getters, dataSets: DataSet[]): DatasetVa
     }
 
     let data = ds.dataRange ? getData(getters, ds) : [];
-    if (
+    if (!data.some((cell) => isNumberResult(cell)) && data.some((cell) => isBooleanResult(cell))) {
+      // When the labels are the boolean values themselves (categorical chart), each boolean
+      // occurrence is counted as 1 so it can be aggregated per TRUE/FALSE label. Otherwise, the
+      // booleans are used as regular numeric values: TRUE = 1, FALSE = 0.
+      const isCategorical =
+        !labelRange ||
+        (labelRange.sheetId === ds.dataRange.sheetId &&
+          isEqual(labelRange.zone, ds.dataRange.zone));
+      data = data.map((cell) => {
+        if (!isBooleanResult(cell)) {
+          return EMPTY;
+        } else if (isCategorical) {
+          return ONE;
+        } else {
+          return { value: cell.value ? 1 : 0 };
+        }
+      });
+    } else if (
       data.every((cell) => !cell.value || isTextResult(cell)) &&
       data.filter(isTextResult).length > 1
     ) {

--- a/src/helpers/figures/charts/smart_chart_engine.ts
+++ b/src/helpers/figures/charts/smart_chart_engine.ts
@@ -12,7 +12,7 @@ import { Zone } from "../../../types/misc";
 import { isDateTimeFormat } from "../../format/format";
 import { getZoneArea, getZonesByColumns, zoneToXc } from "../../zones";
 
-type ColumnType = "number" | "text" | "date" | "percentage" | "empty";
+type ColumnType = "number" | "text" | "date" | "percentage" | "boolean" | "empty";
 
 const DEFAULT_BAR_CHART_CONFIG: BarChartDefinition = {
   type: "bar",
@@ -49,7 +49,7 @@ function detectColumnType(cells: EvaluatedCell[]): ColumnType {
   if (!cells.length) {
     return "empty";
   }
-  const counts = { number: 0, text: 0, date: 0, percentage: 0 };
+  const counts = { number: 0, text: 0, date: 0, percentage: 0, boolean: 0 };
   let max = 0;
   let detectedType: ColumnType = "empty";
   for (const cell of cells) {
@@ -64,6 +64,8 @@ function detectColumnType(cells: EvaluatedCell[]): ColumnType {
       }
     } else if (cell.type === CellValueType.text) {
       type = "text";
+    } else if (cell.type === CellValueType.boolean) {
+      type = "boolean";
     }
     if (type) {
       const newCount = ++counts[type];
@@ -107,7 +109,7 @@ function isDatasetTitled(getters: Getters, column: ColumnInfo): boolean {
  * Builds a chart definition for a single column selection. The logic to detect the chart type is as follows:
  * - If the column contains a single cell, create a scorecard.
  * - If the column type is "percentage", create a pie chart.
- * - If the column type is "text", create a pie chart
+ * - If the column type is "text" or "boolean", create a pie chart
  * - If the column type is "date", create a calendar chart.
  * - Otherwise, create a bar chart.
  */
@@ -133,6 +135,7 @@ function buildSingleColumnChart(column: ColumnInfo, getters: Getters): ChartDefi
       };
 
     case "text":
+    case "boolean":
       const cells = getters.getEvaluatedCellsInZone(sheetId, zone);
       const titleCount = cells.reduce(
         (count, cell) => (cell.value === titleCell.value ? count + 1 : count),

--- a/tests/figures/chart/chart_plugin.test.ts
+++ b/tests/figures/chart/chart_plugin.test.ts
@@ -3760,7 +3760,78 @@ describe("Pie chart invalid values", () => {
     expect(data.datasets[0].data.length).toBe(3);
     expect(data.datasets[0].data).toEqual([1, 1, 1]);
   });
+
+  test("Pie chart with only boolean entries counts each distinct value as 1", () => {
+    const booleanModel = createModelFromGrid({
+      A1: "=TRUE",
+      A2: "=FALSE",
+      A3: "=TRUE",
+    });
+    createChart(
+      booleanModel,
+      {
+        ...toChartDataSource({ dataSets: [{ dataRange: "A1:A3" }], dataSetsHaveTitle: false }),
+        type: "pie",
+      },
+      "1"
+    );
+    const data = getChartConfiguration(booleanModel, "1").data;
+    expect(data.datasets[0].data).toEqual([1, 1, 1]);
+  });
+
+  test("Bar chart with boolean data series and distinct labels maps TRUE/FALSE to 1/0", () => {
+    const booleanModel = createModelFromGrid({
+      A1: "Q1",
+      A2: "Q2",
+      A3: "Q3",
+      B1: "=TRUE",
+      B2: "=FALSE",
+      B3: "=TRUE",
+    });
+    createChart(
+      booleanModel,
+      {
+        ...toChartDataSource({
+          dataSets: [{ dataRange: "B1:B3" }],
+          labelRange: "A1:A3",
+          dataSetsHaveTitle: false,
+        }),
+        type: "bar",
+      },
+      "1"
+    );
+    const data = getChartConfiguration(booleanModel, "1").data;
+    expect(data.datasets[0].data).toEqual([1, 0, 1]);
+  });
 });
+
+test.each([
+  ["A1:A3", "bar", [3]],
+  ["A2:A4", "pie", [1, 1]],
+  ["A1:A5", "pie", [3, 2]],
+])(
+  "Single column with different type of data: respect number > boolean > text priority",
+  (range, chartType: "bar" | "pie", result) => {
+    const model = createModelFromGrid({
+      A1: "3",
+      A2: "TRUE",
+      A3: "FALSE",
+      A4: "Text1",
+      A5: "2",
+    });
+    createChart(
+      model,
+      {
+        ...toChartDataSource({ dataSets: [{ dataRange: range }], dataSetsHaveTitle: false }),
+        type: chartType,
+      },
+      "1"
+    );
+
+    const data = getChartConfiguration(model, "1").data;
+    expect(data.datasets[0].data).toEqual(result);
+  }
+);
 
 test("Duplicating a sheet dispatches CREATE_CHART for each chart", () => {
   createChart(

--- a/tests/figures/chart/menu_item_insert_chart.test.ts
+++ b/tests/figures/chart/menu_item_insert_chart.test.ts
@@ -461,6 +461,8 @@ describe("Smart chart type detection", () => {
           setCellContent(model, xc, `2022-10-${generator + 1}`);
         } else if (type === "percentage") {
           setCellContent(model, xc, `${generator * 10}%`);
+        } else if (type === "boolean") {
+          setCellContent(model, xc, generator % 2 === 0 ? "=TRUE()" : "=FALSE()");
         }
       }
     }
@@ -481,6 +483,7 @@ describe("Smart chart type detection", () => {
     [["percentage"], { type: "pie", dataSetsHaveTitle: false }],
     [["number"], { type: "bar", dataSetsHaveTitle: false }],
     [["text"], { type: "pie", labelRange: "A1:A6", aggregated: true, dataSetsHaveTitle: true }], // categorical pie chart, the data range is also the label range
+    [["boolean"], { type: "pie", labelRange: "A1:A6", aggregated: true, dataSetsHaveTitle: false }],
     [["percentage_with_header"], { type: "pie", dataSetsHaveTitle: true }],
   ] as const)("Single column %s creates chart", async (datasetPattern, expected) => {
     createDatasetFromDescription([...datasetPattern]);


### PR DESCRIPTION
## Description:

A single-column of boolean values is now detected as a categorical dataset, producing an aggregated pie chart with TRUE/FALSE as labels — same behaviour as text columns, where boolean values in the dataset are mapped to 1 so the chart can count occurrences.
If the boolean values are in the data serie with something else as label, we treat them as 0 and 1 and use them as normal numerical values.

## Related Task(s):
- Task: [6344909](https://www.odoo.com/odoo/2328/tasks/6344909)
