### PR TITLE
[IMP] default_clipboard: enlarge content in instead of multiple

### DIFF
--- a/src/clipboard_handlers/default_clipboard.ts
+++ b/src/clipboard_handlers/default_clipboard.ts
@@ -1,6 +1,5 @@
 import { DEFAULT_STYLE } from "../constants";
-import { splitZoneForPaste } from "../helpers/clipboard/clipboard_helpers";
-import { defaultDict, isObjectEmptyRecursive } from "../helpers/misc";
+import { deepCopy, defaultDict, isObjectEmptyRecursive, repeat } from "../helpers/misc";
 import { defaultValue } from "../plugins/core/default";
 import { ClipboardCellData, ClipboardOptions, ClipboardPasteTarget } from "../types/clipboard";
 import { Format } from "../types/format";
@@ -21,9 +20,9 @@ export class DefaultClipboardHandler extends AbstractCellClipboardHandler<
   unknown
 > {
   copy(data: ClipboardCellData): ClipboardContent | undefined {
-    const content = {
+    const content: ClipboardContent = {
       style: {},
-      format: {} as defaultValue<Format>,
+      format: {},
       width: data.columnsIndexes.length,
       height: data.rowsIndexes.length,
       sheetId: data.sheetId,
@@ -51,12 +50,12 @@ export class DefaultClipboardHandler extends AbstractCellClipboardHandler<
       rowIndex++;
     }
     for (const key in DEFAULT_STYLE) {
-      content.style[key] = {
+      content.style[key as keyof Style] = {
         sheetDefault:
           this.getters.getDefaultStyle(data.sheetId, key as keyof Style, "SHEET", undefined) ??
           DEFAULT_STYLE[key],
-        colDefault: {},
-        rowDefault: {},
+        colDefault: [],
+        rowDefault: [],
       };
       let colIndex = 0;
       for (const col of data.columnsIndexes) {
@@ -78,8 +77,38 @@ export class DefaultClipboardHandler extends AbstractCellClipboardHandler<
     return content;
   }
 
-  clearStyleFormat(sheetId: UID, zone: Zone) {
-    this.dispatch("SET_FORMATTING", { sheetId, target: [zone], format: "" });
+  adaptContentToZone(zone: Zone, content: ClipboardContent): ClipboardContent {
+    const colRepetition = Math.max(Math.floor((zone.right - zone.left + 1) / content.width), 1);
+    const rowRepetition = Math.max(Math.floor((zone.bottom - zone.top + 1) / content.height), 1);
+
+    if (colRepetition === 1 && rowRepetition === 1) {
+      return content;
+    }
+
+    const newContent = deepCopy(content);
+    newContent.height *= rowRepetition;
+    newContent.width *= colRepetition;
+
+    if (rowRepetition > 1 && newContent.format.rowDefault) {
+      newContent.format.rowDefault.length = content.height;
+      newContent.format.rowDefault = repeat(newContent.format.rowDefault, rowRepetition);
+    }
+    if (colRepetition > 1 && newContent.format.colDefault) {
+      newContent.format.colDefault.length = content.width;
+      newContent.format.colDefault = repeat(newContent.format.colDefault, colRepetition);
+    }
+    for (const key in content.style) {
+      if (rowRepetition > 1 && newContent.style[key].rowDefault) {
+        newContent.style[key].rowDefault.length = content.height;
+        newContent.style[key].rowDefault = repeat(newContent.style[key].rowDefault, rowRepetition);
+      }
+      if (colRepetition > 1 && newContent.style[key].colDefault) {
+        newContent.style[key].colDefault.length = content.width;
+        newContent.style[key].colDefault = repeat(newContent.style[key].colDefault, colRepetition);
+      }
+    }
+
+    return newContent;
   }
 
   paste(target: ClipboardPasteTarget, content: ClipboardContent, options: ClipboardOptions) {
@@ -90,24 +119,23 @@ export class DefaultClipboardHandler extends AbstractCellClipboardHandler<
     const zones = target.zones;
     if (!options.isCutOperation) {
       for (const zone of zones) {
-        for (const pasteZone of splitZoneForPaste(zone, content.width, content.height)) {
-          this.pasteStyle(
-            sheetId,
-            pasteZone.left,
-            pasteZone.top,
-            content.width,
-            content.height,
-            content.style
-          );
-          this.pasteFormat(
-            sheetId,
-            pasteZone.left,
-            pasteZone.top,
-            content.width,
-            content.height,
-            content.format
-          );
-        }
+        const newContent = this.adaptContentToZone(zone, content);
+        this.pasteStyle(
+          sheetId,
+          zone.left,
+          zone.top,
+          newContent.width,
+          newContent.height,
+          newContent.style
+        );
+        this.pasteFormat(
+          sheetId,
+          zone.left,
+          zone.top,
+          newContent.width,
+          newContent.height,
+          newContent.format
+        );
       }
     } else {
       this.clearClippedZones(content);
@@ -232,7 +260,9 @@ export class DefaultClipboardHandler extends AbstractCellClipboardHandler<
     const commands: [number, Zone, Format | undefined][] = [];
     for (const [zoneStr, [zone, priority]] of Object.entries(zones)) {
       const format = updateCells[zoneStr];
-      commands.push([priority, zone, format]);
+      if (format !== undefined) {
+        commands.push([priority, zone, format]);
+      }
     }
     commands.sort((a, b) => a[0] - b[0]);
     for (const [_, zone, format] of commands) {

--- a/src/helpers/misc.ts
+++ b/src/helpers/misc.ts
@@ -826,3 +826,16 @@ export function defaultDict<T>(def: T) {
     },
   };
 }
+
+export function repeat<T>(array: T[], times: number): T[] {
+  const len = array.length;
+  const result = new Array<T>(len * times);
+
+  for (let t = 0; t < times; t++) {
+    for (let i = 0; i < len; i++) {
+      result[t * len + i] = array[i];
+    }
+  }
+
+  return result;
+}

--- a/src/plugins/core/default.ts
+++ b/src/plugins/core/default.ts
@@ -549,15 +549,16 @@ export class DefaultPlugin extends CorePlugin<defaultState> implements defaultSt
       const deltaStyle: Style = {};
       let hasDelta = false;
       const styleSheet = this.style[position.sheetId];
-      if (!styleSheet) {
-        continue;
-      }
       for (const key in newDefaultStyle) {
         if (key in cellStyle) {
           continue;
         }
-        const defaults = styleSheet[key];
+        const defaults = styleSheet?.[key];
         if (!defaults) {
+          if (newDefaultStyle[key] !== DEFAULT_STYLE[key]) {
+            deltaStyle[key] = DEFAULT_STYLE[key];
+            hasDelta = true;
+          }
           continue;
         }
         const rowDefault = defaults.rowDefault?.[position.row];

--- a/src/plugins/core/default.ts
+++ b/src/plugins/core/default.ts
@@ -614,10 +614,14 @@ export class DefaultPlugin extends CorePlugin<defaultState> implements defaultSt
         if (!defaults) {
           continue;
         }
-        style[key] =
+        const styleValue =
           defaults.rowDefault?.[position.row] ??
           defaults.colDefault?.[position.col] ??
           defaults.sheetDefault;
+
+        if (styleValue !== undefined) {
+          style[key] = styleValue;
+        }
       }
     }
     return style;

--- a/tests/default/default_plugin_style.test.ts
+++ b/tests/default/default_plugin_style.test.ts
@@ -1030,6 +1030,15 @@ describe("Default Plugin: Style", () => {
     expect(getCellStyle(model, "C2")).toEqual(style);
     expect(getCellStyle(model, "D2")).toEqual(style);
   });
+
+  test("Cell not impacted by the default style have an empty style by default", () => {
+    model.dispatch("SET_FORMATTING", {
+      sheetId,
+      target: [model.getters.getColsZone(sheetId, 1, 1)],
+      style: { bold: true, fillColor: "#FF0000" },
+    });
+    expect(getCellStyle(model, "A1")).toStrictEqual({});
+  });
 });
 
 describe("Default Plugin: setRowsStyle preserves cells outside the zone", () => {

--- a/tests/default/default_plugin_style.test.ts
+++ b/tests/default/default_plugin_style.test.ts
@@ -355,6 +355,15 @@ describe("Default Plugin: Style", () => {
     });
   });
 
+  test("Editing default on a new sheet", () => {
+    const zone = { left: 0, right: 0, top: 0, bottom: 14 };
+    setStyle(model, [zone], BOLD_STYLE);
+    expect(getCellStyle(model, "A1")).toEqual(BOLD_STYLE);
+    expect(getCellStyle(model, "A15")).toEqual(BOLD_STYLE);
+    expect(getCellStyle(model, "A16")).toEqual({ bold: false });
+    expect(getCellStyle(model, "A20")).toEqual({ bold: false });
+  });
+
   describe("Sheet Manipulation: Add Column", () => {
     test("Default Row", () => {
       setStyle(model, [model.getters.getRowsZone(sheetId, 1, 1)], MULTI_STYLE);


### PR DESCRIPTION
## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo