### PR TITLE
[FIX] chart: geoChart uses same d3 projection for main and full screen chart

### DIFF
--- a/src/components/figures/chart/chartJs/chartjs.ts
+++ b/src/components/figures/chart/chartJs/chartjs.ts
@@ -18,6 +18,7 @@ import {
   getFunnelChartController,
   getFunnelChartElement,
 } from "./chartjs_funnel_chart";
+import { geoProjectionPlugin } from "./chartjs_geo_projection_plugin";
 import { chartMinorGridPlugin } from "./chartjs_minor_grid_plugin";
 import { chartShowValuesPlugin } from "./chartjs_show_values_plugin";
 import { sunburstHoverPlugin } from "./chartjs_sunburst_hover_plugin";
@@ -78,6 +79,10 @@ chartJsExtensionRegistry.add("zoomWindowPlugin", {
 chartJsExtensionRegistry.add("chartBackgroundPlugin", {
   register: (Chart) => Chart.register(chartBackgroundPlugin),
   unregister: (Chart) => Chart.unregister(chartBackgroundPlugin),
+});
+chartJsExtensionRegistry.add("geoProjectionPlugin", {
+  register: (Chart) => Chart.register(geoProjectionPlugin),
+  unregister: (Chart) => Chart.unregister(geoProjectionPlugin),
 });
 
 export class ChartJsComponent extends Component<Props, SpreadsheetChildEnv> {

--- a/src/components/figures/chart/chartJs/chartjs_geo_projection_plugin.ts
+++ b/src/components/figures/chart/chartJs/chartjs_geo_projection_plugin.ts
@@ -1,0 +1,20 @@
+import { Plugin } from "chart.js";
+
+/**
+ * ChartJS plugin to apply custom changes to a d3 projection.
+ *
+ * We pass the projection as a string instead of a customized d3 object so
+ * Chart.js creates a fresh projection instance. Custom changes (e.g. rotation)
+ * are then applied in `beforeUpdate`.
+ *
+ * This is important because Chart.js mutates the projection instance at runtime,
+ * and a customize d3 projection object would not be copied during deepCopy.
+ */
+export const geoProjectionPlugin: Plugin = {
+  id: "geoProjection",
+  beforeUpdate(chart: any) {
+    if (chart.options?.scales?.projection?.projection === "conicConformal") {
+      chart.scales?.projection?.projection?.rotate([100, 0]); // Centered on the US
+    }
+  },
+};

--- a/src/helpers/figures/charts/runtime/chartjs_scales.ts
+++ b/src/helpers/figures/charts/runtime/chartjs_scales.ts
@@ -27,7 +27,6 @@ import {
 import { CalendarChartDefinition } from "../../../../types/chart/calendar_chart";
 import {
   GeoChartDefinition,
-  GeoChartProjection,
   GeoChartRuntimeGenerationArgs,
 } from "../../../../types/chart/geo_chart";
 import { RadarChartDefinition } from "../../../../types/chart/radar_chart";
@@ -377,8 +376,7 @@ export function getGeoChartScales(
   const format = axisFormats?.y || axisFormats?.y1;
   return {
     projection: {
-      // projection: region?.defaultProjection,
-      projection: getGeoChartProjection(region?.defaultProjection || "mercator"),
+      projection: region?.defaultProjection || "mercator",
       axis: "x" as const,
     },
     color: {
@@ -443,13 +441,6 @@ export function getFunnelChartScales(
       grid: { display: false },
     },
   };
-}
-
-function getGeoChartProjection(projection: GeoChartProjection) {
-  if (projection === "conicConformal") {
-    return globalThis.ChartGeo.geoConicConformal().rotate([100, 0]); // Centered on the US
-  }
-  return projection;
 }
 
 function getChartAxisTitleRuntime(design?: AxisDesign):

--- a/tests/figures/chart/charts_component.test.ts
+++ b/tests/figures/chart/charts_component.test.ts
@@ -3145,6 +3145,7 @@ test("ChartJS charts extensions are loaded when mounting a spreadsheet, are only
     "calendar", // Calendar controller
     "zoomWindowPlugin",
     "background",
+    "geoProjection",
   ]);
 
   createChart(model, { type: "line" }, "chart2");

--- a/tests/figures/chart/geochart/geo_chart_panel_component.test.ts
+++ b/tests/figures/chart/geochart/geo_chart_panel_component.test.ts
@@ -84,7 +84,7 @@ describe("Geo chart side panel", () => {
       const choices = [
         ...fixture.querySelectorAll<HTMLOptionElement>(".o-popover .o-select-option"),
       ];
-      expect(choices.map((el) => el.dataset.id)).toEqual(["world", "usa"]);
+      expect(choices.map((el) => el.dataset.id)).toEqual(["world", "usa", "northAmerica"]);
 
       await simulateClick(`.o-popover .o-select-option[data-id="usa"]`);
       expect(getGeoChartDefinition(chartId)?.region).toEqual("usa");

--- a/tests/figures/chart/geochart/geo_chart_plugin.test.ts
+++ b/tests/figures/chart/geochart/geo_chart_plugin.test.ts
@@ -1,4 +1,5 @@
 import { Model } from "../../../../src";
+import { geoProjectionPlugin } from "../../../../src/components/figures/chart/chartJs/chartjs_geo_projection_plugin";
 import { GeoChartRuntime } from "../../../../src/types/chart/geo_chart";
 import {
   createChart,
@@ -148,6 +149,12 @@ describe("Geo charts plugin tests", () => {
     updateChart(model, "chartId", { region: "usa" });
     const runtime2 = model.getters.getChartRuntime("chartId") as GeoChartRuntime;
     expect(runtime2.chartJsConfig.options?.scales?.projection?.["projection"]).toBe("albersUsa");
+
+    updateChart(model, "chartId", { region: "northAmerica" });
+    const runtime3 = model.getters.getChartRuntime("chartId") as GeoChartRuntime;
+    expect(runtime3.chartJsConfig.options?.scales?.projection?.["projection"]).toBe(
+      "conicConformal"
+    );
   });
 
   test("Can define colors of countries not in the dataset", () => {
@@ -157,6 +164,28 @@ describe("Geo charts plugin tests", () => {
 
     // The countries that have no data should still be in the runtime, otherwise the missing color won't be applied
     expect(runtime.chartJsConfig.data.datasets[0].data.length).toBe(3);
+  });
+
+  describe("geoProjectionPlugin", () => {
+    test("applies rotation for conicConformal projection", () => {
+      const rotateFn = jest.fn();
+      const chart = {
+        options: { scales: { projection: { projection: "conicConformal" } } },
+        scales: { projection: { projection: { rotate: rotateFn } } },
+      };
+      (geoProjectionPlugin.beforeUpdate as Function)(chart);
+      expect(rotateFn).toHaveBeenCalledWith([100, 0]);
+    });
+
+    test("does not rotate non-conicConformal projections", () => {
+      const rotateFn = jest.fn();
+      const chart = {
+        options: { scales: { projection: { projection: "mercator" } } },
+        scales: { projection: { projection: { rotate: rotateFn } } },
+      };
+      (geoProjectionPlugin.beforeUpdate as Function)(chart);
+      expect(rotateFn).not.toHaveBeenCalled();
+    });
   });
 
   describe("UPDATE_CHART_REGION", () => {
@@ -171,7 +200,7 @@ describe("Geo charts plugin tests", () => {
     test("getAvailableChartRegions returns alternatives for a world chart", () => {
       createGeoChart(model, { region: "world" });
       const regions = model.getters.getAvailableChartRegions("chartId");
-      expect(regions.map((r) => r.id)).toEqual(["world"]);
+      expect(regions.map((r) => r.id)).toEqual(["world", "northAmerica"]);
       expect(regions.find((r) => r.id === "usa")).toBeUndefined();
     });
 

--- a/tests/test_helpers/helpers.ts
+++ b/tests/test_helpers/helpers.ts
@@ -987,6 +987,7 @@ export const mockChart = (options: any = {}) => {
 const getAvailableRegions: () => GeoChartRegion[] = () => [
   { id: "world", label: "World", defaultProjection: "mercator" },
   { id: "usa", label: "United States", defaultProjection: "albersUsa" },
+  { id: "northAmerica", label: "North America", defaultProjection: "conicConformal" },
 ];
 
 export const mockGeoJsonService: ModelExternalConfig["geoJsonService"] = {


### PR DESCRIPTION
## Description:

Current behavior before PR:
- For North America, we pass a custom d3 projection to rotate the 
`conicConformal` projection.
- However, since functions are not deep copied, the same projection object is
shared between the main and full screen charts.
- ChartJS updates this projection in place, causing the charts to
reuse each other's scale and resulting in an incorrect chart size.
- Other regions are not affected as they pass the projection as a string,
allowing ChartJS to create a fresh d3 projection for each chart.

Desired behavior after PR is merged:
- We now pass `conicConformal` as a string as well and use a ChartJS plugin
to apply the required 100-degree rotation.
- This ensures each chart gets its own d3 projection instance and
prevents the projection state from being shared between the main and full screen charts.

Task: [6395379](https://www.odoo.com/odoo/2328/tasks/6395379)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo