### PR TITLE
[FIX] viewport: scroll to the last cell

### DIFF
--- a/src/helpers/internal_viewport.ts
+++ b/src/helpers/internal_viewport.ts
@@ -88,8 +88,8 @@ export class InternalViewport {
 
     const leftColIndex = this.searchHeaderIndex("COL", lastColEnd - this.viewportWidth, 0);
     const leftColSize = this.getters.getColSize(this.sheetId, leftColIndex);
-    const leftRowIndex = this.searchHeaderIndex("ROW", lastRowEnd - this.viewportHeight, 0);
-    const topRowSize = this.getters.getRowSize(this.sheetId, leftRowIndex);
+    const topRowIndex = this.searchHeaderIndex("ROW", lastRowEnd - this.viewportHeight, 0);
+    const topRowSize = this.getters.getRowSize(this.sheetId, topRowIndex);
 
     let width = lastColEnd - this.offsetCorrectionX;
     if (this.canScrollHorizontally) {
@@ -385,7 +385,20 @@ export class InternalViewport {
       return;
     }
     if (this.left === -1) {
-      this.left = this.boundaries.left;
+      const colsHeight = this.getters.getColRowOffset(
+        "COL",
+        this.boundaries.left,
+        this.boundaries.right
+      );
+      if (
+        // Edge case: the user wants to scroll right but the last column is smaller than the viewport width, we snap to the right
+        0 < colsHeight &&
+        colsHeight <= this.offsetScrollbarX
+      ) {
+        this.left = this.boundaries.right;
+      } else {
+        this.left = this.boundaries.left;
+      }
     }
     if (this.right === -1) {
       this.right = this.boundaries.right;
@@ -408,7 +421,20 @@ export class InternalViewport {
       return;
     }
     if (this.top === -1) {
-      this.top = this.boundaries.top;
+      const rowsHeight = this.getters.getColRowOffset(
+        "ROW",
+        this.boundaries.top,
+        this.boundaries.bottom
+      );
+      if (
+        // Edge case: the user wants to scroll down but the last row is smaller than the viewport height, we snap to the bottom
+        0 < rowsHeight &&
+        rowsHeight <= this.offsetScrollbarY
+      ) {
+        this.top = this.boundaries.bottom;
+      } else {
+        this.top = this.boundaries.top;
+      }
     }
     if (this.bottom === -1) {
       this.bottom = this.boundaries.bottom;

--- a/tests/sheet/sheetview_plugin.test.ts
+++ b/tests/sheet/sheetview_plugin.test.ts
@@ -38,6 +38,7 @@ import {
   setCellContent,
   setFormat,
   setSelection,
+  setSheetviewSize,
   setStyle,
   setViewportOffset,
   undo,
@@ -1179,6 +1180,38 @@ describe("Multi Panes viewport", () => {
     originalActiveMainViewport = model.getters.getActiveMainViewport();
     hideColumns(model, ["E", "F", "G", "H"]);
     expect(model.getters.getActiveMainViewport()).toEqual(originalActiveMainViewport);
+  });
+
+  test("can scroll to the last row on a very small scrollable viewport", () => {
+    const model = new Model();
+    const sheetId = model.getters.getActiveSheetId();
+    const { width } = model.getters.getSheetViewDimension();
+    setSheetviewSize(model, 7.5 * DEFAULT_CELL_HEIGHT, width);
+    freezeRows(model, 7);
+    // scroll at more than max value knowing that the command handler clips the payload
+    setViewportOffset(model, 0, model.getters.getNumberRows(sheetId) * DEFAULT_CELL_HEIGHT);
+    expect(model.getters.getActiveMainViewport()).toEqual({
+      top: 99,
+      bottom: 99,
+      left: 0,
+      right: 10,
+    });
+  });
+
+  test("can scroll to the last column on a very small scrollable viewport", () => {
+    const model = new Model();
+    const sheetId = model.getters.getActiveSheetId();
+    const { height } = model.getters.getSheetViewDimension();
+    setSheetviewSize(model, height, 7.5 * DEFAULT_CELL_WIDTH);
+    freezeColumns(model, 7);
+    // scroll at more than max value knowing that the command handler clips the payload
+    setViewportOffset(model, model.getters.getNumberCols(sheetId) * DEFAULT_CELL_WIDTH, 0);
+    expect(model.getters.getActiveMainViewport()).toEqual({
+      top: 0,
+      bottom: 43,
+      left: 25,
+      right: 25,
+    });
   });
 
   test("filtered row rect after updating another sheet", () => {


### PR DESCRIPTION
How to reproduce:

- on a spreadsheet, freeze the antepenultimate visible row
- scroll completely

=> instead of seeing the last row, you "jump" back the first row of the non frozen pane



## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [6103620](https://www.odoo.com/odoo/2328/tasks/6103620)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo