### PR TITLE
[IMP] stores: add globalStore

### DIFF
--- a/src/components/spreadsheet/spreadsheet.ts
+++ b/src/components/spreadsheet/spreadsheet.ts
@@ -21,6 +21,7 @@ import {
   useSubEnv,
 } from "../../owl3_compatibility_layer";
 import { useStore, useStoreProvider } from "../../store_engine/store_hooks";
+import { globalStores } from "../../store_engine/store_registries";
 import { ModelStore } from "../../stores/model_store";
 import { NotificationStore } from "../../stores/notification_store";
 import { ScreenWidthStore } from "../../stores/screen_width_store";
@@ -149,6 +150,9 @@ export class Spreadsheet extends Component<SpreadsheetChildEnv> {
     this.notificationStore = useStore(NotificationStore);
     this.composerFocusStore = useStore(ComposerFocusStore);
     this.sidePanel = useStore(SidePanelStore);
+    for (const store of globalStores.getAll()) {
+      useStore(store);
+    }
     const fileStore = this.model.config.external.fileStore;
 
     useSubEnv({

--- a/src/index.ts
+++ b/src/index.ts
@@ -358,6 +358,7 @@ import { chartSubtypeRegistry } from "./registries/chart_subtype_registry";
 import { clipboardHandlersRegistries } from "./registries/clipboardHandlersRegistries";
 import { onIterationEndEvaluationRegistry } from "./registries/evaluation_registry";
 import { specificRangeTransformRegistry } from "./registries/srt_registry";
+import { globalStores } from "./store_engine/store_registries";
 import { ViewportsStore } from "./stores/viewports_store";
 
 export const helpers = {
@@ -556,6 +557,7 @@ export const stores = {
   ClientFocusStore,
   GridRenderer,
   ViewportsStore,
+  globalStores,
 };
 
 export { getCaretDownSvg, getCaretUpSvg } from "./components/icons/icons";

--- a/src/store_engine/store_registries.ts
+++ b/src/store_engine/store_registries.ts
@@ -1,0 +1,5 @@
+import { Registry } from "../registries/registry";
+import { SpreadsheetStore } from "../stores/spreadsheet_store";
+import { StoreConstructor } from "../types/store_engine";
+
+export const globalStores = new Registry<StoreConstructor<SpreadsheetStore>>();

--- a/tests/test_helpers/helpers.ts
+++ b/tests/test_helpers/helpers.ts
@@ -58,6 +58,7 @@ import { detectDateFormat } from "../../src/helpers/format/format";
 import { topbarMenuRegistry } from "../../src/registries/menus/topbar_menu_registry";
 import { DependencyContainer } from "../../src/store_engine/dependency_container";
 import { proxifyStoreMutation, useStore } from "../../src/store_engine/store_hooks";
+import { globalStores } from "../../src/store_engine/store_registries";
 import { FormulaFingerprintStore } from "../../src/stores/formula_fingerprints_store";
 import { HighlightProvider, HighlightStore } from "../../src/stores/highlight_store";
 import { ModelStore } from "../../src/stores/model_store";
@@ -229,6 +230,9 @@ export function makeTestEnv(
 
   const store = container.get(SidePanelStore);
   const sidePanelStore = proxifyStoreMutation(store, () => container.trigger("store-updated"));
+  for (const store of globalStores.getAll()) {
+    container.get(store);
+  }
   return {
     model,
     openSidePanel: mockEnv.openSidePanel || sidePanelStore.open.bind(sidePanelStore),

--- a/tests/test_helpers/stores.ts
+++ b/tests/test_helpers/stores.ts
@@ -1,5 +1,6 @@
 import { Model, StoreConstructor, StoreParams } from "../../src";
 import { DependencyContainer } from "../../src/store_engine/dependency_container";
+import { globalStores } from "../../src/store_engine/store_registries";
 
 import { ModelStore } from "../../src/stores/model_store";
 import { NotificationStore } from "../../src/stores/notification_store";
@@ -10,11 +11,7 @@ export function makeStore<T extends StoreConstructor>(Store: T, ...args: StorePa
   return makeStoreWithModel(new Model(), Store, ...args);
 }
 
-export function makeStoreWithModel<T extends StoreConstructor>(
-  model: Model,
-  Store: T,
-  ...args: StoreParams<T>
-) {
+export function makeGlobalStoreWithModel(model: Model) {
   const container = new DependencyContainer();
   registerCleanup(() => {
     container.dispose();
@@ -22,7 +19,22 @@ export function makeStoreWithModel<T extends StoreConstructor>(
 
   container.inject(ModelStore, model);
   container.inject(NotificationStore, makeTestNotificationStore());
+  for (const store of globalStores.getAll()) {
+    container.get(store);
+  }
 
+  return {
+    container,
+    model: container.get(ModelStore),
+  };
+}
+
+export function makeStoreWithModel<T extends StoreConstructor>(
+  model: Model,
+  Store: T,
+  ...args: StoreParams<T>
+) {
+  const { container } = makeGlobalStoreWithModel(model);
   // Use container.get instead of container.instantiate where we can, otherwise the store won't be in the dependency
   // container, and calls to container.get will create a new instance of the store.
   // If we have args, that means the store is a local store and shouldn't be in the dependency container


### PR DESCRIPTION
Add a global store registry, global store are store that should always be present.

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo