### PR TITLE
[FIX] functions: omit functions from the squisher

### DIFF
--- a/src/functions/function_registry.ts
+++ b/src/functions/function_registry.ts
@@ -85,3 +85,7 @@ for (const category of categories) {
     functionRegistry.add(name, { isExported: false, ...addDescr });
   }
 }
+
+/** Formulas using one of these functions are never squished: they are always exported
+ * as a full formula string, and they don't become the base formula of the next cells. */
+export const NonSquishableFunctionRegistry = new Registry<FunctionDescription["name"]>();

--- a/src/index.ts
+++ b/src/index.ts
@@ -140,7 +140,7 @@ import { HoveredTableStore } from "./components/tables/hovered_table_store";
 import { TextInput } from "./components/text_input/text_input";
 import { ChartTerms } from "./components/translations_terms";
 import { arg } from "./functions/arguments";
-import { functionRegistry } from "./functions/function_registry";
+import { NonSquishableFunctionRegistry, functionRegistry } from "./functions/function_registry";
 import { PositionMap } from "./helpers/cells/position_map";
 import * as CHART_HELPERS from "./helpers/figures/charts";
 import { chartJsExtensionRegistry } from "./helpers/figures/charts/chart_js_extension";
@@ -325,6 +325,7 @@ export const registries = {
   pivotToFunctionValueRegistry,
   migrationStepRegistry,
   chartJsExtensionRegistry,
+  NonSquishableFunctionRegistry,
 };
 
 import "./registries/chart_types";
@@ -519,7 +520,10 @@ export { getCaretDownSvg, getCaretUpSvg } from "./components/icons/icons";
 
 export { createAutocompleteArgumentsProvider } from "./functions/autocomplete_arguments_provider";
 export { categories } from "./functions/function_registry";
-export type { FunctionRegistry } from "./functions/function_registry";
+export type {
+  FunctionRegistry,
+  NonSquishableFunctionRegistry,
+} from "./functions/function_registry";
 export type { StoreConstructor, StoreParams } from "./store_engine";
 export function addFunction(functionName: string, functionDescription: AddFunctionDescription) {
   functionRegistry.add(functionName, functionDescription);

--- a/src/plugins/core/squisher.ts
+++ b/src/plugins/core/squisher.ts
@@ -1,4 +1,5 @@
 import { CompiledFormula } from "../../formulas/compiler";
+import { NonSquishableFunctionRegistry } from "../../functions/function_registry";
 import { deepCopy, deepEquals } from "../../helpers";
 import { toCartesian, toXC } from "../../helpers/coordinates";
 import { getRangeString } from "../../helpers/range";
@@ -105,7 +106,8 @@ export class Squisher {
    * The result of this method is:
    * - if the cell is not a formula, returns the content as is and resets the base formula
    * - if the cell is a formula:
-   *   - if there is no previous formula, or the normalized formula is different from the previous one, resets the base formula to this one and returns the full formula string
+   *   - if there is no previous formula, or the normalized formula is different from the previous one or it contains blacklisted functions (see NonSquishableFunctionRegistry),
+   *        resets the base formula to this one and returns the full formula string
    *   - else, compares the literal values and range dependencies to the previous formula, and for each parameter:
    *     - for numbers: returns a relative change (+N or -N) if possible, else the full number or "=" if unchanged
    *     - for strings: returns the full string if changed, else "="
@@ -115,6 +117,15 @@ export class Squisher {
     if (!cell.isFormula) {
       this.resetBase();
       return cell.content;
+    }
+
+    if (
+      NonSquishableFunctionRegistry.getAll().some((functionName) =>
+        cell.compiledFormula.usesSymbol(functionName)
+      )
+    ) {
+      this.resetBase();
+      return cell.compiledFormula.toFormulaString(this.getters, this.rangeToStringOptions);
     }
 
     let numbers: string[] = [];

--- a/tests/model/squish.test.ts
+++ b/tests/model/squish.test.ts
@@ -1,8 +1,12 @@
-import { FormulaCell } from "../../src";
+import { FormulaCell, FunctionResultObject, Maybe } from "../../src";
+import {
+  functionRegistry,
+  NonSquishableFunctionRegistry,
+} from "../../src/functions/function_registry";
 import { createRangeFromXc } from "../../src/helpers/range";
 import { Model } from "../../src/model";
 import { createSheet, deleteColumns, getCell, getCellContent, getCellText } from "../test_helpers";
-import { createModelFromGrid } from "../test_helpers/helpers";
+import { addToRegistry, createModelFromGrid } from "../test_helpers/helpers";
 
 describe("squish - unsquish", () => {
   let model: Model;
@@ -588,6 +592,36 @@ describe("squish - unsquish specific cases", () => {
     const importedFromSquished = new Model(exportSquished);
     const exportUnSquished = importedFromSquished._exportData(false);
     expect(exportUnSquished.sheets[0].cells).toEqual(sheetContent);
+  });
+
+  test("formulas using a non-squishable function are exported as is", () => {
+    addToRegistry(functionRegistry, "NOSQUISH", {
+      description: "DO no squish",
+      compute: (term: Maybe<FunctionResultObject>) => term?.value ?? "",
+      args: [{ name: "term", description: "", type: ["ANY"] }],
+    });
+    NonSquishableFunctionRegistry.add("NOSQUISH", "NOSQUISH");
+    const sheetContent = {
+      A1: "=SUM(B1)",
+      A2: "=SUM(B2)",
+      A3: '=NOSQUISH("hello")',
+      A4: '=NOSQUISH("hello")',
+      A5: '=NOSQUISH("world")',
+    };
+    const model = createModelFromGrid(sheetContent);
+
+    const exportSquished = model._exportData(true);
+    expect(exportSquished.sheets[0].cells).toEqual({
+      A1: "=SUM(B1)",
+      A2: { R: "+R1" },
+      "A3:A4": '=NOSQUISH("hello")',
+      A5: '=NOSQUISH("world")',
+    });
+
+    const importedFromSquished = new Model(exportSquished);
+    const exportUnSquished = importedFromSquished._exportData(false);
+    expect(exportUnSquished.sheets[0].cells).toEqual(sheetContent);
+    NonSquishableFunctionRegistry.remove("NOSQUISH");
   });
 });
 


### PR DESCRIPTION
Some functions do not react nicely to the squisher as the squished file becomes harder to post-process. In Odoo, for instance, we need to extract translatable terms and if it is squished, the extraction method then needs a case-by-case handling (squished or not) and requires a lot of extra code (basically some unsquishing logic) to extract the terms.

This revision adds a registry for the squisher to ignore the formulas including those problematic functions.

Task: 6452075

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo