### PR TITLE
[FIX] table computed style: fix render table

### DIFF
--- a/src/plugins/ui_feature/table_computed_style.ts
+++ b/src/plugins/ui_feature/table_computed_style.ts
@@ -1,5 +1,7 @@
+import { isEvaluationError } from "../../functions/helpers";
 import { lazy } from "../../helpers/misc";
 import { getComputedTableStyle } from "../../helpers/table_helpers";
+import { EvaluationError } from "../../types";
 import { Command, CommandTypes, invalidateEvaluationCommands } from "../../types/commands";
 import { Border, CellPosition, Lazy, Style, TableId, UID } from "../../types/misc";
 import { Table, TableConfig, TableMetaData } from "../../types/table";
@@ -60,7 +62,14 @@ export class TableComputedStylePlugin extends UIPlugin {
       return undefined;
     }
 
-    return this.tableStyles[position.sheetId][table.id]().styles[position.col]?.[position.row];
+    try {
+      return this.tableStyles[position.sheetId][table.id]().styles[position.col]?.[position.row];
+    } catch (e) {
+      if (isEvaluationError(e) || e instanceof EvaluationError) {
+        return undefined;
+      }
+      throw e;
+    }
   }
 
   getCellTableBorder(position: CellPosition): Border | undefined {
@@ -68,7 +77,14 @@ export class TableComputedStylePlugin extends UIPlugin {
     if (!table) {
       return undefined;
     }
-    return this.tableStyles[position.sheetId][table.id]().borders[position.col]?.[position.row];
+    try {
+      return this.tableStyles[position.sheetId][table.id]().borders[position.col]?.[position.row];
+    } catch (e) {
+      if (isEvaluationError(e) || e instanceof EvaluationError) {
+        return undefined;
+      }
+      throw e;
+    }
   }
 
   private computeTableStyle(sheetId: UID, table: Table): Lazy<ComputedTableStyle> {

--- a/tests/pivots/pivot_table_style.test.ts
+++ b/tests/pivots/pivot_table_style.test.ts
@@ -1,7 +1,7 @@
-import { Model, Style, TableStyle, UID } from "../../src";
+import { EvaluationError, Model, Style, TableStyle, UID } from "../../src";
 import { PIVOT_TABLE_PRESETS } from "../../src/helpers/pivot_table_presets";
 import { getTables, hideColumns, hideRows, setCellContent } from "../test_helpers";
-import { getGridStyle } from "../test_helpers/helpers";
+import { getGridStyle, toCellPosition } from "../test_helpers/helpers";
 import { createModelWithPivot, updatePivot } from "../test_helpers/pivot_helpers";
 
 let model: Model;
@@ -367,5 +367,29 @@ describe("Pivot table style", () => {
   test("Pivot table style are not editable", () => {
     expect(model.getters.isTableStyleEditable("TestStyle")).toBe(false);
     expect(model.getters.isTableStyleEditable("PivotTableStyleLight1")).toBe(false);
+  });
+
+  test("Cell table style/border do not throw and recover when computing the pivot structure throws an EvaluationError", () => {
+    tableStyle.wholeTable = { style: wholePivotStyle };
+    updatePivot(model, "1", {
+      rows: [{ fieldName: "Salesperson" }],
+      style: { tableStyleId: "TestStyle" },
+    });
+
+    const pivot = model.getters.getPivot("1");
+    const position = toCellPosition(sheetId, "A25"); // top-left cell of the pivot table
+
+    const spy = jest.spyOn(pivot, "getCollapsedTableStructure").mockImplementation(() => {
+      throw new EvaluationError("Pivot data is not loaded yet");
+    });
+
+    expect(model.getters.getCellTableStyle(position)).toBeUndefined();
+    expect(() => model.getters.getCellTableBorder(position)).not.toThrow();
+
+    spy.mockRestore();
+
+    // once the transient error is gone, the getters recover on their own (no cache invalidation needed)
+    expect(model.getters.getCellTableStyle(position)).toMatchObject(wholePivotStyle);
+    expect(() => model.getters.getCellTableBorder(position)).not.toThrow();
   });
 });


### PR DESCRIPTION
In table_computed_style.ts, the function `getTableComputedStyle` was modified to ensure that the computed styles for table elements are correctly retrieved and applied.
This fix addresses issues with rendering tables of Odoo pivots while they are loading, and have computed measures that fail when Loading.

Task: 6396322
