### PR TITLE
[FIX] TableResizer: deactivate when the grid selection is inactive

### DIFF
--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -931,4 +931,12 @@ export class Grid extends Component<SpreadsheetChildEnv> {
     const sheetId = this.env.model.getters.getActiveSheetId();
     return this.env.model.getters.getClientsToDisplay(sheetId);
   }
+
+  get displayTableResizer() {
+    return (
+      this.env.model.getters.isGridSelectionActive() &&
+      !this.env.model.getters.isReadonly() &&
+      !this.env.model.getters.isSheetLocked(this.env.model.getters.getActiveSheetId())
+    );
+  }
 }

--- a/src/components/grid/grid.xml
+++ b/src/components/grid/grid.xml
@@ -54,7 +54,7 @@
         onClose="() => this.closeMenu()"
       />
       <t
-        t-if="!this.env.model.getters.isReadonly()"
+        t-if="this.displayTableResizer"
         t-foreach="this.staticTables"
         t-as="table"
         t-key="table.id">

--- a/src/components/tables/table_resizer/table_resizer.ts
+++ b/src/components/tables/table_resizer/table_resizer.ts
@@ -37,12 +37,8 @@ export class TableResizer extends Component<SpreadsheetChildEnv> {
   }
 
   get containerStyle(): string {
-    const tableZone = this.props.table.range.zone;
     const sheetId = this.props.table.range.sheetId;
-
-    if (this.env.model.getters.isReadonly() || this.env.model.getters.isSheetLocked(sheetId)) {
-      return cssPropertiesToCss({ display: "none" });
-    }
+    const tableZone = this.props.table.range.zone;
     const bottomRight = { ...tableZone, left: tableZone.right, top: tableZone.bottom };
     const rect = this.viewStore.viewports.getVisibleRect(sheetId, bottomRight);
     if (rect.height === 0 || rect.width === 0) {

--- a/tests/table/table_resizer_component.test.ts
+++ b/tests/table/table_resizer_component.test.ts
@@ -1,4 +1,5 @@
 import { Model, UID } from "../../src";
+import { CellComposerStore } from "../../src/components/composer/composer/cell_composer_store";
 import { Grid } from "../../src/components/grid/grid";
 import { DEFAULT_CELL_HEIGHT, DEFAULT_CELL_WIDTH } from "../../src/constants";
 import { toZone, zoneToXc } from "../../src/helpers/zones";
@@ -109,6 +110,16 @@ describe("Table resizer component", () => {
     await nextTick();
     expect(".o-table-resizer").toHaveCount(1);
     model.updateMode("readonly");
+    await nextTick();
+    expect(".o-table-resizer").toHaveCount(0);
+  });
+
+  test("table resizer is not loaded when the grid selection is not active", async () => {
+    createTable(model, "A1:B2");
+    await nextTick();
+    expect(".o-table-resizer").toHaveCount(1);
+    // start the edition and steal the selection from the grid
+    env.getStore(CellComposerStore).startEdition();
     await nextTick();
     expect(".o-table-resizer").toHaveCount(0);
   });


### PR DESCRIPTION
When the grid selection is inactive, whether through the composer or a selectionInput, the user intention is to modify a specific definition or cell content but not to alter an object present in the grid. They act as a sort of "modal" that allows to select ranges in the grid and nothing else.

As such, the table resizer should not be active when the grid selection isn't eiter.

Task: 6431758

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo