### PR TITLE
[REL] 19.0.45

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@odoo/o-spreadsheet",
-  "version": "19.0.44",
+  "version": "19.0.45",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@odoo/o-spreadsheet",
-      "version": "19.0.44",
+      "version": "19.0.45",
       "license": "LGPL-3.0-or-later",
       "dependencies": {
         "@odoo/owl": "2.8.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@odoo/o-spreadsheet",
-  "version": "19.0.44",
+  "version": "19.0.45",
   "description": "A spreadsheet component",
   "type": "module",
   "main": "dist/o-spreadsheet.cjs.js",


### PR DESCRIPTION
### Contains the following commits:

https://github.com/odoo/o-spreadsheet/commit/04cfd7b34b [FIX] ui_sheet: `getCellWidth` getter for non-active sheet [Task: 6409426](https://www.odoo.com/odoo/2328/tasks/6409426)
https://github.com/odoo/o-spreadsheet/commit/2ebb191a58 [FIX] dashboard: clickable cell is not triggered by a right click [Task: 6365823](https://www.odoo.com/odoo/2328/tasks/6365823)

Task: 0
