### PR TITLE
[FIX] xlsx: fix geo chart xlsx export

### DIFF
--- a/demo/main.js
+++ b/demo/main.js
@@ -48,6 +48,7 @@ topbarMenuRegistry.addChild("xlsx", ["file"], {
   name: "Save as XLSX",
   sequence: 20,
   execute: async (env) => {
+    await env.model.getters.loadUsedGeoJsonFeatures();
     const doc = await env.model.exportXLSX();
     const zip = new JSZip();
     for (const file of doc.files) {

--- a/src/plugins/ui_feature/geo_features.ts
+++ b/src/plugins/ui_feature/geo_features.ts
@@ -1,5 +1,6 @@
 import * as GeoJSON from "geojson";
 import TopoJSON from "topojson-specification";
+import { isDefined } from "../../helpers";
 import { ModelConfig } from "../../model";
 import { GeoChartRegion } from "../../types/chart/geo_chart";
 import { UIPlugin, UIPluginConfig } from "../ui_plugin";
@@ -9,6 +10,7 @@ export class GeoFeaturePlugin extends UIPlugin {
     "getGeoJsonFeatures",
     "geoFeatureNameToId",
     "getGeoChartAvailableRegions",
+    "loadUsedGeoJsonFeatures",
   ] as const;
 
   private readonly geoJsonService: ModelConfig["external"]["geoJsonService"];
@@ -58,6 +60,36 @@ export class GeoFeaturePlugin extends UIPlugin {
       return;
     }
     return this.geoJsonService.geoFeatureNameToId(region, featureName);
+  }
+
+  loadUsedGeoJsonFeatures(): Promise<void> {
+    const regions = this.getters
+      .getSheetIds()
+      .flatMap((sheetId) =>
+        this.getters.getChartIds(sheetId).map((chartId) => {
+          const definition = this.getters.getChartDefinition(chartId);
+          return definition.type === "geo"
+            ? definition.region || this.getters.getGeoChartAvailableRegions()[0]?.id
+            : undefined;
+        })
+      )
+      .filter(isDefined);
+
+    const uniqueRegions = Array.from(new Set(regions));
+    if (uniqueRegions.length && !this.geoJsonService) {
+      console.error("No geoJsonService provided to the model");
+      return Promise.resolve();
+    }
+
+    for (const region of uniqueRegions) {
+      this.getGeoJsonFeatures(region); // Trigger the loading of the regions
+    }
+
+    const promises = uniqueRegions.map((region) => {
+      const cachedGeoJson = this.geoJsonCache[region];
+      return cachedGeoJson instanceof Promise ? cachedGeoJson : Promise.resolve();
+    });
+    return Promise.all(promises).then(() => {});
   }
 
   private convertToGeoJson(

--- a/tests/figures/chart/geochart/geo_chart_plugin.test.ts
+++ b/tests/figures/chart/geochart/geo_chart_plugin.test.ts
@@ -7,17 +7,6 @@ import { mockChart, mockGeoJsonService, nextTick } from "../../../test_helpers/h
 mockChart();
 let model: Model;
 
-beforeEach(async () => {
-  model = new Model({}, { external: { geoJsonService: mockGeoJsonService } });
-  // Wait for the geoJsonService to resolve the promise and cache the geoJson features
-  model.getters.getGeoChartAvailableRegions();
-  model.getters.getGeoJsonFeatures("world");
-  for (const country of ["France", "Germany", "Spain"]) {
-    model.getters.geoFeatureNameToId("world", country);
-  }
-  await nextTick();
-});
-
 /**
  * Get the data points of the chart that have a value.
  * It's useful because the chart dataset always contains a point for ALL the features, even if they have no value
@@ -34,6 +23,17 @@ function getGeoChartNonEmptyData(runtime: GeoChartRuntime) {
 }
 
 describe("Geo charts plugin tests", () => {
+  beforeEach(async () => {
+    model = new Model({}, { external: { geoJsonService: mockGeoJsonService } });
+    // Wait for the geoJsonService to resolve the promise and cache the geoJson features
+    model.getters.getGeoChartAvailableRegions();
+    model.getters.getGeoJsonFeatures("world");
+    for (const country of ["France", "Germany", "Spain"]) {
+      model.getters.geoFeatureNameToId("world", country);
+    }
+    await nextTick();
+  });
+
   test("Basic geo chart runtime", () => {
     setCellContent(model, "A2", "France");
     setCellContent(model, "A3", "Germany");
@@ -136,4 +136,16 @@ describe("Geo charts plugin tests", () => {
     // The countries that have no data should still be in the runtime, otherwise the missing color won't be applied
     expect(runtime.chartJsConfig.data.datasets[0].data.length).toBe(3);
   });
+});
+
+test("loadUsedGeoJsonFeatures loads all the used geo json", async () => {
+  const spy = jest.spyOn(mockGeoJsonService, "getTopoJson");
+  const model = new Model({}, { external: { geoJsonService: mockGeoJsonService } });
+  createGeoChart(model, { region: undefined }, "chart1"); // Defaults to world (first available region)
+  createGeoChart(model, { region: "usa" }, "chart2");
+
+  await model.getters.loadUsedGeoJsonFeatures();
+  expect(spy).toHaveBeenCalledTimes(2);
+  expect(spy).toHaveBeenCalledWith("world");
+  expect(spy).toHaveBeenCalledWith("usa");
 });

--- a/tests/test_helpers/helpers.ts
+++ b/tests/test_helpers/helpers.ts
@@ -919,7 +919,7 @@ export const mockChart = () => {
   return mockChartData;
 };
 
-export const mockGeoJsonService: ModelExternalConfig["geoJsonService"] = {
+export const mockGeoJsonService: NonNullable<ModelExternalConfig["geoJsonService"]> = {
   getAvailableRegions: () => [
     { id: "world", label: "World", defaultProjection: "mercator" },
     { id: "usa", label: "United States", defaultProjection: "albersUsa" },


### PR DESCRIPTION
## Description

If a geo chart was present when exporting a spreadsheet to xlsx, more often than not the exported chart would be empty. It was because we didn't wait for the geo json to be loaded before exporting the xlsx.

This commit introduces a new helper `waitForSpreadsheetDataLoaded` that can be called before any spreadsheet export to ensure that all the data is loaded.

Task: [4632983](https://www.odoo.com/odoo/2328/tasks/4632983)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo