### PR TITLE
[FIX] chart annotation: text input style

### DIFF
--- a/src/components/side_panel/chart/building_blocks/annotation/annotation.css
+++ b/src/components/side_panel/chart/building_blocks/annotation/annotation.css
@@ -3,6 +3,10 @@
     height: fit-content;
     max-height: 200px;
     min-height: 1.2em;
+    border-style: none;
+    &:focus {
+      border-color: var(--os-action-color) !important;
+    }
   }
 
   .o-input-infotext:empty:before {


### PR DESCRIPTION
Before this commit:
The input have thick borders and is supposed to only have a thin bottom border.

Task: [6533642](https://www.odoo.com/odoo/2328/tasks/6533642)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo