### PR TITLE
[IMP] viewports_store: do not jump viewport on UNDO/REDO

### DIFF
--- a/src/stores/viewports_store.ts
+++ b/src/stores/viewports_store.ts
@@ -66,7 +66,6 @@ export class ViewportsStore extends SpreadsheetStore {
     getFooterSize: this.getFooterSizeCallback,
   });
   private sheetsWithDirtyViewports: Set<UID> = new Set();
-  private shouldRepositionViewports: boolean = false;
 
   displayedSheetId: UID = this.model.getters.getActiveSheetId();
 
@@ -128,7 +127,6 @@ export class ViewportsStore extends SpreadsheetStore {
           this.sheetsWithDirtyViewports.add(sheetId);
           this.syncPaneDivision(sheetId);
         }
-        this.shouldRepositionViewports = !this.getters.getSelectedFigureIds().length;
         break;
       case "UNFREEZE_ROWS":
       case "UNFREEZE_COLUMNS":
@@ -178,15 +176,8 @@ export class ViewportsStore extends SpreadsheetStore {
   finalize() {
     for (const sheetId of this.sheetsWithDirtyViewports) {
       this.viewports.resetViewports(sheetId);
-      if (this.shouldRepositionViewports) {
-        const position = this.getters.getSheetPosition(sheetId);
-        this.viewports.getSubViewports(sheetId).forEach((viewport) => {
-          viewport.repositionViewport(position);
-        });
-      }
     }
     this.sheetsWithDirtyViewports = new Set();
-    this.shouldRepositionViewports = false;
     this.setViewports();
   }
 


### PR DESCRIPTION
On UNDO/REDO we would scroll all the viewports to the position of the selection. But only if no figure was selected.

I have no idea why we did it, it was introduced in seemingly unrelated commit 7b9055e, never tested, and didn't make much sense. We can most likely remove it.


Task: [6481352](https://www.odoo.com/odoo/2328/tasks/6481352)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo