### PR TITLE
[FIX] standalone_viewport: stop following selection

### DIFF
--- a/src/stores/main_viewport_store.ts
+++ b/src/stores/main_viewport_store.ts
@@ -1,5 +1,8 @@
+import { findCellInNewZone, isEqual } from "../helpers/zones";
 import { Command } from "../types/commands";
+import { SelectionEvent } from "../types/event_stream/selection_events";
 import { UID } from "../types/misc";
+import { Get } from "../types/store_engine";
 import { SpreadsheetStore } from "./spreadsheet_store";
 import { ViewportsStore } from "./viewports_store";
 
@@ -10,6 +13,42 @@ export class MainViewportStore extends SpreadsheetStore {
   private viewStore = this.get(ViewportsStore);
 
   private sheetIdAtFinalize: UID | undefined = undefined;
+
+  constructor(get: Get) {
+    super(get);
+    this.model.selection.observe(this, {
+      handleEvent: this.handleEvent.bind(this),
+    });
+    this.onDispose(() => {
+      this.model.selection.unobserve(this);
+    });
+  }
+
+  private handleEvent(event: SelectionEvent) {
+    const eventSheetId = this.getters.getActiveSheetId();
+    if (event.options.scrollIntoView) {
+      const oldZone = event.previousAnchor.zone;
+      const newZone = event.anchor.zone;
+      const isUpdateAnchorEvent = event.mode === "updateAnchor";
+      const sameZone = isEqual(oldZone, newZone);
+      let { col, row } =
+        isUpdateAnchorEvent && sameZone ? event.anchor.cell : findCellInNewZone(oldZone, newZone);
+      if (isUpdateAnchorEvent && !sameZone) {
+        // altering a zone should not move the viewport in a dimension that wasn't changed
+        const { top, bottom, left, right } =
+          this.viewStore.viewports.getMainInternalViewport(eventSheetId);
+        if (oldZone.left === newZone.left && oldZone.right === newZone.right) {
+          col = left > col || col > right ? left : col;
+        }
+        if (oldZone.top === newZone.top && oldZone.bottom === newZone.bottom) {
+          row = top > row || row > bottom ? top : row;
+        }
+      }
+      col = Math.min(col, this.getters.getNumberCols(eventSheetId) - 1);
+      row = Math.min(row, this.getters.getNumberRows(eventSheetId) - 1);
+      this.viewStore.scrollToCell(eventSheetId, col, row);
+    }
+  }
 
   protected handle(cmd: Command): void {
     switch (cmd.type) {

--- a/src/stores/viewports_store.ts
+++ b/src/stores/viewports_store.ts
@@ -13,9 +13,7 @@ import {
 import { FOOTER_HEIGHT, getDefaultSheetViewSize } from "../constants";
 import { deepEquals } from "../helpers/misc";
 import { ViewportCollection } from "../helpers/viewport_collection";
-import { findCellInNewZone, isEqual } from "../helpers/zones";
 import { Command, invalidateEvaluationCommands } from "../types/commands";
-import { SelectionEvent } from "../types/event_stream/selection_events";
 import {
   DOMCoordinates,
   DOMDimension,
@@ -72,44 +70,7 @@ export class ViewportsStore extends SpreadsheetStore {
 
   constructor(get: Get) {
     super(get);
-    this.model.selection.observe(this, {
-      handleEvent: this.handleEvent.bind(this),
-    });
-    this.onDispose(() => {
-      this.model.selection.unobserve(this);
-    });
     this.viewports.resetViewports(this.displayedSheetId);
-  }
-
-  // ---------------------------------------------------------------------------
-  // Command Handling
-  // ---------------------------------------------------------------------------
-
-  private handleEvent(event: SelectionEvent) {
-    const eventSheetId = this.getters.getActiveSheetId();
-    if (event.options.scrollIntoView) {
-      const oldZone = event.previousAnchor.zone;
-      const newZone = event.anchor.zone;
-      const isUpdateAnchorEvent = event.mode === "updateAnchor";
-      const sameZone = isEqual(oldZone, newZone);
-      let { col, row } =
-        isUpdateAnchorEvent && sameZone ? event.anchor.cell : findCellInNewZone(oldZone, newZone);
-      if (isUpdateAnchorEvent && !sameZone) {
-        // altering a zone should not move the viewport in a dimension that wasn't changed
-        const { top, bottom, left, right } = this.viewports.getMainInternalViewport(eventSheetId);
-        if (oldZone.left === newZone.left && oldZone.right === newZone.right) {
-          col = left > col || col > right ? left : col;
-        }
-        if (oldZone.top === newZone.top && oldZone.bottom === newZone.bottom) {
-          row = top > row || row > bottom ? top : row;
-        }
-      }
-      col = Math.min(col, this.getters.getNumberCols(eventSheetId) - 1);
-      row = Math.min(row, this.getters.getNumberRows(eventSheetId) - 1);
-      if (!this.sheetsWithDirtyViewports.has(eventSheetId)) {
-        this.viewports.refreshViewport(eventSheetId, { col, row });
-      }
-    }
   }
 
   handle(cmd: Command) {
@@ -246,6 +207,10 @@ export class ViewportsStore extends SpreadsheetStore {
   }
 
   scrollToCell(sheetId: UID, col: HeaderIndex, row: HeaderIndex) {
+    if (this.sheetsWithDirtyViewports.has(sheetId)) {
+      // we mark the viewports dirty when we cannot update them without waiting for finalize. Trying to refreshViewport would crash.
+      return;
+    }
     this.viewports.refreshViewport(sheetId, { col, row });
   }
 

--- a/tests/figures/carousel/standalone_viewport.test.ts
+++ b/tests/figures/carousel/standalone_viewport.test.ts
@@ -25,6 +25,7 @@ import {
   hideColumns,
   hoverCell,
   hoverGridIcon,
+  selectCell,
   setCellContent,
   setFormatting,
   simulateClick,
@@ -234,6 +235,17 @@ describe("Standalone viewport", () => {
     expect(viewStore.mainViewportCoordinates.y).toBe(cellHeight * 3); // Three frozen rows in A2:A10
     expect(viewStore.mainViewportRect.height).toBe(cellHeight * 6); // 6 non-frozen rows in A2:A10
     expect(".o-scrollbar").toHaveCount(1);
+  });
+
+  test("Standalone viewport does not scroll to follow the selection", async () => {
+    setGrid(model, { A1: "Hello", A2: "World", A3: "!" });
+    await mountViewport("A1:A3", { size: { width: 1000, height: 30 } });
+    const viewStore = subEnv.getStore(ViewportsStore);
+    expect(viewStore.activeSheetScrollInfo.scrollY).toBe(0);
+
+    selectCell(model, "A3");
+    await nextTick();
+    expect(viewStore.activeSheetScrollInfo.scrollY).toBe(0);
   });
 
   test("Double clicking on a cell selects the cell", async () => {


### PR DESCRIPTION
## Description

All the viewports would listen to the selection events and scroll to follow the selection, even though it only made sens for the main viewport, not the carousel viewports.

Task: [6481678](https://www.odoo.com/odoo/2328/tasks/6481678)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo