### PR TITLE
[FIX] chart: set point color for radar charts

### DIFF
--- a/src/helpers/figures/charts/runtime/chartjs_dataset.ts
+++ b/src/helpers/figures/charts/runtime/chartjs_dataset.ts
@@ -307,6 +307,7 @@ export function getRadarChartDatasets(
       hidden,
       borderColor,
       backgroundColor: borderColor,
+      pointBackgroundColor: borderColor,
     };
     if (fill) {
       dataset.backgroundColor = setColorAlpha(borderColor, LINE_FILL_TRANSPARENCY);

--- a/tests/figures/chart/radar_chart_plugin.test.ts
+++ b/tests/figures/chart/radar_chart_plugin.test.ts
@@ -52,6 +52,17 @@ describe("radar chart", () => {
     expect(runtime.chartJsConfig.data.datasets[0]?.["fill"]).toEqual("start");
   });
 
+  test("Radar chart points have the correct background color", () => {
+    const model = createModelFromGrid({ A2: "2" });
+    createRadarChart(model, { dataSets: [{ dataRange: "A1:A2" }] }, "chartId");
+    let runtime = model.getters.getChartRuntime("chartId") as any;
+    expect(runtime.chartJsConfig.data.datasets[0]?.pointBackgroundColor).toEqual("#4EA7F2");
+
+    updateChart(model, "chartId", { fillArea: true });
+    runtime = model.getters.getChartRuntime("chartId") as any;
+    expect(runtime.chartJsConfig.data.datasets[0]?.pointBackgroundColor).toEqual("#4EA7F2");
+  });
+
   test("Radar chart legend", () => {
     const model = createModelFromGrid({
       A1: "1",


### PR DESCRIPTION
## Description

The radar charts didn't have a color set for the background of their points. By default ChartJS use the same color as the dataset background, which is transparent for filled radar charts.

This commit adds an explicit color for the points, so neither the points nor the values are half transparent for filled radar charts.

Task: [6474893](https://www.odoo.com/odoo/2328/tasks/6474893)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo