### PR TITLE
[REF] add sheetId in all UI commands

### DIFF
--- a/src/actions/edit_actions.ts
+++ b/src/actions/edit_actions.ts
@@ -30,7 +30,9 @@ export const copy: ActionSpec = {
   shortcut: "Ctrl+C",
   isReadonlyAllowed: true,
   execute: async (env) => {
-    env.model.dispatch("COPY");
+    const sheetId = env.model.getters.getActiveSheetId();
+    const target = env.model.getters.getSelectedZones();
+    env.model.dispatch("COPY", { sheetId, target });
     await env.clipboard.write(await env.model.getters.getClipboardTextAndImageContent());
   },
   isEnabledOnLockedSheet: true,
@@ -134,8 +136,9 @@ export const deleteCells: ActionSpec = {
 export const deleteCellShiftUp: ActionSpec = {
   name: _t("Delete cell and shift up"),
   execute: (env) => {
+    const sheetId = env.model.getters.getActiveSheetId();
     const zone = env.model.getters.getSelectedZone();
-    const result = env.model.dispatch("DELETE_CELL", { zone, shiftDimension: "ROW" });
+    const result = env.model.dispatch("DELETE_CELL", { sheetId, zone, shiftDimension: "ROW" });
     handlePasteResult(env, result);
   },
 };
@@ -143,8 +146,9 @@ export const deleteCellShiftUp: ActionSpec = {
 export const deleteCellShiftLeft: ActionSpec = {
   name: _t("Delete cell and shift left"),
   execute: (env) => {
+    const sheetId = env.model.getters.getActiveSheetId();
     const zone = env.model.getters.getSelectedZone();
-    const result = env.model.dispatch("DELETE_CELL", { zone, shiftDimension: "COL" });
+    const result = env.model.dispatch("DELETE_CELL", { sheetId, zone, shiftDimension: "COL" });
     handlePasteResult(env, result);
   },
 };

--- a/src/actions/figure_menu_actions.ts
+++ b/src/actions/figure_menu_actions.ts
@@ -192,7 +192,9 @@ function getCopyMenuItem(
       if (!env.model.getters.getSelectedFigureIds().includes(figureId)) {
         env.model.dispatch("SELECT_FIGURE", { figureId });
       }
-      env.model.dispatch("COPY");
+      const sheetId = env.model.getters.getActiveSheetId();
+      const target = env.model.getters.getSelectedZones();
+      env.model.dispatch("COPY", { sheetId, target });
       const osClipboardContent = await env.model.getters.getClipboardTextAndImageContent();
       await env.clipboard.write(osClipboardContent);
       if (copiedNotificationMessage) {
@@ -213,7 +215,9 @@ function getCutMenuItem(figureId: UID, env: SpreadsheetChildEnv): ActionSpec {
       if (!env.model.getters.getSelectedFigureIds().includes(figureId)) {
         env.model.dispatch("SELECT_FIGURE", { figureId });
       }
-      env.model.dispatch("CUT");
+      const sheetId = env.model.getters.getActiveSheetId();
+      const target = env.model.getters.getSelectedZones();
+      env.model.dispatch("CUT", { sheetId, target });
       await env.clipboard.write(await env.model.getters.getClipboardTextAndImageContent());
     },
     icon: "o-spreadsheet-Icon.CUT",

--- a/src/actions/insert_actions.ts
+++ b/src/actions/insert_actions.ts
@@ -158,8 +158,9 @@ export const insertCell: ActionSpec = {
 export const insertCellShiftDown: ActionSpec = {
   name: _t("Insert cells and shift down"),
   execute: (env) => {
+    const sheetId = env.model.getters.getActiveSheetId();
     const zone = env.model.getters.getSelectedZone();
-    const result = env.model.dispatch("INSERT_CELL", { zone, shiftDimension: "ROW" });
+    const result = env.model.dispatch("INSERT_CELL", { sheetId, zone, shiftDimension: "ROW" });
     handlePasteResult(env, result);
   },
   isVisible: (env) =>
@@ -170,8 +171,9 @@ export const insertCellShiftDown: ActionSpec = {
 export const insertCellShiftRight: ActionSpec = {
   name: _t("Insert cells and shift right"),
   execute: (env) => {
+    const sheetId = env.model.getters.getActiveSheetId();
     const zone = env.model.getters.getSelectedZone();
-    const result = env.model.dispatch("INSERT_CELL", { zone, shiftDimension: "COL" });
+    const result = env.model.dispatch("INSERT_CELL", { sheetId, zone, shiftDimension: "COL" });
     handlePasteResult(env, result);
   },
   isVisible: (env) =>

--- a/src/actions/menu_items_actions.ts
+++ b/src/actions/menu_items_actions.ts
@@ -57,15 +57,14 @@ async function paste(env: SpreadsheetChildEnv, pasteOption?: ClipboardPasteOptio
   switch (osClipboard.status) {
     case "ok":
       const clipboardId = env.model.getters.getClipboardId();
-      const target = env.model.getters.getSelectedZones();
       const htmlClipboardId = getOSheetClipboardIdFromHTML(
         osClipboard.content[ClipboardMIMEType.Html]
       );
       if (clipboardId === htmlClipboardId) {
-        interactivePaste(env, target, pasteOption);
+        interactivePaste(env, pasteOption);
       } else {
         const osClipboardContent = parseOSClipboardContent(osClipboard.content);
-        await interactivePasteFromOS(env, target, osClipboardContent, pasteOption);
+        await interactivePasteFromOS(env, osClipboardContent, pasteOption);
       }
       if (env.model.getters.isCutOperation() && pasteOption !== "asValue") {
         await env.clipboard.write({ [ClipboardMIMEType.PlainText]: "" });

--- a/src/clipboard_handlers/image_clipboard.ts
+++ b/src/clipboard_handlers/image_clipboard.ts
@@ -69,7 +69,7 @@ export class ImageClipboardHandler extends AbstractFigureClipboardHandler<Clipbo
     const { zones } = target;
     for (const clippedFigure of clippedContent.figures) {
       const figureId = target.figureIds[clippedFigure.figureId];
-      const sheetId = this.getters.getActiveSheetId();
+      const sheetId = target.sheetId;
       const { width, height } = clippedFigure.copiedFigure;
       const copy = deepCopy(clippedFigure.copiedImage);
       const { col, row, offset } = boundColRowOffsetInSheet(

--- a/src/clipboard_handlers/merge_clipboard.ts
+++ b/src/clipboard_handlers/merge_clipboard.ts
@@ -13,7 +13,7 @@ export class MergeClipboardHandler extends AbstractCellClipboardHandler<
   Maybe<Merge>
 > {
   copy(data: ClipboardCellData): ClipboardContent | undefined {
-    const sheetId = this.getters.getActiveSheetId();
+    const sheetId = data.sheetId;
     const { rowsIndexes, columnsIndexes } = data;
     const merges: Maybe<Merge>[][] = [];
 

--- a/src/components/autofill/autofill.ts
+++ b/src/components/autofill/autofill.ts
@@ -90,7 +90,9 @@ export class Autofill extends Component<SpreadsheetChildEnv> {
     const onMouseUp = () => {
       this.state.handler = false;
       this.state.position = { ...this.props.position };
-      this.env.model.dispatch("AUTOFILL");
+      const sheetId = this.env.model.getters.getActiveSheetId();
+      const source = this.env.model.getters.getSelectedZone();
+      this.env.model.dispatch("AUTOFILL", { sheetId, source });
     };
 
     const onMouseMove = (col: HeaderIndex, row: HeaderIndex, ev: MouseEvent) => {
@@ -105,7 +107,14 @@ export class Autofill extends Component<SpreadsheetChildEnv> {
         lastCol = col === -1 ? lastCol : clip(col, 0, numberOfCols);
         lastRow = row === -1 ? lastRow : clip(row, 0, numberOfRows);
         if (lastCol !== undefined && lastRow !== undefined) {
-          this.env.model.dispatch("AUTOFILL_SELECT", { col: lastCol, row: lastRow });
+          const sheetId = this.env.model.getters.getActiveSheetId();
+          const source = this.env.model.getters.getSelectedZone();
+          this.env.model.dispatch("AUTOFILL_SELECT", {
+            col: lastCol,
+            row: lastRow,
+            sheetId,
+            source,
+          });
         }
       }
     };
@@ -113,7 +122,10 @@ export class Autofill extends Component<SpreadsheetChildEnv> {
   }
 
   onDblClick() {
-    this.env.model.dispatch("AUTOFILL_AUTO");
+    const { col, row } = this.env.model.getters.getActivePosition();
+    const sheetId = this.env.model.getters.getActiveSheetId();
+    const source = this.env.model.getters.getSelectedZone();
+    this.env.model.dispatch("AUTOFILL_AUTO", { col, row, sheetId, source });
   }
 }
 

--- a/src/components/autofill/autofill_store.ts
+++ b/src/components/autofill/autofill_store.ts
@@ -13,7 +13,7 @@ import {
   Tooltip,
 } from "../../types/autofill";
 import { Cell, CellValueType } from "../../types/cells";
-import { AutoFillCellCommand, Command } from "../../types/commands";
+import { AutofillAutoCommand, AutoFillCellCommand, Command } from "../../types/commands";
 import { Getters } from "../../types/getters";
 import { Border, DIRECTION, HeaderIndex, Style, UID, Zone } from "../../types/misc";
 import { GridRenderingContext } from "../../types/rendering";
@@ -80,7 +80,7 @@ class AutofillGenerator {
 export class AutofillStore extends SpreadsheetStore {
   static layers = ["Autofill"] as const;
 
-  private autofillZone: Zone | undefined;
+  private autofillZone: { zone: Zone; sheetId: UID } | undefined;
   private steps: number | undefined;
   private lastCellSelected: { col?: number; row?: number } = {};
   private direction: DIRECTION | undefined;
@@ -90,8 +90,7 @@ export class AutofillStore extends SpreadsheetStore {
   // Command Handling
   // ---------------------------------------------------------------------------
 
-  canAutofillSelect(col: HeaderIndex, row: HeaderIndex): boolean {
-    const sheetId = this.getters.getActiveSheetId();
+  canAutofillSelect(sheetId, col: HeaderIndex, row: HeaderIndex): boolean {
     this.lastCellSelected.col =
       col === -1 ? this.lastCellSelected.col : clip(col, 0, this.getters.getNumberCols(sheetId));
     this.lastCellSelected.row =
@@ -105,16 +104,16 @@ export class AutofillStore extends SpreadsheetStore {
   handle(cmd: Command) {
     switch (cmd.type) {
       case "AUTOFILL":
-        this.autofill(true);
+        this.autofill(cmd.source, true);
         break;
       case "AUTOFILL_SELECT":
-        if (!this.canAutofillSelect(cmd.col, cmd.row)) {
+        if (!this.canAutofillSelect(cmd.sheetId, cmd.col, cmd.row)) {
           break;
         }
-        this.select(cmd.col, cmd.row);
+        this.select(cmd.sheetId, cmd.source, cmd.col, cmd.row);
         break;
       case "AUTOFILL_AUTO":
-        this.autofillAuto();
+        this.autofillAuto(cmd);
         break;
     }
   }
@@ -128,13 +127,13 @@ export class AutofillStore extends SpreadsheetStore {
    * @param apply Flag set to true to apply the autofill in the model. It's
    *              useful to set it to false when we need to fill the tooltip
    */
-  private autofill(apply: boolean) {
+  private autofill(source: Zone, apply: boolean) {
     if (!this.autofillZone || !this.steps || this.direction === undefined) {
       this.tooltip = undefined;
       return;
     }
-    const source = this.getters.getSelectedZone();
-    const target = this.autofillZone;
+    const target = this.autofillZone.zone;
+    const sheetId = this.autofillZone.sheetId;
     const autofillCellsData: AutofillCellData[] = [];
 
     switch (this.direction) {
@@ -146,7 +145,7 @@ export class AutofillStore extends SpreadsheetStore {
           }
           const generator = this.createGenerator(xcs);
           for (let row = target.top; row <= target.bottom; row++) {
-            autofillCellsData.push(this.computeNewCell(generator, col, row));
+            autofillCellsData.push(this.computeNewCell(sheetId, generator, col, row));
           }
         }
         break;
@@ -158,7 +157,7 @@ export class AutofillStore extends SpreadsheetStore {
           }
           const generator = this.createGenerator(xcs);
           for (let row = target.bottom; row >= target.top; row--) {
-            autofillCellsData.push(this.computeNewCell(generator, col, row));
+            autofillCellsData.push(this.computeNewCell(sheetId, generator, col, row));
           }
         }
         break;
@@ -170,7 +169,7 @@ export class AutofillStore extends SpreadsheetStore {
           }
           const generator = this.createGenerator(xcs);
           for (let col = target.right; col >= target.left; col--) {
-            autofillCellsData.push(this.computeNewCell(generator, col, row));
+            autofillCellsData.push(this.computeNewCell(sheetId, generator, col, row));
           }
         }
         break;
@@ -182,7 +181,7 @@ export class AutofillStore extends SpreadsheetStore {
           }
           const generator = this.createGenerator(xcs);
           for (let col = target.left; col <= target.right; col++) {
-            autofillCellsData.push(this.computeNewCell(generator, col, row));
+            autofillCellsData.push(this.computeNewCell(sheetId, generator, col, row));
           }
         }
         break;
@@ -320,62 +319,56 @@ export class AutofillStore extends SpreadsheetStore {
   /**
    * Select a cell which becomes the last cell of the autofillZone
    */
-  private select(col: HeaderIndex, row: HeaderIndex) {
-    const source = this.getters.getSelectedZone();
+  private select(sheetId: UID, source: Zone, col: HeaderIndex, row: HeaderIndex) {
     if (isInside(col, row, source)) {
       this.autofillZone = undefined;
       return;
     }
-    this.direction = this.getDirection(col, row);
+    this.direction = this.getDirection(source, col, row);
     switch (this.direction) {
       case DIRECTION.UP:
-        this.saveZone(row, source.top - 1, source.left, source.right);
+        this.saveZone(sheetId, row, source.top - 1, source.left, source.right);
         this.steps = source.top - row;
         break;
       case DIRECTION.DOWN:
-        this.saveZone(source.bottom + 1, row, source.left, source.right);
+        this.saveZone(sheetId, source.bottom + 1, row, source.left, source.right);
         this.steps = row - source.bottom;
         break;
       case DIRECTION.LEFT:
-        this.saveZone(source.top, source.bottom, col, source.left - 1);
+        this.saveZone(sheetId, source.top, source.bottom, col, source.left - 1);
         this.steps = source.left - col;
         break;
       case DIRECTION.RIGHT:
-        this.saveZone(source.top, source.bottom, source.right + 1, col);
+        this.saveZone(sheetId, source.top, source.bottom, source.right + 1, col);
         this.steps = col - source.right;
         break;
     }
-    this.autofill(false);
+    this.autofill(source, false);
   }
 
   /**
    * Computes the autofillZone to autofill when the user double click on the
    * autofiller
    */
-  private autofillAuto() {
-    const activePosition = this.getters.getActivePosition();
-
-    const table = this.getters.getTable(activePosition);
-    let autofillRow = table ? table.range.zone.bottom : this.getAutofillAutoLastRow();
+  private autofillAuto(cmd: AutofillAutoCommand) {
+    const table = this.getters.getTable(cmd);
+    let autofillRow = table ? table.range.zone.bottom : this.getAutofillAutoLastRow(cmd);
 
     // Stop autofill at the next non-empty cell
-    const selection = this.getters.getSelectedZone();
-    for (let row = selection.bottom + 1; row <= autofillRow; row++) {
-      if (this.getters.getEvaluatedCell({ ...activePosition, row }).type !== CellValueType.empty) {
+    for (let row = cmd.source.bottom + 1; row <= autofillRow; row++) {
+      if (this.getters.getEvaluatedCell({ ...cmd, row }).type !== CellValueType.empty) {
         autofillRow = row - 1;
         break;
       }
     }
 
-    if (autofillRow > selection.bottom) {
-      this.select(activePosition.col, autofillRow);
-      this.autofill(true);
+    if (autofillRow > cmd.source.bottom) {
+      this.select(cmd.sheetId, cmd.source, cmd.col, autofillRow);
+      this.autofill(cmd.source, true);
     }
   }
 
-  private getAutofillAutoLastRow() {
-    const zone = this.getters.getSelectedZone();
-    const sheetId = this.getters.getActiveSheetId();
+  private getAutofillAutoLastRow({ source: zone, sheetId }: AutofillAutoCommand) {
     let col: HeaderIndex = zone.left;
     let row: HeaderIndex = zone.bottom;
 
@@ -403,6 +396,7 @@ export class AutofillStore extends SpreadsheetStore {
    * Generate the next cell
    */
   private computeNewCell(
+    sheetId: UID,
     generator: AutofillGenerator,
     col: HeaderIndex,
     row: HeaderIndex
@@ -411,6 +405,7 @@ export class AutofillStore extends SpreadsheetStore {
     const { content, style, border, format } = cellData;
     this.tooltip = tooltip;
     return {
+      sheetId,
       originCol: origin.col,
       originRow: origin.row,
       col,
@@ -473,16 +468,21 @@ export class AutofillStore extends SpreadsheetStore {
     return new AutofillGenerator(nextCells, this.getters, this.direction!);
   }
 
-  private saveZone(top: HeaderIndex, bottom: HeaderIndex, left: HeaderIndex, right: HeaderIndex) {
-    this.autofillZone = { top, bottom, left, right };
+  private saveZone(
+    sheetId: UID,
+    top: HeaderIndex,
+    bottom: HeaderIndex,
+    left: HeaderIndex,
+    right: HeaderIndex
+  ) {
+    this.autofillZone = { zone: { top, bottom, left, right }, sheetId };
   }
 
   /**
    * Compute the direction of the autofill from the last selected zone and
    * a given cell (col, row)
    */
-  private getDirection(col: HeaderIndex, row: HeaderIndex): DIRECTION {
-    const source = this.getters.getSelectedZone();
+  private getDirection(source: Zone, col: HeaderIndex, row: HeaderIndex): DIRECTION {
     const position = {
       up: { number: source.top - row, value: DIRECTION.UP },
       down: { number: row - source.bottom, value: DIRECTION.DOWN },
@@ -538,11 +538,11 @@ export class AutofillStore extends SpreadsheetStore {
   // ---------------------------------------------------------------------------
 
   drawLayer(renderingContext: GridRenderingContext) {
-    if (!this.autofillZone) {
+    const { ctx, thinLineWidth, viewports, sheetId } = renderingContext;
+    if (!this.autofillZone || sheetId !== this.autofillZone.sheetId) {
       return;
     }
-    const { ctx, thinLineWidth, viewports, sheetId } = renderingContext;
-    const { x, y, width, height } = viewports.getVisibleRect(sheetId, this.autofillZone);
+    const { x, y, width, height } = viewports.getVisibleRect(sheetId, this.autofillZone.zone);
     if (width > 0 && height > 0) {
       ctx.strokeStyle = "black";
       ctx.lineWidth = thinLineWidth;

--- a/src/components/autofill/table_autofill_store.ts
+++ b/src/components/autofill/table_autofill_store.ts
@@ -1,5 +1,5 @@
 import { getTableContentZone } from "../../helpers/table_helpers";
-import { isInside } from "../../helpers/zones";
+import { isInside, positionToZone } from "../../helpers/zones";
 import { SpreadsheetStore } from "../../stores/spreadsheet_store";
 import { CellValueType } from "../../types/cells";
 import { Command } from "../../types/commands";
@@ -49,13 +49,21 @@ export class TableAutofillStore extends SpreadsheetStore {
       cell: this.getters.getActivePosition(),
     };
 
-    this.model.selection.selectCell(col, row);
-    this.model.dispatch("AUTOFILL_SELECT", { col, row: zone.bottom });
-    this.model.dispatch("AUTOFILL");
+    this.model.dispatch("AUTOFILL_SELECT", {
+      col,
+      row: zone.bottom,
+      sheetId,
+      source: positionToZone(autofillSource),
+    });
+    this.model.dispatch("AUTOFILL", { sheetId, source: positionToZone(autofillSource) });
 
-    this.model.selection.selectCell(col, row);
-    this.model.dispatch("AUTOFILL_SELECT", { col, row: zone.top });
-    this.model.dispatch("AUTOFILL");
+    this.model.dispatch("AUTOFILL_SELECT", {
+      col,
+      row: zone.top,
+      sheetId,
+      source: positionToZone(autofillSource),
+    });
+    this.model.dispatch("AUTOFILL", { sheetId, source: positionToZone(autofillSource) });
 
     this.model.selection.selectZone(oldSelection);
   }

--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -321,7 +321,9 @@ export class Grid extends Component<SpreadsheetChildEnv> {
         const formula = `=SUM(${zoneXc})`;
         this.onComposerCellFocused(formula, { start: 5, end: 5 + zoneXc.length });
       } else {
-        this.env.model.dispatch("SUM_SELECTION");
+        const target = this.env.model.getters.getSelectedZones();
+        const position = this.env.model.getters.getActivePosition();
+        this.env.model.dispatch("SUM_SELECTION", { target, ...position });
       }
     },
     "Alt+Enter": () => {
@@ -376,13 +378,13 @@ export class Grid extends Component<SpreadsheetChildEnv> {
       this.env.model.selection.selectZone({ cell: position, zone: newZone });
     },
     "Ctrl+D": () => {
-      handleCopyPasteResult(this.env, { type: "COPY_PASTE_CELLS_ABOVE" });
+      handleCopyPasteResult(this.env, "COPY_PASTE_CELLS_ABOVE");
     },
     "Ctrl+R": () => {
-      handleCopyPasteResult(this.env, { type: "COPY_PASTE_CELLS_ON_LEFT" });
+      handleCopyPasteResult(this.env, "COPY_PASTE_CELLS_ON_LEFT");
     },
     "Ctrl+Enter": () => {
-      handleCopyPasteResult(this.env, { type: "COPY_PASTE_CELLS_ON_ZONE" });
+      handleCopyPasteResult(this.env, "COPY_PASTE_CELLS_ON_ZONE");
     },
     "Ctrl+H": () => this.sidePanel.open("FindAndReplace", {}),
     "Ctrl+F": () => this.sidePanel.open("FindAndReplace", {}),
@@ -741,7 +743,9 @@ export class Grid extends Component<SpreadsheetChildEnv> {
     if (cut) {
       interactiveCut(this.env);
     } else {
-      this.env.model.dispatch("COPY");
+      const target = this.env.model.getters.getSelectedZones();
+      const sheetId = this.env.model.getters.getActiveSheetId();
+      this.env.model.dispatch("COPY", { sheetId, target });
     }
     const osContent = await this.env.model.getters.getClipboardTextAndImageContent();
     await this.env.clipboard.write(osContent);
@@ -773,7 +777,6 @@ export class Grid extends Component<SpreadsheetChildEnv> {
       osClipboard.content[image.type] = image;
     }
 
-    const target = this.env.model.getters.getSelectedZones();
     const isCutOperation = this.env.model.getters.isCutOperation();
 
     const clipboardId = this.env.model.getters.getClipboardId();
@@ -781,10 +784,10 @@ export class Grid extends Component<SpreadsheetChildEnv> {
       osClipboard.content[ClipboardMIMEType.Html]
     );
     if (clipboardId === htmlClipboardId) {
-      interactivePaste(this.env, target);
+      interactivePaste(this.env);
     } else {
       const osClipboardContent = parseOSClipboardContent(osClipboard.content);
-      await interactivePasteFromOS(this.env, target, osClipboardContent);
+      await interactivePasteFromOS(this.env, osClipboardContent);
     }
     if (isCutOperation) {
       await this.env.clipboard.write({ [ClipboardMIMEType.PlainText]: "" });

--- a/src/components/highlight/highlight/highlight.ts
+++ b/src/components/highlight/highlight/highlight.ts
@@ -76,7 +76,10 @@ export class Highlight extends Component<SpreadsheetChildEnv> {
       scrollDirection = dirX === 0 ? "vertical" : dirY === 0 ? "horizontal" : "all";
     }
 
-    this.env.model.dispatch("START_CHANGE_HIGHLIGHT", { zone: currentZone });
+    this.env.model.dispatch("START_CHANGE_HIGHLIGHT", {
+      zone: currentZone,
+      sheetId: this.env.model.getters.getActiveSheetId(),
+    });
 
     const mouseMove = (col: HeaderIndex, row: HeaderIndex) => {
       if (lastCol !== col || lastRow !== row) {
@@ -148,7 +151,10 @@ export class Highlight extends Component<SpreadsheetChildEnv> {
     const deltaRowMax = this.env.model.getters.getNumberRows(activeSheetId) - z.bottom - 1;
 
     let currentZone = z;
-    this.env.model.dispatch("START_CHANGE_HIGHLIGHT", { zone: currentZone });
+    this.env.model.dispatch("START_CHANGE_HIGHLIGHT", {
+      zone: currentZone,
+      sheetId: this.env.model.getters.getActiveSheetId(),
+    });
 
     let lastCol = initCol;
     let lastRow = initRow;

--- a/src/components/side_panel/remove_duplicates/remove_duplicates.ts
+++ b/src/components/side_panel/remove_duplicates/remove_duplicates.ts
@@ -40,7 +40,9 @@ export class RemoveDuplicatesPanel extends Component<SpreadsheetChildEnv> {
   }
 
   onRemoveDuplicates() {
-    this.env.model.dispatch("REMOVE_DUPLICATES");
+    const zone = this.env.model.getters.getSelectedZone();
+    const sheetId = this.env.model.getters.getActiveSheetId();
+    this.env.model.dispatch("REMOVE_DUPLICATES", { sheetId, zone });
   }
 
   getColLabel(colKey: string): string {

--- a/src/components/side_panel/split_to_columns_panel/split_to_columns_panel.ts
+++ b/src/components/side_panel/split_to_columns_panel/split_to_columns_panel.ts
@@ -88,10 +88,14 @@ export class SplitIntoColumnsPanel extends Component<SpreadsheetChildEnv> {
   }
 
   get errorMessages(): string[] {
+    const sheetId = this.env.model.getters.getActiveSheetId();
+    const zone = this.env.model.getters.getSelectedZone();
     const cancelledReasons = this.env.model.canDispatch("SPLIT_TEXT_INTO_COLUMNS", {
       separator: this.separatorValue,
       addNewColumns: this.state.addNewColumns,
       force: true,
+      sheetId,
+      zone,
     }).reasons;
 
     const errors = new Set<string>();
@@ -109,8 +113,12 @@ export class SplitIntoColumnsPanel extends Component<SpreadsheetChildEnv> {
   }
 
   get warningMessages(): string[] {
+    const sheetId = this.env.model.getters.getActiveSheetId();
+    const zone = this.env.model.getters.getSelectedZone();
     const warnings: string[] = [];
     const cancelledReasons = this.env.model.canDispatch("SPLIT_TEXT_INTO_COLUMNS", {
+      sheetId,
+      zone,
       separator: this.separatorValue,
       addNewColumns: this.state.addNewColumns,
       force: false,

--- a/src/helpers/ui/cut_interactive.ts
+++ b/src/helpers/ui/cut_interactive.ts
@@ -3,7 +3,9 @@ import { CommandResult } from "../../types/commands";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 
 export function interactiveCut(env: SpreadsheetChildEnv) {
-  const result = env.model.dispatch("CUT");
+  const sheetId = env.model.getters.getActiveSheetId();
+  const target = env.model.getters.getSelectedZones();
+  const result = env.model.dispatch("CUT", { sheetId, target });
 
   if (!result.isSuccessful) {
     if (result.isCancelledBecause(CommandResult.WrongCutSelection)) {

--- a/src/helpers/ui/paste_interactive.ts
+++ b/src/helpers/ui/paste_interactive.ts
@@ -13,14 +13,19 @@ import {
   CopyPasteCellsOnZoneCommand,
   DispatchResult,
 } from "../../types/commands";
-import { Zone } from "../../types/misc";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 
 export const handleCopyPasteResult = (
   env: SpreadsheetChildEnv,
-  command: CopyPasteCellsAboveCommand | CopyPasteCellsOnLeftCommand | CopyPasteCellsOnZoneCommand
+  commandType: (
+    | CopyPasteCellsAboveCommand
+    | CopyPasteCellsOnLeftCommand
+    | CopyPasteCellsOnZoneCommand
+  )["type"]
 ) => {
-  const result = env.model.dispatch(command.type);
+  const sheetId = env.model.getters.getActiveSheetId();
+  const target = env.model.getters.getSelectedZones();
+  const result = env.model.dispatch(commandType, { sheetId, target });
   if (result.isCancelledBecause(CommandResult.WillRemoveExistingMerge)) {
     env.raiseError(MergeErrorMessage);
   }
@@ -47,21 +52,22 @@ export function handlePasteResult(env: SpreadsheetChildEnv, result: DispatchResu
   }
 }
 
-export function interactivePaste(
-  env: SpreadsheetChildEnv,
-  target: Zone[],
-  pasteOption?: ClipboardPasteOptions
-) {
-  const result = env.model.dispatch("PASTE", { target, pasteOption });
+export function interactivePaste(env: SpreadsheetChildEnv, pasteOption?: ClipboardPasteOptions) {
+  const sheetId = env.model.getters.getActiveSheetId();
+  const target = env.model.getters.getSelectedZones();
+
+  const result = env.model.dispatch("PASTE", { target, sheetId, pasteOption });
   handlePasteResult(env, result);
 }
 
 export async function interactivePasteFromOS(
   env: SpreadsheetChildEnv,
-  target: Zone[],
   parsedClipboardContent: ParsedOSClipboardContent,
   pasteOption?: ClipboardPasteOptions
 ) {
+  const sheetId = env.model.getters.getActiveSheetId();
+  const target = env.model.getters.getSelectedZones();
+
   if (parsedClipboardContent.data && parsedClipboardContent.data.version !== getCurrentVersion()) {
     env.notifyUser({
       type: "warning",
@@ -86,6 +92,7 @@ export async function interactivePasteFromOS(
   }
 
   const result = env.model.dispatch("PASTE_FROM_OS_CLIPBOARD", {
+    sheetId,
     target,
     clipboardContent: parsedClipboardContent,
     pasteOption,

--- a/src/helpers/ui/split_to_columns_interactive.ts
+++ b/src/helpers/ui/split_to_columns_interactive.ts
@@ -11,13 +11,23 @@ export function interactiveSplitToColumns(
   separator: string,
   addNewColumns: boolean
 ): DispatchResult {
-  let result = env.model.dispatch("SPLIT_TEXT_INTO_COLUMNS", { separator, addNewColumns });
+  const sheetId = env.model.getters.getActiveSheetId();
+  const zone = env.model.getters.getSelectedZone();
+
+  let result = env.model.dispatch("SPLIT_TEXT_INTO_COLUMNS", {
+    separator,
+    addNewColumns,
+    sheetId,
+    zone,
+  });
   if (result.isCancelledBecause(CommandResult.SplitWillOverwriteContent)) {
     env.askConfirmation(SplitToColumnsInteractiveContent.SplitIsDestructive, () => {
       result = env.model.dispatch("SPLIT_TEXT_INTO_COLUMNS", {
         separator,
         addNewColumns,
         force: true,
+        sheetId,
+        zone,
       });
     });
   }

--- a/src/history/repeat_commands/repeat_commands_specific.ts
+++ b/src/history/repeat_commands/repeat_commands_specific.ts
@@ -149,6 +149,7 @@ export function repeatPasteCommand(getters: Getters, cmd: PasteCommand): RepeatP
     type: "REPEAT_PASTE",
     pasteOption: deepCopy(cmd.pasteOption),
     target: getters.getSelectedZones(),
+    sheetId: getters.getActiveSheetId(),
   };
 }
 

--- a/src/plugins/ui_feature/split_to_columns.ts
+++ b/src/plugins/ui_feature/split_to_columns.ts
@@ -3,7 +3,7 @@ import { canonicalizeNumberContent } from "../../helpers/locale";
 import { range } from "../../helpers/misc";
 import { CellValueType } from "../../types/cells";
 import { Command, CommandResult, SplitTextIntoColumnsCommand } from "../../types/commands";
-import { CellPosition, Zone } from "../../types/misc";
+import { CellPosition, UID, Zone } from "../../types/misc";
 import { UIPlugin } from "../ui_plugin";
 
 export class SplitToColumnsPlugin extends UIPlugin {
@@ -51,21 +51,24 @@ export class SplitToColumnsPlugin extends UIPlugin {
     return;
   }
 
-  private splitIntoColumns({ separator, addNewColumns }: SplitTextIntoColumnsCommand) {
-    const selection = this.getters.getSelectedZone();
-    const sheetId = this.getters.getActiveSheetId();
-    const splitted = this.getSplittedCols(selection, separator);
+  private splitIntoColumns({
+    separator,
+    addNewColumns,
+    zone,
+    sheetId,
+  }: SplitTextIntoColumnsCommand) {
+    const splitted = this.getSplittedCols(sheetId, zone, separator);
     if (addNewColumns) {
-      this.addColsToAvoidCollisions(selection, splitted);
+      this.addColsToAvoidCollisions(sheetId, zone, splitted);
     }
-    this.removeMergesInSplitZone(selection, splitted);
-    this.addColumnsToNotOverflowSheet(selection, splitted);
+    this.removeMergesInSplitZone(sheetId, zone, splitted);
+    this.addColumnsToNotOverflowSheet(sheetId, zone, splitted);
 
     for (let i = 0; i < splitted.length; i++) {
-      const row = selection.top + i;
+      const row = zone.top + i;
       const splittedContent = splitted[i];
 
-      const col = selection.left;
+      const col = zone.left;
       const mainCell = this.getters.getCell({ sheetId, col, row });
 
       if (
@@ -89,11 +92,10 @@ export class SplitToColumnsPlugin extends UIPlugin {
     }
   }
 
-  private getSplittedCols(selection: Zone, separator: string): string[][] {
+  private getSplittedCols(sheetId: UID, selection: Zone, separator: string): string[][] {
     if (!separator) {
       throw new Error("Separator cannot be empty");
     }
-    const sheetId = this.getters.getActiveSheetId();
     const splitted: string[][] = [];
     for (const row of range(selection.top, selection.bottom + 1)) {
       const text = this.getters.getEvaluatedCell({
@@ -114,8 +116,11 @@ export class SplitToColumnsPlugin extends UIPlugin {
     return splitted;
   }
 
-  private willSplittedColsOverwriteContent(selection: Zone, splittedCols: string[][]) {
-    const sheetId = this.getters.getActiveSheetId();
+  private willSplittedColsOverwriteContent(
+    sheetId: UID,
+    selection: Zone,
+    splittedCols: string[][]
+  ) {
     for (const row of range(selection.top, selection.bottom + 1)) {
       const splittedText = splittedCols[row - selection.top];
       for (let i = 1; i < splittedText.length; i++) {
@@ -128,17 +133,14 @@ export class SplitToColumnsPlugin extends UIPlugin {
     return false;
   }
 
-  private removeMergesInSplitZone(selection: Zone, splittedCols: string[][]) {
-    const sheetId = this.getters.getActiveSheetId();
+  private removeMergesInSplitZone(sheetId: UID, selection: Zone, splittedCols: string[][]) {
     const colsInSplitZone = Math.max(...splittedCols.map((s) => s.length));
     const splitZone = { ...selection, right: selection.left + colsInSplitZone - 1 };
     const merges = this.getters.getMergesInZone(sheetId, splitZone);
     this.dispatch("REMOVE_MERGE", { sheetId, target: merges });
   }
 
-  private addColsToAvoidCollisions(selection: Zone, splittedCols: string[][]) {
-    const sheetId = this.getters.getActiveSheetId();
-
+  private addColsToAvoidCollisions(sheetId: UID, selection: Zone, splittedCols: string[][]) {
     let colsToAdd = 0;
 
     for (const row of range(selection.top, selection.bottom + 1)) {
@@ -174,8 +176,7 @@ export class SplitToColumnsPlugin extends UIPlugin {
     return 0;
   }
 
-  private addColumnsToNotOverflowSheet(selection: Zone, splittedCols: string[][]) {
-    const sheetId = this.getters.getActiveSheetId();
+  private addColumnsToNotOverflowSheet(sheetId: UID, selection: Zone, splittedCols: string[][]) {
     const maxColumnsToSpread = Math.max(...splittedCols.map((s) => s.length - 1));
     const maxColIndex = this.getters.getNumberCols(sheetId) - 1;
     if (selection.left + maxColumnsToSpread > maxColIndex) {
@@ -209,8 +210,8 @@ export class SplitToColumnsPlugin extends UIPlugin {
       return CommandResult.Success;
     }
     const selection = this.getters.getSelectedZones()[0];
-    const splitted = this.getSplittedCols(selection, cmd.separator);
-    if (this.willSplittedColsOverwriteContent(selection, splitted)) {
+    const splitted = this.getSplittedCols(cmd.sheetId, selection, cmd.separator);
+    if (this.willSplittedColsOverwriteContent(cmd.sheetId, selection, splitted)) {
       return CommandResult.SplitWillOverwriteContent;
     }
     return CommandResult.Success;

--- a/src/plugins/ui_stateful/clipboard.ts
+++ b/src/plugins/ui_stateful/clipboard.ts
@@ -71,65 +71,75 @@ export class ClipboardPlugin extends UIPlugin {
   allowDispatch(cmd: LocalCommand): CommandResult {
     switch (cmd.type) {
       case "CUT":
-        const zones = this.getters.getSelectedZones();
-        return this.isCutAllowedOn(zones);
+        return this.isCutAllowedOn(cmd.sheetId, cmd.target);
       case "PASTE_FROM_OS_CLIPBOARD": {
         const copiedData = this.convertTextToClipboardData(cmd.clipboardContent.text ?? "");
         const pasteOption = cmd.pasteOption;
-        return this.isPasteAllowed(cmd.target, copiedData, { pasteOption, isCutOperation: false });
+        return this.isPasteAllowed(cmd.sheetId, cmd.target, copiedData, {
+          pasteOption,
+          isCutOperation: false,
+        });
       }
       case "PASTE": {
         if (!this.copiedData) {
           return CommandResult.EmptyClipboard;
         }
         const pasteOption = cmd.pasteOption;
-        return this.isPasteAllowed(cmd.target, this.copiedData, {
+        return this.isPasteAllowed(cmd.sheetId, cmd.target, this.copiedData, {
           pasteOption: pasteOption,
           isCutOperation: this._isCutOperation,
         });
       }
       case "COPY_PASTE_CELLS_ABOVE": {
-        const zones = this.getters.getSelectedZones();
+        const zones = cmd.target;
         if (zones.length > 1 || (zones[0].top === 0 && zones[0].bottom === 0)) {
           return CommandResult.InvalidCopyPasteSelection;
         }
-        const zone = this.getters.getSelectedZone();
-        const copiedData = this.getCopiedDataAbove(zone);
-        return this.isPasteAllowed(zones, copiedData, {
+        const zone = cmd.target[0];
+        const copiedData = this.getCopiedDataAbove(cmd.sheetId, zone);
+        return this.isPasteAllowed(cmd.sheetId, zones, copiedData, {
           isCutOperation: false,
         });
       }
       case "COPY_PASTE_CELLS_ON_LEFT": {
-        const zones = this.getters.getSelectedZones();
+        const zones = cmd.target;
         if (zones.length > 1 || (zones[0].left === 0 && zones[0].right === 0)) {
           return CommandResult.InvalidCopyPasteSelection;
         }
-        const zone = this.getters.getSelectedZone();
-        const copiedData = this.getCopiedDataOnLeft(zone);
-        return this.isPasteAllowed(zones, copiedData, {
+        const zone = cmd.target[0];
+        const copiedData = this.getCopiedDataOnLeft(cmd.sheetId, zone);
+        return this.isPasteAllowed(cmd.sheetId, zones, copiedData, {
           isCutOperation: false,
         });
       }
       case "COPY_PASTE_CELLS_ON_ZONE": {
-        const zones = this.getters.getSelectedZones();
+        const zones = cmd.target;
         if (zones.length > 1) {
           return CommandResult.InvalidCopyPasteSelection;
         }
-        const zone = this.getters.getSelectedZone();
-        const copiedData = this.getCopiedDataOnLeft(zone);
-        return this.isPasteAllowed(zones, copiedData, {
+        const zone = cmd.target[0];
+        const copiedData = this.getCopiedDataOnLeft(cmd.sheetId, zone);
+        return this.isPasteAllowed(cmd.sheetId, zones, copiedData, {
           isCutOperation: false,
         });
       }
       case "INSERT_CELL": {
-        const { cut, paste } = this.getInsertCellsTargets(cmd.zone, cmd.shiftDimension);
-        const copiedData = this.copy(cut, "shiftCells");
-        return this.isPasteAllowed(paste, copiedData, { isCutOperation: true });
+        const { cut, paste } = this.getInsertCellsTargets(
+          cmd.sheetId,
+          cmd.zone,
+          cmd.shiftDimension
+        );
+        const copiedData = this.copy(cmd.sheetId, cut, "shiftCells");
+        return this.isPasteAllowed(cmd.sheetId, paste, copiedData, { isCutOperation: true });
       }
       case "DELETE_CELL": {
-        const { cut, paste } = this.getDeleteCellsTargets(cmd.zone, cmd.shiftDimension);
-        const copiedData = this.copy(cut, "shiftCells");
-        return this.isPasteAllowed(paste, copiedData, { isCutOperation: true });
+        const { cut, paste } = this.getDeleteCellsTargets(
+          cmd.sheetId,
+          cmd.zone,
+          cmd.shiftDimension
+        );
+        const copiedData = this.copy(cmd.sheetId, cut, "shiftCells");
+        return this.isPasteAllowed(cmd.sheetId, paste, copiedData, { isCutOperation: true });
       }
     }
     return CommandResult.Success;
@@ -139,11 +149,10 @@ export class ClipboardPlugin extends UIPlugin {
     switch (cmd.type) {
       case "COPY":
       case "CUT":
-        const zones = this.getters.getSelectedZones();
         this.status = "visible";
-        this.originSheetId = this.getters.getActiveSheetId();
+        this.originSheetId = cmd.sheetId;
         this._isCutOperation = cmd.type === "CUT";
-        this.copiedData = this.copy(zones);
+        this.copiedData = this.copy(cmd.sheetId, cmd.target);
         break;
       case "PASTE_FROM_OS_CLIPBOARD": {
         this._isCutOperation = false;
@@ -158,7 +167,7 @@ export class ClipboardPlugin extends UIPlugin {
 
         // TODO: support multiple image import
         if (contentToPaste.imageData) {
-          const sheetId = this.getters.getActiveSheetId();
+          const sheetId = cmd.sheetId;
           const figureId = UuidGenerator.uuidv4();
           const definition = contentToPaste.imageData;
 
@@ -179,7 +188,7 @@ export class ClipboardPlugin extends UIPlugin {
           this.copiedData = this.convertTextToClipboardData(contentToPaste.text ?? "");
         }
         const pasteOption = cmd.pasteOption;
-        this.paste(cmd.target, this.copiedData, {
+        this.paste(cmd.sheetId, cmd.target, this.copiedData, {
           pasteOption,
           selectTarget: true,
           isCutOperation: false,
@@ -190,7 +199,7 @@ export class ClipboardPlugin extends UIPlugin {
       }
       case "PASTE": {
         const pasteOption = cmd.pasteOption;
-        this.paste(cmd.target, this.copiedData, {
+        this.paste(cmd.sheetId, cmd.target, this.copiedData, {
           pasteOption,
           selectTarget: true,
           isCutOperation: this._isCutOperation,
@@ -204,10 +213,10 @@ export class ClipboardPlugin extends UIPlugin {
       }
       case "COPY_PASTE_CELLS_ABOVE":
         {
-          const zone = this.getters.getSelectedZone();
-          this.originSheetId = this.getters.getActiveSheetId();
-          const copiedData = this.getCopiedDataAbove(zone);
-          this.paste([zone], copiedData, {
+          const zone = cmd.target[0];
+          this.originSheetId = cmd.sheetId;
+          const copiedData = this.getCopiedDataAbove(cmd.sheetId, zone);
+          this.paste(cmd.sheetId, [zone], copiedData, {
             isCutOperation: false,
             selectTarget: true,
           });
@@ -215,10 +224,10 @@ export class ClipboardPlugin extends UIPlugin {
         break;
       case "COPY_PASTE_CELLS_ON_LEFT":
         {
-          const zone = this.getters.getSelectedZone();
-          this.originSheetId = this.getters.getActiveSheetId();
-          const copiedData = this.getCopiedDataOnLeft(zone);
-          this.paste([zone], copiedData, {
+          const zone = cmd.target[0];
+          this.originSheetId = cmd.sheetId;
+          const copiedData = this.getCopiedDataOnLeft(cmd.sheetId, zone);
+          this.paste(cmd.sheetId, [zone], copiedData, {
             isCutOperation: false,
             selectTarget: true,
           });
@@ -226,10 +235,10 @@ export class ClipboardPlugin extends UIPlugin {
         break;
       case "COPY_PASTE_CELLS_ON_ZONE":
         {
-          const zone = this.getters.getSelectedZone();
-          this.originSheetId = this.getters.getActiveSheetId();
-          const copiedData = this.getCopiedDataAboveOnLeft(zone);
-          this.paste([zone], copiedData, {
+          const zone = cmd.target[0];
+          this.originSheetId = cmd.sheetId;
+          const copiedData = this.getCopiedDataAboveOnLeft(cmd.sheetId, zone);
+          this.paste(cmd.sheetId, [zone], copiedData, {
             isCutOperation: false,
             selectTarget: true,
           });
@@ -239,22 +248,30 @@ export class ClipboardPlugin extends UIPlugin {
         this.status = "invisible";
         break;
       case "DELETE_CELL": {
-        const { cut, paste } = this.getDeleteCellsTargets(cmd.zone, cmd.shiftDimension);
+        const { cut, paste } = this.getDeleteCellsTargets(
+          cmd.sheetId,
+          cmd.zone,
+          cmd.shiftDimension
+        );
         if (!isZoneValid(cut[0])) {
           this.dispatch("CLEAR_CELLS", {
             target: [cmd.zone],
-            sheetId: this.getters.getActiveSheetId(),
+            sheetId: cmd.sheetId,
           });
           break;
         }
-        const copiedData = this.copy(cut, "shiftCells");
-        this.paste(paste, copiedData, { isCutOperation: true });
+        const copiedData = this.copy(cmd.sheetId, cut, "shiftCells");
+        this.paste(cmd.sheetId, paste, copiedData, { isCutOperation: true });
         break;
       }
       case "INSERT_CELL": {
-        const { cut, paste } = this.getInsertCellsTargets(cmd.zone, cmd.shiftDimension);
-        const copiedData = this.copy(cut, "shiftCells");
-        this.paste(paste, copiedData, { isCutOperation: true });
+        const { cut, paste } = this.getInsertCellsTargets(
+          cmd.sheetId,
+          cmd.zone,
+          cmd.shiftDimension
+        );
+        const copiedData = this.copy(cmd.sheetId, cut, "shiftCells");
+        this.paste(cmd.sheetId, paste, copiedData, { isCutOperation: true });
         break;
       }
       case "ADD_COLUMNS_ROWS": {
@@ -291,7 +308,7 @@ export class ClipboardPlugin extends UIPlugin {
         break;
       }
       case "REPEAT_PASTE": {
-        this.paste(cmd.target, this.copiedData, {
+        this.paste(cmd.sheetId, cmd.target, this.copiedData, {
           isCutOperation: false,
           pasteOption: cmd.pasteOption,
           selectTarget: true,
@@ -314,33 +331,33 @@ export class ClipboardPlugin extends UIPlugin {
     }
   }
 
-  private getCopiedDataAbove(zone: Zone) {
+  private getCopiedDataAbove(sheetId: UID, zone: Zone) {
     const multipleRowsInSelection = zone.top !== zone.bottom;
     const copyTarget = {
       ...zone,
       bottom: multipleRowsInSelection ? zone.top : zone.top - 1,
       top: multipleRowsInSelection ? zone.top : zone.top - 1,
     };
-    return this.copy([copyTarget]);
+    return this.copy(sheetId, [copyTarget]);
   }
 
-  private getCopiedDataOnLeft(zone: Zone) {
+  private getCopiedDataOnLeft(sheetId: UID, zone: Zone) {
     const multipleColsInSelection = zone.left !== zone.right;
     const copyTarget = {
       ...zone,
       right: multipleColsInSelection ? zone.left : zone.left - 1,
       left: multipleColsInSelection ? zone.left : zone.left - 1,
     };
-    return this.copy([copyTarget]);
+    return this.copy(sheetId, [copyTarget]);
   }
 
-  private getCopiedDataAboveOnLeft(zone: Zone) {
+  private getCopiedDataAboveOnLeft(sheetId: UID, zone: Zone) {
     const copyTarget = {
       ...zone,
       right: zone.left,
       bottom: zone.top,
     };
-    return this.copy([copyTarget]);
+    return this.copy(sheetId, [copyTarget]);
   }
 
   private convertTextToClipboardData(clipboardData: string): {} {
@@ -375,8 +392,8 @@ export class ClipboardPlugin extends UIPlugin {
     });
   }
 
-  private isCutAllowedOn(zones: Zone[]) {
-    const clipboardData = this.getClipboardData(zones);
+  private isCutAllowedOn(sheetId: UID, zones: Zone[]) {
+    const clipboardData = this.getClipboardData(sheetId, zones);
     for (const { handler } of this.selectClipboardHandlers(clipboardData)) {
       const result = handler.isCutAllowed(clipboardData);
       if (result !== CommandResult.Success) {
@@ -386,9 +403,9 @@ export class ClipboardPlugin extends UIPlugin {
     return CommandResult.Success;
   }
 
-  private isPasteAllowed(target: Zone[], copiedData: {}, options: ClipboardOptions) {
+  private isPasteAllowed(sheetId: UID, target: Zone[], copiedData: {}, options: ClipboardOptions) {
     for (const { handler } of this.selectClipboardHandlers(copiedData)) {
-      const result = handler.isPasteAllowed(this.getters.getActiveSheetId(), target, copiedData, {
+      const result = handler.isPasteAllowed(sheetId, target, copiedData, {
         ...options,
       });
       if (result !== CommandResult.Success) {
@@ -414,9 +431,13 @@ export class ClipboardPlugin extends UIPlugin {
     return false;
   }
 
-  private copy(zones: Zone[], mode: ClipboardCopyOptions = "copyPaste"): MinimalClipboardData {
+  private copy(
+    sheetId: UID,
+    zones: Zone[],
+    mode: ClipboardCopyOptions = "copyPaste"
+  ): MinimalClipboardData {
     const copiedData = {};
-    const clipboardData = this.getClipboardData(zones);
+    const clipboardData = this.getClipboardData(sheetId, zones);
     for (const { handlerName, handler } of this.selectClipboardHandlers(clipboardData)) {
       const data = handler.copy(clipboardData, this._isCutOperation, mode);
       copiedData[handlerName] = data;
@@ -431,6 +452,7 @@ export class ClipboardPlugin extends UIPlugin {
   }
 
   private paste(
+    sheetId: UID,
     zones: Zone[],
     copiedData: MinimalClipboardData | undefined,
     options: ClipboardOptions
@@ -438,7 +460,6 @@ export class ClipboardPlugin extends UIPlugin {
     if (!copiedData) {
       return;
     }
-    const sheetId = this.getters.getActiveSheetId();
     const handlers = this.selectClipboardHandlers(copiedData);
     const { target, zone, selectedZones } = getPasteTargetFromHandlers(
       sheetId,
@@ -696,8 +717,11 @@ export class ClipboardPlugin extends UIPlugin {
   // Private methods
   // ---------------------------------------------------------------------------
 
-  private getDeleteCellsTargets(zone: Zone, dimension: Dimension): InsertDeleteCellsTargets {
-    const sheetId = this.getters.getActiveSheetId();
+  private getDeleteCellsTargets(
+    sheetId: UID,
+    zone: Zone,
+    dimension: Dimension
+  ): InsertDeleteCellsTargets {
     let cut: Zone;
     if (dimension === "COL") {
       cut = {
@@ -715,8 +739,11 @@ export class ClipboardPlugin extends UIPlugin {
     return { cut: [cut], paste: [zone] };
   }
 
-  private getInsertCellsTargets(zone: Zone, dimension: Dimension): InsertDeleteCellsTargets {
-    const sheetId = this.getters.getActiveSheetId();
+  private getInsertCellsTargets(
+    sheetId: UID,
+    zone: Zone,
+    dimension: Dimension
+  ): InsertDeleteCellsTargets {
     let cut: Zone;
     let paste: Zone;
     if (dimension === "COL") {
@@ -739,8 +766,7 @@ export class ClipboardPlugin extends UIPlugin {
     return { cut: [cut], paste: [paste] };
   }
 
-  private getClipboardData(zones: Zone[]): ClipboardData {
-    const sheetId = this.getters.getActiveSheetId();
+  private getClipboardData(sheetId: UID, zones: Zone[]): ClipboardData {
     const selectedFiguresIds = this.getters.getSelectedFigureIds();
     if (selectedFiguresIds.length) {
       return { figureIds: selectedFiguresIds, sheetId };

--- a/src/stores/automatic_sum_store.ts
+++ b/src/stores/automatic_sum_store.ts
@@ -17,10 +17,9 @@ export class AutomaticSumStore extends SpreadsheetStore {
   handle(cmd: Command) {
     switch (cmd.type) {
       case "SUM_SELECTION":
-        const sheetId = this.getters.getActiveSheetId();
-        const { zones, anchor } = this.getters.getSelection();
-        for (const zone of zones) {
-          const sums = this.getAutomaticSums(sheetId, zone, anchor.cell);
+        const sheetId = cmd.sheetId;
+        for (const zone of cmd.target) {
+          const sums = this.getAutomaticSums(sheetId, zone, { col: cmd.col, row: cmd.row });
           this.dispatchCellUpdates(sheetId, sums);
         }
         break;

--- a/src/stores/data_cleanup_store.ts
+++ b/src/stores/data_cleanup_store.ts
@@ -3,7 +3,12 @@ import { getClipboardDataPositions } from "../helpers/clipboard/clipboard_helper
 import { deepEquals, range } from "../helpers/misc";
 import { zoneToDimension } from "../helpers/zones";
 import { _t } from "../translation";
-import { CancelledReason, Command, CommandResult } from "../types/commands";
+import {
+  CancelledReason,
+  Command,
+  CommandResult,
+  RemoveDuplicatesCommand,
+} from "../types/commands";
 import { HeaderIndex, UID, Zone } from "../types/misc";
 import { Get } from "../types/store_engine";
 import { NotificationStore } from "./notification_store";
@@ -85,7 +90,7 @@ export class DataCleanupStore extends SpreadsheetStore {
   handle(cmd: Command) {
     switch (cmd.type) {
       case "REMOVE_DUPLICATES":
-        this.removeDuplicates();
+        this.removeDuplicates(cmd);
         break;
     }
   }
@@ -94,9 +99,7 @@ export class DataCleanupStore extends SpreadsheetStore {
   // Private
   // ---------------------------------------------------------------------------
 
-  private removeDuplicates() {
-    const sheetId = this.getters.getActiveSheetId();
-    const zone = this.getters.getSelectedZone();
+  private removeDuplicates({ sheetId, zone }: RemoveDuplicatesCommand) {
     if (this.hasHeader) {
       zone.top += 1;
     }

--- a/src/stores/trim_whitespace_store.ts
+++ b/src/stores/trim_whitespace_store.ts
@@ -13,7 +13,10 @@ export class TrimWhitespaceStore extends SpreadsheetStore {
 
   trimWhitespace() {
     // Command for history step
-    this.model.dispatch("TRIM_WHITESPACE");
+    this.model.dispatch("TRIM_WHITESPACE", {
+      sheetId: this.getters.getActiveSheetId(),
+      target: this.getters.getSelectedZones(),
+    });
   }
 
   handle(cmd: Command) {

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -840,11 +840,11 @@ export interface DuplicatePivotCommand {
 // DATA CLEANUP
 // ------------------------------------------------
 
-export interface RemoveDuplicatesCommand {
+export interface RemoveDuplicatesCommand extends ZoneDependentCommand {
   type: "REMOVE_DUPLICATES";
 }
 
-export interface TrimWhitespaceCommand {
+export interface TrimWhitespaceCommand extends TargetDependentCommand {
   type: "TRIM_WHITESPACE";
 }
 
@@ -934,35 +934,33 @@ export interface DeleteNamedRangeCommand {
 
 //#region Local Commands
 // ------------------------------------------------
-export interface CopyCommand {
+export interface CopyCommand extends TargetDependentCommand {
   type: "COPY";
 }
 
-export interface CutCommand {
+export interface CutCommand extends TargetDependentCommand {
   type: "CUT";
 }
 
-export interface PasteCommand {
+export interface PasteCommand extends TargetDependentCommand {
   type: "PASTE";
-  target: Zone[];
   pasteOption?: ClipboardPasteOptions;
 }
 
-export interface CopyPasteCellsAboveCommand {
+export interface CopyPasteCellsAboveCommand extends TargetDependentCommand {
   type: "COPY_PASTE_CELLS_ABOVE";
 }
 
-export interface CopyPasteCellsOnLeftCommand {
+export interface CopyPasteCellsOnLeftCommand extends TargetDependentCommand {
   type: "COPY_PASTE_CELLS_ON_LEFT";
 }
 
-export interface CopyPasteCellsOnZoneCommand {
+export interface CopyPasteCellsOnZoneCommand extends TargetDependentCommand {
   type: "COPY_PASTE_CELLS_ON_ZONE";
 }
 
-export interface RepeatPasteCommand {
+export interface RepeatPasteCommand extends TargetDependentCommand {
   type: "REPEAT_PASTE";
-  target: Zone[];
   pasteOption?: ClipboardPasteOptions;
 }
 
@@ -970,21 +968,18 @@ export interface CleanClipBoardHighlightCommand {
   type: "CLEAN_CLIPBOARD_HIGHLIGHT";
 }
 
-export interface AutoFillCellCommand {
+export interface AutoFillCellCommand extends PositionDependentCommand {
   type: "AUTOFILL_CELL";
   originCol: number;
   originRow: number;
-  col: HeaderIndex;
-  row: HeaderIndex;
   content?: string;
   style?: Style | null;
   border?: Border;
   format?: Format;
 }
 
-export interface PasteFromOSClipboardCommand {
+export interface PasteFromOSClipboardCommand extends TargetDependentCommand {
   type: "PASTE_FROM_OS_CLIPBOARD";
-  target: Zone[];
   clipboardContent: ParsedOsClipboardContentWithImageData;
   pasteOption?: ClipboardPasteOptions;
 }
@@ -1017,9 +1012,8 @@ export interface EvaluateChartsCommand {
   type: "EVALUATE_CHARTS";
 }
 
-export interface StartChangeHighlightCommand {
+export interface StartChangeHighlightCommand extends ZoneDependentCommand {
   type: "START_CHANGE_HIGHLIGHT";
-  zone: Zone;
 }
 
 export interface ShowFormulaCommand {
@@ -1068,18 +1062,23 @@ export interface StartCommand {
   type: "START";
 }
 
-export interface AutofillCommand {
+export interface AutofillCommand extends SheetDependentCommand {
   type: "AUTOFILL";
+  source: Zone;
 }
 
-export interface AutofillSelectCommand {
+export interface AutofillSelectCommand extends SheetDependentCommand {
   type: "AUTOFILL_SELECT";
   col: HeaderIndex;
   row: HeaderIndex;
+  source: Zone;
 }
 
-export interface AutofillAutoCommand {
+export interface AutofillAutoCommand extends SheetDependentCommand {
   type: "AUTOFILL_AUTO";
+  col: HeaderIndex;
+  row: HeaderIndex;
+  source: Zone;
 }
 
 export interface SelectFigureCommand {
@@ -1115,20 +1114,18 @@ export interface SortCommand {
  * Sum data according to the selected zone(s) in the appropriated
  * cells.
  */
-export interface SumSelectionCommand {
+export interface SumSelectionCommand extends PositionDependentCommand, TargetDependentCommand {
   type: "SUM_SELECTION";
 }
 
-export interface DeleteCellCommand {
+export interface DeleteCellCommand extends ZoneDependentCommand {
   type: "DELETE_CELL";
   shiftDimension: Dimension;
-  zone: Zone;
 }
 
-export interface InsertCellCommand {
+export interface InsertCellCommand extends ZoneDependentCommand {
   type: "INSERT_CELL";
   shiftDimension: Dimension;
-  zone: Zone;
 }
 
 //#endregion
@@ -1141,7 +1138,7 @@ export interface ActivatePreviousSheetCommand {
   type: "ACTIVATE_PREVIOUS_SHEET";
 }
 
-export interface SplitTextIntoColumnsCommand {
+export interface SplitTextIntoColumnsCommand extends ZoneDependentCommand {
   type: "SPLIT_TEXT_INTO_COLUMNS";
   separator: string;
   addNewColumns: boolean;

--- a/tests/autofill/autofill_component.test.ts
+++ b/tests/autofill/autofill_component.test.ts
@@ -3,6 +3,7 @@ import { Spreadsheet } from "../../src";
 import { AutofillStore } from "../../src/components/autofill/autofill_store";
 import { types } from "../../src/components/props_validation";
 import { DEFAULT_CELL_WIDTH, HEADER_HEIGHT, HEADER_WIDTH } from "../../src/constants";
+import { toZone } from "../../src/helpers/zones";
 import { Model } from "../../src/model";
 import { Component } from "../../src/owl3_compatibility_layer";
 import { ViewportsStore } from "../../src/stores/viewports_store";
@@ -27,11 +28,14 @@ let fixture: HTMLElement;
 let model: Model;
 let parent: Spreadsheet;
 let env: SpreadsheetChildEnv;
+let sheetId: string;
 
 describe("Autofill component", () => {
   beforeEach(async () => {
     ({ parent, model, fixture, env } = await mountSpreadsheet());
+    sheetId = model.getters.getActiveSheetId();
   });
+
   test("Can drag and drop autofill on columns", async () => {
     const dispatch = spyDispatch(parent);
     const autofill = fixture.querySelector(".o-autofill-handler");
@@ -40,14 +44,19 @@ describe("Autofill component", () => {
     triggerMouseEvent(
       autofill,
       "pointermove",
-      model.getters.getColDimensions(model.getters.getActiveSheetId(), 0)!.start + 10,
-      model.getters.getRowDimensions(model.getters.getActiveSheetId(), 1)!.end + 10
+      model.getters.getColDimensions(sheetId, 0)!.start + 10,
+      model.getters.getRowDimensions(sheetId, 1)!.end + 10
     );
     await nextTick();
-    expect(dispatch).toHaveBeenCalledWith("AUTOFILL_SELECT", { col: 0, row: 2 });
+    expect(dispatch).toHaveBeenCalledWith("AUTOFILL_SELECT", {
+      col: 0,
+      row: 2,
+      sheetId,
+      source: toZone("A1"),
+    });
     triggerMouseEvent(autofill, "pointerup");
     await nextTick();
-    expect(dispatch).toHaveBeenCalledWith("AUTOFILL");
+    expect(dispatch).toHaveBeenCalledWith("AUTOFILL", { sheetId, source: toZone("A1") });
   });
 
   test("Can drag and drop autofill on rows", async () => {
@@ -58,14 +67,19 @@ describe("Autofill component", () => {
     triggerMouseEvent(
       autofill,
       "pointermove",
-      model.getters.getColDimensions(model.getters.getActiveSheetId(), 1)!.end + 10,
-      model.getters.getRowDimensions(model.getters.getActiveSheetId(), 0)!.start + 10
+      model.getters.getColDimensions(sheetId, 1)!.end + 10,
+      model.getters.getRowDimensions(sheetId, 0)!.start + 10
     );
     await nextTick();
-    expect(dispatch).toHaveBeenCalledWith("AUTOFILL_SELECT", { col: 2, row: 0 });
+    expect(dispatch).toHaveBeenCalledWith("AUTOFILL_SELECT", {
+      col: 2,
+      row: 0,
+      sheetId,
+      source: toZone("A1"),
+    });
     triggerMouseEvent(autofill, "pointerup");
     await nextTick();
-    expect(dispatch).toHaveBeenCalledWith("AUTOFILL");
+    expect(dispatch).toHaveBeenCalledWith("AUTOFILL", { sheetId, source: toZone("A1") });
   });
 
   test("Can auto-autofill with dblclick", async () => {
@@ -73,7 +87,12 @@ describe("Autofill component", () => {
     const autofill = fixture.querySelector(".o-autofill-handler");
     triggerMouseEvent(autofill, "dblclick", 4, 4);
     await nextTick();
-    expect(dispatch).toHaveBeenCalledWith("AUTOFILL_AUTO");
+    expect(dispatch).toHaveBeenCalledWith("AUTOFILL_AUTO", {
+      sheetId: sheetId,
+      col: 0,
+      row: 0,
+      source: toZone("A1"),
+    });
   });
 
   test("tooltip position when moving the mouse", async () => {
@@ -84,7 +103,6 @@ describe("Autofill component", () => {
     triggerMouseEvent(autofill, "pointerdown", 40, 40);
     await nextTick();
     expect(fixture.querySelector(".o-autofill-nextvalue")).toBeNull();
-    const sheetId = model.getters.getActiveSheetId();
     const x = HEADER_WIDTH + model.getters.getColDimensions(sheetId, 1)!.end + 20;
     const y = model.getters.getRowDimensions(sheetId, 0)!.start + 20;
     triggerMouseEvent(autofill, "pointermove", x, y);
@@ -110,7 +128,6 @@ describe("Autofill component", () => {
     triggerMouseEvent(autofill, "pointerdown", 40, 40);
     await nextTick();
     expect(fixture.querySelector(".o-autofill-nextvalue")).toBeNull();
-    const sheetId = model.getters.getActiveSheetId();
     const x = HEADER_WIDTH + model.getters.getColDimensions(sheetId, 1)!.end + 20;
     const y = model.getters.getRowDimensions(sheetId, 0)!.start + 20;
     triggerWheelEvent(".o-grid", { clientX: x, clientY: y });
@@ -139,7 +156,6 @@ describe("Autofill component", () => {
     triggerMouseEvent(autofill, "pointerdown", 40, 40);
     await nextTick();
     expect(fixture.querySelector(".o-autofill-nextvalue")).toBeNull();
-    const sheetId = model.getters.getActiveSheetId();
     const x = HEADER_WIDTH + model.getters.getColDimensions(sheetId, 1)!.end + 20;
     const y = model.getters.getRowDimensions(sheetId, 0)!.start + 20;
     triggerMouseEvent(autofill, "pointermove", x, y);
@@ -167,10 +183,8 @@ describe("Autofill component", () => {
     triggerMouseEvent(
       autofill,
       "pointermove",
-      HEADER_WIDTH +
-        model.getters.getColDimensions(model.getters.getActiveSheetId(), 0)!.start +
-        10,
-      model.getters.getRowDimensions(model.getters.getActiveSheetId(), 1)!.end + 10
+      HEADER_WIDTH + model.getters.getColDimensions(sheetId, 0)!.start + 10,
+      model.getters.getRowDimensions(sheetId, 1)!.end + 10
     );
     await nextTick();
     expect(fixture.querySelector(".o-autofill-nextvalue")).not.toBeNull();
@@ -187,20 +201,16 @@ describe("Autofill component", () => {
     triggerMouseEvent(
       autofill,
       "pointermove",
-      HEADER_WIDTH +
-        model.getters.getColDimensions(model.getters.getActiveSheetId(), 0)!.start +
-        10,
-      model.getters.getRowDimensions(model.getters.getActiveSheetId(), 1)!.end + 10
+      HEADER_WIDTH + model.getters.getColDimensions(sheetId, 0)!.start + 10,
+      model.getters.getRowDimensions(sheetId, 1)!.end + 10
     );
     await nextTick();
     expect(fixture.querySelector(".o-autofill-nextvalue")).not.toBeNull();
     triggerMouseEvent(
       autofill,
       "pointermove",
-      HEADER_WIDTH +
-        model.getters.getColDimensions(model.getters.getActiveSheetId(), 0)!.start +
-        10,
-      model.getters.getRowDimensions(model.getters.getActiveSheetId(), 0)!.start + 10
+      HEADER_WIDTH + model.getters.getColDimensions(sheetId, 0)!.start + 10,
+      model.getters.getRowDimensions(sheetId, 0)!.start + 10
     );
     await nextTick();
     triggerMouseEvent(autofill, "pointerup");
@@ -233,11 +243,9 @@ describe("Autofill component", () => {
     triggerMouseEvent(
       autofill,
       "pointermove",
-      HEADER_WIDTH +
-        model.getters.getColDimensions(model.getters.getActiveSheetId(), 0)!.start +
-        10,
+      HEADER_WIDTH + model.getters.getColDimensions(sheetId, 0)!.start + 10,
 
-      model.getters.getRowDimensions(model.getters.getActiveSheetId(), 1)!.end + 10
+      model.getters.getRowDimensions(sheetId, 1)!.end + 10
     );
     await nextTick();
     expect(fixture.querySelector(".o-autofill-nextvalue")).not.toBeNull();
@@ -254,7 +262,7 @@ describe("Autofill component", () => {
     await nextTick();
     const newX =
       HEADER_WIDTH +
-      parent.model.getters.getColDimensions(parent.model.getters.getActiveSheetId(), 0)!.start +
+      parent.model.getters.getColDimensions(sheetId, 0)!.start +
       2 * DEFAULT_CELL_WIDTH;
     triggerMouseEvent(autofill, "pointermove", newX, HEADER_HEIGHT + 4);
     await nextTick();

--- a/tests/autofill/autofill_plugin.test.ts
+++ b/tests/autofill/autofill_plugin.test.ts
@@ -60,9 +60,9 @@ function autofillTooltip(from: string, to: string): string | undefined {
  * Retrieve the direction from a zone to a cell
  */
 function getDirection(from: string, xc: string): DIRECTION {
-  setSelection(model, [from]);
   const { col, row } = toCartesian(xc);
-  return autoFill["getDirection"](col, row);
+  const source = toZone(from);
+  return autoFill["getDirection"](source, col, row);
 }
 
 beforeEach(() => {
@@ -103,7 +103,7 @@ describe("Autofill", () => {
     ["C3:D4", "E4", "E3:E4"],
   ])("From %s, selecting %s should select the good zone (%s)", (from, xc, expected) => {
     autofillSelect(model, from, xc);
-    expect(autoFill["autofillZone"]).toEqual(toZone(expected));
+    expect(autoFill["autofillZone"].zone).toEqual(toZone(expected));
   });
 
   test.each([

--- a/tests/bottom_bar/automatic_sum_storel.test.ts
+++ b/tests/bottom_bar/automatic_sum_storel.test.ts
@@ -519,7 +519,7 @@ describe("automatic sum", () => {
   });
 
   test("multiple selected zones in an empty sheet", () => {
-    automaticSumMulti(model, ["A1:A2", "B1:B3"]);
+    automaticSumMulti(model, ["A1:A2", "B1:B3"], { anchor: "A1" });
     const sheetId = model.getters.getActiveSheetId();
     expect(model.getters.getEvaluatedCells(sheetId)).toEqual([]);
   });
@@ -529,14 +529,14 @@ describe("automatic sum", () => {
     setCellContent(model, "B1", "4");
     setCellContent(model, "B2", "4");
     setCellContent(model, "B3", "4");
-    automaticSumMulti(model, ["A1:A2", "B1:B3"]);
+    automaticSumMulti(model, ["A1:A2", "B1:B3"], { anchor: "A1" });
     expect(getCellText(model, "A2")).toBe("=SUM(A1)");
     expect(getCellText(model, "B4")).toBe("=SUM(B1:B3)");
   });
 
   test("first sum is taken into account for the second zone", () => {
     setCellContent(model, "A1", "4");
-    automaticSumMulti(model, ["B1", "C1:C2"]);
+    automaticSumMulti(model, ["B1", "C1:C2"], { anchor: "B1" });
     expect(getCellText(model, "B1")).toBe("=SUM(A1)");
     expect(getCellText(model, "C1")).toBe("=SUM(A1:B1)");
     expect(getCellText(model, "C2")).toBe("=SUM(A2:B2)");

--- a/tests/clipboard/clipboard_figure_plugin.test.ts
+++ b/tests/clipboard/clipboard_figure_plugin.test.ts
@@ -218,7 +218,8 @@ describe.each(["chart", "image"])("Clipboard for %s figures", (type: string) => 
     test("Cannot paste with empty target", () => {
       selectFigure(model, figureId);
       copy(model);
-      const result = model.dispatch("PASTE", { target: [] });
+      const sheetId = model.getters.getActiveSheetId();
+      const result = model.dispatch("PASTE", { sheetId, target: [] });
       expect(result).toBeCancelledBecause(CommandResult.EmptyTarget);
     });
 

--- a/tests/clipboard/clipboard_plugin.test.ts
+++ b/tests/clipboard/clipboard_plugin.test.ts
@@ -163,8 +163,7 @@ describe("clipboard", () => {
   test("cut command will cut the selection if no target were given", () => {
     const model = new Model();
     setCellContent(model, "B2", "b2");
-    setSelection(model, ["B2"]);
-    cut(model);
+    cut(model, "B2");
     paste(model, "D2");
     expect(getCellRawContent(model, "D2")).toBe("b2");
   });
@@ -450,7 +449,7 @@ describe("clipboard", () => {
     const model = new Model();
     const sheetId = model.getters.getActiveSheetId();
     merge(model, "B2:C3");
-    copy(model, "B2");
+    copy(model, "B2:C3");
     const result = paste(model, "A1");
     expect(result).toBeCancelledBecause(CommandResult.WillRemoveExistingMerge);
     expect(model.getters.getMerges(sheetId).map(zoneToXc)).toEqual(["B2:C3"]);
@@ -484,7 +483,7 @@ describe("clipboard", () => {
     const model = new Model({
       sheets: [{ id: "s1", merges: ["A1:A3", "C1:C3"] }],
     });
-    copy(model, "A1", "C1");
+    copy(model, "A1, C1");
     paste(model, "E1");
     const sheetId = model.getters.getActiveSheetId();
     expect(model.getters.getMerges(sheetId).map(zoneToXc)).toEqual([
@@ -763,7 +762,7 @@ describe("clipboard", () => {
     setCellContent(model, "A1", "a1");
     setCellContent(model, "A2", "a2");
     setCellContent(model, "C1", "c1");
-    copy(model, "A1:A2", "C1");
+    copy(model, "A1:A2, C1");
 
     expect(getClipboardVisibleZones(model).length).toBe(1);
 
@@ -779,7 +778,7 @@ describe("clipboard", () => {
     setCellContent(model, "A2", "a2");
     setCellContent(model, "C1", "c1");
     setCellContent(model, "C2", "c2");
-    copy(model, "A1:A2", " C1:C2");
+    copy(model, "A1:A2,  C1:C2");
 
     expect(getClipboardVisibleZones(model).length).toBe(2);
 
@@ -972,7 +971,7 @@ describe("clipboard", () => {
   describe("cut/paste several zones", () => {
     test("cutting is not allowed if multiple selection", () => {
       const model = new Model();
-      const result = cut(model, "A1", "A2");
+      const result = cut(model, "A1, A2");
       expect(result).toBeCancelledBecause(CommandResult.WrongCutSelection);
     });
   });
@@ -993,7 +992,7 @@ describe("clipboard", () => {
 
     describe("if they have same left and same right", () => {
       test("copy all zones", () => {
-        copy(model, "A1:B1", " A2:B2");
+        copy(model, "A1:B1,  A2:B2");
         expect(getClipboardVisibleZones(model)[0]).toEqual(toZone("A1:B1"));
         expect(getClipboardVisibleZones(model)[1]).toEqual(toZone("A2:B2"));
         expect(getClipboardVisibleZones(model).length).toBe(2);
@@ -1005,7 +1004,7 @@ describe("clipboard", () => {
       });
 
       test("Copy cells only once", () => {
-        copy(model, "A1:A3", "A1:A2", "A2:A3", "A1", "A2", "A3");
+        copy(model, "A1:A3, A1:A2, A2:A3, A1, A2, A3");
         expect(getClipboardVisibleZones(model)[0]).toEqual(toZone("A1:A3"));
         expect(getClipboardVisibleZones(model).length).toBe(1);
         paste(model, "F6");
@@ -1017,7 +1016,7 @@ describe("clipboard", () => {
 
       test("paste zones without gap", () => {
         // gap between 1st selection and 2nd selection is one row
-        copy(model, "A1:B1", "A3:B3");
+        copy(model, "A1:B1, A3:B3");
         expect(getClipboardVisibleZones(model)[0]).toEqual(toZone("A1:B1"));
         expect(getClipboardVisibleZones(model)[1]).toEqual(toZone("A3:B3"));
         expect(getClipboardVisibleZones(model).length).toBe(2);
@@ -1029,12 +1028,12 @@ describe("clipboard", () => {
       });
 
       test("paste zones selected from different orders does not influence the final result", () => {
-        copy(model, "A1", "A2");
+        copy(model, "A1, A2");
         paste(model, "F6");
         expect(getCellContent(model, "F6")).toBe("a1");
         expect(getCellContent(model, "F7")).toBe("a2");
 
-        copy(model, "A2", "A1");
+        copy(model, "A2, A1");
         paste(model, "F6");
         expect(getCellContent(model, "F6")).toBe("a1");
         expect(getCellContent(model, "F7")).toBe("a2");
@@ -1043,7 +1042,7 @@ describe("clipboard", () => {
 
     describe("if zones have same top and same bottom", () => {
       test("copy all zones", () => {
-        copy(model, "A1:A2", "B1:B2");
+        copy(model, "A1:A2, B1:B2");
         expect(getClipboardVisibleZones(model)[0]).toEqual(toZone("A1:A2"));
         expect(getClipboardVisibleZones(model)[1]).toEqual(toZone("B1:B2"));
         expect(getClipboardVisibleZones(model).length).toBe(2);
@@ -1055,7 +1054,7 @@ describe("clipboard", () => {
       });
 
       test("Copy cells only once", () => {
-        copy(model, "A1:C1", "A1:B1", "B1:C1", "A1", "B1", "C1");
+        copy(model, "A1:C1, A1:B1, B1:C1, A1, B1, C1");
         expect(getClipboardVisibleZones(model)[0]).toEqual(toZone("A1:C1"));
         expect(getClipboardVisibleZones(model).length).toBe(1);
         paste(model, "F6");
@@ -1067,7 +1066,7 @@ describe("clipboard", () => {
 
       test("paste zones without gap", () => {
         // gap between 1st selection and 2nd selection is one column
-        copy(model, "A1:A2", "C1:C2");
+        copy(model, "A1:A2, C1:C2");
         paste(model, "F6");
         expect(getCellContent(model, "F6")).toBe("a1");
         expect(getCellContent(model, "F7")).toBe("a2");
@@ -1076,12 +1075,12 @@ describe("clipboard", () => {
       });
 
       test("paste zones selected from different orders does not influence the final result", () => {
-        copy(model, "A1", "B1");
+        copy(model, "A1, B1");
         paste(model, "F6");
         expect(getCellContent(model, "F6")).toBe("a1");
         expect(getCellContent(model, "G6")).toBe("b1");
 
-        copy(model, "A1", "B1");
+        copy(model, "A1, B1");
         paste(model, "F6");
         expect(getCellContent(model, "F6")).toBe("a1");
         expect(getCellContent(model, "G6")).toBe("b1");
@@ -1090,7 +1089,7 @@ describe("clipboard", () => {
 
     describe("copy/paste the last zone if zones don't have [same top and same bottom] or [same left and same right]", () => {
       test("test with dissociated zones", () => {
-        copy(model, "A1:A2", "B2:B3");
+        copy(model, "A1:A2, B2:B3");
         expect(getClipboardVisibleZones(model)[0]).toEqual(toZone("B2:B3"));
         expect(getClipboardVisibleZones(model).length).toBe(1);
         paste(model, "F6");
@@ -1099,7 +1098,7 @@ describe("clipboard", () => {
       });
 
       test("test with overlapped zones", () => {
-        copy(model, "A1:B2", "B2:B3");
+        copy(model, "A1:B2, B2:B3");
         expect(getClipboardVisibleZones(model)[0]).toEqual(toZone("B2:B3"));
         expect(getClipboardVisibleZones(model).length).toBe(1);
         paste(model, "F6");
@@ -1109,7 +1108,7 @@ describe("clipboard", () => {
     });
 
     test("can paste zones in a larger selection", () => {
-      copy(model, "A1", "C1");
+      copy(model, "A1, C1");
       paste(model, "E1:I1");
       expect(getCellContent(model, "E1")).toBe("a1");
       expect(getCellContent(model, "F1")).toBe("c1");
@@ -1119,7 +1118,7 @@ describe("clipboard", () => {
     });
 
     test("is not allowed if paste in several selection", () => {
-      copy(model, "A1", "C1");
+      copy(model, "A1, C1");
       const result = paste(model, "A2, B2");
       expect(result).toBeCancelledBecause(CommandResult.WrongPasteSelection);
     });
@@ -1892,8 +1891,7 @@ describe("clipboard", () => {
     const model = new Model({ sheets: [{ id: "sheet1" }, { id: "sheet2" }] });
     addEqualCf(model, "A1:A2", { fillColor: "#FF0000" }, "1");
     cut(model, "A1:A2");
-    activateSheet(model, "sheet2");
-    paste(model, "A1");
+    paste(model, "A1", undefined, "sheet2");
     expect(model.getters.getConditionalFormats("sheet2")).toMatchObject([
       { ranges: ["A1:A2"], rule: { style: { fillColor: "#FF0000" } } },
     ]);
@@ -2622,7 +2620,7 @@ describe("clipboard: pasting outside of sheet", () => {
 
     createImage(model, { figureId: "test" });
     selectFigure(model, "test");
-    copy(model);
+    copy(model, "A1");
     await model.getters.getClipboardTextAndImageContent();
     expect(spyNotifyUI).toHaveBeenCalledWith({
       sticky: false,

--- a/tests/default/default_plugin_style.test.ts
+++ b/tests/default/default_plugin_style.test.ts
@@ -8,6 +8,7 @@ import { clipboardHandlersRegistries } from "../../src/registries/clipboardHandl
 import {
   addColumns,
   addRows,
+  autofill,
   deleteCells,
   deleteColumns,
   deleteRows,
@@ -15,7 +16,6 @@ import {
   merge,
   moveColumns,
   moveRows,
-  setSelection,
   unMerge,
 } from "../test_helpers";
 import { target } from "../test_helpers/helpers";
@@ -1011,9 +1011,7 @@ describe("Default Plugin: Style", () => {
       style,
     });
 
-    setSelection(model, ["B2"]);
-    model.dispatch("AUTOFILL_SELECT", toCartesian("B4"));
-    model.dispatch("AUTOFILL");
+    autofill(model, "B2", "B4");
 
     expect(getCellStyle(model, "B3")).toEqual(style);
     expect(getCellStyle(model, "B4")).toEqual(style);
@@ -1026,9 +1024,7 @@ describe("Default Plugin: Style", () => {
       style,
     });
 
-    setSelection(model, ["B2"]);
-    model.dispatch("AUTOFILL_SELECT", toCartesian("D2"));
-    model.dispatch("AUTOFILL");
+    autofill(model, "B2", "D2");
 
     expect(getCellStyle(model, "C2")).toEqual(style);
     expect(getCellStyle(model, "D2")).toEqual(style);

--- a/tests/grid/grid_component.test.ts
+++ b/tests/grid/grid_component.test.ts
@@ -2150,7 +2150,7 @@ describe("Copy paste keyboard shortcut", () => {
     setCellContent(model, "A1", "a1");
     merge(model, "A2:A3");
     setSelection(model, ["A1:A3"]);
-    handleCopyPasteResult(env, { type: "COPY_PASTE_CELLS_ON_ZONE" });
+    handleCopyPasteResult(env, "COPY_PASTE_CELLS_ON_ZONE");
     const notificationStore = env.getStore(NotificationStore);
     expect(notificationStore.raiseError).toHaveBeenCalled();
   });

--- a/tests/grid/highlight_component.test.ts
+++ b/tests/grid/highlight_component.test.ts
@@ -193,7 +193,10 @@ describe("Corner component", () => {
 
       // select B2 nw corner
       await selectNWCellCorner(cornerEl, "B2");
-      expect(spyDispatch).toHaveBeenCalledWith("START_CHANGE_HIGHLIGHT", { zone: toZone("B2") });
+      expect(spyDispatch).toHaveBeenLastCalledWith("START_CHANGE_HIGHLIGHT", {
+        sheetId: model.getters.getSheetIds()[0],
+        zone: toZone("B2"),
+      });
       // move to A1
       await moveToCell(cornerEl, "A1");
       expect(spyHandleEvent).toHaveBeenCalledWith(expectedResult("A1:B2"));
@@ -205,7 +208,8 @@ describe("Corner component", () => {
 
       // select B2 ne corner
       await selectNECellCorner(cornerEl, "B2");
-      expect(model.dispatch).toHaveBeenCalledWith("START_CHANGE_HIGHLIGHT", {
+      expect(model.dispatch).toHaveBeenLastCalledWith("START_CHANGE_HIGHLIGHT", {
+        sheetId: model.getters.getSheetIds()[0],
         zone: toZone("B2"),
       });
 
@@ -220,7 +224,8 @@ describe("Corner component", () => {
 
       // select B2 sw corner
       await selectSWCellCorner(cornerEl, "B2");
-      expect(parent.model.dispatch).toHaveBeenCalledWith("START_CHANGE_HIGHLIGHT", {
+      expect(parent.model.dispatch).toHaveBeenLastCalledWith("START_CHANGE_HIGHLIGHT", {
+        sheetId: model.getters.getSheetIds()[0],
         zone: toZone("B2"),
       });
 
@@ -235,7 +240,8 @@ describe("Corner component", () => {
 
       // select B2 se corner
       await selectSECellCorner(cornerEl, "B2");
-      expect(parent.model.dispatch).toHaveBeenCalledWith("START_CHANGE_HIGHLIGHT", {
+      expect(parent.model.dispatch).toHaveBeenLastCalledWith("START_CHANGE_HIGHLIGHT", {
+        sheetId: model.getters.getSheetIds()[0],
         zone: toZone("B2"),
       });
 
@@ -334,7 +340,8 @@ describe("Corner component", () => {
     // select A1 nw corner
     await selectNWCellCorner(cornerEl, "A1");
 
-    expect(spyDispatch).toHaveBeenCalledWith("START_CHANGE_HIGHLIGHT", {
+    expect(spyDispatch).toHaveBeenLastCalledWith("START_CHANGE_HIGHLIGHT", {
+      sheetId: model.getters.getSheetIds()[0],
       zone: toZone("A1"),
     });
 
@@ -369,7 +376,8 @@ describe("Corner component", () => {
 
       // select B2 ne corner
       await selectNWCellCorner(cornerEl, "B2");
-      expect(parent.model.dispatch).toHaveBeenCalledWith("START_CHANGE_HIGHLIGHT", {
+      expect(parent.model.dispatch).toHaveBeenLastCalledWith("START_CHANGE_HIGHLIGHT", {
+        sheetId: model.getters.getSheetIds()[0],
         zone: toZone("B2"),
       });
 
@@ -384,7 +392,8 @@ describe("Corner component", () => {
       cornerEl = fixture.querySelector(".o-corner-ne")!;
 
       await selectNECellCorner(cornerEl, "A1");
-      expect(parent.model.dispatch).toHaveBeenCalledWith("START_CHANGE_HIGHLIGHT", {
+      expect(parent.model.dispatch).toHaveBeenLastCalledWith("START_CHANGE_HIGHLIGHT", {
+        sheetId: model.getters.getSheetIds()[0],
         zone: toZone("A1:A10"),
       });
 
@@ -398,7 +407,8 @@ describe("Corner component", () => {
       cornerEl = fixture.querySelector(".o-corner-sw")!;
 
       await selectSWCellCorner(cornerEl, "A1");
-      expect(parent.model.dispatch).toHaveBeenCalledWith("START_CHANGE_HIGHLIGHT", {
+      expect(parent.model.dispatch).toHaveBeenLastCalledWith("START_CHANGE_HIGHLIGHT", {
+        sheetId: model.getters.getSheetIds()[0],
         zone: toZone("A1:J1"),
       });
 
@@ -422,7 +432,8 @@ describe("Corner component", () => {
 
     // select B1 nw corner
     await selectNWCellCorner(cornerEl, "B1");
-    expect(model.dispatch).toHaveBeenCalledWith("START_CHANGE_HIGHLIGHT", {
+    expect(model.dispatch).toHaveBeenLastCalledWith("START_CHANGE_HIGHLIGHT", {
+      sheetId: model.getters.getSheetIds()[0],
       zone: toZone("B1"),
     });
 
@@ -446,7 +457,8 @@ describe("Corner component", () => {
 
     // select A2 nw corner
     await selectTopCellBorder(cornerEl, "A2");
-    expect(model.dispatch).toHaveBeenCalledWith("START_CHANGE_HIGHLIGHT", {
+    expect(model.dispatch).toHaveBeenLastCalledWith("START_CHANGE_HIGHLIGHT", {
+      sheetId: model.getters.getSheetIds()[0],
       zone: toZone("A2"),
     });
 
@@ -471,7 +483,8 @@ describe("Border component", () => {
 
       // select B2 top border
       await selectTopCellBorder(borderEl, "B2");
-      expect(parent.model.dispatch).toHaveBeenCalledWith("START_CHANGE_HIGHLIGHT", {
+      expect(parent.model.dispatch).toHaveBeenLastCalledWith("START_CHANGE_HIGHLIGHT", {
+        sheetId: model.getters.getSheetIds()[0],
         zone: toZone("B2"),
       });
 
@@ -486,7 +499,8 @@ describe("Border component", () => {
 
       // select B2 left border
       await selectLeftCellBorder(borderEl, "B2");
-      expect(parent.model.dispatch).toHaveBeenCalledWith("START_CHANGE_HIGHLIGHT", {
+      expect(parent.model.dispatch).toHaveBeenLastCalledWith("START_CHANGE_HIGHLIGHT", {
+        sheetId: model.getters.getSheetIds()[0],
         zone: toZone("B2"),
       });
 
@@ -501,7 +515,8 @@ describe("Border component", () => {
 
       // select B2 right border
       await selectRightCellBorder(borderEl, "B2");
-      expect(parent.model.dispatch).toHaveBeenCalledWith("START_CHANGE_HIGHLIGHT", {
+      expect(parent.model.dispatch).toHaveBeenLastCalledWith("START_CHANGE_HIGHLIGHT", {
+        sheetId: model.getters.getSheetIds()[0],
         zone: toZone("B2"),
       });
 
@@ -516,7 +531,8 @@ describe("Border component", () => {
 
       // select B2 bottom border
       await selectBottomCellBorder(borderEl, "B2");
-      expect(parent.model.dispatch).toHaveBeenCalledWith("START_CHANGE_HIGHLIGHT", {
+      expect(parent.model.dispatch).toHaveBeenLastCalledWith("START_CHANGE_HIGHLIGHT", {
+        sheetId: model.getters.getSheetIds()[0],
         zone: toZone("B2"),
       });
 
@@ -605,7 +621,8 @@ describe("Border component", () => {
 
     // select A1 top border
     await selectTopCellBorder(borderEl, "A1");
-    expect(parent.model.dispatch).toHaveBeenCalledWith("START_CHANGE_HIGHLIGHT", {
+    expect(parent.model.dispatch).toHaveBeenLastCalledWith("START_CHANGE_HIGHLIGHT", {
+      sheetId: model.getters.getSheetIds()[0],
       zone: toZone("A1:B2"),
     });
 
@@ -624,7 +641,8 @@ describe("Border component", () => {
 
     // select B1 top border
     await selectTopCellBorder(borderEl, "B1");
-    expect(parent.model.dispatch).toHaveBeenCalledWith("START_CHANGE_HIGHLIGHT", {
+    expect(parent.model.dispatch).toHaveBeenLastCalledWith("START_CHANGE_HIGHLIGHT", {
+      sheetId: model.getters.getSheetIds()[0],
       zone: toZone("A1:B2"),
     });
 
@@ -639,7 +657,8 @@ describe("Border component", () => {
 
     // select B2 bottom border
     await selectBottomCellBorder(borderEl, "B2");
-    expect(parent.model.dispatch).toHaveBeenCalledWith("START_CHANGE_HIGHLIGHT", {
+    expect(parent.model.dispatch).toHaveBeenLastCalledWith("START_CHANGE_HIGHLIGHT", {
+      sheetId: model.getters.getSheetIds()[0],
       zone: toZone("A1:B2"),
     });
 
@@ -667,7 +686,8 @@ describe("Border component", () => {
 
       // select A1 top border
       await selectTopCellBorder(borderEl, "A1");
-      expect(parent.model.dispatch).toHaveBeenCalledWith("START_CHANGE_HIGHLIGHT", {
+      expect(parent.model.dispatch).toHaveBeenLastCalledWith("START_CHANGE_HIGHLIGHT", {
+        sheetId: model.getters.getSheetIds()[0],
         zone: toZone("A1"),
       });
 
@@ -682,7 +702,8 @@ describe("Border component", () => {
       borderEl = fixture.querySelector(".o-border-n")!;
 
       await selectTopCellBorder(borderEl, "A1");
-      expect(parent.model.dispatch).toHaveBeenCalledWith("START_CHANGE_HIGHLIGHT", {
+      expect(parent.model.dispatch).toHaveBeenLastCalledWith("START_CHANGE_HIGHLIGHT", {
+        sheetId: model.getters.getSheetIds()[0],
         zone: toZone("A1:A10"),
       });
 
@@ -696,7 +717,8 @@ describe("Border component", () => {
       borderEl = fixture.querySelector(".o-border-n")!;
 
       await selectTopCellBorder(borderEl, "A1");
-      expect(parent.model.dispatch).toHaveBeenCalledWith("START_CHANGE_HIGHLIGHT", {
+      expect(parent.model.dispatch).toHaveBeenLastCalledWith("START_CHANGE_HIGHLIGHT", {
+        sheetId: model.getters.getSheetIds()[0],
         zone: toZone("A1:J1"),
       });
 
@@ -719,7 +741,8 @@ describe("Border component", () => {
 
     // select B1 top border
     await selectTopCellBorder(borderEl, "B1");
-    expect(model.dispatch).toHaveBeenCalledWith("START_CHANGE_HIGHLIGHT", {
+    expect(model.dispatch).toHaveBeenLastCalledWith("START_CHANGE_HIGHLIGHT", {
+      sheetId: model.getters.getSheetIds()[0],
       zone: toZone("B1"),
     });
 
@@ -742,7 +765,8 @@ describe("Border component", () => {
 
     // select A2 top border
     await selectTopCellBorder(borderEl, "A2");
-    expect(model.dispatch).toHaveBeenCalledWith("START_CHANGE_HIGHLIGHT", {
+    expect(model.dispatch).toHaveBeenLastCalledWith("START_CHANGE_HIGHLIGHT", {
+      sheetId: model.getters.getSheetIds()[0],
       zone: toZone("A2"),
     });
 

--- a/tests/helpers/ui_helpers.test.ts
+++ b/tests/helpers/ui_helpers.test.ts
@@ -175,7 +175,8 @@ describe("UI Helpers", () => {
 
   describe("Interactive paste", () => {
     test("paste without copied value interactively", () => {
-      interactivePaste(env, target("D2"));
+      setSelection(model, ["D2"]);
+      interactivePaste(env);
       expect(getCellContent(model, "D2")).toBe("");
     });
 
@@ -186,9 +187,12 @@ describe("UI Helpers", () => {
 
       copy(model, "A1");
       const env = makeTestEnv({ model });
-      interactivePaste(env, target("B1"), "onlyFormat");
-      interactivePaste(env, target("B2"), "asValue");
-      interactivePaste(env, target("B3"));
+      setSelection(model, ["B1"]);
+      interactivePaste(env, "onlyFormat");
+      setSelection(model, ["B2"]);
+      interactivePaste(env, "asValue");
+      setSelection(model, ["B3"]);
+      interactivePaste(env);
 
       expect(getCellText(model, "B1")).toBe("");
       expect(getCell(model, "B1")!.style).toEqual(style);
@@ -205,7 +209,7 @@ describe("UI Helpers", () => {
 
       selectCell(model, "C4");
       addCellToSelection(model, "F6");
-      interactivePaste(env, model.getters.getSelectedZones());
+      interactivePaste(env);
       expect(notifyUserTextSpy).toHaveBeenCalledWith(
         PasteInteractiveContent.wrongPasteSelection.toString()
       );
@@ -218,15 +222,16 @@ describe("UI Helpers", () => {
       selectCell(model, "C4");
       addCellToSelection(model, "F6");
 
-      interactivePaste(env, model.getters.getSelectedZones());
+      interactivePaste(env);
       expect(notifyUserTextSpy).toHaveBeenCalledWith(
         PasteInteractiveContent.wrongPasteSelection.toString()
       );
     });
 
     test("will warn user if paste in several selection", () => {
-      copy(model, "A1", "C1");
-      interactivePaste(env, target("A2, B2"));
+      copy(model, "A1, C1");
+      setSelection(model, ["A2", "B2"]);
+      interactivePaste(env);
       expect(notifyUserTextSpy).toHaveBeenCalledWith(
         PasteInteractiveContent.wrongPasteSelection.toString()
       );
@@ -236,7 +241,8 @@ describe("UI Helpers", () => {
       createChart(model, { type: "bar" }, "chartId", undefined, { figureId: "figureId" });
       selectFigure(model, "figureId");
       copy(model);
-      interactivePaste(env, target("A1"), "onlyFormat");
+      selectCell(model, "A1");
+      interactivePaste(env, "onlyFormat");
       expect(notifyUserTextSpy).toHaveBeenCalledWith(
         PasteInteractiveContent.wrongFigurePasteOption.toString()
       );
@@ -244,9 +250,9 @@ describe("UI Helpers", () => {
 
     test("Pasting content that will destroy a merge will notify the user", async () => {
       merge(model, "B2:C3");
-      copy(model, "B2");
+      copy(model, "B2:C3");
       selectCell(model, "A1");
-      interactivePaste(env, model.getters.getSelectedZones());
+      interactivePaste(env);
       expect(notifyUserTextSpy).toHaveBeenCalledWith(
         PasteInteractiveContent.willRemoveExistingMerge.toString()
       );
@@ -256,7 +262,8 @@ describe("UI Helpers", () => {
       const clipboardString = "a\t1\nb\t2";
 
       test("Can interactive paste", async () => {
-        await interactivePasteFromOS(env, target("D2"), { text: clipboardString });
+        setSelection(model, ["D2"]);
+        await interactivePasteFromOS(env, { text: clipboardString });
         expect(getCellContent(model, "D2")).toBe("a");
         expect(getCellContent(model, "E2")).toBe("1");
         expect(getCellContent(model, "D3")).toBe("b");
@@ -266,7 +273,7 @@ describe("UI Helpers", () => {
       test("Pasting content that will destroy a merge will notify the user", async () => {
         merge(model, "B2:C3");
         selectCell(model, "A1");
-        await interactivePasteFromOS(env, model.getters.getSelectedZones(), {
+        await interactivePasteFromOS(env, {
           text: clipboardString,
         });
         expect(notifyUserTextSpy).toHaveBeenCalledWith(
@@ -281,7 +288,7 @@ describe("UI Helpers", () => {
       copy(model, "F4:G5");
 
       selectCell(model, "B4");
-      interactivePaste(env, model.getters.getSelectedZones());
+      interactivePaste(env);
       expect(notifyUserTextSpy).toHaveBeenCalledWith(
         PasteInteractiveContent.frozenPaneOverlap.toString()
       );
@@ -293,7 +300,7 @@ describe("UI Helpers", () => {
       copy(model, "F4:G5");
 
       selectCell(model, "B2");
-      interactivePaste(env, model.getters.getSelectedZones());
+      interactivePaste(env);
       expect(notifyUserTextSpy).toHaveBeenCalledWith(
         PasteInteractiveContent.frozenPaneOverlap.toString()
       );

--- a/tests/menus/menu_items_registry.test.ts
+++ b/tests/menus/menu_items_registry.test.ts
@@ -189,7 +189,10 @@ describe("Menu Item actions", () => {
   test("Edit -> copy", async () => {
     const spyWriteClipboard = jest.spyOn(env.clipboard!, "write");
     await doAction(["edit", "copy"], env);
-    expect(dispatch).toHaveBeenCalledWith("COPY");
+    expect(dispatch).toHaveBeenCalledWith("COPY", {
+      sheetId: model.getters.getActiveSheetId(),
+      target: model.getters.getSelectedZones(),
+    });
     expect(spyWriteClipboard).toHaveBeenCalledWith(
       await model.getters.getClipboardTextAndImageContent()
     );
@@ -198,7 +201,10 @@ describe("Menu Item actions", () => {
   test("Edit -> cut", async () => {
     const spyWriteClipboard = jest.spyOn(env.clipboard!, "write");
     await doAction(["edit", "cut"], env);
-    expect(dispatch).toHaveBeenCalledWith("CUT");
+    expect(dispatch).toHaveBeenCalledWith("CUT", {
+      sheetId: model.getters.getActiveSheetId(),
+      target: model.getters.getSelectedZones(),
+    });
     expect(spyWriteClipboard).toHaveBeenCalledWith(
       await model.getters.getClipboardTextAndImageContent()
     );
@@ -218,7 +224,7 @@ describe("Menu Item actions", () => {
     await env.clipboard!.writeText("First copy in OS clipboard");
     await doAction(["edit", "copy"], env); // then copy from grid
     await doAction(["edit", "paste"], env);
-    interactivePaste(env, target("A1"));
+    interactivePaste(env);
     expect(getCellContent(model, "A1")).toEqual("");
   });
 
@@ -228,7 +234,8 @@ describe("Menu Item actions", () => {
     setCellContent(model, "A1", "os clipboard");
     selectCell(model, "C3");
     await doAction(["edit", "paste"], env);
-    expect(dispatch).toHaveBeenCalledWith("PASTE", {
+    expect(dispatch).toHaveBeenLastCalledWith("PASTE", {
+      sheetId: model.getters.getSheetIds()[0],
       target: env.model.getters.getSelectedZones(),
       pasteOption: undefined,
     });
@@ -239,7 +246,8 @@ describe("Menu Item actions", () => {
     await env.clipboard!.writeText("Copy in OS clipboard");
     selectCell(model, "A1");
     await doAction(["edit", "paste_special", "paste_special_format"], env);
-    expect(dispatch).toHaveBeenCalledWith("PASTE_FROM_OS_CLIPBOARD", {
+    expect(dispatch).toHaveBeenLastCalledWith("PASTE_FROM_OS_CLIPBOARD", {
+      sheetId: model.getters.getSheetIds()[0],
       clipboardContent: { text: "Copy in OS clipboard" },
       target: target("A1"),
       pasteOption: "onlyFormat",
@@ -303,7 +311,8 @@ describe("Menu Item actions", () => {
   test("Edit -> paste_special -> paste_special_value", async () => {
     await doAction(["edit", "copy"], env);
     await doAction(["edit", "paste_special", "paste_special_value"], env);
-    expect(dispatch).toHaveBeenCalledWith("PASTE", {
+    expect(dispatch).toHaveBeenLastCalledWith("PASTE", {
+      sheetId: model.getters.getSheetIds()[0],
       target: env.model.getters.getSelectedZones(),
       pasteOption: "asValue",
     });
@@ -313,7 +322,8 @@ describe("Menu Item actions", () => {
     const text = "in OS clipboard";
     await env.clipboard!.writeText(text);
     await doAction(["edit", "paste_special", "paste_special_value"], env);
-    expect(dispatch).toHaveBeenCalledWith("PASTE_FROM_OS_CLIPBOARD", {
+    expect(dispatch).toHaveBeenLastCalledWith("PASTE_FROM_OS_CLIPBOARD", {
+      sheetId: model.getters.getSheetIds()[0],
       target: target("A1"),
       clipboardContent: { text },
       pasteOption: "asValue",
@@ -323,7 +333,8 @@ describe("Menu Item actions", () => {
   test("Edit -> paste_special -> paste_special_format", async () => {
     await doAction(["edit", "copy"], env);
     await doAction(["edit", "paste_special", "paste_special_format"], env);
-    expect(dispatch).toHaveBeenCalledWith("PASTE", {
+    expect(dispatch).toHaveBeenLastCalledWith("PASTE", {
+      sheetId: model.getters.getSheetIds()[0],
       target: env.model.getters.getSelectedZones(),
       pasteOption: "onlyFormat",
     });
@@ -333,7 +344,8 @@ describe("Menu Item actions", () => {
     const text = "in OS clipboard";
     await env.clipboard!.writeText(text);
     await doAction(["edit", "paste_special", "paste_special_format"], env);
-    expect(dispatch).toHaveBeenCalledWith("PASTE_FROM_OS_CLIPBOARD", {
+    expect(dispatch).toHaveBeenLastCalledWith("PASTE_FROM_OS_CLIPBOARD", {
+      sheetId: model.getters.getSheetIds()[0],
       target: target("A1"),
       clipboardContent: { text },
       pasteOption: "onlyFormat",
@@ -937,6 +949,7 @@ describe("Menu Item actions", () => {
       expect(getName(insertCellShiftDownPath, env)).toBe("Shift down");
       await doAction(insertCellShiftDownPath, env);
       expect(dispatch).toHaveBeenLastCalledWith("INSERT_CELL", {
+        sheetId: model.getters.getSheetIds()[0],
         zone: env.model.getters.getSelectedZone(),
         shiftDimension: "ROW",
       });
@@ -949,6 +962,7 @@ describe("Menu Item actions", () => {
       expect(getName(insertCellShiftDownPath, env)).toBe("Shift down");
       await doAction(insertCellShiftDownPath, env);
       expect(dispatch).toHaveBeenLastCalledWith("INSERT_CELL", {
+        sheetId: model.getters.getSheetIds()[0],
         zone: env.model.getters.getSelectedZone(),
         shiftDimension: "ROW",
       });
@@ -998,6 +1012,7 @@ describe("Menu Item actions", () => {
       expect(getName(insertCellShiftRightPath, env)).toBe("Shift right");
       await doAction(insertCellShiftRightPath, env);
       expect(dispatch).toHaveBeenLastCalledWith("INSERT_CELL", {
+        sheetId: model.getters.getSheetIds()[0],
         zone: env.model.getters.getSelectedZone(),
         shiftDimension: "COL",
       });
@@ -1010,6 +1025,7 @@ describe("Menu Item actions", () => {
       expect(getName(insertCellShiftRightPath, env)).toBe("Shift right");
       await doAction(insertCellShiftRightPath, env);
       expect(dispatch).toHaveBeenLastCalledWith("INSERT_CELL", {
+        sheetId: model.getters.getSheetIds()[0],
         zone: env.model.getters.getSelectedZone(),
         shiftDimension: "COL",
       });

--- a/tests/model/model.test.ts
+++ b/tests/model/model.test.ts
@@ -96,6 +96,7 @@ describe("Model", () => {
         if (cmd.type === "COPY") {
           result = this.dispatch("PASTE", {
             target: [toZone("A2")],
+            sheetId: model.getters.getSheetIds()[0],
           });
         }
       }

--- a/tests/remove_duplicates/remove_duplicates_plugin.test.ts
+++ b/tests/remove_duplicates/remove_duplicates_plugin.test.ts
@@ -23,7 +23,9 @@ export function removeDuplicates(
   }
   store.setColumns(columns);
   store.setHasHeader(hasHeader);
-  return model.dispatch("REMOVE_DUPLICATES", { columns, hasHeader });
+  const sheetId = model.getters.getActiveSheetId();
+  const zone = model.getters.getSelectedZone();
+  return model.dispatch("REMOVE_DUPLICATES", { sheetId, zone });
 }
 
 describe("remove duplicates", () => {

--- a/tests/renderer/renderer_store.test.ts
+++ b/tests/renderer/renderer_store.test.ts
@@ -1512,7 +1512,7 @@ describe("renderer", () => {
     "compatible copied zones %s are all outlined with dots",
     (targetXc) => {
       const { drawGridRenderer, model, container } = setRenderer(new Model(), ["Clipboard"]);
-      copy(model, ...targetXc.split(","));
+      copy(model, targetXc);
       const { ctx, isDotOutlined, reset } = watchClipboardOutline(model, container);
       drawGridRenderer(ctx);
       const copiedTarget = target(targetXc);
@@ -1528,7 +1528,7 @@ describe("renderer", () => {
     "only last copied non-compatible zones %s is outlined with dots",
     (targetXc) => {
       const { drawGridRenderer, model, container } = setRenderer(new Model(), ["Clipboard"]);
-      copy(model, ...targetXc.split(","));
+      copy(model, targetXc);
       const { ctx, isDotOutlined, reset } = watchClipboardOutline(model, container);
       drawGridRenderer(ctx);
       const copiedTarget = target(targetXc);

--- a/tests/repeat_commands_plugin.test.ts
+++ b/tests/repeat_commands_plugin.test.ts
@@ -402,8 +402,7 @@ describe("Repeat local commands", () => {
     addEqualCf(model, "A1:A2", { fillColor: "#FF0000" }, "1");
     createTableWithFilter(model, "A1:A2");
 
-    setSelection(model, ["A1:A2"]);
-    copy(model);
+    copy(model, "A1:A2");
     paste(model, "B1");
 
     setSelection(model, ["C1"]);

--- a/tests/sheet/sheet_manipulation_plugin.test.ts
+++ b/tests/sheet/sheet_manipulation_plugin.test.ts
@@ -1582,7 +1582,8 @@ describe("Delete cell", () => {
   test("Undo/redo is correctly supported", () => {
     setCellContent(model, "A2", "=A3");
     setFormatting(model, "A3", { fillColor: "orange" });
-    testUndoRedo(model, expect, "DELETE_CELL", { zone: toZone("A1"), dimension: "ROW" });
+    const sheetId = model.getters.getActiveSheetId();
+    testUndoRedo(model, expect, "DELETE_CELL", { sheetId, zone: toZone("A1"), dimension: "ROW" });
   });
 
   test.each(["up", "left"] as const)("can delete the last cell of the grid", (direction) => {
@@ -1675,7 +1676,8 @@ describe("Insert cell", () => {
   test("Undo/redo is correctly supported", () => {
     setCellContent(model, "A2", "=A3");
     setFormatting(model, "A3", { fillColor: "orange" });
-    testUndoRedo(model, expect, "INSERT_CELL", { zone: toZone("A1"), dimension: "ROW" });
+    const sheetId = model.getters.getActiveSheetId();
+    testUndoRedo(model, expect, "INSERT_CELL", { sheetId, zone: toZone("A1"), dimension: "ROW" });
   });
 });
 

--- a/tests/split_to_column/split_to_columns_panel.test.ts
+++ b/tests/split_to_column/split_to_columns_panel.test.ts
@@ -1,6 +1,7 @@
 import { EditionMode, Model } from "../../src";
 import { ComposerFocusStore } from "../../src/components/composer/composer_focus_store";
 import { SplitIntoColumnsPanel } from "../../src/components/side_panel/split_to_columns_panel/split_to_columns_panel";
+import { toZone } from "../../src/helpers/zones";
 import { SpreadsheetChildEnv } from "../../src/types/spreadsheet_env";
 import { setCellContent, setSelection } from "../test_helpers/commands_helpers";
 import {
@@ -25,6 +26,7 @@ describe("split to columns sidePanel component", () => {
   let checkBox: HTMLInputElement;
   let onCloseSidePanel: jest.Mock;
   let env: SpreadsheetChildEnv;
+  let sheetId: string;
 
   beforeEach(async () => {
     onCloseSidePanel = jest.fn();
@@ -34,6 +36,7 @@ describe("split to columns sidePanel component", () => {
     dispatch = spyModelDispatch(model);
     confirmButton = fixture.querySelector(".o-split-to-cols-panel button")!;
     checkBox = fixture.querySelector('.o-split-to-cols-panel input[type="checkbox"]')!;
+    sheetId = model.getters.getActiveSheetId();
   });
 
   test("Separator values", async () => {
@@ -55,6 +58,8 @@ describe("split to columns sidePanel component", () => {
     await editSelectComponent(".o-split-to-cols-panel .o-select", ",");
     await click(confirmButton);
     expect(dispatch).toHaveBeenCalledWith("SPLIT_TEXT_INTO_COLUMNS", {
+      sheetId,
+      zone: toZone("A1"),
       separator: ",",
       addNewColumns: expect.any(Boolean),
     });
@@ -62,6 +67,8 @@ describe("split to columns sidePanel component", () => {
     await editSelectComponent(".o-split-to-cols-panel .o-select", ";");
     await click(confirmButton);
     expect(dispatch).toHaveBeenCalledWith("SPLIT_TEXT_INTO_COLUMNS", {
+      sheetId,
+      zone: toZone("A1"),
       separator: ";",
       addNewColumns: expect.any(Boolean),
     });
@@ -77,6 +84,8 @@ describe("split to columns sidePanel component", () => {
     await setInputValueAndTrigger(input, "customSeparator");
     await click(confirmButton);
     expect(dispatch).toHaveBeenCalledWith("SPLIT_TEXT_INTO_COLUMNS", {
+      sheetId,
+      zone: toZone("A1"),
       separator: "customSeparator",
       addNewColumns: expect.any(Boolean),
     });
@@ -86,6 +95,8 @@ describe("split to columns sidePanel component", () => {
     setCheckboxValueAndTrigger(checkBox, true, "change");
     await click(confirmButton);
     expect(dispatch).toHaveBeenCalledWith("SPLIT_TEXT_INTO_COLUMNS", {
+      sheetId,
+      zone: toZone("A1"),
       separator: expect.any(String),
       addNewColumns: true,
     });
@@ -93,6 +104,8 @@ describe("split to columns sidePanel component", () => {
     setCheckboxValueAndTrigger(checkBox, false, "change");
     await click(confirmButton);
     expect(dispatch).toHaveBeenCalledWith("SPLIT_TEXT_INTO_COLUMNS", {
+      sheetId,
+      zone: toZone("A1"),
       separator: expect.any(String),
       addNewColumns: true,
     });

--- a/tests/test_helpers/commands_helpers.ts
+++ b/tests/test_helpers/commands_helpers.ts
@@ -650,21 +650,23 @@ export function updateChartDataSource(
 /**
  * Copy a zone
  */
-export function copy(model: Model, ...ranges: string[]): DispatchResult {
-  if (ranges && ranges.length) {
-    setSelection(model, ranges);
-  }
-  return model.dispatch("COPY");
+export function copy(
+  model: Model,
+  ranges?: string,
+  sheetId: UID = model.getters.getActiveSheetId()
+): DispatchResult {
+  return model.dispatch("COPY", { sheetId, target: target(ranges || "A1") });
 }
 
 /**
  * Cut a zone
  */
-export function cut(model: Model, ...ranges: string[]): DispatchResult {
-  if (ranges && ranges.length) {
-    setSelection(model, ranges);
-  }
-  return model.dispatch("CUT");
+export function cut(
+  model: Model,
+  ranges?: string,
+  sheetId: UID = model.getters.getActiveSheetId()
+): DispatchResult {
+  return model.dispatch("CUT", { sheetId, target: target(ranges || "A1") });
 }
 
 /**
@@ -673,9 +675,10 @@ export function cut(model: Model, ...ranges: string[]): DispatchResult {
 export function paste(
   model: Model,
   range: string,
-  pasteOption?: ClipboardPasteOptions
+  pasteOption?: ClipboardPasteOptions,
+  sheetId: UID = model.getters.getActiveSheetId()
 ): DispatchResult {
-  return model.dispatch("PASTE", { target: target(range), pasteOption });
+  return model.dispatch("PASTE", { sheetId, target: target(range), pasteOption });
 }
 
 /**
@@ -691,6 +694,7 @@ export function pasteFromOSClipboard(
     clipboardContent: content,
     target: target(range),
     pasteOption,
+    sheetId: model.getters.getActiveSheetId(),
   });
 }
 
@@ -698,21 +702,27 @@ export function pasteFromOSClipboard(
  * Copy cells above a zone and paste on zone
  */
 export function copyPasteAboveCells(model: Model): DispatchResult {
-  return model.dispatch("COPY_PASTE_CELLS_ABOVE");
+  const sheetId = model.getters.getActiveSheetId();
+  const target = model.getters.getSelectedZones();
+  return model.dispatch("COPY_PASTE_CELLS_ABOVE", { sheetId, target });
 }
 
 /**
  * Copy cells to the left of a zone and paste on zone
  */
 export function copyPasteCellsOnLeft(model: Model): DispatchResult {
-  return model.dispatch("COPY_PASTE_CELLS_ON_LEFT");
+  const sheetId = model.getters.getActiveSheetId();
+  const target = model.getters.getSelectedZones();
+  return model.dispatch("COPY_PASTE_CELLS_ON_LEFT", { sheetId, target });
 }
 
 /**
  * Copy cell and paste on zone
  */
 export function copyPasteCellsOnZone(model: Model): DispatchResult {
-  return model.dispatch("COPY_PASTE_CELLS_ON_ZONE");
+  const sheetId = model.getters.getActiveSheetId();
+  const target = model.getters.getSelectedZones();
+  return model.dispatch("COPY_PASTE_CELLS_ON_ZONE", { sheetId, target });
 }
 
 /**
@@ -910,6 +920,7 @@ export function deleteCells(model: Model, range: string, shift: "left" | "up"): 
   return model.dispatch("DELETE_CELL", {
     zone: toZone(range),
     shiftDimension: shift === "left" ? "COL" : "ROW",
+    sheetId: model.getters.getActiveSheetId(),
   });
 }
 
@@ -926,6 +937,7 @@ export function deleteContent(
 
 export function insertCells(model: Model, range: string, shift: "right" | "down"): DispatchResult {
   return model.dispatch("INSERT_CELL", {
+    sheetId: model.getters.getActiveSheetId(),
     zone: toZone(range),
     shiftDimension: shift === "right" ? "COL" : "ROW",
   });
@@ -1544,6 +1556,8 @@ export function splitTextToColumns(
     separator,
     force: options.force || false,
     addNewColumns: options.addNewColumns || false,
+    sheetId: model.getters.getActiveSheetId(),
+    zone: toZone(target || "A1"),
   });
 }
 
@@ -1963,7 +1977,10 @@ export function deleteUnfilteredContent(
 }
 
 export function autofillAuto(model: Model) {
-  return model.dispatch("AUTOFILL_AUTO");
+  const { col, row } = model.getters.getActivePosition();
+  const sheetId = model.getters.getActiveSheetId();
+  const source = model.getters.getSelectedZone();
+  return model.dispatch("AUTOFILL_AUTO", { col, row, sheetId, source });
 }
 
 export function selectFigure(model: Model, figureId: UID, selectMultiple?: boolean) {
@@ -1998,13 +2015,16 @@ export function setZoom(env: SpreadsheetChildEnv, zoom: number) {
 }
 
 export function autofillSelect(model: Model, from: string, to: string) {
-  setSelection(model, [from]);
-  return model.dispatch("AUTOFILL_SELECT", toCartesian(to));
+  const sheetId = model.getters.getActiveSheetId();
+  const source = toZone(from);
+  return model.dispatch("AUTOFILL_SELECT", { ...toCartesian(to), sheetId, source });
 }
 
 export function autofill(model: Model, from: string, to: string) {
   autofillSelect(model, from, to);
-  return model.dispatch("AUTOFILL");
+  const sheetId = model.getters.getActiveSheetId();
+  const source = toZone(from);
+  return model.dispatch("AUTOFILL", { sheetId, source });
 }
 
 export function setFormulaVisibility(model: Model, show: boolean) {
@@ -2033,6 +2053,7 @@ export function removeTableStyle(model: Model, tableStyleId: UID) {
 export function startChangeHighlight(model: Model, xc: string) {
   return model.dispatch("START_CHANGE_HIGHLIGHT", {
     zone: toZone(xc),
+    sheetId: model.getters.getActiveSheetId(),
   });
 }
 

--- a/tests/test_helpers/getters_helpers.ts
+++ b/tests/test_helpers/getters_helpers.ts
@@ -16,8 +16,7 @@ import { toCartesian, toXC } from "../../src/helpers/coordinates";
 import { toZone, zoneToXc } from "../../src/helpers/zones";
 import { Model } from "../../src/model";
 import { ClipboardPlugin } from "../../src/plugins/ui_stateful/clipboard";
-import { setSelection } from "./commands_helpers";
-import { getPlugin } from "./helpers";
+import { getPlugin, target } from "./helpers";
 
 /**
  * Get the active XC
@@ -237,17 +236,24 @@ export function automaticSum(
   { anchor }: { anchor?: string } = {},
   sheetId?: UID
 ) {
+  if (!anchor) {
+    const zone = toZone(xc);
+    anchor = toXC(zone.left, zone.top);
+  }
   return automaticSumMulti(model, [xc], { anchor }, sheetId);
 }
 
 export function automaticSumMulti(
   model: Model,
   xcs: string[],
-  { anchor }: { anchor?: string } = {},
-  sheetId?: UID
+  { anchor }: { anchor: string },
+  sheetId: UID = model.getters.getActiveSheetId()
 ) {
-  setSelection(model, xcs, { anchor });
-  return model.dispatch("SUM_SELECTION");
+  return model.dispatch("SUM_SELECTION", {
+    ...toCartesian(anchor),
+    sheetId,
+    target: target(xcs.join(",")),
+  });
 }
 
 export function getTable(


### PR DESCRIPTION
## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo