### PR TITLE
[REF] stores: make table resize plugin into a store

### DIFF
--- a/src/components/side_panel/table_panel/table_panel.ts
+++ b/src/components/side_panel/table_panel/table_panel.ts
@@ -7,8 +7,8 @@ import { Range } from "../../../types/range";
 import { TableConfig } from "../../../types/table";
 
 import { getTableTopLeft } from "../../../helpers/table_helpers";
-import { TableResizeStore } from "../../../plugins/ui_feature/table_resize_ui";
 import { useStore } from "../../../store_engine/store_hooks";
+import { TableResizeStore } from "../../../stores/table_resize_store";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
 import { NumberInput } from "../../number_input/number_input";
 import { types } from "../../props_validation";

--- a/src/components/side_panel/table_panel/table_panel.ts
+++ b/src/components/side_panel/table_panel/table_panel.ts
@@ -7,6 +7,8 @@ import { Range } from "../../../types/range";
 import { TableConfig } from "../../../types/table";
 
 import { getTableTopLeft } from "../../../helpers/table_helpers";
+import { TableResizeStore } from "../../../plugins/ui_feature/table_resize_ui";
+import { useStore } from "../../../store_engine/store_hooks";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
 import { NumberInput } from "../../number_input/number_input";
 import { types } from "../../props_validation";
@@ -49,6 +51,7 @@ export class TablePanel extends Component<SpreadsheetChildEnv> {
       tableXc: this.env.model.getters.getRangeString(this.props.table.range, sheetId),
       filtersEnabledIfPossible: this.props.table.config.hasFilters,
     });
+    useStore(TableResizeStore);
   }
 
   updateHasFilters(hasFilters: boolean) {

--- a/src/components/tables/table_resizer/table_resizer.ts
+++ b/src/components/tables/table_resizer/table_resizer.ts
@@ -1,5 +1,6 @@
 import { proxy, useProps } from "@odoo/owl";
 import { Component } from "../../../owl3_compatibility_layer";
+import { TableResizeStore } from "../../../plugins/ui_feature/table_resize_ui";
 import { useStore } from "../../../store_engine/store_hooks";
 import { ViewportsStore } from "../../../stores/viewports_store";
 import { HeaderIndex, Highlight, Zone } from "../../../types/misc";
@@ -32,6 +33,7 @@ export class TableResizer extends Component<SpreadsheetChildEnv> {
   setup(): void {
     useHighlights(this);
     this.viewStore = useStore(ViewportsStore);
+    useStore(TableResizeStore);
   }
 
   get containerStyle(): string {

--- a/src/components/tables/table_resizer/table_resizer.ts
+++ b/src/components/tables/table_resizer/table_resizer.ts
@@ -1,7 +1,7 @@
 import { proxy, useProps } from "@odoo/owl";
 import { Component } from "../../../owl3_compatibility_layer";
-import { TableResizeStore } from "../../../plugins/ui_feature/table_resize_ui";
 import { useStore } from "../../../store_engine/store_hooks";
+import { TableResizeStore } from "../../../stores/table_resize_store";
 import { ViewportsStore } from "../../../stores/viewports_store";
 import { HeaderIndex, Highlight, Zone } from "../../../types/misc";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";

--- a/src/plugins/plugin_registries.ts
+++ b/src/plugins/plugin_registries.ts
@@ -49,7 +49,6 @@ import { SortPlugin } from "./ui_feature/sort";
 import { SplitToColumnsPlugin } from "./ui_feature/split_to_columns";
 import { SubtotalEvaluationPlugin } from "./ui_feature/subtotal_evaluation";
 import { TableComputedStylePlugin } from "./ui_feature/table_computed_style";
-import { TableResizeUI } from "./ui_feature/table_resize_ui";
 import { UIOptionsPlugin } from "./ui_feature/ui_options";
 import { SheetUIPlugin } from "./ui_feature/ui_sheet";
 import { UIPluginConstructor } from "./ui_plugin";
@@ -93,7 +92,6 @@ export const featurePluginRegistry = new Registry<UIPluginConstructor>()
   .add("subtotal_evaluation", SubtotalEvaluationPlugin)
   .add("collaborative", CollaborativePlugin)
   .add("history", HistoryPlugin)
-  .add("table_ui_resize", TableResizeUI)
   .add("datavalidation_insert", DataValidationInsertionPlugin)
   .add("dynamic_translate", DynamicTranslate)
   .add("geo_features", GeoFeaturePlugin)

--- a/src/plugins/ui_feature/table_resize_ui.ts
+++ b/src/plugins/ui_feature/table_resize_ui.ts
@@ -1,36 +1,35 @@
-import { Command, CommandResult } from "../../types/commands";
-import { UIPlugin } from "../ui_plugin";
+import { SpreadsheetStore } from "../../stores/spreadsheet_store";
+import { Command, CommandResult, DispatchResult, ResizeTableCommand } from "../../types/commands";
 
-export class TableResizeUI extends UIPlugin {
-  allowDispatch(cmd: Command): CommandResult | CommandResult[] {
-    switch (cmd.type) {
-      case "RESIZE_TABLE":
-        const table = this.getters.getCoreTableMatchingTopLeft(cmd.sheetId, cmd.zone);
-        if (!table) {
-          return CommandResult.TableNotFound;
-        }
-
-        const oldTableZone = table.range.zone;
-        const newTableZone = this.getters.getRangeFromRangeData(cmd.newTableRange).zone;
-        if (newTableZone.top !== oldTableZone.top || newTableZone.left !== oldTableZone.left) {
-          return CommandResult.InvalidTableResize;
-        }
-        return this.canDispatch("UPDATE_TABLE", { ...cmd }).reasons;
+export class TableResizeStore extends SpreadsheetStore {
+  canResizeTable(cmd: ResizeTableCommand): DispatchResult {
+    const table = this.getters.getCoreTableMatchingTopLeft(cmd.sheetId, cmd.zone);
+    if (!table) {
+      return new DispatchResult([CommandResult.TableNotFound]);
     }
-    return CommandResult.Success;
+
+    const oldTableZone = table.range.zone;
+    const newTableZone = this.getters.getRangeFromRangeData(cmd.newTableRange).zone;
+    if (newTableZone.top !== oldTableZone.top || newTableZone.left !== oldTableZone.left) {
+      return new DispatchResult([CommandResult.InvalidTableResize]);
+    }
+    return this.model.canDispatch("UPDATE_TABLE", { ...cmd });
   }
 
   handle(cmd: Command) {
     switch (cmd.type) {
       case "RESIZE_TABLE": {
+        if (!this.canResizeTable(cmd).isSuccessful) {
+          return;
+        }
         const table = this.getters.getCoreTableMatchingTopLeft(cmd.sheetId, cmd.zone);
-        this.dispatch("UPDATE_TABLE", { ...cmd });
+        this.model.dispatch("UPDATE_TABLE", { ...cmd });
 
         if (!table) {
           return;
         }
         const newTableZone = this.getters.getRangeFromRangeData(cmd.newTableRange).zone;
-        this.selection.selectCell(newTableZone.right, newTableZone.bottom);
+        this.model.selection.selectCell(newTableZone.right, newTableZone.bottom);
         if (!table.config.automaticAutofill) {
           return;
         }
@@ -40,7 +39,7 @@ export class TableResizeUI extends UIPlugin {
           for (let col = newTableZone.left; col <= newTableZone.right; col++) {
             const autofillSource = { col, row: oldTableZone.bottom, sheetId: cmd.sheetId };
             if (this.getters.getCell(autofillSource)?.isFormula) {
-              this.dispatch("AUTOFILL_TABLE_COLUMN", {
+              this.model.dispatch("AUTOFILL_TABLE_COLUMN", {
                 ...autofillSource,
                 autofillRowStart: oldTableZone.bottom,
                 autofillRowEnd: newTableZone.bottom,

--- a/src/stores/table_resize_store.ts
+++ b/src/stores/table_resize_store.ts
@@ -1,5 +1,5 @@
-import { SpreadsheetStore } from "../../stores/spreadsheet_store";
-import { Command, CommandResult, DispatchResult, ResizeTableCommand } from "../../types/commands";
+import { Command, CommandResult, DispatchResult, ResizeTableCommand } from "../types/commands";
+import { SpreadsheetStore } from "./spreadsheet_store";
 
 export class TableResizeStore extends SpreadsheetStore {
   canResizeTable(cmd: ResizeTableCommand): DispatchResult {

--- a/tests/table/table_resize_ui_plugin.test.ts
+++ b/tests/table/table_resize_ui_plugin.test.ts
@@ -1,18 +1,21 @@
-import { CommandResult, Model, UID } from "../../src";
+import { CommandResult, Model, ResizeTableCommand, UID } from "../../src";
 import { AutofillStore } from "../../src/components/autofill/autofill_store";
 import { TableAutofillStore } from "../../src/components/autofill/table_autofill_store";
 import { toZone } from "../../src/helpers/zones";
+import { TableResizeStore } from "../../src/plugins/ui_feature/table_resize_ui";
 import {
   createDynamicTable,
   createTable,
   resizeTable,
   setCellContent,
 } from "../test_helpers/commands_helpers";
-import { getActivePosition, getCellRawContent } from "../test_helpers/getters_helpers";
+import { getActivePosition, getCellRawContent, getTable } from "../test_helpers/getters_helpers";
+import { toRangeData } from "../test_helpers/helpers";
 import { makeStoreWithModel } from "../test_helpers/stores";
 
 let model: Model;
 let sheetId: UID;
+let tableResizeStore: TableResizeStore;
 
 describe("Table resize", () => {
   beforeEach(() => {
@@ -20,23 +23,43 @@ describe("Table resize", () => {
     sheetId = model.getters.getActiveSheetId();
     const { container } = makeStoreWithModel(model, AutofillStore);
     container.get(TableAutofillStore);
+    tableResizeStore = container.get(TableResizeStore);
   });
 
   describe("dispatch result", () => {
     test("Cannot resize a table zone to a wrong zone", () => {
       createTable(model, "A1:A5");
 
-      expect(resizeTable(model, "A1", "A1:A600")).toBeCancelledBecause(
+      let cmd: ResizeTableCommand = {
+        type: "RESIZE_TABLE",
+        sheetId,
+        zone: getTable(model, "A1")!.range.zone,
+        newTableRange: toRangeData(sheetId, "A1:A600"),
+      };
+
+      expect(tableResizeStore.canResizeTable(cmd)).toBeCancelledBecause(
         CommandResult.TargetOutOfSheet
       );
 
       createTable(model, "B1:B5");
-      expect(resizeTable(model, "A1", "A1:B5")).toBeCancelledBecause(CommandResult.TableOverlap);
+      cmd = {
+        type: "RESIZE_TABLE",
+        sheetId,
+        zone: getTable(model, "A1")!.range.zone,
+        newTableRange: toRangeData(sheetId, "A1:B5"),
+      };
+      expect(tableResizeStore.canResizeTable(cmd)).toBeCancelledBecause(CommandResult.TableOverlap);
     });
 
     test("Cannot resize a table while changing it's top-left", () => {
       createTable(model, "A1:A5");
-      expect(resizeTable(model, "A1", "B1:B5")).toBeCancelledBecause(
+      const cmd: ResizeTableCommand = {
+        type: "RESIZE_TABLE",
+        sheetId,
+        zone: getTable(model, "A1")!.range.zone,
+        newTableRange: toRangeData(sheetId, "B1:B5"),
+      };
+      expect(tableResizeStore.canResizeTable(cmd)).toBeCancelledBecause(
         CommandResult.InvalidTableResize
       );
     });

--- a/tests/table/table_resize_ui_plugin.test.ts
+++ b/tests/table/table_resize_ui_plugin.test.ts
@@ -2,7 +2,7 @@ import { CommandResult, Model, ResizeTableCommand, UID } from "../../src";
 import { AutofillStore } from "../../src/components/autofill/autofill_store";
 import { TableAutofillStore } from "../../src/components/autofill/table_autofill_store";
 import { toZone } from "../../src/helpers/zones";
-import { TableResizeStore } from "../../src/plugins/ui_feature/table_resize_ui";
+import { TableResizeStore } from "../../src/stores/table_resize_store";
 import {
   createDynamicTable,
   createTable,


### PR DESCRIPTION
## Description:

### [MOV] stores: move table resize store in correct folder

### [REF] stores: make table resize plugin into a store

This commit transforms the table resize plugin into a store.

Task: [6408800](https://www.odoo.com/odoo/2328/tasks/6408800)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo