### PR TITLE
[IMP] chart_suggestion_engine: boolean column

### DIFF
--- a/src/helpers/figures/charts/chart_suggestion_engine.ts
+++ b/src/helpers/figures/charts/chart_suggestion_engine.ts
@@ -184,9 +184,12 @@ function buildSinglePercentageContext(
 }
 
 /** Pattern C — Single date column */
-function buildSingleDateContext([col]: ColumnAnalysis[]): SingleDateContext {
+function buildSingleDateContext([col]: ColumnAnalysis[], getters: Getters): SingleDateContext {
   const { lastCellXC } = interestingCellsXc(col);
-  return { title: col.header ?? "", lastCellXC, rowCount: col.rowCount };
+  const hasTitle = col.hasHeader;
+  const labelRange = getUnboundRange(getters, col.zone);
+  const source = rangeSource([dataset(col.zone, getters)], hasTitle, labelRange);
+  return { title: col.header ?? "", lastCellXC, rowCount: col.rowCount, source };
 }
 
 /** Pattern D — Single categorical column */

--- a/src/helpers/figures/charts/chart_suggestion_engine.ts
+++ b/src/helpers/figures/charts/chart_suggestion_engine.ts
@@ -472,6 +472,7 @@ function buildManyNumbersContext(cols: ColumnAnalysis[], getters: Getters): Many
 }
 
 const NUMBER_OR_PERCENTAGE: readonly ExtendedColumnType[] = ["number", "percentage"];
+const CATEGORICAL_OR_BOOLEAN: readonly ExtendedColumnType[] = ["categorical", "boolean"];
 const EXACT_PATTERNS: ChartSuggestionRule<any>[] = [
   {
     pattern: { leadingTypes: ["number"] },
@@ -489,7 +490,7 @@ const EXACT_PATTERNS: ChartSuggestionRule<any>[] = [
     suggestions: SINGLE_DATE_COLUMN_SUGGESTIONS,
   },
   {
-    pattern: { leadingTypes: ["categorical"] },
+    pattern: { leadingTypes: [CATEGORICAL_OR_BOOLEAN] },
     buildContext: buildSingleCategoricalContext,
     suggestions: SINGLE_CATEGORICAL_COLUMN_SUGGESTIONS,
   },
@@ -499,7 +500,7 @@ const EXACT_PATTERNS: ChartSuggestionRule<any>[] = [
     suggestions: SINGLE_LABEL_COLUMN_SUGGESTIONS,
   },
   {
-    pattern: { leadingTypes: ["categorical", "number"] },
+    pattern: { leadingTypes: [CATEGORICAL_OR_BOOLEAN, "number"] },
     buildContext: buildCategoricalVsNumberContext,
     suggestions: CATEGORICAL_VS_NUMBER_SUGGESTIONS,
   },
@@ -514,7 +515,7 @@ const EXACT_PATTERNS: ChartSuggestionRule<any>[] = [
     suggestions: NUMBER_VS_NUMBER_SUGGESTIONS,
   },
   {
-    pattern: { leadingTypes: ["categorical", "percentage"] },
+    pattern: { leadingTypes: [CATEGORICAL_OR_BOOLEAN, "percentage"] },
     buildContext: buildCategoricalVsPercentageContext,
     suggestions: CATEGORICAL_VS_PERCENTAGE_SUGGESTIONS,
   },
@@ -529,22 +530,22 @@ const EXACT_PATTERNS: ChartSuggestionRule<any>[] = [
     suggestions: CATEGORICAL_VS_PERCENTAGE_SUGGESTIONS,
   },
   {
-    pattern: { leadingTypes: ["categorical", "categorical", "number"] },
+    pattern: { leadingTypes: [CATEGORICAL_OR_BOOLEAN, CATEGORICAL_OR_BOOLEAN, "number"] },
     buildContext: buildMultipleCategoricalsVsNumberContext,
     suggestions: MULTIPLE_CATEGORICALS_VS_NUMBER_SUGGESTIONS,
   },
   {
-    pattern: { leadingTypes: ["categorical", "label", "number"] },
+    pattern: { leadingTypes: [CATEGORICAL_OR_BOOLEAN, "label", "number"] },
     buildContext: buildMultipleCategoricalsVsNumberContext,
     suggestions: MULTIPLE_CATEGORICALS_VS_NUMBER_SUGGESTIONS,
   },
   {
-    pattern: { leadingTypes: ["categorical", "date", NUMBER_OR_PERCENTAGE] },
+    pattern: { leadingTypes: [CATEGORICAL_OR_BOOLEAN, "date", NUMBER_OR_PERCENTAGE] },
     buildContext: buildCategoricalDateNumberContext,
     suggestions: CATEGORICAL_DATE_NUMBER_SUGGESTIONS,
   },
   {
-    pattern: { leadingTypes: ["categorical", NUMBER_OR_PERCENTAGE, NUMBER_OR_PERCENTAGE] },
+    pattern: { leadingTypes: [CATEGORICAL_OR_BOOLEAN, NUMBER_OR_PERCENTAGE, NUMBER_OR_PERCENTAGE] },
     buildContext: buildCategoricalTwoNumbersContext,
     suggestions: CATEGORICAL_TWO_NUMBERS_SUGGESTIONS,
   },

--- a/src/helpers/figures/charts/charts_suggestions_constants.ts
+++ b/src/helpers/figures/charts/charts_suggestions_constants.ts
@@ -340,12 +340,17 @@ export const SINGLE_PERCENTAGE_COLUMN_SUGGESTIONS: Suggestion<SinglePercentageCo
 ];
 
 /** Pattern C — Single date column */
-// TODO(ANHE): add line/bar/calendar suggestions once date-bucketing is supported.
+// TODO(ANHE): add line/bar suggestions once date-bucketing is supported.
 export const SINGLE_DATE_COLUMN_SUGGESTIONS: Suggestion<SingleDateContext>[] = [
   {
     description: _t("Shows the last date value."),
     isApplicable: ({ rowCount }) => rowCount === 1,
     build: (ctx) => scorecardChart(ctx.title, `=${ctx.lastCellXC}`),
+  },
+  {
+    description: _t("Shows occurrences for each time slot."),
+    isApplicable: ({ rowCount }) => rowCount > 1,
+    build: (ctx) => calendarChart(ctx.title, ctx.source),
   },
 ];
 

--- a/src/types/chart/chart_suggestion.ts
+++ b/src/types/chart/chart_suggestion.ts
@@ -33,6 +33,7 @@ export interface SingleDateContext {
   title: string;
   lastCellXC: string;
   rowCount: number;
+  source: ChartRangeDataSource<string>;
 }
 
 /** Pattern D — Single categorical column */

--- a/tests/figures/chart/chart_suggestion_engine.test.ts
+++ b/tests/figures/chart/chart_suggestion_engine.test.ts
@@ -188,12 +188,15 @@ describe("getChartSuggestions", () => {
       expect(suggestionTypes(model, "A1")).toEqual(["scorecard"]);
     });
 
-    test(">1 row → no suggestions yet (date-bucketing not supported)", () => {
+    test(">1 row → calendar chart", () => {
       const model = new Model();
       setCellContent(model, "A1", "1/1/2024");
       setCellContent(model, "A2", "2/1/2024");
       setFormat(model, "A1:A2", "mm/dd/yyyy");
-      expect(suggestions(model, "A1:A2")).toHaveLength(0);
+      expect(suggestions(model, "A1:A2")).toHaveLength(1);
+      expect(
+        (runtimeFor(model, "A1:A2", (d) => d.type === "calendar") as any).chartJsConfig
+      ).toBeDefined();
     });
   });
 

--- a/tests/figures/chart/chart_suggestion_engine.test.ts
+++ b/tests/figures/chart/chart_suggestion_engine.test.ts
@@ -74,7 +74,7 @@ describe("getChartSuggestions", () => {
       ) as ScorecardChartRuntime;
       expect(kpiRuntime.keyValue).toBe("20");
       const barRuntime = runtimeFor(model, "A1:A2", (d) => d.type === "bar") as any;
-      expect(barRuntime.chartJsConfig.type).toBe("bar");
+      expect(barRuntime.chartJsConfig).toBeDefined();
       expect(barRuntime.chartJsConfig.data.datasets[0].data).toEqual([10, 20]);
     });
 
@@ -171,11 +171,10 @@ describe("getChartSuggestions", () => {
       setFormat(model, "A1:A2", "0%");
       expect(
         (runtimeFor(model, "A1:A2", (d) => d.type === "pie" && !!d.isDoughnut) as any).chartJsConfig
-          .type
-      ).toBe("doughnut");
-      expect((runtimeFor(model, "A1:A2", (d) => d.type === "bar") as any).chartJsConfig.type).toBe(
-        "bar"
-      );
+      ).toBeDefined();
+      expect(
+        (runtimeFor(model, "A1:A2", (d) => d.type === "bar") as any).chartJsConfig
+      ).toBeDefined();
     });
   });
 
@@ -212,15 +211,13 @@ describe("getChartSuggestions", () => {
       });
       expect(
         (runtimeFor(model, "A1:A5", (d) => d.type === "pie" && !d.isDoughnut) as any).chartJsConfig
-          .type
-      ).toBe("pie");
+      ).toBeDefined();
       expect(
         (runtimeFor(model, "A1:A5", (d) => d.type === "pie" && !!d.isDoughnut) as any).chartJsConfig
-          .type
-      ).toBe("doughnut");
-      expect((runtimeFor(model, "A1:A5", (d) => d.type === "bar") as any).chartJsConfig.type).toBe(
-        "bar"
-      );
+      ).toBeDefined();
+      expect(
+        (runtimeFor(model, "A1:A5", (d) => d.type === "bar") as any).chartJsConfig
+      ).toBeDefined();
     });
 
     test("boolean column → pie, donut, and bar (count) charts produced", () => {
@@ -287,8 +284,8 @@ describe("getChartSuggestions", () => {
       ) as any;
       expect(hBarRuntime.chartJsConfig.options.indexAxis).toBe("y");
       expect(
-        (runtimeFor(model, ["A1:A3", "B1:B3"], (d) => d.type === "pie") as any).chartJsConfig.type
-      ).toBe("pie");
+        (runtimeFor(model, ["A1:A3", "B1:B3"], (d) => d.type === "pie") as any).chartJsConfig
+      ).toBeDefined();
     });
 
     test("No title if there is no header", () => {
@@ -332,19 +329,18 @@ describe("getChartSuggestions", () => {
       setCellContent(model, "B3", "30");
       expect(
         (runtimeFor(model, ["A1:A3", "B1:B3"], (d) => d.type === "line" && !d.fillArea) as any)
-          .chartJsConfig.type
-      ).toBe("line");
+          .chartJsConfig
+      ).toBeDefined();
       expect(
         (runtimeFor(model, ["A1:A3", "B1:B3"], (d) => d.type === "line" && !!d.fillArea) as any)
           .chartJsConfig.data.datasets[0].fill
       ).toBeTruthy();
       expect(
-        (runtimeFor(model, ["A1:A3", "B1:B3"], (d) => d.type === "bar") as any).chartJsConfig.type
-      ).toBe("bar");
+        (runtimeFor(model, ["A1:A3", "B1:B3"], (d) => d.type === "bar") as any).chartJsConfig
+      ).toBeDefined();
       expect(
         (runtimeFor(model, ["A1:A3", "B1:B3"], (d) => d.type === "calendar") as any).chartJsConfig
-          .type
-      ).toBe("calendar");
+      ).toBeDefined();
     });
   });
 
@@ -474,7 +470,7 @@ describe("getChartSuggestions", () => {
         ["A1:A3", "B1:B3"],
         (d) => d.type === "bar" && !d.horizontal
       ) as any;
-      expect(barRuntime.chartJsConfig.type).toBe("bar");
+      expect(barRuntime.chartJsConfig).toBeDefined();
     });
 
     test("3-10 rows → radar chart produced", () => {
@@ -487,7 +483,7 @@ describe("getChartSuggestions", () => {
         B3: "30",
       });
       const radarRuntime = runtimeFor(model, ["A1:A3", "B1:B3"], (d) => d.type === "radar") as any;
-      expect(radarRuntime.chartJsConfig.type).toBe("radar");
+      expect(radarRuntime.chartJsConfig).toBeDefined();
     });
   });
 
@@ -741,7 +737,7 @@ describe("getChartSuggestions", () => {
         ["A1", "B1", "C1"],
         (d) => d.type === "bar" && !d.stacked
       ) as any;
-      expect(runtime.chartJsConfig.type).toBe("bar");
+      expect(runtime.chartJsConfig).toBeDefined();
       expect(runtime.chartJsConfig.data.datasets).toHaveLength(3);
     });
 

--- a/tests/figures/chart/chart_suggestion_engine.test.ts
+++ b/tests/figures/chart/chart_suggestion_engine.test.ts
@@ -219,6 +219,25 @@ describe("getChartSuggestions", () => {
         "bar"
       );
     });
+
+    test("boolean column → pie, donut, and bar (count) charts produced", () => {
+      const model = createModelFromGrid({
+        A1: "TRUE",
+        A2: "FALSE",
+        A3: "TRUE",
+        A4: "FALSE",
+        A5: "TRUE",
+      });
+      expect(
+        (runtimeFor(model, "A1:A5", (d) => d.type === "pie" && !d.isDoughnut) as any).chartJsConfig
+      ).toBeDefined();
+      expect(
+        (runtimeFor(model, "A1:A5", (d) => d.type === "pie" && !!d.isDoughnut) as any).chartJsConfig
+      ).toBeDefined();
+      expect(
+        (runtimeFor(model, "A1:A5", (d) => d.type === "bar") as any).chartJsConfig
+      ).toBeDefined();
+    });
   });
 
   // Pattern E — single label column


### PR DESCRIPTION
Before this commit:
No chart suggestion was made for boolean columns.

Now:
We made the same suggestions as for categorical columns: pie, doughnut an columns charts.


Task: [6537589](https://www.odoo.com/odoo/2328/tasks/6537589)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo