### PR TITLE
[FIX] pivot: unbounded ranges in the pivot side panel

### DIFF
--- a/src/components/side_panel/pivot/pivot_side_panel/pivot_spreadsheet_side_panel/pivot_spreadsheet_side_panel.ts
+++ b/src/components/side_panel/pivot/pivot_side_panel/pivot_spreadsheet_side_panel/pivot_spreadsheet_side_panel.ts
@@ -76,7 +76,15 @@ export class PivotSpreadsheetSidePanel extends Component<Props, SpreadsheetChild
 
   onSelectionChanged(ranges: string[]) {
     this.state.rangeHasChanged = true;
-    this.state.range = ranges[0];
+    if (ranges.length === 0) {
+      this.state.range = undefined;
+      return;
+    }
+    const sheetId = this.env.model.getters.getActiveSheetId();
+    const range = this.env.model.getters.getRangeFromSheetXC(sheetId, ranges[0]);
+    this.state.range = this.env.model.getters.getRangeString(range, "forceSheetReference", {
+      useBoundedReference: true,
+    });
   }
 
   onSelectionConfirmed() {

--- a/tests/pivots/spreadsheet_pivot/spreadsheet_pivot_side_panel.test.ts
+++ b/tests/pivots/spreadsheet_pivot/spreadsheet_pivot_side_panel.test.ts
@@ -18,6 +18,7 @@ import {
   dragElement,
   keyDown,
   setInputValueAndTrigger,
+  simulateClick,
 } from "../../test_helpers/dom_helper";
 import { getCellText, getCoreTable } from "../../test_helpers/getters_helpers";
 import {
@@ -71,6 +72,15 @@ describe("Spreadsheet pivot side panel", () => {
     await nextTick();
     setInputValueAndTrigger(".os-pivot-title", "New Pivot Name");
     expect(model.getters.getPivotName("1")).toEqual("New Pivot Name");
+  });
+
+  test("Cannot add an unbounded zone as the pivot dataset", async () => {
+    setInputValueAndTrigger(".o-selection-input input", "A:C");
+    await nextTick();
+    await simulateClick(".o-selection-ok");
+
+    expect(".o-selection-input input").toHaveValue("Sheet1!A1:C100");
+    expect(model.getters.getPivotCoreDefinition("1")["dataSet"].zone).toEqual(toZone("A1:C100"));
   });
 
   test("It should be able to defer updates", async () => {


### PR DESCRIPTION
## Description

We currently do not support unbounded ranges as a pivot dataset, but in the side panel we allow selecting an unbounded range, which is converted to a bounded range in the commands but not in the UI.

Task: [6478220](https://www.odoo.com/odoo/2328/tasks/6478220)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo