### PR TITLE
[FIX] cf: color is picked when no color

### DIFF
--- a/src/components/side_panel/conditional_formatting/cf_editor/cell_is_rule_editor.xml
+++ b/src/components/side_panel/conditional_formatting/cf_editor/cell_is_rule_editor.xml
@@ -60,7 +60,7 @@
           <t t-call="o-spreadsheet-Icon.STRIKE"/>
         </div>
         <ColorPickerWidget
-          currentColor="this.rule.style.textColor || '#000000'"
+          currentColor="this.rule.style.textColor"
           toggleColorPicker="() => this.props.store.toggleMenu('cellIsRule-textColor')"
           showColorPicker="this.props.store.state.openedMenu === 'cellIsRule-textColor'"
           onColorPicked="(color) => this.props.store.setColor('textColor', color)"

--- a/tests/conditional_formatting/conditional_formatting_panel_component.test.ts
+++ b/tests/conditional_formatting/conditional_formatting_panel_component.test.ts
@@ -905,6 +905,18 @@ describe("UI of conditional formats", () => {
         expect(style.textDecoration).toBe("line-through");
       });
 
+      test("no color is selected in the text color picker when the rule has no text color", async () => {
+        await click(fixture, selectors.buttonAdd);
+
+        const textColorButton = `${selectors.editorPanel} .o-color-picker-button[title="Text Color"]`;
+        await click(fixture, textColorButton);
+        expect(".o-color-picker-line-item[data-color='#000000'] div").toHaveCount(0);
+
+        await click(fixture, ".o-color-picker-line-item[data-color='#000000']");
+        await click(fixture, textColorButton);
+        expect(".o-color-picker-line-item[data-color='#000000'] div").toHaveCount(1);
+      });
+
       test("can create a new CellIsRule", async () => {
         await click(fixture, selectors.buttonAdd);
         await nextTick();


### PR DESCRIPTION
Task: 6515043

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [6515043](https://www.odoo.com/odoo/2328/tasks/6515043)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo