### PR TITLE
[FIX] print: always print in light mode

### DIFF
--- a/src/components/dashboard/dashboard.ts
+++ b/src/components/dashboard/dashboard.ts
@@ -67,12 +67,20 @@ export class SpreadsheetDashboard extends Component<SpreadsheetChildEnv> {
     useGridDrawing({
       canvasRef: this.canvasRef,
       rendererStore,
-      renderingCtx: () => ({
-        dpr: window.devicePixelRatio || 1,
-        viewports: this.viewStore.viewports,
-        ...this.env.model.getters.getSelectionState(),
-        hideGridLines: true,
-      }),
+      renderingCtx: () => {
+        const selectionState = this.env.model.getters.getSelectionState();
+        const theme = this.env.model.getters.getSpreadsheetTheme();
+        const sheet = this.env.model.getters.getSheet(selectionState.sheetId);
+        return {
+          dpr: window.devicePixelRatio || 1,
+          viewports: this.viewStore.viewports,
+          ...selectionState,
+          hideGridLines: true,
+          theme,
+          backgroundColor: sheet.backgroundColor || theme.backgroundColor,
+          dataBarVerticalPadding: 2,
+        };
+      },
     });
     this.onMouseWheel = useWheelHandler((deltaX, deltaY) => {
       this.moveCanvas(deltaX, deltaY);

--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -196,11 +196,19 @@ export class Grid extends Component<SpreadsheetChildEnv> {
     this.props.exposeFocus(() => this.focusDefaultElement());
     useGridDrawing({
       canvasRef: this.canvasRef,
-      renderingCtx: () => ({
-        dpr: window.devicePixelRatio || 1,
-        viewports: this.viewStore.viewports,
-        ...this.env.model.getters.getSelectionState(),
-      }),
+      renderingCtx: () => {
+        const selectionState = this.env.model.getters.getSelectionState();
+        const theme = this.env.model.getters.getSpreadsheetTheme();
+        const sheet = this.env.model.getters.getSheet(selectionState.sheetId);
+        return {
+          dpr: window.devicePixelRatio || 1,
+          viewports: this.viewStore.viewports,
+          ...selectionState,
+          hideGridLines: !this.env.model.getters.getGridLinesVisibility(selectionState.sheetId),
+          theme,
+          backgroundColor: sheet.backgroundColor || theme.backgroundColor,
+        };
+      },
     });
     this.onMouseWheel = useWheelHandler((deltaX, deltaY) => {
       this.moveCanvas(deltaX, deltaY);

--- a/src/components/spreadsheet_print/spreadsheet_print_store.ts
+++ b/src/components/spreadsheet_print/spreadsheet_print_store.ts
@@ -182,6 +182,8 @@ export class SpreadsheetPrintStore extends SpreadsheetStore {
     });
     viewports.setSheetViewOffset(sheetId, firstColStart, firstRowStart);
 
+    const theme = this.getters.getSpreadsheetTheme();
+    const sheet = this.getters.getSheet(sheetId);
     return {
       sheetId,
       viewports,
@@ -191,6 +193,8 @@ export class SpreadsheetPrintStore extends SpreadsheetStore {
       activeCols: new Set(),
       activeRows: new Set(),
       activePosition: undefined,
+      theme,
+      backgroundColor: sheet.backgroundColor || theme.backgroundColor,
     };
   }
 

--- a/src/components/spreadsheet_print/spreadsheet_print_store.ts
+++ b/src/components/spreadsheet_print/spreadsheet_print_store.ts
@@ -1,6 +1,7 @@
 import { PRINT_DPR } from "../../constants";
 import { ViewportCollection } from "../../helpers/viewport_collection";
 import { cellPositions, intersection } from "../../helpers/zones";
+import { COLOR_THEMES } from "../../plugins/ui_feature/color_theme";
 import { SpreadsheetStore } from "../../stores/spreadsheet_store";
 import { _t } from "../../translation";
 import { CellValueType } from "../../types/cells";
@@ -182,7 +183,7 @@ export class SpreadsheetPrintStore extends SpreadsheetStore {
     });
     viewports.setSheetViewOffset(sheetId, firstColStart, firstRowStart);
 
-    const theme = this.getters.getSpreadsheetTheme();
+    const theme = COLOR_THEMES.light;
     const sheet = this.getters.getSheet(sheetId);
     return {
       sheetId,

--- a/src/components/standalone_grid_canvas/figure_renderer_store.ts
+++ b/src/components/standalone_grid_canvas/figure_renderer_store.ts
@@ -103,8 +103,7 @@ export class FigureRendererStore extends DisposableStore {
     ctx.rect(figureRect.x, figureRect.y, figureRect.width, figureRect.height);
     ctx.clip();
 
-    ctx.fillStyle =
-      chartDefinition?.background || this.getters.getSpreadsheetTheme().backgroundColor;
+    ctx.fillStyle = chartDefinition?.background || renderingCtx.backgroundColor;
     ctx.fillRect(figureRect.x, figureRect.y, figureRect.width, figureRect.height);
 
     const title = { ...DEFAULT_CAROUSEL_TITLE_STYLE, ...carousel.title };

--- a/src/components/standalone_viewport/standalone_viewport_store.ts
+++ b/src/components/standalone_viewport/standalone_viewport_store.ts
@@ -126,6 +126,8 @@ export class StandaloneViewportStore extends SpreadsheetStore {
   get renderingContext(): Omit<GridRenderingContext, "ctx" | "thinLineWidth"> {
     const { sheetId } = this.range;
 
+    const theme = this.getters.getSpreadsheetTheme();
+    const sheet = this.getters.getSheet(sheetId);
     const renderingCtx: Omit<GridRenderingContext, "ctx" | "thinLineWidth"> = {
       sheetId,
       viewports: this.viewStore.viewports,
@@ -136,6 +138,8 @@ export class StandaloneViewportStore extends SpreadsheetStore {
       activeCols: new Set(),
       activeRows: new Set(),
       activePosition: undefined,
+      backgroundColor: sheet.backgroundColor || theme.backgroundColor,
+      theme: this.getters.getSpreadsheetTheme(),
     };
     return renderingCtx;
   }

--- a/src/helpers/canvas_renderer.ts
+++ b/src/helpers/canvas_renderer.ts
@@ -1,0 +1,475 @@
+import { getPath2D } from "../components/icons/icons";
+import {
+  CANVAS_SHIFT,
+  DEFAULT_FONT,
+  HEADER_FONT_SIZE,
+  HEADER_HEIGHT,
+  HEADER_WIDTH,
+  MIN_CELL_TEXT_MARGIN,
+} from "../constants";
+import { Pixel } from "../types/misc";
+import { BorderDescrWithOpacity, Box, GridRenderingContext } from "../types/rendering";
+import { blendColors, setColorAlpha, toHex } from "./color";
+import { numberToLetters } from "./coordinates";
+import { computeRotationPosition, computeTextFont, drawDecoratedText } from "./text_helper";
+import { getZonesCols, getZonesRows } from "./zones";
+
+export function drawGlobalBackground(renderingContext: GridRenderingContext) {
+  const { ctx, viewports } = renderingContext;
+  const { width, height } = viewports.getSheetViewDimensionWithHeaders();
+
+  ctx.fillStyle = renderingContext.backgroundColor;
+  ctx.fillRect(0, 0, width + CANVAS_SHIFT, height + CANVAS_SHIFT);
+}
+
+export function drawBackground(renderingContext: GridRenderingContext, boxes: Box[]) {
+  const { ctx, thinLineWidth } = renderingContext;
+
+  const areGridLinesVisible = !renderingContext.hideGridLines;
+  const inset = areGridLinesVisible ? 0.1 * thinLineWidth : 0;
+
+  if (areGridLinesVisible) {
+    const theme = renderingContext.theme;
+    const background = renderingContext.backgroundColor;
+    const blendedGridColor = blendColors(theme.gridBorderColor + "aa", background + "50");
+    ctx.strokeStyle = setColorAlpha(blendedGridColor, 1);
+    ctx.lineWidth = thinLineWidth;
+    for (const box of boxes) {
+      if (box.style.hideGridLines) {
+        continue;
+      }
+      ctx.strokeRect(box.x + inset, box.y + inset, box.width - 2 * inset, box.height - 2 * inset);
+    }
+  }
+}
+
+export function drawCellBackground(renderingContext: GridRenderingContext, boxes: Box[]) {
+  const { ctx } = renderingContext;
+  for (const box of boxes) {
+    const style = box.style;
+    if (style.fillColor && toHex(style.fillColor) !== toHex(renderingContext.backgroundColor)) {
+      ctx.fillStyle = toHex(style.fillColor);
+      // We shift the canvas by CANVAS_SHIFT to avoid blurry lines (lines are drawn between pixels), but fillRect
+      // are drawn at the exact pixel position, so we need to compensate this shift here. We also want to extend
+      // the fill by 1px to draw over the gridLines.
+      ctx.fillRect(
+        box.x - CANVAS_SHIFT,
+        box.y - CANVAS_SHIFT,
+        box.width + CANVAS_SHIFT * 2,
+        box.height + CANVAS_SHIFT * 2
+      );
+    }
+    if (box.dataBarFill) {
+      ctx.fillStyle = box.dataBarFill.color;
+      const percentage = box.dataBarFill.percentage;
+      const width = box.width * (percentage / 100);
+      const padding = renderingContext.dataBarVerticalPadding ?? 0;
+      const y = box.y + padding;
+      const height = box.height - 2 * padding;
+      ctx.fillRect(box.x, y, width, height);
+    }
+    if (box.overlayColor) {
+      ctx.fillStyle = blendColors(
+        style.fillColor || renderingContext.backgroundColor,
+        box.overlayColor
+      );
+      ctx.fillRect(
+        box.x - CANVAS_SHIFT,
+        box.y - CANVAS_SHIFT,
+        box.width + CANVAS_SHIFT * 2,
+        box.height + CANVAS_SHIFT * 2
+      );
+    }
+    if (box?.chip) {
+      ctx.save();
+      ctx.beginPath();
+      ctx.rect(box.x, box.y, box.width, box.height);
+      ctx.clip();
+      const chip = box.chip;
+      ctx.fillStyle = box.overlayColor ? blendColors(chip.color, box.overlayColor) : chip.color;
+      const radius = 10;
+      ctx.beginPath();
+      ctx.roundRect(chip.x, chip.y, chip.width, chip.height, radius);
+      ctx.fill();
+      ctx.restore();
+    }
+    if (box.isError) {
+      ctx.fillStyle = "red";
+      ctx.beginPath();
+      ctx.moveTo(box.x + box.width - 5, box.y);
+      ctx.lineTo(box.x + box.width, box.y);
+      ctx.lineTo(box.x + box.width, box.y + 5);
+      ctx.fill();
+    }
+  }
+}
+
+export function drawOverflowingCellBackground(
+  renderingContext: GridRenderingContext,
+  boxes: Box[]
+) {
+  const { ctx, thinLineWidth } = renderingContext;
+  for (const box of boxes) {
+    if (box.content && box.isOverflow) {
+      const align = box.content.align || "left";
+      let x: number;
+      let width: number;
+      const y = box.y + thinLineWidth / 2;
+      const height = box.height - thinLineWidth;
+      const clipWidth = Math.min(box.clipRect?.width || Infinity, box.content.width);
+      if (align === "left") {
+        x = box.x + thinLineWidth / 2;
+        width = clipWidth - 2 * thinLineWidth;
+      } else if (align === "right") {
+        x = box.x + box.width - thinLineWidth / 2;
+        width = -clipWidth + 2 * thinLineWidth;
+      } else {
+        x = (box.clipRect?.x || box.x + box.width / 2 - box.content.width / 2) + thinLineWidth / 2;
+        width = clipWidth - 2 * thinLineWidth;
+      }
+      ctx.fillStyle = renderingContext.backgroundColor;
+      ctx.fillRect(x, y, width, height);
+    }
+  }
+}
+
+export function drawBorders(renderingContext: GridRenderingContext, boxes: Box[]) {
+  const { ctx } = renderingContext;
+  for (const box of boxes) {
+    const border = box.border;
+    if (border) {
+      const { x, y, width, height } = box;
+      if (border.left) {
+        drawBorder(border.left, x, y, x, y + height);
+      }
+      if (border.top) {
+        drawBorder(border.top, x, y, x + width, y);
+      }
+      if (border.right) {
+        drawBorder(border.right, x + width, y, x + width, y + height);
+      }
+      if (border.bottom) {
+        drawBorder(border.bottom, x, y + height, x + width, y + height);
+      }
+    }
+  }
+
+  /**
+   * Following https://usefulangle.com/post/17/html5-canvas-drawing-1px-crisp-straight-lines,
+   * we need to make sure that a "single" pixel line is drawn on a "half" pixel coordinate,
+   * while a "double" pixel line is drawn on a "full" pixel coordinate. As, in the rendering
+   * process, we always had 0.5 before rendering line (to make sure it is drawn on a "half"
+   * pixel), we need to correct this behavior for the "medium" and the "dotted" styles, as
+   * they are drawing a two pixels width line.
+   * We also adapt here the coordinates of the line to make sure corner are correctly drawn,
+   * avoiding a "round corners" effect. This is done by subtracting 1 pixel to the origin of
+   * each line and adding 1 pixel to the end of each line (depending on the direction of the
+   * line).
+   */
+  function drawBorder(
+    { color, style, opacity }: BorderDescrWithOpacity,
+    x1: Pixel,
+    y1: Pixel,
+    x2: Pixel,
+    y2: Pixel
+  ) {
+    ctx.globalAlpha = opacity ?? 1;
+    ctx.strokeStyle = color;
+    switch (style) {
+      case "medium":
+        ctx.lineWidth = 2;
+        x1 += y1 === y2 ? -0.5 : 0.5;
+        x2 += y1 === y2 ? 1.5 : 0.5;
+        y1 += x1 === x2 ? -0.5 : 0.5;
+        y2 += x1 === x2 ? 1.5 : 0.5;
+        break;
+      case "thick":
+        ctx.lineWidth = 3;
+        if (y1 === y2) {
+          x1--;
+          x2++;
+        }
+        if (x1 === x2) {
+          y1--;
+          y2++;
+        }
+        break;
+      case "dashed":
+        ctx.lineWidth = 1;
+        ctx.setLineDash([1, 3]);
+        break;
+      case "dotted":
+        ctx.lineWidth = 1;
+        if (y1 === y2) {
+          x1 += 0.5;
+          x2 += 0.5;
+        }
+        if (x1 === x2) {
+          y1 += 0.5;
+          y2 += 0.5;
+        }
+        ctx.setLineDash([1, 1]);
+        break;
+      case "thin":
+      default:
+        ctx.lineWidth = 1;
+        break;
+    }
+    ctx.beginPath();
+    ctx.moveTo(x1, y1);
+    ctx.lineTo(x2, y2);
+    ctx.stroke();
+
+    ctx.lineWidth = 1;
+    ctx.setLineDash([]);
+    ctx.globalAlpha = 1;
+  }
+}
+
+export function drawTexts(renderingContext: GridRenderingContext, boxes: Box[]) {
+  const { ctx } = renderingContext;
+  ctx.textBaseline = "top";
+  let currentFont;
+  for (const box of boxes) {
+    if (box.content) {
+      ctx.globalAlpha = box.textOpacity ?? 1;
+      const align = box.content.align || "left";
+      const rotation = box.chip ? 0 : box.style.rotation;
+      const style = { ...box.style, align, rotation };
+
+      // compute font and textColor
+      const font = computeTextFont(style);
+      if (font !== currentFont) {
+        currentFont = font;
+        ctx.font = font;
+      }
+      ctx.fillStyle = style.textColor || "#000";
+
+      // horizontal align text direction
+      ctx.textAlign = align;
+
+      // clip rect if needed
+      if (box.clipRect) {
+        ctx.save();
+        ctx.beginPath();
+        const { x, y, width, height } = box.clipRect;
+        ctx.rect(x, y, width, height);
+        ctx.clip();
+      }
+      let x = box.content.x;
+      let y = box.content.y;
+      if (style.rotation) {
+        ctx.save();
+        ctx.rotate(style.rotation);
+        ({ x, y } = computeRotationPosition(box.content, style));
+      }
+
+      // use the horizontal and the vertical start points to:
+      // fill text / fill strikethrough / fill underline
+      for (const brokenLine of box.content.textLines) {
+        drawDecoratedText(ctx, brokenLine, { x, y }, style.underline, style.strikethrough);
+        y += MIN_CELL_TEXT_MARGIN + box.content.fontSizePx;
+      }
+
+      if (style.rotation) {
+        ctx.restore();
+      }
+      if (box.clipRect) {
+        ctx.restore();
+      }
+      ctx.globalAlpha = 1;
+    }
+  }
+}
+
+export function drawIcon(renderingContext: GridRenderingContext, boxes: Box[]) {
+  const { ctx } = renderingContext;
+  for (const box of boxes) {
+    for (const icon of Object.values(box.icons)) {
+      if (!icon) {
+        continue;
+      }
+      const svg = icon.isHovered ? icon.hoverSvg || icon.svg : icon.svg;
+      if (!svg) {
+        continue;
+      }
+      ctx.save();
+      ctx.globalAlpha = icon.opacity ?? 1;
+      ctx.beginPath();
+      const clipRect = icon.clipRect || box;
+      ctx.rect(clipRect.x, clipRect.y, clipRect.width, clipRect.height);
+      ctx.clip();
+
+      const iconSize = icon.size;
+      const { x, y } = icon.rect;
+      ctx.translate(x, y);
+      ctx.scale(iconSize / svg.width, iconSize / svg.height);
+      for (const path of svg.paths) {
+        ctx.fillStyle = path.fillColor;
+        ctx.fill(getPath2D(path.path));
+      }
+      ctx.restore();
+    }
+  }
+}
+
+export function drawHeaders(renderingContext: GridRenderingContext) {
+  const { ctx, thinLineWidth, viewports, sheetId } = renderingContext;
+  const visibleCols = viewports.getSheetViewVisibleCols(sheetId);
+  const left = visibleCols[0];
+  const visibleRows = viewports.getSheetViewVisibleRows(sheetId);
+  const top = visibleRows[0];
+  const { width, height } = viewports.getSheetViewDimensionWithHeaders();
+  const selection = renderingContext.selectedZones;
+  const selectedCols = getZonesCols(selection);
+  const selectedRows = getZonesRows(selection);
+  const activeCols = renderingContext.activeCols;
+  const activeRows = renderingContext.activeRows;
+
+  const theme = renderingContext.theme;
+  ctx.font = `400 ${HEADER_FONT_SIZE}px ${DEFAULT_FONT}`;
+  ctx.textAlign = "center";
+  ctx.textBaseline = "middle";
+  ctx.lineWidth = thinLineWidth;
+  ctx.strokeStyle = theme.headerTextColor;
+
+  // Background for headers to separate from possible grid background color
+  ctx.fillStyle = renderingContext.theme.backgroundColor;
+  ctx.fillRect(0, 0, HEADER_WIDTH, height);
+  ctx.fillRect(0, 0, width, HEADER_HEIGHT);
+
+  // Columns headers background
+  for (const col of visibleCols) {
+    const colZone = { left: col, right: col, top: 0, bottom: Number.MAX_SAFE_INTEGER };
+    const { x, width } = viewports.getVisibleRect(sheetId, colZone);
+    const isColActive = activeCols.has(col);
+    const isColSelected = selectedCols.has(col);
+    if (isColActive) {
+      ctx.fillStyle = theme.headerActiveBackgroundColor;
+    } else if (isColSelected) {
+      ctx.fillStyle = theme.headerSelectedBackgroundColor;
+    } else {
+      ctx.fillStyle = theme.headerBackgroundColor;
+    }
+    ctx.fillRect(x, 0, width, HEADER_HEIGHT);
+  }
+
+  // Rows headers background
+  for (const row of visibleRows) {
+    const rowZone = { top: row, bottom: row, left: 0, right: Number.MAX_SAFE_INTEGER };
+    const { y, height } = viewports.getVisibleRect(sheetId, rowZone);
+
+    const isRowActive = activeRows.has(row);
+    const isRowSelected = selectedRows.has(row);
+    if (isRowActive) {
+      ctx.fillStyle = theme.headerActiveBackgroundColor;
+    } else if (isRowSelected) {
+      ctx.fillStyle = theme.headerSelectedBackgroundColor;
+    } else {
+      ctx.fillStyle = theme.headerBackgroundColor;
+    }
+    ctx.fillRect(0, y, HEADER_WIDTH, height);
+  }
+
+  // 2 main lines
+  ctx.beginPath();
+  ctx.moveTo(HEADER_WIDTH, 0);
+  ctx.lineTo(HEADER_WIDTH, height);
+  ctx.moveTo(0, HEADER_HEIGHT);
+  ctx.lineTo(width, HEADER_HEIGHT);
+  ctx.strokeStyle = theme.headerBorderColor;
+  ctx.stroke();
+
+  // column text + separator
+  for (const col of visibleCols) {
+    const colName = numberToLetters(col);
+    ctx.fillStyle = activeCols.has(col) ? "#fff" : theme.headerTextColor;
+    const zone = { left: col, right: col, top: top, bottom: top };
+    const { x: colStart, width: colSize } = viewports.getRect(sheetId, zone);
+    const { x, width } = viewports.getVisibleRect(sheetId, zone);
+    ctx.save();
+    ctx.beginPath();
+    ctx.rect(x, 0, width, HEADER_HEIGHT);
+    ctx.clip();
+    ctx.fillText(colName, colStart + colSize / 2, HEADER_HEIGHT / 2);
+    ctx.restore();
+    ctx.beginPath();
+    ctx.moveTo(colStart + colSize, 0);
+    ctx.lineTo(colStart + colSize, HEADER_HEIGHT);
+    ctx.stroke();
+  }
+
+  // row text + separator
+  for (const row of visibleRows) {
+    ctx.fillStyle = activeRows.has(row) ? "#fff" : theme.headerTextColor;
+    const zone = { top: row, bottom: row, left: left, right: left };
+    const { y: rowStart, height: rowSize } = viewports.getRect(sheetId, zone);
+    const { y, height } = viewports.getVisibleRect(sheetId, zone);
+    ctx.save();
+    ctx.beginPath();
+    ctx.rect(0, y, HEADER_WIDTH, height);
+    ctx.clip();
+    ctx.fillText(String(row + 1), HEADER_WIDTH / 2, rowStart + rowSize / 2);
+    ctx.restore();
+    ctx.beginPath();
+    ctx.moveTo(0, rowStart + rowSize);
+    ctx.lineTo(HEADER_WIDTH, rowStart + rowSize);
+    ctx.stroke();
+  }
+}
+
+export function drawFrozenPanesHeaders(renderingContext: GridRenderingContext) {
+  const { ctx, thinLineWidth, sheetId, viewports } = renderingContext;
+
+  const { paneWidth: offsetCorrectionX, paneHeight: offsetCorrectionY } =
+    viewports.getPanesDimensions(sheetId);
+
+  const widthCorrection = viewports.getGridOffsetX();
+  const heightCorrection = viewports.getGridOffsetY();
+  ctx.lineWidth = 6 * thinLineWidth;
+  ctx.strokeStyle = renderingContext.theme.frozenPaneHeaderBorderColor;
+  ctx.beginPath();
+  if (offsetCorrectionX) {
+    ctx.moveTo(widthCorrection + offsetCorrectionX, 0);
+    ctx.lineTo(widthCorrection + offsetCorrectionX, heightCorrection);
+  }
+  if (offsetCorrectionY) {
+    ctx.moveTo(0, heightCorrection + offsetCorrectionY);
+    ctx.lineTo(widthCorrection, heightCorrection + offsetCorrectionY);
+  }
+  ctx.stroke();
+}
+
+export function drawFrozenPanes(renderingContext: GridRenderingContext) {
+  if (renderingContext.hideFrozenPaneBorder) {
+    return;
+  }
+  const { ctx, thinLineWidth, sheetId, viewports } = renderingContext;
+
+  const { x: offsetCorrectionX, y: offsetCorrectionY } =
+    viewports.getMainViewportCoordinates(sheetId);
+
+  const visibleCols = viewports.getSheetViewVisibleCols(sheetId);
+  const left = visibleCols[0];
+  const right = visibleCols[visibleCols.length - 1];
+  const visibleRows = viewports.getSheetViewVisibleRows(sheetId);
+  const top = visibleRows[0];
+  const bottom = visibleRows[visibleRows.length - 1];
+  const viewport = { left, right, top, bottom };
+
+  const rect = renderingContext.viewports.getVisibleRect(renderingContext.sheetId, viewport);
+  const widthCorrection = viewports.getGridOffsetX();
+  const heightCorrection = viewports.getGridOffsetY();
+  ctx.lineWidth = 6 * thinLineWidth;
+  ctx.strokeStyle = renderingContext.theme.frozenPaneBorderColor;
+  ctx.beginPath();
+  if (offsetCorrectionX) {
+    ctx.moveTo(widthCorrection + offsetCorrectionX, heightCorrection);
+    ctx.lineTo(widthCorrection + offsetCorrectionX, rect.height + heightCorrection);
+  }
+  if (offsetCorrectionY) {
+    ctx.moveTo(widthCorrection, heightCorrection + offsetCorrectionY);
+    ctx.lineTo(rect.width + widthCorrection, heightCorrection + offsetCorrectionY);
+  }
+  ctx.stroke();
+}

--- a/src/stores/grid_renderer_store.ts
+++ b/src/stores/grid_renderer_store.ts
@@ -1,51 +1,31 @@
 import { HoveredIconStore } from "../components/grid_overlay/hovered_icon_store";
-import { getPath2D } from "../components/icons/icons";
+import { DATA_VALIDATION_CHIP_MARGIN, MIN_CELL_TEXT_MARGIN } from "../constants";
 import {
-  CANVAS_SHIFT,
-  DATA_VALIDATION_CHIP_MARGIN,
-  DEFAULT_FONT,
-  HEADER_FONT_SIZE,
-  HEADER_HEIGHT,
-  HEADER_WIDTH,
-  MIN_CELL_TEXT_MARGIN,
-} from "../constants";
-import { blendColors, setColorAlpha, toHex } from "../helpers/color";
-import { numberToLetters } from "../helpers/coordinates";
+  drawBackground,
+  drawBorders,
+  drawCellBackground,
+  drawFrozenPanes,
+  drawFrozenPanesHeaders,
+  drawGlobalBackground,
+  drawHeaders,
+  drawIcon,
+  drawOverflowingCellBackground,
+  drawTexts,
+} from "../helpers/canvas_renderer";
 import { formatHasRepeatedChar } from "../helpers/format/format";
 import { deepCopy, deepEquals } from "../helpers/misc";
 import { recomputeZones } from "../helpers/recompute_zones";
-import {
-  computeRotationPosition,
-  computeTextFont,
-  computeTextFontSizeInPixels,
-  computeTextLinesHeight,
-  drawDecoratedText,
-} from "../helpers/text_helper";
+import { computeTextFontSizeInPixels, computeTextLinesHeight } from "../helpers/text_helper";
 import { ViewportCollection } from "../helpers/viewport_collection";
-import {
-  getZonesCols,
-  getZonesRows,
-  isZoneInside,
-  overlap,
-  positionToZone,
-  union,
-  zoneToXc,
-} from "../helpers/zones";
+import { isZoneInside, overlap, positionToZone, union, zoneToXc } from "../helpers/zones";
 import { Model } from "../model";
 import { cellAnimationRegistry } from "../registries/cell_animation_registry";
 import { DisposableStore } from "../store_engine/store";
 import { CellValueType } from "../types/cells";
 import { Command } from "../types/commands";
 import { RenderingGetters } from "../types/getters";
-import { Align, CellPosition, HeaderIndex, Pixel, UID, Zone } from "../types/misc";
-import {
-  BorderDescrWithOpacity,
-  Box,
-  GridRenderingContext,
-  LayerName,
-  RenderingBox,
-  Viewport,
-} from "../types/rendering";
+import { Align, CellPosition, HeaderIndex, UID, Zone } from "../types/misc";
+import { Box, GridRenderingContext, LayerName, RenderingBox, Viewport } from "../types/rendering";
 import { Get, Store } from "../types/store_engine";
 import { CellHoverOverlayStore } from "./cell_hover_overlay_store";
 import { FormulaFingerprintStore } from "./formula_fingerprints_store";
@@ -162,7 +142,7 @@ export class GridRenderer extends DisposableStore {
   ) {
     switch (layer) {
       case "Background":
-        this.drawGlobalBackground(renderingContext);
+        drawGlobalBackground(renderingContext);
         const oldBoxes =
           renderingContext.sheetId === this.lastRenderSheetId ? this.lastRenderBoxes : new Map();
         this.lastRenderSheetId = renderingContext.sheetId;
@@ -177,492 +157,23 @@ export class GridRenderer extends DisposableStore {
           ctx.clip();
           const boxesWithoutAnimations = this.getGridBoxes(viewports, sheetId, zone);
           const boxes = this.getBoxesWithAnimations(boxesWithoutAnimations, oldBoxes, timeStamp);
-          this.drawBackground(renderingContext, boxes);
-          this.drawOverflowingCellBackground(renderingContext, boxes);
-          this.drawCellBackground(renderingContext, boxes);
-          this.drawBorders(renderingContext, boxes);
-          this.drawTexts(renderingContext, boxes);
-          this.drawIcon(renderingContext, boxes);
+          drawBackground(renderingContext, boxes);
+          drawOverflowingCellBackground(renderingContext, boxes);
+          drawCellBackground(renderingContext, boxes);
+          drawBorders(renderingContext, boxes);
+          drawTexts(renderingContext, boxes);
+          drawIcon(renderingContext, boxes);
           ctx.restore();
         }
-        this.drawFrozenPanes(renderingContext);
+        drawFrozenPanes(renderingContext);
         this.preventNewAnimationsInNextFrame = false;
         this.zonesWithPreventedAnimationsInNextFrame = {};
         break;
       case "Headers":
-        this.drawHeaders(renderingContext);
-        this.drawFrozenPanesHeaders(renderingContext);
+        drawHeaders(renderingContext);
+        drawFrozenPanesHeaders(renderingContext);
         break;
     }
-  }
-
-  private drawGlobalBackground(renderingContext: GridRenderingContext) {
-    const { ctx, viewports } = renderingContext;
-    const { width, height } = viewports.getSheetViewDimensionWithHeaders();
-
-    ctx.fillStyle = this.getBackgroundColor(renderingContext);
-    ctx.fillRect(0, 0, width + CANVAS_SHIFT, height + CANVAS_SHIFT);
-  }
-
-  private drawBackground(renderingContext: GridRenderingContext, boxes: Box[]) {
-    const { ctx, thinLineWidth } = renderingContext;
-
-    const areGridLinesVisible =
-      !renderingContext.hideGridLines &&
-      this.getters.getGridLinesVisibility(renderingContext.sheetId);
-    const inset = areGridLinesVisible ? 0.1 * thinLineWidth : 0;
-
-    if (areGridLinesVisible) {
-      const theme = this.getters.getSpreadsheetTheme();
-      const background = this.getBackgroundColor(renderingContext);
-      const blendedGridColor = blendColors(theme.gridBorderColor + "aa", background + "50");
-      ctx.strokeStyle = setColorAlpha(blendedGridColor, 1);
-      ctx.lineWidth = thinLineWidth;
-      for (const box of boxes) {
-        if (box.style.hideGridLines) {
-          continue;
-        }
-        ctx.strokeRect(box.x + inset, box.y + inset, box.width - 2 * inset, box.height - 2 * inset);
-      }
-    }
-  }
-
-  private drawCellBackground(renderingContext: GridRenderingContext, boxes: Box[]) {
-    const { ctx } = renderingContext;
-    for (const box of boxes) {
-      const style = box.style;
-      if (
-        style.fillColor &&
-        toHex(style.fillColor) !== toHex(this.getBackgroundColor(renderingContext))
-      ) {
-        ctx.fillStyle = toHex(style.fillColor);
-        // We shift the canvas by CANVAS_SHIFT to avoid blurry lines (lines are drawn between pixels), but fillRect
-        // are drawn at the exact pixel position, so we need to compensate this shift here. We also want to extend
-        // the fill by 1px to draw over the gridLines.
-        ctx.fillRect(
-          box.x - CANVAS_SHIFT,
-          box.y - CANVAS_SHIFT,
-          box.width + CANVAS_SHIFT * 2,
-          box.height + CANVAS_SHIFT * 2
-        );
-      }
-      if (box.dataBarFill) {
-        ctx.fillStyle = box.dataBarFill.color;
-        const percentage = box.dataBarFill.percentage;
-        const width = box.width * (percentage / 100);
-        const isDashboard = this.getters.isDashboard();
-        const y = isDashboard ? box.y + 2 : box.y;
-        const height = isDashboard ? box.height - 4 : box.height;
-        ctx.fillRect(box.x, y, width, height);
-      }
-      if (box.overlayColor) {
-        ctx.fillStyle = blendColors(
-          style.fillColor || this.getBackgroundColor(renderingContext),
-          box.overlayColor
-        );
-        ctx.fillRect(
-          box.x - CANVAS_SHIFT,
-          box.y - CANVAS_SHIFT,
-          box.width + CANVAS_SHIFT * 2,
-          box.height + CANVAS_SHIFT * 2
-        );
-      }
-      if (box?.chip) {
-        ctx.save();
-        ctx.beginPath();
-        ctx.rect(box.x, box.y, box.width, box.height);
-        ctx.clip();
-        const chip = box.chip;
-        ctx.fillStyle = box.overlayColor ? blendColors(chip.color, box.overlayColor) : chip.color;
-        const radius = 10;
-        ctx.beginPath();
-        ctx.roundRect(chip.x, chip.y, chip.width, chip.height, radius);
-        ctx.fill();
-        ctx.restore();
-      }
-      if (box.isError) {
-        ctx.fillStyle = "red";
-        ctx.beginPath();
-        ctx.moveTo(box.x + box.width - 5, box.y);
-        ctx.lineTo(box.x + box.width, box.y);
-        ctx.lineTo(box.x + box.width, box.y + 5);
-        ctx.fill();
-      }
-    }
-  }
-
-  private drawOverflowingCellBackground(renderingContext: GridRenderingContext, boxes: Box[]) {
-    const { ctx, thinLineWidth } = renderingContext;
-    for (const box of boxes) {
-      if (box.content && box.isOverflow) {
-        const align = box.content.align || "left";
-        let x: number;
-        let width: number;
-        const y = box.y + thinLineWidth / 2;
-        const height = box.height - thinLineWidth;
-        const clipWidth = Math.min(box.clipRect?.width || Infinity, box.content.width);
-        if (align === "left") {
-          x = box.x + thinLineWidth / 2;
-          width = clipWidth - 2 * thinLineWidth;
-        } else if (align === "right") {
-          x = box.x + box.width - thinLineWidth / 2;
-          width = -clipWidth + 2 * thinLineWidth;
-        } else {
-          x =
-            (box.clipRect?.x || box.x + box.width / 2 - box.content.width / 2) + thinLineWidth / 2;
-          width = clipWidth - 2 * thinLineWidth;
-        }
-        ctx.fillStyle = this.getBackgroundColor(renderingContext);
-        ctx.fillRect(x, y, width, height);
-      }
-    }
-  }
-
-  private drawBorders(renderingContext: GridRenderingContext, boxes: Box[]) {
-    const { ctx } = renderingContext;
-    for (const box of boxes) {
-      const border = box.border;
-      if (border) {
-        const { x, y, width, height } = box;
-        if (border.left) {
-          drawBorder(border.left, x, y, x, y + height);
-        }
-        if (border.top) {
-          drawBorder(border.top, x, y, x + width, y);
-        }
-        if (border.right) {
-          drawBorder(border.right, x + width, y, x + width, y + height);
-        }
-        if (border.bottom) {
-          drawBorder(border.bottom, x, y + height, x + width, y + height);
-        }
-      }
-    }
-
-    /**
-     * Following https://usefulangle.com/post/17/html5-canvas-drawing-1px-crisp-straight-lines,
-     * we need to make sure that a "single" pixel line is drawn on a "half" pixel coordinate,
-     * while a "double" pixel line is drawn on a "full" pixel coordinate. As, in the rendering
-     * process, we always had 0.5 before rendering line (to make sure it is drawn on a "half"
-     * pixel), we need to correct this behavior for the "medium" and the "dotted" styles, as
-     * they are drawing a two pixels width line.
-     * We also adapt here the coordinates of the line to make sure corner are correctly drawn,
-     * avoiding a "round corners" effect. This is done by subtracting 1 pixel to the origin of
-     * each line and adding 1 pixel to the end of each line (depending on the direction of the
-     * line).
-     */
-    function drawBorder(
-      { color, style, opacity }: BorderDescrWithOpacity,
-      x1: Pixel,
-      y1: Pixel,
-      x2: Pixel,
-      y2: Pixel
-    ) {
-      ctx.globalAlpha = opacity ?? 1;
-      ctx.strokeStyle = color;
-      switch (style) {
-        case "medium":
-          ctx.lineWidth = 2;
-          x1 += y1 === y2 ? -0.5 : 0.5;
-          x2 += y1 === y2 ? 1.5 : 0.5;
-          y1 += x1 === x2 ? -0.5 : 0.5;
-          y2 += x1 === x2 ? 1.5 : 0.5;
-          break;
-        case "thick":
-          ctx.lineWidth = 3;
-          if (y1 === y2) {
-            x1--;
-            x2++;
-          }
-          if (x1 === x2) {
-            y1--;
-            y2++;
-          }
-          break;
-        case "dashed":
-          ctx.lineWidth = 1;
-          ctx.setLineDash([1, 3]);
-          break;
-        case "dotted":
-          ctx.lineWidth = 1;
-          if (y1 === y2) {
-            x1 += 0.5;
-            x2 += 0.5;
-          }
-          if (x1 === x2) {
-            y1 += 0.5;
-            y2 += 0.5;
-          }
-          ctx.setLineDash([1, 1]);
-          break;
-        case "thin":
-        default:
-          ctx.lineWidth = 1;
-          break;
-      }
-      ctx.beginPath();
-      ctx.moveTo(x1, y1);
-      ctx.lineTo(x2, y2);
-      ctx.stroke();
-
-      ctx.lineWidth = 1;
-      ctx.setLineDash([]);
-      ctx.globalAlpha = 1;
-    }
-  }
-
-  private drawTexts(renderingContext: GridRenderingContext, boxes: Box[]) {
-    const { ctx } = renderingContext;
-    ctx.textBaseline = "top";
-    let currentFont;
-    for (const box of boxes) {
-      if (box.content) {
-        ctx.globalAlpha = box.textOpacity ?? 1;
-        const align = box.content.align || "left";
-        const rotation = box.chip ? 0 : box.style.rotation;
-        const style = { ...box.style, align, rotation };
-
-        // compute font and textColor
-        const font = computeTextFont(style);
-        if (font !== currentFont) {
-          currentFont = font;
-          ctx.font = font;
-        }
-        ctx.fillStyle = style.textColor || "#000";
-
-        // horizontal align text direction
-        ctx.textAlign = align;
-
-        // clip rect if needed
-        if (box.clipRect) {
-          ctx.save();
-          ctx.beginPath();
-          const { x, y, width, height } = box.clipRect;
-          ctx.rect(x, y, width, height);
-          ctx.clip();
-        }
-        let x = box.content.x;
-        let y = box.content.y;
-        if (style.rotation) {
-          ctx.save();
-          ctx.rotate(style.rotation);
-          ({ x, y } = computeRotationPosition(box.content, style));
-        }
-
-        // use the horizontal and the vertical start points to:
-        // fill text / fill strikethrough / fill underline
-        for (const brokenLine of box.content.textLines) {
-          drawDecoratedText(ctx, brokenLine, { x, y }, style.underline, style.strikethrough);
-          y += MIN_CELL_TEXT_MARGIN + box.content.fontSizePx;
-        }
-
-        if (style.rotation) {
-          ctx.restore();
-        }
-        if (box.clipRect) {
-          ctx.restore();
-        }
-        ctx.globalAlpha = 1;
-      }
-    }
-  }
-
-  private drawIcon(renderingContext: GridRenderingContext, boxes: Box[]) {
-    const { ctx } = renderingContext;
-    for (const box of boxes) {
-      for (const icon of Object.values(box.icons)) {
-        if (!icon) {
-          continue;
-        }
-        const isHovered = deepEquals(
-          { id: icon.type, position: icon.position },
-          this.hoveredIcon.hoveredIcon
-        );
-        const svg = isHovered ? icon.hoverSvg || icon.svg : icon.svg;
-        if (!svg) {
-          continue;
-        }
-        ctx.save();
-        ctx.globalAlpha = icon.opacity ?? 1;
-        ctx.beginPath();
-        const clipRect = icon.clipRect || box;
-        ctx.rect(clipRect.x, clipRect.y, clipRect.width, clipRect.height);
-        ctx.clip();
-
-        const iconSize = icon.size;
-        const { x, y } = this.getters.getCellIconRect(icon, box);
-        ctx.translate(x, y);
-        ctx.scale(iconSize / svg.width, iconSize / svg.height);
-        for (const path of svg.paths) {
-          ctx.fillStyle = path.fillColor;
-          ctx.fill(getPath2D(path.path));
-        }
-        ctx.restore();
-      }
-    }
-  }
-
-  private drawHeaders(renderingContext: GridRenderingContext) {
-    const { ctx, thinLineWidth, viewports, sheetId } = renderingContext;
-    const visibleCols = viewports.getSheetViewVisibleCols(sheetId);
-    const left = visibleCols[0];
-    const visibleRows = viewports.getSheetViewVisibleRows(sheetId);
-    const top = visibleRows[0];
-    const { width, height } = viewports.getSheetViewDimensionWithHeaders();
-    const selection = renderingContext.selectedZones;
-    const selectedCols = getZonesCols(selection);
-    const selectedRows = getZonesRows(selection);
-    const numberOfCols = this.getters.getNumberCols(sheetId);
-    const numberOfRows = this.getters.getNumberRows(sheetId);
-    const activeCols = renderingContext.activeCols;
-    const activeRows = renderingContext.activeRows;
-
-    const theme = this.getters.getSpreadsheetTheme();
-    ctx.font = `400 ${HEADER_FONT_SIZE}px ${DEFAULT_FONT}`;
-    ctx.textAlign = "center";
-    ctx.textBaseline = "middle";
-    ctx.lineWidth = thinLineWidth;
-    ctx.strokeStyle = theme.headerTextColor;
-
-    // Background for headers to separate from possible grid background color
-    ctx.fillStyle = this.getters.getSpreadsheetTheme().backgroundColor;
-    ctx.fillRect(0, 0, HEADER_WIDTH, height);
-    ctx.fillRect(0, 0, width, HEADER_HEIGHT);
-
-    // Columns headers background
-    for (const col of visibleCols) {
-      const colZone = { left: col, right: col, top: 0, bottom: numberOfRows - 1 };
-      const { x, width } = viewports.getVisibleRect(sheetId, colZone);
-      const isColActive = activeCols.has(col);
-      const isColSelected = selectedCols.has(col);
-      if (isColActive) {
-        ctx.fillStyle = theme.headerActiveBackgroundColor;
-      } else if (isColSelected) {
-        ctx.fillStyle = theme.headerSelectedBackgroundColor;
-      } else {
-        ctx.fillStyle = theme.headerBackgroundColor;
-      }
-      ctx.fillRect(x, 0, width, HEADER_HEIGHT);
-    }
-
-    // Rows headers background
-    for (const row of visibleRows) {
-      const rowZone = { top: row, bottom: row, left: 0, right: numberOfCols - 1 };
-      const { y, height } = viewports.getVisibleRect(sheetId, rowZone);
-
-      const isRowActive = activeRows.has(row);
-      const isRowSelected = selectedRows.has(row);
-      if (isRowActive) {
-        ctx.fillStyle = theme.headerActiveBackgroundColor;
-      } else if (isRowSelected) {
-        ctx.fillStyle = theme.headerSelectedBackgroundColor;
-      } else {
-        ctx.fillStyle = theme.headerBackgroundColor;
-      }
-      ctx.fillRect(0, y, HEADER_WIDTH, height);
-    }
-
-    // 2 main lines
-    ctx.beginPath();
-    ctx.moveTo(HEADER_WIDTH, 0);
-    ctx.lineTo(HEADER_WIDTH, height);
-    ctx.moveTo(0, HEADER_HEIGHT);
-    ctx.lineTo(width, HEADER_HEIGHT);
-    ctx.strokeStyle = theme.headerBorderColor;
-    ctx.stroke();
-
-    // column text + separator
-    for (const col of visibleCols) {
-      const colName = numberToLetters(col);
-      ctx.fillStyle = activeCols.has(col) ? "#fff" : theme.headerTextColor;
-      const zone = { left: col, right: col, top: top, bottom: top };
-      const { x: colStart, width: colSize } = viewports.getRect(sheetId, zone);
-      const { x, width } = viewports.getVisibleRect(sheetId, zone);
-      ctx.save();
-      ctx.beginPath();
-      ctx.rect(x, 0, width, HEADER_HEIGHT);
-      ctx.clip();
-      ctx.fillText(colName, colStart + colSize / 2, HEADER_HEIGHT / 2);
-      ctx.restore();
-      ctx.beginPath();
-      ctx.moveTo(colStart + colSize, 0);
-      ctx.lineTo(colStart + colSize, HEADER_HEIGHT);
-      ctx.stroke();
-    }
-
-    // row text + separator
-    for (const row of visibleRows) {
-      ctx.fillStyle = activeRows.has(row) ? "#fff" : theme.headerTextColor;
-      const zone = { top: row, bottom: row, left: left, right: left };
-      const { y: rowStart, height: rowSize } = viewports.getRect(sheetId, zone);
-      const { y, height } = viewports.getVisibleRect(sheetId, zone);
-      ctx.save();
-      ctx.beginPath();
-      ctx.rect(0, y, HEADER_WIDTH, height);
-      ctx.clip();
-      ctx.fillText(String(row + 1), HEADER_WIDTH / 2, rowStart + rowSize / 2);
-      ctx.restore();
-      ctx.beginPath();
-      ctx.moveTo(0, rowStart + rowSize);
-      ctx.lineTo(HEADER_WIDTH, rowStart + rowSize);
-      ctx.stroke();
-    }
-  }
-
-  private drawFrozenPanesHeaders(renderingContext: GridRenderingContext) {
-    const { ctx, thinLineWidth, sheetId, viewports } = renderingContext;
-
-    const { paneWidth: offsetCorrectionX, paneHeight: offsetCorrectionY } =
-      viewports.getPanesDimensions(sheetId);
-
-    const widthCorrection = viewports.getGridOffsetX();
-    const heightCorrection = viewports.getGridOffsetY();
-    ctx.lineWidth = 6 * thinLineWidth;
-    ctx.strokeStyle = this.getters.getSpreadsheetTheme().frozenPaneHeaderBorderColor;
-    ctx.beginPath();
-    if (offsetCorrectionX) {
-      ctx.moveTo(widthCorrection + offsetCorrectionX, 0);
-      ctx.lineTo(widthCorrection + offsetCorrectionX, heightCorrection);
-    }
-    if (offsetCorrectionY) {
-      ctx.moveTo(0, heightCorrection + offsetCorrectionY);
-      ctx.lineTo(widthCorrection, heightCorrection + offsetCorrectionY);
-    }
-    ctx.stroke();
-  }
-
-  private drawFrozenPanes(renderingContext: GridRenderingContext) {
-    if (renderingContext.hideFrozenPaneBorder) {
-      return;
-    }
-    const { ctx, thinLineWidth, sheetId, viewports } = renderingContext;
-
-    const { x: offsetCorrectionX, y: offsetCorrectionY } =
-      viewports.getMainViewportCoordinates(sheetId);
-
-    const visibleCols = viewports.getSheetViewVisibleCols(sheetId);
-    const left = visibleCols[0];
-    const right = visibleCols[visibleCols.length - 1];
-    const visibleRows = viewports.getSheetViewVisibleRows(sheetId);
-    const top = visibleRows[0];
-    const bottom = visibleRows[visibleRows.length - 1];
-    const viewport = { left, right, top, bottom };
-
-    const rect = renderingContext.viewports.getVisibleRect(renderingContext.sheetId, viewport);
-    const widthCorrection = viewports.getGridOffsetX();
-    const heightCorrection = viewports.getGridOffsetY();
-    ctx.lineWidth = 6 * thinLineWidth;
-    ctx.strokeStyle = this.getters.getSpreadsheetTheme().frozenPaneBorderColor;
-    ctx.beginPath();
-    if (offsetCorrectionX) {
-      ctx.moveTo(widthCorrection + offsetCorrectionX, heightCorrection);
-      ctx.lineTo(widthCorrection + offsetCorrectionX, rect.height + heightCorrection);
-    }
-    if (offsetCorrectionY) {
-      ctx.moveTo(widthCorrection, heightCorrection + offsetCorrectionY);
-      ctx.lineTo(rect.width + widthCorrection, heightCorrection + offsetCorrectionY);
-    }
-    ctx.stroke();
   }
 
   private findNextEmptyCol(
@@ -746,7 +257,8 @@ export class GridRenderer extends DisposableStore {
     const position = { sheetId, col, row };
     const cell = this.getters.getEvaluatedCell(position);
     const showFormula = this.getters.shouldShowFormulas();
-    const { x, y, width, height } = viewports.getRect(sheetId, zone);
+    const rect = viewports.getRect(sheetId, zone);
+    const { x, y, width, height } = rect;
     const chipStyle = this.getters.getDataValidationChipStyle(position);
 
     let style = this.getters.getCellComputedStyle(position);
@@ -761,10 +273,21 @@ export class GridRenderer extends DisposableStore {
       ? undefined
       : this.getters.getConditionalDataBar(position);
     const iconsList = this.getters.getCellIcons(position);
+    const getRenderingIcon = (position: string) => {
+      const icon = iconsList.find((icon) => icon?.horizontalAlign === position);
+      if (!icon) {
+        return undefined;
+      }
+      const isHovered = deepEquals(
+        { id: icon.type, position: icon.position },
+        this.hoveredIcon.hoveredIcon
+      );
+      return { ...icon, isHovered, rect: this.getters.getCellIconRect(icon, rect) };
+    };
     const cellIcons = {
-      left: iconsList.find((icon) => icon?.horizontalAlign === "left"),
-      right: iconsList.find((icon) => icon?.horizontalAlign === "right"),
-      center: iconsList.find((icon) => icon?.horizontalAlign === "center"),
+      left: getRenderingIcon("left"),
+      right: getRenderingIcon("right"),
+      center: getRenderingIcon("center"),
     };
 
     const box: Box = {
@@ -1081,12 +604,5 @@ export class GridRenderer extends DisposableStore {
         this.animations.set(box.id, animation);
       }
     }
-  }
-
-  private getBackgroundColor(renderingContext: GridRenderingContext) {
-    return (
-      this.getters.getSheet(renderingContext.sheetId).backgroundColor ||
-      this.getters.getSpreadsheetTheme().backgroundColor
-    );
   }
 }

--- a/src/types/rendering.ts
+++ b/src/types/rendering.ts
@@ -40,7 +40,12 @@ export type RenderingBorder = {
   left?: BorderDescrWithOpacity;
 };
 
-export type RenderingGridIcon = GridIcon & { clipRect?: Rect; opacity?: number };
+export type RenderingGridIcon = GridIcon & {
+  clipRect?: Rect;
+  opacity?: number;
+  rect: Rect;
+  isHovered: boolean;
+};
 
 export interface RenderingBox {
   id: string;
@@ -114,6 +119,9 @@ export type GridRenderingContext = {
   viewports: ViewportCollection;
   hideGridLines?: boolean;
   hideFrozenPaneBorder?: boolean;
+  theme: GridRenderingTheme;
+  backgroundColor: Color;
+  dataBarVerticalPadding?: number;
 } & SelectionState;
 
 const LAYERS = {

--- a/tests/colors/color_picker_component.test.ts
+++ b/tests/colors/color_picker_component.test.ts
@@ -3,7 +3,7 @@ import { ColorPicker } from "../../src/components/color_picker/color_picker";
 import { toHex } from "../../src/helpers/color";
 import { PropsOf } from "../../src/types/props_of";
 import { registerCleanup } from "../setup/jest.setup";
-import { setFormatting } from "../test_helpers/commands_helpers";
+import { setFormatting, updateColorScheme } from "../test_helpers/commands_helpers";
 import {
   getElComputedStyle,
   setInputValueAndTrigger,
@@ -232,7 +232,7 @@ describe("Color Picker buttons", () => {
     const model = await mountColorPicker({});
     expect(".eyedropper").toHaveCount(1);
 
-    model.dispatch("UPDATE_COLOR_SCHEME", { colorScheme: "dark" });
+    updateColorScheme(model, "dark");
     await nextTick();
     expect(".eyedropper").toHaveCount(0);
   });

--- a/tests/plugins/color_theme_plugin.test.ts
+++ b/tests/plugins/color_theme_plugin.test.ts
@@ -1,6 +1,7 @@
 import { Model } from "../../src/model";
 import { COLOR_THEMES } from "../../src/plugins/ui_feature/color_theme";
 import { MockTransportService } from "../__mocks__/transport_service";
+import { updateColorScheme } from "../test_helpers";
 
 const expectedLightTheme = COLOR_THEMES.light;
 const expectedDarkTheme = COLOR_THEMES.dark;
@@ -50,7 +51,7 @@ describe("ColorThemeUIPlugin via Model getters", () => {
     expect(theme.backgroundColor.toUpperCase()).toBe(expectedLightTheme.backgroundColor);
 
     // Simulate color scheme change
-    model.dispatch("UPDATE_COLOR_SCHEME", { colorScheme: "dark" });
+    updateColorScheme(model, "dark");
     theme = model.getters.getSpreadsheetTheme();
     expect(theme.backgroundColor.toUpperCase()).toBe(expectedDarkTheme.backgroundColor);
   });

--- a/tests/renderer/cell_animations.test.ts
+++ b/tests/renderer/cell_animations.test.ts
@@ -1,4 +1,4 @@
-import { Box, CellIsRule, GridRenderingContext, Model } from "../../src";
+import { Box, CellIsRule, Model } from "../../src";
 import { ICONS } from "../../src/components/icons/icons";
 import {
   DEFAULT_BORDER_DESC,
@@ -87,11 +87,18 @@ beforeEach(() => {
   drawGrid = () => rendererStore.draw(ctx);
   gridRenderer = gridRendererStore;
 
+  const originalGetBoxesWithAnimations =
+    gridRendererStore["getBoxesWithAnimations"].bind(gridRendererStore);
+
   jest // @ts-expect-error
-    .spyOn(gridRendererStore, "drawBackground") // @ts-expect-error
-    .mockImplementation((ctx: GridRenderingContext, boxes: Box[]) => {
-      boxesOfLastRender = boxes;
-    });
+    .spyOn(gridRendererStore, "getBoxesWithAnimations")
+    .mockImplementation(
+      // @ts-expect-error
+      (boxes: Box[], oldBoxes: Map<string, Box>, timeStamp: number | undefined) => {
+        boxesOfLastRender = originalGetBoxesWithAnimations(boxes, oldBoxes, timeStamp);
+        return boxesOfLastRender;
+      }
+    );
 
   spyRequestAnimationFrame = jest
     .spyOn(window, "requestAnimationFrame")

--- a/tests/spreadsheet/spreadsheet_print_store.test.ts
+++ b/tests/spreadsheet/spreadsheet_print_store.test.ts
@@ -1,6 +1,12 @@
 import { Model } from "../../src";
 import { SpreadsheetPrintStore } from "../../src/components/spreadsheet_print/spreadsheet_print_store";
-import { createChart, createSheet, setCellContent, setSelection } from "../test_helpers";
+import {
+  createChart,
+  createSheet,
+  setCellContent,
+  setSelection,
+  updateColorScheme,
+} from "../test_helpers";
 import { makeStore } from "../test_helpers/stores";
 
 describe("Spreadsheet print rendering", () => {
@@ -157,5 +163,12 @@ describe("Spreadsheet print rendering", () => {
       // Nothing is printed between rows 44 and 89
       { sheetId, left: 0, top: 88, right: 0, bottom: 89 },
     ]);
+  });
+
+  test("The spreadsheet is not printed with dark mode style", () => {
+    updateColorScheme(model, "dark");
+    setCellContent(model, "A1", "Hello");
+
+    expect(printStore.printPages[0].renderingCtx.theme?.backgroundColor).toBeSameColorAs("#FFFFFF");
   });
 });

--- a/tests/test_helpers/commands_helpers.ts
+++ b/tests/test_helpers/commands_helpers.ts
@@ -2093,3 +2093,7 @@ export function deleteNamedRange(model: Model, name: string): DispatchResult {
     name: name,
   });
 }
+
+export function updateColorScheme(model: Model, colorScheme: "light" | "dark") {
+  return model.dispatch("UPDATE_COLOR_SCHEME", { colorScheme });
+}

--- a/tests/test_helpers/renderer_helpers.ts
+++ b/tests/test_helpers/renderer_helpers.ts
@@ -112,8 +112,23 @@ export class MockGridRenderingContext implements GridRenderingContext {
   }
 
   get hideGridLines(): boolean {
-    // Handled in the rendering context created by the `Dashboard` component in practice
-    return this.model.getters.isDashboard();
+    // Handled in the rendering context created by the `Dashboard`/`Grid` components in practice
+    return this.model.getters.isDashboard()
+      ? true
+      : !this.model.getters.getGridLinesVisibility(this.sheetId);
+  }
+
+  get dataBarVerticalPadding() {
+    // Handled in the rendering context created by the `Dashboard`/`Grid` components in practice
+    return this.model.getters.isDashboard() ? 2 : 0;
+  }
+
+  get theme() {
+    return this.model.getters.getSpreadsheetTheme();
+  }
+
+  get backgroundColor() {
+    return this.model.getters.getSheet(this.sheetId).backgroundColor || this.theme.backgroundColor;
   }
 }
 


### PR DESCRIPTION
### [FIX] print: always print in light mode

When printing a spreadsheet a dark mode, we would use the dark color
theme. But we always want to print in light mode to have a white
background and black text.

### [REF] rendering: avoid getter usage

This commit aims to make the drawing process more independent from the
getters. All the drawing of the grid is now done in helpers that
don't have the getters.

Task: [6432165](https://www.odoo.com/odoo/2328/tasks/6432165)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo