### PR TITLE
[REF] filters: remove getter `getFirstTableInSelection`

### DIFF
--- a/src/actions/insert_actions.ts
+++ b/src/actions/insert_actions.ts
@@ -215,7 +215,7 @@ export const insertTable: ActionSpec = {
   shortcut: "Alt+T",
   execute: ACTIONS.INSERT_TABLE,
   isVisible: (env) =>
-    ACTIONS.IS_SELECTION_CONTINUOUS(env) && !env.model.getters.getFirstTableInSelection(),
+    ACTIONS.IS_SELECTION_CONTINUOUS(env) && !ACTIONS.FIRST_TABLE_IN_SELECTION(env),
   isEnabled: (env) => !env.isSmall,
   icon: "o-spreadsheet-Icon.PAINT_TABLE",
 };

--- a/src/actions/menu_items_actions.ts
+++ b/src/actions/menu_items_actions.ts
@@ -23,6 +23,7 @@ import { ClipboardMIMEType, ClipboardPasteOptions } from "../types/clipboard";
 import { Format } from "../types/format";
 import { Dimension, Style } from "../types/misc";
 import { SpreadsheetChildEnv } from "../types/spreadsheet_env";
+import { Table } from "../types/table";
 import { ActionSpec } from "./action";
 
 //------------------------------------------------------------------------------
