### PR TITLE
[FIX] radio_selection: add focus style

### DIFF
--- a/src/components/side_panel/components/radio_selection/radio_selection.ts
+++ b/src/components/side_panel/components/radio_selection/radio_selection.ts
@@ -40,6 +40,12 @@ css/* scss */ `
         background-color: ${ACTION_COLOR};
         border-color: ${ACTION_COLOR};
       }
+
+      &:focus {
+        outline: none;
+        box-shadow: 0 0 0 0.25rem rgba(113, 75, 103, 0.25);
+        border-color: ${ACTION_COLOR};
+      }
     }
   }
 `;


### PR DESCRIPTION
Before this commit:
the absence of outline is such that changing the focus of a node in a radio button is not visible.

How to reproduce:
1. Open the design side panel of a combo chart
2. There is  radio selection buttons in the "Datas series" section (Vertical axis and serie type)
3. Click on a radio button to select it
4. Press the tab key to change the focus to the next radio button
5. The focus is not visible

After this commit:
There is a box shadow around the radio button when it is focused.

Task: [6384097](https://www.odoo.com/odoo/2328/tasks/6384097)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo