### PR TITLE
[FIX] gaugeCharts: fix GaugeChartBuilder typing

### DIFF
--- a/src/helpers/figures/charts/gauge_chart.ts
+++ b/src/helpers/figures/charts/gauge_chart.ts
@@ -1,4 +1,4 @@
-import { ColorThemeName } from "../../..";
+import { ColorThemeName, EvaluationGetters } from "../../..";
 import {
   DEFAULT_GAUGE_LOWER_COLOR,
   DEFAULT_GAUGE_MIDDLE_COLOR,
@@ -20,7 +20,6 @@ import {
 import { CommandResult } from "../../../types/commands";
 import { CellErrorType } from "../../../types/errors";
 import { Format } from "../../../types/format";
-import { Getters } from "../../../types/getters";
 import { Color, UID, Validation } from "../../../types/misc";
 import { Range } from "../../../types/range";
 import { formatOrHumanizeValue, humanizeNumber } from "../../format/format";
@@ -264,7 +263,7 @@ export const GaugeChart: ChartTypeBuilder<"gauge"> = {
   },
 
   getRuntime(
-    getters: Getters,
+    getters,
     definition,
     dataSource,
     sheetId,
@@ -390,7 +389,7 @@ function getSectionThresholdValue(
   threshold: SectionThreshold,
   minValue: number,
   maxValue: number,
-  getters: Getters
+  getters: EvaluationGetters
 ): number | undefined {
   const numberValue = getFormulaNumberValue(sheetId, threshold.value, getters);
   if (numberValue === undefined) {
@@ -403,7 +402,7 @@ function getSectionThresholdValue(
   return clip(value, minValue, maxValue);
 }
 
-function getFormulaNumberValue(sheetId: UID, formula: string, getters: Getters) {
+function getFormulaNumberValue(sheetId: UID, formula: string, getters: EvaluationGetters) {
   const value = getters.evaluateFormula(sheetId, formula);
   return isMultipleElementMatrix(value)
     ? undefined
@@ -412,7 +411,7 @@ function getFormulaNumberValue(sheetId: UID, formula: string, getters: Getters) 
 
 function getInvalidGaugeRuntime(
   definition: GaugeChartDefinition<Range>,
-  getters: Getters,
+  getters: EvaluationGetters,
   colorThemeName: ColorThemeName
 ): GaugeChartRuntime {
   return {


### PR DESCRIPTION
All the methods defined in the chart builder will only ever receive EvaluationGetters and not all Getters.

Task: 0

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: [TASK_ID](https://www.odoo.com/odoo/2328/tasks/TASK_ID)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo