### PR TITLE
[FIX] search and replace: manage invalid range

### DIFF
--- a/src/components/side_panel/find_and_replace/find_and_replace.ts
+++ b/src/components/side_panel/find_and_replace/find_and_replace.ts
@@ -80,7 +80,7 @@ export class FindAndReplacePanel extends Component<Props, SpreadsheetChildEnv> {
 
   get specificRangeMatchesCount() {
     const range = this.searchOptions.specificRange;
-    if (!range) {
+    if (!range || range.invalidSheetName || range.invalidXc) {
       return "";
     }
     const { sheetId, zone } = range;

--- a/tests/find_and_replace/find_replace_side_panel_component.test.ts
+++ b/tests/find_and_replace/find_replace_side_panel_component.test.ts
@@ -432,4 +432,18 @@ describe("find and replace sidePanel component", () => {
     composerStore.stopEdition("down");
     expect(model.getters.getSelectedZones()).toMatchObject([toZone("C12")]);
   });
+
+  test("Invalid ranges are not stored", async () => {
+    changeSearchScope("specificRange");
+    await nextTick();
+    await nextTick(); // selection input need 2 nextTicks because ¯\_(ツ)_/¯
+    (fixture.querySelector(selectors.searchRange) as HTMLInputElement).focus();
+    setInputValueAndTrigger(selectors.searchRange, "thisIsInvalid");
+    await nextTick();
+    (fixture.querySelector(selectors.inputSearch) as HTMLInputElement).focus();
+    inputSearchValue("hello");
+    await nextTick();
+    expect(selectors.searchRange).toHaveClass("o-invalid");
+    expect(getMatchesCount()).toMatchObject({ specificRange: 0 });
+  });
 });


### PR DESCRIPTION
How to reproduce the bug:
- open the find&replace side panel
- select "specific range" instead of "current sheet"
- write "sgdsgdsgdsg" in the range input
- try to write a world in the search input

Task: [6483222](https://www.odoo.com/odoo/2328/tasks/6483222)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo