### PR TITLE
[FIX] figures: fix movement issue with arrow keys

### DIFF
--- a/src/components/figures/figure/figure.ts
+++ b/src/components/figures/figure/figure.ts
@@ -252,7 +252,11 @@ export class FigureComponent extends Component<Props, SpreadsheetChildEnv> {
       case "ArrowLeft":
       case "ArrowRight":
       case "ArrowUp":
-        const { col, row, offset } = this.postionInBoundary(this.props.figureUI, ev.key);
+        const { col, row, offset } = this.postionInBoundary(
+          this.env.model.getters.getActiveSheetId(),
+          this.props.figureUI,
+          ev.key
+        );
         this.env.model.dispatch("UPDATE_FIGURE", {
           sheetId: this.env.model.getters.getActiveSheetId(),
           figureId: this.props.figureUI.id,
@@ -281,14 +285,21 @@ export class FigureComponent extends Component<Props, SpreadsheetChildEnv> {
     }
   }
 
-  private postionInBoundary(position: AnchorOffset, key: string): AnchorOffset {
-    const sheetId = this.env.model.getters.getActiveSheetId();
-    let { col, row, offset } = position;
+  private postionInBoundary(sheetId: UID, figure: FigureUI, key: string): AnchorOffset {
+    let { col, row, offset } = figure;
     offset = { ...offset };
+    const maxAnchor = this.env.model.getters.getMaxAnchorOffset(
+      sheetId,
+      figure.height,
+      figure.width
+    );
     switch (key) {
       case "ArrowUp":
         if (offset.y === 0) {
           row--;
+          while (row > 0 && this.env.model.getters.isRowHiddenByUser(sheetId, row)) {
+            row--;
+          }
           offset.y = this.env.model.getters.getRowSize(sheetId, row) - 1;
         } else {
           offset.y--;
@@ -297,6 +308,9 @@ export class FigureComponent extends Component<Props, SpreadsheetChildEnv> {
       case "ArrowLeft":
         if (offset.x === 0) {
           col--;
+          while (col > 0 && this.env.model.getters.isColHiddenByUser(sheetId, col)) {
+            col--;
+          }
           offset.x = this.env.model.getters.getColSize(sheetId, col) - 1;
         } else {
           offset.x--;
@@ -305,6 +319,9 @@ export class FigureComponent extends Component<Props, SpreadsheetChildEnv> {
       case "ArrowDown":
         if (offset.y === this.env.model.getters.getRowSize(sheetId, row)) {
           row++;
+          while (row <= maxAnchor.row && this.env.model.getters.isRowHiddenByUser(sheetId, row)) {
+            row++;
+          }
           offset.y = 0;
         } else {
           offset.y++;
@@ -313,10 +330,27 @@ export class FigureComponent extends Component<Props, SpreadsheetChildEnv> {
       case "ArrowRight":
         if (offset.x === this.env.model.getters.getColSize(sheetId, row)) {
           col++;
+          while (col <= maxAnchor.col && this.env.model.getters.isColHiddenByUser(sheetId, col)) {
+            col++;
+          }
           offset.x = 0;
         } else {
           offset.x++;
         }
+    }
+    if (col < 0) {
+      col = 0;
+      offset.x = 0;
+    } else if (col > maxAnchor.col || (col === maxAnchor.col && offset.x > maxAnchor.offset.x)) {
+      col = maxAnchor.col;
+      offset.x = maxAnchor.offset.x;
+    }
+    if (row < 0) {
+      row = 0;
+      offset.y = 0;
+    } else if (row > maxAnchor.row || (row === maxAnchor.row && offset.y > maxAnchor.offset.y)) {
+      row = maxAnchor.row;
+      offset.y = maxAnchor.offset.y;
     }
     return { col, row, offset };
   }

--- a/tests/figures/figure_component.test.ts
+++ b/tests/figures/figure_component.test.ts
@@ -26,6 +26,8 @@ import {
   createSheet,
   freezeColumns,
   freezeRows,
+  hideColumns,
+  hideRows,
   paste,
   selectCell,
   setCellContent,
@@ -275,6 +277,121 @@ describe("figures", () => {
       col: 0,
       row: 0,
       offset: { x: 2, y: 2 },
+    });
+  });
+
+  test("a figure cannot be moved past the bottom-right edge of the grid", async () => {
+    const width = 100;
+    const height = 100;
+    const maxAnchor = model.getters.getMaxAnchorOffset(sheetId, height, width);
+    // place the figure just inside the bottom-right boundary
+    createFigure(model, {
+      id: "someuuid",
+      col: maxAnchor.col,
+      row: maxAnchor.row,
+      offset: { x: maxAnchor.offset.x - 1, y: maxAnchor.offset.y - 1 },
+      width,
+      height,
+    });
+
+    model.dispatch("SCROLL_TO_CELL", { col: maxAnchor.col, row: maxAnchor.row });
+    await nextTick();
+    await simulateClick(".o-figure");
+    await nextTick();
+    const selectedFigure = model.getters.getSelectedFigureId();
+    expect(selectedFigure).toBe("someuuid");
+
+    // pushing further right/down clamps the figure to the last valid position
+    await keyDown({ key: "ArrowRight" });
+    await keyDown({ key: "ArrowRight" });
+    await keyDown({ key: "ArrowDown" });
+    await keyDown({ key: "ArrowDown" });
+
+    expect(model.getters.getFigure(sheetId, "someuuid")).toMatchObject(maxAnchor);
+  });
+
+  test("a figure cannot be moved past the top-left edge of the grid", async () => {
+    createFigure(model, {
+      id: "someuuid",
+      col: 0,
+      row: 0,
+      offset: { x: 0, y: 0 },
+      width: 100,
+      height: 100,
+    });
+
+    await nextTick();
+    await simulateClick(".o-figure");
+    await nextTick();
+    const selectedFigure = model.getters.getSelectedFigureId();
+    expect(selectedFigure).toBe("someuuid");
+
+    await keyDown({ key: "ArrowLeft" });
+    await keyDown({ key: "ArrowUp" });
+    expect(model.getters.getFigure(sheetId, "someuuid")).toMatchObject({
+      col: 0,
+      row: 0,
+      offset: { x: 0, y: 0 },
+    });
+  });
+
+  test("moving a figure with arrow keys skips hidden columns and rows", async () => {
+    hideColumns(model, ["B"]); // hide the column right after the figure's anchor
+    hideRows(model, [1]); // hide the row right after the figure's anchor
+    createFigure(model, {
+      id: "someuuid",
+      col: 0,
+      row: 0,
+      offset: { x: cellWidth - 1, y: cellHeight - 1 },
+      width: 100,
+      height: 100,
+    });
+    await nextTick();
+    await simulateClick(".o-figure");
+    await nextTick();
+    const selectedFigure = model.getters.getSelectedFigureId();
+    expect(selectedFigure).toBe("someuuid");
+    // crossing the cell boundary lands on the next visible column/row (C and row 3), not the hidden one
+    await keyDown({ key: "ArrowRight" });
+    await keyDown({ key: "ArrowRight" });
+
+    await keyDown({ key: "ArrowDown" });
+    await keyDown({ key: "ArrowDown" });
+
+    expect(model.getters.getFigure(sheetId, "someuuid")).toMatchObject({
+      col: 2,
+      row: 2,
+      offset: { x: 0, y: 0 },
+    });
+  });
+
+  test("moving a figure backwards with arrow keys skips hidden columns and rows", async () => {
+    hideColumns(model, ["B"]); // hidden column between the figure's anchor and the target column
+    hideRows(model, [1]); // hidden row between the figure's anchor and the target row
+    createFigure(model, {
+      id: "someuuid",
+      col: 2,
+      row: 2,
+      offset: { x: 1, y: 1 },
+      width: 100,
+      height: 100,
+    });
+    await nextTick();
+    await simulateClick(".o-figure");
+    await nextTick();
+    const selectedFigure = model.getters.getSelectedFigureId();
+    expect(selectedFigure).toBe("someuuid");
+    // crossing the cell boundary lands on the previous visible column/row (A and row 1), not the hidden one
+    await keyDown({ key: "ArrowLeft" });
+    await keyDown({ key: "ArrowLeft" });
+
+    await keyDown({ key: "ArrowUp" });
+    await keyDown({ key: "ArrowUp" });
+
+    expect(model.getters.getFigure(sheetId, "someuuid")).toMatchObject({
+      col: 0,
+      row: 0,
+      offset: { x: cellWidth - 1, y: cellHeight - 1 },
     });
   });
 


### PR DESCRIPTION
- you can make the figure shift to the right up until the left edge of the figure reaches the end of the grid

- You jump when going over hidden col/rows

Task: 6374091

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [6374091](https://www.odoo.com/odoo/2328/tasks/6374091)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo