### PR TITLE
[FIX] calendar chart: wrong groupBy choice filtering

### DIFF
--- a/src/components/side_panel/chart/calendar_chart/calendar_chart_config_panel.ts
+++ b/src/components/side_panel/chart/calendar_chart/calendar_chart_config_panel.ts
@@ -1,9 +1,4 @@
-import { toJsDate } from "../../../../functions/helpers";
-import { createValidRange, isDateTime } from "../../../../helpers";
-import { createDataSets } from "../../../../helpers/figures/charts";
-import { getBarChartData } from "../../../../helpers/figures/charts/runtime";
 import { ALL_PERIODS } from "../../../../helpers/pivot/pivot_helpers";
-import { DEFAULT_LOCALE } from "../../../../types";
 import {
   CALENDAR_CHART_GRANULARITIES,
   CalendarChartDefinition,
@@ -31,73 +26,6 @@ export class CalendarChartConfigPanel extends GenericChartConfigPanel<
         onChange: this.onUpdateDataSetsHaveTitle.bind(this),
       },
     ];
-  }
-
-  getGroupByOptions() {
-    const sheetId = this.env.model.getters.getFigureSheetId(
-      this.env.model.getters.getFigureIdFromChartId(this.props.chartId)
-    )!;
-    const dataSets = createDataSets(
-      this.env.model.getters,
-      this.props.definition.dataSets,
-      sheetId,
-      this.props.definition.dataSetsHaveTitle
-    );
-    if (dataSets.length === 0) {
-      return [];
-    }
-    const labelRange = createValidRange(
-      this.env.model.getters,
-      sheetId,
-      this.props.definition.labelRange
-    );
-    const data = getBarChartData(
-      this.props.definition,
-      dataSets,
-      labelRange,
-      this.env.model.getters
-    );
-    const labels = data.labels.filter((l) => isDateTime(l, DEFAULT_LOCALE));
-    if (labels.length === 0) {
-      return [];
-    }
-    const dates = labels.map((label) => toJsDate(label, this.env.model.getters.getLocale()));
-    const uniqueYears = new Set<number>();
-    const uniqueMonths = new Set<number>();
-    const uniqueDays = new Set<number>();
-    const uniqueHours = new Set<number>();
-    const uniqueMinutes = new Set<number>();
-    const uniqueSeconds = new Set<number>();
-    for (const date of dates) {
-      uniqueYears.add(date.getFullYear());
-      uniqueMonths.add(date.getMonth());
-      uniqueDays.add(date.getDate());
-      uniqueHours.add(date.getHours());
-      uniqueMinutes.add(date.getMinutes());
-      uniqueSeconds.add(date.getSeconds());
-    }
-    const groupByPossibilities = this.groupByChoices.filter((groupBy) => {
-      switch (groupBy.value) {
-        case "year":
-          return uniqueYears.size > 1;
-        case "quarter_number":
-        case "month_number":
-          return uniqueMonths.size > 1;
-        case "iso_week_number":
-        case "day_of_month":
-        case "day_of_week":
-          return uniqueDays.size > 1;
-        case "hour_number":
-          return uniqueHours.size > 1;
-        case "minute_number":
-          return uniqueMinutes.size > 1;
-        case "second_number":
-          return uniqueSeconds.size > 1;
-        default:
-          return false;
-      }
-    });
-    return groupByPossibilities;
   }
 
   getGroupByType(currentAxis: "horizontal" | "vertical"): CalendarChartGranularity {

--- a/src/components/side_panel/chart/calendar_chart/calendar_chart_config_panel.xml
+++ b/src/components/side_panel/chart/calendar_chart/calendar_chart_config_panel.xml
@@ -26,7 +26,7 @@
             t-att-value="getGroupByType('horizontal')"
             class="o-input o-horizontal-group-by"
             t-on-change="ev => this.updateGroupBy('horizontal', ev.target.value)">
-            <t t-foreach="getGroupByOptions()" t-as="groupBy" t-key="groupBy.value">
+            <t t-foreach="this.groupByChoices" t-as="groupBy" t-key="groupBy.value">
               <option
                 t-att-selected="getGroupByType('horizontal') === groupBy.value"
                 t-att-value="groupBy.value">
@@ -41,7 +41,7 @@
             t-att-value="getGroupByType('vertical')"
             class="o-input o-vertical-group-by"
             t-on-change="ev => this.updateGroupBy('vertical', ev.target.value)">
-            <t t-foreach="getGroupByOptions()" t-as="groupBy" t-key="groupBy.value">
+            <t t-foreach="this.groupByChoices" t-as="groupBy" t-key="groupBy.value">
               <option
                 t-att-selected="getGroupByType('vertical') === groupBy.value"
                 t-att-value="groupBy.value">


### PR DESCRIPTION
## Description

In the side panel of the calendar chart, we would filter the available granularities based on the chart data. There were a bunch of issues with this filtering:

- It's functionally limiting what the user can do. He cannot select a year granularity if the data is only for one year, which he might want to do to take future data into account.
- The side panel code would use different logic than the actual calendar runtime. Eg. calendar runtime accept non-date-formatted number values, the side panel would not.
- It wouldn't display the current granularity if it was not in the filtered list, showing a blank select.
- It would use private-ish chart helpers that we don't really want to use everywhere
- It would only work for range data, but in future version the side panel should be chart datasource-agnostic.
- It wasn't tested

This commit plainly removes the filtering logic, and instead show all available granularity. It's also consistent with what we do with pivot date granularities.

Task: [5358625](https://www.odoo.com/odoo/2328/tasks/5358625)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo