### PR TITLE
[REF] print: use an iframe to print the spreadsheet

### DIFF
--- a/src/components/helpers/draw_grid_hook.ts
+++ b/src/components/helpers/draw_grid_hook.ts
@@ -1,4 +1,3 @@
-import type { Signal } from "@odoo/owl";
 import { CANVAS_SHIFT } from "../../constants";
 import { useLayoutEffect } from "../../owl3_compatibility_layer";
 import { useLocalStore, useStore } from "../../store_engine/store_hooks";
@@ -9,7 +8,7 @@ import { Store } from "../../types/store_engine";
 import { cssPropertiesToCss } from "./css";
 
 interface GridDrawingArgs {
-  canvasRef: Signal<HTMLElement | null>;
+  canvasRef: () => HTMLElement | null;
   renderingCtx: () => Omit<GridRenderingContext, "ctx" | "thinLineWidth">;
   rendererStore?: Store<RendererStore>;
   changeCanvasSizeOnZoom?: boolean;
@@ -26,7 +25,10 @@ export function useGridDrawing({
   useLocalStore(GridRenderer, renderer);
 
   function drawGrid() {
-    const canvas = canvasRef() as HTMLCanvasElement;
+    const canvas = canvasRef() as HTMLCanvasElement | null;
+    if (!canvas) {
+      return;
+    }
     const ctx = canvas.getContext("2d", { alpha: false })!;
     const renderingContext: GridRenderingContext = {
       ctx,

--- a/src/components/helpers/draw_grid_hook.ts
+++ b/src/components/helpers/draw_grid_hook.ts
@@ -49,6 +49,7 @@ export function useGridDrawing({
     if (width === 0 || height === 0) {
       return;
     }
+    ctx.resetTransform();
     // Imagine each pixel as a large square. The whole-number coordinates (0, 1, 2…)
     // are the edges of the squares. If you draw a one-unit-wide line between whole-number
     // coordinates, it will overlap opposite sides of the pixel square, and the resulting

--- a/src/components/spreadsheet_print/print_iframe.ts
+++ b/src/components/spreadsheet_print/print_iframe.ts
@@ -1,0 +1,193 @@
+import { onMounted, Signal, signal } from "@odoo/owl";
+import { useLayoutEffect } from "../../owl3_compatibility_layer";
+import { _t } from "../../translation";
+import { keyboardEventToShortcutString } from "../helpers/dom_helpers";
+
+const PRINT_IFRAME_CSS = /* css */ `
+  html, body {
+    margin: 0;
+    padding: 0;
+  }
+
+  body {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    background-color: #e7e9ed;
+    font-family: "Roboto", "Arial";
+    min-width: min-content; /* Ensure the body does not shrink smaller than its content */
+  }
+
+  .o-print-page {
+    display: flex;
+    justify-content: center;
+    flex-shrink: 0;
+    box-sizing: border-box;
+    margin: 1rem;
+    background-color: #ffffff;
+    box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
+  }
+
+  .o-empty-print-page {
+    align-items: center;
+    color: #5f636f;
+    font-style: italic;
+  }
+
+  @media print {
+    body {
+      display: block;
+      background-color: transparent;
+    }
+
+    .o-print-page {
+      margin: 0 !important;
+      padding: 0 !important;
+      width: 100% !important;
+      height: 100% !important;
+      box-shadow: none;
+      break-after: page;
+    }
+
+    .o-print-page:last-child {
+      break-after: auto;
+    }
+
+    .o-empty-print-page {
+      display: none;
+    }
+  }
+`;
+
+interface PrintIframeArgs {
+  iframeRef: () => HTMLIFrameElement | null;
+  pageCount: () => number;
+  /** Dimensions/padding of a page */
+  pageStyle: () => string;
+  /** `@page` css rules */
+  pageRule: () => string;
+}
+
+export interface PrintIframe {
+  canvases: Signal<HTMLCanvasElement[]>;
+  print: () => void;
+}
+
+export function usePrintIframe(args: PrintIframeArgs): PrintIframe {
+  const canvases = signal<HTMLCanvasElement[]>([]);
+  let styleElement: HTMLStyleElement | undefined = undefined;
+  let currentIframeDocument: Document | null = null;
+
+  onMounted(initializeIframe);
+  useLayoutEffect(syncIframeContent);
+
+  function initializeIframe() {
+    const iframe = args.iframeRef();
+    if (!iframe || !iframe?.contentDocument) {
+      throw new Error("No iframe element found for print preview");
+    }
+
+    iframe.addEventListener("load", () => {
+      // In older firefox versions with an `about:blank` iframe, the iframe would have a readyState "complete" at first
+      // render, marking it ready to use. But then an async navigation event would occur, replacing the whole iframe document.
+      // And for those `about:blank` iframes, other browsers might not dispatch a `load` event at all.
+      // https://bugzilla.mozilla.org/show_bug.cgi?id=543435
+      // FIXME: can most likely be decommissioned when Firefox ESR reaches version > 148
+      if (currentIframeDocument !== iframe.contentDocument) {
+        currentIframeDocument = iframe.contentDocument;
+        setupIframeDocument(currentIframeDocument);
+        syncIframeContent();
+      }
+    });
+    currentIframeDocument = iframe.contentDocument;
+    setupIframeDocument(currentIframeDocument);
+    syncIframeContent();
+  }
+
+  function setupIframeDocument(doc: Document | null) {
+    if (!doc) {
+      throw new Error("No document in the iframe");
+    }
+
+    styleElement = doc.createElement("style");
+    doc.head.appendChild(styleElement);
+    doc.body.replaceChildren();
+
+    doc.addEventListener("keydown", (ev: KeyboardEvent) => {
+      if (keyboardEventToShortcutString(ev) === "Ctrl+P") {
+        ev.preventDefault();
+      }
+    });
+  }
+
+  function syncIframeContent() {
+    const iframe = args.iframeRef();
+    const doc = iframe?.contentDocument;
+    if (!iframe || !doc) {
+      return;
+    }
+
+    const pageRule = args.pageRule();
+    if (styleElement) {
+      styleElement.textContent = PRINT_IFRAME_CSS + pageRule;
+    }
+    syncPages(doc);
+  }
+
+  function syncPages(doc: Document) {
+    const pageCount = args.pageCount();
+    const isEmptyPage = !!doc.body.querySelector(".o-empty-print-page");
+    if (pageCount === 0) {
+      if (!isEmptyPage) {
+        doc.body.replaceChildren(createEmptyPageElement());
+      }
+    } else {
+      if (isEmptyPage) {
+        doc.body.replaceChildren();
+      }
+      while (doc.body.children.length > pageCount) {
+        doc.body.lastElementChild?.remove();
+      }
+      while (doc.body.children.length < pageCount) {
+        doc.body.appendChild(createPageElement());
+      }
+    }
+
+    for (const page of doc.body.children) {
+      page.setAttribute("style", args.pageStyle());
+    }
+
+    const newCanvases = [...doc.querySelectorAll("canvas")];
+    if (!areSameCanvases(canvases(), newCanvases)) {
+      canvases.set(newCanvases);
+    }
+  }
+
+  function print() {
+    args.iframeRef()?.contentWindow?.focus();
+    args.iframeRef()?.contentWindow?.print();
+  }
+
+  return { canvases, print };
+}
+
+function createPageElement() {
+  const page = document.createElement("div");
+  page.classList.add("o-print-page");
+  const canvas = document.createElement("canvas");
+  page.appendChild(canvas);
+  return page;
+}
+
+function createEmptyPageElement() {
+  const page = document.createElement("div");
+  page.classList.add("o-print-page", "o-empty-print-page");
+  const message = document.createElement("h4");
+  message.textContent = _t("No content to print");
+  page.appendChild(message);
+  return page;
+}
+
+function areSameCanvases(a: HTMLCanvasElement[], b: HTMLCanvasElement[]): boolean {
+  return a.length === b.length && a.every((canvas, i) => canvas === b[i]);
+}

--- a/src/components/spreadsheet_print/spreadsheet_print.css
+++ b/src/components/spreadsheet_print/spreadsheet_print.css
@@ -7,43 +7,15 @@
     }
   }
 
+  /* The pages are in the iframe document, styled by PRINT_IFRAME_CSS */
   .o-print-preview {
-    background-color: light-dark(var(--os-gray-200), var(--os-gray-100));
-
-    .o-print-page {
-      /* Don't use css variable to keep white on dark mode */
-      background-color: #ffffff;
-    }
+    flex: 1 1 auto;
+    min-width: 0;
+    height: 100%;
+    border: 0;
   }
 
   .o-sidePanel {
     width: 350px;
-  }
-
-  @media print {
-    .o-print-container {
-      overflow: visible !important;
-      height: 100% !important;
-    }
-
-    .o-print-preview {
-      background-color: white !important;
-      box-shadow: none !important;
-      overflow: visible !important;
-      height: 100% !important;
-
-      .o-print-page {
-        box-shadow: none !important;
-        padding: 0 !important;
-        margin: 0 !important;
-        width: 100% !important;
-        height: 100% !important;
-        break-after: page;
-
-        &:last-child {
-          break-after: auto;
-        }
-      }
-    }
   }
 }

--- a/src/components/spreadsheet_print/spreadsheet_print.ts
+++ b/src/components/spreadsheet_print/spreadsheet_print.ts
@@ -1,4 +1,4 @@
-import { onWillUnmount, useListener, useProps } from "@odoo/owl";
+import { signal, useProps } from "@odoo/owl";
 import { Component } from "../../owl3_compatibility_layer";
 import { useLocalStore } from "../../store_engine/store_hooks";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
@@ -10,6 +10,7 @@ import { BadgeSelection } from "../side_panel/components/badge_selection/badge_s
 import { Checkbox } from "../side_panel/components/checkbox/checkbox";
 import { Section } from "../side_panel/components/section/section";
 import { StandaloneGridCanvas } from "../standalone_grid_canvas/standalone_grid_canvas";
+import { PrintIframe, usePrintIframe } from "./print_iframe";
 import {
   Orientation,
   PrintPageLayout,
@@ -26,25 +27,23 @@ export class SpreadsheetPrint extends Component<SpreadsheetChildEnv> {
   static components = { StandaloneGridCanvas, Section, Select, BadgeSelection, Checkbox };
 
   printStore!: Store<SpreadsheetPrintStore>;
+  printIframe!: PrintIframe;
+
+  private iframeRef = signal<HTMLIFrameElement | null>(null);
 
   setup() {
     this.printStore = useLocalStore(SpreadsheetPrintStore);
-    let styleElement: HTMLStyleElement | null = null;
-    useListener(window, "beforeprint", () => {
-      styleElement = document.createElement("style");
-      styleElement.id = "o-spreadsheet-print-style";
-      const size = `${this.printStore.pageLayout} ${this.printStore.orientation}`;
-      styleElement.textContent = `@media print { @page { size: ${size}; margin: ${this.printStore.printMargin}px;}}`;
-      document.head.appendChild(styleElement);
+    this.printIframe = usePrintIframe({
+      iframeRef: this.iframeRef,
+      pageCount: () => this.printStore.printPages.length,
+      pageStyle: () => this.pageStyle,
+      pageRule: () => this.pageRule,
     });
-    const removePrintStyle = () => {
-      if (styleElement) {
-        document.head.removeChild(styleElement);
-        styleElement = null;
-      }
-    };
-    useListener(window, "afterprint", () => removePrintStyle());
-    onWillUnmount(() => removePrintStyle());
+  }
+
+  get pageRule(): string {
+    const size = `${this.printStore.pageLayout} ${this.printStore.orientation}`;
+    return `@page { size: ${size}; margin: ${this.printStore.printMargin}px; }`;
   }
 
   get pageStyle(): string {
@@ -77,7 +76,7 @@ export class SpreadsheetPrint extends Component<SpreadsheetChildEnv> {
   }
 
   onPrint() {
-    window.print();
+    this.printIframe.print();
     this.props.onExitPrintMode();
   }
 }

--- a/src/components/spreadsheet_print/spreadsheet_print.xml
+++ b/src/components/spreadsheet_print/spreadsheet_print.xml
@@ -2,7 +2,7 @@
   <t t-name="o-spreadsheet-SpreadsheetPrint">
     <div class="o-spreadsheet-print d-flex flex-column h-100 w-100">
       <t t-set="pages" t-value="this.printStore.printPages"/>
-      <div class="o-print-header flex-shrink-0 d-flex align-items-center d-print-none">
+      <div class="o-print-header flex-shrink-0 d-flex align-items-center">
         <h3 class="m-0 p-3 ps-4 text-white">Print Preview</h3>
         <span class="text-white">
           <t t-out="pages.length"/>
@@ -14,30 +14,8 @@
         <button class="o-button primary flex-grow-0 me-4" t-on-click="this.onPrint">Next</button>
       </div>
       <div class="o-print-container d-flex flex-grow-1 overflow-hidden">
-        <div class="o-print-preview w-100 overflow-auto d-flex flex-column">
-          <div class="mx-auto">
-            <div
-              t-if="pages.length === 0"
-              class="o-print-page o-empty-print-page m-4 shadow d-flex flex-column align-items-center justify-content-center flex-shrink-0"
-              t-att-style="this.pageStyle">
-              <h4 class="fst-italic text-muted">No content to print</h4>
-            </div>
-            <div
-              t-else=""
-              t-foreach="pages"
-              t-as="page"
-              t-key="page_index"
-              class="o-print-page m-4 shadow d-flex justify-content-center flex-shrink-0"
-              t-att-style="this.pageStyle">
-              <StandaloneGridCanvas
-                sheetId="page.sheetId"
-                zone="page.zone"
-                renderingCtx="page.renderingCtx"
-              />
-            </div>
-          </div>
-        </div>
-        <div class="o-sidePanel flex-shrink-0 bg-white border-top border-start d-print-none">
+        <iframe class="o-print-preview" t-ref="this.iframeRef" title="Print preview"/>
+        <div class="o-sidePanel flex-shrink-0 bg-white border-top border-start">
           <div class="o-sidePanelBody pt-4">
             <Section t-if="!this.env.model.getters.isDashboard()">
               <div class="o-section-title">Print content</div>
@@ -91,6 +69,16 @@
           </div>
         </div>
       </div>
+
+      <t t-foreach="pages" t-as="page" t-key="page_index">
+        <StandaloneGridCanvas
+          t-if="this.printIframe.canvases()[page_index]"
+          canvas="this.printIframe.canvases()[page_index]"
+          sheetId="page.sheetId"
+          zone="page.zone"
+          renderingCtx="page.renderingCtx"
+        />
+      </t>
     </div>
   </t>
 </templates>

--- a/src/components/standalone_grid_canvas/standalone_grid_canvas.ts
+++ b/src/components/standalone_grid_canvas/standalone_grid_canvas.ts
@@ -1,4 +1,4 @@
-import { onWillStart, onWillUpdateProps, signal, useProps } from "@odoo/owl";
+import { onWillStart, onWillUpdateProps, useProps } from "@odoo/owl";
 import { getCarouselLayout } from "../../helpers/carousel_helpers";
 import { isDefined } from "../../helpers/misc";
 import { Component } from "../../owl3_compatibility_layer";
@@ -21,9 +21,8 @@ export class StandaloneGridCanvas extends Component<SpreadsheetChildEnv> {
     sheetId: types.UID(),
     zone: types.Zone(),
     renderingCtx: types.object<Omit<GridRenderingContext, "ctx" | "thinLineWidth">>(),
+    canvas: types.object<HTMLCanvasElement>(),
   });
-
-  private canvasRef = signal.ref(HTMLCanvasElement);
 
   rendererStore!: Store<RendererStore>;
   figureRendererStore!: Store<FigureRendererStore>;
@@ -32,7 +31,7 @@ export class StandaloneGridCanvas extends Component<SpreadsheetChildEnv> {
     this.rendererStore = useLocalStore(RendererStore, ["Background", "Chart"]);
     this.figureRendererStore = useLocalStore(FigureRendererStore, this.rendererStore);
     useGridDrawing({
-      canvasRef: this.canvasRef,
+      canvasRef: () => this.props.canvas,
       renderingCtx: () => this.props.renderingCtx,
       rendererStore: this.rendererStore,
       changeCanvasSizeOnZoom: true,

--- a/src/components/standalone_grid_canvas/standalone_grid_canvas.xml
+++ b/src/components/standalone_grid_canvas/standalone_grid_canvas.xml
@@ -1,6 +1,5 @@
 <templates>
   <t t-name="o-spreadsheet-StandaloneGridCanvas">
-    <canvas t-ref="this.canvasRef"/>
     <t t-foreach="this.carouselDataViews" t-as="carouselDataView" t-key="carouselDataView_index">
       <CarouselDataViewPrint t-props="carouselDataView"/>
     </t>

--- a/tests/spreadsheet/spreadsheet_print_component.test.ts
+++ b/tests/spreadsheet/spreadsheet_print_component.test.ts
@@ -5,7 +5,6 @@ import { SpreadsheetPrintStore } from "../../src/components/spreadsheet_print/sp
 import { FigureRendererStore } from "../../src/components/standalone_grid_canvas/figure_renderer_store";
 import { DEFAULT_CELL_HEIGHT, DEFAULT_CELL_WIDTH, PRINT_DPR } from "../../src/constants";
 import { Store } from "../../src/types/store_engine";
-import { registerCleanup } from "../setup/jest.setup";
 import {
   createCarousel,
   createChart,
@@ -26,18 +25,23 @@ import {
 } from "../test_helpers/helpers";
 import { getLastZonesRendered, spyStoreCreation, StoreSpy } from "../test_helpers/stores";
 
+function getPrintIframe() {
+  return document.querySelector<HTMLIFrameElement>("iframe.o-print-preview")!;
+}
+
+function getPrintPages() {
+  return [...getPrintIframe().contentDocument!.body.querySelectorAll(".o-print-page")];
+}
+
+function mockIframePrint() {
+  const contentWindow = getPrintIframe().contentWindow!;
+  const mockPrint = jest.fn();
+  contentWindow.print = mockPrint;
+  contentWindow.focus = jest.fn(); // Not implemented in jsdom
+  return mockPrint;
+}
+
 describe("Spreadsheet integration tests", () => {
-  let mockWindowPrint: jest.Mock;
-
-  beforeEach(() => {
-    const originalPrint = window.print;
-    mockWindowPrint = jest.fn();
-    window.print = mockWindowPrint;
-    registerCleanup(() => {
-      window.print = originalPrint;
-    });
-  });
-
   test("Can open the print mode with CTRL+P shortcut", async () => {
     await mountSpreadsheet();
     expect(".o-spreadsheet-print").toHaveCount(0);
@@ -57,20 +61,22 @@ describe("Spreadsheet integration tests", () => {
     await mountSpreadsheet();
     await keyDown({ key: "p", ctrlKey: true });
     expect(".o-spreadsheet-print").toHaveCount(1);
+    const iframePrint = mockIframePrint();
 
     await simulateClick(".o-print-header button:not(.primary)");
     expect(".o-spreadsheet-print").toHaveCount(0);
-    expect(mockWindowPrint).not.toHaveBeenCalled();
+    expect(iframePrint).not.toHaveBeenCalled();
   });
 
   test("Can trigger the browser print dialog", async () => {
     await mountSpreadsheet();
     await keyDown({ key: "p", ctrlKey: true });
     expect(".o-spreadsheet-print").toHaveCount(1);
+    const iframePrint = mockIframePrint();
 
     await simulateClick(".o-print-header button.primary");
     expect(".o-spreadsheet-print").toHaveCount(0);
-    expect(mockWindowPrint).toHaveBeenCalledTimes(1);
+    expect(iframePrint).toHaveBeenCalledTimes(1);
   });
 
   test("Printing is always done with a model in light mode", async () => {
@@ -109,10 +115,11 @@ describe("Spreadsheet print rendering", () => {
   });
 
   async function mountSpreadsheetPrint() {
-    return await mountComponentWithPortalTarget(SpreadsheetPrint, {
+    await mountComponentWithPortalTarget(SpreadsheetPrint, {
       props: { onExitPrintMode: () => {} },
       model,
     });
+    await nextTick(); // Need to wait a render for the iframe to be loaded/initialized before we draw the pages
   }
 
   function getPrintStore() {
@@ -134,7 +141,7 @@ describe("Spreadsheet print rendering", () => {
     const drawChartSpy = jest.spyOn(figureRendererStore, "drawChart").mockImplementation(() => {});
     const figure = { figureId: "figureId", col: 0, row: 0, size: { width: 200, height: 200 } };
 
-    expect(".o-print-page").toHaveCount(1);
+    expect(getPrintPages()).toHaveLength(1);
     expect(getLastZonesRendered(storeSpy)).toEqual([
       { sheetId, left: 0, top: 0, right: 0, bottom: 0 },
     ]);
@@ -143,7 +150,7 @@ describe("Spreadsheet print rendering", () => {
     createChart(model, { type: "bar" }, "chartId", undefined, figure);
     await nextTick();
 
-    expect(".o-print-page").toHaveCount(1);
+    expect(getPrintPages()).toHaveLength(1);
     expect(getLastZonesRendered(storeSpy)).toEqual([
       { sheetId, left: 0, top: 0, right: 2, bottom: 8 },
     ]);
@@ -155,12 +162,12 @@ describe("Spreadsheet print rendering", () => {
     await mountSpreadsheetPrint();
 
     expect(".o-print-layout").toHaveText("A4 (210 x 297 mm)");
-    expect(".o-print-page").toHaveStyle({ height: "1122px", width: "793px" });
+    expect(getPrintPages()[0]).toHaveStyle({ height: "1122px", width: "793px" });
     expect(getPrintStore().pageLayout).toBe("A4");
 
     await editSelectComponent(".o-print-layout", "A3");
     expect(".o-print-layout").toHaveText("A3 (297 x 420 mm)");
-    expect(".o-print-page").toHaveStyle({ height: "1587px", width: "1122px" });
+    expect(getPrintPages()[0]).toHaveStyle({ height: "1587px", width: "1122px" });
     expect(getPrintStore().pageLayout).toBe("A3");
   });
 
@@ -169,12 +176,12 @@ describe("Spreadsheet print rendering", () => {
     await mountSpreadsheetPrint();
 
     expect(".o-badge-selection .selected").toHaveAttribute("data-id", "portrait");
-    expect(".o-print-page").toHaveStyle({ height: "1122px", width: "793px" });
+    expect(getPrintPages()[0]).toHaveStyle({ height: "1122px", width: "793px" });
     expect(getPrintStore().orientation).toBe("portrait");
 
     await simulateClick(".o-badge-selection button[data-id='landscape']");
     expect(".o-badge-selection .selected").toHaveAttribute("data-id", "landscape");
-    expect(".o-print-page").toHaveStyle({ height: "793px", width: "1122px" });
+    expect(getPrintPages()[0]).toHaveStyle({ height: "793px", width: "1122px" });
     expect(getPrintStore().orientation).toBe("landscape");
   });
 
@@ -212,30 +219,32 @@ describe("Spreadsheet print rendering", () => {
 
   test("Mock print page is shown if there is no content to print", async () => {
     await mountSpreadsheetPrint();
-    expect(".o-print-page.o-empty-print-page").toHaveCount(1);
+    expect(getPrintPages()[0]).toHaveClass("o-empty-print-page");
 
     setSelection(model, ["B2:D3"]);
     setCellContent(model, "A1", "=MUNIT(5)");
     await editSelectComponent(".o-print-selection", "selection");
 
-    expect(".o-print-page.o-empty-print-page").toHaveCount(0);
+    expect(getPrintPages()[0]).not.toHaveClass("o-empty-print-page");
 
     setSelection(model, ["A25"]);
     await nextTick();
-    expect(".o-print-page.o-empty-print-page").toHaveCount(1);
+    expect(getPrintPages()[0]).toHaveClass("o-empty-print-page");
   });
 
-  test("Style is injected in beforePrint depending on the print setting used", async () => {
+  test("Correct @page css is injected in the iframe", async () => {
     await mountSpreadsheetPrint();
     await simulateClick(".o-badge-selection button[data-id='landscape']");
+
+    const iframe = getPrintIframe();
+    expect(iframe.contentDocument?.head.textContent).toContain(
+      "@page { size: A4 landscape; margin: 50px; }"
+    );
+
     await editSelectComponent(".o-print-layout", "A3");
-
-    expect(document.head).toHaveText("");
-    window.dispatchEvent(new Event("beforeprint"));
-    expect(document.head).toHaveText("@media print { @page { size: A3 landscape; margin: 50px;}}");
-
-    window.dispatchEvent(new Event("afterprint"));
-    expect(document.head).toHaveText("");
+    expect(iframe.contentDocument?.head.textContent).toContain(
+      "@page { size: A3 landscape; margin: 50px; }"
+    );
   });
 
   test("Can print a carousel data view", async () => {


### PR DESCRIPTION
## Description

When printing a spreadsheet, we would display a preview of the print, then use `@media print` rules to try to get a good print result. But the rules needed depend on the the web page where the spreadsheet is embedded.

That meant that every spreadsheet embedding would need to have its own print rules, which is annoying the first time, but even more so considering that any change in the CSS/DOM anywhere could break spreadsheet printing. And it's untestable.

With this commit, we create an iframe to display the spreadsheet print preview, and we print this iframe. This allow us full control of what's printed, independent of the embedding page.

Task: [6466136](https://www.odoo.com/odoo/2328/tasks/6466136)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo