### PR TITLE
[FIX] ComposerHighlight: Highlight the correct sheet with `#`

### DIFF
--- a/src/components/composer/composer/abstract_composer_store.ts
+++ b/src/components/composer/composer/abstract_composer_store.ts
@@ -833,7 +833,7 @@ export abstract class AbstractComposerStore extends SpreadsheetStore {
       row: range.zone.top,
     });
     if (spreadZone) {
-      return this.getters.getRangeFromZone(sheetId, spreadZone);
+      return this.getters.getRangeFromZone(range.sheetId, spreadZone);
     }
     return range;
   }

--- a/tests/composer/composer_store.test.ts
+++ b/tests/composer/composer_store.test.ts
@@ -291,6 +291,15 @@ describe("edition", () => {
     ]);
   });
 
+  test("spilled range is highlighted on the sheet of the reference", () => {
+    createSheetWithName(model, { sheetId: "sh2" }, "Sheet2");
+    setCellContent(model, "A1", "=SEQUENCE(2, 2)", "sh2");
+    composerStore.startEdition("=Sheet2!A1#");
+    expect(composerStore.highlights.map(flattenHighlightRange)).toMatchObject([
+      { zone: toZone("A1:B2"), sheetId: "sh2" },
+    ]);
+  });
+
   test("different ranges have different colors", () => {
     composerStore.startEdition("=SUM(A2:A3, B5)");
     const [firstColor, secondColor] = composerStore.highlights.map((h) => h.color);


### PR DESCRIPTION
Highlight the correct sheet when selecting a formula with spill operator

Task: 6527596

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [6527596](https://www.odoo.com/odoo/2328/tasks/6527596)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo