### PR TITLE
[FIX] carousel: cannot add non-existing chart to carousel

### DIFF
--- a/src/plugins/core/carousel.ts
+++ b/src/plugins/core/carousel.ts
@@ -30,6 +30,11 @@ export class CarouselPlugin extends CorePlugin<CarouselState> implements Carouse
         if (!this.carousels[cmd.sheetId]?.[cmd.figureId]) {
           return CommandResult.InvalidFigureId;
         }
+        for (const item of cmd.definition.items) {
+          if (item.type === "chart" && !this.getters.getChart(item.chartId)) {
+            return CommandResult.ChartDoesNotExist;
+          }
+        }
         return CommandResult.Success;
       }
     }

--- a/tests/figures/carousel/carousel_plugin.test.ts
+++ b/tests/figures/carousel/carousel_plugin.test.ts
@@ -144,6 +144,15 @@ describe("Carousel figure", () => {
     expect(model.getters.getFigures(sheetId)).toHaveLength(1);
   });
 
+  test("Cannot add a non-existing chart to a carousel", () => {
+    createCarousel(model, { items: [] }, "carouselId");
+    const result = updateCarousel(model, "carouselId", {
+      items: [{ type: "chart", chartId: "fakeChartId" }],
+    });
+    expect(result).toBeCancelledBecause(CommandResult.ChartDoesNotExist);
+    expect(model.getters.getCarousel("carouselId").items).toEqual([]);
+  });
+
   test("Can pop a chart out of a carousel", () => {
     createCarousel(model, { items: [] }, "carouselId");
     addNewChartToCarousel(model, "carouselId");


### PR DESCRIPTION
Adding a non-existing chart to a carousel would cause an UI crash, this commit disallow the possibility.

task: 6455790

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [6455790](https://www.odoo.com/odoo/2328/tasks/6455790)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo