### PR TITLE
[FIX] Fonts: fix linux font on css variable

### DIFF
--- a/src/variables.css
+++ b/src/variables.css
@@ -13,7 +13,7 @@
   --os-black: light-dark(#000000, #ffffff);
   --os-white-bg: light-dark(#ffffff, var(--os-gray-200));
 
-  --os-default-font: "Roboto", "Arial";
+  --os-default-font: "Roboto", "Arial", "Liberation Sans";
   --os-default-font-size: 10px;
   --os-link-color: light-dark(#017e84, #02c7b5);
   --os-link-hover-color: light-dark(#01585c, #4ed8cb);


### PR DESCRIPTION
In #9012, we added a default font for linux computers but in later versions (saas-19.1),  the font family variable was duplicated (both js in css).

Task: 6452045

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [6452045](https://www.odoo.com/odoo/2328/tasks/6452045)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo