### PR TITLE
[FIX] dashboard: fix background color

### DIFF
--- a/src/components/dashboard/dashboard.css
+++ b/src/components/dashboard/dashboard.css
@@ -3,4 +3,9 @@
     position: absolute;
     cursor: pointer;
   }
+
+  .o-dashboard-grid {
+    /* Grid itself is transparent, background is applied on another div on which the dark mode filter is applied */
+    background-color: transparent;
+  }
 }

--- a/src/components/dashboard/dashboard.ts
+++ b/src/components/dashboard/dashboard.ts
@@ -166,19 +166,14 @@ export class SpreadsheetDashboard extends Component<SpreadsheetChildEnv> {
   get dashboardStyle() {
     const zoomLevel = this.env.model.getters.getViewportZoomLevel();
     const style = { zoom: `${zoomLevel}` };
-    const sheet = this.env.model.getters.getActiveSheet();
-    if (sheet.backgroundColor) {
-      style["background-color"] = "transparent";
-    }
     return cssPropertiesToCss(style);
   }
 
   get backgroundStyle() {
     const sheet = this.env.model.getters.getActiveSheet();
-    return sheet.backgroundColor
-      ? cssPropertiesToCss({
-          "background-color": sheet.backgroundColor,
-        })
-      : "";
+    const theme = this.env.model.getters.getSpreadsheetTheme();
+    return cssPropertiesToCss({
+      "background-color": sheet.backgroundColor || theme.backgroundColor,
+    });
   }
 }

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -219,6 +219,8 @@ export const readonlyAllowedCommands = new Set<CommandTypes>([
   "UPDATE_CAROUSEL_ACTIVE_ITEM",
 
   "UPDATE_PIVOT",
+
+  "UPDATE_COLOR_SCHEME",
 ]);
 
 export const lockedSheetAllowedCommands = new Set<Command["type"]>([

--- a/tests/grid/dashboard_grid_component.test.ts
+++ b/tests/grid/dashboard_grid_component.test.ts
@@ -9,6 +9,7 @@ import {
 } from "../../src/constants";
 import { toZone } from "../../src/helpers/zones";
 import { Model } from "../../src/model";
+import { COLOR_THEMES } from "../../src/plugins/ui_feature/color_theme";
 import { clickableCellRegistry } from "../../src/registries/cell_clickable_registry";
 import { GridIcon, iconsOnCellRegistry } from "../../src/registries/icons_on_cell_registry";
 import {
@@ -320,5 +321,19 @@ describe("Grid component in dashboard mode", () => {
     model.updateMode("dashboard");
     await nextTick();
     expect(".o-dashboard-background").toHaveStyle({ "background-color": "#FF0000" });
+  });
+
+  test("Dashboard backgrounds is present even if the sheet has no explicit background", async () => {
+    model.updateMode("dashboard");
+    await nextTick();
+    expect(".o-dashboard-background").toHaveStyle({ "background-color": "#FFFFFF" });
+
+    model.updateMode("normal");
+    model.dispatch("UPDATE_COLOR_SCHEME", { colorScheme: "dark" });
+    model.updateMode("dashboard");
+    await nextTick();
+    expect(".o-dashboard-background").toHaveStyle({
+      "background-color": COLOR_THEMES.dark.backgroundColor,
+    });
   });
 });

--- a/tests/grid/dashboard_grid_component.test.ts
+++ b/tests/grid/dashboard_grid_component.test.ts
@@ -328,9 +328,7 @@ describe("Grid component in dashboard mode", () => {
     await nextTick();
     expect(".o-dashboard-background").toHaveStyle({ "background-color": "#FFFFFF" });
 
-    model.updateMode("normal");
     model.dispatch("UPDATE_COLOR_SCHEME", { colorScheme: "dark" });
-    model.updateMode("dashboard");
     await nextTick();
     expect(".o-dashboard-background").toHaveStyle({
       "background-color": COLOR_THEMES.dark.backgroundColor,


### PR DESCRIPTION
## Description

The dashboards were using the default grid background color (some kind of gray), but they should have been using the background color of the sheet.

Task: [6497278](https://www.odoo.com/odoo/2328/tasks/6497278)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo