### PR TITLE
[PERF] evaluation: clip range to sheet

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -175,6 +175,8 @@ export class Model extends EventBus<any> implements CommandDispatcher {
     this.range = new RangeAdapterPlugin(this.coreGetters);
     this.coreGetters.getRangeString = this.range.getRangeString.bind(this.range);
     this.coreGetters.getRangeFromSheetXC = this.range.getRangeFromSheetXC.bind(this.range);
+    this.coreGetters.clipRangesToSheet = this.range.clipRangesToSheet.bind(this.range);
+    this.coreGetters.clipRangeToSheet = this.range.clipRangeToSheet.bind(this.range);
     this.coreGetters.createAdaptedRanges = this.range.createAdaptedRanges.bind(this.range);
     this.coreGetters.getRangeData = this.range.getRangeData.bind(this.range);
     this.coreGetters.getRangeDataFromXc = this.range.getRangeDataFromXc.bind(this.range);

--- a/src/plugins/core/range.ts
+++ b/src/plugins/core/range.ts
@@ -13,7 +13,7 @@ import {
 import { getRangeAdapterFunctions } from "../../helpers/range_adapter_functions";
 import { recomputeZones } from "../../helpers/recompute_zones";
 
-import { isZoneValid, unionUnboundedZones } from "../../helpers/zones";
+import { intersection, isZoneInside, isZoneValid, unionUnboundedZones } from "../../helpers/zones";
 import { Command, CommandHandler, CommandResult, CoreCommand } from "../../types/commands";
 import { CoreGetters } from "../../types/core_getters";
 import { CellErrorType } from "../../types/errors";
@@ -40,6 +40,8 @@ export class RangeAdapterPlugin implements CommandHandler<CoreCommand> {
     "extendRange",
     "getRangeString",
     "getRangeFromSheetXC",
+    "clipRangesToSheet",
+    "clipRangeToSheet",
     "createAdaptedRanges",
     "getRangeData",
     "getRangeDataFromXc",
@@ -98,6 +100,33 @@ export class RangeAdapterPlugin implements CommandHandler<CoreCommand> {
   // ---------------------------------------------------------------------------
   // Getters
   // ---------------------------------------------------------------------------
+
+  clipRangeToSheet(range: Range): Range | undefined {
+    if (range.invalidXc) {
+      return range;
+    }
+    const sheetZone = this.getters.getSheetZone(range.sheetId);
+    if (isZoneInside(range.zone, sheetZone)) {
+      // fast path: most ranges are within the sheet zone
+      return range;
+    }
+    const newZone = intersection(range.zone, sheetZone);
+    if (!newZone) {
+      return undefined;
+    }
+    return this.getters.getRangeFromZone(range.sheetId, newZone);
+  }
+
+  clipRangesToSheet(ranges: Range[]): Range[] {
+    const clippedRanges: Range[] = [];
+    for (const range of ranges) {
+      const clippedRange = this.clipRangeToSheet(range);
+      if (clippedRange) {
+        clippedRanges.push(clippedRange);
+      }
+    }
+    return clippedRanges;
+  }
 
   createAdaptedRanges(ranges: Range[], offsetX: number, offsetY: number, sheetId: UID): Range[] {
     return ranges.map((range) => {

--- a/src/plugins/ui_core_views/cell_evaluation/compilation_parameters.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/compilation_parameters.ts
@@ -1,5 +1,5 @@
 import { functionRegistry } from "../../../functions/function_registry";
-import { intersection, isZoneValid } from "../../../helpers/zones";
+import { isZoneValid } from "../../../helpers/zones";
 import { _t } from "../../../translation";
 import { EvaluatedCell } from "../../../types/cells";
 import { EvaluationError, InvalidReferenceError } from "../../../types/errors";
@@ -99,8 +99,7 @@ class CompilationParametersBuilder {
 
     // Performance issue: Avoid fetching data on positions that are out of the spreadsheet
     // e.g. A1:ZZZ9999 in a sheet with 10 cols and 10 rows should ignore everything past J10 and return a 10x10 array
-    const sheetZone = this.getters.getSheetZone(sheetId);
-    const _zone = intersection(zone, sheetZone);
+    const _zone = this.getters.clipRangeToSheet(range)?.zone;
     if (!_zone) {
       return [[]];
     }

--- a/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
@@ -110,11 +110,17 @@ export class Evaluator {
     // The data structure is optimized for searches the other way around
     this.formulaDependencies().removeAllDependencies(position);
     const dependencies = this.getDirectDependencies(position);
-    this.formulaDependencies().addDependencies(position, dependencies);
+    this.formulaDependencies().addDependencies(
+      position,
+      this.getters.clipRangesToSheet(dependencies)
+    );
   }
 
   private addDependencies(position: CellPosition, dependencies: Range[]) {
-    this.formulaDependencies().addDependencies(position, dependencies);
+    this.formulaDependencies().addDependencies(
+      position,
+      this.getters.clipRangesToSheet(dependencies)
+    );
     this.computeDependencies(dependencies);
   }
 
@@ -209,7 +215,10 @@ export class Evaluator {
         for (const cell of this.getters.getCells(sheetId)) {
           if (cell.isFormula) {
             const cellPosition = this.getters.getCellPosition(cell.id);
-            graph.addDependencies(cellPosition, cell.compiledFormula.rangeDependencies);
+            const dependencies = this.getters.clipRangesToSheet(
+              cell.compiledFormula.rangeDependencies
+            );
+            graph.addDependencies(cellPosition, dependencies);
           }
         }
       }


### PR DESCRIPTION
Some users do stupid things like:

`INDEX($B$2:$ZZZ:$10000)`... repeated thousands of time.

The current data structure for the dependency graph is optimized for row-heavy spreadsheets, which are much more common compared to column-heavy spreadsheets. (`IntervalTree`)

However, if a formula references a range which has many many columns (e.g. A1:ZZZ10), the range is still added to the dependency graph.

With this commit, we clip the ranges added to the dependency graph to the actual sheet size, cutting extra-columns that we don't need to track.

| | Synthetic benchmark [1] | spreadsheet 4756563 | spreadsheet 4185418|
|--------|--------|--------|--------|
| Before | ~10s | cannot open | cannot open |
| After | ~80ms | ~5s | ~14s [2] | 


[1] =INDEX(Sheet1!$A$1:$ZZZ$202, 1, 1) repeated 5200 times
[2] ~14s for initial eval (then ~1 minute, but it's unrelated)


Ticket: [6483083](https://www.odoo.com/odoo/2328/tasks/6483083)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo