### PR TITLE
[FIX] composer speech_bubble: move after rendering

### DIFF
--- a/src/components/composer/speech_bubble/speech_bubble.ts
+++ b/src/components/composer/speech_bubble/speech_bubble.ts
@@ -1,5 +1,5 @@
-import { signal, useEffect, useProps } from "@odoo/owl";
-import { Component } from "../../../owl3_compatibility_layer";
+import { signal, useProps } from "@odoo/owl";
+import { Component, useLayoutEffect } from "../../../owl3_compatibility_layer";
 import { SpreadsheetChildEnv } from "../../../types/spreadsheet_env";
 import { getBoundingRectAsPOJO } from "../../helpers/dom_helpers";
 import { useSpreadsheetRect } from "../../helpers/position_hook";
@@ -20,7 +20,7 @@ export class SpeechBubble extends Component<SpreadsheetChildEnv> {
   private bubbleRef = signal.ref();
 
   setup(): void {
-    useEffect(() => {
+    useLayoutEffect(() => {
       const el = this.bubbleRef();
       if (!el) {
         return;


### PR DESCRIPTION
Move the element after render to be based on the new size.

Task: 6484405

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [6484405](https://www.odoo.com/odoo/2328/tasks/6484405)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo