### PR TITLE
[IMP] carousel: add hover effect in data view

### DIFF
--- a/src/components/dashboard/clickable_cell_sort_icon/clickable_cell_sort_icon.ts
+++ b/src/components/dashboard/clickable_cell_sort_icon/clickable_cell_sort_icon.ts
@@ -6,10 +6,10 @@ import { Color, Style } from "../../../types/misc";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
 import { Store } from "../../../types/store_engine";
 import { cssPropertiesToCss } from "../../helpers/css";
-import { HoveredTableStore } from "../../tables/hovered_table_store";
 
 import { useProps } from "@odoo/owl";
 import { Component } from "../../../owl3_compatibility_layer";
+import { CellHoverOverlayStore } from "../../../stores/cell_hover_overlay_store";
 import { types } from "../../props_validation";
 
 export class ClickableCellSortIcon extends Component<SpreadsheetChildEnv> {
@@ -19,10 +19,10 @@ export class ClickableCellSortIcon extends Component<SpreadsheetChildEnv> {
     position: types.CellPosition(),
     sortDirection: types.or([types.SortDirection, types.literal("none")]),
   });
-  private hoveredTableStore!: Store<HoveredTableStore>;
+  private hoveredCellOverlayStore!: Store<CellHoverOverlayStore>;
 
   setup(): void {
-    this.hoveredTableStore = useStore(HoveredTableStore);
+    this.hoveredCellOverlayStore = useStore(CellHoverOverlayStore);
   }
 
   get style() {
@@ -50,7 +50,7 @@ export class ClickableCellSortIcon extends Component<SpreadsheetChildEnv> {
   }
 
   private getBackgroundColor(cellStyle: Style): Color {
-    const overlayColor = this.hoveredTableStore.overlayColors.get(this.props.position);
+    const overlayColor = this.hoveredCellOverlayStore.overlayColors.get(this.props.position);
     if (overlayColor) {
       return blendColors(cellStyle.fillColor || "#FFFFFF", overlayColor);
     }

--- a/src/components/dashboard/dashboard.ts
+++ b/src/components/dashboard/dashboard.ts
@@ -23,6 +23,7 @@ import { Popover } from "../popover/popover";
 import { types } from "../props_validation";
 import { HorizontalScrollBar } from "../scrollbar/scrollbar_horizontal";
 import { VerticalScrollBar } from "../scrollbar/scrollbar_vertical";
+import { HoveredTableStore } from "../tables/hovered_table_store";
 
 export class SpreadsheetDashboard extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-SpreadsheetDashboard";
@@ -55,6 +56,7 @@ export class SpreadsheetDashboard extends Component<SpreadsheetChildEnv> {
     this.hoveredCell = useStore(DelayedHoveredCellStore);
     this.viewStore = useStore(ViewportsStore);
     this.zoomStore = useStore(ZoomStore);
+    useLocalStore(HoveredTableStore);
 
     const layers = OrderedLayers().filter((layer) => layer !== "Headers");
     const rendererStore = useLocalStore(RendererStore, layers);

--- a/src/components/grid_overlay/grid_overlay.ts
+++ b/src/components/grid_overlay/grid_overlay.ts
@@ -76,7 +76,12 @@ function useCellHovered(
     if (isChildEvent(gridRef(), zoomedMouseEvent.ev)) {
       ({ x, y } = getOffsetRelativeToOverlay(zoomedMouseEvent));
       lastMoved = Date.now();
-      cellHoverOverlay.hover(getPosition());
+      const position = getPosition();
+      if (position.col < 0 || position.row < 0) {
+        cellHoverOverlay.hover(undefined);
+      } else {
+        cellHoverOverlay.hover(getPosition());
+      }
     }
   }
 
@@ -92,7 +97,7 @@ function useCellHovered(
     const { x, y } = getOffsetRelativeToOverlay(zoomedMouseEvent);
     const gridRect = getElBoundingRect(gridRef());
 
-    if (y < 0 || y > gridRect.height || x < 0 || x > gridRect.width) {
+    if (y <= 0 || y >= gridRect.height || x <= 0 || x >= gridRect.width) {
       return updateMousePosition(zoomedMouseEvent);
     } else {
       return pause();

--- a/src/components/grid_overlay/grid_overlay.ts
+++ b/src/components/grid_overlay/grid_overlay.ts
@@ -4,6 +4,7 @@ import { isPointInsideRect } from "../../helpers/rectangle";
 import { positionToZone } from "../../helpers/zones";
 import { Component, useExternalListener } from "../../owl3_compatibility_layer";
 import { useStore } from "../../store_engine/store_hooks";
+import { CellHoverOverlayStore } from "../../stores/cell_hover_overlay_store";
 import { ViewportsStore } from "../../stores/viewports_store";
 import { CellPosition, GridClickModifiers, HeaderIndex, Position } from "../../types/misc";
 import { DOMCoordinates } from "../../types/rendering";
@@ -18,7 +19,6 @@ import { withZoom, ZoomedMouseEvent } from "../helpers/zoom";
 import { PaintFormatStore } from "../paint_format_button/paint_format_store";
 import { CellPopoverStore } from "../popover/cell_popover_store";
 import { types } from "../props_validation";
-import { HoveredTableStore } from "../tables/hovered_table_store";
 import { HoveredIconStore } from "./hovered_icon_store";
 
 function useCellHovered(
@@ -26,7 +26,7 @@ function useCellHovered(
   gridRef: Signal<HTMLElement | null>
 ): Partial<Position> {
   const delayedHoveredCell = useStore(DelayedHoveredCellStore);
-  const hoveredTable = useStore(HoveredTableStore);
+  const cellHoverOverlay = useStore(CellHoverOverlayStore);
   const viewStore = useStore(ViewportsStore);
   const hoveredPosition: Partial<Position> = {
     col: undefined,
@@ -76,7 +76,7 @@ function useCellHovered(
     if (isChildEvent(gridRef(), zoomedMouseEvent.ev)) {
       ({ x, y } = getOffsetRelativeToOverlay(zoomedMouseEvent));
       lastMoved = Date.now();
-      hoveredTable.hover(getPosition());
+      cellHoverOverlay.hover(getPosition());
     }
   }
 

--- a/src/components/standalone_viewport/standalone_viewport.ts
+++ b/src/components/standalone_viewport/standalone_viewport.ts
@@ -2,6 +2,7 @@ import { proxy, signal, useEffect, useProps } from "@odoo/owl";
 import { sumArray } from "../../helpers/misc";
 import { Component } from "../../owl3_compatibility_layer";
 import { useChildStoreProvider, useLocalStore, useStore } from "../../store_engine/store_hooks";
+import { CellHoverOverlayStore } from "../../stores/cell_hover_overlay_store";
 import { RendererStore } from "../../stores/renderer_store";
 import { ViewportsStore } from "../../stores/viewports_store";
 import { ZoomStore } from "../../stores/zoom_store";
@@ -24,7 +25,6 @@ import { withZoom } from "../helpers/zoom";
 import { CellPopoverStore } from "../popover/cell_popover_store";
 import { types } from "../props_validation";
 import { VerticalScrollBar } from "../scrollbar/scrollbar_vertical";
-import { HoveredTableStore } from "../tables/hovered_table_store";
 import { StandaloneViewportStore } from "./standalone_viewport_store";
 
 interface ColResizer {
@@ -67,8 +67,8 @@ export class StandaloneViewport extends Component<SpreadsheetChildEnv> {
     useChildStoreProvider([
       ViewportsStore,
       HoveredIconStore,
-      HoveredTableStore,
       ClickableCellsStore,
+      CellHoverOverlayStore,
       DelayedHoveredCellStore,
       CellPopoverStore,
     ]);

--- a/src/components/standalone_viewport/standalone_viewport_store.ts
+++ b/src/components/standalone_viewport/standalone_viewport_store.ts
@@ -1,10 +1,11 @@
 import { DEFAULT_CELL_WIDTH } from "../../constants";
 import { deepEquals, range, sumArray } from "../../helpers/misc";
-import { isZoneValid } from "../../helpers/zones";
+import { isInside, isZoneValid } from "../../helpers/zones";
+import { CellHoverOverlayStore } from "../../stores/cell_hover_overlay_store";
 import { SpreadsheetStore } from "../../stores/spreadsheet_store";
 import { ViewportsStore } from "../../stores/viewports_store";
 import { Command } from "../../types/commands";
-import { HeaderDimensions, HeaderIndex, UID } from "../../types/misc";
+import { CellPosition, HeaderDimensions, HeaderIndex, UID } from "../../types/misc";
 import { Range } from "../../types/range";
 import { GridRenderingContext } from "../../types/rendering";
 import { Get } from "../../types/store_engine";
@@ -32,6 +33,9 @@ export class StandaloneViewportStore extends SpreadsheetStore {
       zoneToDisplay: this.range.zone,
       getFooterSize: () => 0,
     });
+    const cellHoverOverlayStore = this.get(CellHoverOverlayStore);
+    cellHoverOverlayStore.register(this);
+    this.onDispose(() => cellHoverOverlayStore.unRegister(this));
   }
 
   handle(cmd: Command) {
@@ -226,5 +230,20 @@ export class StandaloneViewportStore extends SpreadsheetStore {
     }
 
     return normalizedWeights;
+  }
+
+  getHighlightedPositions(position: CellPosition): CellPosition[] {
+    const highlightedPositions: CellPosition[] = [];
+
+    const { col, row, sheetId } = position;
+    if (sheetId !== this.range.sheetId || !isInside(col, row, this.range.zone)) {
+      return highlightedPositions;
+    }
+
+    for (let col = this.range.zone.left; col <= this.range.zone.right; col++) {
+      highlightedPositions.push({ ...position, col });
+    }
+
+    return highlightedPositions;
   }
 }

--- a/src/components/tables/hovered_table_store.ts
+++ b/src/components/tables/hovered_table_store.ts
@@ -1,38 +1,28 @@
-import { TABLE_HOVER_BACKGROUND_COLOR } from "../../constants";
-import { PositionMap } from "../../helpers/cells/position_map";
-import { deepEquals, range } from "../../helpers/misc";
+import { range } from "../../helpers/misc";
+import { CellHoverOverlayStore } from "../../stores/cell_hover_overlay_store";
 import { SpreadsheetStore } from "../../stores/spreadsheet_store";
-import { CellPosition, Color } from "../../types/misc";
+import { CellPosition } from "../../types/misc";
+import { Get } from "../../types/store_engine";
 
 export class HoveredTableStore extends SpreadsheetStore {
-  mutators = ["clear", "hover"] as const;
+  mutators = ["hover"] as const;
+  storeGetters = ["getCellHoverOverlayColor"] as const;
 
   position: CellPosition | undefined;
 
-  overlayColors: PositionMap<Color> = new PositionMap();
-
-  hover(position: CellPosition | undefined) {
-    if (!this.getters.isDashboard() || deepEquals(this.position, position)) {
-      return "noStateChange";
-    }
-    this.position = position;
-    this.computeOverlay();
-    return;
+  constructor(get: Get) {
+    super(get);
+    const cellHoverOverlayStore = this.get(CellHoverOverlayStore);
+    cellHoverOverlayStore.register(this);
+    this.onDispose(() => cellHoverOverlayStore.unRegister(this));
   }
 
-  clear() {
-    this.position = undefined;
-  }
-
-  private computeOverlay() {
-    this.overlayColors = new PositionMap();
-    if (!this.position) {
-      return;
-    }
-    const { sheetId, col, row } = this.position;
-    const table = this.getters.getTable({ sheetId, col, row });
+  getHighlightedPositions(hoveredPosition: CellPosition): CellPosition[] {
+    const highlightedPositions: CellPosition[] = [];
+    const { sheetId, row } = hoveredPosition;
+    const table = this.getters.getTable(hoveredPosition);
     if (!table) {
-      return;
+      return highlightedPositions;
     }
     const { left, right, top } = table.range.zone;
     const isTableHeader = row < top + table.config.numberOfHeaders;
@@ -45,8 +35,10 @@ export class HoveredTableStore extends SpreadsheetStore {
 
     if (!isTableHeader && doesTableRowHaveContent) {
       for (let col = left; col <= right; col++) {
-        this.overlayColors.set({ sheetId, col, row }, TABLE_HOVER_BACKGROUND_COLOR);
+        highlightedPositions.push({ sheetId, col, row });
       }
     }
+
+    return highlightedPositions;
   }
 }

--- a/src/stores/cell_hover_overlay_store.ts
+++ b/src/stores/cell_hover_overlay_store.ts
@@ -1,0 +1,39 @@
+import { TABLE_HOVER_BACKGROUND_COLOR } from "../constants";
+import { PositionMap } from "../helpers/cells/position_map";
+import { CellPosition, Color } from "../types/misc";
+import { SpreadsheetStore } from "./spreadsheet_store";
+
+export interface CellHoverOverlayProvider {
+  getHighlightedPositions: (hoveredPosition: CellPosition) => CellPosition[];
+}
+
+export class CellHoverOverlayStore extends SpreadsheetStore {
+  mutators = ["hover", "register", "unRegister"] as const;
+  storeGetters = ["getCellHoverOverlayColor"] as const;
+
+  private providers: CellHoverOverlayProvider[] = [];
+
+  overlayColors: PositionMap<Color> = new PositionMap();
+
+  hover(hoveredPosition: CellPosition | undefined) {
+    this.overlayColors = new PositionMap();
+    if (!hoveredPosition) {
+      return;
+    }
+
+    for (const provider of this.providers) {
+      const positions = provider.getHighlightedPositions(hoveredPosition);
+      for (const position of positions) {
+        this.overlayColors.set(position, TABLE_HOVER_BACKGROUND_COLOR);
+      }
+    }
+  }
+
+  register(highlightProvider: CellHoverOverlayProvider) {
+    this.providers.push(highlightProvider);
+  }
+
+  unRegister(highlightProvider: CellHoverOverlayProvider) {
+    this.providers = this.providers.filter((h) => h !== highlightProvider);
+  }
+}

--- a/src/stores/grid_renderer_store.ts
+++ b/src/stores/grid_renderer_store.ts
@@ -1,6 +1,5 @@
 import { HoveredIconStore } from "../components/grid_overlay/hovered_icon_store";
 import { getPath2D } from "../components/icons/icons";
-import { HoveredTableStore } from "../components/tables/hovered_table_store";
 import {
   CANVAS_SHIFT,
   DATA_VALIDATION_CHIP_MARGIN,
@@ -48,6 +47,7 @@ import {
   Viewport,
 } from "../types/rendering";
 import { Get, Store } from "../types/store_engine";
+import { CellHoverOverlayStore } from "./cell_hover_overlay_store";
 import { FormulaFingerprintStore } from "./formula_fingerprints_store";
 import { ModelStore } from "./model_store";
 import { RendererStore } from "./renderer_store";
@@ -64,7 +64,7 @@ interface Animation {
 
 export class GridRenderer extends DisposableStore {
   private fingerprints: Store<FormulaFingerprintStore>;
-  private hoveredTables: Store<HoveredTableStore>;
+  private cellHoverOverlayStore = this.get(CellHoverOverlayStore);
   private hoveredIcon: Store<HoveredIconStore>;
 
   private lastRenderSheetId: UID | undefined = undefined;
@@ -79,7 +79,6 @@ export class GridRenderer extends DisposableStore {
     const model = get(ModelStore) as Model;
     this.getters = model.getters;
     this.fingerprints = get(FormulaFingerprintStore);
-    this.hoveredTables = get(HoveredTableStore);
     this.hoveredIcon = get(HoveredIconStore);
 
     model.on("command-dispatched", this, this.handle);
@@ -771,7 +770,7 @@ export class GridRenderer extends DisposableStore {
       border: this.getters.getCellComputedBorder(position) || undefined,
       style,
       dataBarFill,
-      overlayColor: this.hoveredTables.overlayColors.get(position),
+      overlayColor: this.cellHoverOverlayStore.overlayColors.get(position),
       isError:
         (cell.type === CellValueType.error && !!cell.message) ||
         this.getters.isDataValidationInvalid(position),

--- a/tests/figures/carousel/standalone_viewport.test.ts
+++ b/tests/figures/carousel/standalone_viewport.test.ts
@@ -1,10 +1,11 @@
 import { Model, UID } from "../../../src";
 import { HoveredIconStore } from "../../../src/components/grid_overlay/hovered_icon_store";
 import { StandaloneViewport } from "../../../src/components/standalone_viewport/standalone_viewport";
-import { DEFAULT_CELL_HEIGHT } from "../../../src/constants";
+import { DEFAULT_CELL_HEIGHT, TABLE_HOVER_BACKGROUND_COLOR } from "../../../src/constants";
 import { buildSheetLink, range } from "../../../src/helpers/misc";
 import { zoneToXc } from "../../../src/helpers/zones";
 import { useChildSubEnv } from "../../../src/owl3_compatibility_layer";
+import { CellHoverOverlayStore } from "../../../src/stores/cell_hover_overlay_store";
 import { GridRenderer } from "../../../src/stores/grid_renderer_store";
 import { ViewportsStore } from "../../../src/stores/viewports_store";
 import { ZoomStore } from "../../../src/stores/zoom_store";
@@ -36,6 +37,7 @@ import {
   mountSpreadsheet,
   nextTick,
   setGrid,
+  toCellPosition,
   toRangeData,
 } from "../../test_helpers/helpers";
 import { spyStoreCreation, StoreSpy } from "../../test_helpers/stores";
@@ -334,6 +336,26 @@ describe("Standalone viewport", () => {
       { id: "A1", height: DEFAULT_CELL_HEIGHT, width: 1000, x: 0, y: 0 },
       { id: "B1", height: DEFAULT_CELL_HEIGHT, width: 1000, x: 1000, y: 0 },
     ]);
+  });
+
+  test("Row is highlighted when hovering a cell", async () => {
+    jest.useFakeTimers();
+    setGrid(model, { A1: "Hello", B1: "World", C1: "!" }, "sh2");
+
+    await mountViewport("A1:C3", { sheetId: "sh2" });
+    const overlayStore = subEnv.getStore(CellHoverOverlayStore);
+    expect(overlayStore.overlayColors.get(toCellPosition("sh2", "A1"))).toBeUndefined();
+
+    await hoverCell(subEnv, "A1", 500);
+    const color = TABLE_HOVER_BACKGROUND_COLOR;
+
+    expect(overlayStore.overlayColors.get(toCellPosition("sh2", "A1"))).toEqual(color);
+    expect(overlayStore.overlayColors.get(toCellPosition("sh2", "B1"))).toEqual(color);
+    expect(overlayStore.overlayColors.get(toCellPosition("sh2", "C1"))).toEqual(color);
+    expect(overlayStore.overlayColors.get(toCellPosition("sh2", "A2"))).toBeUndefined();
+    expect(overlayStore.overlayColors.get(toCellPosition("sh2", "B2"))).toBeUndefined();
+    expect(overlayStore.overlayColors.get(toCellPosition("sh2", "C2"))).toBeUndefined();
+    jest.useRealTimers();
   });
 
   describe("Column resize", () => {

--- a/tests/grid/grid_overlay_component.test.ts
+++ b/tests/grid/grid_overlay_component.test.ts
@@ -13,8 +13,10 @@ import {
 import { lettersToNumber, toXC } from "../../src/helpers/coordinates";
 import { toZone } from "../../src/helpers/zones";
 import { Model } from "../../src/model";
+import { CellHoverOverlayStore } from "../../src/stores/cell_hover_overlay_store";
 import { ViewportsStore } from "../../src/stores/viewports_store";
 import { SpreadsheetChildEnv } from "../../src/types/spreadsheet_env";
+import { extendMockGetBoundingClientRect } from "../test_helpers";
 import {
   deleteColumns,
   deleteRows,
@@ -1387,4 +1389,33 @@ describe("Can select de-select headers", () => {
     await selectRow(2, { ctrlKey: true });
     expect(model.getters.getActiveRows()).toEqual(new Set([0, 1, 3, 4]));
   });
+});
+
+test("Mouse leave events correctly change the hovered cell", async () => {
+  jest.useFakeTimers();
+  extendMockGetBoundingClientRect({
+    "o-grid-overlay": () => ({ x: 0, y: 0, width: 1000, height: 1000 }),
+  });
+  const { model, env } = await mountSpreadsheet();
+  const sheetId = model.getters.getActiveSheetId();
+
+  const hoverStore = env.getStore(CellHoverOverlayStore);
+  const spy = jest.spyOn(hoverStore, "hover");
+
+  triggerMouseEvent(".o-grid-overlay", "pointermove", 10, 10);
+  expect(spy).toHaveBeenCalledTimes(1);
+  expect(spy).toHaveBeenLastCalledWith({ sheetId, col: 0, row: 0 });
+
+  triggerMouseEvent(".o-grid-overlay", "mouseleave", 500, 500);
+  expect(spy).toHaveBeenCalledTimes(1); // mouseleave while still inside the grid overlay => do not trigger an hover
+
+  triggerMouseEvent(".o-grid-overlay", "mouseenter", 500, 500);
+  triggerMouseEvent(".o-grid-overlay", "mouseleave", 2000, 500); // mouseleave outside the grid
+  expect(spy).toHaveBeenLastCalledWith(undefined);
+
+  triggerMouseEvent(".o-grid-overlay", "mouseenter", 500, 500);
+  triggerMouseEvent(".o-grid-overlay", "mouseleave", 1000, 1000); // mouseleave exactly at the limit of the grid
+  expect(spy).toHaveBeenLastCalledWith(undefined);
+
+  jest.useRealTimers();
 });

--- a/tests/pivots/pivot_sorting_dashboard.test.ts
+++ b/tests/pivots/pivot_sorting_dashboard.test.ts
@@ -1,6 +1,6 @@
 import { ClickableCellsStore } from "../../src/components/dashboard/clickable_cell_store";
-import { HoveredTableStore } from "../../src/components/tables/hovered_table_store";
 import { TEXT_BODY_MUTED } from "../../src/constants";
+import { CellHoverOverlayStore } from "../../src/stores/cell_hover_overlay_store";
 import { createTable, setFormatting } from "../test_helpers/commands_helpers";
 import { click, getElComputedStyle } from "../test_helpers/dom_helper";
 import { getCellIcons } from "../test_helpers/getters_helpers";
@@ -171,7 +171,7 @@ describe("Dashboard Pivot Sorting", () => {
     ).toBeSameColorAs(TEXT_BODY_MUTED);
 
     // hover the row -> background should follow the overlay color
-    env.getStore(HoveredTableStore).hover(toCellPosition(sheetId, "B5"));
+    env.getStore(CellHoverOverlayStore).hover(toCellPosition(sheetId, "B5"));
     await nextTick();
     expect(
       getElComputedStyle(".o-dashboard-clickable-cell .sorting-icon", "background-color")

--- a/tests/renderer/renderer_store.test.ts
+++ b/tests/renderer/renderer_store.test.ts
@@ -31,6 +31,7 @@ import {
   BACKGROUND_HEADER_SELECTED_COLOR,
 } from "../../src/plugins/ui_feature/color_theme";
 import { DependencyContainer } from "../../src/store_engine/dependency_container";
+import { CellHoverOverlayStore } from "../../src/stores/cell_hover_overlay_store";
 import { FormulaFingerprintStore } from "../../src/stores/formula_fingerprints_store";
 import { GridRenderer } from "../../src/stores/grid_renderer_store";
 import { RendererStore } from "../../src/stores/renderer_store";
@@ -480,6 +481,7 @@ describe("renderer", () => {
     setFormatting(model, "A1", { fillColor: background });
     setCellContent(model, "A1", "Data");
     model.updateMode("dashboard");
+    container.get(HoveredTableStore); // Instantiate hovered table store
 
     let fillStyle = "";
     let fillStyles: any[] = [];
@@ -505,7 +507,7 @@ describe("renderer", () => {
     ]);
 
     fillStyles = [];
-    container.get(HoveredTableStore).hover({ sheetId, col: 0, row: 0 });
+    container.get(CellHoverOverlayStore).hover({ sheetId, col: 0, row: 0 });
     drawGridRenderer(ctx);
 
     expect(removeOffsetOfFillStyles(fillStyles)).toEqual([

--- a/tests/table/hovered_table_store.test.ts
+++ b/tests/table/hovered_table_store.test.ts
@@ -1,74 +1,56 @@
 import { Model, UID } from "../../src";
 import { HoveredTableStore } from "../../src/components/tables/hovered_table_store";
 import { TABLE_HOVER_BACKGROUND_COLOR } from "../../src/constants";
+import { DependencyContainer } from "../../src/store_engine/dependency_container";
+import { CellHoverOverlayStore } from "../../src/stores/cell_hover_overlay_store";
+import { Store } from "../../src/types/store_engine";
 import { createTable, hideColumns, setCellContent } from "../test_helpers/commands_helpers";
-import { makeStore } from "../test_helpers/stores";
+import { mountSpreadsheet, nextTick } from "../test_helpers/helpers";
+import { makeStore, spyStoreCreation } from "../test_helpers/stores";
 
 describe("Hovered Table Store", () => {
-  let hoveredTableStore: HoveredTableStore;
+  let hoveredCellOverlayStore: Store<CellHoverOverlayStore>;
   let model: Model;
   let sheetId: UID;
+  let container: DependencyContainer;
 
   beforeEach(() => {
-    ({ model, store: hoveredTableStore } = makeStore(HoveredTableStore));
+    ({ model, container } = makeStore(HoveredTableStore));
+    hoveredCellOverlayStore = container.get(CellHoverOverlayStore);
     sheetId = model.getters.getActiveSheetId();
   });
 
-  test("Should not store overlay for header cells, regardless of data", () => {
+  test("Should not have overlay color for header cells, regardless of data", () => {
     const A1 = { sheetId, col: 0, row: 0 };
     createTable(model, "A1");
 
-    model.updateMode("dashboard");
-    hoveredTableStore.hover(A1);
-    expect(hoveredTableStore.overlayColors.has(A1)).toBe(false);
+    hoveredCellOverlayStore.hover(A1);
+    expect(hoveredCellOverlayStore.overlayColors.has(A1)).toBe(false);
 
-    model.updateMode("normal");
     setCellContent(model, "A1", "Header");
 
-    model.updateMode("dashboard");
-    hoveredTableStore.hover(A1);
-    expect(hoveredTableStore.overlayColors.has(A1)).toBe(false);
+    hoveredCellOverlayStore.hover(A1);
+    expect(hoveredCellOverlayStore.overlayColors.has(A1)).toBe(false);
   });
 
-  test("Should not store overlay for empty data cells in dashboard mode", () => {
+  test("Should not have overlay color for empty data cells", () => {
     const A2 = { sheetId, col: 0, row: 1 };
     createTable(model, "A1:A2");
 
-    model.updateMode("dashboard");
-    hoveredTableStore.hover(A2);
-    expect(hoveredTableStore.overlayColors.has(A2)).toBe(false);
+    hoveredCellOverlayStore.hover(A2);
+    expect(hoveredCellOverlayStore.overlayColors.has(A2)).toBe(false);
   });
 
-  test("Should store overlay for full data rows with content in dashboard mode", () => {
+  test("Should have overlay color for full data rows with content", () => {
     const A2 = { sheetId, col: 0, row: 1 };
     const B2 = { sheetId, col: 1, row: 1 };
     createTable(model, "A1:B2");
     setCellContent(model, "A2", "Data");
 
-    model.updateMode("dashboard");
-    hoveredTableStore.hover(A2);
-    expect(hoveredTableStore.overlayColors.has(A2)).toBe(true);
-    expect(hoveredTableStore.overlayColors.has(B2)).toBe(true);
-    expect(hoveredTableStore.overlayColors.get(A2)).toBe(TABLE_HOVER_BACKGROUND_COLOR);
-  });
-
-  test("Overlay colors are applied only in dashboard mode", () => {
-    const A2 = { sheetId, col: 0, row: 1 };
-    createTable(model, "A1:A2");
-    setCellContent(model, "A2", "Data");
-
-    model.updateMode("normal");
-    hoveredTableStore.hover(A2);
-    expect(hoveredTableStore.overlayColors.has(A2)).toBe(false);
-
-    model.updateMode("readonly");
-    hoveredTableStore.hover(A2);
-    expect(hoveredTableStore.overlayColors.has(A2)).toBe(false);
-
-    model.updateMode("dashboard");
-    hoveredTableStore.hover(A2);
-    expect(hoveredTableStore.overlayColors.has(A2)).toBe(true);
-    expect(hoveredTableStore.overlayColors.get(A2)).toBe(TABLE_HOVER_BACKGROUND_COLOR);
+    hoveredCellOverlayStore.hover(A2);
+    expect(hoveredCellOverlayStore.overlayColors.has(A2)).toBe(true);
+    expect(hoveredCellOverlayStore.overlayColors.has(B2)).toBe(true);
+    expect(hoveredCellOverlayStore.overlayColors.get(A2)).toBe(TABLE_HOVER_BACKGROUND_COLOR);
   });
 
   test("Hidden columns should be ignored when applying overlay colors", () => {
@@ -76,16 +58,40 @@ describe("Hovered Table Store", () => {
     createTable(model, "A1:B2");
     setCellContent(model, "A2", "Some data");
 
-    model.updateMode("dashboard");
-    hoveredTableStore.hover(B2);
-    expect(hoveredTableStore.overlayColors.has(B2)).toBe(true);
+    hoveredCellOverlayStore.hover(B2);
+    expect(hoveredCellOverlayStore.overlayColors.has(B2)).toBe(true);
 
-    hoveredTableStore.clear();
-
-    model.updateMode("normal");
     hideColumns(model, ["A"]);
+    hoveredCellOverlayStore.hover(B2);
+    expect(hoveredCellOverlayStore.overlayColors.has(B2)).toBe(false);
+  });
+});
+
+describe("Spreadsheet integration tests", () => {
+  test("Hovered table store is only present in dashboard mode", async () => {
+    const model = new Model();
+    createTable(model, "A1:A2");
+    setCellContent(model, "A2", "Data");
+    const spy = spyStoreCreation();
+
+    const { env } = await mountSpreadsheet({ model });
+    const hoveredCellOverlayStore = env.getStore(CellHoverOverlayStore);
+
+    expect(hoveredCellOverlayStore["providers"]).toHaveLength(0);
+    expect(spy.getStores(HoveredTableStore).length).toBe(0);
+
+    model.updateMode("readonly");
+    await nextTick();
+    expect(hoveredCellOverlayStore["providers"]).toHaveLength(0);
+    expect(spy.getStores(HoveredTableStore).length).toBe(0);
+
     model.updateMode("dashboard");
-    hoveredTableStore.hover(B2);
-    expect(hoveredTableStore.overlayColors.has(B2)).toBe(false);
+    await nextTick();
+    expect(hoveredCellOverlayStore["providers"]).toHaveLength(1);
+    expect(spy.getStores(HoveredTableStore).length).toBe(1);
+
+    model.updateMode("readonly");
+    await nextTick();
+    expect(hoveredCellOverlayStore["providers"]).toHaveLength(0); // Cleaned up on unmount
   });
 });


### PR DESCRIPTION
## Description

This commit adds an hover effect in the carousel data view. The effect is the same as the one you get when hovering a table in a dashboard.

It introduces a new store `CellHoverOverlayStore ` on which different stores can register to provide cells on which a hover effect should be played. The `HoveredTableStore` was changed to register to this store, and is now only used in the `Dashboard` component.

Task: [6449819](https://www.odoo.com/odoo/2328/tasks/6449819)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo