### PR TITLE
[IMP] topbar: improve banner style

### DIFF
--- a/src/components/top_bar/top_bar.css
+++ b/src/components/top_bar/top_bar.css
@@ -5,13 +5,6 @@
     }
   }
 
-  @media (max-width: 768px) {
-    .topbar-banner span {
-      overflow: auto;
-      align-items: normal !important;
-    }
-  }
-
   .tool-container {
     display: flex;
     justify-content: center;
@@ -53,7 +46,11 @@
     }
 
     .topbar-banner {
-      height: var(--os-desktop-topbar-toolbar-height);
+      min-height: var(--os-desktop-topbar-toolbar-height);
+
+      .alert {
+        border: none; /* Remove default bootstrap border */
+      }
 
       .alert-info {
         border-left: 3px solid var(--os-alert-info-border);

--- a/src/components/top_bar/top_bar.xml
+++ b/src/components/top_bar/top_bar.xml
@@ -84,23 +84,25 @@
       </div>
       <div
         t-if="this.fingerprints.isEnabled"
-        class="topbar-banner irregularity-map d-flex align-items-center justify-content-between border-top">
+        class="topbar-banner irregularity-map d-flex align-items-stretch justify-content-between border-top">
         <div
           t-on-click="() => this.fingerprints.disable()"
           role="button"
           title="This tool analyzes spreadsheet formulas for patterns and highlights inconsistencies. Irregularities may indicate potential errors in formula structures, references, or arguments. (Click to turn off)"
-          class="h-100 d-flex align-items-center text-info px-3">
-          <t t-call="o-spreadsheet-Icon.IRREGULARITY_MAP"/>
+          class="d-flex align-items-center text-info px-3 text-nowrap">
+          <span class="pe-2">
+            <t t-call="o-spreadsheet-Icon.IRREGULARITY_MAP"/>
+          </span>
           Irregularity map
         </div>
         <div
-          class="ps-3 h-100 flex-fill d-flex justify-content-between rounded-0 alert alert-info ps-0 py-0 my-0">
+          class="ps-3 flex-fill d-flex justify-content-between align-items-center rounded-0 alert alert-info ps-0 py-1 my-0">
           <span class="d-flex align-items-center">
             This tool analyzes formulas for patterns and highlights inconsistencies. Irregularities
             may indicate potential errors in formula structures, references or arguments.
           </span>
           <div
-            class="ps-3 btn o-button-link flex-shrink-0"
+            class="ps-3 btn o-button-link flex-shrink-0 py-0"
             t-on-click="() => this.fingerprints.disable()">
             Turn off
           </div>
@@ -108,18 +110,18 @@
       </div>
       <div
         t-if="!this.env.model.getters.isAutomaticEvaluationEnabled()"
-        class="topbar-banner manual-evaluation d-flex align-items-center justify-content-between border-top">
-        <div class="h-100 d-flex align-items-center text-warning px-3">
-          <i class="oi me-1" data-icon="pause_circle"/>
+        class="topbar-banner manual-evaluation d-flex align-items-stretch justify-content-between border-top">
+        <div class="d-flex align-items-center text-warning px-3 text-nowrap">
+          <i class="oi me-2" data-icon="pause_circle"/>
           Manual calculation
         </div>
         <div
-          class="ps-3 h-100 flex-fill d-flex justify-content-between rounded-0 alert alert-warning ps-0 py-0 my-0">
+          class="ps-3 flex-fill d-flex justify-content-between align-items-center rounded-0 alert alert-warning ps-0 py-1 my-0">
           <span class="d-flex align-items-center">
             Automatic evaluation is disabled. Press F9 to recalculate.
           </span>
           <div
-            class="ps-3 btn o-button-link flex-shrink-0"
+            class="ps-3 btn o-button-link flex-shrink-0 py-0"
             t-on-click="() => this.env.model.dispatch('SET_AUTOMATIC_EVALUATION', { enabled: true })">
             Re-enable
           </div>


### PR DESCRIPTION
## Description

This commit improves a bit the style of the topbar banner, adding a bit of padding and increasing its size when its content is too large to fit on one line. It also removes a double border inside the banner that appeared because we used the bootstrap alert class.

Task: [6478877](https://www.odoo.com/odoo/2328/tasks/6478877)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo