### PR TITLE
[FIX] composer: crash when hovering a composer token

### DIFF
--- a/src/components/composer/composer/composer.ts
+++ b/src/components/composer/composer/composer.ts
@@ -196,17 +196,22 @@ export class Composer extends Component<CellComposerProps, SpreadsheetChildEnv> 
   private spreadsheetRect = useSpreadsheetRect();
   private lastHoveredTokenIndex: number | undefined = undefined;
 
-  private debouncedHover = debounce((tokenIndex: number | undefined, hoveredRect?: Rect) => {
-    const selection = this.contentHelper.getCurrentSelection();
-    if (selection.start !== selection.end) {
-      return;
-    }
-    const currentHoveredContext = this.props.composerStore.hoveredTokens;
-    this.props.composerStore.hoverToken(tokenIndex);
-    if (!deepEquals(currentHoveredContext, this.props.composerStore.hoveredTokens)) {
-      this.composerState.hoveredRect = hoveredRect;
-    }
-  }, 120);
+  private debouncedHover = debounce(
+    (tokenIndex: number | undefined, composerContent: string, hoveredRect?: Rect) => {
+      const selection = this.contentHelper.getCurrentSelection();
+      // If the composer content changed since the hover event was triggered, the tokenIndex might not be valid
+      const currentContent = this.props.composerStore.currentContent;
+      if (selection.start !== selection.end || currentContent !== composerContent) {
+        return;
+      }
+      const currentHoveredContext = this.props.composerStore.hoveredTokens;
+      this.props.composerStore.hoverToken(tokenIndex);
+      if (!deepEquals(currentHoveredContext, this.props.composerStore.hoveredTokens)) {
+        this.composerState.hoveredRect = hoveredRect;
+      }
+    },
+    120
+  );
 
   get assistantStyleProperties(): CSSProperties {
     const composerRect = this.composerRef.el!.getBoundingClientRect();
@@ -768,7 +773,8 @@ export class Composer extends Component<CellComposerProps, SpreadsheetChildEnv> 
     // if the user keeps moving its mouse over the same token.
     if (this.lastHoveredTokenIndex !== tokenIndex) {
       this.lastHoveredTokenIndex = tokenIndex;
-      this.debouncedHover(tokenIndex, hoveredRect);
+      const composerContent = this.props.composerStore.currentContent;
+      this.debouncedHover(tokenIndex, composerContent, hoveredRect);
     }
   }
 

--- a/tests/composer/composer_hover.test.ts
+++ b/tests/composer/composer_hover.test.ts
@@ -339,6 +339,21 @@ describe("Composer hover", () => {
     expect(getElStyle(".o-speech-bubble", "left")).toEqual("-30px");
     jest.restoreAllMocks();
   });
+
+  test("Debounced hover callback does not crash if the content change before the callback has time to execute", async () => {
+    await typeInComposer("=SUM(1,2)");
+    const spans = fixture.querySelectorAll(".o-composer span");
+    const hoveredSpan = Array.from(spans).find((s) => s.textContent === "2")!;
+    const hoverTokenSpy = jest.spyOn(composerStore, "hoverToken");
+
+    triggerMouseEvent(hoveredSpan, "mousemove");
+    composerStore.setCurrentContent("=4");
+    await nextTick();
+
+    jest.runAllTimers();
+    await nextTick();
+    expect(hoverTokenSpy).toHaveBeenCalledTimes(0);
+  });
 });
 
 describe("Composer hover integration test", () => {


### PR DESCRIPTION
## Description

If you hover a composer token, and that by the time the debounced callback is executed the composer content changed, it might crash because the token index is no longer valid.

Task: [5153319](https://www.odoo.com/odoo/2328/tasks/5153319)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo