### PR TITLE
[FIX] ChartMenu: hide region selection in edit mode

### DIFF
--- a/src/components/figures/chart/chart_menu/chart_menu.xml
+++ b/src/components/figures/chart/chart_menu/chart_menu.xml
@@ -2,7 +2,7 @@
   <t t-name="o-spreadsheet-ChartMenu">
     <div class="o-chart-menu position-absolute top-0 end-0" t-on-click.stop="">
       <div class="d-flex align-items-center gap-1 p-1 rounded" t-att-style="backgroundColor">
-        <t t-if="this.regionOptions.length > 1">
+        <t t-if="this.env.model.getters.isDashboard() and this.regionOptions.length > 1">
           <Select
             class="'o-chart-menu-item w-auto py-0 px-1 text-muted text-nowrap rounded border-0'"
             popoverClass="'w-auto'"


### PR DESCRIPTION
The region selector was meant to be only accessible when in dashboard mode but a recente refactoring of ChartMenu removed that condition by mistake.

Task: 6441988

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo