### PR TITLE
[FIX] dashboard: fix background color

### DIFF
--- a/src/components/dashboard/dashboard.ts
+++ b/src/components/dashboard/dashboard.ts
@@ -34,6 +34,9 @@ css/* scss */ `
     position: absolute;
     cursor: pointer;
   }
+  .o-grid.o-dashboard-grid {
+    background: #ffffff;
+  }
 `;
 
 export class SpreadsheetDashboard extends Component<Props, SpreadsheetChildEnv> {

--- a/src/components/dashboard/dashboard.xml
+++ b/src/components/dashboard/dashboard.xml
@@ -1,7 +1,7 @@
 <templates>
   <t t-name="o-spreadsheet-SpreadsheetDashboard">
     <div
-      class="o-grid o-two-columns"
+      class="o-grid o-dashboard-grid o-two-columns"
       tabindex="-1"
       t-on-wheel="onMouseWheel"
       t-on-click="onClosePopover">

--- a/tests/grid/__snapshots__/dashboard_grid_component.test.ts.snap
+++ b/tests/grid/__snapshots__/dashboard_grid_component.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`Grid component in dashboard mode simple dashboard rendering snapshot 1`] = `
 <div
-  class="o-grid o-two-columns"
+  class="o-grid o-dashboard-grid o-two-columns"
   tabindex="-1"
 >
   <div


### PR DESCRIPTION
## Description

The dashboards were using the default grid background color (some kind of gray), but they should have been using the background color of the sheet (white).

Task: [6497278](https://www.odoo.com/odoo/2328/tasks/6497278)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo