### PR TITLE
[FIX] filter_menu: take number of headers into account when sorting

### DIFF
--- a/src/components/filters/filter_menu/filter_menu.ts
+++ b/src/components/filters/filter_menu/filter_menu.ts
@@ -292,7 +292,7 @@ export class FilterMenu extends Component<Props, SpreadsheetChildEnv> {
       return;
     }
     const sheetId = this.env.model.getters.getActiveSheetId();
-    const contentZone = { ...tableZone, top: tableZone.top + 1 };
+    const contentZone = { ...tableZone, top: tableZone.top + table.config.numberOfHeaders };
     this.env.model.dispatch("SORT_CELLS", {
       sheetId,
       col: filterPosition.col,

--- a/tests/table/filter_menu_component.test.ts
+++ b/tests/table/filter_menu_component.test.ts
@@ -333,6 +333,36 @@ describe("Filter menu component", () => {
     });
   });
 
+  test("Sort filter with non-1 number of headers", async () => {
+    createTable(model, "A10:A14", { numberOfHeaders: 2 });
+    setCellContent(model, "A10", "header 1");
+    setCellContent(model, "A11", "header 2");
+    setCellContent(model, "A12", "1");
+    setCellContent(model, "A13", "-1");
+    setCellContent(model, "A14", "2");
+    await nextTick();
+
+    await openFilterMenu();
+    await simulateClick(".o-filter-menu-item:nth-of-type(1)");
+    expect(getCellsObject(model, sheetId)).toMatchObject({
+      A10: { content: "header 1" },
+      A11: { content: "header 2" },
+      A12: { content: "-1" },
+      A13: { content: "1" },
+      A14: { content: "2" },
+    });
+
+    await openFilterMenu();
+    await simulateClick(".o-filter-menu-item:nth-of-type(2)");
+    expect(getCellsObject(model, sheetId)).toMatchObject({
+      A10: { content: "header 1" },
+      A11: { content: "header 2" },
+      A12: { content: "2" },
+      A13: { content: "1" },
+      A14: { content: "-1" },
+    });
+  });
+
   test("cannot sort filter table in readonly mode", async () => {
     createTable(model, "A10:B15");
     await nextTick();


### PR DESCRIPTION
Task: 6471792
opw-6396073

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo