### PR TITLE
[REF] owl3: remove `t-custom-model` usage

### DIFF
--- a/src/components/link/link_editor/link_editor.ts
+++ b/src/components/link/link_editor/link_editor.ts
@@ -53,6 +53,11 @@ export class LinkEditor extends Component<SpreadsheetChildEnv> {
     onMounted(() => this.urlInput()?.focus());
   }
 
+  onLinkUrlInput(ev: InputEvent) {
+    this.state.url = (ev.target as HTMLInputElement).value;
+    this.computeLinks();
+  }
+
   computeLinks() {
     this.state.selectedIndex = null;
     this.state.linksByCategory = this.linkProposalByCategory;

--- a/src/components/link/link_editor/link_editor.xml
+++ b/src/components/link/link_editor/link_editor.xml
@@ -13,7 +13,8 @@
             title="Link label"
             placeholder="e.g. 'Link label'"
             class="o-input"
-            t-custom-model="this.state.label"
+            t-att-value="this.state.label"
+            t-on-input="(ev) => this.state.label = ev.target.value"
           />
         </div>
 
@@ -30,8 +31,8 @@
               placeholder="e.g. 'http://www.odoo.com'"
               title="Link URL"
               t-ref="this.urlInput"
-              t-custom-model="this.state.url"
-              t-on-input="this.computeLinks"
+              t-att-value="this.state.url"
+              t-on-input="this.onLinkUrlInput"
             />
           </t>
           <t t-else="">

--- a/src/components/side_panel/find_and_replace/find_and_replace.ts
+++ b/src/components/side_panel/find_and_replace/find_and_replace.ts
@@ -150,6 +150,10 @@ export class FindAndReplacePanel extends Component<SpreadsheetChildEnv> {
     this.updateSearchContent((ev.target as HTMLInputElement).value);
   }
 
+  onReplaceInput(ev: InputEvent) {
+    this.store.updateReplaceContent((ev.target as HTMLInputElement).value);
+  }
+
   onKeydownPanel(ev: KeyboardEvent) {
     if (ev.key === "Escape") {
       ev.preventDefault();

--- a/src/components/side_panel/find_and_replace/find_and_replace.xml
+++ b/src/components/side_panel/find_and_replace/find_and_replace.xml
@@ -117,7 +117,8 @@
               type="text"
               class="o-input o-input-without-count o-replace"
               t-on-keydown="this.onKeydownReplace"
-              t-custom-model="this.store.toReplace"
+              t-att-value="this.store.toReplace"
+              t-on-input="this.onReplaceInput"
               placeholder="e.g. 'replace me'"
             />
           </div>

--- a/src/components/side_panel/find_and_replace/find_and_replace_store.ts
+++ b/src/components/side_panel/find_and_replace/find_and_replace_store.ts
@@ -29,6 +29,7 @@ export class FindAndReplaceStore extends SpreadsheetStore implements HighlightPr
   mutators = [
     "updateSearchOptions",
     "updateSearchContent",
+    "updateReplaceContent",
     "searchFormulas",
     "selectPreviousMatch",
     "selectNextMatch",
@@ -93,6 +94,10 @@ export class FindAndReplaceStore extends SpreadsheetStore implements HighlightPr
 
   updateSearchContent(toSearch: string) {
     this._updateSearch(toSearch, this.searchOptions);
+  }
+
+  updateReplaceContent(toReplace: string) {
+    this.toReplace = toReplace;
   }
 
   updateSearchOptions(searchOptions: Partial<SearchOptions>) {

--- a/src/components/side_panel/table_style_editor_panel/table_style_editor_panel.ts
+++ b/src/components/side_panel/table_style_editor_panel/table_style_editor_panel.ts
@@ -9,6 +9,7 @@ import { TableConfig, TableStyle, TableStyleTemplateName } from "../../../types/
 import { cssPropertiesToCss } from "../../helpers/css";
 import { types } from "../../props_validation";
 import { TableStylePreview } from "../../tables/table_style_preview/table_style_preview";
+import { TextInput } from "../../text_input/text_input";
 import { RoundColorPicker } from "../components/round_color_picker/round_color_picker";
 import { Section } from "../components/section/section";
 
@@ -23,7 +24,7 @@ interface State {
 
 export class TableStyleEditorPanel extends Component<SpreadsheetChildEnv> {
   static template = "o-spreadsheet-TableStyleEditorPanel";
-  static components = { Section, RoundColorPicker, TableStylePreview };
+  static components = { Section, RoundColorPicker, TableStylePreview, TextInput };
   protected props = useProps({
     onCloseSidePanel: types.function(),
     onStylePicked: types.function<(styleId: string) => void>().optional(),

--- a/src/components/side_panel/table_style_editor_panel/table_style_editor_panel.xml
+++ b/src/components/side_panel/table_style_editor_panel/table_style_editor_panel.xml
@@ -2,7 +2,11 @@
   <t t-name="o-spreadsheet-TableStyleEditorPanel">
     <div class="o-table-style-editor-panel">
       <Section title.translate="Style name">
-        <input type="text" class="o-input" t-custom-model="this.state.styleName"/>
+        <TextInput
+          value="this.state.styleName"
+          onChange="(value) => this.state.styleName = value"
+          alwaysShowBorder="true"
+        />
       </Section>
       <Section class="'pt-1'" title.translate="Style color">
         <RoundColorPicker

--- a/src/owl3_compatibility_layer.ts
+++ b/src/owl3_compatibility_layer.ts
@@ -12,7 +12,6 @@
  *
  * 1. Update template directives:
  *    - replace `t-portal` → `t-custom-portal`
- *    - replace `t-model`  → `t-custom-model`
  *
  * 2. Load this file immediately after Owl 3.
  *
@@ -27,7 +26,6 @@
  * Gradually remove the compatibility layer by migrating to native Owl 3:
  *
  * - replace `t-custom-portal` with proper Owl 3 portal usage
- * - replace `t-custom-model` with `t-model` + signals
  * - convert `useLayoutEffect` back to `useEffect` where appropriate
  *
  * The end goal is to eliminate all compatibility shims.
@@ -234,20 +232,6 @@ const customDirectives = {
   /**
    * @param {HTMLElement} node
    * @param {string} value
-   * @param {string[]} modifiers
-   */
-  model: (node, value, modifiers) => {
-    let attribute = "t-model";
-    for (const modifier of modifiers) {
-      attribute += `.${modifier}`;
-    }
-    const getter = `() => ${value}`;
-    const setter = `(nv) => {${value} = nv;}`;
-    node.setAttribute(attribute, `__globals__.createModelSignal(${getter}, ${setter})`);
-  },
-  /**
-   * @param {HTMLElement} node
-   * @param {string} value
    */
   portal: (node, value) => {
     if (node.nodeName.toLowerCase() !== "t") {
@@ -284,11 +268,6 @@ const globalValues = {
       },
     };
   },
-  /**
-   * @param {Function} getter
-   * @param {Function} setter
-   */
-  createModelSignal: (getter, setter) => Object.assign(getter, { set: setter }),
   Portal,
 };
 


### PR DESCRIPTION
## Description

This commit removes the usage of the owl2 compatibility directive `t-custom-model`.

Also took the occasion to change the input in the table style editor into a `TextInput` component. The others were left unchanged, as they had a bit more specific behaviour not yet supported by `TextInput` (t-ref, disabled, title, etc.).

The replace input was also wrongly editing the store state directly.

Task: [6515136](https://www.odoo.com/odoo/2328/tasks/6515136)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo