### PR TITLE
[FIX] carousel: increase bottom padding

### DIFF
--- a/src/helpers/carousel_helpers.ts
+++ b/src/helpers/carousel_helpers.ts
@@ -80,7 +80,7 @@ export function getCarouselLayout(
   const contentPaddingTop = selectedItem?.type === "carouselDataView" ? layout.paddingY : 0;
   const rectAboveContent = separatorRect || headerRect;
   const contentY = rectAboveContent.y + rectAboveContent.height + contentPaddingTop;
-  const contentBottom = figureRect.y + figureRect.height - layout.paddingY;
+  const contentBottom = figureRect.y + figureRect.height - 2 * layout.paddingY;
   const contentRect: Rect = {
     x,
     y: contentY,

--- a/tests/figures/carousel/carousel_figure_component.test.ts
+++ b/tests/figures/carousel/carousel_figure_component.test.ts
@@ -103,7 +103,9 @@ describe("Carousel figure component", () => {
   test("Empty rows are not rendered in the data view", async () => {
     const sheetId = model.getters.getActiveSheetId();
     setGrid(model, { A1: "Hello", C3: "World" });
-    createCarouselWithDataView(model, toRangeData(sheetId, "A1:C100"), "carouselId");
+    createCarouselWithDataView(model, toRangeData(sheetId, "A1:C100"), "carouselId", sheetId, {
+      size: { width: 500, height: 400 },
+    });
     const stores = spyStoreCreation();
 
     await mountSpreadsheet({ model });
@@ -144,7 +146,7 @@ describe("Carousel figure component", () => {
       left: `${layout.paddingX}px`,
       top: `${contentY}px`,
       width: `${500 - layout.paddingX * 2}px`,
-      height: `${400 - contentY - layout.paddingY}px`,
+      height: `${400 - contentY - 2 * layout.paddingY}px`,
     });
   });
 
@@ -184,7 +186,7 @@ describe("Carousel figure component", () => {
       left: `${layout.paddingX}px`,
       top: `${contentY}px`,
       width: `${500 - layout.paddingX * 2}px`,
-      height: `${400 - contentY - layout.paddingY}px`,
+      height: `${400 - contentY - 2 * layout.paddingY}px`,
     });
   });
 

--- a/tests/figures/carousel/standalone_viewport.test.ts
+++ b/tests/figures/carousel/standalone_viewport.test.ts
@@ -311,7 +311,7 @@ describe("Standalone viewport", () => {
     const sheetId = model.getters.getActiveSheetId();
     setGrid(model, { A1: "Hello", B1: "Hello" });
     createCarouselWithDataView(model, toRangeData(sheetId, "A1:B1"), "carouselId", sheetId, {
-      size: { width: 1048, height: 1053 }, // Add some padding so the carousel content is exactly 1000x1000
+      size: { width: 1048, height: 1061 }, // Add some padding so the carousel content is exactly 1000x1000
     });
     const { env } = await mountSpreadsheet({ model });
 


### PR DESCRIPTION
## Description

In 6b5a887a4 we changed the carousel to be displayed with a static layout. But we messed up the bottom padding, which was previously twice as big (there was a 8px bottom padding to the carousel itself, AND below the content).

Task: [6481993](https://www.odoo.com/odoo/2328/tasks/6481993)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo