### PR TITLE
[IMP] menu_registry: ensure children unicity

### DIFF
--- a/src/actions/action.ts
+++ b/src/actions/action.ts
@@ -140,11 +140,19 @@ export function createAction(item: ActionSpec): Action {
       : undefined,
     children: children
       ? (env) => {
-          return children
-            .map((child) => (typeof child === "function" ? child(env) : child))
-            .flat()
-            .map(createAction)
-            .sort((a, b) => a.sequence - b.sequence);
+          const uniqueChildren: Record<string, Action> = {};
+          children
+            .flatMap((child) => (typeof child === "function" ? child(env) : child))
+            .forEach((childSpec) => {
+              const childAction = createAction(childSpec);
+              if (uniqueChildren[childAction.id]) {
+                throw new Error(
+                  `Duplicate child action id "${childAction.id}" in action "${itemId}".`
+                );
+              }
+              uniqueChildren[childAction.id] = childAction;
+            });
+          return Object.values(uniqueChildren).sort((a, b) => a.sequence - b.sequence);
         }
       : () => [],
     isReadonlyAllowed: item.isReadonlyAllowed || false,

--- a/tests/menus/menu_items_registry.test.ts
+++ b/tests/menus/menu_items_registry.test.ts
@@ -79,6 +79,18 @@ describe("Top Bar MenuPopover Item Registry", () => {
       'A child with the id "unique" already exists.'
     );
   });
+
+  test("Menu registry items have unique ActionSpec path even when they children are computed", () => {
+    const env = makeTestEnv();
+    addToRegistry(registry, "root", { name: "rootNode" });
+    registry.addChild("child", ["root"], () => ({ id: "unique", name: "child1" }));
+    registry.addChild("child", ["root"], () => ({ id: "unique", name: "child2" }));
+
+    expect(() => registry.getMenuItems()[0].children(env)).toThrow(
+      'Duplicate child action id "unique" in action "root".'
+    );
+  });
+
   test("Menu registry entries can be overriden explicitely", () => {
     addToRegistry(registry, "root", { name: "rootNode" });
     registry.addChild("child", ["root"], { id: "unique", name: "child" });
@@ -86,6 +98,7 @@ describe("Top Bar MenuPopover Item Registry", () => {
       registry.replaceChild("child", ["root"], { id: "unique", name: "child" })
     ).not.toThrow();
   });
+
   test("Menu items can have the same id with different parent nodes", () => {
     addToRegistry(registry, "root1", { name: "rootNode1" });
     addToRegistry(registry, "root2", { name: "rootNode2" });


### PR DESCRIPTION
## Description

The ids in a menu registry are supposed to be unique, but if the children are computed at runtime from a function, they could have duplicate ids.

Task: [5224033](https://www.odoo.com/odoo/2328/tasks/5224033)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo