### PR TITLE
[FIX] figure_container: snapline visibility in dark mode

### DIFF
--- a/src/components/figures/figure_container/figure_container.xml
+++ b/src/components/figures/figure_container/figure_container.xml
@@ -33,14 +33,20 @@
       t-if="this.dnd.horizontalSnap"
       t-att-style="this.dnd.horizontalSnap.containerStyle"
       t-att-data-id="'HorizontalSnapContainer'">
-      <div class="o-figure-snap-line horizontal" t-att-style="this.dnd.horizontalSnap.lineStyle"/>
+      <div
+        class="o-figure-snap-line horizontal os-theme-dependant"
+        t-att-style="this.dnd.horizontalSnap.lineStyle"
+      />
     </div>
     <div
       class="o-figure-container position-absolute pe-none overflow-hidden"
       t-if="this.dnd.verticalSnap"
       t-att-style="this.dnd.verticalSnap.containerStyle"
       t-att-data-id="'VerticalSnapContainer'">
-      <div class="o-figure-snap-line vertical" t-att-style="this.dnd.verticalSnap.lineStyle"/>
+      <div
+        class="o-figure-snap-line vertical os-theme-dependant"
+        t-att-style="this.dnd.verticalSnap.lineStyle"
+      />
     </div>
   </t>
 </templates>


### PR DESCRIPTION
Before this commit:
The snaplines were not easily visible in dark mode, the os-theme-dependant class was needed

Task: [6514646](https://www.odoo.com/odoo/2328/tasks/6514646)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo