### PR TITLE
[REF] evaluation: drop UIPlugin dependencies from formula evaluation

### DIFF
--- a/src/components/pivot_html_renderer/pivot_html_renderer.ts
+++ b/src/components/pivot_html_renderer/pivot_html_renderer.ts
@@ -68,7 +68,8 @@ export class PivotHTMLRenderer extends Component<SpreadsheetChildEnv> {
   }
 
   get tracker() {
-    return this.env.model.getters.getPivotPresenceTracker(this.props.pivotId);
+    const sheetId = this.env.model.getters.getActiveSheetId();
+    return this.env.model.getters.getPivotPresenceTracker(this.props.pivotId, sheetId);
   }
 
   // ---------------------------------------------------------------------

--- a/src/functions/module_lookup.ts
+++ b/src/functions/module_lookup.ts
@@ -838,9 +838,9 @@ export const PIVOT_VALUE = {
       };
     }
     const domain = pivot.parseArgsToPivotDomain(domainArgs);
-    if (this.getters.getActiveSheetId() === this.__originSheetId) {
-      this.getters.getPivotPresenceTracker(pivotId)?.trackValue(_measure, domain);
-    }
+    this.getters
+      .getPivotPresenceTracker(pivotId, this.__originSheetId)
+      ?.trackValue(_measure, domain);
     return pivot.getPivotCellValueAndFormat(_measure, domain);
   },
 } satisfies AddFunctionDescription;
@@ -879,9 +879,7 @@ export const PIVOT_HEADER = {
       };
     }
     const domain = pivot.parseArgsToPivotDomain(domainArgs);
-    if (this.getters.getActiveSheetId() === this.__originSheetId) {
-      this.getters.getPivotPresenceTracker(_pivotId)?.trackHeader(domain);
-    }
+    this.getters.getPivotPresenceTracker(_pivotId, this.__originSheetId)?.trackHeader(domain);
     const lastNode = domain.at(-1);
     if (lastNode?.field === "measure") {
       return pivot.getPivotMeasureValue(toString(lastNode.value), domain);

--- a/src/plugins/plugin_registries.ts
+++ b/src/plugins/plugin_registries.ts
@@ -28,9 +28,11 @@ import { DynamicTablesPlugin } from "./ui_core_views/dynamic_tables";
 import { EvaluationChartPlugin } from "./ui_core_views/evaluation_chart";
 import { EvaluationConditionalFormatPlugin } from "./ui_core_views/evaluation_conditional_format";
 import { EvaluationDataValidationPlugin } from "./ui_core_views/evaluation_data_validation";
+import { FilterEvaluationPlugin } from "./ui_core_views/filter_evaluation";
 import { FingerprintPlugin } from "./ui_core_views/fingerprint";
 import { FormulaTrackerPlugin } from "./ui_core_views/formula_tracker";
 import { HeaderSizeUIPlugin } from "./ui_core_views/header_sizes_ui";
+import { PivotPresencePlugin } from "./ui_core_views/pivot_presence_plugin";
 import { PivotUIPlugin } from "./ui_core_views/pivot_ui";
 import { CollaborativePlugin } from "./ui_feature/collaborative";
 import { ColorThemeUIPlugin } from "./ui_feature/color_theme";
@@ -40,7 +42,6 @@ import { FormatPlugin } from "./ui_feature/format";
 import { GeoFeaturePlugin } from "./ui_feature/geo_features";
 import { InsertPivotPlugin } from "./ui_feature/insert_pivot";
 import { HistoryPlugin } from "./ui_feature/local_history";
-import { PivotPresencePlugin } from "./ui_feature/pivot_presence_plugin";
 import { SortPlugin } from "./ui_feature/sort";
 import { SubtotalEvaluationPlugin } from "./ui_feature/subtotal_evaluation";
 import { UIOptionsPlugin } from "./ui_feature/ui_options";
@@ -50,7 +51,6 @@ import { CarouselUIPlugin } from "./ui_stateful/carousel_ui";
 import { CellComputedStylePlugin } from "./ui_stateful/cell_computed_style";
 import { ClipboardPlugin } from "./ui_stateful/clipboard";
 import { FigureUIPlugin } from "./ui_stateful/figure";
-import { FilterEvaluationPlugin } from "./ui_stateful/filter_evaluation";
 import { HeaderPositionsUIPlugin } from "./ui_stateful/header_positions";
 import { HeaderVisibilityUIPlugin } from "./ui_stateful/header_visibility_ui";
 import { LockSheetPlugin } from "./ui_stateful/lock_sheet";
@@ -86,7 +86,6 @@ export const featurePluginRegistry = new Registry<UIPluginConstructor>()
   .add("sort", SortPlugin)
   .add("format", FormatPlugin)
   .add("insert_pivot", InsertPivotPlugin)
-  .add("pivot_presence", PivotPresencePlugin)
   .add("subtotal_evaluation", SubtotalEvaluationPlugin)
   .add("collaborative", CollaborativePlugin)
   .add("history", HistoryPlugin)
@@ -98,7 +97,6 @@ export const featurePluginRegistry = new Registry<UIPluginConstructor>()
 // Plugins which have a state, but which should not be shared in collaborative
 export const statefulUIPluginRegistry = new Registry<UIPluginConstructor>()
   .add("selection", GridSelectionPlugin)
-  .add("evaluation_filter", FilterEvaluationPlugin)
   .add("header_visibility_ui", HeaderVisibilityUIPlugin)
   .add("cell_computed_style", CellComputedStylePlugin)
   .add("table_computed_style", TableComputedStylePlugin)
@@ -119,5 +117,7 @@ export const coreViewsPluginRegistry = new Registry<CoreViewPluginConstructor>()
   .add("dynamic_tables", DynamicTablesPlugin)
   .add("custom_colors", CustomColorsPlugin)
   .add("pivot_ui", PivotUIPlugin)
+  .add("pivot_presence", PivotPresencePlugin)
   .add("cell_icon", CellIconPlugin)
-  .add("formula_tracker", FormulaTrackerPlugin);
+  .add("formula_tracker", FormulaTrackerPlugin)
+  .add("evaluation_filter", FilterEvaluationPlugin);

--- a/src/plugins/ui_core_views/cell_evaluation/compilation_parameters.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/compilation_parameters.ts
@@ -4,7 +4,7 @@ import { _t } from "../../../translation";
 import { EvaluatedCell } from "../../../types/cells";
 import { EvaluationError, InvalidReferenceError } from "../../../types/errors";
 import { EvalContext } from "../../../types/functions";
-import { Getters } from "../../../types/getters";
+import { EvaluationGetters } from "../../../types/getters";
 import {
   CellPosition,
   EnsureRange,
@@ -30,7 +30,7 @@ const functionMap = functionRegistry.mapping;
  */
 export function buildCompilationParameters(
   context: ModelConfig["custom"],
-  getters: Getters,
+  getters: EvaluationGetters,
   computeCell: (position: CellPosition) => EvaluatedCell
 ): CompilationParameters {
   const builder = new CompilationParametersBuilder(context, getters, computeCell);
@@ -44,7 +44,7 @@ class CompilationParametersBuilder {
 
   constructor(
     context: ModelConfig["custom"],
-    private getters: Getters,
+    private getters: EvaluationGetters,
     private computeCell: (position: CellPosition) => EvaluatedCell
   ) {
     this.evalContext = Object.assign(Object.create(functionMap), context, {

--- a/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
@@ -32,7 +32,7 @@ import {
   PerfProfile,
   RangeTiming,
 } from "../../../types/functions";
-import { Getters } from "../../../types/getters";
+import { EvaluationGetters } from "../../../types/getters";
 import {
   CellPosition,
   FunctionResultObject,
@@ -58,7 +58,7 @@ for (const [op, fn] of Object.entries(UNARY_OPERATOR_MAP)) {
 }
 
 export class Evaluator {
-  private readonly getters: Getters;
+  private readonly getters: EvaluationGetters;
   private compilationParams: CompilationParameters;
 
   private evaluatedCells: PositionMap<EvaluatedCell> = new PositionMap();
@@ -67,7 +67,7 @@ export class Evaluator {
   private spreadingRelations = new SpreadingRelation();
   private perfProfile: PerfProfile | undefined;
 
-  constructor(private readonly context: ModelConfig["custom"], getters: Getters) {
+  constructor(private readonly context: ModelConfig["custom"], getters: EvaluationGetters) {
     this.getters = getters;
     this.compilationParams = buildCompilationParameters(
       this.context,

--- a/src/plugins/ui_core_views/filter_evaluation.ts
+++ b/src/plugins/ui_core_views/filter_evaluation.ts
@@ -6,18 +6,17 @@ import { criterionEvaluatorRegistry } from "../../registries/criterion_registry"
 import { Command, CommandResult, LocalCommand, UpdateFilterCommand } from "../../types/commands";
 import { GenericCriterion } from "../../types/generic_criterion";
 import { CellPosition, FilterId, UID } from "../../types/misc";
-import { CriterionFilter, DataFilterValue, Table } from "../../types/table";
+import { CriterionFilter, DataFilterValue } from "../../types/table";
 import { ExcelFilterData, ExcelWorkbookData } from "../../types/workbook_data";
-import { UIPlugin } from "../ui_plugin";
+import { CoreViewPlugin } from "../core_view_plugin";
 
 const EMPTY_CRITERION: CriterionFilter = { filterType: "criterion", type: "none", values: [] };
 
-export class FilterEvaluationPlugin extends UIPlugin {
+export class FilterEvaluationPlugin extends CoreViewPlugin {
   static getters = [
     "getFilterValue",
     "getFilterHiddenValues",
     "getFilterCriterionValue",
-    "getFirstTableInSelection",
     "isRowFiltered",
     "isFilterActive",
   ] as const;
@@ -133,12 +132,6 @@ export class FilterEvaluationPlugin extends UIPlugin {
       return false;
     }
     return value.filterType === "values" ? value.hiddenValues.length > 0 : value.type !== "none";
-  }
-
-  getFirstTableInSelection(): Table | undefined {
-    const sheetId = this.getters.getActiveSheetId();
-    const selection = this.getters.getSelectedZones();
-    return this.getters.getTablesOverlappingZones(sheetId, selection)[0];
   }
 
   private updateFilter({ col, row, value, sheetId }: UpdateFilterCommand) {

--- a/src/plugins/ui_core_views/pivot_presence_plugin.ts
+++ b/src/plugins/ui_core_views/pivot_presence_plugin.ts
@@ -1,12 +1,13 @@
 import { PivotPresenceTracker } from "../../helpers/pivot/pivot_presence_tracker";
 import { Command } from "../../types/commands";
 import { UID } from "../../types/misc";
-import { UIPlugin } from "../ui_plugin";
+import { CoreViewPlugin } from "../core_view_plugin";
 
-export class PivotPresencePlugin extends UIPlugin {
+export class PivotPresencePlugin extends CoreViewPlugin {
   static getters = ["getPivotPresenceTracker"] as const;
 
   private trackPresencePivotId?: UID;
+  private trackedSheetId?: UID;
   private tracker?: PivotPresenceTracker;
 
   handle(cmd: Command) {
@@ -14,15 +15,17 @@ export class PivotPresencePlugin extends UIPlugin {
       case "PIVOT_START_PRESENCE_TRACKING":
         this.tracker = new PivotPresenceTracker();
         this.trackPresencePivotId = cmd.pivotId;
+        this.trackedSheetId = cmd.sheetId;
         break;
       case "PIVOT_STOP_PRESENCE_TRACKING":
         this.trackPresencePivotId = undefined;
+        this.trackedSheetId = undefined;
         break;
     }
   }
 
-  getPivotPresenceTracker(pivotId: UID) {
-    if (this.trackPresencePivotId !== pivotId) {
+  getPivotPresenceTracker(pivotId: UID, sheetId: UID) {
+    if (this.trackPresencePivotId !== pivotId || this.trackedSheetId !== sheetId) {
       return undefined;
     }
     if (!this.tracker) {

--- a/src/plugins/ui_feature/ui_sheet.ts
+++ b/src/plugins/ui_feature/ui_sheet.ts
@@ -30,6 +30,7 @@ import {
   Zone,
 } from "../../types/misc";
 import { Rect } from "../../types/rendering";
+import { Table } from "../../types/table";
 import { UIPlugin } from "../ui_plugin";
 
 export class SheetUIPlugin extends UIPlugin {
@@ -40,6 +41,7 @@ export class SheetUIPlugin extends UIPlugin {
     "getCellMultiLineText",
     "getMultilineTextSize",
     "getContiguousZone",
+    "getFirstTableInSelection",
     "computeTextYCoordinate",
   ] as const;
 
@@ -208,6 +210,12 @@ export class SheetUIPlugin extends UIPlugin {
       }
     }
     return y + MIN_CELL_TEXT_MARGIN;
+  }
+
+  getFirstTableInSelection(): Table | undefined {
+    const sheetId = this.getters.getActiveSheetId();
+    const selection = this.getters.getSelectedZones();
+    return this.getters.getTablesOverlappingZones(sheetId, selection)[0];
   }
 
   /**

--- a/src/registries/evaluation_registry.ts
+++ b/src/registries/evaluation_registry.ts
@@ -1,4 +1,4 @@
-import { Getters } from "../types/getters";
+import { EvaluationGetters } from "../types/getters";
 import { Registry } from "./registry";
 
 /**
@@ -7,9 +7,11 @@ import { Registry } from "./registry";
  * to avoid to reload the data of the pivot at each function call (PIVOT.VALUE and PIVOT.HEADER). After each
  * evaluation iteration, the pivot has to be re-evaluated during the next iteration.
  */
-export const onIterationEndEvaluationRegistry = new Registry<(getters: Getters) => void>();
+export const onIterationEndEvaluationRegistry = new Registry<
+  (getters: EvaluationGetters) => void
+>();
 
-onIterationEndEvaluationRegistry.add("pivots", (getters: Getters) => {
+onIterationEndEvaluationRegistry.add("pivots", (getters: EvaluationGetters) => {
   for (const pivotId of getters.getPivotIds()) {
     const pivot = getters.getPivot(pivotId);
     pivot.markAsDirtyForEvaluation?.();

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -1189,6 +1189,7 @@ export interface DeleteUnfilteredContentCommand extends TargetDependentCommand {
 export interface PivotStartPresenceTracking {
   type: "PIVOT_START_PRESENCE_TRACKING";
   pivotId: UID;
+  sheetId: UID;
 }
 
 export interface PivotStopPresenceTracking {

--- a/src/types/functions.ts
+++ b/src/types/functions.ts
@@ -1,5 +1,5 @@
 import { CellValue } from "./cells";
-import { Getters } from "./getters";
+import { EvaluationGetters } from "./getters";
 import { Locale } from "./locale";
 import { Arg, CellPosition, FunctionResultObject, Matrix, UID } from "./misc";
 import { Range } from "./range";
@@ -76,7 +76,7 @@ export type EvalContext = {
   __originCellPosition?: CellPosition;
   __timingEntries?: FunctionTimingLog;
   locale: Locale;
-  getters: Getters;
+  getters: EvaluationGetters;
   getFormulaResult: (position: CellPosition) => FunctionResultObject;
   [key: string]: any;
   updateDependencies?: (position: CellPosition) => void;

--- a/src/types/getters.ts
+++ b/src/types/getters.ts
@@ -6,16 +6,17 @@ import { DynamicTablesPlugin } from "../plugins/ui_core_views/dynamic_tables";
 import { EvaluationChartPlugin } from "../plugins/ui_core_views/evaluation_chart";
 import { EvaluationConditionalFormatPlugin } from "../plugins/ui_core_views/evaluation_conditional_format";
 import { EvaluationDataValidationPlugin } from "../plugins/ui_core_views/evaluation_data_validation";
+import { FilterEvaluationPlugin } from "../plugins/ui_core_views/filter_evaluation";
 import { FingerprintPlugin } from "../plugins/ui_core_views/fingerprint";
 import { FormulaTrackerPlugin } from "../plugins/ui_core_views/formula_tracker";
 import { HeaderSizeUIPlugin } from "../plugins/ui_core_views/header_sizes_ui";
+import { PivotPresencePlugin } from "../plugins/ui_core_views/pivot_presence_plugin";
 import { PivotUIPlugin } from "../plugins/ui_core_views/pivot_ui";
 import { CollaborativePlugin } from "../plugins/ui_feature/collaborative";
 import { ColorThemeUIPlugin } from "../plugins/ui_feature/color_theme";
 import { DynamicTranslate } from "../plugins/ui_feature/dynamic_translate";
 import { GeoFeaturePlugin } from "../plugins/ui_feature/geo_features";
 import { HistoryPlugin } from "../plugins/ui_feature/local_history";
-import { PivotPresencePlugin } from "../plugins/ui_feature/pivot_presence_plugin";
 import { SortPlugin } from "../plugins/ui_feature/sort";
 import { SubtotalEvaluationPlugin } from "../plugins/ui_feature/subtotal_evaluation";
 import { UIOptionsPlugin } from "../plugins/ui_feature/ui_options";
@@ -24,7 +25,6 @@ import { CarouselUIPlugin } from "../plugins/ui_stateful/carousel_ui";
 import { CellComputedStylePlugin } from "../plugins/ui_stateful/cell_computed_style";
 import { ClipboardPlugin } from "../plugins/ui_stateful/clipboard";
 import { FigureUIPlugin } from "../plugins/ui_stateful/figure";
-import { FilterEvaluationPlugin } from "../plugins/ui_stateful/filter_evaluation";
 import { HeaderPositionsUIPlugin } from "../plugins/ui_stateful/header_positions";
 import { HeaderVisibilityUIPlugin } from "../plugins/ui_stateful/header_visibility_ui";
 import { LockSheetPlugin } from "../plugins/ui_stateful/lock_sheet";
@@ -36,6 +36,25 @@ import { CoreGetters, PluginGetters } from "./core_getters";
 // -----------------------------------------------------------------------------
 
 /**
+ * Getters available to formula evaluation. Restricted to core and core view
+ * plugins so the evaluation layer cannot depend on any UIPlugin.
+ */
+export type EvaluationGetters = CoreGetters &
+  PluginGetters<typeof CellIconPlugin> &
+  PluginGetters<typeof CustomColorsPlugin> &
+  PluginGetters<typeof DynamicTablesPlugin> &
+  PluginGetters<typeof EvaluationChartPlugin> &
+  PluginGetters<typeof EvaluationConditionalFormatPlugin> &
+  PluginGetters<typeof EvaluationDataValidationPlugin> &
+  PluginGetters<typeof EvaluationPlugin> &
+  PluginGetters<typeof FilterEvaluationPlugin> &
+  PluginGetters<typeof FingerprintPlugin> &
+  PluginGetters<typeof FormulaTrackerPlugin> &
+  PluginGetters<typeof HeaderSizeUIPlugin> &
+  PluginGetters<typeof PivotPresencePlugin> &
+  PluginGetters<typeof PivotUIPlugin>;
+
+/**
  * The getters that can be used in the rendering-related stores and helpers. The SheetView and Selection getters should
  * not be used in those, they should use the values in the GridRenderingContext instead.
  */
@@ -43,34 +62,22 @@ export type RenderingGetters = {
   isReadonly: () => boolean;
   isDashboard: () => boolean;
 } & CoreGetters &
+  EvaluationGetters &
   PluginGetters<typeof HistoryPlugin> &
   PluginGetters<typeof ClipboardPlugin> &
-  PluginGetters<typeof EvaluationPlugin> &
-  PluginGetters<typeof EvaluationChartPlugin> &
-  PluginGetters<typeof EvaluationConditionalFormatPlugin> &
   PluginGetters<typeof HeaderVisibilityUIPlugin> &
-  PluginGetters<typeof CustomColorsPlugin> &
   PluginGetters<typeof CollaborativePlugin> &
   PluginGetters<typeof SortPlugin> &
   PluginGetters<typeof UIOptionsPlugin> &
   PluginGetters<typeof SheetUIPlugin> &
-  PluginGetters<typeof FilterEvaluationPlugin> &
-  PluginGetters<typeof FingerprintPlugin> &
   PluginGetters<typeof SubtotalEvaluationPlugin> &
-  PluginGetters<typeof HeaderSizeUIPlugin> &
-  PluginGetters<typeof EvaluationDataValidationPlugin> &
   PluginGetters<typeof HeaderPositionsUIPlugin> &
   PluginGetters<typeof TableStylePlugin> &
   PluginGetters<typeof CellComputedStylePlugin> &
-  PluginGetters<typeof DynamicTablesPlugin> &
-  PluginGetters<typeof PivotUIPlugin> &
   PluginGetters<typeof TableComputedStylePlugin> &
   PluginGetters<typeof GeoFeaturePlugin> &
-  PluginGetters<typeof PivotPresencePlugin> &
   PluginGetters<typeof TableComputedStylePlugin> &
-  PluginGetters<typeof CellIconPlugin> &
   PluginGetters<typeof DynamicTranslate> &
-  PluginGetters<typeof FormulaTrackerPlugin> &
   PluginGetters<typeof LockSheetPlugin> &
   PluginGetters<typeof CarouselUIPlugin> &
   PluginGetters<typeof ColorThemeUIPlugin> &

--- a/tests/components/pivot_html_renderer.test.ts
+++ b/tests/components/pivot_html_renderer.test.ts
@@ -16,7 +16,10 @@ async function mountPivotHtmlRenderer(
     pivotId,
     onCellClicked,
   };
-  model.dispatch("PIVOT_START_PRESENCE_TRACKING", { pivotId });
+  model.dispatch("PIVOT_START_PRESENCE_TRACKING", {
+    pivotId,
+    sheetId: model.getters.getActiveSheetId(),
+  });
   evaluateCells(model);
   ({ fixture } = await mountComponent(PivotHTMLRenderer, { env: { model }, props }));
 }


### PR DESCRIPTION
Move FilterEvaluationPlugin and PivotPresencePlugin to core view plugins
so that cell evaluation no longer reads from any UIPlugin getter.

- FilterEvaluationPlugin (isRowFiltered) moves to ui_core_views/, extends
  CoreViewPlugin. Its getFirstTableInSelection helper — which relied on
  UIPlugin getters (getActiveSheetId, getSelectedZones) — moves to
  SheetUIPlugin instead.
- PivotPresencePlugin (getPivotPresenceTracker) moves to ui_core_views/,
  extends CoreViewPlugin. PIVOT_START_PRESENCE_TRACKING now carries the
  sheetId to track; the tracker exposes itself only when both pivotId and
  sheetId match, replacing the getActiveSheetId gate previously used in
  module_lookup.ts by PIVOT.VALUE / PIVOT.HEADER.

Add a new EvaluationGetters type restricted to CoreGetters and core view
plugin getters (no UIPlugin), and use it in the evaluation layer:
EvalContext, Evaluator, buildCompilationParameters, and the
onIterationEndEvaluationRegistry. Formulas and evaluation code now fail
to type-check if they try to reach a UIPlugin getter.

Task: 6428159