### PR TITLE
[REF] components: use signal.ref for all DOM refs

### DIFF
--- a/src/components/animation/ripple.ts
+++ b/src/components/animation/ripple.ts
@@ -47,7 +47,7 @@ class RippleEffect extends Component<SpreadsheetChildEnv> {
     style: types.string(),
   });
 
-  private rippleRef = signal<HTMLElement | null>(null);
+  private rippleRef = signal.ref();
 
   setup() {
     let animation: Animation | undefined = undefined;
@@ -109,7 +109,7 @@ export class Ripple extends Component<SpreadsheetChildEnv> {
     class: types.string().optional(""),
   });
 
-  private childContainerRef = signal<HTMLElement | null>(null);
+  private childContainerRef = signal.ref();
 
   private state = proxy<RippleState>({ ripples: [] });
 

--- a/src/components/border_editor/border_editor.ts
+++ b/src/components/border_editor/border_editor.ts
@@ -53,7 +53,7 @@ export class BorderEditor extends Component<SpreadsheetChildEnv> {
   });
   BORDER_POSITIONS = BORDER_POSITIONS;
 
-  lineStyleButtonRef = signal<HTMLElement | null>(null);
+  lineStyleButtonRef = signal.ref();
   borderStyles = borderStyles;
   state: State = proxy({
     activeTool: undefined,

--- a/src/components/border_editor/border_editor_widget.ts
+++ b/src/components/border_editor/border_editor_widget.ts
@@ -30,7 +30,7 @@ export class BorderEditorWidget extends Component<SpreadsheetChildEnv> {
   topBarToolStore!: ToolBarDropdownStore;
   private viewStore!: Store<ViewportsStore>;
 
-  borderEditorButtonRef = signal<HTMLElement | null>(null);
+  borderEditorButtonRef = signal.ref();
   state: State = proxy({
     currentColor: DEFAULT_BORDER_DESC.color,
     currentStyle: DEFAULT_BORDER_DESC.style,

--- a/src/components/bottom_bar/bottom_bar.ts
+++ b/src/components/bottom_bar/bottom_bar.ts
@@ -37,8 +37,8 @@ export class BottomBar extends Component<SpreadsheetChildEnv> {
 
   static components = { MenuPopover, Ripple, BottomBarSheet, BottomBarStatistic };
 
-  private bottomBarRef = signal<HTMLElement | null>(null);
-  private sheetListRef = signal<HTMLElement | null>(null);
+  private bottomBarRef = signal.ref();
+  private sheetListRef = signal.ref();
 
   private dragAndDrop = useDragAndDropListItems();
   private targetScroll: number | undefined = undefined;

--- a/src/components/bottom_bar/bottom_bar_sheet/bottom_bar_sheet.ts
+++ b/src/components/bottom_bar/bottom_bar_sheet/bottom_bar_sheet.ts
@@ -49,9 +49,9 @@ export class BottomBarSheet extends Component<SpreadsheetChildEnv> {
 
   private state = proxy<State>({ isEditing: false, openedPicker: undefined });
 
-  private sheetDivRef = signal<HTMLElement | null>(null);
-  private iconRef = signal<HTMLElement | null>(null);
-  private sheetNameRef = signal<HTMLElement | null>(null);
+  private sheetDivRef = signal.ref();
+  private iconRef = signal.ref();
+  private sheetNameRef = signal.ref();
 
   private editionState: "initializing" | "editing" = "initializing";
 

--- a/src/components/color_picker/color_picker_widget.ts
+++ b/src/components/color_picker/color_picker_widget.ts
@@ -22,7 +22,7 @@ export class ColorPickerWidget extends Component<SpreadsheetChildEnv> {
     class: types.string().optional(),
   });
 
-  colorPickerButtonRef = signal<HTMLElement | null>(null);
+  colorPickerButtonRef = signal.ref();
 
   get iconStyle() {
     return this.props.currentColor

--- a/src/components/composer/autocomplete_dropdown/autocomplete_dropdown.ts
+++ b/src/components/composer/autocomplete_dropdown/autocomplete_dropdown.ts
@@ -14,7 +14,7 @@ export class TextValueProvider extends Component<any> {
     onValueSelected: types.function<(proposal: AutoCompleteProposal) => void>(),
     onValueHovered: types.function<(index: string) => void>(),
   });
-  autoCompleteListRef = signal<HTMLElement | null>(null);
+  autoCompleteListRef = signal.ref();
 
   setup() {
     useEffect(() => {

--- a/src/components/composer/composer/composer.ts
+++ b/src/components/composer/composer/composer.ts
@@ -79,8 +79,8 @@ export class Composer extends Component<SpreadsheetChildEnv> {
 
   private DOMFocusableElementStore!: Store<DOMFocusableElementStore>;
 
-  composerRef = signal<HTMLElement | null>(null);
-  containerRef = signal<HTMLElement | null>(null);
+  composerRef = signal.ref();
+  containerRef = signal.ref();
 
   contentHelper: ContentEditableHelper = new ContentEditableHelper(
     this.composerRef() as unknown as HTMLElement

--- a/src/components/composer/speech_bubble/speech_bubble.ts
+++ b/src/components/composer/speech_bubble/speech_bubble.ts
@@ -17,7 +17,7 @@ export class SpeechBubble extends Component<SpreadsheetChildEnv> {
   });
 
   private spreadsheetRect = useSpreadsheetRect();
-  private bubbleRef = signal<HTMLElement | null>(null);
+  private bubbleRef = signal.ref();
 
   setup(): void {
     useEffect(() => {

--- a/src/components/dashboard/dashboard.ts
+++ b/src/components/dashboard/dashboard.ts
@@ -48,8 +48,8 @@ export class SpreadsheetDashboard extends Component<SpreadsheetChildEnv> {
   private viewStore!: Store<ViewportsStore>;
   private zoomStore!: Store<ZoomStore>;
 
-  private gridRef = signal<HTMLElement | null>(null);
-  private canvasRef = signal<HTMLElement | null>(null);
+  private gridRef = signal.ref();
+  private canvasRef = signal.ref(HTMLCanvasElement);
 
   setup() {
     this.hoveredCell = useStore(DelayedHoveredCellStore);

--- a/src/components/figures/chart/chartJs/chartjs.ts
+++ b/src/components/figures/chart/chartJs/chartjs.ts
@@ -90,7 +90,7 @@ export class ChartJsComponent extends Component<SpreadsheetChildEnv> {
     isFullScreen: types.boolean().optional(),
   });
 
-  protected canvas = signal<HTMLCanvasElement | null>(null);
+  protected canvas = signal.ref(HTMLCanvasElement);
   protected chart?: Chart;
   protected currentRuntime!: ChartJSRuntime;
   protected animationStore: Store<ChartAnimationStore> | undefined;

--- a/src/components/figures/chart/chartJs/zoomable_chart/zoomable_chartjs.ts
+++ b/src/components/figures/chart/chartJs/zoomable_chart/zoomable_chartjs.ts
@@ -19,7 +19,7 @@ export class ZoomableChartJsComponent extends ChartJsComponent {
 
   private store!: Store<ZoomableChartStore>;
 
-  private masterChartCanvas = signal<HTMLCanvasElement | null>(null);
+  private masterChartCanvas = signal.ref(HTMLCanvasElement);
   private masterChart?: Chart;
   private mode?: "selectInMaster" | "moveInMaster";
   private hasLinearScale?: boolean;

--- a/src/components/figures/chart/gauge/gauge_chart_component.ts
+++ b/src/components/figures/chart/gauge/gauge_chart_component.ts
@@ -21,7 +21,7 @@ export class GaugeChartComponent extends Component<SpreadsheetChildEnv> {
     isFullScreen: types.boolean().optional(),
   });
 
-  private canvas = signal<HTMLCanvasElement | null>(null);
+  private canvas = signal.ref(HTMLCanvasElement);
 
   private animationStore: Store<ChartAnimationStore> | undefined;
   private zoomStore!: Store<ZoomStore>;

--- a/src/components/figures/chart/scorecard/chart_scorecard.ts
+++ b/src/components/figures/chart/scorecard/chart_scorecard.ts
@@ -18,7 +18,7 @@ export class ScorecardChart extends Component<SpreadsheetChildEnv> {
     chartId: types.string(),
     isFullScreen: types.boolean().optional(),
   });
-  private canvas = signal<HTMLCanvasElement | null>(null);
+  private canvas = signal.ref(HTMLCanvasElement);
   private zoomStore!: Store<ZoomStore>;
 
   get runtime(): ScorecardChartRuntime {

--- a/src/components/figures/figure/figure.ts
+++ b/src/components/figures/figure/figure.ts
@@ -44,7 +44,7 @@ export class FigureComponent extends Component<SpreadsheetChildEnv> {
 
   private menuState: MenuState = proxy({ isOpen: false, anchorRect: null, menuItems: [] });
 
-  private figureRef = signal<HTMLElement | null>(null);
+  private figureRef = signal.ref();
 
   get isSelected(): boolean {
     return (

--- a/src/components/figures/figure_carousel/figure_carousel.ts
+++ b/src/components/figures/figure_carousel/figure_carousel.ts
@@ -35,8 +35,8 @@ export class CarouselFigure extends Component<SpreadsheetChildEnv> {
     openContextMenu: types.function<(anchorRect: Rect, onClose?: () => void) => void>().optional(),
   });
 
-  private carouselTabsRef = signal<HTMLElement | null>(null);
-  private carouselTabsDropdownRef = signal<HTMLElement | null>(null);
+  private carouselTabsRef = signal.ref();
+  private carouselTabsDropdownRef = signal.ref();
 
   private menuState = proxy<MenuState>({ isOpen: false, anchorRect: null, menuItems: [] });
   private hiddenItems: CarouselItem[] = [];

--- a/src/components/figures/figure_image/figure_image.ts
+++ b/src/components/figures/figure_image/figure_image.ts
@@ -15,7 +15,7 @@ export class ImageFigure extends Component<SpreadsheetChildEnv> {
     openContextMenu: types.function<(anchorRect: Rect, onClose?: () => void) => void>(),
   });
 
-  private menuButtonRef = signal<HTMLElement | null>(null);
+  private menuButtonRef = signal.ref();
 
   showMenu(ev: MouseEvent) {
     if (!this.env.model.getters.getSelectedFigureIds().includes(this.props.figureUI.id)) {

--- a/src/components/filters/filter_menu_item/filter_menu_value_item.ts
+++ b/src/components/filters/filter_menu_item/filter_menu_value_item.ts
@@ -17,7 +17,7 @@ export class FilterMenuValueItem extends Component<SpreadsheetChildEnv> {
     scrolledTo: types.or([types.literal("top"), types.literal("bottom")]).optional(),
   });
 
-  itemRef = signal<HTMLElement | null>(null);
+  itemRef = signal.ref();
 
   setup() {
     onWillPatch(() => {

--- a/src/components/full_screen_figure/full_screen_figure.ts
+++ b/src/components/full_screen_figure/full_screen_figure.ts
@@ -14,7 +14,7 @@ export class FullScreenFigure extends Component<SpreadsheetChildEnv> {
   static components = { ChartFigure };
 
   private fullScreenFigureStore!: Store<FullScreenFigureStore>;
-  private fullScreenFigureRef = signal<HTMLElement | null>(null);
+  private fullScreenFigureRef = signal.ref();
 
   spreadsheetRect = useSpreadsheetRect();
 

--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -150,8 +150,8 @@ export class Grid extends Component<SpreadsheetChildEnv> {
   readonly HEADER_HEIGHT = HEADER_HEIGHT;
   readonly HEADER_WIDTH = HEADER_WIDTH;
   private menuState!: MenuState;
-  private gridRef = signal<HTMLElement | null>(null);
-  private canvasRef = signal<HTMLElement | null>(null);
+  private gridRef = signal.ref();
+  private canvasRef = signal.ref(HTMLCanvasElement);
   private highlightStore!: Store<HighlightStore>;
   viewStore!: Store<ViewportsStore>;
   private zoomStore!: Store<ZoomStore>;

--- a/src/components/grid_overlay/grid_overlay.ts
+++ b/src/components/grid_overlay/grid_overlay.ts
@@ -159,7 +159,7 @@ export class GridOverlay extends Component<SpreadsheetChildEnv> {
     gridOverlayDimensions: types.string(),
     hasFooter: types.boolean().optional(() => true),
   });
-  private gridOverlayRef: Signal<HTMLElement | null> = signal(null);
+  private gridOverlayRef = signal.ref();
   private cellPopovers!: Store<CellPopoverStore>;
   private paintFormatStore!: Store<PaintFormatStore>;
   private hoveredIconStore!: Store<HoveredIconStore>;

--- a/src/components/headers_overlay/headers_overlay.ts
+++ b/src/components/headers_overlay/headers_overlay.ts
@@ -349,7 +349,7 @@ export class ColResizer extends AbstractResizer {
   static template = "o-spreadsheet-ColResizer";
   static components = { UnhideColumnHeaders };
 
-  private colResizerRef = signal<HTMLElement | null>(null);
+  private colResizerRef = signal.ref();
 
   setup() {
     super.setup();
@@ -518,7 +518,7 @@ export class RowResizer extends AbstractResizer {
   static template = "o-spreadsheet-RowResizer";
   static components = { UnhideRowHeaders };
 
-  private rowResizerRef = signal<HTMLElement | null>(null);
+  private rowResizerRef = signal.ref();
 
   setup() {
     super.setup();

--- a/src/components/info_popover/info_popover.ts
+++ b/src/components/info_popover/info_popover.ts
@@ -23,7 +23,7 @@ export class InfoPopover extends Component<SpreadsheetChildEnv> {
     useExternalListener(window, "click", this.onExternalClick, { capture: true });
   }
 
-  private infoRef = signal<HTMLElement | null>(null);
+  private infoRef = signal.ref();
 
   get popoverProps(): PropsOf<Popover> {
     return {

--- a/src/components/link/link_editor/link_editor.ts
+++ b/src/components/link/link_editor/link_editor.ts
@@ -39,9 +39,9 @@ export class LinkEditor extends Component<SpreadsheetChildEnv> {
   });
   static size = { maxHeight: 500 };
 
-  urlInput = signal<HTMLElement | null>(null);
-  suggestionListRef = signal<HTMLElement | null>(null);
-  urlInputContainer = signal<HTMLElement | null>(null);
+  urlInput = signal.ref(HTMLInputElement);
+  suggestionListRef = signal.ref();
+  urlInputContainer = signal.ref();
 
   private state!: LinkState;
   private viewStore!: Store<ViewportsStore>;

--- a/src/components/menu/menu.ts
+++ b/src/components/menu/menu.ts
@@ -45,7 +45,7 @@ export class Menu extends Component<SpreadsheetChildEnv> {
     disableKeyboardNavigation: types.boolean().optional(),
   });
 
-  private menuRef = signal<HTMLElement | null>(null);
+  private menuRef = signal.ref();
 
   setup(): void {
     useLayoutEffect(() => {

--- a/src/components/menu_popover/menu_popover.ts
+++ b/src/components/menu_popover/menu_popover.ts
@@ -72,7 +72,7 @@ export class MenuPopover extends Component<SpreadsheetChildEnv> {
   private state: State = proxy({
     hoveredMenu: this.props.autoSelectFirstItem ? this.getNextEnabledMenuItem() : undefined,
   });
-  private menuRef = signal<HTMLElement | null>(null);
+  private menuRef = signal.ref();
 
   private openingTimeOut = useTimeOut();
 

--- a/src/components/named_range_selector/named_range_selector.ts
+++ b/src/components/named_range_selector/named_range_selector.ts
@@ -36,7 +36,7 @@ export class NamedRangeSelector extends Component<SpreadsheetChildEnv> {
   topBarToolStore!: ToolBarDropdownStore;
   menuState = proxy<State>({ anchorRect: null, menuItems: [] });
 
-  private namedRangeSelectorRef = signal<HTMLElement | null>(null);
+  private namedRangeSelectorRef = signal.ref();
 
   setup() {
     this.topBarToolStore = useToolBarDropdownStore();

--- a/src/components/number_editor/number_editor.ts
+++ b/src/components/number_editor/number_editor.ts
@@ -34,8 +34,8 @@ export class NumberEditor extends Component<SpreadsheetChildEnv> {
   dropdown: State = proxy({ isOpen: false });
 
   private inputRef = signal.ref(HTMLInputElement);
-  private rootEditorRef = signal<HTMLElement | null>(null);
-  private valueListRef = signal<HTMLElement | null>(null);
+  private rootEditorRef = signal.ref();
+  private valueListRef = signal.ref();
 
   private DOMFocusableElementStore!: Store<DOMFocusableElementStore>;
 

--- a/src/components/popover/popover.ts
+++ b/src/components/popover/popover.ts
@@ -29,8 +29,8 @@ export class Popover extends Component<SpreadsheetChildEnv> {
     class: types.string().optional(),
   });
 
-  private popoverRef = signal<HTMLElement | null>(null);
-  private popoverContentRef = signal<HTMLElement | null>(null);
+  private popoverRef = signal.ref();
+  private popoverContentRef = signal.ref();
   private currentPosition: PopoverPosition | undefined = undefined;
   private currentDisplayValue: DisplayValue | undefined = undefined;
 

--- a/src/components/scrollbar/scrollbar.ts
+++ b/src/components/scrollbar/scrollbar.ts
@@ -28,7 +28,7 @@ export class ScrollBar extends Component<any> {
     onScroll: types.function<(offset: Pixel) => void>(),
   });
 
-  private scrollbarRef = signal<HTMLElement | null>(null);
+  private scrollbarRef = signal.ref();
   private scrollbar!: ScrollBarElement;
 
   setup() {

--- a/src/components/select/select.ts
+++ b/src/components/select/select.ts
@@ -26,8 +26,8 @@ export class Select extends Component<SpreadsheetChildEnv> {
     title: types.string().optional(),
   });
 
-  private selectRef = signal<HTMLElement | null>(null);
-  private dropdownRef = signal<HTMLElement | null>(null);
+  private selectRef = signal.ref();
+  private dropdownRef = signal.ref();
 
   private state = proxy<State>({ isPopoverOpen: false, hoveredValue: undefined });
 

--- a/src/components/selection_input/selection_input.ts
+++ b/src/components/selection_input/selection_input.ts
@@ -56,7 +56,7 @@ export class SelectionInput extends Component<SpreadsheetChildEnv> {
   private dragAndDrop = useDragAndDropListItems();
   private focusedInputRef = signal.ref(HTMLInputElement);
   unfocusedInputRef = signal.ref(HTMLInputElement);
-  private selectionRef = signal<HTMLElement | null>(null);
+  private selectionRef = signal.ref();
   private DOMFocusableElementStore!: Store<DOMFocusableElementStore>;
   private store!: Store<SelectionInputStore>;
 

--- a/src/components/side_panel/carousel_panel/carousel_panel.ts
+++ b/src/components/side_panel/carousel_panel/carousel_panel.ts
@@ -54,8 +54,8 @@ export class CarouselPanel extends Component<SpreadsheetChildEnv> {
   DEFAULT_CAROUSEL_TITLE_STYLE = DEFAULT_CAROUSEL_TITLE_STYLE;
 
   private dragAndDrop = useDragAndDropListItems();
-  private previewListRef = signal<HTMLElement | null>(null);
-  addChartButton = signal<HTMLElement | null>(null);
+  private previewListRef = signal.ref();
+  addChartButton = signal.ref(HTMLButtonElement);
 
   state = proxy<CarouselPanelState>({ popoverProps: undefined, currentRange: undefined });
 

--- a/src/components/side_panel/chart/building_blocks/annotation/annotation.ts
+++ b/src/components/side_panel/chart/building_blocks/annotation/annotation.ts
@@ -18,7 +18,7 @@ export class ChartAnnotation extends Component<SpreadsheetChildEnv> {
   static components = { SidePanelCollapsible, Section, TextInput };
   protected props = useProps(chartSidePanelPropsDefinition) as unknown as ChartSidePanelProps<any>;
 
-  private editorRef = signal<HTMLElement | null>(null);
+  private editorRef = signal.ref();
 
   private state: annotationState = proxy({
     annotationTextInput: this.props.definition.annotationText || "",

--- a/src/components/side_panel/chart/building_blocks/color_scale/color_scale_picker.ts
+++ b/src/components/side_panel/chart/building_blocks/color_scale/color_scale_picker.ts
@@ -38,7 +38,7 @@ export class ColorScalePicker extends Component<SpreadsheetChildEnv> {
   }));
 
   state = proxy<ColorScalePickerState>({ popoverProps: undefined, popoverStyle: "" });
-  popoverRef = signal<HTMLElement | null>(null);
+  popoverRef = signal.ref(HTMLTableElement);
 
   setup() {
     useExternalListener(window, "click", this.closePopover);

--- a/src/components/side_panel/chart/chart_type_picker/chart_type_picker.ts
+++ b/src/components/side_panel/chart/chart_type_picker/chart_type_picker.ts
@@ -26,7 +26,7 @@ export class ChartTypePicker extends Component<SpreadsheetChildEnv> {
     chartPanelStore: types.Store<MainChartPanelStore>(),
   });
 
-  selectRef = signal<HTMLElement | null>(null);
+  selectRef = signal.ref();
 
   state = proxy<ChartTypePickerState>({ popoverProps: undefined });
 

--- a/src/components/side_panel/chart/chart_type_picker_popover/chart_type_picker_popover.ts
+++ b/src/components/side_panel/chart/chart_type_picker_popover/chart_type_picker_popover.ts
@@ -28,7 +28,7 @@ export class ChartTypePickerPopover extends Component<SpreadsheetChildEnv> {
   categories = chartCategories;
   chartTypeByCategories: Record<string, ChartSubtypeProperties[]> = {};
 
-  popoverRef = signal<HTMLElement | null>(null);
+  popoverRef = signal.ref();
 
   setup(): void {
     useListener(window, "pointerdown", this.onExternalClick.bind(this), { capture: true });

--- a/src/components/side_panel/column_stats/column_stats_panel.ts
+++ b/src/components/side_panel/column_stats/column_stats_panel.ts
@@ -33,7 +33,7 @@ export class ColumnStatsPanel extends Component<SpreadsheetChildEnv> {
   });
 
   store!: Store<ColumnStatisticsStore>;
-  private chartCanvasRef = signal<HTMLCanvasElement | null>(null);
+  private chartCanvasRef = signal.ref(HTMLCanvasElement);
   private chart?: Chart;
 
   setup() {

--- a/src/components/side_panel/components/cog_wheel_menu/cog_wheel_menu.ts
+++ b/src/components/side_panel/components/cog_wheel_menu/cog_wheel_menu.ts
@@ -15,7 +15,7 @@ export class CogWheelMenu extends Component<SpreadsheetChildEnv> {
     items: types.array(types.ActionSpec()),
   });
 
-  private buttonRef = signal<HTMLElement | null>(null);
+  private buttonRef = signal.ref();
   private menuState: MenuState = proxy({ isOpen: false, anchorRect: null, menuItems: [] });
 
   private menuId = UuidGenerator.uuidv4();

--- a/src/components/side_panel/components/collapse/collapse.ts
+++ b/src/components/side_panel/components/collapse/collapse.ts
@@ -10,7 +10,7 @@ export class Collapse extends Component<SpreadsheetChildEnv> {
     isCollapsed: types.boolean(),
   });
 
-  private contentRef = signal<HTMLElement | null>(null);
+  private contentRef = signal.ref();
 
   setup() {
     onMounted(() => {

--- a/src/components/side_panel/components/round_color_picker/round_color_picker.ts
+++ b/src/components/side_panel/components/round_color_picker/round_color_picker.ts
@@ -29,7 +29,7 @@ export class RoundColorPicker extends Component<SpreadsheetChildEnv> {
     disableNoColor: types.boolean().optional(),
   });
 
-  colorPickerButtonRef = signal<HTMLElement | null>(null);
+  colorPickerButtonRef = signal.ref();
 
   private state!: State;
 

--- a/src/components/side_panel/conditional_formatting/cf_preview/cf_preview.ts
+++ b/src/components/side_panel/conditional_formatting/cf_preview/cf_preview.ts
@@ -20,7 +20,7 @@ export class ConditionalFormatPreview extends Component<SpreadsheetChildEnv> {
   });
 
   icons = ICONS;
-  private cfPreviewRef = signal<HTMLElement | null>(null);
+  private cfPreviewRef = signal.ref();
 
   setup() {
     useHighlightsOnHover(this.cfPreviewRef, this);

--- a/src/components/side_panel/conditional_formatting/cf_preview_list/cf_preview_list.ts
+++ b/src/components/side_panel/conditional_formatting/cf_preview_list/cf_preview_list.ts
@@ -19,7 +19,7 @@ export class ConditionalFormatPreviewList extends Component<SpreadsheetChildEnv>
   });
 
   private dragAndDrop = useDragAndDropListItems();
-  private cfListRef = signal<HTMLElement | null>(null);
+  private cfListRef = signal.ref();
 
   get conditionalFormats(): ConditionalFormat[] {
     const cfs = this.env.model.getters.getConditionalFormats(

--- a/src/components/side_panel/data_validation/dv_preview/dv_preview.ts
+++ b/src/components/side_panel/data_validation/dv_preview/dv_preview.ts
@@ -14,7 +14,7 @@ export class DataValidationPreview extends Component<SpreadsheetChildEnv> {
     rule: types.DataValidationRule(),
   });
 
-  private dvPreviewRef = signal<HTMLElement | null>(null);
+  private dvPreviewRef = signal.ref();
 
   setup() {
     useHighlightsOnHover(this.dvPreviewRef, this);

--- a/src/components/side_panel/named_ranges_panel/named_range_preview/named_range_preview.ts
+++ b/src/components/side_panel/named_ranges_panel/named_range_preview/named_range_preview.ts
@@ -24,7 +24,7 @@ export class NamedRangePreview extends Component<SpreadsheetChildEnv> {
 
   state = proxy<State>({});
 
-  private namedRangePreviewRef = signal<HTMLElement | null>(null);
+  private namedRangePreviewRef = signal.ref();
 
   setup() {
     useHighlightsOnHover(this.namedRangePreviewRef, this);

--- a/src/components/side_panel/pivot/pivot_filter/pivot_filter.ts
+++ b/src/components/side_panel/pivot/pivot_filter/pivot_filter.ts
@@ -46,7 +46,7 @@ export class PivotFilterEditor extends Component<SpreadsheetChildEnv> {
 
   private state!: State;
 
-  private buttonFilter = signal<HTMLElement | null>(null);
+  private buttonFilter = signal.ref();
   private popover!: { isOpen: boolean };
 
   setup() {

--- a/src/components/side_panel/pivot/pivot_layout_configurator/add_dimension_button/add_dimension_button.ts
+++ b/src/components/side_panel/pivot/pivot_layout_configurator/add_dimension_button/add_dimension_button.ts
@@ -25,11 +25,11 @@ export class AddDimensionButton extends Component<SpreadsheetChildEnv> {
     fields: types.array(),
   });
 
-  private buttonRef = signal<HTMLElement | null>(null);
+  private buttonRef = signal.ref(HTMLButtonElement);
   private popover = proxy({ isOpen: false });
   private search = proxy({ input: "" });
   private autoComplete!: Store<AutoCompleteStore>;
-  private autofocusRef = signal<HTMLElement | null>(null);
+  private autofocusRef = signal.ref(HTMLInputElement);
 
   // TODO navigation keys. (this looks a lot like auto-complete list. Could maybe be factorized)
   setup() {

--- a/src/components/side_panel/pivot/pivot_layout_configurator/pivot_layout_configurator.ts
+++ b/src/components/side_panel/pivot/pivot_layout_configurator/pivot_layout_configurator.ts
@@ -57,7 +57,7 @@ export class PivotLayoutConfigurator extends Component<SpreadsheetChildEnv> {
     pivotId: types.UID(),
   });
 
-  private dimensionsRef = signal<HTMLElement | null>(null);
+  private dimensionsRef = signal.ref();
   private dragAndDrop = useDragAndDropListItems();
   AGGREGATORS = AGGREGATORS;
 

--- a/src/components/side_panel/pivot/pivot_side_panel/pivot_spreadsheet_side_panel/pivot_spreadsheet_side_panel.ts
+++ b/src/components/side_panel/pivot/pivot_side_panel/pivot_spreadsheet_side_panel/pivot_spreadsheet_side_panel.ts
@@ -38,7 +38,7 @@ export class PivotSpreadsheetSidePanel extends Component<SpreadsheetChildEnv> {
 
   state!: { range?: string; rangeHasChanged: boolean };
 
-  pivotSidePanelRef = signal<HTMLElement | null>(null);
+  pivotSidePanelRef = signal.ref();
 
   setup() {
     this.store = useLocalStore(PivotSidePanelStore, this.props.pivotId);

--- a/src/components/small_bottom_bar/ribbon_menu/ribbon_menu.ts
+++ b/src/components/small_bottom_bar/ribbon_menu/ribbon_menu.ts
@@ -25,8 +25,8 @@ export class RibbonMenu extends Component<SpreadsheetChildEnv> {
   });
 
   rootItems = topbarMenuRegistry.getMenuItems();
-  private menuRef = signal<HTMLElement | null>(null);
-  private containerRef = signal<HTMLElement | null>(null);
+  private menuRef = signal.ref();
+  private containerRef = signal.ref();
 
   state: State = proxy({
     menuItems: this.rootItems,

--- a/src/components/small_bottom_bar/small_bottom_bar.ts
+++ b/src/components/small_bottom_bar/small_bottom_bar.ts
@@ -29,7 +29,7 @@ export class SmallBottomBar extends Component<SpreadsheetChildEnv> {
   private composerStore!: Store<CellComposerStore>;
   private viewStore!: Store<ViewportsStore>;
   private composerInterface!: ComposerInterface;
-  private composerRef = signal<HTMLElement | null>(null);
+  private composerRef = signal.ref();
 
   private menuState = proxy({
     isOpen: false,

--- a/src/components/spreadsheet/spreadsheet.ts
+++ b/src/components/spreadsheet/spreadsheet.ts
@@ -89,7 +89,7 @@ export class Spreadsheet extends Component<SpreadsheetChildEnv> {
   };
 
   sidePanel!: Store<SidePanelStore>;
-  spreadsheetRef = signal<HTMLElement | null>(null);
+  spreadsheetRef = signal.ref();
   spreadsheetRect = useSpreadsheetRect();
 
   state = proxy({ printModeEnabled: false });

--- a/src/components/standalone_grid_canvas/standalone_grid_canvas.ts
+++ b/src/components/standalone_grid_canvas/standalone_grid_canvas.ts
@@ -19,7 +19,7 @@ export class StandaloneGridCanvas extends Component<SpreadsheetChildEnv> {
     renderingCtx: types.object<Omit<GridRenderingContext, "ctx" | "thinLineWidth">>(),
   });
 
-  private canvasRef = signal<HTMLElement | null>(null);
+  private canvasRef = signal.ref(HTMLCanvasElement);
 
   rendererStore!: Store<RendererStore>;
   figureRendererStore!: Store<FigureRendererStore>;

--- a/src/components/standalone_viewport/standalone_viewport.ts
+++ b/src/components/standalone_viewport/standalone_viewport.ts
@@ -47,8 +47,8 @@ export class StandaloneViewport extends Component<SpreadsheetChildEnv> {
     columnWeights: types.array<number>().optional(),
   });
 
-  private canvasRef = signal<HTMLElement | null>(null);
-  private containerRef = signal<HTMLElement | null>(null);
+  private canvasRef = signal.ref(HTMLCanvasElement);
+  private containerRef = signal.ref();
 
   private store!: Store<StandaloneViewportStore>;
 

--- a/src/components/tables/table_style_preview/table_style_preview.ts
+++ b/src/components/tables/table_style_preview/table_style_preview.ts
@@ -23,7 +23,7 @@ export class TableStylePreview extends Component<SpreadsheetChildEnv> {
     onClick: types.function().optional(),
   });
 
-  private canvasRef = signal<HTMLCanvasElement | null>(null);
+  private canvasRef = signal.ref(HTMLCanvasElement);
   menu: MenuState = proxy({ isOpen: false, anchorRect: null, menuItems: [] });
 
   setup() {

--- a/src/components/tables/table_styles_popover/table_styles_popover.ts
+++ b/src/components/tables/table_styles_popover/table_styles_popover.ts
@@ -30,7 +30,7 @@ export class TableStylesPopover extends Component<SpreadsheetChildEnv> {
     type: types.or([types.literal("table"), types.literal("pivot")]),
   });
 
-  private tableStyleListRef = signal<HTMLElement | null>(null);
+  private tableStyleListRef = signal.ref();
   state = proxy<State>({ selectedCategory: this.initialSelectedCategory });
 
   setup(): void {

--- a/src/components/top_bar/dropdown_action/dropdown_action.ts
+++ b/src/components/top_bar/dropdown_action/dropdown_action.ts
@@ -20,7 +20,7 @@ export class DropdownAction extends Component<SpreadsheetChildEnv> {
   });
 
   topBarToolStore!: ToolBarDropdownStore;
-  actionRef = signal<HTMLElement | null>(null);
+  actionRef = signal.ref();
 
   setup() {
     this.topBarToolStore = useToolBarDropdownStore();

--- a/src/components/top_bar/number_formats_tool/number_formats_tool.ts
+++ b/src/components/top_bar/number_formats_tool/number_formats_tool.ts
@@ -23,7 +23,7 @@ export class NumberFormatsTool extends Component<SpreadsheetChildEnv> {
   formatNumberMenuItemSpec = formatNumberMenuItemSpec;
   topBarToolStore!: ToolBarDropdownStore;
 
-  buttonRef = signal<HTMLElement | null>(null);
+  buttonRef = signal.ref();
   state: State = proxy({
     anchorRect: { x: 0, y: 0, width: 0, height: 0 },
     menuItems: [],

--- a/src/components/top_bar/top_bar.ts
+++ b/src/components/top_bar/top_bar.ts
@@ -69,13 +69,13 @@ export class TopBar extends Component<SpreadsheetChildEnv> {
   fingerprints!: Store<FormulaFingerprintStore>;
   topBarToolStore!: Store<TopBarToolStore>;
 
-  toolBarContainerRef = signal<HTMLElement | null>(null);
-  toolbarRef = signal<HTMLElement | null>(null);
-  namedRangesRef = signal<HTMLElement | null>(null);
-  topBarTopRef = signal<HTMLElement | null>(null);
+  toolBarContainerRef = signal.ref();
+  toolbarRef = signal.ref();
+  namedRangesRef = signal.ref();
+  topBarTopRef = signal.ref();
 
-  moreToolsContainerRef = signal<HTMLElement | null>(null);
-  moreToolsButtonRef = signal<HTMLElement | null>(null);
+  moreToolsContainerRef = signal.ref();
+  moreToolsButtonRef = signal.ref();
 
   spreadsheetRect = useSpreadsheetRect();
 


### PR DESCRIPTION
## Description:

Convert the remaining signals bound with t-ref to signal.ref(). Use element constructors where a narrower TypeScript type is useful.

This aligns DOM references with the Owl 3 reference API.

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo