### PR TITLE
[FIX] figure: color of snap lines in dark mode

### DIFF
--- a/src/components/figures/figure_container/figure_container.css
+++ b/src/components/figures/figure_container/figure_container.css
@@ -4,10 +4,10 @@
     z-index: var(--os-components-importance-figure-snap-line);
     &.vertical {
       width: 0px;
-      border-left: 1px dashed black;
+      border-left: 1px dashed var(--os-gray-800);
     }
     &.horizontal {
-      border-top: 1px dashed black;
+      border-top: 1px dashed var(--os-gray-800);
       height: 0px;
     }
   }


### PR DESCRIPTION
## Description

Figure snap lines are always black, which make them almost invisible in dark mode.

Task: [6515587](https://www.odoo.com/odoo/2328/tasks/6515587)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo