### PR TITLE
[FIX] bottom_bar_statistic: padding of the selection button

### DIFF
--- a/src/components/bottom_bar/bottom_bar_statistic/bottom_bar_statistic.css
+++ b/src/components/bottom_bar/bottom_bar_statistic/bottom_bar_statistic.css
@@ -2,7 +2,7 @@
   .o-bottom-bar-statistic {
     .o-selection-statistic {
       margin-right: 10px;
-      padding: 0px 4px 0px 8px;
+      padding: 4px 4px 4px 8px;
       cursor: pointer;
       &:hover {
         background-color: var(--os-background-gray-color-hover) !important;


### PR DESCRIPTION
Before this commit:
The selection button did not have the same height as the bottom bar, which made it look misaligned.
Unexpected behavior due to this commit e94bae05e2eaa41b8e57d2eaee7ec03f8ab4957f (task 6348280)

Task: 0

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo