### PR TITLE
[IMP] chart: render invalid stacked area values as zero

### DIFF
--- a/src/helpers/figures/charts/runtime/chart_data_extractor.ts
+++ b/src/helpers/figures/charts/runtime/chart_data_extractor.ts
@@ -277,7 +277,9 @@ export function getLineChartData(
           formatValue(value, { format, locale: getters.getLocale() })
         );
 
-  ({ labels, dataSetsValues } = filterInvalidDataPoints(labels, dataSetsValues));
+  // Area charts use non-numeric values as zero.
+  const invalidDataValue = definition.fillArea ? ZERO : EMPTY;
+  ({ labels, dataSetsValues } = filterInvalidDataPoints(labels, dataSetsValues, invalidDataValue));
   if (axisType === "time") {
     ({ labels, dataSetsValues } = fixEmptyLabelsForDateCharts(labels, dataSetsValues));
   }
@@ -852,7 +854,8 @@ function fixEmptyLabelsForDateCharts(
  */
 function filterInvalidDataPoints(
   labels: string[],
-  datasets: DatasetValues[]
+  datasets: DatasetValues[],
+  invalidDataValue: FunctionResultObject = EMPTY
 ): { labels: string[]; dataSetsValues: DatasetValues[] } {
   const numberOfDataPoints = Math.max(
     labels.length,
@@ -868,7 +871,7 @@ function filterInvalidDataPoints(
     dataSetsValues: datasets.map((dataset) => ({
       ...dataset,
       data: dataPointsIndexes.map((i) =>
-        isNumberResult(dataset.data[i]) ? dataset.data[i] : EMPTY
+        isNumberResult(dataset.data[i]) ? dataset.data[i] : invalidDataValue
       ),
     })),
   };

--- a/tests/figures/chart/chart_plugin.test.ts
+++ b/tests/figures/chart/chart_plugin.test.ts
@@ -4081,7 +4081,7 @@ describe("trending line", () => {
       model,
       {
         type: "line",
-        fillArea: true,
+        fillArea: false,
         ...toChartDataSource({
           dataSets: [
             { dataRange: "B1:B4", trend: { type: "polynomial", order: 2, display: true } },
@@ -4102,6 +4102,36 @@ describe("trending line", () => {
       expect(value.x).toEqual(expectedLabel);
       expect(value.y).toBeCloseTo(expectedValue);
     }
+  });
+
+  test("area chart trend line uses invalid values as zero", () => {
+    // prettier-ignore
+    const model = createModelFromGrid({
+      A1: "1", B1: "1",
+      A2: "2", B2: "not a number",
+      A3: "3", B3: "9",
+    });
+    createChart(
+      model,
+      {
+        type: "line",
+        fillArea: true,
+        ...toChartDataSource({
+          dataSets: [
+            { dataRange: "B1:B3", trend: { type: "polynomial", order: 1, display: true } },
+          ],
+          labelRange: "A1:A3",
+          dataSetsHaveTitle: false,
+        }),
+      },
+      "chartId"
+    );
+    let runtime = model.getters.getChartRuntime("chartId") as LineChartRuntime;
+    const trendData = runtime.chartJsConfig.data.datasets[1].data;
+
+    setCellContent(model, "B2", "0");
+    runtime = model.getters.getChartRuntime("chartId") as LineChartRuntime;
+    expect(runtime.chartJsConfig.data.datasets[1].data).toEqual(trendData);
   });
 
   test("Trend line dataset is correctly styled", () => {

--- a/tests/figures/chart/line_chart_plugin.test.ts
+++ b/tests/figures/chart/line_chart_plugin.test.ts
@@ -166,6 +166,41 @@ describe("line chart", () => {
     expect(isChartAxisStacked(model, "chartId", "y")).toBe(true);
   });
 
+  test("Area charts treat non-numeric values as zero", () => {
+    // prettier-ignore
+    const model = createModelFromGrid({
+      A1: "A", B1: "1", C1: "4",
+      A2: "B",          C2: "invalid",
+    });
+    createChart(
+      model,
+      {
+        type: "line",
+        fillArea: true,
+        stacked: false,
+        ...toChartDataSource({
+          labelRange: "A1:A2",
+          dataSets: [{ dataRange: "B1:B2" }, { dataRange: "C1:C2" }],
+          dataSetsHaveTitle: false,
+        }),
+      },
+      "chartId"
+    );
+    let datasets = getChartConfiguration(model, "chartId").data.datasets!;
+    expect(datasets[0].data).toEqual([1, 0]);
+    expect(datasets[1].data).toEqual([4, 0]);
+
+    updateChart(model, "chartId", { stacked: true });
+    datasets = getChartConfiguration(model, "chartId").data.datasets!;
+    expect(datasets[0].data).toEqual([1, 0]);
+    expect(datasets[1].data).toEqual([4, 0]);
+
+    updateChart(model, "chartId", { fillArea: false });
+    datasets = getChartConfiguration(model, "chartId").data.datasets!;
+    expect(datasets[0].data).toEqual([1, NaN]);
+    expect(datasets[1].data).toEqual([4, NaN]);
+  });
+
   test("Trend lines have no fill color in area chart", () => {
     const model = new Model();
     setCellContent(model, "A1", "data");


### PR DESCRIPTION
## Description:

Stacked area charts pass non-numeric values to Chart.js as NaN, which breaks the line and filled area. Google Sheets instead renders these values at the baseline.

Normalize non-numeric values to zero when extracting data for stacked area charts. The normalization happens after invalid points without a label have been filtered out, so no empty categories are introduced.

Other chart types keep their existing behavior: invalid values remain gaps in regular area and line charts.

Task: [6458796](https://www.odoo.com/odoo/2328/tasks/6458796)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo