### PR TITLE
[FIX] toLocaleString : new helper to use the locale's decimal separator

### DIFF
--- a/src/functions/helpers.ts
+++ b/src/functions/helpers.ts
@@ -174,6 +174,26 @@ export function toString(data: FunctionResultObject | CellValue | undefined): st
 }
 
 /**
+ * Only converts the decimal separator, ignore number format such as % or dates
+ */
+export function toLocaleString(
+  data: FunctionResultObject | CellValue | undefined,
+  locale: Locale
+): string {
+  const value = toValue(data);
+  switch (typeof value) {
+    case "string":
+      return value;
+    case "number":
+      return value.toString().replace(".", locale.decimalSeparator);
+    case "boolean":
+      return value ? "TRUE" : "FALSE";
+    default:
+      return "";
+  }
+}
+
+/**
  * Normalize range by setting all the string in the range to lowercase and replacing
  * accent letters with plain letters
  */

--- a/src/functions/module_array.ts
+++ b/src/functions/module_array.ts
@@ -12,10 +12,10 @@ import {
   isEvaluationError,
   toBoolean,
   toInteger,
+  toLocaleString,
   toMatrix,
   toNumber,
   toNumberMatrix,
-  toString,
   transposeMatrix,
 } from "./helpers";
 
@@ -859,7 +859,9 @@ export const ARRAYTOTEXT = {
       const arrayStr = transposeMatrix(_array)
         .flatMap((row) =>
           row.map((value) => {
-            return isEvaluationError(value.value) ? value.value : toString(value);
+            return isEvaluationError(value.value)
+              ? value.value
+              : toLocaleString(value, this.locale);
           })
         )
         .join(rowSeparator);

--- a/tests/functions/module_array.test.ts
+++ b/tests/functions/module_array.test.ts
@@ -1,6 +1,7 @@
 import { Model } from "../../src";
 import { ErrorCell } from "../../src/types";
-import { setCellContent, setFormat } from "../test_helpers/commands_helpers";
+import { setCellContent, setFormat, updateLocale } from "../test_helpers/commands_helpers";
+import { FR_LOCALE } from "../test_helpers/constants";
 import { getCellContent, getEvaluatedCell, getRangeValues } from "../test_helpers/getters_helpers";
 import {
   checkFunctionDoesntSpreadBeyondRange,
@@ -1772,5 +1773,16 @@ describe("ARRAYTOTEXT formula", () => {
                                     D5: "=ARRAYTOTEXT(A1:C2)"
     };
     expect(evaluateCell("D5", grid)).toBe("www.odoo.com,TRUE,41255,3.14,#DIV/0!,");
+  });
+  test("when using ARRAYTOTEXT with number cells, decimal separator follows the locale but number's format is ignored", () => {
+    const grid = {
+      A1: "1.2",
+      A2: "7%",
+      A3: "1/1/2021",
+      A4: "=ARRAYTOTEXT(A1:A3)",
+    };
+    const model = createModelFromGrid(grid);
+    updateLocale(model, FR_LOCALE);
+    expect(getCellContent(model, "A4")).toBe("1,2/0,07/44197");
   });
 });


### PR DESCRIPTION
Convert numbers to strings using the locale's decimal separator. Cell formats are intentionally ignored (like percentages or dates).

Task: [6232818](https://www.odoo.com/odoo/2328/tasks/6232818)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo