### PR TITLE
[FIX] dashboard: fix carousel size in full screen charts

### DIFF
--- a/src/components/full_screen_figure/full_screen_figure.ts
+++ b/src/components/full_screen_figure/full_screen_figure.ts
@@ -1,4 +1,4 @@
-import { onWillUpdateProps, signal, useEffect } from "@odoo/owl";
+import { onWillUpdateProps, proxy, signal, useEffect } from "@odoo/owl";
 import { Component } from "../../owl3_compatibility_layer";
 import { figureRegistry } from "../../registries/figures_registry";
 import { useStore } from "../../store_engine/store_hooks";
@@ -15,6 +15,7 @@ export class FullScreenFigure extends Component<SpreadsheetChildEnv> {
 
   private fullScreenFigureStore!: Store<FullScreenFigureStore>;
   private fullScreenFigureRef = signal.ref();
+  private containerSize = proxy({ width: 0, height: 0 });
 
   spreadsheetRect = useSpreadsheetRect();
 
@@ -33,10 +34,30 @@ export class FullScreenFigure extends Component<SpreadsheetChildEnv> {
     });
 
     useEffect(() => this.fullScreenFigureRef()?.focus());
+    useEffect(() => {
+      const el = this.fullScreenFigureRef();
+      if (!el) {
+        return;
+      }
+      const resizeObserver = new ResizeObserver(([entry]) => {
+        this.containerSize.width = entry.contentRect.width;
+        this.containerSize.height = entry.contentRect.height;
+      });
+      resizeObserver.observe(el);
+      return () => resizeObserver.disconnect();
+    });
   }
 
   get figureUI() {
-    return this.fullScreenFigureStore.fullScreenFigure;
+    const figureUI = this.fullScreenFigureStore.fullScreenFigure;
+    if (!figureUI) {
+      return undefined;
+    }
+    return {
+      ...figureUI,
+      width: this.containerSize.width,
+      height: this.containerSize.height,
+    };
   }
 
   get chartId() {

--- a/src/components/full_screen_figure/full_screen_figure.xml
+++ b/src/components/full_screen_figure/full_screen_figure.xml
@@ -22,6 +22,7 @@
           t-on-keydown="(ev) => this.onKeyDown(ev)">
           <t>
             <t
+              t-if="this.figureUI.width and this.figureUI.height"
               t-component="this.figureComponent"
               figureUI="this.figureUI"
               isFullScreen="true"

--- a/tests/figures/carousel/carousel_full_screen.test.ts
+++ b/tests/figures/carousel/carousel_full_screen.test.ts
@@ -1,4 +1,5 @@
 import { Model } from "../../../src";
+import { CAROUSEL_LAYOUT } from "../../../src/constants";
 import {
   addNewChartToCarousel,
   createCarousel,
@@ -62,5 +63,17 @@ describe("full screen carousel", () => {
     expect(".o-fullscreen-figure .o-carousel-tab").toHaveCount(2);
     expect(".o-fullscreen-figure .o-carousel-tab:nth-child(1)").toHaveText("Data");
     expect(".o-fullscreen-figure .o-carousel-tab:nth-child(2)").toHaveText("Radar");
+  });
+
+  test("Full screen carousel uses the actual full screen container size for layout", async () => {
+    createCarousel(model, { items: [] }, "carouselId");
+    addNewChartToCarousel(model, "carouselId");
+    model.updateMode("dashboard");
+    await nextTick();
+
+    await click(fixture, ".o-figure .o-carousel-full-screen-button");
+    const content = fixture.querySelector<HTMLElement>(".o-fullscreen-figure .o-carousel-content");
+    expect(content!.style.width).toBe(`${1000 - 2 * CAROUSEL_LAYOUT.paddingX}px`);
+    expect(content!.style.height).not.toBe("0px");
   });
 });

--- a/tests/setup/jest.setup.ts
+++ b/tests/setup/jest.setup.ts
@@ -180,6 +180,7 @@ beforeEach(() => {
     }),
     "o-grid": () => ({ x: 0, y: 0, width: 1000 + HEADER_WIDTH, height: 1000 + HEADER_HEIGHT }),
     // "o-grid-overlay": () => ({ x: HEADER_WIDTH, y: HEADER_HEIGHT, width: 1000 + HEADER_WIDTH, height: 1000 + HEADER_HEIGHT }),
+    "o-fullscreen-figure": () => ({ x: 0, y: 0, width: 1000, height: 1000 }),
   });
 });
 


### PR DESCRIPTION
## Description:

Current behavior before PR:
- The carousel layout was statically defined in https://github.com/odoo/o-spreadsheet/commit/6b5a887a46abf77390efb2921c651e039a22634f
- Previously, passing 0px for the width and height worked for regular charts,
as Chart.js automatically calculates the chart dimensions.
- However, for a full screen carousel, we were passing the default 0px width
and height, causing the carousel to be invisible.

Desired behavior after PR is merged:
- Get the width and height of the full screen container from the DOM.
- Pass the actual dimensions to the carousel so it can be laid out
correctly in full screen charts.

Task: [6498191](https://www.odoo.com/odoo/2328/tasks/6498191)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo