### PR TITLE
[FIX] grid: hide AddRowFooter when the mainViewport is too small

### DIFF
--- a/src/components/grid_overlay/grid_overlay.ts
+++ b/src/components/grid_overlay/grid_overlay.ts
@@ -1,4 +1,5 @@
 import { Component, onMounted, onWillUnmount, useExternalListener, useRef } from "@odoo/owl";
+import { FOOTER_HEIGHT } from "../../constants";
 import { Store, useStore } from "../../store_engine";
 import {
   DOMCoordinates,
@@ -243,5 +244,11 @@ export class GridOverlay extends Component<Props, SpreadsheetChildEnv> {
     const colIndex = this.env.model.getters.getColIndex(x);
     const rowIndex = this.env.model.getters.getRowIndex(y);
     return [colIndex, rowIndex];
+  }
+
+  get isFooterVisible() {
+    const { y } = this.env.model.getters.getMainViewportCoordinates();
+    const { height } = this.env.model.getters.getSheetViewDimension();
+    return !this.env.model.getters.isReadonly() && height - y > FOOTER_HEIGHT;
   }
 }

--- a/src/components/grid_overlay/grid_overlay.xml
+++ b/src/components/grid_overlay/grid_overlay.xml
@@ -13,10 +13,7 @@
       t-on-contextmenu.stop.prevent="onContextMenu">
       <DataValidationOverlay/>
       <FilterIconsOverlay/>
-      <GridAddRowsFooter
-        t-if="!env.model.getters.isReadonly()"
-        t-key="env.model.getters.getActiveSheetId()"
-      />
+      <GridAddRowsFooter t-if="this.isFooterVisible" t-key="env.model.getters.getActiveSheetId()"/>
       <t t-slot="default"/>
     </div>
   </t>

--- a/src/helpers/internal_viewport.ts
+++ b/src/helpers/internal_viewport.ts
@@ -87,8 +87,12 @@ export class InternalViewport {
     if (this.canScrollVertically) {
       height = Math.max(height, this.viewportHeight); // if the viewport grid size is smaller than its client height, return client height
 
-      if (lastRowEnd + FOOTER_HEIGHT > height && !this.getters.isReadonly()) {
-        height += FOOTER_HEIGHT;
+      if (
+        lastRowEnd + FOOTER_HEIGHT > height &&
+        !this.getters.isReadonly() &&
+        this.viewportHeight > FOOTER_HEIGHT
+      ) {
+        height += FOOTER_HEIGHT; // if the footer is visible, we add its height to the viewport height
       }
     }
 

--- a/tests/sheet/sheet_manipulation_component.test.ts
+++ b/tests/sheet/sheet_manipulation_component.test.ts
@@ -6,11 +6,13 @@ import {
   activateSheet,
   createSheet,
   deleteRows,
+  freezeRows,
   hideColumns,
   hideRows,
   selectColumn,
   selectRow,
   setSelection,
+  setViewportOffset,
 } from "../test_helpers/commands_helpers";
 import {
   click,
@@ -403,5 +405,16 @@ describe("Adding rows footer at the end of sheet", () => {
     activateSheet(model, "sheet2");
     await nextTick();
     expect(fixture.querySelector<HTMLInputElement>(".o-grid-add-rows input")!.value).toBe("100");
+  });
+
+  test("Footer will not show if the main viewport is too small to show the footer", async () => {
+    const { bottom } = model.getters.getActiveMainViewport();
+    expect(fixture.querySelector(".o-grid-add-rows")).toBeTruthy();
+
+    // only let a very small part of the viewport to be scrollable
+    freezeRows(model, bottom + 1);
+    setViewportOffset(model, 0, 10000);
+    await nextTick();
+    expect(fixture.querySelector(".o-grid-add-rows")).toBeFalsy();
   });
 });

--- a/tests/sheet/sheet_manipulation_plugin.test.ts
+++ b/tests/sheet/sheet_manipulation_plugin.test.ts
@@ -949,7 +949,7 @@ describe("Rows", () => {
       const newDimensions = model.getters.getMainViewportRect();
       expect(newDimensions).toMatchObject({
         width: DEFAULT_CELL_WIDTH, // sum of col sizes
-        height: 142, // sum of row sizes  + 46px for adding rows footer
+        height: 96, // sum of row sizes
       });
     });
     test("On addition after", () => {
@@ -971,7 +971,7 @@ describe("Rows", () => {
       const newDimensions = model.getters.getMainViewportRect();
       expect(newDimensions).toMatchObject({
         width: DEFAULT_CELL_WIDTH, // sum of col sizes
-        height: 162, // sum of row sizes + 46px for adding rows footer
+        height: 116, // sum of row sizes + 1 correction px
       });
       expect(model.getters.getNumberRows(sheetId)).toBe(6);
     });
@@ -991,7 +991,7 @@ describe("Rows", () => {
       let dimensions = model.getters.getMainViewportRect();
       expect(dimensions).toMatchObject({
         width: DEFAULT_CELL_WIDTH, // sum of col sizes
-        height: 142, // sum of row sizes + 46px for adding rows footer
+        height: 96, // sum of row sizes
       });
       const to = model.getters.getActiveSheetId();
       createSheet(model, { activate: true, sheetId: "42" });
@@ -999,7 +999,7 @@ describe("Rows", () => {
       dimensions = model.getters.getMainViewportRect();
       expect(dimensions).toMatchObject({
         width: DEFAULT_CELL_WIDTH, // sum of col sizes
-        height: 142, // sum of row sizes + 46px for adding rows footer
+        height: 96, // sum of row sizes (footer is hidden)
       });
     });
 

--- a/tests/sheet/sheetview_plugin.test.ts
+++ b/tests/sheet/sheetview_plugin.test.ts
@@ -39,6 +39,7 @@ import {
   setCellContent,
   setFormat,
   setSelection,
+  setSheetviewSize,
   setStyle,
   setViewportOffset,
   undo,
@@ -1241,6 +1242,38 @@ describe("Multi Panes viewport", () => {
     updateFilter(model, "A1", ["2808"]);
 
     expect(model.getters.getActiveMainViewport()).toEqual(originalActiveMainViewport);
+  });
+
+  test("can scroll to the last row on a very small scrollable viewport", () => {
+    const model = new Model();
+    const sheetId = model.getters.getActiveSheetId();
+    const { width } = model.getters.getSheetViewDimension();
+    setSheetviewSize(model, 7.5 * DEFAULT_CELL_HEIGHT, width);
+    freezeRows(model, 7);
+    // scroll at more than max value knowing that the command handler clips the payload
+    setViewportOffset(model, 0, model.getters.getNumberRows(sheetId) * DEFAULT_CELL_HEIGHT);
+    expect(model.getters.getActiveMainViewport()).toEqual({
+      top: 99,
+      bottom: 99,
+      left: 0,
+      right: 10,
+    });
+  });
+
+  test("can scroll to the last column on a very small scrollable viewport", () => {
+    const model = new Model();
+    const sheetId = model.getters.getActiveSheetId();
+    const { height } = model.getters.getSheetViewDimension();
+    setSheetviewSize(model, height, 7.5 * DEFAULT_CELL_WIDTH);
+    freezeColumns(model, 7);
+    // scroll at more than max value knowing that the command handler clips the payload
+    setViewportOffset(model, model.getters.getNumberCols(sheetId) * DEFAULT_CELL_WIDTH, 0);
+    expect(model.getters.getActiveMainViewport()).toEqual({
+      top: 0,
+      bottom: 43,
+      left: 25,
+      right: 25,
+    });
   });
 
   test("Visible Cols and Rows are correctly computed when the sheetview has a 0 width", () => {


### PR DESCRIPTION
How to reproduce:
- insert a list
- freeze pane to the lowest visible row
- start scrolling to get to the bottom of the page

=> the full layout is broken

Task: 6103620

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo