### PR TITLE
[IMP] chart: evaluation do not rely on UI getter

### DIFF
--- a/src/actions/figure_menu_actions.ts
+++ b/src/actions/figure_menu_actions.ts
@@ -234,7 +234,12 @@ function getCopyAsImageMenuItem(figureId: UID, env: SpreadsheetChildEnv): Action
       }
       const chartType = env.model.getters.getChartType(chartId);
       const runtime = env.model.getters.getChartRuntime(chartId);
-      const blob = await chartToImageFile(runtime, figure, chartType);
+      const blob = await chartToImageFile(
+        runtime,
+        figure,
+        chartType,
+        env.model.getters.getSpreadsheetTheme().colorThemeName
+      );
       if (!blob) {
         return;
       }
@@ -280,7 +285,12 @@ function getDownloadChartMenuItem(figureId: UID, env: SpreadsheetChildEnv): Acti
       }
       const chartType = env.model.getters.getChartType(chartId);
       const runtime = env.model.getters.getChartRuntime(chartId);
-      const url = await chartToImageUrl(runtime, figure, chartType);
+      const url = await chartToImageUrl(
+        runtime,
+        figure,
+        chartType,
+        env.model.getters.getSpreadsheetTheme().colorThemeName
+      );
       if (!url) {
         return;
       }

--- a/src/components/helpers/chart_drag_and_drop.ts
+++ b/src/components/helpers/chart_drag_and_drop.ts
@@ -145,7 +145,8 @@ export function startChartDragAndDrop(
 
       const runtime = SpreadsheetChart.fromStrDefinition(getters, sheetId, definition).getRuntime(
         getters,
-        "newChart"
+        "newChart",
+        getters.getSpreadsheetTheme().colorThemeName
       );
       destroyChart = drawChartOnCanvas(canvas, runtime, { width, height }, definition.type, zoom);
     }

--- a/src/components/side_panel/chart/calendar_chart/calendar_chart_config_panel.ts
+++ b/src/components/side_panel/chart/calendar_chart/calendar_chart_config_panel.ts
@@ -39,7 +39,8 @@ export class CalendarChartConfigPanel extends GenericChartConfigPanel<
     const data = getBarChartData(
       definition,
       getChartData(this.env.model.getters, definition.dataSource as ChartRangeDataSource),
-      this.env.model.getters
+      this.env.model.getters,
+      this.env.model.getters.getSpreadsheetTheme().colorThemeName
     );
     const labels = data.labels.filter((l) => isDateTime(l, DEFAULT_LOCALE));
     if (labels.length === 0) {

--- a/src/components/side_panel/data_analysis/chart_suggestion_preview.ts
+++ b/src/components/side_panel/data_analysis/chart_suggestion_preview.ts
@@ -41,7 +41,11 @@ export class ChartSuggestionPreview extends Component<SpreadsheetChildEnv> {
     const getters = this.env.model.getters;
     const activeSheetId = getters.getActiveSheetId();
     const chart = SpreadsheetChart.fromStrDefinition(getters, activeSheetId, this.props.definition);
-    const runtime = chart.getRuntime(getters, "myChart");
+    const runtime = chart.getRuntime(
+      getters,
+      "myChart",
+      getters.getSpreadsheetTheme().colorThemeName
+    );
     if (!("chartJsConfig" in runtime)) {
       return null;
     }
@@ -146,7 +150,11 @@ export class ChartSuggestionPreview extends Component<SpreadsheetChildEnv> {
       getters.getActiveSheetId(),
       this.props.definition
     );
-    let runtime = chart.getRuntime(getters, "myChart");
+    let runtime = chart.getRuntime(
+      getters,
+      "myChart",
+      getters.getSpreadsheetTheme().colorThemeName
+    );
     const { type } = this.props.definition;
     if (type === "scorecard") {
       const rect = canvas.getBoundingClientRect();

--- a/src/helpers/color_themes.ts
+++ b/src/helpers/color_themes.ts
@@ -1,0 +1,41 @@
+import { ColorThemeName, GridRenderingTheme } from "../types/rendering";
+import { adaptForDarkMode } from "./color";
+
+const FROZEN_PANE_HEADER_BORDER_COLOR = "#BCBCBC";
+const FROZEN_PANE_BORDER_COLOR = "#DADFE8";
+const HEADER_BORDER_COLOR = "#C0C0C0";
+const TEXT_HEADER_COLOR = "#666666";
+const BACKGROUND_HEADER_COLOR = "#F8F9FA";
+const BACKGROUND_HEADER_SELECTED_COLOR = "#E8EAED";
+const BACKGROUND_HEADER_ACTIVE_COLOR = "#595959";
+
+export const COLOR_THEMES: Record<ColorThemeName, GridRenderingTheme> = {
+  light: {
+    colorThemeName: "light",
+    backgroundColor: "#FFFFFF",
+    gridBorderColor: "#CECFCF",
+    headerBackgroundColor: BACKGROUND_HEADER_COLOR,
+    headerActiveBackgroundColor: BACKGROUND_HEADER_ACTIVE_COLOR,
+    headerSelectedBackgroundColor: BACKGROUND_HEADER_SELECTED_COLOR,
+    headerTextColor: TEXT_HEADER_COLOR,
+    headerBorderColor: HEADER_BORDER_COLOR,
+    frozenPaneBorderColor: FROZEN_PANE_BORDER_COLOR,
+    frozenPaneHeaderBorderColor: FROZEN_PANE_HEADER_BORDER_COLOR,
+    singleCellSelectionBackgroundColor: "#F3F7FE",
+    multipleCellsSelectionBackgroundColor: "#E9F0FF",
+  },
+  dark: {
+    colorThemeName: "dark",
+    backgroundColor: adaptForDarkMode("#1A1C2E"),
+    gridBorderColor: adaptForDarkMode("#6B706F"),
+    headerBackgroundColor: adaptForDarkMode("#262A36"),
+    headerActiveBackgroundColor: adaptForDarkMode("#3A4052"),
+    headerSelectedBackgroundColor: adaptForDarkMode("#4E566E"),
+    headerTextColor: adaptForDarkMode("#A1A6B3"),
+    headerBorderColor: adaptForDarkMode("#7A7F91"),
+    frozenPaneBorderColor: adaptForDarkMode("#7A7F91"),
+    frozenPaneHeaderBorderColor: adaptForDarkMode("#9FA5BD"),
+    singleCellSelectionBackgroundColor: adaptForDarkMode("#696E8044"),
+    multipleCellsSelectionBackgroundColor: adaptForDarkMode("#828AA044"),
+  },
+};

--- a/src/helpers/figures/chart.ts
+++ b/src/helpers/figures/chart.ts
@@ -19,6 +19,7 @@ import { CoreGetters } from "../../types/core_getters";
 import { Getters } from "../../types/getters";
 import { RangeAdapterFunctions, UID } from "../../types/misc";
 import { Range } from "../../types/range";
+import { ColorThemeName } from "../../types/rendering";
 import { Validator } from "../../types/validator";
 
 export class SpreadsheetChart {
@@ -190,7 +191,7 @@ export class SpreadsheetChart {
     return this.chartTypeBuilder.getFormulas(getters, this.sheetId, this.definition);
   }
 
-  getRuntime(getters: Getters, chartId: UID) {
+  getRuntime(getters: Getters, chartId: UID, colorThemeName: ColorThemeName) {
     const dataSource = this.dataSource;
     const dataExtractors = dataSource
       ? {
@@ -227,7 +228,8 @@ export class SpreadsheetChart {
       this.definition,
       dataExtractors,
       this.sheetId,
-      eventHandlers
+      eventHandlers,
+      colorThemeName
     );
   }
 

--- a/src/helpers/figures/charts/bar_chart.ts
+++ b/src/helpers/figures/charts/bar_chart.ts
@@ -2,6 +2,7 @@ import type { ChartConfiguration } from "chart.js";
 import { ChartTypeBuilder } from "../../../registries/chart_registry";
 import { BarChartRuntime } from "../../../types/chart/bar_chart";
 import { CommandResult } from "../../../types/commands";
+import { ColorThemeName } from "../../../types/rendering";
 import { toXlsxHexColor } from "../../../xlsx/helpers/colors";
 import { AbstractChart } from "./abstract_chart";
 import { chartFontColor, getDefinedAxis } from "./chart_common";
@@ -84,9 +85,16 @@ export const BarChart: ChartTypeBuilder<"bar"> = {
     };
   },
 
-  getRuntime(getters, definition, { extractData }, sheetId, eventHandlers): BarChartRuntime {
+  getRuntime(
+    getters,
+    definition,
+    { extractData },
+    sheetId,
+    eventHandlers,
+    colorThemeName: ColorThemeName
+  ): BarChartRuntime {
     const data = extractData();
-    const chartData = getBarChartData(definition, data, getters);
+    const chartData = getBarChartData(definition, data, getters, colorThemeName);
     const config: ChartConfiguration<"bar" | "line"> = {
       type: "bar",
       data: {

--- a/src/helpers/figures/charts/bubble_chart.ts
+++ b/src/helpers/figures/charts/bubble_chart.ts
@@ -4,6 +4,7 @@ import { BubbleChartDefinition } from "../../../types/chart/bubble_chart";
 import { ChartCreationContext, ChartRuntimeGenerationArgs } from "../../../types/chart/chart";
 import { CommandResult } from "../../../types/commands";
 import { Range } from "../../../types/range";
+import { ColorThemeName } from "../../../types/rendering";
 import { isDefined } from "../../misc";
 import { createValidRange } from "../../range";
 import { rangeReference } from "../../references";
@@ -185,8 +186,15 @@ export const BubbleChart: ChartTypeBuilder<"bubble"> = {
 
   copyInSheetId: (definition) => definition,
 
-  getRuntime(getters, definition) {
-    const chartData = getBubbleChartData(definition, getters);
+  getRuntime(
+    getters,
+    definition,
+    chartDataExtractors,
+    sheetId,
+    eventHandlers,
+    colorThemeName: ColorThemeName
+  ) {
+    const chartData = getBubbleChartData(definition, getters, colorThemeName);
     const config: ChartConfiguration<"line"> = {
       type: "line",
       data: {

--- a/src/helpers/figures/charts/calendar_chart.ts
+++ b/src/helpers/figures/charts/calendar_chart.ts
@@ -7,6 +7,7 @@ import {
 } from "../../../types/chart/calendar_chart";
 import { LegendPosition } from "../../../types/chart/common_chart";
 import { CommandResult } from "../../../types/commands";
+import { ColorThemeName } from "../../../types/rendering";
 import { Validator } from "../../../types/validator";
 import { AbstractChart } from "./abstract_chart";
 import { CHART_COMMON_OPTIONS } from "./chart_ui_common";
@@ -90,9 +91,16 @@ export const CalendarChart: ChartTypeBuilder<"calendar"> = {
 
   getDefinitionForExcel: () => undefined,
 
-  getRuntime(getters, definition, { extractData }): CalendarChartRuntime {
+  getRuntime(
+    getters,
+    definition,
+    { extractData },
+    sheetId,
+    eventHandlers,
+    colorThemeName: ColorThemeName
+  ): CalendarChartRuntime {
     const data = extractData();
-    const chartData = getCalendarChartData(definition, data, getters);
+    const chartData = getCalendarChartData(definition, data, getters, colorThemeName);
     const { labels, datasets } = getCalendarChartDatasetAndLabels(definition, chartData);
 
     const config: ChartConfiguration<"calendar"> = {

--- a/src/helpers/figures/charts/chart_common.ts
+++ b/src/helpers/figures/charts/chart_common.ts
@@ -13,12 +13,13 @@ import {
 import { CommandResult } from "../../../types/commands";
 import { CoreGetters } from "../../../types/core_getters";
 import { LocaleFormat } from "../../../types/format";
-import { Getters } from "../../../types/getters";
 import { Locale } from "../../../types/locale";
 import { Color, RangeAdapterFunctions, UID, UnboundedZone, Zone } from "../../../types/misc";
 import { Range } from "../../../types/range";
+import { ColorThemeName } from "../../../types/rendering";
 import { MAX_XLSX_POLYNOMIAL_DEGREE } from "../../../xlsx/constants";
 import { ColorGenerator, relativeLuminance } from "../../color";
+import { COLOR_THEMES } from "../../color_themes";
 import { formatValue, humanizeNumber } from "../../format/format";
 import { largeMax } from "../../misc";
 import { createRange, duplicateRangeInDuplicatedSheet } from "../../range";
@@ -367,11 +368,10 @@ export function isTrendLineAxis(axisID: string) {
 
 export function getChartBackgroundColor(
   { background }: { background?: Color },
-  getters: Getters
+  colorThemeName: ColorThemeName
 ): Color {
-  const defaultColor = getters.getSpreadsheetTheme().backgroundColor;
   if (!background) {
-    return defaultColor;
+    return COLOR_THEMES[colorThemeName].backgroundColor;
   }
   return background;
 }

--- a/src/helpers/figures/charts/chart_ui_common.ts
+++ b/src/helpers/figures/charts/chart_ui_common.ts
@@ -4,7 +4,8 @@ import { ChartRuntime, ChartType } from "../../../types/chart/chart";
 import { GaugeChartRuntime } from "../../../types/chart/gauge_chart";
 import { ScorecardChartRuntime } from "../../../types/chart/scorecard_chart";
 import { Figure } from "../../../types/figure";
-import { DOMDimension } from "../../../types/rendering";
+import { ColorThemeName, DOMDimension } from "../../../types/rendering";
+import { DARK_MODE_FILTER_STRING } from "../../color";
 import { deepCopy } from "../../misc";
 import {
   areChartJSExtensionsLoaded,
@@ -87,12 +88,15 @@ function sampleIndices(length: number, maxPoints: number): number[] {
 export async function chartToImageUrl(
   runtime: ChartRuntime,
   figure: Figure,
-  type: ChartType
+  type: ChartType,
+  colorThemeName: ColorThemeName = "light"
 ): Promise<string | undefined> {
   try {
     const canvas = createRenderingSurface(figure.width, figure.height);
     const cleanup = drawChartOnCanvas(canvas, runtime, figure, type);
-    const imageUrl = await canvasToObjectUrl(canvas);
+    const imageUrl = await canvasToObjectUrl(
+      colorThemeName === "dark" ? applyDarkMode(canvas) : canvas
+    );
     cleanup();
     return imageUrl;
   } catch (error) {
@@ -101,15 +105,36 @@ export async function chartToImageUrl(
   return undefined;
 }
 
+/**
+ * Charts are drawn with pre-inverted colors (see `adaptForDarkMode`) because they are displayed
+ * through the `os-theme-dependant` CSS filter. An exported image doesn't get that filter, so it
+ * has to be applied to the pixels to obtain what is actually displayed on screen.
+ */
+function applyDarkMode(canvas: OffscreenCanvas): OffscreenCanvas {
+  const filtered = createRenderingSurface(canvas.width, canvas.height);
+  const ctx = filtered.getContext("2d");
+  // Safari does not support the `filter` property...
+  const isFilterSupportedInCanvas = !ctx || !("filter" in ctx);
+  if (isFilterSupportedInCanvas) {
+    return canvas;
+  }
+  ctx.filter = DARK_MODE_FILTER_STRING;
+  ctx.drawImage(canvas, 0, 0);
+  return filtered;
+}
+
 export async function chartToImageFile(
   runtime: ChartRuntime,
   figure: Figure,
-  type: ChartType
+  type: ChartType,
+  colorThemeName: ColorThemeName = "light"
 ): Promise<Blob | null> {
   try {
     const canvas = createRenderingSurface(figure.width, figure.height);
     const cleanup = drawChartOnCanvas(canvas, runtime, figure, type);
-    const chartBlob = await canvasToBlob(canvas);
+    const chartBlob = await canvasToBlob(
+      colorThemeName === "dark" ? applyDarkMode(canvas) : canvas
+    );
     cleanup();
     return chartBlob;
   } catch (error) {

--- a/src/helpers/figures/charts/combo_chart.ts
+++ b/src/helpers/figures/charts/combo_chart.ts
@@ -2,6 +2,7 @@ import { ChartConfiguration } from "chart.js";
 import { ChartTypeBuilder } from "../../../registries/chart_registry";
 import { ComboChartDataSetStyle, ComboChartRuntime } from "../../../types/chart/combo_chart";
 import { CommandResult } from "../../../types/commands";
+import { ColorThemeName } from "../../../types/rendering";
 import { toXlsxHexColor } from "../../../xlsx/helpers/colors";
 import { AbstractChart } from "./abstract_chart";
 import { chartFontColor, getDefinedAxis } from "./chart_common";
@@ -87,9 +88,16 @@ export const ComboChart: ChartTypeBuilder<"combo"> = {
     };
   },
 
-  getRuntime(getters, definition, { extractData }, sheetId, eventHandlers): ComboChartRuntime {
+  getRuntime(
+    getters,
+    definition,
+    { extractData },
+    sheetId,
+    eventHandlers,
+    colorThemeName: ColorThemeName
+  ): ComboChartRuntime {
     const data = extractData();
-    const chartData = getBarChartData(definition, data, getters);
+    const chartData = getBarChartData(definition, data, getters, colorThemeName);
 
     const config: ChartConfiguration<"bar" | "line"> = {
       type: "bar",

--- a/src/helpers/figures/charts/funnel_chart.ts
+++ b/src/helpers/figures/charts/funnel_chart.ts
@@ -2,6 +2,7 @@ import { ChartConfiguration } from "chart.js";
 import { ChartTypeBuilder } from "../../../registries/chart_registry";
 import { FunnelChartRuntime } from "../../../types/chart/funnel_chart";
 import { CommandResult } from "../../../types/commands";
+import { ColorThemeName } from "../../../types/rendering";
 import { AbstractChart } from "./abstract_chart";
 import { CHART_COMMON_OPTIONS } from "./chart_ui_common";
 import { getFunnelChartData } from "./runtime/chart_data_extractor";
@@ -68,9 +69,16 @@ export const FunnelChart: ChartTypeBuilder<"funnel"> = {
 
   getDefinitionForExcel: () => undefined,
 
-  getRuntime(getters, definition, { extractData }, sheetId, eventHandlers): FunnelChartRuntime {
+  getRuntime(
+    getters,
+    definition,
+    { extractData },
+    sheetId,
+    eventHandlers,
+    colorThemeName: ColorThemeName
+  ): FunnelChartRuntime {
     const data = extractData();
-    const chartData = getFunnelChartData(definition, data, getters);
+    const chartData = getFunnelChartData(definition, data, getters, colorThemeName);
 
     const config: ChartConfiguration = {
       type: "funnel",

--- a/src/helpers/figures/charts/gauge_chart.ts
+++ b/src/helpers/figures/charts/gauge_chart.ts
@@ -1,3 +1,4 @@
+import { ColorThemeName } from "../../..";
 import {
   DEFAULT_GAUGE_LOWER_COLOR,
   DEFAULT_GAUGE_MIDDLE_COLOR,
@@ -262,7 +263,14 @@ export const GaugeChart: ChartTypeBuilder<"gauge"> = {
       .map((formula) => CompiledFormula.Compile(formula, sheetId, getters));
   },
 
-  getRuntime(getters: Getters, definition, dataSource, sheetId): GaugeChartRuntime {
+  getRuntime(
+    getters: Getters,
+    definition,
+    dataSource,
+    sheetId,
+    eventHandlers,
+    colorThemeName: ColorThemeName
+  ): GaugeChartRuntime {
     const locale = getters.getLocale();
     const chartColors = definition.sectionRule.colors;
 
@@ -287,7 +295,7 @@ export const GaugeChart: ChartTypeBuilder<"gauge"> = {
     let minValue = getFormulaNumberValue(sheetId, definition.sectionRule.rangeMin, getters);
     let maxValue = getFormulaNumberValue(sheetId, definition.sectionRule.rangeMax, getters);
     if (minValue === undefined || maxValue === undefined) {
-      return getInvalidGaugeRuntime(definition, getters);
+      return getInvalidGaugeRuntime(definition, getters, colorThemeName);
     }
     if (maxValue < minValue) {
       [minValue, maxValue] = [maxValue, minValue];
@@ -345,7 +353,11 @@ export const GaugeChart: ChartTypeBuilder<"gauge"> = {
     colors.push(chartColors.upperColor);
 
     return {
-      background: getters.getStyleOfSingleCellChart(definition.background, dataRange).background,
+      background: getters.getStyleOfSingleCellChart(
+        definition.background,
+        dataRange,
+        colorThemeName
+      ).background,
       title: {
         ...title,
         text: title.text ? getters.dynamicTranslate(title.text) : "",
@@ -400,11 +412,15 @@ function getFormulaNumberValue(sheetId: UID, formula: string, getters: Getters) 
 
 function getInvalidGaugeRuntime(
   definition: GaugeChartDefinition<Range>,
-  getters: Getters
+  getters: Getters,
+  colorThemeName: ColorThemeName
 ): GaugeChartRuntime {
   return {
-    background: getters.getStyleOfSingleCellChart(definition.background, definition.dataRange)
-      .background,
+    background: getters.getStyleOfSingleCellChart(
+      definition.background,
+      definition.dataRange,
+      colorThemeName
+    ).background,
     title: definition.title ?? { text: "" },
     minValue: { value: 0, label: "" },
     maxValue: { value: 100, label: "" },

--- a/src/helpers/figures/charts/geo_chart.ts
+++ b/src/helpers/figures/charts/geo_chart.ts
@@ -2,6 +2,7 @@ import { ChartConfiguration } from "chart.js";
 import { ChartTypeBuilder } from "../../../registries/chart_registry";
 import { GeoChartRuntime } from "../../../types/chart/geo_chart";
 import { CommandResult } from "../../../types/commands";
+import { ColorThemeName } from "../../../types/rendering";
 import { AbstractChart } from "./abstract_chart";
 import { CHART_COMMON_OPTIONS } from "./chart_ui_common";
 import { getGeoChartData } from "./runtime/chart_data_extractor";
@@ -59,9 +60,16 @@ export const GeoChart: ChartTypeBuilder<"geo"> = {
 
   getDefinitionForExcel: () => undefined,
 
-  getRuntime(getters, definition, { extractData }, sheetId, eventHandlers): GeoChartRuntime {
+  getRuntime(
+    getters,
+    definition,
+    { extractData },
+    sheetId,
+    eventHandlers,
+    colorThemeName: ColorThemeName
+  ): GeoChartRuntime {
     const data = extractData();
-    const chartData = getGeoChartData(definition, data, getters);
+    const chartData = getGeoChartData(definition, data, getters, colorThemeName);
 
     const config: ChartConfiguration = {
       type: "choropleth",

--- a/src/helpers/figures/charts/line_chart.ts
+++ b/src/helpers/figures/charts/line_chart.ts
@@ -2,6 +2,7 @@ import { ChartConfiguration } from "chart.js";
 import { ChartTypeBuilder } from "../../../registries/chart_registry";
 import { LineChartRuntime } from "../../../types/chart/line_chart";
 import { CommandResult } from "../../../types/commands";
+import { ColorThemeName } from "../../../types/rendering";
 import { toXlsxHexColor } from "../../../xlsx/helpers/colors";
 import { AbstractChart } from "./abstract_chart";
 import { chartFontColor, getDefinedAxis } from "./chart_common";
@@ -86,9 +87,16 @@ export const LineChart: ChartTypeBuilder<"line"> = {
     };
   },
 
-  getRuntime(getters, definition, { extractData }, sheetId, eventHandlers): LineChartRuntime {
+  getRuntime(
+    getters,
+    definition,
+    { extractData },
+    sheetId,
+    eventHandlers,
+    colorThemeName: ColorThemeName
+  ): LineChartRuntime {
     const data = extractData();
-    const chartData = getLineChartData(definition, data, getters);
+    const chartData = getLineChartData(definition, data, getters, colorThemeName);
 
     const config: ChartConfiguration<"line"> = {
       type: "line",

--- a/src/helpers/figures/charts/pie_chart.ts
+++ b/src/helpers/figures/charts/pie_chart.ts
@@ -2,6 +2,7 @@ import type { ChartConfiguration } from "chart.js";
 import { ChartTypeBuilder } from "../../../registries/chart_registry";
 import { PieChartRuntime } from "../../../types/chart/pie_chart";
 import { CommandResult } from "../../../types/commands";
+import { ColorThemeName } from "../../../types/rendering";
 import { toXlsxHexColor } from "../../../xlsx/helpers/colors";
 import { AbstractChart } from "./abstract_chart";
 import { chartFontColor } from "./chart_common";
@@ -75,9 +76,16 @@ export const PieChart: ChartTypeBuilder<"pie"> = {
     };
   },
 
-  getRuntime(getters, definition, { extractData }, sheetId, eventHandlers): PieChartRuntime {
+  getRuntime(
+    getters,
+    definition,
+    { extractData },
+    sheetId,
+    eventHandlers,
+    colorThemeName: ColorThemeName
+  ): PieChartRuntime {
     const data = extractData();
-    const chartData = getPieChartData(definition, data, getters);
+    const chartData = getPieChartData(definition, data, getters, colorThemeName);
 
     const config: ChartConfiguration<"doughnut" | "pie"> = {
       type: definition.isDoughnut ? "doughnut" : "pie",

--- a/src/helpers/figures/charts/pyramid_chart.ts
+++ b/src/helpers/figures/charts/pyramid_chart.ts
@@ -2,6 +2,7 @@ import { ChartConfiguration, ChartDataset } from "chart.js";
 import { ChartTypeBuilder } from "../../../registries/chart_registry";
 import { PyramidChartRuntime } from "../../../types/chart/pyramid_chart";
 import { CommandResult } from "../../../types/commands";
+import { ColorThemeName } from "../../../types/rendering";
 import { toXlsxHexColor } from "../../../xlsx/helpers/colors";
 import { isNumberResult } from "../../cells/cell_evaluation";
 import { AbstractChart } from "./abstract_chart";
@@ -78,7 +79,7 @@ export const PyramidChart: ChartTypeBuilder<"pyramid"> = {
       return undefined;
     }
     const data = getChartData(getters, definition.dataSource);
-    const chartData = getPyramidChartData(definition, data, getters);
+    const chartData = getPyramidChartData(definition, data, getters, "light");
     const { dataSetsValues } = chartData;
     const maxValue = Math.max(
       ...dataSetsValues.map((dataSet) =>
@@ -99,9 +100,16 @@ export const PyramidChart: ChartTypeBuilder<"pyramid"> = {
     };
   },
 
-  getRuntime(getters, definition, { extractData }, sheetId, eventHandlers): PyramidChartRuntime {
+  getRuntime(
+    getters,
+    definition,
+    { extractData },
+    sheetId,
+    eventHandlers,
+    colorThemeName: ColorThemeName
+  ): PyramidChartRuntime {
     const data = extractData();
-    const chartData = getPyramidChartData(definition, data, getters);
+    const chartData = getPyramidChartData(definition, data, getters, colorThemeName);
 
     const config: ChartConfiguration<"bar"> = {
       type: "bar",

--- a/src/helpers/figures/charts/radar_chart.ts
+++ b/src/helpers/figures/charts/radar_chart.ts
@@ -2,6 +2,7 @@ import { ChartConfiguration } from "chart.js";
 import { ChartTypeBuilder } from "../../../registries/chart_registry";
 import { RadarChartRuntime } from "../../../types/chart/radar_chart";
 import { CommandResult } from "../../../types/commands";
+import { ColorThemeName } from "../../../types/rendering";
 import { toXlsxHexColor } from "../../../xlsx/helpers/colors";
 import { AbstractChart } from "./abstract_chart";
 import { chartFontColor } from "./chart_common";
@@ -76,9 +77,16 @@ export const RadarChart: ChartTypeBuilder<"radar"> = {
     };
   },
 
-  getRuntime(getters, definition, { extractData }, sheetId, eventHandlers): RadarChartRuntime {
+  getRuntime(
+    getters,
+    definition,
+    { extractData },
+    sheetId,
+    eventHandlers,
+    colorThemeName: ColorThemeName
+  ): RadarChartRuntime {
     const data = extractData();
-    const chartData = getRadarChartData(definition, data, getters);
+    const chartData = getRadarChartData(definition, data, getters, colorThemeName);
 
     const config: ChartConfiguration<"radar"> = {
       type: "radar",

--- a/src/helpers/figures/charts/runtime/chart_data_extractor.ts
+++ b/src/helpers/figures/charts/runtime/chart_data_extractor.ts
@@ -42,6 +42,7 @@ import { Getters } from "../../../../types/getters";
 import { DEFAULT_LOCALE, Locale } from "../../../../types/locale";
 import { FunctionResultObject } from "../../../../types/misc";
 import { Range } from "../../../../types/range";
+import { ColorThemeName } from "../../../../types/rendering";
 import { isNumberResult } from "../../../cells/cell_evaluation";
 import { timeFormatLuxonCompatible } from "../../../chart_date";
 import { DAYS, formatValue, isDateTimeFormat, MONTHS } from "../../../format/format";
@@ -56,7 +57,8 @@ const ZERO = Object.freeze({ value: 0 });
 export function getBarChartData(
   definition: GenericDefinition<BarChartDefinition>,
   { labelValues, dataSetsValues }: ChartData,
-  getters: Getters
+  getters: Getters,
+  colorThemeName: ColorThemeName
 ): ChartRuntimeGenerationArgs {
   const locale = getters.getLocale();
   let labels = labelValues.map(({ value, format }) => formatValue(value, { format, locale }));
@@ -93,7 +95,7 @@ export function getBarChartData(
     labels,
     locale: getters.getLocale(),
     topPadding: getTopPaddingForDashboard(definition, getters),
-    background: getChartBackgroundColor(definition, getters),
+    background: getChartBackgroundColor(definition, colorThemeName),
   };
 }
 
@@ -191,7 +193,8 @@ function computeValuesAndLabels(
 export function getCalendarChartData(
   definition: GenericDefinition<CalendarChartDefinition>,
   { labelValues, dataSetsValues }: ChartData,
-  getters: Getters
+  getters: Getters,
+  colorThemeName: ColorThemeName
 ): ChartRuntimeGenerationArgs {
   let labels = labelValues;
 
@@ -222,19 +225,21 @@ export function getCalendarChartData(
     labels: labels.map(({ value }) => String(value ?? "")),
     locale: getters.getLocale(),
     topPadding: getTopPaddingForDashboard(definition, getters),
-    background: getChartBackgroundColor(definition, getters),
+    background: getChartBackgroundColor(definition, colorThemeName),
   };
 }
 
 export function getPyramidChartData(
   definition: PyramidChartDefinition,
   { labelValues, dataSetsValues }: ChartData,
-  getters: Getters
+  getters: Getters,
+  colorThemeName: ColorThemeName
 ): ChartRuntimeGenerationArgs {
   const barChartData = getBarChartData(
     definition,
     { labelValues, dataSetsValues: dataSetsValues.slice(0, 2) },
-    getters
+    getters,
+    colorThemeName
   );
   const barDataset = barChartData.dataSetsValues.filter((ds) => !ds.hidden);
 
@@ -261,7 +266,8 @@ export function getPyramidChartData(
 export function getLineChartData(
   definition: GenericDefinition<LineChartDefinition>,
   { labelValues, dataSetsValues }: ChartData,
-  getters: Getters
+  getters: Getters,
+  colorThemeName: ColorThemeName
 ): ChartRuntimeGenerationArgs {
   const axisType = getChartAxisType(definition, { labelValues, dataSetsValues });
   let labels =
@@ -309,14 +315,15 @@ export function getLineChartData(
     trendDataSetsValues,
     axisType,
     topPadding: getTopPaddingForDashboard(definition, getters),
-    background: getChartBackgroundColor(definition, getters),
+    background: getChartBackgroundColor(definition, colorThemeName),
   };
 }
 
 export function getPieChartData(
   definition: GenericDefinition<PieChartDefinition>,
   { labelValues, dataSetsValues }: ChartData,
-  getters: Getters
+  getters: Getters,
+  colorThemeName: ColorThemeName
 ): ChartRuntimeGenerationArgs {
   let labels = labelValues.map(({ value, format }) =>
     formatValue(value, { format, locale: getters.getLocale() })
@@ -338,14 +345,15 @@ export function getPieChartData(
     labels,
     locale: getters.getLocale(),
     topPadding: getTopPaddingForDashboard(definition, getters),
-    background: getChartBackgroundColor(definition, getters),
+    background: getChartBackgroundColor(definition, colorThemeName),
   };
 }
 
 export function getRadarChartData(
   definition: GenericDefinition<RadarChartDefinition>,
   { labelValues, dataSetsValues }: ChartData,
-  getters: Getters
+  getters: Getters,
+  colorThemeName: ColorThemeName
 ): ChartRuntimeGenerationArgs {
   let labels = labelValues.map(({ value, format }) =>
     formatValue(value, { format, locale: getters.getLocale() })
@@ -366,14 +374,15 @@ export function getRadarChartData(
     axisFormats,
     labels,
     locale: getters.getLocale(),
-    background: getChartBackgroundColor(definition, getters),
+    background: getChartBackgroundColor(definition, colorThemeName),
   };
 }
 
 export function getGeoChartData(
   definition: GeoChartDefinition,
   { labelValues, dataSetsValues }: ChartData,
-  getters: Getters
+  getters: Getters,
+  colorThemeName: ColorThemeName
 ): GeoChartRuntimeGenerationArgs {
   dataSetsValues = dataSetsValues.slice(0, 1);
   let labels = labelValues.map(({ value, format }) =>
@@ -393,14 +402,15 @@ export function getGeoChartData(
     availableRegions: getters.getGeoChartAvailableRegions(),
     geoFeatureNameToId: getters.geoFeatureNameToId,
     getGeoJsonFeatures: getters.getGeoJsonFeatures,
-    background: getChartBackgroundColor(definition, getters),
+    background: getChartBackgroundColor(definition, colorThemeName),
   };
 }
 
 export function getFunnelChartData(
   definition: GenericDefinition<FunnelChartDefinition>,
   { labelValues, dataSetsValues }: ChartData,
-  getters: Getters
+  getters: Getters,
+  colorThemeName: ColorThemeName
 ): ChartRuntimeGenerationArgs {
   let labels = labelValues.map(({ value, format }) =>
     formatValue(value, { format, locale: getters.getLocale() })
@@ -422,14 +432,15 @@ export function getFunnelChartData(
     axisFormats: { x: format },
     labels,
     locale: getters.getLocale(),
-    background: getChartBackgroundColor(definition, getters),
+    background: getChartBackgroundColor(definition, colorThemeName),
   };
 }
 
 export function getHierarchalChartData(
   definition: SunburstChartDefinition | TreeMapChartDefinition,
   { labelValues, dataSetsValues }: ChartData,
-  getters: Getters
+  getters: Getters,
+  colorThemeName: ColorThemeName
 ): ChartRuntimeGenerationArgs {
   // In hierarchical charts, labels are the leaf values (numbers), and the hierarchy is defined in the dataSets (strings)
   let labels = labelValues;
@@ -441,16 +452,17 @@ export function getHierarchalChartData(
     axisFormats: { y: getChartLabelFormat(labels) },
     labels: labels.map(({ value }) => String(value ?? "")),
     locale: getters.getLocale(),
-    background: getChartBackgroundColor(definition, getters),
+    background: getChartBackgroundColor(definition, colorThemeName),
   };
 }
 
 export function getBubbleChartData(
   definition: BubbleChartDefinition<Range>,
-  getters: Getters
+  getters: Getters,
+  colorThemeName: ColorThemeName
 ): BubbleChartData {
   const chartData = getBubbleChartSourceData(definition, getters);
-  const data = getLineChartData(definition, chartData, getters);
+  const data = getLineChartData(definition, chartData, getters, colorThemeName);
 
   let labelValues = definition.labelRange
     ? getters.getVisibleRangeValues(definition.labelRange)

--- a/src/helpers/figures/charts/scatter_chart.ts
+++ b/src/helpers/figures/charts/scatter_chart.ts
@@ -2,6 +2,7 @@ import { ChartConfiguration } from "chart.js";
 import { ChartTypeBuilder } from "../../../registries/chart_registry";
 import { ScatterChartRuntime } from "../../../types/chart/scatter_chart";
 import { CommandResult } from "../../../types/commands";
+import { ColorThemeName } from "../../../types/rendering";
 import { toXlsxHexColor } from "../../../xlsx/helpers/colors";
 import { AbstractChart } from "./abstract_chart";
 import { chartFontColor, getDefinedAxis } from "./chart_common";
@@ -75,9 +76,16 @@ export const ScatterChart: ChartTypeBuilder<"scatter"> = {
     };
   },
 
-  getRuntime(getters, definition, { extractData }, sheetId, eventHandlers): ScatterChartRuntime {
+  getRuntime(
+    getters,
+    definition,
+    { extractData },
+    sheetId,
+    eventHandlers,
+    colorThemeName: ColorThemeName
+  ): ScatterChartRuntime {
     const data = extractData();
-    const chartData = getLineChartData(definition, data, getters);
+    const chartData = getLineChartData(definition, data, getters, colorThemeName);
 
     const config: ChartConfiguration<"line"> = {
       // use chartJS line chart and disable the lines instead of chartJS scatter chart. This is because the scatter chart

--- a/src/helpers/figures/charts/scorecard_chart.ts
+++ b/src/helpers/figures/charts/scorecard_chart.ts
@@ -1,3 +1,4 @@
+import { ColorThemeName } from "../../..";
 import {
   CHART_PADDING,
   DEFAULT_SCORECARD_BASELINE_COLOR_DOWN,
@@ -317,7 +318,14 @@ export const ScorecardChart: ChartTypeBuilder<"scorecard"> = {
     return formulas;
   },
 
-  getRuntime(getters, definition, _dataExtractor, sheetId): ScorecardChartRuntime {
+  getRuntime(
+    getters,
+    definition,
+    _dataExtractor,
+    sheetId,
+    eventHandlers,
+    colorThemeName: ColorThemeName
+  ): ScorecardChartRuntime {
     let formattedKeyValue = "";
     const { scalar: keyValue, range: keyValueRange } = getData(
       definition.keyValue,
@@ -338,7 +346,8 @@ export const ScorecardChart: ChartTypeBuilder<"scorecard"> = {
     );
     const { background, fontColor } = getters.getStyleOfSingleCellChart(
       definition.background,
-      keyValueRange
+      keyValueRange,
+      colorThemeName
     );
 
     const baselineDisplay = getBaselineText(

--- a/src/helpers/figures/charts/sunburst_chart.ts
+++ b/src/helpers/figures/charts/sunburst_chart.ts
@@ -2,6 +2,7 @@ import type { ChartConfiguration, ChartOptions } from "chart.js";
 import { ChartTypeBuilder } from "../../../registries/chart_registry";
 import { SunburstChartRuntime } from "../../../types/chart/sunburst_chart";
 import { CommandResult } from "../../../types/commands";
+import { ColorThemeName } from "../../../types/rendering";
 import { AbstractChart } from "./abstract_chart";
 import { CHART_COMMON_OPTIONS } from "./chart_ui_common";
 import { getHierarchalChartData } from "./runtime/chart_data_extractor";
@@ -75,10 +76,11 @@ export const SunburstChart: ChartTypeBuilder<"sunburst"> = {
     definition,
     { extractHierarchicalData },
     sheetId,
-    eventHandlers
+    eventHandlers,
+    colorThemeName: ColorThemeName
   ): SunburstChartRuntime {
     const data = extractHierarchicalData();
-    const chartData = getHierarchalChartData(definition, data, getters);
+    const chartData = getHierarchalChartData(definition, data, getters, colorThemeName);
 
     const config: ChartConfiguration<"doughnut"> = {
       type: "doughnut",

--- a/src/helpers/figures/charts/tree_map_chart.ts
+++ b/src/helpers/figures/charts/tree_map_chart.ts
@@ -2,6 +2,7 @@ import { ChartConfiguration } from "chart.js";
 import { ChartTypeBuilder } from "../../../registries/chart_registry";
 import { TreeMapChartRuntime } from "../../../types/chart/tree_map_chart";
 import { CommandResult } from "../../../types/commands";
+import { ColorThemeName } from "../../../types/rendering";
 import { AbstractChart } from "./abstract_chart";
 import { CHART_COMMON_OPTIONS } from "./chart_ui_common";
 import { getHierarchalChartData } from "./runtime/chart_data_extractor";
@@ -76,10 +77,11 @@ export const TreeMapChart: ChartTypeBuilder<"treemap"> = {
     definition,
     { extractHierarchicalData },
     sheetId,
-    eventHandlers
+    eventHandlers,
+    colorThemeName: ColorThemeName
   ): TreeMapChartRuntime {
     const data = extractHierarchicalData();
-    const chartData = getHierarchalChartData(definition, data, getters);
+    const chartData = getHierarchalChartData(definition, data, getters, colorThemeName);
 
     const config: ChartConfiguration = {
       type: "treemap",

--- a/src/helpers/figures/charts/waterfall_chart.ts
+++ b/src/helpers/figures/charts/waterfall_chart.ts
@@ -2,6 +2,7 @@ import type { ChartConfiguration } from "chart.js";
 import { ChartTypeBuilder } from "../../../registries/chart_registry";
 import { WaterfallChartRuntime } from "../../../types/chart/waterfall_chart";
 import { CommandResult } from "../../../types/commands";
+import { ColorThemeName } from "../../../types/rendering";
 import { AbstractChart } from "./abstract_chart";
 import { CHART_COMMON_OPTIONS } from "./chart_ui_common";
 import { getBarChartData } from "./runtime/chart_data_extractor";
@@ -75,9 +76,16 @@ export const WaterfallChart: ChartTypeBuilder<"waterfall"> = {
 
   getDefinitionForExcel: () => undefined,
 
-  getRuntime(getters, definition, { extractData }, sheetId, eventHandlers): WaterfallChartRuntime {
+  getRuntime(
+    getters,
+    definition,
+    { extractData },
+    sheetId,
+    eventHandlers,
+    colorThemeName: ColorThemeName
+  ): WaterfallChartRuntime {
     const data = extractData();
-    const chartData = getBarChartData(definition, data, getters);
+    const chartData = getBarChartData(definition, data, getters, colorThemeName);
 
     const { labels, datasets } = getWaterfallDatasetAndLabels(definition, chartData);
     const config: ChartConfiguration = {

--- a/src/plugins/plugin_registries.ts
+++ b/src/plugins/plugin_registries.ts
@@ -32,6 +32,7 @@ import { FingerprintPlugin } from "./ui_core_views/fingerprint";
 import { FormulaTrackerPlugin } from "./ui_core_views/formula_tracker";
 import { HeaderSizeUIPlugin } from "./ui_core_views/header_sizes_ui";
 import { PivotUIPlugin } from "./ui_core_views/pivot_ui";
+import { ChartUIPlugin } from "./ui_feature/chart_ui";
 import { CollaborativePlugin } from "./ui_feature/collaborative";
 import { ColorThemeUIPlugin } from "./ui_feature/color_theme";
 import { DataValidationInsertionPlugin } from "./ui_feature/datavalidation_insertion";
@@ -94,7 +95,8 @@ export const featurePluginRegistry = new Registry<UIPluginConstructor>()
   .add("dynamic_translate", DynamicTranslate)
   .add("geo_features", GeoFeaturePlugin)
   .add("color_theme", ColorThemeUIPlugin)
-  .add("lock_sheet", LockSheetPlugin);
+  .add("lock_sheet", LockSheetPlugin)
+  .add("chart_ui", ChartUIPlugin);
 
 // Plugins which have a state, but which should not be shared in collaborative
 export const statefulUIPluginRegistry = new Registry<UIPluginConstructor>()

--- a/src/plugins/ui_core_views/evaluation_chart.ts
+++ b/src/plugins/ui_core_views/evaluation_chart.ts
@@ -1,4 +1,5 @@
 import { ChartConfiguration } from "chart.js";
+import { COLOR_THEMES } from "../../helpers/color_themes";
 import { SpreadsheetChart } from "../../helpers/figures/chart";
 import { chartFontColor } from "../../helpers/figures/charts/chart_common";
 import { chartToImageUrl } from "../../helpers/figures/charts/chart_ui_common";
@@ -12,6 +13,7 @@ import {
 } from "../../types/commands";
 import { Color, UID } from "../../types/misc";
 import { Range } from "../../types/range";
+import { ColorThemeName } from "../../types/rendering";
 import { ExcelWorkbookData, FigureData } from "../../types/workbook_data";
 import { CoreViewPlugin } from "../core_view_plugin";
 
@@ -21,13 +23,13 @@ interface EvaluationChartStyle {
 }
 
 interface EvaluationChartState {
-  charts: Record<UID, ChartRuntime | undefined>;
+  charts: Record<UID, Partial<Record<ColorThemeName, ChartRuntime | undefined>>>;
 }
 
 export class EvaluationChartPlugin extends CoreViewPlugin<EvaluationChartState> {
-  static getters = ["getChartRuntime", "getStyleOfSingleCellChart"] as const;
+  static getters = ["getStyleOfSingleCellChart", "getChartRuntimeWithTheme"] as const;
 
-  charts: Record<UID, ChartRuntime | undefined> = {};
+  charts: Record<UID, Partial<Record<ColorThemeName, ChartRuntime | undefined>>> = {};
 
   handle(cmd: CoreViewCommand) {
     if (
@@ -36,37 +38,44 @@ export class EvaluationChartPlugin extends CoreViewPlugin<EvaluationChartState> 
       invalidateChartEvaluationCommands.has(cmd.type)
     ) {
       for (const chartId in this.charts) {
-        this.charts[chartId] = undefined;
+        this.charts[chartId] = {};
       }
     }
 
     switch (cmd.type) {
       case "UPDATE_CHART":
       case "CREATE_CHART":
-        this.charts[cmd.chartId] = undefined;
+        this.charts[cmd.chartId] = {};
         break;
       case "DELETE_CHART":
-        this.charts[cmd.chartId] = undefined;
+        this.charts[cmd.chartId] = {};
         break;
       case "DELETE_SHEET":
         for (const chartId in this.charts) {
           if (!this.getters.isChartDefined(chartId)) {
-            this.charts[chartId] = undefined;
+            this.charts[chartId] = {};
           }
         }
         break;
     }
   }
 
-  getChartRuntime(chartId: UID): ChartRuntime {
+  getChartRuntimeWithTheme(chartId: UID, colorThemeName: ColorThemeName): ChartRuntime {
     if (!this.charts[chartId]) {
+      this.charts[chartId] = {};
+    }
+    if (!this.charts[chartId][colorThemeName]) {
       const chart = this.getters.getChart(chartId);
       if (!chart) {
         throw new Error(`No chart for the given id: ${chartId}`);
       }
-      this.charts[chartId] = this.createRuntimeChart(chartId, chart);
+      this.charts[chartId][colorThemeName] = this.createRuntimeChart(
+        chartId,
+        chart,
+        colorThemeName
+      );
     }
-    return this.charts[chartId] as ChartRuntime;
+    return this.charts[chartId][colorThemeName] as ChartRuntime;
   }
 
   /**
@@ -74,9 +83,10 @@ export class EvaluationChartPlugin extends CoreViewPlugin<EvaluationChartState> 
    */
   getStyleOfSingleCellChart(
     chartBackground: Color | undefined,
-    mainRange: Range | undefined
+    mainRange: Range | undefined,
+    colorThemeName: ColorThemeName
   ): EvaluationChartStyle {
-    const themeBackground = this.getters.getSpreadsheetTheme().backgroundColor;
+    const themeBackground = COLOR_THEMES[colorThemeName].backgroundColor;
     if (chartBackground) {
       return { background: chartBackground, fontColor: chartFontColor(chartBackground) };
     }
@@ -126,7 +136,8 @@ export class EvaluationChartPlugin extends CoreViewPlugin<EvaluationChartState> 
             continue;
           }
           const type = this.getters.getChartType(chartId);
-          const runtime = this.getters.getChartRuntime(chartId);
+          // Export excel should always export its chart using light theme.
+          const runtime = this.getChartRuntimeWithTheme(chartId, "light");
           const img = await chartToImageUrl(runtime, figure, type);
           if (img) {
             sheet.images.push({
@@ -145,9 +156,13 @@ export class EvaluationChartPlugin extends CoreViewPlugin<EvaluationChartState> 
     }
   }
 
-  private createRuntimeChart(chartId: UID, chart: SpreadsheetChart): ChartRuntime {
+  private createRuntimeChart(
+    chartId: UID,
+    chart: SpreadsheetChart,
+    colorThemeName: ColorThemeName
+  ): ChartRuntime {
     const definition = chart.getRangeDefinition();
-    const runtime = chart.getRuntime(this.getters, chartId);
+    const runtime = chart.getRuntime(this.getters, chartId, colorThemeName);
     if ("chartJsConfig" in runtime && /line|combo|bar|scatter|waterfall/.test(definition.type)) {
       const chartJsConfig = runtime.chartJsConfig as ChartConfiguration<any>;
       runtime["masterChartConfig"] = generateMasterChartConfig(chartJsConfig);

--- a/src/plugins/ui_feature/chart_ui.ts
+++ b/src/plugins/ui_feature/chart_ui.ts
@@ -1,0 +1,13 @@
+import { ChartRuntime } from "../../types/chart/chart";
+import { UIPlugin } from "../ui_plugin";
+
+export class ChartUIPlugin extends UIPlugin {
+  static getters = ["getChartRuntime"] as const;
+
+  getChartRuntime(chartId: string): ChartRuntime {
+    return this.getters.getChartRuntimeWithTheme(
+      chartId,
+      this.getters.getSpreadsheetTheme().colorThemeName
+    );
+  }
+}

--- a/src/plugins/ui_feature/color_theme.ts
+++ b/src/plugins/ui_feature/color_theme.ts
@@ -1,47 +1,11 @@
-import { adaptForDarkMode } from "../../helpers/color";
+import { COLOR_THEMES } from "../../helpers/color_themes";
 import { Command } from "../../types/commands";
-import { GridRenderingTheme } from "../../types/rendering";
+import { ColorThemeName, GridRenderingTheme } from "../../types/rendering";
 import { UIPlugin, UIPluginConfig } from "../ui_plugin";
 
-const FROZEN_PANE_HEADER_BORDER_COLOR = "#BCBCBC";
-const FROZEN_PANE_BORDER_COLOR = "#DADFE8";
-const HEADER_BORDER_COLOR = "#C0C0C0";
-const TEXT_HEADER_COLOR = "#666666";
-const BACKGROUND_HEADER_COLOR = "#F8F9FA";
-export const BACKGROUND_HEADER_SELECTED_COLOR = "#E8EAED";
-export const BACKGROUND_HEADER_ACTIVE_COLOR = "#595959";
-
-export const COLOR_THEMES: Record<string, GridRenderingTheme> = {
-  light: {
-    backgroundColor: "#FFFFFF",
-    gridBorderColor: "#CECFCF",
-    headerBackgroundColor: BACKGROUND_HEADER_COLOR,
-    headerActiveBackgroundColor: BACKGROUND_HEADER_ACTIVE_COLOR,
-    headerSelectedBackgroundColor: BACKGROUND_HEADER_SELECTED_COLOR,
-    headerTextColor: TEXT_HEADER_COLOR,
-    headerBorderColor: HEADER_BORDER_COLOR,
-    frozenPaneBorderColor: FROZEN_PANE_BORDER_COLOR,
-    frozenPaneHeaderBorderColor: FROZEN_PANE_HEADER_BORDER_COLOR,
-    singleCellSelectionBackgroundColor: "#F3F7FE",
-    multipleCellsSelectionBackgroundColor: "#E9F0FF",
-  },
-  dark: {
-    backgroundColor: adaptForDarkMode("#1A1C2E"),
-    gridBorderColor: adaptForDarkMode("#6B706F"),
-    headerBackgroundColor: adaptForDarkMode("#262A36"),
-    headerActiveBackgroundColor: adaptForDarkMode("#3A4052"),
-    headerSelectedBackgroundColor: adaptForDarkMode("#4E566E"),
-    headerTextColor: adaptForDarkMode("#A1A6B3"),
-    headerBorderColor: adaptForDarkMode("#7A7F91"),
-    frozenPaneBorderColor: adaptForDarkMode("#7A7F91"),
-    frozenPaneHeaderBorderColor: adaptForDarkMode("#9FA5BD"),
-    singleCellSelectionBackgroundColor: adaptForDarkMode("#696E8044"),
-    multipleCellsSelectionBackgroundColor: adaptForDarkMode("#828AA044"),
-  },
-};
 export class ColorThemeUIPlugin extends UIPlugin {
   static getters = ["isDarkMode", "getSpreadsheetTheme"] as const;
-  private colorScheme?: "light" | "dark";
+  private colorScheme?: ColorThemeName;
 
   constructor(config: UIPluginConfig) {
     super(config);

--- a/src/registries/chart_registry.ts
+++ b/src/registries/chart_registry.ts
@@ -1,5 +1,5 @@
 import { CoreChartOptions } from "chart.js";
-import { CompiledFormula } from "..";
+import { ColorThemeName, CompiledFormula } from "..";
 import {
   ChartCreationContext,
   ChartData,
@@ -100,7 +100,8 @@ export interface ChartTypeBuilder<T extends ChartType> {
     definition: ChartTypeDefinition<T, Range>,
     chartDataExtractors: ChartDataExtractors,
     sheetId: UID,
-    eventHandlers: ChartJsEventHandlers
+    eventHandlers: ChartJsEventHandlers,
+    colorThemeName: ColorThemeName
   ): ChartRuntime;
   /** Get all the formulas used in the chart */
   getFormulas(

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -27,6 +27,7 @@ import { Image } from "./image";
 import { Locale } from "./locale";
 import { PivotCoreDefinition, PivotTableData } from "./pivot";
 import { RangeData } from "./range";
+import { ColorThemeName } from "./rendering";
 import { CoreTableType, DataFilterValue, TableConfig, TableStyleTemplateName } from "./table";
 
 // -----------------------------------------------------------------------------
@@ -1217,7 +1218,7 @@ export interface ToggleCheckboxCommand extends TargetDependentCommand {
 
 export interface UpdateColorSchemeCommand {
   type: "UPDATE_COLOR_SCHEME";
-  colorScheme: "light" | "dark";
+  colorScheme: ColorThemeName;
 }
 
 export type CoreCommand =

--- a/src/types/getters.ts
+++ b/src/types/getters.ts
@@ -10,6 +10,7 @@ import { FingerprintPlugin } from "../plugins/ui_core_views/fingerprint";
 import { FormulaTrackerPlugin } from "../plugins/ui_core_views/formula_tracker";
 import { HeaderSizeUIPlugin } from "../plugins/ui_core_views/header_sizes_ui";
 import { PivotUIPlugin } from "../plugins/ui_core_views/pivot_ui";
+import { ChartUIPlugin } from "../plugins/ui_feature/chart_ui";
 import { CollaborativePlugin } from "../plugins/ui_feature/collaborative";
 import { ColorThemeUIPlugin } from "../plugins/ui_feature/color_theme";
 import { DynamicTranslate } from "../plugins/ui_feature/dynamic_translate";
@@ -74,6 +75,7 @@ export type RenderingGetters = {
   PluginGetters<typeof LockSheetPlugin> &
   PluginGetters<typeof CarouselUIPlugin> &
   PluginGetters<typeof ColorThemeUIPlugin> &
+  PluginGetters<typeof ChartUIPlugin> &
   PluginGetters<typeof FigureUIPlugin>;
 
 export type Getters = RenderingGetters & PluginGetters<typeof GridSelectionPlugin>;

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -6,6 +6,7 @@ import { InformationNotification } from "./env";
 import { FileStore } from "./files";
 import { Locale } from "./locale";
 import { Color } from "./misc";
+import { ColorThemeName } from "./rendering";
 
 export type Mode = "normal" | "readonly" | "dashboard" | "export_verification";
 
@@ -32,7 +33,7 @@ export interface ModelConfig {
   readonly notifyUI: (payload: InformationNotification) => void;
   readonly raiseBlockingErrorUI: (text: string) => void;
   readonly customColors: Color[];
-  readonly colorScheme?: "light" | "dark";
+  readonly colorScheme?: ColorThemeName;
 }
 
 export interface ModelExternalConfig {

--- a/src/types/rendering.ts
+++ b/src/types/rendering.ts
@@ -93,7 +93,10 @@ export interface SheetDOMScrollInfo {
   scrollY: Pixel;
 }
 
+export type ColorThemeName = "light" | "dark";
+
 export interface GridRenderingTheme {
+  colorThemeName: ColorThemeName;
   backgroundColor: string;
   gridBorderColor: string;
   headerBackgroundColor: string;

--- a/tests/grid/dashboard_grid_component.test.ts
+++ b/tests/grid/dashboard_grid_component.test.ts
@@ -7,9 +7,9 @@ import {
   GRID_ICON_MARGIN,
   MIN_CELL_TEXT_MARGIN,
 } from "../../src/constants";
+import { COLOR_THEMES } from "../../src/helpers/color_themes";
 import { toZone } from "../../src/helpers/zones";
 import { Model } from "../../src/model";
-import { COLOR_THEMES } from "../../src/plugins/ui_feature/color_theme";
 import { clickableCellRegistry } from "../../src/registries/cell_clickable_registry";
 import { GridIcon, iconsOnCellRegistry } from "../../src/registries/icons_on_cell_registry";
 import { ViewportsStore } from "../../src/stores/viewports_store";

--- a/tests/plugins/color_theme_plugin.test.ts
+++ b/tests/plugins/color_theme_plugin.test.ts
@@ -1,5 +1,5 @@
+import { COLOR_THEMES } from "../../src/helpers/color_themes";
 import { Model } from "../../src/model";
-import { COLOR_THEMES } from "../../src/plugins/ui_feature/color_theme";
 import { MockTransportService } from "../__mocks__/transport_service";
 
 const expectedLightTheme = COLOR_THEMES.light;
@@ -18,7 +18,10 @@ describe("ColorThemeUIPlugin via Model getters", () => {
     );
     const theme = model.getters.getSpreadsheetTheme();
     for (const key of THEME_KEYS) {
-      expect(theme[key].toUpperCase()).toBe(expectedLightTheme[key]);
+      if (key === "colorThemeName") {
+        continue;
+      }
+      expect(theme[key]).toBeSameColorAs(expectedLightTheme[key]);
     }
   });
 
@@ -33,7 +36,10 @@ describe("ColorThemeUIPlugin via Model getters", () => {
     );
     const theme = model.getters.getSpreadsheetTheme();
     for (const key of THEME_KEYS) {
-      expect(theme[key].toUpperCase()).toBe(expectedDarkTheme[key]);
+      if (key === "colorThemeName") {
+        continue;
+      }
+      expect(theme[key]).toBeSameColorAs(expectedDarkTheme[key]);
     }
   });
 

--- a/tests/renderer/renderer_store.test.ts
+++ b/tests/renderer/renderer_store.test.ts
@@ -24,12 +24,9 @@ import {
   TABLE_HOVER_BACKGROUND_COLOR,
 } from "../../src/constants";
 import { blendColors, toHex } from "../../src/helpers/color";
+import { COLOR_THEMES } from "../../src/helpers/color_themes";
 import { fontSizeInPixels, getContextFontSize } from "../../src/helpers/text_helper";
 import { toZone } from "../../src/helpers/zones";
-import {
-  BACKGROUND_HEADER_ACTIVE_COLOR,
-  BACKGROUND_HEADER_SELECTED_COLOR,
-} from "../../src/plugins/ui_feature/color_theme";
 import { DependencyContainer } from "../../src/store_engine/dependency_container";
 import { CellHoverOverlayStore } from "../../src/stores/cell_hover_overlay_store";
 import { FormulaFingerprintStore } from "../../src/stores/formula_fingerprints_store";
@@ -204,9 +201,9 @@ describe("renderer", () => {
       drawGridRenderer(ctx);
 
       const fillColHeaderInstr = getFirstColHeaderFillColor();
-      expect(fillColHeaderInstr).toEqual(BACKGROUND_HEADER_SELECTED_COLOR);
+      expect(fillColHeaderInstr).toEqual(COLOR_THEMES.light.headerSelectedBackgroundColor);
       const fillRowHeaderInstr = getFirstRowHeaderFillColor();
-      expect(fillRowHeaderInstr).toEqual(BACKGROUND_HEADER_SELECTED_COLOR);
+      expect(fillRowHeaderInstr).toEqual(COLOR_THEMES.light.headerSelectedBackgroundColor);
     });
 
     test("Color of active headers", () => {
@@ -214,9 +211,9 @@ describe("renderer", () => {
       drawGridRenderer(ctx);
 
       const fillColHeaderInstr = getFirstColHeaderFillColor();
-      expect(fillColHeaderInstr).toEqual(BACKGROUND_HEADER_ACTIVE_COLOR);
+      expect(fillColHeaderInstr).toEqual(COLOR_THEMES.light.headerActiveBackgroundColor);
       const fillRowHeaderInstr = getFirstRowHeaderFillColor();
-      expect(fillRowHeaderInstr).toEqual(BACKGROUND_HEADER_ACTIVE_COLOR);
+      expect(fillRowHeaderInstr).toEqual(COLOR_THEMES.light.headerActiveBackgroundColor);
     });
   });
 


### PR DESCRIPTION
Before this commit, evaluation chart relied on the UI getter to obtain the theme (dark or light).
After this commit, the theme is directly passed to the runtime creation function, so the chart can be evaluated independently of the UI.

Before this commit, downloading or copying as image a chart in dark mode would copy the chart with an ugly background, the inversed background. Now, it uses the current theme to render the chart correctly.

Task: 6514275

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo