### PR TITLE
[IMP] Side panel: improve pinned side panel behavior

### DIFF
--- a/src/components/side_panel/side_panel/side_panel_store.ts
+++ b/src/components/side_panel/side_panel/side_panel_store.ts
@@ -119,12 +119,9 @@ export class SidePanelStore extends SpreadsheetStore {
     }
 
     // Try to open secondary panel if main panel is pinned
-    const nonCollapsedPanelSize = this.mainPanel.isCollapsed
-      ? DEFAULT_SIDE_PANEL_SIZE
-      : this.mainPanel.size;
     if (
       !this.secondaryPanel &&
-      nonCollapsedPanelSize + DEFAULT_SIDE_PANEL_SIZE > this.availableWidth
+      COLLAPSED_SIDE_PANEL_SIZE + DEFAULT_SIDE_PANEL_SIZE > this.availableWidth
     ) {
       this.get(NotificationStore).notifyUser({
         sticky: false,
@@ -132,6 +129,10 @@ export class SidePanelStore extends SpreadsheetStore {
         text: _t("The window is too small to display multiple side panels."),
       });
       return;
+    }
+
+    if (!this.mainPanel.isCollapsed) {
+      this.toggleCollapsePanel("mainPanel");
     }
 
     this._openPanel("secondaryPanel", newPanelInfo, state);
@@ -208,6 +209,9 @@ export class SidePanelStore extends SpreadsheetStore {
       if (this.secondaryPanel) {
         this.secondaryPanel.currentPanelProps.onCloseSidePanel?.();
         this.secondaryPanel = undefined;
+        if (this.mainPanel.isCollapsed) {
+          this.toggleCollapsePanel("mainPanel");
+        }
       }
       return;
     }

--- a/tests/spreadsheet/side_panel_component.test.ts
+++ b/tests/spreadsheet/side_panel_component.test.ts
@@ -438,31 +438,49 @@ describe("Side Panel", () => {
       expect(sidePanelStore.mainPanel?.size).toBe(DEFAULT_SIDE_PANEL_SIZE);
     });
 
+    test("Opening a secondary panel collapses the pinned main panel", async () => {
+      sidePanelStore.togglePinPanel();
+      expect(sidePanelStore.mainPanel?.isCollapsed).toBeFalsy();
+
+      parent.env.openSidePanel("CUSTOM_PANEL_2");
+      await nextTick();
+      expect(sidePanelStore.mainPanel?.isCollapsed).toBe(true);
+      expect(sidePanelStore.mainPanel?.size).toBe(COLLAPSED_SIDE_PANEL_SIZE);
+      expect(sidePanelStore.secondaryPanel?.isCollapsed).toBeFalsy();
+    });
+
+    test("Closing the secondary panel expands the pinned main panel back", async () => {
+      sidePanelStore.togglePinPanel();
+      parent.env.openSidePanel("CUSTOM_PANEL_2");
+      await nextTick();
+      expect(sidePanelStore.mainPanel?.isCollapsed).toBe(true);
+
+      const closeButtons = fixture.querySelectorAll(".o-sidePanelClose");
+      await click(closeButtons[0]);
+      expect(sidePanelStore.secondaryPanel).toBeUndefined();
+      expect(sidePanelStore.mainPanel?.isCollapsed).toBe(false);
+      expect(sidePanelStore.mainPanel?.size).toBe(DEFAULT_SIDE_PANEL_SIZE);
+    });
+
     test("Can collapse both panels", async () => {
       sidePanelStore.togglePinPanel();
       parent.env.openSidePanel("CUSTOM_PANEL_2");
       await nextTick();
 
+      // opening a secondary panel automatically collapses the pinned main panel
       let panels = fixture.querySelectorAll(".o-sidePanel");
-      const collapsePanelButtons = fixture.querySelectorAll(".o-collapse-panel");
-      expect(panels[1]).not.toHaveClass("collapsed");
-      expect(sidePanelStore.mainPanel?.size).toBe(DEFAULT_SIDE_PANEL_SIZE);
+      expect(panels[1]).toHaveClass("collapsed");
+      expect(sidePanelStore.mainPanel?.size).toBe(COLLAPSED_SIDE_PANEL_SIZE);
       expect(panels[0]).not.toHaveClass("collapsed");
       expect(sidePanelStore.secondaryPanel?.size).toBe(DEFAULT_SIDE_PANEL_SIZE);
 
+      const collapsePanelButtons = fixture.querySelectorAll(".o-collapse-panel");
       await click(collapsePanelButtons[0]);
       panels = fixture.querySelectorAll(".o-sidePanel");
       expect(panels[0]).toHaveClass("collapsed");
       expect(sidePanelStore.secondaryPanel?.size).toBe(COLLAPSED_SIDE_PANEL_SIZE);
-      expect(panels[1]).not.toHaveClass("collapsed");
-      expect(sidePanelStore.mainPanel?.size).toBe(DEFAULT_SIDE_PANEL_SIZE);
-
-      await click(collapsePanelButtons[1]);
-      panels = fixture.querySelectorAll(".o-sidePanel");
-      expect(panels[0]).toHaveClass("collapsed");
-      expect(sidePanelStore.mainPanel?.size).toBe(COLLAPSED_SIDE_PANEL_SIZE);
       expect(panels[1]).toHaveClass("collapsed");
-      expect(sidePanelStore.secondaryPanel?.size).toBe(COLLAPSED_SIDE_PANEL_SIZE);
+      expect(sidePanelStore.mainPanel?.size).toBe(COLLAPSED_SIDE_PANEL_SIZE);
     });
 
     test("Cannot open two panels with the same key", async () => {
@@ -539,6 +557,9 @@ describe("Side Panel", () => {
       sidePanelStore.togglePinPanel();
       parent.env.openSidePanel("CUSTOM_PANEL_2");
       await nextTick();
+      // opening the secondary panel auto-collapsed the main panel, expand it back
+      sidePanelStore.toggleCollapsePanel("mainPanel");
+      await nextTick();
 
       const handles = fixture.querySelectorAll(".o-sidePanel-handle");
       expect(handles).toHaveLength(2);
@@ -555,6 +576,9 @@ describe("Side Panel", () => {
     test("Resizing the man panel reduces the size of the secondary panel if there is not enough space", async () => {
       sidePanelStore.togglePinPanel();
       parent.env.openSidePanel("CUSTOM_PANEL_2");
+      await nextTick();
+      // opening the secondary panel auto-collapsed the main panel, expand it back
+      sidePanelStore.toggleCollapsePanel("mainPanel");
       await nextTick();
 
       const handles = fixture.querySelectorAll(".o-sidePanel-handle");
@@ -577,7 +601,7 @@ describe("Side Panel", () => {
       await nextTick();
       expect(".o-sidePanel").toHaveCount(2);
 
-      sidePanelStore.changeSpreadsheetWidth(600);
+      sidePanelStore.changeSpreadsheetWidth(500);
       await nextTick();
 
       expect(".o-sidePanel").toHaveCount(1);
@@ -585,7 +609,7 @@ describe("Side Panel", () => {
     });
 
     test("Cannot open second size panel if the spreadsheet is too small", async () => {
-      sidePanelStore.changeSpreadsheetWidth(600);
+      sidePanelStore.changeSpreadsheetWidth(400);
       sidePanelStore.togglePinPanel();
       parent.env.openSidePanel("CUSTOM_PANEL_2");
       await nextTick();


### PR DESCRIPTION
## Task Description

When having a pinned side panel and opening another side panel, having a double side panel can take a lot of space on the screen. This PR aims to change this behavior by collapsing the pinned panel when opening another. The user can still un-collapse it if need to have both open at the same time.

- Task: [6499284](https://www.odoo.com/odoo/2328/tasks/6499284)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo