### PR TITLE
[FIX] xlsx: fix geo chart xlsx export

### DIFF
--- a/src/helpers/figures/chart.ts
+++ b/src/helpers/figures/chart.ts
@@ -242,4 +242,8 @@ export class SpreadsheetChart {
     }
     return definition;
   }
+
+  async loadDataForExport(getters: EvaluationGetters) {
+    return this.chartTypeBuilder.loadDataForExport?.(getters);
+  }
 }

--- a/src/helpers/figures/charts/geo_chart.ts
+++ b/src/helpers/figures/charts/geo_chart.ts
@@ -92,4 +92,8 @@ export const GeoChart: ChartTypeBuilder<"geo"> = {
 
     return { chartJsConfig: config };
   },
+
+  loadDataForExport: async (getters) => {
+    return getters.loadUsedGeoJsonFeatures();
+  },
 };

--- a/src/plugins/evaluation/evaluation_chart.ts
+++ b/src/plugins/evaluation/evaluation_chart.ts
@@ -4,6 +4,7 @@ import { SpreadsheetChart } from "../../helpers/figures/chart";
 import { chartFontColor } from "../../helpers/figures/charts/chart_common";
 import { chartToImageUrl } from "../../helpers/figures/charts/chart_ui_common";
 import { generateMasterChartConfig } from "../../helpers/figures/charts/runtime/chart_zoom";
+import { isDefined } from "../../helpers/misc";
 import { ChartRuntime, ExcelChartDefinition } from "../../types/chart/chart";
 import {
   EvaluationCommand,
@@ -108,6 +109,13 @@ export class EvaluationChartPlugin extends EvaluationPlugin<EvaluationChartState
   }
 
   async exportForExcel(data: ExcelWorkbookData) {
+    const loadChartDataPromises = this.getters
+      .getSheetIds()
+      .flatMap((sheetId) => this.getters.getChartIds(sheetId))
+      .map((chartId) => this.getters.getChart(chartId)?.loadDataForExport(this.getters))
+      .filter(isDefined);
+    await Promise.all(loadChartDataPromises);
+
     for (const sheet of data.sheets) {
       if (!sheet.images) {
         sheet.images = [];

--- a/src/plugins/evaluation/geo_loader.ts
+++ b/src/plugins/evaluation/geo_loader.ts
@@ -1,3 +1,4 @@
+import { isDefined } from "../../helpers/misc";
 import { GeoChartRegion } from "../../types/chart/geo_chart";
 import { ModelConfig } from "../../types/model";
 import { EvaluationPlugin, EvaluationPluginConfig } from "../evaluation_plugin";
@@ -7,6 +8,7 @@ export class GeoLoaderEvaluation extends EvaluationPlugin {
     "getGeoJsonFeatures",
     "geoFeatureNameToId",
     "getGeoChartAvailableRegions",
+    "loadUsedGeoJsonFeatures",
   ] as const;
 
   private readonly geoJsonService: ModelConfig["external"]["geoJsonService"];
@@ -78,5 +80,35 @@ export class GeoLoaderEvaluation extends EvaluationPlugin {
     }
 
     throw new Error("Invalid TopoJSON");
+  }
+
+  async loadUsedGeoJsonFeatures() {
+    const regions = this.getters
+      .getSheetIds()
+      .flatMap((sheetId) =>
+        this.getters.getChartIds(sheetId).map((chartId) => {
+          const definition = this.getters.getChartDefinition(chartId);
+          return definition.type === "geo"
+            ? definition.region || this.getters.getGeoChartAvailableRegions()[0]?.id
+            : undefined;
+        })
+      )
+      .filter(isDefined);
+
+    const uniqueRegions = Array.from(new Set(regions));
+    if (uniqueRegions.length && !this.geoJsonService) {
+      console.error("No geoJsonService provided to the model");
+      return;
+    }
+
+    for (const region of uniqueRegions) {
+      this.getGeoJsonFeatures(region); // Trigger the loading of the regions
+    }
+
+    const promises = uniqueRegions.map((region) => {
+      const cachedGeoJson = this.geoJsonCache[region];
+      return cachedGeoJson instanceof Promise ? cachedGeoJson : Promise.resolve();
+    });
+    await Promise.all(promises);
   }
 }

--- a/src/registries/chart_registry.ts
+++ b/src/registries/chart_registry.ts
@@ -111,6 +111,7 @@ export interface ChartTypeBuilder<T extends ChartType> {
   allowedDefinitionKeys: readonly string[];
   sequence: number;
   dataSeriesLimit?: number;
+  loadDataForExport?: (getters: EvaluationGetters) => Promise<void>;
 }
 
 interface ChartDataExtractors {

--- a/tests/figures/chart/geochart/geo_chart_plugin.test.ts
+++ b/tests/figures/chart/geochart/geo_chart_plugin.test.ts
@@ -14,17 +14,6 @@ import { mockChart, mockGeoJsonService, nextTick } from "../../../test_helpers/h
 mockChart();
 let model: Model;
 
-beforeEach(async () => {
-  model = new Model({}, { external: { geoJsonService: mockGeoJsonService } });
-  // Wait for the geoJsonService to resolve the promise and cache the geoJson features
-  model.getters.getGeoChartAvailableRegions();
-  model.getters.getGeoJsonFeatures("world");
-  for (const country of ["France", "Germany", "Spain"]) {
-    model.getters.geoFeatureNameToId("world", country);
-  }
-  await nextTick();
-});
-
 /**
  * Get the data points of the chart that have a value.
  * It's useful because the chart dataset always contains a point for ALL the features, even if they have no value
@@ -41,6 +30,17 @@ function getGeoChartNonEmptyData(runtime: GeoChartRuntime) {
 }
 
 describe("Geo charts plugin tests", () => {
+  beforeEach(async () => {
+    model = new Model({}, { external: { geoJsonService: mockGeoJsonService } });
+    // Wait for the geoJsonService to resolve the promise and cache the geoJson features
+    model.getters.getGeoChartAvailableRegions();
+    model.getters.getGeoJsonFeatures("world");
+    for (const country of ["France", "Germany", "Spain"]) {
+      model.getters.geoFeatureNameToId("world", country);
+    }
+    await nextTick();
+  });
+
   test("Basic geo chart runtime", () => {
     setCellContent(model, "A2", "France");
     setCellContent(model, "A3", "Germany");
@@ -249,4 +249,16 @@ describe("Geo charts plugin tests", () => {
       expect(model.getters.getAvailableChartRegions("barChartId")).toEqual([]);
     });
   });
+});
+
+test("Excel export loads all the used geo json", async () => {
+  const spy = jest.spyOn(mockGeoJsonService, "getTopoJson");
+  const model = new Model({}, { external: { geoJsonService: mockGeoJsonService } });
+  createGeoChart(model, { region: undefined }, "chart1"); // Defaults to world (first available region)
+  createGeoChart(model, { region: "usa" }, "chart2");
+
+  await model.exportXLSX();
+  expect(spy).toHaveBeenCalledTimes(2);
+  expect(spy).toHaveBeenCalledWith("world");
+  expect(spy).toHaveBeenCalledWith("usa");
 });

--- a/tests/test_helpers/helpers.ts
+++ b/tests/test_helpers/helpers.ts
@@ -994,7 +994,7 @@ const getAvailableRegions: () => GeoChartRegion[] = () => [
   { id: "northAmerica", label: "North America", defaultProjection: "conicConformal" },
 ];
 
-export const mockGeoJsonService: ModelExternalConfig["geoJsonService"] = {
+export const mockGeoJsonService: NonNullable<ModelExternalConfig["geoJsonService"]> = {
   getAvailableRegions,
   getTopoJson: async () => ({
     type: "FeatureCollection",


### PR DESCRIPTION
If a geo chart was present when exporting a spreadsheet to xlsx, more often than not the exported chart would be empty. It was because we didn't wait for the geo json to be loaded before exporting the xlsx.

This commit introduces a new getter `loadUsedGeoJsonFeatures` that can be called before any spreadsheet export to ensure that all the geo chart data is loaded.

Task: 4632983

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo