### PR TITLE
[FIX] TableComputedStylePlugin: skip table style for invalid pivot

### DIFF
--- a/src/plugins/ui_feature/table_computed_style.ts
+++ b/src/plugins/ui_feature/table_computed_style.ts
@@ -74,7 +74,11 @@ export class TableComputedStylePlugin extends UIPlugin {
   private computeTableStyle(sheetId: UID, table: Table): Lazy<ComputedTableStyle> {
     return lazy(() => {
       const style = this.getters.getTableStyle(table.config.styleId);
-      const { tableMetaData, config } = this.getTableMetaData(sheetId, table);
+      const tableMetaDataAndConfig = this.getTableMetaData(sheetId, table);
+      if (!tableMetaDataAndConfig) {
+        return { borders: {}, styles: {} };
+      }
+      const { tableMetaData, config } = tableMetaDataAndConfig;
       const relativeTableStyle = getComputedTableStyle(config, style, tableMetaData);
 
       // Return the style with sheet coordinates instead of tables coordinates
@@ -98,7 +102,7 @@ export class TableComputedStylePlugin extends UIPlugin {
   private getTableMetaData(
     sheetId: UID,
     table: Table
-  ): { tableMetaData: TableMetaData; config: TableConfig } {
+  ): { tableMetaData: TableMetaData; config: TableConfig } | undefined {
     const { config, numberOfCols, numberOfRows } = this.getTableRuntimeConfig(sheetId, table);
     if (!table.isPivotTable) {
       return { tableMetaData: { numberOfCols, numberOfRows, mode: "table" }, config };
@@ -110,6 +114,9 @@ export class TableComputedStylePlugin extends UIPlugin {
       throw new Error("No dynamic pivot info found at pivot table position");
     }
     const pivot = this.getters.getPivot(pivotInfo.pivotId);
+    if (!pivot.isValid()) {
+      return undefined;
+    }
     const pivotStyle = pivotInfo.pivotStyle;
     const maxRowDepth = pivot.getExpandedTableStructure().getNumberOfRowGroupBys();
     const pivotCells = pivot.getCollapsedTableStructure().getPivotCells(pivotStyle);


### PR DESCRIPTION
## Description:

Pivot table style computation could call pivot runtime getters while an Odoo pivot was temporarily invalid/loading. Guard the pivot before reading its table structure and return no table style until it is valid again.

Task: [6306263](https://www.odoo.com/odoo/2328/tasks/6306263)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo