### PR TITLE
[FIX] dashboard: clickable cell is not triggered by a right click

### DIFF
--- a/src/components/dashboard/dashboard.ts
+++ b/src/components/dashboard/dashboard.ts
@@ -96,6 +96,9 @@ export class SpreadsheetDashboard extends Component<Props, SpreadsheetChildEnv> 
   }
 
   selectClickableCell(ev: MouseEvent, clickableCell: ClickableCell) {
+    if (![0, 1].includes(ev.button)) {
+      return;
+    }
     const { position, action } = clickableCell;
     action(position, this.env, isMiddleClickOrCtrlClick(ev));
   }

--- a/tests/grid/dashboard_grid_component.test.ts
+++ b/tests/grid/dashboard_grid_component.test.ts
@@ -150,7 +150,7 @@ describe("Grid component in dashboard mode", () => {
     expect(fn).toHaveBeenCalledWith(1, 9);
   });
 
-  test("Triggers clickable cell actions with correct params on left-click and middle-click", async () => {
+  test("Triggers clickable cell actions with correct params on left-click and middle-click only", async () => {
     const fn = jest.fn();
     addToRegistry(clickableCellRegistry, "fake", {
       condition: (position, getters) => {
@@ -166,6 +166,10 @@ describe("Grid component in dashboard mode", () => {
     expect(fn).toHaveBeenCalledWith(false);
     await simulateClick("div.o-dashboard-clickable-cell", 10, 10, { bubbles: true, button: 1 });
     expect(fn).toHaveBeenCalledWith(true);
+    expect(fn).toHaveBeenCalledTimes(2);
+    // any button different from left or middle click should not trigger the action
+    await simulateClick("div.o-dashboard-clickable-cell", 10, 10, { bubbles: true, button: 2 });
+    expect(fn).toHaveBeenCalledTimes(2);
   });
 
   test("Clickable cell actions are computed only once per cell", async () => {


### PR DESCRIPTION
How to reproduce:
- On a dashboard in Odoo, right-click on a cell that contains a formula pointing towards records (ODOO.PIVOT or ODOO.LIST)

=> you are redirected to the said records

This is a side-effect from PR #5642 which was meant to detect a Ctrl-Click but not a right click.

Task: 6365823

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo