### PR TITLE
[IMP] index: export some helper for odoo list

### DIFF
--- a/src/components/helpers/dom_helpers.ts
+++ b/src/components/helpers/dom_helpers.ts
@@ -81,6 +81,17 @@ export function getBoundingRectAsPOJO(el: Element): Rect {
   };
 }
 
+export function getBoundingRectWithMargins(el: Element): Rect {
+  const style = getComputedStyle(el);
+  const rect = el.getBoundingClientRect();
+  return {
+    x: rect.x,
+    y: rect.y,
+    width: rect.width + parseInt(style.marginLeft || "0") + parseInt(style.marginRight || "0"),
+    height: rect.height + parseInt(style.marginTop || "0") + parseInt(style.marginBottom || "0"),
+  };
+}
+
 /**
  * Iterate over all the children of `el` in the dom tree starting at `el`, depth first.
  */

--- a/src/components/side_panel/pivot/pivot_layout_configurator/pivot_layout_configurator.ts
+++ b/src/components/side_panel/pivot/pivot_layout_configurator/pivot_layout_configurator.ts
@@ -20,7 +20,10 @@ import {
   PivotMeasure,
 } from "../../../../types/pivot";
 import { SpreadsheetChildEnv } from "../../../../types/spreadsheet_env";
-import { hasInteractiveElementInEventTree } from "../../../helpers/dom_helpers";
+import {
+  getBoundingRectWithMargins,
+  hasInteractiveElementInEventTree,
+} from "../../../helpers/dom_helpers";
 import { useDragAndDropListItems } from "../../../helpers/drag_and_drop_dom_items_hook";
 import { types } from "../../../props_validation";
 import { SidePanelCollapsible } from "../../components/collapsible/side_panel_collapsible";
@@ -163,17 +166,7 @@ export class PivotLayoutConfigurator extends Component<SpreadsheetChildEnv> {
   }
 
   getDimensionElementsRects() {
-    return Array.from(this.dimensionsRef()!.children).map((el) => {
-      const style = getComputedStyle(el)!;
-      const rect = el.getBoundingClientRect();
-      return {
-        x: rect.x,
-        y: rect.y,
-        width: rect.width + parseInt(style.marginLeft || "0") + parseInt(style.marginRight || "0"),
-        height:
-          rect.height + parseInt(style.marginTop || "0") + parseInt(style.marginBottom || "0"),
-      };
-    });
+    return Array.from(this.dimensionsRef()!.children).map((el) => getBoundingRectWithMargins(el));
   }
 
   removeDimension(dimension: PivotDimensionType) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -341,7 +341,11 @@ import { TableAutofillStore } from "./components/autofill/table_autofill_store";
 import { Composer } from "./components/composer/composer/composer";
 import { StandaloneComposer } from "./components/composer/standalone_composer/standalone_composer";
 import { CarouselFigure } from "./components/figures/figure_carousel/figure_carousel";
-import { isMobileOS } from "./components/helpers/dom_helpers";
+import {
+  getBoundingRectWithMargins,
+  hasInteractiveElementInEventTree,
+  isMobileOS,
+} from "./components/helpers/dom_helpers";
 import { Select } from "./components/select/select";
 import { ChartRangeDataSourceComponent } from "./components/side_panel/chart/building_blocks/range_data_source/range_data_source";
 import { CalendarButton } from "./components/side_panel/criterion_form/calendar_button/calendar_button";
@@ -450,6 +454,8 @@ export const helpers = {
   createComputeFunction,
   isMobileOS,
   drawHighlight,
+  getBoundingRectWithMargins,
+  hasInteractiveElementInEventTree,
 };
 
 export const links = {


### PR DESCRIPTION
## Description:

Export `getBoundingRectWithMargins` and `hasInteractiveElementInEventTree`
so they can be reused by the Odoo side panels.

Task: [6219600](https://www.odoo.com/odoo/2328/tasks/6219600)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo