### PR TITLE
[FIX] standalone viewport: use correct devicePixelRatio

### DIFF
--- a/src/components/standalone_viewport/standalone_viewport_store.ts
+++ b/src/components/standalone_viewport/standalone_viewport_store.ts
@@ -131,7 +131,7 @@ export class StandaloneViewportStore extends SpreadsheetStore {
       viewports: this.viewStore.viewports,
       hideGridLines: this.getters.isDashboard(),
       hideFrozenPaneBorder: true,
-      dpr: 1,
+      dpr: window.devicePixelRatio || 1,
       selectedZones: [],
       activeCols: new Set(),
       activeRows: new Set(),

--- a/tests/figures/carousel/standalone_viewport.test.ts
+++ b/tests/figures/carousel/standalone_viewport.test.ts
@@ -8,6 +8,7 @@ import { buildSheetLink, range } from "../../../src/helpers/misc";
 import { zoneToXc } from "../../../src/helpers/zones";
 import { CellHoverOverlayStore } from "../../../src/stores/cell_hover_overlay_store";
 import { GridRenderer } from "../../../src/stores/grid_renderer_store";
+import { RendererStore } from "../../../src/stores/renderer_store";
 import { ViewportsStore } from "../../../src/stores/viewports_store";
 import { ZoomStore } from "../../../src/stores/zoom_store";
 import { PropsOf } from "../../../src/types/props_of";
@@ -347,6 +348,29 @@ describe("Standalone viewport", () => {
     expect(overlayStore.overlayColors.get(toCellPosition("sh2", "B2"))).toBeUndefined();
     expect(overlayStore.overlayColors.get(toCellPosition("sh2", "C2"))).toBeUndefined();
     jest.useRealTimers();
+  });
+
+  test("Standalone viewport is drawn with the window devicePixelRatio", async () => {
+    await mountViewport("A1:A2");
+    const rendererStore: RendererStore = storeSpy.getStores(RendererStore).at(-1)!;
+
+    let lastDpr = 0;
+    rendererStore.register({
+      renderingLayers: ["Background"],
+      drawLayer: (ctx) => (lastDpr = ctx.dpr),
+    });
+
+    setCellContent(model, "A1", "Hello");
+    await nextTick();
+    expect(lastDpr).toEqual(1);
+
+    const originalDpr = window.devicePixelRatio;
+    window.devicePixelRatio = 2;
+    setCellContent(model, "A1", "There");
+    await nextTick();
+    expect(lastDpr).toEqual(2);
+
+    window.devicePixelRatio = originalDpr;
   });
 
   describe("Column resize", () => {


### PR DESCRIPTION
## Description



Task: [6445656](https://www.odoo.com/odoo/2328/tasks/6445656)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo