### PR TITLE
[FIX] charts: calendar charts cannot be aggregated

### DIFF
--- a/src/components/side_panel/chart/calendar_chart/calendar_chart_config_panel.xml
+++ b/src/components/side_panel/chart/calendar_chart/calendar_chart_config_panel.xml
@@ -7,7 +7,7 @@
         updateChart="props.updateChart"
         canUpdateChart="props.canUpdateChart"
         onErrorMessagesChanged.bind="onErrorMessagesChanged"
-        getLabelRangeOptions.bind="getLabelRangeOptions"
+        getLabelRangeOptions="() => []"
         labelRangeTitle.translate="Date range"
       />
 

--- a/src/components/side_panel/chart/hierarchical_chart/hierarchical_chart_config_panel.xml
+++ b/src/components/side_panel/chart/hierarchical_chart/hierarchical_chart_config_panel.xml
@@ -7,7 +7,7 @@
         updateChart="props.updateChart"
         canUpdateChart="props.canUpdateChart"
         onErrorMessagesChanged.bind="onErrorMessagesChanged"
-        getLabelRangeOptions.bind="getLabelRangeOptions"
+        getLabelRangeOptions="() => []"
         dataSeriesTitle.translate="Hierarchy"
         labelRangeTitle.translate="Values"
       />

--- a/tests/figures/chart/calendar/calendar_chart_panel_component.test.ts
+++ b/tests/figures/chart/calendar/calendar_chart_panel_component.test.ts
@@ -61,6 +61,7 @@ describe("Calendar chart side panel", () => {
       expect(".o-data-labels input").toHaveValue("A1:A3");
       expect(".o-horizontal-group-by").toHaveText("Day of Week");
       expect(".o-vertical-group-by").toHaveText("Month");
+      expect('input[name="aggregated"]').toHaveCount(0);
     });
 
     test("Only one data range is enabled", async () => {

--- a/tests/figures/chart/sunburst/sunburst_panel_component.test.ts
+++ b/tests/figures/chart/sunburst/sunburst_panel_component.test.ts
@@ -51,6 +51,7 @@ describe("Sunburst chart side panel", () => {
       expect(getHTMLInputValue(".o-data-series input")).toEqual("A1:A3");
       expect(getHTMLInputValue(".o-data-labels input")).toEqual("B1:B3");
       expect(getHTMLCheckboxValue('input[name="dataSetsHaveTitle"]')).toBe(true);
+      expect('input[name="aggregated"]').toHaveCount(0);
     });
 
     test("Can change chart values in config side panel", async () => {

--- a/tests/figures/chart/treemap/treemap_panel_component.test.ts
+++ b/tests/figures/chart/treemap/treemap_panel_component.test.ts
@@ -51,6 +51,7 @@ describe("TreeMap chart side panel", () => {
       expect(getHTMLInputValue(".o-data-series input")).toEqual("A1:A3");
       expect(getHTMLInputValue(".o-data-labels input")).toEqual("B1:B3");
       expect(getHTMLCheckboxValue('input[name="dataSetsHaveTitle"]')).toBe(true);
+      expect('input[name="aggregated"]').toHaveCount(0);
     });
 
     test("Can change chart values in config side panel", async () => {


### PR DESCRIPTION
## Description

Since the big chart datasource refactor, the `aggregate` checkbox appeared in the calendar chart side panels, even though it's not an option for calendar charts (they are always aggregated).

Task: [6501177](https://www.odoo.com/odoo/2328/tasks/6501177)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo