### PR TITLE
[REL] 19.4.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@odoo/o-spreadsheet",
-  "version": "19.4.5",
+  "version": "19.4.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@odoo/o-spreadsheet",
-      "version": "19.4.5",
+      "version": "19.4.6",
       "license": "LGPL-3.0-or-later",
       "dependencies": {
         "@odoo/owl": "3.0.0-alpha.45",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@odoo/o-spreadsheet",
-  "version": "19.4.5",
+  "version": "19.4.6",
   "description": "A spreadsheet component",
   "type": "module",
   "main": "dist/o_spreadsheet.cjs",


### PR DESCRIPTION
### Contains the following commits:

https://github.com/odoo/o-spreadsheet/commit/48df9225db [IMP] composer: writing an number value should override date formats [Task: 6353692](https://www.odoo.com/odoo/2328/tasks/6353692)
https://github.com/odoo/o-spreadsheet/commit/48e2180e31 [FIX] index: export `CarouselFigure` [Task: 6449019](https://www.odoo.com/odoo/2328/tasks/6449019)
https://github.com/odoo/o-spreadsheet/commit/1a6144752d [FIX] chart: geoChart uses same d3 projection for main and full screen chart [Task: 6395379](https://www.odoo.com/odoo/2328/tasks/6395379)
https://github.com/odoo/o-spreadsheet/commit/60d40c1514 [FIX] carousel: crash on multiuser when deleting chart [Task: 6445004](https://www.odoo.com/odoo/2328/tasks/6445004)
https://github.com/odoo/o-spreadsheet/commit/4e9affe04f [FIX] figures: fix movement issue with arrow keys [Task: 6374091](https://www.odoo.com/odoo/2328/tasks/6374091)
https://github.com/odoo/o-spreadsheet/commit/01acbcaa9d [IMP] package: update owl to 45 [Task: 0](https://www.odoo.com/odoo/2328/tasks/0)

Task: 0
