### PR TITLE
[FIX] print: always print in light mode

### DIFF
--- a/src/components/spreadsheet/spreadsheet.ts
+++ b/src/components/spreadsheet/spreadsheet.ts
@@ -27,7 +27,7 @@ import { ScreenWidthStore } from "../../stores/screen_width_store";
 import { _t } from "../../translation";
 import { CommandResult } from "../../types/commands";
 import { InformationNotification } from "../../types/env";
-import { CSSProperties, HeaderGroup, Pixel } from "../../types/misc";
+import { ColorScheme, CSSProperties, HeaderGroup, Pixel } from "../../types/misc";
 import { PropsOf } from "../../types/props_of";
 import { SpreadsheetChildEnv } from "../../types/spreadsheet_env";
 import { Store } from "../../types/store_engine";
@@ -58,6 +58,11 @@ import { instantiateClipboard } from "./../../helpers/clipboard/navigator_clipbo
 // SpreadSheet
 // -----------------------------------------------------------------------------
 
+interface State {
+  printModeEnabled: boolean;
+  colorThemeBeforePrint: ColorScheme;
+}
+
 export class Spreadsheet extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-Spreadsheet";
   protected props = useProps({
@@ -82,7 +87,7 @@ export class Spreadsheet extends Component<SpreadsheetChildEnv> {
   spreadsheetRef = signal<HTMLElement | null>(null);
   spreadsheetRect = useSpreadsheetRect();
 
-  state = proxy({ printModeEnabled: false });
+  state = proxy<State>({ printModeEnabled: false, colorThemeBeforePrint: "light" });
 
   private _focusGrid?: () => void;
 
@@ -99,7 +104,7 @@ export class Spreadsheet extends Component<SpreadsheetChildEnv> {
     const scrollbarWidth = this.env.model.getters.getScrollBarWidth();
     properties["--os-scrollbar-width"] = `${scrollbarWidth}px`;
     properties["--os-dark-mode-filter"] = DARK_MODE_FILTER_STRING;
-    properties["color-scheme"] = this.props.model.getters.isDarkMode() ? "dark" : "light";
+    properties["color-scheme"] = this.colorScheme;
 
     if (this.state.printModeEnabled) {
       properties["display"] = `block`;
@@ -157,7 +162,7 @@ export class Spreadsheet extends Component<SpreadsheetChildEnv> {
         this.notificationStore.askConfirmation(text, confirm, cancel),
       raiseError: (text, cb) => this.notificationStore.raiseError(text, cb),
       isMobile: isMobileOS,
-      printSpreadsheet: () => (this.state.printModeEnabled = true),
+      printSpreadsheet: this.enterPrintMode.bind(this),
     } satisfies Partial<SpreadsheetChildEnv>);
 
     this.notificationStore.updateNotificationCallbacks({ ...this.props });
@@ -186,7 +191,7 @@ export class Spreadsheet extends Component<SpreadsheetChildEnv> {
       async (event: KeyboardEvent) => {
         const keyDownString = keyboardEventToShortcutString(event);
         if (keyDownString === "Ctrl+P") {
-          this.state.printModeEnabled = true;
+          this.enterPrintMode();
           event.stopPropagation();
           event.preventDefault();
         }
@@ -354,7 +359,30 @@ export class Spreadsheet extends Component<SpreadsheetChildEnv> {
     ].join(" ");
   }
 
+  enterPrintMode() {
+    if (this.state.printModeEnabled) {
+      return;
+    }
+    this.state.colorThemeBeforePrint = this.props.model.getters.isDarkMode() ? "dark" : "light";
+    this.env.model.dispatch("UPDATE_COLOR_SCHEME", { colorScheme: "light" });
+    this.state.printModeEnabled = true;
+  }
+
   exitPrintMode() {
+    if (!this.state.printModeEnabled) {
+      return;
+    }
+    this.env.model.dispatch("UPDATE_COLOR_SCHEME", {
+      colorScheme: this.state.colorThemeBeforePrint,
+    });
     this.state.printModeEnabled = false;
+  }
+
+  get colorScheme(): ColorScheme {
+    if (this.state.printModeEnabled) {
+      // We want to have the canvas/charts (the model) in light mode when printing, but the UI can be in dark mode
+      return this.state.colorThemeBeforePrint;
+    }
+    return this.props.model.getters.isDarkMode() ? "dark" : "light";
   }
 }

--- a/src/components/spreadsheet_print/spreadsheet_print.css
+++ b/src/components/spreadsheet_print/spreadsheet_print.css
@@ -27,6 +27,7 @@
     }
 
     .o-print-preview {
+      background-color: white !important;
       box-shadow: none !important;
       overflow: visible !important;
       height: 100% !important;

--- a/src/plugins/ui_feature/color_theme.ts
+++ b/src/plugins/ui_feature/color_theme.ts
@@ -1,5 +1,6 @@
 import { adaptForDarkMode } from "../../helpers/color";
 import { Command } from "../../types/commands";
+import { ColorScheme } from "../../types/misc";
 import { GridRenderingTheme } from "../../types/rendering";
 import { UIPlugin, UIPluginConfig } from "../ui_plugin";
 
@@ -41,7 +42,7 @@ export const COLOR_THEMES: Record<string, GridRenderingTheme> = {
 };
 export class ColorThemeUIPlugin extends UIPlugin {
   static getters = ["isDarkMode", "getSpreadsheetTheme"] as const;
-  private colorScheme?: "light" | "dark";
+  private colorScheme?: ColorScheme;
 
   constructor(config: UIPluginConfig) {
     super(config);

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -4,6 +4,7 @@ import {
   BorderData,
   CellPosition,
   Color,
+  ColorScheme,
   Dimension,
   HeaderIndex,
   Pixel,
@@ -1257,7 +1258,7 @@ export interface ToggleCheckboxCommand extends TargetDependentCommand {
 
 export interface UpdateColorSchemeCommand {
   type: "UPDATE_COLOR_SCHEME";
-  colorScheme: "light" | "dark";
+  colorScheme: ColorScheme;
 }
 
 export type CoreCommand =

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -164,6 +164,7 @@ export const invalidateChartEvaluationCommands = new Set<CommandTypes>([
   "UPDATE_FILTER",
   "UNDO",
   "REDO",
+  "UPDATE_COLOR_SCHEME",
 ]);
 
 export const invalidateDependenciesCommands = new Set<CommandTypes>(["MOVE_RANGES"]);

--- a/src/types/misc.ts
+++ b/src/types/misc.ts
@@ -446,3 +446,5 @@ export interface NamedRange {
   name: string;
   range: Range;
 }
+
+export type ColorScheme = "light" | "dark";

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -5,7 +5,7 @@ import { Currency } from "./currency";
 import { InformationNotification } from "./env";
 import { FileStore } from "./files";
 import { Locale } from "./locale";
-import { Color } from "./misc";
+import { Color, ColorScheme } from "./misc";
 
 export type Mode = "normal" | "readonly" | "dashboard" | "export_verification";
 
@@ -32,7 +32,7 @@ export interface ModelConfig {
   readonly notifyUI: (payload: InformationNotification) => void;
   readonly raiseBlockingErrorUI: (text: string) => void;
   readonly customColors: Color[];
-  readonly colorScheme?: "light" | "dark";
+  readonly colorScheme?: ColorScheme;
 }
 
 export interface ModelExternalConfig {

--- a/tests/colors/color_picker_component.test.ts
+++ b/tests/colors/color_picker_component.test.ts
@@ -3,7 +3,7 @@ import { ColorPicker } from "../../src/components/color_picker/color_picker";
 import { toHex } from "../../src/helpers/color";
 import { PropsOf } from "../../src/types/props_of";
 import { registerCleanup } from "../setup/jest.setup";
-import { setFormatting } from "../test_helpers/commands_helpers";
+import { setFormatting, updateColorScheme } from "../test_helpers/commands_helpers";
 import {
   getElComputedStyle,
   setInputValueAndTrigger,
@@ -232,7 +232,7 @@ describe("Color Picker buttons", () => {
     const model = await mountColorPicker({});
     expect(".eyedropper").toHaveCount(1);
 
-    model.dispatch("UPDATE_COLOR_SCHEME", { colorScheme: "dark" });
+    updateColorScheme(model, "dark");
     await nextTick();
     expect(".eyedropper").toHaveCount(0);
   });

--- a/tests/figures/chart/chart_plugin.test.ts
+++ b/tests/figures/chart/chart_plugin.test.ts
@@ -59,7 +59,7 @@ import { BarChartDefinition, BarChartRuntime } from "../../../src/types/chart/ba
 import { LineChartRuntime } from "../../../src/types/chart/line_chart";
 import { PieChartDefinition, PieChartRuntime } from "../../../src/types/chart/pie_chart";
 import { ScatterChartRuntime } from "../../../src/types/chart/scatter_chart";
-import { getChartDataSource } from "../../test_helpers";
+import { getChartDataSource, updateColorScheme } from "../../test_helpers";
 import {
   drawChartOnNodeCanvas,
   getCategoryAxisTickLabels,
@@ -3384,7 +3384,7 @@ describe("Linear/Time charts", () => {
     let runtime = model.getters.getChartRuntime("chartId") as BarChartRuntime;
     expect(runtime.chartJsConfig.options?.plugins?.background?.color).toBe("#FFFFFF");
 
-    model.dispatch("UPDATE_COLOR_SCHEME", { colorScheme: "dark" });
+    updateColorScheme(model, "dark");
     runtime = model.getters.getChartRuntime("chartId") as BarChartRuntime;
     expect(runtime.chartJsConfig.options?.plugins?.background?.color).toBe(
       COLOR_THEMES.dark.backgroundColor

--- a/tests/figures/chart/chart_plugin.test.ts
+++ b/tests/figures/chart/chart_plugin.test.ts
@@ -54,6 +54,7 @@ import { toNumber } from "../../../src/functions/helpers";
 import { convertDateFormatForLuxon } from "../../../src/helpers/chart_date";
 import { ChartPlugin } from "../../../src/plugins/core/chart";
 import { FigurePlugin } from "../../../src/plugins/core/figures";
+import { COLOR_THEMES } from "../../../src/plugins/ui_feature/color_theme";
 import { BarChartDefinition, BarChartRuntime } from "../../../src/types/chart/bar_chart";
 import { LineChartRuntime } from "../../../src/types/chart/line_chart";
 import { PieChartDefinition, PieChartRuntime } from "../../../src/types/chart/pie_chart";
@@ -3375,6 +3376,19 @@ describe("Linear/Time charts", () => {
 
     const chart = (model.getters.getChartRuntime(chartId) as LineChartRuntime).chartJsConfig;
     expect(chart.data!.labels).toEqual(["2024-01-01"]);
+  });
+
+  test("Chart runtime background follows the spreadsheet theme", () => {
+    createChart(model, { type: "bar" }, "chartId");
+
+    let runtime = model.getters.getChartRuntime("chartId") as BarChartRuntime;
+    expect(runtime.chartJsConfig.options?.plugins?.background?.color).toBe("#FFFFFF");
+
+    model.dispatch("UPDATE_COLOR_SCHEME", { colorScheme: "dark" });
+    runtime = model.getters.getChartRuntime("chartId") as BarChartRuntime;
+    expect(runtime.chartJsConfig.options?.plugins?.background?.color).toBe(
+      COLOR_THEMES.dark.backgroundColor
+    );
   });
 });
 

--- a/tests/plugins/color_theme_plugin.test.ts
+++ b/tests/plugins/color_theme_plugin.test.ts
@@ -1,6 +1,7 @@
 import { Model } from "../../src/model";
 import { COLOR_THEMES } from "../../src/plugins/ui_feature/color_theme";
 import { MockTransportService } from "../__mocks__/transport_service";
+import { updateColorScheme } from "../test_helpers";
 
 const expectedLightTheme = COLOR_THEMES.light;
 const expectedDarkTheme = COLOR_THEMES.dark;
@@ -49,8 +50,7 @@ describe("ColorThemeUIPlugin via Model getters", () => {
     let theme = model.getters.getSpreadsheetTheme();
     expect(theme.backgroundColor.toUpperCase()).toBe(expectedLightTheme.backgroundColor);
 
-    // Simulate color scheme change
-    model.dispatch("UPDATE_COLOR_SCHEME", { colorScheme: "dark" });
+    updateColorScheme(model, "dark");
     theme = model.getters.getSpreadsheetTheme();
     expect(theme.backgroundColor.toUpperCase()).toBe(expectedDarkTheme.backgroundColor);
   });

--- a/tests/spreadsheet/spreadsheet_print_component.test.ts
+++ b/tests/spreadsheet/spreadsheet_print_component.test.ts
@@ -15,6 +15,7 @@ import {
   setCellContent,
   setSelection,
   simulateClick,
+  updateColorScheme,
 } from "../test_helpers";
 import {
   mountComponentWithPortalTarget,
@@ -68,6 +69,25 @@ describe("Spreadsheet integration tests", () => {
     await simulateClick(".o-print-header button.primary");
     expect(".o-spreadsheet-print").toHaveCount(0);
     expect(mockWindowPrint).toHaveBeenCalledTimes(1);
+  });
+
+  test("Printing is always done with a model in light mode", async () => {
+    const { model } = await mountSpreadsheet();
+    updateColorScheme(model, "dark");
+    await nextTick();
+
+    expect(model.getters.isDarkMode()).toBe(true);
+    expect(".o-spreadsheet").toHaveStyle({ "color-scheme": "dark" });
+
+    await keyDown({ key: "p", ctrlKey: true });
+    expect(".o-spreadsheet-print").toHaveCount(1);
+    expect(model.getters.isDarkMode()).toBe(false); // Model in light mode
+    expect(".o-spreadsheet").toHaveStyle({ "color-scheme": "dark" }); // UI stays in dark mode
+
+    await simulateClick(".o-print-header button:not(.primary)");
+    expect(".o-spreadsheet-print").toHaveCount(0);
+    expect(model.getters.isDarkMode()).toBe(true);
+    expect(".o-spreadsheet").toHaveStyle({ "color-scheme": "dark" });
   });
 });
 

--- a/tests/test_helpers/commands_helpers.ts
+++ b/tests/test_helpers/commands_helpers.ts
@@ -2087,3 +2087,7 @@ export function deleteNamedRange(model: Model, name: string): DispatchResult {
     name: name,
   });
 }
+
+export function updateColorScheme(model: Model, colorScheme: "light" | "dark") {
+  return model.dispatch("UPDATE_COLOR_SCHEME", { colorScheme });
+}


### PR DESCRIPTION
### [FIX] print: always print in light mode

When printing in dark mode, we don't want to print black pages (think
of the planet!). We should render the grid/charts in light mode,
but still keep the UI in dark mode.

### [FIX] charts: change chart runtime when changing the theme

The chart runtime would depend on the theme of the spreadsheet, but
were not invalidated when changing the theme.
Task: [6432165](https://www.odoo.com/odoo/2328/tasks/6432165)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo