### PR TITLE
[FIX] Session: deactivate command squisher

### DIFF
--- a/src/collaborative/session.ts
+++ b/src/collaborative/session.ts
@@ -431,7 +431,9 @@ export class Session extends EventBus<CollaborativeEvent> {
       }
       message = {
         ...message,
-        commands: this.commandSquisher.squish(revision.commands),
+        commands: revision.commands,
+        // deactivated squishing for now, as it is causing issues with empty cells & literals with inlined formats
+        //this.commandSquisher.squish(revision.commands),
       };
     }
     if (this.isReplayingInitialRevisions) {

--- a/tests/collaborative/collaborative_session_squish.test.ts
+++ b/tests/collaborative/collaborative_session_squish.test.ts
@@ -7,7 +7,8 @@ import { setCellContent } from "../test_helpers/commands_helpers";
 import { setupCollaborativeEnv } from "./collaborative_helpers";
 
 describe("Collaborative session", () => {
-  test("Update_cell on same value and contiguous cells", () => {
+  // FIXME: reactivate the test when we resquish the commands on the network
+  test.skip("Update_cell on same value and contiguous cells", () => {
     const transport = new MockTransportService();
     const model = new Model(
       { sheets: [{ id: "sheet1", name: "Sheet 1", cells: { A1: "Hello" } }] },


### PR DESCRIPTION
Some issues were reported with the squished revisions where there is a loss of information and even command corruption when handling edge-cases like the presence of update_cell with an empty content or content with inlined format (e.g. `100%`, `2/2/2022`, etc).

Since these issues are nocive and can simply break a spreadsheet through their corrupted revisions, we deactivate the squisher on the session for the time being until we can come up with a satifying and robust solution.

reference task with the issues 6462247


Task: [6462247](https://www.odoo.com/odoo/2328/tasks/6462247)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo