### PR TITLE
[IMP] owl3: remove `env.getPopoverContainerRect`

### DIFF
--- a/src/components/dashboard/dashboard.ts
+++ b/src/components/dashboard/dashboard.ts
@@ -1,5 +1,5 @@
-import { signal, useProps } from "@odoo/owl";
-import { Component, useSubEnv } from "../../owl3_compatibility_layer";
+import { providePlugins, signal, useProps } from "@odoo/owl";
+import { Component } from "../../owl3_compatibility_layer";
 import { useLocalStore, useStore } from "../../store_engine/store_hooks";
 import { RendererStore } from "../../stores/renderer_store";
 import { ViewportsStore } from "../../stores/viewports_store";
@@ -20,6 +20,7 @@ import { useTouchHandlers } from "../helpers/touch_handlers_hook";
 import { useWheelHandler } from "../helpers/wheel_hook";
 import { CellPopoverStore } from "../popover/cell_popover_store";
 import { Popover } from "../popover/popover";
+import { PopoverContainerPlugin } from "../popover/popover_container_owl_plugin";
 import { types } from "../props_validation";
 import { HorizontalScrollBar } from "../scrollbar/scrollbar_horizontal";
 import { VerticalScrollBar } from "../scrollbar/scrollbar_vertical";
@@ -60,7 +61,7 @@ export class SpreadsheetDashboard extends Component<SpreadsheetChildEnv> {
 
     const layers = OrderedLayers().filter((layer) => layer !== "Headers");
     const rendererStore = useLocalStore(RendererStore, layers);
-    useSubEnv({
+    providePlugins([PopoverContainerPlugin], {
       getPopoverContainerRect: () => this.zoomStore.getZoomedRect(this.getGridRect()),
     });
 

--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -1,4 +1,4 @@
-import { onMounted, proxy, signal, useListener, useProps } from "@odoo/owl";
+import { onMounted, providePlugins, proxy, signal, useListener, useProps } from "@odoo/owl";
 import { insertSheet, insertTable } from "../../actions/insert_actions";
 import {
   CREATE_IMAGE,
@@ -22,7 +22,7 @@ import {
   interactivePasteFromOS,
 } from "../../helpers/ui/paste_interactive";
 import { isInside } from "../../helpers/zones";
-import { Component, useLayoutEffect, useSubEnv } from "../../owl3_compatibility_layer";
+import { Component, useLayoutEffect } from "../../owl3_compatibility_layer";
 import { cellMenuRegistry } from "../../registries/menus/cell_menu_registry";
 import { colMenuRegistry } from "../../registries/menus/col_menu_registry";
 import {
@@ -80,6 +80,7 @@ import { MenuPopover, MenuState } from "../menu_popover/menu_popover";
 import { PaintFormatStore } from "../paint_format_button/paint_format_store";
 import { CellPopoverStore } from "../popover/cell_popover_store";
 import { Popover } from "../popover/popover";
+import { PopoverContainerPlugin } from "../popover/popover_container_owl_plugin";
 import { types } from "../props_validation";
 import { HorizontalScrollBar } from "../scrollbar/scrollbar_horizontal";
 import { VerticalScrollBar } from "../scrollbar/scrollbar_vertical";
@@ -183,7 +184,7 @@ export class Grid extends Component<SpreadsheetChildEnv> {
     useStore(ArrayFormulaHighlight);
     this.automaticSumStore = useLocalStore(AutomaticSumStore);
 
-    useSubEnv({ getPopoverContainerRect: () => this.getGridRect() });
+    providePlugins([PopoverContainerPlugin], { getPopoverContainerRect: () => this.getGridRect() });
     useListener(document.body, "cut", this.copy.bind(this, true));
     useListener(document.body, "copy", this.copy.bind(this, false));
     useListener(document.body, "paste", this.paste.bind(this));

--- a/src/components/grid_popover/grid_popover.xml
+++ b/src/components/grid_popover/grid_popover.xml
@@ -6,7 +6,6 @@
       maxHeight="this.cellPopover.Component.size and this.cellPopover.Component.size.maxHeight"
       maxWidth="this.cellPopover.Component.size and this.cellPopover.Component.size.maxWidth"
       anchorRect="this.cellPopover.anchorRect"
-      containerRect="this.env.getPopoverContainerRect()"
       onMouseWheel="this.props.onMouseWheel"
       class="'o-popover-grid-index'">
       <t

--- a/src/components/helpers/position_hook.ts
+++ b/src/components/helpers/position_hook.ts
@@ -1,6 +1,6 @@
-import { onMounted, onPatched, proxy } from "@odoo/owl";
-import { useComponent } from "../../owl3_compatibility_layer";
+import { onMounted, onPatched, proxy, usePlugin } from "@odoo/owl";
 import { Rect } from "../../types/rendering";
+import { PopoverContainerPlugin } from "../popover/popover_container_owl_plugin";
 
 /**
  * Return the o-spreadsheet element position relative
@@ -35,14 +35,9 @@ export function useSpreadsheetRect(): Rect {
  */
 export function usePopoverContainer(): Rect {
   const container = proxy({ x: 0, y: 0, width: 0, height: 0 });
-  const component = useComponent();
-  const spreadsheetRect = useSpreadsheetRect();
+  const popoverContainerPlugin = usePlugin(PopoverContainerPlugin);
   function updateRect() {
-    const env = component.env;
-    const newRect =
-      "getPopoverContainerRect" in env && env.getPopoverContainerRect
-        ? env.getPopoverContainerRect()
-        : spreadsheetRect;
+    const newRect = popoverContainerPlugin.getContainerRect();
     container.x = newRect.x;
     container.y = newRect.y;
     container.width = newRect.width;

--- a/src/components/popover/popover.ts
+++ b/src/components/popover/popover.ts
@@ -15,7 +15,6 @@ export class Popover extends Component<SpreadsheetChildEnv> {
 
   protected props = useProps({
     anchorRect: types.Rect(),
-    containerRect: types.object({}).optional(),
     positioning: types
       .or([types.literal("top-right"), types.literal("bottom-left")])
       .optional("bottom-left"),

--- a/src/components/popover/popover_container_owl_plugin.ts
+++ b/src/components/popover/popover_container_owl_plugin.ts
@@ -1,0 +1,6 @@
+import { Plugin, useConfig } from "@odoo/owl";
+import { Rect } from "../../types/rendering";
+
+export class PopoverContainerPlugin extends Plugin {
+  getContainerRect: () => Rect = useConfig("getPopoverContainerRect");
+}

--- a/src/components/spreadsheet/spreadsheet.ts
+++ b/src/components/spreadsheet/spreadsheet.ts
@@ -3,6 +3,7 @@ import {
   onPatched,
   onWillUnmount,
   onWillUpdateProps,
+  providePlugins,
   proxy,
   signal,
   useEffect,
@@ -40,12 +41,14 @@ import { Grid } from "../grid/grid";
 import { HeaderGroupContainer } from "../header_group/header_group_container";
 import { cssPropertiesToCss } from "../helpers/css";
 import {
+  getElBoundingRect,
   isMobileOS,
   keyboardEventToShortcutString,
   zoomCorrectedElementRect,
 } from "../helpers/dom_helpers";
 import { useSpreadsheetRect } from "../helpers/position_hook";
 import { useScreenWidth } from "../helpers/screen_width_hook";
+import { PopoverContainerPlugin } from "../popover/popover_container_owl_plugin";
 import { types } from "../props_validation";
 import { DEFAULT_SIDE_PANEL_SIZE, SidePanelStore } from "../side_panel/side_panel/side_panel_store";
 import { SidePanels } from "../side_panel/side_panels/side_panels";
@@ -141,6 +144,10 @@ export class Spreadsheet extends Component<SpreadsheetChildEnv> {
     stores.inject(ModelStore, this.model);
     this.viewStore = useStore(ViewportsStore);
     this.zoomStore = useStore(ZoomStore);
+
+    providePlugins([PopoverContainerPlugin], {
+      getPopoverContainerRect: () => getElBoundingRect(this.spreadsheetRef()),
+    });
 
     const env = this.env;
     stores.get(ScreenWidthStore).setSmallThreshhold(() => {

--- a/tests/borders/border_editor_widget_component.test.ts
+++ b/tests/borders/border_editor_widget_component.test.ts
@@ -1,6 +1,7 @@
-import { proxy, xml } from "@odoo/owl";
+import { providePlugins, proxy, xml } from "@odoo/owl";
 import { BorderPosition, BorderStyle, Color, Model } from "../../src";
 import { BorderEditorWidget } from "../../src/components/border_editor/border_editor_widget";
+import { PopoverContainerPlugin } from "../../src/components/popover/popover_container_owl_plugin";
 import { toHex } from "../../src/helpers/color";
 import { toZone } from "../../src/helpers/zones";
 import { Component } from "../../src/owl3_compatibility_layer";
@@ -49,6 +50,10 @@ class BorderWidgetContainer extends Component<SpreadsheetChildEnv> {
   setup() {
     this.state = proxy({
       showBorderEditor: false,
+    });
+
+    providePlugins([PopoverContainerPlugin], {
+      getPopoverContainerRect: () => ({ x: 0, y: 0, height: 1000, width: 1000 }),
     });
   }
 

--- a/tests/figures/carousel/standalone_viewport.test.ts
+++ b/tests/figures/carousel/standalone_viewport.test.ts
@@ -1,10 +1,11 @@
+import { providePlugins } from "@odoo/owl";
 import { Model, UID } from "../../../src";
 import { HoveredIconStore } from "../../../src/components/grid_overlay/hovered_icon_store";
+import { PopoverContainerPlugin } from "../../../src/components/popover/popover_container_owl_plugin";
 import { StandaloneViewport } from "../../../src/components/standalone_viewport/standalone_viewport";
 import { DEFAULT_CELL_HEIGHT, TABLE_HOVER_BACKGROUND_COLOR } from "../../../src/constants";
 import { buildSheetLink, range } from "../../../src/helpers/misc";
 import { zoneToXc } from "../../../src/helpers/zones";
-import { useSubEnv } from "../../../src/owl3_compatibility_layer";
 import { CellHoverOverlayStore } from "../../../src/stores/cell_hover_overlay_store";
 import { GridRenderer } from "../../../src/stores/grid_renderer_store";
 import { ViewportsStore } from "../../../src/stores/viewports_store";
@@ -63,8 +64,7 @@ beforeEach(() => {
     .spyOn(StandaloneViewport.prototype, "setup")
     .mockImplementation(function (this: StandaloneViewport) {
       originalSetup.call(this);
-      // In real life this is defined by the standalone viewport's parent (grid)
-      useSubEnv({
+      providePlugins([PopoverContainerPlugin], {
         getPopoverContainerRect: () => ({ x: 0, y: 0, width: 1000, height: 1000 }),
       });
       subEnv = this.env;

--- a/tests/menus/context_menu_component.test.ts
+++ b/tests/menus/context_menu_component.test.ts
@@ -1,4 +1,4 @@
-import { useProps, xml } from "@odoo/owl";
+import { providePlugins, useProps, xml } from "@odoo/owl";
 import { Action, ActionSpec, createActions } from "../../src/actions/action";
 import { MenuPopover } from "../../src/components/menu_popover/menu_popover";
 import {
@@ -27,6 +27,7 @@ import {
 import { getCell, getCellContent, getEvaluatedCell } from "../test_helpers/getters_helpers";
 
 import { Rect } from "../../src";
+import { PopoverContainerPlugin } from "../../src/components/popover/popover_container_owl_plugin";
 import { types } from "../../src/components/props_validation";
 import { render } from "../../src/helpers/owl3_helpers";
 import { PopoverPropsPosition } from "../../src/types/cell_popovers";
@@ -214,6 +215,12 @@ class ContextMenuParent extends Component {
     };
     this.menus = this.props.config.menuItems || createActions([makeTestMenuItem("Action")]);
     resizeSheetView(this.env, { height: this.props.height, width: this.props.width });
+  }
+
+  setup() {
+    providePlugins([PopoverContainerPlugin], {
+      getPopoverContainerRect: () => ({ x: 0, y: 0, height: 1000, width: 1000 }),
+    });
   }
 }
 

--- a/tests/popover/popover_component.test.ts
+++ b/tests/popover/popover_component.test.ts
@@ -1,6 +1,7 @@
-import { App, useProps, xml } from "@odoo/owl";
+import { providePlugins, useProps, xml } from "@odoo/owl";
 import { Model, Pixel, Rect } from "../../src";
 import { Popover } from "../../src/components/popover/popover";
+import { PopoverContainerPlugin } from "../../src/components/popover/popover_container_owl_plugin";
 import { types } from "../../src/components/props_validation";
 import { getDefaultSheetViewSize } from "../../src/constants";
 import { Component, useSubEnv } from "../../src/owl3_compatibility_layer";
@@ -13,7 +14,6 @@ const POPOVER_WIDTH = 200;
 
 let fixture: HTMLElement;
 let model: Model;
-let app: App;
 
 interface MountPopoverArgs extends Partial<PropsOf<Popover>> {
   childWidth?: Pixel;
@@ -39,9 +39,10 @@ async function mountTestPopover(args: MountPopoverArgs) {
       const env: any = {
         model: this.props.model,
       };
-      if (args.containerRect) {
-        env.getPopoverContainerRect = () => args.containerRect;
-      }
+      providePlugins([PopoverContainerPlugin], {
+        getPopoverContainerRect: () =>
+          args.containerRect || { x: 0, y: 0, height: 1000, width: 1000 },
+      });
       useSubEnv(env);
     }
 
@@ -55,7 +56,7 @@ async function mountTestPopover(args: MountPopoverArgs) {
     }
   }
 
-  ({ fixture, app } = await mountComponent(Parent, { props: { model } }));
+  ({ fixture } = await mountComponent(Parent, { props: { model } }));
 }
 
 beforeEach(async () => {
@@ -312,40 +313,6 @@ describe("Popover positioning", () => {
     });
     const popover = fixture.querySelector(".o-popover")! as HTMLElement;
     expect(popover).toBeTruthy();
-    expect(popover.style.display).toEqual("none");
-  });
-
-  test("The containerRect is the spreadsheet element if it is not explicitly in the popover props", async () => {
-    extendMockGetBoundingClientRect({
-      "o-spreadsheet": () => ({ x: 200, y: 200, width: 1000, height: 1000 }),
-    });
-    await mountTestPopover({
-      anchorRect: { x: 0, y: 0, width: 0, height: 0 },
-      positioning: "bottom-left",
-      childHeight: 100,
-      childWidth: 100,
-    });
-    let popover = fixture.querySelector(".o-popover")! as HTMLElement;
-    expect(popover.style.display).toEqual("none");
-
-    app.destroy();
-    await mountTestPopover({
-      anchorRect: { x: 300, y: 300, width: 0, height: 0 },
-      positioning: "bottom-left",
-      childHeight: 100,
-      childWidth: 100,
-    });
-    popover = fixture.querySelector(".o-popover")! as HTMLElement;
-    expect(popover.style.display).toEqual("block");
-
-    app.destroy();
-    await mountTestPopover({
-      anchorRect: { x: 1400, y: 1400, width: 0, height: 0 },
-      positioning: "bottom-left",
-      childHeight: 100,
-      childWidth: 100,
-    });
-    popover = fixture.querySelector(".o-popover")! as HTMLElement;
     expect(popover.style.display).toEqual("none");
   });
 

--- a/tests/table/table_dropdown_button_component.test.ts
+++ b/tests/table/table_dropdown_button_component.test.ts
@@ -1,5 +1,6 @@
-import { xml } from "@odoo/owl";
+import { providePlugins, xml } from "@odoo/owl";
 import { Model, UID } from "../../src";
+import { PopoverContainerPlugin } from "../../src/components/popover/popover_container_owl_plugin";
 import { SidePanels } from "../../src/components/side_panel/side_panels/side_panels";
 import { TableDropdownButton } from "../../src/components/tables/table_dropdown_button/table_dropdown_button";
 import { toZone, zoneToXc } from "../../src/helpers/zones";
@@ -22,6 +23,12 @@ class Parent extends Component<SpreadsheetChildEnv> {
     <SidePanels />
   </div>
   `;
+
+  setup() {
+    providePlugins([PopoverContainerPlugin], {
+      getPopoverContainerRect: () => ({ x: 0, y: 0, height: 1000, width: 1000 }),
+    });
+  }
 }
 
 beforeEach(async () => {

--- a/tests/test_helpers/helpers.ts
+++ b/tests/test_helpers/helpers.ts
@@ -1,4 +1,4 @@
-import { proxy, useProps, xml } from "@odoo/owl";
+import { providePlugins, proxy, useProps, xml } from "@odoo/owl";
 import { type ChartConfiguration } from "chart.js";
 import format from "xml-formatter";
 import { functionCache, type StoreConstructor } from "../../src";
@@ -54,6 +54,7 @@ import {
   UID,
   Zone,
 } from "../../src";
+import { PopoverContainerPlugin } from "../../src/components/popover/popover_container_owl_plugin";
 import { computeFunctionsCache } from "../../src/formulas/compiler";
 import { getItemId } from "../../src/helpers/data_normalization";
 import { detectDateFormat } from "../../src/helpers/format/format";
@@ -291,6 +292,12 @@ class ParentWithPortalTarget extends Component<SpreadsheetChildEnv> {
     </div>
   `;
   protected props = useProps() as unknown as ParentProps;
+
+  setup() {
+    providePlugins([PopoverContainerPlugin], {
+      getPopoverContainerRect: () => ({ x: 0, y: 0, height: 1000, width: 1000 }),
+    });
+  }
 }
 
 interface MountComponentArgs<Props extends ComponentProps> {

--- a/tests/top_bar_component.test.ts
+++ b/tests/top_bar_component.test.ts
@@ -1,7 +1,8 @@
-import { xml } from "@odoo/owl";
+import { providePlugins, xml } from "@odoo/owl";
 import { Currency, Model, Pixel, Style } from "../src";
 import { CellComposerStore } from "../src/components/composer/composer/cell_composer_store";
 import { PaintFormatStore } from "../src/components/paint_format_button/paint_format_store";
+import { PopoverContainerPlugin } from "../src/components/popover/popover_container_owl_plugin";
 import { TopBar } from "../src/components/top_bar/top_bar";
 import { topBarToolBarRegistry } from "../src/components/top_bar/top_bar_tools_registry";
 import { DEFAULT_FONT_SIZE } from "../src/constants";
@@ -126,6 +127,17 @@ class Parent extends Component<SpreadsheetChildEnv> {
   get gridHeight(): Pixel {
     const { height } = this.env.getStore(ViewportsStore).sheetViewDimension;
     return height;
+  }
+
+  setup() {
+    providePlugins([PopoverContainerPlugin], {
+      getPopoverContainerRect: () => ({
+        x: 0,
+        y: 0,
+        height: spreadsheetHeight,
+        width: spreadsheetWidth,
+      }),
+    });
   }
 }
 


### PR DESCRIPTION
## Description

This commit replaces the usage of `env.getPopoverContainerRect()` by an owl plugin `PopoverContainerPlugin`.

Some notes:
- there was an unused props `containerRect` for the Popover component
- the plugin is not reactive, we still need the `usePopoverContainer` hook. We'd need to make the zoom store and the viewport store reactive, and change Popover to use useEffect instead of useLayoutEffect.

Task: [6510584](https://www.odoo.com/odoo/2328/tasks/6510584)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo