### PR TITLE
[FIX] side panel: broken checkbox icon

### DIFF
--- a/src/components/side_panel/components/checkbox/checkbox.ts
+++ b/src/components/side_panel/components/checkbox/checkbox.ts
@@ -3,12 +3,6 @@ import { ACTION_COLOR, GRAY_300 } from "../../../../constants";
 import { SpreadsheetChildEnv } from "../../../../types";
 import { css } from "../../../helpers/css";
 
-const CHECK_SVG = /*xml*/ `
-<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'>
-  <path fill='none' stroke='#FFF' stroke-linecap='round' stroke-linejoin='round' stroke-width='3' d='m6 10 3 3 6-6'/>
-</svg>
-`;
-
 interface Props {
   label?: string;
   value: boolean;
@@ -40,7 +34,7 @@ css/* scss */ `
       }
 
       &:checked {
-        background: url("data:image/svg+xml,${encodeURIComponent(CHECK_SVG)}");
+        background: url("data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20viewBox%3D%270%200%2020%2020%27%3E%3Cpath%20fill%3D%27none%27%20stroke%3D%27%23FFF%27%20stroke-linecap%3D%27round%27%20stroke-linejoin%3D%27round%27%20stroke-width%3D%273%27%20d%3D%27m6%2010%203%203%206-6%27/%3E%3C/svg%3E");
         background-color: ${ACTION_COLOR};
         border-color: ${ACTION_COLOR};
       }

--- a/src/components/side_panel/components/radio_selection/radio_selection.ts
+++ b/src/components/side_panel/components/radio_selection/radio_selection.ts
@@ -16,12 +16,6 @@ interface Props {
   direction: "horizontal" | "vertical";
 }
 
-const CIRCLE_SVG = /*xml*/ `
-<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'>
-  <circle r="2" fill="#FFF"/>
-</svg>
-`;
-
 css/* scss */ `
   .o-radio {
     input {
@@ -36,7 +30,7 @@ css/* scss */ `
       border-radius: 8px;
 
       &:checked {
-        background: url("data:image/svg+xml,${encodeURIComponent(CIRCLE_SVG)}");
+        background: url("data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20viewBox%3D%27-4%20-4%208%208%27%3E%3Ccircle%20r%3D%222%22%20fill%3D%22%23FFF%22/%3E%3C/svg%3E");
         background-color: ${ACTION_COLOR};
         border-color: ${ACTION_COLOR};
       }


### PR DESCRIPTION
## Description

The check icon is sometime missing inside checkbox. Same for the circle icon inside radio button. It seems to be an url encoding issue, sometime the resulting svg is broken. I'm honestly not sure on when and why it happens, I cannot reproduce it locally.

The issue doesn't happen in 19.1+ where the icon is inlined inside the CSS. We can backport this and inline the correctly encoded svg.

Task: [6516338](https://www.odoo.com/odoo/2328/tasks/6516338)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo