### PR TITLE
[FIX] autofill: restore drag highlight

### DIFF
--- a/src/components/autofill/autofill_store.ts
+++ b/src/components/autofill/autofill_store.ts
@@ -78,8 +78,6 @@ class AutofillGenerator {
 }
 
 export class AutofillStore extends SpreadsheetStore {
-  static layers = ["Autofill"] as const;
-
   private autofillZone: Zone | undefined;
   private steps: number | undefined;
   private lastCellSelected: { col?: number; row?: number } = {};
@@ -536,6 +534,10 @@ export class AutofillStore extends SpreadsheetStore {
   // ---------------------------------------------------------------------------
   // Grid rendering
   // ---------------------------------------------------------------------------
+
+  get renderingLayers() {
+    return ["Autofill"] as const;
+  }
 
   drawLayer(renderingContext: GridRenderingContext) {
     if (!this.autofillZone) {

--- a/tests/autofill/autofill_plugin.test.ts
+++ b/tests/autofill/autofill_plugin.test.ts
@@ -45,10 +45,14 @@ import {
 import { DIRECTION, Model } from "../../src";
 import { AutofillStore } from "../../src/components/autofill/autofill_store";
 import { functionRegistry } from "../../src/functions/function_registry";
+import { DependencyContainer } from "../../src/store_engine/dependency_container";
+import { RendererStore } from "../../src/stores/renderer_store";
 import { Store } from "../../src/types/store_engine";
+import { watchDashedOutline } from "../test_helpers/renderer_helpers";
 import { makeStoreWithModel } from "../test_helpers/stores";
 
 let autoFill: Store<AutofillStore>;
+let container: DependencyContainer;
 let model: Model;
 
 function autofillTooltip(from: string, to: string): string | undefined {
@@ -67,7 +71,9 @@ function getDirection(from: string, xc: string): DIRECTION {
 
 beforeEach(() => {
   model = new Model();
-  autoFill = makeStoreWithModel(model, AutofillStore).store;
+  const storeData = makeStoreWithModel(model, AutofillStore);
+  autoFill = storeData.store;
+  container = storeData.container;
 });
 
 describe("Autofill", () => {
@@ -104,6 +110,15 @@ describe("Autofill", () => {
   ])("From %s, selecting %s should select the good zone (%s)", (from, xc, expected) => {
     autofillSelect(model, from, xc);
     expect(autoFill["autofillZone"]).toEqual(toZone(expected));
+  });
+
+  test("Autofill zone is rendered through the renderer store", () => {
+    const { ctx, isDotOutlined } = watchDashedOutline(model, container);
+
+    autofillSelect(model, "A1", "A2");
+    container.get(RendererStore).draw(ctx);
+
+    expect(isDotOutlined([toZone("A2")])).toBeTruthy();
   });
 
   test.each([

--- a/tests/renderer/renderer_store.test.ts
+++ b/tests/renderer/renderer_store.test.ts
@@ -66,7 +66,7 @@ import {
 import { getCell } from "../test_helpers/getters_helpers";
 import { getFingerprint, target } from "../test_helpers/helpers";
 import { createModelWithTestPivotDataset } from "../test_helpers/pivot_helpers";
-import { MockGridRenderingContext, watchClipboardOutline } from "../test_helpers/renderer_helpers";
+import { MockGridRenderingContext, watchDashedOutline } from "../test_helpers/renderer_helpers";
 import { makeStoreWithModel } from "../test_helpers/stores";
 
 MockCanvasRenderingContext2D.prototype.measureText = function (text: string) {
@@ -1513,7 +1513,7 @@ describe("renderer", () => {
     (targetXc) => {
       const { drawGridRenderer, model, container } = setRenderer(new Model(), ["Clipboard"]);
       copy(model, ...targetXc.split(","));
-      const { ctx, isDotOutlined, reset } = watchClipboardOutline(model, container);
+      const { ctx, isDotOutlined, reset } = watchDashedOutline(model, container);
       drawGridRenderer(ctx);
       const copiedTarget = target(targetXc);
       expect(isDotOutlined(copiedTarget)).toBeTruthy();
@@ -1529,7 +1529,7 @@ describe("renderer", () => {
     (targetXc) => {
       const { drawGridRenderer, model, container } = setRenderer(new Model(), ["Clipboard"]);
       copy(model, ...targetXc.split(","));
-      const { ctx, isDotOutlined, reset } = watchClipboardOutline(model, container);
+      const { ctx, isDotOutlined, reset } = watchDashedOutline(model, container);
       drawGridRenderer(ctx);
       const copiedTarget = target(targetXc);
       const expectedOutlinedZone = copiedTarget.slice(-1);
@@ -1548,7 +1548,7 @@ describe("renderer", () => {
   ])("copied zone outline is removed at first change to the grid", (coreOperation) => {
     const { drawGridRenderer, model, container } = setRenderer(new Model(), ["Clipboard"]);
     copy(model, "A1:A2");
-    const { ctx, isDotOutlined, reset } = watchClipboardOutline(model, container);
+    const { ctx, isDotOutlined, reset } = watchDashedOutline(model, container);
     drawGridRenderer(ctx);
 
     const copiedTarget = target("A1:A2");

--- a/tests/test_helpers/renderer_helpers.ts
+++ b/tests/test_helpers/renderer_helpers.ts
@@ -118,10 +118,9 @@ export class MockGridRenderingContext implements GridRenderingContext {
 }
 
 /**
- * Create a rendering context watching the blue dotted
- * outline around copied zones
+ * Create a rendering context watching dashed outlines around zones.
  */
-export function watchClipboardOutline(model: Model, container: DependencyContainer) {
+export function watchDashedOutline(model: Model, container: DependencyContainer) {
   const sheetViewSize = getDefaultSheetViewSize();
   let lineDash = false;
   let outlinedRects: any[][] = [];


### PR DESCRIPTION
## Description:

When dragging the autofill handle, the target zone should be outlined before dropping.

This stopped working when the autofill plugin was converted into a store: the rendering layer was still declared as a static plugin layer, so it was ignored by the renderer store and the autofill drawLayer was never called.

Expose the Autofill layer through the store renderingLayers getter.

Task: [6424354](https://www.odoo.com/odoo/2328/tasks/6424354)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo