### PR TITLE
Stop throwing EvaluationError in getters

### DIFF
--- a/src/functions/module_text.ts
+++ b/src/functions/module_text.ts
@@ -3,7 +3,7 @@ import { escapeRegExp, trimContent } from "../helpers/misc";
 import { _t } from "../translation";
 import { CellErrorType, EvaluationError, NotAvailableError } from "../types/errors";
 import { AddFunctionDescription } from "../types/functions";
-import { Arg, FunctionResultNumber, FunctionResultObject, Maybe } from "../types/misc";
+import { Arg, FunctionResultObject, Maybe } from "../types/misc";
 import { arg } from "./arguments";
 import {
   matrixMap,
@@ -165,10 +165,14 @@ export const FORMAT_LARGE_NUMBER = {
       ]
     ),
   ],
-  compute: function (
-    value: Maybe<FunctionResultObject>,
-    unite: Maybe<FunctionResultObject>
-  ): FunctionResultNumber {
+  compute: function (value: Maybe<FunctionResultObject>, unite: Maybe<FunctionResultObject>) {
+    const uniteValue = unite?.value;
+    if (
+      uniteValue !== undefined &&
+      (typeof uniteValue !== "string" || !["k", "m", "b"].includes(uniteValue))
+    ) {
+      return new EvaluationError(_t("The formatting unit should be 'k', 'm' or 'b'."));
+    }
     return {
       value: toNumber(value, this.locale),
       format: formatLargeNumber(value, unite, this.locale),

--- a/src/helpers/format/format.ts
+++ b/src/helpers/format/format.ts
@@ -2,7 +2,6 @@ import { toNumber, tryToNumber } from "../../functions/helpers";
 import { _t } from "../../translation";
 import { CellValue } from "../../types/cells";
 import { Currency } from "../../types/currency";
-import { EvaluationError } from "../../types/errors";
 import { Format, FormattedValue, LocaleFormat } from "../../types/format";
 import { DEFAULT_LOCALE, DEFAULT_LOCALE_DIGIT_GROUPING, Locale } from "../../types/locale";
 import { FunctionResultObject, Maybe } from "../../types/misc";
@@ -773,7 +772,7 @@ export function formatLargeNumber(
   }
   const format = arg?.format;
   if (unit !== undefined) {
-    const postFix = unit?.value;
+    const postFix = unit.value;
     switch (postFix) {
       case "k":
         return createLargeNumberFormat(format, 1, "k");
@@ -782,7 +781,7 @@ export function formatLargeNumber(
       case "b":
         return createLargeNumberFormat(format, 3, "b");
       default:
-        throw new EvaluationError(_t("The formatting unit should be 'k', 'm' or 'b'."));
+        throw new Error("The formatting unit should be 'k', 'm' or 'b'.");
     }
   }
   if (value < 1e5) {

--- a/tests/functions/module_custom.test.ts
+++ b/tests/functions/module_custom.test.ts
@@ -129,6 +129,8 @@ describe("FORMAT.LARGE.NUMBER formula", () => {
     expect(evaluateCellText("A1", { A1: '=FORMAT.LARGE.NUMBER(10000000000, "b")' })).toBe("10b");
 
     expect(evaluateCellText("A1", { A1: '=FORMAT.LARGE.NUMBER(100, "something")' })).toBe("#ERROR");
+    expect(evaluateCellText("A1", { A1: "=FORMAT.LARGE.NUMBER(1000, True)" })).toBe("#ERROR");
+    expect(evaluateCellText("A1", { A1: "=FORMAT.LARGE.NUMBER(1000, 0)" })).toBe("#ERROR");
   });
 
   test("Original currency format is kept", () => {


### PR DESCRIPTION
## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [6306250](https://www.odoo.com/odoo/2328/tasks/6306250)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo