### PR TITLE
[FIX] print: figure border wrong render

### DIFF
--- a/src/components/standalone_grid_canvas/figure_renderer_store.ts
+++ b/src/components/standalone_grid_canvas/figure_renderer_store.ts
@@ -57,7 +57,7 @@ export class FigureRendererStore extends DisposableStore {
       if (!this.getters.isDashboard()) {
         ctx.strokeStyle = GRAY_400;
         ctx.lineWidth = 1;
-        ctx.strokeRect(x, y, figure.width, figure.height);
+        ctx.strokeRect(x + 0.5, y + 0.5, figure.width - 1, figure.height - 1);
       }
     }
   }


### PR DESCRIPTION
## Description

When printing, the figure border was drawn with a `strokeRect`. But its argument were wrong, `strokeRect` draw a border centered of the rectangle given as args, which mean that if we want a border to be drawn inside the rectangle we have to offset it by half a pixel.

Task: [6458624](https://www.odoo.com/odoo/2328/tasks/6458624)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo