### PR TITLE
[FIX] chart suggestions: fix header for category

### DIFF
--- a/src/components/side_panel/data_analysis/data_analysis_panel.xml
+++ b/src/components/side_panel/data_analysis/data_analysis_panel.xml
@@ -12,7 +12,8 @@
           </t>
         </div>
         <div t-else="" class="o-data-analysis-empty text-muted p-3 text-center">
-          No chart suggestions available for the selected data.
+          No chart suggestions available for the selected data. Note that the order of selected
+        columns can impact chart suggestions.
         </div>
       </div>
       <div t-else="" class="o-data-analysis-empty text-muted p-3 text-center">

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -242,7 +242,7 @@ export const DEFAULT_WINDOW_SIZE = 2;
 
 // Maximum number of data points rendered by Chart.js in lightweight previews (drag preview,
 // chart suggestions), sampled down from the full dataset for performance.
-export const MAX_CHART_PREVIEW_DATA_POINTS = 150;
+export const MAX_CHART_PREVIEW_DATA_POINTS = 20;
 
 // session
 export const MESSAGE_VERSION = 1;

--- a/src/helpers/figures/charts/chart_suggestion_engine.ts
+++ b/src/helpers/figures/charts/chart_suggestion_engine.ts
@@ -150,6 +150,18 @@ function interestingCellsXc(col: ColumnAnalysis): {
   return { firstCellXC, lastCellXC, prevCellXC };
 }
 
+function getCategoryHeader(getters: Getters, catCol: ColumnAnalysis): string {
+  let catHeader = catCol.header ?? "";
+  if (!catHeader && catCol.rowCount > 0) {
+    const { left, top } = catCol.zone;
+    catHeader = (
+      getters.getEvaluatedCell({ sheetId: getters.getActiveSheetId(), col: left, row: top })
+        ?.value || _t("Category")
+    ).toString();
+  }
+  return catHeader;
+}
+
 /** Pattern A — Single numeric column */
 function buildSingleNumberContext([col]: ColumnAnalysis[], getters: Getters): SingleNumberContext {
   const title = col.header ?? _t("Value");
@@ -191,9 +203,8 @@ function buildSingleCategoricalContext(
 
 /** Pattern E — Single label column */
 function buildSingleLabelContext([col]: ColumnAnalysis[]): SingleLabelContext {
-  const title = col.header ?? _t("Label");
   const { lastCellXC } = interestingCellsXc(col);
-  return { title, lastCellXC, rowCount: col.rowCount };
+  return { title: "", lastCellXC, rowCount: col.rowCount };
 }
 
 /** Pattern F — Categorical + Number */
@@ -203,10 +214,11 @@ function buildCategoricalVsNumberContext(
 ): CategoricalVsNumberContext {
   const labelRange = getUnboundRange(getters, catCol.zone);
   const hasTitle = numCol.hasHeader;
+  const categoryHeader = hasTitle ? getCategoryHeader(getters, catCol) : _t("Category");
   const title = numCol.header
     ? _t("%(numberHeader)s by %(categoryHeader)s", {
         numberHeader: numCol.header,
-        categoryHeader: catCol.header ?? _t("Category"),
+        categoryHeader,
       })
     : _t("By Category");
   const source = rangeSource([dataset(numCol.zone, getters)], hasTitle, labelRange);
@@ -274,10 +286,11 @@ function buildCategoricalVsPercentageContext(
 ): CategoricalVsPercentageContext {
   const labelRange = getUnboundRange(getters, catCol.zone);
   const hasTitle = pctCol.hasHeader;
+  const categoryHeader = hasTitle ? getCategoryHeader(getters, catCol) : _t("Category");
   const title = pctCol.header
     ? _t("%(percentageHeader)s by %(categoryHeader)s", {
         percentageHeader: pctCol.header,
-        categoryHeader: catCol.header ?? _t("Category"),
+        categoryHeader,
       })
     : _t("Rates by Category");
   const source = rangeSource([dataset(pctCol.zone, getters)], hasTitle, labelRange);
@@ -310,7 +323,8 @@ function buildCategoricalVsMultipleNumbersContext(
 ): CategoricalVsMultipleNumbersContext {
   const labelRange = getUnboundRange(getters, catCol.zone);
   const hasTitle = numCols.some((c) => c.hasHeader);
-  const title = catCol.header ? _t("By %(header)s", { header: catCol.header }) : _t("Multi-series");
+  const categoryHeader = hasTitle ? getCategoryHeader(getters, catCol) : _t("Category");
+  const title = _t("Multi-series By %(categoryHeader)s", { categoryHeader });
   const dataSets = numCols.map((c, i) => dataset(c.zone, getters, String(i)));
   const source = rangeSource(dataSets, hasTitle, labelRange);
   return { title, source, rowCount: catCol.rowCount };
@@ -366,10 +380,11 @@ function buildCategoricalDateNumberContext(
   const dateRange = getUnboundRange(getters, dateCol.zone);
   const catRange = getUnboundRange(getters, catCol.zone);
   const hasTitle = numCol.hasHeader;
+  const catHeader = hasTitle ? getCategoryHeader(getters, catCol) : _t("Category");
   const title = numCol.header
     ? _t("%(numHeader)s by %(catHeader)s over %(dateHeader)s", {
         numHeader: numCol.header,
-        catHeader: catCol.header ?? _t("Category"),
+        catHeader: catHeader,
         dateHeader: dateCol.header ?? _t("Time"),
       })
     : _t("Multi-series over Time");
@@ -422,16 +437,15 @@ function buildCategoricalTwoNumbersContext(
 ): CategoricalTwoNumbersContext {
   const catRange = getUnboundRange(getters, catCol.zone);
   const hasTitle = numCol1.hasHeader || numCol2.hasHeader;
+  const catHeader = hasTitle ? getCategoryHeader(getters, catCol) : _t("Category");
   const title =
     numCol1.header && numCol2.header
       ? _t("%(num1Header)s vs %(num2Header)s by %(catHeader)s", {
           num1Header: numCol1.header,
           num2Header: numCol2.header,
-          catHeader: catCol.header ?? _t("Category"),
+          catHeader: catHeader,
         })
-      : catCol.header
-      ? _t("By %(header)s", { header: catCol.header })
-      : _t("Category Comparison");
+      : _t("By %(header)s", { header: catHeader });
   const isPyramid = isPyramidLike(numCol1, numCol2);
   const sourceBoth = rangeSource(
     [dataset(numCol1.zone, getters, "0"), dataset(numCol2.zone, getters, "1")],

--- a/src/helpers/figures/charts/chart_suggestion_engine.ts
+++ b/src/helpers/figures/charts/chart_suggestion_engine.ts
@@ -164,7 +164,7 @@ function getCategoryHeader(getters: Getters, catCol: ColumnAnalysis): string {
 
 /** Pattern A — Single numeric column */
 function buildSingleNumberContext([col]: ColumnAnalysis[], getters: Getters): SingleNumberContext {
-  const title = col.header ?? _t("Value");
+  const title = col.header ?? "";
   const { firstCellXC, lastCellXC, prevCellXC } = interestingCellsXc(col);
   const source = rangeSource([dataset(col.zone, getters)], col.hasHeader);
   return { title, source, rowCount: col.rowCount, firstCellXC, lastCellXC, prevCellXC };
@@ -176,7 +176,7 @@ function buildSinglePercentageContext(
   getters: Getters
 ): SinglePercentageContext {
   const hasTitle = col.hasHeader;
-  const title = col.header ?? _t("Rate");
+  const title = col.header ?? "";
   const { firstCellXC, lastCellXC, prevCellXC } = interestingCellsXc(col);
   const source = rangeSource([dataset(col.zone, getters)], hasTitle);
   const isAboveOne = (col.maxValue ?? 0) > 1;
@@ -186,7 +186,7 @@ function buildSinglePercentageContext(
 /** Pattern C — Single date column */
 function buildSingleDateContext([col]: ColumnAnalysis[]): SingleDateContext {
   const { lastCellXC } = interestingCellsXc(col);
-  return { title: col.header ?? _t("Date"), lastCellXC, rowCount: col.rowCount };
+  return { title: col.header ?? "", lastCellXC, rowCount: col.rowCount };
 }
 
 /** Pattern D — Single categorical column */
@@ -195,7 +195,7 @@ function buildSingleCategoricalContext(
   getters: Getters
 ): SingleCategoricalContext {
   const hasTitle = col.hasHeader;
-  const title = col.header ?? _t("Category");
+  const title = col.header ?? "";
   const range = getUnboundRange(getters, col.zone);
   const source = rangeSource([dataset(col.zone, getters)], hasTitle, range);
   return { title, source, range };
@@ -220,7 +220,7 @@ function buildCategoricalVsNumberContext(
         numberHeader: numCol.header,
         categoryHeader,
       })
-    : _t("By Category");
+    : "";
   const source = rangeSource([dataset(numCol.zone, getters)], hasTitle, labelRange);
   const treemapSource = rangeSource(
     [dataset(catCol.zone, getters)],
@@ -240,9 +240,7 @@ function buildDateVsSeriesContext(
   const hasTitle = isDatasetTitled(getters, dateCol.zone);
   const title = seriesCol.header
     ? _t("%(seriesHeader)s over time", { seriesHeader: seriesCol.header })
-    : isPercentage
-    ? _t("Rate over Time")
-    : _t("Over Time");
+    : "";
   const source = rangeSource([dataset(seriesCol.zone, getters)], hasTitle, labelRange);
   return { title, source, isPercentage };
 }
@@ -255,7 +253,7 @@ function buildNumberVsNumberContext(
   const title =
     col1.header && col2.header
       ? _t("%(col2Header)s vs %(col1Header)s", { col2Header: col2.header, col1Header: col1.header })
-      : _t("Correlation");
+      : "";
   const hasTitle = col1.hasHeader || col2.hasHeader;
   const source2 = rangeSource(
     [dataset(col2.zone, getters)],
@@ -292,7 +290,7 @@ function buildCategoricalVsPercentageContext(
         percentageHeader: pctCol.header,
         categoryHeader,
       })
-    : _t("Rates by Category");
+    : "";
   const source = rangeSource([dataset(pctCol.zone, getters)], hasTitle, labelRange);
   return { title, source, rowCount: catCol.rowCount };
 }
@@ -309,7 +307,7 @@ function buildLabelVsNumberContext(
         numberHeader: numCol.header,
         labelHeader: labelCol.header ?? _t("Name"),
       })
-    : _t("By Name");
+    : "";
   const source = rangeSource([dataset(numCol.zone, getters)], hasTitle, labelRange);
   const { lastCellXC } = interestingCellsXc(numCol);
   const { lastCellXC: prevCellXC } = interestingCellsXc(labelCol);
@@ -323,8 +321,8 @@ function buildCategoricalVsMultipleNumbersContext(
 ): CategoricalVsMultipleNumbersContext {
   const labelRange = getUnboundRange(getters, catCol.zone);
   const hasTitle = numCols.some((c) => c.hasHeader);
-  const categoryHeader = hasTitle ? getCategoryHeader(getters, catCol) : _t("Category");
-  const title = _t("Multi-series By %(categoryHeader)s", { categoryHeader });
+  const categoryHeader = hasTitle ? getCategoryHeader(getters, catCol) : "";
+  const title = hasTitle ? _t("Multi-series By %(categoryHeader)s", { categoryHeader }) : "";
   const dataSets = numCols.map((c, i) => dataset(c.zone, getters, String(i)));
   const source = rangeSource(dataSets, hasTitle, labelRange);
   return { title, source, rowCount: catCol.rowCount };
@@ -340,7 +338,7 @@ function buildDateVsMultipleNumbersContext(
   const title =
     numCols.length === 1 && numCols[0].header
       ? _t("%(header)s over time", { header: numCols[0].header })
-      : _t("Multi-series over Time");
+      : "";
   const dataSets = numCols.map((c, i) => dataset(c.zone, getters, String(i)));
   const source = rangeSource(dataSets, hasTitle, labelRange);
   return { title, source };
@@ -357,7 +355,7 @@ function buildMultipleCategoricalsVsNumberContext(
         cat1Header: cat1.header ?? _t("Level 1"),
         cat2Header: cat2.header ?? _t("Level 2"),
       })
-    : _t("Two-level hierarchy");
+    : "";
   const hasTitle = numCol.hasHeader;
   const hierarchySource = rangeSource(
     [dataset(cat1.zone, getters, "0"), dataset(cat2.zone, getters, "1")],
@@ -387,7 +385,7 @@ function buildCategoricalDateNumberContext(
         catHeader: catHeader,
         dateHeader: dateCol.header ?? _t("Time"),
       })
-    : _t("Multi-series over Time");
+    : "";
   const sourceByDate = rangeSource([dataset(numCol.zone, getters)], hasTitle, dateRange);
   const sourceByCat = rangeSource([dataset(numCol.zone, getters)], hasTitle, catRange);
   return { title, sourceByDate, sourceByCat };
@@ -400,9 +398,7 @@ function buildLabelVsMultipleNumbersContext(
 ): LabelVsMultipleNumbersContext {
   const labelRange = getUnboundRange(getters, labelCol.zone);
   const hasTitle = numCols.some((c) => c.hasHeader);
-  const title = labelCol.header
-    ? _t("By %(header)s", { header: labelCol.header })
-    : _t("Profile Comparison");
+  const title = labelCol.header ? _t("By %(header)s", { header: labelCol.header }) : "";
   const dataSets = numCols.map((c, i) => dataset(c.zone, getters, String(i)));
   const source = rangeSource(dataSets, hasTitle, labelRange);
   const scatterSource = rangeSource(
@@ -445,7 +441,7 @@ function buildCategoricalTwoNumbersContext(
           num2Header: numCol2.header,
           catHeader: catHeader,
         })
-      : _t("By %(header)s", { header: catHeader });
+      : "";
   const isPyramid = isPyramidLike(numCol1, numCol2);
   const sourceBoth = rangeSource(
     [dataset(numCol1.zone, getters, "0"), dataset(numCol2.zone, getters, "1")],
@@ -457,9 +453,7 @@ function buildCategoricalTwoNumbersContext(
 
 /** Pattern S — Many Numbers (3+ numeric columns, no categorical/date) */
 function buildManyNumbersContext(cols: ColumnAnalysis[], getters: Getters): ManyNumbersContext {
-  const title = cols.every((c) => c.hasHeader)
-    ? cols.map((c) => c.header!).join(" / ")
-    : _t("KPI Overview");
+  const title = cols.every((c) => c.hasHeader) ? cols.map((c) => c.header!).join(" / ") : "";
   const hasTitle = cols.some((c) => c.hasHeader);
   const dataSets = cols.map((c, i) => dataset(c.zone, getters, String(i)));
   const source = rangeSource(dataSets, hasTitle);

--- a/src/helpers/figures/charts/charts_suggestions_constants.ts
+++ b/src/helpers/figures/charts/charts_suggestions_constants.ts
@@ -237,7 +237,7 @@ function scorecardChart(
   return {
     ...opts,
     type: "scorecard",
-    title: { text: titleText },
+    title: titleText ? { text: titleText } : {},
     keyValue,
     baselineMode: opts.baselineMode ?? "difference",
     baselineColorUp: DEFAULT_SCORECARD_BASELINE_COLOR_UP,

--- a/tests/figures/chart/chart_data_analysis.test.ts
+++ b/tests/figures/chart/chart_data_analysis.test.ts
@@ -51,7 +51,7 @@ test("shows a message when the selection has data but no chart can be suggested"
   selectCell(model, "A1");
   await simulateClick(".o-data-analysis-button");
   expect(fixture.querySelector(".o-data-analysis-empty")?.textContent?.trim()).toBe(
-    "No chart suggestions available for the selected data."
+    "No chart suggestions available for the selected data. Note that the order of selected columns can impact chart suggestions."
   );
 });
 

--- a/tests/figures/chart/chart_suggestion_engine.test.ts
+++ b/tests/figures/chart/chart_suggestion_engine.test.ts
@@ -219,6 +219,28 @@ describe("getChartSuggestions", () => {
         "bar"
       );
     });
+
+    test("Title uses the first cell value instead of a generic 'Category' label", () => {
+      const model = createModelFromGrid({
+        A1: "Fruit",
+        A2: "banana",
+        A3: "apple",
+        A4: "banana",
+        A5: "apple",
+      });
+      const defs = suggestions(model, "A1:A5").map((s) => s.definition);
+      expect(defs[0].title.text).toBe("Fruit");
+    });
+
+    test("blank first cell in the zone → title falls back to 'Category'", () => {
+      const model = createModelFromGrid({
+        A2: "apple",
+        A3: "banana",
+        A4: "apple",
+      });
+      const defs = suggestions(model, "A1:A4").map((s) => s.definition);
+      expect(defs[0].title.text).toBe("Category");
+    });
   });
 
   // Pattern E — single label column
@@ -232,6 +254,7 @@ describe("getChartSuggestions", () => {
         (d) => d.type === "scorecard"
       ) as ScorecardChartRuntime;
       expect(runtime.keyValue).toBe("Alice");
+      expect(runtime.title.text).toBe("");
     });
 
     test(">1 row → no suggestions yet", () => {
@@ -266,6 +289,33 @@ describe("getChartSuggestions", () => {
       expect(
         (runtimeFor(model, ["A1:A3", "B1:B3"], (d) => d.type === "pie") as any).chartJsConfig.type
       ).toBe("pie");
+    });
+
+    test("Title uses 'Category' if there is no header", () => {
+      const model = createModelFromGrid({
+        A1: "apple",
+        A2: "apple",
+        A3: "cherry",
+        B1: "10",
+        B2: "5",
+        B3: "30",
+      });
+      const defs = suggestions(model, ["A1:A3", "B1:B3"]).map((s) => s.definition);
+      expect(defs[0].title.text).toBe("By Category");
+    });
+
+    test("number column has a header → title combines it with the category's first value", () => {
+      const model = createModelFromGrid({
+        A1: "apple",
+        A2: "apple",
+        A3: "cherry",
+        B1: "Sales",
+        B2: "10",
+        B3: "5",
+        B4: "30",
+      });
+      const defs = suggestions(model, ["A1:A3", "B1:B4"]).map((s) => s.definition);
+      expect(defs[0].title.text).toBe("Sales by apple");
     });
   });
 
@@ -376,6 +426,20 @@ describe("getChartSuggestions", () => {
       setFormat(model, "B1:B2", "0%");
       expect(suggestionTypes(model, ["A1:A2", "B1:B2"])).not.toContain("radar");
     });
+
+    test("Title uses 'Category' if there is no header", () => {
+      const model = createModelFromGrid({
+        A1: "North",
+        A2: "South",
+        A3: "North",
+        B1: "0.3",
+        B2: "0.5",
+        B3: "0.2",
+      });
+      setFormat(model, "B1:B3", "0%");
+      const defs = suggestions(model, ["A1:A3", "B1:B3"]).map((s) => s.definition);
+      expect(defs[0].title.text).toBe("Rates by Category");
+    });
   });
 
   // Pattern K — label + number
@@ -461,6 +525,27 @@ describe("getChartSuggestions", () => {
       });
       expect(suggestionTypes(model, ["A1:A2", "B1:B2", "C1:C2", "D1:D2"])).not.toContain("radar");
     });
+
+    test("no header at all → title falls back to the generic 'Category' label", () => {
+      const model = createModelFromGrid({
+        A1: "North",
+        A2: "South",
+        A3: "North",
+        B1: "10",
+        B2: "20",
+        B3: "30",
+        C1: "1",
+        C2: "2",
+        C3: "3",
+        D1: "5",
+        D2: "6",
+        D3: "7",
+      });
+      const defs = suggestions(model, ["A1:A3", "B1:B3", "C1:C3", "D1:D3"]).map(
+        (s) => s.definition
+      );
+      expect(defs[0].title.text).toBe("Multi-series By Category");
+    });
   });
 
   // Pattern N — date + multiple numbers
@@ -520,6 +605,26 @@ describe("getChartSuggestions", () => {
       setCellContent(model, "C3", "30");
       const types = suggestionTypes(model, ["A1:A3", "B1:B3", "C1:C3"]);
       expect(types).toEqual(["line", "line", "bar", "bar"]);
+    });
+
+    test("no category header, number column has a header → title uses the category's first value", () => {
+      const model = new Model();
+      setCellContent(model, "A1", "Direction");
+      setCellContent(model, "A2", "South");
+      setCellContent(model, "A3", "North");
+      setCellContent(model, "A4", "South");
+      setCellContent(model, "A5", "South");
+      setCellContent(model, "B1", "1/1/2024");
+      setCellContent(model, "B2", "1/1/2024");
+      setCellContent(model, "B3", "2/1/2024");
+      setCellContent(model, "B4", "3/1/2024");
+      setFormat(model, "B1:B4", "mm/dd/yyyy");
+      setCellContent(model, "C1", "Sales");
+      setCellContent(model, "C2", "10");
+      setCellContent(model, "C3", "20");
+      setCellContent(model, "C4", "30");
+      const defs = suggestions(model, ["A1:A5", "B1:B4", "C1:C4"]).map((s) => s.definition);
+      expect(defs[0].title.text).toBe("Sales by Direction over Time");
     });
   });
 
@@ -584,6 +689,26 @@ describe("getChartSuggestions", () => {
       const defs = suggestions(model, ["A1:A4", "B1:B4", "C1:C4"]).map((s) => s.definition);
       expect(defs.some((d) => d.type === "pyramid")).toBe(true);
       expect(defs.some((d) => d.type === "bar" && (d as any).stacked)).toBe(false);
+      expect(defs[0].title.text).toBe("Male vs Female by North");
+    });
+
+    test("no headers at all → title falls back to the generic 'Category' label", () => {
+      const model = createModelFromGrid({
+        A1: "North",
+        A2: "North",
+        A3: "South",
+        A4: "South",
+        B1: "10",
+        B2: "20",
+        B3: "15",
+        B4: "5",
+        C1: "12",
+        C2: "18",
+        C3: "20",
+        C4: "8",
+      });
+      const defs = suggestions(model, ["A1:A4", "B1:B4", "C1:C4"]).map((s) => s.definition);
+      expect(defs[0].title.text).toBe("By Category");
     });
 
     test("non-pyramid headers → no pyramid chart, stacked bar produced instead", () => {

--- a/tests/figures/chart/chart_suggestion_engine.test.ts
+++ b/tests/figures/chart/chart_suggestion_engine.test.ts
@@ -219,28 +219,6 @@ describe("getChartSuggestions", () => {
         "bar"
       );
     });
-
-    test("Title uses the first cell value instead of a generic 'Category' label", () => {
-      const model = createModelFromGrid({
-        A1: "Fruit",
-        A2: "banana",
-        A3: "apple",
-        A4: "banana",
-        A5: "apple",
-      });
-      const defs = suggestions(model, "A1:A5").map((s) => s.definition);
-      expect(defs[0].title.text).toBe("Fruit");
-    });
-
-    test("blank first cell in the zone → title falls back to 'Category'", () => {
-      const model = createModelFromGrid({
-        A2: "apple",
-        A3: "banana",
-        A4: "apple",
-      });
-      const defs = suggestions(model, "A1:A4").map((s) => s.definition);
-      expect(defs[0].title.text).toBe("Category");
-    });
   });
 
   // Pattern E — single label column
@@ -291,7 +269,7 @@ describe("getChartSuggestions", () => {
       ).toBe("pie");
     });
 
-    test("Title uses 'Category' if there is no header", () => {
+    test("No title if there is no header", () => {
       const model = createModelFromGrid({
         A1: "apple",
         A2: "apple",
@@ -301,7 +279,7 @@ describe("getChartSuggestions", () => {
         B3: "30",
       });
       const defs = suggestions(model, ["A1:A3", "B1:B3"]).map((s) => s.definition);
-      expect(defs[0].title.text).toBe("By Category");
+      expect(defs[0].title.text).toBe("");
     });
 
     test("number column has a header → title combines it with the category's first value", () => {
@@ -427,7 +405,7 @@ describe("getChartSuggestions", () => {
       expect(suggestionTypes(model, ["A1:A2", "B1:B2"])).not.toContain("radar");
     });
 
-    test("Title uses 'Category' if there is no header", () => {
+    test("No title if there is no header", () => {
       const model = createModelFromGrid({
         A1: "North",
         A2: "South",
@@ -438,7 +416,7 @@ describe("getChartSuggestions", () => {
       });
       setFormat(model, "B1:B3", "0%");
       const defs = suggestions(model, ["A1:A3", "B1:B3"]).map((s) => s.definition);
-      expect(defs[0].title.text).toBe("Rates by Category");
+      expect(defs[0].title.text).toBe("");
     });
   });
 
@@ -526,7 +504,7 @@ describe("getChartSuggestions", () => {
       expect(suggestionTypes(model, ["A1:A2", "B1:B2", "C1:C2", "D1:D2"])).not.toContain("radar");
     });
 
-    test("no header at all → title falls back to the generic 'Category' label", () => {
+    test("no header at all → no chart title", () => {
       const model = createModelFromGrid({
         A1: "North",
         A2: "South",
@@ -544,7 +522,7 @@ describe("getChartSuggestions", () => {
       const defs = suggestions(model, ["A1:A3", "B1:B3", "C1:C3", "D1:D3"]).map(
         (s) => s.definition
       );
-      expect(defs[0].title.text).toBe("Multi-series By Category");
+      expect(defs[0].title).toBeUndefined;
     });
   });
 
@@ -692,7 +670,7 @@ describe("getChartSuggestions", () => {
       expect(defs[0].title.text).toBe("Male vs Female by North");
     });
 
-    test("no headers at all → title falls back to the generic 'Category' label", () => {
+    test("no headers at all → no title", () => {
       const model = createModelFromGrid({
         A1: "North",
         A2: "North",
@@ -708,7 +686,7 @@ describe("getChartSuggestions", () => {
         C4: "8",
       });
       const defs = suggestions(model, ["A1:A4", "B1:B4", "C1:C4"]).map((s) => s.definition);
-      expect(defs[0].title.text).toBe("By Category");
+      expect(defs[0].title.text).toBe("");
     });
 
     test("non-pyramid headers → no pyramid chart, stacked bar produced instead", () => {


### PR DESCRIPTION
## Task Description

When creating a chart from the chart suggestion with a category column, we currently decide that there is no header in the column and count the first row as an entry. This PR aims to change this behavior to use the first entry as an header in a more smart way :
 * If we have only category, we use the first entry as header
 * If we have a column of another type, we use the first entry as header if the other column has a header.

## Related Task

Task: 0

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo