### PR TITLE
[FIX] ui_sheet: `getCellWidth` getter for non-active sheet

### DIFF
--- a/src/plugins/ui_feature/ui_sheet.ts
+++ b/src/plugins/ui_feature/ui_sheet.ts
@@ -89,7 +89,7 @@ export class SheetUIPlugin extends UIPlugin {
 
     contentWidth += 2 * PADDING_AUTORESIZE_HORIZONTAL;
     if (style.wrapping === "wrap") {
-      const colWidth = this.getters.getColSize(this.getters.getActiveSheetId(), position.col);
+      const colWidth = this.getters.getColSize(position.sheetId, position.col);
       return Math.min(colWidth, contentWidth);
     }
 

--- a/tests/formats/formatting_plugin.test.ts
+++ b/tests/formats/formatting_plugin.test.ts
@@ -507,6 +507,16 @@ describe("Autoresize", () => {
     expect(model.getters.getColSize(sheetId, 0)).toBe(newCellWidth);
   });
 
+  test("Autoresize with works on a non-active sheet and text wrapping", () => {
+    createSheet(model, { sheetId: "sh2" });
+    setStyle(model, "A1", { wrapping: "wrap" }, "sh2");
+    setCellContent(model, "A1", LONG_TEXT, "sh2");
+    resizeColumns(model, ["A"], 5, "sh2");
+    expect(model.getters.getColSize("sh2", 0)).toBe(5);
+    model.dispatch("AUTORESIZE_COLUMNS", { sheetId: "sh2", cols: [0] });
+    expect(model.getters.getColSize("sh2", 0)).toBe(5);
+  });
+
   test("Can autoresize two columns", () => {
     setCellContent(model, "A1", TEXT);
     setCellContent(model, "C1", LONG_TEXT);


### PR DESCRIPTION
## Description

The getter `getCellWidth` takes a cell position (with a sheetId) as argument, but inside the getter it uses the active sheet to get the column width instead. This make `AUTORESIZE_COLUMNS` command resize the column to the wrong with if called on a non-active sheet with text wrapping style.

Note that we never actually use `AUTORESIZE_COLUMNS` on a non-active sheet in practice.

Task: [6409426](https://www.odoo.com/odoo/2328/tasks/6409426)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo