### PR TITLE
[FIX] scorecardPanel: mismatch baseline/keyValue

### DIFF
--- a/src/components/side_panel/chart/scorecard_chart_panel/scorecard_chart_config_panel.ts
+++ b/src/components/side_panel/chart/scorecard_chart_panel/scorecard_chart_config_panel.ts
@@ -46,7 +46,7 @@ export class ScorecardChartConfigPanel extends Component<Props, SpreadsheetChild
   }
 
   get isBaselineInvalid(): boolean {
-    return !!this.state.keyValueDispatchResult?.isCancelledBecause(
+    return !!this.state.baselineDispatchResult?.isCancelledBecause(
       CommandResult.InvalidScorecardBaseline
     );
   }


### PR DESCRIPTION
The condition to define if a range was invalid for the baseline was based on the `canDispatch` of a change of keyValue.

The error was invisible because the only case where `InvalidScorecardBaseline` is raised is when a xc does not have the profile of a reference but this is also checked inside the component `SelectionInput`.

However, in later versions (19.4+ , with owl3) the state does no longer seem global, it behaves as a signal. Which means a component will only be re-rerendered if it listens actively to the signal.

In this case, the SelectionInput of the baseline is listening to `state.keyValueDispatchResult` so changing
`state.baselineDispatchResult` would no trigger a re-rendering of the SelectionInput related to the baseline. It lead to infinite loops of rerendering.

How to reproduce in 19.4+:
- create a scorecard chart
- edit the baseline input
- click on the grid
- hit a direction arrow twice

=> infinite loop of rendering

Task: 6380393

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo