### PR TITLE
[FIX] figures: fix mouvement issue with arrow keys

### DIFF
--- a/src/components/figures/figure/figure.ts
+++ b/src/components/figures/figure/figure.ts
@@ -2,8 +2,8 @@ import { props, proxy, signal } from "@odoo/owl";
 import { Component, useLayoutEffect } from "../../../owl3_compatibility_layer";
 import { figureRegistry } from "../../../registries/figures_registry";
 import { MoveFiguresPayload } from "../../../types/commands";
-import { AnchorOffset, ResizeDirection } from "../../../types/figure";
-import { CSSProperties, Pixel } from "../../../types/misc";
+import { AnchorOffset, FigureUI, ResizeDirection } from "../../../types/figure";
+import { CSSProperties, Pixel, UID } from "../../../types/misc";
 import { Rect } from "../../../types/rendering";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
 import { cssPropertiesToCss } from "../../helpers/css";
@@ -171,7 +171,8 @@ export class FigureComponent extends Component<SpreadsheetChildEnv> {
           figures.push({
             sheetId,
             figureId,
-            ...this.postionInBoundary(
+            ...this.positionInBoundary(
+              sheetId,
               this.env.model.getters.getFigureUI(sheetId, figure),
               ev.key,
               ev.shiftKey
@@ -200,15 +201,27 @@ export class FigureComponent extends Component<SpreadsheetChildEnv> {
     }
   }
 
-  private postionInBoundary(position: AnchorOffset, key: string, shift: boolean): AnchorOffset {
-    const sheetId = this.env.model.getters.getActiveSheetId();
+  private positionInBoundary(
+    sheetId: UID,
+    figure: FigureUI,
+    key: string,
+    shift: boolean
+  ): AnchorOffset {
     const shiftAmount = shift ? 1 : 5;
-    let { col, row, offset } = position;
+    let { col, row, offset } = figure;
     offset = { ...offset };
+    const maxAnchor = this.env.model.getters.getMaxAnchorOffset(
+      sheetId,
+      figure.height,
+      figure.width
+    );
     switch (key) {
       case "ArrowUp":
         if (offset.y < shiftAmount) {
           row--;
+          while (row > 0 && this.env.model.getters.isRowHiddenByUser(sheetId, row)) {
+            row--;
+          }
           offset.y = this.env.model.getters.getRowSize(sheetId, row) - shiftAmount + offset.y;
         } else {
           offset.y -= shiftAmount;
@@ -217,6 +230,9 @@ export class FigureComponent extends Component<SpreadsheetChildEnv> {
       case "ArrowLeft":
         if (offset.x < shiftAmount) {
           col--;
+          while (col > 0 && this.env.model.getters.isColHiddenByUser(sheetId, col)) {
+            col--;
+          }
           offset.x = this.env.model.getters.getColSize(sheetId, col) - shiftAmount + offset.x;
         } else {
           offset.x -= shiftAmount;
@@ -226,6 +242,9 @@ export class FigureComponent extends Component<SpreadsheetChildEnv> {
         const rowSize = this.env.model.getters.getRowSize(sheetId, row);
         if (offset.y + shiftAmount >= rowSize) {
           row++;
+          while (row <= maxAnchor.row && this.env.model.getters.isRowHiddenByUser(sheetId, row)) {
+            row++;
+          }
           offset.y = offset.y + shiftAmount - rowSize;
         } else {
           offset.y += shiftAmount;
@@ -235,10 +254,27 @@ export class FigureComponent extends Component<SpreadsheetChildEnv> {
         const colSize = this.env.model.getters.getColSize(sheetId, col);
         if (offset.x + shiftAmount >= colSize) {
           col++;
+          while (col <= maxAnchor.col && this.env.model.getters.isColHiddenByUser(sheetId, col)) {
+            col++;
+          }
           offset.x = offset.x + shiftAmount - colSize;
         } else {
           offset.x += shiftAmount;
         }
+    }
+    if (col < 0) {
+      col = 0;
+      offset.x = 0;
+    } else if (col > maxAnchor.col || (col === maxAnchor.col && offset.x > maxAnchor.offset.x)) {
+      col = maxAnchor.col;
+      offset.x = maxAnchor.offset.x;
+    }
+    if (row < 0) {
+      row = 0;
+      offset.y = 0;
+    } else if (row > maxAnchor.row || (row === maxAnchor.row && offset.y > maxAnchor.offset.y)) {
+      row = maxAnchor.row;
+      offset.y = maxAnchor.offset.y;
     }
     return { col, row, offset };
   }

--- a/tests/figures/figure_component.test.ts
+++ b/tests/figures/figure_component.test.ts
@@ -12,6 +12,7 @@ import {
 import { Component } from "../../src/owl3_compatibility_layer";
 
 import { downloadFile } from "../../src/components/helpers/dom_helpers";
+import { toXC } from "../../src/helpers/coordinates";
 import { figureRegistry } from "../../src/registries/figures_registry";
 import { ClipboardMIMEType } from "../../src/types/clipboard";
 import { SpreadsheetChildEnv } from "../../src/types/spreadsheet_env";
@@ -26,6 +27,8 @@ import {
   deleteFigure,
   freezeColumns,
   freezeRows,
+  hideColumns,
+  hideRows,
   paste,
   selectCell,
   selectFigure,
@@ -448,6 +451,99 @@ describe("figures", () => {
     await keyDown({ key: "ArrowUp", shiftKey: true });
     expectXY("fig1", 2, 2);
     expectXY("fig2", 3, 3);
+  });
+
+  test("a figure cannot be moved past the bottom-right edge of the grid", async () => {
+    const width = 100;
+    const height = 100;
+    const maxAnchor = model.getters.getMaxAnchorOffset(sheetId, height, width);
+    // place the figure just inside the bottom-right boundary
+    createFigure(model, {
+      id: "someuuid",
+      col: maxAnchor.col,
+      row: maxAnchor.row,
+      offset: { x: maxAnchor.offset.x - 2, y: maxAnchor.offset.y - 2 },
+      width,
+      height,
+    });
+
+    await nextTick();
+    selectCell(model, toXC(maxAnchor.col, maxAnchor.row));
+    selectFigure(model, "someuuid");
+    await nextTick();
+    // pushing further right/down clamps the figure to the last valid position
+    await keyDown({ key: "ArrowRight" });
+    await keyDown({ key: "ArrowDown" });
+    expect(model.getters.getFigure(sheetId, "someuuid")).toMatchObject(maxAnchor);
+  });
+
+  test("a figure cannot be moved past the top-left edge of the grid", async () => {
+    createFigure(model, {
+      id: "someuuid",
+      col: 0,
+      row: 0,
+      offset: { x: 3, y: 3 },
+      width: 100,
+      height: 100,
+    });
+    await nextTick();
+    selectFigure(model, "someuuid");
+    await nextTick();
+    await keyDown({ key: "ArrowLeft" });
+    await keyDown({ key: "ArrowUp" });
+    expect(model.getters.getFigure(sheetId, "someuuid")).toMatchObject({
+      col: 0,
+      row: 0,
+      offset: { x: 0, y: 0 },
+    });
+  });
+
+  test("moving a figure with arrow keys skips hidden columns and rows", async () => {
+    hideColumns(model, ["B"]); // hide the column right after the figure's anchor
+    hideRows(model, [1]); // hide the row right after the figure's anchor
+    createFigure(model, {
+      id: "someuuid",
+      col: 0,
+      row: 0,
+      offset: { x: cellWidth - 1, y: cellHeight - 1 },
+      width: 100,
+      height: 100,
+    });
+    await nextTick();
+    selectFigure(model, "someuuid");
+    await nextTick();
+    // crossing the cell boundary lands on the next visible column/row (C and row 3), not the hidden one
+    await keyDown({ key: "ArrowRight" });
+    await keyDown({ key: "ArrowDown" });
+    expect(model.getters.getFigure(sheetId, "someuuid")).toMatchObject({
+      col: 2,
+      row: 2,
+      offset: { x: 4, y: 4 },
+    });
+  });
+
+  test("moving a figure backwards with arrow keys skips hidden columns and rows", async () => {
+    hideColumns(model, ["B"]); // hidden column between the figure's anchor and the target column
+    hideRows(model, [1]); // hidden row between the figure's anchor and the target row
+    createFigure(model, {
+      id: "someuuid",
+      col: 2,
+      row: 2,
+      offset: { x: 1, y: 1 },
+      width: 100,
+      height: 100,
+    });
+    await nextTick();
+    selectFigure(model, "someuuid");
+    await nextTick();
+    // crossing the cell boundary lands on the previous visible column/row (A and row 1), not the hidden one
+    await keyDown({ key: "ArrowLeft" });
+    await keyDown({ key: "ArrowUp" });
+    expect(model.getters.getFigure(sheetId, "someuuid")).toMatchObject({
+      col: 0,
+      row: 0,
+      offset: { x: cellWidth - 4, y: cellHeight - 4 },
+    });
   });
 
   test("figure is focused after a SELECT_FIGURE", async () => {


### PR DESCRIPTION
- you can make the figure shift to the right up until the left edge of the figure reaches the end of the grid

- You jump when going over hidden col/rows

Task: [6374091](https://www.odoo.com/odoo/2328/tasks/6374091)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo