### PR TITLE
[FIX] inputs: explicitly define border-style

### DIFF
--- a/src/components/spreadsheet/spreadsheet.ts
+++ b/src/components/spreadsheet/spreadsheet.ts
@@ -162,6 +162,7 @@ css/* scss */ `
       width: 100%;
       outline: none;
       border-color: ${GRAY_300};
+      border-style: solid;
       color: ${GRAY_900};
 
       &::placeholder {

--- a/src/components/text_input/text_input.ts
+++ b/src/components/text_input/text_input.ts
@@ -9,6 +9,7 @@ css/* scss */ `
     .os-input {
       box-sizing: border-box;
       border-width: 0 0 1px 0;
+      border-style: solid;
       border-color: transparent;
       outline: none;
       text-overflow: ellipsis;


### PR DESCRIPTION
## Description

The border style for `o-input` class was not explicitly defined. It breaks in chrome 151 which somewhy changed the default from `solid` to `inset`.

Task: [0](https://www.odoo.com/odoo/2328/tasks/0)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo