### PR TITLE
[IMP] store: move zoom level to its own shared store

### DIFF
--- a/src/actions/view_actions.ts
+++ b/src/actions/view_actions.ts
@@ -2,7 +2,7 @@ import { SidePanelStore } from "../components/side_panel/side_panel/side_panel_s
 import { numberToLetters } from "../helpers/coordinates";
 import { interactiveFreezeColumnsRows } from "../helpers/ui/freeze_interactive";
 import { FormulaFingerprintStore } from "../stores/formula_fingerprints_store";
-import { ViewportsStore } from "../stores/viewports_store";
+import { ZoomStore } from "../stores/zoom_store";
 import { _t } from "../translation";
 import { Dimension } from "../types/misc";
 import { SpreadsheetChildEnv } from "../types/spreadsheet_env";
@@ -224,9 +224,9 @@ export function zoomAction(zoom: number): ActionSpec {
   return {
     name: _t("%(zoom_percentage)s%", { zoom_percentage: zoom }),
     execute: (env) => {
-      env.getStore(ViewportsStore).setZoom(zoom / 100);
+      env.getStore(ZoomStore).setZoom(zoom / 100);
     },
-    isActive: (env: SpreadsheetChildEnv) => env.getStore(ViewportsStore).zoomLevel === zoom / 100,
+    isActive: (env: SpreadsheetChildEnv) => env.getStore(ZoomStore).zoomLevel === zoom / 100,
     isReadonlyAllowed: true,
     isEnabledOnLockedSheet: true,
     sequence: zoom,

--- a/src/components/autofill/autofill.ts
+++ b/src/components/autofill/autofill.ts
@@ -2,7 +2,7 @@ import { proxy, useProps, xml } from "@odoo/owl";
 import { clip } from "../../helpers/misc";
 import { Component } from "../../owl3_compatibility_layer";
 import { useStore } from "../../store_engine/store_hooks";
-import { ViewportsStore } from "../../stores/viewports_store";
+import { ZoomStore } from "../../stores/zoom_store";
 import { HeaderIndex } from "../../types/misc";
 import { DOMCoordinates } from "../../types/rendering";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
@@ -36,11 +36,11 @@ export class Autofill extends Component<SpreadsheetChildEnv> {
   });
 
   dragNDropGrid = useDragAndDropBeyondTheViewport(this.env);
-  private viewStore!: Store<ViewportsStore>;
+  private zoomStore!: Store<ZoomStore>;
   private autofillStore!: Store<AutofillStore>;
 
   setup(): void {
-    this.viewStore = useStore(ViewportsStore);
+    this.zoomStore = useStore(ZoomStore);
     this.autofillStore = useStore(AutofillStore);
     useStore(TableAutofillStore);
   }
@@ -81,7 +81,7 @@ export class Autofill extends Component<SpreadsheetChildEnv> {
   onMouseDown(ev: PointerEvent) {
     this.state.handler = true;
     const zoomedMouseEvent = withZoom(this.env, ev);
-    const zoom = this.viewStore.zoomLevel;
+    const zoom = this.zoomStore.zoomLevel;
     let lastCol: HeaderIndex | undefined;
     let lastRow: HeaderIndex | undefined;
     const start = {

--- a/src/components/dashboard/dashboard.ts
+++ b/src/components/dashboard/dashboard.ts
@@ -3,6 +3,7 @@ import { Component, useChildSubEnv } from "../../owl3_compatibility_layer";
 import { useLocalStore, useStore } from "../../store_engine/store_hooks";
 import { RendererStore } from "../../stores/renderer_store";
 import { ViewportsStore } from "../../stores/viewports_store";
+import { ZoomStore } from "../../stores/zoom_store";
 import { Pixel } from "../../types/misc";
 import { DOMCoordinates, DOMDimension, OrderedLayers, Rect } from "../../types/rendering";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
@@ -17,7 +18,6 @@ import { getElBoundingRect } from "../helpers/dom_helpers";
 import { useGridDrawing } from "../helpers/draw_grid_hook";
 import { useTouchHandlers } from "../helpers/touch_handlers_hook";
 import { useWheelHandler } from "../helpers/wheel_hook";
-import { getZoomedRect } from "../helpers/zoom";
 import { CellPopoverStore } from "../popover/cell_popover_store";
 import { Popover } from "../popover/popover";
 import { types } from "../props_validation";
@@ -46,6 +46,7 @@ export class SpreadsheetDashboard extends Component<SpreadsheetChildEnv> {
   canvasPosition!: DOMCoordinates;
   hoveredCell!: Store<DelayedHoveredCellStore>;
   private viewStore!: Store<ViewportsStore>;
+  private zoomStore!: Store<ZoomStore>;
 
   private gridRef = signal<HTMLElement | null>(null);
   private canvasRef = signal<HTMLElement | null>(null);
@@ -53,11 +54,12 @@ export class SpreadsheetDashboard extends Component<SpreadsheetChildEnv> {
   setup() {
     this.hoveredCell = useStore(DelayedHoveredCellStore);
     this.viewStore = useStore(ViewportsStore);
+    this.zoomStore = useStore(ZoomStore);
 
     const layers = OrderedLayers().filter((layer) => layer !== "Headers");
     const rendererStore = useLocalStore(RendererStore, layers);
     useChildSubEnv({
-      getPopoverContainerRect: () => getZoomedRect(this.viewStore.zoomLevel, this.getGridRect()),
+      getPopoverContainerRect: () => this.zoomStore.getZoomedRect(this.getGridRect()),
     });
 
     useGridDrawing({
@@ -87,8 +89,8 @@ export class SpreadsheetDashboard extends Component<SpreadsheetChildEnv> {
         const { scrollY } = this.viewStore.activeSheetScrollInfo;
         return scrollY < maxOffsetY;
       },
-      getZoom: () => this.viewStore.zoomLevel,
-      setZoom: (zoom: number) => this.viewStore.setZoom(zoom),
+      getZoom: () => this.zoomStore.zoomLevel,
+      setZoom: (zoom: number) => this.zoomStore.setZoom(zoom),
     });
   }
 
@@ -138,8 +140,7 @@ export class SpreadsheetDashboard extends Component<SpreadsheetChildEnv> {
   }
 
   get dashboardStyle() {
-    const zoomLevel = this.viewStore.zoomLevel;
-    const style = { zoom: `${zoomLevel}` };
+    const style = { zoom: this.zoomStore.cssZoom };
     const sheet = this.env.model.getters.getActiveSheet();
     if (sheet.backgroundColor) {
       style["background-color"] = "transparent";

--- a/src/components/figures/chart/gauge/gauge_chart_component.ts
+++ b/src/components/figures/chart/gauge/gauge_chart_component.ts
@@ -4,7 +4,7 @@ import { deepEquals } from "../../../../helpers/misc";
 import { Component, useLayoutEffect } from "../../../../owl3_compatibility_layer";
 import { EASING_FN } from "../../../../registries/cell_animation_registry";
 import { useStore } from "../../../../store_engine/store_hooks";
-import { ViewportsStore } from "../../../../stores/viewports_store";
+import { ZoomStore } from "../../../../stores/zoom_store";
 import { GaugeChartRuntime } from "../../../../types/chart/gauge_chart";
 import { SpreadsheetChildEnv } from "../../../../types/spreadsheet_env";
 import { Store } from "../../../../types/store_engine";
@@ -24,14 +24,14 @@ export class GaugeChartComponent extends Component<SpreadsheetChildEnv> {
   private canvas = signal<HTMLCanvasElement | null>(null);
 
   private animationStore: Store<ChartAnimationStore> | undefined;
-  private viewStore!: Store<ViewportsStore>;
+  private zoomStore!: Store<ZoomStore>;
 
   get runtime(): GaugeChartRuntime {
     return this.env.model.getters.getChartRuntime(this.props.chartId) as GaugeChartRuntime;
   }
 
   setup() {
-    this.viewStore = useStore(ViewportsStore);
+    this.zoomStore = useStore(ZoomStore);
     if (this.env.model.getters.isDashboard()) {
       this.animationStore = useStore(ChartAnimationStore);
     }
@@ -55,7 +55,7 @@ export class GaugeChartComponent extends Component<SpreadsheetChildEnv> {
           animation = this.drawGaugeWithAnimation();
           this.animationStore?.disableAnimationForChart(this.animationChartId, "gauge");
         } else {
-          const zoom = this.viewStore.zoomLevel;
+          const zoom = this.zoomStore.zoomLevel;
           drawGaugeChart(this.canvasEl, this.runtime, zoom);
         }
 
@@ -76,7 +76,7 @@ export class GaugeChartComponent extends Component<SpreadsheetChildEnv> {
         animation.stop();
         animation = null;
       }
-      drawGaugeChart(this.canvasEl, this.runtime, this.viewStore.zoomLevel);
+      drawGaugeChart(this.canvasEl, this.runtime, this.zoomStore.zoomLevel);
     });
     onMounted(() => {
       const canvas = this.canvas();

--- a/src/components/figures/chart/scorecard/chart_scorecard.ts
+++ b/src/components/figures/chart/scorecard/chart_scorecard.ts
@@ -1,14 +1,14 @@
 import { onMounted, onWillUnmount, signal, useProps } from "@odoo/owl";
 import { drawScoreChart } from "../../../../helpers/figures/charts/scorecard_chart";
 import { getScorecardConfiguration } from "../../../../helpers/figures/charts/scorecard_chart_config_builder";
+import { getZoomedRect } from "../../../../helpers/rectangle";
 import { Component, useLayoutEffect } from "../../../../owl3_compatibility_layer";
 import { useStore } from "../../../../store_engine/store_hooks";
-import { ViewportsStore } from "../../../../stores/viewports_store";
+import { ZoomStore } from "../../../../stores/zoom_store";
 import { ScorecardChartRuntime } from "../../../../types/chart/scorecard_chart";
 import { Rect } from "../../../../types/rendering";
 import { SpreadsheetChildEnv } from "../../../../types/spreadsheet_env";
 import { Store } from "../../../../types/store_engine";
-import { getZoomedRect } from "../../../helpers/zoom";
 import { types } from "../../../props_validation";
 
 export class ScorecardChart extends Component<SpreadsheetChildEnv> {
@@ -19,7 +19,7 @@ export class ScorecardChart extends Component<SpreadsheetChildEnv> {
     isFullScreen: types.boolean().optional(),
   });
   private canvas = signal<HTMLCanvasElement | null>(null);
-  private viewStore!: Store<ViewportsStore>;
+  private zoomStore!: Store<ZoomStore>;
 
   get runtime(): ScorecardChartRuntime {
     return this.env.model.getters.getChartRuntime(this.props.chartId) as ScorecardChartRuntime;
@@ -31,7 +31,7 @@ export class ScorecardChart extends Component<SpreadsheetChildEnv> {
   }
 
   setup() {
-    this.viewStore = useStore(ViewportsStore);
+    this.zoomStore = useStore(ZoomStore);
     useLayoutEffect(this.createChart.bind(this), () => {
       const canvas = this.canvas();
       if (!canvas) {
@@ -59,7 +59,7 @@ export class ScorecardChart extends Component<SpreadsheetChildEnv> {
     if (!canvas) {
       return;
     }
-    const zoom = this.viewStore.zoomLevel;
+    const zoom = this.zoomStore.zoomLevel;
     const config = this.config(canvas.getBoundingClientRect(), zoom);
     drawScoreChart(config, canvas, zoom);
   }

--- a/src/components/figures/figure_carousel/figure_carousel.ts
+++ b/src/components/figures/figure_carousel/figure_carousel.ts
@@ -7,7 +7,6 @@ import { cellPositions } from "../../../helpers/zones";
 import { Component, useLayoutEffect } from "../../../owl3_compatibility_layer";
 import { chartComponentRegistry } from "../../../registries/chart_component_registry";
 import { useStore } from "../../../store_engine/store_hooks";
-import { ViewportsStore } from "../../../stores/viewports_store";
 import { _t } from "../../../translation";
 import { CellValueType } from "../../../types/cells";
 import { Carousel, CarouselItem } from "../../../types/figure";
@@ -44,12 +43,10 @@ export class CarouselFigure extends Component<SpreadsheetChildEnv> {
 
   protected animationStore: Store<ChartAnimationStore> | undefined;
   private fullScreenFigureStore!: Store<FullScreenFigureStore>;
-  viewStore!: Store<ViewportsStore>;
 
   setup(): void {
     this.animationStore = useStore(ChartAnimationStore);
     this.fullScreenFigureStore = useStore(FullScreenFigureStore);
-    this.viewStore = useStore(ViewportsStore);
 
     useLayoutEffect(() => {
       this.updateTabsVisibility();

--- a/src/components/figures/figure_carousel/figure_carousel.xml
+++ b/src/components/figures/figure_carousel/figure_carousel.xml
@@ -94,7 +94,6 @@
           columnWeights="selectedItem.columnWeights"
           canResizeColumns="this.canResizeDataViewColumns"
           onResizeColumns.bind="this.onResizeColumns"
-          zoomLevel="this.viewStore.zoomLevel"
         />
       </div>
     </div>

--- a/src/components/figures/figure_container/figure_container.ts
+++ b/src/components/figures/figure_container/figure_container.ts
@@ -6,6 +6,7 @@ import { Component } from "../../../owl3_compatibility_layer";
 import { figureRegistry } from "../../../registries/figures_registry";
 import { useStore } from "../../../store_engine/store_hooks";
 import { ViewportsStore } from "../../../stores/viewports_store";
+import { ZoomStore } from "../../../stores/zoom_store";
 import { AnchorOffset, Figure, FigureUI, ResizeDirection } from "../../../types/figure";
 import { UID } from "../../../types/misc";
 import { Rect } from "../../../types/rendering";
@@ -123,9 +124,11 @@ export class FiguresContainer extends Component<SpreadsheetChildEnv> {
     overlappingChartOrCarousel: undefined,
   });
   private viewStore!: Store<ViewportsStore>;
+  private zoomStore!: Store<ZoomStore>;
 
   setup() {
     this.viewStore = useStore(ViewportsStore);
+    this.zoomStore = useStore(ZoomStore);
     onMounted(() => {
       // horrible, but necessary
       // the following line ensures that we render the figures with the correct
@@ -316,7 +319,7 @@ export class FiguresContainer extends Component<SpreadsheetChildEnv> {
     }
 
     const sheetId = this.env.model.getters.getActiveSheetId();
-    const zoom = this.viewStore.zoomLevel;
+    const zoom = this.zoomStore.zoomLevel;
 
     const initialMousePosition = { x: ev.clientX / zoom, y: ev.clientY / zoom };
     const initialScrollPosition = this.viewStore.activeSheetScrollInfo;
@@ -450,7 +453,7 @@ export class FiguresContainer extends Component<SpreadsheetChildEnv> {
 
     const keepRatio = figureRegistry.get(figureUI.tag).keepRatio || false;
     const minFigSize = figureRegistry.get(figureUI.tag).minFigSize || MIN_FIG_SIZE;
-    const zoom = this.viewStore.zoomLevel;
+    const zoom = this.zoomStore.zoomLevel;
     const sheetId = this.env.model.getters.getActiveSheetId();
 
     const initialMousePosition = { x: ev.clientX / zoom, y: ev.clientY / zoom };

--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -43,6 +43,7 @@ import { CheckboxToggleStore } from "../../stores/checkbox_toggle";
 import { ClientFocusStore } from "../../stores/client_focus_store";
 import { HighlightStore } from "../../stores/highlight_store";
 import { ViewportsStore } from "../../stores/viewports_store";
+import { ZoomStore } from "../../stores/zoom_store";
 import { CellValueType } from "../../types/cells";
 import { ClipboardMIMEType } from "../../types/clipboard";
 import { Client } from "../../types/collaborative/session";
@@ -153,6 +154,7 @@ export class Grid extends Component<SpreadsheetChildEnv> {
   private canvasRef = signal<HTMLElement | null>(null);
   private highlightStore!: Store<HighlightStore>;
   viewStore!: Store<ViewportsStore>;
+  private zoomStore!: Store<ZoomStore>;
   private cellPopovers!: Store<CellPopoverStore>;
   private composerFocusStore!: Store<ComposerFocusStore>;
   private DOMFocusableElementStore!: Store<DOMFocusableElementStore>;
@@ -170,6 +172,7 @@ export class Grid extends Component<SpreadsheetChildEnv> {
   setup() {
     this.highlightStore = useStore(HighlightStore);
     this.viewStore = useStore(ViewportsStore);
+    this.zoomStore = useStore(ZoomStore);
     this.menuState = proxy({
       isOpen: false,
       anchorRect: null,
@@ -225,8 +228,8 @@ export class Grid extends Component<SpreadsheetChildEnv> {
         const { scrollY } = this.viewStore.activeSheetScrollInfo;
         return scrollY < maxOffsetY;
       },
-      getZoom: () => this.viewStore.zoomLevel,
-      setZoom: (zoom: number) => this.viewStore.setZoom(zoom),
+      getZoom: () => this.zoomStore.zoomLevel,
+      setZoom: (zoom: number) => this.zoomStore.setZoom(zoom),
     });
   }
 
@@ -235,7 +238,7 @@ export class Grid extends Component<SpreadsheetChildEnv> {
   }
 
   get gridOverlayDimensions() {
-    const scrollbarWidth = this.viewStore.scrollBarWidth;
+    const scrollbarWidth = this.zoomStore.scrollBarWidth;
     return cssPropertiesToCss({
       top: `${HEADER_HEIGHT}px`,
       left: `${HEADER_WIDTH}px`,
@@ -570,7 +573,7 @@ export class Grid extends Component<SpreadsheetChildEnv> {
   }
 
   private getGridRect(): Rect {
-    const zoom = this.viewStore.zoomLevel;
+    const zoom = this.zoomStore.zoomLevel;
     const { width, height } = this.viewStore.sheetViewDimensionWithHeaders;
     return {
       ...getElBoundingRect(this.gridRef()),

--- a/src/components/grid_popover/grid_popover.ts
+++ b/src/components/grid_popover/grid_popover.ts
@@ -1,9 +1,8 @@
 import { useStore } from "../../store_engine/store_hooks";
-import { ViewportsStore } from "../../stores/viewports_store";
+import { ZoomStore } from "../../stores/zoom_store";
 import { ClosedCellPopover, PositionedCellPopoverComponent } from "../../types/cell_popovers";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 import { Store } from "../../types/store_engine";
-import { getZoomedRect } from "../helpers/zoom";
 import { CellPopoverStore } from "../popover/cell_popover_store";
 import { Popover } from "../popover/popover";
 import { types } from "../props_validation";
@@ -21,11 +20,11 @@ export class GridPopover extends Component<SpreadsheetChildEnv> {
     gridRect: types.Rect(),
   });
   protected cellPopovers!: Store<CellPopoverStore>;
-  private viewStore!: Store<ViewportsStore>;
+  private zoomStore!: Store<ZoomStore>;
 
   setup() {
     this.cellPopovers = useStore(CellPopoverStore);
-    this.viewStore = useStore(ViewportsStore);
+    this.zoomStore = useStore(ZoomStore);
   }
 
   get cellPopover(): PositionedCellPopoverComponent | ClosedCellPopover {
@@ -33,8 +32,7 @@ export class GridPopover extends Component<SpreadsheetChildEnv> {
     if (!popover.isOpen) {
       return { isOpen: false };
     }
-    const zoom = this.viewStore.zoomLevel;
-    const anchorRect = getZoomedRect(zoom, popover.anchorRect);
+    const anchorRect = this.zoomStore.getZoomedRect(popover.anchorRect);
     return {
       ...popover,
       // transform from the "canvas coordinate system" to the "body coordinate system"

--- a/src/components/helpers/drag_and_drop_grid_hook.ts
+++ b/src/components/helpers/drag_and_drop_grid_hook.ts
@@ -2,6 +2,7 @@ import { onWillUnmount } from "@odoo/owl";
 import { MAX_DELAY } from "../../helpers/edge_scrolling";
 import { useLayoutEffect } from "../../owl3_compatibility_layer";
 import { ViewportsStore } from "../../stores/viewports_store";
+import { ZoomStore } from "../../stores/zoom_store";
 import { HeaderIndex, Pixel } from "../../types/misc";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 import { gridOverlayPosition } from "./dom_helpers";
@@ -28,6 +29,7 @@ export function useDragAndDropBeyondTheViewport(env: SpreadsheetChildEnv) {
   let scrollDirection: DnDDirection = "all";
   const getters = env.model.getters;
   const viewStore = env.getStore(ViewportsStore);
+  const zoomStore = env.getStore(ZoomStore);
 
   const blockKeyboard = (ev: KeyboardEvent) => ev.preventDefault();
   const cleanUpBlockKeyboard = () =>
@@ -52,7 +54,7 @@ export function useDragAndDropBeyondTheViewport(env: SpreadsheetChildEnv) {
     }
 
     const sheetId = getters.getActiveSheetId();
-    const zoomLevel = viewStore.zoomLevel;
+    const zoomLevel = zoomStore.zoomLevel;
     const position = gridOverlayPosition(zoomLevel);
     const zoomedMouseEvent = withZoom(env, currentEv, position);
     const { x: offsetCorrectionX, y: offsetCorrectionY } = viewStore.mainViewportCoordinates;
@@ -163,7 +165,7 @@ export function useDragAndDropBeyondTheViewport(env: SpreadsheetChildEnv) {
     startScrollDirection: DnDDirection = "all"
   ) => {
     cleanUp();
-    const zoomLevel = viewStore.zoomLevel;
+    const zoomLevel = zoomStore.zoomLevel;
     const position = gridOverlayPosition(zoomLevel);
     scrollDirection = startScrollDirection;
     startingX = initialPointerCoordinates.clientX - position.x;

--- a/src/components/helpers/zoom.ts
+++ b/src/components/helpers/zoom.ts
@@ -1,6 +1,6 @@
-import { ViewportsStore } from "../../stores/viewports_store";
+import { ZoomStore } from "../../stores/zoom_store";
 import { Pixel } from "../../types/misc";
-import { DOMCoordinates, Rect } from "../../types/rendering";
+import { DOMCoordinates } from "../../types/rendering";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 import { zoomCorrectedElementRect } from "./dom_helpers";
 
@@ -24,7 +24,7 @@ export function withZoom<T extends MouseEvent>(
   ev: T,
   originalTargetPosition?: DOMCoordinates | null
 ): ZoomedMouseEvent<T> {
-  const zoomLevel = env.getStore(ViewportsStore).zoomLevel;
+  const zoomLevel = env.getStore(ZoomStore).zoomLevel;
   if (originalTargetPosition === undefined) {
     originalTargetPosition = getZoomTargetPosition(ev, zoomLevel);
   }
@@ -51,18 +51,6 @@ function withNoZoom<T extends MouseEvent>(ev: T): ZoomedMouseEvent<T> {
     clientY: ev.clientY,
     offsetX: ev.offsetX,
     offsetY: ev.offsetY,
-  };
-}
-
-/**
- * Return a Rect with position and size on the zoomed canvas
- */
-export function getZoomedRect(zoom: number, rect: Rect): Rect {
-  return {
-    height: rect.height * zoom,
-    width: rect.width * zoom,
-    x: rect.x * zoom,
-    y: rect.y * zoom,
   };
 }
 

--- a/src/components/highlight/highlight/highlight.ts
+++ b/src/components/highlight/highlight/highlight.ts
@@ -4,6 +4,7 @@ import { isEqual } from "../../../helpers/zones";
 import { Component } from "../../../owl3_compatibility_layer";
 import { useStore } from "../../../store_engine/store_hooks";
 import { ViewportsStore } from "../../../stores/viewports_store";
+import { ZoomStore } from "../../../stores/zoom_store";
 import { ResizeDirection } from "../../../types/figure";
 import { HeaderIndex, Zone } from "../../../types/misc";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
@@ -38,9 +39,11 @@ export class Highlight extends Component<SpreadsheetChildEnv> {
   });
   dragNDropGrid = useDragAndDropBeyondTheViewport(this.env);
   private viewStore!: Store<ViewportsStore>;
+  private zoomStore!: Store<ZoomStore>;
 
   setup(): void {
     this.viewStore = useStore(ViewportsStore);
+    this.zoomStore = useStore(ZoomStore);
   }
 
   get cornerOrientations(): Array<"nw" | "ne" | "sw" | "se" | "n" | "s" | "e" | "w"> {
@@ -126,7 +129,7 @@ export class Highlight extends Component<SpreadsheetChildEnv> {
     this.highlightState.shiftingMode = "isMoving";
     const z = this.props.range.zone;
 
-    const zoomLevel = this.viewStore.zoomLevel;
+    const zoomLevel = this.zoomStore.zoomLevel;
     const position = gridOverlayPosition(zoomLevel);
     const zoomedMouseEvent = withZoom(this.env, ev, position);
 

--- a/src/components/scrollbar/scrollbar_horizontal.ts
+++ b/src/components/scrollbar/scrollbar_horizontal.ts
@@ -2,6 +2,7 @@ import { useProps, xml } from "@odoo/owl";
 import { Component } from "../../owl3_compatibility_layer";
 import { useStore } from "../../store_engine/store_hooks";
 import { ViewportsStore } from "../../stores/viewports_store";
+import { ZoomStore } from "../../stores/zoom_store";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 import { Store } from "../../types/store_engine";
 import { types } from "../props_validation";
@@ -10,6 +11,7 @@ import { ScrollBar } from "./scrollbar";
 export class HorizontalScrollBar extends Component<SpreadsheetChildEnv> {
   static components = { ScrollBar };
   private viewStore!: Store<ViewportsStore>;
+  private zoomStore!: Store<ZoomStore>;
   static template = xml/*xml*/ `
       <ScrollBar
         t-if="this.isDisplayed"
@@ -22,6 +24,7 @@ export class HorizontalScrollBar extends Component<SpreadsheetChildEnv> {
 
   setup(): void {
     this.viewStore = useStore(ViewportsStore);
+    this.zoomStore = useStore(ZoomStore);
   }
 
   protected props = useProps({
@@ -45,7 +48,7 @@ export class HorizontalScrollBar extends Component<SpreadsheetChildEnv> {
 
   get position() {
     const { x } = this.viewStore.viewports.getMainViewportRect(this.viewStore.displayedSheetId);
-    const scrollbarWidth = this.viewStore.viewports.getScrollBarWidth();
+    const scrollbarWidth = this.zoomStore.scrollBarWidth;
     return {
       left: `${this.props.leftOffset + x}px`,
       bottom: "0px",

--- a/src/components/scrollbar/scrollbar_vertical.ts
+++ b/src/components/scrollbar/scrollbar_vertical.ts
@@ -2,6 +2,7 @@ import { useProps, xml } from "@odoo/owl";
 import { Component } from "../../owl3_compatibility_layer";
 import { useStore } from "../../store_engine/store_hooks";
 import { ViewportsStore } from "../../stores/viewports_store";
+import { ZoomStore } from "../../stores/zoom_store";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 import { Store } from "../../types/store_engine";
 import { types } from "../props_validation";
@@ -10,6 +11,7 @@ import { ScrollBar } from "./scrollbar";
 export class VerticalScrollBar extends Component<SpreadsheetChildEnv> {
   static components = { ScrollBar };
   private viewStore!: Store<ViewportsStore>;
+  private zoomStore!: Store<ZoomStore>;
   static template = xml/*xml*/ `
     <ScrollBar
       t-if="this.isDisplayed"
@@ -22,6 +24,7 @@ export class VerticalScrollBar extends Component<SpreadsheetChildEnv> {
 
   setup(): void {
     this.viewStore = useStore(ViewportsStore);
+    this.zoomStore = useStore(ZoomStore);
   }
 
   protected props = useProps({
@@ -46,7 +49,7 @@ export class VerticalScrollBar extends Component<SpreadsheetChildEnv> {
 
   get position() {
     const { y } = this.viewStore.viewports.getMainViewportRect(this.viewStore.displayedSheetId);
-    const scrollbarWidth = this.viewStore.viewports.getScrollBarWidth();
+    const scrollbarWidth = this.zoomStore.scrollBarWidth;
     return {
       top: `${this.props.topOffset + y}px`,
       right: "0px",

--- a/src/components/spreadsheet/spreadsheet.ts
+++ b/src/components/spreadsheet/spreadsheet.ts
@@ -26,6 +26,7 @@ import { ModelStore } from "../../stores/model_store";
 import { NotificationStore } from "../../stores/notification_store";
 import { ScreenWidthStore } from "../../stores/screen_width_store";
 import { ViewportsStore } from "../../stores/viewports_store";
+import { ZoomStore } from "../../stores/zoom_store";
 import { _t } from "../../translation";
 import { CommandResult } from "../../types/commands";
 import { InformationNotification } from "../../types/env";
@@ -99,6 +100,7 @@ export class Spreadsheet extends Component<SpreadsheetChildEnv> {
   private notificationStore!: Store<NotificationStore>;
   private composerFocusStore!: Store<ComposerFocusStore>;
   private viewStore!: Store<ViewportsStore>;
+  private zoomStore!: Store<ZoomStore>;
 
   get model(): Model {
     return this.props.model;
@@ -106,7 +108,7 @@ export class Spreadsheet extends Component<SpreadsheetChildEnv> {
 
   getStyle(): string {
     const properties: CSSProperties = {};
-    const scrollbarWidth = this.viewStore.scrollBarWidth;
+    const scrollbarWidth = this.zoomStore.scrollBarWidth;
     properties["--os-scrollbar-width"] = `${scrollbarWidth}px`;
     properties["--os-dark-mode-filter"] = DARK_MODE_FILTER_STRING;
     properties["color-scheme"] = this.props.model.getters.isDarkMode() ? "dark" : "light";
@@ -141,6 +143,7 @@ export class Spreadsheet extends Component<SpreadsheetChildEnv> {
     const stores = useStoreProvider();
     stores.inject(ModelStore, this.model);
     this.viewStore = useStore(ViewportsStore);
+    this.zoomStore = useStore(ZoomStore);
 
     const env = this.env;
     stores.get(ScreenWidthStore).setSmallThreshhold(() => {
@@ -315,11 +318,10 @@ export class Spreadsheet extends Component<SpreadsheetChildEnv> {
   get gridContainerStyle(): string {
     const gridColSize = GROUP_LAYER_WIDTH * this.rowLayers.length;
     const gridRowSize = GROUP_LAYER_WIDTH * this.colLayers.length;
-    const zoom = this.viewStore.zoomLevel;
     return cssPropertiesToCss({
       "grid-template-columns": `${gridColSize ? gridColSize + 2 : 0}px auto`, // +2: margins
       "grid-template-rows": `${gridRowSize ? gridRowSize + 2 : 0}px auto`,
-      zoom: `${zoom}`,
+      zoom: this.zoomStore.cssZoom,
     });
   }
 
@@ -339,8 +341,8 @@ export class Spreadsheet extends Component<SpreadsheetChildEnv> {
       return { width: 0, height: 0 };
     }
 
-    const zoom = this.viewStore.zoomLevel;
-    const scrollbarWidth = this.viewStore.scrollBarWidth;
+    const zoom = this.zoomStore.zoomLevel;
+    const scrollbarWidth = this.zoomStore.scrollBarWidth;
 
     const getHeight = (s: string) =>
       (el.querySelector(s) && zoomCorrectedElementRect(el.querySelector(s)!, zoom).height) || 0;

--- a/src/components/spreadsheet_print/spreadsheet_print_store.ts
+++ b/src/components/spreadsheet_print/spreadsheet_print_store.ts
@@ -176,7 +176,7 @@ export class SpreadsheetPrintStore extends SpreadsheetStore {
       paneDivision: { [sheetId]: { xSplit: 0, ySplit: 0 } },
       sheetViewWidth,
       sheetViewHeight,
-      zoomLevel: zoom,
+      getZoomLevel: () => zoom,
       getFooterSize: () => 0,
     });
     viewports.setSheetViewOffset(sheetId, firstColStart, firstRowStart);

--- a/src/components/standalone_viewport/standalone_viewport.ts
+++ b/src/components/standalone_viewport/standalone_viewport.ts
@@ -4,6 +4,7 @@ import { Component } from "../../owl3_compatibility_layer";
 import { useChildStoreProvider, useLocalStore, useStore } from "../../store_engine/store_hooks";
 import { RendererStore } from "../../stores/renderer_store";
 import { ViewportsStore } from "../../stores/viewports_store";
+import { ZoomStore } from "../../stores/zoom_store";
 import { HeaderIndex } from "../../types/misc";
 import { Rect } from "../../types/rendering";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
@@ -44,7 +45,6 @@ export class StandaloneViewport extends Component<SpreadsheetChildEnv> {
     canResizeColumns: types.boolean().optional(true),
     onResizeColumns: types.function<(columnWeights: number[] | undefined) => void>().optional(),
     columnWeights: types.array<number>().optional(),
-    zoomLevel: types.number(),
   });
 
   private canvasRef = signal<HTMLElement | null>(null);
@@ -60,6 +60,7 @@ export class StandaloneViewport extends Component<SpreadsheetChildEnv> {
 
   rendererStore!: Store<RendererStore>;
   viewStore!: Store<ViewportsStore>;
+  zoomStore!: Store<ZoomStore>;
   cellPopoverStore!: Store<CellPopoverStore>;
 
   setup() {
@@ -73,6 +74,7 @@ export class StandaloneViewport extends Component<SpreadsheetChildEnv> {
     ]);
     this.store = useLocalStore(StandaloneViewportStore, this.props.range, this.props.columnWeights);
     this.viewStore = useStore(ViewportsStore);
+    this.zoomStore = useStore(ZoomStore);
     this.cellPopoverStore = useStore(CellPopoverStore);
     this.rendererStore = useLocalStore(RendererStore, ["Background", "Chart"]);
     const resizeObserver = new ResizeObserver(() => {
@@ -90,7 +92,6 @@ export class StandaloneViewport extends Component<SpreadsheetChildEnv> {
       if (this.dndState.col === undefined) {
         this.store.setCustomColWeights(this.props.columnWeights);
       }
-      this.viewStore.setZoom(this.props.zoomLevel);
       this.store.setContainerSize(this.containerWidth, this.containerHeight);
     });
 
@@ -115,11 +116,11 @@ export class StandaloneViewport extends Component<SpreadsheetChildEnv> {
   }
 
   get containerWidth() {
-    return Math.floor(getElBoundingRect(this.containerRef()).width / this.viewStore.zoomLevel);
+    return Math.floor(getElBoundingRect(this.containerRef()).width / this.zoomStore.zoomLevel);
   }
 
   get containerHeight() {
-    return Math.floor(getElBoundingRect(this.containerRef()).height / this.viewStore.zoomLevel);
+    return Math.floor(getElBoundingRect(this.containerRef()).height / this.zoomStore.zoomLevel);
   }
 
   get hasVerticalScrollBar() {
@@ -132,7 +133,7 @@ export class StandaloneViewport extends Component<SpreadsheetChildEnv> {
 
   get scrollBarContainerStyle() {
     return cssPropertiesToCss({
-      width: `${this.viewStore.scrollBarWidth}px`,
+      width: `${this.zoomStore.scrollBarWidth}px`,
     });
   }
 

--- a/src/components/top_bar/zoom_editor/zoom_editor.ts
+++ b/src/components/top_bar/zoom_editor/zoom_editor.ts
@@ -2,7 +2,7 @@ import { useProps } from "@odoo/owl";
 import { ZOOM_VALUES } from "../../../constants";
 import { Component } from "../../../owl3_compatibility_layer";
 import { useStore } from "../../../store_engine/store_hooks";
-import { ViewportsStore } from "../../../stores/viewports_store";
+import { ZoomStore } from "../../../stores/zoom_store";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
 import { Store } from "../../../types/store_engine";
 import { ToolBarDropdownStore, useToolBarDropdownStore } from "../../helpers/top_bar_tool_hook";
@@ -15,22 +15,22 @@ export class ToolBarZoom extends Component<SpreadsheetChildEnv> {
 
   protected props = useProps({ class: types.string() });
   topBarToolStore!: ToolBarDropdownStore;
-  private viewStore!: Store<ViewportsStore>;
+  private zoomStore!: Store<ZoomStore>;
 
   valueList = ZOOM_VALUES;
 
   setup() {
     this.topBarToolStore = useToolBarDropdownStore();
-    this.viewStore = useStore(ViewportsStore);
+    this.zoomStore = useStore(ZoomStore);
   }
 
   get currentFontSize(): number {
-    const zoom = this.viewStore.zoomLevel || 1;
+    const zoom = this.zoomStore.zoomLevel || 1;
     return zoom * 100;
   }
 
   setZoom(fontSize: number) {
-    this.viewStore.setZoom(fontSize / 100);
+    this.zoomStore.setZoom(fontSize / 100);
   }
 
   toggle() {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -170,6 +170,9 @@ export const MENU_SEPARATOR_HEIGHT = MENU_SEPARATOR_BORDER_WIDTH + 2 * MENU_SEPA
 
 // Zoom
 export const ZOOM_VALUES = [50, 75, 100, 125, 150, 200];
+export const MIN_ZOOM = 0.5;
+export const MAX_ZOOM = 2;
+export const DEFAULT_ZOOM = 1;
 
 // Style
 export const DEFAULT_STYLE = {

--- a/src/helpers/rectangle.ts
+++ b/src/helpers/rectangle.ts
@@ -38,3 +38,15 @@ function zoneToRect(zone: Zone | undefined): Rect | undefined {
 export function isPointInsideRect(x: number, y: number, rect: Rect): boolean {
   return x >= rect.x && x <= rect.x + rect.width && y >= rect.y && y <= rect.y + rect.height;
 }
+
+/**
+ * Return a Rect with position and size on the zoomed canvas
+ */
+export function getZoomedRect(zoom: number, rect: Rect): Rect {
+  return {
+    height: rect.height * zoom,
+    width: rect.width * zoom,
+    x: rect.x * zoom,
+    y: rect.y * zoom,
+  };
+}

--- a/src/helpers/viewport_collection.ts
+++ b/src/helpers/viewport_collection.ts
@@ -1,4 +1,3 @@
-import { SCROLLBAR_WIDTH } from "../constants";
 import { AnchorOffset, Figure, FigureUI } from "../types/figure";
 import { ViewportsGetters } from "../types/getters";
 import {
@@ -53,7 +52,7 @@ interface ViewportCollectionArgs {
   paneDivision: Record<UID, PaneDivision>;
   sheetViewWidth: Pixel;
   sheetViewHeight: Pixel;
-  zoomLevel: number;
+  getZoomLevel: () => number;
   getFooterSize: () => number;
   zoneToDisplay?: Zone;
 }
@@ -104,7 +103,7 @@ export class ViewportCollection {
   private paneDivision: Record<UID, PaneDivision>;
   private sheetViewWidth: Pixel;
   private sheetViewHeight: Pixel;
-  private zoomLevel: number;
+  getZoomLevel: () => number;
   private getFooterSize: () => number;
   private zoneToDisplay?: Zone;
 
@@ -113,7 +112,7 @@ export class ViewportCollection {
     this.paneDivision = args.paneDivision;
     this.sheetViewWidth = args.sheetViewWidth;
     this.sheetViewHeight = args.sheetViewHeight;
-    this.zoomLevel = args.zoomLevel;
+    this.getZoomLevel = args.getZoomLevel;
     this.getFooterSize = args.getFooterSize;
     this.zoneToDisplay = args.zoneToDisplay;
   }
@@ -272,7 +271,7 @@ export class ViewportCollection {
     for (const i of relevantIndexes) {
       offset += this.getters.getHeaderSize(sheetId, dimension, i);
     }
-    return offset * this.zoomLevel;
+    return offset * this.getZoomLevel();
   }
 
   /**
@@ -284,10 +283,6 @@ export class ViewportCollection {
 
   isZoneVisibleInViewport(sheetId: UID, zone: Zone): boolean {
     return this.getSubViewports(sheetId).some((viewport) => viewport.isZoneVisible(zone));
-  }
-
-  getScrollBarWidth(): Pixel {
-    return SCROLLBAR_WIDTH / this.zoomLevel;
   }
 
   // => returns the new offset
@@ -380,7 +375,7 @@ export class ViewportCollection {
    * Computes the coordinates and size to draw the zone on the canvas after it has been zoomed
    */
   getVisibleRectWithZoom(sheetId: UID, zone: Zone): Rect {
-    const zoom = this.getViewportZoomLevel();
+    const zoom = this.getZoomLevel();
     const rect = this.getVisibleRectWithoutHeaders(sheetId, zone);
     rect.width = rect.width * zoom;
     rect.height = rect.height * zoom;
@@ -468,10 +463,6 @@ export class ViewportCollection {
         },
       };
     });
-  }
-
-  getViewportZoomLevel(): number {
-    return this.zoomLevel;
   }
 
   ensureMainViewportExist(sheetId: UID) {
@@ -936,14 +927,6 @@ export class ViewportCollection {
 
   getGridOffsetY(): Pixel {
     return this.gridOffsetY;
-  }
-
-  getZoomLevel(): number {
-    return this.zoomLevel;
-  }
-
-  setZoomLevel(zoomLevel: number) {
-    this.zoomLevel = zoomLevel;
   }
 
   private getPaneDivisions(sheetId: UID): PaneDivision {

--- a/src/index.ts
+++ b/src/index.ts
@@ -207,6 +207,7 @@ import { ModelStore } from "./stores/model_store";
 import { NotificationStore } from "./stores/notification_store";
 import { RendererStore } from "./stores/renderer_store";
 import { SpreadsheetStore } from "./stores/spreadsheet_store";
+import { ZoomStore } from "./stores/zoom_store";
 import { CHART_TYPES, schemeToColorScale } from "./types/chart/chart";
 import { AddFunctionDescription } from "./types/functions";
 import { DEFAULT_LOCALE } from "./types/locale";
@@ -567,6 +568,7 @@ export const stores = {
   ClientFocusStore,
   GridRenderer,
   ViewportsStore,
+  ZoomStore,
   globalStores,
 };
 

--- a/src/stores/viewports_store.ts
+++ b/src/stores/viewports_store.ts
@@ -10,7 +10,7 @@ import {
   ViewportsGetters,
   Zone,
 } from "..";
-import { FOOTER_HEIGHT, getDefaultSheetViewSize, SCROLLBAR_WIDTH } from "../constants";
+import { FOOTER_HEIGHT, getDefaultSheetViewSize } from "../constants";
 import { deepEquals } from "../helpers/misc";
 import { ViewportCollection } from "../helpers/viewport_collection";
 import { findCellInNewZone, isEqual } from "../helpers/zones";
@@ -25,6 +25,7 @@ import {
 } from "../types/rendering";
 import { Get } from "../types/store_engine";
 import { SpreadsheetStore } from "./spreadsheet_store";
+import { ZoomStore } from "./zoom_store";
 
 type getHeaderDimensionsCallback = (
   sheetId: UID,
@@ -42,7 +43,6 @@ export class ViewportsStore extends SpreadsheetStore {
   mutators = [
     "setViewportOffset",
     "resizeSheetView",
-    "setZoom",
     "shiftViewportDown",
     "shiftViewportUp",
     "scrollToCell",
@@ -51,8 +51,10 @@ export class ViewportsStore extends SpreadsheetStore {
     "rebuildViewports",
   ] as const;
 
+  private zoomStore = this.get(ZoomStore);
   private getHeaderDimensionsCallback = this.getters.getHeaderDimensions;
   private getFooterSizeCallback = this.getFooterSize.bind(this);
+  private getZoomLevelCallback = () => this.zoomStore.zoomLevel;
   private zoneToDisplay: Zone | undefined = undefined;
 
   viewports: ViewportCollection = new ViewportCollection({
@@ -60,7 +62,7 @@ export class ViewportsStore extends SpreadsheetStore {
     paneDivision: this.getPaneDivisions(),
     sheetViewHeight: getDefaultSheetViewSize(),
     sheetViewWidth: getDefaultSheetViewSize(),
-    zoomLevel: 1,
+    getZoomLevel: this.getZoomLevelCallback,
     getFooterSize: this.getFooterSizeCallback,
   });
   private sheetsWithDirtyViewports: Set<UID> = new Set();
@@ -229,14 +231,6 @@ export class ViewportsStore extends SpreadsheetStore {
     return;
   }
 
-  setZoom(zoom: number) {
-    if (zoom > 2 || zoom < 0.5 || zoom === this.viewports.getZoomLevel()) {
-      return "noStateChange";
-    }
-    this.viewports.setZoomLevel(zoom);
-    return;
-  }
-
   shiftViewportDown() {
     const sheetId = this.displayedSheetId;
     const { top, viewportHeight, boundaryTopY } = this.viewports.getMainInternalViewport(sheetId);
@@ -310,10 +304,6 @@ export class ViewportsStore extends SpreadsheetStore {
     return this.viewports.getMaximumSheetOffset(this.displayedSheetId);
   }
 
-  get scrollBarWidth(): Pixel {
-    return SCROLLBAR_WIDTH / this.viewports.getZoomLevel();
-  }
-
   /**
    * Returns the position of the MainViewport relatively to the start of the grid (without headers)
    * It corresponds to the summed dimensions of the visible cols/rows (in x/y respectively)
@@ -321,10 +311,6 @@ export class ViewportsStore extends SpreadsheetStore {
    */
   get mainViewportCoordinates(): DOMCoordinates {
     return this.viewports.getMainViewportCoordinates(this.displayedSheetId);
-  }
-
-  get zoomLevel(): number {
-    return this.viewports.getZoomLevel();
   }
 
   get visibleFigures(): FigureUI[] {
@@ -394,7 +380,7 @@ export class ViewportsStore extends SpreadsheetStore {
       paneDivision: this.getPaneDivisions(),
       sheetViewHeight: this.viewports.getSheetViewDimension().height,
       sheetViewWidth: this.viewports.getSheetViewDimension().width,
-      zoomLevel: this.viewports.getZoomLevel(),
+      getZoomLevel: this.getZoomLevelCallback,
       getFooterSize: this.getFooterSizeCallback,
       zoneToDisplay: this.zoneToDisplay,
     });

--- a/src/stores/zoom_store.ts
+++ b/src/stores/zoom_store.ts
@@ -1,0 +1,33 @@
+import { DEFAULT_ZOOM, MAX_ZOOM, MIN_ZOOM, SCROLLBAR_WIDTH } from "../constants";
+import { getZoomedRect } from "../helpers/rectangle";
+import { Pixel } from "../types/misc";
+import { Rect } from "../types/rendering";
+
+/**
+ * Holds the zoom level of the spreadsheet UI, and everything derived purely from it.
+ */
+export class ZoomStore {
+  mutators = ["setZoom"] as const;
+  storeGetters = ["getZoomedRect"] as const;
+  zoomLevel: number = DEFAULT_ZOOM;
+
+  setZoom(zoom: number) {
+    if (zoom > MAX_ZOOM || zoom < MIN_ZOOM || zoom === this.zoomLevel) {
+      return "noStateChange";
+    }
+    this.zoomLevel = zoom;
+    return;
+  }
+
+  getZoomedRect(rect: Rect): Rect {
+    return getZoomedRect(this.zoomLevel, rect);
+  }
+
+  get scrollBarWidth(): Pixel {
+    return SCROLLBAR_WIDTH / this.zoomLevel;
+  }
+
+  get cssZoom(): string {
+    return `${this.zoomLevel}`;
+  }
+}

--- a/tests/figures/carousel/standalone_viewport.test.ts
+++ b/tests/figures/carousel/standalone_viewport.test.ts
@@ -7,6 +7,7 @@ import { zoneToXc } from "../../../src/helpers/zones";
 import { useChildSubEnv } from "../../../src/owl3_compatibility_layer";
 import { GridRenderer } from "../../../src/stores/grid_renderer_store";
 import { ViewportsStore } from "../../../src/stores/viewports_store";
+import { ZoomStore } from "../../../src/stores/zoom_store";
 import { PropsOf } from "../../../src/types/props_of";
 import { SpreadsheetChildEnv } from "../../../src/types/spreadsheet_env";
 import {
@@ -86,7 +87,7 @@ async function mountViewport(zone: string, args: MountViewportArgs = {}) {
   const range = model.getters.getRangeFromSheetXC(sheetId, zone);
   const returnValue = await mountComponentWithPortalTarget(StandaloneViewport, {
     model,
-    props: { ...args, range, zoomLevel: 1 },
+    props: { ...args, range },
   });
   await nextTick(); // Need another render for the size to be correct
   return returnValue;
@@ -308,7 +309,7 @@ describe("Standalone viewport", () => {
     createCarouselWithDataView(model, toRangeData(sheetId, "A1:B1"), "carouselId");
     const { env } = await mountSpreadsheet({ model });
 
-    const mainViewportStore = env.getStore(ViewportsStore);
+    const mainZoomStore = env.getStore(ZoomStore);
     const standaloneViewportStore = subEnv.getStore(ViewportsStore);
     expect(standaloneViewportStore.sheetViewDimension).toEqual({ width: 1000, height: 1000 });
     expect(getLastRenderedBoxes()).toMatchObject([
@@ -316,18 +317,18 @@ describe("Standalone viewport", () => {
       { id: "B1", height: DEFAULT_CELL_HEIGHT, width: 500, x: 500, y: 0 },
     ]);
 
-    mainViewportStore.setZoom(2);
+    mainZoomStore.setZoom(2);
     await nextTick();
-    expect(standaloneViewportStore.zoomLevel).toEqual(2);
+    expect(subEnv.getStore(ZoomStore).zoomLevel).toEqual(2);
     expect(standaloneViewportStore.sheetViewDimension).toEqual({ width: 500, height: 500 });
     expect(getLastRenderedBoxes()).toMatchObject([
       { id: "A1", height: DEFAULT_CELL_HEIGHT, width: 250, x: 0, y: 0 },
       { id: "B1", height: DEFAULT_CELL_HEIGHT, width: 250, x: 250, y: 0 },
     ]);
 
-    mainViewportStore.setZoom(0.5);
+    mainZoomStore.setZoom(0.5);
     await nextTick();
-    expect(standaloneViewportStore.zoomLevel).toEqual(0.5);
+    expect(subEnv.getStore(ZoomStore).zoomLevel).toEqual(0.5);
     expect(standaloneViewportStore.sheetViewDimension).toEqual({ width: 2000, height: 2000 });
     expect(getLastRenderedBoxes()).toMatchObject([
       { id: "A1", height: DEFAULT_CELL_HEIGHT, width: 1000, x: 0, y: 0 },

--- a/tests/grid/grid_component.test.ts
+++ b/tests/grid/grid_component.test.ts
@@ -30,6 +30,7 @@ import { ClientFocusStore } from "../../src/stores/client_focus_store";
 import { HighlightStore } from "../../src/stores/highlight_store";
 import { NotificationStore } from "../../src/stores/notification_store";
 import { ViewportsStore } from "../../src/stores/viewports_store";
+import { ZoomStore } from "../../src/stores/zoom_store";
 import { SpreadsheetChildEnv } from "../../src/types/spreadsheet_env";
 import { Store } from "../../src/types/store_engine";
 import { xmlEscape } from "../../src/xlsx/helpers/xml_helpers";
@@ -2572,7 +2573,7 @@ test("Can pinch to zoom in", async () => {
   );
 
   await nextTick();
-  expect(viewStore.zoomLevel).toBeCloseTo(1.54);
+  expect(env.getStore(ZoomStore).zoomLevel).toBeCloseTo(1.54);
 
   // go back to initial
   triggerPointerEvent(grid, "pointermove", secondPointerStartX, secondPointerStartY, {
@@ -2580,7 +2581,7 @@ test("Can pinch to zoom in", async () => {
     bubbles: true,
   });
   await nextTick();
-  expect(viewStore.zoomLevel).toBeCloseTo(1);
+  expect(env.getStore(ZoomStore).zoomLevel).toBeCloseTo(1);
 
   // // pinch to zoom out - closer pointers
   triggerPointerEvent(grid, "pointermove", 110, 110, {
@@ -2588,14 +2589,14 @@ test("Can pinch to zoom in", async () => {
     bubbles: true,
   });
   await nextTick();
-  expect(viewStore.zoomLevel).toBeCloseTo(0.74);
+  expect(env.getStore(ZoomStore).zoomLevel).toBeCloseTo(0.74);
 
   // go back to initial
   triggerPointerEvent(grid, "pointermove", 100, 100, {
     pointerId: 1,
     bubbles: true,
   });
-  expect(viewStore.zoomLevel).toBeCloseTo(1);
+  expect(env.getStore(ZoomStore).zoomLevel).toBeCloseTo(1);
 });
 
 test("pinch to zoom stops on pointerup", async () => {
@@ -2630,7 +2631,7 @@ test("pinch to zoom stops on pointerup", async () => {
   );
 
   await nextTick();
-  expect(viewStore.zoomLevel).toBeCloseTo(1.54);
+  expect(env.getStore(ZoomStore).zoomLevel).toBeCloseTo(1.54);
 
   triggerPointerEvent(window, "pointerup", secondPointerStartX, secondPointerStartY, {
     pointerId: 2,
@@ -2643,7 +2644,7 @@ test("pinch to zoom stops on pointerup", async () => {
     bubbles: true,
   });
   await nextTick();
-  expect(viewStore.zoomLevel).toBeCloseTo(1.54);
+  expect(env.getStore(ZoomStore).zoomLevel).toBeCloseTo(1.54);
 });
 
 test("Cannot pinch to zoom with right-click", async () => {
@@ -2664,11 +2665,11 @@ test("Cannot pinch to zoom with right-click", async () => {
     bubbles: true,
     button: 1,
   });
-  expect(viewStore.zoomLevel).toBe(1);
+  expect(env.getStore(ZoomStore).zoomLevel).toBe(1);
   triggerPointerEvent(grid, "pointermove", secondPointerStartX + 100, secondPointerStartY + 100, {
     pointerId: 2,
     bubbles: true,
     button: 1,
   });
-  expect(viewStore.zoomLevel).toBe(1);
+  expect(env.getStore(ZoomStore).zoomLevel).toBe(1);
 });

--- a/tests/test_helpers/commands_helpers.ts
+++ b/tests/test_helpers/commands_helpers.ts
@@ -59,6 +59,7 @@ import { isInside, toZone } from "../../src/helpers/zones";
 import { chartDataSourceRegistry } from "../../src/registries/chart_data_source_registry";
 import { chartTypeRegistry } from "../../src/registries/chart_registry";
 import { ViewportsStore } from "../../src/stores/viewports_store";
+import { ZoomStore } from "../../src/stores/zoom_store";
 import { BubbleChartDefinition } from "../../src/types/chart/bubble_chart";
 import { CalendarChartDefinition } from "../../src/types/chart/calendar_chart";
 import { ComboChartDefinition } from "../../src/types/chart/combo_chart";
@@ -2016,7 +2017,7 @@ export function shiftViewportUp(env: SpreadsheetChildEnv) {
 }
 
 export function setZoom(env: SpreadsheetChildEnv, zoom: number) {
-  const store = env.getStore(ViewportsStore);
+  const store = env.getStore(ZoomStore);
   return store.setZoom(zoom);
 }
 

--- a/tests/test_helpers/dom_helper.ts
+++ b/tests/test_helpers/dom_helper.ts
@@ -7,6 +7,7 @@ import { MIN_DELAY, scrollDelay } from "../../src/helpers/edge_scrolling";
 import { ViewportCollection } from "../../src/helpers/viewport_collection";
 import { positionToZone, toZone } from "../../src/helpers/zones";
 import { ViewportsStore } from "../../src/stores/viewports_store";
+import { ZoomStore } from "../../src/stores/zoom_store";
 import { SpreadsheetChildEnv } from "../../src/types/spreadsheet_env";
 import { nextTick } from "./helpers";
 
@@ -176,7 +177,7 @@ export async function clickCell(
   const viewStore = env.getStore(ViewportsStore);
   const zone = toZone(xc);
   const sheetId = env.model.getters.getActiveSheetId();
-  const zoom = viewStore.zoomLevel;
+  const zoom = env.getStore(ZoomStore).zoomLevel;
   if (!viewStore.viewports.isVisibleInViewport({ sheetId, col: zone.left, row: zone.top })) {
     throw new Error(`You can't click on ${xc} because it is not visible`);
   }
@@ -459,7 +460,7 @@ export async function selectColumnByClicking(
 ) {
   const model = env.model;
   const index = lettersToNumber(letter);
-  const zoom = env.getStore(ViewportsStore).zoomLevel;
+  const zoom = env.getStore(ZoomStore).zoomLevel;
   const x =
     model.getters.getColDimensions(model.getters.getActiveSheetId(), index)!.start * zoom + 1;
   triggerMouseEvent(".o-overlay .o-col-resizer", "pointermove", x, 10);


### PR DESCRIPTION
Zoom level was owned by ViewportsStore, so each viewport store had its own zoom, forcing the carousel to forward the main grid's zoom through a prop and a setZoom in a useEffect.

This commit extract the zoom level to its own store.

Task: 6448259