### PR TITLE
[FIX] print: empty pages when printing

### DIFF
--- a/src/components/spreadsheet_print/spreadsheet_print.css
+++ b/src/components/spreadsheet_print/spreadsheet_print.css
@@ -31,6 +31,12 @@
       overflow: visible !important;
       height: 100% !important;
 
+      div.mx-auto {
+        margin: 0 !important;
+        width: 100% !important;
+        height: 100% !important;
+      }
+
       .o-print-page {
         box-shadow: none !important;
         padding: 0 !important;


### PR DESCRIPTION
## Description

Some of the pages could have a width/height greater than 100% when printing, leading to empty pages being printed.

Task: [6559815](https://www.odoo.com/odoo/2328/tasks/6559815)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo