### PR TITLE
[FIX] hover_overlay: avoid useless render

### DIFF
--- a/src/stores/cell_hover_overlay_store.ts
+++ b/src/stores/cell_hover_overlay_store.ts
@@ -16,9 +16,14 @@ export class CellHoverOverlayStore extends SpreadsheetStore {
   overlayColors: PositionMap<Color> = new PositionMap();
 
   hover(hoveredPosition: CellPosition | undefined) {
+    if (!this.providers.length) {
+      return "noStateChange";
+    }
+
+    const oldOverlayColors = this.overlayColors;
     this.overlayColors = new PositionMap();
     if (!hoveredPosition) {
-      return;
+      return oldOverlayColors.keys().length === 0 ? "noStateChange" : undefined;
     }
 
     for (const provider of this.providers) {
@@ -27,13 +32,24 @@ export class CellHoverOverlayStore extends SpreadsheetStore {
         this.overlayColors.set(position, TABLE_HOVER_BACKGROUND_COLOR);
       }
     }
+
+    let hasChanged = false;
+    for (const position of [...this.overlayColors.keys(), ...oldOverlayColors.keys()]) {
+      if (this.overlayColors.get(position) !== oldOverlayColors.get(position)) {
+        hasChanged = true;
+        break;
+      }
+    }
+    return hasChanged ? undefined : "noStateChange";
   }
 
   register(highlightProvider: CellHoverOverlayProvider) {
     this.providers.push(highlightProvider);
+    this.overlayColors = new PositionMap();
   }
 
   unRegister(highlightProvider: CellHoverOverlayProvider) {
     this.providers = this.providers.filter((h) => h !== highlightProvider);
+    this.overlayColors = new PositionMap();
   }
 }

--- a/tests/spreadsheet/cell_hover_overlay_store.test.ts
+++ b/tests/spreadsheet/cell_hover_overlay_store.test.ts
@@ -1,0 +1,68 @@
+import { Model, UID } from "../../src";
+import { TABLE_HOVER_BACKGROUND_COLOR } from "../../src/constants";
+import { DependencyContainer } from "../../src/store_engine/dependency_container";
+import {
+  CellHoverOverlayProvider,
+  CellHoverOverlayStore,
+} from "../../src/stores/cell_hover_overlay_store";
+import { Store } from "../../src/types/store_engine";
+import { makeStore } from "../test_helpers/stores";
+
+describe("Cell hover overlay store", () => {
+  let hoveredCellOverlayStore: Store<CellHoverOverlayStore>;
+  let model: Model;
+  let sheetId: UID;
+  let container: DependencyContainer;
+
+  beforeEach(() => {
+    ({ model, container } = makeStore(CellHoverOverlayStore));
+    hoveredCellOverlayStore = container.get(CellHoverOverlayStore);
+    sheetId = model.getters.getActiveSheetId();
+  });
+
+  test("Store doesn't trigger a re-render when nothing changes", () => {
+    const A1 = { sheetId, col: 0, row: 0 };
+    let result = hoveredCellOverlayStore.hover(A1);
+    expect(result).toBe("noStateChange"); // No render: no overlay provider are registered in the store yet
+    expect(hoveredCellOverlayStore.overlayColors.get(A1)).toBe(undefined);
+
+    hoveredCellOverlayStore.register({
+      getHighlightedPositions: (hoveredPosition) => [hoveredPosition],
+    });
+
+    result = hoveredCellOverlayStore.hover(A1);
+    expect(result).toBe(undefined); // Trigger render
+    expect(hoveredCellOverlayStore.overlayColors.get(A1)).toBe(TABLE_HOVER_BACKGROUND_COLOR);
+
+    result = hoveredCellOverlayStore.hover(A1);
+    expect(result).toBe("noStateChange"); // No render: hover the same cell
+    expect(hoveredCellOverlayStore.overlayColors.get(A1)).toBe(TABLE_HOVER_BACKGROUND_COLOR);
+  });
+
+  test("Store content is reset when registering/unregistering overlay providers", () => {
+    const A1 = { sheetId, col: 0, row: 0 };
+    const A2 = { sheetId, col: 0, row: 1 };
+
+    const A1Provider: CellHoverOverlayProvider = {
+      getHighlightedPositions: (hoveredPosition) =>
+        hoveredPosition.row === 0 ? [hoveredPosition] : [],
+    };
+    const A2Provider: CellHoverOverlayProvider = {
+      getHighlightedPositions: (hoveredPosition) =>
+        hoveredPosition.row === 1 ? [hoveredPosition] : [],
+    };
+
+    hoveredCellOverlayStore.register(A1Provider);
+    hoveredCellOverlayStore.hover(A1);
+    expect(hoveredCellOverlayStore.overlayColors.get(A1)).toBe(TABLE_HOVER_BACKGROUND_COLOR);
+
+    hoveredCellOverlayStore.register(A2Provider);
+    expect(hoveredCellOverlayStore.overlayColors.get(A1)).toBe(undefined);
+
+    hoveredCellOverlayStore.hover(A2);
+    expect(hoveredCellOverlayStore.overlayColors.get(A2)).toBe(TABLE_HOVER_BACKGROUND_COLOR);
+
+    hoveredCellOverlayStore.unRegister(A2Provider);
+    expect(hoveredCellOverlayStore.overlayColors.get(A2)).toBe(undefined);
+  });
+});


### PR DESCRIPTION
## Description

a call to `CellHoverOverlayStore.hover` would trigger a render every time (so at each mouse move), even if nothing changed.

Task: [6526551](https://www.odoo.com/odoo/2328/tasks/6526551)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo