### PR TITLE
[FIX] carousel: crash on multiuser when deleting chart

### DIFF
--- a/src/registries/inverse_command_registry.ts
+++ b/src/registries/inverse_command_registry.ts
@@ -8,6 +8,7 @@ import {
   CreateFigureCommand,
   CreateSheetCommand,
   CreateTableStyleCommand,
+  DeleteChartCommand,
   DeleteFigureCommand,
   DeleteSheetCommand,
   DuplicateSheetCommand,
@@ -123,8 +124,11 @@ function inverseCreateFigure(cmd: CreateFigureCommand): DeleteFigureCommand[] {
   return [{ type: "DELETE_FIGURE", figureId: cmd.figureId, sheetId: cmd.sheetId }];
 }
 
-function inverseCreateChart(cmd: CreateChartCommand): DeleteFigureCommand[] {
-  return [{ type: "DELETE_FIGURE", figureId: cmd.figureId, sheetId: cmd.sheetId }];
+function inverseCreateChart(cmd: CreateChartCommand): (DeleteFigureCommand | DeleteChartCommand)[] {
+  return [
+    { type: "DELETE_CHART", chartId: cmd.chartId, sheetId: cmd.sheetId },
+    { type: "DELETE_FIGURE", figureId: cmd.figureId, sheetId: cmd.sheetId },
+  ];
 }
 
 function inverseHideColumnsRows(cmd: HideColumnsRowsCommand): UnhideColumnsRowsCommand[] {

--- a/tests/collaborative/collaborative.test.ts
+++ b/tests/collaborative/collaborative.test.ts
@@ -15,11 +15,13 @@ import { CollaborationMessage } from "../../src/types/collaborative/transport_se
 import { MockTransportService } from "../__mocks__/transport_service";
 import {
   activateSheet,
+  addChartFigureToCarousel,
   addDataValidation,
   addRows,
   changeCFPriority,
   clearCell,
   copy,
+  createCarousel,
   createChart,
   createFigure,
   createSheet,
@@ -572,6 +574,28 @@ describe("Multi users synchronisation", () => {
       (user) => user.getters.getFigures(sheetId),
       []
     );
+  });
+
+  test("Undo the creation of a chart that another user moved into a carousel", () => {
+    const sheetId = alice.getters.getActiveSheetId();
+    createChart(alice, { type: "bar" }, "chartId", sheetId, { figureId: "chartFigureId" });
+    createCarousel(bob, { items: [] }, "carouselId");
+    addChartFigureToCarousel(bob, "carouselId", "chartFigureId", sheetId);
+    expect([alice, bob, charlie]).toHaveSynchronizedValue(
+      (user) => user.getters.getCarousel("carouselId").items,
+      [{ type: "chart", chartId: "chartId" }]
+    );
+
+    undo(alice);
+    expect([alice, bob, charlie]).toHaveSynchronizedValue(
+      (user) => user.getters.getCarousel("carouselId").items,
+      []
+    );
+    expect([alice, bob, charlie]).toHaveSynchronizedValue(
+      (user) => user.getters.getChartIds(sheetId),
+      []
+    );
+    expect([alice, bob, charlie]).toHaveSynchronizedExportedData();
   });
 
   test("Do not handle duplicated message", () => {


### PR DESCRIPTION
- User A adds a chart
- User B inserts a carousel
- User B drag & drops the chart (created by A) in the carousel
- User A undo

Task: 6445004

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [6445004](https://www.odoo.com/odoo/2328/tasks/6445004)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo