### PR TITLE
[FIX] collaborative: add sheetId as argument to `getClientsToDisplay`

### DIFF
--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -913,4 +913,9 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
   get displaySelectionHandler() {
     return this.env.isMobile() && this.composerFocusStore.activeComposer.editionMode === "inactive";
   }
+
+  get clientsToDisplay(): Required<Client>[] {
+    const sheetId = this.env.model.getters.getActiveSheetId();
+    return this.env.model.getters.getClientsToDisplay(sheetId);
+  }
 }

--- a/src/components/grid/grid.xml
+++ b/src/components/grid/grid.xml
@@ -23,10 +23,7 @@
       />
       <canvas t-ref="canvas"/>
       <t t-set="focused" t-value="focusedClients"/>
-      <t
-        t-foreach="env.model.getters.getClientsToDisplay()"
-        t-as="client"
-        t-key="getClientPositionKey(client)">
+      <t t-foreach="this.clientsToDisplay" t-as="client" t-key="getClientPositionKey(client)">
         <ClientTag
           name="client.name"
           color="client.color"

--- a/src/plugins/ui_feature/collaborative.ts
+++ b/src/plugins/ui_feature/collaborative.ts
@@ -1,3 +1,4 @@
+import { UID } from "../..";
 import { ClientDisconnectedError } from "../../collaborative/session";
 import { DEFAULT_FONT, DEFAULT_FONT_SIZE } from "../../constants";
 import { AlternatingColorMap } from "../../helpers/color";
@@ -58,7 +59,7 @@ export class CollaborativePlugin extends UIPlugin {
    * Get the list of others connected clients which are present in the same sheet
    * and with a valid position
    */
-  getClientsToDisplay(): ClientToDisplay[] {
+  getClientsToDisplay(sheetId: UID): ClientToDisplay[] {
     try {
       this.getters.getCurrentClient();
     } catch (e) {
@@ -68,7 +69,6 @@ export class CollaborativePlugin extends UIPlugin {
         throw e;
       }
     }
-    const sheetId = this.getters.getActiveSheetId();
     const clients: ClientToDisplay[] = [];
     for (const client of this.getters.getConnectedClients()) {
       if (
@@ -89,7 +89,7 @@ export class CollaborativePlugin extends UIPlugin {
     }
     const { ctx, thinLineWidth, viewports, sheetId } = renderingContext;
 
-    for (const client of this.getClientsToDisplay()) {
+    for (const client of this.getClientsToDisplay(sheetId)) {
       const { row, col } = client.position!;
       const zone = this.getters.expandZone(sheetId, {
         top: row,

--- a/tests/collaborative/collaborative.test.ts
+++ b/tests/collaborative/collaborative.test.ts
@@ -652,7 +652,8 @@ describe("Multi users synchronisation", () => {
   );
 
   test("readonly client is visible to other users", async () => {
-    expect(alice.getters.getClientsToDisplay().map((client) => client.name)).toEqual([
+    const sheetId = alice.getters.getSheetIds()[0];
+    expect(alice.getters.getClientsToDisplay(sheetId).map((client) => client.name)).toEqual([
       "Bob",
       "Charlie",
     ]);
@@ -661,18 +662,18 @@ describe("Multi users synchronisation", () => {
       mode: "readonly",
       client: { id: "david", name: "David" },
     });
-    expect(alice.getters.getClientsToDisplay().map((client) => client.name)).toEqual([
+    expect(alice.getters.getClientsToDisplay(sheetId).map((client) => client.name)).toEqual([
       "Bob",
       "Charlie",
       "David",
     ]);
-    expect(david.getters.getClientsToDisplay().map((client) => client.name)).toEqual([
+    expect(david.getters.getClientsToDisplay(sheetId).map((client) => client.name)).toEqual([
       "Alice",
       "Bob",
       "Charlie",
     ]);
     await david.leaveSession();
-    expect(alice.getters.getClientsToDisplay().map((client) => client.name)).toEqual([
+    expect(alice.getters.getClientsToDisplay(sheetId).map((client) => client.name)).toEqual([
       "Bob",
       "Charlie",
     ]);


### PR DESCRIPTION
## Description

The getter `getters.getClientsToDisplay()` was using the active sheet id to determine which clients to display.

The rendering can be done in an arbitrary sheet, but the `drawLayer` of the collaborative plugin was using `getClientsToDisplay()` which always used the active sheet.

Task: [6408720](https://www.odoo.com/odoo/2328/tasks/6408720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo