### PR TITLE
[IMP] model: add external allow dispatch handlers

### DIFF
--- a/src/actions/sheet_actions.ts
+++ b/src/actions/sheet_actions.ts
@@ -1,5 +1,6 @@
 import { buildSheetLink, markdownLink } from "../helpers/misc";
 import { UuidGenerator } from "../helpers/uuid";
+import { LockSheetStore } from "../stores/lock_sheet_store";
 import { _t } from "../translation";
 import { ActionSpec } from "./action";
 
@@ -124,7 +125,7 @@ export const hideSheet: ActionSpec = {
 export const lockSheet: ActionSpec = {
   name: _t("Lock sheet"),
   isVisible: (env) => {
-    return !env.model.getters.isCurrentSheetLocked();
+    return !env.getStore(LockSheetStore).isCurrentSheetLocked;
   },
   execute: (env) => {
     env.model.dispatch("LOCK_SHEET", {
@@ -137,7 +138,7 @@ export const lockSheet: ActionSpec = {
 export const unlockSheet: ActionSpec = {
   name: _t("Unlock sheet"),
   isVisible: (env) => {
-    return env.model.getters.isCurrentSheetLocked();
+    return env.getStore(LockSheetStore).isCurrentSheetLocked;
   },
   execute: (env) => {
     env.model.dispatch("UNLOCK_SHEET", {

--- a/src/components/action_button/action_button.ts
+++ b/src/components/action_button/action_button.ts
@@ -1,8 +1,11 @@
 import { onWillUpdateProps, useProps } from "@odoo/owl";
 import { adaptShortcutStringToMacOs, createAction } from "../../actions/action";
 import { Component } from "../../owl3_compatibility_layer";
+import { useStore } from "../../store_engine/store_hooks";
+import { LockSheetStore } from "../../stores/lock_sheet_store";
 import { PropsOf } from "../../types/props_of";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
+import { Store } from "../../types/store_engine";
 import { cssPropertiesToCss } from "../helpers/css";
 import { types } from "../props_validation";
 
@@ -18,8 +21,10 @@ export class ActionButton extends Component<SpreadsheetChildEnv> {
   });
 
   private actionButton = createAction(this.props.action);
+  private lockSheetStore!: Store<LockSheetStore>;
 
   setup() {
+    this.lockSheetStore = useStore(LockSheetStore);
     onWillUpdateProps((nextProps: PropsOf<ActionButton>) => {
       if (nextProps.action !== this.props.action) {
         this.actionButton = createAction(nextProps.action);
@@ -33,7 +38,7 @@ export class ActionButton extends Component<SpreadsheetChildEnv> {
 
   get isEnabled() {
     const isLockedAvailable =
-      this.actionButton.isEnabledOnLockedSheet || !this.env.model.getters.isCurrentSheetLocked();
+      this.actionButton.isEnabledOnLockedSheet || !this.lockSheetStore.isCurrentSheetLocked;
     return this.actionButton.isEnabled(this.env) && isLockedAvailable;
   }
 

--- a/src/components/border_editor/border_editor_widget.ts
+++ b/src/components/border_editor/border_editor_widget.ts
@@ -2,6 +2,7 @@ import { onWillUpdateProps, proxy, signal, useProps } from "@odoo/owl";
 import { DEFAULT_BORDER_DESC } from "../../constants";
 import { Component } from "../../owl3_compatibility_layer";
 import { useStore } from "../../store_engine/store_hooks";
+import { LockSheetStore } from "../../stores/lock_sheet_store";
 import { ViewportsStore } from "../../stores/viewports_store";
 import { BorderPosition, BorderStyle, Color, Pixel } from "../../types/misc";
 import { Rect } from "../../types/rendering";
@@ -29,6 +30,7 @@ export class BorderEditorWidget extends Component<SpreadsheetChildEnv> {
   });
   topBarToolStore!: ToolBarDropdownStore;
   private viewStore!: Store<ViewportsStore>;
+  lockSheetStore!: Store<LockSheetStore>;
 
   borderEditorButtonRef = signal<HTMLElement | null>(null);
   state: State = proxy({
@@ -40,6 +42,7 @@ export class BorderEditorWidget extends Component<SpreadsheetChildEnv> {
   setup() {
     this.topBarToolStore = useToolBarDropdownStore();
     this.viewStore = useStore(ViewportsStore);
+    this.lockSheetStore = useStore(LockSheetStore);
     onWillUpdateProps(() => {
       if (!this.isActive) {
         this.state.currentPosition = undefined;

--- a/src/components/border_editor/border_editor_widget.xml
+++ b/src/components/border_editor/border_editor_widget.xml
@@ -2,7 +2,7 @@
   <t t-name="o-spreadsheet-BorderEditorWidget">
     <div
       class="d-flex position-relative"
-      t-att-class="{'o-disabled': this.env.model.getters.isCurrentSheetLocked()}"
+      t-att-class="{'o-disabled': this.lockSheetStore.isCurrentSheetLocked}"
       title="Borders">
       <span
         t-ref="this.borderEditorButtonRef"

--- a/src/components/composer/composer/cell_composer_store.ts
+++ b/src/components/composer/composer/cell_composer_store.ts
@@ -21,6 +21,7 @@ import {
   updateSelectionOnInsertion,
 } from "../../../helpers/zones";
 import { criterionEvaluatorRegistry } from "../../../registries/criterion_registry";
+import { LockSheetStore } from "../../../stores/lock_sheet_store";
 import { _t } from "../../../translation";
 import { CellValueType, FormulaCell } from "../../../types/cells";
 import {
@@ -39,6 +40,8 @@ import { AbstractComposerStore, ComposerSelection } from "./abstract_composer_st
 const CELL_DELETED_MESSAGE = _t("The cell you are trying to edit has been deleted.");
 
 export class CellComposerStore extends AbstractComposerStore {
+  private lockSheetStore = this.get(LockSheetStore);
+
   private canStopEdition(): boolean {
     if (this.editionMode === "inactive") {
       return true;
@@ -362,7 +365,7 @@ export class CellComposerStore extends AbstractComposerStore {
   }
 
   startEdition(text?: string, selection?: ComposerSelection) {
-    if (this.getters.isCurrentSheetLocked()) {
+    if (this.lockSheetStore.isCurrentSheetLocked) {
       this.model.trigger("command-rejected", {
         result: new DispatchResult(CommandResult.SheetLocked),
         command: { sheetId: this.getters.getActiveSheetId() },

--- a/src/components/composer/top_bar_composer/top_bar_composer.ts
+++ b/src/components/composer/top_bar_composer/top_bar_composer.ts
@@ -10,6 +10,7 @@ import { Composer } from "../composer/composer";
 import { ComposerFocusStore, ComposerInterface } from "../composer_focus_store";
 
 import { Component } from "../../../owl3_compatibility_layer";
+import { LockSheetStore } from "../../../stores/lock_sheet_store";
 const COMPOSER_MAX_HEIGHT = 300;
 
 export class TopBarComposer extends Component<SpreadsheetChildEnv> {
@@ -19,10 +20,12 @@ export class TopBarComposer extends Component<SpreadsheetChildEnv> {
   private composerFocusStore!: Store<ComposerFocusStore>;
   private composerStore!: Store<CellComposerStore>;
   private composerInterface!: ComposerInterface;
+  private lockSheetStore!: Store<LockSheetStore>;
 
   setup() {
     this.composerFocusStore = useStore(ComposerFocusStore);
     const composerStore = useStore(CellComposerStore);
+    this.lockSheetStore = useStore(LockSheetStore);
     this.composerStore = composerStore;
     this.composerInterface = {
       id: "topbarComposer",
@@ -55,7 +58,7 @@ export class TopBarComposer extends Component<SpreadsheetChildEnv> {
       "max-height": `${COMPOSER_MAX_HEIGHT}px`,
       "line-height": "24px",
     };
-    if (this.env.model.getters.isCurrentSheetLocked()) {
+    if (this.lockSheetStore.isCurrentSheetLocked) {
       style["pointer-events"] = "none";
     }
     style.height = this.focus === "inactive" ? `${DESKTOP_TOPBAR_TOOLBAR_HEIGHT}px` : "fit-content";

--- a/src/components/figures/figure/figure.ts
+++ b/src/components/figures/figure/figure.ts
@@ -1,11 +1,14 @@
 import { proxy, signal, useProps } from "@odoo/owl";
 import { Component, useLayoutEffect } from "../../../owl3_compatibility_layer";
 import { figureRegistry } from "../../../registries/figures_registry";
+import { useStore } from "../../../store_engine/store_hooks";
+import { LockSheetStore } from "../../../stores/lock_sheet_store";
 import { MoveFiguresPayload } from "../../../types/commands";
 import { AnchorOffset, ResizeDirection } from "../../../types/figure";
 import { CSSProperties, Pixel } from "../../../types/misc";
 import { Rect } from "../../../types/rendering";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
+import { Store } from "../../../types/store_engine";
 import { cssPropertiesToCss } from "../../helpers/css";
 import { keyboardEventToShortcutString } from "../../helpers/dom_helpers";
 import { withZoom } from "../../helpers/zoom";
@@ -42,6 +45,8 @@ export class FigureComponent extends Component<SpreadsheetChildEnv> {
       .function<(dirX: ResizeDirection, dirY: ResizeDirection, ev: MouseEvent) => void>()
       .optional(() => () => {}),
   });
+
+  private lockSheetStore!: Store<LockSheetStore>;
 
   private menuState: MenuState = proxy({ isOpen: false, anchorRect: null, menuItems: [] });
 
@@ -101,6 +106,7 @@ export class FigureComponent extends Component<SpreadsheetChildEnv> {
   }
 
   setup() {
+    this.lockSheetStore = useStore(LockSheetStore);
     const borderWidth = figureRegistry.get(this.props.figureUI.tag).borderWidth;
     this.borderWidth = borderWidth !== undefined ? borderWidth : BORDER_WIDTH;
     useLayoutEffect(
@@ -278,7 +284,7 @@ export class FigureComponent extends Component<SpreadsheetChildEnv> {
       this.isSelected &&
       !this.env.isMobile() &&
       !this.env.model.getters.isDashboard() &&
-      !this.env.model.getters.isCurrentSheetLocked()
+      !this.lockSheetStore.isCurrentSheetLocked
     );
   }
 }

--- a/src/components/figures/figure_container/figure_container.ts
+++ b/src/components/figures/figure_container/figure_container.ts
@@ -5,6 +5,7 @@ import { rectUnion } from "../../../helpers/rectangle";
 import { Component } from "../../../owl3_compatibility_layer";
 import { figureRegistry } from "../../../registries/figures_registry";
 import { useStore } from "../../../store_engine/store_hooks";
+import { LockSheetStore } from "../../../stores/lock_sheet_store";
 import { ViewportsStore } from "../../../stores/viewports_store";
 import { AnchorOffset, Figure, FigureUI, ResizeDirection } from "../../../types/figure";
 import { UID } from "../../../types/misc";
@@ -123,9 +124,11 @@ export class FiguresContainer extends Component<SpreadsheetChildEnv> {
     overlappingChartOrCarousel: undefined,
   });
   private viewStore!: Store<ViewportsStore>;
+  private lockSheetStore!: Store<LockSheetStore>;
 
   setup() {
     this.viewStore = useStore(ViewportsStore);
+    this.lockSheetStore = useStore(LockSheetStore);
     onMounted(() => {
       // horrible, but necessary
       // the following line ensures that we render the figures with the correct
@@ -311,7 +314,7 @@ export class FiguresContainer extends Component<SpreadsheetChildEnv> {
       }
     }
 
-    if (this.env.isMobile() || this.env.model.getters.isCurrentSheetLocked()) {
+    if (this.env.isMobile() || this.lockSheetStore.isCurrentSheetLocked) {
       return;
     }
 

--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -42,6 +42,7 @@ import { AutomaticSumStore } from "../../stores/automatic_sum_store";
 import { CheckboxToggleStore } from "../../stores/checkbox_toggle";
 import { ClientFocusStore } from "../../stores/client_focus_store";
 import { HighlightStore } from "../../stores/highlight_store";
+import { LockSheetStore } from "../../stores/lock_sheet_store";
 import { ViewportsStore } from "../../stores/viewports_store";
 import { CellValueType } from "../../types/cells";
 import { ClipboardMIMEType } from "../../types/clipboard";
@@ -164,10 +165,12 @@ export class Grid extends Component<SpreadsheetChildEnv> {
   hoveredCell!: Store<DelayedHoveredCellStore>;
   sidePanel!: Store<SidePanelStore>;
   private automaticSumStore!: Store<AutomaticSumStore>;
+  private lockSheetStore!: Store<LockSheetStore>;
 
   setup() {
     this.highlightStore = useStore(HighlightStore);
     this.viewStore = useStore(ViewportsStore);
+    this.lockSheetStore = useStore(LockSheetStore);
     this.menuState = proxy({
       isOpen: false,
       anchorRect: null,
@@ -509,7 +512,7 @@ export class Grid extends Component<SpreadsheetChildEnv> {
   }
 
   get isAutofillVisible(): boolean {
-    if (this.env.model.getters.isCurrentSheetLocked()) {
+    if (this.lockSheetStore.isCurrentSheetLocked) {
       return false;
     }
     const zone = this.env.model.getters.getSelectedZone();

--- a/src/components/paint_format_button/paint_format_button.ts
+++ b/src/components/paint_format_button/paint_format_button.ts
@@ -5,6 +5,7 @@ import { PaintFormatStore } from "./paint_format_store";
 
 import { useProps } from "@odoo/owl";
 import { Component } from "../../owl3_compatibility_layer";
+import { LockSheetStore } from "../../stores/lock_sheet_store";
 import { types } from "../props_validation";
 export class PaintFormatButton extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-PaintFormatButton";
@@ -14,9 +15,11 @@ export class PaintFormatButton extends Component<SpreadsheetChildEnv> {
   });
 
   private paintFormatStore!: Store<PaintFormatStore>;
+  lockSheetStore!: Store<LockSheetStore>;
 
   setup() {
     this.paintFormatStore = useStore(PaintFormatStore);
+    this.lockSheetStore = useStore(LockSheetStore);
   }
 
   get isActive() {

--- a/src/components/paint_format_button/paint_format_button.xml
+++ b/src/components/paint_format_button/paint_format_button.xml
@@ -3,7 +3,7 @@
     <span
       class="o-menu-item-button"
       title="Paint Format"
-      t-att-class="{'active': this.isActive, 'o-disabled': this.env.model.getters.isCurrentSheetLocked()}"
+      t-att-class="{'active': this.isActive, 'o-disabled': this.lockSheetStore.isCurrentSheetLocked}"
       t-attf-class="{{this.props.class}}"
       t-on-click="this.togglePaintFormat"
       t-on-dblclick="this.onDblClick">

--- a/src/components/tables/table_dropdown_button/table_dropdown_button.ts
+++ b/src/components/tables/table_dropdown_button/table_dropdown_button.ts
@@ -4,10 +4,13 @@ import { DEFAULT_TABLE_CONFIG } from "../../../helpers/table_presets";
 import { interactiveCreateTable } from "../../../helpers/ui/table_interactive";
 import { cellPositions } from "../../../helpers/zones";
 import { Component } from "../../../owl3_compatibility_layer";
+import { useStore } from "../../../store_engine/store_hooks";
+import { LockSheetStore } from "../../../stores/lock_sheet_store";
 import { _t } from "../../../translation";
 import { UID } from "../../../types/misc";
 import { PropsOf } from "../../../types/props_of";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
+import { Store } from "../../../types/store_engine";
 import { TableConfig } from "../../../types/table";
 import { ActionButton } from "../../action_button/action_button";
 import { ToolBarDropdownStore, useToolBarDropdownStore } from "../../helpers/top_bar_tool_hook";
@@ -32,9 +35,11 @@ export class TableDropdownButton extends Component<SpreadsheetChildEnv> {
 
   topBarToolStore!: ToolBarDropdownStore;
   state = proxy<State>({ popoverProps: undefined });
+  lockSheetStore!: Store<LockSheetStore>;
 
   setup() {
     this.topBarToolStore = useToolBarDropdownStore();
+    this.lockSheetStore = useStore(LockSheetStore);
   }
 
   onStylePicked(styleId: string) {
@@ -133,7 +138,7 @@ export class TableDropdownButton extends Component<SpreadsheetChildEnv> {
 
   get class() {
     return `${this.props.class ? this.props.class : ""} ${
-      this.env.model.getters.isCurrentSheetLocked() ? "o-disabled" : ""
+      this.lockSheetStore.isCurrentSheetLocked ? "o-disabled" : ""
     }`;
   }
 }

--- a/src/components/top_bar/color_editor/color_editor.ts
+++ b/src/components/top_bar/color_editor/color_editor.ts
@@ -2,7 +2,10 @@ import { proxy, useProps } from "@odoo/owl";
 import { setStyle } from "../../../actions/menu_items_actions";
 import { deepEquals } from "../../../helpers/misc";
 import { Component } from "../../../owl3_compatibility_layer";
+import { useStore } from "../../../store_engine/store_hooks";
+import { LockSheetStore } from "../../../stores/lock_sheet_store";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
+import { Store } from "../../../types/store_engine";
 import { ColorPickerWidget } from "../../color_picker/color_picker_widget";
 import { ToolBarDropdownStore, useToolBarDropdownStore } from "../../helpers/top_bar_tool_hook";
 import { types } from "../../props_validation";
@@ -18,6 +21,7 @@ export class TopBarColorEditor extends Component<SpreadsheetChildEnv> {
     title: types.string(),
   });
   topBarToolStore!: ToolBarDropdownStore;
+  lockSheetStore!: Store<LockSheetStore>;
 
   state = proxy({
     isOpen: false,
@@ -25,6 +29,7 @@ export class TopBarColorEditor extends Component<SpreadsheetChildEnv> {
 
   setup() {
     this.topBarToolStore = useToolBarDropdownStore();
+    this.lockSheetStore = useStore(LockSheetStore);
   }
   get currentColor(): string {
     return (

--- a/src/components/top_bar/color_editor/color_editor.xml
+++ b/src/components/top_bar/color_editor/color_editor.xml
@@ -2,7 +2,7 @@
   <t t-name="o-spreadsheet-ColorEditor">
     <div
       class="d-flex align-items-center"
-      t-att-class="{'o-disabled': this.env.model.getters.isCurrentSheetLocked() }">
+      t-att-class="{'o-disabled': this.lockSheetStore.isCurrentSheetLocked }">
       <ColorPickerWidget
         currentColor="this.currentColor"
         toggleColorPicker.bind="this.onClick"

--- a/src/components/top_bar/font_size_editor/font_size_editor.ts
+++ b/src/components/top_bar/font_size_editor/font_size_editor.ts
@@ -2,7 +2,10 @@ import { useProps } from "@odoo/owl";
 import { setStyle } from "../../../actions/menu_items_actions";
 import { DEFAULT_FONT_SIZE } from "../../../constants";
 import { Component } from "../../../owl3_compatibility_layer";
+import { useStore } from "../../../store_engine/store_hooks";
+import { LockSheetStore } from "../../../stores/lock_sheet_store";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
+import { Store } from "../../../types/store_engine";
 import { FontSizeEditor } from "../../font_size_editor/font_size_editor";
 import { ToolBarDropdownStore, useToolBarDropdownStore } from "../../helpers/top_bar_tool_hook";
 import { types } from "../../props_validation";
@@ -13,9 +16,11 @@ export class TopBarFontSizeEditor extends Component<SpreadsheetChildEnv> {
 
   protected props = useProps({ class: types.string() });
   topBarToolStore!: ToolBarDropdownStore;
+  lockSheetStore!: Store<LockSheetStore>;
 
   setup() {
     this.topBarToolStore = useToolBarDropdownStore();
+    this.lockSheetStore = useStore(LockSheetStore);
   }
 
   get currentFontSize(): number {
@@ -42,8 +47,6 @@ export class TopBarFontSizeEditor extends Component<SpreadsheetChildEnv> {
   }
 
   get class() {
-    return `${this.props.class} ${
-      this.env.model.getters.isCurrentSheetLocked() ? "o-disabled" : ""
-    }`;
+    return `${this.props.class} ${this.lockSheetStore.isCurrentSheetLocked ? "o-disabled" : ""}`;
   }
 }

--- a/src/model.ts
+++ b/src/model.ts
@@ -29,6 +29,7 @@ import { StateObserver } from "./state_observer";
 import { _t, setDefaultTranslationMethod } from "./translation";
 import { StateUpdateMessage } from "./types/collaborative/transport_service";
 import {
+  AllowDispatchHandler,
   canExecuteInReadonly,
   Command,
   CommandDispatcher,
@@ -38,6 +39,7 @@ import {
   CoreCommand,
   DispatchResult,
   isCoreCommand,
+  LocalCommand,
 } from "./types/commands";
 import { CoreGetters } from "./types/core_getters";
 import { Getters } from "./types/getters";
@@ -139,6 +141,10 @@ export class Model extends EventBus<any> implements CommandDispatcher {
   private readonly uiHandlers: CommandHandler<Command>[] = [];
   private readonly coreHandlers: CommandHandler<CoreCommand>[] = [];
 
+  // TODO FIXME: Remove this and do something better for the stores
+  private readonly allowDispatchHandlers: AllowDispatchHandler<Command>[] = [];
+  private readonly uiAllowDispatchHandlers: AllowDispatchHandler<Command>[] = [];
+
   constructor(
     data: any = {},
     config: Partial<ModelConfig> = {},
@@ -190,6 +196,7 @@ export class Model extends EventBus<any> implements CommandDispatcher {
 
     this.coreHandlers.push(this.range);
     this.handlers.push(this.range);
+    this.allowDispatchHandlers.push(this.range);
 
     this.corePluginConfig = this.setupCorePluginConfig();
     this.coreViewPluginConfig = this.setupCoreViewPluginConfig();
@@ -206,19 +213,25 @@ export class Model extends EventBus<any> implements CommandDispatcher {
     for (const Plugin of coreViewsPluginRegistry.getAll()) {
       const plugin = this.setupCoreViewPlugin(Plugin);
       this.handlers.push(plugin);
+      this.allowDispatchHandlers.push(plugin);
       this.uiHandlers.push(plugin);
+      this.uiAllowDispatchHandlers.push(plugin);
       this.coreHandlers.push(plugin);
     }
     for (const Plugin of statefulUIPluginRegistry.getAll()) {
       const plugin = this.setupUiPlugin(Plugin);
       this.statefulUIPlugins.push(plugin);
       this.handlers.push(plugin);
+      this.allowDispatchHandlers.push(plugin);
       this.uiHandlers.push(plugin);
+      this.uiAllowDispatchHandlers.push(plugin);
     }
     for (const Plugin of featurePluginRegistry.getAll()) {
       const plugin = this.setupUiPlugin(Plugin);
       this.handlers.push(plugin);
+      this.allowDispatchHandlers.push(plugin);
       this.uiHandlers.push(plugin);
+      this.uiAllowDispatchHandlers.push(plugin);
     }
 
     if (this.config.mode !== "export_verification") {
@@ -312,6 +325,7 @@ export class Model extends EventBus<any> implements CommandDispatcher {
     this.corePlugins.push(plugin);
     this.coreHandlers.push(plugin);
     this.handlers.push(plugin);
+    this.allowDispatchHandlers.push(plugin);
   }
 
   private onRemoteRevisionReceived({ commands }: { commands: readonly CoreCommand[] }) {
@@ -472,11 +486,11 @@ export class Model extends EventBus<any> implements CommandDispatcher {
   }
 
   private checkDispatchAllowedCoreCommand(command: CoreCommand) {
-    return this.handlers.map((handler) => handler.allowDispatch(command));
+    return this.allowDispatchHandlers.map((handler) => handler.allowDispatch(command));
   }
 
-  private checkDispatchAllowedLocalCommand(command: Command) {
-    return this.uiHandlers.map((handler) => handler.allowDispatch(command));
+  private checkDispatchAllowedLocalCommand(command: LocalCommand) {
+    return this.uiAllowDispatchHandlers.map((handler) => handler.allowDispatch(command));
   }
 
   private finalize() {
@@ -698,6 +712,22 @@ export class Model extends EventBus<any> implements CommandDispatcher {
     data = deepCopy(data);
 
     return getXLSX(data);
+  }
+
+  registerExternalAllowDispatch(allowDispatchHandler: AllowDispatchHandler<Command>) {
+    this.allowDispatchHandlers.push(allowDispatchHandler);
+    this.uiAllowDispatchHandlers.push(allowDispatchHandler);
+  }
+
+  unregisterExternalAllowDispatch(allowDispatchHandler: AllowDispatchHandler<Command>) {
+    const uiIndex = this.uiAllowDispatchHandlers.indexOf(allowDispatchHandler);
+    if (uiIndex !== -1) {
+      this.uiAllowDispatchHandlers.splice(uiIndex, 1);
+    }
+    const index = this.allowDispatchHandlers.indexOf(allowDispatchHandler);
+    if (index !== -1) {
+      this.allowDispatchHandlers.splice(index, 1);
+    }
   }
 }
 

--- a/src/plugins/plugin_registries.ts
+++ b/src/plugins/plugin_registries.ts
@@ -43,7 +43,6 @@ import { GeoFeaturePlugin } from "./ui_feature/geo_features";
 import { HeaderVisibilityUIPlugin } from "./ui_feature/header_visibility_ui";
 import { InsertPivotPlugin } from "./ui_feature/insert_pivot";
 import { HistoryPlugin } from "./ui_feature/local_history";
-import { LockSheetPlugin } from "./ui_feature/lock_sheet";
 import { PivotPresencePlugin } from "./ui_feature/pivot_presence_plugin";
 import { SortPlugin } from "./ui_feature/sort";
 import { SplitToColumnsPlugin } from "./ui_feature/split_to_columns";
@@ -109,7 +108,6 @@ export const statefulUIPluginRegistry = new Registry<UIPluginConstructor>()
   .add("header_positions", HeaderPositionsUIPlugin)
   .add("clipboard", ClipboardPlugin)
   .add("carousel_ui", CarouselUIPlugin)
-  .add("lock_sheet", LockSheetPlugin)
   .add("figure_ui", FigureUIPlugin);
 
 // Plugins which have a derived state from core data

--- a/src/store_engine/store_registries.ts
+++ b/src/store_engine/store_registries.ts
@@ -1,5 +1,8 @@
 import { Registry } from "../registries/registry";
+import { LockSheetStore } from "../stores/lock_sheet_store";
 import { SpreadsheetStore } from "../stores/spreadsheet_store";
 import { StoreConstructor } from "../types/store_engine";
 
 export const globalStores = new Registry<StoreConstructor<SpreadsheetStore>>();
+
+globalStores.add("lock_sheet", LockSheetStore);

--- a/src/stores/lock_sheet_store.ts
+++ b/src/stores/lock_sheet_store.ts
@@ -3,12 +3,11 @@ import {
   CommandResult,
   isCoreCommand,
   lockedSheetAllowedCommands,
-} from "../../types/commands";
-import { UIPlugin } from "../ui_plugin";
+} from "../types/commands";
+import { Get } from "../types/store_engine";
+import { SpreadsheetStore } from "./spreadsheet_store";
 
-export class LockSheetPlugin extends UIPlugin {
-  static getters = ["isCurrentSheetLocked"] as const;
-
+export class LockSheetStore extends SpreadsheetStore {
   allowDispatch(cmd: Command): CommandResult | CommandResult[] {
     /**
      * isDashboard() implies that the user is not connected
@@ -20,14 +19,22 @@ export class LockSheetPlugin extends UIPlugin {
     }
     if (
       ("sheetId" in cmd && this.getters.isSheetLocked(cmd.sheetId)) ||
-      (!isCoreCommand(cmd) && this.isCurrentSheetLocked())
+      (!isCoreCommand(cmd) && this.isCurrentSheetLocked)
     ) {
       return CommandResult.SheetLocked;
     }
     return CommandResult.Success;
   }
 
-  isCurrentSheetLocked() {
+  get isCurrentSheetLocked() {
     return this.getters.isSheetLocked(this.getters.getActiveSheetId());
+  }
+
+  constructor(get: Get) {
+    super(get);
+    this.model.registerExternalAllowDispatch(this);
+    this.onDispose(() => {
+      this.model.unregisterExternalAllowDispatch(this);
+    });
   }
 }

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -1566,6 +1566,10 @@ export interface CommandHandler<T> {
   finalize(): void;
 }
 
+export interface AllowDispatchHandler<T> {
+  allowDispatch(command: T): CommandResult | CommandResult[];
+}
+
 export interface CommandDispatcher {
   dispatch<T extends CommandTypes, C extends Extract<Command, { type: T }>>(
     type: {} extends Omit<C, "type"> ? T : never

--- a/src/types/getters.ts
+++ b/src/types/getters.ts
@@ -18,7 +18,6 @@ import { FigureUIPlugin } from "../plugins/ui_feature/figure";
 import { GeoFeaturePlugin } from "../plugins/ui_feature/geo_features";
 import { HeaderVisibilityUIPlugin } from "../plugins/ui_feature/header_visibility_ui";
 import { HistoryPlugin } from "../plugins/ui_feature/local_history";
-import { LockSheetPlugin } from "../plugins/ui_feature/lock_sheet";
 import { PivotPresencePlugin } from "../plugins/ui_feature/pivot_presence_plugin";
 import { SortPlugin } from "../plugins/ui_feature/sort";
 import { SplitToColumnsPlugin } from "../plugins/ui_feature/split_to_columns";
@@ -73,7 +72,6 @@ export type RenderingGetters = {
   PluginGetters<typeof CellIconPlugin> &
   PluginGetters<typeof DynamicTranslate> &
   PluginGetters<typeof FormulaTrackerPlugin> &
-  PluginGetters<typeof LockSheetPlugin> &
   PluginGetters<typeof CarouselUIPlugin> &
   PluginGetters<typeof ColorThemeUIPlugin> &
   PluginGetters<typeof FigureUIPlugin>;

--- a/tests/lock_sheet/lock_sheet_plugin.test.ts
+++ b/tests/lock_sheet/lock_sheet_plugin.test.ts
@@ -11,6 +11,7 @@ import {
 import { createChart, createSheet, lockSheet } from "../test_helpers/commands_helpers";
 import { TEST_COMMANDS } from "../test_helpers/constants";
 import { addPivot } from "../test_helpers/pivot_helpers";
+import { makeGlobalStoreWithModel } from "../test_helpers/stores";
 
 const allowedCommands: Command["type"][] = [];
 const rejectedCommands: Command["type"][] = [];
@@ -34,7 +35,7 @@ describe("Lock Sheet plugin", () => {
   test.each<Command["type"]>(rejectedCommands)(
     "Cannot dispatch blacklisted command %s on a locked sheet",
     (cmdType) => {
-      const model = new Model();
+      const { model } = makeGlobalStoreWithModel(new Model());
       lockSheet(model);
       const result = model.dispatch(cmdType, TEST_COMMANDS[cmdType]);
       expect(result.reasons).toContain(CommandResult.SheetLocked);
@@ -42,7 +43,7 @@ describe("Lock Sheet plugin", () => {
   );
 
   test("Can dispatch white-listed commands on a locked sheet", () => {
-    const model = new Model();
+    const { model } = makeGlobalStoreWithModel(new Model());
     createSheet(model, { name: "Another sheet", position: 0 });
     lockSheet(model);
     for (const cmdType of allowedCommands) {
@@ -53,7 +54,7 @@ describe("Lock Sheet plugin", () => {
 
   test("read only commands bypass lock in dashboard mode", () => {
     for (const cmdType of readonlyCommands) {
-      const model = new Model();
+      const { model } = makeGlobalStoreWithModel(new Model());
       createSheet(model, { name: "Another sheet", position: 0 });
       createChart(model, { type: "bar" }, "chartId");
       addPivot(model);
@@ -65,7 +66,7 @@ describe("Lock Sheet plugin", () => {
   });
 
   test("sheet navigation commands are allowed on locked sheets", () => {
-    const model = new Model();
+    const { model } = makeGlobalStoreWithModel(new Model());
     const firstSheetId = model.getters.getActiveSheetId();
     const lockedSheetId = "locked";
     createSheet(model, {

--- a/tests/model/model.test.ts
+++ b/tests/model/model.test.ts
@@ -420,4 +420,42 @@ describe("Model", () => {
       type: "SNAPSHOT",
     });
   });
+
+  test("Can register an external allow dispatch handler", () => {
+    const receivedCommands: CommandTypes[] = [];
+    class TestHandler {
+      allowDispatch(cmd: Command): CommandResult {
+        receivedCommands.push(cmd.type);
+        return CommandResult.CancelledForUnknownReason;
+      }
+    }
+    const model = new Model();
+    model.registerExternalAllowDispatch(new TestHandler());
+    expect(model.dispatch("EVALUATE_CELLS")).toBeCancelledBecause(
+      CommandResult.CancelledForUnknownReason
+    );
+    expect(setCellContent(model, "A1", "hello")).toBeCancelledBecause(
+      CommandResult.CancelledForUnknownReason
+    );
+    expect(receivedCommands).toEqual(["EVALUATE_CELLS", "UPDATE_CELL"]);
+  });
+
+  test("External allow dispatch handler do not receive remote commands", () => {
+    const receivedCommands: CommandTypes[] = [];
+    class TestHandler {
+      allowDispatch(cmd: Command): CommandResult {
+        receivedCommands.push(cmd.type);
+        return CommandResult.CancelledForUnknownReason;
+      }
+    }
+    const { alice, bob, charlie } = setupCollaborativeEnv();
+    bob.registerExternalAllowDispatch(new TestHandler());
+
+    expect(setCellContent(alice, "A1", "hello")).toBeSuccessfullyDispatched();
+    expect(receivedCommands).toEqual([]);
+    expect([alice, bob, charlie]).toHaveSynchronizedValue(
+      (user) => getCellContent(user, "A1"),
+      "hello"
+    );
+  });
 });


### PR DESCRIPTION
## Description:

### [REF] lock_sheet: make lock sheet plugin into a store

This commit transforms the lock sheet plugin into a store.

### [IMP] model: add external allow dispatch handlers

This commit adds a method `registerExternalAllowDispatch` to the
model that allows external allow dispatch handlers (stores).

It's not great. This should eb a temporary solution to transform plugin
into stores, with a later reflection and re-evaluation or the command
handling/store business.

Task: [6395361](https://www.odoo.com/odoo/2328/tasks/6395361)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo