### PR TITLE
[REF] automatic evaluation: move it to a core view plugin

### DIFF
--- a/src/plugins/ui_core_views/cell_evaluation/evaluation_plugin.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluation_plugin.ts
@@ -6,7 +6,7 @@ import { positions } from "../../../helpers/zones";
 import { CellValue, CellValueType, EvaluatedCell, FormulaCell } from "../../../types/cells";
 import {
   Command,
-  CoreViewCommand,
+  CommandResult,
   invalidateDependenciesCommands,
   invalidateEvaluationCommands,
 } from "../../../types/commands";
@@ -159,10 +159,12 @@ export class EvaluationPlugin extends CoreViewPlugin {
     "isArrayFormulaSpillBlocked",
     "isEmpty",
     "getPerfProfile",
+    "isAutomaticEvaluationEnabled",
   ] as const;
 
   private shouldRebuildDependenciesGraph = true;
   private forceEvaluation = false;
+  private automaticEvaluation: boolean = true;
 
   private evaluator: Evaluator;
   private positionsToUpdate: CellPosition[] = [];
@@ -176,6 +178,17 @@ export class EvaluationPlugin extends CoreViewPlugin {
   // Command Handling
   // ---------------------------------------------------------------------------
 
+  allowDispatch(cmd: Command) {
+    switch (cmd.type) {
+      case "SET_AUTOMATIC_EVALUATION":
+        if (cmd.enabled === this.automaticEvaluation) {
+          return CommandResult.NoChangeInAutomaticEvaluation;
+        }
+        return CommandResult.Success;
+    }
+    return CommandResult.Success;
+  }
+
   beforeHandle(cmd: Command) {
     this.forceEvaluation = false;
     if (
@@ -186,7 +199,7 @@ export class EvaluationPlugin extends CoreViewPlugin {
     }
   }
 
-  handle(cmd: CoreViewCommand) {
+  handle(cmd: Command) {
     switch (cmd.type) {
       case "UPDATE_CELL":
         if (!("content" in cmd || "format" in cmd) || this.shouldRebuildDependenciesGraph) {
@@ -199,9 +212,15 @@ export class EvaluationPlugin extends CoreViewPlugin {
           this.evaluator.updateDependencies(position);
         }
         break;
+      case "SET_AUTOMATIC_EVALUATION":
+        this.automaticEvaluation = cmd.enabled;
+        if (cmd.enabled) {
+          this.shouldRebuildDependenciesGraph = true;
+        }
+        break;
       case "EVALUATE_CELLS":
         this.forceEvaluation = true;
-        if (!this.getters.isAutomaticEvaluationEnabled()) {
+        if (!this.automaticEvaluation) {
           // When automatic evaluation is disabled, EVALUATE_CELLS should rebuild dependencies
           // and evaluate all cells to ensure consistency
           this.shouldRebuildDependenciesGraph = true;
@@ -240,6 +259,14 @@ export class EvaluationPlugin extends CoreViewPlugin {
   // ---------------------------------------------------------------------------
   // Getters
   // ---------------------------------------------------------------------------
+
+  /**
+   * Returns whether automatic evaluation is enabled.
+   * When disabled, cells are only re-evaluated on explicit EVALUATE_CELLS commands (F9).
+   */
+  isAutomaticEvaluationEnabled(): boolean {
+    return this.automaticEvaluation;
+  }
 
   evaluateFormula(
     sheetId: UID,
@@ -329,7 +356,7 @@ export class EvaluationPlugin extends CoreViewPlugin {
   }
 
   shouldPerformEvaluation(): boolean {
-    return this.forceEvaluation || this.getters.isAutomaticEvaluationEnabled();
+    return this.forceEvaluation || this.isAutomaticEvaluationEnabled();
   }
 
   /**

--- a/src/plugins/ui_feature/ui_options.ts
+++ b/src/plugins/ui_feature/ui_options.ts
@@ -2,9 +2,8 @@ import { Command } from "../../types/commands";
 import { UIPlugin } from "../ui_plugin";
 
 export class UIOptionsPlugin extends UIPlugin {
-  static getters = ["shouldShowFormulas", "isAutomaticEvaluationEnabled"] as const;
+  static getters = ["shouldShowFormulas"] as const;
   private showFormulas: boolean = false;
-  private automaticEvaluation: boolean = true;
 
   // ---------------------------------------------------------------------------
   // Command Handling
@@ -15,15 +14,6 @@ export class UIOptionsPlugin extends UIPlugin {
       case "SET_FORMULA_VISIBILITY":
         this.showFormulas = cmd.show;
         break;
-      case "SET_AUTOMATIC_EVALUATION":
-        const wasDisabled = !this.automaticEvaluation;
-        this.automaticEvaluation = cmd.enabled;
-        // When re-enabling automatic evaluation, trigger a full evaluation
-        // to update all cells, charts, pivots, etc. that may have changed
-        if (wasDisabled && cmd.enabled) {
-          this.dispatch("EVALUATE_CELLS");
-        }
-        break;
     }
   }
 
@@ -33,13 +23,5 @@ export class UIOptionsPlugin extends UIPlugin {
 
   shouldShowFormulas(): boolean {
     return this.showFormulas;
-  }
-
-  /**
-   * Returns whether automatic evaluation is enabled.
-   * When disabled, cells are only re-evaluated on explicit EVALUATE_CELLS commands (F9).
-   */
-  isAutomaticEvaluationEnabled(): boolean {
-    return this.automaticEvaluation;
   }
 }

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -1557,6 +1557,7 @@ export const enum CommandResult {
   NamedRangeNameLooksLikeCellReference = "NamedRangeNameLooksLikeCellReference",
   NamedRangeNotFound = "NamedRangeNotFound",
   SubCommandOnly = "SubCommandOnly",
+  NoChangeInAutomaticEvaluation = "NoChangeInAutomaticEvaluation",
 }
 
 export interface CommandHandler<T> {


### PR DESCRIPTION
Evaluation should only depend on the core and core view plugins. This commit moves the automatic evaluation feature to a core view plugin.

Note that this commit introduces a little regression: re-enabling automatic evaluation does not trigger evaluation automatically. This is because the automatic evaluation plugin is a core view plugin, and core view plugins cannot dispatch a command. We could add a ui_feature plugin with a beforeHandle that checks the state of the automatic evaluation plugin and dispatches the evaluation command, but this would be a bit overkill. Instead, we can just add a dispatch to the two places where automatic evaluation is re-enabled (the top bar and the data action).

Task: 6425453

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo