### PR TITLE
[FIX] evaluation: wrong dependencies invalidation with spread formulas

### DIFF
--- a/src/plugins/ui_core_views/cell_evaluation/formula_dependency_graph.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/formula_dependency_graph.ts
@@ -58,18 +58,25 @@ export class FormulaDependencyGraph {
    */
   getCellsDependingOn(ranges: Iterable<BoundedRange>, visited = new RangeSet()): RangeSet {
     visited = visited.copy();
+
+    // At the end we want to remove from the visited set all the initial range positions, except the ones we're actually depending on
+    // Some of the cells of the initial ranges might be depending on other cells of the initial ranges, and we want to keep those in the visited set
+    let initialRangesToRemove = visited.copy();
+
     const queue: BoundedRange[] = Array.from(ranges).reverse();
     while (queue.length > 0) {
       const range = queue.pop()!;
       visited.add(range);
       const impactedRanges = this.rTree.search(range);
       queue.push(...impactedRanges.difference(visited));
+      initialRangesToRemove = initialRangesToRemove.difference(impactedRanges);
     }
 
     // remove initial ranges
-    for (const range of ranges) {
+    for (const range of initialRangesToRemove) {
       visited.delete(range);
     }
+
     return visited;
   }
 }

--- a/tests/evaluation/evaluation_formula_array.test.ts
+++ b/tests/evaluation/evaluation_formula_array.test.ts
@@ -134,6 +134,13 @@ describe("evaluate formulas that return an array", () => {
     expect(model.getters.getArrayFormulaSpreadingOn(positionA1)).not.toBeDefined();
   });
 
+  test("Changing a cell of a spreaded formula to reference another cell of the spreaded formula", () => {
+    setCellContent(model, "A1", "=MFILL(3,3, 42)");
+    setCellContent(model, "A2", "=B2");
+    expect(getEvaluatedCell(model, "A1").value).toBe("#SPILL!");
+    expect(getEvaluatedCell(model, "A2").value).toBe(0);
+  });
+
   test("Spreading relations are properly cleared upon cell content change", () => {
     setCellContent(model, "A1", "=MUNIT(2)");
     const positionA1 = model.getters.getActivePosition();


### PR DESCRIPTION
## Description

- Write =MUNIT(3) in A1
- Write =B2 in B3
- A1 will now be #SPILL!, but B3 will be 1 instead of 0

We didn't properly invalidate the spill dependencies if the cell we changed the value of was inside a spread formula.

Task: [5103328](https://www.odoo.com/odoo/2328/tasks/5103328)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo