### PR TITLE
[FIX] pivot: fix scope of `pivot_html_renderer` css

### DIFF
--- a/.husky/css_check.js
+++ b/.husky/css_check.js
@@ -4,6 +4,7 @@ import process from "process";
 
 const commentPattern = /\/\/.*|\/\*[\s\S]*?\*\//g;
 const firstLevelSelectorPattern = /^(?!(\s|\}|:root)).+/gm;
+const ignoreFilePattern = /^\/\*\s*css-check-ignore/
 
 // Get css files in diff
 const files = execSync("git diff --name-only --cached")
@@ -16,6 +17,9 @@ const faultyFiles = [];
 for (const file of files) {
   if (!existsSync(file)) continue;
   let content = readFileSync(file, "utf8");
+  if(ignoreFilePattern.test(content)) {
+    continue;
+  }
 
   // Remove content of comments
   content = content.replace(commentPattern, "");

--- a/src/components/pivot_html_renderer/pivot_html_renderer.css
+++ b/src/components/pivot_html_renderer/pivot_html_renderer.css
@@ -1,37 +1,37 @@
-.o-spreadsheet {
-  .o_pivot_html_renderer {
-    width: 100%;
-    border-collapse: collapse;
+/* css-check-ignore */
+
+.o_pivot_html_renderer {
+  width: 100%;
+  border-collapse: collapse;
+
+  &:hover {
+    cursor: pointer;
+  }
+
+  td,
+  th {
+    border: 1px solid var(--os-border-color);
+    background-color: var(--os-white-bg);
+    padding: 0.3rem;
+    white-space: nowrap;
 
     &:hover {
-      cursor: pointer;
+      filter: brightness(0.9);
     }
+  }
 
-    td,
-    th {
-      border: 1px solid var(--os-border-color);
-      background-color: var(--os-white-bg);
-      padding: 0.3rem;
-      white-space: nowrap;
+  td {
+    text-align: right;
+  }
 
-      &:hover {
-        filter: brightness(0.9);
-      }
-    }
+  th {
+    background-color: var(--os-gray-100);
+    font-weight: bold;
+    color: var(--os-black);
+  }
 
-    td {
-      text-align: right;
-    }
-
-    th {
-      background-color: var(--os-background-gray-color);
-      font-weight: bold;
-      color: var(--os-black);
-    }
-
-    .o_missing_value {
-      color: var(--os-gray-600);
-      background: var(--os-button-active-bg);
-    }
+  .o_missing_value {
+    color: var(--os-gray-600);
+    background: var(--os-button-active-bg);
   }
 }

--- a/src/components/pivot_html_renderer/pivot_html_renderer.xml
+++ b/src/components/pivot_html_renderer/pivot_html_renderer.xml
@@ -1,6 +1,6 @@
 <templates>
   <t t-name="o_spreadsheet.PivotHTMLRenderer">
-    <div class="o_pivot_html_renderer">
+    <div class="w-100">
       <Checkbox
         name="'missing_values'"
         label.translate="Display missing cells only"

--- a/tests/components/__snapshots__/pivot_html_renderer.test.ts.snap
+++ b/tests/components/__snapshots__/pivot_html_renderer.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`Pivot HTML Renderer Rendering a simple pivot table 1`] = `
 <div>
   <div
-    class="o_pivot_html_renderer"
+    class="w-100"
   >
     <label
       class="o-checkbox d-flex align-items-center m-2"


### PR DESCRIPTION
## Description

The `pivot_html_renderer` css was scoped to `o-spreadsheet`, but was sometime used outisde of the spreadsheet in a modal.

Also the class `o_pivot_html_renderer` was added twice in the template.

Task: [6523521](https://www.odoo.com/odoo/2328/tasks/6523521)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo