### PR TITLE
[FIX] DefaultPlugin: no format should be preserved

### DIFF
--- a/src/plugins/core/cell.ts
+++ b/src/plugins/core/cell.ts
@@ -276,7 +276,7 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
           positionsByStyle[styleId] ??= [];
           positionsByStyle[styleId].push(position);
         }
-        if (cell.format) {
+        if (cell.format !== undefined) {
           const formatId = getItemId<Format>(cell.format, formats);
           positionsByFormat[formatId] ??= [];
           positionsByFormat[formatId].push(position);

--- a/src/plugins/core/default.ts
+++ b/src/plugins/core/default.ts
@@ -300,29 +300,26 @@ export class DefaultPlugin extends CorePlugin<defaultState> implements defaultSt
     const defaults: [CellPosition, Format][] = [];
     for (const position of zones.flatMap((zone) => cellPositions(sheetId, zone))) {
       const cellFormat = this.getters.getCell(position)?.format;
-      if (cellFormat) {
+      if (cellFormat !== undefined) {
         continue;
       }
       const rowDefault = this.format[sheetId]?.rowDefault?.[position.row];
-      if (rowDefault) {
+      if (rowDefault !== undefined) {
         if (priorities.shouldUseDefaultRow) {
           defaults.push([position, rowDefault]);
         }
         continue;
       }
       const colDefault = this.format[sheetId]?.colDefault?.[position.col];
-      if (colDefault) {
+      if (colDefault !== undefined) {
         if (priorities.shouldUseDefaultCol) {
           defaults.push([position, colDefault]);
         }
         continue;
       }
-      const sheetDefault = this.format[sheetId]?.sheetDefault;
-      if (sheetDefault) {
-        if (priorities.shouldUseDefaultSheet) {
-          defaults.push([position, sheetDefault]);
-        }
-        continue;
+      const sheetDefault = this.format[sheetId]?.sheetDefault ?? "";
+      if (priorities.shouldUseDefaultSheet) {
+        defaults.push([position, sheetDefault]);
       }
     }
     return defaults;

--- a/tests/default/default_plugin_format.test.ts
+++ b/tests/default/default_plugin_format.test.ts
@@ -13,6 +13,7 @@ import {
   merge,
   moveColumns,
   moveRows,
+  setCellContent,
   unMerge,
 } from "../test_helpers";
 import { target } from "../test_helpers/helpers";
@@ -451,7 +452,8 @@ describe("Default Plugin: Format", () => {
       deleteCells(model, "B1", "up");
       expect(getCellFormat(model, "B1")).toEqual(DATE_FORMAT);
       expect(getCellFormat(model, "B2")).toEqual(DATE_FORMAT);
-      expect(model.getters.getCells(sheetId).length).toBe(0);
+      expect(getCellFormat(model, "B20")).toEqual("");
+      expect(model.getters.getCells(sheetId).length).toBe(1);
     });
 
     test("Default Sheet", () => {
@@ -459,8 +461,8 @@ describe("Default Plugin: Format", () => {
       deleteCells(model, "B1", "up");
       expect(getCellFormat(model, "B1")).toEqual(DATE_FORMAT);
       expect(getCellFormat(model, "B2")).toEqual(DATE_FORMAT);
-      expect(getCellFormat(model, "B19")).toEqual(DATE_FORMAT);
-      expect(model.getters.getCells(sheetId).length).toBe(0);
+      expect(getCellFormat(model, "B20")).toEqual("");
+      expect(model.getters.getCells(sheetId).length).toBe(1);
     });
   });
 
@@ -470,7 +472,8 @@ describe("Default Plugin: Format", () => {
       deleteCells(model, "A2", "left");
       expect(getCellFormat(model, "A2")).toEqual(DATE_FORMAT);
       expect(getCellFormat(model, "B2")).toEqual(DATE_FORMAT);
-      expect(model.getters.getCells(sheetId).length).toBe(0);
+      expect(getCellFormat(model, "Y2")).toEqual("");
+      expect(model.getters.getCells(sheetId).length).toBe(1);
     });
 
     test("Default Col", () => {
@@ -487,8 +490,8 @@ describe("Default Plugin: Format", () => {
       deleteCells(model, "A2", "left");
       expect(getCellFormat(model, "A2")).toEqual(DATE_FORMAT);
       expect(getCellFormat(model, "B2")).toEqual(DATE_FORMAT);
-      expect(getCellFormat(model, "Y2")).toEqual(DATE_FORMAT);
-      expect(model.getters.getCells(sheetId).length).toBe(0);
+      expect(getCellFormat(model, "Y2")).toEqual("");
+      expect(model.getters.getCells(sheetId).length).toBe(1);
     });
   });
 
@@ -504,17 +507,17 @@ describe("Default Plugin: Format", () => {
     test("Default Col", () => {
       setFormat(model, [model.getters.getColsZone(sheetId, 1, 1)], DATE_FORMAT);
       insertCells(model, "B2", "down");
-      expect(getCellFormat(model, "B2")).toEqual(DATE_FORMAT); // ??
+      expect(getCellFormat(model, "B2")).toEqual("");
       expect(getCellFormat(model, "B21")).toEqual(DATE_FORMAT);
-      expect(model.getters.getCells(sheetId).length).toBe(1);
+      expect(model.getters.getCells(sheetId).length).toBe(2); // TO FIX
     });
 
     test("Default Sheet", () => {
       setFormat(model, [model.getters.getSheetZone(sheetId)], DATE_FORMAT);
       insertCells(model, "B2", "down");
-      expect(getCellFormat(model, "B2")).toEqual(DATE_FORMAT);
+      expect(getCellFormat(model, "B2")).toEqual("");
       expect(getCellFormat(model, "B21")).toEqual(DATE_FORMAT);
-      expect(model.getters.getCells(sheetId).length).toBe(1); // ??
+      expect(model.getters.getCells(sheetId).length).toBe(2); // TO FIX
     });
   });
 
@@ -522,9 +525,9 @@ describe("Default Plugin: Format", () => {
     test("Default Row", () => {
       setFormat(model, [model.getters.getRowsZone(sheetId, 1, 1)], DATE_FORMAT);
       insertCells(model, "B2", "right");
-      expect(getCellFormat(model, "B2")).toEqual(DATE_FORMAT); // ??
+      expect(getCellFormat(model, "B2")).toEqual("");
       expect(getCellFormat(model, "C2")).toEqual(DATE_FORMAT);
-      expect(model.getters.getCells(sheetId).length).toBe(1);
+      expect(model.getters.getCells(sheetId).length).toBe(2); // TO FIX
     });
 
     test("Default Col", () => {
@@ -538,9 +541,9 @@ describe("Default Plugin: Format", () => {
     test("Default Sheet", () => {
       setFormat(model, [model.getters.getSheetZone(sheetId)], DATE_FORMAT);
       insertCells(model, "B2", "right");
-      expect(getCellFormat(model, "B2")).toEqual(DATE_FORMAT);
+      expect(getCellFormat(model, "B2")).toEqual("");
       expect(getCellFormat(model, "C2")).toEqual(DATE_FORMAT);
-      expect(model.getters.getCells(sheetId).length).toBe(1);
+      expect(model.getters.getCells(sheetId).length).toBe(2); // TO FIX
     });
   });
 
@@ -802,7 +805,8 @@ describe("Default Plugin: setRowsFormat preserves cells outside the zone", () =>
     setFormat(model, [model.getters.getColsZone(sheetId, 8, 8)], DATE_FORMAT);
 
     // Multi-row zone: rows 0-2 ensures zone.bottom > zone.top so the reversed-args bug fires
-    setFormat(model, [{ left: 0, right: 5, top: 0, bottom: 2 }], PERCENT_FORMAT);
+    const zone = toZone("A1:F3");
+    setFormat(model, [zone], PERCENT_FORMAT);
 
     // Cells inside the zone get the new format
     expect(getCellFormat(model, "A1")).toBe(PERCENT_FORMAT);
@@ -812,5 +816,31 @@ describe("Default Plugin: setRowsFormat preserves cells outside the zone", () =>
     expect(getCellFormat(model, "I1")).toBe(DATE_FORMAT);
     expect(getCellFormat(model, "I2")).toBe(DATE_FORMAT);
     expect(getCellFormat(model, "I3")).toBe(DATE_FORMAT);
+  });
+});
+
+describe("Default Plugin: setSheetFormat preserves cells outside the zone", () => {
+  test("a cell with content but no format keeps no format after setSheetFormat, even after a reload", () => {
+    // Default sheet is 26 cols x 100 rows. Selecting columns B:Z (25/26 cols, full height)
+    // covers more than half the sheet area, so SET_FORMATTING is stored as a sheet default,
+    // not a per-column default.
+    const model = new Model();
+    const sheetId = model.getters.getActiveSheetId();
+    setCellContent(model, "A1", "1");
+
+    setFormat(model, [model.getters.getColsZone(sheetId, 1, 25)], DATE_FORMAT);
+
+    // A1 was not part of the selection: it must keep no explicit/default format.
+    expect(getCellFormat(model, "A1")).toEqual("");
+    expect(model.getters.getEvaluatedCell({ sheetId, ...toCartesian("A1") }).formattedValue).toBe(
+      "1"
+    );
+
+    // Simulate a reload (export + reimport), which forces a full re-evaluation
+    const reloadedModel = new Model(model.exportData());
+    expect(getCellFormat(reloadedModel, "A1")).toEqual("");
+    expect(
+      reloadedModel.getters.getEvaluatedCell({ sheetId, ...toCartesian("A1") }).formattedValue
+    ).toBe("1");
   });
 });


### PR DESCRIPTION
When applying a default format to a dimension, we "pin" the format of the pre-existing cells so that it does not get overriden. However, a cell with a content an no format at all (the "General" case) was not handled. For those cells, we need to set an explicit ̀`""` format.

In future work, the format should probably always be defined on a cell, and we could keep the optimisation to not export it.

Task: 6345022

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo