### PR TITLE
[IMP] charts: allow to create calendar chart with only dates

### DIFF
--- a/src/helpers/figures/charts/runtime/chart_data_extractor.ts
+++ b/src/helpers/figures/charts/runtime/chart_data_extractor.ts
@@ -127,7 +127,8 @@ function computeValuesAndLabels(
   values: FunctionResultObject[],
   horizontalGroupBy: CalendarChartGranularity,
   verticalGroupBy: CalendarChartGranularity,
-  locale: Locale
+  locale: Locale,
+  countEntries: boolean
 ) {
   const grouping: Record<string, Record<string, { value: number }>> = {};
   const xValues: number[] = [];
@@ -161,9 +162,13 @@ function computeValuesAndLabels(
     if (!(yValue in grouping[xValue])) {
       grouping[xValue][yValue] = { value: 0 };
     }
-    const cell = values[i];
-    if (isNumberResult(cell)) {
-      grouping[xValue][yValue].value += cell.value;
+    if (countEntries) {
+      grouping[xValue][yValue].value += 1;
+    } else {
+      const cell = values[i];
+      if (isNumberResult(cell)) {
+        grouping[xValue][yValue].value += cell.value;
+      }
     }
   }
 
@@ -191,8 +196,13 @@ export function getCalendarChartData(
   let labels = labelValues;
 
   const locale = getters.getLocale();
+  const countEntries = dataSetsValues.length === 0;
 
-  ({ labels, dataSetsValues } = filterInvalidCalendarDataPoints(labels, dataSetsValues));
+  ({ labels, dataSetsValues } = filterInvalidCalendarDataPoints(
+    labels,
+    dataSetsValues,
+    countEntries
+  ));
   const axisFormats = {
     y: getChartDatasetFormat(definition.dataSetStyles, dataSetsValues, "left"),
   };
@@ -202,7 +212,8 @@ export function getCalendarChartData(
     dataSetsValues[0]?.data ?? [],
     definition.horizontalGroupBy ?? "day_of_week",
     definition.verticalGroupBy ?? "hour_number",
-    locale
+    locale,
+    countEntries
   ));
 
   return {
@@ -852,13 +863,14 @@ function filterInvalidDataPoints(
 }
 
 /**
- * Filter the data points that:
- * - have neither a label nor a value
- * - have no label and a non-numeric value
+ * Keep only data points that:
+ * - have a valid numeric label if countEntries is true
+ * - have both a valid numeric date label and a valid numeric value else
  */
 function filterInvalidCalendarDataPoints(
   labels: LabelValues,
-  datasets: DatasetValues[]
+  datasets: DatasetValues[],
+  countEntries: boolean
 ): { labels: LabelValues; dataSetsValues: DatasetValues[] } {
   const numberOfDataPoints = Math.max(
     labels.length,
@@ -866,8 +878,13 @@ function filterInvalidCalendarDataPoints(
   );
   const dataPointsIndexes = range(0, numberOfDataPoints).filter((dataPointIndex) => {
     const label = labels[dataPointIndex];
+    if (!isNumberResult(label)) {
+      return false;
+    } else if (countEntries) {
+      return true;
+    }
     const values = datasets.map((dataset) => dataset.data?.[dataPointIndex]);
-    return isNumberResult(label) && isNumberResult(values[0]);
+    return isNumberResult(values[0]);
   });
   return {
     labels: dataPointsIndexes.map((i) => labels[i] || ""),

--- a/src/helpers/figures/charts/smart_chart_engine.ts
+++ b/src/helpers/figures/charts/smart_chart_engine.ts
@@ -108,7 +108,7 @@ function isDatasetTitled(getters: Getters, column: ColumnInfo): boolean {
  * - If the column contains a single cell, create a scorecard.
  * - If the column type is "percentage", create a pie chart.
  * - If the column type is "text", create a pie chart
- * - If the column type is "date", create a line chart.
+ * - If the column type is "date", create a calendar chart.
  * - Otherwise, create a bar chart.
  */
 function buildSingleColumnChart(column: ColumnInfo, getters: Getters): ChartDefinition {
@@ -155,11 +155,18 @@ function buildSingleColumnChart(column: ColumnInfo, getters: Getters): ChartDefi
 
     case "date":
       return {
-        ...DEFAULT_LINE_CHART_CONFIG,
-        type: "line",
+        type: "calendar",
         title: dataSetsHaveTitle ? { text: String(titleCell.value) } : {},
-        dataSource: { type: "range", dataSets: [{ dataRange, dataSetId: "0" }], dataSetsHaveTitle },
+        dataSource: {
+          type: "range",
+          dataSets: [],
+          dataSetsHaveTitle,
+          labelRange: dataRange,
+        },
         dataSetStyles: {},
+        legendPosition: "left",
+        horizontalGroupBy: "day_of_week",
+        verticalGroupBy: "month_number",
       };
   }
   return {

--- a/tests/figures/chart/calendar/calendar_chart_plugin.test.ts
+++ b/tests/figures/chart/calendar/calendar_chart_plugin.test.ts
@@ -1,4 +1,4 @@
-import { ScaleChartOptions } from "chart.js";
+import { ChartConfiguration, ScaleChartOptions } from "chart.js";
 import { ChartCreationContext, Model } from "../../../../src";
 import { UuidGenerator } from "../../../../src/helpers/uuid";
 import {
@@ -265,5 +265,33 @@ describe("calendar chart", () => {
     const scales = runtime.chartJsConfig.options?.scales as ScaleChartOptions<"bar">["scales"];
     expect(scales?.x?.border?.display).toBe(false);
     expect(scales?.y?.border?.display).toBe(false);
+  });
+
+  test("calendar chart without values counts entries per date bucket", () => {
+    const model = new Model();
+    createSheet(model, { sheetId: "calendar", activate: true, rows: 3, cols: 1 });
+    setCellContent(model, "A1", "=DATE(2024,1,1)");
+    setCellContent(model, "A2", "=DATE(2024,1,8)");
+    setCellContent(model, "A3", "=DATE(2024,2,5)");
+    const chartId = UuidGenerator.uuidv4();
+    createCalendarChart(
+      model,
+      {
+        type: "calendar" as const,
+        ...toChartDataSource({ dataSets: [], labelRange: "A1:A3" }),
+        horizontalGroupBy: "day_of_week",
+        verticalGroupBy: "month_number",
+      },
+      chartId,
+      "calendar"
+    );
+    const runtime = model.getters.getChartRuntime(chartId) as CalendarChartRuntime;
+    const config = runtime.chartJsConfig as ChartConfiguration<"calendar">;
+    const datasets = config.data.datasets!;
+    expect(config.data.labels).toEqual(["Monday"]);
+    // datasets are sorted descending by month: February first, January second
+    expect(datasets.map((ds) => ds.label)).toEqual(["February", "January"]);
+    expect(datasets[1].values).toEqual([2]); // January: 2 entries
+    expect(datasets[0].values).toEqual([1]); // February: 1 entry
   });
 });

--- a/tests/figures/chart/menu_item_insert_chart.test.ts
+++ b/tests/figures/chart/menu_item_insert_chart.test.ts
@@ -474,9 +474,7 @@ describe("Smart chart type detection", () => {
     [["percentage"], { type: "pie", dataSetsHaveTitle: false }],
     [["number"], { type: "bar", dataSetsHaveTitle: false }],
     [["text"], { type: "pie", labelRange: "A1:A6", aggregated: true, dataSetsHaveTitle: true }], // categorical pie chart, the data range is also the label range
-    [["date"], { type: "line", dataSetsHaveTitle: false }],
     [["percentage_with_header"], { type: "pie", dataSetsHaveTitle: true }],
-    [["date_with_header"], { type: "line", dataSetsHaveTitle: true }],
   ] as const)("Single column %s creates chart", async (datasetPattern, expected) => {
     createDatasetFromDescription([...datasetPattern]);
     await doAction(["insert", "insert_chart"], env);
@@ -491,6 +489,28 @@ describe("Smart chart type detection", () => {
         labelRange: "labelRange" in expected ? expected.labelRange : undefined,
         dataSetsHaveTitle: expected.dataSetsHaveTitle,
       }),
+    });
+  });
+
+  test.each([
+    [["date"], undefined],
+    [["date_with_header"], "Header0"],
+  ] as const)("Single date column %s creates a calendar chart", async (datasetPattern, title) => {
+    createDatasetFromDescription([...datasetPattern]);
+    await doAction(["insert", "insert_chart"], env);
+
+    const chartId = model.getters.getChartIds(model.getters.getActiveSheetId())[0];
+    const definition = model.getters.getChartDefinition(chartId);
+    expect(definition).toMatchObject({
+      type: "calendar",
+      title: title ? { text: title } : {},
+      dataSource: {
+        type: "range",
+        dataSets: [],
+        labelRange: "A1:A6",
+      },
+      horizontalGroupBy: "day_of_week",
+      verticalGroupBy: "month_number",
     });
   });
 


### PR DESCRIPTION
## Task Description

Just as we do with the pie chart when we only have one column of strings, we should be able to create a calendar chart with only a column of dates by counting the appearance by granularity. This PR aims to add this possibility, needed for the task 6209080

## Related Task

- Task: [6352279](https://www.odoo.com/odoo/2328/tasks/6352279)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo