### PR TITLE
[FIX] squisher: adapted ranges that become cells

### DIFF
--- a/src/formulas/compiler.ts
+++ b/src/formulas/compiler.ts
@@ -261,6 +261,23 @@ export class CompiledFormula implements Omit<ICompiledFormula, "tokens" | "depen
       params.execute
     );
   }
+
+  /*
+   * If you create a formula with a range as parameter, then delete all the dimensions of this range except one by removing columns and rows,
+   * it is possible that the formula AST and normalized formula says this range is a |R| kind of parameter while it is actually a |C| kind of parameter.
+   * This is useful because when squishing formulas, the kind of parameter must be correct according to the actual shape of the range to be compacted
+   * */
+  areRangeShapesInLineWithNormalizedFormula() {
+    const matches = Array.from(this.normalizedFormula.matchAll(/\|C\||\|R\|/g));
+    return matches.every((value, index) => {
+      return (
+        (this.rangeDependencies[index].parts.length === 1 && value[0] === "|C|") ||
+        (this.rangeDependencies[index].parts.length === 2 && value[0] === "|R|") ||
+        this.rangeDependencies[index].invalidXc ||
+        this.rangeDependencies[index].invalidSheetName
+      );
+    });
+  }
 }
 
 /**

--- a/src/helpers/range.ts
+++ b/src/helpers/range.ts
@@ -155,7 +155,8 @@ export function getRangeString(
       range.parts[0].rowFixed ||
       range.parts[0].colFixed ||
       range.parts[1].rowFixed ||
-      range.parts[1].colFixed
+      range.parts[1].colFixed ||
+      options.doNotSimplifyRange
     ) {
       rangeString += ":";
       rangeString += getRangePartString(range, 1, options);

--- a/src/plugins/core/squisher.ts
+++ b/src/plugins/core/squisher.ts
@@ -42,6 +42,8 @@ export class Squisher {
   // whether the base formula was already transformed. Formulas that have already been transformed must continue to be transformed
   private baseFormulaWasTransformed: boolean = false;
 
+  private rangeToStringOptions = { doNotSimplifyRange: true };
+
   constructor(getters: CoreGetters) {
     this.getters = getters;
   }
@@ -124,14 +126,14 @@ export class Squisher {
       this.baseFormula.normalizedFormula !== cell.compiledFormula.normalizedFormula
     ) {
       this.resetBaseTo(cell.compiledFormula);
-      return cell.compiledFormula.toFormulaString(this.getters);
+      return cell.compiledFormula.toFormulaString(this.getters, this.rangeToStringOptions);
     } else {
       if (
         !this.baseFormulaWasTransformed &&
         deepEquals(cell.compiledFormula.literalValues, this.baseFormula.literalValues) &&
         deepEquals(cell.compiledFormula.rangeDependencies, this.baseFormula.rangeDependencies)
       ) {
-        return cell.compiledFormula.toFormulaString(this.getters);
+        return cell.compiledFormula.toFormulaString(this.getters, this.rangeToStringOptions);
       }
       numbers = this.squishNumbers(cell.compiledFormula.literalValues.numbers);
       strings = this.squishStrings(cell.compiledFormula.literalValues.strings);
@@ -207,11 +209,17 @@ export class Squisher {
       previousReference.sheetId !== reference.sheetId ||
       previousReference.prefixSheet !== reference.prefixSheet ||
       previousReference.invalidSheetName !== reference.invalidSheetName ||
-      previousReference.invalidXc !== reference.invalidXc
+      previousReference.invalidXc !== reference.invalidXc ||
+      previousReference.parts.length !== reference.parts.length
     ) {
       // sheet changed or valid/invalid changed, cannot squish
       previousReferences[index] = deepCopy(reference);
-      return getRangeString(reference, forSheetId, this.getters.getSheetName);
+      return getRangeString(
+        reference,
+        forSheetId,
+        this.getters.getSheetName,
+        this.rangeToStringOptions
+      );
     }
     if (
       previousReference.unboundedZone.bottom === undefined ||
@@ -221,7 +229,12 @@ export class Squisher {
     ) {
       // unbounded ranges, cannot squish
       previousReferences[index] = deepCopy(reference);
-      return getRangeString(reference, forSheetId, this.getters.getSheetName);
+      return getRangeString(
+        reference,
+        forSheetId,
+        this.getters.getSheetName,
+        this.rangeToStringOptions
+      );
     }
     for (let i = 0; i < reference.parts.length; i++) {
       if (
@@ -230,7 +243,12 @@ export class Squisher {
       ) {
         // absolute/relative parts changed, cannot squish
         previousReferences[index] = deepCopy(reference);
-        return getRangeString(reference, forSheetId, this.getters.getSheetName);
+        return getRangeString(
+          reference,
+          forSheetId,
+          this.getters.getSheetName,
+          this.rangeToStringOptions
+        );
       }
     }
     const currentZone = reference.zone;
@@ -243,7 +261,12 @@ export class Squisher {
     ) {
       // ranges, cannot squish
       previousReferences[index] = deepCopy(reference);
-      return getRangeString(reference, forSheetId, this.getters.getSheetName);
+      return getRangeString(
+        reference,
+        forSheetId,
+        this.getters.getSheetName,
+        this.rangeToStringOptions
+      );
     }
 
     // 1D range squishing
@@ -257,7 +280,12 @@ export class Squisher {
       return `${diffRow > 0 ? "+" : "-"}R${Math.abs(diffRow)}`; // ex. +R5 or -R4
     }
 
-    return getRangeString(reference, forSheetId, this.getters.getSheetName);
+    return getRangeString(
+      reference,
+      forSheetId,
+      this.getters.getSheetName,
+      this.rangeToStringOptions
+    );
   }
 
   /**

--- a/src/plugins/core/unsquisher.ts
+++ b/src/plugins/core/unsquisher.ts
@@ -104,7 +104,14 @@ export class Unsquisher {
           this.previousOffset = current as SquishedFormula;
           for (const position of positionsOfKey) {
             const result = this.unsquish(current as SquishedFormula, sheetId, getters);
-            yield { position, compiled: result };
+            if (!result.areRangeShapesInLineWithNormalizedFormula()) {
+              // not optimum, but needed to recover badly squished sheets
+              const formulaString = result.toFormulaString(getters);
+              const newCompiledFormula = CompiledFormula.Compile(formulaString, sheetId, getters);
+              yield { position, compiled: newCompiledFormula };
+            } else {
+              yield { position, compiled: result };
+            }
           }
           break;
         case "COMBINE_OFFSET":
@@ -117,7 +124,14 @@ export class Unsquisher {
           this.previousOffset.R = currentOffset.R ?? this.previousOffset.R;
           for (const position of positionsOfKey) {
             const result = this.unsquish(this.previousOffset, sheetId, getters);
-            yield { position, compiled: result };
+            if (!result.areRangeShapesInLineWithNormalizedFormula()) {
+              // not optimum, but needed to recover badly squished sheets
+              const formulaString = result.toFormulaString(getters);
+              const newCompiledFormula = CompiledFormula.Compile(formulaString, sheetId, getters);
+              yield { position, compiled: newCompiledFormula };
+            } else {
+              yield { position, compiled: result };
+            }
           }
           break;
       }

--- a/src/types/range.ts
+++ b/src/types/range.ts
@@ -26,6 +26,7 @@ export interface BoundedRange {
 export interface RangeStringOptions {
   useBoundedReference?: boolean;
   useFixedReference?: boolean;
+  doNotSimplifyRange?: boolean;
 }
 
 export interface RangeData {

--- a/tests/model/squish.test.ts
+++ b/tests/model/squish.test.ts
@@ -1,6 +1,7 @@
+import { FormulaCell } from "../../src";
 import { createRangeFromXc } from "../../src/helpers/range";
 import { Model } from "../../src/model";
-import { createSheet } from "../test_helpers";
+import { createSheet, deleteColumns, getCell, getCellContent, getCellText } from "../test_helpers";
 import { createModelFromGrid } from "../test_helpers/helpers";
 
 describe("squish - unsquish", () => {
@@ -82,6 +83,119 @@ describe("squish - unsquish", () => {
 });
 
 describe("squish - unsquish specific cases", () => {
+  test("squish the same formula on a range that becomes a cell reference by removing column, show autocorrection steps", () => {
+    const model = new Model({
+      sheets: [
+        {
+          id: "Sheet1",
+          name: "Sheet1",
+          colNumber: 10,
+          rowNumber: 10,
+          cells: {
+            A1: "=isnumber(B1:C1)", // becomes B1
+            A2: "=isnumber(B1:D1)", // becomes B1:C1
+            A3: "=isnumber(B1:C1)", // becomes B1
+          },
+        },
+      ],
+    });
+
+    deleteColumns(model, ["C"]);
+    const squished = model._exportData(true);
+    expect(squished.sheets[0].cells).toEqual({
+      A1: "=isnumber(B1:B1)",
+      A2: { R: "B1:C1" },
+      A3: { R: "B1:B1" },
+    });
+    const newModel = new Model(squished);
+    expect((getCell(newModel, "A1") as FormulaCell).compiledFormula.normalizedFormula).toEqual(
+      "=isnumber(|R|)"
+      // it was explicitly saved with a range, it stays a range (that is the origin of the bug)
+    );
+    expect((getCell(newModel, "A2") as FormulaCell).compiledFormula.normalizedFormula).toEqual(
+      "=isnumber(|R|)"
+    );
+    expect((getCell(newModel, "A3") as FormulaCell).compiledFormula.normalizedFormula).toEqual(
+      "=isnumber(|C|)" // this updated reference becomes a cell
+    );
+
+    const exportedSecondTime = newModel._exportData(true);
+    expect(exportedSecondTime.sheets[0].cells).toEqual({
+      A1: "=isnumber(B1)",
+      A2: { R: "B1:C1" },
+      A3: "=isnumber(B1)",
+    });
+    const modelImportedSecondTime = new Model(exportedSecondTime);
+    expect(
+      (getCell(modelImportedSecondTime, "A1") as FormulaCell).compiledFormula.normalizedFormula
+    ).toEqual(
+      "=isnumber(|C|)" // normal, the second export corrected the range to a cell
+    );
+    expect(
+      (getCell(modelImportedSecondTime, "A2") as FormulaCell).compiledFormula.normalizedFormula
+    ).toEqual(
+      "=isnumber(|R|)" // the import corrected the cell to a range
+    );
+    expect(
+      (getCell(modelImportedSecondTime, "A3") as FormulaCell).compiledFormula.normalizedFormula
+    ).toEqual(
+      "=isnumber(|C|)" // the export corrected the range to cell
+    );
+    expect(getCellContent(modelImportedSecondTime, "A3")).toEqual("FALSE");
+
+    const exportThirdTime = modelImportedSecondTime._exportData(true);
+    expect(exportThirdTime.sheets[0].cells).toEqual({
+      A1: "=isnumber(B1)",
+      A2: "=isnumber(B1:C1)", // completely corrected
+      A3: "=isnumber(B1)",
+    });
+  });
+
+  test("range/cell normalized formula squished together", () => {
+    const squishedData = {
+      sheets: [
+        {
+          cells: {
+            A1: "=isNumber(C1)",
+            A2: { R: "D1:E1" },
+            "A3:A4": { R: "D2:E2" },
+          },
+        },
+      ],
+    };
+
+    const model = new Model(squishedData);
+    expect(getCellText(model, "A1")).toEqual("=isNumber(C1)");
+    expect(getCellText(model, "A2")).toEqual("=isNumber(D1:E1)");
+    expect(getCellText(model, "A3")).toEqual("=isNumber(D2:E2)");
+    expect(getCellText(model, "A4")).toEqual("=isNumber(D2:E2)");
+    expect(getCellContent(model, "B4")).toEqual("FALSE");
+    expect(getCellContent(model, "B3")).toEqual("FALSE");
+  });
+
+  test("range/cell normalized formula squished together extended", () => {
+    const squishedData = {
+      sheets: [
+        {
+          cells: {
+            A1: "=iferror(isNumber(C1),F1)",
+            A2: { R: "D1:E1|+R1" },
+            "A3:A4": { R: "D2:E2|+R1" },
+          },
+        },
+      ],
+    };
+
+    const model = new Model(squishedData);
+    expect(getCellContent(model, "A1")).toEqual("FALSE");
+    expect(getCellContent(model, "A2")).toEqual("FALSE");
+    expect(getCellContent(model, "A3")).toEqual("FALSE");
+    expect(getCellContent(model, "A4")).toEqual("FALSE");
+    expect(getCellContent(model, "B4")).toEqual("FALSE");
+    expect(getCellContent(model, "B3")).toEqual("FALSE");
+    expect(getCellText(model, "A4")).toEqual("=iferror(isNumber(D2:E2),F4)");
+  });
+
   test("squish always reset when changing sheet", () => {
     const model = new Model({
       sheets: [


### PR DESCRIPTION
Steps to reproduce the error:
from a new spreadsheet
in A1, =sum(B1:C1)
in A2, =sum(B1:D1)
delete column C
export the data (it's already corrupted, you lost) reimport it as a new spreadsheet (everything seems to work) try to re-export it

This fix does 2 things: on the squisher side it never simplifies ranges into cells, on the un-squisher side it still supports when ranges become cells.

Task: 6390727