@@ -573,7 +574,7 @@ export const INSERT_LINK_NAME = (env: SpreadsheetChildEnv) => {
 //------------------------------------------------------------------------------
 
 export const SELECTED_TABLE_HAS_FILTERS = (env: SpreadsheetChildEnv): boolean => {
-  const table = env.model.getters.getFirstTableInSelection();
+  const table = FIRST_TABLE_IN_SELECTION(env);
   return table?.config.hasFilters || false;
 };
 
@@ -588,9 +589,15 @@ export const IS_SELECTION_CONTINUOUS = (env: SpreadsheetChildEnv): boolean => {
   return areZonesContinuous(env.model.getters.getSelectedZones());
 };
 
+export const FIRST_TABLE_IN_SELECTION = (env: SpreadsheetChildEnv): Table | undefined => {
+  const sheetId = env.model.getters.getActiveSheetId();
+  const selection = env.model.getters.getSelectedZones();
+  return env.model.getters.getTablesOverlappingZones(sheetId, selection)[0];
+};
+
 export const ADD_DATA_FILTER = (env: SpreadsheetChildEnv) => {
   const sheetId = env.model.getters.getActiveSheetId();
-  const table = env.model.getters.getFirstTableInSelection();
+  const table = FIRST_TABLE_IN_SELECTION(env);
   if (table) {
     env.model.dispatch("UPDATE_TABLE", {
       sheetId,
@@ -610,7 +617,7 @@ export const ADD_DATA_FILTER = (env: SpreadsheetChildEnv) => {
 
 export const REMOVE_DATA_FILTER = (env: SpreadsheetChildEnv) => {
   const sheetId = env.model.getters.getActiveSheetId();
-  const table = env.model.getters.getFirstTableInSelection();
+  const table = FIRST_TABLE_IN_SELECTION(env);
   if (!table) {
     return;
   }
@@ -631,7 +638,7 @@ export const INSERT_TABLE = (env: SpreadsheetChildEnv) => {
 };
 
 export const DELETE_SELECTED_TABLE = (env: SpreadsheetChildEnv) => {
-  const table = env.model.getters.getFirstTableInSelection();
+  const table = FIRST_TABLE_IN_SELECTION(env);
   if (!table) {
     return;
   }

--- a/src/components/tables/table_dropdown_button/table_dropdown_button.ts
+++ b/src/components/tables/table_dropdown_button/table_dropdown_button.ts
@@ -1,5 +1,6 @@
 import { proxy, useProps } from "@odoo/owl";
 import { ActionSpec } from "../../../actions/action";
+import { FIRST_TABLE_IN_SELECTION } from "../../../actions/menu_items_actions";
 import { DEFAULT_TABLE_CONFIG } from "../../../helpers/table_presets";
 import { interactiveCreateTable } from "../../../helpers/ui/table_interactive";
 import { cellPositions } from "../../../helpers/zones";
@@ -57,7 +58,7 @@ export class TableDropdownButton extends Component<SpreadsheetChildEnv> {
       this.env.openSidePanel("PivotSidePanel", { pivotId, openTab: "design" });
       return;
     }
-    if (this.env.model.getters.getFirstTableInSelection()) {
+    if (FIRST_TABLE_IN_SELECTION(this.env)) {
       this.topBarToolStore.closeDropdowns();
       this.env.toggleSidePanel("TableSidePanel", {});
       return;
@@ -87,10 +88,9 @@ export class TableDropdownButton extends Component<SpreadsheetChildEnv> {
     }
 
     return {
-      name: (env) =>
-        env.model.getters.getFirstTableInSelection() ? _t("Edit table") : _t("Insert table"),
+      name: (env) => (FIRST_TABLE_IN_SELECTION(env) ? _t("Edit table") : _t("Insert table")),
       icon: (env) =>
-        env.model.getters.getFirstTableInSelection()
+        FIRST_TABLE_IN_SELECTION(env)
           ? "o-spreadsheet-Icon.EDIT_TABLE"
           : "o-spreadsheet-Icon.PAINT_TABLE",
     };

--- a/src/plugins/ui_stateful/filter_evaluation.ts
+++ b/src/plugins/ui_stateful/filter_evaluation.ts
@@ -6,7 +6,7 @@ import { criterionEvaluatorRegistry } from "../../registries/criterion_registry"
 import { Command, CommandResult, LocalCommand, UpdateFilterCommand } from "../../types/commands";
 import { GenericCriterion } from "../../types/generic_criterion";
 import { CellPosition, FilterId, UID } from "../../types/misc";
-import { CriterionFilter, DataFilterValue, Table } from "../../types/table";
+import { CriterionFilter, DataFilterValue } from "../../types/table";
 import { ExcelFilterData, ExcelWorkbookData } from "../../types/workbook_data";
 import { UIPlugin } from "../ui_plugin";
 
@@ -17,7 +17,6 @@ export class FilterEvaluationPlugin extends UIPlugin {
     "getFilterValue",
     "getFilterHiddenValues",
     "getFilterCriterionValue",
-    "getFirstTableInSelection",
     "isRowFiltered",
     "isFilterActive",
   ] as const;
@@ -133,12 +132,6 @@ export class FilterEvaluationPlugin extends UIPlugin {
       return false;
     }
     return value.filterType === "values" ? value.hiddenValues.length > 0 : value.type !== "none";
-  }
-
-  getFirstTableInSelection(): Table | undefined {
-    const sheetId = this.getters.getActiveSheetId();
-    const selection = this.getters.getSelectedZones();
-    return this.getters.getTablesOverlappingZones(sheetId, selection)[0];
   }
 
   private updateFilter({ col, row, value, sheetId }: UpdateFilterCommand) {

--- a/src/registries/side_panel_registry.ts
+++ b/src/registries/side_panel_registry.ts
@@ -130,7 +130,9 @@ sidePanelRegistry.add("TableSidePanel", {
   title: _t("Edit table"),
   Body: TablePanel,
   computeState: (getters: Getters) => {
-    const table = getters.getFirstTableInSelection();
+    const sheetId = getters.getActiveSheetId();
+    const selection = getters.getSelectedZones();
+    const table = getters.getTablesOverlappingZones(sheetId, selection)[0];
     if (!table || table.isPivotTable) {
       return { isOpen: false };
     }


### PR DESCRIPTION
## Description

This commit removes the getter `getFirstTableInSelection` so that the `FilterEvaluationPlugin` does not depend on the selection anymore.

Task: [6409781](https://www.odoo.com/odoo/2328/tasks/6409781)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo